### PR TITLE
ci: add commit message linting workflow

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,0 +1,30 @@
+name: Commit Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: commit-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commit-check:
+    name: Commit Message Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: action-works/omni-dev-commit-check@v1
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          guidelines: .omni-dev/commit-guidelines.md
+          model: claude-haiku-4-5
+          verbose: true
+          github-token: ${{ github.token }}


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions workflow that automatically validates commit messages against conventional commit guidelines using the omni-dev commit-check action. The workflow ensures all commits follow the project's commit format standards before being merged to main.

The commit message linting workflow provides:
- Automated validation of commit messages on push to main and pull requests
- AI-powered commit analysis using Claude Haiku 4.5 model
- Validation against project-specific guidelines defined in `.omni-dev/commit-guidelines.md`
- Concurrency control to cancel outdated workflow runs
- Verbose output for debugging and transparency

## Type of Change
- [x] CI/CD changes

## Related Issue
Relates to issue #201

## Changes Made

**CI/CD Workflow:**
- Added `.github/workflows/commit-check.yml` workflow file with 30 lines
- Configured workflow to trigger on push to main branch and pull requests targeting main
- Set up job to run on Ubuntu latest with full git history (`fetch-depth: 0`)
- Integrated `action-works/omni-dev-commit-check@v1` action for commit validation
- Configured to use `claude-haiku-4-5` model for AI-powered commit analysis
- Enabled verbose output mode for transparency and debugging
- Added concurrency control (`commit-check-${{ github.ref }}`) to cancel in-progress runs
- Configured minimal permissions (contents: read) for security

## Testing

**Automated Testing:**
- [x] Workflow file validated with proper YAML syntax
- [x] GitHub Actions workflow configuration follows best practices
- [x] All existing tests pass

**Manual Testing:**
- [x] Workflow syntax verified
- [x] Action references are correct and pinned to v1
- [x] Environment variable references (secrets and github.token) are valid

## Performance Impact
- [x] No performance impact

The workflow runs only on commits to main and pull requests, with concurrency control to cancel outdated runs, ensuring efficient CI/CD pipeline usage.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

This workflow complements the project's commit message guidelines by providing automated validation. The use of the omni-dev commit-check action with Claude Haiku ensures intelligent, context-aware validation of commit messages while keeping CI/CD costs minimal.

The workflow requires the `ANTHROPIC_API_KEY` secret to be configured in the repository settings for the workflow to function properly.