### PR TITLE
fix(jq): make keys function ordering compatible with yq mode

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1789,7 +1789,13 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("keys") {
             self.consume_keyword("keys");
-            return Ok(Some(Builtin::Keys));
+            // In Yq mode, `keys` returns document order (like yq) instead of sorted (like jq)
+            // Use `keys_unsorted` in jq mode to get document order
+            return Ok(Some(if self.mode == ParserMode::Yq {
+                Builtin::KeysUnsorted
+            } else {
+                Builtin::Keys
+            }));
         }
 
         // has(expr) - takes an argument


### PR DESCRIPTION
## Description

This PR fixes a compatibility issue where the `keys` function in Yq mode was returning sorted keys (like jq behavior) instead of document order (like yq behavior). The fix ensures that when parsing in Yq mode, the `keys` function returns keys in document order by internally using `KeysUnsorted`, while maintaining the standard sorted behavior in jq mode.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

## Related Issue
Addresses compatibility issue with yq's keys function behavior

## Changes Made
- Modified `keys` function handling in `src/jq/parser.rs` to check parser mode
- Added conditional logic to return `KeysUnsorted` builtin when in Yq mode
- Added inline documentation explaining the behavior difference between modes
- Maintained backward compatibility by keeping standard `Keys` behavior in jq mode

## Testing

**Automated Testing:**
- [ ] All existing tests pass
- [ ] New tests added for new functionality

**Manual Testing:**
- [ ] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

This change improves yq compatibility by ensuring the `keys` function behaves like native yq (document order) when in Yq mode, while preserving the traditional jq behavior (sorted order) when in jq mode. The implementation uses the existing `KeysUnsorted` builtin to achieve document order, making this a minimal and safe change.