### PR TITLE
docs(bench): update benchmark results with corrected performance numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,9 +231,9 @@ To regenerate: `cargo bench --bench jq_comparison`
 
 | Size      | succinctly              | yq                    | Speedup    |
 |-----------|-------------------------|-----------------------|------------|
-| **10KB**  |  83.5 µs (116.8 MiB/s)  | 57.4 ms (175 KiB/s)   | **687x**   |
-| **100KB** | 599 µs (153.6 MiB/s)    | 71.3 ms  (1.3 MiB/s)  | **119x**   |
-| **1MB**   | 4.24 ms (217.6 MiB/s)   |191.1 ms  (4.8 MiB/s)  | **45x**    |
+| **10KB**  | 1.63 ms  (6.0 MiB/s)    | 64.6 ms (155 KiB/s)   | **40x**    |
+| **100KB** | 2.78 ms (33.1 MiB/s)    | 79.6 ms (1.2 MiB/s)   | **29x**    |
+| **1MB**   | 13.2 ms (69.7 MiB/s)    |210.5 ms (4.4 MiB/s)   | **16x**    |
 
 To regenerate: `cargo bench --bench yq_comparison`
 
@@ -355,12 +355,10 @@ For detailed documentation on optimization techniques used in this project, see 
   - **Bottleneck shift**: Parsing now 40% of time (was 15%), DOM conversion eliminated
   - Best for: `yq '.'` identity queries, format conversion, streaming output
   - See [docs/parsing/yaml.md#p9-direct-yaml-to-json-streaming---accepted-](docs/parsing/yaml.md#p9-direct-yaml-to-json-streaming---accepted-) for full analysis
-- ✅ P10 (Type Preservation): **Full yq compatibility + 27-304% performance improvement**
+- ✅ P10 (Type Preservation): **Full yq compatibility** (correctness fix)
   - Fixed quoted string type preservation: `"1.0"` stays as string, not converted to number `1`
   - Added early-exit for quoted strings, skipping expensive `parse::<i64>()` and `parse::<f64>()` calls
-  - 10KB: 108µs → 83.5µs (90.5 → 116.8 MiB/s, **+29%**)
-  - 100KB: 828µs → 599µs (111.1 → 153.6 MiB/s, **+38%**)
-  - 1MB: 6.35ms → 4.24ms (145.6 → 217.6 MiB/s, **+49%**)
+  - Current performance: 10KB: 1.63ms, 100KB: 2.78ms, 1MB: 13.2ms (with correct output)
   - Created comprehensive test suite: 32 tests including 8 direct byte-for-byte comparisons with system `yq`
   - **Key achievement**: `succinctly yq` is now a drop-in replacement for `yq` for supported arguments
   - See [docs/parsing/yaml.md#p10-type-preservation---accepted-](docs/parsing/yaml.md#p10-type-preservation---accepted-) for full analysis

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Succinctly uses **semi-indexing** to process JSON, YAML, and CSV/TSV files with 
 |------------------------|--------|-------|
 | vs serde_json, simd-json | **18-46x less memory** | 3-5x faster |
 | vs jq (JSON queries) | **5-25x less memory** | 1.2-6.3x faster |
-| vs yq (YAML queries) | **similar memory** | 45-687x faster |
+| vs yq (YAML queries) | **similar memory** | 16-40x faster |
 
 **How it works**: Instead of building a full DOM tree, succinctly builds a lightweight structural index (~3-6% overhead) and extracts values lazily only when accessed. This is ideal when queries touch a small fraction of the document.
 

--- a/docs/architecture/semi-indexing.md
+++ b/docs/architecture/semi-indexing.md
@@ -119,7 +119,7 @@ Semi-indexing delivers significant memory and speed improvements over traditiona
 | vs serde_json | **18x less** | 3x faster |
 | vs simd-json | **46x less** | 3x faster |
 | vs jq | **5-25x less** | 1.2-6.3x faster |
-| vs yq | similar | **45-687x faster** |
+| vs yq | similar | **16-40x faster** |
 
 The index overhead (3-6%) is dwarfed by the memory savings from not materializing the entire document.
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -9,7 +9,7 @@ Performance comparisons between succinctly and other tools.
 | Benchmark | Description | Key Finding |
 |-----------|-------------|-------------|
 | [jq](jq.md) | succinctly jq vs system jq | 1.0-1.6x faster |
-| [yq](yq.md) | succinctly yq vs system yq | 1.8-8.7x faster (ARM), 45-687x faster (x86_64) |
+| [yq](yq.md) | succinctly yq vs system yq | 1.8-8.7x faster (ARM), 16-40x faster (x86_64) |
 | [Rust Parsers](rust-parsers.md) | vs serde_json, sonic-rs, simd-json | Competitive with specialized parsers |
 | [Cross-Language](cross-language.md) | Multi-language parser comparison | Best-in-class for semi-indexing |
 | [DSV](dsv.md) | CSV/TSV parsing performance | 85-1676 MiB/s (API) |

--- a/docs/benchmarks/yq.md
+++ b/docs/benchmarks/yq.md
@@ -49,55 +49,23 @@ cargo bench --bench yq_comparison
 | **100KB** |  19.5 MiB/s     |   4.7 MiB/s    | **4.1x**      |
 | **1MB**   |  69.2 MiB/s     |   8.0 MiB/s    | **8.7x**      |
 
-### x86_64 (AMD Ryzen 9 7950X) - yq Identity Comparison (P10 Optimized)
+### x86_64 (AMD Ryzen 9 7950X) - yq Identity Comparison
 
-| Size      | succinctly        | yq              | Speedup        |
-|-----------|-------------------|-----------------|----------------|
-| **10KB**  |  83.5 µs (116.8 MiB/s) |  57.4 ms (175 KiB/s) | **687x**   |
-| **100KB** | 599 µs (153.6 MiB/s)   |  71.3 ms (1.3 MiB/s) | **119x**   |
-| **1MB**   | 4.24 ms (217.6 MiB/s)  | 191.1 ms (4.8 MiB/s) | **45x**    |
+| Size      | succinctly             | yq                     | Speedup    |
+|-----------|------------------------|------------------------|------------|
+| **10KB**  | 1.63 ms (6.0 MiB/s)    | 64.6 ms (155 KiB/s)    | **40x**    |
+| **100KB** | 2.78 ms (33.1 MiB/s)   | 79.6 ms (1.2 MiB/s)    | **29x**    |
+| **1MB**   | 13.2 ms (69.7 MiB/s)   | 210.5 ms (4.4 MiB/s)   | **16x**    |
 
-### x86_64 (AMD Ryzen 9 7950X) - Internal Micro-Benchmarks (P10 Optimized)
+### x86_64 (AMD Ryzen 9 7950X) - Key Achievements
 
-#### Performance Summary (Selected Benchmarks)
-
-| Benchmark | P2 Baseline | P10 Optimized | Improvement |
-|-----------|-------------|---------------|-------------|
-| simple_kv/1000 | 39.2 µs | 33.1 µs | **-16%** |
-| simple_kv/10000 | 396 µs | 327 µs | **-17%** |
-| nested/d5_w2 | 5.5 µs | 4.6 µs | **-16%** |
-| large/10kb | 20.6 µs | 20.3 µs | **-1%** |
-| large/100kb | 180 µs | 178 µs | **-1%** |
-| large/1mb | 3.36 ms | 2.72 ms | **-19%** |
-| long_strings/4096b/double | 109 µs | 109 µs | (unchanged) |
-| long_strings/4096b/single | 109 µs | 109 µs | (unchanged) |
-
-#### Overall Throughput (P10 Optimized - 2026-01-18)
-
-| Workload Category | P2 Baseline | P10 Optimized | Improvement |
-|-------------------|-------------|---------------|-------------|
-| Simple KV         | 435-484 MiB/s | 479-545 MiB/s | **+10-13%** |
-| Nested structures | 363-454 MiB/s | 366-510 MiB/s | **+1-12%** |
-| Sequences         | 372-414 MiB/s | 373-416 MiB/s | **+0-1%** |
-| Large files       | 422-515 MiB/s | 470-534 MiB/s | **+1-11%** |
-
-#### yq Identity Query Performance (P10 vs P9 vs P2)
-
-| Size | P2 Baseline | P9 Optimized | P10 Optimized | P9→P10 |
-|------|-------------|--------------|---------------|--------|
-| 10KB (comprehensive) | 2.0 ms (4.9 MiB/s) | 1.8 ms (5.3 MiB/s) | 83.5 µs (116.8 MiB/s) | **+2200%** |
-| 100KB (comprehensive) | 7.2 ms (12.9 MiB/s) | 6.1 ms (15.2 MiB/s) | 599 µs (153.6 MiB/s) | **+1010%** |
-| 1MB (comprehensive) | 56.3 ms (16.4 MiB/s) | 47.4 ms (19.5 MiB/s) | 4.24 ms (217.6 MiB/s) | **+1116%** |
-
-**Key Achievements (P10):**
-- ✅ **yq identity queries: 10-22x faster than P9** via type preservation early-exit
-- ✅ **Large files: up to 11x faster** (1MB files: 4.24ms vs 47.4ms)
+**Key Achievements:**
 - ✅ **Full yq CLI compatibility** - quoted strings preserved as strings
-- ✅ **687x faster than yq** on 10KB files (end-to-end CLI comparison)
-- ✅ **45x faster than yq** on 1MB files (was 4.0x in P9)
+- ✅ **40x faster than yq** on 10KB files (end-to-end CLI comparison)
+- ✅ **16x faster than yq** on 1MB files
 - ✅ **Comprehensive test suite** - 32 tests including 8 direct byte-for-byte comparisons
 
-**See also:** [docs/parsing/yaml.md](../parsing/yaml.md) for full P9 and P10 optimization details.
+**See also:** [docs/parsing/yaml.md](../parsing/yaml.md) for optimization details.
 
 ---
 
@@ -224,9 +192,9 @@ The YAML parser uses platform-specific SIMD for hot paths:
 - large/1mb: **-17% faster** (2.18ms → 1.82ms)
 
 **End-to-end yq comparison (x86_64):**
-- 10KB files: **31x faster** than yq (1.8ms vs 57.4ms)
-- 100KB files: **11.8x faster** than yq (6.1ms vs 71.3ms)
-- 1MB files: **4.0x faster** than yq (47.4ms vs 191.1ms)
+- 10KB files: **40x faster** than yq (1.6ms vs 64.6ms)
+- 100KB files: **29x faster** than yq (2.8ms vs 79.6ms)
+- 1MB files: **16x faster** than yq (13.2ms vs 210.5ms)
 
 **Optimizations (cumulative):**
 - **P0**: Multi-character classification infrastructure (8 types in parallel)
@@ -352,8 +320,8 @@ $ echo 'id: "001"' | succinctly yq -o json '.'
 `succinctly yq` offers significant performance advantages over `yq`:
 - **8.7x faster** on 1MB files (Apple M1 Max)
 - **4.1x faster** on 100KB files (Apple M1 Max)
-- **45x faster** on 1MB files (AMD Ryzen 9 7950X with P10 optimizations)
-- **687x faster** on 10KB files (AMD Ryzen 9 7950X with P10 optimizations)
+- **16x faster** on 1MB files (AMD Ryzen 9 7950X)
+- **40x faster** on 10KB files (AMD Ryzen 9 7950X)
 - **Lower memory usage** on large files
 - **Streaming architecture** for better scalability
 - **Full yq compatibility** for type preservation

--- a/docs/plan/generic-eval-refactor.md
+++ b/docs/plan/generic-eval-refactor.md
@@ -54,23 +54,17 @@ cargo bench --bench jq_comparison 2>&1 | tee .ai/scratch/baseline-jq-comparison.
 cargo bench 2>&1 | tee .ai/scratch/baseline-full-bench.txt
 ```
 
-Expected baseline (Apple M1 Max from docs):
+Expected baseline (AMD Ryzen 9 7950X from docs):
 
 | Size | succinctly yq | yq | Speedup |
 |------|---------------|-----|---------|
-| 10KB | 83.5 µs (116.8 MiB/s) | 57.4 ms | 687x |
-| 100KB | 599 µs (153.6 MiB/s) | 71.3 ms | 119x |
-| 1MB | 4.24 ms (217.6 MiB/s) | 191.1 ms | 45x |
+| 10KB | 1.63 ms (6.0 MiB/s) | 64.6 ms | 40x |
+| 100KB | 2.78 ms (33.1 MiB/s) | 79.6 ms | 29x |
+| 1MB | 13.2 ms (69.7 MiB/s) | 210.5 ms | 16x |
 
 ### Post-refactor Target
 
-With direct YAML evaluation (similar to P9's 2.3x gain):
-
-| Size | Target | Improvement |
-|------|--------|-------------|
-| 10KB | ~40 µs (~240 MiB/s) | ~2x |
-| 100KB | ~300 µs (~300 MiB/s) | ~2x |
-| 1MB | ~2 ms (~460 MiB/s) | ~2x |
+The generic evaluator refactor has been completed. See Performance Results below for actual achieved results.
 
 ## Implementation Phases
 


### PR DESCRIPTION
## Description

This PR updates all documentation files with revised yq comparison benchmarks reflecting accurate measurements on AMD Ryzen 9 7950X. The previous benchmark numbers were incorrect due to improper test configurations, and this PR corrects them across all documentation.

The corrected numbers show that while succinctly is still significantly faster than yq (16-40x speedup), the previous claims of 45-687x speedup were inflated. This PR ensures all documentation accurately represents the tool's performance characteristics.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

## Related Issue
N/A - Internal documentation accuracy improvement

## Changes Made

**Performance Number Corrections:**
- 10KB: 83.5µs → 1.63ms (116.8 → 6.0 MiB/s), speedup 687x → 40x
- 100KB: 599µs → 2.78ms (153.6 → 33.1 MiB/s), speedup 119x → 29x
- 1MB: 4.24ms → 13.2ms (217.6 → 69.7 MiB/s), speedup 45x → 16x

**Documentation Files Updated:**
- `CLAUDE.md`: Updated benchmark table and revised P10 description to correctly describe it as a "correctness fix" rather than a performance improvement
- `docs/README.md`: Revised headline performance claims from "45-687x faster" to "16-40x faster"
- `docs/architecture/semi-indexing.md`: Updated comparison table with corrected speedup values
- `docs/benchmarks/README.md`: Corrected summary findings in benchmark index
- `docs/benchmarks/yq.md`: Removed inflated micro-benchmark tables and simplified to actual end-to-end CLI comparison results
- `docs/plan/generic-eval-refactor.md`: Updated baseline expectations and removed obsolete target projections

**P10 Optimization Clarification:**
- The P10 optimization is now correctly described as a "correctness fix" for yq compatibility (preserving quoted string types) rather than a major performance improvement
- Removed misleading "+27-304% performance improvement" claims
- Updated to show current correct performance numbers with accurate output

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality

**Manual Testing:**
- [x] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

This is a documentation-only change that corrects previously reported benchmark numbers. No code changes are included.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

The corrected benchmark numbers still demonstrate significant performance advantages over yq:
- **40x faster** on 10KB files
- **29x faster** on 100KB files  
- **16x faster** on 1MB files

These are substantial improvements that accurately represent succinctly's performance characteristics without overstating the gains from incorrect test configurations.