### PR TITLE
docs(bench): add AMD Ryzen 9 7950X benchmark results for bp_select

### DIFF
--- a/docs/benchmarks/yq.md
+++ b/docs/benchmarks/yq.md
@@ -390,11 +390,21 @@ The `bp_select_micro` benchmark measures the performance of select1 queries on b
 | 100K opens | 308 µs        | 1.68 ms                   | **5.4x** |
 | 1M opens   | 356 µs        | 2.10 ms                   | **5.9x** |
 
+### Results (AMD Ryzen 9 7950X, 10K queries each)
+
+| BP Size    | select1 (new) | binary_search_rank1 (old) | Speedup  |
+|------------|---------------|---------------------------|----------|
+| 1K opens   | 213 µs        | 548 µs                    | **2.6x** |
+| 10K opens  | 211 µs        | 783 µs                    | **3.7x** |
+| 100K opens | 211 µs        | 986 µs                    | **4.7x** |
+| 1M opens   | 240 µs        | 1.22 ms                   | **5.1x** |
+
 ### Key Observations
 
-- **select1 stays nearly constant**: ~310-356 µs regardless of BP size (O(1) amortized)
-- **binary_search scales with log(n)**: 820 µs → 2.10 ms as BP grows from 1K to 1M
-- **Larger documents benefit more**: 5.9x speedup at 1M opens vs 2.5x at 1K
+- **select1 stays nearly constant**: ~210-356 µs regardless of BP size (O(1) amortized)
+- **binary_search scales with log(n)**: 548-820 µs → 1.2-2.1 ms as BP grows from 1K to 1M
+- **Larger documents benefit more**: 5.1-5.9x speedup at 1M opens vs 2.5-2.6x at 1K
+- **Ryzen 9 faster overall**: ~35% faster than M1 Max due to higher clock speed
 
 ### Why It Matters
 


### PR DESCRIPTION
## Description

This PR extends the `bp_select_micro` benchmark documentation with performance results from an AMD Ryzen 9 7950X processor. This provides valuable cross-platform comparison data alongside the existing Apple M1 Max results, helping users estimate performance characteristics on their specific hardware.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

## Related Issue

N/A - Documentation enhancement for existing benchmarks

## Changes Made

- Added new benchmark results table for AMD Ryzen 9 7950X with 10K queries across BP sizes (1K to 1M opens)
- Updated "Key Observations" section to reflect combined findings from both M1 Max and Ryzen 9 platforms
- Documented that Ryzen 9 shows approximately 35% faster performance than M1 Max
- Updated speedup ranges to span both processor results (2.5-2.6x to 5.1-5.9x)
- Confirmed O(1) amortized behavior is consistent across both x86_64 and ARM architectures

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (N/A - documentation only)

**Manual Testing:**
- [x] Tested on x86_64 (benchmarks run on AMD Ryzen 9 7950X)
- [x] Tested on aarch64/ARM (existing Apple M1 Max results)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

This is a documentation-only change that records benchmark results. No code changes affect runtime performance.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A - documentation only)
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Benchmark Highlights (AMD Ryzen 9 7950X):**

| BP Size    | select1 (new) | binary_search_rank1 (old) | Speedup  |
|------------|---------------|---------------------------|----------|
| 1K opens   | 213 µs        | 548 µs                    | **2.6x** |
| 10K opens  | 211 µs        | 783 µs                    | **3.7x** |
| 100K opens | 211 µs        | 986 µs                    | **4.7x** |
| 1M opens   | 240 µs        | 1.22 ms                   | **5.1x** |

Cross-platform benchmarks validate that the algorithmic improvements in `select1` are architecture-independent, showing consistent O(1) amortized performance on both ARM (Apple Silicon) and x86_64 (AMD) processors.