### PR TITLE
chore(cargo): update succinctly dependency to version 0.6.0

### DIFF
--- a/bench-compare/Cargo.lock
+++ b/bench-compare/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "succinctly"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "indexmap",


### PR DESCRIPTION
## Description
This PR updates the `succinctly` dependency from version 0.5.1 to 0.6.0 in the benchmark comparison workspace. This maintenance update ensures the project uses the latest version of the succinctly library with any bug fixes, performance improvements, or new features available in the 0.6.0 release.

## Type of Change
- [x] CI/CD changes

## Related Issue
No specific issue - routine dependency maintenance

## Changes Made
**Dependency Updates:**
- Updated `succinctly` dependency version from 0.5.1 to 0.6.0 in `bench-compare/Cargo.lock`

## Testing
**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (N/A for dependency update)

**Manual Testing:**
- [x] Tested on x86_64
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A for dependency update)
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed (N/A for dependency update)
- [x] My changes generate no new warnings

## Additional Notes
This is a routine dependency update to keep the project current with the latest version of the succinctly library. The change only affects the benchmark comparison workspace and should not impact the core library functionality. The version bump from 0.5.1 to 0.6.0 indicates a minor version update which should maintain backward compatibility while potentially including new features or improvements.