### PR TITLE
docs(docs): add M1 broadword select optimization analysis and benchmark updates

### DIFF
--- a/src/util/broadword.rs
+++ b/src/util/broadword.rs
@@ -85,8 +85,15 @@ fn select_in_word_ctz(x: u64, k: u32) -> u32 {
 /// It computes byte popcounts and prefix sums in parallel, then uses a lookup
 /// table for the final byte.
 ///
-/// Note: The CTZ loop (`select_in_word`) is often faster on modern CPUs due
-/// to the efficient `tzcnt` instruction.
+/// # Performance (Apple M1 Max)
+///
+/// Broadword is faster than CTZ loop for k≥4:
+/// - k=0-1: CTZ wins (0.7-1.0 ns vs 1.5-1.8 ns)
+/// - k=4+: Broadword wins, gap widens with k
+/// - k=31: 12.4 ns (CTZ) vs 3.6 ns (Broadword) = 3.4× faster
+/// - k=63: 28.1 ns (CTZ) vs 4.6 ns (Broadword) = 6.1× faster
+///
+/// For Elias-Fano `select1` where k averages ~32, broadword is ~3× faster.
 #[inline]
 #[allow(dead_code)]
 pub fn select_in_word_broadword(x: u64, k: u32) -> u32 {


### PR DESCRIPTION
## Description

This PR documents comprehensive benchmark results and performance analysis for the Elias-Fano implementation, including the discovery of a significant broadword SWAR optimization opportunity specifically for Apple M1/M2/M3 processors. The analysis shows that broadword select can achieve 3-6x speedup over the current CTZ loop implementation for typical use cases.

Additionally, this PR refactors the `select_in_word` implementation by moving it from the Elias-Fano module to the dedicated broadword utility module, improving code organization and preparing for architecture-specific optimizations.

## Type of Change
- [x] Performance improvement
- [x] Documentation update
- [x] Refactoring (no functional changes)

## Related Issue
Part of the ongoing Elias-Fano compact index investigation for JSON/YAML indexing optimization.

## Changes Made

**Documentation Updates:**
- Updated `docs/optimizations/hierarchical-structures.md` with detailed criterion benchmark results for 100K elements
- Enhanced `docs/plan/compact-index-investigation.md` with comprehensive performance analysis and M1-specific optimization discovery
- Added platform-specific optimization expectations table showing 3-4x speedup potential for M1/M2/M3
- Documented key performance insights: broadword SWAR beats CTZ loop for k≥4 on Apple Silicon
- Updated benchmark comparisons showing 46x vs Vec for random access (improved from previous 36x measurement)
- Added skip-by-small pattern analysis showing only 6.2x slowdown for tree navigation patterns

**Code Refactoring:**
- Moved `select_in_word` implementation from `src/bits/elias_fano.rs` to `src/util/broadword.rs`
- Updated function calls in Elias-Fano to use `broadword::select_in_word`
- Removed duplicate `select_in_word` implementation and associated tests from elias_fano.rs
- Added detailed performance documentation to broadword select functions

**Benchmark Analysis:**
- CTZ loop performance: O(k) complexity, 12.4ns for k=31, 28.1ns for k=63
- Broadword SWAR performance: O(1) complexity, 3.6ns for k=31, 4.6ns for k=63
- Crossover point: k≥4 where broadword becomes faster than CTZ
- Expected overall speedup: 46x → ~15x vs Vec for random access patterns

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Moved select_in_word tests to broadword module

**Manual Testing:**
- [x] Tested on aarch64/ARM (Apple M1 Max benchmarks included)
- [x] Verified benchmark accuracy with criterion framework

### Test Commands
```bash
cargo test
cargo bench -- select_in_word
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] Performance improvement (include benchmarks below)

**Current Benchmark Results (Apple M1 Max, 100K elements):**

| Operation                | EliasFano     | Vec<u32>      | Ratio   |
|--------------------------|---------------|---------------|---------|
| Sequential iteration     | 1.77 ns/elem  | 0.048 ns/elem | 37x     |
| Random access (get)      | 30.7 ns       | 0.67 ns       | 46x     |
| cursor_from + 5 iter     | 32.6 ns       | 1.69 ns       | 19x     |
| Skip-by-2-8 patterns     | 128 μs total  | 20.8 μs total | 6.2x    |

**Select-in-word optimization potential:**

| k  | CTZ (ns) | Broadword (ns) | Speedup |
|----|----------|----------------|---------|
| 4  | 2.57     | 2.43           | 1.1x    |
| 8  | 3.85     | 1.52           | 2.5x    |
| 31 | 12.37    | 3.59           | 3.4x    |
| 63 | 28.14    | 4.62           | 6.1x    |

**Expected improvement**: With broadword optimization, random access should improve from 46x to ~15x slower than Vec, bringing Elias-Fano within acceptable performance bounds for the JSON/YAML indexing system.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

This analysis provides the foundation for implementing architecture-specific optimizations in a future PR. The key insight is that Apple Silicon processors benefit significantly from broadword SWAR techniques for select operations, which will be crucial for making Elias-Fano competitive with Vec<u32> for the hierarchical JSON/YAML indexing use case.

**Next Steps:**
1. Implement conditional broadword selection based on k value and platform detection
2. Add x86 BMI2 PDEP+TZCNT optimization for Intel/AMD processors  
3. Consider ARM SVE2 BDEP optimization for server-class ARM processors

The refactoring in this PR prepares the codebase for these platform-specific optimizations while maintaining the current portable implementation as a fallback.