### PR TITLE
feat(text): implement UTF-8 validation with scalar algorithm, CLI, and benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,10 @@ harness = false
 name = "json_validate_bench"
 harness = false
 
+[[bench]]
+name = "utf8_validate_bench"
+harness = false
+
 # =============================================================================
 # Lints
 #

--- a/benches/utf8_validate_bench.rs
+++ b/benches/utf8_validate_bench.rs
@@ -1,0 +1,336 @@
+//! Benchmarks for UTF-8 validation.
+//!
+//! These benchmarks measure the performance of UTF-8 validation across
+//! different content types and sizes.
+//!
+//! ## Content Types
+//!
+//! - **ASCII**: Pure 7-bit ASCII content (fastest to validate)
+//! - **Mixed UTF-8**: Realistic mix of ASCII and multi-byte characters
+//! - **Multi-byte Heavy**: Predominantly 2-4 byte UTF-8 sequences
+//! - **CJK Text**: Chinese/Japanese/Korean characters (3-byte sequences)
+//! - **Emoji Heavy**: Heavy use of 4-byte sequences (emojis)
+//!
+//! ## Sizes
+//!
+//! Benchmarks run at multiple sizes to show scaling characteristics:
+//! - 1KB, 10KB, 100KB, 1MB, 10MB
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use succinctly::text::utf8::validate_utf8;
+
+/// Generate pure ASCII content of the specified size.
+fn generate_ascii(size: usize) -> Vec<u8> {
+    let pattern =
+        b"The quick brown fox jumps over the lazy dog. 0123456789!@#$%^&*()_+-=[]{}|;':\",./<>?\n";
+    let mut result = Vec::with_capacity(size);
+    while result.len() < size {
+        let remaining = size - result.len();
+        let chunk = &pattern[..remaining.min(pattern.len())];
+        result.extend_from_slice(chunk);
+    }
+    result
+}
+
+/// Generate mixed UTF-8 content (ASCII with occasional multi-byte).
+/// Approximately 70% ASCII, 20% 2-byte, 8% 3-byte, 2% 4-byte.
+fn generate_mixed(size: usize) -> Vec<u8> {
+    let pattern = "Hello, world! Café résumé naïve über. 日本語 中文 한국어. Emoji: 🎉🚀💻. More ASCII text here.\n";
+    let pattern_bytes = pattern.as_bytes();
+    let mut result = Vec::with_capacity(size);
+    while result.len() < size {
+        let remaining = size - result.len();
+        if remaining >= pattern_bytes.len() {
+            result.extend_from_slice(pattern_bytes);
+        } else {
+            // Careful: don't split multi-byte sequences
+            // Just pad with ASCII to avoid partial sequences
+            result.extend(std::iter::repeat(b'A').take(remaining));
+        }
+    }
+    result.truncate(size);
+    result
+}
+
+/// Generate predominantly multi-byte content (CJK characters).
+fn generate_cjk(size: usize) -> Vec<u8> {
+    // Each CJK character is 3 bytes
+    let cjk_chars = "日本語中文韓國語漢字假名平仮名片仮名ひらがなカタカナ한글조선어";
+    let cjk_bytes = cjk_chars.as_bytes();
+    let mut result = Vec::with_capacity(size);
+    while result.len() < size {
+        let remaining = size - result.len();
+        if remaining >= cjk_bytes.len() {
+            result.extend_from_slice(cjk_bytes);
+        } else {
+            // Pad with ASCII to avoid partial sequences
+            result.extend(std::iter::repeat(b'X').take(remaining));
+        }
+    }
+    result.truncate(size);
+    result
+}
+
+/// Generate emoji-heavy content (4-byte sequences).
+fn generate_emoji(size: usize) -> Vec<u8> {
+    // Each emoji is 4 bytes
+    let emojis = "🎉🚀💻🔥🌍😀🎯💡🌟⭐🎨🎭🎪🎢🎡🎠🎰🎲🎳🎯🎱🎾🏀🏈⚽🏐🏉🎿⛷️🏂";
+    let emoji_bytes = emojis.as_bytes();
+    let mut result = Vec::with_capacity(size);
+    while result.len() < size {
+        let remaining = size - result.len();
+        if remaining >= emoji_bytes.len() {
+            result.extend_from_slice(emoji_bytes);
+        } else {
+            // Pad with ASCII to avoid partial sequences
+            result.extend(std::iter::repeat(b'E').take(remaining));
+        }
+    }
+    result.truncate(size);
+    result
+}
+
+/// Generate 2-byte character content (Latin Extended, Greek, Cyrillic).
+fn generate_2byte(size: usize) -> Vec<u8> {
+    // 2-byte characters: Latin Extended, Greek, Cyrillic
+    let chars =
+        "éèêëàâäùûüôöîïçñÉÈÊËÀÂÄÙÛÜÔÖÎÏÇÑαβγδεζηθικλμνξοπρστυφχψωАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ";
+    let char_bytes = chars.as_bytes();
+    let mut result = Vec::with_capacity(size);
+    while result.len() < size {
+        let remaining = size - result.len();
+        if remaining >= char_bytes.len() {
+            result.extend_from_slice(char_bytes);
+        } else {
+            result.extend(std::iter::repeat(b'L').take(remaining));
+        }
+    }
+    result.truncate(size);
+    result
+}
+
+/// Generate worst-case content: invalid byte at various positions.
+/// This tests early-exit behavior.
+fn generate_with_error_at_end(size: usize) -> Vec<u8> {
+    let mut data = generate_ascii(size);
+    if !data.is_empty() {
+        // Put invalid byte near the end
+        let pos = data.len().saturating_sub(1);
+        data[pos] = 0x80; // Invalid lead byte
+    }
+    data
+}
+
+fn bench_ascii(c: &mut Criterion) {
+    let mut group = c.benchmark_group("utf8_ascii");
+
+    for size in [1024, 10 * 1024, 100 * 1024, 1024 * 1024, 10 * 1024 * 1024] {
+        let data = generate_ascii(size);
+        let size_name = format_size(size);
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(&size_name), &data, |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_mixed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("utf8_mixed");
+
+    for size in [1024, 10 * 1024, 100 * 1024, 1024 * 1024, 10 * 1024 * 1024] {
+        let data = generate_mixed(size);
+        let size_name = format_size(size);
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(&size_name), &data, |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_cjk(c: &mut Criterion) {
+    let mut group = c.benchmark_group("utf8_cjk");
+
+    for size in [1024, 10 * 1024, 100 * 1024, 1024 * 1024, 10 * 1024 * 1024] {
+        let data = generate_cjk(size);
+        let size_name = format_size(size);
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(&size_name), &data, |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_emoji(c: &mut Criterion) {
+    let mut group = c.benchmark_group("utf8_emoji");
+
+    for size in [1024, 10 * 1024, 100 * 1024, 1024 * 1024, 10 * 1024 * 1024] {
+        let data = generate_emoji(size);
+        let size_name = format_size(size);
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(&size_name), &data, |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_2byte(c: &mut Criterion) {
+    let mut group = c.benchmark_group("utf8_2byte");
+
+    for size in [1024, 10 * 1024, 100 * 1024, 1024 * 1024, 10 * 1024 * 1024] {
+        let data = generate_2byte(size);
+        let size_name = format_size(size);
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(&size_name), &data, |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_error_at_end(c: &mut Criterion) {
+    let mut group = c.benchmark_group("utf8_error_at_end");
+
+    for size in [1024, 10 * 1024, 100 * 1024, 1024 * 1024] {
+        let data = generate_with_error_at_end(size);
+        let size_name = format_size(size);
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(&size_name), &data, |b, data| {
+            b.iter(|| {
+                let result = validate_utf8(black_box(data));
+                black_box(result)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark comparing different byte sequence lengths at same total size.
+fn bench_sequence_types(c: &mut Criterion) {
+    let mut group = c.benchmark_group("utf8_sequence_types_1mb");
+    let size = 1024 * 1024; // 1MB
+
+    // ASCII (1-byte)
+    let ascii = generate_ascii(size);
+    group.throughput(Throughput::Bytes(size as u64));
+    group.bench_with_input(BenchmarkId::new("ascii_1byte", "1mb"), &ascii, |b, data| {
+        b.iter(|| validate_utf8(black_box(data)));
+    });
+
+    // 2-byte sequences
+    let twobyte = generate_2byte(size);
+    group.bench_with_input(
+        BenchmarkId::new("extended_2byte", "1mb"),
+        &twobyte,
+        |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        },
+    );
+
+    // 3-byte sequences (CJK)
+    let cjk = generate_cjk(size);
+    group.bench_with_input(BenchmarkId::new("cjk_3byte", "1mb"), &cjk, |b, data| {
+        b.iter(|| validate_utf8(black_box(data)));
+    });
+
+    // 4-byte sequences (emoji)
+    let emoji = generate_emoji(size);
+    group.bench_with_input(BenchmarkId::new("emoji_4byte", "1mb"), &emoji, |b, data| {
+        b.iter(|| validate_utf8(black_box(data)));
+    });
+
+    // Mixed
+    let mixed = generate_mixed(size);
+    group.bench_with_input(BenchmarkId::new("mixed", "1mb"), &mixed, |b, data| {
+        b.iter(|| validate_utf8(black_box(data)));
+    });
+
+    group.finish();
+}
+
+/// Compare with std::str::from_utf8
+fn bench_vs_std(c: &mut Criterion) {
+    let mut group = c.benchmark_group("utf8_vs_std");
+    let size = 1024 * 1024; // 1MB
+
+    // ASCII comparison
+    let ascii = generate_ascii(size);
+    group.throughput(Throughput::Bytes(size as u64));
+    group.bench_with_input(
+        BenchmarkId::new("succinctly_ascii", "1mb"),
+        &ascii,
+        |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        },
+    );
+    group.bench_with_input(BenchmarkId::new("std_ascii", "1mb"), &ascii, |b, data| {
+        b.iter(|| std::str::from_utf8(black_box(data)));
+    });
+
+    // Mixed comparison
+    let mixed = generate_mixed(size);
+    group.bench_with_input(
+        BenchmarkId::new("succinctly_mixed", "1mb"),
+        &mixed,
+        |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        },
+    );
+    group.bench_with_input(BenchmarkId::new("std_mixed", "1mb"), &mixed, |b, data| {
+        b.iter(|| std::str::from_utf8(black_box(data)));
+    });
+
+    // CJK comparison
+    let cjk = generate_cjk(size);
+    group.bench_with_input(
+        BenchmarkId::new("succinctly_cjk", "1mb"),
+        &cjk,
+        |b, data| {
+            b.iter(|| validate_utf8(black_box(data)));
+        },
+    );
+    group.bench_with_input(BenchmarkId::new("std_cjk", "1mb"), &cjk, |b, data| {
+        b.iter(|| std::str::from_utf8(black_box(data)));
+    });
+
+    group.finish();
+}
+
+fn format_size(bytes: usize) -> String {
+    if bytes >= 1024 * 1024 {
+        format!("{}mb", bytes / (1024 * 1024))
+    } else if bytes >= 1024 {
+        format!("{}kb", bytes / 1024)
+    } else {
+        format!("{}b", bytes)
+    }
+}
+
+criterion_group!(
+    benches,
+    bench_ascii,
+    bench_mixed,
+    bench_cjk,
+    bench_emoji,
+    bench_2byte,
+    bench_error_at_end,
+    bench_sequence_types,
+    bench_vs_std,
+);
+
+criterion_main!(benches);

--- a/benches/utf8_validate_bench.rs
+++ b/benches/utf8_validate_bench.rs
@@ -263,61 +263,13 @@ fn bench_sequence_types(c: &mut Criterion) {
     group.finish();
 }
 
-/// Compare with std::str::from_utf8
-fn bench_vs_std(c: &mut Criterion) {
-    let mut group = c.benchmark_group("utf8_vs_std");
-    let size = 1024 * 1024; // 1MB
-
-    // ASCII comparison
-    let ascii = generate_ascii(size);
-    group.throughput(Throughput::Bytes(size as u64));
-    group.bench_with_input(
-        BenchmarkId::new("succinctly_ascii", "1mb"),
-        &ascii,
-        |b, data| {
-            b.iter(|| validate_utf8(black_box(data)));
-        },
-    );
-    group.bench_with_input(BenchmarkId::new("std_ascii", "1mb"), &ascii, |b, data| {
-        b.iter(|| std::str::from_utf8(black_box(data)));
-    });
-
-    // Mixed comparison
-    let mixed = generate_mixed(size);
-    group.bench_with_input(
-        BenchmarkId::new("succinctly_mixed", "1mb"),
-        &mixed,
-        |b, data| {
-            b.iter(|| validate_utf8(black_box(data)));
-        },
-    );
-    group.bench_with_input(BenchmarkId::new("std_mixed", "1mb"), &mixed, |b, data| {
-        b.iter(|| std::str::from_utf8(black_box(data)));
-    });
-
-    // CJK comparison
-    let cjk = generate_cjk(size);
-    group.bench_with_input(
-        BenchmarkId::new("succinctly_cjk", "1mb"),
-        &cjk,
-        |b, data| {
-            b.iter(|| validate_utf8(black_box(data)));
-        },
-    );
-    group.bench_with_input(BenchmarkId::new("std_cjk", "1mb"), &cjk, |b, data| {
-        b.iter(|| std::str::from_utf8(black_box(data)));
-    });
-
-    group.finish();
-}
-
 fn format_size(bytes: usize) -> String {
     if bytes >= 1024 * 1024 {
         format!("{}mb", bytes / (1024 * 1024))
     } else if bytes >= 1024 {
         format!("{}kb", bytes / 1024)
     } else {
-        format!("{}b", bytes)
+        format!("{bytes}b")
     }
 }
 
@@ -330,7 +282,6 @@ criterion_group!(
     bench_2byte,
     bench_error_at_end,
     bench_sequence_types,
-    bench_vs_std,
 );
 
 criterion_main!(benches);

--- a/docs/benchmarks/inventory.md
+++ b/docs/benchmarks/inventory.md
@@ -133,9 +133,20 @@ Benchmarks for `succinctly json validate` - strict RFC 8259 JSON validation thro
 Benchmarks for `succinctly text validate utf8` - scalar UTF-8 validation throughput. Serves as baseline for future SIMD implementations.
 
 ### Platforms Covered
+- Apple M4 Pro (ARM)
 - AMD Ryzen 9 7950X (x86_64)
 
 ### Benchmark Sections
+
+#### Apple M4 Pro (ARM)
+- Performance by Pattern Type (5 patterns at 1MB)
+- Detailed Results (5 sizes: 1KB-10MB):
+  - ASCII (Pure 7-bit)
+  - Mixed (Realistic content)
+  - CJK (3-byte sequences)
+  - Emoji (4-byte sequences)
+  - Latin Extended (2-byte sequences)
+- Sequence Type Comparison (1MB)
 
 #### AMD Ryzen 9 7950X (x86_64)
 - Summary Table (all patterns at 100MB)
@@ -147,7 +158,7 @@ Benchmarks for `succinctly text validate utf8` - scalar UTF-8 validation through
   - Mixed (Realistic content)
   - Latin Extended (2-byte sequences)
   - All Lengths (Uniform 1-4 byte mix)
-- Key Findings (throughput by character type, scaling)
+- Key Findings (throughput by character type, scaling, cross-platform comparison)
 
 ---
 
@@ -634,7 +645,7 @@ cargo bench --bench neon_movemask
 - **ARM Neoverse-V2 (Graviton 4)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [rust-parsers.md](rust-parsers.md), [rust-yaml-parsers.md](rust-yaml-parsers.md)
 - **ARM Neoverse-V1 (Graviton 3)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md)
 - **Apple M1 Max**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [cross-language.md](cross-language.md), [yaml.md](../parsing/yaml.md)
-- **Apple M4 Pro**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [json-validate.md](json-validate.md)
+- **Apple M4 Pro**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [json-validate.md](json-validate.md), [utf8-validate.md](utf8-validate.md)
 
 ### By Format
 - **JSON**: [jq.md](jq.md), [json-validate.md](json-validate.md), [cross-language.md](cross-language.md), [rust-parsers.md](rust-parsers.md)

--- a/docs/benchmarks/inventory.md
+++ b/docs/benchmarks/inventory.md
@@ -135,6 +135,7 @@ Benchmarks for `succinctly text validate utf8` - scalar UTF-8 validation through
 ### Platforms Covered
 - Apple M4 Pro (ARM)
 - AMD Ryzen 9 7950X (x86_64)
+- Apple M1 Max (ARM)
 
 ### Benchmark Sections
 
@@ -159,6 +160,17 @@ Benchmarks for `succinctly text validate utf8` - scalar UTF-8 validation through
   - Latin Extended (2-byte sequences)
   - All Lengths (Uniform 1-4 byte mix)
 - Key Findings (throughput by character type, scaling, cross-platform comparison)
+
+#### Apple M1 Max (ARM)
+- Performance by Pattern Type (5 patterns x 5 sizes)
+- Detailed Results:
+  - ASCII (Pure 7-bit)
+  - Mixed (Realistic content)
+  - CJK (3-byte sequences)
+  - Emoji (4-byte sequences)
+  - 2-byte (Latin Extended)
+- Sequence Types Comparison (1MB)
+- Key Observations
 
 ---
 
@@ -644,7 +656,7 @@ cargo bench --bench neon_movemask
 - **AMD Ryzen 9 7950X (x86_64)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [json-validate.md](json-validate.md), [utf8-validate.md](utf8-validate.md), [cross-language.md](cross-language.md), [rust-parsers.md](rust-parsers.md), [rust-yaml-parsers.md](rust-yaml-parsers.md), [yaml.md](../parsing/yaml.md)
 - **ARM Neoverse-V2 (Graviton 4)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [rust-parsers.md](rust-parsers.md), [rust-yaml-parsers.md](rust-yaml-parsers.md)
 - **ARM Neoverse-V1 (Graviton 3)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md)
-- **Apple M1 Max**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [cross-language.md](cross-language.md), [yaml.md](../parsing/yaml.md)
+- **Apple M1 Max**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [cross-language.md](cross-language.md), [yaml.md](../parsing/yaml.md), [utf8-validate.md](utf8-validate.md)
 - **Apple M4 Pro**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [json-validate.md](json-validate.md), [utf8-validate.md](utf8-validate.md)
 
 ### By Format

--- a/docs/benchmarks/inventory.md
+++ b/docs/benchmarks/inventory.md
@@ -6,13 +6,14 @@ This document provides a comprehensive index of all benchmark reports in the pro
 
 ## Overview
 
-The project contains **9 main benchmark documentation files** with approximately **160+ distinct benchmark report sections**, plus **6 core/internal benchmark suites**.
+The project contains **10 main benchmark documentation files** with approximately **175+ distinct benchmark report sections**, plus **6 core/internal benchmark suites**.
 
 | File                                           | Description                                 | Sections |
 |------------------------------------------------|---------------------------------------------|----------|
 | [jq.md](jq.md)                                 | JSON query performance vs system jq         | ~40      |
 | [yq.md](yq.md)                                 | YAML query performance vs system yq         | ~35      |
 | [json-validate.md](json-validate.md)           | JSON validation (RFC 8259) throughput       | ~12      |
+| [utf8-validate.md](utf8-validate.md)           | UTF-8 validation throughput (scalar)        | ~15      |
 | [dsv.md](dsv.md)                               | CSV/TSV parsing performance                 | ~8       |
 | [cross-language.md](cross-language.md)         | Multi-parser JSON comparison                | ~15      |
 | [rust-parsers.md](rust-parsers.md)             | Rust JSON parser comparison (x86_64 + ARM)  | ~20      |
@@ -124,6 +125,29 @@ Benchmarks for `succinctly json validate` - strict RFC 8259 JSON validation thro
 
 #### Analysis
 - Key Findings (cross-platform comparison)
+
+---
+
+## [utf8-validate.md](utf8-validate.md) - UTF-8 Validation Benchmarks
+
+Benchmarks for `succinctly text validate utf8` - scalar UTF-8 validation throughput. Serves as baseline for future SIMD implementations.
+
+### Platforms Covered
+- AMD Ryzen 9 7950X (x86_64)
+
+### Benchmark Sections
+
+#### AMD Ryzen 9 7950X (x86_64)
+- Summary Table (all patterns at 100MB)
+- Performance by Pattern Type (11 patterns x 6 sizes)
+- Detailed Results:
+  - ASCII (Pure 7-bit)
+  - CJK (3-byte sequences)
+  - Emoji (4-byte sequences)
+  - Mixed (Realistic content)
+  - Latin Extended (2-byte sequences)
+  - All Lengths (Uniform 1-4 byte mix)
+- Key Findings (throughput by character type, scaling)
 
 ---
 
@@ -606,7 +630,7 @@ cargo bench --bench neon_movemask
 ## Finding Specific Benchmarks
 
 ### By Platform
-- **AMD Ryzen 9 7950X (x86_64)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [json-validate.md](json-validate.md), [cross-language.md](cross-language.md), [rust-parsers.md](rust-parsers.md), [rust-yaml-parsers.md](rust-yaml-parsers.md), [yaml.md](../parsing/yaml.md)
+- **AMD Ryzen 9 7950X (x86_64)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [json-validate.md](json-validate.md), [utf8-validate.md](utf8-validate.md), [cross-language.md](cross-language.md), [rust-parsers.md](rust-parsers.md), [rust-yaml-parsers.md](rust-yaml-parsers.md), [yaml.md](../parsing/yaml.md)
 - **ARM Neoverse-V2 (Graviton 4)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [rust-parsers.md](rust-parsers.md), [rust-yaml-parsers.md](rust-yaml-parsers.md)
 - **ARM Neoverse-V1 (Graviton 3)**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md)
 - **Apple M1 Max**: [jq.md](jq.md), [yq.md](yq.md), [dsv.md](dsv.md), [cross-language.md](cross-language.md), [yaml.md](../parsing/yaml.md)
@@ -616,6 +640,7 @@ cargo bench --bench neon_movemask
 - **JSON**: [jq.md](jq.md), [json-validate.md](json-validate.md), [cross-language.md](cross-language.md), [rust-parsers.md](rust-parsers.md)
 - **YAML**: [yq.md](yq.md), [rust-yaml-parsers.md](rust-yaml-parsers.md), [yaml.md](../parsing/yaml.md)
 - **DSV/CSV/TSV**: [dsv.md](dsv.md)
+- **UTF-8 Text**: [utf8-validate.md](utf8-validate.md)
 
 ### By Comparison Type
 - **vs External Tools**: [jq.md](jq.md) (vs jq), [yq.md](yq.md) (vs yq)
@@ -669,6 +694,9 @@ cargo run --release --features cli -- yaml generate-suite
 
 # DSV
 cargo run --release --features cli -- dsv generate-suite
+
+# UTF-8
+cargo run --release --features cli -- text generate-suite
 ```
 
 ### Run Benchmarks
@@ -680,6 +708,7 @@ cargo build --release --features bench-runner
 ./target/release/succinctly bench run jq_bench
 ./target/release/succinctly bench run yq_bench
 ./target/release/succinctly bench run dsv_bench
+./target/release/succinctly bench run utf8_bench
 
 # Criterion benchmarks
 cargo bench --bench jq_comparison
@@ -687,6 +716,7 @@ cargo bench --bench yq_comparison
 cargo bench --bench yq_select
 cargo bench --bench yaml_bench
 cargo bench --bench json_parsers
+cargo bench --bench utf8_validate_bench
 
 # Cross-parser comparison
 cd bench-compare

--- a/docs/benchmarks/utf8-validate.md
+++ b/docs/benchmarks/utf8-validate.md
@@ -10,6 +10,7 @@ This serves as the baseline for future SIMD implementations.
 |-------------------------------|---------------|-------------|---------------|---------------|
 | Apple M4 Pro (ARM)            | 2.0           | 2.5         | 2.9           | 2.1           |
 | AMD Ryzen 9 7950X (x86_64)    | 2.2           | 1.3         | 1.0           | 1.8           |
+| Apple M1 Max (ARM)            | 1.3           | 1.1         | 1.2           | 1.2           |
 
 **Key Finding**: Apple M4 Pro is **2-3x faster** than AMD Ryzen 9 7950X on multi-byte sequences (CJK, emoji) while maintaining comparable ASCII throughput.
 
@@ -56,46 +57,48 @@ This serves as the baseline for future SIMD implementations.
 #### CJK (3-byte sequences)
 
 | Size  | Time       | Throughput (GiB/s) |
-|-------|------------|-------------------|
-| 1KB   | 382.1 ns   | 2.50              |
-| 10KB  | 3.82 µs    | 2.49              |
-| 100KB | 38.7 µs    | 2.46              |
-| 1MB   | 396.5 µs   | 2.46              |
-| 10MB  | 3.94 ms    | 2.48              |
+|-------|------------|--------------------|
+| 1KB   | 382.1 ns   | 2.50               |
+| 10KB  | 3.82 µs    | 2.49               |
+| 100KB | 38.7 µs    | 2.46               |
+| 1MB   | 396.5 µs   | 2.46               |
+| 10MB  | 3.94 ms    | 2.48               |
 
 #### Emoji (4-byte sequences)
 
 | Size  | Time       | Throughput (GiB/s) |
-|-------|------------|-------------------|
-| 1KB   | 355.3 ns   | 2.68              |
-| 10KB  | 3.31 µs    | 2.88              |
-| 100KB | 33.4 µs    | 2.85              |
-| 1MB   | 340.6 µs   | 2.87              |
-| 10MB  | 3.44 ms    | 2.84              |
+|-------|------------|--------------------|
+| 1KB   | 355.3 ns   | 2.68               |
+| 10KB  | 3.31 µs    | 2.88               |
+| 100KB | 33.4 µs    | 2.85               |
+| 1MB   | 340.6 µs   | 2.87               |
+| 10MB  | 3.44 ms    | 2.84               |
 
 #### Latin Extended (2-byte sequences)
 
 | Size  | Time       | Throughput (GiB/s) |
-|-------|------------|-------------------|
-| 1KB   | 458.0 ns   | 2.08              |
-| 10KB  | 3.99 µs    | 2.39              |
-| 100KB | 40.6 µs    | 2.35              |
-| 1MB   | 431.4 µs   | 2.26              |
-| 10MB  | 4.31 ms    | 2.27              |
+|-------|------------|--------------------|
+| 1KB   | 458.0 ns   | 2.08               |
+| 10KB  | 3.99 µs    | 2.39               |
+| 100KB | 40.6 µs    | 2.35               |
+| 1MB   | 431.4 µs   | 2.26               |
+| 10MB  | 4.31 ms    | 2.27               |
 
 ### Sequence Type Comparison (1MB)
 
 Direct comparison of byte sequence lengths at 1MB:
 
 | Sequence Type      | Time (µs) | Throughput (GiB/s) |
-|--------------------|-----------|-------------------|
-| ASCII (1-byte)     | 505.0     | 1.93              |
-| Extended (2-byte)  | 403.9     | 2.42              |
-| CJK (3-byte)       | 394.4     | 2.48              |
-| Emoji (4-byte)     | 350.7     | 2.79              |
-| Mixed              | 469.8     | 2.08              |
+|--------------------|-----------|--------------------|
+| ASCII (1-byte)     | 505.0     | 1.93               |
+| Extended (2-byte)  | 403.9     | 2.42               |
+| CJK (3-byte)       | 394.4     | 2.48               |
+| Emoji (4-byte)     | 350.7     | 2.79               |
+| Mixed              | 469.8     | 2.08               |
 
 **Observation**: Longer UTF-8 sequences validate *faster* on M4 Pro due to fewer continuation byte validations per MB of data.
+
+---
 
 ## AMD Ryzen 9 7950X (x86_64)
 
@@ -126,68 +129,159 @@ Direct comparison of byte sequence lengths at 1MB:
 #### ASCII (Pure 7-bit)
 
 | Size  | Time (ms) | Throughput (MiB/s) |
-|-------|-----------|-------------------|
-| 1KB   | 0.00      | 2,271             |
-| 10KB  | 0.00      | 2,299             |
-| 100KB | 0.04      | 2,308             |
-| 1MB   | 0.43      | 2,308             |
-| 10MB  | 4.45      | 2,245             |
-| 100MB | 44.22     | 2,262             |
+|-------|-----------|--------------------|
+| 1KB   | 0.00      | 2,271              |
+| 10KB  | 0.00      | 2,299              |
+| 100KB | 0.04      | 2,308              |
+| 1MB   | 0.43      | 2,308              |
+| 10MB  | 4.45      | 2,245              |
+| 100MB | 44.22     | 2,262              |
 
 #### CJK (3-byte sequences)
 
 | Size  | Time (ms) | Throughput (MiB/s) |
-|-------|-----------|-------------------|
-| 1KB   | 0.00      | 1,684             |
-| 10KB  | 0.01      | 1,852             |
-| 100KB | 0.07      | 1,386             |
-| 1MB   | 0.74      | 1,358             |
-| 10MB  | 7.31      | 1,368             |
-| 100MB | 73.58     | 1,359             |
+|-------|-----------|--------------------|
+| 1KB   | 0.00      | 1,684              |
+| 10KB  | 0.01      | 1,852              |
+| 100KB | 0.07      | 1,386              |
+| 1MB   | 0.74      | 1,358              |
+| 10MB  | 7.31      | 1,368              |
+| 100MB | 73.58     | 1,359              |
 
 #### Emoji (4-byte sequences)
 
 | Size  | Time (ms) | Throughput (MiB/s) |
-|-------|-----------|-------------------|
-| 1KB   | 0.00      | 651               |
-| 10KB  | 0.01      | 1,225             |
-| 100KB | 0.05      | 1,946             |
-| 1MB   | 0.96      | 1,040             |
-| 10MB  | 9.43      | 1,061             |
-| 100MB | 96.56     | 1,036             |
+|-------|-----------|--------------------|
+| 1KB   | 0.00      | 651                |
+| 10KB  | 0.01      | 1,225              |
+| 100KB | 0.05      | 1,946              |
+| 1MB   | 0.96      | 1,040              |
+| 10MB  | 9.43      | 1,061              |
+| 100MB | 96.56     | 1,036              |
 
 #### Mixed (Realistic content)
 
 | Size  | Time (ms) | Throughput (MiB/s) |
-|-------|-----------|-------------------|
-| 1KB   | 0.00      | 967               |
-| 10KB  | 0.01      | 1,278             |
-| 100KB | 0.05      | 1,936             |
-| 1MB   | 0.54      | 1,856             |
-| 10MB  | 5.49      | 1,823             |
-| 100MB | 54.98     | 1,819             |
+|-------|-----------|--------------------|
+| 1KB   | 0.00      | 967                |
+| 10KB  | 0.01      | 1,278              |
+| 100KB | 0.05      | 1,936              |
+| 1MB   | 0.54      | 1,856              |
+| 10MB  | 5.49      | 1,823              |
+| 100MB | 54.98     | 1,819              |
 
 #### Latin Extended (2-byte sequences)
 
 | Size  | Time (ms) | Throughput (MiB/s) |
-|-------|-----------|-------------------|
-| 1KB   | 0.00      | 1,528             |
-| 10KB  | 0.01      | 1,531             |
-| 100KB | 0.11      | 894               |
-| 1MB   | 1.18      | 848               |
-| 10MB  | 11.45     | 874               |
-| 100MB | 116.34    | 860               |
+|-------|-----------|--------------------|
+| 1KB   | 0.00      | 1,528              |
+| 10KB  | 0.01      | 1,531              |
+| 100KB | 0.11      | 894                |
+| 1MB   | 1.18      | 848                |
+| 10MB  | 11.45     | 874                |
+| 100MB | 116.34    | 860                |
 
 #### All Lengths (Uniform 1-4 byte mix)
 
 | Size  | Time (ms) | Throughput (MiB/s) |
-|-------|-----------|-------------------|
-| 1KB   | 0.00      | 1,221             |
-| 10KB  | 0.01      | 1,094             |
-| 100KB | 0.18      | 536               |
-| 1MB   | 2.00      | 500               |
-| 10MB  | 19.94     | 502               |
-| 100MB | 203.44    | 492               |
+|-------|-----------|--------------------|
+| 1KB   | 0.00      | 1,221              |
+| 10KB  | 0.01      | 1,094              |
+| 100KB | 0.18      | 536                |
+| 1MB   | 2.00      | 500                |
+| 10MB  | 19.94     | 502                |
+| 100MB | 203.44    | 492                |
+
+---
+
+## Apple M1 Max (ARM)
+
+**Date**: 2026-02-06
+**Commit**: b58037fd (utf8-validation-scalar branch)
+**CPU**: Apple M1 Max
+**OS**: macOS 26.1
+**Rust**: 1.89.0
+**Benchmark**: Criterion (micro-benchmark)
+
+### Performance by Pattern Type
+
+| Pattern    | 1KB (GiB/s) | 10KB (GiB/s) | 100KB (GiB/s) | 1MB (GiB/s) | 10MB (GiB/s) |
+|------------|-------------|--------------|---------------|-------------|--------------|
+| ascii      | 1.34        | 1.35         | 1.34          | 1.35        | 1.36         |
+| mixed      | 1.19        | 1.21         | 1.23          | 1.22        | 1.20         |
+| cjk        | 1.05        | 1.06         | 1.07          | 1.07        | 1.03         |
+| emoji      | 1.17        | 1.17         | 1.17          | 1.18        | 1.15         |
+| 2-byte     | 1.02        | 1.00         | 1.01          | 1.00        | 1.00         |
+| error_end  | 1.25        | 1.25         | 1.28          | 1.32        | -            |
+
+### Detailed Results
+
+#### ASCII (Pure 7-bit)
+
+| Size  | Time (µs) | Throughput (GiB/s) |
+|-------|-----------|--------------------|
+| 1KB   | 0.71      | 1.34               |
+| 10KB  | 7.06      | 1.35               |
+| 100KB | 71.4      | 1.34               |
+| 1MB   | 722       | 1.35               |
+| 10MB  | 7,195     | 1.36               |
+
+#### Mixed (Realistic content)
+
+| Size  | Time (µs) | Throughput (GiB/s) |
+|-------|-----------|--------------------|
+| 1KB   | 0.80      | 1.19               |
+| 10KB  | 7.87      | 1.21               |
+| 100KB | 77.8      | 1.23               |
+| 1MB   | 798       | 1.22               |
+| 10MB  | 8,109     | 1.20               |
+
+#### CJK (3-byte sequences)
+
+| Size  | Time (µs) | Throughput (GiB/s) |
+|-------|-----------|--------------------|
+| 1KB   | 0.91      | 1.05               |
+| 10KB  | 8.97      | 1.06               |
+| 100KB | 89.0      | 1.07               |
+| 1MB   | 912       | 1.07               |
+| 10MB  | 9,463     | 1.03               |
+
+#### Emoji (4-byte sequences)
+
+| Size  | Time (µs) | Throughput (GiB/s) |
+|-------|-----------|--------------------|
+| 1KB   | 0.82      | 1.17               |
+| 10KB  | 8.13      | 1.17               |
+| 100KB | 81.5      | 1.17               |
+| 1MB   | 830       | 1.18               |
+| 10MB  | 8,501     | 1.15               |
+
+#### 2-byte (Latin Extended)
+
+| Size  | Time (µs) | Throughput (GiB/s) |
+|-------|-----------|--------------------|
+| 1KB   | 0.94      | 1.02               |
+| 10KB  | 9.49      | 1.00               |
+| 100KB | 94.8      | 1.01               |
+| 1MB   | 972       | 1.00               |
+| 10MB  | 9,724     | 1.00               |
+
+#### Sequence Types Comparison (1MB)
+
+| Sequence Type     | Time (µs) | Throughput (GiB/s) |
+|-------------------|-----------|--------------------|
+| ascii (1-byte)    | 740       | 1.32               |
+| extended (2-byte) | 979       | 1.00               |
+| cjk (3-byte)      | 937       | 1.04               |
+| emoji (4-byte)    | 871       | 1.12               |
+| mixed             | 820       | 1.19               |
+
+### Key Observations
+
+- **Consistent throughput**: All patterns show stable throughput from 1KB to 10MB
+- **ASCII is fastest**: ~1.35 GiB/s, single-byte validation is simplest
+- **Emoji faster than CJK**: 1.17 vs 1.05 GiB/s - fewer characters per MB means fewer state transitions
+- **2-byte is slowest multi-byte**: 1.00 GiB/s - highest character density for multi-byte sequences
 
 ## Key Findings
 

--- a/docs/benchmarks/utf8-validate.md
+++ b/docs/benchmarks/utf8-validate.md
@@ -1,0 +1,157 @@
+# UTF-8 Validation Benchmarks
+
+Benchmarks for `succinctly text validate utf8` - scalar UTF-8 validation throughput.
+
+This serves as the baseline for future SIMD implementations.
+
+## Summary
+
+| Platform                      | ASCII (MiB/s) | CJK (MiB/s) | Emoji (MiB/s) | Mixed (MiB/s) |
+|-------------------------------|---------------|-------------|---------------|---------------|
+| AMD Ryzen 9 7950X (x86_64)    | 2,261         | 1,359       | 1,036         | 1,819         |
+
+## AMD Ryzen 9 7950X (x86_64)
+
+**Date**: 2026-02-06
+**Commit**: 71ce3fa (utf8-validation-scalar branch)
+**CPU**: AMD Ryzen 9 7950X 16-Core Processor
+**OS**: Ubuntu 22.04.5 LTS
+**Rust**: 1.92.0
+
+### Performance by Pattern Type
+
+| Pattern         | 1KB (MiB/s) | 10KB (MiB/s) | 100KB (MiB/s) | 1MB (MiB/s) | 10MB (MiB/s) | 100MB (MiB/s) |
+|-----------------|-------------|--------------|---------------|-------------|--------------|---------------|
+| ascii           | 2,271       | 2,299        | 2,308         | 2,308       | 2,245        | 2,262         |
+| log_file        | 1,434       | 1,461        | 2,226         | 2,176       | 2,147        | 2,137         |
+| pathological    | 1,358       | 1,416        | 2,165         | 2,149       | 2,147        | 2,153         |
+| source_code     | 1,953       | 2,095        | 2,055         | 1,987       | 1,984        | 1,979         |
+| json_like       | 1,915       | 1,307        | 1,278         | 1,911       | 1,873        | 1,879         |
+| mixed           | 967         | 1,278        | 1,936         | 1,856       | 1,823        | 1,819         |
+| cjk             | 1,684       | 1,852        | 1,386         | 1,358       | 1,368        | 1,359         |
+| greek_cyrillic  | 904         | 1,680        | 1,192         | 1,147       | 1,134        | 1,119         |
+| emoji           | 651         | 1,225        | 1,946         | 1,040       | 1,061        | 1,036         |
+| latin           | 1,528       | 1,531        | 894           | 848         | 874          | 860           |
+| all_lengths     | 1,221       | 1,094        | 536           | 500         | 502          | 492           |
+
+### Detailed Results by Pattern
+
+#### ASCII (Pure 7-bit)
+
+| Size  | Time (ms) | Throughput (MiB/s) |
+|-------|-----------|-------------------|
+| 1KB   | 0.00      | 2,271             |
+| 10KB  | 0.00      | 2,299             |
+| 100KB | 0.04      | 2,308             |
+| 1MB   | 0.43      | 2,308             |
+| 10MB  | 4.45      | 2,245             |
+| 100MB | 44.22     | 2,262             |
+
+#### CJK (3-byte sequences)
+
+| Size  | Time (ms) | Throughput (MiB/s) |
+|-------|-----------|-------------------|
+| 1KB   | 0.00      | 1,684             |
+| 10KB  | 0.01      | 1,852             |
+| 100KB | 0.07      | 1,386             |
+| 1MB   | 0.74      | 1,358             |
+| 10MB  | 7.31      | 1,368             |
+| 100MB | 73.58     | 1,359             |
+
+#### Emoji (4-byte sequences)
+
+| Size  | Time (ms) | Throughput (MiB/s) |
+|-------|-----------|-------------------|
+| 1KB   | 0.00      | 651               |
+| 10KB  | 0.01      | 1,225             |
+| 100KB | 0.05      | 1,946             |
+| 1MB   | 0.96      | 1,040             |
+| 10MB  | 9.43      | 1,061             |
+| 100MB | 96.56     | 1,036             |
+
+#### Mixed (Realistic content)
+
+| Size  | Time (ms) | Throughput (MiB/s) |
+|-------|-----------|-------------------|
+| 1KB   | 0.00      | 967               |
+| 10KB  | 0.01      | 1,278             |
+| 100KB | 0.05      | 1,936             |
+| 1MB   | 0.54      | 1,856             |
+| 10MB  | 5.49      | 1,823             |
+| 100MB | 54.98     | 1,819             |
+
+#### Latin Extended (2-byte sequences)
+
+| Size  | Time (ms) | Throughput (MiB/s) |
+|-------|-----------|-------------------|
+| 1KB   | 0.00      | 1,528             |
+| 10KB  | 0.01      | 1,531             |
+| 100KB | 0.11      | 894               |
+| 1MB   | 1.18      | 848               |
+| 10MB  | 11.45     | 874               |
+| 100MB | 116.34    | 860               |
+
+#### All Lengths (Uniform 1-4 byte mix)
+
+| Size  | Time (ms) | Throughput (MiB/s) |
+|-------|-----------|-------------------|
+| 1KB   | 0.00      | 1,221             |
+| 10KB  | 0.01      | 1,094             |
+| 100KB | 0.18      | 536               |
+| 1MB   | 2.00      | 500               |
+| 10MB  | 19.94     | 502               |
+| 100MB | 203.44    | 492               |
+
+## Key Findings
+
+### Throughput by Character Type
+
+1. **ASCII-dominant content** (~2.2-2.3 GiB/s): Pure ASCII, log files, source code, pathological
+2. **Mixed content** (~1.8-1.9 GiB/s): JSON-like, mixed prose
+3. **Multi-byte content** (~1.0-1.4 GiB/s): CJK (3-byte), emoji (4-byte), Greek/Cyrillic (2-byte)
+4. **Uniform multi-byte** (~0.5 GiB/s): All-lengths pattern with maximum byte diversity
+
+### Performance Characteristics
+
+- **ASCII is fastest**: Single-byte validation requires no continuation byte checks
+- **3-byte (CJK) faster than 4-byte (emoji)**: Fewer continuation bytes to validate per character
+- **Latin (2-byte) slower than CJK (3-byte)**: Higher character density means more state machine transitions
+- **All-lengths is slowest**: Maximum branch prediction misses from alternating sequence lengths
+
+### Scaling
+
+- Throughput is consistent from 1MB to 100MB (memory-bound)
+- Small files (1KB-10KB) show higher variance due to measurement overhead
+- No cache effects visible - sequential access pattern is optimal for hardware prefetching
+
+## Running the Benchmarks
+
+```bash
+# Generate test files
+./target/release/succinctly text generate-suite
+
+# Run CLI benchmark
+./target/release/succinctly dev bench utf8
+
+# Run Criterion benchmark
+cargo bench --bench utf8_validate_bench
+
+# Via unified runner
+./target/release/succinctly bench run utf8_bench
+```
+
+## Test Data Patterns
+
+| Pattern         | Description                                      |
+|-----------------|--------------------------------------------------|
+| ascii           | Pure 7-bit ASCII (single-byte sequences)         |
+| latin           | Latin Extended characters (2-byte sequences)     |
+| greek_cyrillic  | Greek and Cyrillic (2-byte sequences)            |
+| cjk             | Chinese/Japanese/Korean (3-byte sequences)       |
+| emoji           | Emoji and symbols (4-byte sequences)             |
+| mixed           | Realistic prose with occasional non-ASCII        |
+| all_lengths     | Uniform mix of all sequence lengths (1-4 bytes)  |
+| log_file        | Log file style (mostly ASCII with timestamps)    |
+| source_code     | Source code style (ASCII with unicode in strings)|
+| json_like       | JSON-like structure with unicode strings         |
+| pathological    | Maximum multi-byte density                       |

--- a/docs/benchmarks/utf8-validate.md
+++ b/docs/benchmarks/utf8-validate.md
@@ -4,6 +4,14 @@ Benchmarks for `succinctly text validate utf8` - scalar UTF-8 validation through
 
 This serves as the baseline for future SIMD implementations.
 
+> **⚠️ Provisional — pending re-measurement.** The figures below were captured on a
+> pre-rebase branch tip; those commits were orphaned when this branch was rebased onto
+> `main`, so the per-platform **Commit** references no longer resolve. The scalar
+> validator is unchanged by the rebase, so the numbers should still hold, but per the
+> project's benchmark-freshness rule they must be re-measured on each named platform
+> (and the commit references restored) before being cited as authoritative. Downstream
+> issues #133 and #134 pin their projected gains to these baselines.
+
 ## Summary
 
 | Platform                      | ASCII (GiB/s) | CJK (GiB/s) | Emoji (GiB/s) | Mixed (GiB/s) |
@@ -17,7 +25,7 @@ This serves as the baseline for future SIMD implementations.
 ## Apple M4 Pro (ARM)
 
 **Date**: 2026-02-06
-**Commit**: b58037f (utf8-validation-scalar branch)
+**Commit**: _orphaned by rebase — provisional, pending re-measurement_
 **CPU**: Apple M4 Pro (12 cores)
 **OS**: macOS 15.6.1
 **Rust**: 1.93.0
@@ -103,7 +111,7 @@ Direct comparison of byte sequence lengths at 1MB:
 ## AMD Ryzen 9 7950X (x86_64)
 
 **Date**: 2026-02-06
-**Commit**: 71ce3fa (utf8-validation-scalar branch)
+**Commit**: _orphaned by rebase — provisional, pending re-measurement_
 **CPU**: AMD Ryzen 9 7950X 16-Core Processor
 **OS**: Ubuntu 22.04.5 LTS
 **Rust**: 1.92.0
@@ -197,7 +205,7 @@ Direct comparison of byte sequence lengths at 1MB:
 ## Apple M1 Max (ARM)
 
 **Date**: 2026-02-06
-**Commit**: b58037fd (utf8-validation-scalar branch)
+**Commit**: _orphaned by rebase — provisional, pending re-measurement_
 **CPU**: Apple M1 Max
 **OS**: macOS 26.1
 **Rust**: 1.89.0

--- a/src/bin/succinctly/bench_runner/registry.rs
+++ b/src/bin/succinctly/bench_runner/registry.rs
@@ -13,6 +13,7 @@ pub enum BenchmarkCategory {
     Json,
     Yaml,
     Dsv,
+    Text,
     CrossParser,
 }
 
@@ -23,6 +24,7 @@ impl fmt::Display for BenchmarkCategory {
             Self::Json => write!(f, "json"),
             Self::Yaml => write!(f, "yaml"),
             Self::Dsv => write!(f, "dsv"),
+            Self::Text => write!(f, "text"),
             Self::CrossParser => write!(f, "cross-parser"),
         }
     }
@@ -37,9 +39,10 @@ impl std::str::FromStr for BenchmarkCategory {
             "json" => Ok(Self::Json),
             "yaml" => Ok(Self::Yaml),
             "dsv" => Ok(Self::Dsv),
+            "text" => Ok(Self::Text),
             "cross-parser" | "crossparser" | "cross_parser" => Ok(Self::CrossParser),
             _ => Err(format!(
-                "unknown category '{s}', expected: core, json, yaml, dsv, cross-parser"
+                "unknown category '{s}', expected: core, json, yaml, dsv, text, cross-parser"
             )),
         }
     }
@@ -308,6 +311,25 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         cli_subcommand: Some("dsv"),
         working_dir: ".",
     },
+    // ========== TEXT ==========
+    BenchmarkInfo {
+        name: "utf8_validate_bench",
+        description: "UTF-8 validation throughput (Criterion)",
+        category: BenchmarkCategory::Text,
+        bench_type: BenchmarkType::Criterion,
+        criterion_name: Some("utf8_validate_bench"),
+        cli_subcommand: None,
+        working_dir: ".",
+    },
+    BenchmarkInfo {
+        name: "utf8_bench",
+        description: "CLI: UTF-8 scalar validation baseline",
+        category: BenchmarkCategory::Text,
+        bench_type: BenchmarkType::CliBench,
+        criterion_name: None,
+        cli_subcommand: Some("utf8"),
+        working_dir: ".",
+    },
     // ========== CROSS-PARSER ==========
     BenchmarkInfo {
         name: "json_parsers",
@@ -375,6 +397,7 @@ mod tests {
         assert!(!filter_by_category(BenchmarkCategory::Json).is_empty());
         assert!(!filter_by_category(BenchmarkCategory::Yaml).is_empty());
         assert!(!filter_by_category(BenchmarkCategory::Dsv).is_empty());
+        assert!(!filter_by_category(BenchmarkCategory::Text).is_empty());
         assert!(!filter_by_category(BenchmarkCategory::CrossParser).is_empty());
     }
 

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -36,6 +36,32 @@ enum Command {
     /// Unified benchmark runner (list and run all benchmarks)
     #[cfg(feature = "bench-runner")]
     Bench(BenchRunnerCommand),
+    /// Text processing operations (UTF-8 validation, etc.)
+    Text(TextCommand),
+}
+
+#[derive(Debug, Parser)]
+struct TextCommand {
+    #[command(subcommand)]
+    command: TextSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum TextSubcommand {
+    /// Text validation operations
+    Validate(TextValidateCommand),
+}
+
+#[derive(Debug, Parser)]
+struct TextValidateCommand {
+    #[command(subcommand)]
+    command: TextValidateSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum TextValidateSubcommand {
+    /// Validate UTF-8 encoding
+    Utf8(text_validate::ValidateUtf8Args),
 }
 
 #[derive(Debug, Parser)]
@@ -1083,6 +1109,14 @@ fn main() -> Result<()> {
             BenchRunnerSubcommand::List(args) => bench_runner::run_list(args),
             BenchRunnerSubcommand::Run(args) => bench_runner::run_benchmarks(args),
         },
+        Command::Text(text_cmd) => match text_cmd.command {
+            TextSubcommand::Validate(validate_cmd) => match validate_cmd.command {
+                TextValidateSubcommand::Utf8(args) => {
+                    let exit_code = text_validate::run(args)?;
+                    std::process::exit(exit_code);
+                }
+            },
+        },
     }
 }
 
@@ -1734,6 +1768,7 @@ mod jq_bench;
 mod jq_locate;
 mod jq_runner;
 mod json_validate;
+mod text_validate;
 mod yaml_generators;
 mod yq_bench;
 mod yq_locate;

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -50,6 +50,10 @@ struct TextCommand {
 enum TextSubcommand {
     /// Text validation operations
     Validate(TextValidateCommand),
+    /// Generate UTF-8 text files for benchmarking and testing
+    Generate(GenerateUtf8),
+    /// Generate a suite of UTF-8 files with various sizes and patterns
+    GenerateSuite(GenerateUtf8Suite),
 }
 
 #[derive(Debug, Parser)]
@@ -62,6 +66,98 @@ struct TextValidateCommand {
 enum TextValidateSubcommand {
     /// Validate UTF-8 encoding
     Utf8(text_validate::ValidateUtf8Args),
+}
+
+#[derive(Debug, Parser)]
+struct GenerateUtf8 {
+    /// Size of text to generate (supports b, kb, mb, gb - case insensitive)
+    /// Examples: 1024, 1kb, 512MB, 2Gb
+    #[arg(value_parser = parse_size)]
+    size: usize,
+
+    /// Output file path (defaults to stdout)
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// UTF-8 pattern to generate
+    #[arg(short, long, default_value = "mixed")]
+    pattern: Utf8PatternArg,
+
+    /// Random seed for reproducible generation
+    #[arg(short, long)]
+    seed: Option<u64>,
+
+    /// Verify generated content is valid UTF-8
+    #[arg(long)]
+    verify: bool,
+}
+
+#[derive(Debug, Parser)]
+struct GenerateUtf8Suite {
+    /// Output directory (defaults to data/bench/generated/utf8)
+    #[arg(short, long, default_value = "data/bench/generated/utf8")]
+    output_dir: PathBuf,
+
+    /// Base seed for deterministic generation (each file uses seed + file_index)
+    #[arg(short, long, default_value = "42")]
+    seed: u64,
+
+    /// Clean output directory before generating
+    #[arg(long)]
+    clean: bool,
+
+    /// Verify all generated files are valid UTF-8
+    #[arg(long)]
+    verify: bool,
+
+    /// Maximum file size to generate (files larger than this are skipped)
+    /// Supports units: b, kb, mb, gb (e.g., "100mb", "1gb")
+    #[arg(short, long, value_parser = parse_size, default_value = "1gb")]
+    max_size: usize,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+enum Utf8PatternArg {
+    /// Pure ASCII (7-bit, single-byte sequences)
+    Ascii,
+    /// Latin Extended characters (2-byte sequences: accents, diacritics)
+    Latin,
+    /// Greek and Cyrillic (2-byte sequences)
+    GreekCyrillic,
+    /// Chinese/Japanese/Korean (3-byte sequences)
+    Cjk,
+    /// Emoji and symbols (4-byte sequences)
+    Emoji,
+    /// Mixed realistic content (prose with occasional non-ASCII)
+    Mixed,
+    /// Uniform mix of all sequence lengths (1-4 bytes)
+    AllLengths,
+    /// Log file style (mostly ASCII with timestamps)
+    LogFile,
+    /// Source code style (ASCII with unicode in strings/comments)
+    SourceCode,
+    /// JSON-like structure with unicode strings
+    JsonLike,
+    /// Pathological: maximum multi-byte density
+    Pathological,
+}
+
+impl From<Utf8PatternArg> for text_generators::Utf8Pattern {
+    fn from(arg: Utf8PatternArg) -> Self {
+        match arg {
+            Utf8PatternArg::Ascii => Self::Ascii,
+            Utf8PatternArg::Latin => Self::Latin,
+            Utf8PatternArg::GreekCyrillic => Self::GreekCyrillic,
+            Utf8PatternArg::Cjk => Self::Cjk,
+            Utf8PatternArg::Emoji => Self::Emoji,
+            Utf8PatternArg::Mixed => Self::Mixed,
+            Utf8PatternArg::AllLengths => Self::AllLengths,
+            Utf8PatternArg::LogFile => Self::LogFile,
+            Utf8PatternArg::SourceCode => Self::SourceCode,
+            Utf8PatternArg::JsonLike => Self::JsonLike,
+            Utf8PatternArg::Pathological => Self::Pathological,
+        }
+    }
 }
 
 #[derive(Debug, Parser)]
@@ -162,6 +258,8 @@ enum BenchSubcommand {
     Yq(BenchYqArgs),
     /// Benchmark succinctly jq with DSV input
     Dsv(BenchDsvArgs),
+    /// Benchmark succinctly UTF-8 validation vs std::str::from_utf8
+    Utf8(BenchUtf8Args),
 }
 
 /// Arguments for jq benchmark
@@ -295,6 +393,38 @@ struct BenchDsvArgs {
     /// Skip memory measurement (memory is collected by default)
     #[arg(long)]
     no_memory: bool,
+}
+
+/// Arguments for UTF-8 validation benchmark
+#[derive(Debug, Parser)]
+struct BenchUtf8Args {
+    /// Directory containing generated UTF-8 files
+    #[arg(short, long, default_value = "data/bench/generated/utf8")]
+    data_dir: PathBuf,
+
+    /// Output JSONL file for raw results
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Output markdown file for formatted tables
+    #[arg(short, long)]
+    markdown: Option<PathBuf>,
+
+    /// Patterns to benchmark (comma-separated, or "all")
+    #[arg(short, long, default_value = "all")]
+    patterns: String,
+
+    /// Sizes to benchmark (comma-separated, or "all")
+    #[arg(short, long, default_value = "all")]
+    sizes: String,
+
+    /// Number of warmup runs before benchmarking
+    #[arg(long, default_value = "1")]
+    warmup: usize,
+
+    /// Number of benchmark runs (median is taken)
+    #[arg(long, default_value = "3")]
+    runs: usize,
 }
 
 /// Generate synthetic JSON files for benchmarking and testing
@@ -1101,6 +1231,7 @@ fn main() -> Result<()> {
                 BenchSubcommand::Jq(args) => run_jq_benchmark(args),
                 BenchSubcommand::Yq(args) => run_yq_benchmark(args),
                 BenchSubcommand::Dsv(args) => run_dsv_benchmark(args),
+                BenchSubcommand::Utf8(args) => run_utf8_benchmark(args),
             },
         },
         Command::InstallAliases(args) => install_aliases(args),
@@ -1116,6 +1247,30 @@ fn main() -> Result<()> {
                     std::process::exit(exit_code);
                 }
             },
+            TextSubcommand::Generate(args) => {
+                let data =
+                    text_generators::generate_utf8(args.size, args.pattern.into(), args.seed);
+
+                if args.verify {
+                    succinctly::text::utf8::validate_utf8(&data)
+                        .map_err(|e| anyhow::anyhow!("Generated invalid UTF-8: {e}"))?;
+                    eprintln!("✓ UTF-8 validated successfully");
+                }
+
+                match args.output {
+                    Some(path) => {
+                        std::fs::write(&path, &data)?;
+                        eprintln!("✓ Wrote {} bytes to {}", data.len(), path.display());
+                    }
+                    None => {
+                        use std::io::Write;
+                        std::io::stdout().write_all(&data)?;
+                    }
+                }
+
+                Ok(())
+            }
+            TextSubcommand::GenerateSuite(args) => generate_utf8_suite(args),
         },
     }
 }
@@ -1386,6 +1541,70 @@ fn run_dsv_benchmark(args: BenchDsvArgs) -> Result<()> {
     }
 
     let _results = dsv_bench::run_benchmark(
+        &config,
+        Some(output_jsonl.as_path()),
+        Some(output_md.as_path()),
+    )?;
+
+    Ok(())
+}
+
+fn run_utf8_benchmark(args: BenchUtf8Args) -> Result<()> {
+    let all_patterns = vec![
+        "ascii",
+        "latin",
+        "greek_cyrillic",
+        "cjk",
+        "emoji",
+        "mixed",
+        "all_lengths",
+        "log_file",
+        "source_code",
+        "json_like",
+        "pathological",
+    ];
+    let all_sizes = vec!["1kb", "10kb", "100kb", "1mb", "10mb", "100mb"];
+
+    let patterns = if args.patterns == "all" {
+        all_patterns.into_iter().map(String::from).collect()
+    } else {
+        args.patterns
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect()
+    };
+
+    let sizes = if args.sizes == "all" {
+        all_sizes.into_iter().map(String::from).collect()
+    } else {
+        args.sizes
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect()
+    };
+
+    let config = utf8_bench::BenchConfig {
+        data_dir: args.data_dir,
+        patterns,
+        sizes,
+        warmup_runs: args.warmup,
+        benchmark_runs: args.runs,
+    };
+
+    // Use default output paths if not specified
+    let results_dir = PathBuf::from("data/bench/results");
+    let default_jsonl = results_dir.join("utf8-bench.jsonl");
+    let default_md = results_dir.join("utf8-bench.md");
+
+    let output_jsonl = args.output.unwrap_or(default_jsonl);
+    let output_md = args.markdown.unwrap_or(default_md);
+
+    // Ensure results directory exists
+    if let Some(parent) = output_jsonl.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let _results = utf8_bench::run_benchmark(
         &config,
         Some(output_jsonl.as_path()),
         Some(output_md.as_path()),
@@ -1746,6 +1965,110 @@ fn generate_yaml_suite(args: GenerateYamlSuite) -> Result<()> {
     Ok(())
 }
 
+/// UTF-8 patterns for suite generation
+const UTF8_SUITE_PATTERNS: &[(&str, text_generators::Utf8Pattern)] = &[
+    ("ascii", text_generators::Utf8Pattern::Ascii),
+    ("latin", text_generators::Utf8Pattern::Latin),
+    (
+        "greek_cyrillic",
+        text_generators::Utf8Pattern::GreekCyrillic,
+    ),
+    ("cjk", text_generators::Utf8Pattern::Cjk),
+    ("emoji", text_generators::Utf8Pattern::Emoji),
+    ("mixed", text_generators::Utf8Pattern::Mixed),
+    ("all_lengths", text_generators::Utf8Pattern::AllLengths),
+    ("log_file", text_generators::Utf8Pattern::LogFile),
+    ("source_code", text_generators::Utf8Pattern::SourceCode),
+    ("json_like", text_generators::Utf8Pattern::JsonLike),
+    ("pathological", text_generators::Utf8Pattern::Pathological),
+];
+
+fn generate_utf8_suite(args: GenerateUtf8Suite) -> Result<()> {
+    let output_dir = &args.output_dir;
+
+    // Clean directory if requested
+    if args.clean && output_dir.exists() {
+        std::fs::remove_dir_all(output_dir)
+            .with_context(|| format!("Failed to clean directory: {}", output_dir.display()))?;
+        eprintln!("Cleaned {}", output_dir.display());
+    }
+
+    // Create output directory
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("Failed to create directory: {}", output_dir.display()))?;
+
+    let mut file_index: u64 = 0;
+    let mut total_bytes: usize = 0;
+    let mut file_count: usize = 0;
+    let mut skipped_count: usize = 0;
+
+    eprintln!(
+        "Generating UTF-8 suite in {} (max size: {})...",
+        output_dir.display(),
+        format_bytes(args.max_size)
+    );
+
+    // Generate patterns at various sizes
+    for (pattern_name, pattern) in UTF8_SUITE_PATTERNS {
+        // Create pattern subdirectory
+        let pattern_dir = output_dir.join(pattern_name);
+        std::fs::create_dir_all(&pattern_dir)?;
+
+        for (size_name, size) in SUITE_SIZES {
+            // Skip files that exceed max_size
+            if *size > args.max_size {
+                skipped_count += 1;
+                continue;
+            }
+
+            let filename = format!("{size_name}.txt");
+            let path = pattern_dir.join(&filename);
+
+            // Deterministic seed: base_seed + file_index
+            let seed = args.seed.wrapping_add(file_index);
+            file_index += 1;
+
+            let data = text_generators::generate_utf8(*size, *pattern, Some(seed));
+
+            if args.verify {
+                if let Err(e) = succinctly::text::utf8::validate_utf8(&data) {
+                    anyhow::bail!("Generated invalid UTF-8 for {}: {}", path.display(), e);
+                }
+            }
+
+            std::fs::write(&path, &data)?;
+            total_bytes += data.len();
+            file_count += 1;
+
+            eprintln!(
+                "  {} ({}, seed={})",
+                path.display(),
+                format_bytes(data.len()),
+                seed
+            );
+        }
+    }
+
+    eprintln!(
+        "\n✓ Generated {} files ({} total)",
+        file_count,
+        format_bytes(total_bytes)
+    );
+    if skipped_count > 0 {
+        eprintln!(
+            "  (skipped {} files exceeding max size {})",
+            skipped_count,
+            format_bytes(args.max_size)
+        );
+    }
+
+    if args.verify {
+        eprintln!("All files validated successfully");
+    }
+
+    Ok(())
+}
+
 fn format_bytes(bytes: usize) -> String {
     if bytes >= 1024 * 1024 * 1024 {
         format!("{:.2} GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
@@ -1768,7 +2091,9 @@ mod jq_bench;
 mod jq_locate;
 mod jq_runner;
 mod json_validate;
+mod text_generators;
 mod text_validate;
+mod utf8_bench;
 mod yaml_generators;
 mod yq_bench;
 mod yq_locate;

--- a/src/bin/succinctly/text_generators.rs
+++ b/src/bin/succinctly/text_generators.rs
@@ -1,0 +1,737 @@
+//! UTF-8 text generators for benchmarking and testing.
+//!
+//! Generates various types of UTF-8 content for validating and benchmarking
+//! UTF-8 validation algorithms.
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Pattern types for UTF-8 text generation.
+#[derive(Debug, Clone, Copy)]
+pub enum Utf8Pattern {
+    /// Pure ASCII (7-bit, single-byte sequences)
+    Ascii,
+    /// Latin Extended characters (2-byte sequences: accents, diacritics)
+    Latin,
+    /// Greek and Cyrillic (2-byte sequences)
+    GreekCyrillic,
+    /// Chinese/Japanese/Korean (3-byte sequences)
+    Cjk,
+    /// Emoji and symbols (4-byte sequences)
+    Emoji,
+    /// Mixed realistic content (prose with occasional non-ASCII)
+    Mixed,
+    /// Uniform mix of all sequence lengths (1-4 bytes)
+    AllLengths,
+    /// Log file style (mostly ASCII with timestamps and occasional unicode)
+    LogFile,
+    /// Source code style (ASCII with unicode in strings/comments)
+    SourceCode,
+    /// JSON-like structure (tests escape sequences context)
+    JsonLike,
+    /// Pathological: maximum multi-byte density
+    Pathological,
+}
+
+/// Generate UTF-8 text of approximately target_size bytes.
+pub fn generate_utf8(target_size: usize, pattern: Utf8Pattern, seed: Option<u64>) -> Vec<u8> {
+    match pattern {
+        Utf8Pattern::Ascii => generate_ascii(target_size, seed),
+        Utf8Pattern::Latin => generate_latin(target_size, seed),
+        Utf8Pattern::GreekCyrillic => generate_greek_cyrillic(target_size, seed),
+        Utf8Pattern::Cjk => generate_cjk(target_size, seed),
+        Utf8Pattern::Emoji => generate_emoji(target_size, seed),
+        Utf8Pattern::Mixed => generate_mixed(target_size, seed),
+        Utf8Pattern::AllLengths => generate_all_lengths(target_size, seed),
+        Utf8Pattern::LogFile => generate_log_file(target_size, seed),
+        Utf8Pattern::SourceCode => generate_source_code(target_size, seed),
+        Utf8Pattern::JsonLike => generate_json_like(target_size, seed),
+        Utf8Pattern::Pathological => generate_pathological(target_size, seed),
+    }
+}
+
+/// Pure ASCII content (English prose).
+fn generate_ascii(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let sentences = [
+        "The quick brown fox jumps over the lazy dog.",
+        "Pack my box with five dozen liquor jugs.",
+        "How vexingly quick daft zebras jump!",
+        "The five boxing wizards jump quickly.",
+        "Sphinx of black quartz, judge my vow.",
+        "Two driven jocks help fax my big quiz.",
+        "The jay, pig, fox, zebra and my wolves quack!",
+        "Sympathizing would fix Quaker objectives.",
+        "A wizard's job is to vex chumps quickly in fog.",
+        "Watch Jeopardy!, Alex Trebek's fun TV quiz game.",
+    ];
+
+    let mut line_len = 0;
+    while result.len() < target_size {
+        let idx = rng.as_mut().map_or(result.len() % sentences.len(), |r| {
+            r.gen_range(0..sentences.len())
+        });
+        let sentence = sentences[idx];
+
+        if line_len > 0 && line_len + sentence.len() + 1 > 80 {
+            result.push(b'\n');
+            line_len = 0;
+        } else if line_len > 0 {
+            result.push(b' ');
+            line_len += 1;
+        }
+
+        let remaining = target_size.saturating_sub(result.len());
+        let to_add = sentence.len().min(remaining);
+        result.extend_from_slice(&sentence.as_bytes()[..to_add]);
+        line_len += to_add;
+    }
+
+    result.truncate(target_size);
+    result
+}
+
+/// Latin Extended characters (2-byte UTF-8).
+fn generate_latin(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let words = [
+        "café",
+        "résumé",
+        "naïve",
+        "über",
+        "fiancée",
+        "cliché",
+        "décor",
+        "élite",
+        "entrée",
+        "façade",
+        "jalapeño",
+        "piñata",
+        "señor",
+        "mañana",
+        "niño",
+        "Ångström",
+        "smörgåsbord",
+        "Müller",
+        "Größe",
+        "Füße",
+        "Köln",
+        "Zürich",
+        "Ærø",
+        "Malmö",
+        "Göteborg",
+        "Øresund",
+        "Łódź",
+        "Kraków",
+        "Wrocław",
+    ];
+
+    let mut line_len = 0;
+    while result.len() < target_size {
+        let idx = rng
+            .as_mut()
+            .map_or(result.len() % words.len(), |r| r.gen_range(0..words.len()));
+        let word = words[idx];
+        let word_bytes = word.as_bytes();
+
+        if line_len > 0 && line_len + word_bytes.len() + 1 > 80 {
+            result.push(b'\n');
+            line_len = 0;
+        } else if line_len > 0 {
+            result.push(b' ');
+            line_len += 1;
+        }
+
+        if result.len() + word_bytes.len() <= target_size {
+            result.extend_from_slice(word_bytes);
+            line_len += word_bytes.len();
+        } else {
+            break;
+        }
+    }
+
+    // Pad with ASCII if needed
+    while result.len() < target_size {
+        result.push(b' ');
+    }
+    result.truncate(target_size);
+    result
+}
+
+/// Greek and Cyrillic text (2-byte UTF-8).
+fn generate_greek_cyrillic(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let greek = [
+        "αλφα",
+        "βητα",
+        "γαμμα",
+        "δελτα",
+        "επσιλον",
+        "ζητα",
+        "ητα",
+        "θητα",
+        "ιωτα",
+        "καππα",
+        "λαμδα",
+        "μυ",
+        "νυ",
+        "ξι",
+        "ομικρον",
+        "πι",
+        "ρω",
+        "σιγμα",
+        "ταυ",
+        "υψιλον",
+        "φι",
+        "χι",
+        "ψι",
+        "ωμεγα",
+    ];
+
+    let cyrillic = [
+        "Москва",
+        "Санкт",
+        "Киев",
+        "Минск",
+        "Алматы",
+        "Ташкент",
+        "Баку",
+        "Тбилиси",
+        "Ереван",
+        "Кишинёв",
+        "Душанбе",
+        "Бишкек",
+        "Астана",
+        "привет",
+        "мир",
+        "добро",
+        "пожаловать",
+        "спасибо",
+        "здравствуйте",
+    ];
+
+    let mut line_len = 0;
+    let mut use_greek = true;
+    while result.len() < target_size {
+        let words = if use_greek { &greek[..] } else { &cyrillic[..] };
+        let idx = rng
+            .as_mut()
+            .map_or(result.len() % words.len(), |r| r.gen_range(0..words.len()));
+        let word = words[idx];
+        let word_bytes = word.as_bytes();
+
+        if line_len > 0 && line_len + word_bytes.len() + 1 > 80 {
+            result.push(b'\n');
+            line_len = 0;
+            use_greek = !use_greek;
+        } else if line_len > 0 {
+            result.push(b' ');
+            line_len += 1;
+        }
+
+        if result.len() + word_bytes.len() <= target_size {
+            result.extend_from_slice(word_bytes);
+            line_len += word_bytes.len();
+        } else {
+            break;
+        }
+    }
+
+    while result.len() < target_size {
+        result.push(b' ');
+    }
+    result.truncate(target_size);
+    result
+}
+
+/// CJK characters (3-byte UTF-8).
+fn generate_cjk(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let phrases = [
+        "日本語",
+        "中国語",
+        "韓国語",
+        "漢字",
+        "仮名",
+        "平仮名",
+        "片仮名",
+        "東京",
+        "北京",
+        "上海",
+        "香港",
+        "台北",
+        "首爾",
+        "大阪",
+        "京都",
+        "你好",
+        "再见",
+        "谢谢",
+        "对不起",
+        "没关系",
+        "欢迎",
+        "祝福",
+        "안녕하세요",
+        "감사합니다",
+        "죄송합니다",
+        "반갑습니다",
+        "こんにちは",
+        "ありがとう",
+        "すみません",
+        "おはよう",
+        "さようなら",
+    ];
+
+    let mut line_len = 0;
+    while result.len() < target_size {
+        let idx = rng.as_mut().map_or(result.len() % phrases.len(), |r| {
+            r.gen_range(0..phrases.len())
+        });
+        let phrase = phrases[idx];
+        let phrase_bytes = phrase.as_bytes();
+
+        if line_len > 0 && line_len + phrase_bytes.len() > 60 {
+            result.push(b'\n');
+            line_len = 0;
+        } else if line_len > 0 {
+            // CJK typically doesn't use spaces, but add occasionally
+            if rng.as_mut().is_some_and(|r| r.gen_bool(0.3)) {
+                result.push(b' ');
+                line_len += 1;
+            }
+        }
+
+        if result.len() + phrase_bytes.len() <= target_size {
+            result.extend_from_slice(phrase_bytes);
+            line_len += phrase_bytes.len();
+        } else {
+            break;
+        }
+    }
+
+    while result.len() < target_size {
+        result.push(b' ');
+    }
+    result.truncate(target_size);
+    result
+}
+
+/// Emoji and symbols (4-byte UTF-8).
+fn generate_emoji(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let emojis = [
+        "😀", "😃", "😄", "😁", "😆", "😅", "🤣", "😂", "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍",
+        "🤩", "😘", "😗", "😚", "😙", "🥲", "😋", "😛", "😜", "🤪", "😝", "🤑", "🤗", "🤭", "🤫",
+        "🎉", "🎊", "🎈", "🎁", "🎀", "🎄", "🎃", "🎗️", "🎟️", "🎫", "🚀", "✈️", "🚁", "🚂", "🚃",
+        "🚄", "🚅", "🚆", "🚇", "🚈", "🌍", "🌎", "🌏", "🌐", "🗺️", "🧭", "🏔️", "⛰️", "🌋", "🗻",
+        "💻", "🖥️", "🖨️", "⌨️", "🖱️", "🖲️", "💽", "💾", "💿", "📀", "🔥", "💧", "🌊", "💨", "⚡",
+        "❄️", "☀️", "🌙", "⭐", "🌟",
+    ];
+
+    while result.len() < target_size {
+        let idx = rng.as_mut().map_or(result.len() % emojis.len(), |r| {
+            r.gen_range(0..emojis.len())
+        });
+        let emoji = emojis[idx];
+        let emoji_bytes = emoji.as_bytes();
+
+        if result.len() + emoji_bytes.len() <= target_size {
+            result.extend_from_slice(emoji_bytes);
+        } else {
+            break;
+        }
+
+        // Occasionally add space or newline
+        if result.len() < target_size {
+            let choice = rng.as_mut().map_or(0, |r| r.gen_range(0..10));
+            if choice == 0 {
+                result.push(b'\n');
+            } else if choice < 3 {
+                result.push(b' ');
+            }
+        }
+    }
+
+    while result.len() < target_size {
+        result.push(b' ');
+    }
+    result.truncate(target_size);
+    result
+}
+
+/// Mixed realistic content.
+fn generate_mixed(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let phrases = [
+        // ASCII (most common)
+        "The quick brown fox jumps over the lazy dog.",
+        "Hello, world! This is a test message.",
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "Pack my box with five dozen liquor jugs.",
+        // Latin extended
+        "Café au lait with crème brûlée is très délicieux.",
+        "The naïve résumé was written by the fiancée.",
+        "Señor García lives in São Paulo near the Ångström lab.",
+        // With emoji
+        "Great job! 🎉 Keep up the good work! 💪",
+        "Weather forecast: ☀️ sunny with occasional 🌧️ rain.",
+        "I love coding 💻 and drinking ☕ coffee!",
+        // CJK mixed
+        "Meeting at 東京 station at 3pm tomorrow.",
+        "The document was translated to 中文 and 日本語.",
+        // Currency and symbols
+        "Price: €50.00 or £42.00 or ¥6,000 or ₹4,200",
+        "Math: α + β = γ, ∑(x²) = n, ∞ > 0",
+    ];
+
+    let mut line_len = 0;
+    while result.len() < target_size {
+        let idx = rng.as_mut().map_or(result.len() % phrases.len(), |r| {
+            r.gen_range(0..phrases.len())
+        });
+        let phrase = phrases[idx];
+        let phrase_bytes = phrase.as_bytes();
+
+        if line_len > 0 && line_len + phrase_bytes.len() + 1 > 100 {
+            result.push(b'\n');
+            line_len = 0;
+        } else if line_len > 0 {
+            result.push(b' ');
+            line_len += 1;
+        }
+
+        if result.len() + phrase_bytes.len() <= target_size {
+            result.extend_from_slice(phrase_bytes);
+            line_len += phrase_bytes.len();
+        } else {
+            break;
+        }
+    }
+
+    while result.len() < target_size {
+        result.push(b' ');
+    }
+    result.truncate(target_size);
+    result
+}
+
+/// Uniform distribution of all sequence lengths.
+fn generate_all_lengths(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    // Characters of each byte length
+    let one_byte = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let two_byte = [
+        "é", "ñ", "ü", "ö", "ä", "ß", "ç", "ø", "å", "æ", "α", "β", "γ", "δ", "ε",
+    ];
+    let three_byte = [
+        "日", "本", "語", "中", "文", "韓", "国", "漢", "字", "你", "好", "世", "界",
+    ];
+    let four_byte = ["😀", "🎉", "🚀", "💻", "🔥", "⭐", "🌍", "💡", "🎯", "🎨"];
+
+    while result.len() < target_size {
+        let choice = rng.as_mut().map_or(result.len() % 4, |r| r.gen_range(0..4));
+
+        let bytes: &[u8] = match choice {
+            0 => {
+                let idx = rng.as_mut().map_or(0, |r| r.gen_range(0..one_byte.len()));
+                &one_byte[idx..=idx]
+            }
+            1 => {
+                let idx = rng.as_mut().map_or(0, |r| r.gen_range(0..two_byte.len()));
+                two_byte[idx].as_bytes()
+            }
+            2 => {
+                let idx = rng.as_mut().map_or(0, |r| r.gen_range(0..three_byte.len()));
+                three_byte[idx].as_bytes()
+            }
+            _ => {
+                let idx = rng.as_mut().map_or(0, |r| r.gen_range(0..four_byte.len()));
+                four_byte[idx].as_bytes()
+            }
+        };
+
+        if result.len() + bytes.len() <= target_size {
+            result.extend_from_slice(bytes);
+        } else {
+            break;
+        }
+
+        // Occasionally add whitespace
+        if result.len() < target_size {
+            let add_ws = rng.as_mut().map_or(0, |r| r.gen_range(0..8));
+            if add_ws == 0 {
+                result.push(b'\n');
+            } else if add_ws == 1 {
+                result.push(b' ');
+            }
+        }
+    }
+
+    while result.len() < target_size {
+        result.push(b' ');
+    }
+    result.truncate(target_size);
+    result
+}
+
+/// Log file style (mostly ASCII with timestamps).
+fn generate_log_file(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let levels = ["INFO", "DEBUG", "WARN", "ERROR", "TRACE"];
+    let components = [
+        "server",
+        "database",
+        "cache",
+        "auth",
+        "api",
+        "worker",
+        "scheduler",
+        "queue",
+    ];
+    let messages = [
+        "Request processed successfully",
+        "Connection established to endpoint",
+        "Cache miss for key",
+        "User authentication completed",
+        "Query executed in 42ms",
+        "Task scheduled for execution",
+        "Message published to queue",
+        "Configuration reloaded",
+        "Health check passed",
+        "Retry attempt 1 of 3",
+        "Connection closed gracefully",
+        "Processing batch of 100 items",
+        // Some with unicode
+        "User 田中太郎 logged in",
+        "Order from São Paulo processed",
+        "Message from user@münchen.de",
+        "Payment of €50.00 received",
+        "Temperature: 23°C",
+    ];
+
+    let mut hour = 0u32;
+    let mut minute = 0u32;
+    let mut second = 0u32;
+    let mut ms = 0u32;
+
+    while result.len() < target_size {
+        // Timestamp
+        let timestamp = format!("2024-01-15T{hour:02}:{minute:02}:{second:02}.{ms:03}Z");
+        result.extend_from_slice(timestamp.as_bytes());
+        result.push(b' ');
+
+        // Level
+        let level_idx = rng.as_mut().map_or(0, |r| r.gen_range(0..levels.len()));
+        result.extend_from_slice(levels[level_idx].as_bytes());
+        result.push(b' ');
+
+        // Component
+        let comp_idx = rng.as_mut().map_or(0, |r| r.gen_range(0..components.len()));
+        result.push(b'[');
+        result.extend_from_slice(components[comp_idx].as_bytes());
+        result.push(b']');
+        result.push(b' ');
+
+        // Message
+        let msg_idx = rng.as_mut().map_or(0, |r| r.gen_range(0..messages.len()));
+        result.extend_from_slice(messages[msg_idx].as_bytes());
+        result.push(b'\n');
+
+        // Advance time
+        ms += rng.as_mut().map_or(100, |r| r.gen_range(1..500));
+        if ms >= 1000 {
+            ms = 0;
+            second += 1;
+            if second >= 60 {
+                second = 0;
+                minute += 1;
+                if minute >= 60 {
+                    minute = 0;
+                    hour = (hour + 1) % 24;
+                }
+            }
+        }
+    }
+
+    result.truncate(target_size);
+    result
+}
+
+/// Source code style content.
+fn generate_source_code(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let code_lines = [
+        "fn main() {",
+        "    println!(\"Hello, world!\");",
+        "}",
+        "",
+        "// This is a comment",
+        "/* Multi-line",
+        "   comment */",
+        "let x = 42;",
+        "let name = \"Alice\";",
+        "let greeting = \"Hello, 世界!\";",
+        "let emoji = \"🎉🚀💻\";",
+        "const PI: f64 = 3.14159;",
+        "const GREETING: &str = \"Bonjour!\";",
+        "// TODO: Add error handling",
+        "// FIXME: This is a workaround",
+        "struct User {",
+        "    name: String,",
+        "    email: String,",
+        "}",
+        "impl User {",
+        "    fn new(name: &str) -> Self {",
+        "        Self { name: name.to_string(), email: String::new() }",
+        "    }",
+        "}",
+        "// Unicode in identifiers (not valid Rust, but valid UTF-8)",
+        "// let 変数 = \"value\";",
+        "// let données = vec![1, 2, 3];",
+        "fn calculate(α: f64, β: f64) -> f64 {",
+        "    α * β + 2.0 * α",
+        "}",
+        "#[test]",
+        "fn test_basic() {",
+        "    assert_eq!(2 + 2, 4);",
+        "}",
+    ];
+
+    while result.len() < target_size {
+        let idx = rng.as_mut().map_or(result.len() % code_lines.len(), |r| {
+            r.gen_range(0..code_lines.len())
+        });
+        let line = code_lines[idx];
+        let line_bytes = line.as_bytes();
+
+        if result.len() + line_bytes.len() < target_size {
+            result.extend_from_slice(line_bytes);
+            result.push(b'\n');
+        } else {
+            break;
+        }
+    }
+
+    while result.len() < target_size {
+        result.push(b' ');
+    }
+    result.truncate(target_size);
+    result
+}
+
+/// JSON-like structure with unicode strings.
+fn generate_json_like(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    let names = [
+        "Alice",
+        "Bob",
+        "Charlie",
+        "田中太郎",
+        "Müller",
+        "García",
+        "Αλέξανδρος",
+    ];
+    let cities = [
+        "New York",
+        "London",
+        "東京",
+        "Paris",
+        "München",
+        "São Paulo",
+        "Москва",
+    ];
+    let descriptions = [
+        "Software engineer",
+        "Data scientist",
+        "プログラマー",
+        "Développeur",
+        "Ingenieur",
+    ];
+
+    result.extend_from_slice(b"[\n");
+    let mut first = true;
+
+    while result.len() < target_size.saturating_sub(100) {
+        if !first {
+            result.extend_from_slice(b",\n");
+        }
+        first = false;
+
+        let name_idx = rng.as_mut().map_or(0, |r| r.gen_range(0..names.len()));
+        let city_idx = rng.as_mut().map_or(0, |r| r.gen_range(0..cities.len()));
+        let desc_idx = rng
+            .as_mut()
+            .map_or(0, |r| r.gen_range(0..descriptions.len()));
+        let age = rng.as_mut().map_or(30, |r| r.gen_range(20..70));
+
+        let entry = format!(
+            "  {{\n    \"name\": \"{}\",\n    \"city\": \"{}\",\n    \"description\": \"{}\",\n    \"age\": {}\n  }}",
+            names[name_idx], cities[city_idx], descriptions[desc_idx], age
+        );
+
+        result.extend_from_slice(entry.as_bytes());
+    }
+
+    result.extend_from_slice(b"\n]\n");
+
+    while result.len() < target_size {
+        result.push(b' ');
+    }
+    result.truncate(target_size);
+    result
+}
+
+/// Pathological case: maximum multi-byte density.
+fn generate_pathological(target_size: usize, seed: Option<u64>) -> Vec<u8> {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut result = Vec::with_capacity(target_size);
+
+    // Use only 4-byte characters (maximum bytes per character)
+    let four_byte_chars = [
+        "😀", "😃", "😄", "😁", "😆", "😅", "🤣", "😂", "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍",
+        "🤩", "😘", "😗", "😚", "😙", "🥲", "😋", "😛", "😜", "🤪", "😝", "🤑", "🤗", "🤭", "🤫",
+        "🤔", "🤐", "🤨", "😐", "😑", "😶", "😏", "😒", "🙄", "😬", "🤥", "😌", "😔", "😪", "🤤",
+        "😴", "😷", "🤒", "🤕", "🤢", "🤮", "🤧", "🥵", "🥶", "🥴", "😵", "🤯", "🤠", "🥳", "🥸",
+    ];
+
+    while result.len() < target_size {
+        let idx = rng
+            .as_mut()
+            .map_or(result.len() % four_byte_chars.len(), |r| {
+                r.gen_range(0..four_byte_chars.len())
+            });
+        let char_bytes = four_byte_chars[idx].as_bytes();
+
+        if result.len() + char_bytes.len() <= target_size {
+            result.extend_from_slice(char_bytes);
+        } else {
+            break;
+        }
+    }
+
+    // Pad with ASCII if needed (shouldn't happen much)
+    while result.len() < target_size {
+        result.push(b'X');
+    }
+    result.truncate(target_size);
+    result
+}

--- a/src/bin/succinctly/text_validate.rs
+++ b/src/bin/succinctly/text_validate.rs
@@ -1,0 +1,325 @@
+//! CLI handler for the `text validate utf8` command.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::fs;
+use std::io::{self, IsTerminal, Read};
+use std::path::PathBuf;
+use succinctly::text::utf8::{self, Utf8Error, Utf8ErrorKind};
+
+/// Validate text files for UTF-8 compliance.
+#[derive(Debug, Parser)]
+pub struct ValidateUtf8Args {
+    /// Input files to validate (reads from stdin if none provided)
+    #[arg(trailing_var_arg = true)]
+    pub files: Vec<PathBuf>,
+
+    /// Quiet mode: exit code only, no output
+    #[arg(short, long)]
+    pub quiet: bool,
+
+    /// Force color output even when not a TTY
+    #[arg(short = 'C', long = "color")]
+    pub color: bool,
+
+    /// Disable color output
+    #[arg(short = 'M', long = "no-color")]
+    pub no_color: bool,
+}
+
+/// Exit codes for the validate command.
+pub mod exit_codes {
+    /// UTF-8 is valid.
+    pub const SUCCESS: i32 = 0;
+    /// UTF-8 is invalid (validation error).
+    pub const INVALID: i32 = 1;
+    /// I/O error (file not found, permission denied, etc.).
+    pub const IO_ERROR: i32 = 2;
+}
+
+/// ANSI color codes for error output.
+mod colors {
+    pub const RESET: &str = "\x1b[0m";
+    pub const ERROR: &str = "\x1b[1;31m"; // Bold red
+    pub const LOCATION: &str = "\x1b[1;34m"; // Bold blue
+    pub const LINE_NUM: &str = "\x1b[0;34m"; // Blue
+    pub const CARET: &str = "\x1b[1;32m"; // Bold green
+    pub const MESSAGE: &str = "\x1b[0;33m"; // Yellow
+}
+
+/// Color scheme that can be disabled.
+struct ColorScheme {
+    error: &'static str,
+    location: &'static str,
+    line_num: &'static str,
+    caret: &'static str,
+    message: &'static str,
+    reset: &'static str,
+}
+
+impl ColorScheme {
+    fn new(use_color: bool) -> Self {
+        if use_color {
+            Self {
+                error: colors::ERROR,
+                location: colors::LOCATION,
+                line_num: colors::LINE_NUM,
+                caret: colors::CARET,
+                message: colors::MESSAGE,
+                reset: colors::RESET,
+            }
+        } else {
+            Self {
+                error: "",
+                location: "",
+                line_num: "",
+                caret: "",
+                message: "",
+                reset: "",
+            }
+        }
+    }
+}
+
+/// Run the validate utf8 command.
+pub fn run(args: ValidateUtf8Args) -> Result<i32> {
+    // Determine color output
+    let use_color = if args.no_color {
+        false
+    } else if args.color {
+        true
+    } else {
+        io::stderr().is_terminal()
+    };
+
+    let scheme = ColorScheme::new(use_color);
+
+    if args.files.is_empty() {
+        // Read from stdin
+        let mut input = Vec::new();
+        io::stdin()
+            .read_to_end(&mut input)
+            .context("failed to read from stdin")?;
+
+        validate_input(&input, None, &args, &scheme)
+    } else {
+        // Validate each file
+        let mut any_invalid = false;
+        let mut any_io_error = false;
+
+        for path in &args.files {
+            match fs::read(path) {
+                Ok(input) => {
+                    let filename = path.to_string_lossy();
+                    let result = validate_input(&input, Some(&filename), &args, &scheme)?;
+                    if result == exit_codes::INVALID {
+                        any_invalid = true;
+                    }
+                }
+                Err(e) => {
+                    any_io_error = true;
+                    if !args.quiet {
+                        eprintln!(
+                            "{}error{}: {}: {}",
+                            scheme.error,
+                            scheme.reset,
+                            path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        if any_io_error {
+            Ok(exit_codes::IO_ERROR)
+        } else if any_invalid {
+            Ok(exit_codes::INVALID)
+        } else {
+            Ok(exit_codes::SUCCESS)
+        }
+    }
+}
+
+/// Validate a single input and print errors.
+fn validate_input(
+    input: &[u8],
+    filename: Option<&str>,
+    args: &ValidateUtf8Args,
+    scheme: &ColorScheme,
+) -> Result<i32> {
+    match utf8::validate_utf8(input) {
+        Ok(()) => Ok(exit_codes::SUCCESS),
+        Err(err) => {
+            if !args.quiet {
+                print_error(&err, input, filename, scheme);
+            }
+            Ok(exit_codes::INVALID)
+        }
+    }
+}
+
+/// Print a formatted error message with context snippet.
+fn print_error(err: &Utf8Error, input: &[u8], filename: Option<&str>, scheme: &ColorScheme) {
+    // Print error header
+    eprintln!(
+        "{}error{}: {}",
+        scheme.error,
+        scheme.reset,
+        format_error_kind(&err.kind, err.offset, input)
+    );
+
+    // Print location
+    let location = match filename {
+        Some(f) => format!("{}:{}:{}", f, err.line, err.column),
+        None => format!("<stdin>:{}:{}", err.line, err.column),
+    };
+    eprintln!("  {}--> {}{}", scheme.location, location, scheme.reset);
+
+    // Print context snippet
+    if let Some(snippet) = get_error_snippet(input, err.line, err.column) {
+        // Calculate line number width (minimum 3 chars for alignment)
+        let line_num_width = err.line.to_string().len().max(3);
+        let blank_padding = " ".repeat(line_num_width + 2);
+
+        // Print blank line with pipe
+        eprintln!("{}{}|{}", blank_padding, scheme.line_num, scheme.reset);
+
+        // Print the line with line number
+        eprintln!(
+            " {}{:>width$}{} {}|{} {}",
+            scheme.line_num,
+            err.line,
+            scheme.reset,
+            scheme.line_num,
+            scheme.reset,
+            snippet.line_content,
+            width = line_num_width
+        );
+
+        // Print the caret pointer
+        let padding = " ".repeat(snippet.caret_offset);
+        let carets = "^".repeat(snippet.caret_width.max(1));
+        eprintln!(
+            "{}{}|{} {}{}{}{}{}",
+            blank_padding,
+            scheme.line_num,
+            scheme.reset,
+            padding,
+            scheme.caret,
+            carets,
+            scheme.reset,
+            format_error_hint(&err.kind, scheme)
+        );
+    }
+
+    eprintln!();
+}
+
+/// Format the error kind as a human-readable message.
+fn format_error_kind(kind: &Utf8ErrorKind, offset: usize, input: &[u8]) -> String {
+    let byte_info = if offset < input.len() {
+        format!(" (byte 0x{:02X})", input[offset])
+    } else {
+        String::new()
+    };
+
+    match kind {
+        Utf8ErrorKind::InvalidLeadByte => format!("invalid UTF-8 lead byte{byte_info}"),
+        Utf8ErrorKind::InvalidContinuationByte => {
+            format!("invalid UTF-8 continuation byte{byte_info}")
+        }
+        Utf8ErrorKind::OverlongEncoding => "overlong UTF-8 encoding".to_string(),
+        Utf8ErrorKind::SurrogateCodepoint => "surrogate codepoint in UTF-8".to_string(),
+        Utf8ErrorKind::OutOfRangeCodepoint => "codepoint above U+10FFFF".to_string(),
+        Utf8ErrorKind::TruncatedSequence => "truncated UTF-8 sequence at end of input".to_string(),
+    }
+}
+
+/// Format an additional hint for certain error types.
+fn format_error_hint(kind: &Utf8ErrorKind, scheme: &ColorScheme) -> String {
+    let hint = match kind {
+        Utf8ErrorKind::InvalidLeadByte => Some("bytes 0x80-0xBF are continuation bytes"),
+        Utf8ErrorKind::InvalidContinuationByte => Some("expected byte 0x80-0xBF"),
+        Utf8ErrorKind::OverlongEncoding => Some("use shortest possible encoding"),
+        Utf8ErrorKind::SurrogateCodepoint => Some("U+D800-U+DFFF are reserved for UTF-16"),
+        Utf8ErrorKind::OutOfRangeCodepoint => Some("maximum is U+10FFFF"),
+        Utf8ErrorKind::TruncatedSequence => None,
+    };
+
+    match hint {
+        Some(h) => format!(" {}{}{}", scheme.message, h, scheme.reset),
+        None => String::new(),
+    }
+}
+
+/// Information about an error snippet.
+struct ErrorSnippet {
+    /// The content of the line containing the error.
+    line_content: String,
+    /// Number of spaces before the caret.
+    caret_offset: usize,
+    /// Width of the caret (number of ^ characters).
+    caret_width: usize,
+}
+
+/// Extract a snippet of context around an error position.
+fn get_error_snippet(input: &[u8], line: usize, column: usize) -> Option<ErrorSnippet> {
+    // Convert input to string (lossy for display)
+    let text = String::from_utf8_lossy(input);
+
+    // Find the line containing the error
+    let mut current_line = 1;
+    let mut line_start = 0;
+
+    for (i, ch) in text.char_indices() {
+        if current_line == line {
+            line_start = i;
+            break;
+        }
+        if ch == '\n' {
+            current_line += 1;
+        }
+    }
+
+    // If we didn't find the line
+    if current_line != line && line > 1 {
+        return None;
+    }
+
+    // Find the end of this line
+    let line_end = text[line_start..]
+        .find('\n')
+        .map_or(text.len(), |i| line_start + i);
+
+    let line_content = &text[line_start..line_end];
+
+    // Truncate long lines
+    let max_width = 80;
+    let (display_content, caret_offset) = if line_content.len() > max_width {
+        let error_col = column.saturating_sub(1);
+        if error_col < max_width / 2 {
+            let truncated = &line_content[..max_width.min(line_content.len())];
+            (format!("{truncated}..."), error_col)
+        } else if error_col >= line_content.len().saturating_sub(max_width / 2) {
+            let start = line_content.len().saturating_sub(max_width);
+            let truncated = &line_content[start..];
+            let pos_in_truncated = error_col.saturating_sub(start);
+            (format!("...{truncated}"), pos_in_truncated + 3)
+        } else {
+            let start = error_col.saturating_sub(max_width / 2);
+            let end = (start + max_width).min(line_content.len());
+            let truncated = &line_content[start..end];
+            let pos_in_truncated = error_col.saturating_sub(start);
+            (format!("...{truncated}..."), pos_in_truncated + 3)
+        }
+    } else {
+        (line_content.to_string(), column.saturating_sub(1))
+    };
+
+    Some(ErrorSnippet {
+        line_content: display_content,
+        caret_offset,
+        caret_width: 1,
+    })
+}

--- a/src/bin/succinctly/utf8_bench.rs
+++ b/src/bin/succinctly/utf8_bench.rs
@@ -1,0 +1,262 @@
+//! UTF-8 validation benchmarking module.
+//!
+//! Benchmarks the scalar UTF-8 validation implementation across different
+//! content patterns and sizes. This serves as the baseline for future
+//! SIMD implementations.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Benchmark result for a single run
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkResult {
+    pub file: String,
+    pub pattern: String,
+    pub size: String,
+    pub filesize: u64,
+    pub valid: bool,
+    pub wall_time_ms: f64,
+    pub throughput_mib_s: f64,
+}
+
+/// Configuration for the benchmark
+#[derive(Debug, Clone)]
+pub struct BenchConfig {
+    pub data_dir: PathBuf,
+    pub patterns: Vec<String>,
+    pub sizes: Vec<String>,
+    pub warmup_runs: usize,
+    pub benchmark_runs: usize,
+}
+
+impl Default for BenchConfig {
+    fn default() -> Self {
+        Self {
+            data_dir: PathBuf::from("data/bench/generated/utf8"),
+            patterns: vec![
+                "ascii".into(),
+                "latin".into(),
+                "greek_cyrillic".into(),
+                "cjk".into(),
+                "emoji".into(),
+                "mixed".into(),
+                "all_lengths".into(),
+                "log_file".into(),
+                "source_code".into(),
+                "json_like".into(),
+                "pathological".into(),
+            ],
+            sizes: vec![
+                "1kb".into(),
+                "10kb".into(),
+                "100kb".into(),
+                "1mb".into(),
+                "10mb".into(),
+                "100mb".into(),
+            ],
+            warmup_runs: 1,
+            benchmark_runs: 3,
+        }
+    }
+}
+
+/// Run the UTF-8 benchmark suite
+pub fn run_benchmark(
+    config: &BenchConfig,
+    output_jsonl: Option<&Path>,
+    output_md: Option<&Path>,
+) -> Result<Vec<BenchmarkResult>> {
+    let mut results = Vec::new();
+
+    // Set up Ctrl+C handler
+    let interrupted = Arc::new(AtomicBool::new(false));
+    let interrupted_clone = Arc::clone(&interrupted);
+    ctrlc::set_handler(move || {
+        interrupted_clone.store(true, Ordering::SeqCst);
+        eprintln!("\nInterrupted! Writing partial results...");
+    })
+    .context("Failed to set Ctrl+C handler")?;
+
+    eprintln!("Running UTF-8 validation benchmark suite (scalar)...");
+    eprintln!("  Data directory: {}", config.data_dir.display());
+    eprintln!("  Warmup runs: {}", config.warmup_runs);
+    eprintln!("  Benchmark runs: {}", config.benchmark_runs);
+    eprintln!();
+
+    // Open JSONL file for streaming output if requested
+    let mut jsonl_file = output_jsonl
+        .map(|p| {
+            std::fs::File::create(p).with_context(|| format!("Failed to create {}", p.display()))
+        })
+        .transpose()?;
+
+    'outer: for pattern in &config.patterns {
+        for size in &config.sizes {
+            // Check for Ctrl+C
+            if interrupted.load(Ordering::SeqCst) {
+                break 'outer;
+            }
+
+            let file_path = config.data_dir.join(pattern).join(format!("{size}.txt"));
+
+            if !file_path.exists() {
+                eprintln!("  Skipping {} (not found)", file_path.display());
+                continue;
+            }
+
+            let filesize = std::fs::metadata(&file_path)?.len();
+
+            eprint!(
+                "  {} {} ({})... ",
+                pattern,
+                size,
+                format_bytes(filesize as usize)
+            );
+            std::io::stderr().flush()?;
+
+            // Run benchmark
+            match benchmark_file(&file_path, config) {
+                Ok(result) => {
+                    eprintln!(
+                        "{:.2}ms ({:.1} MiB/s){}",
+                        result.wall_time_ms,
+                        result.throughput_mib_s,
+                        if result.valid { "" } else { " [INVALID]" }
+                    );
+
+                    // Write to JSONL immediately
+                    if let Some(ref mut f) = jsonl_file {
+                        serde_json::to_writer(&mut *f, &result)?;
+                        writeln!(f)?;
+                        f.flush()?;
+                    }
+
+                    results.push(result);
+                }
+                Err(e) => {
+                    eprintln!("ERROR: {e}");
+                }
+            }
+        }
+    }
+
+    // Write markdown summary if requested
+    if let Some(md_path) = output_md {
+        write_markdown_summary(&results, md_path)?;
+    }
+
+    // Print summary
+    eprintln!();
+    eprintln!("Completed {} benchmarks", results.len());
+
+    Ok(results)
+}
+
+/// Benchmark a single file
+fn benchmark_file(file_path: &Path, config: &BenchConfig) -> Result<BenchmarkResult> {
+    let data = std::fs::read(file_path)?;
+    let filesize = data.len() as u64;
+
+    let pattern = file_path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let size = file_path
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    // Warmup
+    for _ in 0..config.warmup_runs {
+        let _ = succinctly::text::utf8::validate_utf8(&data);
+    }
+
+    // Benchmark
+    let mut times = Vec::with_capacity(config.benchmark_runs);
+    let mut valid = false;
+    for _ in 0..config.benchmark_runs {
+        let start = Instant::now();
+        valid = succinctly::text::utf8::validate_utf8(&data).is_ok();
+        times.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = times[times.len() / 2];
+
+    // Calculate throughput in MiB/s
+    let throughput = (filesize as f64 / (1024.0 * 1024.0)) / (median / 1000.0);
+
+    Ok(BenchmarkResult {
+        file: file_path.display().to_string(),
+        pattern,
+        size,
+        filesize,
+        valid,
+        wall_time_ms: median,
+        throughput_mib_s: throughput,
+    })
+}
+
+/// Write markdown summary
+fn write_markdown_summary(results: &[BenchmarkResult], path: &Path) -> Result<()> {
+    let mut md = String::new();
+
+    md.push_str("# UTF-8 Validation Benchmark Results (Scalar)\n\n");
+    md.push_str("Baseline scalar implementation of `succinctly::text::utf8::validate_utf8`.\n\n");
+
+    // Group by pattern
+    let mut patterns: Vec<&str> = results.iter().map(|r| r.pattern.as_str()).collect();
+    patterns.sort_unstable();
+    patterns.dedup();
+
+    for pattern in patterns {
+        md.push_str(&format!("## {pattern}\n\n"));
+        md.push_str("| Size | Time (ms) | Throughput (MiB/s) |\n");
+        md.push_str("|------|-----------|--------------------|\n");
+
+        for result in results.iter().filter(|r| r.pattern == pattern) {
+            md.push_str(&format!(
+                "| {} | {:.2} | {:.1} |\n",
+                result.size, result.wall_time_ms, result.throughput_mib_s
+            ));
+        }
+        md.push('\n');
+    }
+
+    std::fs::write(path, md)?;
+    Ok(())
+}
+
+/// Format bytes as human-readable string
+fn format_bytes(bytes: usize) -> String {
+    if bytes >= 1024 * 1024 * 1024 {
+        format!("{:.2} GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+    } else if bytes >= 1024 * 1024 {
+        format!("{:.2} MB", bytes as f64 / (1024.0 * 1024.0))
+    } else if bytes >= 1024 {
+        format!("{:.2} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1024), "1.00 KB");
+        assert_eq!(format_bytes(1024 * 1024), "1.00 MB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.00 GB");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`jq`] - jq-style query language for JSON navigation
 //! - [`dsv`] - High-performance CSV/TSV parsing with succinct indexing
 //! - [`yaml`] - YAML semi-indexing (Phase 1: block style)
+//! - [`text`] - Text processing utilities (UTF-8 validation)
 //!
 //! ## Quick Start
 //!
@@ -85,6 +86,9 @@ pub mod dsv;
 
 /// YAML semi-indexing (Phase 1: YAML-lite).
 pub mod yaml;
+
+/// Text processing utilities (UTF-8 validation, etc.).
+pub mod text;
 
 // =============================================================================
 // Public re-exports (convenience + backward compatibility)

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,0 +1,28 @@
+//! Text processing utilities.
+//!
+//! This module provides utilities for text processing, including UTF-8 validation.
+//!
+//! ## UTF-8 Validation
+//!
+//! The [`utf8`](crate::text::utf8) module provides high-performance UTF-8 validation with detailed
+//! error reporting including byte offset, line number, and column position.
+//!
+//! ```
+//! use succinctly::text::utf8::{validate_utf8, Utf8Error, Utf8ErrorKind};
+//!
+//! // Valid UTF-8
+//! assert!(validate_utf8(b"Hello, world!").is_ok());
+//! assert!(validate_utf8("日本語".as_bytes()).is_ok());
+//!
+//! // Invalid UTF-8 (bare continuation byte)
+//! let result = validate_utf8(&[0x80]);
+//! assert!(result.is_err());
+//! let err = result.unwrap_err();
+//! assert_eq!(err.kind, Utf8ErrorKind::InvalidLeadByte);
+//! assert_eq!(err.offset, 0);
+//! ```
+
+pub mod utf8;
+
+// Re-export commonly used types
+pub use utf8::{validate_utf8, Utf8Error, Utf8ErrorKind};

--- a/src/text/utf8.rs
+++ b/src/text/utf8.rs
@@ -1,0 +1,1446 @@
+//! UTF-8 validation with detailed error reporting.
+//!
+//! This module provides UTF-8 validation that reports:
+//! - The exact byte offset of the error
+//! - The line number (1-indexed)
+//! - The column number (1-indexed, in bytes)
+//! - The specific type of UTF-8 violation
+//!
+//! ## UTF-8 Encoding Rules
+//!
+//! UTF-8 is a variable-width encoding that uses 1-4 bytes per character:
+//!
+//! | Bytes | First byte    | Continuation bytes | Code point range     |
+//! |-------|---------------|-------------------|----------------------|
+//! | 1     | `0xxxxxxx`    | -                 | U+0000 - U+007F      |
+//! | 2     | `110xxxxx`    | `10xxxxxx`        | U+0080 - U+07FF      |
+//! | 3     | `1110xxxx`    | `10xxxxxx` × 2    | U+0800 - U+FFFF      |
+//! | 4     | `11110xxx`    | `10xxxxxx` × 3    | U+10000 - U+10FFFF   |
+//!
+//! ## Validation Checks
+//!
+//! The validator checks for:
+//! 1. **Invalid lead bytes**: Bytes 0x80-0xBF appearing where a lead byte is expected
+//! 2. **Invalid continuation bytes**: Non-continuation bytes where continuation expected
+//! 3. **Overlong encodings**: Using more bytes than necessary (security vulnerability)
+//! 4. **Surrogate code points**: U+D800-U+DFFF (reserved for UTF-16)
+//! 5. **Out of range**: Code points above U+10FFFF
+//! 6. **Truncated sequences**: Multi-byte sequence cut off at end of input
+
+use alloc::string::String;
+
+/// Error information for UTF-8 validation failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Utf8Error {
+    /// The byte offset where the error occurred (0-indexed).
+    pub offset: usize,
+    /// The line number where the error occurred (1-indexed).
+    pub line: usize,
+    /// The column (byte position within the line, 1-indexed).
+    pub column: usize,
+    /// The kind of UTF-8 error.
+    pub kind: Utf8ErrorKind,
+}
+
+impl core::fmt::Display for Utf8Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{} at byte {}, line {}, column {}",
+            self.kind, self.offset, self.line, self.column
+        )
+    }
+}
+
+/// The specific type of UTF-8 validation error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Utf8ErrorKind {
+    /// A byte in the range 0x80-0xBF appeared where a lead byte was expected.
+    /// These bytes are only valid as continuation bytes.
+    InvalidLeadByte,
+
+    /// A byte outside the range 0x80-0xBF appeared where a continuation byte was expected.
+    InvalidContinuationByte,
+
+    /// A character was encoded using more bytes than necessary.
+    /// For example, encoding ASCII 'A' (U+0041) as `C0 81` instead of `41`.
+    /// This is a security vulnerability as it can bypass validation filters.
+    OverlongEncoding,
+
+    /// A surrogate code point (U+D800-U+DFFF) was encoded.
+    /// These are reserved for UTF-16 surrogate pairs and invalid in UTF-8.
+    SurrogateCodepoint,
+
+    /// A code point above U+10FFFF was encoded.
+    /// Unicode only defines code points up to U+10FFFF.
+    OutOfRangeCodepoint,
+
+    /// A multi-byte sequence was truncated at the end of input.
+    TruncatedSequence,
+}
+
+impl core::fmt::Display for Utf8ErrorKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidLeadByte => write!(f, "invalid UTF-8 lead byte"),
+            Self::InvalidContinuationByte => write!(f, "invalid UTF-8 continuation byte"),
+            Self::OverlongEncoding => write!(f, "overlong UTF-8 encoding"),
+            Self::SurrogateCodepoint => write!(f, "surrogate code point in UTF-8"),
+            Self::OutOfRangeCodepoint => write!(f, "code point above U+10FFFF"),
+            Self::TruncatedSequence => write!(f, "truncated UTF-8 sequence"),
+        }
+    }
+}
+
+/// Validate that the input is valid UTF-8.
+///
+/// Returns `Ok(())` if the input is valid UTF-8, or an `Err(Utf8Error)` with
+/// detailed information about the first validation error.
+///
+/// # Examples
+///
+/// ```
+/// use succinctly::text::utf8::validate_utf8;
+///
+/// // Valid ASCII
+/// assert!(validate_utf8(b"Hello, world!").is_ok());
+///
+/// // Valid multi-byte UTF-8
+/// assert!(validate_utf8("日本語".as_bytes()).is_ok());
+/// assert!(validate_utf8("émoji: 🎉".as_bytes()).is_ok());
+///
+/// // Invalid: bare continuation byte
+/// assert!(validate_utf8(&[0x80]).is_err());
+///
+/// // Invalid: truncated sequence
+/// assert!(validate_utf8(&[0xC2]).is_err());
+/// ```
+#[inline]
+pub fn validate_utf8(input: &[u8]) -> Result<(), Utf8Error> {
+    validate_utf8_scalar(input)
+}
+
+/// Validate UTF-8 using a scalar (byte-by-byte) algorithm.
+///
+/// This is a portable implementation that works on all platforms.
+/// It provides detailed error information including the exact byte offset,
+/// line number, and column position of any error.
+pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
+    let mut pos = 0;
+    let mut line = 1;
+    let mut line_start = 0;
+    let len = input.len();
+
+    while pos < len {
+        let byte = input[pos];
+
+        // Track newlines for error reporting
+        if pos > 0 && input[pos - 1] == b'\n' {
+            line += 1;
+            line_start = pos;
+        }
+
+        // Determine sequence length from lead byte
+        let seq_len = match byte {
+            // ASCII: 0x00-0x7F (single byte)
+            0x00..=0x7F => {
+                pos += 1;
+                continue;
+            }
+            // Continuation bytes appearing as lead: invalid
+            0x80..=0xBF => {
+                return Err(Utf8Error {
+                    offset: pos,
+                    line,
+                    column: pos - line_start + 1,
+                    kind: Utf8ErrorKind::InvalidLeadByte,
+                });
+            }
+            // 2-byte sequence: 0xC0-0xDF
+            0xC0..=0xDF => 2,
+            // 3-byte sequence: 0xE0-0xEF
+            0xE0..=0xEF => 3,
+            // 4-byte sequence: 0xF0-0xF7
+            0xF0..=0xF7 => 4,
+            // Invalid lead bytes: 0xF8-0xFF
+            0xF8..=0xFF => {
+                return Err(Utf8Error {
+                    offset: pos,
+                    line,
+                    column: pos - line_start + 1,
+                    kind: Utf8ErrorKind::InvalidLeadByte,
+                });
+            }
+        };
+
+        // Check for truncation
+        if pos + seq_len > len {
+            return Err(Utf8Error {
+                offset: pos,
+                line,
+                column: pos - line_start + 1,
+                kind: Utf8ErrorKind::TruncatedSequence,
+            });
+        }
+
+        // Validate continuation bytes and decode code point
+        match seq_len {
+            2 => {
+                let b1 = input[pos + 1];
+                if !is_continuation_byte(b1) {
+                    return Err(Utf8Error {
+                        offset: pos + 1,
+                        line,
+                        column: pos + 1 - line_start + 1,
+                        kind: Utf8ErrorKind::InvalidContinuationByte,
+                    });
+                }
+
+                // Check for overlong encoding (code points < 0x80 must use 1 byte)
+                // 2-byte sequences must encode U+0080 or higher
+                // Lead byte 0xC0 or 0xC1 would encode < 0x80
+                if byte <= 0xC1 {
+                    return Err(Utf8Error {
+                        offset: pos,
+                        line,
+                        column: pos - line_start + 1,
+                        kind: Utf8ErrorKind::OverlongEncoding,
+                    });
+                }
+            }
+            3 => {
+                let b1 = input[pos + 1];
+                let b2 = input[pos + 2];
+
+                if !is_continuation_byte(b1) {
+                    return Err(Utf8Error {
+                        offset: pos + 1,
+                        line,
+                        column: pos + 1 - line_start + 1,
+                        kind: Utf8ErrorKind::InvalidContinuationByte,
+                    });
+                }
+                if !is_continuation_byte(b2) {
+                    return Err(Utf8Error {
+                        offset: pos + 2,
+                        line,
+                        column: pos + 2 - line_start + 1,
+                        kind: Utf8ErrorKind::InvalidContinuationByte,
+                    });
+                }
+
+                // Decode code point for validation
+                let cp =
+                    ((byte as u32 & 0x0F) << 12) | ((b1 as u32 & 0x3F) << 6) | (b2 as u32 & 0x3F);
+
+                // Check for overlong encoding (code points < 0x800 must use 2 bytes)
+                if cp < 0x800 {
+                    return Err(Utf8Error {
+                        offset: pos,
+                        line,
+                        column: pos - line_start + 1,
+                        kind: Utf8ErrorKind::OverlongEncoding,
+                    });
+                }
+
+                // Check for surrogate code points (U+D800-U+DFFF)
+                if (0xD800..=0xDFFF).contains(&cp) {
+                    return Err(Utf8Error {
+                        offset: pos,
+                        line,
+                        column: pos - line_start + 1,
+                        kind: Utf8ErrorKind::SurrogateCodepoint,
+                    });
+                }
+            }
+            4 => {
+                let b1 = input[pos + 1];
+                let b2 = input[pos + 2];
+                let b3 = input[pos + 3];
+
+                if !is_continuation_byte(b1) {
+                    return Err(Utf8Error {
+                        offset: pos + 1,
+                        line,
+                        column: pos + 1 - line_start + 1,
+                        kind: Utf8ErrorKind::InvalidContinuationByte,
+                    });
+                }
+                if !is_continuation_byte(b2) {
+                    return Err(Utf8Error {
+                        offset: pos + 2,
+                        line,
+                        column: pos + 2 - line_start + 1,
+                        kind: Utf8ErrorKind::InvalidContinuationByte,
+                    });
+                }
+                if !is_continuation_byte(b3) {
+                    return Err(Utf8Error {
+                        offset: pos + 3,
+                        line,
+                        column: pos + 3 - line_start + 1,
+                        kind: Utf8ErrorKind::InvalidContinuationByte,
+                    });
+                }
+
+                // Decode code point for validation
+                let cp = ((byte as u32 & 0x07) << 18)
+                    | ((b1 as u32 & 0x3F) << 12)
+                    | ((b2 as u32 & 0x3F) << 6)
+                    | (b3 as u32 & 0x3F);
+
+                // Check for overlong encoding (code points < 0x10000 must use 3 bytes)
+                if cp < 0x10000 {
+                    return Err(Utf8Error {
+                        offset: pos,
+                        line,
+                        column: pos - line_start + 1,
+                        kind: Utf8ErrorKind::OverlongEncoding,
+                    });
+                }
+
+                // Check for out of range (> U+10FFFF)
+                if cp > 0x10FFFF {
+                    return Err(Utf8Error {
+                        offset: pos,
+                        line,
+                        column: pos - line_start + 1,
+                        kind: Utf8ErrorKind::OutOfRangeCodepoint,
+                    });
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        pos += seq_len;
+    }
+
+    Ok(())
+}
+
+/// Check if a byte is a valid UTF-8 continuation byte (0x80-0xBF).
+#[inline(always)]
+fn is_continuation_byte(byte: u8) -> bool {
+    (byte & 0xC0) == 0x80
+}
+
+/// Get the expected sequence length from a lead byte.
+/// Returns 0 for invalid lead bytes (continuation bytes or 0xF8+).
+#[inline]
+pub fn sequence_length(lead_byte: u8) -> usize {
+    match lead_byte {
+        0x00..=0x7F => 1,
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        _ => 0, // Invalid lead byte
+    }
+}
+
+/// Decode a UTF-8 code point from a byte slice.
+///
+/// Returns `None` if the input is empty or contains an invalid sequence.
+/// On success, returns the decoded code point and the number of bytes consumed.
+///
+/// # Examples
+///
+/// ```
+/// use succinctly::text::utf8::decode_code_point;
+///
+/// // ASCII
+/// assert_eq!(decode_code_point(b"A"), Some(('A' as u32, 1)));
+///
+/// // Multi-byte
+/// assert_eq!(decode_code_point("日".as_bytes()), Some((0x65E5, 3)));
+///
+/// // Empty input
+/// assert_eq!(decode_code_point(b""), None);
+/// ```
+pub fn decode_code_point(input: &[u8]) -> Option<(u32, usize)> {
+    if input.is_empty() {
+        return None;
+    }
+
+    let lead = input[0];
+    let len = sequence_length(lead);
+
+    if len == 0 || input.len() < len {
+        return None;
+    }
+
+    let cp = match len {
+        1 => lead as u32,
+        2 => {
+            let b1 = input[1];
+            if !is_continuation_byte(b1) {
+                return None;
+            }
+            ((lead as u32 & 0x1F) << 6) | (b1 as u32 & 0x3F)
+        }
+        3 => {
+            let b1 = input[1];
+            let b2 = input[2];
+            if !is_continuation_byte(b1) || !is_continuation_byte(b2) {
+                return None;
+            }
+            ((lead as u32 & 0x0F) << 12) | ((b1 as u32 & 0x3F) << 6) | (b2 as u32 & 0x3F)
+        }
+        4 => {
+            let b1 = input[1];
+            let b2 = input[2];
+            let b3 = input[3];
+            if !is_continuation_byte(b1) || !is_continuation_byte(b2) || !is_continuation_byte(b3) {
+                return None;
+            }
+            ((lead as u32 & 0x07) << 18)
+                | ((b1 as u32 & 0x3F) << 12)
+                | ((b2 as u32 & 0x3F) << 6)
+                | (b3 as u32 & 0x3F)
+        }
+        _ => return None,
+    };
+
+    Some((cp, len))
+}
+
+/// Encode a Unicode code point as UTF-8.
+///
+/// Returns `None` if the code point is invalid (surrogate or > U+10FFFF).
+/// On success, returns the UTF-8 bytes and the number of bytes used.
+///
+/// # Examples
+///
+/// ```
+/// use succinctly::text::utf8::encode_code_point;
+///
+/// // ASCII
+/// let (bytes, len) = encode_code_point(0x41).unwrap();
+/// assert_eq!(&bytes[..len], b"A");
+///
+/// // 2-byte character (é)
+/// let (bytes, len) = encode_code_point(0xE9).unwrap();
+/// assert_eq!(&bytes[..len], "é".as_bytes());
+///
+/// // 4-byte character (🎉)
+/// let (bytes, len) = encode_code_point(0x1F389).unwrap();
+/// assert_eq!(&bytes[..len], "🎉".as_bytes());
+///
+/// // Invalid: surrogate
+/// assert!(encode_code_point(0xD800).is_none());
+///
+/// // Invalid: out of range
+/// assert!(encode_code_point(0x110000).is_none());
+/// ```
+pub fn encode_code_point(cp: u32) -> Option<([u8; 4], usize)> {
+    // Reject surrogates and out-of-range
+    if (0xD800..=0xDFFF).contains(&cp) || cp > 0x10FFFF {
+        return None;
+    }
+
+    let mut buf = [0u8; 4];
+
+    let len = if cp < 0x80 {
+        buf[0] = cp as u8;
+        1
+    } else if cp < 0x800 {
+        buf[0] = 0xC0 | ((cp >> 6) as u8);
+        buf[1] = 0x80 | ((cp & 0x3F) as u8);
+        2
+    } else if cp < 0x10000 {
+        buf[0] = 0xE0 | ((cp >> 12) as u8);
+        buf[1] = 0x80 | (((cp >> 6) & 0x3F) as u8);
+        buf[2] = 0x80 | ((cp & 0x3F) as u8);
+        3
+    } else {
+        buf[0] = 0xF0 | ((cp >> 18) as u8);
+        buf[1] = 0x80 | (((cp >> 12) & 0x3F) as u8);
+        buf[2] = 0x80 | (((cp >> 6) & 0x3F) as u8);
+        buf[3] = 0x80 | ((cp & 0x3F) as u8);
+        4
+    };
+
+    Some((buf, len))
+}
+
+/// Format a byte as a human-readable string for error messages.
+pub fn format_byte(byte: u8) -> String {
+    if byte.is_ascii_graphic() || byte == b' ' {
+        alloc::format!("0x{:02X} ({:?})", byte, byte as char)
+    } else {
+        alloc::format!("0x{byte:02X}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // Valid UTF-8 Tests
+    // =========================================================================
+
+    mod valid_utf8 {
+        use super::*;
+
+        #[test]
+        fn empty_input() {
+            assert!(validate_utf8(b"").is_ok());
+        }
+
+        #[test]
+        fn ascii_single_byte() {
+            // All ASCII characters (0x00-0x7F)
+            for byte in 0x00..=0x7F {
+                assert!(
+                    validate_utf8(&[byte]).is_ok(),
+                    "ASCII byte 0x{byte:02X} should be valid"
+                );
+            }
+        }
+
+        #[test]
+        fn ascii_string() {
+            assert!(validate_utf8(b"Hello, world!").is_ok());
+            assert!(validate_utf8(b"The quick brown fox jumps over the lazy dog").is_ok());
+        }
+
+        #[test]
+        fn ascii_with_control_chars() {
+            assert!(validate_utf8(b"line1\nline2\ttab\rcarriage").is_ok());
+            assert!(validate_utf8(b"\x00\x01\x02\x1F").is_ok()); // Control characters
+        }
+
+        #[test]
+        fn two_byte_sequences() {
+            // U+0080 (first 2-byte code point)
+            assert!(validate_utf8(&[0xC2, 0x80]).is_ok());
+
+            // U+00FF (Latin Small Letter Y with Diaeresis)
+            assert!(validate_utf8(&[0xC3, 0xBF]).is_ok());
+
+            // U+07FF (last 2-byte code point)
+            assert!(validate_utf8(&[0xDF, 0xBF]).is_ok());
+
+            // Common 2-byte characters
+            assert!(validate_utf8("é".as_bytes()).is_ok()); // U+00E9
+            assert!(validate_utf8("ñ".as_bytes()).is_ok()); // U+00F1
+            assert!(validate_utf8("ü".as_bytes()).is_ok()); // U+00FC
+            assert!(validate_utf8("©".as_bytes()).is_ok()); // U+00A9
+            assert!(validate_utf8("®".as_bytes()).is_ok()); // U+00AE
+        }
+
+        #[test]
+        fn three_byte_sequences() {
+            // U+0800 (first 3-byte code point)
+            assert!(validate_utf8(&[0xE0, 0xA0, 0x80]).is_ok());
+
+            // U+FFFF (last valid 3-byte code point in BMP)
+            assert!(validate_utf8(&[0xEF, 0xBF, 0xBF]).is_ok());
+
+            // Japanese characters
+            assert!(validate_utf8("日本語".as_bytes()).is_ok());
+            assert!(validate_utf8("こんにちは".as_bytes()).is_ok());
+
+            // Chinese characters
+            assert!(validate_utf8("中文".as_bytes()).is_ok());
+            assert!(validate_utf8("你好世界".as_bytes()).is_ok());
+
+            // Korean characters
+            assert!(validate_utf8("한국어".as_bytes()).is_ok());
+            assert!(validate_utf8("안녕하세요".as_bytes()).is_ok());
+
+            // Arabic
+            assert!(validate_utf8("مرحبا".as_bytes()).is_ok());
+
+            // Hebrew
+            assert!(validate_utf8("שלום".as_bytes()).is_ok());
+
+            // Thai
+            assert!(validate_utf8("สวัสดี".as_bytes()).is_ok());
+
+            // Currency symbols
+            assert!(validate_utf8("€".as_bytes()).is_ok()); // U+20AC Euro
+            assert!(validate_utf8("₹".as_bytes()).is_ok()); // U+20B9 Indian Rupee
+            assert!(validate_utf8("₿".as_bytes()).is_ok()); // U+20BF Bitcoin
+        }
+
+        #[test]
+        fn four_byte_sequences() {
+            // U+10000 (first 4-byte code point)
+            assert!(validate_utf8(&[0xF0, 0x90, 0x80, 0x80]).is_ok());
+
+            // U+10FFFF (last valid code point)
+            assert!(validate_utf8(&[0xF4, 0x8F, 0xBF, 0xBF]).is_ok());
+
+            // Emoji
+            assert!(validate_utf8("🎉".as_bytes()).is_ok()); // U+1F389 Party Popper
+            assert!(validate_utf8("😀".as_bytes()).is_ok()); // U+1F600 Grinning Face
+            assert!(validate_utf8("🚀".as_bytes()).is_ok()); // U+1F680 Rocket
+            assert!(validate_utf8("🌍".as_bytes()).is_ok()); // U+1F30D Earth
+            assert!(validate_utf8("💻".as_bytes()).is_ok()); // U+1F4BB Laptop
+            assert!(validate_utf8("🔥".as_bytes()).is_ok()); // U+1F525 Fire
+
+            // Mathematical symbols
+            assert!(validate_utf8("𝕳".as_bytes()).is_ok()); // U+1D573 Mathematical Bold Fraktur H
+            assert!(validate_utf8("𝔸".as_bytes()).is_ok()); // U+1D538 Mathematical Double-Struck A
+
+            // Ancient scripts
+            assert!(validate_utf8("𐀀".as_bytes()).is_ok()); // U+10000 Linear B Syllable B008 A
+
+            // Music symbols
+            assert!(validate_utf8("𝄞".as_bytes()).is_ok()); // U+1D11E Musical Symbol G Clef
+        }
+
+        #[test]
+        fn mixed_sequences() {
+            // Mix of all sequence lengths
+            let mixed = "A é 日 🎉";
+            assert!(validate_utf8(mixed.as_bytes()).is_ok());
+
+            // Complex mixed text
+            let complex = "Hello! 你好 مرحبا 🌍🚀 Ñoño café";
+            assert!(validate_utf8(complex.as_bytes()).is_ok());
+        }
+
+        #[test]
+        fn boundary_code_points() {
+            // First code point of each length
+            assert!(validate_utf8(&[0x00]).is_ok()); // U+0000
+            assert!(validate_utf8(&[0xC2, 0x80]).is_ok()); // U+0080
+            assert!(validate_utf8(&[0xE0, 0xA0, 0x80]).is_ok()); // U+0800
+            assert!(validate_utf8(&[0xF0, 0x90, 0x80, 0x80]).is_ok()); // U+10000
+
+            // Last code point of each length
+            assert!(validate_utf8(&[0x7F]).is_ok()); // U+007F
+            assert!(validate_utf8(&[0xDF, 0xBF]).is_ok()); // U+07FF
+            assert!(validate_utf8(&[0xEF, 0xBF, 0xBF]).is_ok()); // U+FFFF
+            assert!(validate_utf8(&[0xF4, 0x8F, 0xBF, 0xBF]).is_ok()); // U+10FFFF
+        }
+
+        #[test]
+        fn non_characters() {
+            // Unicode non-characters are technically valid UTF-8
+            // U+FFFE and U+FFFF
+            assert!(validate_utf8(&[0xEF, 0xBF, 0xBE]).is_ok()); // U+FFFE
+            assert!(validate_utf8(&[0xEF, 0xBF, 0xBF]).is_ok()); // U+FFFF
+
+            // BOM (Byte Order Mark)
+            assert!(validate_utf8(&[0xEF, 0xBB, 0xBF]).is_ok()); // U+FEFF
+        }
+
+        #[test]
+        fn long_valid_string() {
+            // 1KB of mixed valid UTF-8
+            let mut s = String::new();
+            for i in 0..100 {
+                s.push_str(&format!("Line {i}: Hello 世界 🎉\n"));
+            }
+            assert!(validate_utf8(s.as_bytes()).is_ok());
+        }
+    }
+
+    // =========================================================================
+    // Invalid Lead Byte Tests
+    // =========================================================================
+
+    mod invalid_lead_byte {
+        use super::*;
+
+        #[test]
+        fn continuation_byte_as_lead() {
+            // Continuation bytes (0x80-0xBF) cannot start a sequence
+            for byte in 0x80..=0xBF {
+                let result = validate_utf8(&[byte]);
+                assert!(
+                    result.is_err(),
+                    "Byte 0x{byte:02X} should be invalid as lead"
+                );
+                let err = result.unwrap_err();
+                assert_eq!(err.kind, Utf8ErrorKind::InvalidLeadByte);
+                assert_eq!(err.offset, 0);
+            }
+        }
+
+        #[test]
+        fn continuation_byte_after_valid() {
+            // Valid ASCII followed by bare continuation byte
+            let input = [b'A', 0x80];
+            let result = validate_utf8(&input);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::InvalidLeadByte);
+            assert_eq!(err.offset, 1);
+        }
+
+        #[test]
+        fn f8_ff_lead_bytes() {
+            // 0xF8-0xFF are always invalid lead bytes
+            for byte in 0xF8..=0xFF {
+                let result = validate_utf8(&[byte]);
+                assert!(
+                    result.is_err(),
+                    "Byte 0x{byte:02X} should be invalid as lead"
+                );
+                let err = result.unwrap_err();
+                assert_eq!(err.kind, Utf8ErrorKind::InvalidLeadByte);
+            }
+        }
+
+        #[test]
+        fn fe_ff_bytes() {
+            // 0xFE and 0xFF are never valid in UTF-8
+            assert!(validate_utf8(&[0xFE]).is_err());
+            assert!(validate_utf8(&[0xFF]).is_err());
+            assert!(validate_utf8(&[0xFE, 0xFE, 0xFF, 0xFF]).is_err());
+        }
+    }
+
+    // =========================================================================
+    // Invalid Continuation Byte Tests
+    // =========================================================================
+
+    mod invalid_continuation {
+        use super::*;
+
+        #[test]
+        fn missing_continuation_2byte() {
+            // 2-byte lead followed by ASCII instead of continuation
+            let result = validate_utf8(&[0xC2, b'A']);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::InvalidContinuationByte);
+            assert_eq!(err.offset, 1);
+        }
+
+        #[test]
+        fn missing_continuation_3byte_first() {
+            // 3-byte lead followed by ASCII
+            let result = validate_utf8(&[0xE0, b'A', 0x80]);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::InvalidContinuationByte);
+            assert_eq!(err.offset, 1);
+        }
+
+        #[test]
+        fn missing_continuation_3byte_second() {
+            // 3-byte sequence with second continuation wrong
+            let result = validate_utf8(&[0xE0, 0xA0, b'A']);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::InvalidContinuationByte);
+            assert_eq!(err.offset, 2);
+        }
+
+        #[test]
+        fn missing_continuation_4byte() {
+            // 4-byte sequence with various wrong continuations
+            // Wrong first continuation
+            let result = validate_utf8(&[0xF0, b'A', 0x80, 0x80]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().offset, 1);
+
+            // Wrong second continuation
+            let result = validate_utf8(&[0xF0, 0x90, b'A', 0x80]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().offset, 2);
+
+            // Wrong third continuation
+            let result = validate_utf8(&[0xF0, 0x90, 0x80, b'A']);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().offset, 3);
+        }
+
+        #[test]
+        fn continuation_is_another_lead() {
+            // 2-byte lead followed by another lead byte
+            let result = validate_utf8(&[0xC2, 0xC2]);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::InvalidContinuationByte);
+        }
+
+        #[test]
+        fn continuation_is_high_byte() {
+            // Continuation position has 0xF0+ byte
+            let result = validate_utf8(&[0xC2, 0xF0]);
+            assert!(result.is_err());
+            assert_eq!(
+                result.unwrap_err().kind,
+                Utf8ErrorKind::InvalidContinuationByte
+            );
+        }
+    }
+
+    // =========================================================================
+    // Overlong Encoding Tests
+    // =========================================================================
+
+    mod overlong_encoding {
+        use super::*;
+
+        #[test]
+        fn overlong_2byte_null() {
+            // NUL (U+0000) encoded as 2 bytes: C0 80
+            let result = validate_utf8(&[0xC0, 0x80]);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::OverlongEncoding);
+        }
+
+        #[test]
+        fn overlong_2byte_ascii() {
+            // ASCII 'A' (U+0041) encoded as 2 bytes: C1 81
+            let result = validate_utf8(&[0xC1, 0x81]);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::OverlongEncoding);
+        }
+
+        #[test]
+        fn overlong_2byte_all_c0_c1() {
+            // C0 and C1 lead bytes always indicate overlong encoding
+            for lead in [0xC0, 0xC1] {
+                for cont in 0x80..=0xBF {
+                    let result = validate_utf8(&[lead, cont]);
+                    assert!(
+                        result.is_err(),
+                        "0x{lead:02X} 0x{cont:02X} should be overlong"
+                    );
+                    assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::OverlongEncoding);
+                }
+            }
+        }
+
+        #[test]
+        fn overlong_3byte_null() {
+            // NUL (U+0000) encoded as 3 bytes: E0 80 80
+            let result = validate_utf8(&[0xE0, 0x80, 0x80]);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::OverlongEncoding);
+        }
+
+        #[test]
+        fn overlong_3byte_2byte_char() {
+            // U+007F encoded as 3 bytes: E0 81 BF
+            let result = validate_utf8(&[0xE0, 0x81, 0xBF]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::OverlongEncoding);
+
+            // U+07FF encoded as 3 bytes: E0 9F BF (should be DF BF)
+            let result = validate_utf8(&[0xE0, 0x9F, 0xBF]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::OverlongEncoding);
+        }
+
+        #[test]
+        fn overlong_4byte_null() {
+            // NUL (U+0000) encoded as 4 bytes: F0 80 80 80
+            let result = validate_utf8(&[0xF0, 0x80, 0x80, 0x80]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::OverlongEncoding);
+        }
+
+        #[test]
+        fn overlong_4byte_3byte_char() {
+            // U+FFFF encoded as 4 bytes: F0 8F BF BF (should be EF BF BF)
+            let result = validate_utf8(&[0xF0, 0x8F, 0xBF, 0xBF]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::OverlongEncoding);
+        }
+
+        #[test]
+        fn security_overlong_slash() {
+            // Security test: overlong encoding of '/' (U+002F)
+            // Attackers might use this to bypass path traversal filters
+
+            // 2-byte: C0 AF
+            let result = validate_utf8(&[0xC0, 0xAF]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::OverlongEncoding);
+
+            // 3-byte: E0 80 AF
+            let result = validate_utf8(&[0xE0, 0x80, 0xAF]);
+            assert!(result.is_err());
+
+            // 4-byte: F0 80 80 AF
+            let result = validate_utf8(&[0xF0, 0x80, 0x80, 0xAF]);
+            assert!(result.is_err());
+        }
+    }
+
+    // =========================================================================
+    // Surrogate Code Point Tests
+    // =========================================================================
+
+    mod surrogate_codepoints {
+        use super::*;
+
+        #[test]
+        fn high_surrogate_start() {
+            // U+D800 (first high surrogate): ED A0 80
+            let result = validate_utf8(&[0xED, 0xA0, 0x80]);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::SurrogateCodepoint);
+        }
+
+        #[test]
+        fn high_surrogate_end() {
+            // U+DBFF (last high surrogate): ED AF BF
+            let result = validate_utf8(&[0xED, 0xAF, 0xBF]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::SurrogateCodepoint);
+        }
+
+        #[test]
+        fn low_surrogate_start() {
+            // U+DC00 (first low surrogate): ED B0 80
+            let result = validate_utf8(&[0xED, 0xB0, 0x80]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::SurrogateCodepoint);
+        }
+
+        #[test]
+        fn low_surrogate_end() {
+            // U+DFFF (last low surrogate): ED BF BF
+            let result = validate_utf8(&[0xED, 0xBF, 0xBF]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::SurrogateCodepoint);
+        }
+
+        #[test]
+        fn all_surrogates() {
+            // Test a sample of surrogate code points
+            let surrogates = [
+                0xD800, 0xD801, 0xDB00, 0xDBFF, 0xDC00, 0xDC01, 0xDF00, 0xDFFF,
+            ];
+            for cp in surrogates {
+                // Encode surrogate manually
+                let bytes = [
+                    0xE0 | ((cp >> 12) as u8),
+                    0x80 | (((cp >> 6) & 0x3F) as u8),
+                    0x80 | ((cp & 0x3F) as u8),
+                ];
+                let result = validate_utf8(&bytes);
+                assert!(result.is_err(), "U+{cp:04X} should be invalid surrogate");
+                assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::SurrogateCodepoint);
+            }
+        }
+
+        #[test]
+        fn surrogate_in_middle_of_valid() {
+            // Valid text followed by surrogate
+            let mut input = Vec::from(b"Hello ");
+            input.extend_from_slice(&[0xED, 0xA0, 0x80]); // U+D800
+            input.extend_from_slice(b" world");
+
+            let result = validate_utf8(&input);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::SurrogateCodepoint);
+            assert_eq!(err.offset, 6);
+        }
+
+        #[test]
+        fn non_surrogate_ed_valid() {
+            // U+D7FF (just below surrogates): ED 9F BF
+            assert!(validate_utf8(&[0xED, 0x9F, 0xBF]).is_ok());
+
+            // U+E000 (just above surrogates): EE 80 80
+            assert!(validate_utf8(&[0xEE, 0x80, 0x80]).is_ok());
+        }
+    }
+
+    // =========================================================================
+    // Out of Range Code Point Tests
+    // =========================================================================
+
+    mod out_of_range {
+        use super::*;
+
+        #[test]
+        fn just_above_max() {
+            // U+110000 (first invalid): F4 90 80 80
+            let result = validate_utf8(&[0xF4, 0x90, 0x80, 0x80]);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::OutOfRangeCodepoint);
+        }
+
+        #[test]
+        fn max_valid() {
+            // U+10FFFF (last valid): F4 8F BF BF
+            assert!(validate_utf8(&[0xF4, 0x8F, 0xBF, 0xBF]).is_ok());
+        }
+
+        #[test]
+        fn very_high_codepoints() {
+            // Various out-of-range code points
+            // U+1FFFFF: F7 BF BF BF
+            let result = validate_utf8(&[0xF7, 0xBF, 0xBF, 0xBF]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::OutOfRangeCodepoint);
+
+            // U+13FFFF: F4 BF BF BF
+            let result = validate_utf8(&[0xF4, 0xBF, 0xBF, 0xBF]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::OutOfRangeCodepoint);
+        }
+    }
+
+    // =========================================================================
+    // Truncated Sequence Tests
+    // =========================================================================
+
+    mod truncated_sequences {
+        use super::*;
+
+        #[test]
+        fn truncated_2byte() {
+            // 2-byte lead with no continuation
+            let result = validate_utf8(&[0xC2]);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::TruncatedSequence);
+            assert_eq!(err.offset, 0);
+        }
+
+        #[test]
+        fn truncated_3byte_1() {
+            // 3-byte lead with no continuations
+            let result = validate_utf8(&[0xE0]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::TruncatedSequence);
+        }
+
+        #[test]
+        fn truncated_3byte_2() {
+            // 3-byte lead with only 1 continuation
+            let result = validate_utf8(&[0xE0, 0xA0]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::TruncatedSequence);
+        }
+
+        #[test]
+        fn truncated_4byte_1() {
+            // 4-byte lead with no continuations
+            let result = validate_utf8(&[0xF0]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::TruncatedSequence);
+        }
+
+        #[test]
+        fn truncated_4byte_2() {
+            // 4-byte lead with only 1 continuation
+            let result = validate_utf8(&[0xF0, 0x90]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::TruncatedSequence);
+        }
+
+        #[test]
+        fn truncated_4byte_3() {
+            // 4-byte lead with only 2 continuations
+            let result = validate_utf8(&[0xF0, 0x90, 0x80]);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::TruncatedSequence);
+        }
+
+        #[test]
+        fn truncated_after_valid() {
+            // Valid text followed by truncated sequence
+            let mut input = Vec::from(b"Hello ");
+            input.push(0xC2); // Truncated 2-byte sequence
+
+            let result = validate_utf8(&input);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, Utf8ErrorKind::TruncatedSequence);
+            assert_eq!(err.offset, 6);
+        }
+    }
+
+    // =========================================================================
+    // Error Position Tests
+    // =========================================================================
+
+    mod error_positions {
+        use super::*;
+
+        #[test]
+        fn line_and_column_first_byte() {
+            let result = validate_utf8(&[0x80]);
+            let err = result.unwrap_err();
+            assert_eq!(err.offset, 0);
+            assert_eq!(err.line, 1);
+            assert_eq!(err.column, 1);
+        }
+
+        #[test]
+        fn line_and_column_after_ascii() {
+            let input = b"Hello\x80";
+            let result = validate_utf8(input);
+            let err = result.unwrap_err();
+            assert_eq!(err.offset, 5);
+            assert_eq!(err.line, 1);
+            assert_eq!(err.column, 6);
+        }
+
+        #[test]
+        fn line_and_column_second_line() {
+            let input = b"Hello\nWorld\x80";
+            let result = validate_utf8(input);
+            let err = result.unwrap_err();
+            assert_eq!(err.offset, 11);
+            assert_eq!(err.line, 2);
+            assert_eq!(err.column, 6);
+        }
+
+        #[test]
+        fn line_and_column_third_line() {
+            let input = b"Line 1\nLine 2\nLine \x80 3";
+            let result = validate_utf8(input);
+            let err = result.unwrap_err();
+            assert_eq!(err.offset, 19);
+            assert_eq!(err.line, 3);
+            assert_eq!(err.column, 6);
+        }
+
+        #[test]
+        fn line_and_column_after_multibyte() {
+            // "日本" followed by invalid byte
+            let mut input = "日本".as_bytes().to_vec();
+            input.push(0x80);
+            let result = validate_utf8(&input);
+            let err = result.unwrap_err();
+            assert_eq!(err.offset, 6); // After 6 bytes (2 × 3-byte chars)
+            assert_eq!(err.line, 1);
+            assert_eq!(err.column, 7);
+        }
+
+        #[test]
+        fn line_after_crlf() {
+            let input = b"Line 1\r\nLine 2\x80";
+            let result = validate_utf8(input);
+            let err = result.unwrap_err();
+            // Line should be 2 (after \n)
+            assert_eq!(err.line, 2);
+        }
+
+        #[test]
+        fn multiple_newlines() {
+            let input = b"\n\n\n\n\x80";
+            let result = validate_utf8(input);
+            let err = result.unwrap_err();
+            assert_eq!(err.offset, 4);
+            assert_eq!(err.line, 5);
+            assert_eq!(err.column, 1);
+        }
+    }
+
+    // =========================================================================
+    // Decode/Encode Tests
+    // =========================================================================
+
+    mod decode_encode {
+        use super::*;
+
+        #[test]
+        fn decode_ascii() {
+            assert_eq!(decode_code_point(b"A"), Some((0x41, 1)));
+            assert_eq!(decode_code_point(b"\x00"), Some((0x00, 1)));
+            assert_eq!(decode_code_point(b"\x7F"), Some((0x7F, 1)));
+        }
+
+        #[test]
+        fn decode_2byte() {
+            assert_eq!(decode_code_point(&[0xC2, 0x80]), Some((0x80, 2)));
+            assert_eq!(decode_code_point(&[0xDF, 0xBF]), Some((0x7FF, 2)));
+            assert_eq!(decode_code_point("é".as_bytes()), Some((0xE9, 2)));
+        }
+
+        #[test]
+        fn decode_3byte() {
+            assert_eq!(decode_code_point(&[0xE0, 0xA0, 0x80]), Some((0x800, 3)));
+            assert_eq!(decode_code_point("日".as_bytes()), Some((0x65E5, 3)));
+            assert_eq!(decode_code_point("€".as_bytes()), Some((0x20AC, 3)));
+        }
+
+        #[test]
+        fn decode_4byte() {
+            assert_eq!(
+                decode_code_point(&[0xF0, 0x90, 0x80, 0x80]),
+                Some((0x10000, 4))
+            );
+            assert_eq!(decode_code_point("🎉".as_bytes()), Some((0x1F389, 4)));
+        }
+
+        #[test]
+        fn decode_invalid() {
+            assert_eq!(decode_code_point(b""), None);
+            assert_eq!(decode_code_point(&[0x80]), None); // Bare continuation
+            assert_eq!(decode_code_point(&[0xC2]), None); // Truncated
+            assert_eq!(decode_code_point(&[0xC2, 0x00]), None); // Invalid continuation
+        }
+
+        #[test]
+        fn encode_ascii() {
+            let (bytes, len) = encode_code_point(0x41).unwrap();
+            assert_eq!(&bytes[..len], b"A");
+
+            let (bytes, len) = encode_code_point(0x00).unwrap();
+            assert_eq!(&bytes[..len], b"\x00");
+        }
+
+        #[test]
+        fn encode_2byte() {
+            let (bytes, len) = encode_code_point(0x80).unwrap();
+            assert_eq!(&bytes[..len], &[0xC2, 0x80]);
+
+            let (bytes, len) = encode_code_point(0xE9).unwrap(); // é
+            assert_eq!(&bytes[..len], "é".as_bytes());
+        }
+
+        #[test]
+        fn encode_3byte() {
+            let (bytes, len) = encode_code_point(0x800).unwrap();
+            assert_eq!(&bytes[..len], &[0xE0, 0xA0, 0x80]);
+
+            let (bytes, len) = encode_code_point(0x65E5).unwrap(); // 日
+            assert_eq!(&bytes[..len], "日".as_bytes());
+        }
+
+        #[test]
+        fn encode_4byte() {
+            let (bytes, len) = encode_code_point(0x10000).unwrap();
+            assert_eq!(&bytes[..len], &[0xF0, 0x90, 0x80, 0x80]);
+
+            let (bytes, len) = encode_code_point(0x1F389).unwrap(); // 🎉
+            assert_eq!(&bytes[..len], "🎉".as_bytes());
+        }
+
+        #[test]
+        fn encode_invalid() {
+            // Surrogate
+            assert!(encode_code_point(0xD800).is_none());
+            assert!(encode_code_point(0xDFFF).is_none());
+
+            // Out of range
+            assert!(encode_code_point(0x110000).is_none());
+            assert!(encode_code_point(0xFFFFFFFF).is_none());
+        }
+
+        #[test]
+        fn roundtrip() {
+            // Test roundtrip encoding/decoding
+            let test_points = [
+                0x00, 0x41, 0x7F, // ASCII
+                0x80, 0xFF, 0x7FF, // 2-byte
+                0x800, 0x65E5, 0xFFFF, // 3-byte
+                0x10000, 0x1F389, 0x10FFFF, // 4-byte
+            ];
+
+            for cp in test_points {
+                let (encoded, len) = encode_code_point(cp).unwrap();
+                let (decoded, decoded_len) = decode_code_point(&encoded[..len]).unwrap();
+                assert_eq!(cp, decoded);
+                assert_eq!(len, decoded_len);
+            }
+        }
+    }
+
+    // =========================================================================
+    // Sequence Length Tests
+    // =========================================================================
+
+    mod sequence_length_tests {
+        use super::*;
+
+        #[test]
+        fn ascii_length() {
+            for byte in 0x00..=0x7F {
+                assert_eq!(sequence_length(byte), 1);
+            }
+        }
+
+        #[test]
+        fn continuation_length() {
+            for byte in 0x80..=0xBF {
+                assert_eq!(sequence_length(byte), 0); // Invalid as lead
+            }
+        }
+
+        #[test]
+        fn two_byte_length() {
+            for byte in 0xC0..=0xDF {
+                assert_eq!(sequence_length(byte), 2);
+            }
+        }
+
+        #[test]
+        fn three_byte_length() {
+            for byte in 0xE0..=0xEF {
+                assert_eq!(sequence_length(byte), 3);
+            }
+        }
+
+        #[test]
+        fn four_byte_length() {
+            for byte in 0xF0..=0xF7 {
+                assert_eq!(sequence_length(byte), 4);
+            }
+        }
+
+        #[test]
+        fn invalid_lead_length() {
+            for byte in 0xF8..=0xFF {
+                assert_eq!(sequence_length(byte), 0);
+            }
+        }
+    }
+
+    // =========================================================================
+    // Edge Cases and Stress Tests
+    // =========================================================================
+
+    mod edge_cases {
+        use super::*;
+
+        #[test]
+        fn all_same_continuation() {
+            // Many continuation bytes in a row
+            let input = vec![0x80; 100];
+            let result = validate_utf8(&input);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind, Utf8ErrorKind::InvalidLeadByte);
+        }
+
+        #[test]
+        fn alternating_valid_invalid() {
+            // Valid character followed by invalid, repeated
+            let mut input = vec![b'A'; 10];
+            input.push(0x80); // First invalid
+
+            let result = validate_utf8(&input);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().offset, 10);
+        }
+
+        #[test]
+        fn many_emoji() {
+            // Many 4-byte sequences
+            let emoji = "🎉🚀🌍💻🔥";
+            let repeated: String = emoji.repeat(100);
+            assert!(validate_utf8(repeated.as_bytes()).is_ok());
+        }
+
+        #[test]
+        fn mixed_newline_styles() {
+            let input = "Line 1\nLine 2\r\nLine 3\rLine 4";
+            assert!(validate_utf8(input.as_bytes()).is_ok());
+        }
+
+        #[test]
+        fn null_bytes() {
+            // Null bytes are valid ASCII
+            assert!(validate_utf8(&[0x00, 0x00, 0x00]).is_ok());
+            assert!(validate_utf8(b"Hello\x00World").is_ok());
+        }
+
+        #[test]
+        fn only_newlines() {
+            assert!(validate_utf8(b"\n\n\n\n\n").is_ok());
+            assert!(validate_utf8(b"\r\n\r\n\r\n").is_ok());
+        }
+
+        #[test]
+        fn long_lines() {
+            // Very long line without newlines
+            let long_line = "A".repeat(10000);
+            assert!(validate_utf8(long_line.as_bytes()).is_ok());
+        }
+
+        #[test]
+        fn invalid_at_various_offsets() {
+            // Test invalid byte at different positions
+            for offset in [0, 1, 7, 15, 31, 63, 64, 65, 100, 127, 128, 255, 256] {
+                let mut input = vec![b'A'; offset + 1];
+                input[offset] = 0x80;
+
+                let result = validate_utf8(&input);
+                assert!(result.is_err());
+                assert_eq!(result.unwrap_err().offset, offset);
+            }
+        }
+
+        #[test]
+        fn boundary_64_bytes() {
+            // Test around 64-byte boundary (common SIMD width)
+            let mut input = vec![b'A'; 64];
+            assert!(validate_utf8(&input).is_ok());
+
+            input.push(0x80);
+            let result = validate_utf8(&input);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().offset, 64);
+        }
+
+        #[test]
+        fn boundary_chunk_crossing() {
+            // Multi-byte sequence crossing 64-byte boundary
+            let mut input = vec![b'A'; 63];
+            // Add a 3-byte character that crosses boundary
+            input.extend_from_slice("日".as_bytes());
+            assert!(validate_utf8(&input).is_ok());
+        }
+    }
+
+    // =========================================================================
+    // Comparison with std::str
+    // =========================================================================
+
+    mod std_comparison {
+        use super::*;
+
+        #[test]
+        fn agree_on_valid_strings() {
+            let test_cases = [
+                "",
+                "Hello, world!",
+                "日本語",
+                "🎉🚀🌍",
+                "Mixed: café 日本 🎉",
+                "\n\t\r",
+                "\x00\x01\x02",
+            ];
+
+            for s in test_cases {
+                let our_result = validate_utf8(s.as_bytes());
+                assert!(our_result.is_ok(), "Should agree {s} is valid");
+            }
+        }
+
+        #[test]
+        fn agree_on_invalid_bytes() {
+            let test_cases: &[&[u8]] = &[
+                &[0x80],                   // Bare continuation
+                &[0xC2],                   // Truncated 2-byte
+                &[0xE0, 0x80],             // Truncated 3-byte
+                &[0xC0, 0x80],             // Overlong
+                &[0xED, 0xA0, 0x80],       // Surrogate
+                &[0xF4, 0x90, 0x80, 0x80], // Out of range
+            ];
+
+            for bytes in test_cases {
+                let our_result = validate_utf8(bytes);
+                let std_result = core::str::from_utf8(bytes);
+
+                assert!(
+                    our_result.is_err() && std_result.is_err(),
+                    "Should agree {bytes:?} is invalid"
+                );
+            }
+        }
+    }
+}

--- a/src/text/utf8.rs
+++ b/src/text/utf8.rs
@@ -1443,4 +1443,102 @@ mod tests {
             }
         }
     }
+
+    // =========================================================================
+    // Error formatting and code-point decoding
+    // =========================================================================
+
+    mod error_formatting {
+        use super::*;
+
+        #[test]
+        fn error_kind_display_covers_all_variants() {
+            let cases = [
+                (Utf8ErrorKind::InvalidLeadByte, "invalid UTF-8 lead byte"),
+                (
+                    Utf8ErrorKind::InvalidContinuationByte,
+                    "invalid UTF-8 continuation byte",
+                ),
+                (Utf8ErrorKind::OverlongEncoding, "overlong UTF-8 encoding"),
+                (
+                    Utf8ErrorKind::SurrogateCodepoint,
+                    "surrogate code point in UTF-8",
+                ),
+                (
+                    Utf8ErrorKind::OutOfRangeCodepoint,
+                    "code point above U+10FFFF",
+                ),
+                (Utf8ErrorKind::TruncatedSequence, "truncated UTF-8 sequence"),
+            ];
+            for (kind, expected) in cases {
+                assert_eq!(alloc::format!("{kind}"), expected);
+            }
+        }
+
+        #[test]
+        fn error_display_includes_position_and_kind() {
+            let err = Utf8Error {
+                offset: 5,
+                line: 2,
+                column: 3,
+                kind: Utf8ErrorKind::InvalidLeadByte,
+            };
+            let text = alloc::format!("{err}");
+            assert!(text.contains("invalid UTF-8 lead byte"), "{text}");
+            assert!(text.contains("byte 5"), "{text}");
+            assert!(text.contains("line 2"), "{text}");
+            assert!(text.contains("column 3"), "{text}");
+        }
+
+        #[test]
+        fn format_byte_distinguishes_graphic_and_non_graphic() {
+            assert_eq!(format_byte(b'A'), "0x41 ('A')");
+            assert_eq!(format_byte(b' '), "0x20 (' ')");
+            // Non-graphic bytes render as bare hex.
+            assert_eq!(format_byte(0x00), "0x00");
+            assert_eq!(format_byte(0x80), "0x80");
+            assert_eq!(format_byte(0x0A), "0x0A");
+        }
+    }
+
+    mod decode_code_point_tests {
+        use super::*;
+
+        #[test]
+        fn decodes_all_sequence_lengths() {
+            assert_eq!(decode_code_point(b"A"), Some((0x41, 1)));
+            assert_eq!(decode_code_point("\u{00E9}".as_bytes()), Some((0x00E9, 2)));
+            assert_eq!(decode_code_point("\u{20AC}".as_bytes()), Some((0x20AC, 3)));
+            assert_eq!(
+                decode_code_point("\u{1F389}".as_bytes()),
+                Some((0x1F389, 4))
+            );
+        }
+
+        #[test]
+        fn rejects_empty_and_truncated() {
+            assert_eq!(decode_code_point(b""), None);
+            // 3-byte lead with only one following byte -> too short.
+            assert_eq!(decode_code_point(&[0xE2, 0x82]), None);
+        }
+
+        #[test]
+        fn rejects_bad_continuation_bytes() {
+            // 2-byte lead, non-continuation second byte.
+            assert_eq!(decode_code_point(&[0xC3, 0x28]), None);
+            // 3-byte lead, bad first / second continuation byte.
+            assert_eq!(decode_code_point(&[0xE2, 0x28, 0xA1]), None);
+            assert_eq!(decode_code_point(&[0xE2, 0x82, 0x28]), None);
+            // 4-byte lead, bad continuation bytes in each position.
+            assert_eq!(decode_code_point(&[0xF0, 0x28, 0x8C, 0xBC]), None);
+            assert_eq!(decode_code_point(&[0xF0, 0x9F, 0x28, 0x8C]), None);
+            assert_eq!(decode_code_point(&[0xF0, 0x9F, 0x8E, 0x28]), None);
+        }
+
+        #[test]
+        fn rejects_invalid_lead_byte() {
+            // 0x80 is a continuation byte, never a lead -> sequence_length 0.
+            assert_eq!(decode_code_point(&[0x80]), None);
+        }
+    }
 }

--- a/tests/snapshots/cli_golden_tests__help_main.snap
+++ b/tests/snapshots/cli_golden_tests__help_main.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/cli_golden_tests.rs
-assertion_line: 43
 expression: output
 ---
 Succinct data structures toolkit
@@ -17,6 +16,7 @@ Commands:
   yq-locate        Find yq expression for a position in a YAML file
   dev              Developer tools (benchmarking, profiling)
   install-aliases  Install short alias symlinks (sjq, syq, sjq-locate, syq-locate)
+  text             Text processing operations (UTF-8 validation, etc.)
   help             Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/text_cli_tests.rs
+++ b/tests/text_cli_tests.rs
@@ -1,0 +1,430 @@
+//! Integration tests for the `succinctly text` CLI commands.
+//!
+//! Covers `text validate utf8` (validation, error reporting, exit codes) and
+//! `text generate` / `text generate-suite` (all UTF-8 patterns, verification,
+//! file and stdout output). These drive the pre-built binary so the CLI handler
+//! modules (`text_validate`, `text_generators`) and their `main` dispatch are
+//! exercised end-to-end.
+//!
+//! Run with: cargo test --features cli --test text_cli_tests
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+
+use anyhow::Result;
+use tempfile::{NamedTempFile, TempDir};
+
+/// Resolve the path to the pre-built `succinctly` CLI binary, building it once.
+///
+/// Mirrors the helper in `json_validate_tests.rs`: the integration-test harness
+/// is compiled without the `cli` feature, and the `succinctly` binary is gated by
+/// `required-features = ["cli"]`, so `CARGO_BIN_EXE_succinctly` is unavailable
+/// here. We build the binary once with the `cli` feature and derive its path from
+/// this test executable's own location. Invoking the built binary directly (not
+/// `cargo run`) keeps cargo's output out of each child's captured stderr.
+fn succinctly_bin() -> &'static Path {
+    static BIN: OnceLock<PathBuf> = OnceLock::new();
+    BIN.get_or_init(|| {
+        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+        let output = Command::new(cargo)
+            .args(["build", "--features", "cli", "--bin", "succinctly"])
+            .output()
+            .expect("failed to spawn `cargo build`");
+        assert!(
+            output.status.success(),
+            "`cargo build --features cli --bin succinctly` failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let mut path = std::env::current_exe().expect("resolve current_exe");
+        path.pop(); // drop the test executable's file name -> `.../deps`
+        if path.file_name().and_then(|s| s.to_str()) == Some("deps") {
+            path.pop(); // drop `deps` -> `.../<profile>`
+        }
+        path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
+        assert!(
+            path.is_file(),
+            "built `succinctly` binary not found at {}",
+            path.display()
+        );
+        path
+    })
+}
+
+/// Run `text validate utf8` with raw bytes piped on stdin.
+fn run_validate_stdin(input: &[u8], extra_args: &[&str]) -> Result<(Vec<u8>, String, i32)> {
+    let mut cmd = Command::new(succinctly_bin())
+        .args(["text", "validate", "utf8"])
+        .args(extra_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(input)?;
+    }
+
+    let output = cmd.wait_with_output()?;
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    Ok((output.stdout, stderr, exit_code))
+}
+
+/// Run `text validate utf8` against one or more file paths.
+fn run_validate_files(paths: &[&str], extra_args: &[&str]) -> Result<(Vec<u8>, String, i32)> {
+    let output = Command::new(succinctly_bin())
+        .args(["text", "validate", "utf8"])
+        .args(extra_args)
+        .args(paths)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    Ok((output.stdout, stderr, exit_code))
+}
+
+/// Run `text generate` and capture raw stdout bytes, stderr, and exit code.
+fn run_generate(size: &str, extra_args: &[&str]) -> Result<(Vec<u8>, String, i32)> {
+    let output = Command::new(succinctly_bin())
+        .args(["text", "generate", size])
+        .args(extra_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    Ok((output.stdout, stderr, exit_code))
+}
+
+/// Every `--pattern` value accepted by `text generate` (clap kebab-cases the
+/// `Utf8PatternArg` variants).
+const PATTERNS: &[&str] = &[
+    "ascii",
+    "latin",
+    "greek-cyrillic",
+    "cjk",
+    "emoji",
+    "mixed",
+    "all-lengths",
+    "log-file",
+    "source-code",
+    "json-like",
+    "pathological",
+];
+
+// ============================================================================
+// `text validate utf8` — exit codes and valid input
+// ============================================================================
+
+#[test]
+fn validate_valid_ascii_stdin_exit_0() -> Result<()> {
+    let (stdout, stderr, code) = run_validate_stdin(b"Hello, world!\n", &[])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stdout.is_empty(), "stdout should be empty on success");
+    Ok(())
+}
+
+#[test]
+fn validate_valid_multibyte_stdin_exit_0() -> Result<()> {
+    let (_, stderr, code) = run_validate_stdin("日本語 café — 🎉".as_bytes(), &[])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn validate_valid_file_exit_0() -> Result<()> {
+    let mut f = NamedTempFile::new()?;
+    f.write_all("Grüße, 世界! 🚀".as_bytes())?;
+    let (_, stderr, code) = run_validate_files(&[f.path().to_str().unwrap()], &[])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn validate_empty_input_is_valid() -> Result<()> {
+    let (_, _, code) = run_validate_stdin(b"", &[])?;
+    assert_eq!(code, 0);
+    Ok(())
+}
+
+// ============================================================================
+// `text validate utf8` — invalid input and error kinds
+// ============================================================================
+
+#[test]
+fn validate_bare_continuation_byte_is_invalid_lead() -> Result<()> {
+    // 0x80 cannot start a sequence -> invalid lead byte.
+    let (_, stderr, code) = run_validate_stdin(&[0x80], &[])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("invalid UTF-8 lead byte"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn validate_invalid_continuation_byte() -> Result<()> {
+    // 0xE2 begins a 3-byte sequence; 0x28 '(' is not a continuation byte.
+    let (_, stderr, code) = run_validate_stdin(&[0xE2, 0x28, 0xA1], &[])?;
+    assert_eq!(code, 1);
+    assert!(stderr.contains("continuation byte"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn validate_truncated_sequence_at_eof() -> Result<()> {
+    // 0xE2 0x82 is the start of a 3-byte sequence, missing its final byte.
+    let (_, stderr, code) = run_validate_stdin(&[0xE2, 0x82], &[])?;
+    assert_eq!(code, 1);
+    assert!(stderr.contains("truncated"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn validate_overlong_encoding() -> Result<()> {
+    // 0xC0 0x80 is an overlong (2-byte) encoding of U+0000.
+    let (_, stderr, code) = run_validate_stdin(&[0xC0, 0x80], &[])?;
+    assert_eq!(code, 1);
+    assert!(!stderr.is_empty(), "expected an error message");
+    Ok(())
+}
+
+#[test]
+fn validate_surrogate_codepoint() -> Result<()> {
+    // 0xED 0xA0 0x80 encodes U+D800, a reserved UTF-16 surrogate.
+    let (_, stderr, code) = run_validate_stdin(&[0xED, 0xA0, 0x80], &[])?;
+    assert_eq!(code, 1);
+    assert!(stderr.contains("surrogate"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn validate_out_of_range_codepoint() -> Result<()> {
+    // 0xF4 0x90 0x80 0x80 would encode U+110000, above the U+10FFFF maximum.
+    let (_, stderr, code) = run_validate_stdin(&[0xF4, 0x90, 0x80, 0x80], &[])?;
+    assert_eq!(code, 1);
+    assert!(!stderr.is_empty(), "expected an error message");
+    Ok(())
+}
+
+// ============================================================================
+// `text validate utf8` — flags and reporting
+// ============================================================================
+
+#[test]
+fn validate_quiet_mode_suppresses_output() -> Result<()> {
+    let (stdout, stderr, code) = run_validate_stdin(&[0x80], &["--quiet"])?;
+    assert_eq!(code, 1);
+    assert!(stdout.is_empty(), "stdout should be empty");
+    assert!(
+        stderr.is_empty(),
+        "stderr should be empty in quiet mode, got: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn validate_no_color_has_no_ansi() -> Result<()> {
+    let (_, stderr, code) = run_validate_stdin(&[0x80], &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(!stderr.is_empty());
+    assert!(
+        !stderr.contains('\x1b'),
+        "no-color output must not contain ANSI escapes: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn validate_forced_color_has_ansi() -> Result<()> {
+    let (_, stderr, code) = run_validate_stdin(&[0x80], &["--color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains('\x1b'),
+        "forced color output should contain ANSI escapes: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn validate_file_error_reports_filename_and_position() -> Result<()> {
+    let mut f = NamedTempFile::new()?;
+    // Valid first line, then an invalid byte on line 2.
+    let mut bytes = b"first line ok\nsecond ".to_vec();
+    bytes.push(0x80);
+    f.write_all(&bytes)?;
+    let path = f.path().to_str().unwrap();
+    let (_, stderr, code) = run_validate_files(&[path], &["--no-color"])?;
+    assert_eq!(code, 1);
+    // Location line should mention the file and line 2.
+    assert!(
+        stderr.contains(path),
+        "stderr should name the file: {stderr}"
+    );
+    assert!(
+        stderr.contains(":2:"),
+        "stderr should point at line 2: {stderr}"
+    );
+    // A caret pointer should appear in the snippet.
+    assert!(stderr.contains('^'), "expected a caret pointer: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn validate_multiple_files_mixed_validity_exit_1() -> Result<()> {
+    let mut good = NamedTempFile::new()?;
+    good.write_all("all good ✓".as_bytes())?;
+    let mut bad = NamedTempFile::new()?;
+    bad.write_all(&[b'x', 0x80, b'y'])?;
+    let (_, _, code) = run_validate_files(
+        &[good.path().to_str().unwrap(), bad.path().to_str().unwrap()],
+        &["--no-color"],
+    )?;
+    assert_eq!(code, 1, "any invalid file should yield exit 1");
+    Ok(())
+}
+
+#[test]
+fn validate_nonexistent_file_is_io_error() -> Result<()> {
+    let (_, stderr, code) =
+        run_validate_files(&["/no/such/path/utf8_does_not_exist.txt"], &["--no-color"])?;
+    assert_eq!(code, 2, "missing file should yield the IO_ERROR exit code");
+    assert!(!stderr.is_empty(), "expected an error message");
+    Ok(())
+}
+
+#[test]
+fn validate_long_line_snippet_is_truncated() -> Result<()> {
+    // A line well over the 80-column snippet width, with the error near the end,
+    // exercises the truncation branch of get_error_snippet.
+    let mut bytes = vec![b'a'; 200];
+    bytes.push(0x80);
+    let (_, stderr, code) = run_validate_stdin(&bytes, &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("..."),
+        "long lines should be elided: {stderr}"
+    );
+    Ok(())
+}
+
+// ============================================================================
+// `text generate` — every pattern produces valid UTF-8
+// ============================================================================
+
+#[test]
+fn generate_all_patterns_to_stdout_are_valid_utf8() -> Result<()> {
+    for pattern in PATTERNS {
+        let (stdout, stderr, code) =
+            run_generate("2kb", &["--pattern", pattern, "--seed", "7", "--verify"])?;
+        assert_eq!(code, 0, "pattern {pattern} failed: {stderr}");
+        assert!(
+            stdout.len() >= 2048,
+            "pattern {pattern} produced only {} bytes",
+            stdout.len()
+        );
+        assert!(
+            std::str::from_utf8(&stdout).is_ok(),
+            "pattern {pattern} produced invalid UTF-8"
+        );
+        assert!(
+            stderr.contains("validated successfully"),
+            "pattern {pattern} --verify did not confirm: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn generate_is_deterministic_for_a_fixed_seed() -> Result<()> {
+    let (a, _, ca) = run_generate("4kb", &["--pattern", "mixed", "--seed", "123"])?;
+    let (b, _, cb) = run_generate("4kb", &["--pattern", "mixed", "--seed", "123"])?;
+    assert_eq!(ca, 0);
+    assert_eq!(cb, 0);
+    assert_eq!(a, b, "same seed should produce identical output");
+    Ok(())
+}
+
+#[test]
+fn generate_unseeded_is_valid_utf8() -> Result<()> {
+    // No --seed exercises the deterministic (rng == None) fallback path.
+    let (stdout, stderr, code) = run_generate("2kb", &["--pattern", "cjk"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(std::str::from_utf8(&stdout).is_ok());
+    Ok(())
+}
+
+#[test]
+fn generate_to_file_writes_valid_utf8() -> Result<()> {
+    let dir = TempDir::new()?;
+    let out = dir.path().join("emoji.txt");
+    let out_str = out.to_str().unwrap();
+    let (_, stderr, code) = run_generate(
+        "3kb",
+        &[
+            "--pattern",
+            "emoji",
+            "--seed",
+            "42",
+            "-o",
+            out_str,
+            "--verify",
+        ],
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stderr.contains("Wrote"), "stderr: {stderr}");
+    let data = std::fs::read(&out)?;
+    assert!(data.len() >= 3072);
+    assert!(std::str::from_utf8(&data).is_ok());
+    Ok(())
+}
+
+// ============================================================================
+// `text generate-suite` — writes a directory tree of valid UTF-8 files
+// ============================================================================
+
+#[test]
+fn generate_suite_writes_all_patterns() -> Result<()> {
+    let dir = TempDir::new()?;
+    let out_dir = dir.path().join("suite");
+    let out_dir_str = out_dir.to_str().unwrap();
+    // --max-size 1kb keeps this to one small file per pattern.
+    let output = Command::new(succinctly_bin())
+        .args(["text", "generate-suite"])
+        .args(["--output-dir", out_dir_str])
+        .args(["--max-size", "1kb", "--seed", "42", "--clean", "--verify"])
+        .output()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code().unwrap_or(-1),
+        0,
+        "generate-suite failed: {stderr}"
+    );
+
+    // One subdirectory per pattern, each holding a valid-UTF-8 1kb.txt file.
+    let mut found = 0;
+    for entry in std::fs::read_dir(&out_dir)? {
+        let pattern_dir = entry?.path();
+        if pattern_dir.is_dir() {
+            let file = pattern_dir.join("1kb.txt");
+            if file.is_file() {
+                let data = std::fs::read(&file)?;
+                assert!(
+                    std::str::from_utf8(&data).is_ok(),
+                    "{} is not valid UTF-8",
+                    file.display()
+                );
+                found += 1;
+            }
+        }
+    }
+    assert_eq!(found, PATTERNS.len(), "expected one file per pattern");
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR implements a complete UTF-8 validation system for the `succinctly` library, providing high-performance scalar validation with detailed error reporting, CLI tools for file validation, and a comprehensive benchmarking suite.

The implementation serves as the baseline for future SIMD optimizations while delivering production-ready functionality with thorough error handling and diagnostic output.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue
Establishes UTF-8 validation foundation for text processing capabilities.

## Changes Made

**Core UTF-8 Validation (`src/text/utf8.rs`):**
- Implemented `validate_utf8()` and `validate_utf8_scalar()` functions with detailed error reporting
- Added `Utf8Error` struct with byte offset, line number, column position, and error kind
- Implemented `Utf8ErrorKind` enum covering all UTF-8 violation types:
  - `InvalidLeadByte` - continuation bytes (0x80-0xBF) in lead position
  - `InvalidContinuationByte` - non-continuation bytes where continuation expected
  - `OverlongEncoding` - security vulnerability detection for non-minimal encodings
  - `SurrogateCodepoint` - U+D800-U+DFFF rejection (UTF-16 reserved)
  - `OutOfRangeCodepoint` - code points above U+10FFFF
  - `TruncatedSequence` - incomplete multi-byte sequences at EOF
- Added utility functions: `sequence_length()`, `decode_code_point()`, `encode_code_point()`, `format_byte()`
- Comprehensive test suite with 50+ test cases covering all UTF-8 edge cases

**CLI Integration (`src/bin/succinctly/text_validate.rs`, `main.rs`):**
- Added `text validate utf8` command with colored error output
- Implemented TTY detection with `--color`/`--no-color` flags
- Batch file processing with proper exit codes (0=valid, 1=invalid, 2=IO error)
- Context snippets showing error location with caret highlighting
- Support for stdin processing and quiet mode (`-q`)

**Text Generation System (`src/bin/succinctly/text_generators.rs`):**
- Implemented 11 distinct UTF-8 patterns for benchmarking:
  - `ascii` - Pure 7-bit ASCII content
  - `latin` - Latin Extended (2-byte: é, ñ, ü)
  - `greek_cyrillic` - Greek and Cyrillic scripts (2-byte)
  - `cjk` - Chinese/Japanese/Korean (3-byte)
  - `emoji` - Emoji and symbols (4-byte)
  - `mixed` - Realistic prose with occasional non-ASCII
  - `all_lengths` - Uniform 1-4 byte distribution
  - `log_file` - Server log style with timestamps
  - `source_code` - Code with unicode in strings/comments
  - `json_like` - JSON structure with unicode strings
  - `pathological` - Maximum multi-byte density
- Deterministic generation with configurable seeds for reproducibility
- Added `text generate` and `text generate-suite` CLI commands

**Benchmarking Infrastructure (`src/bin/succinctly/utf8_bench.rs`, `benches/utf8_validate_bench.rs`):**
- Criterion benchmark suite with multiple content patterns and sizes (1KB-100MB)
- CLI benchmark via `dev bench utf8` with JSONL and Markdown output
- Performance comparison framework against `std::str::from_utf8`
- Benchmark registry integration with `BenchmarkCategory::Text`

**Documentation (`docs/benchmarks/utf8-validate.md`, `docs/benchmarks/inventory.md`):**
- Comprehensive benchmark results documentation
- Performance characteristics by character type (ASCII ~2.3 GiB/s, CJK ~1.4 GiB/s, emoji ~1.0 GiB/s)
- Test data pattern descriptions and usage instructions
- Updated benchmark inventory with UTF-8 validation references

**Build Configuration:**
- Added `utf8_validate_bench` Criterion benchmark to `Cargo.toml`
- Exported `text` module from `src/lib.rs`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added covering:
  - Valid UTF-8: ASCII, 2/3/4-byte sequences, boundary code points, non-characters
  - Invalid lead bytes: continuation bytes as lead, 0xF8-0xFF bytes
  - Invalid continuations: missing/wrong continuation bytes in 2/3/4-byte sequences
  - Overlong encodings: 2/3/4-byte overlong patterns, security test cases
  - Surrogate code points: U+D800-U+DFFF rejection
  - Out of range: U+110000+ rejection
  - Truncated sequences: incomplete sequences at all positions
  - Error positions: line/column tracking across newlines
  - Encode/decode roundtrip: all sequence lengths
  - Comparison with `std::str::from_utf8` for validation agreement

**Manual Testing:**
- [x] Tested on x86_64 (AMD Ryzen 9 7950X)
- [ ] Tested on aarch64/ARM (if applicable)

### Test Commands
```bash
cargo test
cargo test text::utf8
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check

# Generate test data
./target/release/succinctly text generate-suite

# Run benchmarks
cargo bench --bench utf8_validate_bench
./target/release/succinctly dev bench utf8
```

## Performance Impact
- [x] Performance improvement (include benchmarks below)

**Benchmark Results (AMD Ryzen 9 7950X @ 100MB):**

| Pattern | Throughput (MiB/s) |
|---------|-------------------|
| ASCII | 2,262 |
| Log file | 2,137 |
| Source code | 1,979 |
| Mixed | 1,819 |
| CJK | 1,359 |
| Emoji | 1,036 |
| All lengths | 492 |

The scalar implementation provides a solid baseline for future SIMD optimizations while delivering competitive performance for ASCII-dominant content.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Architecture Decisions:**
- Scalar implementation chosen as baseline for SIMD comparison
- Error reporting tracks line/column for user-friendly diagnostics
- Separate error kinds enable specific error messages and hints

**Future Work:**
- SIMD implementations (SSE4.2, AVX2, NEON) can be added with the same API
- The benchmark infrastructure supports comparative analysis across implementations
- Test suite validates correctness before optimizing for speed