### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -40,6 +40,7 @@ jobs:
             --exclude '^https://lib\.rs/'
             --exclude '^https://developer\.arm\.com/'
             --exclude '^https://www\.agner\.org/'
+            --exclude '^https://github\.com/rust-works/succinctly/compare/'
             '**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-01-23
+
+### Added
+
+- **ARM SIMD Enhancements**
+  - NEON SIMD optimizations for YAML block scalar parsing (11-23% improvement)
+  - NEON SIMD optimizations for YAML anchor/alias name scanning (3-6% improvement)
+  - NEON PMULL carryless multiply for DSV prefix XOR optimization
+  - Experimental SVE2 JSON semi-indexing with runtime dispatch
+  - SVE2 BDEP/BEXT for ARM64 DSV parsing
+
+### Fixed
+
+- CI link checker exclusions for ARM and Agner URLs
+
+### Documentation
+
+- Added ARM Graviton 4 (Neoverse-V2) benchmark results
+- Added ARM Neoverse-V1 benchmark results for jq and yq
+- Added CPU target optimization guide for ARM Neoverse-V2
+- Documented NEON SIMD optimizations for block scalars and anchors
+- Documented SVE2 optimization plan and popcount regression analysis
+
 ## [0.3.0] - 2026-01-21
 
 ### Added
@@ -187,7 +210,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Select queries: ~50 ns (O(log n))
 - Popcount: 96.8 GiB/s (AVX-512), 18.5 GiB/s (scalar)
 
-[Unreleased]: https://github.com/rust-works/succinctly/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/rust-works/succinctly/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/rust-works/succinctly/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/rust-works/succinctly/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/rust-works/succinctly/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/rust-works/succinctly/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "succinctly"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "succinctly"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["John Ky <newhoggy@gmail.com>"]
 rust-version = "1.73.0"

--- a/bench-compare/Cargo.lock
+++ b/bench-compare/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "succinctly"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "bytemuck",
  "indexmap",

--- a/tests/snapshots/cli_golden_tests__version.snap
+++ b/tests/snapshots/cli_golden_tests__version.snap
@@ -2,4 +2,4 @@
 source: tests/cli_golden_tests.rs
 expression: output
 ---
-succinctly 0.3.0
+succinctly 0.3.1


### PR DESCRIPTION
## Summary

Prepare release v0.3.1 with ARM SIMD optimizations and documentation updates.

### Changes since v0.3.0:

**Added - ARM SIMD Enhancements:**
- NEON SIMD optimizations for YAML block scalar parsing (11-23% improvement)
- NEON SIMD optimizations for YAML anchor/alias name scanning (3-6% improvement)
- NEON PMULL carryless multiply for DSV prefix XOR optimization
- Experimental SVE2 JSON semi-indexing with runtime dispatch
- SVE2 BDEP/BEXT for ARM64 DSV parsing

**Fixed:**
- CI link checker exclusions for ARM and Agner URLs

**Documentation:**
- Added ARM Graviton 4 (Neoverse-V2) benchmark results
- Added ARM Neoverse-V1 benchmark results for jq and yq
- Added CPU target optimization guide for ARM Neoverse-V2
- Documented NEON SIMD optimizations for block scalars and anchors
- Documented SVE2 optimization plan and popcount regression analysis

## Test plan

- [x] All existing tests pass
- [x] Quality checks pass (`./scripts/build.sh`)
- [x] Version snapshot updated

## Post-merge steps

After merging, create and push the tag:
```bash
git checkout main
git pull
git tag -a v0.3.1 -m "Release v0.3.1"
git push origin v0.3.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)