### PR TITLE
fix(json): replace BP-based container range lookup with linear scan

### DIFF
--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -698,17 +698,44 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
         }
 
         let end = match self.text[start] {
-            // Containers: use BP to find closing bracket position
+            // Containers: scan text for matching close bracket.
+            // Closing brackets have IB=0, so we cannot use ib_select1_from to
+            // find their text position. Instead, scan forward tracking depth.
             b'{' | b'[' => {
-                // Find the close paren in BP
-                let close_bp = self.index.bp().find_close(self.bp_pos)?;
-                // Map close BP position to text position
-                // The close bracket is at the BP close position's corresponding IB bit
-                let close_rank = self.index.bp().rank1(close_bp);
-                // For containers, there's a close bracket at this position
-                // We need to find the text position and then include the bracket
-                let close_text = self.index.ib_select1_from(close_rank, close_rank / 8)?;
-                close_text + 1 // Include the closing bracket
+                let close_char = if self.text[start] == b'{' { b'}' } else { b']' };
+                let mut depth = 1u32;
+                let mut i = start + 1;
+                while i < self.text.len() {
+                    match self.text[i] {
+                        b'"' => {
+                            // Skip string contents
+                            i += 1;
+                            while i < self.text.len() {
+                                match self.text[i] {
+                                    b'"' => {
+                                        i += 1;
+                                        break;
+                                    }
+                                    b'\\' => i += 2,
+                                    _ => i += 1,
+                                }
+                            }
+                        }
+                        c if c == self.text[start] => {
+                            depth += 1;
+                            i += 1;
+                        }
+                        c if c == close_char => {
+                            depth -= 1;
+                            if depth == 0 {
+                                return Some((start, i + 1));
+                            }
+                            i += 1;
+                        }
+                        _ => i += 1,
+                    }
+                }
+                return None;
             }
             // String: scan for closing quote
             b'"' => {
@@ -3050,5 +3077,110 @@ mod tests {
                 offset
             );
         }
+    }
+
+    // === text_range tests for containers (issue #137) ===
+
+    #[test]
+    fn test_text_range_nested_object_value() {
+        let json = br#"{"key": {"key2": "value"}}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+
+        let fields = root.value().as_object().unwrap();
+        let (value, _) = fields.uncons().unwrap();
+        let range = value.value_cursor().text_range().unwrap();
+        assert_eq!(range, (8, 25));
+    }
+
+    #[test]
+    fn test_text_range_empty_object_value() {
+        let json = br#"{"key": {}}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let fields = root.value().as_object().unwrap();
+        let (field, _) = fields.uncons().unwrap();
+        let range = field.value_cursor().text_range().unwrap();
+        assert_eq!(range, (8, 10));
+        assert_eq!(&json[range.0..range.1], b"{}");
+    }
+
+    #[test]
+    fn test_text_range_empty_array_value() {
+        let json = br#"{"list": []}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let fields = root.value().as_object().unwrap();
+        let (field, _) = fields.uncons().unwrap();
+        let range = field.value_cursor().text_range().unwrap();
+        assert_eq!(range, (9, 11));
+        assert_eq!(&json[range.0..range.1], b"[]");
+    }
+
+    #[test]
+    fn test_text_range_array_value() {
+        let json = br#"{"items": [1, 2, 3]}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let fields = root.value().as_object().unwrap();
+        let (field, _) = fields.uncons().unwrap();
+        let range = field.value_cursor().text_range().unwrap();
+        assert_eq!(range, (10, 19));
+        assert_eq!(&json[range.0..range.1], b"[1, 2, 3]");
+    }
+
+    #[test]
+    fn test_text_range_second_field() {
+        let json = br#"{"a": 1, "b": "hello"}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let fields = root.value().as_object().unwrap();
+        let (_, rest) = fields.uncons().unwrap();
+        let (field_b, _) = rest.uncons().unwrap();
+        let range = field_b.value_cursor().text_range().unwrap();
+        assert_eq!(range, (14, 21));
+        assert_eq!(&json[range.0..range.1], br#""hello""#);
+    }
+
+    #[test]
+    fn test_text_range_deeply_nested() {
+        let json = br#"{"a": {"b": {"c": 1}}}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+
+        let fields = root.value().as_object().unwrap();
+        let (field_a, _) = fields.uncons().unwrap();
+        assert_eq!(field_a.value_cursor().text_range().unwrap(), (6, 21));
+        assert_eq!(&json[6..21], br#"{"b": {"c": 1}}"#);
+
+        let fields_b = field_a.value().as_object().unwrap();
+        let (field_b, _) = fields_b.uncons().unwrap();
+        assert_eq!(field_b.value_cursor().text_range().unwrap(), (12, 20));
+        assert_eq!(&json[12..20], br#"{"c": 1}"#);
+
+        let fields_c = field_b.value().as_object().unwrap();
+        let (field_c, _) = fields_c.uncons().unwrap();
+        assert_eq!(field_c.value_cursor().text_range().unwrap(), (18, 19));
+        assert_eq!(&json[18..19], b"1");
+    }
+
+    #[test]
+    fn test_text_range_root_object() {
+        let json = br#"{"a": 1}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let range = root.text_range().unwrap();
+        assert_eq!(range, (0, 8));
+        assert_eq!(&json[range.0..range.1], br#"{"a": 1}"#);
+    }
+
+    #[test]
+    fn test_text_range_root_array() {
+        let json = b"[1, 2, 3]";
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let range = root.text_range().unwrap();
+        assert_eq!(range, (0, 9));
+        assert_eq!(&json[range.0..range.1], b"[1, 2, 3]");
     }
 }

--- a/src/util/simd/x86.rs
+++ b/src/util/simd/x86.rs
@@ -187,7 +187,7 @@ fn detect_fast_bmi2() -> bool {
     // - AMD: Check family >= 0x19 (Zen 3+)
 
     // Check vendor string via CPUID leaf 0
-    let cpuid0 = unsafe { core::arch::x86_64::__cpuid(0) };
+    let cpuid0 = core::arch::x86_64::__cpuid(0);
     let is_amd = cpuid0.ebx == 0x6874_7541  // "Auth"
         && cpuid0.edx == 0x6974_6E65        // "enti"
         && cpuid0.ecx == 0x444D_4163; // "cAMD"
@@ -198,7 +198,7 @@ fn detect_fast_bmi2() -> bool {
     }
 
     // AMD: Check family from CPUID leaf 1
-    let cpuid1 = unsafe { core::arch::x86_64::__cpuid(1) };
+    let cpuid1 = core::arch::x86_64::__cpuid(1);
     let family = ((cpuid1.eax >> 8) & 0xF) + ((cpuid1.eax >> 20) & 0xFF);
 
     // Family 0x17 = Zen 1/2 (slow BMI2)


### PR DESCRIPTION
## Description

This PR fixes an incorrect `text_range` implementation for JSON container values (objects and arrays) in `src/json/light.rs`. The previous implementation used the balanced parentheses (BP) index to find the closing bracket position via `bp().find_close`, then mapped back to a text offset via `ib_select1_from`. This approach was fundamentally broken because closing brackets have IB=0 and are therefore not indexed in the IB bitvector, making the BP-based lookup unreliable.

The fix replaces the BP lookup with a direct forward scan over the raw text bytes that tracks nesting depth and correctly skips over string literals (including escaped characters), matching each open bracket with its corresponding close bracket.

Additionally, a minor safety improvement removes unnecessary `unsafe` blocks in `src/util/simd/x86.rs` for CPUID calls that are safe to call directly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #137

## Changes Made

**Core Bug Fix (`src/json/light.rs`):**
- Removed erroneous use of `bp().find_close` and `ib_select1_from` for container text range computation in `JsonCursor::text_range`
- Implemented a depth-tracking linear scan with string-skip logic for `{`/`[` containers that correctly identifies the matching close bracket
- The scan properly handles nested containers, string literals (including backslash-escaped characters), and both object (`{}`) and array (`[]`) container types
- Added early `return None` on scan exhaustion without finding a matching close bracket

**Safety Fix (`src/util/simd/x86.rs`):**
- Removed unnecessary `unsafe` blocks around `core::arch::x86_64::__cpuid(0)` and `__cpuid(1)` calls in `detect_fast_bmi2()`

**New Tests (`src/json/light.rs`):**
- Added 8 comprehensive tests covering `text_range` for container values:
  - `test_text_range_empty_object_value`: empty object `{}`
  - `test_text_range_empty_array_value`: empty array `[]`
  - `test_text_range_array_value`: array with values `[1, 2, 3]`
  - `test_text_range_nested_object_value`: nested object `{"key": {"key2": "value"}}`
  - `test_text_range_second_field`: second field in an object
  - `test_text_range_deeply_nested`: three levels of nesting `{"a": {"b": {"c": 1}}}`
  - `test_text_range_root_object`: root-level object text range
  - `test_text_range_root_array`: root-level array text range

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality (8 new `text_range` tests for containers)

**Manual Testing:**
- [x] Tested on x86_64

### Test Commands
```bash
cargo test
cargo test text_range
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] Potential performance regression (justify below)

The new implementation uses an O(n) linear scan over the container text instead of the O(log n) BP index lookup. However, the BP-based approach was producing incorrect results, so correctness takes priority over performance. For typical JSON payloads the scan is bounded by the size of the container value. No existing benchmarks have regressed in practice. A future optimization could cache or index container boundaries if profiling identifies this as a bottleneck.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Root Cause**: Closing brackets (`}`, `]`) are assigned IB=0 in the index bitvector because only value-opening tokens are indexed. The previous code assumed that `ib_select1_from` could locate a closing bracket by its BP rank, which is incorrect — IB rank only counts open/value tokens, not close brackets. This caused `text_range` to return wrong ranges or `None` for any container value.

**Design Decision**: The linear scan approach was chosen for simplicity and correctness. The scan correctly handles the tricky edge case of `"` characters inside string values that would otherwise appear to be nested brackets or the close bracket itself. Opening bracket characters are matched by comparing directly against `self.text[start]`, and the corresponding close character is computed once before the scan begins.