### PR TITLE
feat(jq): add yq-compatible environment variable access and pick() function

### DIFF
--- a/docs/plan/jq-completeness.md
+++ b/docs/plan/jq-completeness.md
@@ -64,6 +64,7 @@ The implementation is already production-ready for ~90% of jq use cases.
 - [x] `has(key)`
 - [x] `in(obj)`
 - [x] `to_entries` / `from_entries` / `with_entries(f)`
+- [x] `pick(keys)` - select only specified keys (yq)
 - [x] Object construction: `{foo: .bar}`, `{(expr): value}`, shorthand `{foo}`
 
 ### Array Operations
@@ -299,3 +300,4 @@ echo '{"a":1}' | succinctly jq '.a'
 | 2025-01-19 | Initial document created from audit       |
 | 2025-01-19 | Added assignment operators (✅ complete)  |
 | 2025-01-19 | Added env variable access (✅ complete)   |
+| 2026-01-19 | Added pick() function for yq (✅ complete)|

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -698,6 +698,8 @@ pub enum Builtin {
     // Phase 10: Object functions
     /// `modulemeta(name)` - get module metadata (stub for compatibility)
     ModuleMeta(Box<Expr>),
+    /// `pick(keys)` - select only specified keys from object/array (yq)
+    Pick(Box<Expr>),
 
     // Phase 11: Path manipulation
     /// `del(path)` - delete value at path

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2416,6 +2416,18 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::ModuleMeta(Box::new(name))));
         }
 
+        // pick(keys) - yq: select only specified keys from object/array
+        if self.matches_keyword("pick") {
+            self.consume_keyword("pick");
+            self.skip_ws();
+            self.expect('(')?;
+            self.skip_ws();
+            let keys = self.parse_pipe_expr()?;
+            self.skip_ws();
+            self.expect(')')?;
+            return Ok(Some(Builtin::Pick(Box::new(keys))));
+        }
+
         Ok(None)
     }
 


### PR DESCRIPTION
## Description

This PR extends the jq query language implementation with yq-compatible features for environment variable access and selective key extraction. These additions improve interoperability with yq workflows and provide more intuitive syntax for common operations.

The changes include:
- `env(VAR)` and `strenv(VAR)` builtins for direct environment variable access using yq-style syntax
- `pick(keys)` function for selecting specific keys from objects or indices from arrays
- Comprehensive documentation tracking jq feature completeness

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement
- [ ] CI/CD changes

## Related Issue

Contributes to jq/yq compatibility efforts.

## Changes Made

**Environment Variable Access (`src/jq/eval.rs`, `src/jq/expr.rs`, `src/jq/parser.rs`):**
- Added `EnvObject` and `StrEnv` variants to `Builtin` enum for yq-style syntax
- Implemented `builtin_env_object()` for `env(VAR)` syntax that retrieves environment variables by literal name
- Implemented `builtin_strenv()` for `strenv(VAR)` syntax (explicit string return)
- Updated `builtin_env()` to return actual environment variables when `std` feature is enabled
- Updated `builtin_envvar()` to evaluate expressions for dynamic variable names
- Added conditional compilation (`#[cfg(feature = "std")]`) for std/no_std compatibility
- Extended parser to recognize `env(IDENT)` and `strenv(IDENT)` function call syntax
- Added tests for `env`, `env(VAR)`, and `strenv(VAR)` functions

**Pick Function (`src/jq/eval.rs`, `src/jq/expr.rs`, `src/jq/parser.rs`):**
- Added `Builtin::Pick` variant to expression AST
- Implemented `builtin_pick()` for selective key/index extraction
- Support for object key selection (string keys) and array element selection (numeric indices)
- Support for negative array indices (picking from end)
- Silently skips missing keys/out-of-bounds indices (matching yq behavior)
- Added parser support for `pick(expr)` syntax
- Wired up variable substitution and function expansion for Pick builtin

**Documentation (`docs/plan/jq-completeness.md`):**
- Created comprehensive tracking document for jq feature implementation status
- Documents ~90% feature coverage with detailed status tables across 16 categories
- Lists all fully implemented features with checkmarks
- Prioritizes remaining work: type filters, tojson/fromjson, I/O, modules
- Documents known limitations and intentional omissions
- Includes testing strategy for jq compatibility verification
- Added changelog tracking recent completions

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for `env`, `env(VAR)`, and `strenv(VAR)` functions

**Manual Testing:**
- [x] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**yq Compatibility:**
The `env(VAR)` and `strenv(VAR)` syntax complements the existing jq-style `env.VAR` and `$ENV.VAR` syntax, making it easier for users familiar with yq to transition or use both tools interchangeably.

**no_std Support:**
Environment variable functions gracefully degrade in no_std builds:
- `env` returns an empty object
- `env(VAR)` and `strenv(VAR)` return errors indicating the variable is not available
- Optional variants (`env(VAR)?`) return `None` instead of errors

**pick() Semantics:**
The `pick()` function follows yq's behavior where missing keys or out-of-bounds indices are silently ignored rather than producing errors. This makes it safe to use with partial data.