### PR TITLE
docs: add root ARCHITECTURE.md + docs/STYLE_GUIDE.md (#209)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,72 @@
+# Architecture
+
+This is the top-level entry point for understanding how succinctly is built. It gives a
+one-page mental model and then hands off to the deeper documentation under [`docs/`](docs/).
+
+## What succinctly is
+
+Succinctly is a high-performance Rust library of **succinct data structures** — bit vectors
+and trees that store data close to its information-theoretic minimum while still supporting
+fast queries. On top of that foundation it provides **semi-indexing** parsers for JSON, YAML,
+and DSV/CSV, and a `jq`-style query engine over them.
+
+## The core idea: semi-indexing
+
+Rather than building a full in-memory DOM, succinctly builds a lightweight structural index
+(~3–6% overhead) and materialises values lazily. The pipeline is:
+
+1. **Scan** — a SIMD-accelerated pass finds structural characters (braces, brackets, quotes,
+   newlines).
+2. **Encode** — those become a [balanced-parentheses](docs/architecture/balanced-parens.md)
+   bit vector plus "interest bit" vectors.
+3. **Navigate** — O(1) tree operations (parent/child/sibling, subtree skip) run as rank/select
+   over the bit vector.
+4. **Extract** — a value is parsed only when a query actually reads it.
+
+This is what buys the large memory and speed wins over DOM parsers (jq/yq/serde_json). See
+[docs/architecture/semi-indexing.md](docs/architecture/semi-indexing.md) for the full design.
+
+## How the pieces layer
+
+```
+BitVec (rank/select)
+   └─ BalancedParens (succinct trees)
+        ├─ JsonIndex ┐
+        ├─ YamlIndex ┼─ jq / yq evaluator (generic over a Document + cursor)
+        └─ DsvIndex  ┘
+```
+
+Each format module carries a `simd/` subdirectory selected at runtime: x86_64 uses
+AVX2 / BMI2 / SSE4.2, ARM64 uses NEON / SVE2, and a broadword/scalar path is the fallback
+when no accelerated instruction set is detected.
+
+## Module map
+
+```
+src/
+├── lib.rs      # public API, RankSelect trait, no_std crate attrs
+├── bits/       # BitVec: rank/select, popcount
+├── trees/      # BalancedParens: succinct tree navigation
+├── json/       # JSON semi-indexing (+ json/simd/)
+├── yaml/       # YAML semi-indexing (+ yaml/simd/)
+├── dsv/        # DSV/CSV semi-indexing (+ dsv/simd/)
+├── jq/         # jq query language and evaluator
+├── util/       # shared SIMD helpers, broadword (+ util/simd/)
+└── bin/        # CLI tool (jq, yq, jq-locate, yq-locate, bench runner)
+```
+
+## Start here
+
+For anything beyond this overview, follow the canonical docs — this page deliberately does not
+duplicate their detail:
+
+| Go to | For |
+|-------|-----|
+| [docs/index.md](docs/index.md) | The concept-oriented **knowledge map** — how every structure, algorithm, and paper relates |
+| [docs/architecture/](docs/architecture/) | Deep design docs: BitVec, balanced parens, semi-indexing, prior art |
+| [docs/parsing/](docs/parsing/) | Per-format parser internals (JSON PFSM, YAML oracle, DSV) |
+| [docs/optimizations/](docs/optimizations/) | Optimization techniques and the accept/reject history (incl. why AVX-512 was dropped) |
+| [docs/benchmarks/](docs/benchmarks/) | Per-platform benchmark results |
+| [docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md) | Tagged, stable-ID coding & docs conventions |
+| [CLAUDE.md](CLAUDE.md) | Full module map, commands, feature flags, performance summary |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to build, test, and submit changes |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,8 @@ cargo test
 
 | Document                                                          | Purpose                              |
 |-------------------------------------------------------------------|--------------------------------------|
+| [ARCHITECTURE.md](ARCHITECTURE.md)                                | Top-level architecture entry point   |
+| [docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md)                        | Tagged, stable-ID coding conventions |
 | [docs/adrs/README.md](docs/adrs/README.md)                        | Architecture Decision Records (why)  |
 | [docs/guides/release.md](docs/guides/release.md)                  | Release process and checklist        |
 | [docs/optimizations/](docs/optimizations/)                        | Optimization techniques reference    |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,10 @@ cargo test --features huge-tests
 
 ### Code Style
 
-We use standard Rust formatting and linting:
+We use standard Rust formatting and linting. The project's coding, documentation, and
+lint conventions are captured with stable rule IDs in
+[docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md) — consult it (and cite the relevant
+`STYLE-####` when suppressing a lint) before submitting changes.
 
 ```bash
 # Format code

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,473 @@
+# Style Guide
+
+Conventions for code, documentation, and other project artifacts in the succinctly
+project. Each item has a unique ID for easy reference.
+
+Much of the detailed *how* lives in the `.claude/skills/` skills and in
+[CONTRIBUTING.md](../CONTRIBUTING.md); this guide is the stable-ID index that lint
+suppressions, code review, and those docs can point at unambiguously.
+
+## Tag-based lookup
+
+Before writing or reviewing code, documentation, or other project artifacts, identify
+which tags apply to the changes and search this file for those tags. Each rule has a
+**Tags** line immediately after its heading.
+
+**Search command:** `grep "Tags:.*<tag>" docs/STYLE_GUIDE.md` returns matching rule headings.
+
+| When you are…                                     | Search for tags                              |
+|---------------------------------------------------|----------------------------------------------|
+| Adding or reorganizing a module / file            | `module-organization`, `simd`                |
+| Adding or changing a SIMD implementation          | `simd`, `unsafe`, `code-style`               |
+| Writing `unsafe` (SIMD intrinsics, raw pointers)  | `unsafe`, `simd`                             |
+| Suppressing a lint (`#[allow(...)]`)              | `code-style`, `lints`                        |
+| Adding platform-gated / reference / bench-only code | `code-style`, `simd`, `lints`              |
+| Documenting a public item                         | `documentation`                              |
+| Writing or updating tests                         | `testing`                                    |
+| Updating benchmarks or benchmark docs             | `benchmarks`, `documentation`                |
+| Adding or editing a markdown table                | `documentation`                              |
+| Writing commit messages                           | `commits`                                    |
+| Touching `no_std` boundaries or `std`-gated code  | `module-organization`                        |
+| Reviewing code for style compliance               | All tags relevant to the changed code        |
+
+---
+
+## STYLE-0000: Style guide structure
+
+**Tags:** `meta`
+
+### Situation
+
+A new convention needs to be added to this style guide.
+
+### Guidance
+
+Assign the next sequential ID (currently next is `STYLE-0012`) and include:
+
+1. A **Tags** line immediately after the heading — a comma-separated list of category labels
+   from the tag vocabulary below.
+2. Three subheadings:
+   - **Situation** — when this rule applies
+   - **Guidance** — what to do (with examples where helpful)
+   - **Motivation** — why this rule exists
+
+**Tag vocabulary** (extend as needed):
+
+| Tag                   | Covers                                                       |
+|-----------------------|-------------------------------------------------------------|
+| `meta`                | Style guide structure and process                           |
+| `module-organization` | File layout, module tree, visibility, `no_std` boundaries   |
+| `simd`                | SIMD directory layout, feature detection, platform gating   |
+| `unsafe`              | Unsafe code and `// SAFETY:` documentation                  |
+| `code-style`          | Imports, constants, function shape, lint hygiene            |
+| `lints`               | Lint suppression policy and `Cargo.toml [lints]`            |
+| `documentation`       | Doc comments, markdown, benchmark tables                    |
+| `testing`             | Test structure, property tests, feature-gated tests         |
+| `benchmarks`          | Benchmark running and result documentation                  |
+| `commits`             | Commit message format and discipline                        |
+
+A rule may have **multiple tags**. Items are ordered by ID. **Do not** group items under
+section headings; use tags for categorisation instead.
+
+### Motivation
+
+Consistent structure makes the guide scannable, and stable IDs allow code review comments,
+lint suppressions, and cross-references to point at specific rules unambiguously. Tags
+replace section headings so items can stay in strict ID order without being shuffled between
+sections when categories overlap.
+
+---
+
+## STYLE-0001: Module and SIMD directory layout
+
+**Tags:** `module-organization`, `simd`
+
+### Situation
+
+Adding a new module, or adding a platform-specific SIMD implementation to an existing
+format module.
+
+### Guidance
+
+Use the **named-file layout** (Rust 2018+): a module with submodules lives in a file named
+after the module alongside a directory of the same name (`json.rs` + `json/`). Do **not**
+introduce new `mod.rs` files for a module *root* — but note that `simd/` subdirectories in
+this crate do use a `mod.rs` as their dispatch file (see below).
+
+Each format module that has SIMD acceleration owns a `simd/` subdirectory with **one file
+per instruction set**, plus a `mod.rs` that performs runtime dispatch. The instruction-set
+files present depend on what the module actually uses; the JSON module is the fullest example:
+
+```
+src/json/
+├── ...
+└── simd/
+    ├── mod.rs      # runtime dispatch + feature detection (see STYLE-0003)
+    ├── x86.rs      # x86_64 dispatch entry
+    ├── avx2.rs     # AVX2 kernel
+    ├── sse42.rs    # SSE4.2 kernel
+    ├── bmi2.rs     # BMI2 (PDEP/PEXT) kernel
+    ├── neon.rs     # ARM NEON kernel
+    └── sve2.rs     # ARM SVE2 kernel
+```
+
+Other modules carry the subset they need — e.g. `src/yaml/simd/` adds `broadword.rs` (a
+portable SWAR fallback) and omits `avx2.rs`; `src/dsv/simd/` includes `sse2.rs`. Shared,
+format-agnostic SIMD helpers live in `src/util/simd/`.
+
+**Every SIMD path must have a scalar (or broadword) fallback** reachable when no supported
+instruction set is detected. Feature-gated fallback selection is exposed through the
+`broadword-yaml` and `scalar-yaml` Cargo features (see `Cargo.toml`).
+
+### Motivation
+
+One file per instruction set keeps each kernel's `#[target_feature]` scoping local and makes
+`git log`, editor tabs, and search unambiguous. Co-locating kernels under a `simd/` directory
+with a single `mod.rs` dispatcher means the platform-selection logic lives in exactly one
+place per module, and adding a new instruction set is a new file plus one dispatch arm rather
+than edits scattered across the module.
+
+---
+
+## STYLE-0002: `unsafe` code and `// SAFETY:` comments
+
+**Tags:** `unsafe`, `simd`
+
+### Situation
+
+Writing `unsafe` — almost always calling a SIMD intrinsic, or a proven-in-bounds slice
+access on a hot path.
+
+### Guidance
+
+`unsafe` is **permitted** in this crate (unlike a pure-safe library) because SIMD intrinsics
+are `unsafe fn`. Keep it disciplined:
+
+1. **Every `unsafe` block carries a `// SAFETY:` comment** immediately above it, naming the
+   invariant that makes it sound. For an intrinsic call that invariant is normally the
+   feature-detection guard that gates the call:
+
+   ```rust
+   // SAFETY: has_fast_bmi2() verified BMI2 is available on this CPU.
+   let mask = unsafe { bmi2::toggle64(quotes) };
+   ```
+
+   For a bounds-eliding access, cite the check that established the bound:
+
+   ```rust
+   // SAFETY: We verified bounds above.
+   let word = unsafe { *self.words.get_unchecked(i) };
+   ```
+
+2. **The `unsafe` intrinsic kernel is only ever reached through the feature-detected
+   dispatcher** (see STYLE-0003). Never call a `#[target_feature]` function without the
+   matching `is_*_feature_detected!` guard on the path to it.
+
+3. **Prefer a safe abstraction** where one exists at no cost — reach for `unsafe` for the
+   intrinsic itself and the innermost hot loop, not for surrounding bookkeeping.
+
+The clippy lint `undocumented_unsafe_blocks` enforces item 1; enabling it project-wide is
+tracked in the `Cargo.toml [lints]` work (see STYLE-0004 and issue #205). Until then, a
+missing `// SAFETY:` comment is a review defect even though it does not fail the build.
+
+### Motivation
+
+Intrinsics are `unsafe` because the caller, not the compiler, guarantees the CPU supports the
+instruction. Writing the guarantee down at the call site as `// SAFETY:` turns an implicit
+assumption into a reviewable claim, and keeps the "is this feature actually detected?" question
+answerable without tracing the whole call graph.
+
+---
+
+## STYLE-0003: Runtime CPU feature detection
+
+**Tags:** `simd`
+
+### Situation
+
+Selecting which SIMD kernel to run for the current CPU.
+
+### Guidance
+
+Detect features at **runtime**, not only at compile time, so a single binary runs optimally on
+whatever CPU it lands on. Use the standard macros and dispatch in the module's `simd/mod.rs`:
+
+```rust
+#[cfg(target_arch = "x86_64")]
+if std::is_x86_feature_detected!("avx2") {
+    // SAFETY: guarded by the detection above.
+    return unsafe { avx2::scan(input) };
+}
+```
+
+- Guard x86_64 kernels with `is_x86_feature_detected!` and aarch64 kernels with
+  `is_aarch64_feature_detected!`.
+- Annotate each intrinsic kernel with the matching `#[target_feature(enable = "...")]`.
+- **Cache** the detection result where dispatch is hot rather than re-querying per call.
+- Feature detection needs `std`; the `no_std` build (see STYLE-0011) falls back to the portable
+  path. Some paths are additionally switchable via environment variable (e.g. `SUCCINCTLY_SVE2`)
+  — document any such variable where it is read.
+
+### Motivation
+
+Runtime detection lets one artifact ship the fastest path for each machine instead of forcing a
+target-cpu build. Keeping detection in the `mod.rs` dispatcher (rather than sprinkled through
+kernels) means STYLE-0002's safety argument reduces to "the guard is right above the call."
+
+---
+
+## STYLE-0004: Lint suppression discipline
+
+**Tags:** `code-style`, `lints`
+
+### Situation
+
+Adding a `#[allow(...)]` (or considering a project-wide lint override).
+
+### Guidance
+
+Every lint suppression must be **traceable to a documented reason**. Two cases:
+
+1. **Per-item suppression** — annotate the specific item and append a citation comment naming
+   the STYLE rule that justifies the suppression, plus a one-line specific reason:
+
+   ```rust
+   #[allow(clippy::type_complexity)] // STYLE-0004: build-time index tuple; a named struct
+                                     // would add indirection to a build-only path.
+   fn build_bp_index(...) -> (u64, u64, /* ... */) { ... }
+   ```
+
+   When the suppression is an instance of a more specific rule, cite that rule instead — e.g.
+   `dead_code` on conditionally-compiled code cites **STYLE-0005**, not STYLE-0004.
+
+2. **Project-wide policy** — lints that should be allowed (or denied/warned) across the whole
+   crate belong in a `Cargo.toml [lints]` table with a justification comment per entry, **not**
+   in a blanket crate-level `#![allow(...)]` that hides warnings wholesale. Adding that `[lints]`
+   table (with `undocumented_unsafe_blocks`, a pedantic-clippy baseline, and an explicit unsafe
+   policy) is tracked in issue #205; when it lands, each allow comment there cites the STYLE rule
+   that motivates it, exactly as the per-item comments do.
+
+Do not add a bare `#[allow(...)]` with no comment, and do not silence a warning you could fix.
+
+### Motivation
+
+An uncommented `#[allow]` is a decision with no recorded rationale — the next reader cannot tell
+whether it is load-bearing or leftover. A STYLE-ID citation turns each suppression into a link to
+the policy that permits it, so a reviewer verifies "does this match the cited rule?" instead of
+re-deriving the justification. Centralising project-wide decisions in `[lints]` keeps the policy
+auditable in one place.
+
+---
+
+## STYLE-0005: Conditionally-compiled, reference, and bench-only code
+
+**Tags:** `code-style`, `simd`, `lints`
+
+### Situation
+
+A `dead_code` warning fires on code that is intentionally not reachable in the current build.
+
+### Guidance
+
+`#[allow(dead_code)]` is **expected and correct** for these recurring cases in this crate. Cite
+STYLE-0005 and say which case applies:
+
+| Case | Why it looks dead | Comment |
+|------|-------------------|---------|
+| **Platform-gated** | Compiled out on the current `target_arch` / feature combo (e.g. a NEON kernel in an x86_64 build) | `// STYLE-0005: platform-gated (aarch64 NEON)` |
+| **Reference / fallback impl** | A scalar or broadword implementation kept next to the SIMD one for correctness comparison or as the fallback path | `// STYLE-0005: scalar reference impl kept for correctness` |
+| **Test / bench / future-use** | Helpers reachable only from tests or benchmarks, or deliberately kept for imminent future use | `// STYLE-0005: used in tests` |
+| **Retained field / complete set** | A struct field kept for symmetry or a deliberately complete constant set (e.g. all jq exit codes) where only some entries are read today | `// STYLE-0005: complete jq exit-code set; not all emitted yet` |
+
+Use a per-item `#[allow(dead_code)]` where possible. A module-level `#![allow(dead_code)]` is
+acceptable only for a module that is *entirely* one of these cases (e.g. a bench-helper module) —
+give it a `//!` doc line stating so.
+
+Do **not** use `#[allow(dead_code)]` to silence genuinely unused code — delete that instead.
+
+### Motivation
+
+Platform-gated SIMD, paired scalar/SIMD implementations, and deliberately complete API/constant
+sets mean a large amount of code is legitimately unreachable in any single build configuration, so
+`dead_code` would otherwise be noise. Naming which case applies keeps "expected-dead" distinguishable
+from "should be deleted," so the allow does not become a place for real dead code to hide.
+
+---
+
+## STYLE-0006: Doc comments
+
+**Tags:** `documentation`
+
+### Situation
+
+Adding or updating documentation on a module, type, or public function.
+
+### Guidance
+
+- **Module-level docs** — each module file opens with a `//!` summary.
+- **Item-level docs** — every public type, field, variant, and method gets `///`.
+- **Summary line style** — third-person singular present indicative per
+  [RFC 505](https://rust-lang.github.io/rfcs/0505-api-comment-conventions.html)
+  (`/// Returns the k-th set bit.`, not `/// Return ...`), ending with a period.
+- **Runnable examples** — non-trivial public functions should carry a `# Examples` block. These
+  compile and run under `cargo test`, doubling as regression tests. `src/lib.rs` already carries
+  such an example for `BitVec`; keep new public entry points to the same bar.
+
+### Motivation
+
+Third-person summaries match the standard library and `rustdoc` output. Doc examples are compiled,
+so they cannot silently rot, and they document the intended call shape better than prose.
+
+---
+
+## STYLE-0007: Test structure
+
+**Tags:** `testing`
+
+### Situation
+
+Writing a new test.
+
+### Guidance
+
+- **Unit tests** live in a `#[cfg(test)] mod tests` block at the **end** of the source file, with
+  `use super::*;`.
+- **Property tests** use `proptest` and live in `tests/` (`tests/property_tests.rs`,
+  `tests/bp_properties.rs`); **integration tests** likewise live in `tests/`.
+- **Large/expensive tests** are gated behind Cargo features (`large-tests`, `huge-tests`,
+  `mmap-tests`) so the default `cargo test` stays fast.
+- **Snapshot tests** use `insta` where output stability matters.
+
+For deeper patterns and anti-patterns (e.g. asserting on real behaviour rather than
+tautologies), see the [`testing` skill](../.claude/skills/testing/SKILL.md).
+
+### Motivation
+
+The `mod tests` convention gives tests access to private items and keeps them next to the code
+they cover. Feature-gating the multi-gigabyte tests keeps the common test run cheap while leaving
+the heavy coverage available on demand.
+
+---
+
+## STYLE-0008: Benchmark documentation discipline
+
+**Tags:** `benchmarks`, `documentation`
+
+### Situation
+
+Adding, updating, or documenting benchmark results.
+
+### Guidance
+
+- **Regenerate, don't hand-edit numbers.** Produce results with the documented command
+  (`succinctly bench run <bench>`, or the relevant `cargo bench`) and paste the actual output.
+- **Run benchmarks sequentially, never concurrently** — benchmarks need exclusive CPU, and
+  overlapping runs produce meaningless numbers.
+- **Label every result table with the CPU/platform** it was measured on (the existing tables use
+  headings like "Apple M1 Max", "ARM Neoverse-V2"). Numbers without a platform are not comparable.
+- **Keep the summaries in sync** — the performance tables in [CLAUDE.md](../CLAUDE.md) and the
+  detailed pages under [docs/benchmarks/](benchmarks/) must not diverge; update both when a number
+  changes, and note the regeneration command beneath the table.
+
+The [`benchmark-docs` skill](../.claude/skills/benchmark-docs/SKILL.md) codifies the per-platform
+update procedure.
+
+### Motivation
+
+Benchmark numbers are only trustworthy if they are reproducible and attributed to hardware.
+Sequential execution avoids the biggest source of noise; per-platform labelling stops readers
+comparing an M4 result against a Neoverse one; keeping CLAUDE.md and `docs/benchmarks/` in lock-step
+prevents the headline summary from drifting away from the detail.
+
+---
+
+## STYLE-0009: Fixed-width markdown tables
+
+**Tags:** `documentation`
+
+### Situation
+
+Creating or editing a markdown table in any project doc.
+
+### Guidance
+
+Pad every column so cell borders line up in the raw source — the header, the separator row, and
+all body rows share one column width. Prefer this:
+
+```markdown
+| Structure    | Overhead |
+|--------------|----------|
+| BitVec       | 3–4%     |
+| BalancedParens | 6%     |
+```
+→ align to:
+```markdown
+| Structure      | Overhead |
+|----------------|----------|
+| BitVec         | 3–4%     |
+| BalancedParens | 6%       |
+```
+
+The [`markdown-tables` / `format-md-tables` skill](../.claude/skills/markdown-tables/SKILL.md)
+automates this — run it after editing a table rather than aligning by hand.
+
+### Motivation
+
+Fixed-width tables are readable in the raw markdown (not just when rendered), so diffs stay legible
+and a mis-aligned cell is an obvious signal that a column changed. Automating the alignment keeps it
+from being a manual chore.
+
+---
+
+## STYLE-0010: Commit messages
+
+**Tags:** `commits`
+
+### Situation
+
+Writing a commit message.
+
+### Guidance
+
+Use [Conventional Commits](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
+with an optional body and footer. Types in use: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
+`test`, `chore`. Scope names the touched area (`json`, `bp`, `yaml`, `dsv`, `bench`, …). For
+performance commits, put the measured speedup in the body. Full detail and examples are in
+[CONTRIBUTING.md](../CONTRIBUTING.md#commit-messages); the
+[`commit-msg` skill](../.claude/skills/commit-msg/SKILL.md) analyses a diff and drafts a message.
+
+### Motivation
+
+A consistent, machine-parseable commit format keeps `git log` scannable, lets tooling derive
+changelogs and scopes, and makes `git bisect` and history archaeology reliable.
+
+---
+
+## STYLE-0011: `no_std` compatibility
+
+**Tags:** `module-organization`
+
+### Situation
+
+Adding code to the core library (anything outside the CLI / `bin/`).
+
+### Guidance
+
+The core crate is `no_std`. Preserve that:
+
+- The crate declares `#![cfg_attr(not(any(test, feature = "std")), no_std)]` and
+  `extern crate alloc;` in `src/lib.rs` — depend on `alloc` (`Vec`, `String`, `Box`), never on
+  `std`, in core modules.
+- Gate any genuinely `std`-only functionality (notably runtime feature detection, threads, I/O)
+  behind `#[cfg(feature = "std")]`, and provide a `no_std` fallback path.
+- CLI-only code lives behind the `cli` feature (which pulls in `std`) — heavy `std` dependencies
+  belong there, not in the core modules.
+- Verify with `cargo build --no-default-features` (and `cargo test` uses `std`, since tests enable
+  it via the `cfg_attr` above).
+
+### Motivation
+
+`no_std` support lets succinctly be used in embedded and WASM contexts where `std` is unavailable.
+The guarantee is easy to break accidentally with a stray `std::` path, so keeping the `std` surface
+behind explicit feature gates — and testing the default-features-off build — makes the boundary
+enforceable rather than aspirational.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,7 +2,9 @@
 
 [Home](../../) > [Docs](../) > Architecture
 
-Design documentation for succinctly's core data structures and algorithms.
+Design documentation for succinctly's core data structures and algorithms. For the
+one-page top-level overview and orientation, start at the root
+[ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 ## Core Concepts
 

--- a/src/bin/generate_pfsm_tables.rs
+++ b/src/bin/generate_pfsm_tables.rs
@@ -20,7 +20,7 @@
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names)] // STYLE-0004: PFSM state variants share the In* prefix by design (they mirror parser states)
 enum State {
     InJson = 0,
     InString = 1,

--- a/src/bin/succinctly/bench_runner/registry.rs
+++ b/src/bin/succinctly/bench_runner/registry.rs
@@ -347,7 +347,7 @@ pub fn filter_by_names(names: &[String]) -> Vec<&'static BenchmarkInfo> {
 }
 
 /// Get a benchmark by name.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: bench-only lookup helper
 pub fn get_by_name(name: &str) -> Option<&'static BenchmarkInfo> {
     BENCHMARKS.iter().find(|b| b.name == name)
 }

--- a/src/bin/succinctly/bench_runner/utils.rs
+++ b/src/bin/succinctly/bench_runner/utils.rs
@@ -3,7 +3,7 @@
 //! Consolidated from jq_bench.rs, yq_bench.rs, and dsv_bench.rs.
 //! Some functions are not currently used but are provided for future use.
 
-#![allow(dead_code)]
+#![allow(dead_code)] // STYLE-0005: bench-only helper module (see module doc above)
 
 use anyhow::{Context, Result};
 use std::process::{Command, Stdio};

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -22,12 +22,12 @@ use super::JqCommand;
 pub mod exit_codes {
     pub const SUCCESS: i32 = 0;
     pub const FALSE_OR_NULL: i32 = 1; // With -e, last output was false or null
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: complete jq exit-code set; not all emitted yet
     pub const USAGE_ERROR: i32 = 2; // Usage problem or system error
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: complete jq exit-code set; not all emitted yet
     pub const COMPILE_ERROR: i32 = 3; // jq program compile error
     pub const NO_OUTPUT: i32 = 4; // With -e, no valid result produced
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: complete jq exit-code set; not all emitted yet
     pub const HALT_ERROR: i32 = 5; // halt_error without explicit code
 }
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -31,9 +31,9 @@ impl<W: Write> core::fmt::Write for FmtWriter<W> {
 pub mod exit_codes {
     pub const SUCCESS: i32 = 0;
     pub const FALSE_OR_NULL: i32 = 1; // With -e, last output was false or null
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: complete jq exit-code set; not all emitted yet
     pub const USAGE_ERROR: i32 = 2; // Usage problem or system error
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: complete jq exit-code set; not all emitted yet
     pub const COMPILE_ERROR: i32 = 3; // jq program compile error
     pub const NO_OUTPUT: i32 = 4; // With -e, no valid result produced
 }
@@ -312,7 +312,7 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
 /// Parse and evaluate YAML bytes directly using the generic evaluator.
 ///
 /// This keeps the index alive during evaluation and preserves position metadata.
-#[allow(dead_code)] // Used in tests
+#[allow(dead_code)] // STYLE-0005: used in tests
 fn parse_and_evaluate_yaml(bytes: &[u8], expr: &Expr) -> Result<Vec<OwnedValue>> {
     let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {}", e))?;
     let root = index.root(bytes);
@@ -409,7 +409,7 @@ fn evaluate_yaml_direct_filtered(
 /// This processes YAML documents directly without intermediate OwnedValue conversion,
 /// preserving position metadata for `line` and `column` builtins. Returns results
 /// grouped by document for proper multi-doc handling (with `---` separators).
-#[allow(dead_code)] // Used by tests and may be used directly in future
+#[allow(dead_code)] // STYLE-0005: used by tests; may be called directly in future
 fn evaluate_yaml_direct(bytes: &[u8], expr: &Expr) -> Result<Vec<Vec<OwnedValue>>> {
     let (results, _) = evaluate_yaml_direct_filtered(bytes, expr, None)?;
     Ok(results)
@@ -453,7 +453,7 @@ fn evaluate_input(
 /// Evaluate a jq expression directly on a YAML cursor.
 ///
 /// This uses the generic evaluator to preserve position metadata (line/column).
-#[allow(dead_code)] // Used by parse_and_evaluate_yaml
+#[allow(dead_code)] // STYLE-0005: reachable only via the test-only helper above
 fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     cursor: YamlCursor<'_, W>,
     expr: &Expr,

--- a/src/bits/rank.rs
+++ b/src/bits/rank.rs
@@ -18,7 +18,7 @@ use core::ptr::NonNull;
 const WORDS_PER_BLOCK: usize = 8;
 
 /// Number of bits per basic block.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: derived layout constant; unused in some configs
 const BITS_PER_BLOCK: usize = WORDS_PER_BLOCK * 64;
 
 /// Number of blocks per superblock (for L0).
@@ -29,7 +29,7 @@ const BLOCKS_PER_SUPERBLOCK: usize = 1 << 23;
 const CACHE_LINE_SIZE: usize = 64;
 
 /// Number of u128 entries that fit in a cache line (64 / 16 = 4).
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: derived layout constant; unused in some configs
 const ENTRIES_PER_CACHE_LINE: usize = CACHE_LINE_SIZE / 16;
 
 /// Cache-aligned storage for L1+L2 entries.
@@ -65,7 +65,7 @@ impl CacheAlignedL1L2 {
     ///
     /// Note: Prefer using `builder()` for new code to avoid the intermediate
     /// Vec allocation and copy.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: test/utility constructor
     fn from_vec(data: Vec<u128>) -> Self {
         if data.is_empty() {
             return Self::empty();
@@ -94,14 +94,14 @@ impl CacheAlignedL1L2 {
 
     /// Get the number of entries.
     #[inline]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: utility accessor kept for symmetry
     fn len(&self) -> usize {
         self.len
     }
 
     /// Check if empty.
     #[inline]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: utility accessor kept for symmetry
     fn is_empty(&self) -> bool {
         self.len == 0
     }

--- a/src/dsv/cursor.rs
+++ b/src/dsv/cursor.rs
@@ -243,7 +243,7 @@ impl<'a> Iterator for DsvRows<'a> {
 /// Iterator over fields in a row.
 pub struct DsvFields<'a> {
     cursor: DsvCursor<'a>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: retained field (row start) for future use
     row_start: usize,
     started: bool,
     finished: bool,
@@ -309,7 +309,7 @@ impl<'a> Iterator for DsvFields<'a> {
 }
 
 /// Strip surrounding quotes from a field if present.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: helper kept for future use
 pub fn strip_quotes(field: &[u8]) -> &[u8] {
     if field.len() >= 2 && field[0] == b'"' && field[field.len() - 1] == b'"' {
         &field[1..field.len() - 1]

--- a/src/dsv/parser.rs
+++ b/src/dsv/parser.rs
@@ -72,7 +72,7 @@ pub fn build_index(text: &[u8], config: &DsvConfig) -> DsvIndex {
 ///
 /// This version processes 8 bytes at a time using broadword techniques,
 /// which is significantly faster for large files.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: alternate/experimental index builder
 pub fn build_index_fast(text: &[u8], config: &DsvConfig) -> DsvIndex {
     if text.is_empty() {
         return DsvIndex::new_lightweight(DsvIndexLightweight::new(vec![], vec![], 0));

--- a/src/dsv/simd/avx2.rs
+++ b/src/dsv/simd/avx2.rs
@@ -236,6 +236,7 @@ mod tests {
         let mut csv = Vec::new();
         csv.push(b'"');
         #[allow(clippy::same_item_push)]
+        // STYLE-0004: builds a test CSV fixture inline; explicit pushes read as the field being constructed
         for _ in 0..70 {
             csv.push(b'x');
         }

--- a/src/dsv/simd/bmi2.rs
+++ b/src/dsv/simd/bmi2.rs
@@ -346,6 +346,7 @@ mod tests {
         let mut csv = Vec::new();
         csv.push(b'"');
         #[allow(clippy::same_item_push)]
+        // STYLE-0004: builds a test CSV fixture inline; explicit pushes read as the field being constructed
         for _ in 0..70 {
             csv.push(b'x');
         }

--- a/src/dsv/simd/neon.rs
+++ b/src/dsv/simd/neon.rs
@@ -245,7 +245,7 @@ unsafe fn prefix_xor_neon(x: u64) -> u64 {
 
 /// Scalar fallback for prefix XOR (used in tests for comparison).
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar fallback (NEON path used when detected)
 fn prefix_xor_scalar(x: u64) -> u64 {
     // Parallel prefix XOR using doubling with left shifts
     // After step k, each bit i contains XOR of bits max(0, i-2^k+1)..=i

--- a/src/dsv/simd/sse2.rs
+++ b/src/dsv/simd/sse2.rs
@@ -238,6 +238,7 @@ mod tests {
         let mut csv = Vec::new();
         csv.push(b'"');
         #[allow(clippy::same_item_push)]
+        // STYLE-0004: builds a test CSV fixture inline; explicit pushes read as the field being constructed
         for _ in 0..70 {
             csv.push(b'x');
         }

--- a/src/dsv/simd/sve2.rs
+++ b/src/dsv/simd/sve2.rs
@@ -352,6 +352,7 @@ mod tests {
         let mut csv = Vec::new();
         csv.push(b'"');
         #[allow(clippy::same_item_push)]
+        // STYLE-0004: builds a test CSV fixture inline; explicit pushes read as the field being constructed
         for _ in 0..70 {
             csv.push(b'x');
         }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -193,7 +193,7 @@ pub trait DocumentValue: Sized + Clone {
 }
 
 /// Iterator-like access to object fields.
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity)] // STYLE-0004: uncons returns the cons-list contract (field, rest); the nested tuple is intentional
 pub trait DocumentFields: Sized + Copy + Clone {
     /// The value type for keys and values.
     type Value: DocumentValue;
@@ -202,7 +202,7 @@ pub trait DocumentFields: Sized + Copy + Clone {
     type Cursor: DocumentCursor;
 
     /// Get the first field and remaining fields.
-    #[allow(clippy::type_complexity)]
+    #[allow(clippy::type_complexity)] // STYLE-0004: uncons returns the cons-list contract (field, rest); the nested tuple is intentional
     fn uncons(&self) -> Option<(DocumentField<Self::Value, Self::Cursor>, Self)>;
 
     /// Find a field by name.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7967,7 +7967,7 @@ fn eval_pipe_with_path_tracking(
 }
 
 /// Collect intermediate values along with their paths for continuing pipe evaluation
-#[allow(clippy::only_used_in_recursion)]
+#[allow(clippy::only_used_in_recursion)] // STYLE-0004: parameter used only in the recursive call; part of the recursion contract
 fn collect_intermediate_with_paths(
     expr: &Expr,
     value: &OwnedValue,
@@ -8903,7 +8903,7 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Format a time according to strftime format specifiers
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors strftime's broken-down-time field set
 fn format_strftime(
     fmt: &str,
     year: i64,
@@ -9067,7 +9067,7 @@ struct BrokenDownTime {
 }
 
 /// Parse a time string according to strptime format specifiers
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity)] // STYLE-0004: return mirrors strptime's broken-down-time field set
 fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
     let mut year: i64 = 1970;
     let mut month: i64 = 1;
@@ -9080,8 +9080,10 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
     // This matches jq's behavior where weekday/yearday in output are always
     // computed from the date, not taken from the parsed input.
     #[allow(unused_variables, unused_assignments)]
+    // STYLE-0004: weekday parsed from %w/%u then recomputed from the date (jq parity)
     let mut weekday: i64 = 4; // Thursday (Jan 1, 1970)
     #[allow(unused_variables, unused_assignments)]
+    // STYLE-0004: yearday parsed from %j then recomputed from the date (jq parity)
     let mut yearday: i64 = 0;
 
     let mut input_iter = input.chars().peekable();
@@ -9146,16 +9148,19 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
                     }
                 }
                 #[allow(unused_assignments)]
+                // STYLE-0004: assignment superseded once the date is recomputed (jq parity)
                 Some('j') => {
                     // Parse day-of-year, but we recalculate it from the date for consistency
                     yearday = parse_digits(&mut input_iter, 3)? - 1; // Convert to 0-indexed
                 }
                 #[allow(unused_assignments)]
+                // STYLE-0004: assignment superseded once the date is recomputed (jq parity)
                 Some('w') => {
                     // Parse weekday, but we recalculate it from the date for consistency
                     weekday = parse_digits(&mut input_iter, 1)?;
                 }
                 #[allow(unused_assignments)]
+                // STYLE-0004: assignment superseded once the date is recomputed (jq parity)
                 Some('u') => {
                     // Parse ISO weekday (1=Monday, 7=Sunday), convert to 0=Sunday
                     let w = parse_digits(&mut input_iter, 1)?;

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -82,7 +82,7 @@ struct Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    #[allow(dead_code)] // kept for tests and future use
+    #[allow(dead_code)] // STYLE-0005: kept for tests and future use
     fn new(input: &'a str) -> Self {
         Parser {
             input,

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::items_after_test_module)]
+#![allow(clippy::items_after_test_module)] // STYLE-0004: helper items intentionally follow `mod tests` in this file
 //! StandardJson - Lazy JSON navigation using the standard cursor.
 //!
 //! This module provides a cursor-based API for navigating JSON structures

--- a/src/json/simd/neon.rs
+++ b/src/json/simd/neon.rs
@@ -285,7 +285,7 @@ unsafe fn classify_chars(chunk: uint8x16_t) -> CharClass {
 ///
 /// This is the original serial implementation - kept for correctness reference.
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: serial reference impl kept for correctness
 fn process_chunk_standard_serial(
     class: CharClass,
     mut state: State,

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -753,7 +753,7 @@ fn build_l2_index_sse41(
 ///
 /// This is the reference implementation that SSE4.1 and NEON should match exactly.
 #[cfg(test)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar reference impl (SIMD path used in practice)
 fn build_l1_index_scalar(
     l0_min_excess: &[i8],
     l0_word_excess: &[i16],
@@ -787,7 +787,7 @@ fn build_l1_index_scalar(
 
 /// Scalar implementation of L2 index building for testing.
 #[cfg(test)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar reference impl (SIMD path used in practice)
 fn build_l2_index_scalar(
     l1_min_excess: &[i16],
     l1_block_excess: &[i16],
@@ -1476,7 +1476,7 @@ pub struct BalancedParens<W = Vec<u64>, S: SelectSupport = NoSelect> {
 /// Build the V2 index structures with absolute cumulative rank.
 /// Returns (l0_min_excess, l0_word_excess, l1_min_excess, l1_block_excess,
 ///          l2_min_excess, l2_block_excess, rank_l1, rank_l2, total_ones)
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity)] // STYLE-0004: build-time index tuple; a named struct adds indirection to a build-only path
 fn build_bp_index(
     words: &[u64],
     len: usize,

--- a/src/util/broadword.rs
+++ b/src/util/broadword.rs
@@ -6,11 +6,11 @@
 use crate::util::table::select_in_byte;
 
 /// Constant with 1 in each byte's LSB position.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword mask constant; unused under some feature combos
 pub const L8: u64 = 0x0101_0101_0101_0101;
 
 /// Constant with 1 in each byte's MSB position.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword mask constant; unused under some feature combos
 pub const H8: u64 = 0x8080_8080_8080_8080;
 
 /// Select the k-th set bit (0-indexed) in a 64-bit word.
@@ -124,7 +124,7 @@ fn select_in_word_ctz(x: u64, k: u32) -> u32 {
 ///
 /// For Elias-Fano `select1` where k averages ~32, broadword is ~3× faster.
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword select fallback; unused when a SIMD select path is active
 pub fn select_in_word_broadword(x: u64, k: u32) -> u32 {
     if x == 0 {
         return 64;

--- a/src/util/simd/mod.rs
+++ b/src/util/simd/mod.rs
@@ -16,7 +16,7 @@ pub mod x86;
 ///
 /// Uses the best available implementation for the current platform.
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: reference popcount; unused on some targets
 pub fn popcount_512(data: &[u8; 64]) -> u32 {
     #[cfg(target_arch = "aarch64")]
     {
@@ -39,7 +39,7 @@ pub fn popcount_512(data: &[u8; 64]) -> u32 {
 
 /// Scalar fallback for 512-bit popcount.
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar reference popcount
 pub fn popcount_512_scalar(data: &[u8; 64]) -> u32 {
     // Process byte-by-byte to avoid alignment issues
     let mut total = 0u32;
@@ -62,7 +62,7 @@ pub fn popcount_512_scalar(data: &[u8; 64]) -> u32 {
 // Used today only by the aarch64 SVE2 test modules; the x86 BMI2/AVX2/SSE2
 // sites adopt it in #193, so it is dead on x86-only builds until then.
 #[cfg(test)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: test-only skip helper; dead on x86 builds until #193 wires it in
 pub(crate) fn note_simd_skip(feature: &str) {
     eprintln!("SKIPPED: SIMD test - CPU feature `{feature}` unavailable");
 }

--- a/src/util/simd/neon.rs
+++ b/src/util/simd/neon.rs
@@ -15,7 +15,7 @@ use core::arch::aarch64::*;
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: platform-gated (aarch64 NEON)
 pub unsafe fn popcount_512_neon(ptr: *const u8) -> u32 {
     unsafe {
         // Load 4 x 128-bit chunks
@@ -58,7 +58,7 @@ pub unsafe fn popcount_512_neon(ptr: *const u8) -> u32 {
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: platform-gated (aarch64 NEON)
 pub unsafe fn popcount_neon(ptr: *const u8, len: usize) -> u32 {
     unsafe {
         let mut total = 0u32;

--- a/src/util/simd/sve2.rs
+++ b/src/util/simd/sve2.rs
@@ -94,7 +94,7 @@ pub unsafe fn bdep_u64(data: u64, mask: u64) -> u64 {
 /// Requires SVE2 with BITPERM extension. Caller must verify with
 /// `is_aarch64_feature_detected!("sve2-bitperm")`.
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: platform-gated (aarch64 SVE2-bitperm)
 #[target_feature(enable = "sve2-bitperm")]
 pub unsafe fn bext_u64(data: u64, mask: u64) -> u64 {
     let result: u64;
@@ -219,7 +219,7 @@ pub unsafe fn select_in_word_bdep(x: u64, k: u32) -> u32 {
 /// which is required for BDEP/BEXT instructions.
 #[cfg(feature = "std")]
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: platform-gated feature detection (aarch64 build)
 pub fn has_sve2_bitperm() -> bool {
     std::arch::is_aarch64_feature_detected!("sve2-bitperm")
 }
@@ -227,7 +227,7 @@ pub fn has_sve2_bitperm() -> bool {
 /// Check if SVE2-BITPERM is available (no_std version - always false).
 #[cfg(not(feature = "std"))]
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: const fallback for non-aarch64 builds
 pub const fn has_sve2_bitperm() -> bool {
     false
 }

--- a/src/util/simd/x86.rs
+++ b/src/util/simd/x86.rs
@@ -25,7 +25,7 @@ use core::arch::x86_64::*;
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "popcnt")]
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: platform-gated (x86_64 POPCNT)
 pub unsafe fn popcount_512_popcnt(ptr: *const u64) -> u32 {
     unsafe {
         let mut sum = 0i32;
@@ -50,7 +50,7 @@ pub unsafe fn popcount_512_popcnt(ptr: *const u64) -> u32 {
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "popcnt")]
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: platform-gated (x86_64 POPCNT)
 pub unsafe fn popcount_words_popcnt(ptr: *const u64, word_count: usize) -> u32 {
     unsafe {
         let mut total = 0i32;

--- a/src/yaml/end_positions.rs
+++ b/src/yaml/end_positions.rs
@@ -111,7 +111,7 @@ pub struct CompactEndPositions {
     /// Interest bits: one bit per text byte, set at each unique end position.
     ib_words: Vec<u64>,
     /// Number of valid bits in IB (= text length).
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: index metadata field retained
     ib_len: usize,
     /// Sampled select index for IB.
     ib_select_samples: Vec<u32>,

--- a/src/yaml/error.rs
+++ b/src/yaml/error.rs
@@ -188,6 +188,7 @@ impl fmt::Display for YamlError {
                 write!(f, "invalid UTF-8 sequence at offset {}", offset)
             }
             #[allow(deprecated)]
+            // STYLE-0004: Display arm for a deprecated error variant kept for back-compat
             YamlError::MultiDocumentNotSupported { offset } => {
                 write!(
                     f,
@@ -196,6 +197,7 @@ impl fmt::Display for YamlError {
                 )
             }
             #[allow(deprecated)]
+            // STYLE-0004: Display arm for a deprecated error variant kept for back-compat
             YamlError::FlowStyleNotSupported { offset, char } => {
                 write!(
                     f,
@@ -389,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
+    #[allow(deprecated)] // STYLE-0004: test intentionally exercises deprecated variants' Display arms
     fn test_deprecated_variant_display() {
         // Deprecated but still part of the enum and its Display arms.
         let err = YamlError::MultiDocumentNotSupported { offset: 0 };

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -47,7 +47,7 @@ pub struct YamlIndex<W = Vec<u64>> {
     /// Type bits - 0 = mapping, 1 = sequence at each container position
     ty: W,
     /// Number of valid bits in TY
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: index metadata field retained for parity with ib_len
     ty_len: usize,
     /// Memory-efficient BP open index to text position mapping.
     /// Uses Advance Index encoding for ~1.5× compression when positions are monotonic,
@@ -178,7 +178,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// Create a YAML index from pre-existing IB, BP, TY, and bp_to_text data.
     ///
     /// This is useful for loading serialized index data.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)] // STYLE-0004: constructor threads each index array; a builder would hide the 1:1 field mapping
     pub fn from_parts(
         ib: W,
         ib_len: usize,
@@ -227,7 +227,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// Create a YAML index from pre-existing data including newlines.
     ///
     /// This is useful for loading serialized index data with full line/column support.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)] // STYLE-0004: constructor threads each index array; a builder would hide the 1:1 field mapping
     pub fn from_parts_with_newlines(
         ib: W,
         ib_len: usize,

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::items_after_test_module)]
+#![allow(clippy::items_after_test_module)] // STYLE-0004: helper items intentionally follow `mod tests` in this file
 //! YamlCursor - Lazy YAML navigation using the semi-index.
 //!
 //! This module provides a cursor-based API for navigating YAML structures
@@ -431,7 +431,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// Compute base indent for plain scalar continuation checking.
     /// Returns (base_indent, is_document_root) where is_document_root is true
     /// if this scalar is the document root content (right after --- or at start).
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: alternate parse-path helper; unused in current path
     fn compute_base_indent_and_root_flag(&self, value_pos: usize) -> (usize, bool) {
         // Find start of current line
         let mut line_start = value_pos;
@@ -593,7 +593,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
 
     /// Check if a position is inside a flow context (inside `[]` or `{}`).
     /// Returns true if there's an unmatched `[` or `{` before the position.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: alternate parse-path helper; unused in current path
     fn is_in_flow_context(&self, pos: usize) -> bool {
         // Find start of line containing pos
         let mut line_start = pos;
@@ -718,7 +718,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// A continuation line is more indented than base_indent (in block context),
     /// or any line that doesn't start with a flow delimiter (in flow context).
     /// For document root scalars (is_doc_root=true), continuation at indent 0 is allowed.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: alternate parse-path helper; unused in current path
     fn find_plain_scalar_end(&self, start: usize, base_indent: usize, is_doc_root: bool) -> usize {
         let in_flow = self.is_in_flow_context(start);
         let mut end = start;

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -43,7 +43,7 @@ pub enum NodeType {
     /// Sequence (array-like): ordered list
     Sequence,
     /// Scalar value (string, number, etc.)
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: parser style variant retained for completeness
     Scalar,
     /// Sequence item (tracks open items awaiting their value)
     SequenceItem,
@@ -73,7 +73,7 @@ pub enum ChompingIndicator {
 #[derive(Debug)]
 struct BlockScalarHeader {
     /// Literal or folded style (used for debugging/future extensions)
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: retained field (block style) for future use
     style: BlockStyle,
     /// Chomping behavior
     chomping: ChompingIndicator,
@@ -104,12 +104,12 @@ pub struct SemiIndex {
     /// Used to compute correct TY index from BP position.
     pub containers: Vec<u64>,
     /// Number of valid bits in IB (= input length)
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: index metadata field retained
     pub ib_len: usize,
     /// Number of valid bits in BP
     pub bp_len: usize,
     /// Number of valid bits in TY (= number of container opens)
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: index metadata field retained
     pub ty_len: usize,
     /// Anchor definitions: anchor name → BP position of the anchored value
     pub anchors: BTreeMap<String, usize>,
@@ -224,7 +224,7 @@ impl<'a> Parser<'a> {
 
     /// Set an interest bit at a specific position.
     #[inline]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: helper for an experimental SIMD path
     fn set_ib_at(&mut self, pos: usize) {
         let word_idx = pos / 64;
         let bit_idx = pos % 64;
@@ -401,7 +401,7 @@ impl<'a> Parser<'a> {
     /// Find next newline using SIMD acceleration.
     /// Returns offset from current position, or None if not found.
     #[inline]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: helper for an experimental SIMD path
     fn find_next_newline_simd(&self) -> Option<usize> {
         super::simd::find_newline(self.input, self.pos)
     }
@@ -451,7 +451,7 @@ impl<'a> Parser<'a> {
     /// Kept for future investigation. See P4 analysis in docs/parsing/yaml.md.
     #[cfg(all(target_arch = "aarch64", not(feature = "scalar-yaml")))]
     #[inline]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // STYLE-0005: helper for an experimental SIMD path
     fn skip_unquoted_simd(&self, _value_start: usize) -> Option<usize> {
         // Use broadword classify to scan 16 bytes at once (two 8-byte chunks)
         if let Some(class) = super::simd::classify_yaml_chars_16(self.input, self.pos) {

--- a/src/yaml/simd/broadword.rs
+++ b/src/yaml/simd/broadword.rs
@@ -67,7 +67,7 @@ const fn extract_mask_u64(x: u64) -> u8 {
 /// YAML character classification result using broadword operations.
 /// Each field is a u8 bitmask for 8 bytes (one bit per byte position).
 #[derive(Debug, Clone, Copy, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword fallback classifier; unused when SIMD is active
 pub struct YamlCharClassBroadword {
     pub newlines: u8,
     pub colons: u8,
@@ -79,7 +79,7 @@ pub struct YamlCharClassBroadword {
     pub hash: u8,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword fallback classifier; unused when SIMD is active
 impl YamlCharClassBroadword {
     /// Check if any structural character was found.
     #[inline(always)]
@@ -148,7 +148,7 @@ pub fn classify_yaml_chars_broadword(
 /// Returns combined u16 masks (low 8 bits from first chunk, high 8 from second).
 /// Returns `None` if fewer than 16 bytes remain.
 #[derive(Debug, Clone, Copy, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword fallback classifier; unused when SIMD is active
 pub struct YamlCharClass16 {
     pub newlines: u16,
     pub colons: u16,

--- a/src/yaml/simd/mod.rs
+++ b/src/yaml/simd/mod.rs
@@ -249,7 +249,7 @@ pub fn classify_yaml_chars(input: &[u8], offset: usize) -> Option<YamlCharClass>
     not(feature = "scalar-yaml"),
     any(target_arch = "aarch64", not(target_arch = "x86_64"))
 ))]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: alternate classifier; unused in current path
 pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharClass16> {
     // ARM64 with NEON (default)
     #[cfg(all(target_arch = "aarch64", not(feature = "broadword-yaml")))]
@@ -280,7 +280,7 @@ pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharCla
         not(any(target_arch = "aarch64", target_arch = "x86_64"))
     )
 ))]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: alternate classifier; unused in current path
 pub fn classify_yaml_chars_8(input: &[u8], offset: usize) -> Option<YamlCharClassBroadword> {
     broadword::classify_yaml_chars_broadword(input, offset)
 }
@@ -290,7 +290,7 @@ pub fn classify_yaml_chars_8(input: &[u8], offset: usize) -> Option<YamlCharClas
 /// Returns offset from `start` to the newline, or `None` if not found.
 /// Uses SIMD/broadword for fast scanning on supported platforms.
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: SIMD helper; unused in current path
 pub fn find_newline(input: &[u8], start: usize) -> Option<usize> {
     if start >= input.len() {
         return None;
@@ -460,7 +460,7 @@ pub fn find_json_escape(bytes: &[u8], start: usize) -> usize {
 
 /// Scalar implementation of find_json_escape.
 #[inline(always)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
 fn find_json_escape_scalar(bytes: &[u8], start: usize) -> usize {
     for (i, &b) in bytes[start..].iter().enumerate() {
         if b == b'"' || b == b'\\' || b < 0x20 {
@@ -471,7 +471,7 @@ fn find_json_escape_scalar(bytes: &[u8], start: usize) -> usize {
 }
 
 /// Scalar fallback for parse_anchor_name
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
 fn parse_anchor_name_scalar(input: &[u8], start: usize) -> usize {
     let mut pos = start;
     while pos < input.len() {
@@ -496,7 +496,7 @@ fn parse_anchor_name_scalar(input: &[u8], start: usize) -> usize {
 }
 
 /// Scalar fallback for find_block_scalar_end
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
 fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -> Option<usize> {
     let mut pos = start;
 
@@ -529,7 +529,7 @@ fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -
 }
 
 /// Scalar implementation of find_newline.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
 fn find_newline_scalar(input: &[u8], start: usize) -> Option<usize> {
     for (i, &b) in input[start..].iter().enumerate() {
         if b == b'\n' {
@@ -544,7 +544,7 @@ fn find_newline_scalar(input: &[u8], start: usize) -> Option<usize> {
 // ============================================================================
 
 /// Scalar implementation of find_quote_or_escape.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
 fn find_quote_or_escape_scalar(input: &[u8], start: usize, end: usize) -> Option<usize> {
     for (i, &b) in input[start..end].iter().enumerate() {
         if b == b'"' || b == b'\\' {
@@ -555,7 +555,7 @@ fn find_quote_or_escape_scalar(input: &[u8], start: usize, end: usize) -> Option
 }
 
 /// Scalar implementation of find_single_quote.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
 fn find_single_quote_scalar(input: &[u8], start: usize, end: usize) -> Option<usize> {
     for (i, &b) in input[start..end].iter().enumerate() {
         if b == b'\'' {
@@ -566,7 +566,7 @@ fn find_single_quote_scalar(input: &[u8], start: usize, end: usize) -> Option<us
 }
 
 /// Scalar implementation of count_leading_spaces.
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
 fn count_leading_spaces_scalar(input: &[u8], start: usize) -> usize {
     input[start..].iter().take_while(|&&b| b == b' ').count()
 }

--- a/src/yaml/simd/neon.rs
+++ b/src/yaml/simd/neon.rs
@@ -224,7 +224,7 @@ const fn extract_mask_u64(x: u64) -> u8 {
 ///
 /// NOTE: Currently unused - broadword integration is disabled. See P4 analysis.
 #[derive(Debug, Clone, Copy, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
 pub struct YamlCharClassBroadword {
     pub newlines: u8,
     pub colons: u8,
@@ -236,7 +236,7 @@ pub struct YamlCharClassBroadword {
     pub hash: u8,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
 impl YamlCharClassBroadword {
     /// Check if any structural character was found.
     #[inline(always)]
@@ -269,7 +269,7 @@ impl YamlCharClassBroadword {
 ///
 /// NOTE: Currently unused - broadword integration is disabled. See P4 analysis.
 #[inline]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
 pub fn classify_yaml_chars_broadword(
     input: &[u8],
     offset: usize,
@@ -310,7 +310,7 @@ pub fn classify_yaml_chars_broadword(
 ///
 /// NOTE: Currently unused - broadword integration is disabled. See P4 analysis.
 #[derive(Debug, Clone, Copy, Default)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
 pub struct YamlCharClass16 {
     pub newlines: u16,
     pub colons: u16,
@@ -322,7 +322,7 @@ pub struct YamlCharClass16 {
     pub hash: u16,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
 impl YamlCharClass16 {
     /// Get mask of value terminators.
     #[inline(always)]

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -12,7 +12,7 @@ use core::arch::x86_64::*;
 /// Character classification results for a 32-byte chunk (AVX2).
 /// Some fields are not currently used but are part of the classification infrastructure.
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
+#[allow(dead_code)] // STYLE-0005: SIMD classifier type; used only on some paths
 pub struct YamlCharClass {
     /// Mask of bytes that are '\n'
     pub newlines: u32,


### PR DESCRIPTION
## Description

Adds the two documentation entry points that the sibling project
[`rust-works/omni-dev`](https://github.com/rust-works/omni-dev) has and succinctly
lacked, and wires the new style guide's stable rule IDs into every inline lint
suppression so each `#[allow(...)]` points at a documented rationale.

1. **Root [`ARCHITECTURE.md`](ARCHITECTURE.md)** — a thin, top-level entry point (the
   file GitHub and new contributors look for first). It orients the reader on the
   semi-indexing pipeline and the `BitVec → BalancedParens → {Json,Yaml,Dsv}Index → jq`
   layering, then hands off to the existing deep docs (`docs/index.md`,
   `docs/architecture/`, `CLAUDE.md`) rather than duplicating them — lowest drift risk.
2. **[`docs/STYLE_GUIDE.md`](docs/STYLE_GUIDE.md)** — a tagged style guide with stable
   `STYLE-####` IDs (modeled on omni-dev's), capturing succinctly-specific conventions.
3. **Retrofit** — every inline `#[allow(...)]` in `src/` now cites the `STYLE-####` rule
   that justifies it (with a per-site reason), making suppressions traceable.

This is largely **consolidation**: the raw material already existed scattered across
`docs/optimizations/`, the `CLAUDE.md` skills table, and `.claude/skills/*`. No code
behavior changes — the source edits are comment-only.

### Style guide rules

Twelve rules (`STYLE-0000`…`STYLE-0011`). The four topics called out in #209 map to:
SIMD module layout → `STYLE-0001`, `unsafe`/`// SAFETY:` → `STYLE-0002`, benchmark-doc
discipline → `STYLE-0008`, fixed-width markdown tables → `STYLE-0009`. The lint linkage
is `STYLE-0004` (every `#[allow]` cites a rule; project-wide policy belongs in
`Cargo.toml [lints]`) and `STYLE-0005` (when `#[allow(dead_code)]` is expected for
platform-gated / reference / bench-only code). Each rule cross-links the relevant
`.claude/skills/*` file instead of duplicating it.

### Scope notes / forward references

- The `Cargo.toml [lints]` table itself is **out of scope** here — it is owned by #205.
  This PR defines the STYLE-ID scheme and cites IDs at each suppression site; #205 will
  add the centralized `[lints]` allow-list that references the same IDs.
- Adding `// SAFETY:` to the unsafe blocks that still lack one is out of scope
  (documented as the expectation in `STYLE-0002`; driven by clippy
  `undocumented_unsafe_blocks` under #205).
- No ADR-format rule is included; ADRs (#207) landed in the base after this work began
  and an `STYLE-0012` ADR rule is a natural follow-up.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

## Related Issue
Fixes #209

## Changes Made
- Add root `ARCHITECTURE.md` (thin pointer, ~72 lines) linking into `docs/index.md`,
  `docs/architecture/`, `docs/STYLE_GUIDE.md`, `CLAUDE.md`, `CONTRIBUTING.md`.
- Add `docs/STYLE_GUIDE.md` with a tag-based lookup table and 12 stable-ID rules
  (`STYLE-0000`…`STYLE-0011`).
- Cite a `STYLE-####` rule (with a per-site reason) on every inline `#[allow(...)]`
  across the source tree — comment-only, no behavior change. A grep over `src/`
  confirms no `#[allow(...)]` is left without a `STYLE-####` citation (there is no CI
  gate for this yet — a natural follow-up if the project wants it enforced).
- Cross-link the new docs from `CLAUDE.md` (Key Documentation table),
  `CONTRIBUTING.md` (Code Style), and `docs/architecture/README.md`.

**Files changed:** 38 total — 2 new docs, 3 modified docs/config, 33 source files
(comment-only lint-rationale citations).

## Testing

The changes are documentation plus comment-only `#[allow]` rationale citations — there
is no runtime surface to exercise. Verified on the aarch64 dev host:

**Automated Testing:**
- [x] All existing tests pass — `cargo test --features cli,simd,regex,serde` → ~2,300 passed, 0 failed
- [ ] New tests added for new functionality (N/A — docs + comment-only changes)

**Manual Testing:**
- [ ] Tested on x86_64 (CI matrix covers; not run locally)
- [x] Tested on aarch64/ARM — builds and full suite green on Apple Silicon

### Test Commands
```bash
cargo build --features cli,simd,regex,serde
cargo test  --features cli,simd,regex,serde
cargo fmt --check
```
> The CI Clippy check passes on this branch. (Separately, the broader
> `cargo clippy --all-features -D warnings` superset has pre-existing failures tracked in
> #197 — unrelated to this docs-only change, which is comment-only in `src/`.)

### Coverage

Both CI coverage checks pass (x86_64 + ARM64); total **68.86%, +6 pp vs `main`**. **Patch
coverage is N/A — this diff adds no executable lines** (docs plus comment-only `#[allow]`
citations). The coverage bot's single red delta — `src/trees/bp.rs:2097–2147`, 16 lines
`covered → uncovered` — is on **unchanged** code: the data-dependent L2 hierarchical-navigation
branches in `find_close`, whose coverage depends on test input size. It is run-to-run
measurement variance, not a regression from this PR (which touches neither that code nor any
test). No new tests are warranted for a docs + comment-only change.

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A — docs + comment-only)
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

The source edits are strictly additive comments after existing attributes; `cargo fmt`
relocated a handful of in-body attribute comments onto their own line (the canonical
form) and the tree is fmt-clean. A grep-based invariant check (run locally) confirms
every `#[allow(...)]` in `src/` cites a `STYLE-####` id.
