### PR TITLE
docs(bench): correct yq performance comparison numbers in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - YAML identity queries: 90-217 MiB/s (2.3x improvement with direct streaming)
-- yq vs system yq: 45-687x faster on x86_64, 1.8-8.7x faster on ARM
+- yq vs system yq: 16-40x faster on x86_64, 1.9-8.7x faster on ARM
 
 ## [0.2.0] - 2026-01-18
 


### PR DESCRIPTION
## Description

This PR corrects the performance comparison numbers for yq vs system yq in the CHANGELOG. The previous numbers overstated the performance advantage on x86_64, and this update reflects more accurate benchmark results.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

## Related Issue

N/A - Documentation accuracy correction

## Changes Made

- Updated yq performance comparison in CHANGELOG.md from "45-687x faster on x86_64" to "16-40x faster on x86_64"
- ARM performance numbers remain unchanged at "1.9-8.7x faster" (minor correction from 1.8x to 1.9x)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality

**Manual Testing:**
- [x] Verified CHANGELOG formatting is correct
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

This is a documentation-only change that corrects previously reported benchmark numbers to reflect accurate measurements.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

The corrected numbers (16-40x faster on x86_64) still demonstrate significant performance advantages over system yq, but provide users with more accurate expectations when comparing tools.