### PR TITLE
ci(security): add cargo-audit, cargo-deny (+deny.toml), and secret scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,54 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Prebuilt binary via taiki-e/install-action (cacheable), rather than
+      # `cargo install cargo-audit`, which recompiles from source every run.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Run cargo-audit
+        run: cargo audit
+
+  deny:
+    name: Dependency Policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: EmbarkStudios/cargo-deny-action@v2.0.20
+        with:
+          command: check all
+
+  secrets:
+    name: Secret Scanning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog (verified secrets)
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,17 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,15 +460,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -536,7 +516,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -981,7 +961,6 @@ name = "succinctly"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "atty",
  "bytemuck",
  "chrono",
  "clap",
@@ -1143,22 +1122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,12 +1129,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -590,9 +590,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -707,7 +707,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -739,9 +739,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -972,7 +972,7 @@ dependencies = [
  "md5",
  "memmap2",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ portable-popcount = []
 serde = ["dep:serde"]
 
 # CLI tool features
-cli = ["std", "clap", "rand", "rand_chacha", "anyhow", "serde_json", "memmap2", "atty", "md5", "serde", "ctrlc"]
+cli = ["std", "clap", "rand", "rand_chacha", "anyhow", "serde_json", "memmap2", "md5", "serde", "ctrlc"]
 
 # Enable regex support in jq query language
 regex = ["dep:regex"]
@@ -78,7 +78,6 @@ rand = { version = "0.8", optional = true }
 rand_chacha = { version = "0.3", optional = true }
 anyhow = { version = "1.0", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
-atty = { version = "0.2", optional = true }
 md5 = { version = "0.7", optional = true }
 ctrlc = { version = "3.4", optional = true }
 chrono = { version = "0.4", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,48 @@
+# deny.toml -- cargo-deny configuration for succinctly
+# Reference: https://embarkstudios.github.io/cargo-deny/
+#
+# Run locally with:  cargo deny check all
+
+[graph]
+targets = []
+all-features = true
+
+# ── Advisories ────────────────────────────────────────────────────────
+# RustSec advisory database (vulnerabilities, unmaintained, unsound).
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# Flag unmaintained crates that are direct dependencies of this crate.
+unmaintained = "workspace"
+yanked = "warn"
+ignore = []
+
+# ── Licenses ──────────────────────────────────────────────────────────
+# Tuned to the licenses actually encountered in succinctly's dependency
+# tree (`cargo deny check licenses`). A new dependency introducing another
+# permissive license (e.g. ISC, BSD-3-Clause, MPL-2.0) will fail the gate
+# loudly; add it here after review.
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+# ── Bans ──────────────────────────────────────────────────────────────
+# Warn (don't fail) on duplicate versions and wildcard requirements so
+# transitive-dependency skew is surfaced without blocking PRs.
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+# ── Sources ───────────────────────────────────────────────────────────
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
 use std::collections::BTreeMap;
-use std::io::{BufWriter, Read, Write};
+use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
@@ -522,7 +522,7 @@ impl OutputConfig {
             false
         } else {
             // Default: color if stdout is a terminal
-            atty::is(atty::Stream::Stdout)
+            std::io::stdout().is_terminal()
         };
 
         // Get color scheme from JQ_COLORS env var (or defaults)

--- a/src/bin/succinctly/json_validate.rs
+++ b/src/bin/succinctly/json_validate.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
 use succinctly::json::validate::{ValidationError, ValidationErrorKind, Validator};
 
@@ -89,7 +89,7 @@ pub fn run(args: ValidateArgs) -> Result<i32> {
     } else if args.color {
         true
     } else {
-        atty::is(atty::Stream::Stderr)
+        io::stderr().is_terminal()
     };
 
     let scheme = ColorScheme::new(use_color);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use core::fmt::Write as FmtWrite;
 use indexmap::IndexMap;
-use std::io::{BufWriter, Read, Write};
+use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::eval_generic::{eval_with_cursor, to_owned, GenericResult};
@@ -98,7 +98,7 @@ impl OutputConfig {
             true
         } else {
             // Default: color if stdout is a terminal
-            atty::is(atty::Stream::Stdout)
+            std::io::stdout().is_terminal()
         };
 
         // Compact output when indent is 0 (yq-compatible)


### PR DESCRIPTION
Closes #200.

Adds the three supply-chain CI jobs succinctly was missing, mirroring the sibling `rust-works/omni-dev` setup, plus the dependency hygiene needed to make the gate green.

## What's here (three logical commits)

1. **`refactor(cli)`** — replace the unmaintained `atty` (RUSTSEC-2024-0375 unmaintained, RUSTSEC-2021-0145 unsound) with `std::io::IsTerminal` (stable since 1.70; MSRV is 1.73). Drop-in for the 3 terminal-detection call sites; removes `atty` and its transitive deps (`hermit-abi 0.1`, `winapi`) from the tree.
2. **`fix(deps)`** — lockfile-only patch bumps to clear RustSec advisories surfaced by the new gate:
   | Crate | From → To | Advisory |
   |-------|-----------|----------|
   | crossbeam-epoch (via criterion) | 0.9.18 → 0.9.20 | RUSTSEC-2026-0204 (**vulnerability**) |
   | anyhow | 1.0.100 → 1.0.103 | RUSTSEC-2026-0190 (unsound) |
   | memmap2 | 0.9.9 → 0.9.11 | RUSTSEC-2026-0186 (unsound) |
   | rand | 0.8.5 → 0.8.6 | RUSTSEC-2026-0097 (unsound) |
   | rand (via proptest, dev) | 0.9.2 → 0.9.3 | RUSTSEC-2026-0097 (unsound) |
3. **`ci(security)`** — new `.github/workflows/security.yml` with `audit` (cargo-audit via `taiki-e/install-action`), `deny` (`EmbarkStudios/cargo-deny-action`), and `secrets` (TruffleHog `--only-verified`), plus `deny.toml`.

## deny.toml tuning

Per the issue's note, the license allow-list is trimmed to the licenses `cargo deny check licenses` actually encounters in succinctly's tree — MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-2-Clause, Unicode-3.0, Unlicense, Zlib. `multiple-versions` and `wildcards` are `warn` so transitive skew is surfaced without blocking PRs. A future dep pulling in another permissive license will fail loudly and needs a one-line addition after review.

## Verification (local)

- `cargo audit` → 0 vulnerabilities, 0 warnings
- `cargo deny check all` → advisories / bans / licenses / sources **all ok**
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --features cli` green; all three CLI binaries drive correctly (piped → no color, `-C` still forces color)

## Notes / out of scope

- The "docs-only path gate" (companion issue) is intentionally not wired in here; keeping this as a standalone `security.yml` makes adding path filters later straightforward.
- Dependabot (#148) is a separate issue.