### PR TITLE
ci: add path-split gate job to skip heavy matrix on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,61 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  test-x86:
-    name: Test (x86_64)
+  # Path-split gate (#202). Docs/skills-only PRs skip the heavy 3-arch matrix and
+  # coverage while still publishing every required status context, so they merge
+  # in seconds without deadlocking branch protection. A single gate is the source
+  # of truth for the split — no twin `ci-skip.yml` whose stub job names must be
+  # hand-mirrored against this matrix (which would silently rot when the matrix or
+  # protection set changes). Non-PR events (main pushes) always take the full
+  # path. No markdown is `include_str!`-compiled here, but the doc set still
+  # scopes `*.md` to the repo root only — never `**/*.md` — so anything not
+  # explicitly a doc runs full CI (fail-safe).
+  gate:
+    name: Gate
     runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!*.md'
+              - '!docs/**'
+              - '!.claude/skills/**'
+
+      - id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Required-context jobs (Test x86/ARM/macOS, Clippy, Format, Documentation)
+  # always run so their contexts always report `success`; on the fast path every
+  # step is skipped, which is a genuine passing job — not a `skipped` conclusion
+  # whose branch-protection semantics vary. Non-required jobs (bench, coverage)
+  # below skip wholesale via a job-level `if`.
+  test-x86:
+    name: Test (x86_64)
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: needs.gate.outputs.code == 'true'
+
       - name: Install Rust
+        if: needs.gate.outputs.code == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
+        if: needs.gate.outputs.code == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -32,33 +77,43 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
+        if: needs.gate.outputs.code == 'true'
         run: cargo build --verbose
 
       - name: Build CLI (for integration tests)
+        if: needs.gate.outputs.code == 'true'
         run: cargo build --features cli --bin succinctly
 
       - name: Run tests
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose
 
       - name: Run tests (simd feature)
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features simd
 
       - name: Run tests (portable-popcount feature)
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features portable-popcount
 
       - name: Check no_std compatibility
+        if: needs.gate.outputs.code == 'true'
         run: cargo check --no-default-features
 
   test-arm:
     name: Test (ARM64)
+    needs: gate
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+        if: needs.gate.outputs.code == 'true'
 
       - name: Install Rust
+        if: needs.gate.outputs.code == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
+        if: needs.gate.outputs.code == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -70,6 +125,7 @@ jobs:
           key: ${{ runner.os }}-arm64-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check CPU features (SVE2)
+        if: needs.gate.outputs.code == 'true'
         run: |
           echo "=== CPU Info ==="
           lscpu | grep -E "Model name|Architecture|CPU|Flags" || true
@@ -78,30 +134,39 @@ jobs:
           if grep -q svebitperm /proc/cpuinfo 2>/dev/null; then echo "SVE2-BITPERM: supported"; else echo "SVE2-BITPERM: not detected"; fi
 
       - name: Build
+        if: needs.gate.outputs.code == 'true'
         run: cargo build --verbose
 
       - name: Build CLI (for integration tests)
+        if: needs.gate.outputs.code == 'true'
         run: cargo build --features cli --bin succinctly
 
       - name: Run tests
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose
 
       - name: Run tests (simd feature)
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features simd
 
       - name: Run tests (portable-popcount feature)
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features portable-popcount
 
   test-macos-arm:
     name: Test (macOS ARM64)
+    needs: gate
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        if: needs.gate.outputs.code == 'true'
 
       - name: Install Rust
+        if: needs.gate.outputs.code == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
+        if: needs.gate.outputs.code == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -113,22 +178,29 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
+        if: needs.gate.outputs.code == 'true'
         run: cargo build --verbose
 
       - name: Build CLI (for integration tests)
+        if: needs.gate.outputs.code == 'true'
         run: cargo build --features cli --bin succinctly
 
       - name: Run tests
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose
 
       - name: Run tests (simd feature)
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features simd
 
       - name: Run tests (portable-popcount feature)
+        if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features portable-popcount
 
   bench:
     name: Bench (${{ matrix.name }})
+    needs: gate
+    if: needs.gate.outputs.code == 'true'
     strategy:
       matrix:
         include:
@@ -193,48 +265,62 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: needs.gate.outputs.code == 'true'
 
       - name: Install Rust
+        if: needs.gate.outputs.code == 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
       - name: Run Clippy
+        if: needs.gate.outputs.code == 'true'
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   fmt:
     name: Format
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: needs.gate.outputs.code == 'true'
 
       - name: Install Rust
+        if: needs.gate.outputs.code == 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
       - name: Check formatting
+        if: needs.gate.outputs.code == 'true'
         run: cargo fmt --all -- --check
 
   docs:
     name: Documentation
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: needs.gate.outputs.code == 'true'
 
       - name: Install Rust
+        if: needs.gate.outputs.code == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build docs
+        if: needs.gate.outputs.code == 'true'
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings
 
   coverage:
     name: Coverage (${{ matrix.name }})
+    needs: gate
+    if: needs.gate.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Closes #202.

succinctly's CI ran **every job unconditionally** — a 3-arch test matrix plus 2-arch coverage — even on PRs touching only docs or the `docs/` wiki (of which this repo has many). This adds a single path-split **`gate`** job (mirroring the sibling `rust-works/omni-dev`) so docs-only PRs skip the heavy work while still publishing every required status context, merging in seconds without deadlocking branch protection.

## How it works

A single `gate` job is the one source of truth for the split — no twin `ci-skip.yml` whose stub job names would have to be hand-mirrored against the matrix and silently rot when it changes. `gate` runs `dorny/paths-filter@v3` on PRs and emits `code=true/false`:

```yaml
filters: |
  code:
    - '**'
    - '!*.md'
    - '!docs/**'
    - '!.claude/skills/**'
```

Non-PR events (pushes to `main`) short-circuit to `code=true` — full CI, fail-safe.

**Required-context jobs** (`test-x86`, `test-arm`, `test-macos-arm`, `clippy`, `fmt`, `docs`) gain `needs: gate` and an `if: needs.gate.outputs.code == 'true'` guard on **every step**. On the fast path the job still *runs* and reports a genuine `success` — never a `skipped` conclusion, whose branch-protection semantics vary and can deadlock merges.

**Non-required jobs** (`bench`, `coverage`) gain `needs: gate` + a **job-level** `if`, so they skip wholesale.

## Doc set

No markdown is `include_str!`-compiled in this repo (only JSON testdata is), but the doc set still scopes `*.md` to the **repo root only** — never `**/*.md` — so any nested `.md` outside `docs/` / `.claude/skills/` triggers full CI (fail-safe). `docs/**` is the knowledge wiki; `.claude/skills/**` are the vendored skills.

## Behaviour

| Event          | `code`  | Result                                                                                             |
|----------------|---------|----------------------------------------------------------------------------------------------------|
| Docs-only PR   | `false` | Required contexts report `success` (all steps skipped, seconds); `bench` / `coverage` skip wholesale |
| Code PR        | `true`  | Full CI as before                                                                                  |
| Push to `main` | `true`  | Full CI (fail-safe)                                                                                 |

## Verification (local)

- YAML parses cleanly; job/step gating dumped and confirmed: `gate` ungated; the six required jobs gated at **step** level only (9/9, 9/9, 8/8, 3/3, 3/3, 3/3 steps guarded); `bench` / `coverage` gated at **job** level.
- No Rust touched — `.github/workflows/ci.yml` only (+86 lines).

## Notes / follow-up

- **Supply-chain jobs are not gated by this PR.** `audit` / `deny` / `secrets` live in the separate `security.yml` workflow (added in #200 / #212), which has its own `pull_request` trigger — `needs.gate` can't cross workflow boundaries. Issue #202 listed them among the wholesale-skip candidates; gating them needs either a `paths-ignore` filter on `security.yml` or its own gate, so it's left as a follow-up rather than forced into this workflow.
- Wires the coverage job (landed in #198) into the gate, completing the `needs: gate` relationship that issue anticipated.
