### PR TITLE
chore(config): add clippy.toml, rustfmt.toml, .editorconfig + local fmt-check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{rs,toml}]
+indent_size = 4
+
+[*.{json,jsonc,yaml,yml,md,sh}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+too-many-arguments-threshold = 7
+cognitive-complexity-threshold = 25
+type-complexity-threshold = 250
+msrv = "1.73.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+max_width = 100
+use_field_init_shorthand = true
+use_try_shorthand = true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,8 +6,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
-echo "=== Checking succinctly ==="
+echo "=== Checking formatting (rustfmt) ==="
 cd "$ROOT_DIR"
+cargo fmt --all -- --check
+
+echo ""
+echo "=== Checking succinctly ==="
 cargo check --all-targets --all-features
 
 echo ""


### PR DESCRIPTION
## Description

Adds pinned Rust tooling config and a local formatting gate, mirroring the sibling
[`rust-works/omni-dev`](https://github.com/rust-works/omni-dev) project. Before this
PR, succinctly had no `clippy.toml`, `rustfmt.toml`, or `.editorconfig`, and no
`cargo fmt --check` step in `scripts/build.sh` — so complexity thresholds and
formatting were entirely default and ungated locally (CI's `Format` job was the only
gate). This makes those thresholds explicit, MSRV-aware, and catchable before push.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [x] CI/CD changes

## Related Issue
Closes #204

## Changes Made
- **`clippy.toml`** — complexity thresholds (`too-many-arguments-threshold = 7`,
  `cognitive-complexity-threshold = 25`, `type-complexity-threshold = 250`) plus
  `msrv = "1.73.0"` so clippy stops suggesting newer-than-MSRV APIs (matches
  `Cargo.toml`'s `rust-version`).
- **`rustfmt.toml`** — pin `edition = "2021"`, `max_width = 100`,
  `use_field_init_shorthand`, `use_try_shorthand`. The tree already conformed, so
  **no reformatting was required** (zero diffs).
- **`.editorconfig`** — cross-editor LF endings, final newline, trailing-whitespace
  trim, 4-space indent for `*.{rs,toml}`, 2-space for `*.{json,jsonc,yaml,yml,md,sh}`.
- **`scripts/build.sh`** — run `cargo fmt --all -- --check` as the first (cheapest)
  gate so formatting drift is caught locally before CI's `Format` job.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [ ] New tests added for new functionality — N/A (config-only change, no runtime code)

**Manual Testing:**
- [x] Tested on x86_64
- [x] Tested on aarch64/ARM (if applicable) — via CI matrix

### Test Commands
```bash
cargo fmt --all -- --check                                    # clean (tree already conforms)
cargo clippy --all-targets --all-features -- -D warnings      # green under new thresholds
cargo test
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works — N/A (config-only)
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed — N/A
- [x] My changes generate no new warnings

## Additional Notes
- **`.editorconfig` was force-added** past a personal global gitignore
  (`~/.gitignore_global` ignores `/.editorconfig`); #204 explicitly wants it tracked
  in-repo.
- **`bench-compare` is intentionally out of scope.** It's a separate edition-2024
  crate that root `cargo fmt --all` doesn't reach, and it currently fails default
  `fmt --check` (~63-line diff). Normalizing + gating it belongs in a follow-up, not
  this PR.
