### PR TITLE
ci: exclude ARM and Agner URLs from link checking

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -38,6 +38,8 @@ jobs:
             --exclude '^https://www\.intel\.com/'
             --exclude '^https://dl\.acm\.org/'
             --exclude '^https://lib\.rs/'
+            --exclude '^https://developer\.arm\.com/'
+            --exclude '^https://www\.agner\.org/'
             '**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR adds exclusions for ARM developer site and Agner optimization guide URLs from the automated link checker workflow. These external documentation links are valid and functional when accessed manually, but fail automated verification due to bot detection and rate limiting mechanisms employed by these sites.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [x] CI/CD changes

## Related Issue

N/A - Proactive fix for CI reliability

## Changes Made

- Added `--exclude '^https://developer\.arm\.com/'` to link checker configuration (returns 403 Forbidden to automated requests)
- Added `--exclude '^https://www\.agner\.org/'` to link checker configuration (times out during CI due to rate limiting)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (N/A - CI configuration change)

**Manual Testing:**
- [x] Verified excluded URLs are valid when accessed manually via browser
- [ ] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
# Verify CI workflow syntax
yamllint .github/workflows/links.yml

# Run link checker locally to confirm exclusions work
lychee --exclude '^https://developer\.arm\.com/' --exclude '^https://www\.agner\.org/' '**/*.md'
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A - CI config)
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed (N/A)
- [x] My changes generate no new warnings

## Additional Notes

This follows the same pattern as existing exclusions for Intel, ACM, and lib.rs URLs in the workflow. These sites employ anti-bot measures that cause false positive failures in CI, but the links themselves are valid references to important CPU architecture documentation and optimization resources.