### PR TITLE
chore(yaml): remove unused count_seq_items_before method

### DIFF
--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -452,34 +452,6 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             false
         }
     }
-
-    /// Count sequence items at BP positions 0..bp_pos.
-    ///
-    /// This is used to adjust TY index calculations since sequence items
-    /// have BP opens but no TY entries.
-    #[inline]
-    pub fn count_seq_items_before(&self, bp_pos: usize) -> usize {
-        let seq_item_words = self.seq_items.as_ref();
-        if seq_item_words.is_empty() {
-            return 0;
-        }
-
-        let word_idx = bp_pos / 64;
-        let bit_idx = bp_pos % 64;
-
-        let mut count = 0usize;
-        for word in seq_item_words.iter().take(word_idx) {
-            count += word.count_ones() as usize;
-        }
-
-        if word_idx < seq_item_words.len() && bit_idx > 0 {
-            let mask = (1u64 << bit_idx) - 1;
-            count += (seq_item_words[word_idx] & mask).count_ones() as usize;
-        }
-
-        count
-    }
-
     /// Debug helper to get open position for a given open index.
     #[cfg(test)]
     pub fn debug_open_position_at(&self, open_idx: usize) -> Option<u32> {


### PR DESCRIPTION
## Description

This PR removes the unused `count_seq_items_before` method from the `YamlIndex` implementation in `src/yaml/index.rs`. This method was used to count sequence items at BP positions but is no longer needed in the codebase, making this a code cleanup refactoring.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

## Related Issue
Part of unused code cleanup efforts

## Changes Made
- Removed `count_seq_items_before` method from `YamlIndex<W>` implementation
- Eliminated 28 lines of dead code including method documentation
- Method was used to adjust TY index calculations for sequence items with BP opens but no TY entries

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality

**Manual Testing:**
- [x] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

This change removes unused code without affecting any functionality, resulting in a slightly smaller binary size and improved code maintainability.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

The removed method included bit manipulation logic for counting sequence items in word-aligned data structures, but analysis of the codebase showed no callers for this functionality. This cleanup improves code maintainability by removing dead code that could confuse future developers.