### PR TITLE
feat(jq): add path (no-arg) and parent/parent(n) builtins for yq compatibility

### DIFF
--- a/docs/plan/jq-completeness.md
+++ b/docs/plan/jq-completeness.md
@@ -126,9 +126,12 @@ The implementation is already production-ready for ~90% of jq use cases.
 
 ### Path Operations
 - [x] `path(expr)`
+- [x] `path` (no-arg, yq) - returns current traversal path
 - [x] `paths` / `paths(filter)` / `leaf_paths`
 - [x] `getpath(path)` / `setpath(path; value)`
 - [x] `delpaths(paths)` / `del(path)`
+- [x] `parent` (yq) - returns parent node of current position
+- [x] `parent(n)` (yq) - returns nth parent node
 
 ### Math Functions (32 total)
 - [x] Basic: `floor`, `ceil`, `round`, `sqrt`, `fabs`
@@ -301,3 +304,5 @@ echo '{"a":1}' | succinctly jq '.a'
 | 2025-01-19 | Added assignment operators (✅ complete)  |
 | 2025-01-19 | Added env variable access (✅ complete)   |
 | 2026-01-19 | Added pick() function for yq (✅ complete)|
+| 2026-01-19 | Added path (no-arg) for yq (✅ complete)  |
+| 2026-01-19 | Added parent / parent(n) for yq (✅ complete)|

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -584,6 +584,14 @@ pub enum Builtin {
     // Phase 10: Path Expressions
     /// `path(expr)` - return the path to values selected by expr
     Path(Box<Expr>),
+    /// `path` (no-arg, yq) - return the current traversal path
+    /// Used as `.a.b | path` to get `["a", "b"]`
+    PathNoArg,
+    /// `parent` (no-arg, yq) - return the parent node of the current position
+    /// Used as `.a.b | parent` to get the value at `.a`
+    Parent,
+    /// `parent(n)` (yq) - return the nth parent node (0 = self, 1 = parent, etc.)
+    ParentN(Box<Expr>),
     /// `paths` - all paths to values (excluding empty paths)
     Paths,
     /// `paths(filter)` - paths to values matching filter


### PR DESCRIPTION
## Description

This PR adds three new yq-compatible builtins for path-aware JSON traversal:

- `path` (no-arg): Returns the current traversal path as an array, enabling expressions like `.a.b | path` to return `["a", "b"]`
- `parent`: Returns the parent node of the current position in the document
- `parent(n)`: Returns the nth ancestor node (0 = self, 1 = parent, 2 = grandparent, etc.)

These features require tracking the traversal path during expression evaluation, which is implemented through a new path-context-aware evaluation system that activates only when these builtins are used in the expression pipeline.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

## Related Issue
Implements yq-compatible path navigation features for enhanced JSON/YAML processing capabilities.

## Changes Made

**Parser (`src/jq/parser.rs`):**
- Extended `path` keyword parsing to support both `path(expr)` (jq-style) and `path` (no-arg, yq-style)
- Added `parent` keyword parsing with support for both `parent` (no-arg) and `parent(n)` variants
- Parser now distinguishes between function call syntax and standalone keyword usage

**Expression Types (`src/jq/expr.rs`):**
- Added `Builtin::PathNoArg` variant for no-argument path builtin
- Added `Builtin::Parent` variant for parent node access
- Added `Builtin::ParentN(Box<Expr>)` variant for nth parent access

**Evaluator (`src/jq/eval.rs`):**
- Added `needs_path_context()` function to detect when expressions require path tracking
- Implemented `eval_pipe_with_path_context()` for path-aware evaluation
- Implemented `eval_pipe_with_path_context_internal()` that tracks both current path and root value
- Added path tracking for `Field`, `Index`, `Iterate`, `Paren`, `Optional`, and `Pipe` expressions
- Handles `PathNoArg` by returning the current path as an array
- Handles `Parent` by navigating up one level from current position
- Handles `ParentN` by navigating up n levels, returning empty object when past root
- Added `eval_builtin_owned()` helper for builtin evaluation with owned values
- Added `get_value_at_owned_path()` helper for path-based value retrieval
- Updated `substitute_var_in_builtin()`, `expand_func_calls_in_builtin()`, and `substitute_func_param_in_builtin()` to handle new builtins

**Documentation (`docs/plan/jq-completeness.md`):**
- Added `path` (no-arg, yq) to Path Operations section
- Added `parent` and `parent(n)` (yq) to Path Operations section
- Updated changelog with implementation dates

## Testing

**Automated Testing:**
- [ ] All existing tests pass
- [ ] New tests added for new functionality

**Manual Testing:**
- [ ] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check

# Manual testing examples
echo '{"a":{"b":{"c":1}}}' | succinctly jq '.a.b | path'
# Expected: ["a","b"]

echo '{"a":{"b":{"c":1}}}' | succinctly jq '.a.b.c | parent'
# Expected: {"c":1}

echo '{"a":{"b":{"c":1}}}' | succinctly jq '.a.b.c | parent(2)'
# Expected: {"b":{"c":1}}
```

## Performance Impact
- [ ] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [x] Potential performance regression (justify below)

The path-context-aware evaluation is only activated when `PathNoArg`, `Parent`, or `ParentN` builtins are detected in the expression tree via `needs_path_context()`. Regular jq expressions without these builtins use the existing optimized evaluation path with zero overhead.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation as needed
- [ ] My changes generate no new warnings

## Additional Notes

**Implementation Details:**
- The path context system maintains both the current traversal path and the root value, enabling navigation back up the document tree
- When `parent` is called at the root level, an empty object is returned (matching yq behavior)
- The `ParentN` variant evaluates its argument expression to determine how many levels to navigate up
- Path tracking handles array iteration by appending integer indices, and object iteration by appending string keys
- Value-constructing expressions (Object, Array, Literal) reset the path context since they create new value trees