### PR TITLE
feat(simd): add AVX2-accelerated JSON escape scanning for YAML output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,3 +550,13 @@ For detailed documentation on optimization techniques used in this project, see 
   - **yaml_bench**: No regression (query-path only optimization)
   - Results are noisy because the forward-gap path is infrequently hit during typical streaming
   - See [docs/parsing/yaml.md#o2-gap-skipping-via-advance_rank1---accepted-](docs/parsing/yaml.md#o2-gap-skipping-via-advance_rank1---accepted-) for full analysis
+- ✅ O3 (SIMD JSON Escape Scanning): **3-11% faster** JSON output in streaming path, issue #87
+  - AVX2 scans 32-byte chunks for escapable characters (`"`, `\`, control chars < 0x20)
+  - Threshold-based hybrid: SIMD for ≥32 bytes, inline scalar for short spans
+  - **Micro-benchmark**: 28-30x faster raw escape scanning (70 GiB/s vs 2.5 GiB/s)
+  - **End-to-end transcode benchmarks**:
+    - unicode_8digit/100: **-11%** (432 MiB/s)
+    - realistic/config: **-4%** (234 MiB/s)
+    - large/500_items: **-5%** (227 MiB/s)
+  - **Key insight**: Threshold prevents regression on short strings (initial impl was 2-7% slower without)
+  - See [docs/parsing/yaml.md#o3-simd-json-escape-scanning---accepted-](docs/parsing/yaml.md#o3-simd-json-escape-scanning---accepted-) for full analysis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,3 +173,7 @@ harness = false
 [[bench]]
 name = "elias_fano"
 harness = false
+
+[[bench]]
+name = "json_escape_micro"
+harness = false

--- a/benches/json_escape_micro.rs
+++ b/benches/json_escape_micro.rs
@@ -1,0 +1,238 @@
+//! Micro-benchmarks for JSON escape scanning SIMD optimization (Issue #87).
+//!
+//! Measures the performance of `find_json_escape` which uses SIMD to find bytes
+//! that need JSON escaping (", \, or control characters 0x00-0x1F).
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+// Import the SIMD function - this is internal but we can benchmark via the public path
+#[cfg(target_arch = "x86_64")]
+fn find_json_escape(input: &[u8], start: usize) -> Option<usize> {
+    succinctly::yaml::simd::find_json_escape(input, start)
+}
+
+/// Scalar implementation for comparison
+fn find_json_escape_scalar(input: &[u8], start: usize) -> Option<usize> {
+    let data = &input[start..];
+    for (i, &b) in data.iter().enumerate() {
+        if b == b'"' || b == b'\\' || b < 0x20 {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// Generate a string with no escape characters (best case for SIMD)
+fn make_no_escapes(size: usize) -> Vec<u8> {
+    // Use characters that don't need escaping: letters, digits, spaces
+    let pattern = b"abcdefghijklmnopqrstuvwxyz0123456789 ";
+    let mut result = Vec::with_capacity(size);
+    for i in 0..size {
+        result.push(pattern[i % pattern.len()]);
+    }
+    result
+}
+
+/// Generate a string with escape at the end (stress test - full scan)
+fn make_escape_at_end(size: usize) -> Vec<u8> {
+    let mut result = make_no_escapes(size);
+    if !result.is_empty() {
+        result[size - 1] = b'"';
+    }
+    result
+}
+
+/// Generate a string with escape at the beginning (best case for early exit)
+fn make_escape_at_start(size: usize) -> Vec<u8> {
+    let mut result = make_no_escapes(size);
+    if !result.is_empty() {
+        result[0] = b'"';
+    }
+    result
+}
+
+/// Generate a string with frequent escapes (realistic JSON-heavy case)
+fn make_frequent_escapes(size: usize) -> Vec<u8> {
+    // Every ~10 characters has an escape
+    let mut result = make_no_escapes(size);
+    for i in (10..size).step_by(10) {
+        result[i] = match i % 30 {
+            10 => b'"',
+            20 => b'\\',
+            _ => b'\n',
+        };
+    }
+    result
+}
+
+/// Benchmark SIMD vs scalar for various string sizes
+fn bench_simd_vs_scalar(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_escape/simd_vs_scalar");
+
+    for size in [16, 32, 64, 128, 256, 512, 1024, 4096] {
+        let input = make_no_escapes(size);
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("simd", size), &input, |b, input| {
+            b.iter(|| find_json_escape(black_box(input), 0))
+        });
+
+        group.bench_with_input(BenchmarkId::new("scalar", size), &input, |b, input| {
+            b.iter(|| find_json_escape_scalar(black_box(input), 0))
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark escape position impact
+fn bench_escape_position(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_escape/position");
+    let size = 256;
+
+    // No escape (full scan, return None)
+    let no_escape = make_no_escapes(size);
+    group.throughput(Throughput::Bytes(size as u64));
+    group.bench_function("no_escape", |b| {
+        b.iter(|| find_json_escape(black_box(&no_escape), 0))
+    });
+
+    // Escape at start (early exit)
+    let at_start = make_escape_at_start(size);
+    group.bench_function("at_start", |b| {
+        b.iter(|| find_json_escape(black_box(&at_start), 0))
+    });
+
+    // Escape in middle
+    let mut at_middle = make_no_escapes(size);
+    at_middle[size / 2] = b'"';
+    group.bench_function("at_middle", |b| {
+        b.iter(|| find_json_escape(black_box(&at_middle), 0))
+    });
+
+    // Escape at end
+    let at_end = make_escape_at_end(size);
+    group.bench_function("at_end", |b| {
+        b.iter(|| find_json_escape(black_box(&at_end), 0))
+    });
+
+    group.finish();
+}
+
+/// Benchmark different escape types
+fn bench_escape_types(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_escape/types");
+    let size = 256;
+
+    // Quote character
+    let mut with_quote = make_no_escapes(size);
+    with_quote[size / 2] = b'"';
+    group.throughput(Throughput::Bytes(size as u64));
+    group.bench_function("quote", |b| {
+        b.iter(|| find_json_escape(black_box(&with_quote), 0))
+    });
+
+    // Backslash
+    let mut with_backslash = make_no_escapes(size);
+    with_backslash[size / 2] = b'\\';
+    group.bench_function("backslash", |b| {
+        b.iter(|| find_json_escape(black_box(&with_backslash), 0))
+    });
+
+    // Newline (control char)
+    let mut with_newline = make_no_escapes(size);
+    with_newline[size / 2] = b'\n';
+    group.bench_function("newline", |b| {
+        b.iter(|| find_json_escape(black_box(&with_newline), 0))
+    });
+
+    // Tab (control char)
+    let mut with_tab = make_no_escapes(size);
+    with_tab[size / 2] = b'\t';
+    group.bench_function("tab", |b| {
+        b.iter(|| find_json_escape(black_box(&with_tab), 0))
+    });
+
+    // Null (control char - edge case)
+    let mut with_null = make_no_escapes(size);
+    with_null[size / 2] = 0;
+    group.bench_function("null", |b| {
+        b.iter(|| find_json_escape(black_box(&with_null), 0))
+    });
+
+    group.finish();
+}
+
+/// Benchmark realistic workloads
+fn bench_realistic(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_escape/realistic");
+
+    // Typical JSON field value (short, no escapes)
+    let short_value = b"hello_world_value_123";
+    group.throughput(Throughput::Bytes(short_value.len() as u64));
+    group.bench_function("short_value", |b| {
+        b.iter(|| find_json_escape(black_box(short_value), 0))
+    });
+
+    // Typical JSON with quotes (common in config files)
+    let with_quotes = br#"This string has "quotes" inside it"#;
+    group.throughput(Throughput::Bytes(with_quotes.len() as u64));
+    group.bench_function("with_quotes", |b| {
+        b.iter(|| find_json_escape(black_box(with_quotes), 0))
+    });
+
+    // Multiline text with newlines
+    let multiline = b"Line one\nLine two\nLine three\nLine four";
+    group.throughput(Throughput::Bytes(multiline.len() as u64));
+    group.bench_function("multiline", |b| {
+        b.iter(|| find_json_escape(black_box(multiline), 0))
+    });
+
+    // Path-like string with backslashes
+    let path = br"C:\Users\Admin\Documents\file.txt";
+    group.throughput(Throughput::Bytes(path.len() as u64));
+    group.bench_function("path", |b| b.iter(|| find_json_escape(black_box(path), 0)));
+
+    // Long description (common in YAML configs)
+    let long_desc = make_no_escapes(500);
+    group.throughput(Throughput::Bytes(long_desc.len() as u64));
+    group.bench_function("long_desc", |b| {
+        b.iter(|| find_json_escape(black_box(&long_desc), 0))
+    });
+
+    // Frequent escapes (stress test)
+    let frequent = make_frequent_escapes(500);
+    group.throughput(Throughput::Bytes(frequent.len() as u64));
+    group.bench_function("frequent_escapes", |b| {
+        b.iter(|| find_json_escape(black_box(&frequent), 0))
+    });
+
+    group.finish();
+}
+
+/// Benchmark alignment edge cases
+fn bench_alignment(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_escape/alignment");
+
+    // Test various sizes around SIMD boundaries (16, 32 bytes)
+    for size in [15, 16, 17, 31, 32, 33, 63, 64, 65] {
+        let input = make_no_escapes(size);
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| find_json_escape(black_box(input), 0))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_simd_vs_scalar,
+    bench_escape_position,
+    bench_escape_types,
+    bench_realistic,
+    bench_alignment,
+);
+criterion_main!(benches);

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -54,7 +54,8 @@ mod index;
 mod light;
 mod locate;
 mod parser;
-mod simd;
+/// SIMD-accelerated string scanning for YAML parsing.
+pub mod simd;
 
 pub use error::YamlError;
 pub use index::YamlIndex;


### PR DESCRIPTION
## Description

This PR implements SIMD-accelerated JSON escape character scanning for the YAML streaming output path, addressing Issue #87. Profiling identified that `write_json_string` was consuming ~70% of streaming time due to byte-by-byte escape scanning. The new implementation uses AVX2/SSE2 intrinsics to scan 32/16 bytes per iteration, achieving 28-30x faster raw scanning throughput.

A key insight during development was that SIMD overhead can regress performance on short strings. The solution implements a threshold-based hybrid approach: strings with ≥32 bytes remaining use SIMD, while shorter spans use an inline scalar loop to avoid function call overhead.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement
- [ ] CI/CD changes

## Related Issue
Fixes #87

## Changes Made

**Core SIMD Implementation (`src/yaml/simd/x86.rs`):**
- Added `find_json_escape_avx2()` for 32-byte parallel scanning using `_mm256_cmpeq_epi8` and `_mm256_cmpgt_epi8`
- Added `find_json_escape_sse2()` for 16-byte scanning as fallback
- Added `find_json_escape_x86()` public dispatcher with runtime AVX2 detection
- Uses signed comparison trick for control char detection: `_mm256_cmpgt_epi8(0x20, chunk)` detects bytes < 0x20

**SIMD Module Updates (`src/yaml/simd/mod.rs`):**
- Added public `find_json_escape()` function with platform dispatch
- Includes scalar fallback for non-x86 platforms and `scalar-yaml` feature
- Made `simd` module public to expose `find_json_escape` API

**Streaming Path Optimization (`src/yaml/light.rs`):**
- Rewrote `write_json_string()` with threshold-based hybrid approach
- Added `SIMD_THRESHOLD = 32` constant to prevent regression on short strings
- Extracted `write_escape_char()` helper function with `#[inline(always)]`
- SIMD path handles ≥32 byte spans; scalar path handles remainder inline

**Benchmarks (`benches/json_escape_micro.rs`):**
- New comprehensive micro-benchmark suite for escape scanning
- Benchmarks: SIMD vs scalar comparison, escape position impact, escape types, realistic workloads, alignment edge cases
- Tests sizes from 16 to 4096 bytes with throughput reporting

**Documentation:**
- Added O3 optimization analysis to `docs/parsing/yaml.md` with problem, solution, results, and key learnings
- Updated `CLAUDE.md` with benchmark results summary and threshold tuning insight

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**New Test Coverage:**
- `test_find_json_escape_basic` - quote detection
- `test_find_json_escape_backslash` - backslash detection
- `test_find_json_escape_control` - newline/tab/null detection
- `test_find_json_escape_none` - no-escape case
- `test_find_json_escape_long` - >32 byte strings (AVX2 path)
- `test_find_json_escape_at_boundaries` - 16/32-byte boundary edge cases
- `test_find_json_escape_start_offset` - non-zero start positions
- `test_find_json_escape_simd_matches_scalar` - correctness verification
- `test_find_json_escape_all_control_chars` - all 0x00-0x1F characters

**Manual Testing:**
- [x] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check

# Run micro-benchmarks
cargo bench --bench json_escape_micro

# Run end-to-end transcode benchmarks
cargo bench --bench yaml_transcode_micro
```

## Performance Impact
- [ ] No performance impact
- [x] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

**Micro-benchmark Results (raw SIMD vs scalar):**

| Size | SIMD Throughput | Scalar Throughput | Speedup |
|------|-----------------|-------------------|---------|
| 1 KiB | 70 GiB/s (13.5ns) | 2.5 GiB/s (382ns) | **28x** |
| 4 KiB | 75 GiB/s (50ns) | 2.5 GiB/s (1.5µs) | **30x** |

**End-to-end JSON Transcode Improvements:**

| Benchmark | Improvement | Throughput |
|-----------|-------------|------------|
| unicode_8digit/100 | **-11%** | 432 MiB/s |
| large/500_items | **-5%** | 227 MiB/s |
| realistic/config | **-4%** | 234 MiB/s |
| escape_heavy | **-3%** | 233 MiB/s |

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Key Technical Decisions:**

1. **Threshold of 32 bytes**: Initial implementation without threshold showed 2-7% regression on escape-heavy workloads. The 32-byte threshold ensures SIMD overhead is amortized before dispatching.

2. **Control character detection**: Uses `_mm256_cmpgt_epi8(0x20, chunk)` which works correctly for ASCII bytes 0x00-0x7F. This is a signed comparison trick that detects bytes < 0x20.

3. **Inline scalar fallback**: The scalar path in `write_json_string` is kept inline rather than calling `find_json_escape_scalar` to avoid function call overhead on short spans.

4. **Platform support**: Currently optimized for x86_64 only. ARM/NEON support can be added later using the same pattern with `vceqq_u8` and similar intrinsics.

**Future Work:**
- Add NEON implementation for aarch64
- Consider wider AVX-512 implementation for very long strings
- Benchmark on different CPU generations (Zen 3/4, Ice Lake, etc.)