### PR TITLE
feat(jq): implement assignment operators for in-place JSON modification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,32 @@ echo '["a","b|c","d"]' | jq -r '@dsv("|")'      # Output: a|"b|c"|d
 echo '["a","b","c"]' | jq -r '@dsv(";")'        # Output: a;b;c
 ```
 
+### jq Assignment Operators
+
+The jq implementation supports assignment operators for modifying JSON in-place:
+
+| Operator   | Syntax               | Description                                          | Example                    |
+|------------|----------------------|------------------------------------------------------|----------------------------|
+| **=**      | `.path = value`      | Simple assignment                                    | `.a = 42`                  |
+| **\|=**    | `.path \|= filter`   | Update assignment (applies filter to current value)  | `.a \|= . + 1`             |
+| **+=**     | `.path += value`     | Compound add (equivalent to `.path \|= . + value`)   | `.count += 10`             |
+| **-=**     | `.path -= value`     | Compound subtract                                    | `.health -= 25`            |
+| ***=**     | `.path *= value`     | Compound multiply                                    | `.scale *= 2`              |
+| **/=**     | `.path /= value`     | Compound divide                                      | `.total /= 4`              |
+| **%=**     | `.path %= value`     | Compound modulo                                      | `.index %= 10`             |
+| **//=**    | `.path //= value`    | Alternative assignment (sets only if null/false)     | `.default //= "fallback"`  |
+| **del()**  | `del(.path)`         | Delete field or array element                        | `del(.temporary)`          |
+
+```bash
+# Examples
+echo '{"a": 1}' | succinctly jq '.a = 42'           # {"a": 42}
+echo '{"x": 5}' | succinctly jq '.x |= . * 2'       # {"x": 10}
+echo '{"n": 10}' | succinctly jq '.n += 5'          # {"n": 15}
+echo '{"a": null}' | succinctly jq '.a //= "default"'  # {"a": "default"}
+echo '{"a": 1, "b": 2}' | succinctly jq 'del(.a)'   # {"b": 2}
+echo '[1, 2, 3]' | succinctly jq '.[] |= . * 2'     # [2, 4, 6]
+```
+
 ## Feature Flags
 
 | Feature             | Description                    |

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -407,6 +407,65 @@ cat data.json | succinctly jq '.items[]'
 succinctly jq . input.json | diff - <(jq . input.json)
 ```
 
+### Assignment Operators
+
+The jq command supports assignment operators for modifying JSON in-place:
+
+```bash
+# Simple assignment
+echo '{"a": 1}' | succinctly jq '.a = 42'
+# Output: {"a": 42}
+
+# Update assignment (applies filter to current value)
+echo '{"x": 5}' | succinctly jq '.x |= . * 2'
+# Output: {"x": 10}
+
+# Compound assignment (+=, -=, *=, /=, %=)
+echo '{"count": 10}' | succinctly jq '.count += 5'
+# Output: {"count": 15}
+
+echo '{"value": 100}' | succinctly jq '.value -= 25'
+# Output: {"value": 75}
+
+# Alternative assignment (sets only if null/false)
+echo '{"a": null}' | succinctly jq '.a //= "default"'
+# Output: {"a": "default"}
+
+echo '{"a": "existing"}' | succinctly jq '.a //= "default"'
+# Output: {"a": "existing"}  (unchanged)
+
+# Delete field or array element
+echo '{"a": 1, "b": 2}' | succinctly jq 'del(.a)'
+# Output: {"b": 2}
+
+echo '[1, 2, 3]' | succinctly jq 'del(.[1])'
+# Output: [1, 3]
+
+# Update all array elements
+echo '[1, 2, 3]' | succinctly jq '.[] |= . * 2'
+# Output: [2, 4, 6]
+
+# Chained assignments
+echo '{"x": 0, "y": 0}' | succinctly jq '.x = 10 | .y = 20'
+# Output: {"x": 10, "y": 20}
+
+# Nested assignment
+echo '{"user": {"name": "Alice", "age": 30}}' | succinctly jq '.user.age += 1'
+# Output: {"user": {"name": "Alice", "age": 31}}
+```
+
+| Operator | Syntax             | Description                                         |
+|----------|--------------------|-----------------------------------------------------|
+| `=`      | `.path = value`    | Simple assignment                                   |
+| `\|=`    | `.path \|= filter` | Update assignment (apply filter to current value)   |
+| `+=`     | `.path += value`   | Add to current value                                |
+| `-=`     | `.path -= value`   | Subtract from current value                         |
+| `*=`     | `.path *= value`   | Multiply current value                              |
+| `/=`     | `.path /= value`   | Divide current value                                |
+| `%=`     | `.path %= value`   | Modulo of current value                             |
+| `//=`    | `.path //= value`  | Set only if current value is null or false          |
+| `del()`  | `del(.path)`       | Delete field or array element                       |
+
 ## Development
 
 Run tests for the CLI:

--- a/docs/plan/jq.md
+++ b/docs/plan/jq.md
@@ -44,11 +44,21 @@ Support basic jq path syntax for navigating JSON:
 
 ### Phase 4: Advanced (Future)
 
-- Recursive descent `..`
-- Pipe operator `|`
-- Arithmetic and comparison operators
-- String interpolation
-- `reduce`, `group_by`, `sort_by`
+- Recursive descent `..` ✅ Implemented
+- Pipe operator `|` ✅ Implemented
+- Arithmetic and comparison operators ✅ Implemented
+- String interpolation ✅ Implemented
+- `reduce`, `group_by`, `sort_by` ✅ Implemented
+
+### Phase 5: Assignment Operators ✅ Implemented
+
+| Expression         | Meaning                                    |
+|--------------------|-------------------------------------------|
+| `.a = value`       | Simple assignment                          |
+| `.a \|= filter`    | Update assignment (apply filter to value)  |
+| `.a += value`      | Compound add (also -=, *=, /=, %=)         |
+| `.a //= value`     | Alternative assignment (set if null/false) |
+| `del(.a)`          | Delete field or array element              |
 
 ---
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -415,6 +415,24 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
                 .collect();
             Expr::StringInterpolation(new_parts)
         }
+        // Assignment operators
+        Expr::Assign { path, value } => Expr::Assign {
+            path: Box::new(rewrite_namespaced_calls(*path)),
+            value: Box::new(rewrite_namespaced_calls(*value)),
+        },
+        Expr::Update { path, filter } => Expr::Update {
+            path: Box::new(rewrite_namespaced_calls(*path)),
+            filter: Box::new(rewrite_namespaced_calls(*filter)),
+        },
+        Expr::CompoundAssign { op, path, value } => Expr::CompoundAssign {
+            op,
+            path: Box::new(rewrite_namespaced_calls(*path)),
+            value: Box::new(rewrite_namespaced_calls(*value)),
+        },
+        Expr::AlternativeAssign { path, value } => Expr::AlternativeAssign {
+            path: Box::new(rewrite_namespaced_calls(*path)),
+            value: Box::new(rewrite_namespaced_calls(*value)),
+        },
         // Expressions that don't contain sub-expressions - return as-is
         Expr::Identity
         | Expr::Field(_)

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -232,6 +232,45 @@ pub enum Expr {
         /// Arguments (empty for no-arg calls)
         args: Vec<Expr>,
     },
+
+    // Assignment operators
+    /// Simple assignment: `.a = value`
+    /// Sets the path to the value and returns the modified input.
+    Assign {
+        /// Path expression (left side)
+        path: Box<Expr>,
+        /// Value expression (right side)
+        value: Box<Expr>,
+    },
+
+    /// Update assignment: `.a |= f`
+    /// Applies filter f to the value at path and updates it.
+    Update {
+        /// Path expression (left side)
+        path: Box<Expr>,
+        /// Filter expression (right side)
+        filter: Box<Expr>,
+    },
+
+    /// Compound assignment: `.a += value`, `.a -= value`, etc.
+    /// Equivalent to `.a |= . op value`
+    CompoundAssign {
+        /// Assignment operator type
+        op: AssignOp,
+        /// Path expression (left side)
+        path: Box<Expr>,
+        /// Value expression (right side)
+        value: Box<Expr>,
+    },
+
+    /// Alternative assignment: `.a //= value`
+    /// Sets path to value only if current value is null or false.
+    AlternativeAssign {
+        /// Path expression (left side)
+        path: Box<Expr>,
+        /// Default value expression (right side)
+        value: Box<Expr>,
+    },
 }
 
 /// A complete jq program including module directives and the main expression.
@@ -655,6 +694,10 @@ pub enum Builtin {
     // Phase 10: Object functions
     /// `modulemeta(name)` - get module metadata (stub for compatibility)
     ModuleMeta(Box<Expr>),
+
+    // Phase 11: Path manipulation
+    /// `del(path)` - delete value at path
+    Del(Box<Expr>),
 }
 
 /// Arithmetic operators.
@@ -687,6 +730,21 @@ pub enum CompareOp {
     Gt,
     /// Greater than or equal: `>=`
     Ge,
+}
+
+/// Compound assignment operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssignOp {
+    /// Addition assignment: `+=`
+    Add,
+    /// Subtraction assignment: `-=`
+    Sub,
+    /// Multiplication assignment: `*=`
+    Mul,
+    /// Division assignment: `/=`
+    Div,
+    /// Modulo assignment: `%=`
+    Mod,
 }
 
 /// An entry in an object construction expression.

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -33,6 +33,11 @@
 //! | `if .a then .b else .c end` | Conditional |
 //! | `try .a catch .b` | Error handling |
 //! | `error("msg")` | Raise error |
+//! | `.a = value` | Simple assignment |
+//! | `.a \|= filter` | Update assignment |
+//! | `.a += value` | Compound assignment (+=, -=, *=, /=, %=) |
+//! | `.a //= value` | Alternative assignment (set if null/false) |
+//! | `del(.a)` | Delete field/element |
 //!
 //! # Example
 //!
@@ -72,8 +77,8 @@ mod value;
 
 pub use eval::{eval, eval_lenient, substitute_vars, EvalError, QueryResult};
 pub use expr::{
-    ArithOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MetaValue, ModuleMeta,
-    ObjectEntry, ObjectKey, Pattern, PatternEntry, Program, StringPart,
+    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MetaValue,
+    ModuleMeta, ObjectEntry, ObjectKey, Pattern, PatternEntry, Program, StringPart,
 };
 pub use lazy::JqValue;
 pub use parser::{parse, parse_program, ParseError};


### PR DESCRIPTION
## Description

This PR implements jq assignment operators for modifying JSON values in-place. Users can now use familiar jq syntax like `.a = 42`, `.x |= . + 1`, `.count += 5`, and `del(.field)` to transform JSON data without needing to reconstruct entire objects.

The implementation follows standard jq semantics where assignment expressions return the modified input, allowing chained operations like `.a = 1 | .b = 2`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement
- [ ] CI/CD changes

## Related Issue
Implements Phase 5 of the jq implementation plan as documented in `docs/plan/jq.md`.

## Changes Made

**Parser (`src/jq/parser.rs`):**
- Added `parse_assignment()` method to handle assignment operator precedence
- Implemented parsing for `=`, `|=`, `+=`, `-=`, `*=`, `/=`, `%=`, and `//=` operators
- Added `del(path)` builtin parsing
- Updated arithmetic expression parsing to avoid consuming compound assignment operators
- Modified `parse_pipe_expr()` to route through assignment parsing

**Expression Types (`src/jq/expr.rs`):**
- Added `Expr::Assign` for simple assignment (`.a = value`)
- Added `Expr::Update` for update assignment (`.a |= filter`)
- Added `Expr::CompoundAssign` for compound operators (`+=`, `-=`, `*=`, `/=`, `%=`)
- Added `Expr::AlternativeAssign` for alternative assignment (`.a //= default`)
- Added `AssignOp` enum for compound assignment operator types
- Added `Builtin::Del` for the delete builtin

**Evaluator (`src/jq/eval.rs`):**
- Implemented `eval_assign()` for simple assignment evaluation
- Implemented `eval_update()` for update assignment with filter application
- Implemented `eval_compound_assign()` converting to update form
- Implemented `eval_alternative_assign()` for null/false defaulting
- Added `set_path()` and `get_path_mut()` helpers for path navigation
- Added `update_path()` for recursive path updates including array iteration
- Implemented `builtin_del()` and `delete_at_path()` for deletion
- Extended `substitute_var()`, `expand_func_calls()`, and `substitute_func_param()` to handle new expression types

**CLI Rewriter (`src/bin/succinctly/jq_runner.rs`):**
- Extended `rewrite_namespaced_calls()` to handle all assignment expression variants

**Documentation:**
- Updated `CLAUDE.md` with assignment operator reference table and examples
- Updated `docs/guides/cli.md` with comprehensive usage examples
- Updated `docs/plan/jq.md` marking Phase 5 as implemented
- Added module-level documentation in `src/jq/mod.rs`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**New Test Coverage (16 tests in `src/jq/eval.rs`):**
- `test_simple_assign` - Basic field assignment
- `test_nested_assign` - Nested path assignment (`.a.b = value`)
- `test_array_index_assign` - Array index modification
- `test_update_assign` - Update with filter (`.a |= . + 1`)
- `test_update_assign_array` - Update all array elements (`.[] |= . * 2`)
- `test_compound_assign_add` - Addition assignment (`+=`)
- `test_compound_assign_sub` - Subtraction assignment (`-=`)
- `test_compound_assign_mul` - Multiplication assignment (`*=`)
- `test_compound_assign_div` - Division assignment (`/=`)
- `test_compound_assign_mod` - Modulo assignment (`%=`)
- `test_alternative_assign` - Set if null (`.a //= "default"`)
- `test_alternative_assign_existing` - Preserve existing non-null values
- `test_del_field` - Delete object field
- `test_del_array_element` - Delete array element (shifts remaining)
- `test_del_nested` - Delete nested field
- `test_chained_assign` - Chained assignments via pipe

**Manual Testing:**
- [x] Tested on x86_64

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

Assignment operations convert input to owned values for modification, which is the expected behavior for mutation semantics. This does not affect read-only query performance.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Operator Precedence:**
Assignment operators have lower precedence than arithmetic and comparison operators but higher than pipe (`|`). This matches standard jq behavior where `.a = 1 + 2` assigns `3` to `.a`.

**Supported Operations:**
| Operator | Syntax | Description |
|----------|--------|-------------|
| `=` | `.path = value` | Simple assignment |
| `\|=` | `.path \|= filter` | Update with filter |
| `+=` | `.path += value` | Add to current value |
| `-=` | `.path -= value` | Subtract from current value |
| `*=` | `.path *= value` | Multiply current value |
| `/=` | `.path /= value` | Divide current value |
| `%=` | `.path %= value` | Modulo of current value |
| `//=` | `.path //= value` | Set if null or false |
| `del()` | `del(.path)` | Delete field or element |