### PR TITLE
feat(jq): add M2 streaming for YAML output format

### DIFF
--- a/.claude/skills/benchmark-docs/SKILL.md
+++ b/.claude/skills/benchmark-docs/SKILL.md
@@ -151,12 +151,12 @@ cd bench-compare && cargo bench --bench json_parsers
 
 The yq benchmark supports multiple query types to exercise different execution paths:
 
-| Query Type     | Example    | Execution Path | Description                      |
-|----------------|------------|----------------|----------------------------------|
-| `identity`     | `.`        | P9 streaming   | Full document streaming output   |
-| `first_element`| `.[0]`     | M2 streaming   | Navigate to first array element  |
-| `iteration`    | `.[]`      | M2 streaming   | Iterate over array elements      |
-| `length`       | `length`   | OwnedValue     | Requires full DOM construction   |
+| Query Type     | Example    | Execution Path | Description                                     |
+|----------------|------------|----------------|-------------------------------------------------|
+| `identity`     | `.`        | P9 streaming   | Full document streaming output                  |
+| `first_element`| `.[0]`     | M2 streaming   | Navigate to first array element                 |
+| `iteration`    | `.[]`      | M2 streaming   | Iterate over array elements                     |
+| `length`       | `length`   | OwnedValue     | Produces computed value (not cursor-streamable) |
 
 ### Running yq Benchmarks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,12 +328,12 @@ To regenerate: `succinctly dev bench yq` (includes memory) or `cargo bench --ben
 
 | Query       | Path          | succinctly | yq       | Speedup     | succ Mem | yq Mem  |
 |-------------|---------------|------------|----------|-------------|----------|---------|
-| `.`         | P9 streaming  | 1.18s      | 12.06s   | **10.2x**   | 532 MB   | 7 GB    |
-| `.[0]`      | M2 streaming  | 479ms      | 6.05s    | **12.6x**   | 532 MB   | 5 GB    |
-| `.[]`       | M2 streaming  | 3.48s      | 13.80s   | **4.0x**    | 1 GB     | 8 GB    |
-| `length`    | OwnedValue    | 480ms      | 6.04s    | **12.6x**   | 529 MB   | 5 GB    |
+| `.`         | P9 streaming  | 1.12s      | 11.82s   | **10.5x**   | 529 MB   | 7 GB    |
+| `.[0]`      | M2 streaming  | 468ms      | 5.97s    | **12.8x**   | 534 MB   | 5 GB    |
+| `.[]`       | M2 streaming  | 1.91s      | 13.67s   | **7.2x**    | 554 MB   | 8 GB    |
+| `length`    | OwnedValue    | 480ms      | 5.99s    | **12.5x**   | 529 MB   | 5 GB    |
 
-M2 streaming (`.[0]`) is **2.5x faster** than identity (`.`), with **10-15x less memory** than yq.
+M2 streaming (`.[0]`) is **2.4x faster** than identity (`.`), with **7-14% of yq's memory**.
 
 To benchmark: `succinctly dev bench yq --queries all --memory`
 

--- a/src/bin/succinctly/yq_bench.rs
+++ b/src/bin/succinctly/yq_bench.rs
@@ -23,7 +23,7 @@ pub enum QueryType {
     FirstElement,
     /// Iteration (`.[]`) - uses M2 streaming
     Iteration,
-    /// Length builtin (`length`) - uses OwnedValue path
+    /// Length builtin (`length`) - produces computed OwnedValue (not cursor-streamable)
     Length,
 }
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -76,6 +76,38 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     fn cursor_at_position(&self, _line: usize, _col: usize) -> Option<Self> {
         None
     }
+
+    /// Stream this cursor's value as compact JSON to the output.
+    ///
+    /// This enables M2 streaming optimization where navigation query results
+    /// can be written directly to output without materializing OwnedValue.
+    ///
+    /// Default implementation returns an error indicating streaming is not supported.
+    fn stream_json<W: core::fmt::Write>(&self, _out: &mut W) -> core::fmt::Result {
+        Err(core::fmt::Error)
+    }
+
+    /// Stream this cursor's value as YAML to the output.
+    ///
+    /// This enables M2.5 streaming optimization for YAML output format.
+    /// - `indent_spaces`: Spaces per indentation level (0 for flow style)
+    ///
+    /// Default implementation returns an error indicating streaming is not supported.
+    fn stream_yaml<W: core::fmt::Write>(
+        &self,
+        _out: &mut W,
+        _indent_spaces: usize,
+    ) -> core::fmt::Result {
+        Err(core::fmt::Error)
+    }
+
+    /// Check if the value at this cursor is falsy (null or false).
+    ///
+    /// Used for `--exit-status` flag handling without requiring full materialization.
+    /// Default implementation returns false (conservative assumption).
+    fn is_falsy(&self) -> bool {
+        false
+    }
 }
 
 /// A value from a document (JSON value or YAML value).

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -74,6 +74,7 @@ pub mod eval_generic;
 mod expr;
 mod lazy;
 mod parser;
+pub mod stream;
 mod value;
 
 pub use eval::{eval, eval_lenient, substitute_vars, EvalError, QueryResult};
@@ -85,4 +86,5 @@ pub use lazy::JqValue;
 pub use parser::{
     parse, parse_program, parse_program_with_mode, parse_with_mode, ParseError, ParserMode,
 };
+pub use stream::{StreamStats, StreamableValue};
 pub use value::OwnedValue;

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -1,0 +1,572 @@
+//! Streaming output support for jq evaluation results.
+//!
+//! This module provides the `StreamableValue` trait which enables streaming output
+//! without intermediate allocations. Both cursor-based values (YamlCursor) and
+//! owned values (OwnedValue) can implement this trait.
+//!
+//! ## M2 Streaming Optimization
+//!
+//! The M2 streaming path allows navigation queries (`.field`, `.[0]`, `.[]`) to
+//! stream their results directly to output without materializing OwnedValue DOMs.
+//! This provides significant memory savings for queries that only navigate to
+//! subtrees of the document.
+//!
+//! ### Execution Paths
+//!
+//! | Query Type | Execution Path | Memory Usage |
+//! |------------|----------------|--------------|
+//! | `.` (identity) | P9 streaming | ~2x input |
+//! | `.field`, `.[0]` | M2 streaming | ~2x input |
+//! | `.[]` (iterate) | M2 streaming | ~2.5x input |
+//! | `length`, complex | OwnedValue | 5-8x input |
+
+use super::value::OwnedValue;
+
+/// A value that can be streamed directly to output without intermediate allocation.
+///
+/// This trait abstracts over both cursor-based navigation (YamlCursor, JsonCursor)
+/// and owned values (OwnedValue), enabling unified streaming output regardless of
+/// how the value was obtained.
+pub trait StreamableValue {
+    /// Stream this value as compact JSON to the output.
+    ///
+    /// The output should be valid JSON without trailing newlines or separators.
+    fn stream_json<W: core::fmt::Write>(&self, out: &mut W) -> core::fmt::Result;
+
+    /// Stream this value as YAML to the output.
+    ///
+    /// The output should be valid YAML. For block style, pass indent_spaces > 0.
+    /// For flow style (compact), pass indent_spaces = 0.
+    fn stream_yaml<W: core::fmt::Write>(
+        &self,
+        out: &mut W,
+        indent_spaces: usize,
+    ) -> core::fmt::Result;
+
+    /// Check if this value is falsy (null or false).
+    ///
+    /// Used for `--exit-status` flag handling without requiring full materialization.
+    fn is_falsy(&self) -> bool;
+}
+
+/// Statistics returned from streaming operations.
+///
+/// Used to track output for `--exit-status` handling.
+#[derive(Debug, Clone, Default)]
+pub struct StreamStats {
+    /// Number of values streamed.
+    pub count: usize,
+    /// Whether the last value was falsy (null or false).
+    pub last_was_falsy: bool,
+}
+
+impl StreamableValue for OwnedValue {
+    fn stream_json<W: core::fmt::Write>(&self, out: &mut W) -> core::fmt::Result {
+        stream_owned_value_json(self, out)
+    }
+
+    fn stream_yaml<W: core::fmt::Write>(
+        &self,
+        out: &mut W,
+        indent_spaces: usize,
+    ) -> core::fmt::Result {
+        stream_owned_value_yaml(self, out, 0, indent_spaces)
+    }
+
+    fn is_falsy(&self) -> bool {
+        matches!(self, OwnedValue::Null | OwnedValue::Bool(false))
+    }
+}
+
+/// Stream an OwnedValue as JSON without intermediate string allocation.
+fn stream_owned_value_json<W: core::fmt::Write>(
+    value: &OwnedValue,
+    out: &mut W,
+) -> core::fmt::Result {
+    match value {
+        OwnedValue::Null => out.write_str("null"),
+        OwnedValue::Bool(true) => out.write_str("true"),
+        OwnedValue::Bool(false) => out.write_str("false"),
+        OwnedValue::Int(n) => write!(out, "{}", n),
+        OwnedValue::Float(f) => {
+            if f.is_nan() || f.is_infinite() {
+                // JSON doesn't support NaN or Infinity
+                out.write_str("null")
+            } else {
+                write!(out, "{}", f)
+            }
+        }
+        OwnedValue::String(s) => stream_json_string(out, s),
+        OwnedValue::Array(arr) => {
+            out.write_char('[')?;
+            for (i, elem) in arr.iter().enumerate() {
+                if i > 0 {
+                    out.write_char(',')?;
+                }
+                stream_owned_value_json(elem, out)?;
+            }
+            out.write_char(']')
+        }
+        OwnedValue::Object(obj) => {
+            out.write_char('{')?;
+            for (i, (key, value)) in obj.iter().enumerate() {
+                if i > 0 {
+                    out.write_char(',')?;
+                }
+                stream_json_string(out, key)?;
+                out.write_char(':')?;
+                stream_owned_value_json(value, out)?;
+            }
+            out.write_char('}')
+        }
+    }
+}
+
+/// Stream a string as JSON with proper escaping.
+fn stream_json_string<W: core::fmt::Write>(out: &mut W, s: &str) -> core::fmt::Result {
+    out.write_char('"')?;
+
+    let bytes = s.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        // Find the next byte that needs escaping
+        let start = i;
+        while i < bytes.len() {
+            let b = bytes[i];
+            if b == b'"' || b == b'\\' || b < 0x20 {
+                break;
+            }
+            i += 1;
+        }
+
+        // Write unescaped segment
+        if start < i {
+            out.write_str(&s[start..i])?;
+        }
+
+        // Handle escape sequence if needed
+        if i < bytes.len() {
+            let b = bytes[i];
+            match b {
+                b'"' => out.write_str("\\\"")?,
+                b'\\' => out.write_str("\\\\")?,
+                b'\n' => out.write_str("\\n")?,
+                b'\r' => out.write_str("\\r")?,
+                b'\t' => out.write_str("\\t")?,
+                b if b < 0x20 => {
+                    // Control character - escape as \u00XX
+                    out.write_str("\\u00")?;
+                    const HEX: &[u8; 16] = b"0123456789abcdef";
+                    out.write_char(HEX[(b >> 4) as usize] as char)?;
+                    out.write_char(HEX[(b & 0xf) as usize] as char)?;
+                }
+                _ => out.write_char(b as char)?,
+            }
+            i += 1;
+        }
+    }
+
+    out.write_char('"')
+}
+
+// ============================================================================
+// YAML Streaming
+// ============================================================================
+
+/// Stream an OwnedValue as YAML without intermediate string allocation.
+///
+/// - `current_indent`: Current indentation level (number of spaces)
+/// - `indent_spaces`: Spaces per indentation level (0 for flow style)
+fn stream_owned_value_yaml<W: core::fmt::Write>(
+    value: &OwnedValue,
+    out: &mut W,
+    current_indent: usize,
+    indent_spaces: usize,
+) -> core::fmt::Result {
+    match value {
+        OwnedValue::Null => out.write_str("null"),
+        OwnedValue::Bool(true) => out.write_str("true"),
+        OwnedValue::Bool(false) => out.write_str("false"),
+        OwnedValue::Int(n) => write!(out, "{}", n),
+        OwnedValue::Float(f) => {
+            if f.is_nan() {
+                out.write_str(".nan")
+            } else if f.is_infinite() {
+                if *f > 0.0 {
+                    out.write_str(".inf")
+                } else {
+                    out.write_str("-.inf")
+                }
+            } else {
+                write!(out, "{}", f)
+            }
+        }
+        OwnedValue::String(s) => stream_yaml_string(out, s),
+        OwnedValue::Array(arr) => {
+            if arr.is_empty() {
+                out.write_str("[]")
+            } else if indent_spaces == 0 {
+                // Flow style
+                out.write_char('[')?;
+                for (i, elem) in arr.iter().enumerate() {
+                    if i > 0 {
+                        out.write_str(", ")?;
+                    }
+                    stream_owned_value_yaml(elem, out, 0, 0)?;
+                }
+                out.write_char(']')
+            } else {
+                // Block style
+                for (i, elem) in arr.iter().enumerate() {
+                    if i > 0 {
+                        out.write_char('\n')?;
+                        write_indent(out, current_indent)?;
+                    }
+                    out.write_str("- ")?;
+                    // For nested containers, put on next line with extra indent
+                    if matches!(elem, OwnedValue::Array(_) | OwnedValue::Object(_))
+                        && !is_empty_container(elem)
+                    {
+                        out.write_char('\n')?;
+                        write_indent(out, current_indent + indent_spaces)?;
+                        stream_owned_value_yaml(
+                            elem,
+                            out,
+                            current_indent + indent_spaces,
+                            indent_spaces,
+                        )?;
+                    } else {
+                        stream_owned_value_yaml(
+                            elem,
+                            out,
+                            current_indent + indent_spaces,
+                            indent_spaces,
+                        )?;
+                    }
+                }
+                Ok(())
+            }
+        }
+        OwnedValue::Object(obj) => {
+            if obj.is_empty() {
+                out.write_str("{}")
+            } else if indent_spaces == 0 {
+                // Flow style
+                out.write_char('{')?;
+                for (i, (key, val)) in obj.iter().enumerate() {
+                    if i > 0 {
+                        out.write_str(", ")?;
+                    }
+                    stream_yaml_string(out, key)?;
+                    out.write_str(": ")?;
+                    stream_owned_value_yaml(val, out, 0, 0)?;
+                }
+                out.write_char('}')
+            } else {
+                // Block style
+                for (i, (key, val)) in obj.iter().enumerate() {
+                    if i > 0 {
+                        out.write_char('\n')?;
+                        write_indent(out, current_indent)?;
+                    }
+                    stream_yaml_string(out, key)?;
+                    out.write_str(":")?;
+                    // For nested containers, put on next line with extra indent
+                    if matches!(val, OwnedValue::Array(_) | OwnedValue::Object(_))
+                        && !is_empty_container(val)
+                    {
+                        out.write_char('\n')?;
+                        write_indent(out, current_indent + indent_spaces)?;
+                        stream_owned_value_yaml(
+                            val,
+                            out,
+                            current_indent + indent_spaces,
+                            indent_spaces,
+                        )?;
+                    } else {
+                        out.write_char(' ')?;
+                        stream_owned_value_yaml(
+                            val,
+                            out,
+                            current_indent + indent_spaces,
+                            indent_spaces,
+                        )?;
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Check if a value is an empty array or object.
+fn is_empty_container(value: &OwnedValue) -> bool {
+    match value {
+        OwnedValue::Array(arr) => arr.is_empty(),
+        OwnedValue::Object(obj) => obj.is_empty(),
+        _ => false,
+    }
+}
+
+/// Write indentation spaces.
+fn write_indent<W: core::fmt::Write>(out: &mut W, spaces: usize) -> core::fmt::Result {
+    for _ in 0..spaces {
+        out.write_char(' ')?;
+    }
+    Ok(())
+}
+
+/// Stream a string as YAML with smart quoting.
+///
+/// Uses double quotes if the string contains special characters,
+/// otherwise outputs unquoted or single-quoted based on content.
+pub fn stream_yaml_string<W: core::fmt::Write>(out: &mut W, s: &str) -> core::fmt::Result {
+    if s.is_empty() {
+        return out.write_str("''");
+    }
+
+    // Check if we need quoting
+    if needs_yaml_quoting(s) {
+        stream_yaml_double_quoted(out, s)
+    } else {
+        out.write_str(s)
+    }
+}
+
+/// Check if a string needs quoting in YAML.
+fn needs_yaml_quoting(s: &str) -> bool {
+    if s.is_empty() {
+        return true;
+    }
+
+    let bytes = s.as_bytes();
+
+    // Check first character - indicators that require quoting
+    let first = bytes[0];
+    if matches!(
+        first,
+        b'-' | b'?'
+            | b':'
+            | b','
+            | b'['
+            | b']'
+            | b'{'
+            | b'}'
+            | b'#'
+            | b'&'
+            | b'*'
+            | b'!'
+            | b'|'
+            | b'>'
+            | b'\''
+            | b'"'
+            | b'%'
+            | b'@'
+            | b'`'
+    ) {
+        return true;
+    }
+
+    // Check for leading/trailing whitespace
+    if bytes[0] == b' ' || bytes[bytes.len() - 1] == b' ' {
+        return true;
+    }
+
+    // Check for special values that look like YAML keywords
+    let lower = s.to_lowercase();
+    if matches!(
+        lower.as_str(),
+        "null" | "~" | "true" | "false" | "yes" | "no" | "on" | "off" | ".inf" | "-.inf" | ".nan"
+    ) {
+        return true;
+    }
+
+    // Check if it looks like a number
+    if looks_like_number(s) {
+        return true;
+    }
+
+    // Check for characters that need escaping
+    for b in bytes {
+        if *b < 0x20 || *b == b':' || *b == b'#' {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Check if a string looks like a number.
+fn looks_like_number(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+
+    let bytes = s.as_bytes();
+    let mut i = 0;
+
+    // Optional sign
+    if bytes[i] == b'-' || bytes[i] == b'+' {
+        i += 1;
+        if i >= bytes.len() {
+            return false;
+        }
+    }
+
+    // Must have at least one digit
+    if !bytes[i].is_ascii_digit() {
+        return false;
+    }
+
+    // Check remaining characters
+    let mut has_dot = false;
+    let mut has_exp = false;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'0'..=b'9' => {}
+            b'.' if !has_dot && !has_exp => has_dot = true,
+            b'e' | b'E' if !has_exp => {
+                has_exp = true;
+                // Optional sign after exponent
+                if i + 1 < bytes.len() && (bytes[i + 1] == b'-' || bytes[i + 1] == b'+') {
+                    i += 1;
+                }
+            }
+            _ => return false,
+        }
+        i += 1;
+    }
+
+    true
+}
+
+/// Stream a double-quoted YAML string with proper escaping.
+fn stream_yaml_double_quoted<W: core::fmt::Write>(out: &mut W, s: &str) -> core::fmt::Result {
+    out.write_char('"')?;
+
+    for ch in s.chars() {
+        match ch {
+            '"' => out.write_str("\\\"")?,
+            '\\' => out.write_str("\\\\")?,
+            '\n' => out.write_str("\\n")?,
+            '\r' => out.write_str("\\r")?,
+            '\t' => out.write_str("\\t")?,
+            c if c < ' ' => {
+                // Control characters as \xNN
+                let b = c as u8;
+                out.write_str("\\x")?;
+                const HEX: &[u8; 16] = b"0123456789abcdef";
+                out.write_char(HEX[(b >> 4) as usize] as char)?;
+                out.write_char(HEX[(b & 0xf) as usize] as char)?;
+            }
+            c => out.write_char(c)?,
+        }
+    }
+
+    out.write_char('"')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    #[test]
+    fn test_stream_null() {
+        let mut buf = String::new();
+        OwnedValue::Null.stream_json(&mut buf).unwrap();
+        assert_eq!(buf, "null");
+    }
+
+    #[test]
+    fn test_stream_bool() {
+        let mut buf = String::new();
+        OwnedValue::Bool(true).stream_json(&mut buf).unwrap();
+        assert_eq!(buf, "true");
+
+        buf.clear();
+        OwnedValue::Bool(false).stream_json(&mut buf).unwrap();
+        assert_eq!(buf, "false");
+    }
+
+    #[test]
+    fn test_stream_int() {
+        let mut buf = String::new();
+        OwnedValue::Int(42).stream_json(&mut buf).unwrap();
+        assert_eq!(buf, "42");
+
+        buf.clear();
+        OwnedValue::Int(-123).stream_json(&mut buf).unwrap();
+        assert_eq!(buf, "-123");
+    }
+
+    #[test]
+    fn test_stream_float() {
+        let mut buf = String::new();
+        OwnedValue::Float(3.125).stream_json(&mut buf).unwrap();
+        assert_eq!(buf, "3.125");
+    }
+
+    #[test]
+    fn test_stream_string() {
+        let mut buf = String::new();
+        OwnedValue::String("hello".to_string())
+            .stream_json(&mut buf)
+            .unwrap();
+        assert_eq!(buf, "\"hello\"");
+    }
+
+    #[test]
+    fn test_stream_string_escaping() {
+        let mut buf = String::new();
+        OwnedValue::String("hello\nworld".to_string())
+            .stream_json(&mut buf)
+            .unwrap();
+        assert_eq!(buf, "\"hello\\nworld\"");
+
+        buf.clear();
+        OwnedValue::String("tab\there".to_string())
+            .stream_json(&mut buf)
+            .unwrap();
+        assert_eq!(buf, "\"tab\\there\"");
+
+        buf.clear();
+        OwnedValue::String("quote\"here".to_string())
+            .stream_json(&mut buf)
+            .unwrap();
+        assert_eq!(buf, "\"quote\\\"here\"");
+    }
+
+    #[test]
+    fn test_stream_array() {
+        let mut buf = String::new();
+        OwnedValue::Array(vec![
+            OwnedValue::Int(1),
+            OwnedValue::Int(2),
+            OwnedValue::Int(3),
+        ])
+        .stream_json(&mut buf)
+        .unwrap();
+        assert_eq!(buf, "[1,2,3]");
+    }
+
+    #[test]
+    fn test_stream_object() {
+        let mut buf = String::new();
+        let mut map = IndexMap::new();
+        map.insert("name".to_string(), OwnedValue::String("Alice".to_string()));
+        map.insert("age".to_string(), OwnedValue::Int(30));
+        OwnedValue::Object(map).stream_json(&mut buf).unwrap();
+        assert_eq!(buf, "{\"name\":\"Alice\",\"age\":30}");
+    }
+
+    #[test]
+    fn test_is_falsy() {
+        assert!(OwnedValue::Null.is_falsy());
+        assert!(OwnedValue::Bool(false).is_falsy());
+        assert!(!OwnedValue::Bool(true).is_falsy());
+        assert!(!OwnedValue::Int(0).is_falsy());
+        assert!(!OwnedValue::String("".to_string()).is_falsy());
+    }
+}


### PR DESCRIPTION
## Description

This PR extends the M2 streaming optimization to support native YAML output format (M2.5). Previously, the M2 fast path only worked for JSON output (`-o json -I0`). Now, navigation queries like `.field`, `.[0]`, and `.[]` can stream results directly as YAML without materializing OwnedValue DOMs.

The M2.5 path enables the same memory-efficient streaming for the default `yq` output format (YAML), providing significant performance benefits for users who don't need JSON conversion.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement
- [x] Documentation update

## Related Issue
Continues M2 streaming optimization work for navigation queries.

## Changes Made

**Core Streaming Infrastructure:**
- Added `stream_yaml()` method to `DocumentCursor` trait in `src/jq/document.rs`
- Implemented `StreamableValue::stream_yaml()` for `OwnedValue` in `src/jq/stream.rs`
- Added `stream_yaml()` method to `GenericResult` for M2.5 evaluation path in `src/jq/eval_generic.rs`

**YAML Cursor Streaming:**
- Implemented `stream_yaml()` and `stream_yaml_document()` methods on `YamlCursor` in `src/yaml/light.rs`
- Added YAML string smart quoting with `needs_yaml_quoting()` and `looks_like_yaml_number()` helpers
- Implemented both flow style (compact) and block style (indented) output

**JSON Cursor YAML Output:**
- Added `stream_yaml()` support for `JsonCursor` in `src/json/light.rs`
- Implemented JSON-to-YAML streaming conversion without intermediate allocation

**Runner Integration:**
- Updated `yq_runner.rs` to detect and use M2.5 path for YAML output with compact flag
- Added `can_yaml_fast_path` detection alongside existing `can_json_fast_path`
- Extended `stream_cursor!` macro to handle both M2 (JSON) and M2.5 (YAML) paths

**Documentation:**
- Updated benchmark documentation in `docs/benchmarks/yq.md` with M2.5 terminology
- Added 10MB and 100MB benchmark results tables
- Updated `CLAUDE.md` with M2.5 streaming performance data
- Clarified that `length` produces computed values (not cursor-streamable)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for `StreamableValue` JSON streaming in `src/jq/stream.rs`

**Manual Testing:**
- [x] Tested navigation queries with YAML output format
- [x] Verified identity (`.`), field access (`.field`), and iteration (`.[]`) queries

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] Performance improvement (include benchmarks below)

**100MB navigation file benchmarks (Apple M1 Max):**

| Query | Path | succinctly | yq | Speedup | succ Mem | yq Mem |
|-------|------|------------|-------|---------|----------|--------|
| `.` | P9 streaming | 1.12s | 11.82s | **10.5x** | 529 MB | 7 GB |
| `.[0]` | M2 streaming | 468ms | 5.97s | **12.8x** | 534 MB | 5 GB |
| `.[]` | M2 streaming | 1.91s | 13.67s | **7.2x** | 554 MB | 8 GB |
| `length` | OwnedValue | 480ms | 5.99s | **12.5x** | 529 MB | 5 GB |

M2.5 enables the same optimizations for YAML output that M2 provided for JSON output, using 7-14% of yq's memory.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Execution Path Summary:**
- **P9**: Identity streaming (`.`) - full document pass-through
- **M2**: Navigation queries with JSON output (`-o json -I0`)
- **M2.5**: Navigation queries with YAML output (`-I0`, default format)
- **OwnedValue**: Complex expressions requiring DOM construction

The M2.5 path is automatically selected when the expression is streamable (navigation-only), output format is YAML, and compact mode is enabled.