### PR TITLE
docs(docs): add knowledge-map skill and wiki maintenance procedures

### DIFF
--- a/.claude/skills/knowledge-map/SKILL.md
+++ b/.claude/skills/knowledge-map/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: knowledge-map
+description: Update the docs/ knowledge wiki when adding or changing data structures, modules, optimizations, SIMD paths, or paper references. Triggers on "knowledge map", "wiki", "update wiki", "add to wiki".
+user-invocable: false
+---
+
+# Knowledge Map Maintenance
+
+The knowledge wiki lives in `docs/` with `docs/index.md` as the entry point. Each core concept has its own page. When the codebase changes in ways that affect the wiki, update the relevant pages.
+
+## Page Structure
+
+Every concept page follows this structure:
+
+1. **Breadcrumb**: `[Knowledge Map](index.md) > PageName`
+2. **What It Does** — one-paragraph summary
+3. **How It Works** — key algorithms and data structures
+4. **Depends On** — links to wiki pages this concept uses
+5. **Used By** — links to wiki pages that use this concept
+6. **Academic Papers** — citations with links where available
+7. **Source & Docs** — links to implementation files and existing architecture/parsing docs
+
+## When to Update
+
+### New data structure or module
+
+1. Create a new `docs/<name>.md` following the page structure above
+2. Add a row to the Core Data Structures table in `docs/index.md`
+3. Update Depends On / Used By sections on related pages (keep these bidirectional)
+4. If the module has SIMD variants, add to `docs/simd-strategy.md`
+
+### New optimization
+
+1. Add a row to the relevant concept page's optimization table (e.g. the Optimization Journey table in `docs/yaml-index.md`)
+2. If it involves a new SIMD technique, update `docs/simd-strategy.md`
+
+### New academic paper reference
+
+1. Add to the Academic Foundations table in `docs/index.md`
+2. Add to the relevant concept page's Academic Papers section
+3. If the URL is on `doi.org`, it's already excluded from link checking (returns 403 to bots)
+
+### New SIMD path
+
+1. Update the Platform Support table in `docs/simd-strategy.md`
+2. Update the Per-Module SIMD Usage section in `docs/simd-strategy.md`
+3. Update the SIMD Platform Support table in `docs/index.md` if a new platform is added
+
+## Formatting Rules
+
+- Tables must use fixed-width columns with consistent padding (invoke the `format-md-tables` skill)
+- Use mermaid diagrams for flowcharts and dependency graphs, not ASCII art
+- Use relative markdown links (not wikilinks)
+
+## After Updating
+
+1. Append an entry to `docs/log.md` with the date, what changed, and what sources were read
+2. Verify links: `lychee '**/*.md'` (or let CI catch them)
+3. Check that Depends On / Used By links are bidirectional

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Detailed guidance is organized into skills in `.claude/skills/`. Claude will aut
 | **yaml-semi-indexing** | "YAML index", "YAML parser", "sequence item"| YAML parsing and debugging patterns        |
 | **testing**            | "test", "assert", "coverage", "regression"  | Test quality patterns and anti-patterns    |
 | **commit-msg**         | "commit message", "amend commit"            | Conventional commits format                |
+| **knowledge-map**      | "knowledge map", "wiki", "update wiki"      | Maintain docs/ knowledge wiki              |
 | **skill-writing**      | "create skill", "SKILL.md", "write skill"   | Best practices for writing Claude skills   |
 
 ## Knowledge Wiki

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,15 @@ The project documents both successes and failures in optimization:
 
 Key lesson: Micro-benchmark wins often don't translate to end-to-end improvements. Three consecutive YAML optimizations (P2.6, P2.8, P3) showed micro-benchmark gains but caused real-world regressions.
 
+## Maintaining the Knowledge Map
+
+Maintenance procedures are codified in the `knowledge-map` skill (`.claude/skills/knowledge-map/SKILL.md`), which Claude auto-invokes when updating wiki pages. The key rules:
+
+- Every concept page follows a consistent structure: breadcrumb, What It Does, How It Works, Depends On, Used By, Academic Papers, Source & Docs
+- Depends On / Used By links must be bidirectional
+- Tables use fixed-width columns
+- Changes are logged in [log.md](log.md)
+
 ## Ingestion Log
 
 See [log.md](log.md) for a record of wiki updates.


### PR DESCRIPTION
## Description

This PR introduces a new Claude skill for maintaining the `docs/` knowledge wiki and documents the maintenance procedures in `CLAUDE.md` and `docs/index.md`. The `knowledge-map` skill codifies how AI assistants should keep the wiki up to date as the codebase evolves — covering new data structures, optimizations, academic paper references, and SIMD paths.

The skill is auto-invoked by Claude when trigger phrases like "knowledge map", "wiki", or "update wiki" appear in a conversation, ensuring consistent and well-structured wiki updates without manual prompting.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

## Related Issue

No linked issue — this is a standalone documentation and AI tooling improvement.

## Changes Made

**New Claude Skill:**
- Added `.claude/skills/knowledge-map/SKILL.md` defining the `knowledge-map` skill, including:
  - Required page structure for every concept page (breadcrumb, What It Does, How It Works, Depends On, Used By, Academic Papers, Source & Docs)
  - Step-by-step procedures for four categories of wiki updates: new data structures, new optimizations, new academic paper references, and new SIMD paths
  - Formatting rules (fixed-width table columns via `format-md-tables` skill, mermaid diagrams, relative markdown links)
  - Post-update checklist: append to `docs/log.md`, verify links with `lychee '**/*.md'`, confirm bidirectional Depends On / Used By links

**CLAUDE.md Registration:**
- Registered the `knowledge-map` skill in the skills table in `CLAUDE.md` with trigger phrases `"knowledge map"`, `"wiki"`, `"update wiki"`

**docs/index.md Documentation:**
- Added a "Maintaining the Knowledge Map" section to `docs/index.md` summarising the key wiki maintenance rules: consistent page structure, bidirectional Depends On / Used By links, fixed-width table formatting, and change logging in `log.md`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality (documentation-only change; no code tests applicable)

**Manual Testing:**
- [x] Reviewed skill file structure and content for completeness and correctness
- [x] Confirmed trigger phrases in `CLAUDE.md` match the skill's frontmatter description

### Test Commands

```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
# Verify markdown links
lychee '**/*.md'
```

## Performance Impact

- [x] No performance impact

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (documentation-only; no executable code changed)
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

This change is part of the `llm-knowledge-base-skill` branch, which aims to improve AI-assisted development workflows by giving Claude structured, repeatable procedures for keeping the `docs/` knowledge wiki accurate and consistent as the codebase evolves.

The `knowledge-map` skill complements existing skills (`yaml-semi-indexing`, `testing`, `commit-msg`, `skill-writing`) and follows the same frontmatter + markdown structure established for all Claude skills in this project.