### PR TITLE
feat(cli): implement multi-call binary support with comprehensive alias system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,31 +56,56 @@ cargo bench                              # Run benchmarks
 ```bash
 cargo build --release --features cli
 
-# JSON operations
-./target/release/succinctly json generate 10mb -o benchmark.json
-./target/release/succinctly jq '.users[].name' input.json
-./target/release/succinctly jq -r '.users[] | [.name, .age] | @csv' input.json
-./target/release/succinctly jq -r '.users[] | [.name, .age] | @dsv("|")' input.json
-./target/release/succinctly jq-locate input.json --offset 42
-./target/release/succinctly jq-locate input.json --line 5 --column 10
+# Install short aliases (sjq, syq, sjq-locate, syq-locate)
+./target/release/succinctly install-aliases          # symlinks next to binary
+./target/release/succinctly install-aliases --dir ~/bin  # or specify directory
 
-# YAML operations
-./target/release/succinctly yq '.users[].name' config.yaml
-./target/release/succinctly yq -o json '.' config.yaml         # Output as JSON
-./target/release/succinctly yq '.spec.containers[]' k8s.yaml
-./target/release/succinctly yq --doc 0 '.' multi-doc.yaml      # First document only
-./target/release/succinctly yq-locate config.yaml --offset 42
-./target/release/succinctly yq-locate config.yaml --line 5 --column 10
+# JSON operations (sjq is an alias for succinctly jq)
+sjq '.users[].name' input.json
+sjq -r '.users[] | [.name, .age] | @csv' input.json
+sjq -r '.users[] | [.name, .age] | @dsv("|")' input.json
+sjq-locate input.json --offset 42
+sjq-locate input.json --line 5 --column 10
+
+# YAML operations (syq is an alias for succinctly yq)
+syq '.users[].name' config.yaml
+syq -o json '.' config.yaml         # Output as JSON
+syq '.spec.containers[]' k8s.yaml
+syq --doc 0 '.' multi-doc.yaml      # First document only
+syq-locate config.yaml --offset 42
+syq-locate config.yaml --line 5 --column 10
 
 # DSV/CSV operations
-./target/release/succinctly jq --input-dsv ',' '.[] | select(.[0] == "Alice")' data.csv
+sjq --input-dsv ',' '.[] | select(.[0] == "Alice")' data.csv
 ./target/release/succinctly dsv generate users 1000 -o users.csv
+
+# Data generation
+./target/release/succinctly json generate 10mb -o benchmark.json
 
 # Benchmarks
 ./target/release/succinctly dev bench jq
 ./target/release/succinctly dev bench yq
 ./target/release/succinctly dev bench yq --queries all --memory  # M2 streaming comparison
 ./target/release/succinctly dev bench dsv
+```
+
+### Multi-call Aliases
+
+The binary supports multi-call invocation via symlinks. When invoked as `sjq`, `syq`, etc., it dispatches directly to the corresponding subcommand:
+
+| Alias         | Equivalent              | Installed by default |
+|---------------|-------------------------|----------------------|
+| `sjq`         | `succinctly jq`         | Yes                  |
+| `syq`         | `succinctly yq`         | Yes                  |
+| `sjq-locate`  | `succinctly jq-locate`  | Yes                  |
+| `syq-locate`  | `succinctly yq-locate`  | Yes                  |
+| `jq`          | `succinctly jq`         | No (recognized only) |
+| `yq`          | `succinctly yq`         | No (recognized only) |
+
+Run `succinctly install-aliases` to create symlinks, or create them manually:
+
+```bash
+ln -s $(which succinctly) ~/bin/sjq
 ```
 
 ## Code Architecture

--- a/README.md
+++ b/README.md
@@ -257,35 +257,40 @@ The library includes CLI tools for JSON, YAML, and DSV operations:
 # Build the CLI
 cargo build --release --features cli
 
-# Generate synthetic JSON/YAML for benchmarking
-./target/release/succinctly json generate 10mb -o benchmark.json
-./target/release/succinctly yaml generate 10kb -o benchmark.yaml
+# Install short aliases (sjq, syq, sjq-locate, syq-locate)
+succinctly install-aliases
 
 # Query JSON files (jq-compatible)
-./target/release/succinctly jq '.users[].name' input.json
-./target/release/succinctly jq -r '.users[0]' input.json
+sjq '.users[].name' input.json
+sjq -r '.users[0]' input.json
 
 # Query YAML files (yq-compatible)
-./target/release/succinctly yq '.users[].name' config.yaml
-./target/release/succinctly yq -o json '.' config.yaml          # Output as JSON
-./target/release/succinctly yq '.spec.containers[]' k8s.yaml
-./target/release/succinctly yq --doc 0 '.' multi-doc.yaml       # First document only
+syq '.users[].name' config.yaml
+syq -o json '.' config.yaml          # Output as JSON
+syq '.spec.containers[]' k8s.yaml
+syq --doc 0 '.' multi-doc.yaml       # First document only
 
 # Query CSV/TSV files (converted to JSON on-the-fly)
-./target/release/succinctly jq --input-dsv ',' '.[] | .[0]' users.csv
-./target/release/succinctly jq --input-dsv '\t' '.[0]' data.tsv
+sjq --input-dsv ',' '.[] | .[0]' users.csv
+sjq --input-dsv '\t' '.[0]' data.tsv
 
 # Output as CSV/TSV/DSV
-./target/release/succinctly jq -r '.users[] | [.name, .age] | @csv' data.json
-./target/release/succinctly jq -r '.users[] | [.name, .age] | @dsv("|")' data.json
-./target/release/succinctly yq -r '.users[] | [.name, .age] | @csv' data.yaml
+sjq -r '.users[] | [.name, .age] | @csv' data.json
+sjq -r '.users[] | [.name, .age] | @dsv("|")' data.json
+syq -r '.users[] | [.name, .age] | @csv' data.yaml
 
 # Find jq/yq expression for a position (useful for editor integration)
-./target/release/succinctly jq-locate input.json --offset 42
-./target/release/succinctly jq-locate input.json --line 5 --column 10
-./target/release/succinctly yq-locate config.yaml --offset 42
-./target/release/succinctly yq-locate config.yaml --line 5 --column 10
+sjq-locate input.json --offset 42
+sjq-locate input.json --line 5 --column 10
+syq-locate config.yaml --offset 42
+syq-locate config.yaml --line 5 --column 10
+
+# Generate synthetic JSON/YAML for benchmarking
+succinctly json generate 10mb -o benchmark.json
+succinctly yaml generate 10kb -o benchmark.yaml
 ```
+
+The `sjq`/`syq` aliases are symlinks created by `succinctly install-aliases`. All commands also work via the full `succinctly jq`/`succinctly yq` syntax.
 
 ## Architecture
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -52,6 +52,15 @@ Or install globally:
 cargo install succinctly --features cli
 ```
 
+After installing, create short aliases for interactive use:
+
+```bash
+succinctly install-aliases              # symlinks next to the binary
+succinctly install-aliases --dir ~/bin  # or specify a directory
+```
+
+This creates `sjq`, `syq`, `sjq-locate`, and `syq-locate` symlinks so you can use `sjq` instead of `succinctly jq`.
+
 ## Platform-Specific Notes
 
 ### macOS (Apple Silicon)
@@ -96,13 +105,15 @@ fn main() {
 
 ```bash
 # Check version
-./target/release/succinctly --version
+succinctly --version
 
-# Test jq
-echo '{"name": "test"}' | ./target/release/succinctly jq '.name'
+# Test jq (using short alias or full command)
+echo '{"name": "test"}' | sjq '.name'
+echo '{"name": "test"}' | succinctly jq '.name'
 
 # Test yq
-echo 'name: test' | ./target/release/succinctly yq '.name'
+echo 'name: test' | syq '.name'
+echo 'name: test' | succinctly yq '.name'
 ```
 
 ## Troubleshooting

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -69,37 +69,45 @@ fn main() {
 
 ## Using the CLI
 
+Install short aliases for interactive use (optional but recommended):
+
+```bash
+succinctly install-aliases    # creates sjq, syq, sjq-locate, syq-locate
+```
+
 ### Query JSON with jq
 
 ```bash
 # Pretty print
-succinctly jq '.' data.json
+sjq '.' data.json
 
 # Extract field
-succinctly jq '.name' data.json
+sjq '.name' data.json
 
 # Filter array
-succinctly jq '.users[] | select(.age > 30)' data.json
+sjq '.users[] | select(.age > 30)' data.json
 
 # Compact output
-succinctly jq -c '.' data.json
+sjq -c '.' data.json
 ```
 
 ### Query YAML with yq
 
 ```bash
 # Pretty print
-succinctly yq '.' config.yaml
+syq '.' config.yaml
 
 # Convert to JSON
-succinctly yq -o json '.' config.yaml
+syq -o json '.' config.yaml
 
 # Extract field
-succinctly yq '.metadata.name' deployment.yaml
+syq '.metadata.name' deployment.yaml
 
 # Compact JSON output
-succinctly yq -o json -I 0 '.' config.yaml
+syq -o json -I 0 '.' config.yaml
 ```
+
+> **Note:** All commands also work with the full syntax: `succinctly jq`, `succinctly yq`, etc.
 
 ### Generate Test Data
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -12,6 +12,24 @@ cargo build --release --features cli
 
 The binary will be located at `target/release/succinctly`.
 
+### Short Aliases
+
+Install short alias symlinks for interactive use:
+
+```bash
+succinctly install-aliases              # creates symlinks next to the binary
+succinctly install-aliases --dir ~/bin  # or specify a directory on your PATH
+```
+
+This creates `sjq`, `syq`, `sjq-locate`, and `syq-locate` symlinks. With aliases installed, you can use `sjq` instead of `succinctly jq`:
+
+```bash
+sjq '.users[].name' input.json        # instead of: succinctly jq '.users[].name' input.json
+syq '.spec.containers[]' k8s.yaml     # instead of: succinctly yq '.spec.containers[]' k8s.yaml
+```
+
+The binary also recognizes `jq` and `yq` as alias names if you create those symlinks manually, but `install-aliases` does not create them to avoid shadowing system tools.
+
 ## Commands
 
 ### JSON Generation

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -59,6 +59,13 @@ fn test_help_json_generate() -> Result<()> {
 }
 
 #[test]
+fn test_help_install_aliases() -> Result<()> {
+    let output = run_cli(&["install-aliases", "--help"])?;
+    insta::assert_snapshot!("help_install_aliases", output);
+    Ok(())
+}
+
+#[test]
 fn test_version() -> Result<()> {
     let output = run_cli(&["--version"])?;
     insta::assert_snapshot!("version", output);

--- a/tests/snapshots/cli_golden_tests__help_install_aliases.snap
+++ b/tests/snapshots/cli_golden_tests__help_install_aliases.snap
@@ -1,0 +1,12 @@
+---
+source: tests/cli_golden_tests.rs
+assertion_line: 64
+expression: output
+---
+Install short alias symlinks (sjq, syq, sjq-locate, syq-locate)
+
+Usage: succinctly install-aliases [OPTIONS]
+
+Options:
+      --dir <DIR>  Directory to create symlinks in (default: same directory as the binary)
+  -h, --help       Print help

--- a/tests/snapshots/cli_golden_tests__help_main.snap
+++ b/tests/snapshots/cli_golden_tests__help_main.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/cli_golden_tests.rs
+assertion_line: 43
 expression: output
 ---
 Succinct data structures toolkit
@@ -7,15 +8,16 @@ Succinct data structures toolkit
 Usage: succinctly <COMMAND>
 
 Commands:
-  json       JSON operations (generate, parse, benchmark)
-  dsv        DSV (CSV/TSV) operations (generate, parse)
-  yaml       YAML operations (generate, parse)
-  jq         Command-line JSON processor (jq-compatible)
-  yq         Command-line YAML processor (jq-compatible syntax)
-  jq-locate  Find jq expression for a position in a JSON file
-  yq-locate  Find yq expression for a position in a YAML file
-  dev        Developer tools (benchmarking, profiling)
-  help       Print this message or the help of the given subcommand(s)
+  json             JSON operations (generate, parse, benchmark)
+  dsv              DSV (CSV/TSV) operations (generate, parse)
+  yaml             YAML operations (generate, parse)
+  jq               Command-line JSON processor (jq-compatible)
+  yq               Command-line YAML processor (jq-compatible syntax)
+  jq-locate        Find jq expression for a position in a JSON file
+  yq-locate        Find yq expression for a position in a YAML file
+  dev              Developer tools (benchmarking, profiling)
+  install-aliases  Install short alias symlinks (sjq, syq, sjq-locate, syq-locate)
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help


### PR DESCRIPTION
## Description

This PR implements multi-call binary functionality allowing the succinctly binary to be invoked through short symlink aliases like `sjq`, `syq`, `sjq-locate`, and `syq-locate`. This significantly improves user experience by providing familiar, short commands similar to jq/yq while maintaining full backward compatibility with the existing `succinctly jq`/`succinctly yq` syntax.

The implementation includes automatic alias detection from argv[0], direct dispatch to appropriate subcommands, and a new `install-aliases` command for managed symlink creation with conflict detection and cleanup.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue
Relates to improving CLI user experience and adoption

## Changes Made

**Core Multi-call Implementation:**
- Added `try_multicall()` function in `src/bin/succinctly/main.rs` to detect argv[0] and dispatch to appropriate subcommands
- Implemented multi-call support for `sjq`, `syq`, `sjq-locate`, `syq-locate`, `jq`, and `yq` aliases
- Added `InstallAliases` command variant and `InstallAliasesArgs` struct for alias management
- Created `install_aliases()` function with comprehensive symlink management including conflict detection

**Alias Management System:**
- Defined `MULTICALL_ALIASES` constant with default aliases: `["sjq", "syq", "sjq-locate", "syq-locate"]`
- Implemented cross-platform symlink creation (Unix symlinks, Windows hard links)
- Added stale symlink cleanup and non-symlink file conflict detection
- Provided user feedback during alias installation process

**Documentation Updates:**
- Updated `README.md` with alias-first examples and installation instructions
- Enhanced `CLAUDE.md` with multi-call architecture explanation and alias table
- Revised `docs/getting-started/installation.md` to include alias setup as recommended step
- Updated `docs/getting-started/quickstart.md` with alias-based command examples
- Expanded `docs/guides/cli.md` with comprehensive alias installation and usage details

**Testing Infrastructure:**
- Added `test_help_install_aliases()` golden test in `tests/cli_golden_tests.rs`
- Created snapshot `tests/snapshots/cli_golden_tests__help_install_aliases.snap` for help output validation
- Updated main help snapshot to include new `install-aliases` command in command list

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New golden tests added for `install-aliases` help output
- [x] Updated main help snapshot to reflect new command

**Manual Testing:**
- [x] Tested `install-aliases` command creates correct symlinks
- [x] Verified multi-call invocation works for all supported aliases (`sjq`, `syq`, `sjq-locate`, `syq-locate`)
- [x] Confirmed backward compatibility with full command syntax (`succinctly jq`, `succinctly yq`)
- [x] Tested conflict detection for existing files and stale symlinks
- [x] Verified cross-platform compatibility (Unix symlinks)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check

# Test multi-call functionality
cargo build --release --features cli
./target/release/succinctly install-aliases --dir /tmp/test
echo '{"name": "test"}' | /tmp/test/sjq '.name'
echo 'name: test' | /tmp/test/syq '.name'
```

## Performance Impact
- [x] No performance impact

The multi-call detection adds minimal overhead (single argv[0] check) and only runs when binary is invoked via alias names.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**User Experience Improvements:**
- Transforms verbose `succinctly jq` commands into familiar `sjq` short commands
- Maintains 100% backward compatibility with existing scripts and workflows
- Follows Unix convention of multi-call binaries (similar to BusyBox)

**Architecture Benefits:**
- Clean separation between multi-call detection and command execution
- Reuses existing command parsers and runners without duplication
- Extensible design allows easy addition of new aliases in the future

**Deployment Considerations:**
- No breaking changes - existing installations continue to work unchanged
- Optional alias installation allows users to choose their preferred workflow
- Cross-platform symlink handling ensures consistent behavior