### PR TITLE
ci(ci): add CLI prebuild step for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
+      - name: Build CLI (for integration tests)
+        run: cargo build --features cli --bin succinctly
+
       - name: Run tests
         run: cargo test --verbose
 
@@ -69,6 +72,9 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
+      - name: Build CLI (for integration tests)
+        run: cargo build --features cli --bin succinctly
+
       - name: Run tests
         run: cargo test --verbose
 
@@ -100,6 +106,9 @@ jobs:
 
       - name: Build
         run: cargo build --verbose
+
+      - name: Build CLI (for integration tests)
+        run: cargo build --features cli --bin succinctly
 
       - name: Run tests
         run: cargo test --verbose


### PR DESCRIPTION
## Description

This PR adds a CLI prebuild step to the CI workflow to ensure the `succinctly` binary is available for integration tests. Previously, integration tests that depend on the CLI binary may have failed because the binary wasn't explicitly built before running tests.

The change adds `cargo build --features cli --bin succinctly` to all three CI job matrices (Ubuntu, macOS, and Windows) to ensure consistent test environments across platforms.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [x] CI/CD changes

## Related Issue

N/A - Proactive CI improvement to support integration tests

## Changes Made
- Added "Build CLI (for integration tests)" step to Ubuntu CI job after the main build step
- Added "Build CLI (for integration tests)" step to macOS CI job after the main build step
- Added "Build CLI (for integration tests)" step to Windows CI job after the main build step
- Each step runs `cargo build --features cli --bin succinctly` to compile the CLI binary

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality

**Manual Testing:**
- [ ] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

This change will be validated by the CI pipeline itself. The workflow modification ensures the CLI binary is built before tests run, which should allow integration tests to locate and execute the binary.

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

The additional build step adds minimal CI time since Cargo's incremental compilation will reuse most artifacts from the preceding `cargo build --verbose` step.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

The prebuild step is placed after the main build but before tests run, ensuring the CLI binary is available when integration tests attempt to invoke it. This is a standard pattern for projects with integration tests that shell out to compiled binaries.