### PR TITLE
chore(lint): add Cargo [lints] with explicit unsafe policy + pedantic/nursery clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,3 +188,96 @@ harness = false
 [[bench]]
 name = "json_validate_bench"
 harness = false
+
+# =============================================================================
+# Lints
+#
+# succinctly opts the whole crate into clippy's strict groups (`all`,
+# `pedantic`, `nursery`) plus an explicit unsafe policy. CI runs
+# `cargo clippy --all-targets --all-features -- -D warnings`, so every lint
+# configured here is enforced as a hard error.
+#
+# The `allow` overrides below are deliberate and curated: each is a lint we
+# have chosen not to enforce (yet), with a rationale. They are meant to be
+# peeled back over time in focused follow-up PRs. `priority = -1` on the group
+# lines lets these individual `allow`s win over the group-level `warn`.
+# =============================================================================
+[lints.rust]
+# succinctly is an intrinsics-heavy crate, but `unsafe` is confined to a
+# handful of SIMD / popcount / balanced-parens / binary-serialization modules.
+# Each of those opts back in with a localized `#![allow(unsafe_code)]` carrying
+# a rationale; introducing `unsafe` anywhere else is a deliberate, reviewed
+# change rather than an accident.
+unsafe_code = "deny"
+
+[lints.clippy]
+all      = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery  = { level = "warn", priority = -1 }
+
+# --- Numeric casts -----------------------------------------------------------
+# Pervasive and intentional in bit-manipulation / SIMD / indexing code, where
+# narrowing and sign reinterpretation are the whole point. These are guarded by
+# tests and documented invariants rather than by the type system.
+cast_possible_truncation   = "allow"
+cast_possible_wrap         = "allow"
+cast_sign_loss             = "allow"
+cast_precision_loss        = "allow"
+cast_lossless              = "allow"
+cast_ptr_alignment         = "allow"  # SIMD (un)aligned loads are deliberate
+
+# --- API surface / documentation ---------------------------------------------
+must_use_candidate         = "allow"  # would annotate most of the public API; deferred
+return_self_not_must_use   = "allow"  # same policy as must_use_candidate
+missing_errors_doc         = "allow"  # error types are self-describing; pure doc churn
+missing_panics_doc         = "allow"  # ditto for documented panics
+doc_markdown               = "allow"  # domain acronyms (JSON/YAML/AVX2/POPCNT/NEON) trip false positives
+
+# --- Perf-crate idioms -------------------------------------------------------
+inline_always              = "allow"  # `#[inline(always)]` is a deliberate choice on hot paths
+too_many_lines             = "allow"  # parsers / state machines are legitimately long
+needless_pass_by_value     = "allow"  # by-value signatures are often chosen for the API shape
+trivially_copy_pass_by_ref = "allow"  # by-ref kept for signature consistency across a family of fns
+struct_excessive_bools     = "allow"  # config / option structs
+float_cmp                  = "allow"  # exact float comparisons are intentional (parsing / tests)
+unreadable_literal         = "allow"  # large hand-tuned hex / decimal lookup tables
+
+# --- Style / subjective ------------------------------------------------------
+items_after_statements     = "allow"
+match_same_arms            = "allow"  # separate arms often read better in state machines
+similar_names              = "allow"  # lo/hi, i/j, src/dst are clearer than contrived names
+if_not_else                = "allow"
+single_match_else          = "allow"
+unnecessary_wraps          = "allow"  # some wrappers exist for API / trait consistency
+no_effect_underscore_binding = "allow"
+manual_assert              = "allow"
+wildcard_imports           = "allow"  # `use super::*` in test modules
+naive_bytecount            = "allow"
+case_sensitive_file_extension_comparisons = "allow"
+match_wildcard_for_single_variants = "allow"
+ref_option                 = "allow"
+used_underscore_binding    = "allow"
+comparison_chain           = "allow"  # explicit ==/>/< documents fast-path-first branch order in benchmark-tuned cursor get()
+manual_let_else            = "allow"  # clippy declines to autofix these; explicit `match` reads clearer at error-mapping sites
+needless_continue          = "allow"  # explicit `continue` documents loop control in the jq parser / comparison loops
+needless_collect           = "allow"  # test-only: iterators materialised for readable assertions
+doc_link_with_quotes       = "allow"  # false positives on markdown citation links and jq code examples in doc comments
+ignore_without_reason      = "allow"  # test-only `#[ignore]`; reasons tracked in issues
+into_iter_without_iter     = "allow"  # would require adding matching Iterator impls; deferred
+unsafe_derive_deserialize  = "allow"  # types carry manual unsafe but Deserialize itself is safe
+
+# --- Nursery (unstable; higher false-positive rate) --------------------------
+# The nursery group is enabled for its occasional gems, but the noisiest and
+# most false-positive-prone lints are turned back off.
+missing_const_for_fn         = "allow"
+option_if_let_else           = "allow"
+format_push_string           = "allow"
+branches_sharing_code        = "allow"
+redundant_clone              = "allow"
+redundant_pub_crate          = "allow"
+copy_iterator                = "allow"
+unused_peekable              = "allow"
+suboptimal_flops             = "allow"
+derive_partial_eq_without_eq = "allow"
+equatable_if_let             = "allow"
+format_collect               = "allow"

--- a/benches/balanced_parens.rs
+++ b/benches/balanced_parens.rs
@@ -145,13 +145,13 @@ fn bench_find_close(c: &mut Criterion) {
             |b, (bp, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         if let Some(pos) = bp.find_close(black_box(q)) {
                             sum += pos;
                         }
                     }
                     sum
-                })
+                });
             },
         );
 
@@ -162,13 +162,13 @@ fn bench_find_close(c: &mut Criterion) {
             |b, (words, len, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         if let Some(pos) = bp::find_close(words, *len, black_box(q)) {
                             sum += pos;
                         }
                     }
                     sum
-                })
+                });
             },
         );
     }
@@ -197,13 +197,13 @@ fn bench_find_open(c: &mut Criterion) {
             |b, (bp, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         if let Some(pos) = bp.find_open(black_box(q)) {
                             sum += pos;
                         }
                     }
                     sum
-                })
+                });
             },
         );
 
@@ -214,13 +214,13 @@ fn bench_find_open(c: &mut Criterion) {
             |b, (words, len, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         if let Some(pos) = bp::find_open(words, *len, black_box(q)) {
                             sum += pos;
                         }
                     }
                     sum
-                })
+                });
             },
         );
     }
@@ -249,13 +249,13 @@ fn bench_enclose(c: &mut Criterion) {
             |b, (bp, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         if let Some(pos) = bp.enclose(black_box(q)) {
                             sum += pos;
                         }
                     }
                     sum
-                })
+                });
             },
         );
 
@@ -266,13 +266,13 @@ fn bench_enclose(c: &mut Criterion) {
             |b, (words, len, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         if let Some(pos) = bp::enclose(words, *len, black_box(q)) {
                             sum += pos;
                         }
                     }
                     sum
-                })
+                });
             },
         );
     }
@@ -293,20 +293,20 @@ fn bench_tree_structures(c: &mut Criterion) {
 
     // Query from root in deep structure
     group.bench_function("deep_10K/rangemin", |b| {
-        b.iter(|| deep_bp.find_close(black_box(0)))
+        b.iter(|| deep_bp.find_close(black_box(0)));
     });
 
     group.bench_function("deep_10K/linear", |b| {
-        b.iter(|| bp::find_close(&deep_words, deep_len, black_box(0)))
+        b.iter(|| bp::find_close(&deep_words, deep_len, black_box(0)));
     });
 
     // Query first pair in flat structure
     group.bench_function("flat_10K/rangemin", |b| {
-        b.iter(|| flat_bp.find_close(black_box(0)))
+        b.iter(|| flat_bp.find_close(black_box(0)));
     });
 
     group.bench_function("flat_10K/linear", |b| {
-        b.iter(|| bp::find_close(&flat_words, flat_len, black_box(0)))
+        b.iter(|| bp::find_close(&flat_words, flat_len, black_box(0)));
     });
 
     group.finish();
@@ -388,7 +388,7 @@ fn bench_navigation(c: &mut Criterion) {
             }
 
             count
-        })
+        });
     });
 
     // Get excess at various positions
@@ -396,11 +396,11 @@ fn bench_navigation(c: &mut Criterion) {
     group.bench_function("excess_1K_queries", |b| {
         b.iter(|| {
             let mut sum = 0i32;
-            for &q in queries.iter() {
+            for &q in &queries {
                 sum += bp.excess(black_box(q));
             }
             sum
-        })
+        });
     });
 
     group.finish();
@@ -429,11 +429,11 @@ fn bench_rank1(c: &mut Criterion) {
             |b, (bp, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         sum += bp.rank1(black_box(q));
                     }
                     sum
-                })
+                });
             },
         );
     }
@@ -453,11 +453,11 @@ fn bench_excess(c: &mut Criterion) {
     group.bench_function("excess_100K", |b| {
         b.iter(|| {
             let mut sum = 0i32;
-            for &q in queries.iter() {
+            for &q in &queries {
                 sum += bp.excess(black_box(q));
             }
             sum
-        })
+        });
     });
 
     group.finish();

--- a/benches/bp_select_micro.rs
+++ b/benches/bp_select_micro.rs
@@ -67,13 +67,13 @@ fn bench_select1_with_select(c: &mut Criterion) {
             |b, (bp, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         if let Some(pos) = bp.select1(black_box(q)) {
                             sum += pos;
                         }
                     }
                     sum
-                })
+                });
             },
         );
 
@@ -84,7 +84,7 @@ fn bench_select1_with_select(c: &mut Criterion) {
             |b, (bp, queries)| {
                 b.iter(|| {
                     let mut sum = 0usize;
-                    for &q in queries.iter() {
+                    for &q in *queries {
                         let target_rank = black_box(q) + 1;
                         let bp_len = bp.len();
 
@@ -105,7 +105,7 @@ fn bench_select1_with_select(c: &mut Criterion) {
                         }
                     }
                     sum
-                })
+                });
             },
         );
     }

--- a/benches/dsv_bench.rs
+++ b/benches/dsv_bench.rs
@@ -11,10 +11,10 @@ fn bench_dsv_parsing(c: &mut Criterion) {
     let config = DsvConfig::csv();
 
     for (name, path) in sizes {
-        eprintln!("Loading {}...", path);
+        eprintln!("Loading {path}...");
         if let Ok(data) = fs::read(path) {
             eprintln!("Loaded {} bytes", data.len());
-            let mut group = c.benchmark_group(format!("dsv_parse_{}", name));
+            let mut group = c.benchmark_group(format!("dsv_parse_{name}"));
             group.throughput(Throughput::Bytes(data.len() as u64));
 
             // Benchmark 1: Pure parsing (index building)
@@ -22,7 +22,7 @@ fn bench_dsv_parsing(c: &mut Criterion) {
                 b.iter(|| {
                     let index = build_index(black_box(&data), black_box(&config));
                     black_box(index)
-                })
+                });
             });
 
             // Benchmark 2: Parsing + row iteration (no JSON)
@@ -38,7 +38,7 @@ fn bench_dsv_parsing(c: &mut Criterion) {
                         }
                     }
                     black_box(count)
-                })
+                });
             });
 
             // Benchmark 3: Parsing + row iteration + string conversion
@@ -55,7 +55,7 @@ fn bench_dsv_parsing(c: &mut Criterion) {
                         results.push(fields);
                     }
                     black_box(results)
-                })
+                });
             });
 
             group.finish();
@@ -80,7 +80,7 @@ fn bench_dsv_random_access(c: &mut Criterion) {
             let sample_rows: Vec<usize> = (0..row_count).step_by(100).collect();
             let sample_count = sample_rows.len();
 
-            let mut group = c.benchmark_group(format!("dsv_random_access_{}", name));
+            let mut group = c.benchmark_group(format!("dsv_random_access_{name}"));
             group.throughput(Throughput::Elements(sample_count as u64));
 
             // Benchmark: Random access to first field of sampled rows
@@ -95,7 +95,7 @@ fn bench_dsv_random_access(c: &mut Criterion) {
                         }
                     }
                     black_box(total_bytes)
-                })
+                });
             });
 
             // Benchmark: Random access with field iteration
@@ -111,7 +111,7 @@ fn bench_dsv_random_access(c: &mut Criterion) {
                         }
                     }
                     black_box(total_fields)
-                })
+                });
             });
 
             group.finish();

--- a/benches/elias_fano.rs
+++ b/benches/elias_fano.rs
@@ -78,7 +78,7 @@ fn bench_sequential(c: &mut Criterion) {
                         cursor.advance_one();
                     }
                     black_box(sum)
-                })
+                });
             },
         );
 
@@ -93,7 +93,7 @@ fn bench_sequential(c: &mut Criterion) {
                         sum += v as u64;
                     }
                     black_box(sum)
-                })
+                });
             },
         );
     }
@@ -118,11 +118,11 @@ fn bench_random_access(c: &mut Criterion) {
             |b, (ef, queries)| {
                 b.iter(|| {
                     let mut sum = 0u64;
-                    for &i in queries.iter() {
+                    for &i in *queries {
                         sum += ef.get(black_box(i)).unwrap() as u64;
                     }
                     black_box(sum)
-                })
+                });
             },
         );
 
@@ -133,11 +133,11 @@ fn bench_random_access(c: &mut Criterion) {
             |b, (values, queries)| {
                 b.iter(|| {
                     let mut sum = 0u64;
-                    for &i in queries.iter() {
+                    for &i in *queries {
                         sum += values[black_box(i)] as u64;
                     }
                     black_box(sum)
-                })
+                });
             },
         );
     }
@@ -167,7 +167,7 @@ fn bench_skip_by_small(c: &mut Criterion) {
                         skip = (skip % 7) + 2; // Vary skip 2-8
                     }
                     black_box(sum)
-                })
+                });
             },
         );
 
@@ -186,7 +186,7 @@ fn bench_skip_by_small(c: &mut Criterion) {
                         skip = (skip % 7) + 2;
                     }
                     black_box(sum)
-                })
+                });
             },
         );
     }
@@ -212,14 +212,14 @@ fn bench_seek(c: &mut Criterion) {
             |b, (ef, targets)| {
                 b.iter(|| {
                     let mut sum = 0u64;
-                    for &target in targets.iter() {
+                    for &target in *targets {
                         let mut cursor = ef.cursor();
                         if let Some(v) = cursor.seek(black_box(target)) {
                             sum += v as u64;
                         }
                     }
                     black_box(sum)
-                })
+                });
             },
         );
 
@@ -230,11 +230,11 @@ fn bench_seek(c: &mut Criterion) {
             |b, (values, targets)| {
                 b.iter(|| {
                     let mut sum = 0u64;
-                    for &target in targets.iter() {
+                    for &target in *targets {
                         sum += values[black_box(target)] as u64;
                     }
                     black_box(sum)
-                })
+                });
             },
         );
     }
@@ -260,14 +260,14 @@ fn bench_cursor_from(c: &mut Criterion) {
             |b, (ef, positions)| {
                 b.iter(|| {
                     let mut sum = 0u64;
-                    for &pos in positions.iter() {
+                    for &pos in *positions {
                         let cursor = ef.cursor_from(black_box(pos));
                         if let Some(v) = cursor.current() {
                             sum += v as u64;
                         }
                     }
                     black_box(sum)
-                })
+                });
             },
         );
 
@@ -278,7 +278,7 @@ fn bench_cursor_from(c: &mut Criterion) {
             |b, (ef, positions)| {
                 b.iter(|| {
                     let mut sum = 0u64;
-                    for &pos in positions.iter() {
+                    for &pos in *positions {
                         let mut cursor = ef.cursor_from(black_box(pos));
                         // Iterate 5 elements (typical: small container children)
                         for _ in 0..5 {
@@ -291,7 +291,7 @@ fn bench_cursor_from(c: &mut Criterion) {
                         }
                     }
                     black_box(sum)
-                })
+                });
             },
         );
 
@@ -302,11 +302,11 @@ fn bench_cursor_from(c: &mut Criterion) {
             |b, (values, positions)| {
                 b.iter(|| {
                     let mut sum = 0u64;
-                    for &pos in positions.iter() {
+                    for &pos in *positions {
                         sum += values[black_box(pos)] as u64;
                     }
                     black_box(sum)
-                })
+                });
             },
         );
 
@@ -317,7 +317,7 @@ fn bench_cursor_from(c: &mut Criterion) {
             |b, (values, positions)| {
                 b.iter(|| {
                     let mut sum = 0u64;
-                    for &pos in positions.iter() {
+                    for &pos in *positions {
                         let start = black_box(pos);
                         for i in 0..5 {
                             if start + i < values.len() {
@@ -328,7 +328,7 @@ fn bench_cursor_from(c: &mut Criterion) {
                         }
                     }
                     black_box(sum)
-                })
+                });
             },
         );
     }

--- a/benches/jq_comparison.rs
+++ b/benches/jq_comparison.rs
@@ -19,7 +19,7 @@ const PATTERNS: &[&str] = &["comprehensive", "users", "nested", "arrays", "strin
 const SIZES: &[&str] = &["1kb", "10kb", "100kb", "1mb"];
 
 fn file_path(pattern: &str, size: &str) -> String {
-    format!("data/bench/generated/{}/{}.json", pattern, size)
+    format!("data/bench/generated/{pattern}/{size}.json")
 }
 
 fn get_succinctly_binary() -> Option<std::path::PathBuf> {
@@ -40,8 +40,7 @@ fn has_system_jq() -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .is_ok_and(|s| s.success())
 }
 
 /// Benchmark succinctly jq with identity filter
@@ -62,7 +61,7 @@ fn bench_succinctly_identity(c: &mut Criterion) {
                 continue;
             }
 
-            let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+            let file_size = path_obj.metadata().map_or(0, |m| m.len());
             group.throughput(Throughput::Bytes(file_size));
 
             group.bench_with_input(
@@ -78,7 +77,7 @@ fn bench_succinctly_identity(c: &mut Criterion) {
                             .expect("Failed to execute succinctly");
                         assert!(output.status.success());
                         output.stdout
-                    })
+                    });
                 },
             );
         }
@@ -105,7 +104,7 @@ fn bench_system_jq_identity(c: &mut Criterion) {
                 continue;
             }
 
-            let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+            let file_size = path_obj.metadata().map_or(0, |m| m.len());
             group.throughput(Throughput::Bytes(file_size));
 
             group.bench_with_input(BenchmarkId::new(*pattern, *size), &path, |b, path| {
@@ -118,7 +117,7 @@ fn bench_system_jq_identity(c: &mut Criterion) {
                         .expect("Failed to execute jq");
                     assert!(output.status.success());
                     output.stdout
-                })
+                });
             });
         }
     }
@@ -149,7 +148,7 @@ fn bench_jq_comparison(c: &mut Criterion) {
             continue;
         }
 
-        let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+        let file_size = path_obj.metadata().map_or(0, |m| m.len());
         group.throughput(Throughput::Bytes(file_size));
 
         if let Some(ref binary) = succinctly_binary {
@@ -166,7 +165,7 @@ fn bench_jq_comparison(c: &mut Criterion) {
                             .expect("Failed to execute succinctly");
                         assert!(output.status.success());
                         output.stdout
-                    })
+                    });
                 },
             );
         }
@@ -182,7 +181,7 @@ fn bench_jq_comparison(c: &mut Criterion) {
                         .expect("Failed to execute jq");
                     assert!(output.status.success());
                     output.stdout
-                })
+                });
             });
         }
     }

--- a/benches/json_escape_micro.rs
+++ b/benches/json_escape_micro.rs
@@ -68,11 +68,11 @@ fn bench_simd_vs_scalar(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_with_input(BenchmarkId::new("simd", size), &input, |b, input| {
-            b.iter(|| find_json_escape(black_box(input), 0))
+            b.iter(|| find_json_escape(black_box(input), 0));
         });
 
         group.bench_with_input(BenchmarkId::new("scalar", size), &input, |b, input| {
-            b.iter(|| find_json_escape_scalar(black_box(input), 0))
+            b.iter(|| find_json_escape_scalar(black_box(input), 0));
         });
     }
 
@@ -88,26 +88,26 @@ fn bench_escape_position(c: &mut Criterion) {
     let no_escape = make_no_escapes(size);
     group.throughput(Throughput::Bytes(size as u64));
     group.bench_function("no_escape", |b| {
-        b.iter(|| find_json_escape(black_box(&no_escape), 0))
+        b.iter(|| find_json_escape(black_box(&no_escape), 0));
     });
 
     // Escape at start (early exit)
     let at_start = make_escape_at_start(size);
     group.bench_function("at_start", |b| {
-        b.iter(|| find_json_escape(black_box(&at_start), 0))
+        b.iter(|| find_json_escape(black_box(&at_start), 0));
     });
 
     // Escape in middle
     let mut at_middle = make_no_escapes(size);
     at_middle[size / 2] = b'"';
     group.bench_function("at_middle", |b| {
-        b.iter(|| find_json_escape(black_box(&at_middle), 0))
+        b.iter(|| find_json_escape(black_box(&at_middle), 0));
     });
 
     // Escape at end
     let at_end = make_escape_at_end(size);
     group.bench_function("at_end", |b| {
-        b.iter(|| find_json_escape(black_box(&at_end), 0))
+        b.iter(|| find_json_escape(black_box(&at_end), 0));
     });
 
     group.finish();
@@ -123,35 +123,35 @@ fn bench_escape_types(c: &mut Criterion) {
     with_quote[size / 2] = b'"';
     group.throughput(Throughput::Bytes(size as u64));
     group.bench_function("quote", |b| {
-        b.iter(|| find_json_escape(black_box(&with_quote), 0))
+        b.iter(|| find_json_escape(black_box(&with_quote), 0));
     });
 
     // Backslash
     let mut with_backslash = make_no_escapes(size);
     with_backslash[size / 2] = b'\\';
     group.bench_function("backslash", |b| {
-        b.iter(|| find_json_escape(black_box(&with_backslash), 0))
+        b.iter(|| find_json_escape(black_box(&with_backslash), 0));
     });
 
     // Newline (control char)
     let mut with_newline = make_no_escapes(size);
     with_newline[size / 2] = b'\n';
     group.bench_function("newline", |b| {
-        b.iter(|| find_json_escape(black_box(&with_newline), 0))
+        b.iter(|| find_json_escape(black_box(&with_newline), 0));
     });
 
     // Tab (control char)
     let mut with_tab = make_no_escapes(size);
     with_tab[size / 2] = b'\t';
     group.bench_function("tab", |b| {
-        b.iter(|| find_json_escape(black_box(&with_tab), 0))
+        b.iter(|| find_json_escape(black_box(&with_tab), 0));
     });
 
     // Null (control char - edge case)
     let mut with_null = make_no_escapes(size);
     with_null[size / 2] = 0;
     group.bench_function("null", |b| {
-        b.iter(|| find_json_escape(black_box(&with_null), 0))
+        b.iter(|| find_json_escape(black_box(&with_null), 0));
     });
 
     group.finish();
@@ -165,21 +165,21 @@ fn bench_realistic(c: &mut Criterion) {
     let short_value = b"hello_world_value_123";
     group.throughput(Throughput::Bytes(short_value.len() as u64));
     group.bench_function("short_value", |b| {
-        b.iter(|| find_json_escape(black_box(short_value), 0))
+        b.iter(|| find_json_escape(black_box(short_value), 0));
     });
 
     // Typical JSON with quotes (common in config files)
     let with_quotes = br#"This string has "quotes" inside it"#;
     group.throughput(Throughput::Bytes(with_quotes.len() as u64));
     group.bench_function("with_quotes", |b| {
-        b.iter(|| find_json_escape(black_box(with_quotes), 0))
+        b.iter(|| find_json_escape(black_box(with_quotes), 0));
     });
 
     // Multiline text with newlines
     let multiline = b"Line one\nLine two\nLine three\nLine four";
     group.throughput(Throughput::Bytes(multiline.len() as u64));
     group.bench_function("multiline", |b| {
-        b.iter(|| find_json_escape(black_box(multiline), 0))
+        b.iter(|| find_json_escape(black_box(multiline), 0));
     });
 
     // Path-like string with backslashes
@@ -191,14 +191,14 @@ fn bench_realistic(c: &mut Criterion) {
     let long_desc = make_no_escapes(500);
     group.throughput(Throughput::Bytes(long_desc.len() as u64));
     group.bench_function("long_desc", |b| {
-        b.iter(|| find_json_escape(black_box(&long_desc), 0))
+        b.iter(|| find_json_escape(black_box(&long_desc), 0));
     });
 
     // Frequent escapes (stress test)
     let frequent = make_frequent_escapes(500);
     group.throughput(Throughput::Bytes(frequent.len() as u64));
     group.bench_function("frequent_escapes", |b| {
-        b.iter(|| find_json_escape(black_box(&frequent), 0))
+        b.iter(|| find_json_escape(black_box(&frequent), 0));
     });
 
     group.finish();
@@ -214,7 +214,7 @@ fn bench_alignment(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
-            b.iter(|| find_json_escape(black_box(input), 0))
+            b.iter(|| find_json_escape(black_box(input), 0));
         });
     }
 

--- a/benches/json_pipeline.rs
+++ b/benches/json_pipeline.rs
@@ -688,9 +688,7 @@ fn bench_array_indexing(c: &mut Criterion) {
         unreachable!()
     };
 
-    println!(
-        "Using array with {array_len} elements for indexing benchmark"
-    );
+    println!("Using array with {array_len} elements for indexing benchmark");
 
     let mut group = c.benchmark_group("array_indexing");
     group.sample_size(100);

--- a/benches/json_pipeline.rs
+++ b/benches/json_pipeline.rs
@@ -105,7 +105,7 @@ const TEST_FILE: &str = "data/bench/generated/comprehensive/10mb.json";
 fn load_test_file() -> Option<Vec<u8>> {
     let path = std::path::Path::new(TEST_FILE);
     if !path.exists() {
-        eprintln!("Skipping benchmark: {} not found", TEST_FILE);
+        eprintln!("Skipping benchmark: {TEST_FILE} not found");
         eprintln!("Run: ./target/release/succinctly json generate-suite");
         return None;
     }
@@ -125,7 +125,7 @@ fn bench_indexing(c: &mut Criterion) {
     group.sample_size(20);
 
     group.bench_function("build_index", |b| {
-        b.iter(|| JsonIndex::build(black_box(&bytes)))
+        b.iter(|| JsonIndex::build(black_box(&bytes)));
     });
 
     group.finish();
@@ -171,7 +171,7 @@ fn bench_navigation(c: &mut Criterion) {
                 }
                 _ => 1,
             }
-        })
+        });
     });
 
     // Deep traversal - count all leaf values
@@ -179,7 +179,7 @@ fn bench_navigation(c: &mut Criterion) {
         b.iter(|| {
             let root = index.root(black_box(&bytes));
             count_leaves(&root.value())
-        })
+        });
     });
 
     // Extract all string values (simulates field extraction)
@@ -187,7 +187,7 @@ fn bench_navigation(c: &mut Criterion) {
         b.iter(|| {
             let root = index.root(black_box(&bytes));
             extract_strings(&root.value())
-        })
+        });
     });
 
     group.finish();
@@ -245,7 +245,7 @@ fn extract_strings(value: &StandardJson) -> usize {
             }
             count
         }
-        StandardJson::String(s) => s.as_str().map(|s| s.len()).unwrap_or(0),
+        StandardJson::String(s) => s.as_str().map_or(0, |s| s.len()),
         _ => 0,
     }
 }
@@ -273,7 +273,7 @@ fn bench_printing(c: &mut Criterion) {
             let root = index.root(black_box(&bytes));
             print_value(&root.value(), &mut buffer);
             buffer.len()
-        })
+        });
     });
 
     // Print just string values (common operation)
@@ -284,7 +284,7 @@ fn bench_printing(c: &mut Criterion) {
             let root = index.root(black_box(&bytes));
             print_strings(&root.value(), &mut buffer);
             buffer.len()
-        })
+        });
     });
 
     group.finish();
@@ -301,9 +301,9 @@ fn print_value<W: Write>(value: &StandardJson, out: &mut W) {
         }
         StandardJson::Number(n) => {
             if let Ok(i) = n.as_i64() {
-                let _ = write!(out, "{}", i);
+                let _ = write!(out, "{i}");
             } else if let Ok(f) = n.as_f64() {
-                let _ = write!(out, "{}", f);
+                let _ = write!(out, "{f}");
             }
         }
         StandardJson::String(s) => {
@@ -409,7 +409,7 @@ fn bench_full_pipeline(c: &mut Criterion) {
             let root = index.root(&bytes);
             print_value(&root.value(), &mut buffer);
             buffer.len()
-        })
+        });
     });
 
     // Just index + count leaves (no printing)
@@ -418,14 +418,14 @@ fn bench_full_pipeline(c: &mut Criterion) {
             let index = JsonIndex::build(black_box(&bytes));
             let root = index.root(&bytes);
             count_leaves(&root.value())
-        })
+        });
     });
 
     // Compare with serde_json parsing (if available)
     group.bench_function("serde_json_parse", |b| {
         b.iter(|| {
             let _: serde_json::Value = serde_json::from_slice(black_box(&bytes)).unwrap();
-        })
+        });
     });
 
     // serde_json parse + serialize
@@ -436,7 +436,7 @@ fn bench_full_pipeline(c: &mut Criterion) {
             let value: serde_json::Value = serde_json::from_slice(black_box(&bytes)).unwrap();
             serde_json::to_writer(&mut buffer, &value).unwrap();
             buffer.len()
-        })
+        });
     });
 
     group.finish();
@@ -479,7 +479,7 @@ fn bench_v1_vs_v2_text_position(c: &mut Criterion) {
                 sum += rank;
             }
             sum
-        })
+        });
     });
 
     // Benchmark V2 text_position
@@ -492,7 +492,7 @@ fn bench_v1_vs_v2_text_position(c: &mut Criterion) {
                 sum += rank;
             }
             sum
-        })
+        });
     });
 
     group.finish();
@@ -519,7 +519,7 @@ fn bench_v1_vs_v2_full_traverse(c: &mut Criterion) {
         b.iter(|| {
             let root = index_v1.root(black_box(&bytes));
             count_leaves(&root.value())
-        })
+        });
     });
 
     // V2: Same traversal pattern but with V2's O(1) rank1
@@ -550,7 +550,7 @@ fn bench_v1_vs_v2_full_traverse(c: &mut Criterion) {
             }
             black_box(text_sum);
             count
-        })
+        });
     });
 
     group.finish();
@@ -600,7 +600,7 @@ fn bench_select_patterns(c: &mut Criterion) {
                 }
             }
             sum
-        })
+        });
     });
 
     // Benchmark sequential access with binary search (suboptimal for iteration)
@@ -613,7 +613,7 @@ fn bench_select_patterns(c: &mut Criterion) {
                 }
             }
             sum
-        })
+        });
     });
 
     // Benchmark random access WITH hints (exponential search - suboptimal for random)
@@ -628,7 +628,7 @@ fn bench_select_patterns(c: &mut Criterion) {
                 }
             }
             sum
-        })
+        });
     });
 
     // Benchmark random access with binary search (optimal for random)
@@ -641,7 +641,7 @@ fn bench_select_patterns(c: &mut Criterion) {
                 }
             }
             sum
-        })
+        });
     });
 
     group.finish();
@@ -689,8 +689,7 @@ fn bench_array_indexing(c: &mut Criterion) {
     };
 
     println!(
-        "Using array with {} elements for indexing benchmark",
-        array_len
+        "Using array with {array_len} elements for indexing benchmark"
     );
 
     let mut group = c.benchmark_group("array_indexing");
@@ -705,13 +704,13 @@ fn bench_array_indexing(c: &mut Criterion) {
         }
 
         // Benchmark get() - O(n) IB selects
-        group.bench_function(format!("get_{}", idx), |b| {
-            b.iter(|| black_box(elements.get(black_box(idx))))
+        group.bench_function(format!("get_{idx}"), |b| {
+            b.iter(|| black_box(elements.get(black_box(idx))));
         });
 
         // Benchmark get_fast() - O(n) BP ops + O(log n) IB select
-        group.bench_function(format!("get_fast_{}", idx), |b| {
-            b.iter(|| black_box(elements.get_fast(black_box(idx))))
+        group.bench_function(format!("get_fast_{idx}"), |b| {
+            b.iter(|| black_box(elements.get_fast(black_box(idx))));
         });
     }
 
@@ -740,7 +739,7 @@ fn bench_jq_queries(c: &mut Criterion) {
             let cursor = index.root(black_box(&bytes));
             let result = jq::eval::<Vec<u64>, jq::JqSemantics>(&identity_expr, cursor);
             black_box(result)
-        })
+        });
     });
 
     // Parse a jq expression that accesses array elements by index
@@ -752,7 +751,7 @@ fn bench_jq_queries(c: &mut Criterion) {
             let cursor = index.root(black_box(&bytes));
             let result = jq::eval::<Vec<u64>, jq::JqSemantics>(&expr, cursor);
             black_box(result)
-        })
+        });
     });
 
     // Try field access + array index pattern
@@ -762,7 +761,7 @@ fn bench_jq_queries(c: &mut Criterion) {
                 let cursor = index.root(black_box(&bytes));
                 let result = jq::eval::<Vec<u64>, jq::JqSemantics>(&field_expr, cursor);
                 black_box(result)
-            })
+            });
         });
     }
 
@@ -776,7 +775,7 @@ fn bench_jq_queries(c: &mut Criterion) {
             // Only look at first 51 elements
             let first_51: Vec<_> = result.into_iter().take(51).collect();
             black_box(first_51)
-        })
+        });
     });
 
     group.finish();

--- a/benches/json_simd_common.rs
+++ b/benches/json_simd_common.rs
@@ -44,10 +44,10 @@ pub fn discover_json_files() -> Vec<(String, PathBuf, u64)> {
                             .and_then(|n| n.to_str())
                             .unwrap_or("unknown");
 
-                        let file_size = std::fs::metadata(&file_path).map(|m| m.len()).unwrap_or(0);
+                        let file_size = std::fs::metadata(&file_path).map_or(0, |m| m.len());
 
                         // Create display name: pattern/size (e.g., "comprehensive/10mb")
-                        let display_name = format!("{}/{}", pattern_name, size_name);
+                        let display_name = format!("{pattern_name}/{size_name}");
                         files.push((display_name, file_path, file_size));
                     }
                 }

--- a/benches/json_simd_cursor.rs
+++ b/benches/json_simd_cursor.rs
@@ -41,18 +41,18 @@ fn bench_simple_cursor(c: &mut Criterion) {
         // AVX2 (if available)
         if is_x86_feature_detected!("avx2") {
             group.bench_with_input(BenchmarkId::new("AVX2", name), &bytes, |b, bytes| {
-                b.iter(|| succinctly::json::simd::avx2::build_semi_index_simple(black_box(bytes)))
+                b.iter(|| succinctly::json::simd::avx2::build_semi_index_simple(black_box(bytes)));
             });
         }
 
         // SSE2 (always available)
         group.bench_with_input(BenchmarkId::new("SSE2", name), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::simd::x86::build_semi_index_simple(black_box(bytes)))
+            b.iter(|| succinctly::json::simd::x86::build_semi_index_simple(black_box(bytes)));
         });
 
         // Scalar (byte-by-byte simple cursor)
         group.bench_with_input(BenchmarkId::new("Scalar", name), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::simple::build_semi_index(black_box(bytes)))
+            b.iter(|| succinctly::json::simple::build_semi_index(black_box(bytes)));
         });
     }
 
@@ -84,12 +84,12 @@ fn bench_simple_cursor(c: &mut Criterion) {
 
         // NEON simple cursor
         group.bench_with_input(BenchmarkId::new("NEON", name), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::simd::neon::build_semi_index_simple(black_box(bytes)))
+            b.iter(|| succinctly::json::simd::neon::build_semi_index_simple(black_box(bytes)));
         });
 
         // Scalar (byte-by-byte simple cursor)
         group.bench_with_input(BenchmarkId::new("Scalar", name), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::simple::build_semi_index(black_box(bytes)))
+            b.iter(|| succinctly::json::simple::build_semi_index(black_box(bytes)));
         });
     }
 

--- a/benches/json_simd_full.rs
+++ b/benches/json_simd_full.rs
@@ -76,7 +76,9 @@ fn bench_pattern_comparison(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             group.bench_with_input(BenchmarkId::new("AVX2", pattern), &bytes, |b, bytes| {
-                b.iter(|| succinctly::json::simd::avx2::build_semi_index_standard(black_box(bytes)));
+                b.iter(|| {
+                    succinctly::json::simd::avx2::build_semi_index_standard(black_box(bytes))
+                });
             });
         }
 

--- a/benches/json_simd_full.rs
+++ b/benches/json_simd_full.rs
@@ -38,7 +38,7 @@ fn bench_full_index(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(*file_size));
 
         group.bench_with_input(BenchmarkId::new("JsonIndex", name), &bytes, |b, bytes| {
-            b.iter(|| JsonIndex::build(black_box(bytes)))
+            b.iter(|| JsonIndex::build(black_box(bytes)));
         });
     }
 
@@ -76,12 +76,12 @@ fn bench_pattern_comparison(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             group.bench_with_input(BenchmarkId::new("AVX2", pattern), &bytes, |b, bytes| {
-                b.iter(|| succinctly::json::simd::avx2::build_semi_index_standard(black_box(bytes)))
+                b.iter(|| succinctly::json::simd::avx2::build_semi_index_standard(black_box(bytes)));
             });
         }
 
         group.bench_with_input(BenchmarkId::new("PFSM", pattern), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::standard::build_semi_index(black_box(bytes)))
+            b.iter(|| succinctly::json::standard::build_semi_index(black_box(bytes)));
         });
     }
 
@@ -118,11 +118,11 @@ fn bench_pattern_comparison(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(*file_size));
 
         group.bench_with_input(BenchmarkId::new("NEON", pattern), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::simd::neon::build_semi_index_standard(black_box(bytes)))
+            b.iter(|| succinctly::json::simd::neon::build_semi_index_standard(black_box(bytes)));
         });
 
         group.bench_with_input(BenchmarkId::new("PFSM", pattern), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::standard::build_semi_index(black_box(bytes)))
+            b.iter(|| succinctly::json::standard::build_semi_index(black_box(bytes)));
         });
     }
 

--- a/benches/json_simd_indexing.rs
+++ b/benches/json_simd_indexing.rs
@@ -48,7 +48,7 @@ fn bench_json_indexing(c: &mut Criterion) {
         // AVX2 (if available) - fastest on x86_64
         if is_x86_feature_detected!("avx2") {
             group.bench_with_input(BenchmarkId::new("AVX2", name), &bytes, |b, bytes| {
-                b.iter(|| succinctly::json::simd::avx2::build_semi_index_standard(black_box(bytes)))
+                b.iter(|| succinctly::json::simd::avx2::build_semi_index_standard(black_box(bytes)));
             });
         }
 
@@ -57,18 +57,18 @@ fn bench_json_indexing(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("SSE4.2", name), &bytes, |b, bytes| {
                 b.iter(|| {
                     succinctly::json::simd::sse42::build_semi_index_standard(black_box(bytes))
-                })
+                });
             });
         }
 
         // SSE2 (always available on x86_64)
         group.bench_with_input(BenchmarkId::new("SSE2", name), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::simd::x86::build_semi_index_standard(black_box(bytes)))
+            b.iter(|| succinctly::json::simd::x86::build_semi_index_standard(black_box(bytes)));
         });
 
         // PFSM (table-based state machine) baseline
         group.bench_with_input(BenchmarkId::new("PFSM", name), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::standard::build_semi_index(black_box(bytes)))
+            b.iter(|| succinctly::json::standard::build_semi_index(black_box(bytes)));
         });
     }
 
@@ -102,17 +102,17 @@ fn bench_json_indexing(c: &mut Criterion) {
 
         // NEON (always available on aarch64)
         group.bench_with_input(BenchmarkId::new("NEON", name), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::simd::neon::build_semi_index_standard(black_box(bytes)))
+            b.iter(|| succinctly::json::simd::neon::build_semi_index_standard(black_box(bytes)));
         });
 
         // PFSM (table-based state machine) baseline
         group.bench_with_input(BenchmarkId::new("PFSM", name), &bytes, |b, bytes| {
-            b.iter(|| succinctly::json::standard::build_semi_index(black_box(bytes)))
+            b.iter(|| succinctly::json::standard::build_semi_index(black_box(bytes)));
         });
 
         // Full index
         group.bench_with_input(BenchmarkId::new("JsonIndex", name), &bytes, |b, bytes| {
-            b.iter(|| JsonIndex::build(black_box(bytes)))
+            b.iter(|| JsonIndex::build(black_box(bytes)));
         });
     }
 

--- a/benches/json_simd_indexing.rs
+++ b/benches/json_simd_indexing.rs
@@ -48,7 +48,9 @@ fn bench_json_indexing(c: &mut Criterion) {
         // AVX2 (if available) - fastest on x86_64
         if is_x86_feature_detected!("avx2") {
             group.bench_with_input(BenchmarkId::new("AVX2", name), &bytes, |b, bytes| {
-                b.iter(|| succinctly::json::simd::avx2::build_semi_index_standard(black_box(bytes)));
+                b.iter(|| {
+                    succinctly::json::simd::avx2::build_semi_index_standard(black_box(bytes))
+                });
             });
         }
 

--- a/benches/json_validate_bench.rs
+++ b/benches/json_validate_bench.rs
@@ -35,7 +35,7 @@ const BASE_DIR: &str = "data/bench/generated";
 
 /// Load a test file, returning None if it doesn't exist
 fn load_file(pattern: &str, size: &str) -> Option<Vec<u8>> {
-    let path = format!("{}/{}/{}.json", BASE_DIR, pattern, size);
+    let path = format!("{BASE_DIR}/{pattern}/{size}.json");
     let path = Path::new(&path);
     if !path.exists() {
         return None;
@@ -47,7 +47,7 @@ fn load_file(pattern: &str, size: &str) -> Option<Vec<u8>> {
 fn bench_validate_by_size(c: &mut Criterion) {
     // Group benchmarks by size
     for size in SIZES {
-        let mut group = c.benchmark_group(format!("validate_{}", size));
+        let mut group = c.benchmark_group(format!("validate_{size}"));
 
         for pattern in PATTERNS {
             let Some(bytes) = load_file(pattern, size) else {
@@ -60,7 +60,7 @@ fn bench_validate_by_size(c: &mut Criterion) {
                 b.iter(|| {
                     let result = validate::validate(black_box(bytes));
                     black_box(result)
-                })
+                });
             });
         }
 
@@ -72,7 +72,7 @@ fn bench_validate_by_size(c: &mut Criterion) {
 fn bench_validate_by_pattern(c: &mut Criterion) {
     // Focus on comprehensive pattern as it tests all JSON features
     let pattern = "comprehensive";
-    let mut group = c.benchmark_group(format!("validate_{}", pattern));
+    let mut group = c.benchmark_group(format!("validate_{pattern}"));
 
     for size in SIZES {
         let Some(bytes) = load_file(pattern, size) else {
@@ -85,7 +85,7 @@ fn bench_validate_by_pattern(c: &mut Criterion) {
             b.iter(|| {
                 let result = validate::validate(black_box(bytes));
                 black_box(result)
-            })
+            });
         });
     }
 
@@ -108,7 +108,7 @@ fn bench_validate_large_files(c: &mut Criterion) {
             b.iter(|| {
                 let result = validate::validate(black_box(bytes));
                 black_box(result)
-            })
+            });
         });
     }
 
@@ -128,7 +128,7 @@ fn verify_all_files_valid(c: &mut Criterion) {
         for size in SIZES {
             if let Some(bytes) = load_file(pattern, size) {
                 total_bytes += bytes.len() as u64;
-                all_files.push((format!("{}/{}", pattern, size), bytes));
+                all_files.push((format!("{pattern}/{size}"), bytes));
             }
         }
     }
@@ -146,11 +146,11 @@ fn verify_all_files_valid(c: &mut Criterion) {
             for (name, bytes) in &all_files {
                 match validate::validate(black_box(bytes)) {
                     Ok(()) => valid_count += 1,
-                    Err(e) => panic!("Validation failed for {}: {:?}", name, e),
+                    Err(e) => panic!("Validation failed for {name}: {e:?}"),
                 }
             }
             valid_count
-        })
+        });
     });
 
     group.finish();

--- a/benches/neon_movemask.rs
+++ b/benches/neon_movemask.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // NEON intrinsics benchmarked directly
 //! Benchmark comparing different NEON movemask implementations.
 //!
 //! This benchmark measures the performance difference between:
@@ -158,19 +159,19 @@ mod aarch64_benches {
                 let v = vld1q_u8(pattern.as_ptr());
 
                 group.bench_function(BenchmarkId::new("serial", name), |b| {
-                    b.iter(|| movemask_impls::serial(black_box(v)))
+                    b.iter(|| movemask_impls::serial(black_box(v)));
                 });
 
                 group.bench_function(BenchmarkId::new("parallel", name), |b| {
-                    b.iter(|| movemask_impls::parallel(black_box(v)))
+                    b.iter(|| movemask_impls::parallel(black_box(v)));
                 });
 
                 group.bench_function(BenchmarkId::new("parallel_mul", name), |b| {
-                    b.iter(|| movemask_impls::parallel_mul(black_box(v)))
+                    b.iter(|| movemask_impls::parallel_mul(black_box(v)));
                 });
 
                 group.bench_function(BenchmarkId::new("parallel_padd", name), |b| {
-                    b.iter(|| movemask_impls::parallel_padd(black_box(v)))
+                    b.iter(|| movemask_impls::parallel_padd(black_box(v)));
                 });
             }
         }
@@ -200,7 +201,7 @@ mod aarch64_benches {
             let bytes = std::fs::read(test_file).expect("Failed to read test file");
             let file_size = bytes.len() as u64;
 
-            let mut group = c.benchmark_group(format!("json_indexing_{}", name));
+            let mut group = c.benchmark_group(format!("json_indexing_{name}"));
             group.throughput(Throughput::Bytes(file_size));
             group.sample_size(if name == "100mb" { 10 } else { 20 });
 
@@ -208,12 +209,12 @@ mod aarch64_benches {
             group.bench_function("NEON_parallel", |b| {
                 b.iter(|| {
                     succinctly::json::simd::neon::build_semi_index_standard(black_box(&bytes))
-                })
+                });
             });
 
             // Benchmark with scalar (baseline)
             group.bench_function("Scalar", |b| {
-                b.iter(|| succinctly::json::standard::build_semi_index(black_box(&bytes)))
+                b.iter(|| succinctly::json::standard::build_semi_index(black_box(&bytes)));
             });
 
             group.finish();
@@ -247,18 +248,15 @@ mod aarch64_benches {
 
                 assert_eq!(
                     serial, parallel,
-                    "Mismatch: serial={:016b}, parallel={:016b}",
-                    serial, parallel
+                    "Mismatch: serial={serial:016b}, parallel={parallel:016b}"
                 );
                 assert_eq!(
                     serial, parallel_mul,
-                    "Mismatch: serial={:016b}, parallel_mul={:016b}",
-                    serial, parallel_mul
+                    "Mismatch: serial={serial:016b}, parallel_mul={parallel_mul:016b}"
                 );
                 assert_eq!(
                     serial, parallel_padd,
-                    "Mismatch: serial={:016b}, parallel_padd={:016b}",
-                    serial, parallel_padd
+                    "Mismatch: serial={serial:016b}, parallel_padd={parallel_padd:016b}"
                 );
             }
         }

--- a/benches/pfsm_vs_scalar.rs
+++ b/benches/pfsm_vs_scalar.rs
@@ -18,12 +18,12 @@ fn benchmark_pfsm_vs_scalar(c: &mut Criterion) {
         let json = match fs::read(path) {
             Ok(data) => Box::leak(data.into_boxed_slice()),
             Err(_) => {
-                eprintln!("Warning: {} not found, skipping", path);
+                eprintln!("Warning: {path} not found, skipping");
                 continue;
             }
         };
 
-        let mut group = c.benchmark_group(format!("pfsm_vs_scalar/{}", name));
+        let mut group = c.benchmark_group(format!("pfsm_vs_scalar/{name}"));
         group.throughput(Throughput::Bytes(json.len() as u64));
 
         // PFSM: table-based state machine

--- a/benches/pfsm_vs_simd.rs
+++ b/benches/pfsm_vs_simd.rs
@@ -40,7 +40,7 @@ fn discover_json_files() -> Vec<(String, PathBuf, u64)> {
                 .file_stem()
                 .and_then(|n| n.to_str())
                 .unwrap_or("unknown");
-            let name = format!("{}/{}", pattern, size);
+            let name = format!("{pattern}/{size}");
             files.push((name, path, metadata.len()));
         }
     }

--- a/benches/popcount_strategies.rs
+++ b/benches/popcount_strategies.rs
@@ -52,14 +52,14 @@ fn bench_popcount_strategies(c: &mut Criterion) {
 
             #[cfg(feature = "simd")]
             group.bench_with_input(
-                BenchmarkId::new(format!("{}/{}", size_name, pattern_name), "simd"),
+                BenchmarkId::new(format!("{size_name}/{pattern_name}"), "simd"),
                 &words,
                 |b, words| b.iter(|| popcount_words(black_box(words))),
             );
 
             // Always benchmark scalar as baseline
             group.bench_with_input(
-                BenchmarkId::new(format!("{}/{}", size_name, pattern_name), "scalar"),
+                BenchmarkId::new(format!("{size_name}/{pattern_name}"), "scalar"),
                 &words,
                 |b, words| {
                     b.iter(|| {
@@ -68,7 +68,7 @@ fn bench_popcount_strategies(c: &mut Criterion) {
                             total += word.count_ones();
                         }
                         total
-                    })
+                    });
                 },
             );
         }
@@ -109,7 +109,7 @@ fn bench_avx512_alignment(c: &mut Criterion) {
             .collect();
 
         group.bench_with_input(BenchmarkId::new(name, ""), &words, |b, words| {
-            b.iter(|| popcount_words(black_box(words)))
+            b.iter(|| popcount_words(black_box(words)));
         });
     }
 
@@ -138,7 +138,7 @@ fn bench_throughput(c: &mut Criterion) {
                 total += word.count_ones();
             }
             total
-        })
+        });
     });
 
     group.finish();

--- a/benches/rank_select.rs
+++ b/benches/rank_select.rs
@@ -48,11 +48,11 @@ fn bench_rank(c: &mut Criterion) {
                 |b, (bv, queries)| {
                     b.iter(|| {
                         let mut sum = 0usize;
-                        for &q in queries.iter() {
+                        for &q in *queries {
                             sum += bv.rank1(black_box(q));
                         }
                         sum
-                    })
+                    });
                 },
             );
         }
@@ -81,13 +81,13 @@ fn bench_select(c: &mut Criterion) {
                 |b, (bv, queries)| {
                     b.iter(|| {
                         let mut sum = 0usize;
-                        for &q in queries.iter() {
+                        for &q in *queries {
                             if let Some(pos) = bv.select1(black_box(q)) {
                                 sum += pos;
                             }
                         }
                         sum
-                    })
+                    });
                 },
             );
         }
@@ -133,7 +133,7 @@ fn bench_select_in_word(c: &mut Criterion) {
                     sum += select_in_word(black_box(word), k);
                 }
                 sum
-            })
+            });
         });
     }
     group.finish();
@@ -175,28 +175,28 @@ fn bench_popcount(c: &mut Criterion) {
                 sum += popcount_word(black_box(w));
             }
             sum
-        })
+        });
     });
 
     // Bulk popcount - 1M bits (~125KB of data)
     group.bench_function("1M_bits_raw", |b| {
-        b.iter(|| popcount_words(black_box(&words_1m)))
+        b.iter(|| popcount_words(black_box(&words_1m)));
     });
 
     // Bulk popcount - 10M bits (~1.25MB of data)
     group.bench_function("10M_bits_raw", |b| {
-        b.iter(|| popcount_words(black_box(&words_10m)))
+        b.iter(|| popcount_words(black_box(&words_10m)));
     });
 
     // ========== CONSTRUCTION BENCHMARKS ==========
     // These measure popcount in context of BitVec building
 
     group.bench_function("1M_bits_construction", |b| {
-        b.iter(|| BitVec::from_words(black_box(words_1m.clone()), words_1m.len() * 64))
+        b.iter(|| BitVec::from_words(black_box(words_1m.clone()), words_1m.len() * 64));
     });
 
     group.bench_function("10M_bits_construction", |b| {
-        b.iter(|| BitVec::from_words(black_box(words_10m.clone()), words_10m.len() * 64))
+        b.iter(|| BitVec::from_words(black_box(words_10m.clone()), words_10m.len() * 64));
     });
 
     // ========== RANK QUERY BENCHMARKS ==========
@@ -208,11 +208,11 @@ fn bench_popcount(c: &mut Criterion) {
     group.bench_function("1M_rank_queries", |b| {
         b.iter(|| {
             let mut sum = 0usize;
-            for &q in queries.iter() {
+            for &q in &queries {
                 sum += bv_1m.rank1(black_box(q));
             }
             sum
-        })
+        });
     });
 
     group.finish();

--- a/benches/yaml_anchor_micro.rs
+++ b/benches/yaml_anchor_micro.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // SIMD anchor scan benchmarked directly
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 /// Scalar version: parse anchor name byte-by-byte
@@ -40,7 +41,7 @@ unsafe fn parse_anchor_name_simd(input: &[u8], start: usize) -> usize {
 
     // Process 32 bytes at a time with AVX2
     while pos + 32 <= end {
-        let chunk = _mm256_loadu_si256(input.as_ptr().add(pos) as *const __m256i);
+        let chunk = _mm256_loadu_si256(input.as_ptr().add(pos).cast::<__m256i>());
 
         // Check for whitespace characters
         let space = _mm256_cmpeq_epi8(chunk, _mm256_set1_epi8(b' ' as i8));
@@ -116,20 +117,20 @@ fn bench_anchor_name_parsing(c: &mut Criterion) {
     ];
 
     for (name, anchor) in sizes {
-        let input = format!("&{} value", anchor);
+        let input = format!("&{anchor} value");
         let bytes = input.as_bytes();
         let len = anchor.len();
 
         group.throughput(Throughput::Bytes(len as u64));
 
         group.bench_with_input(BenchmarkId::new("scalar", name), &bytes, |b, input| {
-            b.iter(|| parse_anchor_name_scalar(black_box(input), black_box(1)))
+            b.iter(|| parse_anchor_name_scalar(black_box(input), black_box(1)));
         });
 
         #[cfg(target_arch = "x86_64")]
         if is_x86_feature_detected!("avx2") {
             group.bench_with_input(BenchmarkId::new("simd", name), &bytes, |b, input| {
-                b.iter(|| unsafe { parse_anchor_name_simd(black_box(input), black_box(1)) })
+                b.iter(|| unsafe { parse_anchor_name_simd(black_box(input), black_box(1)) });
             });
         }
     }
@@ -152,11 +153,11 @@ fn bench_alias_scanning(c: &mut Criterion) {
         let mut doc = String::new();
         for i in 0..size / 20 {
             if i % 10 == 0 {
-                doc.push_str(&format!("key{}: &anchor{} value\n", i, i));
+                doc.push_str(&format!("key{i}: &anchor{i} value\n"));
             } else if i % 10 == 5 {
                 doc.push_str(&format!("ref{}: *anchor{}\n", i, i / 10));
             } else {
-                doc.push_str(&format!("key{}: value\n", i));
+                doc.push_str(&format!("key{i}: value\n"));
             }
         }
         let bytes = doc.as_bytes();
@@ -170,13 +171,13 @@ fn bench_alias_scanning(c: &mut Criterion) {
                 b.iter(|| {
                     let input = black_box(input);
                     let mut count = 0;
-                    for &byte in input.iter() {
+                    for &byte in *input {
                         if byte == b'&' || byte == b'*' {
                             count += 1;
                         }
                     }
                     count
-                })
+                });
             },
         );
 
@@ -194,7 +195,7 @@ fn bench_alias_scanning(c: &mut Criterion) {
 
                         while pos + 32 <= input.len() {
                             let chunk =
-                                _mm256_loadu_si256(input.as_ptr().add(pos) as *const __m256i);
+                                _mm256_loadu_si256(input.as_ptr().add(pos).cast::<__m256i>());
                             let anchor = _mm256_cmpeq_epi8(chunk, _mm256_set1_epi8(b'&' as i8));
                             let alias = _mm256_cmpeq_epi8(chunk, _mm256_set1_epi8(b'*' as i8));
                             let matches = _mm256_or_si256(anchor, alias);
@@ -211,7 +212,7 @@ fn bench_alias_scanning(c: &mut Criterion) {
                         }
 
                         count
-                    })
+                    });
                 },
             );
         }

--- a/benches/yaml_bench.rs
+++ b/benches/yaml_bench.rs
@@ -118,9 +118,7 @@ fn generate_block_scalars(count: usize, lines_per_block: usize) -> Vec<u8> {
     for i in 0..count {
         yaml.extend_from_slice(format!("block{i}: |\n").as_bytes());
         for j in 0..lines_per_block {
-            yaml.extend_from_slice(
-                format!("  This is line {j} of block scalar {i}\n").as_bytes(),
-            );
+            yaml.extend_from_slice(format!("  This is line {j} of block scalar {i}\n").as_bytes());
         }
     }
     yaml
@@ -156,9 +154,7 @@ fn generate_anchor_heavy(pairs: usize) -> Vec<u8> {
             );
         } else if i % 3 == 1 {
             // Medium anchor names (16-24 chars)
-            yaml.extend_from_slice(
-                format!("setting_{i}: &anchor_medium_{i} val{i}\n").as_bytes(),
-            );
+            yaml.extend_from_slice(format!("setting_{i}: &anchor_medium_{i} val{i}\n").as_bytes());
         } else {
             // Reference previous anchors with aliases
             let ref_idx = i.saturating_sub(3);
@@ -167,9 +163,7 @@ fn generate_anchor_heavy(pairs: usize) -> Vec<u8> {
                     format!("ref_{i}: *config_anchor_very_long_name_{ref_idx}\n").as_bytes(),
                 );
             } else {
-                yaml.extend_from_slice(
-                    format!("ref_{i}: *anchor_medium_{ref_idx}\n").as_bytes(),
-                );
+                yaml.extend_from_slice(format!("ref_{i}: *anchor_medium_{ref_idx}\n").as_bytes());
             }
         }
     }

--- a/benches/yaml_bench.rs
+++ b/benches/yaml_bench.rs
@@ -20,7 +20,7 @@ use succinctly::yaml::YamlIndex;
 fn generate_simple_kv(pairs: usize) -> Vec<u8> {
     let mut yaml = Vec::with_capacity(pairs * 20);
     for i in 0..pairs {
-        yaml.extend_from_slice(format!("key{}: value{}\n", i, i).as_bytes());
+        yaml.extend_from_slice(format!("key{i}: value{i}\n").as_bytes());
     }
     yaml
 }
@@ -36,11 +36,11 @@ fn generate_nested(depth: usize, width: usize) -> Vec<u8> {
 fn generate_nested_recursive(yaml: &mut Vec<u8>, depth: usize, width: usize, indent: usize) {
     let indent_str = "  ".repeat(indent);
     if depth == 0 {
-        yaml.extend_from_slice(format!("{}value: leaf\n", indent_str).as_bytes());
+        yaml.extend_from_slice(format!("{indent_str}value: leaf\n").as_bytes());
         return;
     }
     for i in 0..width {
-        yaml.extend_from_slice(format!("{}level{}_{}: \n", indent_str, depth, i).as_bytes());
+        yaml.extend_from_slice(format!("{indent_str}level{depth}_{i}: \n").as_bytes());
         generate_nested_recursive(yaml, depth - 1, width, indent + 1);
     }
 }
@@ -50,7 +50,7 @@ fn generate_nested_recursive(yaml: &mut Vec<u8>, depth: usize, width: usize, ind
 fn generate_sequence(items: usize) -> Vec<u8> {
     let mut yaml = Vec::with_capacity(items * 12);
     for i in 0..items {
-        yaml.extend_from_slice(format!("- item{}\n", i).as_bytes());
+        yaml.extend_from_slice(format!("- item{i}\n").as_bytes());
     }
     yaml
 }
@@ -60,7 +60,7 @@ fn generate_quoted_strings(count: usize) -> Vec<u8> {
     let mut yaml = Vec::with_capacity(count * 40);
     for i in 0..count {
         yaml.extend_from_slice(
-            format!("key{}: \"This is a quoted string with value {}\"\n", i, i).as_bytes(),
+            format!("key{i}: \"This is a quoted string with value {i}\"\n").as_bytes(),
         );
     }
     yaml
@@ -71,7 +71,7 @@ fn generate_single_quoted_strings(count: usize) -> Vec<u8> {
     let mut yaml = Vec::with_capacity(count * 40);
     for i in 0..count {
         yaml.extend_from_slice(
-            format!("key{}: 'This is a single-quoted string {}'\n", i, i).as_bytes(),
+            format!("key{i}: 'This is a single-quoted string {i}'\n").as_bytes(),
         );
     }
     yaml
@@ -82,7 +82,7 @@ fn generate_long_quoted_strings(count: usize, string_len: usize) -> Vec<u8> {
     let mut yaml = Vec::with_capacity(count * (string_len + 20));
     let long_string: String = "x".repeat(string_len);
     for i in 0..count {
-        yaml.extend_from_slice(format!("key{}: \"{}\"\n", i, long_string).as_bytes());
+        yaml.extend_from_slice(format!("key{i}: \"{long_string}\"\n").as_bytes());
     }
     yaml
 }
@@ -92,7 +92,7 @@ fn generate_long_single_quoted_strings(count: usize, string_len: usize) -> Vec<u
     let mut yaml = Vec::with_capacity(count * (string_len + 20));
     let long_string: String = "y".repeat(string_len);
     for i in 0..count {
-        yaml.extend_from_slice(format!("key{}: '{}'\n", i, long_string).as_bytes());
+        yaml.extend_from_slice(format!("key{i}: '{long_string}'\n").as_bytes());
     }
     yaml
 }
@@ -105,7 +105,7 @@ fn generate_mixed_yaml(target_size: usize) -> Vec<u8> {
     // Simple repeating structure
     let mut i = 0;
     while yaml.len() < target_size {
-        yaml.extend_from_slice(format!("key{}: value{}\n", i, i).as_bytes());
+        yaml.extend_from_slice(format!("key{i}: value{i}\n").as_bytes());
         i += 1;
     }
 
@@ -116,10 +116,10 @@ fn generate_mixed_yaml(target_size: usize) -> Vec<u8> {
 fn generate_block_scalars(count: usize, lines_per_block: usize) -> Vec<u8> {
     let mut yaml = Vec::with_capacity(count * lines_per_block * 50);
     for i in 0..count {
-        yaml.extend_from_slice(format!("block{}: |\n", i).as_bytes());
+        yaml.extend_from_slice(format!("block{i}: |\n").as_bytes());
         for j in 0..lines_per_block {
             yaml.extend_from_slice(
-                format!("  This is line {} of block scalar {}\n", j, i).as_bytes(),
+                format!("  This is line {j} of block scalar {i}\n").as_bytes(),
             );
         }
     }
@@ -131,9 +131,9 @@ fn generate_long_block_scalars(count: usize, lines_per_block: usize) -> Vec<u8> 
     let mut yaml = Vec::with_capacity(count * lines_per_block * 100);
     let long_line = "x".repeat(80);
     for i in 0..count {
-        yaml.extend_from_slice(format!("content{}: |\n", i).as_bytes());
+        yaml.extend_from_slice(format!("content{i}: |\n").as_bytes());
         for _ in 0..lines_per_block {
-            yaml.extend_from_slice(format!("  {}\n", long_line).as_bytes());
+            yaml.extend_from_slice(format!("  {long_line}\n").as_bytes());
         }
     }
     yaml
@@ -150,26 +150,25 @@ fn generate_anchor_heavy(pairs: usize) -> Vec<u8> {
             // Long anchor names (32+ chars) - where SIMD wins big
             yaml.extend_from_slice(
                 format!(
-                    "common_configuration_setting_{}: &config_anchor_very_long_name_{} value{}\n",
-                    i, i, i
+                    "common_configuration_setting_{i}: &config_anchor_very_long_name_{i} value{i}\n"
                 )
                 .as_bytes(),
             );
         } else if i % 3 == 1 {
             // Medium anchor names (16-24 chars)
             yaml.extend_from_slice(
-                format!("setting_{}: &anchor_medium_{} val{}\n", i, i, i).as_bytes(),
+                format!("setting_{i}: &anchor_medium_{i} val{i}\n").as_bytes(),
             );
         } else {
             // Reference previous anchors with aliases
             let ref_idx = i.saturating_sub(3);
             if ref_idx % 3 == 0 {
                 yaml.extend_from_slice(
-                    format!("ref_{}: *config_anchor_very_long_name_{}\n", i, ref_idx).as_bytes(),
+                    format!("ref_{i}: *config_anchor_very_long_name_{ref_idx}\n").as_bytes(),
                 );
             } else {
                 yaml.extend_from_slice(
-                    format!("ref_{}: *anchor_medium_{}\n", i, ref_idx).as_bytes(),
+                    format!("ref_{i}: *anchor_medium_{ref_idx}\n").as_bytes(),
                 );
             }
         }
@@ -192,7 +191,7 @@ fn generate_k8s_like(resources: usize) -> Vec<u8> {
 
     // Generate resources referencing anchors
     for i in 0..resources {
-        yaml.extend_from_slice(format!("resource_{}:\n", i).as_bytes());
+        yaml.extend_from_slice(format!("resource_{i}:\n").as_bytes());
         yaml.extend_from_slice(b"  metadata:\n");
         yaml.extend_from_slice(b"    labels: *common_labels_for_deployment\n");
         yaml.extend_from_slice(b"  spec:\n");
@@ -216,7 +215,7 @@ fn bench_simple_kv(c: &mut Criterion) {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
@@ -229,13 +228,13 @@ fn bench_nested(c: &mut Criterion) {
     // Various depth/width combinations
     for &(depth, width) in &[(3, 3), (5, 2), (10, 2), (3, 5)] {
         let yaml = generate_nested(depth, width);
-        let label = format!("d{}_w{}", depth, width);
+        let label = format!("d{depth}_w{width}");
         group.throughput(Throughput::Bytes(yaml.len() as u64));
         group.bench_with_input(BenchmarkId::new("depth_width", &label), &yaml, |b, yaml| {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
@@ -252,7 +251,7 @@ fn bench_sequences(c: &mut Criterion) {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
@@ -272,7 +271,7 @@ fn bench_quoted_strings(c: &mut Criterion) {
                 b.iter(|| {
                     let index = YamlIndex::build(black_box(yaml)).unwrap();
                     black_box(index)
-                })
+                });
             },
         );
 
@@ -285,7 +284,7 @@ fn bench_quoted_strings(c: &mut Criterion) {
                 b.iter(|| {
                     let index = YamlIndex::build(black_box(yaml)).unwrap();
                     black_box(index)
-                })
+                });
             },
         );
     }
@@ -309,7 +308,7 @@ fn bench_large_files(c: &mut Criterion) {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
@@ -328,13 +327,13 @@ fn bench_long_strings(c: &mut Criterion) {
         let double_yaml = generate_long_quoted_strings(count, string_len);
         group.throughput(Throughput::Bytes(double_yaml.len() as u64));
         group.bench_with_input(
-            BenchmarkId::new("double", format!("{}b", string_len)),
+            BenchmarkId::new("double", format!("{string_len}b")),
             &double_yaml,
             |b, yaml| {
                 b.iter(|| {
                     let index = YamlIndex::build(black_box(yaml)).unwrap();
                     black_box(index)
-                })
+                });
             },
         );
 
@@ -342,13 +341,13 @@ fn bench_long_strings(c: &mut Criterion) {
         let single_yaml = generate_long_single_quoted_strings(count, string_len);
         group.throughput(Throughput::Bytes(single_yaml.len() as u64));
         group.bench_with_input(
-            BenchmarkId::new("single", format!("{}b", string_len)),
+            BenchmarkId::new("single", format!("{string_len}b")),
             &single_yaml,
             |b, yaml| {
                 b.iter(|| {
                     let index = YamlIndex::build(black_box(yaml)).unwrap();
                     black_box(index)
-                })
+                });
             },
         );
     }
@@ -362,27 +361,27 @@ fn bench_block_scalars(c: &mut Criterion) {
 
     // Test with various block sizes
     for &(blocks, lines) in &[(10, 10), (50, 50), (100, 100), (10, 1000)] {
-        let label = format!("{}x{}lines", blocks, lines);
+        let label = format!("{blocks}x{lines}lines");
         let yaml = generate_block_scalars(blocks, lines);
         group.throughput(Throughput::Bytes(yaml.len() as u64));
         group.bench_with_input(BenchmarkId::from_parameter(&label), &yaml, |b, yaml| {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
     // Test long block scalars
     for &(blocks, lines) in &[(10, 100), (50, 100), (100, 100)] {
-        let label = format!("long_{}x{}lines", blocks, lines);
+        let label = format!("long_{blocks}x{lines}lines");
         let yaml = generate_long_block_scalars(blocks, lines);
         group.throughput(Throughput::Bytes(yaml.len() as u64));
         group.bench_with_input(BenchmarkId::from_parameter(&label), &yaml, |b, yaml| {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
@@ -400,20 +399,20 @@ fn bench_anchors(c: &mut Criterion) {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
     // Test Kubernetes-like patterns
     for &resources in &[10, 50, 100] {
-        let label = format!("k8s_{}", resources);
+        let label = format!("k8s_{resources}");
         let yaml = generate_k8s_like(resources);
         group.throughput(Throughput::Bytes(yaml.len() as u64));
         group.bench_with_input(BenchmarkId::from_parameter(&label), &yaml, |b, yaml| {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 

--- a/benches/yaml_transcode_micro.rs
+++ b/benches/yaml_transcode_micro.rs
@@ -63,7 +63,7 @@ fn make_multiline_double_quoted(lines: usize) -> Vec<u8> {
     let mut yaml = Vec::with_capacity(lines * 50);
     yaml.extend_from_slice(b"value: \"line one\n");
     for i in 1..lines {
-        yaml.extend_from_slice(format!("  line {} continues\n", i).as_bytes());
+        yaml.extend_from_slice(format!("  line {i} continues\n").as_bytes());
     }
     // Replace last newline with closing quote
     yaml.pop();
@@ -100,7 +100,7 @@ fn bench_double_quoted(c: &mut Criterion) {
                     let cursor = index.root(black_box(*yaml));
                     let result = cursor.to_json_document();
                     black_box(result)
-                })
+                });
             },
         );
     }
@@ -126,7 +126,7 @@ fn bench_single_quoted(c: &mut Criterion) {
                     let cursor = index.root(black_box(*yaml));
                     let result = cursor.to_json_document();
                     black_box(result)
-                })
+                });
             },
         );
     }
@@ -152,7 +152,7 @@ fn bench_multiline(c: &mut Criterion) {
                     let cursor = index.root(black_box(*yaml));
                     let result = cursor.to_json_document();
                     black_box(result)
-                })
+                });
             },
         );
     }
@@ -178,7 +178,7 @@ fn bench_unicode_8digit(c: &mut Criterion) {
                     let cursor = index.root(black_box(*yaml));
                     let result = cursor.to_json_document();
                     black_box(result)
-                })
+                });
             },
         );
     }
@@ -218,7 +218,7 @@ features:
             let cursor = index.root(black_box(config_yaml));
             let result = cursor.to_json_document();
             black_box(result)
-        })
+        });
     });
 
     // YAML with many escape sequences
@@ -241,7 +241,7 @@ features:
             let cursor = escape_index.root(black_box(escape_heavy));
             let result = cursor.to_json_document();
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -257,8 +257,7 @@ fn bench_large_document(c: &mut Criterion) {
     for i in 0..500 {
         large_yaml.extend_from_slice(
             format!(
-                "  - id: {}\n    name: \"Item {} with escape\\nand tab\\t\"\n    desc: 'Single ''quoted'' text'\n",
-                i, i
+                "  - id: {i}\n    name: \"Item {i} with escape\\nand tab\\t\"\n    desc: 'Single ''quoted'' text'\n"
             )
             .as_bytes(),
         );
@@ -272,7 +271,7 @@ fn bench_large_document(c: &mut Criterion) {
             let cursor = index.root(black_box(&large_yaml));
             let result = cursor.to_json_document();
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -302,11 +301,11 @@ fn bench_escape_scan_no_escapes(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_with_input(BenchmarkId::new("simd", size), &data, |b, data| {
-            b.iter(|| find_json_escape(black_box(data), 0))
+            b.iter(|| find_json_escape(black_box(data), 0));
         });
 
         group.bench_with_input(BenchmarkId::new("scalar", size), &data, |b, data| {
-            b.iter(|| find_json_escape_scalar(black_box(data), 0))
+            b.iter(|| find_json_escape_scalar(black_box(data), 0));
         });
     }
 
@@ -324,11 +323,11 @@ fn bench_escape_scan_early_escape(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_with_input(BenchmarkId::new("simd", size), &data, |b, data| {
-            b.iter(|| find_json_escape(black_box(data), 0))
+            b.iter(|| find_json_escape(black_box(data), 0));
         });
 
         group.bench_with_input(BenchmarkId::new("scalar", size), &data, |b, data| {
-            b.iter(|| find_json_escape_scalar(black_box(data), 0))
+            b.iter(|| find_json_escape_scalar(black_box(data), 0));
         });
     }
 
@@ -346,11 +345,11 @@ fn bench_escape_scan_mid_escape(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_with_input(BenchmarkId::new("simd", size), &data, |b, data| {
-            b.iter(|| find_json_escape(black_box(data), 0))
+            b.iter(|| find_json_escape(black_box(data), 0));
         });
 
         group.bench_with_input(BenchmarkId::new("scalar", size), &data, |b, data| {
-            b.iter(|| find_json_escape_scalar(black_box(data), 0))
+            b.iter(|| find_json_escape_scalar(black_box(data), 0));
         });
     }
 
@@ -369,11 +368,11 @@ fn bench_escape_scan_control_chars(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(size as u64));
 
         group.bench_with_input(BenchmarkId::new("simd", size), &data, |b, data| {
-            b.iter(|| find_json_escape(black_box(data), 0))
+            b.iter(|| find_json_escape(black_box(data), 0));
         });
 
         group.bench_with_input(BenchmarkId::new("scalar", size), &data, |b, data| {
-            b.iter(|| find_json_escape_scalar(black_box(data), 0))
+            b.iter(|| find_json_escape_scalar(black_box(data), 0));
         });
     }
 
@@ -414,7 +413,7 @@ fn bench_escape_scan_realistic(c: &mut Criterion) {
                         break;
                     }
                 }
-            })
+            });
         });
 
         group.bench_with_input(BenchmarkId::new("scalar", size), &data, |b, data| {
@@ -428,7 +427,7 @@ fn bench_escape_scan_realistic(c: &mut Criterion) {
                         break;
                     }
                 }
-            })
+            });
         });
     }
 

--- a/benches/yaml_type_stack_micro.rs
+++ b/benches/yaml_type_stack_micro.rs
@@ -22,16 +22,16 @@ fn generate_deeply_nested_yaml(depth: usize) -> Vec<u8> {
         let indent = "  ".repeat(d);
         if d % 2 == 0 {
             // Mapping
-            yaml.extend_from_slice(format!("{}key{}:\n", indent, d).as_bytes());
+            yaml.extend_from_slice(format!("{indent}key{d}:\n").as_bytes());
         } else {
             // Sequence
-            yaml.extend_from_slice(format!("{}- item{}:\n", indent, d).as_bytes());
+            yaml.extend_from_slice(format!("{indent}- item{d}:\n").as_bytes());
         }
     }
 
     // Add leaf value
     let indent = "  ".repeat(depth);
-    yaml.extend_from_slice(format!("{}value: leaf\n", indent).as_bytes());
+    yaml.extend_from_slice(format!("{indent}value: leaf\n").as_bytes());
 
     yaml
 }
@@ -43,8 +43,8 @@ fn generate_wide_structure(width: usize) -> Vec<u8> {
 
     // Create many mapping entries at root level
     for i in 0..width / 2 {
-        yaml.extend_from_slice(format!("key{}:\n", i).as_bytes());
-        yaml.extend_from_slice(format!("  - item{}\n", i).as_bytes());
+        yaml.extend_from_slice(format!("key{i}:\n").as_bytes());
+        yaml.extend_from_slice(format!("  - item{i}\n").as_bytes());
     }
 
     yaml
@@ -58,14 +58,14 @@ fn generate_mixed_containers(pairs: usize) -> Vec<u8> {
     for i in 0..pairs {
         if i % 3 == 0 {
             // Mapping with sequence value
-            yaml.extend_from_slice(format!("key{}:\n", i).as_bytes());
+            yaml.extend_from_slice(format!("key{i}:\n").as_bytes());
             yaml.extend_from_slice(b"  - a\n  - b\n");
         } else if i % 3 == 1 {
             // Sequence item with nested mapping
             yaml.extend_from_slice(b"- nested:\n    val: x\n");
         } else {
             // Simple mapping
-            yaml.extend_from_slice(format!("key{}: value\n", i).as_bytes());
+            yaml.extend_from_slice(format!("key{i}: value\n").as_bytes());
         }
     }
 
@@ -82,7 +82,7 @@ fn bench_deeply_nested(c: &mut Criterion) {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
@@ -99,7 +99,7 @@ fn bench_wide_structure(c: &mut Criterion) {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 
@@ -116,7 +116,7 @@ fn bench_mixed_containers(c: &mut Criterion) {
             b.iter(|| {
                 let index = YamlIndex::build(black_box(yaml)).unwrap();
                 black_box(index)
-            })
+            });
         });
     }
 

--- a/benches/yq_comparison.rs
+++ b/benches/yq_comparison.rs
@@ -19,7 +19,7 @@ const PATTERNS: &[&str] = &["comprehensive", "users", "nested", "sequences", "st
 const SIZES: &[&str] = &["1kb", "10kb", "100kb", "1mb"];
 
 fn file_path(pattern: &str, size: &str) -> String {
-    format!("data/bench/generated/yaml/{}/{}.yaml", pattern, size)
+    format!("data/bench/generated/yaml/{pattern}/{size}.yaml")
 }
 
 fn get_succinctly_binary() -> Option<std::path::PathBuf> {
@@ -40,8 +40,7 @@ fn has_system_yq() -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .is_ok_and(|s| s.success())
 }
 
 /// Benchmark succinctly yq with identity filter
@@ -62,7 +61,7 @@ fn bench_succinctly_identity(c: &mut Criterion) {
                 continue;
             }
 
-            let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+            let file_size = path_obj.metadata().map_or(0, |m| m.len());
             group.throughput(Throughput::Bytes(file_size));
 
             group.bench_with_input(
@@ -76,9 +75,9 @@ fn bench_succinctly_identity(c: &mut Criterion) {
                             .stderr(Stdio::null())
                             .output()
                             .expect("Failed to execute succinctly");
-                        assert!(output.status.success(), "succinctly yq failed on {}", path);
+                        assert!(output.status.success(), "succinctly yq failed on {path}");
                         output.stdout
-                    })
+                    });
                 },
             );
         }
@@ -105,7 +104,7 @@ fn bench_system_yq_identity(c: &mut Criterion) {
                 continue;
             }
 
-            let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+            let file_size = path_obj.metadata().map_or(0, |m| m.len());
             group.throughput(Throughput::Bytes(file_size));
 
             group.bench_with_input(BenchmarkId::new(*pattern, *size), &path, |b, path| {
@@ -116,9 +115,9 @@ fn bench_system_yq_identity(c: &mut Criterion) {
                         .stderr(Stdio::null())
                         .output()
                         .expect("Failed to execute yq");
-                    assert!(output.status.success(), "system yq failed on {}", path);
+                    assert!(output.status.success(), "system yq failed on {path}");
                     output.stdout
-                })
+                });
             });
         }
     }
@@ -149,7 +148,7 @@ fn bench_yq_comparison(c: &mut Criterion) {
             continue;
         }
 
-        let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+        let file_size = path_obj.metadata().map_or(0, |m| m.len());
         group.throughput(Throughput::Bytes(file_size));
 
         if let Some(ref binary) = succinctly_binary {
@@ -166,7 +165,7 @@ fn bench_yq_comparison(c: &mut Criterion) {
                             .expect("Failed to execute succinctly");
                         assert!(output.status.success());
                         output.stdout
-                    })
+                    });
                 },
             );
         }
@@ -182,7 +181,7 @@ fn bench_yq_comparison(c: &mut Criterion) {
                         .expect("Failed to execute yq");
                     assert!(output.status.success());
                     output.stdout
-                })
+                });
             });
         }
     }

--- a/benches/yq_select.rs
+++ b/benches/yq_select.rs
@@ -82,7 +82,7 @@ const FIELD_QUERIES: &[(&str, &str, &str, &str)] = &[
 ];
 
 fn file_path(pattern: &str, size: &str) -> String {
-    format!("data/bench/generated/yaml/{}/{}.yaml", pattern, size)
+    format!("data/bench/generated/yaml/{pattern}/{size}.yaml")
 }
 
 fn get_succinctly_binary() -> Option<std::path::PathBuf> {
@@ -103,8 +103,7 @@ fn has_system_yq() -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .is_ok_and(|s| s.success())
 }
 
 /// Benchmark succinctly yq with ~5% selection queries
@@ -121,14 +120,14 @@ fn bench_succinctly_select(c: &mut Criterion) {
         let path_obj = std::path::Path::new(&path);
 
         if !path_obj.exists() {
-            eprintln!("Skipping {}/{}: file not found", pattern, size);
+            eprintln!("Skipping {pattern}/{size}: file not found");
             continue;
         }
 
-        let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+        let file_size = path_obj.metadata().map_or(0, |m| m.len());
         group.throughput(Throughput::Bytes(file_size));
 
-        let label = format!("{}/{} ({})", pattern, size, desc);
+        let label = format!("{pattern}/{size} ({desc})");
         group.bench_with_input(
             BenchmarkId::from_parameter(&label),
             &(&binary, &path, succinctly_query),
@@ -142,12 +141,10 @@ fn bench_succinctly_select(c: &mut Criterion) {
                         .expect("Failed to execute succinctly");
                     assert!(
                         output.status.success(),
-                        "succinctly yq failed on {} with query {}",
-                        path,
-                        query
+                        "succinctly yq failed on {path} with query {query}"
                     );
                     output.stdout
-                })
+                });
             },
         );
     }
@@ -172,10 +169,10 @@ fn bench_system_yq_select(c: &mut Criterion) {
             continue;
         }
 
-        let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+        let file_size = path_obj.metadata().map_or(0, |m| m.len());
         group.throughput(Throughput::Bytes(file_size));
 
-        let label = format!("{}/{} ({})", pattern, size, desc);
+        let label = format!("{pattern}/{size} ({desc})");
         group.bench_with_input(
             BenchmarkId::from_parameter(&label),
             &(&path, yq_query),
@@ -187,9 +184,9 @@ fn bench_system_yq_select(c: &mut Criterion) {
                         .stderr(Stdio::null())
                         .output()
                         .expect("Failed to execute yq");
-                    assert!(output.status.success(), "system yq failed on {}", path);
+                    assert!(output.status.success(), "system yq failed on {path}");
                     output.stdout
-                })
+                });
             },
         );
     }
@@ -214,10 +211,10 @@ fn bench_succinctly_field(c: &mut Criterion) {
             continue;
         }
 
-        let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+        let file_size = path_obj.metadata().map_or(0, |m| m.len());
         group.throughput(Throughput::Bytes(file_size));
 
-        let label = format!("{}/{} ({})", pattern, size, desc);
+        let label = format!("{pattern}/{size} ({desc})");
         group.bench_with_input(
             BenchmarkId::from_parameter(&label),
             &(&binary, &path, query),
@@ -231,7 +228,7 @@ fn bench_succinctly_field(c: &mut Criterion) {
                         .expect("Failed to execute succinctly");
                     assert!(output.status.success());
                     output.stdout
-                })
+                });
             },
         );
     }
@@ -256,10 +253,10 @@ fn bench_system_yq_field(c: &mut Criterion) {
             continue;
         }
 
-        let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+        let file_size = path_obj.metadata().map_or(0, |m| m.len());
         group.throughput(Throughput::Bytes(file_size));
 
-        let label = format!("{}/{} ({})", pattern, size, desc);
+        let label = format!("{pattern}/{size} ({desc})");
         group.bench_with_input(
             BenchmarkId::from_parameter(&label),
             &(&path, query),
@@ -273,7 +270,7 @@ fn bench_system_yq_field(c: &mut Criterion) {
                         .expect("Failed to execute yq");
                     assert!(output.status.success());
                     output.stdout
-                })
+                });
             },
         );
     }
@@ -327,11 +324,11 @@ fn bench_select_comparison(c: &mut Criterion) {
             continue;
         }
 
-        let file_size = path_obj.metadata().map(|m| m.len()).unwrap_or(0);
+        let file_size = path_obj.metadata().map_or(0, |m| m.len());
         group.throughput(Throughput::Bytes(file_size));
 
         if let Some(ref binary) = succinctly_binary {
-            let label = format!("succinctly/{}", desc);
+            let label = format!("succinctly/{desc}");
             group.bench_with_input(
                 BenchmarkId::from_parameter(&label),
                 &(binary, &path, succinctly_query),
@@ -345,13 +342,13 @@ fn bench_select_comparison(c: &mut Criterion) {
                             .expect("Failed to execute succinctly");
                         assert!(output.status.success());
                         output.stdout
-                    })
+                    });
                 },
             );
         }
 
         if has_yq {
-            let label = format!("yq/{}", desc);
+            let label = format!("yq/{desc}");
             group.bench_with_input(
                 BenchmarkId::from_parameter(&label),
                 &(&path, yq_query),
@@ -365,7 +362,7 @@ fn bench_select_comparison(c: &mut Criterion) {
                             .expect("Failed to execute yq");
                         assert!(output.status.success());
                         output.stdout
-                    })
+                    });
                 },
             );
         }

--- a/examples/test_anchor.rs
+++ b/examples/test_anchor.rs
@@ -10,7 +10,7 @@ fn main() {
 
     println!("\n=== Anchors ===");
     if let Some(anchor_pos) = index.get_anchor_bp_pos("anchor") {
-        println!("Anchor 'anchor' points to bp_pos={}", anchor_pos);
+        println!("Anchor 'anchor' points to bp_pos={anchor_pos}");
         let cursor = index.cursor_at(anchor_pos, yaml);
         println!("  text_pos: {:?}", cursor.text_position());
     }
@@ -22,8 +22,8 @@ fn main() {
             for field in fields {
                 let key = field.key();
                 let val = field.value();
-                println!("Key: {:?}", key);
-                println!("Value: {:?}", val);
+                println!("Key: {key:?}");
+                println!("Value: {val:?}");
             }
         }
     }

--- a/examples/yaml_profile.rs
+++ b/examples/yaml_profile.rs
@@ -124,12 +124,12 @@ fn main() {
 
     // ========== RESULTS ==========
     eprintln!();
-    eprintln!("=== Comparison for {:.1} KiB ===", size_kb);
+    eprintln!("=== Comparison for {size_kb:.1} KiB ===");
     eprintln!();
     eprintln!("OLD (via OwnedValue):");
-    eprintln!("  Parse:     {:>8.2?}", old_parse_time);
-    eprintln!("  Convert:   {:>8.2?}", old_convert_time);
-    eprintln!("  Serialize: {:>8.2?}", old_serialize_time);
+    eprintln!("  Parse:     {old_parse_time:>8.2?}");
+    eprintln!("  Convert:   {old_convert_time:>8.2?}");
+    eprintln!("  Serialize: {old_serialize_time:>8.2?}");
     eprintln!(
         "  Total:     {:>8.2?}  ({:.1} MiB/s)",
         old_total,
@@ -137,8 +137,8 @@ fn main() {
     );
     eprintln!();
     eprintln!("NEW (direct cursor → JSON):");
-    eprintln!("  Parse:     {:>8.2?}", new_parse_time);
-    eprintln!("  Convert:   {:>8.2?}", new_convert_time);
+    eprintln!("  Parse:     {new_parse_time:>8.2?}");
+    eprintln!("  Convert:   {new_convert_time:>8.2?}");
     eprintln!(
         "  Total:     {:>8.2?}  ({:.1} MiB/s)",
         new_total,
@@ -166,7 +166,7 @@ fn main() {
             if old_bytes[i] != new_bytes[i] {
                 let start = i.saturating_sub(20);
                 let end = (i + 40).min(old_bytes.len()).min(new_bytes.len());
-                eprintln!("  First diff at byte {}", i);
+                eprintln!("  First diff at byte {i}");
                 eprintln!(
                     "  Old[{}..{}]: {:?}",
                     start,

--- a/src/bin/generate_pfsm_tables.rs
+++ b/src/bin/generate_pfsm_tables.rs
@@ -197,12 +197,12 @@ fn generate_phi_table() -> [u32; 256] {
 
 fn format_table(table: &[u32; 256], name: &str) -> String {
     let mut output = String::new();
-    output.push_str(&format!("pub const {}: [u32; 256] = [\n", name));
+    output.push_str(&format!("pub const {name}: [u32; 256] = [\n"));
 
     for chunk in table.chunks(8) {
         output.push_str("    ");
         for (i, &entry) in chunk.iter().enumerate() {
-            output.push_str(&format!("0x{:08X}", entry));
+            output.push_str(&format!("0x{entry:08X}"));
             if i < chunk.len() - 1 {
                 output.push_str(", ");
             }
@@ -268,8 +268,7 @@ fn main() {
             let bp_open = (phi >> 1) & 1;
             let ib = (phi >> 2) & 1;
             eprintln!(
-                "  {:?} -> {:?}, phi=0b{:03b} (IB={}, BP_open={}, BP_close={})",
-                state, next, phi, ib, bp_open, bp_close
+                "  {state:?} -> {next:?}, phi=0b{phi:03b} (IB={ib}, BP_open={bp_open}, BP_close={bp_close})"
             );
         }
     }

--- a/src/bin/succinctly/bench_runner/metadata.rs
+++ b/src/bin/succinctly/bench_runner/metadata.rs
@@ -81,11 +81,11 @@ fn run_git(args: &[&str]) -> Result<String> {
     let output = Command::new("git")
         .args(args)
         .output()
-        .with_context(|| format!("Failed to run git {:?}", args))?;
+        .with_context(|| format!("Failed to run git {args:?}"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git {:?} failed: {}", args, stderr);
+        anyhow::bail!("git {args:?} failed: {stderr}");
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -131,8 +131,7 @@ pub fn collect_git_info() -> Result<GitInfo> {
 pub fn collect_system_info() -> SystemInfo {
     let cpu = get_cpu_info();
     let cpu_cores = std::thread::available_parallelism()
-        .map(|p| p.get() as u32)
-        .unwrap_or(1);
+        .map_or(1, |p| p.get() as u32);
     let ram_gb = get_total_ram_gb();
     let os = std::env::consts::OS.to_string();
     let os_version = get_os_version();
@@ -192,9 +191,9 @@ pub fn collect_toolchain_info() -> Result<ToolchainInfo> {
             }
         }
         if !target_env.is_empty() {
-            format!("{}-unknown-{}-{}", target_arch, target_os, target_env)
+            format!("{target_arch}-unknown-{target_os}-{target_env}")
         } else {
-            format!("{}-{}", target_arch, target_os)
+            format!("{target_arch}-{target_os}")
         }
     } else {
         format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS)

--- a/src/bin/succinctly/bench_runner/metadata.rs
+++ b/src/bin/succinctly/bench_runner/metadata.rs
@@ -130,8 +130,7 @@ pub fn collect_git_info() -> Result<GitInfo> {
 /// Collect system information.
 pub fn collect_system_info() -> SystemInfo {
     let cpu = get_cpu_info();
-    let cpu_cores = std::thread::available_parallelism()
-        .map_or(1, |p| p.get() as u32);
+    let cpu_cores = std::thread::available_parallelism().map_or(1, |p| p.get() as u32);
     let ram_gb = get_total_ram_gb();
     let os = std::env::consts::OS.to_string();
     let os_version = get_os_version();

--- a/src/bin/succinctly/bench_runner/registry.rs
+++ b/src/bin/succinctly/bench_runner/registry.rs
@@ -39,8 +39,7 @@ impl std::str::FromStr for BenchmarkCategory {
             "dsv" => Ok(Self::Dsv),
             "cross-parser" | "crossparser" | "cross_parser" => Ok(Self::CrossParser),
             _ => Err(format!(
-                "unknown category '{}', expected: core, json, yaml, dsv, cross-parser",
-                s
+                "unknown category '{s}', expected: core, json, yaml, dsv, cross-parser"
             )),
         }
     }

--- a/src/bin/succinctly/bench_runner/runner.rs
+++ b/src/bin/succinctly/bench_runner/runner.rs
@@ -138,7 +138,7 @@ pub fn run_benchmarks(args: RunArgs) -> Result<()> {
     if benchmarks.is_empty() {
         eprintln!("No benchmarks selected. Use --all, --category, or specify benchmark names.");
         eprintln!("\nAvailable benchmarks:");
-        for b in BENCHMARKS.iter() {
+        for b in BENCHMARKS {
             eprintln!("  {} ({})", b.name, b.category);
         }
         return Ok(());
@@ -188,7 +188,7 @@ pub fn run_benchmarks(args: RunArgs) -> Result<()> {
         match BenchmarkMetadata::collect() {
             Ok(m) => Some(m),
             Err(e) => {
-                eprintln!("Warning: Failed to collect metadata: {}", e);
+                eprintln!("Warning: Failed to collect metadata: {e}");
                 None
             }
         }
@@ -240,12 +240,12 @@ pub fn run_benchmarks(args: RunArgs) -> Result<()> {
                 eprintln!("FAILED (exit code: {:?})", r.exit_code);
                 if let Some(msg) = &r.error_message {
                     if args.verbose {
-                        eprintln!("    Error: {}", msg);
+                        eprintln!("    Error: {msg}");
                     }
                 }
             }
             Err(e) => {
-                eprintln!("ERROR: {}", e);
+                eprintln!("ERROR: {e}");
             }
         }
 
@@ -292,10 +292,10 @@ pub fn run_benchmarks(args: RunArgs) -> Result<()> {
     // Print summary
     eprintln!();
     eprintln!("Benchmark run complete:");
-    eprintln!("  Passed:   {}", passed);
-    eprintln!("  Failed:   {}", failed);
+    eprintln!("  Passed:   {passed}");
+    eprintln!("  Failed:   {failed}");
     if skipped > 0 {
-        eprintln!("  Skipped:  {}", skipped);
+        eprintln!("  Skipped:  {skipped}");
     }
     eprintln!("  Duration: {}", format_duration(total_duration));
     eprintln!("  Results:  {}", output_dir.display());
@@ -328,7 +328,7 @@ fn select_benchmarks(args: &RunArgs) -> Result<Vec<&'static BenchmarkInfo>> {
         // Check for unknown names
         for name in &args.names {
             if !benchmarks.iter().any(|b| b.name == name) {
-                eprintln!("Warning: Unknown benchmark '{}'", name);
+                eprintln!("Warning: Unknown benchmark '{name}'");
             }
         }
         return Ok(benchmarks);
@@ -405,7 +405,7 @@ fn run_criterion_benchmark(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .with_context(|| format!("Failed to run cargo bench --bench {}", bench_name))?;
+        .with_context(|| format!("Failed to run cargo bench --bench {bench_name}"))?;
 
     // Save stdout
     let stdout_path = stdout_dir.join(format!("{}.txt", benchmark.name));
@@ -463,7 +463,7 @@ fn run_cli_benchmark(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .with_context(|| format!("Failed to run succinctly dev bench {}", subcommand))?;
+        .with_context(|| format!("Failed to run succinctly dev bench {subcommand}"))?;
 
     // Save stdout
     let stdout_path = stdout_dir.join(format!("{}.txt", benchmark.name));
@@ -506,8 +506,7 @@ fn run_cross_parser_benchmark(
         .output()
         .with_context(|| {
             format!(
-                "Failed to run cargo bench --bench {} in bench-compare",
-                bench_name
+                "Failed to run cargo bench --bench {bench_name} in bench-compare"
             )
         })?;
 

--- a/src/bin/succinctly/bench_runner/runner.rs
+++ b/src/bin/succinctly/bench_runner/runner.rs
@@ -505,9 +505,7 @@ fn run_cross_parser_benchmark(
         .stderr(Stdio::piped())
         .output()
         .with_context(|| {
-            format!(
-                "Failed to run cargo bench --bench {bench_name} in bench-compare"
-            )
+            format!("Failed to run cargo bench --bench {bench_name} in bench-compare")
         })?;
 
     // Save stdout

--- a/src/bin/succinctly/bench_runner/utils.rs
+++ b/src/bin/succinctly/bench_runner/utils.rs
@@ -116,7 +116,7 @@ pub fn format_bytes(bytes: u64) -> String {
     } else if bytes >= 1024 {
         format!("{:.2} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{} bytes", bytes)
+        format!("{bytes} bytes")
     }
 }
 
@@ -129,7 +129,7 @@ pub fn format_memory_fixed(bytes: u64) -> String {
     } else if bytes >= 1024 {
         format!("{:>4.0} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{:>4} B ", bytes)
+        format!("{bytes:>4} B ")
     }
 }
 
@@ -138,8 +138,8 @@ pub fn format_time_fixed(ms: f64) -> String {
     if ms >= 1000.0 {
         format!("{:>7.2}s", ms / 1000.0)
     } else {
-        let ms_str = format!("{:.1}ms", ms);
-        format!("{:>8}", ms_str)
+        let ms_str = format!("{ms:.1}ms");
+        format!("{ms_str:>8}")
     }
 }
 
@@ -148,13 +148,13 @@ pub fn format_duration(seconds: f64) -> String {
     if seconds >= 3600.0 {
         let hours = (seconds / 3600.0).floor();
         let mins = ((seconds % 3600.0) / 60.0).floor();
-        format!("{:.0}h {:.0}m", hours, mins)
+        format!("{hours:.0}h {mins:.0}m")
     } else if seconds >= 60.0 {
         let mins = (seconds / 60.0).floor();
         let secs = seconds % 60.0;
-        format!("{:.0}m {:.0}s", mins, secs)
+        format!("{mins:.0}m {secs:.0}s")
     } else {
-        format!("{:.1}s", seconds)
+        format!("{seconds:.1}s")
     }
 }
 
@@ -172,7 +172,7 @@ pub fn run_command_with_timing(program: &str, args: &[&str]) -> Result<TimingRes
         let output = Command::new(program)
             .args(args)
             .output()
-            .with_context(|| format!("Failed to run {}", program))?;
+            .with_context(|| format!("Failed to run {program}"))?;
         (output.stdout, 0, 0.0, 0.0)
     };
 

--- a/src/bin/succinctly/dsv_bench.rs
+++ b/src/bin/succinctly/dsv_bench.rs
@@ -126,7 +126,7 @@ pub fn run_benchmark(
                 break 'outer;
             }
 
-            let file_path = config.data_dir.join(pattern).join(format!("{}.csv", size));
+            let file_path = config.data_dir.join(pattern).join(format!("{size}.csv"));
 
             if !file_path.exists() {
                 eprintln!("  Skipping {} (not found)", file_path.display());
@@ -162,7 +162,7 @@ pub fn run_benchmark(
                     results.push(result);
                 }
                 Err(e) => {
-                    eprintln!("ERROR: {}", e);
+                    eprintln!("ERROR: {e}");
                 }
             }
         }
@@ -288,7 +288,7 @@ fn run_command_with_timing(program: &str, args: &[&str]) -> Result<ToolResult> {
         let output = Command::new(program)
             .args(args)
             .output()
-            .with_context(|| format!("Failed to run {}", program))?;
+            .with_context(|| format!("Failed to run {program}"))?;
         (output.stdout, 0, 0.0, 0.0)
     };
 
@@ -463,7 +463,7 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
 
     // Add CPU info
     let cpu_info = get_cpu_info();
-    md.push_str(&format!("**CPU**: {}\n\n", cpu_info));
+    md.push_str(&format!("**CPU**: {cpu_info}\n\n"));
 
     if results.is_empty() {
         md.push_str("No results.\n");
@@ -471,8 +471,8 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
     }
 
     // Get delimiter from first result
-    let delimiter = results.first().map(|r| r.delimiter).unwrap_or(',');
-    md.push_str(&format!("**Delimiter**: '{}'\n\n", delimiter));
+    let delimiter = results.first().map_or(',', |r| r.delimiter);
+    md.push_str(&format!("**Delimiter**: '{delimiter}'\n\n"));
 
     // Group by pattern (alphabetical order)
     let patterns = [
@@ -498,7 +498,7 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
             continue;
         }
 
-        md.push_str(&format!("## Pattern: {}\n\n", pattern));
+        md.push_str(&format!("## Pattern: {pattern}\n\n"));
         if memory_mode {
             md.push_str("| Size      | Time     | Throughput   | Memory   |\n");
             md.push_str("|-----------|----------|--------------|----------|\n");
@@ -522,22 +522,20 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
 
             // Format values
             let time = format_time_fixed(r.succinctly.wall_time_ms);
-            let throughput_str = format!("{:.1} MiB/s", throughput);
+            let throughput_str = format!("{throughput:.1} MiB/s");
 
             // Size column: **name** with trailing padding (9 chars total)
             let size_bold = format!("**{}**", r.size);
-            let size_col = format!("{:<9}", size_bold);
+            let size_col = format!("{size_bold:<9}");
 
             if memory_mode {
                 let mem = format_memory_fixed(r.succinctly.peak_memory_bytes);
                 md.push_str(&format!(
-                    "| {} | {} | {:>12} | {} |\n",
-                    size_col, time, throughput_str, mem
+                    "| {size_col} | {time} | {throughput_str:>12} | {mem} |\n"
                 ));
             } else {
                 md.push_str(&format!(
-                    "| {} | {} | {:>12} |\n",
-                    size_col, time, throughput_str
+                    "| {size_col} | {time} | {throughput_str:>12} |\n"
                 ));
             }
         }
@@ -556,8 +554,8 @@ fn format_time_fixed(ms: f64) -> String {
         format!("{:>7.2}s", ms / 1000.0)
     } else {
         // Milliseconds: " 765.6ms" = 8 chars total (padding on left)
-        let ms_str = format!("{:.1}ms", ms);
-        format!("{:>8}", ms_str)
+        let ms_str = format!("{ms:.1}ms");
+        format!("{ms_str:>8}")
     }
 }
 
@@ -571,7 +569,7 @@ fn format_memory_fixed(bytes: u64) -> String {
     } else if bytes >= 1024 {
         format!("{:>4.0} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{:>4} B ", bytes)
+        format!("{bytes:>4} B ")
     }
 }
 
@@ -584,6 +582,6 @@ fn format_bytes(bytes: usize) -> String {
     } else if bytes >= 1024 {
         format!("{:.2} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{} bytes", bytes)
+        format!("{bytes} bytes")
     }
 }

--- a/src/bin/succinctly/dsv_bench.rs
+++ b/src/bin/succinctly/dsv_bench.rs
@@ -534,9 +534,7 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
                     "| {size_col} | {time} | {throughput_str:>12} | {mem} |\n"
                 ));
             } else {
-                md.push_str(&format!(
-                    "| {size_col} | {time} | {throughput_str:>12} |\n"
-                ));
+                md.push_str(&format!("| {size_col} | {time} | {throughput_str:>12} |\n"));
             }
         }
 

--- a/src/bin/succinctly/dsv_generators.rs
+++ b/src/bin/succinctly/dsv_generators.rs
@@ -63,41 +63,24 @@ fn generate_tabular(
 
     if include_header {
         csv.push_str(&format!(
-            "id{}name{}email{}age{}score{}active{}created\n",
-            delimiter, delimiter, delimiter, delimiter, delimiter, delimiter
+            "id{delimiter}name{delimiter}email{delimiter}age{delimiter}score{delimiter}active{delimiter}created\n"
         ));
     }
 
     let mut row_id = 1;
     while csv.len() < target_size {
-        let age = rng.as_mut().map(|r| r.gen_range(18..80)).unwrap_or(25);
+        let age = rng.as_mut().map_or(25, |r| r.gen_range(18..80));
         let score = rng
             .as_mut()
-            .map(|r| r.gen_range(0..10000))
-            .unwrap_or(row_id * 10);
+            .map_or(row_id * 10, |r| r.gen_range(0..10000));
         let active = rng
             .as_mut()
-            .map(|r| r.r#gen::<bool>())
-            .unwrap_or(row_id % 2 == 0);
+            .map_or(row_id % 2 == 0, rand::Rng::gen::<bool>);
         let day = (row_id % 28) + 1;
         let month = (row_id % 12) + 1;
 
         csv.push_str(&format!(
-            "{}{}User{}{}user{}@example.com{}{}{}{}{}{}{}2024-{:02}-{:02}\n",
-            row_id,
-            delimiter,
-            row_id,
-            delimiter,
-            row_id,
-            delimiter,
-            age,
-            delimiter,
-            score,
-            delimiter,
-            active,
-            delimiter,
-            month,
-            day
+            "{row_id}{delimiter}User{row_id}{delimiter}user{row_id}@example.com{delimiter}{age}{delimiter}{score}{delimiter}{active}{delimiter}2024-{month:02}-{day:02}\n"
         ));
 
         row_id += 1;
@@ -139,8 +122,7 @@ fn generate_users(
 
     if include_header {
         csv.push_str(&format!(
-            "id{}first_name{}last_name{}email{}phone{}city{}country{}age{}salary\n",
-            delimiter, delimiter, delimiter, delimiter, delimiter, delimiter, delimiter, delimiter
+            "id{delimiter}first_name{delimiter}last_name{delimiter}email{delimiter}phone{delimiter}city{delimiter}country{delimiter}age{delimiter}salary\n"
         ));
     }
 
@@ -150,15 +132,13 @@ fn generate_users(
         let last = last_names[(row_id / 10) % last_names.len()];
         let city = cities[row_id % cities.len()];
         let country = countries[row_id % countries.len()];
-        let age = rng.as_mut().map(|r| r.gen_range(22..65)).unwrap_or(30);
+        let age = rng.as_mut().map_or(30, |r| r.gen_range(22..65));
         let salary = rng
             .as_mut()
-            .map(|r| r.gen_range(30000..200000))
-            .unwrap_or(50000);
+            .map_or(50000, |r| r.gen_range(30000..200000));
         let phone_suffix = rng
             .as_mut()
-            .map(|r| r.gen_range(1000..9999))
-            .unwrap_or(1234);
+            .map_or(1234, |r| r.gen_range(1000..9999));
 
         csv.push_str(&format!(
             "{}{}{}{}{}{}{}.{}@example.com{}+1-555-{:04}{}{}{}{}{}{}{}{}",
@@ -201,8 +181,7 @@ fn generate_numeric(
 
     if include_header {
         csv.push_str(&format!(
-            "id{}value1{}value2{}value3{}value4{}value5{}total{}average\n",
-            delimiter, delimiter, delimiter, delimiter, delimiter, delimiter, delimiter
+            "id{delimiter}value1{delimiter}value2{delimiter}value3{delimiter}value4{delimiter}value5{delimiter}total{delimiter}average\n"
         ));
     }
 
@@ -210,44 +189,24 @@ fn generate_numeric(
     while csv.len() < target_size {
         let v1: f64 = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() * 1000.0)
-            .unwrap_or(row_id as f64);
+            .map_or(row_id as f64, |r| r.r#gen::<f64>() * 1000.0);
         let v2: f64 = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() * 1000.0)
-            .unwrap_or(row_id as f64 * 1.5);
+            .map_or(row_id as f64 * 1.5, |r| r.r#gen::<f64>() * 1000.0);
         let v3: f64 = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() * 1000.0)
-            .unwrap_or(row_id as f64 * 2.0);
+            .map_or(row_id as f64 * 2.0, |r| r.r#gen::<f64>() * 1000.0);
         let v4: f64 = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() * 1000.0)
-            .unwrap_or(row_id as f64 * 2.5);
+            .map_or(row_id as f64 * 2.5, |r| r.r#gen::<f64>() * 1000.0);
         let v5: f64 = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() * 1000.0)
-            .unwrap_or(row_id as f64 * 3.0);
+            .map_or(row_id as f64 * 3.0, |r| r.r#gen::<f64>() * 1000.0);
         let total = v1 + v2 + v3 + v4 + v5;
         let avg = total / 5.0;
 
         csv.push_str(&format!(
-            "{}{}{:.4}{}{:.4}{}{:.4}{}{:.4}{}{:.4}{}{:.4}{}{:.4}\n",
-            row_id,
-            delimiter,
-            v1,
-            delimiter,
-            v2,
-            delimiter,
-            v3,
-            delimiter,
-            v4,
-            delimiter,
-            v5,
-            delimiter,
-            total,
-            delimiter,
-            avg
+            "{row_id}{delimiter}{v1:.4}{delimiter}{v2:.4}{delimiter}{v3:.4}{delimiter}{v4:.4}{delimiter}{v5:.4}{delimiter}{total:.4}{delimiter}{avg:.4}\n"
         ));
 
         row_id += 1;
@@ -288,37 +247,35 @@ fn generate_strings(
 
     if include_header {
         csv.push_str(&format!(
-            "id{}title{}description{}notes\n",
-            delimiter, delimiter, delimiter
+            "id{delimiter}title{delimiter}description{delimiter}notes\n"
         ));
     }
 
     let mut row_id = 1;
     while csv.len() < target_size {
         // Generate title (3-5 words)
-        let title_len = rng.as_mut().map(|r| r.gen_range(3..6)).unwrap_or(4);
+        let title_len = rng.as_mut().map_or(4, |r| r.gen_range(3..6));
         let title: String = (0..title_len)
             .map(|i| lorem_words[(row_id + i) % lorem_words.len()])
             .collect::<Vec<_>>()
             .join(" ");
 
         // Generate description (10-20 words)
-        let desc_len = rng.as_mut().map(|r| r.gen_range(10..21)).unwrap_or(15);
+        let desc_len = rng.as_mut().map_or(15, |r| r.gen_range(10..21));
         let description: String = (0..desc_len)
             .map(|i| lorem_words[(row_id * 2 + i) % lorem_words.len()])
             .collect::<Vec<_>>()
             .join(" ");
 
         // Generate notes (5-10 words)
-        let notes_len = rng.as_mut().map(|r| r.gen_range(5..11)).unwrap_or(7);
+        let notes_len = rng.as_mut().map_or(7, |r| r.gen_range(5..11));
         let notes: String = (0..notes_len)
             .map(|i| lorem_words[(row_id * 3 + i) % lorem_words.len()])
             .collect::<Vec<_>>()
             .join(" ");
 
         csv.push_str(&format!(
-            "{}{}{}{}{}{}{}",
-            row_id, delimiter, title, delimiter, description, delimiter, notes
+            "{row_id}{delimiter}{title}{delimiter}{description}{delimiter}{notes}"
         ));
         csv.push('\n');
 
@@ -340,8 +297,7 @@ fn generate_quoted(
 
     if include_header {
         csv.push_str(&format!(
-            "id{}name{}address{}notes\n",
-            delimiter, delimiter, delimiter
+            "id{delimiter}name{delimiter}address{delimiter}notes\n"
         ));
     }
 
@@ -352,28 +308,26 @@ fn generate_quoted(
 
     let mut row_id = 1;
     while csv.len() < target_size {
-        let street_num = rng.as_mut().map(|r| r.gen_range(1..9999)).unwrap_or(123);
+        let street_num = rng.as_mut().map_or(123, |r| r.gen_range(1..9999));
         let street = street_names[row_id % street_names.len()];
         let city = cities[row_id % cities.len()];
         let zip = 10000 + (row_id % 90000);
 
         // Address contains delimiter, must be quoted
         let address = format!(
-            "{} {}{} {}{} {}",
-            street_num, street, delimiter, city, delimiter, zip
+            "{street_num} {street}{delimiter} {city}{delimiter} {zip}"
         );
 
         // Notes may contain delimiter
         let notes = if row_id % 3 == 0 {
-            format!("Note with{} delimiter", delimiter)
+            format!("Note with{delimiter} delimiter")
         } else {
-            format!("Simple note {}", row_id)
+            format!("Simple note {row_id}")
         };
 
         // Quote fields that contain delimiter
         csv.push_str(&format!(
-            "{}{}\"User{} Name\"{}\"{}\"{}\"{}\"",
-            row_id, delimiter, row_id, delimiter, address, delimiter, notes
+            "{row_id}{delimiter}\"User{row_id} Name\"{delimiter}\"{address}\"{delimiter}\"{notes}\""
         ));
         csv.push('\n');
 
@@ -395,14 +349,13 @@ fn generate_multiline(
 
     if include_header {
         csv.push_str(&format!(
-            "id{}title{}body{}author\n",
-            delimiter, delimiter, delimiter
+            "id{delimiter}title{delimiter}body{delimiter}author\n"
         ));
     }
 
     let mut row_id = 1;
     while csv.len() < target_size {
-        let num_lines = rng.as_mut().map(|r| r.gen_range(2..5)).unwrap_or(3);
+        let num_lines = rng.as_mut().map_or(3, |r| r.gen_range(2..5));
 
         // Body contains newlines, must be quoted
         let body_lines: Vec<String> = (0..num_lines)
@@ -411,8 +364,7 @@ fn generate_multiline(
         let body = body_lines.join("\n");
 
         csv.push_str(&format!(
-            "{}{}Title {}{}\"{}\"{}Author{}",
-            row_id, delimiter, row_id, delimiter, body, delimiter, row_id
+            "{row_id}{delimiter}Title {row_id}{delimiter}\"{body}\"{delimiter}Author{row_id}"
         ));
         csv.push('\n');
 
@@ -434,7 +386,7 @@ fn generate_wide(
     let num_columns = 50;
 
     if include_header {
-        let headers: Vec<String> = (0..num_columns).map(|i| format!("col{}", i)).collect();
+        let headers: Vec<String> = (0..num_columns).map(|i| format!("col{i}")).collect();
         csv.push_str(&headers.join(&delimiter.to_string()));
         csv.push('\n');
     }
@@ -445,8 +397,7 @@ fn generate_wide(
             .map(|col| {
                 let val = rng
                     .as_mut()
-                    .map(|r| r.gen_range(0..1000))
-                    .unwrap_or(row_id * col);
+                    .map_or(row_id * col, |r| r.gen_range(0..1000));
                 val.to_string()
             })
             .collect();
@@ -471,16 +422,15 @@ fn generate_long(
     let mut csv = String::with_capacity(target_size);
 
     if include_header {
-        csv.push_str(&format!("id{}value\n", delimiter));
+        csv.push_str(&format!("id{delimiter}value\n"));
     }
 
     let mut row_id = 1;
     while csv.len() < target_size {
         let value = rng
             .as_mut()
-            .map(|r| r.gen_range(0..1000000))
-            .unwrap_or(row_id);
-        csv.push_str(&format!("{}{}{}\n", row_id, delimiter, value));
+            .map_or(row_id, |r| r.gen_range(0..1000000));
+        csv.push_str(&format!("{row_id}{delimiter}{value}\n"));
         row_id += 1;
     }
 
@@ -499,8 +449,7 @@ fn generate_mixed(
 
     if include_header {
         csv.push_str(&format!(
-            "id{}int_val{}float_val{}bool_val{}string_val{}date_val\n",
-            delimiter, delimiter, delimiter, delimiter, delimiter
+            "id{delimiter}int_val{delimiter}float_val{delimiter}bool_val{delimiter}string_val{delimiter}date_val\n"
         ));
     }
 
@@ -508,33 +457,18 @@ fn generate_mixed(
     while csv.len() < target_size {
         let int_val = rng
             .as_mut()
-            .map(|r| r.gen_range(-1000..1000))
-            .unwrap_or(row_id);
+            .map_or(row_id, |r| r.gen_range(-1000..1000));
         let float_val: f64 = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() * 1000.0 - 500.0)
-            .unwrap_or(row_id as f64 * 1.5);
+            .map_or(row_id as f64 * 1.5, |r| r.r#gen::<f64>() * 1000.0 - 500.0);
         let bool_val = rng
             .as_mut()
-            .map(|r| r.r#gen::<bool>())
-            .unwrap_or(row_id % 2 == 0);
+            .map_or(row_id % 2 == 0, rand::Rng::gen::<bool>);
         let day = (row_id % 28) + 1;
         let month = (row_id % 12) + 1;
 
         csv.push_str(&format!(
-            "{}{}{}{}{}{}{}{}value_{}{}2024-{:02}-{:02}\n",
-            row_id,
-            delimiter,
-            int_val,
-            delimiter,
-            float_val,
-            delimiter,
-            bool_val,
-            delimiter,
-            row_id,
-            delimiter,
-            month,
-            day
+            "{row_id}{delimiter}{int_val}{delimiter}{float_val}{delimiter}{bool_val}{delimiter}value_{row_id}{delimiter}2024-{month:02}-{day:02}\n"
         ));
 
         row_id += 1;
@@ -555,28 +489,26 @@ fn generate_pathological(
 
     if include_header {
         csv.push_str(&format!(
-            "\"id\"{}\"field1\"{}\"field2\"{}\"field3\"\n",
-            delimiter, delimiter, delimiter
+            "\"id\"{delimiter}\"field1\"{delimiter}\"field2\"{delimiter}\"field3\"\n"
         ));
     }
 
     let mut row_id = 1;
     while csv.len() < target_size {
         // Every field contains delimiter, quotes, or both
-        let extra = rng.as_mut().map(|r| r.gen_range(0..100)).unwrap_or(row_id);
+        let extra = rng.as_mut().map_or(row_id, |r| r.gen_range(0..100));
 
         // Field with embedded delimiter
-        let field1 = format!("value{}with{}delimiter", delimiter, extra);
+        let field1 = format!("value{delimiter}with{extra}delimiter");
 
         // Field with embedded quotes (doubled for CSV escaping)
-        let field2 = format!("say \"\"hello\"\" {}", row_id);
+        let field2 = format!("say \"\"hello\"\" {row_id}");
 
         // Field with both delimiter and quotes
-        let field3 = format!("complex{}\"\"data\"\"", delimiter);
+        let field3 = format!("complex{delimiter}\"\"data\"\"");
 
         csv.push_str(&format!(
-            "{}{}\"{}\"{}\"{}\"{}\"{}\"",
-            row_id, delimiter, field1, delimiter, field2, delimiter, field3
+            "{row_id}{delimiter}\"{field1}\"{delimiter}\"{field2}\"{delimiter}\"{field3}\""
         ));
         csv.push('\n');
 

--- a/src/bin/succinctly/dsv_generators.rs
+++ b/src/bin/succinctly/dsv_generators.rs
@@ -70,12 +70,8 @@ fn generate_tabular(
     let mut row_id = 1;
     while csv.len() < target_size {
         let age = rng.as_mut().map_or(25, |r| r.gen_range(18..80));
-        let score = rng
-            .as_mut()
-            .map_or(row_id * 10, |r| r.gen_range(0..10000));
-        let active = rng
-            .as_mut()
-            .map_or(row_id % 2 == 0, rand::Rng::gen::<bool>);
+        let score = rng.as_mut().map_or(row_id * 10, |r| r.gen_range(0..10000));
+        let active = rng.as_mut().map_or(row_id % 2 == 0, rand::Rng::gen::<bool>);
         let day = (row_id % 28) + 1;
         let month = (row_id % 12) + 1;
 
@@ -133,12 +129,8 @@ fn generate_users(
         let city = cities[row_id % cities.len()];
         let country = countries[row_id % countries.len()];
         let age = rng.as_mut().map_or(30, |r| r.gen_range(22..65));
-        let salary = rng
-            .as_mut()
-            .map_or(50000, |r| r.gen_range(30000..200000));
-        let phone_suffix = rng
-            .as_mut()
-            .map_or(1234, |r| r.gen_range(1000..9999));
+        let salary = rng.as_mut().map_or(50000, |r| r.gen_range(30000..200000));
+        let phone_suffix = rng.as_mut().map_or(1234, |r| r.gen_range(1000..9999));
 
         csv.push_str(&format!(
             "{}{}{}{}{}{}{}.{}@example.com{}+1-555-{:04}{}{}{}{}{}{}{}{}",
@@ -314,9 +306,7 @@ fn generate_quoted(
         let zip = 10000 + (row_id % 90000);
 
         // Address contains delimiter, must be quoted
-        let address = format!(
-            "{street_num} {street}{delimiter} {city}{delimiter} {zip}"
-        );
+        let address = format!("{street_num} {street}{delimiter} {city}{delimiter} {zip}");
 
         // Notes may contain delimiter
         let notes = if row_id % 3 == 0 {
@@ -395,9 +385,7 @@ fn generate_wide(
     while csv.len() < target_size {
         let values: Vec<String> = (0..num_columns)
             .map(|col| {
-                let val = rng
-                    .as_mut()
-                    .map_or(row_id * col, |r| r.gen_range(0..1000));
+                let val = rng.as_mut().map_or(row_id * col, |r| r.gen_range(0..1000));
                 val.to_string()
             })
             .collect();
@@ -427,9 +415,7 @@ fn generate_long(
 
     let mut row_id = 1;
     while csv.len() < target_size {
-        let value = rng
-            .as_mut()
-            .map_or(row_id, |r| r.gen_range(0..1000000));
+        let value = rng.as_mut().map_or(row_id, |r| r.gen_range(0..1000000));
         csv.push_str(&format!("{row_id}{delimiter}{value}\n"));
         row_id += 1;
     }
@@ -455,15 +441,11 @@ fn generate_mixed(
 
     let mut row_id = 1;
     while csv.len() < target_size {
-        let int_val = rng
-            .as_mut()
-            .map_or(row_id, |r| r.gen_range(-1000..1000));
+        let int_val = rng.as_mut().map_or(row_id, |r| r.gen_range(-1000..1000));
         let float_val: f64 = rng
             .as_mut()
             .map_or(row_id as f64 * 1.5, |r| r.r#gen::<f64>() * 1000.0 - 500.0);
-        let bool_val = rng
-            .as_mut()
-            .map_or(row_id % 2 == 0, rand::Rng::gen::<bool>);
+        let bool_val = rng.as_mut().map_or(row_id % 2 == 0, rand::Rng::gen::<bool>);
         let day = (row_id % 28) + 1;
         let month = (row_id % 12) + 1;
 

--- a/src/bin/succinctly/generators.rs
+++ b/src/bin/succinctly/generators.rs
@@ -163,7 +163,9 @@ fn add_string_variations(
         // Mix escaped and normal strings based on density
         let use_escape = rng
             .as_mut()
-            .map_or(count % 10 < (escape_density * 10.0) as usize, |r| r.r#gen::<f64>() < escape_density);
+            .map_or(count % 10 < (escape_density * 10.0) as usize, |r| {
+                r.r#gen::<f64>() < escape_density
+            });
 
         if use_escape {
             let pattern = &escape_patterns[count % escape_patterns.len()];
@@ -190,9 +192,9 @@ fn add_number_variations(json: &mut String, target_size: usize, rng: &mut Option
 
         let num = match count % 8 {
             0 => count.to_string(),                              // Simple integer
-            1 => format!("-{count}"),                          // Negative integer
-            2 => format!("0.{count}"),                         // Decimal < 1
-            3 => format!("{count}.{count}"),                 // Decimal
+            1 => format!("-{count}"),                            // Negative integer
+            2 => format!("0.{count}"),                           // Decimal < 1
+            3 => format!("{count}.{count}"),                     // Decimal
             4 => format!("{}e{}", count, count % 10),            // Scientific notation
             5 => format!("-{}.{}e-{}", count, count, count % 5), // Negative scientific
             6 => "0".to_string(),                                // Zero
@@ -363,12 +365,8 @@ fn add_realistic_records(
         }
 
         let age = rng.as_mut().map_or(25, |r| r.gen_range(18..80));
-        let score = rng
-            .as_mut()
-            .map_or(count * 10, |r| r.gen_range(0..1000));
-        let active = rng
-            .as_mut()
-            .map_or(count % 2 == 0, rand::Rng::gen::<bool>);
+        let score = rng.as_mut().map_or(count * 10, |r| r.gen_range(0..1000));
+        let active = rng.as_mut().map_or(count % 2 == 0, rand::Rng::gen::<bool>);
         let salary = rng
             .as_mut()
             .map_or(50000.0, |r| r.r#gen::<f64>() * 200000.0);
@@ -609,9 +607,9 @@ pub fn generate_numbers_json(target_size: usize, seed: Option<u64>) -> String {
             json.push(',');
         }
 
-        let num = rng
-            .as_mut()
-            .map_or(i as f64 * std::f64::consts::PI, |r| r.r#gen::<f64>() * 1000000.0);
+        let num = rng.as_mut().map_or(i as f64 * std::f64::consts::PI, |r| {
+            r.r#gen::<f64>() * 1000000.0
+        });
 
         json.push_str(&format!("{num:.6}"));
 

--- a/src/bin/succinctly/generators.rs
+++ b/src/bin/succinctly/generators.rs
@@ -110,15 +110,15 @@ fn add_simple_values(json: &mut String, target_size: usize, rng: &mut Option<Cha
             json.push(',');
         }
 
-        let key = format!("field_{}", count);
-        let val = match rng.as_mut().map(|r| r.gen_range(0..4)).unwrap_or(count % 4) {
+        let key = format!("field_{count}");
+        let val = match rng.as_mut().map_or(count % 4, |r| r.gen_range(0..4)) {
             0 => "true".to_string(),
             1 => "false".to_string(),
             2 => "null".to_string(),
             _ => count.to_string(),
         };
 
-        json.push_str(&format!(r#""{}":"#, key));
+        json.push_str(&format!(r#""{key}":"#));
         json.push_str(&val);
         count += 1;
     }
@@ -136,11 +136,11 @@ fn add_string_variations(
 
     let escape_patterns = [
         r#"Line with \"quoted\" text"#,
-        r#"Path: C:\\Users\\test\\file.txt"#,
-        r#"Line with\nnewline"#,
-        r#"Tab\tseparated\tvalues"#,
+        r"Path: C:\\Users\\test\\file.txt",
+        r"Line with\nnewline",
+        r"Tab\tseparated\tvalues",
         r#"JSON: {\"key\":\"value\"}"#,
-        r#"Backspace:\b Formfeed:\f"#,
+        r"Backspace:\b Formfeed:\f",
         r#"Mixed: \"quotes\"\tand\nnewlines"#,
     ];
 
@@ -163,8 +163,7 @@ fn add_string_variations(
         // Mix escaped and normal strings based on density
         let use_escape = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() < escape_density)
-            .unwrap_or(count % 10 < (escape_density * 10.0) as usize);
+            .map_or(count % 10 < (escape_density * 10.0) as usize, |r| r.r#gen::<f64>() < escape_density);
 
         if use_escape {
             let pattern = &escape_patterns[count % escape_patterns.len()];
@@ -191,18 +190,17 @@ fn add_number_variations(json: &mut String, target_size: usize, rng: &mut Option
 
         let num = match count % 8 {
             0 => count.to_string(),                              // Simple integer
-            1 => format!("-{}", count),                          // Negative integer
-            2 => format!("0.{}", count),                         // Decimal < 1
-            3 => format!("{}.{}", count, count),                 // Decimal
+            1 => format!("-{count}"),                          // Negative integer
+            2 => format!("0.{count}"),                         // Decimal < 1
+            3 => format!("{count}.{count}"),                 // Decimal
             4 => format!("{}e{}", count, count % 10),            // Scientific notation
             5 => format!("-{}.{}e-{}", count, count, count % 5), // Negative scientific
             6 => "0".to_string(),                                // Zero
             _ => {
                 let val = rng
                     .as_mut()
-                    .map(|r| r.r#gen::<f64>() * 1000000.0 - 500000.0)
-                    .unwrap_or(count as f64);
-                format!("{:.6}", val)
+                    .map_or(count as f64, |r| r.r#gen::<f64>() * 1000000.0 - 500000.0);
+                format!("{val:.6}")
             }
         };
 
@@ -236,9 +234,9 @@ fn add_array_variations(
         if i > 0 {
             json.push(',');
         }
-        json.push_str(&format!(r#""item_{}""#, i));
+        json.push_str(&format!(r#""item_{i}""#));
     }
-    json.push_str(r#"],"#);
+    json.push_str(r"],");
 
     // Nested arrays
     json.push_str(r#""nested":["#);
@@ -257,7 +255,7 @@ fn add_array_variations(
         json.push(']');
         level += 1;
     }
-    json.push_str(r#"],"#);
+    json.push_str(r"],");
 
     // Mixed type arrays
     json.push_str(r#""mixed":[1,"two",true,null,{"key":"value"},[1,2,3]],"#);
@@ -271,7 +269,7 @@ fn add_array_variations(
         }
         first = false;
         json.push('[');
-        let array_len = rng.as_mut().map(|r| r.gen_range(3..10)).unwrap_or(5);
+        let array_len = rng.as_mut().map_or(5, |r| r.gen_range(3..10));
         for i in 0..array_len {
             if i > 0 {
                 json.push(',');
@@ -299,7 +297,7 @@ fn add_nested_objects(
 
     json.push_str(r#""deep":"#);
     for level in 0..depth.min(20) {
-        json.push_str(&format!(r#"{{"level_{}":"#, level));
+        json.push_str(&format!(r#"{{"level_{level}":"#));
     }
     json.push_str(r#""bottom""#);
     for _ in 0..depth.min(20) {
@@ -331,13 +329,13 @@ fn add_tree_structure(
         return;
     }
 
-    let num_children = rng.as_mut().map(|r| r.gen_range(2..5)).unwrap_or(3);
+    let num_children = rng.as_mut().map_or(3, |r| r.gen_range(2..5));
 
     for i in 0..num_children {
         if i > 0 {
             json.push(',');
         }
-        json.push_str(&format!(r#""child_{}":{{"#, i));
+        json.push_str(&format!(r#""child_{i}":{{"#));
         add_tree_structure(
             json,
             remaining / num_children,
@@ -364,29 +362,25 @@ fn add_realistic_records(
             json.push(',');
         }
 
-        let age = rng.as_mut().map(|r| r.gen_range(18..80)).unwrap_or(25);
+        let age = rng.as_mut().map_or(25, |r| r.gen_range(18..80));
         let score = rng
             .as_mut()
-            .map(|r| r.gen_range(0..1000))
-            .unwrap_or(count * 10);
+            .map_or(count * 10, |r| r.gen_range(0..1000));
         let active = rng
             .as_mut()
-            .map(|r| r.r#gen::<bool>())
-            .unwrap_or(count % 2 == 0);
+            .map_or(count % 2 == 0, rand::Rng::gen::<bool>);
         let salary = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() * 200000.0)
-            .unwrap_or(50000.0);
+            .map_or(50000.0, |r| r.r#gen::<f64>() * 200000.0);
 
         // Add escaped characters to some fields
         let name = if rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() < escape_density)
-            .unwrap_or(false)
+            .is_some_and(|r| r.r#gen::<f64>() < escape_density)
         {
-            format!(r#"User \"{}\" Smith"#, count)
+            format!(r#"User \"{count}\" Smith"#)
         } else {
-            format!("User{}", count)
+            format!("User{count}")
         };
 
         json.push_str(&format!(
@@ -463,12 +457,11 @@ pub fn generate_users_json(target_size: usize, seed: Option<u64>) -> String {
             json.push(',');
         }
 
-        let age = rng.as_mut().map(|r| r.gen_range(18..80)).unwrap_or(25);
-        let score = rng.as_mut().map(|r| r.gen_range(0..1000)).unwrap_or(i * 10);
+        let age = rng.as_mut().map_or(25, |r| r.gen_range(18..80));
+        let score = rng.as_mut().map_or(i * 10, |r| r.gen_range(0..1000));
 
         json.push_str(&format!(
-            r#"{{"id":{},"name":"User{}","email":"user{}@example.com","age":{},"active":true,"score":{}}}"#,
-            i, i, i, age, score
+            r#"{{"id":{i},"name":"User{i}","email":"user{i}@example.com","age":{age},"active":true,"score":{score}}}"#
         ));
 
         // Stop if we've exceeded target size
@@ -523,7 +516,7 @@ pub fn generate_arrays_json(target_size: usize, seed: Option<u64>) -> String {
             if j > 0 {
                 json.push(',');
             }
-            let val = rng.as_mut().map(|r| r.gen_range(0..1000)).unwrap_or(j);
+            let val = rng.as_mut().map_or(j, |r| r.gen_range(0..1000));
             json.push_str(&val.to_string());
         }
         json.push(']');
@@ -553,16 +546,15 @@ pub fn generate_mixed_json(target_size: usize, seed: Option<u64>) -> String {
 
         let pattern_idx = rng
             .as_mut()
-            .map(|r| r.gen_range(0..patterns.len()))
-            .unwrap_or(i % patterns.len());
+            .map_or(i % patterns.len(), |r| r.gen_range(0..patterns.len()));
 
         match patterns[pattern_idx] {
-            "string" => json.push_str(&format!(r#""value_{}""#, i)),
+            "string" => json.push_str(&format!(r#""value_{i}""#)),
             "number" => json.push_str(&i.to_string()),
             "bool" => json.push_str(if i % 2 == 0 { "true" } else { "false" }),
             "null" => json.push_str("null"),
             "array" => json.push_str(&format!("[{},{},{}]", i, i + 1, i + 2)),
-            "object" => json.push_str(&format!(r#"{{"key":"val_{}"}}"#, i)),
+            "object" => json.push_str(&format!(r#"{{"key":"val_{i}"}}"#)),
             _ => {}
         }
 
@@ -619,10 +611,9 @@ pub fn generate_numbers_json(target_size: usize, seed: Option<u64>) -> String {
 
         let num = rng
             .as_mut()
-            .map(|r| r.r#gen::<f64>() * 1000000.0)
-            .unwrap_or(i as f64 * std::f64::consts::PI);
+            .map_or(i as f64 * std::f64::consts::PI, |r| r.r#gen::<f64>() * 1000000.0);
 
-        json.push_str(&format!("{:.6}", num));
+        json.push_str(&format!("{num:.6}"));
 
         if json.len() >= target_size.saturating_sub(10) {
             break;
@@ -645,7 +636,7 @@ pub fn generate_literals_json(target_size: usize, seed: Option<u64>) -> String {
             json.push(',');
         }
 
-        let val = match rng.as_mut().map(|r| r.gen_range(0..3)).unwrap_or(count % 3) {
+        let val = match rng.as_mut().map_or(count % 3, |r| r.gen_range(0..3)) {
             0 => "true",
             1 => "false",
             _ => "null",
@@ -667,7 +658,7 @@ pub fn generate_unicode_json(target_size: usize, seed: Option<u64>) -> String {
         target_size,
         &mut seed.map(ChaCha8Rng::seed_from_u64),
     );
-    format!(r#"{{"unicode":[{}]}}"#, json)
+    format!(r#"{{"unicode":[{json}]}}"#)
 }
 
 /// Generate pathological JSON (worst-case for parsing)

--- a/src/bin/succinctly/jq_bench.rs
+++ b/src/bin/succinctly/jq_bench.rs
@@ -125,7 +125,7 @@ pub fn run_benchmark(
                 break 'outer;
             }
 
-            let file_path = config.data_dir.join(pattern).join(format!("{}.json", size));
+            let file_path = config.data_dir.join(pattern).join(format!("{size}.json"));
 
             if !file_path.exists() {
                 eprintln!("  Skipping {} (not found)", file_path.display());
@@ -167,7 +167,7 @@ pub fn run_benchmark(
                     results.push(result);
                 }
                 Err(e) => {
-                    eprintln!("ERROR: {}", e);
+                    eprintln!("ERROR: {e}");
                 }
             }
         }
@@ -310,7 +310,7 @@ fn run_command_with_timing(program: &str, args: &[&str]) -> Result<ToolResult> {
         let output = Command::new(program)
             .args(args)
             .output()
-            .with_context(|| format!("Failed to run {}", program))?;
+            .with_context(|| format!("Failed to run {program}"))?;
         (output.stdout, 0, 0.0, 0.0)
     };
 
@@ -493,7 +493,7 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
 
     // Add CPU info
     let cpu_info = get_cpu_info();
-    md.push_str(&format!("**CPU**: {}\n\n", cpu_info));
+    md.push_str(&format!("**CPU**: {cpu_info}\n\n"));
 
     // Group by pattern (alphabetical order)
     let patterns = [
@@ -519,7 +519,7 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
             continue;
         }
 
-        md.push_str(&format!("## Pattern: {}\n\n", pattern));
+        md.push_str(&format!("## Pattern: {pattern}\n\n"));
         // Column widths (content only, not including | separators):
         // Size: 9 chars (e.g., "**10mb** ")
         // jq: 8 chars (e.g., "  336.7ms")
@@ -553,7 +553,7 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
 
             // Size column: **name** with trailing padding (9 chars total)
             let size_bold = format!("**{}**", r.size);
-            let size_col = format!("{:<9}", size_bold);
+            let size_col = format!("{size_bold:<9}");
 
             // jq time column: already 8 chars from format_time_fixed
             let jq_col = jq_time;
@@ -566,20 +566,20 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
                 let padding = succ_time.len() - trimmed.len();
                 format!("{}**{}**", " ".repeat(padding), trimmed) // spaces before **, not after
             } else {
-                format!("  {}  ", succ_time) // 8 + 4 = 12 chars, same visual width
+                format!("  {succ_time}  ") // 8 + 4 = 12 chars, same visual width
             };
 
             // Speedup column: bold if >= 1.0 (13 chars visual width)
             // Move leading spaces outside ** so markdown renders correctly
-            let speedup_str = format!("{:.1}x", speedup);
+            let speedup_str = format!("{speedup:.1}x");
             let speedup_col = if speedup >= 1.0 {
                 // Right-align: total 9 chars visual, with ** markers = 13 chars
-                let padded = format!("{:>9}", speedup_str);
+                let padded = format!("{speedup_str:>9}");
                 let trimmed = padded.trim_start();
                 let padding = padded.len() - trimmed.len();
                 format!("{}**{}**", " ".repeat(padding), trimmed)
             } else {
-                format!("{:>13}", speedup_str) // Same visual width without bold
+                format!("{speedup_str:>13}") // Same visual width without bold
             };
 
             if memory_mode {
@@ -590,23 +590,15 @@ pub fn generate_markdown(results: &[BenchmarkResult], memory_mode: bool) -> Stri
 
                 // Memory columns: right-aligned, format_memory_fixed returns 7 chars
                 let jq_mem_col = jq_mem;
-                let succ_mem_col = format!("{:>8}", succ_mem); // 8 chars for succ Mem column
-                let mem_ratio_col = format!("{:>9.2}x", mem_ratio);
+                let succ_mem_col = format!("{succ_mem:>8}"); // 8 chars for succ Mem column
+                let mem_ratio_col = format!("{mem_ratio:>9.2}x");
 
                 md.push_str(&format!(
-                    "| {} | {} | {} | {} | {} | {} | {} |\n",
-                    size_col,
-                    jq_col,
-                    succ_col,
-                    speedup_col,
-                    jq_mem_col,
-                    succ_mem_col,
-                    mem_ratio_col
+                    "| {size_col} | {jq_col} | {succ_col} | {speedup_col} | {jq_mem_col} | {succ_mem_col} | {mem_ratio_col} |\n"
                 ));
             } else {
                 md.push_str(&format!(
-                    "| {} | {} | {} | {} |\n",
-                    size_col, jq_col, succ_col, speedup_col
+                    "| {size_col} | {jq_col} | {succ_col} | {speedup_col} |\n"
                 ));
             }
         }
@@ -625,8 +617,8 @@ fn format_time_fixed(ms: f64) -> String {
         format!("{:>7.2}s", ms / 1000.0)
     } else {
         // Milliseconds: " 765.6ms" = 8 chars total (padding on left)
-        let ms_str = format!("{:.1}ms", ms);
-        format!("{:>8}", ms_str)
+        let ms_str = format!("{ms:.1}ms");
+        format!("{ms_str:>8}")
     }
 }
 
@@ -640,7 +632,7 @@ fn format_memory_fixed(bytes: u64) -> String {
     } else if bytes >= 1024 {
         format!("{:>4.0} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{:>4} B ", bytes)
+        format!("{bytes:>4} B ")
     }
 }
 
@@ -653,7 +645,7 @@ fn format_bytes(bytes: usize) -> String {
     } else if bytes >= 1024 {
         format!("{:.2} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{} bytes", bytes)
+        format!("{bytes} bytes")
     }
 }
 
@@ -686,13 +678,11 @@ mod tests {
         // Spaces should be BEFORE **, not after
         assert!(
             succ_col.starts_with("  **"),
-            "Expected spaces before **, got: {}",
-            succ_col
+            "Expected spaces before **, got: {succ_col}"
         );
         assert!(
             !succ_col.contains("** "),
-            "Spaces should not be inside **: {}",
-            succ_col
+            "Spaces should not be inside **: {succ_col}"
         );
         assert_eq!(succ_col, "  **59.6ms**");
     }
@@ -701,8 +691,8 @@ mod tests {
     fn test_speedup_bold_formatting() {
         // Simulate speedup column formatting
         let speedup = 5.8;
-        let speedup_str = format!("{:.1}x", speedup);
-        let padded = format!("{:>9}", speedup_str);
+        let speedup_str = format!("{speedup:.1}x");
+        let padded = format!("{speedup_str:>9}");
         let trimmed = padded.trim_start();
         let padding = padded.len() - trimmed.len();
         let speedup_col = format!("{}**{}**", " ".repeat(padding), trimmed);
@@ -710,13 +700,11 @@ mod tests {
         // Spaces should be BEFORE **, not after
         assert!(
             speedup_col.contains("**5.8x**"),
-            "Expected **5.8x**, got: {}",
-            speedup_col
+            "Expected **5.8x**, got: {speedup_col}"
         );
         assert!(
             !speedup_col.contains("** "),
-            "Spaces should not be inside **: {}",
-            speedup_col
+            "Spaces should not be inside **: {speedup_col}"
         );
     }
 }

--- a/src/bin/succinctly/jq_locate.rs
+++ b/src/bin/succinctly/jq_locate.rs
@@ -56,7 +56,7 @@ pub fn run_jq_locate(args: JqLocateArgs) -> Result<i32> {
             let newline_index = NewlineIndex::build(&text);
             newline_index
                 .to_offset(line, column)
-                .with_context(|| format!("Invalid position: line {} column {}", line, column))?
+                .with_context(|| format!("Invalid position: line {line} column {column}"))?
         }
         (None, None, None) => {
             anyhow::bail!("Either --offset or --line/--column must be specified");
@@ -78,7 +78,7 @@ pub fn run_jq_locate(args: JqLocateArgs) -> Result<i32> {
 
     // Locate the position
     let result = locate_offset_detailed(&index, &text, offset)
-        .with_context(|| format!("Could not locate position at offset {}", offset))?;
+        .with_context(|| format!("Could not locate position at offset {offset}"))?;
 
     // Output
     match args.format {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -138,7 +138,7 @@ impl ModuleLoader {
             }
         }
 
-        ModuleLoader {
+        Self {
             search_path,
             loaded_modules: BTreeMap::new(),
             auto_loaded_defs,
@@ -151,7 +151,7 @@ impl ModuleLoader {
         let module_file = if module_path.ends_with(".jq") {
             module_path.to_string()
         } else {
-            format!("{}.jq", module_path)
+            format!("{module_path}.jq")
         };
 
         // Search in each path
@@ -175,7 +175,7 @@ impl ModuleLoader {
         // Resolve the module path
         let file_path = self
             .resolve_module(module_path)
-            .ok_or_else(|| anyhow::anyhow!("module '{}' not found in search path", module_path))?;
+            .ok_or_else(|| anyhow::anyhow!("module '{module_path}' not found in search path"))?;
 
         // Read and parse the module
         let contents = std::fs::read_to_string(&file_path)
@@ -231,7 +231,7 @@ impl ModuleLoader {
 
             // Add each function with a namespaced name (namespace::funcname)
             for (name, params, body) in defs.into_iter().rev() {
-                let namespaced_name = format!("{}::{}", namespace, name);
+                let namespaced_name = format!("{namespace}::{name}");
                 expr = Expr::FuncDef {
                     name: namespaced_name,
                     params,
@@ -258,7 +258,7 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
             args,
         } => {
             // Convert to a regular function call with the namespaced name
-            let full_name = format!("{}::{}", namespace, name);
+            let full_name = format!("{namespace}::{name}");
             let rewritten_args: Vec<Expr> =
                 args.into_iter().map(rewrite_namespaced_calls).collect();
             Expr::FuncCall {
@@ -534,10 +534,9 @@ impl OutputConfig {
         // 3. Default: on (jq-compatible formatting)
         let jq_compat = !args.preserve_input
             && !std::env::var("SUCCINCTLY_PRESERVE_INPUT")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
+                .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
 
-        OutputConfig {
+        Self {
             compact: args.compact_output,
             raw_output: args.raw_output || args.join_output || args.raw_output0,
             join_output: args.join_output,
@@ -626,14 +625,14 @@ fn print_validation_error(err: &ValidationError, input: &[u8], filename: Option<
         Some(f) => format!("{}:{}:{}", f, pos.line, pos.column),
         None => format!("<stdin>:{}:{}", pos.line, pos.column),
     };
-    eprintln!("  --> {}", location);
+    eprintln!("  --> {location}");
 
     // Print context snippet if possible
     if let Some((line_content, caret_offset)) = get_error_line(input, pos.line, pos.column) {
         let line_num_width = pos.line.to_string().len().max(3);
         let blank_padding = " ".repeat(line_num_width + 2);
 
-        eprintln!("{}|", blank_padding);
+        eprintln!("{blank_padding}|");
         eprintln!(
             " {:>width$} | {}",
             pos.line,
@@ -668,8 +667,7 @@ fn get_error_line(input: &[u8], line: usize, column: usize) -> Option<(String, u
 
     let line_end = text[line_start..]
         .find('\n')
-        .map(|i| line_start + i)
-        .unwrap_or(text.len());
+        .map_or(text.len(), |i| line_start + i);
 
     let line_content = &text[line_start..line_end];
 
@@ -679,13 +677,13 @@ fn get_error_line(input: &[u8], line: usize, column: usize) -> Option<(String, u
         let error_col = column.saturating_sub(1);
         if error_col < max_width / 2 {
             let truncated = &line_content[..max_width.min(line_content.len())];
-            (format!("{}...", truncated), error_col)
+            (format!("{truncated}..."), error_col)
         } else {
             let start = error_col.saturating_sub(max_width / 2);
             let end = (start + max_width).min(line_content.len());
             let truncated = &line_content[start..end];
             let pos_in_truncated = error_col.saturating_sub(start);
-            (format!("...{}...", truncated), pos_in_truncated + 3)
+            (format!("...{truncated}..."), pos_in_truncated + 3)
         }
     } else {
         (line_content.to_string(), column.saturating_sub(1))
@@ -720,14 +718,14 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
 
     // Parse the filter as a full program (with module directives)
     let program = jq::parse_program(&filter_str).map_err(|e| {
-        eprintln!("jq: compile error: {}", e);
+        eprintln!("jq: compile error: {e}");
         anyhow::anyhow!("compile error")
     })?;
 
     // Create module loader and process imports/includes
     let mut module_loader = ModuleLoader::new(&args.library_path);
     let expr = module_loader.process_program(&program).map_err(|e| {
-        eprintln!("jq: module error: {}", e);
+        eprintln!("jq: module error: {e}");
         anyhow::anyhow!("module error")
     })?;
 
@@ -959,7 +957,7 @@ fn build_context(args: &JqCommand) -> Result<EvalContext> {
     for chunk in args.argjson.chunks(2) {
         if let [name, value] = chunk {
             let json_value = parse_json_value(value)
-                .with_context(|| format!("Invalid JSON for --argjson {}", name))?;
+                .with_context(|| format!("Invalid JSON for --argjson {name}"))?;
             context.named.insert(name.clone(), json_value);
         }
     }
@@ -968,7 +966,7 @@ fn build_context(args: &JqCommand) -> Result<EvalContext> {
     for chunk in args.slurpfile.chunks(2) {
         if let [name, file] = chunk {
             let contents = std::fs::read_to_string(file)
-                .with_context(|| format!("Failed to read file for --slurpfile {}", name))?;
+                .with_context(|| format!("Failed to read file for --slurpfile {name}"))?;
             let values = parse_json_stream(&contents)?;
             context
                 .named
@@ -980,7 +978,7 @@ fn build_context(args: &JqCommand) -> Result<EvalContext> {
     for chunk in args.rawfile.chunks(2) {
         if let [name, file] = chunk {
             let contents = std::fs::read_to_string(file)
-                .with_context(|| format!("Failed to read file for --rawfile {}", name))?;
+                .with_context(|| format!("Failed to read file for --rawfile {name}"))?;
             context
                 .named
                 .insert(name.clone(), OwnedValue::String(contents));
@@ -995,7 +993,7 @@ fn build_context(args: &JqCommand) -> Result<EvalContext> {
     // Process --jsonargs: values become JSON positional args
     for arg in &args.jsonargs {
         let json_value = parse_json_value(arg)
-            .with_context(|| format!("Invalid JSON for --jsonargs: {}", arg))?;
+            .with_context(|| format!("Invalid JSON for --jsonargs: {arg}"))?;
         context.positional.push(json_value);
     }
 
@@ -1290,7 +1288,7 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 
     // Use serde_json for parsing, then convert to OwnedValue
     let value: serde_json::Value =
-        serde_json::from_str(s).with_context(|| format!("Invalid JSON: {}", s))?;
+        serde_json::from_str(s).with_context(|| format!("Invalid JSON: {s}"))?;
 
     Ok(serde_to_owned(&value))
 }
@@ -1349,8 +1347,7 @@ fn validate_dsv_delimiter(delimiter: char) -> Result<()> {
             "Invalid delimiter: newline characters cannot be used as delimiter"
         )),
         c if !c.is_ascii() => Err(anyhow::anyhow!(
-            "Invalid delimiter '{}': only ASCII characters are supported",
-            c
+            "Invalid delimiter '{c}': only ASCII characters are supported"
         )),
         _ => Ok(()),
     }
@@ -1447,13 +1444,13 @@ fn evaluate_input(
         GenericResult::Many(vs) => Ok(vs.iter().map(generic_to_owned).collect()),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
-            eprintln!("jq: error: {}", e);
+            eprintln!("jq: error: {e}");
             Ok(vec![])
         }
         GenericResult::Owned(v) => Ok(vec![v]),
         GenericResult::ManyOwned(vs) => Ok(vs),
         GenericResult::Break(label) => {
-            eprintln!("jq: error: break ${} not in label", label);
+            eprintln!("jq: error: break ${label} not in label");
             Ok(vec![])
         }
     }
@@ -1492,13 +1489,13 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
             .collect(),
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
-            eprintln!("jq: error: {}", e);
+            eprintln!("jq: error: {e}");
             vec![]
         }
         GenericResult::Owned(v) => vec![JqValue::from_owned(v)],
         GenericResult::ManyOwned(vs) => vs.into_iter().map(JqValue::from_owned).collect(),
         GenericResult::Break(label) => {
-            eprintln!("jq: error: break ${} not in label", label);
+            eprintln!("jq: error: break ${label} not in label");
             vec![]
         }
     }
@@ -1548,9 +1545,9 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Write a single output JqValue (preserves number formatting when possible).
-fn write_output_jq_value<'a, Out: Write, Wrd: Clone + AsRef<[u64]>>(
+fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
     out: &mut Out,
-    value: &JqValue<'a, Wrd>,
+    value: &JqValue<'_, Wrd>,
     config: &OutputConfig,
 ) -> Result<()> {
     // In seq mode, prepend RS (Record Separator) before each value
@@ -1671,12 +1668,12 @@ impl LiteralFormatter for JqCompatFormatter {
         if f.is_nan() || f.is_infinite() {
             "null".to_string()
         } else {
-            format!("{}", f)
+            format!("{f}")
         }
     }
 
     fn format_int(&self, i: i64) -> String {
-        format!("{}", i)
+        format!("{i}")
     }
 }
 
@@ -1697,12 +1694,12 @@ impl LiteralFormatter for PreserveFormatter {
         if f.is_nan() || f.is_infinite() {
             "null".to_string()
         } else {
-            format!("{}", f)
+            format!("{f}")
         }
     }
 
     fn format_int(&self, i: i64) -> String {
-        format!("{}", i)
+        format!("{i}")
     }
 }
 
@@ -1714,9 +1711,9 @@ impl LiteralFormatter for PreserveFormatter {
 ///
 /// This is the unified printer that handles JSON structure (arrays, objects,
 /// indentation) while delegating literal formatting to the formatter.
-fn print_json<'a, F, Out, Wrd>(
+fn print_json<F, Out, Wrd>(
     out: &mut Out,
-    value: &JqValue<'a, Wrd>,
+    value: &JqValue<'_, Wrd>,
     formatter: &F,
     config: &OutputConfig,
     level: usize,
@@ -2035,11 +2032,9 @@ fn format_number_jq_compat(raw: &[u8]) -> String {
         // Check if result is integer
         if value.fract() == 0.0 && value.abs() < 1e15 {
             return format!("{}", value as i64);
-        } else {
-            // Format as plain decimal
-            let formatted = format!("{}", value);
-            return formatted;
         }
+        // Format as plain decimal
+        return format!("{value}");
     }
 
     // For negative exponents >= -5, jq converts to decimal
@@ -2066,7 +2061,7 @@ fn format_number_jq_compat(raw: &[u8]) -> String {
 
     let sign = if value < 0.0 { "-" } else { "" };
     let exp_sign = if new_exp >= 0 { "+" } else { "" };
-    format!("{}{}E{}{}", sign, mantissa_str, exp_sign, new_exp)
+    format!("{sign}{mantissa_str}E{exp_sign}{new_exp}")
 }
 
 /// Format a mantissa value for jq-compatible output.
@@ -2079,25 +2074,24 @@ fn format_mantissa_jq(value: f64) -> String {
 
     // Try different precisions and pick the shortest that rounds back correctly
     for precision in 1..=15 {
-        let formatted = format!("{:.prec$}", value, prec = precision);
+        let formatted = format!("{value:.precision$}");
         if let Ok(parsed) = formatted.parse::<f64>() {
             if (parsed - value).abs() < 1e-14 {
                 // Trim trailing zeros
                 let trimmed = formatted.trim_end_matches('0');
                 if trimmed.ends_with('.') {
-                    return format!("{}0", trimmed);
-                } else {
-                    return trimmed.to_string();
+                    return format!("{trimmed}0");
                 }
+                return trimmed.to_string();
             }
         }
     }
 
     // Fallback: full precision
-    let formatted = format!("{:.15}", value);
+    let formatted = format!("{value:.15}");
     let trimmed = formatted.trim_end_matches('0');
     if trimmed.ends_with('.') {
-        format!("{}0", trimmed)
+        format!("{trimmed}0")
     } else {
         trimmed.to_string()
     }
@@ -2116,27 +2110,26 @@ fn format_decimal_jq(value: f64) -> String {
 
     // Try different precisions and pick the shortest that rounds back correctly
     for precision in 1..=15 {
-        let formatted = format!("{:.prec$}", abs_value, prec = precision);
+        let formatted = format!("{abs_value:.precision$}");
         if let Ok(parsed) = formatted.parse::<f64>() {
             if (parsed - abs_value).abs() < 1e-14 {
                 // Trim trailing zeros
                 let trimmed = formatted.trim_end_matches('0');
                 if trimmed.ends_with('.') {
-                    return format!("{}{}0", sign, trimmed);
-                } else {
-                    return format!("{}{}", sign, trimmed);
+                    return format!("{sign}{trimmed}0");
                 }
+                return format!("{sign}{trimmed}");
             }
         }
     }
 
     // Fallback: full precision
-    let formatted = format!("{:.15}", abs_value);
+    let formatted = format!("{abs_value:.15}");
     let trimmed = formatted.trim_end_matches('0');
     if trimmed.ends_with('.') {
-        format!("{}{}0", sign, trimmed)
+        format!("{sign}{trimmed}0")
     } else {
-        format!("{}{}", sign, trimmed)
+        format!("{sign}{trimmed}")
     }
 }
 
@@ -2233,7 +2226,7 @@ fn format_json_impl(value: &OwnedValue, indent: &str, level: usize, ascii: bool)
                 format!(
                     "[{}{}{separator}{}]",
                     separator,
-                    items.join(&format!(",{}", separator)),
+                    items.join(&format!(",{separator}")),
                     current_indent
                 )
             }
@@ -2278,12 +2271,12 @@ fn format_json_impl(value: &OwnedValue, indent: &str, level: usize, ascii: bool)
                 // Add indent before each key
                 let indented_items: Vec<String> = items
                     .iter()
-                    .map(|item| format!("{}{}", next_indent, item))
+                    .map(|item| format!("{next_indent}{item}"))
                     .collect();
                 format!(
                     "{{{}{}{separator}{}}}",
                     separator,
-                    indented_items.join(&format!(",{}", separator)),
+                    indented_items.join(&format!(",{separator}")),
                     current_indent
                 )
             }
@@ -2332,13 +2325,13 @@ fn escape_json_string_ascii(s: &str) -> String {
                 // For characters outside BMP, use surrogate pairs
                 let code = c as u32;
                 if code <= 0xFFFF {
-                    result.push_str(&format!("\\u{:04x}", code));
+                    result.push_str(&format!("\\u{code:04x}"));
                 } else {
                     // Surrogate pair for characters above U+FFFF
                     let adjusted = code - 0x10000;
                     let high = 0xD800 + (adjusted >> 10);
                     let low = 0xDC00 + (adjusted & 0x3FF);
-                    result.push_str(&format!("\\u{:04x}\\u{:04x}", high, low));
+                    result.push_str(&format!("\\u{high:04x}\\u{low:04x}"));
                 }
             }
             c => result.push(c),
@@ -2378,7 +2371,7 @@ struct ColorScheme {
 
 impl Default for ColorScheme {
     fn default() -> Self {
-        ColorScheme {
+        Self {
             reset: default_colors::RESET.to_string(),
             null: default_colors::NULL.to_string(),
             false_: default_colors::FALSE.to_string(),
@@ -2397,7 +2390,7 @@ impl ColorScheme {
     /// Format: "null:false:true:numbers:strings:arrays:objects:objectkeys"
     /// Each value is an SGR parameter like "1;30" for bold black.
     fn from_env() -> Self {
-        let mut scheme = ColorScheme::default();
+        let mut scheme = Self::default();
 
         if let Ok(colors) = std::env::var("JQ_COLORS") {
             let parts: Vec<&str> = colors.split(':').collect();
@@ -2405,42 +2398,42 @@ impl ColorScheme {
             // Parse each color in order
             if let Some(sgr) = parts.first() {
                 if !sgr.is_empty() {
-                    scheme.null = format!("\x1b[{}m", sgr);
+                    scheme.null = format!("\x1b[{sgr}m");
                 }
             }
             if let Some(sgr) = parts.get(1) {
                 if !sgr.is_empty() {
-                    scheme.false_ = format!("\x1b[{}m", sgr);
+                    scheme.false_ = format!("\x1b[{sgr}m");
                 }
             }
             if let Some(sgr) = parts.get(2) {
                 if !sgr.is_empty() {
-                    scheme.true_ = format!("\x1b[{}m", sgr);
+                    scheme.true_ = format!("\x1b[{sgr}m");
                 }
             }
             if let Some(sgr) = parts.get(3) {
                 if !sgr.is_empty() {
-                    scheme.number = format!("\x1b[{}m", sgr);
+                    scheme.number = format!("\x1b[{sgr}m");
                 }
             }
             if let Some(sgr) = parts.get(4) {
                 if !sgr.is_empty() {
-                    scheme.string = format!("\x1b[{}m", sgr);
+                    scheme.string = format!("\x1b[{sgr}m");
                 }
             }
             if let Some(sgr) = parts.get(5) {
                 if !sgr.is_empty() {
-                    scheme.array = format!("\x1b[{}m", sgr);
+                    scheme.array = format!("\x1b[{sgr}m");
                 }
             }
             if let Some(sgr) = parts.get(6) {
                 if !sgr.is_empty() {
-                    scheme.object = format!("\x1b[{}m", sgr);
+                    scheme.object = format!("\x1b[{sgr}m");
                 }
             }
             if let Some(sgr) = parts.get(7) {
                 if !sgr.is_empty() {
-                    scheme.key = format!("\x1b[{}m", sgr);
+                    scheme.key = format!("\x1b[{sgr}m");
                 }
             }
         }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -992,8 +992,8 @@ fn build_context(args: &JqCommand) -> Result<EvalContext> {
 
     // Process --jsonargs: values become JSON positional args
     for arg in &args.jsonargs {
-        let json_value = parse_json_value(arg)
-            .with_context(|| format!("Invalid JSON for --jsonargs: {arg}"))?;
+        let json_value =
+            parse_json_value(arg).with_context(|| format!("Invalid JSON for --jsonargs: {arg}"))?;
         context.positional.push(json_value);
     }
 

--- a/src/bin/succinctly/json_validate.rs
+++ b/src/bin/succinctly/json_validate.rs
@@ -226,30 +226,30 @@ fn print_error(err: &ValidationError, input: &[u8], filename: Option<&str>, sche
 fn format_error_kind(kind: &ValidationErrorKind) -> String {
     match kind {
         ValidationErrorKind::UnexpectedCharacter { expected, found } => {
-            format!("expected {}, found '{}'", expected, found)
+            format!("expected {expected}, found '{found}'")
         }
         ValidationErrorKind::UnexpectedEof { expected } => {
-            format!("unexpected end of input, expected {}", expected)
+            format!("unexpected end of input, expected {expected}")
         }
         ValidationErrorKind::TrailingContent => "trailing content after JSON value".to_string(),
         ValidationErrorKind::UnclosedString => "unclosed string".to_string(),
         ValidationErrorKind::InvalidEscape { sequence } => {
-            format!("invalid escape sequence '\\{}'", sequence)
+            format!("invalid escape sequence '\\{sequence}'")
         }
         ValidationErrorKind::InvalidUnicodeEscape { reason } => {
-            format!("invalid unicode escape: {}", reason)
+            format!("invalid unicode escape: {reason}")
         }
         ValidationErrorKind::UnpairedSurrogate { codepoint } => {
-            format!("unpaired surrogate \\u{:04X}", codepoint)
+            format!("unpaired surrogate \\u{codepoint:04X}")
         }
         ValidationErrorKind::ControlCharacter { byte } => {
-            format!("unescaped control character (0x{:02X})", byte)
+            format!("unescaped control character (0x{byte:02X})")
         }
         ValidationErrorKind::LeadingZero => "leading zeros not allowed in numbers".to_string(),
         ValidationErrorKind::LeadingPlus => "leading plus sign not allowed".to_string(),
-        ValidationErrorKind::InvalidNumber { reason } => format!("invalid number: {}", reason),
+        ValidationErrorKind::InvalidNumber { reason } => format!("invalid number: {reason}"),
         ValidationErrorKind::InvalidKeyword { found } => {
-            format!("invalid keyword '{}'", found)
+            format!("invalid keyword '{found}'")
         }
         ValidationErrorKind::InvalidUtf8 => "invalid UTF-8 sequence".to_string(),
     }
@@ -259,7 +259,7 @@ fn format_error_kind(kind: &ValidationErrorKind) -> String {
 fn format_error_hint(kind: &ValidationErrorKind, scheme: &ColorScheme) -> String {
     let hint = match kind {
         ValidationErrorKind::InvalidEscape { sequence } => {
-            Some(format!("unknown escape '\\{}'", sequence))
+            Some(format!("unknown escape '\\{sequence}'"))
         }
         ValidationErrorKind::LeadingZero => Some("remove leading zero".to_string()),
         ValidationErrorKind::LeadingPlus => Some("remove '+' sign".to_string()),
@@ -320,8 +320,7 @@ fn get_error_snippet(
     // Find the end of this line
     let line_end = text[line_start..]
         .find('\n')
-        .map(|i| line_start + i)
-        .unwrap_or(text.len());
+        .map_or(text.len(), |i| line_start + i);
 
     let line_content = &text[line_start..line_end];
 
@@ -332,21 +331,21 @@ fn get_error_snippet(
         if error_col < max_width / 2 {
             // Error is near the start, show beginning
             let truncated = &line_content[..max_width.min(line_content.len())];
-            (format!("{}...", truncated), error_col)
+            (format!("{truncated}..."), error_col)
         } else if error_col >= line_content.len().saturating_sub(max_width / 2) {
             // Error is near the end, show end
             let start = line_content.len().saturating_sub(max_width);
             let truncated = &line_content[start..];
             // caret_offset = position within truncated + length of "..." prefix
             let pos_in_truncated = error_col.saturating_sub(start);
-            (format!("...{}", truncated), pos_in_truncated + 3)
+            (format!("...{truncated}"), pos_in_truncated + 3)
         } else {
             // Error is in the middle, center on it
             let start = error_col.saturating_sub(max_width / 2);
             let end = (start + max_width).min(line_content.len());
             let truncated = &line_content[start..end];
             let pos_in_truncated = error_col.saturating_sub(start);
-            (format!("...{}...", truncated), pos_in_truncated + 3)
+            (format!("...{truncated}..."), pos_in_truncated + 3)
         }
     } else {
         (line_content.to_string(), column.saturating_sub(1))

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -417,16 +417,16 @@ enum DsvPatternArg {
 impl From<DsvPatternArg> for dsv_generators::DsvPattern {
     fn from(arg: DsvPatternArg) -> Self {
         match arg {
-            DsvPatternArg::Tabular => dsv_generators::DsvPattern::Tabular,
-            DsvPatternArg::Users => dsv_generators::DsvPattern::Users,
-            DsvPatternArg::Numeric => dsv_generators::DsvPattern::Numeric,
-            DsvPatternArg::Strings => dsv_generators::DsvPattern::Strings,
-            DsvPatternArg::Quoted => dsv_generators::DsvPattern::Quoted,
-            DsvPatternArg::Multiline => dsv_generators::DsvPattern::Multiline,
-            DsvPatternArg::Wide => dsv_generators::DsvPattern::Wide,
-            DsvPatternArg::Long => dsv_generators::DsvPattern::Long,
-            DsvPatternArg::Mixed => dsv_generators::DsvPattern::Mixed,
-            DsvPatternArg::Pathological => dsv_generators::DsvPattern::Pathological,
+            DsvPatternArg::Tabular => Self::Tabular,
+            DsvPatternArg::Users => Self::Users,
+            DsvPatternArg::Numeric => Self::Numeric,
+            DsvPatternArg::Strings => Self::Strings,
+            DsvPatternArg::Quoted => Self::Quoted,
+            DsvPatternArg::Multiline => Self::Multiline,
+            DsvPatternArg::Wide => Self::Wide,
+            DsvPatternArg::Long => Self::Long,
+            DsvPatternArg::Mixed => Self::Mixed,
+            DsvPatternArg::Pathological => Self::Pathological,
         }
     }
 }
@@ -514,17 +514,17 @@ enum YamlPatternArg {
 impl From<YamlPatternArg> for yaml_generators::YamlPattern {
     fn from(arg: YamlPatternArg) -> Self {
         match arg {
-            YamlPatternArg::Comprehensive => yaml_generators::YamlPattern::Comprehensive,
-            YamlPatternArg::Users => yaml_generators::YamlPattern::Users,
-            YamlPatternArg::Nested => yaml_generators::YamlPattern::Nested,
-            YamlPatternArg::Sequences => yaml_generators::YamlPattern::Sequences,
-            YamlPatternArg::Mixed => yaml_generators::YamlPattern::Mixed,
-            YamlPatternArg::Strings => yaml_generators::YamlPattern::Strings,
-            YamlPatternArg::Numbers => yaml_generators::YamlPattern::Numbers,
-            YamlPatternArg::Config => yaml_generators::YamlPattern::Config,
-            YamlPatternArg::Unicode => yaml_generators::YamlPattern::Unicode,
-            YamlPatternArg::Pathological => yaml_generators::YamlPattern::Pathological,
-            YamlPatternArg::Navigation => yaml_generators::YamlPattern::Navigation,
+            YamlPatternArg::Comprehensive => Self::Comprehensive,
+            YamlPatternArg::Users => Self::Users,
+            YamlPatternArg::Nested => Self::Nested,
+            YamlPatternArg::Sequences => Self::Sequences,
+            YamlPatternArg::Mixed => Self::Mixed,
+            YamlPatternArg::Strings => Self::Strings,
+            YamlPatternArg::Numbers => Self::Numbers,
+            YamlPatternArg::Config => Self::Config,
+            YamlPatternArg::Unicode => Self::Unicode,
+            YamlPatternArg::Pathological => Self::Pathological,
+            YamlPatternArg::Navigation => Self::Navigation,
         }
     }
 }
@@ -853,16 +853,16 @@ pub struct YqCommand {
 impl From<PatternArg> for generators::Pattern {
     fn from(arg: PatternArg) -> Self {
         match arg {
-            PatternArg::Comprehensive => generators::Pattern::Comprehensive,
-            PatternArg::Users => generators::Pattern::Users,
-            PatternArg::Nested => generators::Pattern::Nested,
-            PatternArg::Arrays => generators::Pattern::Arrays,
-            PatternArg::Mixed => generators::Pattern::Mixed,
-            PatternArg::Strings => generators::Pattern::Strings,
-            PatternArg::Numbers => generators::Pattern::Numbers,
-            PatternArg::Literals => generators::Pattern::Literals,
-            PatternArg::Unicode => generators::Pattern::Unicode,
-            PatternArg::Pathological => generators::Pattern::Pathological,
+            PatternArg::Comprehensive => Self::Comprehensive,
+            PatternArg::Users => Self::Users,
+            PatternArg::Nested => Self::Nested,
+            PatternArg::Arrays => Self::Arrays,
+            PatternArg::Mixed => Self::Mixed,
+            PatternArg::Strings => Self::Strings,
+            PatternArg::Numbers => Self::Numbers,
+            PatternArg::Literals => Self::Literals,
+            PatternArg::Unicode => Self::Unicode,
+            PatternArg::Pathological => Self::Pathological,
         }
     }
 }
@@ -887,8 +887,7 @@ fn parse_size(s: &str) -> Result<usize, String> {
         (s.trim_end_matches('b'), 1)
     } else {
         return Err(format!(
-            "Invalid size format: '{}'. Use format like '1mb', '512KB', or '1024'",
-            s
+            "Invalid size format: '{s}'. Use format like '1mb', '512KB', or '1024'"
         ));
     };
 
@@ -896,7 +895,7 @@ fn parse_size(s: &str) -> Result<usize, String> {
         .trim()
         .parse::<usize>()
         .map(|n| n * unit)
-        .map_err(|_| format!("Invalid number in size: '{}'", s))
+        .map_err(|_| format!("Invalid number in size: '{s}'"))
 }
 
 /// Multi-call binary support: detect if invoked via a known alias name.
@@ -913,7 +912,7 @@ fn try_multicall() -> Result<Option<i32>> {
         .as_deref()
         .and_then(|s| std::path::Path::new(s).file_name())
         .and_then(|n| n.to_str())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
 
     let name = match binary_name {
         Some(ref n) => n.as_str(),
@@ -1003,7 +1002,7 @@ fn main() -> Result<()> {
                         eprintln!("✓ Wrote {} bytes to {}", output.len(), path.display());
                     }
                     None => {
-                        println!("{}", output);
+                        println!("{output}");
                     }
                 }
 
@@ -1038,7 +1037,7 @@ fn main() -> Result<()> {
                         eprintln!("✓ Wrote {} bytes to {}", dsv.len(), path.display());
                     }
                     None => {
-                        print!("{}", dsv);
+                        print!("{dsv}");
                     }
                 }
 
@@ -1053,7 +1052,7 @@ fn main() -> Result<()> {
 
                 if args.verify {
                     succinctly::yaml::YamlIndex::build(yaml.as_bytes())
-                        .map_err(|e| anyhow::anyhow!("Generated invalid YAML: {}", e))?;
+                        .map_err(|e| anyhow::anyhow!("Generated invalid YAML: {e}"))?;
                     eprintln!("✓ YAML validated successfully");
                 }
 
@@ -1063,7 +1062,7 @@ fn main() -> Result<()> {
                         eprintln!("✓ Wrote {} bytes to {}", yaml.len(), path.display());
                     }
                     None => {
-                        print!("{}", yaml);
+                        print!("{yaml}");
                     }
                 }
 
@@ -1096,7 +1095,7 @@ fn install_aliases(args: InstallAliasesArgs) -> Result<()> {
         Some(d) => d,
         None => binary
             .parent()
-            .map(|p| p.to_path_buf())
+            .map(std::path::Path::to_path_buf)
             .context("Cannot determine binary directory")?,
     };
 
@@ -1112,7 +1111,7 @@ fn install_aliases(args: InstallAliasesArgs) -> Result<()> {
         if target.is_symlink() {
             if let Ok(existing) = std::fs::read_link(&target) {
                 if existing == binary {
-                    eprintln!("  skip {} (already exists)", alias);
+                    eprintln!("  skip {alias} (already exists)");
                     continue;
                 }
             }
@@ -1120,7 +1119,7 @@ fn install_aliases(args: InstallAliasesArgs) -> Result<()> {
             std::fs::remove_file(&target)
                 .with_context(|| format!("Cannot remove existing symlink: {}", target.display()))?;
         } else if target.exists() {
-            eprintln!("  skip {} (non-symlink file exists)", alias);
+            eprintln!("  skip {alias} (non-symlink file exists)");
             continue;
         }
 
@@ -1423,7 +1422,7 @@ fn generate_json_suite(args: GenerateSuite) -> Result<()> {
                 continue;
             }
 
-            let filename = format!("{}.json", size_name);
+            let filename = format!("{size_name}.json");
             let path = pattern_dir.join(&filename);
 
             // Deterministic seed: base_seed + file_index
@@ -1458,7 +1457,7 @@ fn generate_json_suite(args: GenerateSuite) -> Result<()> {
     );
 
     if skipped_count > 0 {
-        eprintln!("Skipped {} files exceeding max size", skipped_count);
+        eprintln!("Skipped {skipped_count} files exceeding max size");
     }
 
     if args.verify {
@@ -1522,7 +1521,7 @@ fn generate_dsv_suite(args: GenerateDsvSuite) -> Result<()> {
                 continue;
             }
 
-            let filename = format!("{}.{}", size_name, extension);
+            let filename = format!("{size_name}.{extension}");
             let path = pattern_dir.join(&filename);
 
             // Deterministic seed: base_seed + file_index
@@ -1566,7 +1565,7 @@ fn generate_dsv_suite(args: GenerateDsvSuite) -> Result<()> {
     );
 
     if skipped_count > 0 {
-        eprintln!("Skipped {} files exceeding max size", skipped_count);
+        eprintln!("Skipped {skipped_count} files exceeding max size");
     }
 
     if args.verify {
@@ -1632,7 +1631,7 @@ fn generate_yaml_suite(args: GenerateYamlSuite) -> Result<()> {
                 continue;
             }
 
-            let filename = format!("{}.yaml", size_name);
+            let filename = format!("{size_name}.yaml");
             let path = pattern_dir.join(&filename);
 
             // Deterministic seed: base_seed + file_index
@@ -1666,7 +1665,7 @@ fn generate_yaml_suite(args: GenerateYamlSuite) -> Result<()> {
         let pattern_dir = output_dir.join(pattern_name);
         std::fs::create_dir_all(&pattern_dir)?;
 
-        let filename = format!("{}.yaml", pattern_name);
+        let filename = format!("{pattern_name}.yaml");
         let path = pattern_dir.join(&filename);
 
         // Deterministic seed: base_seed + file_index
@@ -1703,7 +1702,7 @@ fn generate_yaml_suite(args: GenerateYamlSuite) -> Result<()> {
     );
 
     if skipped_count > 0 {
-        eprintln!("Skipped {} files exceeding max size", skipped_count);
+        eprintln!("Skipped {skipped_count} files exceeding max size");
     }
 
     if args.verify {
@@ -1721,7 +1720,7 @@ fn format_bytes(bytes: usize) -> String {
     } else if bytes >= 1024 {
         format!("{:.2} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{} bytes", bytes)
+        format!("{bytes} bytes")
     }
 }
 

--- a/src/bin/succinctly/yaml_generators.rs
+++ b/src/bin/succinctly/yaml_generators.rs
@@ -360,9 +360,7 @@ fn generate_navigation(target_size: usize, seed: Option<u64>) -> String {
         let salary = rng
             .as_mut()
             .map_or(60000 + count * 1000, |r| r.gen_range(50000..200000));
-        let years = rng
-            .as_mut()
-            .map_or(1 + count % 15, |r| r.gen_range(1..20));
+        let years = rng.as_mut().map_or(1 + count % 15, |r| r.gen_range(1..20));
 
         // Top-level array item (block style)
         yaml.push_str("- \n");
@@ -489,9 +487,9 @@ fn add_number_values(
     while yaml.len().saturating_sub(start_len) < target_size {
         let num = match count % 6 {
             0 => count.to_string(),                             // Simple integer
-            1 => format!("-{count}"),                         // Negative integer
-            2 => format!("0.{count}"),                        // Decimal < 1
-            3 => format!("{count}.{count}"),                // Decimal
+            1 => format!("-{count}"),                           // Negative integer
+            2 => format!("0.{count}"),                          // Decimal < 1
+            3 => format!("{count}.{count}"),                    // Decimal
             4 => format!("{}.{}e{}", count, count, count % 10), // Scientific notation
             _ => {
                 let val = rng
@@ -576,9 +574,7 @@ fn add_mixed_nested(
     let mut count = 0;
 
     while yaml.len().saturating_sub(start_len) < target_size {
-        let use_sequence = rng
-            .as_mut()
-            .map_or(count % 2 == 0, rand::Rng::gen::<bool>);
+        let use_sequence = rng.as_mut().map_or(count % 2 == 0, rand::Rng::gen::<bool>);
         let used = yaml.len().saturating_sub(start_len);
         let remaining = target_size.saturating_sub(used);
 
@@ -641,9 +637,7 @@ fn add_user_records(
         let age = rng
             .as_mut()
             .map_or(25 + count % 50, |r| r.gen_range(18..80));
-        let score = rng
-            .as_mut()
-            .map_or(count * 10, |r| r.gen_range(0..1000));
+        let score = rng.as_mut().map_or(count * 10, |r| r.gen_range(0..1000));
 
         // Use block style for sequence items with mappings
         // Note: YAML-lite parser requires `- ` (dash-space) not just `-`
@@ -690,12 +684,8 @@ fn add_config_features(
     ];
 
     while yaml.len().saturating_sub(start_len) < target_size && count < feature_names.len() {
-        let enabled = rng
-            .as_mut()
-            .map_or(count % 2 == 0, rand::Rng::gen::<bool>);
-        let priority = rng
-            .as_mut()
-            .map_or(count + 1, |r| r.gen_range(1..10));
+        let enabled = rng.as_mut().map_or(count % 2 == 0, rand::Rng::gen::<bool>);
+        let priority = rng.as_mut().map_or(count + 1, |r| r.gen_range(1..10));
 
         yaml.push_str(&format!("{}{}:\n", ind, feature_names[count]));
         yaml.push_str(&format!("{inner_ind}enabled: {enabled}\n"));

--- a/src/bin/succinctly/yaml_generators.rs
+++ b/src/bin/succinctly/yaml_generators.rs
@@ -356,31 +356,28 @@ fn generate_navigation(target_size: usize, seed: Option<u64>) -> String {
         let dept = departments[count % departments.len()];
         let age = rng
             .as_mut()
-            .map(|r| r.gen_range(22..65))
-            .unwrap_or(25 + count % 40);
+            .map_or(25 + count % 40, |r| r.gen_range(22..65));
         let salary = rng
             .as_mut()
-            .map(|r| r.gen_range(50000..200000))
-            .unwrap_or(60000 + count * 1000);
+            .map_or(60000 + count * 1000, |r| r.gen_range(50000..200000));
         let years = rng
             .as_mut()
-            .map(|r| r.gen_range(1..20))
-            .unwrap_or(1 + count % 15);
+            .map_or(1 + count % 15, |r| r.gen_range(1..20));
 
         // Top-level array item (block style)
         yaml.push_str("- \n");
-        yaml.push_str(&format!("  id: {}\n", count));
-        yaml.push_str(&format!("  name: {} {}\n", first, last));
+        yaml.push_str(&format!("  id: {count}\n"));
+        yaml.push_str(&format!("  name: {first} {last}\n"));
         yaml.push_str(&format!(
             "  email: {}.{}@example.com\n",
             first.to_lowercase(),
             last.to_lowercase()
         ));
-        yaml.push_str(&format!("  age: {}\n", age));
-        yaml.push_str(&format!("  city: {}\n", city));
-        yaml.push_str(&format!("  department: {}\n", dept));
-        yaml.push_str(&format!("  salary: {}\n", salary));
-        yaml.push_str(&format!("  years_employed: {}\n", years));
+        yaml.push_str(&format!("  age: {age}\n"));
+        yaml.push_str(&format!("  city: {city}\n"));
+        yaml.push_str(&format!("  department: {dept}\n"));
+        yaml.push_str(&format!("  salary: {salary}\n"));
+        yaml.push_str(&format!("  years_employed: {years}\n"));
         yaml.push_str(&format!("  active: {}\n", count % 10 != 0));
 
         // Add nested structure for chained navigation tests
@@ -422,14 +419,14 @@ fn add_simple_values(
     let mut count = 0;
 
     while yaml.len().saturating_sub(start_len) < target_size {
-        let value = match rng.as_mut().map(|r| r.gen_range(0..4)).unwrap_or(count % 4) {
+        let value = match rng.as_mut().map_or(count % 4, |r| r.gen_range(0..4)) {
             0 => "true".to_string(),
             1 => "false".to_string(),
             2 => "null".to_string(),
             _ => count.to_string(),
         };
 
-        yaml.push_str(&format!("{}field_{}: {}\n", ind, count, value));
+        yaml.push_str(&format!("{ind}field_{count}: {value}\n"));
         count += 1;
     }
 }
@@ -466,8 +463,7 @@ fn add_string_values(
     while yaml.len().saturating_sub(start_len) < target_size {
         let use_quoted = rng
             .as_mut()
-            .map(|r| r.gen_range(0..5) == 0)
-            .unwrap_or(count % 5 == 0);
+            .map_or(count % 5 == 0, |r| r.gen_range(0..5) == 0);
 
         let value = if use_quoted {
             quoted_patterns[count % quoted_patterns.len()]
@@ -475,7 +471,7 @@ fn add_string_values(
             string_patterns[count % string_patterns.len()]
         };
 
-        yaml.push_str(&format!("{}string_{}: {}\n", ind, count, value));
+        yaml.push_str(&format!("{ind}string_{count}: {value}\n"));
         count += 1;
     }
 }
@@ -493,20 +489,19 @@ fn add_number_values(
     while yaml.len().saturating_sub(start_len) < target_size {
         let num = match count % 6 {
             0 => count.to_string(),                             // Simple integer
-            1 => format!("-{}", count),                         // Negative integer
-            2 => format!("0.{}", count),                        // Decimal < 1
-            3 => format!("{}.{}", count, count),                // Decimal
+            1 => format!("-{count}"),                         // Negative integer
+            2 => format!("0.{count}"),                        // Decimal < 1
+            3 => format!("{count}.{count}"),                // Decimal
             4 => format!("{}.{}e{}", count, count, count % 10), // Scientific notation
             _ => {
                 let val = rng
                     .as_mut()
-                    .map(|r| r.r#gen::<f64>() * 1000.0)
-                    .unwrap_or(count as f64);
-                format!("{:.4}", val)
+                    .map_or(count as f64, |r| r.r#gen::<f64>() * 1000.0);
+                format!("{val:.4}")
             }
         };
 
-        yaml.push_str(&format!("{}number_{}: {}\n", ind, count, num));
+        yaml.push_str(&format!("{ind}number_{count}: {num}\n"));
         count += 1;
     }
 }
@@ -522,13 +517,13 @@ fn add_sequence_values(
     let mut count = 0;
 
     while yaml.len().saturating_sub(start_len) < target_size {
-        let item_type = rng.as_mut().map(|r| r.gen_range(0..4)).unwrap_or(count % 4);
+        let item_type = rng.as_mut().map_or(count % 4, |r| r.gen_range(0..4));
 
         match item_type {
-            0 => yaml.push_str(&format!("{}- item_{}\n", ind, count)),
-            1 => yaml.push_str(&format!("{}- {}\n", ind, count)),
-            2 => yaml.push_str(&format!("{}- true\n", ind)),
-            _ => yaml.push_str(&format!("{}- \"value {}\"\n", ind, count)),
+            0 => yaml.push_str(&format!("{ind}- item_{count}\n")),
+            1 => yaml.push_str(&format!("{ind}- {count}\n")),
+            2 => yaml.push_str(&format!("{ind}- true\n")),
+            _ => yaml.push_str(&format!("{ind}- \"value {count}\"\n")),
         }
 
         count += 1;
@@ -552,7 +547,7 @@ fn add_nested_mapping(
 
         // Nest if we have depth budget and enough remaining space for it to be worthwhile
         if max_depth > 0 && remaining > 100 {
-            yaml.push_str(&format!("{}level_{}:\n", ind, count));
+            yaml.push_str(&format!("{ind}level_{count}:\n"));
             // Give 90% of remaining to nested content to ensure proper scaling
             add_nested_mapping(
                 yaml,
@@ -562,8 +557,8 @@ fn add_nested_mapping(
                 max_depth - 1,
             );
         } else {
-            let value = rng.as_mut().map(|r| r.gen_range(0..100)).unwrap_or(count);
-            yaml.push_str(&format!("{}leaf_{}: {}\n", ind, count, value));
+            let value = rng.as_mut().map_or(count, |r| r.gen_range(0..100));
+            yaml.push_str(&format!("{ind}leaf_{count}: {value}\n"));
         }
         count += 1;
     }
@@ -583,21 +578,20 @@ fn add_mixed_nested(
     while yaml.len().saturating_sub(start_len) < target_size {
         let use_sequence = rng
             .as_mut()
-            .map(|r| r.r#gen::<bool>())
-            .unwrap_or(count % 2 == 0);
+            .map_or(count % 2 == 0, rand::Rng::gen::<bool>);
         let used = yaml.len().saturating_sub(start_len);
         let remaining = target_size.saturating_sub(used);
 
         // Nest if we have depth budget and enough remaining space
         if max_depth > 0 && remaining > 100 {
             if use_sequence {
-                yaml.push_str(&format!("{}list_{}:\n", ind, count));
-                let items = rng.as_mut().map(|r| r.gen_range(2..5)).unwrap_or(3);
+                yaml.push_str(&format!("{ind}list_{count}:\n"));
+                let items = rng.as_mut().map_or(3, |r| r.gen_range(2..5));
                 for i in 0..items {
                     yaml.push_str(&format!("{}- item_{}\n", indent(indent_level + 2), i));
                 }
             } else {
-                yaml.push_str(&format!("{}map_{}:\n", ind, count));
+                yaml.push_str(&format!("{ind}map_{count}:\n"));
                 // Give 90% of remaining to nested content to ensure proper scaling
                 add_mixed_nested(
                     yaml,
@@ -608,7 +602,7 @@ fn add_mixed_nested(
                 );
             }
         } else {
-            yaml.push_str(&format!("{}value_{}: {}\n", ind, count, count));
+            yaml.push_str(&format!("{ind}value_{count}: {count}\n"));
         }
         count += 1;
     }
@@ -646,28 +640,26 @@ fn add_user_records(
         let city = cities[count % cities.len()];
         let age = rng
             .as_mut()
-            .map(|r| r.gen_range(18..80))
-            .unwrap_or(25 + count % 50);
+            .map_or(25 + count % 50, |r| r.gen_range(18..80));
         let score = rng
             .as_mut()
-            .map(|r| r.gen_range(0..1000))
-            .unwrap_or(count * 10);
+            .map_or(count * 10, |r| r.gen_range(0..1000));
 
         // Use block style for sequence items with mappings
         // Note: YAML-lite parser requires `- ` (dash-space) not just `-`
-        yaml.push_str(&format!("{}- \n", ind));
-        yaml.push_str(&format!("{}id: {}\n", inner_ind, count));
-        yaml.push_str(&format!("{}name: {} {}\n", inner_ind, first, last));
+        yaml.push_str(&format!("{ind}- \n"));
+        yaml.push_str(&format!("{inner_ind}id: {count}\n"));
+        yaml.push_str(&format!("{inner_ind}name: {first} {last}\n"));
         yaml.push_str(&format!(
             "{}email: {}.{}@example.com\n",
             inner_ind,
             first.to_lowercase(),
             last.to_lowercase()
         ));
-        yaml.push_str(&format!("{}age: {}\n", inner_ind, age));
-        yaml.push_str(&format!("{}city: {}\n", inner_ind, city));
-        yaml.push_str(&format!("{}score: {}\n", inner_ind, score));
-        yaml.push_str(&format!("{}active: true\n", inner_ind));
+        yaml.push_str(&format!("{inner_ind}age: {age}\n"));
+        yaml.push_str(&format!("{inner_ind}city: {city}\n"));
+        yaml.push_str(&format!("{inner_ind}score: {score}\n"));
+        yaml.push_str(&format!("{inner_ind}active: true\n"));
 
         count += 1;
     }
@@ -700,16 +692,14 @@ fn add_config_features(
     while yaml.len().saturating_sub(start_len) < target_size && count < feature_names.len() {
         let enabled = rng
             .as_mut()
-            .map(|r| r.r#gen::<bool>())
-            .unwrap_or(count % 2 == 0);
+            .map_or(count % 2 == 0, rand::Rng::gen::<bool>);
         let priority = rng
             .as_mut()
-            .map(|r| r.gen_range(1..10))
-            .unwrap_or(count + 1);
+            .map_or(count + 1, |r| r.gen_range(1..10));
 
         yaml.push_str(&format!("{}{}:\n", ind, feature_names[count]));
-        yaml.push_str(&format!("{}enabled: {}\n", inner_ind, enabled));
-        yaml.push_str(&format!("{}priority: {}\n", inner_ind, priority));
+        yaml.push_str(&format!("{inner_ind}enabled: {enabled}\n"));
+        yaml.push_str(&format!("{inner_ind}priority: {priority}\n"));
 
         count += 1;
     }
@@ -767,15 +757,15 @@ fn add_pathological_nested(
     // Generate many siblings at each level with some nesting
     while yaml.len().saturating_sub(start_len) < target_size && count < 100 {
         if max_depth > 0 && count % 3 == 0 {
-            yaml.push_str(&format!("{}node_{}:\n", ind, count));
+            yaml.push_str(&format!("{ind}node_{count}:\n"));
             // Add some immediate values
             yaml.push_str(&format!("{}val: {}\n", indent(indent_level + 2), count));
             // Recurse
             let remaining = target_size.saturating_sub(yaml.len().saturating_sub(start_len));
             add_pathological_nested(yaml, remaining / 4, rng, indent_level + 2, max_depth - 1);
         } else {
-            let value = rng.as_mut().map(|r| r.gen_range(0..10000)).unwrap_or(count);
-            yaml.push_str(&format!("{}item_{}: {}\n", ind, count, value));
+            let value = rng.as_mut().map_or(count, |r| r.gen_range(0..10000));
+            yaml.push_str(&format!("{ind}item_{count}: {value}\n"));
         }
         count += 1;
     }

--- a/src/bin/succinctly/yq_bench.rs
+++ b/src/bin/succinctly/yq_bench.rs
@@ -31,51 +31,51 @@ impl QueryType {
     /// Get the jq query string for this query type
     pub fn query(&self) -> &'static str {
         match self {
-            QueryType::Identity => ".",
-            QueryType::FirstElement => ".[0]",
-            QueryType::Iteration => ".[]",
-            QueryType::Length => "length",
+            Self::Identity => ".",
+            Self::FirstElement => ".[0]",
+            Self::Iteration => ".[]",
+            Self::Length => "length",
         }
     }
 
     /// Get a human-readable name for display
     pub fn name(&self) -> &'static str {
         match self {
-            QueryType::Identity => "identity",
-            QueryType::FirstElement => "first_element",
-            QueryType::Iteration => "iteration",
-            QueryType::Length => "length",
+            Self::Identity => "identity",
+            Self::FirstElement => "first_element",
+            Self::Iteration => "iteration",
+            Self::Length => "length",
         }
     }
 
     /// Get the execution path description
     pub fn path_description(&self) -> &'static str {
         match self {
-            QueryType::Identity => "P9 streaming",
-            QueryType::FirstElement => "M2 streaming",
-            QueryType::Iteration => "M2 streaming",
-            QueryType::Length => "OwnedValue",
+            Self::Identity => "P9 streaming",
+            Self::FirstElement => "M2 streaming",
+            Self::Iteration => "M2 streaming",
+            Self::Length => "OwnedValue",
         }
     }
 
     /// Parse query type from string
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
-            "identity" | "." => Some(QueryType::Identity),
-            "first_element" | "first" | ".[0]" => Some(QueryType::FirstElement),
-            "iteration" | "iter" | ".[]" => Some(QueryType::Iteration),
-            "length" => Some(QueryType::Length),
+            "identity" | "." => Some(Self::Identity),
+            "first_element" | "first" | ".[0]" => Some(Self::FirstElement),
+            "iteration" | "iter" | ".[]" => Some(Self::Iteration),
+            "length" => Some(Self::Length),
             _ => None,
         }
     }
 
     /// Get all available query types
-    pub fn all() -> &'static [QueryType] {
+    pub fn all() -> &'static [Self] {
         &[
-            QueryType::Identity,
-            QueryType::FirstElement,
-            QueryType::Iteration,
-            QueryType::Length,
+            Self::Identity,
+            Self::FirstElement,
+            Self::Iteration,
+            Self::Length,
         ]
     }
 }
@@ -229,7 +229,7 @@ pub fn run_benchmark(
                     break 'outer;
                 }
 
-                let file_path = config.data_dir.join(pattern).join(format!("{}.yaml", size));
+                let file_path = config.data_dir.join(pattern).join(format!("{size}.yaml"));
 
                 if !file_path.exists() {
                     eprintln!("  Skipping {} (not found)", file_path.display());
@@ -295,7 +295,7 @@ pub fn run_benchmark(
                         results.push(result);
                     }
                     Err(e) => {
-                        eprintln!("ERROR: {}", e);
+                        eprintln!("ERROR: {e}");
                     }
                 }
             }
@@ -476,7 +476,7 @@ fn run_command_with_timing(program: &str, args: &[&str]) -> Result<ToolResult> {
         let output = Command::new(program)
             .args(args)
             .output()
-            .with_context(|| format!("Failed to run {}", program))?;
+            .with_context(|| format!("Failed to run {program}"))?;
         (output.stdout, 0, 0.0, 0.0)
     };
 
@@ -619,8 +619,7 @@ fn check_yq_available() -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .is_ok_and(|s| s.success())
 }
 
 /// Get CPU information for the current system
@@ -659,9 +658,7 @@ fn get_yq_version() -> String {
         .arg("--version")
         .output()
         .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "Unknown".to_string())
+        .and_then(|o| String::from_utf8(o.stdout).ok()).map_or_else(|| "Unknown".to_string(), |s| s.trim().to_string())
 }
 
 /// Generate markdown tables from results
@@ -673,11 +670,11 @@ pub fn generate_markdown(results: &[BenchmarkResult], has_yq: bool, memory_mode:
 
     // Add CPU info
     let cpu_info = get_cpu_info();
-    md.push_str(&format!("**CPU**: {}\n", cpu_info));
+    md.push_str(&format!("**CPU**: {cpu_info}\n"));
 
     if has_yq {
         let yq_version = get_yq_version();
-        md.push_str(&format!("**yq version**: {}\n", yq_version));
+        md.push_str(&format!("**yq version**: {yq_version}\n"));
     } else {
         md.push_str("**yq**: Not installed (succinctly-only benchmarks)\n");
     }
@@ -712,7 +709,7 @@ pub fn generate_markdown(results: &[BenchmarkResult], has_yq: bool, memory_mode:
     // If multiple queries, group by query first
     if queries.len() > 1 {
         for (query, query_path) in &queries {
-            md.push_str(&format!("## Query: `{}` ({})\n\n", query, query_path));
+            md.push_str(&format!("## Query: `{query}` ({query_path})\n\n"));
 
             let query_results: Vec<_> = results.iter().filter(|r| r.query == *query).collect();
             generate_pattern_tables(
@@ -727,7 +724,7 @@ pub fn generate_markdown(results: &[BenchmarkResult], has_yq: bool, memory_mode:
     } else {
         // Single query - just show pattern tables
         if let Some((query, query_path)) = queries.first() {
-            md.push_str(&format!("**Query**: `{}` ({})\n\n", query, query_path));
+            md.push_str(&format!("**Query**: `{query}` ({query_path})\n\n"));
         }
         let all_results: Vec<_> = results.iter().collect();
         generate_pattern_tables(
@@ -780,7 +777,7 @@ fn generate_memory_tables(
             continue;
         }
 
-        md.push_str(&format!("### Pattern: {}\n\n", pattern));
+        md.push_str(&format!("### Pattern: {pattern}\n\n"));
 
         if has_yq {
             md.push_str("| Size      | succ Mem | yq Mem  | Mem Ratio  | succ Time | yq Time  | Speedup    |\n");
@@ -802,7 +799,7 @@ fn generate_memory_tables(
             let succ_mem = format_memory_fixed(r.succinctly.peak_memory_bytes);
             let succ_time = format_time_fixed(r.succinctly.wall_time_ms);
             let size_bold = format!("**{}**", r.size);
-            let size_col = format!("{:<9}", size_bold);
+            let size_col = format!("{size_bold:<9}");
 
             if has_yq {
                 let yq_mem = format_memory_fixed(r.yq.peak_memory_bytes);
@@ -815,15 +812,13 @@ fn generate_memory_tables(
                 let speedup = r.yq.wall_time_ms / r.succinctly.wall_time_ms;
 
                 md.push_str(&format!(
-                    "| {} | {} | {} | **{:.2}x** | {} | {} | **{:.1}x** |\n",
-                    size_col, succ_mem, yq_mem, mem_ratio, succ_time, yq_time, speedup
+                    "| {size_col} | {succ_mem} | {yq_mem} | **{mem_ratio:.2}x** | {succ_time} | {yq_time} | **{speedup:.1}x** |\n"
                 ));
             } else {
                 let throughput =
                     r.filesize as f64 / (r.succinctly.wall_time_ms / 1000.0) / (1024.0 * 1024.0);
                 md.push_str(&format!(
-                    "| {} | {} | {} | {:>12.1} MiB/s |\n",
-                    size_col, succ_mem, succ_time, throughput
+                    "| {size_col} | {succ_mem} | {succ_time} | {throughput:>12.1} MiB/s |\n"
                 ));
             }
         }
@@ -850,7 +845,7 @@ fn generate_comparison_tables(
             continue;
         }
 
-        md.push_str(&format!("### Pattern: {}\n\n", pattern));
+        md.push_str(&format!("### Pattern: {pattern}\n\n"));
         md.push_str("| Size      | yq       | succinctly   | Speedup       | yq Mem  | succ Mem | Mem Ratio  |\n");
         md.push_str("|-----------|----------|--------------|---------------|---------|----------|------------|\n");
 
@@ -878,7 +873,7 @@ fn generate_comparison_tables(
 
             // Size column: **name** with trailing padding (9 chars total)
             let size_bold = format!("**{}**", r.size);
-            let size_col = format!("{:<9}", size_bold);
+            let size_col = format!("{size_bold:<9}");
 
             // yq time column
             let yq_col = yq_time;
@@ -889,28 +884,27 @@ fn generate_comparison_tables(
                 let padding = succ_time.len() - trimmed.len();
                 format!("{}**{}**", " ".repeat(padding), trimmed)
             } else {
-                format!("  {}  ", succ_time)
+                format!("  {succ_time}  ")
             };
 
             // Speedup column: bold if >= 1.0 (13 chars visual width)
-            let speedup_str = format!("{:.1}x", speedup);
+            let speedup_str = format!("{speedup:.1}x");
             let speedup_col = if speedup >= 1.0 {
-                let padded = format!("{:>9}", speedup_str);
+                let padded = format!("{speedup_str:>9}");
                 let trimmed = padded.trim_start();
                 let padding = padded.len() - trimmed.len();
                 format!("{}**{}**", " ".repeat(padding), trimmed)
             } else {
-                format!("{:>13}", speedup_str)
+                format!("{speedup_str:>13}")
             };
 
             // Memory columns
             let yq_mem_col = yq_mem;
-            let succ_mem_col = format!("{:>8}", succ_mem);
-            let mem_ratio_col = format!("{:>9.2}x", mem_ratio);
+            let succ_mem_col = format!("{succ_mem:>8}");
+            let mem_ratio_col = format!("{mem_ratio:>9.2}x");
 
             md.push_str(&format!(
-                "| {} | {} | {} | {} | {} | {} | {} |\n",
-                size_col, yq_col, succ_col, speedup_col, yq_mem_col, succ_mem_col, mem_ratio_col
+                "| {size_col} | {yq_col} | {succ_col} | {speedup_col} | {yq_mem_col} | {succ_mem_col} | {mem_ratio_col} |\n"
             ));
         }
 
@@ -936,7 +930,7 @@ fn generate_succinctly_only_tables(
             continue;
         }
 
-        md.push_str(&format!("### Pattern: {}\n\n", pattern));
+        md.push_str(&format!("### Pattern: {pattern}\n\n"));
         md.push_str("| Size      | Time     | Throughput   | Memory   |\n");
         md.push_str("|-----------|----------|--------------|----------|\n");
 
@@ -954,16 +948,15 @@ fn generate_succinctly_only_tables(
 
             // Format values
             let time = format_time_fixed(r.succinctly.wall_time_ms);
-            let throughput_str = format!("{:.1} MiB/s", throughput);
+            let throughput_str = format!("{throughput:.1} MiB/s");
             let mem = format_memory_fixed(r.succinctly.peak_memory_bytes);
 
             // Size column
             let size_bold = format!("**{}**", r.size);
-            let size_col = format!("{:<9}", size_bold);
+            let size_col = format!("{size_bold:<9}");
 
             md.push_str(&format!(
-                "| {} | {} | {:>12} | {} |\n",
-                size_col, time, throughput_str, mem
+                "| {size_col} | {time} | {throughput_str:>12} | {mem} |\n"
             ));
         }
 
@@ -976,8 +969,8 @@ fn format_time_fixed(ms: f64) -> String {
     if ms >= 1000.0 {
         format!("{:>7.2}s", ms / 1000.0)
     } else {
-        let ms_str = format!("{:.1}ms", ms);
-        format!("{:>8}", ms_str)
+        let ms_str = format!("{ms:.1}ms");
+        format!("{ms_str:>8}")
     }
 }
 
@@ -990,7 +983,7 @@ fn format_memory_fixed(bytes: u64) -> String {
     } else if bytes >= 1024 {
         format!("{:>4.0} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{:>4} B ", bytes)
+        format!("{bytes:>4} B ")
     }
 }
 
@@ -1003,7 +996,7 @@ fn format_bytes(bytes: usize) -> String {
     } else if bytes >= 1024 {
         format!("{:.2} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{} bytes", bytes)
+        format!("{bytes} bytes")
     }
 }
 

--- a/src/bin/succinctly/yq_bench.rs
+++ b/src/bin/succinctly/yq_bench.rs
@@ -658,7 +658,8 @@ fn get_yq_version() -> String {
         .arg("--version")
         .output()
         .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok()).map_or_else(|| "Unknown".to_string(), |s| s.trim().to_string())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map_or_else(|| "Unknown".to_string(), |s| s.trim().to_string())
 }
 
 /// Generate markdown tables from results

--- a/src/bin/succinctly/yq_locate.rs
+++ b/src/bin/succinctly/yq_locate.rs
@@ -56,7 +56,7 @@ pub fn run_yq_locate(args: YqLocateArgs) -> Result<i32> {
             let newline_index = NewlineIndex::build(&text);
             newline_index
                 .to_offset(line, column)
-                .with_context(|| format!("Invalid position: line {} column {}", line, column))?
+                .with_context(|| format!("Invalid position: line {line} column {column}"))?
         }
         (None, None, None) => {
             anyhow::bail!("Either --offset or --line/--column must be specified");
@@ -79,7 +79,7 @@ pub fn run_yq_locate(args: YqLocateArgs) -> Result<i32> {
 
     // Locate the position
     let result = locate_offset_detailed(&index, &text, offset)
-        .with_context(|| format!("Could not locate position at offset {}", offset))?;
+        .with_context(|| format!("Could not locate position at offset {offset}"))?;
 
     // Output
     match args.format {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -112,7 +112,7 @@ impl OutputConfig {
             " ".repeat(args.indent as usize)
         };
 
-        OutputConfig {
+        Self {
             output_format: args.output_format,
             compact,
             raw_output: args.raw_output || args.join_output || args.nul_output,
@@ -133,7 +133,7 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(value: YamlValue<'_, W>) -> Result<Owned
         YamlValue::String(s) => {
             let str_value = s
                 .as_str()
-                .map_err(|e| anyhow::anyhow!("invalid YAML string: {}", e))?;
+                .map_err(|e| anyhow::anyhow!("invalid YAML string: {e}"))?;
 
             // Quoted strings should always be treated as strings (yq-compatible behavior)
             // Only unquoted scalars should undergo type detection
@@ -177,7 +177,7 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(value: YamlValue<'_, W>) -> Result<Owned
                 let key = match field.key() {
                     YamlValue::String(s) => s
                         .as_str()
-                        .map_err(|e| anyhow::anyhow!("invalid YAML key: {}", e))?
+                        .map_err(|e| anyhow::anyhow!("invalid YAML key: {e}"))?
                         .into_owned(),
                     other => {
                         // Non-string keys - convert to string representation
@@ -206,7 +206,7 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(value: YamlValue<'_, W>) -> Result<Owned
                 Ok(OwnedValue::Null)
             }
         }
-        YamlValue::Error(msg) => Err(anyhow::anyhow!("YAML error: {}", msg)),
+        YamlValue::Error(msg) => Err(anyhow::anyhow!("YAML error: {msg}")),
         YamlValue::Null => Ok(OwnedValue::Null),
     }
 }
@@ -265,7 +265,7 @@ fn read_file(path: &Path) -> Result<Vec<u8>> {
 fn detect_format_from_path(path: &Path) -> InputFormat {
     match path.extension().and_then(|e| e.to_str()) {
         Some("json") => InputFormat::Json,
-        Some("yaml") | Some("yml") => InputFormat::Yaml,
+        Some("yaml" | "yml") => InputFormat::Yaml,
         _ => InputFormat::Yaml, // Default to YAML
     }
 }
@@ -274,8 +274,7 @@ fn detect_format_from_path(path: &Path) -> InputFormat {
 fn resolve_input_format(format: InputFormat, path: Option<&Path>) -> InputFormat {
     match format {
         InputFormat::Auto => path
-            .map(detect_format_from_path)
-            .unwrap_or(InputFormat::Yaml),
+            .map_or(InputFormat::Yaml, detect_format_from_path),
         other => other,
     }
 }
@@ -292,7 +291,7 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
         InputFormat::Yaml | InputFormat::Auto => {
             // Parse as YAML (Auto defaults to YAML when no extension hint)
             let index =
-                YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {}", e))?;
+                YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
             let root = index.root(bytes);
 
             match root.value() {
@@ -314,7 +313,7 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
 /// This keeps the index alive during evaluation and preserves position metadata.
 #[allow(dead_code)] // STYLE-0005: used in tests
 fn parse_and_evaluate_yaml(bytes: &[u8], expr: &Expr) -> Result<Vec<OwnedValue>> {
-    let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {}", e))?;
+    let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
     let root = index.root(bytes);
 
     // YAML documents are wrapped in a sequence at the root
@@ -354,7 +353,7 @@ fn evaluate_yaml_direct_filtered(
     expr: &Expr,
     doc_filter: Option<(usize, usize)>,
 ) -> Result<(Vec<Vec<OwnedValue>>, usize)> {
-    let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {}", e))?;
+    let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
     let root = index.root(bytes);
 
     // YAML documents are wrapped in a sequence at the root
@@ -438,13 +437,13 @@ fn evaluate_input(
         QueryResult::Many(vs) => Ok(vs.iter().map(standard_json_to_owned).collect()),
         QueryResult::None => Ok(vec![]),
         QueryResult::Error(e) => {
-            eprintln!("yq: error: {}", e);
+            eprintln!("yq: error: {e}");
             Ok(vec![])
         }
         QueryResult::Owned(v) => Ok(vec![v]),
         QueryResult::ManyOwned(vs) => Ok(vs),
         QueryResult::Break(label) => {
-            eprintln!("yq: error: break ${} not in label", label);
+            eprintln!("yq: error: break ${label} not in label");
             Ok(vec![])
         }
     }
@@ -467,13 +466,13 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).collect()),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
-            eprintln!("yq: error: {}", e);
+            eprintln!("yq: error: {e}");
             Ok(vec![])
         }
         GenericResult::Owned(v) => Ok(vec![v]),
         GenericResult::ManyOwned(vs) => Ok(vs),
         GenericResult::Break(label) => {
-            eprintln!("yq: error: break ${} not in label", label);
+            eprintln!("yq: error: break ${label} not in label");
             Ok(vec![])
         }
     }
@@ -555,7 +554,7 @@ fn output_value<W: Write>(writer: &mut W, value: &OwnedValue, config: &OutputCon
     // Handle raw output for scalars
     if config.raw_output {
         if let OwnedValue::String(s) = value {
-            write!(writer, "{}", s)?;
+            write!(writer, "{s}")?;
             write_terminator(writer, config)?;
             return Ok(());
         }
@@ -568,7 +567,7 @@ fn output_value<W: Write>(writer: &mut W, value: &OwnedValue, config: &OutputCon
         if config.use_color {
             write!(writer, "{}", colorize_yaml(&output))?;
         } else {
-            write!(writer, "{}", output)?;
+            write!(writer, "{output}")?;
         }
         write_terminator(writer, config)?;
         return Ok(());
@@ -585,7 +584,7 @@ fn output_value<W: Write>(writer: &mut W, value: &OwnedValue, config: &OutputCon
     if config.use_color {
         write!(writer, "{}", colorize_json(&json_str))?;
     } else {
-        write!(writer, "{}", json_str)?;
+        write!(writer, "{json_str}")?;
     }
 
     write_terminator(writer, config)?;
@@ -614,7 +613,7 @@ fn emit_yaml_value(
                     "-.inf".to_string()
                 }
             } else if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
-                format!("{:.1}", f)
+                format!("{f:.1}")
             } else {
                 f.to_string()
             }
@@ -643,9 +642,9 @@ fn emit_yaml_value(
                             && !item.starts_with('{')
                         {
                             // Multi-line value - emit nested content which handles its own indentation
-                            format!("{}-\n{}", indent, item)
+                            format!("{indent}-\n{item}")
                         } else {
-                            format!("{}- {}", indent, item)
+                            format!("{indent}- {item}")
                         }
                     })
                     .collect();
@@ -662,7 +661,7 @@ fn emit_yaml_value(
                     .map(|(k, v)| {
                         let key = yaml_quote_key(k);
                         let val = emit_yaml_value(v, config, depth, true);
-                        format!("{}: {}", key, val)
+                        format!("{key}: {val}")
                     })
                     .collect();
                 format!("{{{}}}", entries.join(", "))
@@ -687,10 +686,10 @@ fn emit_yaml_value(
                         {
                             // For nested containers, emit at depth+1 which handles its own indentation
                             let val = emit_yaml_value(v, config, depth + 1, false);
-                            format!("{}{}:\n{}", indent, key, val)
+                            format!("{indent}{key}:\n{val}")
                         } else {
                             let val = emit_yaml_value(v, config, depth + 1, false);
-                            format!("{}{}: {}", indent, key, val)
+                            format!("{indent}{key}: {val}")
                         }
                     })
                     .collect();
@@ -886,7 +885,7 @@ fn pretty_print_json_value(value: &OwnedValue, config: &OutputConfig, depth: usi
             if f.is_nan() || f.is_infinite() {
                 "null".to_string() // JSON doesn't support NaN or Infinity
             } else if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
-                format!("{:.1}", f) // Preserve decimal point for whole numbers
+                format!("{f:.1}") // Preserve decimal point for whole numbers
             } else {
                 f.to_string()
             }
@@ -1007,7 +1006,7 @@ fn escape_string_ascii(s: &str) -> String {
         } else {
             // Non-ASCII: escape as \uXXXX
             for unit in c.encode_utf16(&mut [0; 2]) {
-                result.push_str(&format!("\\u{:04x}", unit));
+                result.push_str(&format!("\\u{unit:04x}"));
             }
         }
     }
@@ -1104,7 +1103,7 @@ fn parse_variables(args: &YqCommand) -> Result<EvalContext> {
         if chunk.len() == 2 {
             let name = chunk[0].clone();
             let value = parse_json_value(&chunk[1])
-                .with_context(|| format!("invalid JSON for --argjson {}", name))?;
+                .with_context(|| format!("invalid JSON for --argjson {name}"))?;
             context.named.insert(name, value);
         }
     }
@@ -1372,7 +1371,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
     // Parse the jq program (use Yq mode for extended identifier syntax like kebab-case)
     let program = jq::parse_program_with_mode(&filter_str, jq::ParserMode::Yq)
-        .map_err(|e| anyhow::anyhow!("parse error: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("parse error: {e}"))?;
 
     // Parse variables
     let context = parse_variables(&args)?;
@@ -1475,7 +1474,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         if args.files.is_empty() {
             let yaml_bytes = read_stdin()?;
             let index = YamlIndex::build(&yaml_bytes)
-                .map_err(|e| anyhow::anyhow!("YAML parse error: {}", e))?;
+                .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
             let root = index.root(&yaml_bytes);
 
             // Output each document using M2 streaming
@@ -1520,7 +1519,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             for file_path in &args.files {
                 let yaml_bytes = read_file(Path::new(file_path))?;
                 let index = YamlIndex::build(&yaml_bytes)
-                    .map_err(|e| anyhow::anyhow!("YAML parse error in {}: {}", file_path, e))?;
+                    .map_err(|e| anyhow::anyhow!("YAML parse error in {file_path}: {e}"))?;
                 let root = index.root(&yaml_bytes);
 
                 match root.value() {
@@ -1584,7 +1583,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             let mut content = String::new();
             for file_path in &args.files {
                 let file_content = std::fs::read_to_string(file_path)
-                    .with_context(|| format!("failed to read file: {}", file_path))?;
+                    .with_context(|| format!("failed to read file: {file_path}"))?;
                 content.push_str(&file_content);
             }
             content
@@ -1684,11 +1683,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 let mut buf_writer = BufWriter::new(&mut output_buffer);
                 // Count matching docs for multi-doc separator logic
                 let matching_docs: usize = if let Some(target_doc) = args.document {
-                    if (global_doc_index..global_doc_index + inputs.len()).contains(&target_doc) {
-                        1
-                    } else {
-                        0
-                    }
+                    usize::from((global_doc_index..global_doc_index + inputs.len()).contains(&target_doc))
                 } else {
                     inputs.len()
                 };
@@ -1792,7 +1787,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         }
 
         // Count total documents from collected results (after filtering)
-        let total_docs: usize = all_results.iter().map(|docs| docs.len()).sum();
+        let total_docs: usize = all_results.iter().map(std::vec::Vec::len).sum();
         let is_multi_doc = total_docs > 1;
 
         // Output all results with proper separators
@@ -2180,8 +2175,8 @@ mod tests {
         assert_eq!(inputs.len(), 1);
         if let OwnedValue::Object(map) = &inputs[0] {
             println!("map len: {}", map.len());
-            for (k, v) in map.iter() {
-                println!("  key={:?}, value={:?}", k, v);
+            for (k, v) in map {
+                println!("  key={k:?}, value={v:?}");
             }
             assert_eq!(map.len(), 1);
             // Empty key (null key in YAML becomes empty string in our representation)
@@ -2203,8 +2198,8 @@ mod tests {
         assert_eq!(results.len(), 1);
         if let OwnedValue::Object(map) = &results[0] {
             println!("direct eval map len: {}", map.len());
-            for (k, v) in map.iter() {
-                println!("  key={:?}, value={:?}", k, v);
+            for (k, v) in map {
+                println!("  key={k:?}, value={v:?}");
             }
             assert_eq!(map.len(), 1, "expected 1 key but got {} keys", map.len());
         } else {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -273,8 +273,7 @@ fn detect_format_from_path(path: &Path) -> InputFormat {
 /// Get effective input format, resolving Auto to a specific format.
 fn resolve_input_format(format: InputFormat, path: Option<&Path>) -> InputFormat {
     match format {
-        InputFormat::Auto => path
-            .map_or(InputFormat::Yaml, detect_format_from_path),
+        InputFormat::Auto => path.map_or(InputFormat::Yaml, detect_format_from_path),
         other => other,
     }
 }
@@ -1683,7 +1682,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 let mut buf_writer = BufWriter::new(&mut output_buffer);
                 // Count matching docs for multi-doc separator logic
                 let matching_docs: usize = if let Some(target_doc) = args.document {
-                    usize::from((global_doc_index..global_doc_index + inputs.len()).contains(&target_doc))
+                    usize::from(
+                        (global_doc_index..global_doc_index + inputs.len()).contains(&target_doc),
+                    )
                 } else {
                     inputs.len()
                 };

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // memory-mapped file access (Mmap) is inherently unsafe
 //! Binary serialization for succinct data structures.
 //!
 //! This module provides zero-copy binary serialization compatible with memory-mapped files.

--- a/src/bits/bitvec.rs
+++ b/src/bits/bitvec.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // unchecked bit access + aligned allocation on hot rank/select paths
 //! Bitvector with rank/select support.
 //!
 //! This module provides `BitVec`, the main data structure for storing bits
@@ -408,7 +409,7 @@ mod tests {
             if bv.get(i) {
                 let rank = bv.rank1(i);
                 let select = bv.select1(rank);
-                assert_eq!(select, Some(i), "roundtrip failed at i={}", i);
+                assert_eq!(select, Some(i), "roundtrip failed at i={i}");
             }
         }
     }
@@ -484,19 +485,18 @@ mod tests {
             let words: Vec<u64> = vec![u64::MAX; num_words];
             let bv = BitVec::from_words(words, len);
 
-            assert_eq!(bv.len(), len, "len mismatch for {}", len);
-            assert_eq!(bv.count_ones(), len, "count_ones mismatch for len={}", len);
-            assert_eq!(bv.rank1(len), len, "rank1(len) mismatch for len={}", len);
+            assert_eq!(bv.len(), len, "len mismatch for {len}");
+            assert_eq!(bv.count_ones(), len, "count_ones mismatch for len={len}");
+            assert_eq!(bv.rank1(len), len, "rank1(len) mismatch for len={len}");
 
             if len > 0 {
                 assert_eq!(
                     bv.select1(len - 1),
                     Some(len - 1),
-                    "select1 last bit for len={}",
-                    len
+                    "select1 last bit for len={len}"
                 );
             }
-            assert_eq!(bv.select1(len), None, "select1 beyond for len={}", len);
+            assert_eq!(bv.select1(len), None, "select1 beyond for len={len}");
         }
     }
 
@@ -546,10 +546,10 @@ mod tests {
             words[num_words - 1] = 1u64 << bit_in_last_word;
             let bv = BitVec::from_words(words, len);
 
-            assert_eq!(bv.count_ones(), 1, "count_ones for len={}", len);
-            assert_eq!(bv.select1(0), Some(len - 1), "select1 for len={}", len);
-            assert_eq!(bv.rank1(len - 1), 0, "rank1(len-1) for len={}", len);
-            assert_eq!(bv.rank1(len), 1, "rank1(len) for len={}", len);
+            assert_eq!(bv.count_ones(), 1, "count_ones for len={len}");
+            assert_eq!(bv.select1(0), Some(len - 1), "select1 for len={len}");
+            assert_eq!(bv.rank1(len - 1), 0, "rank1(len-1) for len={len}");
+            assert_eq!(bv.rank1(len), 1, "rank1(len) for len={len}");
         }
     }
 
@@ -625,9 +625,7 @@ mod tests {
             assert_eq!(
                 bv.rank1(pos),
                 expected,
-                "rank1({}) at word {} boundary",
-                pos,
-                word_idx
+                "rank1({pos}) at word {word_idx} boundary"
             );
         }
     }
@@ -663,7 +661,7 @@ mod tests {
         assert_eq!(bv.count_ones(), 256);
         // With sample rate 1, every position should be directly indexed
         for k in 0..256 {
-            assert!(bv.select1(k).is_some(), "select1({}) should be Some", k);
+            assert!(bv.select1(k).is_some(), "select1({k}) should be Some");
         }
     }
 
@@ -678,7 +676,7 @@ mod tests {
 
         assert_eq!(bv.count_ones(), 8);
         for k in 0..8 {
-            assert_eq!(bv.select1(k), Some(k * 64), "select1({}) failed", k);
+            assert_eq!(bv.select1(k), Some(k * 64), "select1({k}) failed");
         }
     }
 
@@ -744,7 +742,7 @@ mod tests {
         // Verify rank(select(k)) = k for valid k
         for k in 0..bv.count_ones() {
             if let Some(pos) = bv.select1(k) {
-                assert_eq!(bv.rank1(pos), k, "rank1(select1({})) should be {}", k, k);
+                assert_eq!(bv.rank1(pos), k, "rank1(select1({k})) should be {k}");
             }
         }
     }

--- a/src/bits/compact_rank.rs
+++ b/src/bits/compact_rank.rs
@@ -238,8 +238,7 @@ mod tests {
             assert_eq!(
                 cr.rank_at_word(&words, i),
                 expected as usize,
-                "mismatch at word {}",
-                i
+                "mismatch at word {i}"
             );
         }
     }
@@ -267,10 +266,7 @@ mod tests {
 
         assert!(
             overhead_pct < 5.0,
-            "Overhead {:.1}% exceeds 5% target (bitmap={}, index={})",
-            overhead_pct,
-            bitmap_bytes,
-            index_bytes
+            "Overhead {overhead_pct:.1}% exceeds 5% target (bitmap={bitmap_bytes}, index={index_bytes})"
         );
     }
 }

--- a/src/bits/elias_fano.rs
+++ b/src/bits/elias_fano.rs
@@ -869,9 +869,7 @@ mod tests {
 
         // Print compression ratio for inspection
         let ratio = vec_size as f64 / ef_size as f64;
-        eprintln!(
-            "Compression: {vec_size} bytes -> {ef_size} bytes ({ratio:.2}x)"
-        );
+        eprintln!("Compression: {vec_size} bytes -> {ef_size} bytes ({ratio:.2}x)");
     }
 
     #[test]
@@ -964,9 +962,7 @@ mod tests {
         }
         let vec_seq_time = start.elapsed();
 
-        eprintln!(
-            "\nSequential iteration ({n} elements × {iterations} iterations):"
-        );
+        eprintln!("\nSequential iteration ({n} elements × {iterations} iterations):");
         eprintln!(
             "  Vec<u32>:    {:?} ({:.1} ns/elem)",
             vec_seq_time,
@@ -1054,9 +1050,7 @@ mod tests {
         }
         let vec_skip_time = start.elapsed();
 
-        eprintln!(
-            "\nSkip-by-small (advance_by 2-8 × {iterations} iterations):"
-        );
+        eprintln!("\nSkip-by-small (advance_by 2-8 × {iterations} iterations):");
         eprintln!("  Vec<u32>:    {vec_skip_time:?}");
         eprintln!("  EliasFano:   {ef_skip_time:?}");
         eprintln!(

--- a/src/bits/elias_fano.rs
+++ b/src/bits/elias_fano.rs
@@ -390,7 +390,7 @@ impl EliasFano {
     }
 }
 
-impl<'a> EliasFanoCursor<'a> {
+impl EliasFanoCursor<'_> {
     /// Returns the current element value, or `None` if exhausted.
     #[inline]
     pub fn current(&self) -> Option<u32> {
@@ -568,7 +568,7 @@ pub struct EliasFanoIter<'a> {
     started: bool,
 }
 
-impl<'a> Iterator for EliasFanoIter<'a> {
+impl Iterator for EliasFanoIter<'_> {
     type Item = u32;
 
     #[inline]
@@ -588,7 +588,7 @@ impl<'a> Iterator for EliasFanoIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for EliasFanoIter<'a> {}
+impl ExactSizeIterator for EliasFanoIter<'_> {}
 
 #[cfg(test)]
 mod tests {
@@ -628,7 +628,7 @@ mod tests {
 
         // Test random access
         for (i, &v) in values.iter().enumerate() {
-            assert_eq!(ef.get(i), Some(v), "get({}) failed", i);
+            assert_eq!(ef.get(i), Some(v), "get({i}) failed");
         }
 
         // Test cursor iteration
@@ -649,7 +649,7 @@ mod tests {
 
         // Test random access
         for (i, &v) in values.iter().enumerate() {
-            assert_eq!(ef.get(i), Some(v), "get({}) failed", i);
+            assert_eq!(ef.get(i), Some(v), "get({i}) failed");
         }
 
         // Test cursor iteration
@@ -740,12 +740,11 @@ mod tests {
         // Test various positions
         for &idx in &[0, 1, 10, 50, 100, 255, 256, 257, 500, 512, 513, 999] {
             let cursor = ef.cursor_from(idx);
-            assert_eq!(cursor.index(), idx, "cursor_from({}).index()", idx);
+            assert_eq!(cursor.index(), idx, "cursor_from({idx}).index()");
             assert_eq!(
                 cursor.current(),
                 Some(values[idx]),
-                "cursor_from({}).current()",
-                idx
+                "cursor_from({idx}).current()"
             );
         }
 
@@ -816,9 +815,7 @@ mod tests {
                     assert_eq!(
                         cursor.current(),
                         Some(values[idx]),
-                        "cursor_from({}) near boundary {}",
-                        idx,
-                        boundary
+                        "cursor_from({idx}) near boundary {boundary}"
                     );
                 }
             }
@@ -839,7 +836,7 @@ mod tests {
         let ef = EliasFano::build(&values);
 
         for (i, &v) in values.iter().enumerate() {
-            assert_eq!(ef.get(i), Some(v), "get({}) failed", i);
+            assert_eq!(ef.get(i), Some(v), "get({i}) failed");
         }
 
         let collected: Vec<u32> = ef.into_iter().collect();
@@ -867,16 +864,13 @@ mod tests {
         // EF should be significantly smaller
         assert!(
             ef_size < vec_size,
-            "EF size {} should be less than Vec size {}",
-            ef_size,
-            vec_size
+            "EF size {ef_size} should be less than Vec size {vec_size}"
         );
 
         // Print compression ratio for inspection
         let ratio = vec_size as f64 / ef_size as f64;
         eprintln!(
-            "Compression: {} bytes -> {} bytes ({:.2}x)",
-            vec_size, ef_size, ratio
+            "Compression: {vec_size} bytes -> {ef_size} bytes ({ratio:.2}x)"
         );
     }
 
@@ -936,7 +930,7 @@ mod tests {
         let ef = EliasFano::build(&values);
 
         eprintln!("\n=== EliasFano Benchmark ===");
-        eprintln!("Elements: {}", n);
+        eprintln!("Elements: {n}");
         eprintln!("Universe: {}", values.last().unwrap());
         eprintln!(
             "Size: Vec<u32>={} bytes, EliasFano={} bytes ({:.2}x compression)",
@@ -971,8 +965,7 @@ mod tests {
         let vec_seq_time = start.elapsed();
 
         eprintln!(
-            "\nSequential iteration ({} elements × {} iterations):",
-            n, iterations
+            "\nSequential iteration ({n} elements × {iterations} iterations):"
         );
         eprintln!(
             "  Vec<u32>:    {:?} ({:.1} ns/elem)",
@@ -1062,11 +1055,10 @@ mod tests {
         let vec_skip_time = start.elapsed();
 
         eprintln!(
-            "\nSkip-by-small (advance_by 2-8 × {} iterations):",
-            iterations
+            "\nSkip-by-small (advance_by 2-8 × {iterations} iterations):"
         );
-        eprintln!("  Vec<u32>:    {:?}", vec_skip_time);
-        eprintln!("  EliasFano:   {:?}", ef_skip_time);
+        eprintln!("  Vec<u32>:    {vec_skip_time:?}");
+        eprintln!("  EliasFano:   {ef_skip_time:?}");
         eprintln!(
             "  Ratio:       {:.2}x",
             ef_skip_time.as_nanos() as f64 / vec_skip_time.as_nanos() as f64

--- a/src/bits/popcount.rs
+++ b/src/bits/popcount.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // hardware popcount intrinsics (NEON/POPCNT)
 //! Popcount implementations with compile-time switching.
 //!
 //! This module provides different popcount strategies that can be selected
@@ -132,7 +133,7 @@ fn popcount_words_neon(words: &[u64]) -> usize {
     }
 
     let mut total = 0usize;
-    let ptr = words.as_ptr() as *const u8;
+    let ptr = words.as_ptr().cast::<u8>();
     let byte_len = words.len() * 8;
     let mut offset = 0;
 
@@ -304,7 +305,7 @@ mod tests {
                 .map(|i| (i as u64) | 0x8000_0000_0000_0001)
                 .collect();
             let expected: usize = words.iter().map(|w| w.count_ones() as usize).sum();
-            assert_eq!(popcount_words(&words), expected, "len={}", len);
+            assert_eq!(popcount_words(&words), expected, "len={len}");
         }
     }
 
@@ -322,7 +323,7 @@ mod tests {
                 .map(|i| (i as u64).wrapping_mul(0xDEAD_BEEF_CAFE_BABE) | 1)
                 .collect();
             let expected: usize = words.iter().map(|w| w.count_ones() as usize).sum();
-            assert_eq!(popcount_words(&words), expected, "len={}", len);
+            assert_eq!(popcount_words(&words), expected, "len={len}");
         }
     }
 
@@ -332,7 +333,7 @@ mod tests {
     fn test_popcount_words_all_ones() {
         for len in [1, 8, 32, 33, 64, 100, 256] {
             let words = vec![u64::MAX; len];
-            assert_eq!(popcount_words(&words), len * 64, "len={}", len);
+            assert_eq!(popcount_words(&words), len * 64, "len={len}");
         }
     }
 
@@ -341,7 +342,7 @@ mod tests {
     fn test_popcount_words_all_zeros() {
         for len in [1, 8, 32, 64, 100] {
             let words = vec![0u64; len];
-            assert_eq!(popcount_words(&words), 0, "len={}", len);
+            assert_eq!(popcount_words(&words), 0, "len={len}");
         }
     }
 
@@ -390,8 +391,7 @@ mod tests {
             assert_eq!(
                 popcount_word_portable(word),
                 word.count_ones(),
-                "word={:#x}",
-                word
+                "word={word:#x}"
             );
         }
     }

--- a/src/bits/rank.rs
+++ b/src/bits/rank.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // manual aligned allocation for the rank directory
 //! Rank directory for O(1) rank queries.
 //!
 //! This module implements a Poppy-style 3-level rank directory that provides
@@ -75,7 +76,7 @@ impl CacheAlignedL1L2 {
         let layout = Layout::from_size_align(len * 16, CACHE_LINE_SIZE).expect("layout error");
 
         // Safety: layout is valid (non-zero size, power-of-two alignment)
-        let ptr = unsafe { alloc::alloc::alloc(layout) as *mut u128 };
+        let ptr = unsafe { alloc::alloc::alloc(layout).cast::<u128>() };
         if ptr.is_null() {
             alloc::alloc::handle_alloc_error(layout);
         }
@@ -127,7 +128,7 @@ impl Clone for CacheAlignedL1L2 {
         let layout = Layout::from_size_align(self.len * 16, CACHE_LINE_SIZE).expect("layout error");
 
         // Safety: layout is valid
-        let ptr = unsafe { alloc::alloc::alloc(layout) as *mut u128 };
+        let ptr = unsafe { alloc::alloc::alloc(layout).cast::<u128>() };
         if ptr.is_null() {
             alloc::alloc::handle_alloc_error(layout);
         }
@@ -152,7 +153,7 @@ impl Drop for CacheAlignedL1L2 {
                 Layout::from_size_align(self.len * 16, CACHE_LINE_SIZE).expect("layout error");
             // Safety: ptr was allocated with this layout
             unsafe {
-                alloc::alloc::dealloc(self.ptr.as_ptr() as *mut u8, layout);
+                alloc::alloc::dealloc(self.ptr.as_ptr().cast::<u8>(), layout);
             }
         }
     }
@@ -198,7 +199,7 @@ impl CacheAlignedL1L2Builder {
         let layout = Layout::from_size_align(capacity * 16, CACHE_LINE_SIZE).expect("layout error");
 
         // Safety: layout is valid (non-zero size, power-of-two alignment)
-        let ptr = unsafe { alloc::alloc::alloc(layout) as *mut u128 };
+        let ptr = unsafe { alloc::alloc::alloc(layout).cast::<u128>() };
         if ptr.is_null() {
             alloc::alloc::handle_alloc_error(layout);
         }
@@ -243,7 +244,7 @@ impl CacheAlignedL1L2Builder {
                     Layout::from_size_align(self.capacity * 16, CACHE_LINE_SIZE).expect("layout");
                 // Safety: ptr was allocated with this layout
                 unsafe {
-                    alloc::alloc::dealloc(self.ptr.as_ptr() as *mut u8, layout);
+                    alloc::alloc::dealloc(self.ptr.as_ptr().cast::<u8>(), layout);
                 }
             }
             return CacheAlignedL1L2::empty();
@@ -265,7 +266,7 @@ impl CacheAlignedL1L2Builder {
             Layout::from_size_align(self.len * 16, CACHE_LINE_SIZE).expect("layout error");
 
         // Safety: new_layout is valid
-        let new_ptr = unsafe { alloc::alloc::alloc(new_layout) as *mut u128 };
+        let new_ptr = unsafe { alloc::alloc::alloc(new_layout).cast::<u128>() };
         if new_ptr.is_null() {
             alloc::alloc::handle_alloc_error(new_layout);
         }
@@ -280,7 +281,7 @@ impl CacheAlignedL1L2Builder {
         let old_layout =
             Layout::from_size_align(self.capacity * 16, CACHE_LINE_SIZE).expect("layout");
         unsafe {
-            alloc::alloc::dealloc(self.ptr.as_ptr() as *mut u8, old_layout);
+            alloc::alloc::dealloc(self.ptr.as_ptr().cast::<u8>(), old_layout);
         }
 
         // Prevent Drop from running
@@ -301,7 +302,7 @@ impl Drop for CacheAlignedL1L2Builder {
                 Layout::from_size_align(self.capacity * 16, CACHE_LINE_SIZE).expect("layout error");
             // Safety: ptr was allocated with this layout
             unsafe {
-                alloc::alloc::dealloc(self.ptr.as_ptr() as *mut u8, layout);
+                alloc::alloc::dealloc(self.ptr.as_ptr().cast::<u8>(), layout);
             }
         }
     }

--- a/src/dsv/simd/avx2.rs
+++ b/src/dsv/simd/avx2.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 AVX2 SIMD intrinsics
 //! AVX2-accelerated DSV indexing for x86_64.
 //!
 //! Processes 64 bytes at a time using x86_64 AVX2 SIMD instructions to find
@@ -95,8 +96,8 @@ unsafe fn process_chunk_64(
     in_quote: bool,
 ) -> (u64, u64, bool) {
     // Load 2 x 32-byte chunks
-    let chunk0 = _mm256_loadu_si256(ptr as *const __m256i);
-    let chunk1 = _mm256_loadu_si256(ptr.add(32) as *const __m256i);
+    let chunk0 = _mm256_loadu_si256(ptr.cast::<__m256i>());
+    let chunk1 = _mm256_loadu_si256(ptr.add(32).cast::<__m256i>());
 
     // Create comparison vectors
     let v_delimiter = _mm256_set1_epi8(delimiter);

--- a/src/dsv/simd/bmi2.rs
+++ b/src/dsv/simd/bmi2.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 BMI2 (PDEP) SIMD intrinsics
 //! BMI2-accelerated DSV indexing for x86_64.
 //!
 //! Uses BMI2 PDEP instruction for quote state masking, providing ~10x speedup
@@ -107,8 +108,8 @@ unsafe fn process_chunk_64_bmi2(
     qq_carry: u64,
 ) -> (u64, u64, u64) {
     // Load 2 x 32-byte chunks using AVX2
-    let chunk0 = _mm256_loadu_si256(ptr as *const __m256i);
-    let chunk1 = _mm256_loadu_si256(ptr.add(32) as *const __m256i);
+    let chunk0 = _mm256_loadu_si256(ptr.cast::<__m256i>());
+    let chunk1 = _mm256_loadu_si256(ptr.add(32).cast::<__m256i>());
 
     // Create comparison vectors
     let v_delimiter = _mm256_set1_epi8(delimiter);
@@ -200,7 +201,7 @@ unsafe fn toggle64_bmi2(carry: u64, w: u64) -> (u64, u64) {
 
     // The new carry depends on whether addition overflowed
     // and the final state of the quote parity
-    let new_carry = if overflow { 1 } else { 0 };
+    let new_carry = u64::from(overflow);
 
     (result, new_carry)
 }

--- a/src/dsv/simd/neon.rs
+++ b/src/dsv/simd/neon.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ARM64 NEON SIMD intrinsics
 //! NEON-accelerated DSV indexing for ARM64.
 //!
 //! Processes 64 bytes at a time using ARM NEON SIMD instructions to find
@@ -319,8 +320,7 @@ mod tests {
             let neon_result = unsafe { prefix_xor_neon(pattern) };
             assert_eq!(
                 neon_result, scalar_result,
-                "Mismatch for pattern {:#018x}: NEON={:#018x}, scalar={:#018x}",
-                pattern, neon_result, scalar_result
+                "Mismatch for pattern {pattern:#018x}: NEON={neon_result:#018x}, scalar={scalar_result:#018x}"
             );
         }
     }

--- a/src/dsv/simd/sse2.rs
+++ b/src/dsv/simd/sse2.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 SSE2 SIMD intrinsics
 //! SSE2-accelerated DSV indexing for x86_64.
 //!
 //! SSE2 is baseline for all x86_64 CPUs, providing universal availability.
@@ -100,10 +101,10 @@ unsafe fn process_chunk_64(
     in_quote: bool,
 ) -> (u64, u64, bool) {
     // Load 4 x 16-byte chunks
-    let chunk0 = _mm_loadu_si128(ptr as *const __m128i);
-    let chunk1 = _mm_loadu_si128(ptr.add(16) as *const __m128i);
-    let chunk2 = _mm_loadu_si128(ptr.add(32) as *const __m128i);
-    let chunk3 = _mm_loadu_si128(ptr.add(48) as *const __m128i);
+    let chunk0 = _mm_loadu_si128(ptr.cast::<__m128i>());
+    let chunk1 = _mm_loadu_si128(ptr.add(16).cast::<__m128i>());
+    let chunk2 = _mm_loadu_si128(ptr.add(32).cast::<__m128i>());
+    let chunk3 = _mm_loadu_si128(ptr.add(48).cast::<__m128i>());
 
     // Create comparison vectors
     let v_delimiter = _mm_set1_epi8(delimiter);

--- a/src/dsv/simd/sve2.rs
+++ b/src/dsv/simd/sve2.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ARM64 SVE2 (BDEP) SIMD intrinsics
 //! SVE2-accelerated DSV indexing for ARM64.
 //!
 //! Uses SVE2 BDEP instruction for quote state masking, providing ~10x speedup

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -98,7 +98,7 @@ pub enum QueryResult<'a, W = Vec<u64>> {
     Break(String),
 }
 
-impl<'a, W: Clone + AsRef<[u64]>> QueryResult<'a, W> {
+impl<W: Clone + AsRef<[u64]>> QueryResult<'_, W> {
     /// Convert OneCursor to One by materializing the cursor value.
     /// Used internally when we need StandardJson from a result.
     #[inline]
@@ -146,24 +146,24 @@ pub struct EvalError {
 impl EvalError {
     /// Create a new evaluation error with a message.
     pub fn new(message: impl Into<String>) -> Self {
-        EvalError {
+        Self {
             message: message.into(),
         }
     }
 
     /// Create a type error.
     pub fn type_error(expected: &str, got: &str) -> Self {
-        EvalError::new(format!("expected {}, got {}", expected, got))
+        Self::new(format!("expected {expected}, got {got}"))
     }
 
     /// Create a field not found error.
     pub fn field_not_found(name: &str) -> Self {
-        EvalError::new(format!("field '{}' not found", name))
+        Self::new(format!("field '{name}' not found"))
     }
 
     /// Create an index out of bounds error.
     pub fn index_out_of_bounds(index: i64, len: usize) -> Self {
-        EvalError::new(format!("index {} out of bounds (length {})", index, len))
+        Self::new(format!("index {index} out of bounds (length {len})"))
     }
 }
 
@@ -331,8 +331,8 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     }
                 };
 
-                let start_idx = start.map(resolve_idx).unwrap_or(0);
-                let end_idx = end.map(resolve_idx).unwrap_or(len);
+                let start_idx = start.map_or(0, resolve_idx);
+                let end_idx = end.map_or(len, resolve_idx);
 
                 // Check for empty slice
                 if start_idx >= end_idx || start_idx >= len {
@@ -424,7 +424,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Expr::Var(name) => {
             // Variable references without context should error
             // In practice, variables are resolved by eval_as which substitutes them
-            QueryResult::Error(EvalError::new(format!("undefined variable: ${}", name)))
+            QueryResult::Error(EvalError::new(format!("undefined variable: ${name}")))
         }
         Expr::Loc { line } => {
             // $__loc__ returns {"file": "<stdin>", "line": N}
@@ -491,8 +491,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // For now, namespaced calls return an error (modules not loaded)
             // This will be properly handled once module loading is implemented
             QueryResult::Error(EvalError::new(format!(
-                "module '{}' not loaded (namespaced call {}::{})",
-                namespace, namespace, name
+                "module '{namespace}' not loaded (namespaced call {namespace}::{name})"
             )))
         }
 
@@ -664,9 +663,9 @@ fn eval_object_construction<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Evaluate recursive descent.
-fn eval_recursive_descent<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
-    value: StandardJson<'a, W>,
-) -> QueryResult<'a, W> {
+fn eval_recursive_descent<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    value: StandardJson<'_, W>,
+) -> QueryResult<'_, W> {
     let mut results = Vec::new();
     collect_recursive::<W, S>(&value, &mut results);
     QueryResult::Many(results)
@@ -718,7 +717,7 @@ fn result_to_owned<W: Clone + AsRef<[u64]>>(
         }
         QueryResult::None => Err(EvalError::new("no value")),
         QueryResult::Error(e) => Err(e),
-        QueryResult::Break(label) => Err(EvalError::new(format!("break ${} not in label", label))),
+        QueryResult::Break(label) => Err(EvalError::new(format!("break ${label} not in label"))),
     }
 }
 
@@ -1151,7 +1150,7 @@ fn eval_or<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Evaluate boolean NOT.
-fn eval_not<'a, W: Clone + AsRef<[u64]>>(value: StandardJson<'a, W>) -> QueryResult<'a, W> {
+fn eval_not<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     QueryResult::Owned(OwnedValue::Bool(!owned.is_truthy()))
 }
@@ -1171,8 +1170,8 @@ fn eval_alternative<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::One(v) => to_owned(v).is_truthy(),
         QueryResult::OneCursor(_) => unreachable!("eval_single never produces OneCursor"),
         QueryResult::Owned(v) => v.is_truthy(),
-        QueryResult::Many(vs) => vs.first().map(|v| to_owned(v).is_truthy()).unwrap_or(false),
-        QueryResult::ManyOwned(vs) => vs.first().map(|v| v.is_truthy()).unwrap_or(false),
+        QueryResult::Many(vs) => vs.first().is_some_and(|v| to_owned(v).is_truthy()),
+        QueryResult::ManyOwned(vs) => vs.first().is_some_and(super::value::OwnedValue::is_truthy),
         QueryResult::None => false,
         QueryResult::Error(_) => false,
         QueryResult::Break(label) => return QueryResult::Break(label.clone()),
@@ -1201,8 +1200,8 @@ fn eval_if<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::One(v) => to_owned(v).is_truthy(),
         QueryResult::OneCursor(_) => unreachable!("eval_single never produces OneCursor"),
         QueryResult::Owned(v) => v.is_truthy(),
-        QueryResult::Many(vs) => vs.first().map(|v| to_owned(v).is_truthy()).unwrap_or(false),
-        QueryResult::ManyOwned(vs) => vs.first().map(|v| v.is_truthy()).unwrap_or(false),
+        QueryResult::Many(vs) => vs.first().is_some_and(|v| to_owned(v).is_truthy()),
+        QueryResult::ManyOwned(vs) => vs.first().is_some_and(super::value::OwnedValue::is_truthy),
         QueryResult::None => false,
         QueryResult::Error(e) => return QueryResult::Error(e.clone()),
         QueryResult::Break(label) => return QueryResult::Break(label.clone()),
@@ -1705,10 +1704,10 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: length
-fn builtin_length<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_length<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Null => QueryResult::Owned(OwnedValue::Int(0)),
         StandardJson::String(s) => {
@@ -1743,10 +1742,10 @@ fn builtin_length<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: utf8bytelength
-fn builtin_utf8bytelength<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_utf8bytelength<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
@@ -1761,11 +1760,11 @@ fn builtin_utf8bytelength<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: keys / keys_unsorted
-fn builtin_keys<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_keys<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
     sorted: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Object(fields) => {
             let mut keys: Vec<String> = Vec::new();
@@ -1918,8 +1917,8 @@ fn builtin_select<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::One(v) => to_owned(v).is_truthy(),
         QueryResult::OneCursor(_) => unreachable!("eval_single never produces OneCursor"),
         QueryResult::Owned(v) => v.is_truthy(),
-        QueryResult::Many(vs) => vs.first().map(|v| to_owned(v).is_truthy()).unwrap_or(false),
-        QueryResult::ManyOwned(vs) => vs.first().map(|v| v.is_truthy()).unwrap_or(false),
+        QueryResult::Many(vs) => vs.first().is_some_and(|v| to_owned(v).is_truthy()),
+        QueryResult::ManyOwned(vs) => vs.first().is_some_and(super::value::OwnedValue::is_truthy),
         QueryResult::None => false,
         QueryResult::Error(e) => return QueryResult::Error(e.clone()),
         QueryResult::Break(label) => return QueryResult::Break(label.clone()),
@@ -2040,10 +2039,10 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: add
-fn builtin_add<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
-    value: StandardJson<'a, W>,
+fn builtin_add<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
@@ -2067,10 +2066,10 @@ fn builtin_add<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: any
-fn builtin_any<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_any<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             for elem in elements {
@@ -2087,10 +2086,10 @@ fn builtin_any<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: all
-fn builtin_all<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_all<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             for elem in elements {
@@ -2107,10 +2106,10 @@ fn builtin_all<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: min
-fn builtin_min<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_min<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
@@ -2127,10 +2126,10 @@ fn builtin_min<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: max
-fn builtin_max<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_max<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
@@ -2223,10 +2222,10 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 // =============================================================================
 
 /// Builtin: ascii_downcase - lowercase ASCII characters
-fn builtin_ascii_downcase<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_ascii_downcase<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
@@ -2242,10 +2241,10 @@ fn builtin_ascii_downcase<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: ascii_upcase - uppercase ASCII characters
-fn builtin_ascii_upcase<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_ascii_upcase<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
@@ -2516,10 +2515,10 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 // =============================================================================
 
 /// Builtin: first - first element (.[0])
-fn builtin_first<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_first<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => match elements.get(0) {
             Some(v) => QueryResult::One(v),
@@ -2533,10 +2532,10 @@ fn builtin_first<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: last - last element (.[-1])
-fn builtin_last<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_last<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let items: Vec<_> = elements.collect();
@@ -2584,10 +2583,10 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: reverse - reverse array
-fn builtin_reverse<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_reverse<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let mut items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
@@ -2610,11 +2609,11 @@ fn builtin_reverse<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: flatten - flatten nested arrays (1 level)
-fn builtin_flatten<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_flatten<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
     depth: usize,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
@@ -2720,10 +2719,10 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: unique - remove duplicates
-fn builtin_unique<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_unique<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let mut items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
@@ -2778,10 +2777,10 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: sort - sort array
-fn builtin_sort<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_sort<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let mut items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
@@ -2831,10 +2830,10 @@ fn builtin_sort_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 // =============================================================================
 
 /// Builtin: to_entries - {k:v} → [{key:k, value:v}]
-fn builtin_to_entries<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Object(fields) => {
             let mut entries: Vec<OwnedValue> = Vec::new();
@@ -2863,10 +2862,10 @@ fn builtin_to_entries<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: from_entries - [{key:k, value:v}] → {k:v}
-fn builtin_from_entries<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_from_entries<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let mut result = IndexMap::new();
@@ -3040,19 +3039,19 @@ fn owned_to_string(value: &OwnedValue) -> String {
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
-        OwnedValue::Int(n) => format!("{}", n),
-        OwnedValue::Float(f) => format!("{}", f),
+        OwnedValue::Int(n) => format!("{n}"),
+        OwnedValue::Float(f) => format!("{f}"),
         OwnedValue::String(s) => s.clone(), // Don't quote strings in interpolation
         OwnedValue::Array(_) | OwnedValue::Object(_) => value.to_json(),
     }
 }
 
 /// Evaluate a format string: `@json`, `@uri`, etc.
-fn eval_format<'a, W: Clone + AsRef<[u64]>>(
+fn eval_format<W: Clone + AsRef<[u64]>>(
     format_type: FormatType,
-    value: StandardJson<'a, W>,
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
 
     let result = match format_type {
@@ -3111,7 +3110,7 @@ fn format_uri(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> 
             result.push(c);
         } else {
             for b in c.to_string().as_bytes() {
-                result.push_str(&format!("%{:02X}", b));
+                result.push_str(&format!("%{b:02X}"));
             }
         }
     }
@@ -3235,8 +3234,8 @@ fn format_base64(value: &OwnedValue, optional: bool) -> Result<String, EvalError
 
             for chunk in bytes.chunks(3) {
                 let b0 = chunk[0] as u32;
-                let b1 = chunk.get(1).map(|&b| b as u32).unwrap_or(0);
-                let b2 = chunk.get(2).map(|&b| b as u32).unwrap_or(0);
+                let b1 = chunk.get(1).map_or(0, |&b| b as u32);
+                let b2 = chunk.get(2).map_or(0, |&b| b as u32);
 
                 let triple = (b0 << 16) | (b1 << 8) | b2;
 
@@ -3353,9 +3352,9 @@ fn shell_quote_value(value: &OwnedValue) -> String {
         OwnedValue::String(s) => {
             if s.contains('\'') {
                 let escaped = s.replace('\'', "'\\''");
-                format!("'{}'", escaped)
+                format!("'{escaped}'")
             } else {
-                format!("'{}'", s)
+                format!("'{s}'")
             }
         }
         // Numbers, bools, null are NOT quoted in jq
@@ -3380,9 +3379,9 @@ fn format_sh(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
             // Use single quotes and escape single quotes
             if s.contains('\'') {
                 let escaped = s.replace('\'', "'\\''");
-                Ok(format!("'{}'", escaped))
+                Ok(format!("'{escaped}'"))
             } else {
-                Ok(format!("'{}'", s))
+                Ok(format!("'{s}'"))
             }
         }
         // jq: [1, 2, 3] | @sh => "1 2 3"
@@ -3427,11 +3426,11 @@ fn format_props(value: &OwnedValue) -> Result<String, EvalError> {
 fn format_props_recursive(value: &OwnedValue, prefix: String, lines: &mut Vec<String>) {
     match value {
         OwnedValue::Object(obj) => {
-            for (key, val) in obj.iter() {
+            for (key, val) in obj {
                 let new_prefix = if prefix.is_empty() {
                     key.clone()
                 } else {
-                    format!("{}.{}", prefix, key)
+                    format!("{prefix}.{key}")
                 };
                 format_props_recursive(val, new_prefix, lines);
             }
@@ -3439,9 +3438,9 @@ fn format_props_recursive(value: &OwnedValue, prefix: String, lines: &mut Vec<St
         OwnedValue::Array(arr) => {
             for (idx, val) in arr.iter().enumerate() {
                 let new_prefix = if prefix.is_empty() {
-                    format!("{}", idx)
+                    format!("{idx}")
                 } else {
-                    format!("{}.{}", prefix, idx)
+                    format!("{prefix}.{idx}")
                 };
                 format_props_recursive(val, new_prefix, lines);
             }
@@ -3453,7 +3452,7 @@ fn format_props_recursive(value: &OwnedValue, prefix: String, lines: &mut Vec<St
                 // Top-level scalar without key
                 lines.push(value_str);
             } else {
-                lines.push(format!("{} = {}", prefix, value_str));
+                lines.push(format!("{prefix} = {value_str}"));
             }
         }
     }
@@ -3465,7 +3464,7 @@ fn props_value_to_string(value: &OwnedValue) -> String {
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
-        OwnedValue::Int(n) => format!("{}", n),
+        OwnedValue::Int(n) => format!("{n}"),
         OwnedValue::Float(f) => {
             if f.is_nan() {
                 ".nan".to_string()
@@ -3476,7 +3475,7 @@ fn props_value_to_string(value: &OwnedValue) -> String {
                     "-.inf".to_string()
                 }
             } else {
-                format!("{}", f)
+                format!("{f}")
             }
         }
         OwnedValue::String(s) => {
@@ -3495,7 +3494,7 @@ fn owned_to_yaml(value: &OwnedValue) -> String {
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
-        OwnedValue::Int(n) => format!("{}", n),
+        OwnedValue::Int(n) => format!("{n}"),
         OwnedValue::Float(f) => {
             if f.is_nan() {
                 ".nan".to_string()
@@ -3506,7 +3505,7 @@ fn owned_to_yaml(value: &OwnedValue) -> String {
                     "-.inf".to_string()
                 }
             } else {
-                format!("{}", f)
+                format!("{f}")
             }
         }
         OwnedValue::String(s) => yaml_quote_string(s),
@@ -3593,28 +3592,28 @@ fn yaml_quote_string(s: &str) -> String {
 // =============================================================================
 
 /// Builtin: tostring - convert any value to string
-fn builtin_tostring<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_tostring<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     let s = match owned {
         OwnedValue::String(s) => s,
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
-        OwnedValue::Int(n) => format!("{}", n),
-        OwnedValue::Float(f) => format!("{}", f),
+        OwnedValue::Int(n) => format!("{n}"),
+        OwnedValue::Float(f) => format!("{f}"),
         OwnedValue::Array(_) | OwnedValue::Object(_) => owned.to_json(),
     };
     QueryResult::Owned(OwnedValue::String(s))
 }
 
 /// Builtin: tonumber - convert string to number
-fn builtin_tonumber<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_tonumber<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Number(n) => {
             // Already a number, return as-is
@@ -3636,7 +3635,7 @@ fn builtin_tonumber<'a, W: Clone + AsRef<[u64]>>(
                 } else if optional {
                     QueryResult::None
                 } else {
-                    QueryResult::Error(EvalError::new(format!("cannot parse '{}' as number", s)))
+                    QueryResult::Error(EvalError::new(format!("cannot parse '{s}' as number")))
                 }
             } else if optional {
                 QueryResult::None
@@ -3651,10 +3650,10 @@ fn builtin_tonumber<'a, W: Clone + AsRef<[u64]>>(
 
 /// Builtin: toboolean - convert to boolean
 /// Accepts: true, false, "true", "false"
-fn builtin_toboolean<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_toboolean<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Bool(b) => QueryResult::Owned(OwnedValue::Bool(*b)),
         StandardJson::String(s) => {
@@ -3664,8 +3663,7 @@ fn builtin_toboolean<'a, W: Clone + AsRef<[u64]>>(
                     "false" => QueryResult::Owned(OwnedValue::Bool(false)),
                     _ if optional => QueryResult::None,
                     other => QueryResult::Error(EvalError::new(format!(
-                        "string ({:?}) cannot be parsed as a boolean",
-                        other
+                        "string ({other:?}) cannot be parsed as a boolean"
                     ))),
                 }
             } else if optional {
@@ -3757,20 +3755,20 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: tojson - convert any value to JSON string
-fn builtin_tojson<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_tojson<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     let json_string = owned.to_json();
     QueryResult::Owned(OwnedValue::String(json_string))
 }
 
 /// Builtin: fromjson - parse JSON string to value
-fn builtin_fromjson<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_fromjson<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
@@ -3779,7 +3777,7 @@ fn builtin_fromjson<'a, W: Clone + AsRef<[u64]>>(
                 match parse_json_string(json_str) {
                     Ok(owned) => QueryResult::Owned(owned),
                     Err(_) if optional => QueryResult::None,
-                    Err(e) => QueryResult::Error(EvalError::new(format!("fromjson: {}", e))),
+                    Err(e) => QueryResult::Error(EvalError::new(format!("fromjson: {e}"))),
                 }
             } else if optional {
                 QueryResult::None
@@ -4160,10 +4158,10 @@ fn parse_json_number(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String
 // =============================================================================
 
 /// Builtin: explode - string to array of Unicode codepoints
-fn builtin_explode<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_explode<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
@@ -4184,10 +4182,10 @@ fn builtin_explode<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: implode - array of codepoints to string
-fn builtin_implode<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_implode<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Array(elements) => {
             let mut result = String::new();
@@ -4200,8 +4198,7 @@ fn builtin_implode<'a, W: Clone + AsRef<[u64]>>(
                             continue;
                         } else {
                             return QueryResult::Error(EvalError::new(format!(
-                                "invalid codepoint: {}",
-                                codepoint
+                                "invalid codepoint: {codepoint}"
                             )));
                         }
                     }
@@ -4390,10 +4387,10 @@ fn builtin_rindex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: tojsonstream - convert to JSON text stream format (simplified)
-fn builtin_tojsonstream<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_tojsonstream<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     // Simplified: just return the value as JSON lines format
     let owned = to_owned(&value);
     fn collect_stream(value: &OwnedValue, path: &[OwnedValue], results: &mut Vec<OwnedValue>) {
@@ -4406,7 +4403,7 @@ fn builtin_tojsonstream<'a, W: Clone + AsRef<[u64]>>(
                 }
             }
             OwnedValue::Object(obj) => {
-                for (k, v) in obj.iter() {
+                for (k, v) in obj {
                     let mut new_path = path.to_vec();
                     new_path.push(OwnedValue::String(k.clone()));
                     collect_stream(v, &new_path, results);
@@ -4426,10 +4423,10 @@ fn builtin_tojsonstream<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: fromjsonstream - convert from JSON text stream format (simplified)
-fn builtin_fromjsonstream<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_fromjsonstream<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     // This is a complex operation - provide a simplified version
     match &value {
         StandardJson::Array(_) => {
@@ -4513,11 +4510,11 @@ fn build_regex(pattern: &str, flags: Option<&str>) -> Result<regex::Regex, EvalE
         }
         if prefix.len() > 2 {
             prefix.push(')');
-            pattern = format!("{}{}", prefix, pattern);
+            pattern = format!("{prefix}{pattern}");
         }
     }
 
-    regex::Regex::new(&pattern).map_err(|e| EvalError::new(format!("invalid regex: {}", e)))
+    regex::Regex::new(&pattern).map_err(|e| EvalError::new(format!("invalid regex: {e}")))
 }
 
 /// Builtin: match(re) or match(re; flags) - return match object
@@ -4555,7 +4552,7 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     // Check if global flag is set
-    let global = flags.map(|f| f.contains('g')).unwrap_or(false);
+    let global = flags.is_some_and(|f| f.contains('g'));
 
     if global {
         // Return all matches
@@ -4596,23 +4593,19 @@ fn build_match_object(re: &regex::Regex, matched: &str, offset: usize, input: &s
             let mut cap_obj = IndexMap::new();
             cap_obj.insert(
                 "offset".to_string(),
-                cap.map(|m| OwnedValue::Int(m.start() as i64))
-                    .unwrap_or(OwnedValue::Null),
+                cap.map_or(OwnedValue::Null, |m| OwnedValue::Int(m.start() as i64)),
             );
             cap_obj.insert(
                 "length".to_string(),
-                cap.map(|m| OwnedValue::Int(m.len() as i64))
-                    .unwrap_or(OwnedValue::Int(0)),
+                cap.map_or(OwnedValue::Int(0), |m| OwnedValue::Int(m.len() as i64)),
             );
             cap_obj.insert(
                 "string".to_string(),
-                cap.map(|m| OwnedValue::String(m.as_str().to_string()))
-                    .unwrap_or(OwnedValue::Null),
+                cap.map_or(OwnedValue::Null, |m| OwnedValue::String(m.as_str().to_string())),
             );
             cap_obj.insert(
                 "name".to_string(),
-                name.map(|n| OwnedValue::String(n.to_string()))
-                    .unwrap_or(OwnedValue::Null),
+                name.map_or(OwnedValue::Null, |n| OwnedValue::String(n.to_string())),
             );
             captures.push(OwnedValue::Object(cap_obj));
         }
@@ -5508,10 +5501,10 @@ fn find_field<'a, W: Clone + AsRef<[u64]>>(
 ///
 /// Uses `get_fast` for O(n) BP operations + O(log n) IB select,
 /// instead of `get` which does O(n) IB selects.
-fn get_element_at_index<'a, W: Clone + AsRef<[u64]>>(
-    elements: JsonElements<'a, W>,
+fn get_element_at_index<W: Clone + AsRef<[u64]>>(
+    elements: JsonElements<'_, W>,
     idx: i64,
-) -> Option<StandardJson<'a, W>> {
+) -> Option<StandardJson<'_, W>> {
     if idx >= 0 {
         elements.get_fast(idx as usize)
     } else {
@@ -5532,11 +5525,11 @@ fn count_elements<W: Clone + AsRef<[u64]>>(elements: JsonElements<'_, W>) -> usi
 }
 
 /// Slice elements from an array.
-fn slice_elements<'a, W: Clone + AsRef<[u64]>>(
-    elements: JsonElements<'a, W>,
+fn slice_elements<W: Clone + AsRef<[u64]>>(
+    elements: JsonElements<'_, W>,
     start: Option<i64>,
     end: Option<i64>,
-) -> Vec<StandardJson<'a, W>> {
+) -> Vec<StandardJson<'_, W>> {
     let all: Vec<_> = elements.collect();
     let len = all.len();
 
@@ -5554,8 +5547,8 @@ fn slice_elements<'a, W: Clone + AsRef<[u64]>>(
         }
     };
 
-    let start_idx = start.map(|i| resolve_idx(i, 0)).unwrap_or(0);
-    let end_idx = end.map(|i| resolve_idx(i, len)).unwrap_or(len);
+    let start_idx = start.map_or(0, |i| resolve_idx(i, 0));
+    let end_idx = end.map_or(len, |i| resolve_idx(i, len));
 
     if start_idx >= end_idx || start_idx >= len {
         return Vec::new();
@@ -6792,7 +6785,7 @@ fn eval_owned_expr<S: EvalSemantics>(
         }
         QueryResult::None => Ok(OwnedValue::Null),
         QueryResult::Error(e) => Err(e),
-        QueryResult::Break(label) => Err(EvalError::new(format!("break ${} not in label", label))),
+        QueryResult::Break(label) => Err(EvalError::new(format!("break ${label} not in label"))),
     }
 }
 
@@ -6802,12 +6795,12 @@ fn owned_value_to_json_string(value: &OwnedValue) -> String {
         OwnedValue::Null => "null".into(),
         OwnedValue::Bool(true) => "true".into(),
         OwnedValue::Bool(false) => "false".into(),
-        OwnedValue::Int(i) => format!("{}", i),
+        OwnedValue::Int(i) => format!("{i}"),
         OwnedValue::Float(f) => {
             if f.is_nan() || f.is_infinite() {
                 "null".into() // JSON doesn't have NaN or Infinity
             } else {
-                format!("{}", f)
+                format!("{f}")
             }
         }
         OwnedValue::String(s) => {
@@ -7271,10 +7264,10 @@ fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: recurse (recurse(.[]))
-fn builtin_recurse<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
-    value: StandardJson<'a, W>,
+fn builtin_recurse<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     // Default recurse is equivalent to recurse(.[]?)
     let f = Expr::Optional(Box::new(Expr::Iterate));
     builtin_recurse_f::<W, S>(&f, value, optional)
@@ -8101,10 +8094,10 @@ fn collect_paths(value: &OwnedValue, current_path: &[OwnedValue], paths: &mut Ve
 
 /// Builtin: paths - all paths to values (excluding empty paths)
 /// Returns each path as a separate output (streaming), matching jq behavior
-fn builtin_paths<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_paths<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     let mut paths = Vec::new();
     collect_paths(&owned, &[], &mut paths);
@@ -8226,10 +8219,10 @@ fn collect_leaf_paths(
 
 /// Builtin: leaf_paths - paths to scalar (non-container) values
 /// Returns each path as a separate output (streaming), matching jq's paths(scalars) behavior
-fn builtin_leaf_paths<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_leaf_paths<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     let mut paths = Vec::new();
     collect_leaf_paths(&owned, &[], &mut paths);
@@ -8555,10 +8548,10 @@ fn builtin_now<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 
 /// Builtin: gmtime - convert Unix timestamp to broken-down UTC time
 /// Returns [year, month(0-11), day(1-31), hour, minute, second, weekday(0-6, Sunday=0), yearday(0-365)]
-fn builtin_gmtime<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_gmtime<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let timestamp = match get_float_value::<W>(&value, optional) {
         Ok(f) => f,
         Err(r) => return r,
@@ -8589,7 +8582,7 @@ fn builtin_gmtime<'a, W: Clone + AsRef<[u64]>>(
     let mp = (5 * doy + 2) / 153; // month [0, 11] starting from March
     let day = (doy - (153 * mp + 2) / 5 + 1) as i64;
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = y + if month <= 2 { 1 } else { 0 };
+    let year = y + i64::from(month <= 2);
 
     // Calculate weekday (0 = Sunday, 6 = Saturday)
     // Jan 1, 1970 was a Thursday (4)
@@ -8620,10 +8613,10 @@ fn builtin_gmtime<'a, W: Clone + AsRef<[u64]>>(
 
 /// Builtin: localtime - convert Unix timestamp to broken-down local time
 /// Returns [year, month(0-11), day(1-31), hour, minute, second, weekday(0-6, Sunday=0), yearday(0-365)]
-fn builtin_localtime<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_localtime<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     #[cfg(feature = "std")]
     {
         let timestamp = match get_float_value::<W>(&value, optional) {
@@ -8639,8 +8632,7 @@ fn builtin_localtime<'a, W: Clone + AsRef<[u64]>>(
         use std::time::{SystemTime, UNIX_EPOCH};
         let now_utc = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs() as i64);
 
         // We need to compute the local offset. A simple approach is to use environment TZ,
         // but that's complex. For simplicity, we'll compute gmtime and apply a local offset.
@@ -8689,7 +8681,7 @@ fn builtin_localtime<'a, W: Clone + AsRef<[u64]>>(
         let mp = (5 * doy + 2) / 153;
         let day = (doy - (153 * mp + 2) / 5 + 1) as i64;
         let month = if mp < 10 { mp + 3 } else { mp - 9 };
-        let year = y + if month <= 2 { 1 } else { 0 };
+        let year = y + i64::from(month <= 2);
 
         let weekday = (days % 7 + 4 + 7) % 7;
 
@@ -8771,10 +8763,10 @@ fn parse_simple_tz_offset(tz: &str) -> Option<i64> {
 }
 
 /// Builtin: mktime - convert broken-down time to Unix timestamp
-fn builtin_mktime<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_mktime<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let arr = match to_owned(&value) {
         OwnedValue::Array(a) => a,
         _ if optional => return QueryResult::None,
@@ -8796,8 +8788,7 @@ fn builtin_mktime<'a, W: Clone + AsRef<[u64]>>(
             Some(OwnedValue::Int(n)) => Ok(*n),
             Some(OwnedValue::Float(f)) => Ok(*f as i64),
             _ => Err(EvalError::new(format!(
-                "mktime: element {} must be a number",
-                idx
+                "mktime: element {idx} must be a number"
             ))),
         }
     };
@@ -8835,7 +8826,7 @@ fn builtin_mktime<'a, W: Clone + AsRef<[u64]>>(
 
     // Convert to Unix timestamp using inverse of the gmtime algorithm
     // Algorithm from Howard Hinnant's date library (civil_from_days inverse)
-    let y = year - if month <= 2 { 1 } else { 0 };
+    let y = year - i64::from(month <= 2);
     let era = if y >= 0 { y } else { y - 399 } / 400;
     let yoe = (y - era * 400) as u32; // year of era [0, 399]
     let m = month as u32;
@@ -8922,12 +8913,12 @@ fn format_strftime(
         if c == '%' {
             match chars.next() {
                 Some('%') => result.push('%'),
-                Some('Y') => result.push_str(&format!("{:04}", year)),
+                Some('Y') => result.push_str(&format!("{year:04}")),
                 Some('y') => result.push_str(&format!("{:02}", year % 100)),
-                Some('m') => result.push_str(&format!("{:02}", month)),
-                Some('d') => result.push_str(&format!("{:02}", day)),
-                Some('e') => result.push_str(&format!("{:2}", day)),
-                Some('H') => result.push_str(&format!("{:02}", hour)),
+                Some('m') => result.push_str(&format!("{month:02}")),
+                Some('d') => result.push_str(&format!("{day:02}")),
+                Some('e') => result.push_str(&format!("{day:2}")),
+                Some('H') => result.push_str(&format!("{hour:02}")),
                 Some('I') => result.push_str(&format!(
                     "{:02}",
                     if hour == 0 {
@@ -8938,14 +8929,14 @@ fn format_strftime(
                         hour
                     }
                 )),
-                Some('M') => result.push_str(&format!("{:02}", minute)),
-                Some('S') => result.push_str(&format!("{:02}", second)),
+                Some('M') => result.push_str(&format!("{minute:02}")),
+                Some('S') => result.push_str(&format!("{second:02}")),
                 Some('p') => result.push_str(if hour < 12 { "AM" } else { "PM" }),
                 Some('P') => result.push_str(if hour < 12 { "am" } else { "pm" }),
                 Some('j') => result.push_str(&format!("{:03}", yearday + 1)), // 1-indexed
-                Some('w') => result.push_str(&format!("{}", weekday)),
+                Some('w') => result.push_str(&format!("{weekday}")),
                 Some('u') => {
-                    result.push_str(&format!("{}", if weekday == 0 { 7 } else { weekday }))
+                    result.push_str(&format!("{}", if weekday == 0 { 7 } else { weekday }));
                 } // Monday=1
                 Some('a') => {
                     let names = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -8963,7 +8954,7 @@ fn format_strftime(
                     ];
                     result.push_str(names[weekday as usize % 7]);
                 }
-                Some('b') | Some('h') => {
+                Some('b' | 'h') => {
                     let names = [
                         "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct",
                         "Nov", "Dec",
@@ -8989,9 +8980,9 @@ fn format_strftime(
                 }
                 Some('C') => result.push_str(&format!("{:02}", year / 100)),
                 Some('D') => result.push_str(&format!("{:02}/{:02}/{:02}", month, day, year % 100)),
-                Some('F') => result.push_str(&format!("{:04}-{:02}-{:02}", year, month, day)),
-                Some('R') => result.push_str(&format!("{:02}:{:02}", hour, minute)),
-                Some('T') => result.push_str(&format!("{:02}:{:02}:{:02}", hour, minute, second)),
+                Some('F') => result.push_str(&format!("{year:04}-{month:02}-{day:02}")),
+                Some('R') => result.push_str(&format!("{hour:02}:{minute:02}")),
+                Some('T') => result.push_str(&format!("{hour:02}:{minute:02}:{second:02}")),
                 Some('n') => result.push('\n'),
                 Some('t') => result.push('\t'),
                 Some('z') => result.push_str("+0000"), // UTC offset (we're always UTC for gmtime)
@@ -9130,7 +9121,7 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
                 Some('S') => {
                     second = parse_digits(&mut input_iter, 2)?;
                 }
-                Some('p') | Some('P') => {
+                Some('p' | 'P') => {
                     let mut ampm = String::new();
                     while let Some(&c) = input_iter.peek() {
                         if c.is_ascii_alphabetic() {
@@ -9166,7 +9157,7 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
                     let w = parse_digits(&mut input_iter, 1)?;
                     weekday = if w == 7 { 0 } else { w };
                 }
-                Some('a') | Some('A') => {
+                Some('a' | 'A') => {
                     // Skip day name
                     while let Some(&c) = input_iter.peek() {
                         if c.is_ascii_alphabetic() {
@@ -9176,7 +9167,7 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
                         }
                     }
                 }
-                Some('b') | Some('B') | Some('h') => {
+                Some('b' | 'B' | 'h') => {
                     let mut name = String::new();
                     while let Some(&c) = input_iter.peek() {
                         if c.is_ascii_alphabetic() {
@@ -9247,7 +9238,7 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
                     }
                     second = parse_digits(&mut input_iter, 2)?;
                 }
-                Some('n') | Some('t') => {
+                Some('n' | 't') => {
                     // Skip whitespace
                     while let Some(&c) = input_iter.peek() {
                         if c.is_whitespace() {
@@ -9265,8 +9256,7 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
                             for _ in 0..4 {
                                 if input_iter
                                     .peek()
-                                    .map(|c| c.is_ascii_digit())
-                                    .unwrap_or(false)
+                                    .is_some_and(char::is_ascii_digit)
                                 {
                                     input_iter.next();
                                 }
@@ -9287,7 +9277,7 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
                 Some(other) => {
                     // Unknown specifier - skip % and match literal
                     if input_iter.next() != Some(other) {
-                        return Err(format!("expected '{}'", other));
+                        return Err(format!("expected '{other}'"));
                     }
                 }
                 None => {
@@ -9310,15 +9300,15 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
             // Match literal character
             match input_iter.next() {
                 Some(c) if c == fc => {}
-                Some(c) => return Err(format!("expected '{}', got '{}'", fc, c)),
-                None => return Err(format!("expected '{}', got end of input", fc)),
+                Some(c) => return Err(format!("expected '{fc}', got '{c}'")),
+                None => return Err(format!("expected '{fc}', got end of input")),
             }
         }
     }
 
     // Calculate weekday if not explicitly set
     // Using Zeller's congruence or similar
-    let y = year - if month <= 2 { 1 } else { 0 };
+    let y = year - i64::from(month <= 2);
     let era = if y >= 0 { y } else { y - 399 } / 400;
     let yoe = (y - era * 400) as u32;
     let m = month as u32;
@@ -9376,10 +9366,10 @@ fn parse_digits(
 }
 
 /// Builtin: todate - convert Unix timestamp to ISO 8601 date string
-fn builtin_todate<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_todate<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let timestamp = match get_float_value::<W>(&value, optional) {
         Ok(f) => f,
         Err(r) => return r,
@@ -9406,21 +9396,20 @@ fn builtin_todate<'a, W: Clone + AsRef<[u64]>>(
     let mp = (5 * doy + 2) / 153;
     let day = doy - (153 * mp + 2) / 5 + 1;
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = y + if month <= 2 { 1 } else { 0 };
+    let year = y + i64::from(month <= 2);
 
     let result = format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
-        year, month, day, hour, minute, second
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z"
     );
 
     QueryResult::Owned(OwnedValue::String(result))
 }
 
 /// Builtin: fromdate - parse ISO 8601 date string to Unix timestamp
-fn builtin_fromdate<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_fromdate<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
             Ok(cow) => cow.into_owned(),
@@ -9488,7 +9477,7 @@ fn parse_iso8601(input: &str) -> Result<f64, String> {
                 // Skip fractional seconds
                 if chars.peek() == Some(&'.') {
                     chars.next();
-                    while chars.peek().map(|c| c.is_ascii_digit()).unwrap_or(false) {
+                    while chars.peek().is_some_and(char::is_ascii_digit) {
                         chars.next();
                     }
                 }
@@ -9499,7 +9488,7 @@ fn parse_iso8601(input: &str) -> Result<f64, String> {
 
             // Parse timezone
             let tz_offset = match chars.peek() {
-                Some('Z') | Some('z') => {
+                Some('Z' | 'z') => {
                     chars.next();
                     0
                 }
@@ -9509,7 +9498,7 @@ fn parse_iso8601(input: &str) -> Result<f64, String> {
                     let m = if chars.peek() == Some(&':') {
                         chars.next();
                         parse_digits(&mut chars, 2)?
-                    } else if chars.peek().map(|c| c.is_ascii_digit()).unwrap_or(false) {
+                    } else if chars.peek().is_some_and(char::is_ascii_digit) {
                         parse_digits(&mut chars, 2)?
                     } else {
                         0
@@ -9522,7 +9511,7 @@ fn parse_iso8601(input: &str) -> Result<f64, String> {
                     let m = if chars.peek() == Some(&':') {
                         chars.next();
                         parse_digits(&mut chars, 2)?
-                    } else if chars.peek().map(|c| c.is_ascii_digit()).unwrap_or(false) {
+                    } else if chars.peek().is_some_and(char::is_ascii_digit) {
                         parse_digits(&mut chars, 2)?
                     } else {
                         0
@@ -9538,7 +9527,7 @@ fn parse_iso8601(input: &str) -> Result<f64, String> {
         };
 
     // Convert to Unix timestamp
-    let y = year - if month <= 2 { 1 } else { 0 };
+    let y = year - i64::from(month <= 2);
     let era = if y >= 0 { y } else { y - 399 } / 400;
     let yoe = (y - era * 400) as u32;
     let m = month as u32;
@@ -9556,20 +9545,20 @@ fn parse_iso8601(input: &str) -> Result<f64, String> {
 
 /// Builtin: from_unix - convert Unix epoch to ISO 8601 date string
 /// This is semantically identical to todate/todateiso8601 but with yq naming convention
-fn builtin_from_unix<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_from_unix<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     // from_unix is the same as todate - converts Unix timestamp to ISO 8601 string
     builtin_todate::<W>(value, optional)
 }
 
 /// Builtin: to_unix - convert ISO 8601 date string to Unix epoch
 /// This is semantically identical to fromdate/fromdateiso8601 but with yq naming convention
-fn builtin_to_unix<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_to_unix<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     // to_unix is the same as fromdate - parses ISO 8601 string to Unix timestamp
     builtin_fromdate::<W>(value, optional)
 }
@@ -9598,20 +9587,18 @@ fn format_datetime_with_offset(timestamp: f64, offset_seconds: i64) -> String {
     let mp = (5 * doy + 2) / 153;
     let day = doy - (153 * mp + 2) / 5 + 1;
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = y + if month <= 2 { 1 } else { 0 };
+    let year = y + i64::from(month <= 2);
 
     if offset_seconds == 0 {
         format!(
-            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
-            year, month, day, hour, minute, second
+            "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z"
         )
     } else {
         let offset_hours = offset_seconds.abs() / 3600;
         let offset_mins = (offset_seconds.abs() % 3600) / 60;
         let sign = if offset_seconds >= 0 { '+' } else { '-' };
         format!(
-            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}{}{:02}:{:02}",
-            year, month, day, hour, minute, second, sign, offset_hours, offset_mins
+            "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}{sign}{offset_hours:02}:{offset_mins:02}"
         )
     }
 }
@@ -9751,7 +9738,7 @@ fn get_timezone_offset(zone: &str, timestamp: f64) -> Result<i64, String> {
                             if let Some(offset) = parse_numeric_offset(zone) {
                                 return Ok(offset);
                             }
-                            return Err(format!("unknown timezone: {}", zone));
+                            return Err(format!("unknown timezone: {zone}"));
                         }
                     };
                     return Ok(offset);
@@ -9933,8 +9920,7 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
         Err(e) => {
             return QueryResult::Error(EvalError::new(format!(
-                "load: failed to read file '{}': {}",
-                filename, e
+                "load: failed to read file '{filename}': {e}"
             )));
         }
     };
@@ -9944,8 +9930,7 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let is_json = path
         .extension()
         .and_then(|e| e.to_str())
-        .map(|ext| ext.eq_ignore_ascii_case("json"))
-        .unwrap_or(false);
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"));
 
     if is_json {
         // Parse as JSON
@@ -9977,8 +9962,7 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
             Err(_) if optional => QueryResult::None,
             Err(e) => QueryResult::Error(EvalError::new(format!(
-                "load: failed to parse YAML file '{}': {}",
-                filename, e
+                "load: failed to parse YAML file '{filename}': {e}"
             ))),
         }
     }
@@ -10088,10 +10072,10 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
 /// Builtin: combinations - generate all combinations from array of arrays
 /// Input: [[1,2], [3,4]] -> outputs [1,3], [1,4], [2,3], [2,4]
-fn builtin_combinations<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_combinations<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     // Input must be an array of arrays
     let arrays = match &value {
         StandardJson::Array(elements) => {
@@ -10115,7 +10099,7 @@ fn builtin_combinations<'a, W: Clone + AsRef<[u64]>>(
     };
 
     // If any array is empty, return no results
-    if arrays.iter().any(|a| a.is_empty()) {
+    if arrays.iter().any(alloc::vec::Vec::is_empty) {
         return QueryResult::None;
     }
 
@@ -10419,7 +10403,7 @@ fn builtin_builtins<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 }
 
 /// Builtin: normals - select only normal numbers (not zero, infinite, NaN, or subnormal)
-fn builtin_normals<'a, W: Clone + AsRef<[u64]>>(value: StandardJson<'a, W>) -> QueryResult<'a, W> {
+fn builtin_normals<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryResult<'_, W> {
     if let StandardJson::Number(n) = &value {
         if let Ok(f) = n.as_f64() {
             if f.is_normal() {
@@ -10431,7 +10415,7 @@ fn builtin_normals<'a, W: Clone + AsRef<[u64]>>(value: StandardJson<'a, W>) -> Q
 }
 
 /// Builtin: finites - select only finite numbers (not infinite or NaN)
-fn builtin_finites<'a, W: Clone + AsRef<[u64]>>(value: StandardJson<'a, W>) -> QueryResult<'a, W> {
+fn builtin_finites<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryResult<'_, W> {
     if let StandardJson::Number(n) = &value {
         if let Ok(f) = n.as_f64() {
             if f.is_finite() {
@@ -10908,10 +10892,10 @@ fn sqrt_f64(x: f64) -> f64 {
 }
 
 /// Builtin: floor
-fn builtin_floor<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_floor<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Int(floor_f64(n) as i64)),
         Err(r) => r,
@@ -10919,10 +10903,10 @@ fn builtin_floor<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: ceil
-fn builtin_ceil<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_ceil<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Int(ceil_f64(n) as i64)),
         Err(r) => r,
@@ -10930,10 +10914,10 @@ fn builtin_ceil<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: round
-fn builtin_round<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_round<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Int(round_f64(n) as i64)),
         Err(r) => r,
@@ -10941,10 +10925,10 @@ fn builtin_round<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: trunc - truncate toward zero
-fn builtin_trunc<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_trunc<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Int(libm::trunc(n) as i64)),
         Err(r) => r,
@@ -10952,10 +10936,10 @@ fn builtin_trunc<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: sqrt
-fn builtin_sqrt<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_sqrt<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(sqrt_f64(n))),
         Err(r) => r,
@@ -10963,10 +10947,10 @@ fn builtin_sqrt<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: fabs (absolute value)
-fn builtin_fabs<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_fabs<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::fabs(n))),
         Err(r) => r,
@@ -10974,10 +10958,10 @@ fn builtin_fabs<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: log (natural logarithm)
-fn builtin_log<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_log<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::log(n))),
         Err(r) => r,
@@ -10985,10 +10969,10 @@ fn builtin_log<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: log10
-fn builtin_log10<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_log10<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::log10(n))),
         Err(r) => r,
@@ -10996,10 +10980,10 @@ fn builtin_log10<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: log2
-fn builtin_log2<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_log2<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::log2(n))),
         Err(r) => r,
@@ -11007,10 +10991,10 @@ fn builtin_log2<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: exp (e^x)
-fn builtin_exp<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_exp<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::exp(n))),
         Err(r) => r,
@@ -11018,10 +11002,10 @@ fn builtin_exp<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: exp10 (10^x)
-fn builtin_exp10<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_exp10<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::pow(10.0, n))),
         Err(r) => r,
@@ -11029,10 +11013,10 @@ fn builtin_exp10<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: exp2 (2^x)
-fn builtin_exp2<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_exp2<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::exp2(n))),
         Err(r) => r,
@@ -11091,10 +11075,10 @@ fn builtin_pow<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 // Trigonometric functions
 
 /// Builtin: sin
-fn builtin_sin<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_sin<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::sin(n))),
         Err(r) => r,
@@ -11102,10 +11086,10 @@ fn builtin_sin<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: cos
-fn builtin_cos<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_cos<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::cos(n))),
         Err(r) => r,
@@ -11113,10 +11097,10 @@ fn builtin_cos<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: tan
-fn builtin_tan<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_tan<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::tan(n))),
         Err(r) => r,
@@ -11124,10 +11108,10 @@ fn builtin_tan<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: asin
-fn builtin_asin<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_asin<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::asin(n))),
         Err(r) => r,
@@ -11135,10 +11119,10 @@ fn builtin_asin<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: acos
-fn builtin_acos<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_acos<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::acos(n))),
         Err(r) => r,
@@ -11146,10 +11130,10 @@ fn builtin_acos<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: atan
-fn builtin_atan<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_atan<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::atan(n))),
         Err(r) => r,
@@ -11184,10 +11168,10 @@ fn builtin_atan2<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 // Hyperbolic functions
 
 /// Builtin: sinh
-fn builtin_sinh<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_sinh<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::sinh(n))),
         Err(r) => r,
@@ -11195,10 +11179,10 @@ fn builtin_sinh<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: cosh
-fn builtin_cosh<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_cosh<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::cosh(n))),
         Err(r) => r,
@@ -11206,10 +11190,10 @@ fn builtin_cosh<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: tanh
-fn builtin_tanh<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_tanh<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::tanh(n))),
         Err(r) => r,
@@ -11217,10 +11201,10 @@ fn builtin_tanh<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: asinh
-fn builtin_asinh<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_asinh<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::asinh(n))),
         Err(r) => r,
@@ -11228,10 +11212,10 @@ fn builtin_asinh<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: acosh
-fn builtin_acosh<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_acosh<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::acosh(n))),
         Err(r) => r,
@@ -11239,10 +11223,10 @@ fn builtin_acosh<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: atanh
-fn builtin_atanh<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_atanh<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Float(libm::atanh(n))),
         Err(r) => r,
@@ -11253,10 +11237,10 @@ fn builtin_atanh<'a, W: Clone + AsRef<[u64]>>(
 // Note: is_infinite(), is_nan(), is_normal(), is_finite() are available on f64 in no_std
 
 /// Builtin: isinfinite
-fn builtin_isinfinite<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_isinfinite<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Number(n) => {
             if let Ok(f) = n.as_f64() {
@@ -11270,10 +11254,10 @@ fn builtin_isinfinite<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: isnan
-fn builtin_isnan<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_isnan<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Number(n) => {
             if let Ok(f) = n.as_f64() {
@@ -11287,10 +11271,10 @@ fn builtin_isnan<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: isnormal
-fn builtin_isnormal<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_isnormal<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Number(n) => {
             if let Ok(f) = n.as_f64() {
@@ -11304,10 +11288,10 @@ fn builtin_isnormal<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: isfinite
-fn builtin_isfinite<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_isfinite<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match get_float_value::<W>(&value, optional) {
         Ok(n) => QueryResult::Owned(OwnedValue::Bool(n.is_finite())),
         Err(_) => QueryResult::Owned(OwnedValue::Bool(false)),
@@ -11317,10 +11301,10 @@ fn builtin_isfinite<'a, W: Clone + AsRef<[u64]>>(
 // Debug functions
 
 /// Builtin: debug - output value to stderr, pass through unchanged
-fn builtin_debug<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_debug<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     // In a library context we don't actually print to stderr
     // We just pass through the value unchanged
     QueryResult::Owned(to_owned(&value))
@@ -11357,10 +11341,10 @@ fn eval_env<'a, W: Clone + AsRef<[u64]>>(_optional: bool) -> QueryResult<'a, W> 
 
 /// Builtin: env - object of all environment variables
 #[cfg(feature = "std")]
-fn builtin_env<'a, W: Clone + AsRef<[u64]>>(
-    _value: StandardJson<'a, W>,
+fn builtin_env<W: Clone + AsRef<[u64]>>(
+    _value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let mut env_obj = IndexMap::new();
     for (key, value) in std::env::vars() {
         env_obj.insert(key, OwnedValue::String(value));
@@ -11420,8 +11404,7 @@ fn builtin_env_object<'a, W: Clone + AsRef<[u64]>>(
         Ok(val) => QueryResult::Owned(OwnedValue::String(val)),
         Err(_) if optional => QueryResult::None,
         Err(_) => QueryResult::Error(EvalError::new(format!(
-            "value for env variable '{}' not provided in env()",
-            name
+            "value for env variable '{name}' not provided in env()"
         ))),
     }
 }
@@ -11449,8 +11432,7 @@ fn builtin_strenv<'a, W: Clone + AsRef<[u64]>>(name: &str, optional: bool) -> Qu
         Ok(val) => QueryResult::Owned(OwnedValue::String(val)),
         Err(_) if optional => QueryResult::None,
         Err(_) => QueryResult::Error(EvalError::new(format!(
-            "value for env variable '{}' not provided in strenv()",
-            name
+            "value for env variable '{name}' not provided in strenv()"
         ))),
     }
 }
@@ -11470,10 +11452,10 @@ fn builtin_strenv<'a, W: Clone + AsRef<[u64]>>(name: &str, optional: bool) -> Qu
 // String functions
 
 /// Builtin: trim - remove leading/trailing whitespace
-fn builtin_trim<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_trim<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
@@ -11488,10 +11470,10 @@ fn builtin_trim<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: ltrim - remove leading whitespace
-fn builtin_ltrim<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_ltrim<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
@@ -11506,10 +11488,10 @@ fn builtin_ltrim<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: rtrim - remove trailing whitespace
-fn builtin_rtrim<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_rtrim<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
@@ -11526,10 +11508,10 @@ fn builtin_rtrim<'a, W: Clone + AsRef<[u64]>>(
 // Array functions
 
 /// Builtin: transpose - transpose array of arrays
-fn builtin_transpose<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_transpose<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     let elements = match value {
         StandardJson::Array(a) => a,
         _ if optional => return QueryResult::None,
@@ -11555,7 +11537,7 @@ fn builtin_transpose<'a, W: Clone + AsRef<[u64]>>(
     }
 
     // Find max length
-    let max_len = inner_arrays.iter().map(|a| a.len()).max().unwrap_or(0);
+    let max_len = inner_arrays.iter().map(alloc::vec::Vec::len).max().unwrap_or(0);
 
     // Build transposed result
     let mut result = Vec::with_capacity(max_len);
@@ -11841,7 +11823,7 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
 // Builtin: tag - return YAML type tag (!!str, !!int, !!map, etc.)
 // Since we evaluate on JSON/OwnedValue (not raw YAML), we derive the tag from the JSON type.
-fn builtin_tag<'a, W: Clone + AsRef<[u64]>>(value: StandardJson<'a, W>) -> QueryResult<'a, W> {
+fn builtin_tag<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryResult<'_, W> {
     let tag = match &value {
         StandardJson::Null => "!!null",
         StandardJson::Bool(_) => "!!bool",
@@ -11873,7 +11855,7 @@ fn builtin_anchor<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 // Builtin: style - return scalar/collection style
 // Since YAML style metadata is lost during conversion to OwnedValue, this returns
 // reasonable defaults based on the JSON structure.
-fn builtin_style<'a, W: Clone + AsRef<[u64]>>(value: StandardJson<'a, W>) -> QueryResult<'a, W> {
+fn builtin_style<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryResult<'_, W> {
     let style = match &value {
         // Collections: yq returns "flow" for flow-style, empty for block-style
         // Since we lose this info, we return empty string (block-style is more common)
@@ -11887,7 +11869,7 @@ fn builtin_style<'a, W: Clone + AsRef<[u64]>>(value: StandardJson<'a, W>) -> Que
 
 /// `kind` - returns the node kind: "scalar", "seq", or "map"
 /// This is a yq function that returns the YAML node kind.
-fn builtin_kind<'a, W: Clone + AsRef<[u64]>>(value: StandardJson<'a, W>) -> QueryResult<'a, W> {
+fn builtin_kind<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryResult<'_, W> {
     let kind = match &value {
         StandardJson::Array(_) => "seq",
         StandardJson::Object(_) => "map",
@@ -11928,10 +11910,10 @@ fn builtin_document_index<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 /// `shuffle` - randomly shuffle array elements (yq)
 /// Uses non-cryptographic RNG for performance.
 #[cfg(feature = "cli")]
-fn builtin_shuffle<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_shuffle<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     use rand::seq::SliceRandom;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
@@ -11952,10 +11934,10 @@ fn builtin_shuffle<'a, W: Clone + AsRef<[u64]>>(
 
 /// `shuffle` - fallback when cli feature is not enabled
 #[cfg(not(feature = "cli"))]
-fn builtin_shuffle<'a, W: Clone + AsRef<[u64]>>(
-    _value: StandardJson<'a, W>,
+fn builtin_shuffle<W: Clone + AsRef<[u64]>>(
+    _value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     QueryResult::Error(EvalError::new(
         "shuffle requires the 'cli' feature to be enabled",
     ))
@@ -11971,10 +11953,10 @@ fn builtin_shuffle<'a, W: Clone + AsRef<[u64]>>(
 ///   → {name: ["Alice", "Bob"], age: [30, 25]}
 ///
 /// Handles missing keys with null padding.
-fn builtin_pivot<'a, W: Clone + AsRef<[u64]>>(
-    value: StandardJson<'a, W>,
+fn builtin_pivot<W: Clone + AsRef<[u64]>>(
+    value: StandardJson<'_, W>,
     optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
             let items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
@@ -13419,7 +13401,7 @@ fn eval_func_call<'a, W: Clone + AsRef<[u64]>>(
     _value: StandardJson<'a, W>,
     _optional: bool,
 ) -> QueryResult<'a, W> {
-    QueryResult::Error(EvalError::new(format!("undefined function: {}", name)))
+    QueryResult::Error(EvalError::new(format!("undefined function: {name}")))
 }
 
 #[cfg(test)]
@@ -13495,23 +13477,23 @@ mod tests {
     #[test]
     fn test_field_on_non_object() {
         // Accessing .field on non-object is an error (unlike missing field on object)
-        query!(br#"123"#, ".field",
+        query!(br"123", ".field",
             QueryResult::Error(e) => {
                 assert!(e.message.contains("expected object"));
             }
         );
 
         // But with optional, it returns nothing (not null)
-        query!(br#"123"#, ".field?",
+        query!(br"123", ".field?",
             QueryResult::None => {}
         );
 
         // For null input, jq returns null (not error)
-        query!(br#"null"#, ".field",
+        query!(br"null", ".field",
             QueryResult::One(StandardJson::Null) => {}
         );
 
-        query!(br#"null"#, ".field?",
+        query!(br"null", ".field?",
             QueryResult::One(StandardJson::Null) => {}
         );
     }
@@ -13536,20 +13518,20 @@ mod tests {
 
     #[test]
     fn test_array_index() {
-        query!(br#"[10, 20, 30]"#, ".[0]",
+        query!(br"[10, 20, 30]", ".[0]",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 10);
             }
         );
 
-        query!(br#"[10, 20, 30]"#, ".[2]",
+        query!(br"[10, 20, 30]", ".[2]",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 30);
             }
         );
 
         // Negative index
-        query!(br#"[10, 20, 30]"#, ".[-1]",
+        query!(br"[10, 20, 30]", ".[-1]",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 30);
             }
@@ -13558,7 +13540,7 @@ mod tests {
 
     #[test]
     fn test_iterate() {
-        query!(br#"[1, 2, 3]"#, ".[]",
+        query!(br"[1, 2, 3]", ".[]",
             QueryResult::Many(values) => {
                 assert_eq!(values.len(), 3);
             }
@@ -13581,7 +13563,7 @@ mod tests {
                     StandardJson::String(s) => {
                         assert_eq!(s.as_str().unwrap().as_ref(), "Alice");
                     }
-                    other => panic!("unexpected: {:?}", other),
+                    other => panic!("unexpected: {other:?}"),
                 }
             }
         );
@@ -13589,19 +13571,19 @@ mod tests {
 
     #[test]
     fn test_slice() {
-        query!(br#"[0, 1, 2, 3, 4, 5]"#, ".[1:4]",
+        query!(br"[0, 1, 2, 3, 4, 5]", ".[1:4]",
             QueryResult::Many(values) => {
                 assert_eq!(values.len(), 3);
             }
         );
 
-        query!(br#"[0, 1, 2, 3, 4, 5]"#, ".[2:]",
+        query!(br"[0, 1, 2, 3, 4, 5]", ".[2:]",
             QueryResult::Many(values) => {
                 assert_eq!(values.len(), 4); // 2, 3, 4, 5
             }
         );
 
-        query!(br#"[0, 1, 2, 3, 4, 5]"#, ".[:2]",
+        query!(br"[0, 1, 2, 3, 4, 5]", ".[:2]",
             QueryResult::Many(values) => {
                 assert_eq!(values.len(), 2); // 0, 1
             }
@@ -13619,19 +13601,19 @@ mod tests {
 
     #[test]
     fn test_literals() {
-        query!(br#"{}"#, "null",
+        query!(br"{}", "null",
             QueryResult::Owned(OwnedValue::Null) => {}
         );
 
-        query!(br#"{}"#, "true",
+        query!(br"{}", "true",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
 
-        query!(br#"{}"#, "42",
+        query!(br"{}", "42",
             QueryResult::Owned(OwnedValue::Int(42)) => {}
         );
 
-        query!(br#"{}"#, "\"hello\"",
+        query!(br"{}", "\"hello\"",
             QueryResult::Owned(OwnedValue::String(s)) if s == "hello" => {}
         );
     }
@@ -13647,7 +13629,7 @@ mod tests {
         );
 
         // Empty array
-        query!(br#"{}"#, "[]",
+        query!(br"{}", "[]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 0);
             }
@@ -13665,7 +13647,7 @@ mod tests {
         );
 
         // Empty object
-        query!(br#"{}"#, "{}",
+        query!(br"{}", "{}",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 assert_eq!(obj.len(), 0);
             }
@@ -13761,12 +13743,12 @@ mod tests {
     #[test]
     fn test_arithmetic_precedence() {
         // 2 + 3 * 4 = 2 + 12 = 14
-        query!(br#"{}"#, "2 + 3 * 4",
+        query!(br"{}", "2 + 3 * 4",
             QueryResult::Owned(OwnedValue::Int(14)) => {}
         );
 
         // (2 + 3) * 4 = 5 * 4 = 20
-        query!(br#"{}"#, "(2 + 3) * 4",
+        query!(br"{}", "(2 + 3) * 4",
             QueryResult::Owned(OwnedValue::Int(20)) => {}
         );
     }
@@ -13859,20 +13841,20 @@ mod tests {
 
     #[test]
     fn test_boolean_not() {
-        query!(br#"true"#, ". | not",
+        query!(br"true", ". | not",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
 
-        query!(br#"false"#, ". | not",
+        query!(br"false", ". | not",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
 
-        query!(br#"null"#, ". | not",
+        query!(br"null", ". | not",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
 
         // Numbers are truthy
-        query!(br#"0"#, ". | not",
+        query!(br"0", ". | not",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
     }
@@ -13892,7 +13874,7 @@ mod tests {
         );
 
         // Missing value uses alternative
-        query!(br#"{}"#, ".missing? // \"default\"",
+        query!(br"{}", ".missing? // \"default\"",
             QueryResult::Owned(OwnedValue::String(s)) if s == "default" => {}
         );
 
@@ -14011,27 +13993,27 @@ mod tests {
     fn test_try_catch_error() {
         // try with catch on missing field - no error to catch, returns null
         // (jq returns null for missing fields on objects, not an error)
-        query!(br#"{}"#, "try .missing catch \"default\"",
+        query!(br"{}", "try .missing catch \"default\"",
             QueryResult::One(StandardJson::Null) => {}
         );
 
         // try without catch on missing field - returns null
-        query!(br#"{}"#, "try .missing",
+        query!(br"{}", "try .missing",
             QueryResult::One(StandardJson::Null) => {}
         );
 
         // try with catch on actual error (field access on number) - catch is triggered
-        query!(br#"123"#, "try .foo catch \"default\"",
+        query!(br"123", "try .foo catch \"default\"",
             QueryResult::Owned(OwnedValue::String(s)) if s == "default" => {}
         );
 
         // try without catch on actual error - error is suppressed (returns None)
-        query!(br#"123"#, "try .foo",
+        query!(br"123", "try .foo",
             QueryResult::None => {}
         );
 
         // try with null catch on actual error
-        query!(br#"123"#, "try .foo catch null",
+        query!(br"123", "try .foo catch null",
             QueryResult::Owned(OwnedValue::Null) => {}
         );
     }
@@ -14039,12 +14021,12 @@ mod tests {
     #[test]
     fn test_try_catch_optional() {
         // Optional on missing field returns null, not None
-        query!(br#"{}"#, "try .missing? catch \"default\"",
+        query!(br"{}", "try .missing? catch \"default\"",
             QueryResult::One(StandardJson::Null) => {}
         );
 
         // Optional on actual error (field on number) - optional suppresses error
-        query!(br#"123"#, "try .foo? catch \"default\"",
+        query!(br"123", "try .foo? catch \"default\"",
             QueryResult::None => {}
         );
     }
@@ -14052,21 +14034,21 @@ mod tests {
     #[test]
     fn test_error_basic() {
         // error without message
-        query!(br#"{}"#, "error",
+        query!(br"{}", "error",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "null");
             }
         );
 
         // error with string message
-        query!(br#"{}"#, "error(\"something went wrong\")",
+        query!(br"{}", "error(\"something went wrong\")",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "something went wrong");
             }
         );
 
         // error with number message (gets serialized)
-        query!(br#"{}"#, "error(42)",
+        query!(br"{}", "error(42)",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "42");
             }
@@ -14086,12 +14068,12 @@ mod tests {
     #[test]
     fn test_try_catch_raised_error() {
         // try-catch with error - error is caught
-        query!(br#"{}"#, "try error(\"oops\") catch \"caught\"",
+        query!(br"{}", "try error(\"oops\") catch \"caught\"",
             QueryResult::Owned(OwnedValue::String(s)) if s == "caught" => {}
         );
 
         // try without catch - error is suppressed
-        query!(br#"{}"#, "try error(\"oops\")",
+        query!(br"{}", "try error(\"oops\")",
             QueryResult::None => {}
         );
     }
@@ -14128,19 +14110,19 @@ mod tests {
 
     #[test]
     fn test_builtin_type() {
-        query!(br#"null"#, "type",
+        query!(br"null", "type",
             QueryResult::Owned(OwnedValue::String(s)) if s == "null" => {}
         );
-        query!(br#"true"#, "type",
+        query!(br"true", "type",
             QueryResult::Owned(OwnedValue::String(s)) if s == "boolean" => {}
         );
-        query!(br#"42"#, "type",
+        query!(br"42", "type",
             QueryResult::Owned(OwnedValue::String(s)) if s == "number" => {}
         );
         query!(br#""hello""#, "type",
             QueryResult::Owned(OwnedValue::String(s)) if s == "string" => {}
         );
-        query!(br#"[1, 2]"#, "type",
+        query!(br"[1, 2]", "type",
             QueryResult::Owned(OwnedValue::String(s)) if s == "array" => {}
         );
         query!(br#"{"a": 1}"#, "type",
@@ -14151,23 +14133,23 @@ mod tests {
     #[test]
     fn test_builtin_is_type() {
         // isnull
-        query!(br#"null"#, "isnull",
+        query!(br"null", "isnull",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
-        query!(br#"1"#, "isnull",
+        query!(br"1", "isnull",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
 
         // isboolean
-        query!(br#"true"#, "isboolean",
+        query!(br"true", "isboolean",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
-        query!(br#"1"#, "isboolean",
+        query!(br"1", "isboolean",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
 
         // isnumber
-        query!(br#"42"#, "isnumber",
+        query!(br"42", "isnumber",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
         query!(br#""42""#, "isnumber",
@@ -14178,15 +14160,15 @@ mod tests {
         query!(br#""hello""#, "isstring",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
-        query!(br#"42"#, "isstring",
+        query!(br"42", "isstring",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
 
         // isarray
-        query!(br#"[1, 2]"#, "isarray",
+        query!(br"[1, 2]", "isarray",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
-        query!(br#"{}"#, "isarray",
+        query!(br"{}", "isarray",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
 
@@ -14194,7 +14176,7 @@ mod tests {
         query!(br#"{"a": 1}"#, "isobject",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
-        query!(br#"[]"#, "isobject",
+        query!(br"[]", "isobject",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
     }
@@ -14202,7 +14184,7 @@ mod tests {
     #[test]
     fn test_builtin_length() {
         // null has length 0
-        query!(br#"null"#, "length",
+        query!(br"null", "length",
             QueryResult::Owned(OwnedValue::Int(0)) => {}
         );
 
@@ -14217,7 +14199,7 @@ mod tests {
         );
 
         // array length
-        query!(br#"[1, 2, 3]"#, "length",
+        query!(br"[1, 2, 3]", "length",
             QueryResult::Owned(OwnedValue::Int(3)) => {}
         );
 
@@ -14227,7 +14209,7 @@ mod tests {
         );
 
         // number length is absolute value
-        query!(br#"-5"#, "length",
+        query!(br"-5", "length",
             QueryResult::Owned(OwnedValue::Int(5)) => {}
         );
     }
@@ -14289,10 +14271,10 @@ mod tests {
         );
 
         // Array has index
-        query!(br#"[1, 2, 3]"#, "has(0)",
+        query!(br"[1, 2, 3]", "has(0)",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
-        query!(br#"[1, 2, 3]"#, "has(5)",
+        query!(br"[1, 2, 3]", "has(5)",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
     }
@@ -14310,21 +14292,21 @@ mod tests {
     #[test]
     fn test_builtin_select() {
         // select outputs input only if condition is true
-        query!(br#"5"#, "select(. > 3)",
+        query!(br"5", "select(. > 3)",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 5);
             }
         );
 
         // select outputs nothing if condition is false
-        query!(br#"2"#, "select(. > 3)",
+        query!(br"2", "select(. > 3)",
             QueryResult::None => {}
         );
     }
 
     #[test]
     fn test_builtin_empty() {
-        query!(br#"1"#, "empty",
+        query!(br"1", "empty",
             QueryResult::None => {}
         );
     }
@@ -14332,7 +14314,7 @@ mod tests {
     #[test]
     fn test_builtin_map() {
         // map applies function to each element
-        query!(br#"[1, 2, 3]"#, "map(. * 2)",
+        query!(br"[1, 2, 3]", "map(. * 2)",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 3);
                 assert_eq!(arr[0], OwnedValue::Int(2));
@@ -14342,7 +14324,7 @@ mod tests {
         );
 
         // map with type check
-        query!(br#"[1, 2, 3]"#, "map(. + 1)",
+        query!(br"[1, 2, 3]", "map(. + 1)",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr[0], OwnedValue::Int(2));
             }
@@ -14360,7 +14342,7 @@ mod tests {
         );
 
         // map_values on array
-        query!(br#"[1, 2, 3]"#, "map_values(. + 1)",
+        query!(br"[1, 2, 3]", "map_values(. + 1)",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr[0], OwnedValue::Int(2));
                 assert_eq!(arr[1], OwnedValue::Int(3));
@@ -14372,7 +14354,7 @@ mod tests {
     #[test]
     fn test_builtin_add() {
         // Add numbers
-        query!(br#"[1, 2, 3]"#, "add",
+        query!(br"[1, 2, 3]", "add",
             QueryResult::Owned(OwnedValue::Int(6)) => {}
         );
 
@@ -14382,69 +14364,69 @@ mod tests {
         );
 
         // Add arrays
-        query!(br#"[[1], [2], [3]]"#, "add",
+        query!(br"[[1], [2], [3]]", "add",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 3);
             }
         );
 
         // Empty array returns null
-        query!(br#"[]"#, "add",
+        query!(br"[]", "add",
             QueryResult::Owned(OwnedValue::Null) => {}
         );
     }
 
     #[test]
     fn test_builtin_any() {
-        query!(br#"[true, false]"#, "any",
+        query!(br"[true, false]", "any",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
-        query!(br#"[false, false]"#, "any",
+        query!(br"[false, false]", "any",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
-        query!(br#"[null, null]"#, "any",
+        query!(br"[null, null]", "any",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
-        query!(br#"[1, 0]"#, "any",
+        query!(br"[1, 0]", "any",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}  // numbers are truthy
         );
     }
 
     #[test]
     fn test_builtin_all() {
-        query!(br#"[true, true]"#, "all",
+        query!(br"[true, true]", "all",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
-        query!(br#"[true, false]"#, "all",
+        query!(br"[true, false]", "all",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
-        query!(br#"[1, 2, 3]"#, "all",
+        query!(br"[1, 2, 3]", "all",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}  // numbers are truthy
         );
     }
 
     #[test]
     fn test_builtin_min() {
-        query!(br#"[3, 1, 2]"#, "min",
+        query!(br"[3, 1, 2]", "min",
             QueryResult::Owned(OwnedValue::Int(1)) => {}
         );
         query!(br#"["c", "a", "b"]"#, "min",
             QueryResult::Owned(OwnedValue::String(s)) if s == "a" => {}
         );
-        query!(br#"[]"#, "min",
+        query!(br"[]", "min",
             QueryResult::Owned(OwnedValue::Null) => {}
         );
     }
 
     #[test]
     fn test_builtin_max() {
-        query!(br#"[3, 1, 2]"#, "max",
+        query!(br"[3, 1, 2]", "max",
             QueryResult::Owned(OwnedValue::Int(3)) => {}
         );
         query!(br#"["c", "a", "b"]"#, "max",
             QueryResult::Owned(OwnedValue::String(s)) if s == "c" => {}
         );
-        query!(br#"[]"#, "max",
+        query!(br"[]", "max",
             QueryResult::Owned(OwnedValue::Null) => {}
         );
     }
@@ -14470,7 +14452,7 @@ mod tests {
     #[test]
     fn test_builtin_combinations() {
         // map alone works
-        query!(br#"[1, 2, 3, 4, 5]"#, "map(. * 2)",
+        query!(br"[1, 2, 3, 4, 5]", "map(. * 2)",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 5);
                 assert_eq!(arr[0], OwnedValue::Int(2));
@@ -14478,7 +14460,7 @@ mod tests {
         );
 
         // Use select in map
-        query!(br#"[1, 2, 3, 4, 5]"#, "[.[] | select(. > 2)]",
+        query!(br"[1, 2, 3, 4, 5]", "[.[] | select(. > 2)]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 3);
             }
@@ -14624,7 +14606,7 @@ mod tests {
         );
 
         // Array contains
-        query!(br#"[1, 2, 3]"#, r#"contains([2])"#,
+        query!(br"[1, 2, 3]", r"contains([2])",
             QueryResult::Owned(OwnedValue::Bool(b)) => {
                 assert!(b);
             }
@@ -14641,7 +14623,7 @@ mod tests {
     #[test]
     fn test_builtin_inside() {
         // inside is the inverse of contains
-        query!(br#"[2]"#, r#"inside([1, 2, 3])"#,
+        query!(br"[2]", r"inside([1, 2, 3])",
             QueryResult::Owned(OwnedValue::Bool(b)) => {
                 assert!(b);
             }
@@ -14660,7 +14642,7 @@ mod tests {
 
     #[test]
     fn test_builtin_first() {
-        query!(br#"[1, 2, 3]"#, "first",
+        query!(br"[1, 2, 3]", "first",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 1);
             }
@@ -14669,7 +14651,7 @@ mod tests {
 
     #[test]
     fn test_builtin_last() {
-        query!(br#"[1, 2, 3]"#, "last",
+        query!(br"[1, 2, 3]", "last",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 3);
             }
@@ -14678,7 +14660,7 @@ mod tests {
 
     #[test]
     fn test_builtin_nth() {
-        query!(br#"[10, 20, 30]"#, "nth(1)",
+        query!(br"[10, 20, 30]", "nth(1)",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 20);
             }
@@ -14687,7 +14669,7 @@ mod tests {
 
     #[test]
     fn test_builtin_reverse() {
-        query!(br#"[1, 2, 3]"#, "reverse",
+        query!(br"[1, 2, 3]", "reverse",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![OwnedValue::Int(3), OwnedValue::Int(2), OwnedValue::Int(1)]);
             }
@@ -14703,7 +14685,7 @@ mod tests {
 
     #[test]
     fn test_builtin_flatten() {
-        query!(br#"[[1, 2], [3, [4]]]"#, "flatten",
+        query!(br"[[1, 2], [3, [4]]]", "flatten",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 4);
                 assert_eq!(arr[0], OwnedValue::Int(1));
@@ -14712,7 +14694,7 @@ mod tests {
         );
 
         // Flatten with depth
-        query!(br#"[[1], [[2]], [[[3]]]]"#, "flatten(2)",
+        query!(br"[[1], [[2]], [[[3]]]]", "flatten(2)",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 3);
                 assert_eq!(arr[0], OwnedValue::Int(1));
@@ -14734,7 +14716,7 @@ mod tests {
 
     #[test]
     fn test_builtin_unique() {
-        query!(br#"[1, 2, 1, 3, 2]"#, "unique",
+        query!(br"[1, 2, 1, 3, 2]", "unique",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]);
             }
@@ -14752,7 +14734,7 @@ mod tests {
 
     #[test]
     fn test_builtin_sort() {
-        query!(br#"[3, 1, 2]"#, "sort",
+        query!(br"[3, 1, 2]", "sort",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]);
             }
@@ -14865,7 +14847,7 @@ mod tests {
             }
         );
 
-        query!(br#"42"#, "@text",
+        query!(br"42", "@text",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "42");
             }
@@ -15004,7 +14986,7 @@ mod tests {
         );
 
         // Array
-        query!(br#"[1, 2, 3]"#, "@yaml",
+        query!(br"[1, 2, 3]", "@yaml",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "[1, 2, 3]");
             }
@@ -15032,20 +15014,20 @@ mod tests {
         );
 
         // Empty containers
-        query!(br#"[]"#, "@yaml",
+        query!(br"[]", "@yaml",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "[]");
             }
         );
 
-        query!(br#"{}"#, "@yaml",
+        query!(br"{}", "@yaml",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "{}");
             }
         );
 
         // Float values
-        query!(br#"3.14"#, "@yaml",
+        query!(br"3.14", "@yaml",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "3.14");
             }
@@ -15090,7 +15072,7 @@ mod tests {
         );
 
         // Null
-        query!(br#"null"#, "@props",
+        query!(br"null", "@props",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "null");
             }
@@ -15111,14 +15093,14 @@ mod tests {
         );
 
         // Empty object
-        query!(br#"{}"#, "@props",
+        query!(br"{}", "@props",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "");
             }
         );
 
         // Top-level array
-        query!(br#"[1, 2, 3]"#, "@props",
+        query!(br"[1, 2, 3]", "@props",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "0 = 1\n1 = 2\n2 = 3");
             }
@@ -15131,19 +15113,19 @@ mod tests {
 
     #[test]
     fn test_builtin_tostring() {
-        query!(br#"42"#, "tostring",
+        query!(br"42", "tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "42");
             }
         );
 
-        query!(br#"true"#, "tostring",
+        query!(br"true", "tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "true");
             }
         );
 
-        query!(br#"null"#, "tostring",
+        query!(br"null", "tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "null");
             }
@@ -15165,7 +15147,7 @@ mod tests {
         );
 
         // Already a number
-        query!(br#"42"#, "tonumber",
+        query!(br"42", "tonumber",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 42);
             }
@@ -15190,7 +15172,7 @@ mod tests {
 
     #[test]
     fn test_builtin_implode() {
-        query!(br#"[97, 98, 99]"#, "implode",
+        query!(br"[97, 98, 99]", "implode",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "abc");
             }
@@ -15253,20 +15235,20 @@ mod tests {
             }
         );
 
-        query!(br#"[1, 2, 3]"#, r#"getpath([1])"#,
+        query!(br"[1, 2, 3]", r"getpath([1])",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 2);
             }
         );
 
         // Negative index support
-        query!(br#"[1, 2, 3]"#, r#"getpath([-1])"#,
+        query!(br"[1, 2, 3]", r"getpath([-1])",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 3);
             }
         );
 
-        query!(br#"[1, 2, 3]"#, r#"getpath([-2])"#,
+        query!(br"[1, 2, 3]", r"getpath([-2])",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 2);
             }
@@ -15372,7 +15354,7 @@ mod tests {
     #[test]
     fn test_variable_binding_as() {
         // Simple variable binding: .foo as $x | .bar + $x
-        query!(br#"{"foo": 10, "bar": 5}"#, r#".foo as $x | .bar + $x"#,
+        query!(br#"{"foo": 10, "bar": 5}"#, r".foo as $x | .bar + $x",
             QueryResult::Owned(OwnedValue::Int(15)) => {}
         );
 
@@ -15388,12 +15370,12 @@ mod tests {
     #[test]
     fn test_reduce() {
         // Sum array elements
-        query!(br#"[1, 2, 3, 4, 5]"#, r#"reduce .[] as $x (0; . + $x)"#,
+        query!(br"[1, 2, 3, 4, 5]", r"reduce .[] as $x (0; . + $x)",
             QueryResult::Owned(OwnedValue::Int(15)) => {}
         );
 
         // Count elements
-        query!(br#"["a", "b", "c"]"#, r#"reduce .[] as $x (0; . + 1)"#,
+        query!(br#"["a", "b", "c"]"#, r"reduce .[] as $x (0; . + 1)",
             QueryResult::Owned(OwnedValue::Int(3)) => {}
         );
     }
@@ -15401,7 +15383,7 @@ mod tests {
     #[test]
     fn test_foreach() {
         // Running sum
-        query!(br#"[1, 2, 3]"#, r#"[foreach .[] as $x (0; . + $x)]"#,
+        query!(br"[1, 2, 3]", r"[foreach .[] as $x (0; . + $x)]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 3);
                 assert_eq!(arr[0], OwnedValue::Int(1));
@@ -15414,7 +15396,7 @@ mod tests {
     #[test]
     fn test_range() {
         // range(n) - generates 0 to n-1
-        query!(br#"null"#, r#"[range(5)]"#,
+        query!(br"null", r"[range(5)]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![
                     OwnedValue::Int(0),
@@ -15427,7 +15409,7 @@ mod tests {
         );
 
         // range(a;b) - generates a to b-1
-        query!(br#"null"#, r#"[range(2;5)]"#,
+        query!(br"null", r"[range(2;5)]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![
                     OwnedValue::Int(2),
@@ -15438,7 +15420,7 @@ mod tests {
         );
 
         // range(a;b;step)
-        query!(br#"null"#, r#"[range(0;10;2)]"#,
+        query!(br"null", r"[range(0;10;2)]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![
                     OwnedValue::Int(0),
@@ -15454,7 +15436,7 @@ mod tests {
     #[test]
     fn test_limit() {
         // limit(n; expr) - take first n outputs
-        query!(br#"null"#, r#"[limit(3; range(10))]"#,
+        query!(br"null", r"[limit(3; range(10))]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![
                     OwnedValue::Int(0),
@@ -15468,14 +15450,14 @@ mod tests {
     #[test]
     fn test_first_last_expr() {
         // first(expr) - returns a reference to first element
-        query!(br#"[1, 2, 3]"#, r#"first(.[])"#,
+        query!(br"[1, 2, 3]", r"first(.[])",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 1);
             }
         );
 
         // last(expr) - returns a reference to last element
-        query!(br#"[1, 2, 3]"#, r#"last(.[])"#,
+        query!(br"[1, 2, 3]", r"last(.[])",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 3);
             }
@@ -15485,7 +15467,7 @@ mod tests {
     #[test]
     fn test_until() {
         // until(cond; update) - iterate until condition is true
-        query!(br#"1"#, r#"until(. >= 10; . * 2)"#,
+        query!(br"1", r"until(. >= 10; . * 2)",
             QueryResult::Owned(OwnedValue::Int(16)) => {}
         );
     }
@@ -15493,7 +15475,7 @@ mod tests {
     #[test]
     fn test_while() {
         // while(cond; update) - output while condition is true
-        query!(br#"1"#, r#"[while(. < 10; . * 2)]"#,
+        query!(br"1", r"[while(. < 10; . * 2)]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![
                     OwnedValue::Int(1),
@@ -15509,7 +15491,7 @@ mod tests {
     fn test_repeat() {
         // repeat(expr) - repeatedly evaluate expr with original input
         // jq behavior: repeat(. * 2) on input 1 produces 2, 2, 2, ...
-        query!(br#"1"#, r#"[limit(5; repeat(. * 2))]"#,
+        query!(br"1", r"[limit(5; repeat(. * 2))]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![
                     OwnedValue::Int(2),
@@ -15525,7 +15507,7 @@ mod tests {
     #[test]
     fn test_repeat_identity() {
         // repeat(.) produces the same value infinitely
-        query!(br#""hello""#, r#"[limit(3; repeat(.))]"#,
+        query!(br#""hello""#, r"[limit(3; repeat(.))]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![
                     OwnedValue::String("hello".into()),
@@ -15539,7 +15521,7 @@ mod tests {
     #[test]
     fn test_recurse() {
         // Basic recurse with filter - collect all values recursively
-        query!(br#"{"a": 1, "b": {"c": 2}}"#, r#"[recurse | .a? // .c? // empty]"#,
+        query!(br#"{"a": 1, "b": {"c": 2}}"#, r"[recurse | .a? // .c? // empty]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 // Should contain the values 1 and 2
                 assert!(arr.len() >= 2);
@@ -15550,17 +15532,17 @@ mod tests {
     #[test]
     fn test_isvalid() {
         // isvalid returns true for valid expressions
-        query!(br#"{"a": 1}"#, r#"isvalid(.a)"#,
+        query!(br#"{"a": 1}"#, r"isvalid(.a)",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
 
         // isvalid returns true for missing field (returns null, not error)
-        query!(br#"{"a": 1}"#, r#"isvalid(.b)"#,
+        query!(br#"{"a": 1}"#, r"isvalid(.b)",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
 
         // isvalid returns false for actual error-producing expressions
-        query!(br#"123"#, r#"isvalid(.foo)"#,
+        query!(br"123", r"isvalid(.foo)",
             QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
     }
@@ -15582,7 +15564,7 @@ mod tests {
     #[test]
     fn test_destructuring_array_pattern() {
         // Array destructuring: . as [$first, $second] | ...
-        query!(br#"[1, 2, 3]"#, r#". as [$a, $b] | $a + $b"#,
+        query!(br"[1, 2, 3]", r". as [$a, $b] | $a + $b",
             QueryResult::Owned(OwnedValue::Int(3)) => {}
         );
     }
@@ -15590,7 +15572,7 @@ mod tests {
     #[test]
     fn test_destructuring_nested_pattern() {
         // Nested destructuring
-        query!(br#"{"user": {"name": "Bob", "id": 42}}"#, r#". as {user: {name: $n}} | $n"#,
+        query!(br#"{"user": {"name": "Bob", "id": 42}}"#, r". as {user: {name: $n}} | $n",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "Bob");
             }
@@ -15600,7 +15582,7 @@ mod tests {
     #[test]
     fn test_function_def_simple() {
         // Simple function definition without parameters
-        query!(br#"5"#, r#"def double: . * 2; double"#,
+        query!(br"5", r"def double: . * 2; double",
             QueryResult::Owned(OwnedValue::Int(10)) => {}
         );
     }
@@ -15608,7 +15590,7 @@ mod tests {
     #[test]
     fn test_function_def_with_params() {
         // Function with parameters (using 'addtwo' to avoid conflict with builtin 'add')
-        query!(br#"null"#, r#"def addtwo(a; b): a + b; addtwo(3; 4)"#,
+        query!(br"null", r"def addtwo(a; b): a + b; addtwo(3; 4)",
             QueryResult::Owned(OwnedValue::Int(7)) => {}
         );
     }
@@ -15616,23 +15598,23 @@ mod tests {
     #[test]
     fn test_function_def_chained() {
         // Single def, then use in pipe
-        query!(br#"5"#, r#"def inc: . + 1; . | inc"#,
+        query!(br"5", r"def inc: . + 1; . | inc",
             QueryResult::Owned(OwnedValue::Int(6)) => {}
         );
 
         // Two defs, use only second - this exercises nested func def
-        query!(br#"5"#, r#"def double: . * 2; def inc: . + 1; inc"#,
+        query!(br"5", r"def double: . * 2; def inc: . + 1; inc",
             QueryResult::Owned(OwnedValue::Int(6)) => {}
         );
 
         // Two defs, use only first
-        query!(br#"5"#, r#"def double: . * 2; def inc: . + 1; double"#,
+        query!(br"5", r"def double: . * 2; def inc: . + 1; double",
             QueryResult::Owned(OwnedValue::Int(10)) => {}
         );
 
         // This should work: use both in a pipe, but inc is defined first
         // (so inc isn't nested inside double's scope)
-        query!(br#"5"#, r#"def inc: . + 1; def double: . * 2; double | inc"#,
+        query!(br"5", r"def inc: . + 1; def double: . * 2; double | inc",
             QueryResult::Owned(OwnedValue::Int(11)) => {}
         );
     }
@@ -15640,7 +15622,7 @@ mod tests {
     #[test]
     fn test_function_uses_input() {
         // Function that uses the input value
-        query!(br#"{"x": 10}"#, r#"def getx: .x; getx"#,
+        query!(br#"{"x": 10}"#, r"def getx: .x; getx",
             QueryResult::One(StandardJson::Number(n)) => {
                 assert_eq!(n.as_i64().unwrap(), 10);
             }
@@ -15650,7 +15632,7 @@ mod tests {
     #[test]
     fn test_function_with_filter_param() {
         // Function with filter parameter (jq-style)
-        query!(br#"[1, 2, 3]"#, r#"def apply(f): map(f); apply(. * 2)"#,
+        query!(br"[1, 2, 3]", r"def apply(f): map(f); apply(. * 2)",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![
                     OwnedValue::Int(2),
@@ -15796,7 +15778,7 @@ mod tests {
 
     #[test]
     fn test_transpose() {
-        query!(br#"[[1, 2], [3, 4], [5, 6]]"#, "transpose",
+        query!(br"[[1, 2], [3, 4], [5, 6]]", "transpose",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 2);
                 match &arr[0] {
@@ -15815,13 +15797,13 @@ mod tests {
     #[test]
     fn test_bsearch() {
         // Found case - returns index
-        query!(br#"[1, 2, 3, 4, 5]"#, "bsearch(3)",
+        query!(br"[1, 2, 3, 4, 5]", "bsearch(3)",
             QueryResult::Owned(OwnedValue::Int(idx)) => {
                 assert_eq!(idx, 2);
             }
         );
         // Not found case - returns object with index
-        query!(br#"[1, 2, 4, 5]"#, "bsearch(3)",
+        query!(br"[1, 2, 4, 5]", "bsearch(3)",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 assert_eq!(obj.get("index"), Some(&OwnedValue::Int(2)));
             }
@@ -15894,7 +15876,7 @@ mod tests {
     #[test]
     fn test_leaf_paths_array() {
         // Arrays also work
-        query!(br#"[1, [2, 3]]"#, "[leaf_paths]",
+        query!(br"[1, [2, 3]]", "[leaf_paths]",
             QueryResult::Owned(OwnedValue::Array(paths)) => {
                 // Paths: [0], [1, 0], [1, 1]
                 assert_eq!(paths.len(), 3);
@@ -16149,7 +16131,7 @@ mod tests {
         );
 
         // Test array index
-        query!(br#"[10, 20, 30]"#, "path(.[1])",
+        query!(br"[10, 20, 30]", "path(.[1])",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 1);
                 assert_eq!(arr[0], OwnedValue::Int(1));
@@ -16157,7 +16139,7 @@ mod tests {
         );
 
         // Test negative index (preserved as-is, matching jq)
-        query!(br#"[10, 20, 30]"#, "path(.[-1])",
+        query!(br"[10, 20, 30]", "path(.[-1])",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 1);
                 assert_eq!(arr[0], OwnedValue::Int(-1));
@@ -16311,7 +16293,7 @@ mod tests {
         // OneCursor: identity passes a container through unchanged.
         assert_eq!(owned(br#"{"a":1}"#, ".").len(), 1);
         // Many: iterating an array yields several values.
-        assert_eq!(owned(br#"[1,2,3]"#, ".[]").len(), 3);
+        assert_eq!(owned(br"[1,2,3]", ".[]").len(), 3);
         // One: field access returns a scalar reference.
         assert_eq!(owned(br#"{"a":1}"#, ".a"), vec![OwnedValue::Int(1)]);
     }
@@ -16325,7 +16307,7 @@ mod tests {
         // localtime is timezone-dependent, so assert only the 8-field structure.
         // This still exercises the hour/minute/second/weekday computation
         // regardless of the host's $TZ.
-        query!(b"0", r#"localtime"#,
+        query!(b"0", r"localtime",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 8);
             }
@@ -16335,7 +16317,7 @@ mod tests {
     #[test]
     fn test_gmtime() {
         // Unix epoch (Jan 1, 1970 00:00:00 UTC)
-        query!(b"0", r#"gmtime"#,
+        query!(b"0", r"gmtime",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 8);
                 assert_eq!(arr[0], OwnedValue::Int(1970)); // year
@@ -16353,14 +16335,14 @@ mod tests {
     #[test]
     fn test_mktime() {
         // Round-trip: gmtime | mktime should return original timestamp
-        query!(b"[1970,0,1,0,0,0,4,0]", r#"mktime"#,
+        query!(b"[1970,0,1,0,0,0,4,0]", r"mktime",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 0.0);
             }
         );
 
         // Jan 15, 2024 10:30:00 UTC
-        query!(b"[2024,0,15,10,30,0,1,14]", r#"mktime"#,
+        query!(b"[2024,0,15,10,30,0,1,14]", r"mktime",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 1705314600.0);
             }
@@ -16400,7 +16382,7 @@ mod tests {
     #[test]
     fn test_todate() {
         // todate converts timestamp to ISO 8601 string
-        query!(b"0", r#"todate"#,
+        query!(b"0", r"todate",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "1970-01-01T00:00:00Z");
             }
@@ -16410,13 +16392,13 @@ mod tests {
     #[test]
     fn test_fromdate() {
         // fromdate parses ISO 8601 string to timestamp
-        query!(br#""1970-01-01T00:00:00Z""#, r#"fromdate"#,
+        query!(br#""1970-01-01T00:00:00Z""#, r"fromdate",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 0.0);
             }
         );
 
-        query!(br#""2024-01-15T10:30:00Z""#, r#"fromdate"#,
+        query!(br#""2024-01-15T10:30:00Z""#, r"fromdate",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 1705314600.0);
             }
@@ -16426,14 +16408,14 @@ mod tests {
     #[test]
     fn test_date_roundtrip() {
         // gmtime | mktime should return original value
-        query!(b"1705314600", r#"gmtime | mktime"#,
+        query!(b"1705314600", r"gmtime | mktime",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 1705314600.0);
             }
         );
 
         // todate | fromdate should return original value
-        query!(b"1705314600", r#"todate | fromdate"#,
+        query!(b"1705314600", r"todate | fromdate",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 1705314600.0);
             }
@@ -16447,13 +16429,13 @@ mod tests {
     #[test]
     fn test_from_unix() {
         // from_unix converts timestamp to ISO 8601 string (same as todate)
-        query!(b"0", r#"from_unix"#,
+        query!(b"0", r"from_unix",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "1970-01-01T00:00:00Z");
             }
         );
 
-        query!(b"1705314600", r#"from_unix"#,
+        query!(b"1705314600", r"from_unix",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "2024-01-15T10:30:00Z");
             }
@@ -16463,13 +16445,13 @@ mod tests {
     #[test]
     fn test_to_unix() {
         // to_unix parses ISO 8601 string to timestamp (same as fromdate)
-        query!(br#""1970-01-01T00:00:00Z""#, r#"to_unix"#,
+        query!(br#""1970-01-01T00:00:00Z""#, r"to_unix",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 0.0);
             }
         );
 
-        query!(br#""2024-01-15T10:30:00Z""#, r#"to_unix"#,
+        query!(br#""2024-01-15T10:30:00Z""#, r"to_unix",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 1705314600.0);
             }
@@ -16479,7 +16461,7 @@ mod tests {
     #[test]
     fn test_from_unix_to_unix_roundtrip() {
         // from_unix | to_unix should return original value
-        query!(b"1705314600", r#"from_unix | to_unix"#,
+        query!(b"1705314600", r"from_unix | to_unix",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 assert_eq!(n, 1705314600.0);
             }
@@ -16610,7 +16592,7 @@ mod tests {
     #[test]
     fn test_simple_assign() {
         // Simple assignment: .a = value
-        query!(br#"{"a": 1, "b": 2}"#, r#".a = 42"#,
+        query!(br#"{"a": 1, "b": 2}"#, r".a = 42",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 assert_eq!(*a, OwnedValue::Int(42));
@@ -16623,7 +16605,7 @@ mod tests {
     #[test]
     fn test_nested_assign() {
         // Nested assignment: .a.b = value
-        query!(br#"{"a": {"b": 1}}"#, r#".a.b = 99"#,
+        query!(br#"{"a": {"b": 1}}"#, r".a.b = 99",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 if let OwnedValue::Object(inner) = a {
@@ -16639,7 +16621,7 @@ mod tests {
     #[test]
     fn test_array_index_assign() {
         // Array index assignment: .[0] = value
-        query!(br#"[1, 2, 3]"#, r#".[1] = 99"#,
+        query!(br"[1, 2, 3]", r".[1] = 99",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr[0], OwnedValue::Int(1));
                 assert_eq!(arr[1], OwnedValue::Int(99));
@@ -16651,7 +16633,7 @@ mod tests {
     #[test]
     fn test_update_assign() {
         // Update assignment: .a |= . + 1
-        query!(br#"{"a": 5}"#, r#".a |= . + 1"#,
+        query!(br#"{"a": 5}"#, r".a |= . + 1",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 assert_eq!(*a, OwnedValue::Int(6));
@@ -16662,7 +16644,7 @@ mod tests {
     #[test]
     fn test_update_assign_array() {
         // Update assignment on array elements: .[] |= . * 2
-        query!(br#"[1, 2, 3]"#, r#".[] |= . * 2"#,
+        query!(br"[1, 2, 3]", r".[] |= . * 2",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr[0], OwnedValue::Int(2));
                 assert_eq!(arr[1], OwnedValue::Int(4));
@@ -16674,7 +16656,7 @@ mod tests {
     #[test]
     fn test_compound_assign_add() {
         // Compound assignment: .a += 10
-        query!(br#"{"a": 5}"#, r#".a += 10"#,
+        query!(br#"{"a": 5}"#, r".a += 10",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 assert_eq!(*a, OwnedValue::Int(15));
@@ -16685,7 +16667,7 @@ mod tests {
     #[test]
     fn test_compound_assign_sub() {
         // Compound subtraction: .a -= 3
-        query!(br#"{"a": 10}"#, r#".a -= 3"#,
+        query!(br#"{"a": 10}"#, r".a -= 3",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 assert_eq!(*a, OwnedValue::Int(7));
@@ -16696,7 +16678,7 @@ mod tests {
     #[test]
     fn test_compound_assign_mul() {
         // Compound multiplication: .a *= 4
-        query!(br#"{"a": 5}"#, r#".a *= 4"#,
+        query!(br#"{"a": 5}"#, r".a *= 4",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 assert_eq!(*a, OwnedValue::Int(20));
@@ -16708,13 +16690,13 @@ mod tests {
     fn test_compound_assign_div() {
         // Compound division: .a /= 2
         // Division returns float even for integer inputs
-        query!(br#"{"a": 10}"#, r#".a /= 2"#,
+        query!(br#"{"a": 10}"#, r".a /= 2",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 match a {
                     OwnedValue::Float(f) => assert!((f - 5.0).abs() < 0.001),
                     OwnedValue::Int(i) => assert_eq!(*i, 5),
-                    _ => panic!("Expected number, got {:?}", a),
+                    _ => panic!("Expected number, got {a:?}"),
                 }
             }
         );
@@ -16723,7 +16705,7 @@ mod tests {
     #[test]
     fn test_compound_assign_mod() {
         // Compound modulo: .a %= 3
-        query!(br#"{"a": 10}"#, r#".a %= 3"#,
+        query!(br#"{"a": 10}"#, r".a %= 3",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 assert_eq!(*a, OwnedValue::Int(1));
@@ -16756,7 +16738,7 @@ mod tests {
     #[test]
     fn test_del_field() {
         // del(.a) removes a field
-        query!(br#"{"a": 1, "b": 2}"#, r#"del(.a)"#,
+        query!(br#"{"a": 1, "b": 2}"#, r"del(.a)",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 assert!(!obj.contains_key("a"));
                 assert!(obj.contains_key("b"));
@@ -16767,7 +16749,7 @@ mod tests {
     #[test]
     fn test_del_array_element() {
         // del(.[1]) removes an array element
-        query!(br#"[1, 2, 3]"#, r#"del(.[1])"#,
+        query!(br"[1, 2, 3]", r"del(.[1])",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 2);
                 assert_eq!(arr[0], OwnedValue::Int(1));
@@ -16779,7 +16761,7 @@ mod tests {
     #[test]
     fn test_del_nested() {
         // del(.a.b) removes nested field
-        query!(br#"{"a": {"b": 1, "c": 2}}"#, r#"del(.a.b)"#,
+        query!(br#"{"a": {"b": 1, "c": 2}}"#, r"del(.a.b)",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 if let OwnedValue::Object(inner) = a {
@@ -16795,7 +16777,7 @@ mod tests {
     #[test]
     fn test_chained_assign() {
         // Chained: .a = 1 | .b = 2
-        query!(br#"{"a": 0, "b": 0}"#, r#".a = 1 | .b = 2"#,
+        query!(br#"{"a": 0, "b": 0}"#, r".a = 1 | .b = 2",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 assert_eq!(*a, OwnedValue::Int(1));
@@ -16811,7 +16793,7 @@ mod tests {
 
     #[test]
     fn test_tag_null() {
-        query!(br#"null"#, "tag",
+        query!(br"null", "tag",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "!!null");
             }
@@ -16820,12 +16802,12 @@ mod tests {
 
     #[test]
     fn test_tag_bool() {
-        query!(br#"true"#, "tag",
+        query!(br"true", "tag",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "!!bool");
             }
         );
-        query!(br#"false"#, "tag",
+        query!(br"false", "tag",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "!!bool");
             }
@@ -16834,7 +16816,7 @@ mod tests {
 
     #[test]
     fn test_tag_int() {
-        query!(br#"42"#, "tag",
+        query!(br"42", "tag",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "!!int");
             }
@@ -16843,7 +16825,7 @@ mod tests {
 
     #[test]
     fn test_tag_float() {
-        query!(br#"3.14"#, "tag",
+        query!(br"3.14", "tag",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "!!float");
             }
@@ -16861,7 +16843,7 @@ mod tests {
 
     #[test]
     fn test_tag_array() {
-        query!(br#"[1, 2, 3]"#, "tag",
+        query!(br"[1, 2, 3]", "tag",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "!!seq");
             }
@@ -16905,7 +16887,7 @@ mod tests {
                 assert_eq!(s, "");
             }
         );
-        query!(br#"[1, 2, 3]"#, "style",
+        query!(br"[1, 2, 3]", "style",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "");
             }
@@ -17135,7 +17117,7 @@ mod tests {
         query!(b"null", "builtins | length",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 // Should have many builtins (at least 100)
-                assert!(n > 100, "should have many builtins, got {}", n);
+                assert!(n > 100, "should have many builtins, got {n}");
             }
         );
         // Check some known builtins exist
@@ -17236,7 +17218,7 @@ mod tests {
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 2, "expected line 2 for $__loc__ on second line");
             }
-            other => panic!("expected Int, got {:?}", other),
+            other => panic!("expected Int, got {other:?}"),
         }
     }
 
@@ -17253,7 +17235,7 @@ mod tests {
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 3, "expected line 3 for $__loc__ on third line");
             }
-            other => panic!("expected Int, got {:?}", other),
+            other => panic!("expected Int, got {other:?}"),
         }
     }
 
@@ -17269,7 +17251,7 @@ mod tests {
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 1, "expected line 1 for $__loc__ in function on line 1");
             }
-            other => panic!("expected Int, got {:?}", other),
+            other => panic!("expected Int, got {other:?}"),
         }
     }
 
@@ -17546,7 +17528,7 @@ mod tests {
     #[test]
     fn test_indices_array() {
         // Find all occurrences of element in array
-        query!(br#"[1, 2, 3, 1, 2]"#, "indices(1)",
+        query!(br"[1, 2, 3, 1, 2]", "indices(1)",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![OwnedValue::Int(0), OwnedValue::Int(3)]);
             }
@@ -17586,7 +17568,7 @@ mod tests {
     #[test]
     fn test_index_array() {
         // First occurrence of element in array
-        query!(br#"[1, 2, 3, 1, 2]"#, "index(2)",
+        query!(br"[1, 2, 3, 1, 2]", "index(2)",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 1);
             }
@@ -17614,7 +17596,7 @@ mod tests {
     #[test]
     fn test_rindex_array() {
         // Last occurrence of element in array
-        query!(br#"[1, 2, 3, 1, 2]"#, "rindex(2)",
+        query!(br"[1, 2, 3, 1, 2]", "rindex(2)",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 4);
             }
@@ -17642,7 +17624,7 @@ mod tests {
     #[test]
     fn test_index_array_null() {
         // Find null in array
-        query!(br#"[1, null, 2, null]"#, "index(null)",
+        query!(br"[1, null, 2, null]", "index(null)",
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert_eq!(n, 1);
             }
@@ -17776,7 +17758,7 @@ mod tests {
     #[test]
     fn test_di_json_returns_zero() {
         // For JSON input, di returns 0 (single document assumed)
-        query!(br#"[1, 2, 3]"#, "di",
+        query!(br"[1, 2, 3]", "di",
             QueryResult::Owned(OwnedValue::Int(0)) => {}
         );
     }
@@ -17807,7 +17789,7 @@ mod tests {
     #[cfg(feature = "cli")]
     fn test_shuffle_returns_array_same_length() {
         // shuffle should return an array with the same length
-        query!(br#"[1, 2, 3, 4, 5]"#, "shuffle",
+        query!(br"[1, 2, 3, 4, 5]", "shuffle",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 5);
                 // All original elements should be present (just reordered)
@@ -17839,7 +17821,7 @@ mod tests {
     #[cfg(feature = "cli")]
     fn test_shuffle_empty_array() {
         // shuffle of empty array should return empty array
-        query!(br#"[]"#, "shuffle",
+        query!(br"[]", "shuffle",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert!(arr.is_empty());
             }
@@ -17850,7 +17832,7 @@ mod tests {
     #[cfg(feature = "cli")]
     fn test_shuffle_single_element() {
         // shuffle of single element should return the same element
-        query!(br#"[42]"#, "shuffle",
+        query!(br"[42]", "shuffle",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![OwnedValue::Int(42)]);
             }
@@ -17862,7 +17844,7 @@ mod tests {
         // shuffle requires array input
         query!(br#""not an array""#, "shuffle",
             QueryResult::Error(err) => {
-                let msg = format!("{}", err);
+                let msg = format!("{err}");
                 assert!(msg.contains("array") || msg.contains("cli"));
             }
         );
@@ -17872,7 +17854,7 @@ mod tests {
     #[cfg(feature = "cli")]
     fn test_shuffle_in_pipeline() {
         // shuffle can be used in a pipeline
-        query!(br#"[3, 1, 2]"#, "shuffle | length",
+        query!(br"[3, 1, 2]", "shuffle | length",
             QueryResult::Owned(OwnedValue::Int(3)) => {}
         );
     }
@@ -17894,7 +17876,7 @@ mod tests {
     #[test]
     fn test_pivot_array_of_arrays() {
         // Transpose array of arrays: [[a, b], [x, y]] → [[a, x], [b, y]]
-        query!(br#"[[1, 2], [3, 4]]"#, "pivot",
+        query!(br"[[1, 2], [3, 4]]", "pivot",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 2);
                 assert_eq!(arr[0], OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(3)]));
@@ -17906,7 +17888,7 @@ mod tests {
     #[test]
     fn test_pivot_array_of_arrays_3x3() {
         // 3x3 matrix transpose
-        query!(br#"[[1, 2, 3], [4, 5, 6], [7, 8, 9]]"#, "pivot",
+        query!(br"[[1, 2, 3], [4, 5, 6], [7, 8, 9]]", "pivot",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 3);
                 assert_eq!(arr[0], OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(4), OwnedValue::Int(7)]));
@@ -17919,7 +17901,7 @@ mod tests {
     #[test]
     fn test_pivot_array_of_arrays_ragged() {
         // Ragged arrays get null padding: [[1, 2], [3]] → [[1, 3], [2, null]]
-        query!(br#"[[1, 2], [3]]"#, "pivot",
+        query!(br"[[1, 2], [3]]", "pivot",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 2);
                 assert_eq!(arr[0], OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(3)]));
@@ -17967,7 +17949,7 @@ mod tests {
     #[test]
     fn test_pivot_empty_array() {
         // Empty array returns empty array
-        query!(br#"[]"#, "pivot",
+        query!(br"[]", "pivot",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert!(arr.is_empty());
             }
@@ -17977,7 +17959,7 @@ mod tests {
     #[test]
     fn test_pivot_array_of_empty_arrays() {
         // Array of empty arrays returns empty array
-        query!(br#"[[], []]"#, "pivot",
+        query!(br"[[], []]", "pivot",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert!(arr.is_empty());
             }
@@ -17987,7 +17969,7 @@ mod tests {
     #[test]
     fn test_pivot_array_of_empty_objects() {
         // Array of empty objects returns empty object
-        query!(br#"[{}, {}]"#, "pivot",
+        query!(br"[{}, {}]", "pivot",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 assert!(obj.is_empty());
             }
@@ -17999,7 +17981,7 @@ mod tests {
         // pivot requires array input
         query!(br#""not an array""#, "pivot",
             QueryResult::Error(err) => {
-                let msg = format!("{}", err);
+                let msg = format!("{err}");
                 assert!(msg.contains("array"));
             }
         );
@@ -18010,7 +17992,7 @@ mod tests {
         // pivot requires all arrays or all objects, not mixed
         query!(br#"[[1], {"a": 2}]"#, "pivot",
             QueryResult::Error(err) => {
-                let msg = format!("{}", err);
+                let msg = format!("{err}");
                 assert!(msg.contains("array of arrays") || msg.contains("array of objects"));
             }
         );
@@ -18019,9 +18001,9 @@ mod tests {
     #[test]
     fn test_pivot_error_on_scalars() {
         // pivot requires arrays or objects, not scalar values
-        query!(br#"[1, 2, 3]"#, "pivot",
+        query!(br"[1, 2, 3]", "pivot",
             QueryResult::Error(err) => {
-                let msg = format!("{}", err);
+                let msg = format!("{err}");
                 assert!(msg.contains("array of arrays") || msg.contains("array of objects"));
             }
         );
@@ -18030,7 +18012,7 @@ mod tests {
     #[test]
     fn test_pivot_in_pipeline() {
         // pivot can be used in a pipeline
-        query!(br#"[[1, 2], [3, 4]]"#, "pivot | .[0]",
+        query!(br"[[1, 2], [3, 4]]", "pivot | .[0]",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(3)]);
             }
@@ -18040,7 +18022,7 @@ mod tests {
     #[test]
     fn test_pivot_double_pivot_identity() {
         // Double pivot should return original for square matrices
-        query!(br#"[[1, 2], [3, 4]]"#, "pivot | pivot",
+        query!(br"[[1, 2], [3, 4]]", "pivot | pivot",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 2);
                 assert_eq!(arr[0], OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]));
@@ -18060,7 +18042,7 @@ mod tests {
         where
             F: FnOnce(&str) -> R,
         {
-            let path = format!("/tmp/succinctly_test_{}", name);
+            let path = format!("/tmp/succinctly_test_{name}");
             fs::write(&path, content).unwrap();
             let result = f(&path);
             let _ = fs::remove_file(&path);
@@ -18076,7 +18058,7 @@ mod tests {
                     let json_bytes: &[u8] = b"null";
                     let index = JsonIndex::build(json_bytes);
                     let cursor = index.root(json_bytes);
-                    let query = format!(r#"load("{}")"#, path);
+                    let query = format!(r#"load("{path}")"#);
                     let expr = parse(&query).unwrap();
                     match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
                         QueryResult::Owned(OwnedValue::Object(obj)) => {
@@ -18086,7 +18068,7 @@ mod tests {
                             );
                             assert_eq!(obj.get("value"), Some(&OwnedValue::Int(42)));
                         }
-                        other => panic!("unexpected result: {:?}", other),
+                        other => panic!("unexpected result: {other:?}"),
                     }
                 },
             );
@@ -18098,7 +18080,7 @@ mod tests {
                 let json_bytes: &[u8] = b"null";
                 let index = JsonIndex::build(json_bytes);
                 let cursor = index.root(json_bytes);
-                let query = format!(r#"load("{}")"#, path);
+                let query = format!(r#"load("{path}")"#);
                 let expr = parse(&query).unwrap();
                 match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
                     QueryResult::Owned(OwnedValue::Object(obj)) => {
@@ -18108,7 +18090,7 @@ mod tests {
                         );
                         assert_eq!(obj.get("value"), Some(&OwnedValue::Int(42)));
                     }
-                    other => panic!("unexpected result: {:?}", other),
+                    other => panic!("unexpected result: {other:?}"),
                 }
             });
         }
@@ -18119,7 +18101,7 @@ mod tests {
                 let json_bytes: &[u8] = b"null";
                 let index = JsonIndex::build(json_bytes);
                 let cursor = index.root(json_bytes);
-                let query = format!(r#"load("{}")"#, path);
+                let query = format!(r#"load("{path}")"#);
                 let expr = parse(&query).unwrap();
                 match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
                     QueryResult::Owned(OwnedValue::Object(obj)) => {
@@ -18133,7 +18115,7 @@ mod tests {
                             _ => panic!("expected array"),
                         }
                     }
-                    other => panic!("unexpected result: {:?}", other),
+                    other => panic!("unexpected result: {other:?}"),
                 }
             });
         }
@@ -18151,7 +18133,7 @@ mod tests {
                             || err.message.contains("No such file")
                     );
                 }
-                other => panic!("expected error, got: {:?}", other),
+                other => panic!("expected error, got: {other:?}"),
             }
         }
 
@@ -18164,7 +18146,7 @@ mod tests {
             let expr = parse(r#"try load("/tmp/nonexistent_file_12345.yaml") catch null"#).unwrap();
             match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
                 QueryResult::Owned(OwnedValue::Null) => {}
-                other => panic!("expected null, got: {:?}", other),
+                other => panic!("expected null, got: {other:?}"),
             }
         }
 
@@ -18179,7 +18161,7 @@ mod tests {
                 QueryResult::Owned(OwnedValue::String(s)) => {
                     assert_eq!(s, "not found");
                 }
-                other => panic!("expected 'not found', got: {:?}", other),
+                other => panic!("expected 'not found', got: {other:?}"),
             }
         }
 
@@ -18189,7 +18171,7 @@ mod tests {
                 let json_bytes: &[u8] = br#"{"name": "main"}"#;
                 let index = JsonIndex::build(json_bytes);
                 let cursor = index.root(json_bytes);
-                let query = format!(r#". + {{config: load("{}")}}"#, path);
+                let query = format!(r#". + {{config: load("{path}")}}"#);
                 let expr = parse(&query).unwrap();
                 match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
                     QueryResult::Owned(OwnedValue::Object(obj)) => {
@@ -18208,7 +18190,7 @@ mod tests {
                             _ => panic!("expected config to be object"),
                         }
                     }
-                    other => panic!("unexpected result: {:?}", other),
+                    other => panic!("unexpected result: {other:?}"),
                 }
             });
         }
@@ -18219,7 +18201,7 @@ mod tests {
                 let json_bytes: &[u8] = b"null";
                 let index = JsonIndex::build(json_bytes);
                 let cursor = index.root(json_bytes);
-                let query = format!(r#"load("{}")"#, path);
+                let query = format!(r#"load("{path}")"#);
                 let expr = parse(&query).unwrap();
                 match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
                     QueryResult::Owned(OwnedValue::Array(arr)) => {
@@ -18243,7 +18225,7 @@ mod tests {
                             _ => panic!("expected second doc to be object"),
                         }
                     }
-                    other => panic!("expected array of documents, got: {:?}", other),
+                    other => panic!("expected array of documents, got: {other:?}"),
                 }
             });
         }
@@ -18252,16 +18234,16 @@ mod tests {
         fn test_load_with_dynamic_path() {
             with_temp_file("dynamic.json", r#"{"loaded": true}"#, |path| {
                 // Input contains the path to load
-                let json_bytes = format!(r#"{{"path": "{}"}}"#, path);
+                let json_bytes = format!(r#"{{"path": "{path}"}}"#);
                 let json_bytes = json_bytes.as_bytes();
                 let index = JsonIndex::build(json_bytes);
                 let cursor = index.root(json_bytes);
-                let expr = parse(r#"load(.path)"#).unwrap();
+                let expr = parse(r"load(.path)").unwrap();
                 match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
                     QueryResult::Owned(OwnedValue::Object(obj)) => {
                         assert_eq!(obj.get("loaded"), Some(&OwnedValue::Bool(true)));
                     }
-                    other => panic!("unexpected result: {:?}", other),
+                    other => panic!("unexpected result: {other:?}"),
                 }
             });
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4601,7 +4601,9 @@ fn build_match_object(re: &regex::Regex, matched: &str, offset: usize, input: &s
             );
             cap_obj.insert(
                 "string".to_string(),
-                cap.map_or(OwnedValue::Null, |m| OwnedValue::String(m.as_str().to_string())),
+                cap.map_or(OwnedValue::Null, |m| {
+                    OwnedValue::String(m.as_str().to_string())
+                }),
             );
             cap_obj.insert(
                 "name".to_string(),
@@ -9254,10 +9256,7 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
                         if c == '+' || c == '-' {
                             input_iter.next();
                             for _ in 0..4 {
-                                if input_iter
-                                    .peek()
-                                    .is_some_and(char::is_ascii_digit)
-                                {
+                                if input_iter.peek().is_some_and(char::is_ascii_digit) {
                                     input_iter.next();
                                 }
                             }
@@ -9398,9 +9397,7 @@ fn builtin_todate<W: Clone + AsRef<[u64]>>(
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
     let year = y + i64::from(month <= 2);
 
-    let result = format!(
-        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z"
-    );
+    let result = format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z");
 
     QueryResult::Owned(OwnedValue::String(result))
 }
@@ -9590,9 +9587,7 @@ fn format_datetime_with_offset(timestamp: f64, offset_seconds: i64) -> String {
     let year = y + i64::from(month <= 2);
 
     if offset_seconds == 0 {
-        format!(
-            "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z"
-        )
+        format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
     } else {
         let offset_hours = offset_seconds.abs() / 3600;
         let offset_mins = (offset_seconds.abs() % 3600) / 60;
@@ -11537,7 +11532,11 @@ fn builtin_transpose<W: Clone + AsRef<[u64]>>(
     }
 
     // Find max length
-    let max_len = inner_arrays.iter().map(alloc::vec::Vec::len).max().unwrap_or(0);
+    let max_len = inner_arrays
+        .iter()
+        .map(alloc::vec::Vec::len)
+        .max()
+        .unwrap_or(0);
 
     // Build transposed result
     let mut result = Vec::with_capacity(max_len);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1081,9 +1081,7 @@ fn eval_builtin<V: DocumentValue>(
                 } else if let Ok(f) = s.parse::<f64>() {
                     GenericResult::Owned(OwnedValue::Float(f))
                 } else {
-                    GenericResult::Error(EvalError::new(format!(
-                        "cannot convert '{s}' to number"
-                    )))
+                    GenericResult::Error(EvalError::new(format!("cannot convert '{s}' to number")))
                 }
             } else {
                 GenericResult::Error(EvalError::new(format!(
@@ -1128,9 +1126,7 @@ fn eval_builtin<V: DocumentValue>(
                     if optional {
                         GenericResult::None
                     } else {
-                        GenericResult::Error(EvalError::new(format!(
-                            "no node at offset {offset}"
-                        )))
+                        GenericResult::Error(EvalError::new(format!("no node at offset {offset}")))
                     }
                 }
             }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1893,4 +1893,39 @@ mod tests {
         assert!(collected[4].is_empty()); // Break
         assert_eq!(collected[5], vec![OwnedValue::Bool(true)]); // Owned
     }
+
+    #[test]
+    fn test_generic_result_one_cursor_streaming() {
+        // at_offset lands on a node and yields a OneCursor result, exercising
+        // the OneCursor arms of collect_owned / stream_json / stream_yaml.
+        let json = br#"{"a": 1}"#;
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse("at_offset(6)").unwrap(); // offset 6 == the `1`
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert!(result.is_single_cursor());
+        let mut j = String::new();
+        result.stream_json(&mut j, |_| Ok(())).unwrap();
+        assert_eq!(j, "1");
+        let mut y = String::new();
+        result.stream_yaml(&mut y, 2, |_| Ok(())).unwrap();
+
+        let result2 = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(result2.collect_owned(), vec![OwnedValue::Int(1)]);
+    }
+
+    #[test]
+    fn test_at_position_no_node_and_tonumber_error() {
+        // at_position with an out-of-range line yields the "no node" error.
+        let json = br#"{"a": "xyz"}"#;
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse("at_position(99; 1)").unwrap();
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert!(result.is_error());
+
+        // tonumber on a non-numeric string yields a conversion error.
+        let expr = crate::jq::parse(".a | tonumber").unwrap();
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert!(result.is_error());
+    }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1806,4 +1806,91 @@ mod tests {
         let result = eval_with_cursor(&expr, cursor);
         assert!(matches!(result, GenericResult::Error(_)));
     }
+
+    #[test]
+    fn test_generic_result_conversions_all_variants() {
+        // A real document-backed result fixes the generic `V` for the whole
+        // Vec, letting the owned / none / error / break variants sit alongside.
+        let doc = br#"{"a": 1, "b": [1, 2, 3]}"#;
+        let index = JsonIndex::build(doc);
+        let c0 = index.root(doc);
+        let c1 = index.root(doc);
+        let results = vec![
+            eval(&Expr::Field("a".to_string()), c0.value()), // single value
+            eval(
+                &Expr::pipe(vec![Expr::Field("b".to_string()), Expr::Iterate]),
+                c1.value(),
+            ), // Many
+            GenericResult::Owned(OwnedValue::Int(5)),
+            GenericResult::ManyOwned(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
+            GenericResult::None,
+            GenericResult::Error(EvalError::new("boom")),
+            GenericResult::Break("lbl".to_string()),
+        ];
+
+        // is_error / error / is_single_cursor (borrow &self)
+        assert!(results[5].is_error());
+        assert!(results[5].error().is_some());
+        assert!(!results[2].is_error());
+        assert!(results[2].error().is_none());
+        assert!(!results[2].is_single_cursor());
+
+        // stream_json / stream_yaml exercise every variant's match arm.
+        for r in &results {
+            let mut j = String::new();
+            r.stream_json(&mut j, |_| Ok(())).unwrap();
+            let mut y = String::new();
+            r.stream_yaml(&mut y, 2, |_| Ok(())).unwrap();
+        }
+        // Spot-check the owned and error stream output.
+        let mut owned_json = String::new();
+        results[2].stream_json(&mut owned_json, |_| Ok(())).unwrap();
+        assert_eq!(owned_json, "5");
+        let mut err_json = String::new();
+        results[5].stream_json(&mut err_json, |_| Ok(())).unwrap();
+        assert!(err_json.contains("boom"));
+
+        // into_owned consumes; check the owned-family variants.
+        let owned: Vec<Option<OwnedValue>> =
+            results.into_iter().map(GenericResult::into_owned).collect();
+        assert_eq!(owned[2], Some(OwnedValue::Int(5))); // Owned
+        assert_eq!(
+            owned[3],
+            Some(OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2)
+            ]))
+        ); // ManyOwned
+        assert_eq!(owned[4], None); // None
+        assert_eq!(owned[5], None); // Error
+        assert_eq!(owned[6], None); // Break
+    }
+
+    #[test]
+    fn test_generic_result_collect_owned_all_variants() {
+        let doc = br#"{"b": [1, 2, 3]}"#;
+        let index = JsonIndex::build(doc);
+        let c = index.root(doc);
+        let results = vec![
+            eval(
+                &Expr::pipe(vec![Expr::Field("b".to_string()), Expr::Iterate]),
+                c.value(),
+            ), // Many
+            GenericResult::ManyOwned(vec![OwnedValue::Int(9)]),
+            GenericResult::None,
+            GenericResult::Error(EvalError::new("e")),
+            GenericResult::Break("l".to_string()),
+            GenericResult::Owned(OwnedValue::Bool(true)),
+        ];
+        let collected: Vec<Vec<OwnedValue>> = results
+            .into_iter()
+            .map(GenericResult::collect_owned)
+            .collect();
+        assert_eq!(collected[0].len(), 3); // Many -> 3 elements
+        assert_eq!(collected[1], vec![OwnedValue::Int(9)]); // ManyOwned
+        assert!(collected[2].is_empty()); // None
+        assert!(collected[3].is_empty()); // Error
+        assert!(collected[4].is_empty()); // Break
+        assert_eq!(collected[5], vec![OwnedValue::Bool(true)]); // Owned
+    }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -230,40 +230,40 @@ impl<V: DocumentValue> GenericResult<V> {
     /// Convert to OwnedValue for output.
     pub fn into_owned(self) -> Option<OwnedValue> {
         match self {
-            GenericResult::One(v) => Some(to_owned(&v)),
-            GenericResult::OneCursor(c) => Some(to_owned(&c.value())),
-            GenericResult::Many(vs) => Some(OwnedValue::Array(vs.iter().map(to_owned).collect())),
-            GenericResult::None => None,
-            GenericResult::Error(_) => None,
-            GenericResult::Owned(o) => Some(o),
-            GenericResult::ManyOwned(os) => Some(OwnedValue::Array(os)),
-            GenericResult::Break(_) => None,
+            Self::One(v) => Some(to_owned(&v)),
+            Self::OneCursor(c) => Some(to_owned(&c.value())),
+            Self::Many(vs) => Some(OwnedValue::Array(vs.iter().map(to_owned).collect())),
+            Self::None => None,
+            Self::Error(_) => None,
+            Self::Owned(o) => Some(o),
+            Self::ManyOwned(os) => Some(OwnedValue::Array(os)),
+            Self::Break(_) => None,
         }
     }
 
     /// Collect all results into a Vec of OwnedValues.
     pub fn collect_owned(self) -> Vec<OwnedValue> {
         match self {
-            GenericResult::One(v) => vec![to_owned(&v)],
-            GenericResult::OneCursor(c) => vec![to_owned(&c.value())],
-            GenericResult::Many(vs) => vs.iter().map(to_owned).collect(),
-            GenericResult::None => vec![],
-            GenericResult::Error(_) => vec![],
-            GenericResult::Owned(o) => vec![o],
-            GenericResult::ManyOwned(os) => os,
-            GenericResult::Break(_) => vec![],
+            Self::One(v) => vec![to_owned(&v)],
+            Self::OneCursor(c) => vec![to_owned(&c.value())],
+            Self::Many(vs) => vs.iter().map(to_owned).collect(),
+            Self::None => vec![],
+            Self::Error(_) => vec![],
+            Self::Owned(o) => vec![o],
+            Self::ManyOwned(os) => os,
+            Self::Break(_) => vec![],
         }
     }
 
     /// Check if this is an error.
     pub fn is_error(&self) -> bool {
-        matches!(self, GenericResult::Error(_))
+        matches!(self, Self::Error(_))
     }
 
     /// Get the error if this is an error result.
     pub fn error(&self) -> Option<&EvalError> {
         match self {
-            GenericResult::Error(e) => Some(e),
+            Self::Error(e) => Some(e),
             _ => None,
         }
     }
@@ -284,7 +284,7 @@ impl<V: DocumentValue> GenericResult<V> {
         let mut stats = StreamStats::default();
 
         match self {
-            GenericResult::One(v) => {
+            Self::One(v) => {
                 // Convert to owned for streaming
                 let owned = to_owned(v);
                 owned.stream_json(out)?;
@@ -292,14 +292,14 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.count = 1;
                 stats.last_was_falsy = owned.is_falsy();
             }
-            GenericResult::OneCursor(c) => {
+            Self::OneCursor(c) => {
                 // Stream directly from cursor using DocumentCursor trait
                 c.stream_json(out)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = c.is_falsy();
             }
-            GenericResult::Many(vs) => {
+            Self::Many(vs) => {
                 for v in vs {
                     let owned = to_owned(v);
                     owned.stream_json(out)?;
@@ -308,21 +308,21 @@ impl<V: DocumentValue> GenericResult<V> {
                 }
                 stats.count = vs.len();
             }
-            GenericResult::None => {
+            Self::None => {
                 // No output
             }
-            GenericResult::Error(e) => {
+            Self::Error(e) => {
                 // Write error message (like jq does)
-                write!(out, "jq: error: {}", e)?;
+                write!(out, "jq: error: {e}")?;
                 on_value(out)?;
             }
-            GenericResult::Owned(o) => {
+            Self::Owned(o) => {
                 o.stream_json(out)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = o.is_falsy();
             }
-            GenericResult::ManyOwned(os) => {
+            Self::ManyOwned(os) => {
                 for o in os {
                     o.stream_json(out)?;
                     on_value(out)?;
@@ -330,8 +330,8 @@ impl<V: DocumentValue> GenericResult<V> {
                 }
                 stats.count = os.len();
             }
-            GenericResult::Break(label) => {
-                write!(out, "jq: error: break ${} not in label", label)?;
+            Self::Break(label) => {
+                write!(out, "jq: error: break ${label} not in label")?;
                 on_value(out)?;
             }
         }
@@ -343,7 +343,7 @@ impl<V: DocumentValue> GenericResult<V> {
     ///
     /// This is used to detect if M2 streaming can be applied for navigation queries.
     pub fn is_single_cursor(&self) -> bool {
-        matches!(self, GenericResult::OneCursor(_))
+        matches!(self, Self::OneCursor(_))
     }
 
     /// Stream results as YAML to the output writer.
@@ -363,21 +363,21 @@ impl<V: DocumentValue> GenericResult<V> {
         let mut stats = StreamStats::default();
 
         match self {
-            GenericResult::One(v) => {
+            Self::One(v) => {
                 let owned = to_owned(v);
                 owned.stream_yaml(out, indent_spaces)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = owned.is_falsy();
             }
-            GenericResult::OneCursor(c) => {
+            Self::OneCursor(c) => {
                 // Stream directly from cursor using DocumentCursor trait
                 c.stream_yaml(out, indent_spaces)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = c.is_falsy();
             }
-            GenericResult::Many(vs) => {
+            Self::Many(vs) => {
                 for v in vs {
                     let owned = to_owned(v);
                     owned.stream_yaml(out, indent_spaces)?;
@@ -386,21 +386,21 @@ impl<V: DocumentValue> GenericResult<V> {
                 }
                 stats.count = vs.len();
             }
-            GenericResult::None => {
+            Self::None => {
                 // No output
             }
-            GenericResult::Error(e) => {
+            Self::Error(e) => {
                 // Write error message (like yq does)
-                write!(out, "yq: error: {}", e)?;
+                write!(out, "yq: error: {e}")?;
                 on_value(out)?;
             }
-            GenericResult::Owned(o) => {
+            Self::Owned(o) => {
                 o.stream_yaml(out, indent_spaces)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = o.is_falsy();
             }
-            GenericResult::ManyOwned(os) => {
+            Self::ManyOwned(os) => {
                 for o in os {
                     o.stream_yaml(out, indent_spaces)?;
                     on_value(out)?;
@@ -408,8 +408,8 @@ impl<V: DocumentValue> GenericResult<V> {
                 }
                 stats.count = os.len();
             }
-            GenericResult::Break(label) => {
-                write!(out, "yq: error: break ${} not in label", label)?;
+            Self::Break(label) => {
+                write!(out, "yq: error: break ${label} not in label")?;
                 on_value(out)?;
             }
         }
@@ -475,8 +475,7 @@ fn eval_single<V: DocumentValue>(
                     Some(v) => GenericResult::One(v),
                     None if optional => GenericResult::None,
                     None => GenericResult::Error(EvalError::new(format!(
-                        "index {} out of bounds (length {})",
-                        idx, len
+                        "index {idx} out of bounds (length {len})"
                     ))),
                 }
             } else if optional {
@@ -709,12 +708,12 @@ fn eval_builtin<V: DocumentValue>(
 ) -> GenericResult<V> {
     match builtin {
         Builtin::Line => {
-            let line = cursor.map(|c| c.line()).unwrap_or(0);
+            let line = cursor.map_or(0, |c| c.line());
             GenericResult::Owned(OwnedValue::Int(line as i64))
         }
 
         Builtin::Column => {
-            let column = cursor.map(|c| c.column()).unwrap_or(0);
+            let column = cursor.map_or(0, |c| c.column());
             GenericResult::Owned(OwnedValue::Int(column as i64))
         }
 
@@ -1083,8 +1082,7 @@ fn eval_builtin<V: DocumentValue>(
                     GenericResult::Owned(OwnedValue::Float(f))
                 } else {
                     GenericResult::Error(EvalError::new(format!(
-                        "cannot convert '{}' to number",
-                        s
+                        "cannot convert '{s}' to number"
                     )))
                 }
             } else {
@@ -1131,8 +1129,7 @@ fn eval_builtin<V: DocumentValue>(
                         GenericResult::None
                     } else {
                         GenericResult::Error(EvalError::new(format!(
-                            "no node at offset {}",
-                            offset
+                            "no node at offset {offset}"
                         )))
                     }
                 }
@@ -1193,8 +1190,7 @@ fn eval_builtin<V: DocumentValue>(
                         GenericResult::None
                     } else {
                         GenericResult::Error(EvalError::new(format!(
-                            "no node at position line {} column {}",
-                            line, col
+                            "no node at position line {line} column {col}"
                         )))
                     }
                 }
@@ -1251,7 +1247,7 @@ mod tests {
 
     #[test]
     fn test_generic_array_index() {
-        let json = br#"[1, 2, 3]"#;
+        let json = br"[1, 2, 3]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
@@ -1264,7 +1260,7 @@ mod tests {
 
     #[test]
     fn test_generic_iterate() {
-        let json = br#"[1, 2, 3]"#;
+        let json = br"[1, 2, 3]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
@@ -1293,7 +1289,7 @@ mod tests {
 
     #[test]
     fn test_generic_length() {
-        let json = br#"[1, 2, 3, 4, 5]"#;
+        let json = br"[1, 2, 3, 4, 5]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
@@ -1372,7 +1368,7 @@ mod tests {
                 );
                 assert_eq!(map.get("age"), Some(&OwnedValue::Int(30)));
             }
-            _ => panic!("Expected object, got {:?}", owned),
+            _ => panic!("Expected object, got {owned:?}"),
         }
     }
 

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -33,18 +33,18 @@ pub enum Expr {
     Iterate,
 
     /// Optional access: `.foo?` - returns null instead of error if missing
-    Optional(Box<Expr>),
+    Optional(Box<Self>),
 
     /// Chained expressions: `.foo.bar[0]`
     /// Each element is applied in sequence to the result of the previous.
-    Pipe(Vec<Expr>),
+    Pipe(Vec<Self>),
 
     /// Comma operator: `.foo, .bar` - outputs from both expressions
-    Comma(Vec<Expr>),
+    Comma(Vec<Self>),
 
     /// Array construction: `[.foo, .bar]` or `[.items[]]`
     /// Collects all outputs from the inner expression into an array.
-    Array(Box<Expr>),
+    Array(Box<Self>),
 
     /// Object construction: `{foo: .bar, baz: .qux}`
     /// Each entry is (key_expr, value_expr). Key can be literal or dynamic.
@@ -59,53 +59,53 @@ pub enum Expr {
 
     /// Parenthesized expression (for grouping)
     /// This is mostly handled by the parser, but we keep it for clarity.
-    Paren(Box<Expr>),
+    Paren(Box<Self>),
 
     /// Arithmetic operation: `.a + .b`, `.a - .b`, `.a * .b`, `.a / .b`, `.a % .b`
     Arithmetic {
         op: ArithOp,
-        left: Box<Expr>,
-        right: Box<Expr>,
+        left: Box<Self>,
+        right: Box<Self>,
     },
 
     /// Comparison operation: `.a == .b`, `.a != .b`, `.a < .b`, etc.
     Compare {
         op: CompareOp,
-        left: Box<Expr>,
-        right: Box<Expr>,
+        left: Box<Self>,
+        right: Box<Self>,
     },
 
     /// Boolean AND: `.a and .b`
-    And(Box<Expr>, Box<Expr>),
+    And(Box<Self>, Box<Self>),
 
     /// Boolean OR: `.a or .b`
-    Or(Box<Expr>, Box<Expr>),
+    Or(Box<Self>, Box<Self>),
 
     /// Boolean NOT: `not` (unary, applied via pipe)
     Not,
 
     /// Alternative operator: `.foo // "default"`
     /// Returns left if truthy, otherwise right.
-    Alternative(Box<Expr>, Box<Expr>),
+    Alternative(Box<Self>, Box<Self>),
 
     /// If-then-else conditional: `if .foo then .bar else .baz end`
     /// elif is desugared to nested If during parsing.
     If {
-        cond: Box<Expr>,
-        then_branch: Box<Expr>,
-        else_branch: Box<Expr>,
+        cond: Box<Self>,
+        then_branch: Box<Self>,
+        else_branch: Box<Self>,
     },
 
     /// Try-catch error handling: `try .foo catch "default"`
     /// If catch is None, errors are silently suppressed (outputs nothing).
     Try {
-        expr: Box<Expr>,
-        catch: Option<Box<Expr>>,
+        expr: Box<Self>,
+        catch: Option<Box<Self>>,
     },
 
     /// Error raising: `error` or `error("message")`
     /// Raises an error that can be caught by try-catch.
-    Error(Option<Box<Expr>>),
+    Error(Option<Box<Self>>),
 
     /// Builtin function call: `type`, `length`, `keys`, etc.
     Builtin(Builtin),
@@ -121,11 +121,11 @@ pub enum Expr {
     /// Variable binding: `.foo as $x | .bar + $x`
     As {
         /// Expression to evaluate and bind
-        expr: Box<Expr>,
+        expr: Box<Self>,
         /// Variable name (without the $)
         var: String,
         /// Body expression where the variable is in scope
-        body: Box<Expr>,
+        body: Box<Self>,
     },
 
     /// Variable reference: `$x`
@@ -146,60 +146,60 @@ pub enum Expr {
     /// Reduce: `reduce .[] as $x (0; . + $x)`
     Reduce {
         /// Input expression (what to iterate over)
-        input: Box<Expr>,
+        input: Box<Self>,
         /// Variable name for each element
         var: String,
         /// Initial accumulator value
-        init: Box<Expr>,
+        init: Box<Self>,
         /// Update expression (has access to accumulator via . and element via $var)
-        update: Box<Expr>,
+        update: Box<Self>,
     },
 
     /// Foreach: `foreach .[] as $x (0; . + 1)` or `foreach .[] as $x (0; . + 1; .)`
     Foreach {
         /// Input expression
-        input: Box<Expr>,
+        input: Box<Self>,
         /// Variable name for each element
         var: String,
         /// Initial accumulator value
-        init: Box<Expr>,
+        init: Box<Self>,
         /// Update expression
-        update: Box<Expr>,
+        update: Box<Self>,
         /// Extract expression (optional, defaults to identity)
-        extract: Option<Box<Expr>>,
+        extract: Option<Box<Self>>,
     },
 
     /// Limit: `limit(n; expr)` - take first n outputs
     Limit {
         /// Number of outputs to take
-        n: Box<Expr>,
+        n: Box<Self>,
         /// Expression to limit
-        expr: Box<Expr>,
+        expr: Box<Self>,
     },
 
     /// First with expression: `first(expr)` - first output of expr
-    FirstExpr(Box<Expr>),
+    FirstExpr(Box<Self>),
 
     /// Last with expression: `last(expr)` - last output of expr
-    LastExpr(Box<Expr>),
+    LastExpr(Box<Self>),
 
     /// Nth with expression: `nth(n; expr)` - nth output of expr
-    NthExpr { n: Box<Expr>, expr: Box<Expr> },
+    NthExpr { n: Box<Self>, expr: Box<Self> },
 
     /// Until: `until(cond; update)` - loop until condition is true
-    Until { cond: Box<Expr>, update: Box<Expr> },
+    Until { cond: Box<Self>, update: Box<Self> },
 
     /// While: `while(cond; update)` - loop while condition is true
-    While { cond: Box<Expr>, update: Box<Expr> },
+    While { cond: Box<Self>, update: Box<Self> },
 
     /// Repeat: `repeat(expr)` - infinite repetition
-    Repeat(Box<Expr>),
+    Repeat(Box<Self>),
 
     /// Range: `range(n)` or `range(a;b)` or `range(a;b;step)`
     Range {
-        from: Box<Expr>,
-        to: Option<Box<Expr>>,
-        step: Option<Box<Expr>>,
+        from: Box<Self>,
+        to: Option<Box<Self>>,
+        step: Option<Box<Self>>,
     },
 
     /// Label for non-local control flow: `label $name | expr`
@@ -208,7 +208,7 @@ pub enum Expr {
         /// Label name (without the $)
         name: String,
         /// Body expression
-        body: Box<Expr>,
+        body: Box<Self>,
     },
 
     /// Break from a labeled scope: `break $name`
@@ -220,11 +220,11 @@ pub enum Expr {
     /// or `. as [$first, $second] | ...`
     AsPattern {
         /// Expression to evaluate and destructure
-        expr: Box<Expr>,
+        expr: Box<Self>,
         /// Pattern to match against
         pattern: Pattern,
         /// Body expression where the variables are in scope
-        body: Box<Expr>,
+        body: Box<Self>,
     },
 
     /// Function definition: `def name: body;` or `def name(params): body;`
@@ -235,9 +235,9 @@ pub enum Expr {
         /// Parameter names (empty for no-arg functions)
         params: Vec<String>,
         /// Function body
-        body: Box<Expr>,
+        body: Box<Self>,
         /// Expression where this function is in scope
-        then: Box<Expr>,
+        then: Box<Self>,
     },
 
     /// Function call: `name` or `name(args)`
@@ -245,7 +245,7 @@ pub enum Expr {
         /// Function name
         name: String,
         /// Arguments (empty for no-arg calls)
-        args: Vec<Expr>,
+        args: Vec<Self>,
     },
 
     /// Namespaced function call: `module::func` or `module::func(args)`
@@ -255,7 +255,7 @@ pub enum Expr {
         /// Function name
         name: String,
         /// Arguments (empty for no-arg calls)
-        args: Vec<Expr>,
+        args: Vec<Self>,
     },
 
     // Assignment operators
@@ -263,18 +263,18 @@ pub enum Expr {
     /// Sets the path to the value and returns the modified input.
     Assign {
         /// Path expression (left side)
-        path: Box<Expr>,
+        path: Box<Self>,
         /// Value expression (right side)
-        value: Box<Expr>,
+        value: Box<Self>,
     },
 
     /// Update assignment: `.a |= f`
     /// Applies filter f to the value at path and updates it.
     Update {
         /// Path expression (left side)
-        path: Box<Expr>,
+        path: Box<Self>,
         /// Filter expression (right side)
-        filter: Box<Expr>,
+        filter: Box<Self>,
     },
 
     /// Compound assignment: `.a += value`, `.a -= value`, etc.
@@ -283,18 +283,18 @@ pub enum Expr {
         /// Assignment operator type
         op: AssignOp,
         /// Path expression (left side)
-        path: Box<Expr>,
+        path: Box<Self>,
         /// Value expression (right side)
-        value: Box<Expr>,
+        value: Box<Self>,
     },
 
     /// Alternative assignment: `.a //= value`
     /// Sets path to value only if current value is null or false.
     AlternativeAssign {
         /// Path expression (left side)
-        path: Box<Expr>,
+        path: Box<Self>,
         /// Default value expression (right side)
-        value: Box<Expr>,
+        value: Box<Self>,
     },
 }
 
@@ -313,7 +313,7 @@ pub struct Program {
 
 impl Default for Program {
     fn default() -> Self {
-        Program {
+        Self {
             module: None,
             imports: Vec::new(),
             includes: Vec::new(),
@@ -325,7 +325,7 @@ impl Default for Program {
 impl Program {
     /// Create a program from just an expression (no module directives).
     pub fn from_expr(expr: Expr) -> Self {
-        Program {
+        Self {
             module: None,
             imports: Vec::new(),
             includes: Vec::new(),
@@ -351,9 +351,9 @@ pub enum MetaValue {
     /// Boolean value
     Bool(bool),
     /// Array of values
-    Array(Vec<MetaValue>),
+    Array(Vec<Self>),
     /// Nested object
-    Object(BTreeMap<String, MetaValue>),
+    Object(BTreeMap<String, Self>),
 }
 
 /// Import directive: `import "path" as name;` or `import "path" as name { meta };`
@@ -384,7 +384,7 @@ pub enum Pattern {
     /// Object pattern: `{name: $n, age: $a}`
     Object(Vec<PatternEntry>),
     /// Array pattern: `[$first, $second]`
-    Array(Vec<Pattern>),
+    Array(Vec<Self>),
 }
 
 /// An entry in an object destructuring pattern.
@@ -1004,80 +1004,80 @@ pub enum Literal {
 impl Expr {
     /// Create an identity expression.
     pub fn identity() -> Self {
-        Expr::Identity
+        Self::Identity
     }
 
     /// Create a field access expression.
     pub fn field(name: impl Into<String>) -> Self {
-        Expr::Field(name.into())
+        Self::Field(name.into())
     }
 
     /// Create an index expression.
     pub fn index(i: i64) -> Self {
-        Expr::Index(i)
+        Self::Index(i)
     }
 
     /// Create an iterate expression.
     pub fn iterate() -> Self {
-        Expr::Iterate
+        Self::Iterate
     }
 
     /// Create a slice expression.
     pub fn slice(start: Option<i64>, end: Option<i64>) -> Self {
-        Expr::Slice { start, end }
+        Self::Slice { start, end }
     }
 
     /// Make this expression optional.
     pub fn optional(self) -> Self {
-        Expr::Optional(Box::new(self))
+        Self::Optional(Box::new(self))
     }
 
     /// Chain multiple expressions together.
-    pub fn pipe(exprs: Vec<Expr>) -> Self {
+    pub fn pipe(exprs: Vec<Self>) -> Self {
         if exprs.len() == 1 {
             exprs.into_iter().next().unwrap()
         } else {
-            Expr::Pipe(exprs)
+            Self::Pipe(exprs)
         }
     }
 
     /// Create a comma expression (multiple outputs).
-    pub fn comma(exprs: Vec<Expr>) -> Self {
+    pub fn comma(exprs: Vec<Self>) -> Self {
         if exprs.len() == 1 {
             exprs.into_iter().next().unwrap()
         } else {
-            Expr::Comma(exprs)
+            Self::Comma(exprs)
         }
     }
 
     /// Create an array construction expression.
-    pub fn array(inner: Expr) -> Self {
-        Expr::Array(Box::new(inner))
+    pub fn array(inner: Self) -> Self {
+        Self::Array(Box::new(inner))
     }
 
     /// Create an object construction expression.
     pub fn object(entries: Vec<ObjectEntry>) -> Self {
-        Expr::Object(entries)
+        Self::Object(entries)
     }
 
     /// Create a literal expression.
     pub fn literal(lit: Literal) -> Self {
-        Expr::Literal(lit)
+        Self::Literal(lit)
     }
 
     /// Create a recursive descent expression.
     pub fn recursive_descent() -> Self {
-        Expr::RecursiveDescent
+        Self::RecursiveDescent
     }
 
     /// Create a parenthesized expression.
-    pub fn paren(inner: Expr) -> Self {
-        Expr::Paren(Box::new(inner))
+    pub fn paren(inner: Self) -> Self {
+        Self::Paren(Box::new(inner))
     }
 
     /// Create an arithmetic expression.
-    pub fn arithmetic(op: ArithOp, left: Expr, right: Expr) -> Self {
-        Expr::Arithmetic {
+    pub fn arithmetic(op: ArithOp, left: Self, right: Self) -> Self {
+        Self::Arithmetic {
             op,
             left: Box::new(left),
             right: Box::new(right),
@@ -1085,8 +1085,8 @@ impl Expr {
     }
 
     /// Create a comparison expression.
-    pub fn compare(op: CompareOp, left: Expr, right: Expr) -> Self {
-        Expr::Compare {
+    pub fn compare(op: CompareOp, left: Self, right: Self) -> Self {
+        Self::Compare {
             op,
             left: Box::new(left),
             right: Box::new(right),
@@ -1094,28 +1094,28 @@ impl Expr {
     }
 
     /// Create an AND expression.
-    pub fn and(left: Expr, right: Expr) -> Self {
-        Expr::And(Box::new(left), Box::new(right))
+    pub fn and(left: Self, right: Self) -> Self {
+        Self::And(Box::new(left), Box::new(right))
     }
 
     /// Create an OR expression.
-    pub fn or(left: Expr, right: Expr) -> Self {
-        Expr::Or(Box::new(left), Box::new(right))
+    pub fn or(left: Self, right: Self) -> Self {
+        Self::Or(Box::new(left), Box::new(right))
     }
 
     /// Create a NOT expression.
     pub fn not() -> Self {
-        Expr::Not
+        Self::Not
     }
 
     /// Create an alternative expression.
-    pub fn alternative(left: Expr, right: Expr) -> Self {
-        Expr::Alternative(Box::new(left), Box::new(right))
+    pub fn alternative(left: Self, right: Self) -> Self {
+        Self::Alternative(Box::new(left), Box::new(right))
     }
 
     /// Create an if-then-else expression.
-    pub fn if_then_else(cond: Expr, then_branch: Expr, else_branch: Expr) -> Self {
-        Expr::If {
+    pub fn if_then_else(cond: Self, then_branch: Self, else_branch: Self) -> Self {
+        Self::If {
             cond: Box::new(cond),
             then_branch: Box::new(then_branch),
             else_branch: Box::new(else_branch),
@@ -1123,33 +1123,33 @@ impl Expr {
     }
 
     /// Create a try expression.
-    pub fn try_expr(expr: Expr, catch: Option<Expr>) -> Self {
-        Expr::Try {
+    pub fn try_expr(expr: Self, catch: Option<Self>) -> Self {
+        Self::Try {
             expr: Box::new(expr),
             catch: catch.map(Box::new),
         }
     }
 
     /// Create an error expression.
-    pub fn error(msg: Option<Expr>) -> Self {
-        Expr::Error(msg.map(Box::new))
+    pub fn error(msg: Option<Self>) -> Self {
+        Self::Error(msg.map(Box::new))
     }
 
     /// Create a builtin function expression.
     pub fn builtin(b: Builtin) -> Self {
-        Expr::Builtin(b)
+        Self::Builtin(b)
     }
 
     /// Returns true if this is the identity expression.
     pub fn is_identity(&self) -> bool {
-        matches!(self, Expr::Identity)
+        matches!(self, Self::Identity)
     }
 }
 
 impl ObjectEntry {
     /// Create a new object entry with a literal key.
     pub fn new(key: impl Into<String>, value: Expr) -> Self {
-        ObjectEntry {
+        Self {
             key: ObjectKey::Literal(key.into()),
             value,
         }
@@ -1157,7 +1157,7 @@ impl ObjectEntry {
 
     /// Create a new object entry with a dynamic key.
     pub fn dynamic(key_expr: Expr, value: Expr) -> Self {
-        ObjectEntry {
+        Self {
             key: ObjectKey::Expr(Box::new(key_expr)),
             value,
         }
@@ -1167,27 +1167,27 @@ impl ObjectEntry {
 impl Literal {
     /// Create a null literal.
     pub fn null() -> Self {
-        Literal::Null
+        Self::Null
     }
 
     /// Create a boolean literal.
     pub fn bool(b: bool) -> Self {
-        Literal::Bool(b)
+        Self::Bool(b)
     }
 
     /// Create an integer literal.
     pub fn int(n: i64) -> Self {
-        Literal::Int(n)
+        Self::Int(n)
     }
 
     /// Create a float literal.
     pub fn float(f: f64) -> Self {
-        Literal::Float(f)
+        Self::Float(f)
     }
 
     /// Create a string literal.
     pub fn string(s: impl Into<String>) -> Self {
-        Literal::String(s.into())
+        Self::String(s.into())
     }
 }
 

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1263,4 +1263,84 @@ mod tests {
             Expr::Literal(Literal::String("hello".into()))
         );
     }
+
+    #[test]
+    fn test_literal_float() {
+        assert_eq!(Literal::float(2.5), Literal::Float(2.5));
+    }
+
+    #[test]
+    fn test_optional_and_paren() {
+        assert_eq!(
+            Expr::field("x").optional(),
+            Expr::Optional(Box::new(Expr::Field("x".into())))
+        );
+        assert_eq!(
+            Expr::paren(Expr::identity()),
+            Expr::Paren(Box::new(Expr::Identity))
+        );
+    }
+
+    #[test]
+    fn test_recursive_descent_and_not() {
+        assert_eq!(Expr::recursive_descent(), Expr::RecursiveDescent);
+        assert_eq!(Expr::not(), Expr::Not);
+    }
+
+    #[test]
+    fn test_arithmetic_and_compare() {
+        let one = || Expr::literal(Literal::int(1));
+        let two = || Expr::literal(Literal::int(2));
+        assert_eq!(
+            Expr::arithmetic(ArithOp::Add, one(), two()),
+            Expr::Arithmetic {
+                op: ArithOp::Add,
+                left: Box::new(Expr::Literal(Literal::Int(1))),
+                right: Box::new(Expr::Literal(Literal::Int(2))),
+            }
+        );
+        assert!(matches!(
+            Expr::compare(CompareOp::Lt, one(), two()),
+            Expr::Compare {
+                op: CompareOp::Lt,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_boolean_and_alternative() {
+        assert!(matches!(
+            Expr::and(Expr::identity(), Expr::identity()),
+            Expr::And(_, _)
+        ));
+        assert!(matches!(
+            Expr::or(Expr::identity(), Expr::identity()),
+            Expr::Or(_, _)
+        ));
+        assert!(matches!(
+            Expr::alternative(Expr::identity(), Expr::literal(Literal::int(0))),
+            Expr::Alternative(_, _)
+        ));
+    }
+
+    #[test]
+    fn test_if_try_error_builtin() {
+        assert!(matches!(
+            Expr::if_then_else(Expr::identity(), Expr::identity(), Expr::identity()),
+            Expr::If { .. }
+        ));
+        assert!(matches!(
+            Expr::try_expr(Expr::identity(), Some(Expr::identity())),
+            Expr::Try { .. }
+        ));
+        assert!(matches!(Expr::error(None), Expr::Error(None)));
+        assert_eq!(Expr::builtin(Builtin::Type), Expr::Builtin(Builtin::Type));
+    }
+
+    #[test]
+    fn test_is_identity() {
+        assert!(Expr::identity().is_identity());
+        assert!(!Expr::field("x").is_identity());
+    }
 }

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1343,4 +1343,13 @@ mod tests {
         assert!(Expr::identity().is_identity());
         assert!(!Expr::field("x").is_identity());
     }
+
+    #[test]
+    fn test_program_from_expr() {
+        let prog = Program::from_expr(Expr::identity());
+        assert_eq!(prog.expr, Expr::Identity);
+        assert!(prog.module.is_none());
+        assert!(prog.imports.is_empty());
+        assert!(prog.includes.is_empty());
+    }
 }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -70,13 +70,13 @@ pub enum JqValue<'a, W = Vec<u64>> {
     ///
     /// Created when constructing arrays with `[.a, .b + 1]` or collecting
     /// iteration results. Children can be `Cursor` (lazy) or materialized.
-    Array(Vec<JqValue<'a, W>>),
+    Array(Vec<Self>),
 
     /// JSON object with potentially mixed lazy/materialized values.
     ///
     /// Created when constructing objects with `{a: .x, b: .y + 1}`.
     /// Keys are always strings, values can be lazy or materialized.
-    Object(IndexMap<String, JqValue<'a, W>>),
+    Object(IndexMap<String, Self>),
 }
 
 impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
@@ -122,7 +122,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
 
     /// Create an array from values.
     #[inline]
-    pub fn array(values: Vec<JqValue<'a, W>>) -> Self {
+    pub fn array(values: Vec<Self>) -> Self {
         JqValue::Array(values)
     }
 
@@ -134,7 +134,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
 
     /// Create an object from key-value pairs.
     #[inline]
-    pub fn object(pairs: impl IntoIterator<Item = (String, JqValue<'a, W>)>) -> Self {
+    pub fn object(pairs: impl IntoIterator<Item = (String, Self)>) -> Self {
         JqValue::Object(pairs.into_iter().collect())
     }
 
@@ -366,7 +366,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                 OwnedValue::Float(0.0)
             }
             JqValue::String(s) => OwnedValue::String(s.clone()),
-            JqValue::Array(arr) => OwnedValue::Array(arr.iter().map(|v| v.materialize()).collect()),
+            JqValue::Array(arr) => OwnedValue::Array(arr.iter().map(JqValue::materialize).collect()),
             JqValue::Object(obj) => OwnedValue::Object(
                 obj.iter()
                     .map(|(k, v)| (k.clone(), v.materialize()))
@@ -399,7 +399,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             }
             JqValue::String(s) => OwnedValue::String(s),
             JqValue::Array(arr) => {
-                OwnedValue::Array(arr.into_iter().map(|v| v.into_owned()).collect())
+                OwnedValue::Array(arr.into_iter().map(JqValue::into_owned).collect())
             }
             JqValue::Object(obj) => {
                 OwnedValue::Object(obj.into_iter().map(|(k, v)| (k, v.into_owned())).collect())
@@ -446,12 +446,12 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Null => out.write_str("null"),
             JqValue::Bool(true) => out.write_str("true"),
             JqValue::Bool(false) => out.write_str("false"),
-            JqValue::Int(n) => write!(out, "{}", n),
+            JqValue::Int(n) => write!(out, "{n}"),
             JqValue::Float(f) => {
                 if f.is_nan() || f.is_infinite() {
                     out.write_str("null")
                 } else {
-                    write!(out, "{}", f)
+                    write!(out, "{f}")
                 }
             }
             JqValue::RawNumber(bytes) => {
@@ -568,31 +568,31 @@ fn cursor_to_owned<W: Clone + AsRef<[u64]>>(cursor: &JsonCursor<'_, W>) -> Owned
 // From implementations
 // ============================================================================
 
-impl<'a, W> From<bool> for JqValue<'a, W> {
+impl<W> From<bool> for JqValue<'_, W> {
     fn from(b: bool) -> Self {
         JqValue::Bool(b)
     }
 }
 
-impl<'a, W> From<i64> for JqValue<'a, W> {
+impl<W> From<i64> for JqValue<'_, W> {
     fn from(n: i64) -> Self {
         JqValue::Int(n)
     }
 }
 
-impl<'a, W> From<f64> for JqValue<'a, W> {
+impl<W> From<f64> for JqValue<'_, W> {
     fn from(f: f64) -> Self {
         JqValue::Float(f)
     }
 }
 
-impl<'a, W> From<String> for JqValue<'a, W> {
+impl<W> From<String> for JqValue<'_, W> {
     fn from(s: String) -> Self {
         JqValue::String(s)
     }
 }
 
-impl<'a, W> From<&str> for JqValue<'a, W> {
+impl<W> From<&str> for JqValue<'_, W> {
     fn from(s: &str) -> Self {
         JqValue::String(s.to_string())
     }
@@ -618,7 +618,7 @@ mod tests {
 
         let s: JqValue<'_, Vec<u64>> = JqValue::string("hello");
         assert_eq!(
-            s.as_str().map(|c| c.into_owned()),
+            s.as_str().map(alloc::borrow::Cow::into_owned),
             Some("hello".to_string())
         );
     }
@@ -719,7 +719,7 @@ mod tests {
         let lit = Literal::String("hello".to_string());
         let val: JqValue<'_, Vec<u64>> = JqValue::from_literal(&lit);
         assert_eq!(
-            val.as_str().map(|c| c.into_owned()),
+            val.as_str().map(alloc::borrow::Cow::into_owned),
             Some("hello".to_string())
         );
     }
@@ -729,7 +729,7 @@ mod tests {
         use crate::json::JsonIndex;
 
         // Just a number
-        let json = br#"4e4"#;
+        let json = br"4e4";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
 
@@ -747,7 +747,7 @@ mod tests {
         use crate::json::JsonIndex;
 
         // JSON with exponential notation that would be reformatted if parsed
-        let json = br#"4e4"#;
+        let json = br"4e4";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
 
@@ -776,7 +776,7 @@ mod tests {
         use crate::json::JsonIndex;
 
         // Create a cursor value
-        let json = br#"4e4"#;
+        let json = br"4e4";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let cursor_val = JqValue::from_cursor(cursor);

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -366,7 +366,9 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                 OwnedValue::Float(0.0)
             }
             JqValue::String(s) => OwnedValue::String(s.clone()),
-            JqValue::Array(arr) => OwnedValue::Array(arr.iter().map(JqValue::materialize).collect()),
+            JqValue::Array(arr) => {
+                OwnedValue::Array(arr.iter().map(JqValue::materialize).collect())
+            }
             JqValue::Object(obj) => OwnedValue::Object(
                 obj.iter()
                     .map(|(k, v)| (k.clone(), v.materialize()))

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -793,4 +793,25 @@ mod tests {
         // cursor_val should preserve "4e4", computed_val is "100"
         assert_eq!(output, "[4e4,100]");
     }
+
+    #[test]
+    fn test_jqvalue_object_constructor() {
+        let obj: JqValue<'_, Vec<u64>> = JqValue::object([("a".to_string(), JqValue::Int(1))]);
+        assert_eq!(obj.to_json_string(), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn test_jqvalue_array_into_owned() {
+        let arr: JqValue<'_, Vec<u64>> = JqValue::Array(vec![JqValue::Int(1), JqValue::Int(2)]);
+        assert_eq!(
+            arr.into_owned(),
+            OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
+        );
+    }
+
+    #[test]
+    fn test_jqvalue_float_json() {
+        let f: JqValue<'_, Vec<u64>> = JqValue::Float(2.5);
+        assert_eq!(f.to_json_string(), "2.5");
+    }
 }

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3098,9 +3098,7 @@ impl<'a> Parser<'a> {
     fn is_expr_terminator(&self) -> bool {
         match self.peek() {
             // Structural terminators
-            Some(',' | ')' | ']' | '}' | '|' | ':' | ';') => {
-                true
-            }
+            Some(',' | ')' | ']' | '}' | '|' | ':' | ';') => true,
             // Arithmetic operators
             Some('+' | '-' | '*' | '/' | '%') => true,
             // Comparison operators

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -57,7 +57,7 @@ pub struct ParseError {
 
 impl ParseError {
     fn new(message: impl Into<String>, position: usize) -> Self {
-        ParseError {
+        Self {
             message: message.into(),
             position,
         }
@@ -162,11 +162,11 @@ impl<'a> Parser<'a> {
                 Ok(())
             }
             Some(c) => Err(ParseError::new(
-                format!("expected '{}', found '{}'", expected, c),
+                format!("expected '{expected}', found '{c}'"),
                 self.pos,
             )),
             None => Err(ParseError::new(
-                format!("expected '{}', found end of input", expected),
+                format!("expected '{expected}', found end of input"),
                 self.pos,
             )),
         }
@@ -218,7 +218,7 @@ impl<'a> Parser<'a> {
             }
             Some(c) => {
                 return Err(ParseError::new(
-                    format!("expected identifier, found '{}'", c),
+                    format!("expected identifier, found '{c}'"),
                     self.pos,
                 ));
             }
@@ -304,12 +304,12 @@ impl<'a> Parser<'a> {
         }
 
         // Check for exponent
-        if matches!(self.peek(), Some('e') | Some('E')) {
+        if matches!(self.peek(), Some('e' | 'E')) {
             self.next();
             is_float = true;
 
             // Optional sign
-            if matches!(self.peek(), Some('+') | Some('-')) {
+            if matches!(self.peek(), Some('+' | '-')) {
                 self.next();
             }
 
@@ -463,7 +463,7 @@ impl<'a> Parser<'a> {
                         }
                         Some(c) => {
                             return Err(ParseError::new(
-                                format!("invalid escape sequence '\\{}'", c),
+                                format!("invalid escape sequence '\\{c}'"),
                                 self.pos,
                             ));
                         }
@@ -568,7 +568,7 @@ impl<'a> Parser<'a> {
                         }
                         Some(c) => {
                             return Err(ParseError::new(
-                                format!("invalid escape sequence '\\{}'", c),
+                                format!("invalid escape sequence '\\{c}'"),
                                 self.pos,
                             ));
                         }
@@ -662,7 +662,7 @@ impl<'a> Parser<'a> {
                 }
             }
             Some(c) => Err(ParseError::new(
-                format!("expected ']' or ':', found '{}'", c),
+                format!("expected ']' or ':', found '{c}'"),
                 self.pos,
             )),
             None => Err(ParseError::new(
@@ -771,7 +771,7 @@ impl<'a> Parser<'a> {
                 }
                 Some(c) => {
                     return Err(ParseError::new(
-                        format!("expected ',' or '}}', found '{}'", c),
+                        format!("expected ',' or '}}', found '{c}'"),
                         self.pos,
                     ));
                 }
@@ -956,7 +956,7 @@ impl<'a> Parser<'a> {
             }
 
             Some(c) => Err(ParseError::new(
-                format!("unexpected character '{}', expected expression", c),
+                format!("unexpected character '{c}', expected expression"),
                 self.pos,
             )),
             None => Err(ParseError::new("unexpected end of input", self.pos)),
@@ -1533,7 +1533,7 @@ impl<'a> Parser<'a> {
                     self.skip_ws();
 
                     match self.peek() {
-                        Some(';') | Some(',') => {
+                        Some(';' | ',') => {
                             self.next();
                             self.skip_ws();
                         }
@@ -1683,7 +1683,7 @@ impl<'a> Parser<'a> {
             "props" => FormatType::Props,
             _ => {
                 return Err(ParseError::new(
-                    format!("unknown format '@{}'", format_name),
+                    format!("unknown format '@{format_name}'"),
                     format_start,
                 ));
             }
@@ -3098,13 +3098,13 @@ impl<'a> Parser<'a> {
     fn is_expr_terminator(&self) -> bool {
         match self.peek() {
             // Structural terminators
-            Some(',') | Some(')') | Some(']') | Some('}') | Some('|') | Some(':') | Some(';') => {
+            Some(',' | ')' | ']' | '}' | '|' | ':' | ';') => {
                 true
             }
             // Arithmetic operators
-            Some('+') | Some('-') | Some('*') | Some('/') | Some('%') => true,
+            Some('+' | '-' | '*' | '/' | '%') => true,
             // Comparison operators
-            Some('=') | Some('!') | Some('<') | Some('>') => true,
+            Some('=' | '!' | '<' | '>') => true,
             // Keywords that follow expressions
             Some('a') if self.matches_keyword("and") || self.matches_keyword("as") => true,
             Some('o') if self.matches_keyword("or") => true,
@@ -3491,7 +3491,7 @@ impl<'a> Parser<'a> {
                     body: Box::new(body),
                 })
             }
-            Some('{') | Some('[') => {
+            Some('{' | '[') => {
                 // Pattern destructuring: `{key: $var}` or `[$first, $second]`
                 let pattern = self.parse_pattern()?;
                 self.skip_ws();
@@ -3633,7 +3633,7 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
 
                 match self.peek() {
-                    Some(';') | Some(',') => {
+                    Some(';' | ',') => {
                         self.next();
                         self.skip_ws();
                     }
@@ -4605,7 +4605,7 @@ mod tests {
         );
 
         // Empty string key
-        assert_eq!(parse(".\"\"").unwrap(), Expr::Field("".into()));
+        assert_eq!(parse(".\"\"").unwrap(), Expr::Field(String::new()));
 
         // Quoted field in chained access
         assert_eq!(
@@ -4646,7 +4646,7 @@ mod tests {
         );
 
         // Empty string key
-        assert_eq!(parse(".[\"\"]").unwrap(), Expr::Field("".into()));
+        assert_eq!(parse(".[\"\"]").unwrap(), Expr::Field(String::new()));
 
         // Bracket string in chained access
         assert_eq!(
@@ -4772,10 +4772,10 @@ mod tests {
                     Expr::Var(name) => {
                         assert_eq!(name, "bar");
                     }
-                    other => panic!("expected FuncCall or Var, got {:?}", other),
+                    other => panic!("expected FuncCall or Var, got {other:?}"),
                 }
             }
-            _ => panic!("expected subtraction, got {:?}", expr),
+            _ => panic!("expected subtraction, got {expr:?}"),
         }
     }
 

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -4818,4 +4818,35 @@ mod tests {
             Expr::Literal(Literal::String("hello # world".into()))
         );
     }
+
+    #[test]
+    fn test_parse_error_paths() {
+        // Unknown @format.
+        assert!(parse("@foobar")
+            .unwrap_err()
+            .message
+            .contains("unknown format"));
+        // Invalid escape inside a string literal.
+        assert!(parse(r#""\q""#)
+            .unwrap_err()
+            .message
+            .contains("invalid escape"));
+        // Unexpected character where an expression is expected.
+        assert!(parse("%").is_err());
+        // Array index/slice: expected ']' or ':'.
+        assert!(parse(".[1 2]").is_err());
+        // Object: expected ',' or '}'.
+        assert!(parse("{a: 1 c: 2}").is_err());
+        // Grouping: expected ')', found another char.
+        assert!(parse("(.foo]").is_err());
+        // Grouping: expected ')', found end of input.
+        assert!(parse("(.foo").is_err());
+    }
+
+    #[test]
+    fn test_parse_number_exponent_sign() {
+        // Exercises the optional +/- sign branch in exponent parsing.
+        assert!(parse("1e+5").is_ok());
+        assert!(parse("1e-5").is_ok());
+    }
 }

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -75,7 +75,7 @@ impl StreamableValue for OwnedValue {
     }
 
     fn is_falsy(&self) -> bool {
-        matches!(self, OwnedValue::Null | OwnedValue::Bool(false))
+        matches!(self, Self::Null | Self::Bool(false))
     }
 }
 
@@ -88,13 +88,13 @@ fn stream_owned_value_json<W: core::fmt::Write>(
         OwnedValue::Null => out.write_str("null"),
         OwnedValue::Bool(true) => out.write_str("true"),
         OwnedValue::Bool(false) => out.write_str("false"),
-        OwnedValue::Int(n) => write!(out, "{}", n),
+        OwnedValue::Int(n) => write!(out, "{n}"),
         OwnedValue::Float(f) => {
             if f.is_nan() || f.is_infinite() {
                 // JSON doesn't support NaN or Infinity
                 out.write_str("null")
             } else {
-                write!(out, "{}", f)
+                write!(out, "{f}")
             }
         }
         OwnedValue::String(s) => stream_json_string(out, s),
@@ -190,7 +190,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
         OwnedValue::Null => out.write_str("null"),
         OwnedValue::Bool(true) => out.write_str("true"),
         OwnedValue::Bool(false) => out.write_str("false"),
-        OwnedValue::Int(n) => write!(out, "{}", n),
+        OwnedValue::Int(n) => write!(out, "{n}"),
         OwnedValue::Float(f) => {
             if f.is_nan() {
                 out.write_str(".nan")
@@ -201,7 +201,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                     out.write_str("-.inf")
                 }
             } else {
-                write!(out, "{}", f)
+                write!(out, "{f}")
             }
         }
         OwnedValue::String(s) => stream_yaml_string(out, s),
@@ -569,6 +569,6 @@ mod tests {
         assert!(OwnedValue::Bool(false).is_falsy());
         assert!(!OwnedValue::Bool(true).is_falsy());
         assert!(!OwnedValue::Int(0).is_falsy());
-        assert!(!OwnedValue::String("".to_string()).is_falsy());
+        assert!(!OwnedValue::String(String::new()).is_falsy());
     }
 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -118,9 +118,7 @@ impl OwnedValue {
     pub fn as_i64(&self) -> Option<i64> {
         match self {
             Self::Int(n) => Some(*n),
-            Self::Float(f) if (*f - (*f as i64 as f64)).abs() < f64::EPSILON => {
-                Some(*f as i64)
-            }
+            Self::Float(f) if (*f - (*f as i64 as f64)).abs() < f64::EPSILON => Some(*f as i64),
             _ => None,
         }
     }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -33,83 +33,83 @@ pub enum OwnedValue {
     /// JSON string
     String(String),
     /// JSON array
-    Array(Vec<OwnedValue>),
+    Array(Vec<Self>),
     /// JSON object (IndexMap preserves insertion order like jq)
-    Object(IndexMap<String, OwnedValue>),
+    Object(IndexMap<String, Self>),
 }
 
 impl OwnedValue {
     /// Create a null value.
     pub fn null() -> Self {
-        OwnedValue::Null
+        Self::Null
     }
 
     /// Create a boolean value.
     pub fn bool(b: bool) -> Self {
-        OwnedValue::Bool(b)
+        Self::Bool(b)
     }
 
     /// Create an integer value.
     pub fn int(n: i64) -> Self {
-        OwnedValue::Int(n)
+        Self::Int(n)
     }
 
     /// Create a float value.
     pub fn float(f: f64) -> Self {
-        OwnedValue::Float(f)
+        Self::Float(f)
     }
 
     /// Create a string value.
     pub fn string(s: impl Into<String>) -> Self {
-        OwnedValue::String(s.into())
+        Self::String(s.into())
     }
 
     /// Create an empty array.
     pub fn array() -> Self {
-        OwnedValue::Array(Vec::new())
+        Self::Array(Vec::new())
     }
 
     /// Create an array from a vector of values.
-    pub fn array_from(values: Vec<OwnedValue>) -> Self {
-        OwnedValue::Array(values)
+    pub fn array_from(values: Vec<Self>) -> Self {
+        Self::Array(values)
     }
 
     /// Create an empty object.
     pub fn object() -> Self {
-        OwnedValue::Object(IndexMap::new())
+        Self::Object(IndexMap::new())
     }
 
     /// Create an object from key-value pairs.
-    pub fn object_from(pairs: impl IntoIterator<Item = (String, OwnedValue)>) -> Self {
-        OwnedValue::Object(pairs.into_iter().collect())
+    pub fn object_from(pairs: impl IntoIterator<Item = (String, Self)>) -> Self {
+        Self::Object(pairs.into_iter().collect())
     }
 
     /// Check if this value is null.
     pub fn is_null(&self) -> bool {
-        matches!(self, OwnedValue::Null)
+        matches!(self, Self::Null)
     }
 
     /// Check if this value is "truthy" (not null and not false).
     pub fn is_truthy(&self) -> bool {
-        !matches!(self, OwnedValue::Null | OwnedValue::Bool(false))
+        !matches!(self, Self::Null | Self::Bool(false))
     }
 
     /// Get the type name of this value.
     pub fn type_name(&self) -> &'static str {
         match self {
-            OwnedValue::Null => "null",
-            OwnedValue::Bool(_) => "boolean",
-            OwnedValue::Int(_) | OwnedValue::Float(_) => "number",
-            OwnedValue::String(_) => "string",
-            OwnedValue::Array(_) => "array",
-            OwnedValue::Object(_) => "object",
+            Self::Null => "null",
+            Self::Bool(_) => "boolean",
+            Self::Int(_) | Self::Float(_) => "number",
+            Self::String(_) => "string",
+            Self::Array(_) => "array",
+            Self::Object(_) => "object",
         }
     }
 
     /// Convert to a boolean, if possible.
     pub fn as_bool(&self) -> Option<bool> {
         match self {
-            OwnedValue::Bool(b) => Some(*b),
+            Self::Bool(b) => Some(*b),
             _ => None,
         }
     }
@@ -117,8 +117,8 @@ impl OwnedValue {
     /// Convert to an i64, if possible.
     pub fn as_i64(&self) -> Option<i64> {
         match self {
-            OwnedValue::Int(n) => Some(*n),
-            OwnedValue::Float(f) if (*f - (*f as i64 as f64)).abs() < f64::EPSILON => {
+            Self::Int(n) => Some(*n),
+            Self::Float(f) if (*f - (*f as i64 as f64)).abs() < f64::EPSILON => {
                 Some(*f as i64)
             }
             _ => None,
@@ -128,8 +128,8 @@ impl OwnedValue {
     /// Convert to an f64, if possible.
     pub fn as_f64(&self) -> Option<f64> {
         match self {
-            OwnedValue::Int(n) => Some(*n as f64),
-            OwnedValue::Float(f) => Some(*f),
+            Self::Int(n) => Some(*n as f64),
+            Self::Float(f) => Some(*f),
             _ => None,
         }
     }
@@ -137,39 +137,39 @@ impl OwnedValue {
     /// Convert to a string reference, if possible.
     pub fn as_str(&self) -> Option<&str> {
         match self {
-            OwnedValue::String(s) => Some(s),
+            Self::String(s) => Some(s),
             _ => None,
         }
     }
 
     /// Convert to an array reference, if possible.
-    pub fn as_array(&self) -> Option<&Vec<OwnedValue>> {
+    pub fn as_array(&self) -> Option<&Vec<Self>> {
         match self {
-            OwnedValue::Array(arr) => Some(arr),
+            Self::Array(arr) => Some(arr),
             _ => None,
         }
     }
 
     /// Convert to a mutable array reference, if possible.
-    pub fn as_array_mut(&mut self) -> Option<&mut Vec<OwnedValue>> {
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<Self>> {
         match self {
-            OwnedValue::Array(arr) => Some(arr),
+            Self::Array(arr) => Some(arr),
             _ => None,
         }
     }
 
     /// Convert to an object reference, if possible.
-    pub fn as_object(&self) -> Option<&IndexMap<String, OwnedValue>> {
+    pub fn as_object(&self) -> Option<&IndexMap<String, Self>> {
         match self {
-            OwnedValue::Object(obj) => Some(obj),
+            Self::Object(obj) => Some(obj),
             _ => None,
         }
     }
 
     /// Convert to a mutable object reference, if possible.
-    pub fn as_object_mut(&mut self) -> Option<&mut IndexMap<String, OwnedValue>> {
+    pub fn as_object_mut(&mut self) -> Option<&mut IndexMap<String, Self>> {
         match self {
-            OwnedValue::Object(obj) => Some(obj),
+            Self::Object(obj) => Some(obj),
             _ => None,
         }
     }
@@ -182,10 +182,10 @@ impl OwnedValue {
     /// - other: error (returns None)
     pub fn length(&self) -> Option<usize> {
         match self {
-            OwnedValue::Null => Some(0),
-            OwnedValue::String(s) => Some(s.chars().count()),
-            OwnedValue::Array(arr) => Some(arr.len()),
-            OwnedValue::Object(obj) => Some(obj.len()),
+            Self::Null => Some(0),
+            Self::String(s) => Some(s.chars().count()),
+            Self::Array(arr) => Some(arr.len()),
+            Self::Object(obj) => Some(obj.len()),
             _ => None,
         }
     }
@@ -193,23 +193,23 @@ impl OwnedValue {
     /// Format this value as JSON string.
     pub fn to_json(&self) -> String {
         match self {
-            OwnedValue::Null => "null".into(),
-            OwnedValue::Bool(true) => "true".into(),
-            OwnedValue::Bool(false) => "false".into(),
-            OwnedValue::Int(n) => format!("{}", n),
-            OwnedValue::Float(f) => {
+            Self::Null => "null".into(),
+            Self::Bool(true) => "true".into(),
+            Self::Bool(false) => "false".into(),
+            Self::Int(n) => format!("{n}"),
+            Self::Float(f) => {
                 if f.is_nan() || f.is_infinite() {
                     "null".into() // JSON doesn't support NaN or Infinity
                 } else {
-                    format!("{}", f)
+                    format!("{f}")
                 }
             }
-            OwnedValue::String(s) => format!("\"{}\"", escape_json_string(s)),
-            OwnedValue::Array(arr) => {
-                let elements: Vec<String> = arr.iter().map(|v| v.to_json()).collect();
+            Self::String(s) => format!("\"{}\"", escape_json_string(s)),
+            Self::Array(arr) => {
+                let elements: Vec<String> = arr.iter().map(Self::to_json).collect();
                 format!("[{}]", elements.join(","))
             }
-            OwnedValue::Object(obj) => {
+            Self::Object(obj) => {
                 let entries: Vec<String> = obj
                     .iter()
                     .map(|(k, v)| format!("\"{}\":{}", escape_json_string(k), v.to_json()))
@@ -242,48 +242,48 @@ fn escape_json_string(s: &str) -> String {
 impl From<Literal> for OwnedValue {
     fn from(lit: Literal) -> Self {
         match lit {
-            Literal::Null => OwnedValue::Null,
-            Literal::Bool(b) => OwnedValue::Bool(b),
-            Literal::Int(n) => OwnedValue::Int(n),
-            Literal::Float(f) => OwnedValue::Float(f),
-            Literal::String(s) => OwnedValue::String(s),
+            Literal::Null => Self::Null,
+            Literal::Bool(b) => Self::Bool(b),
+            Literal::Int(n) => Self::Int(n),
+            Literal::Float(f) => Self::Float(f),
+            Literal::String(s) => Self::String(s),
         }
     }
 }
 
 impl From<bool> for OwnedValue {
     fn from(b: bool) -> Self {
-        OwnedValue::Bool(b)
+        Self::Bool(b)
     }
 }
 
 impl From<i64> for OwnedValue {
     fn from(n: i64) -> Self {
-        OwnedValue::Int(n)
+        Self::Int(n)
     }
 }
 
 impl From<f64> for OwnedValue {
     fn from(f: f64) -> Self {
-        OwnedValue::Float(f)
+        Self::Float(f)
     }
 }
 
 impl From<String> for OwnedValue {
     fn from(s: String) -> Self {
-        OwnedValue::String(s)
+        Self::String(s)
     }
 }
 
 impl From<&str> for OwnedValue {
     fn from(s: &str) -> Self {
-        OwnedValue::String(s.to_string())
+        Self::String(s.to_string())
     }
 }
 
-impl<T: Into<OwnedValue>> From<Vec<T>> for OwnedValue {
+impl<T: Into<Self>> From<Vec<T>> for OwnedValue {
     fn from(arr: Vec<T>) -> Self {
-        OwnedValue::Array(arr.into_iter().map(Into::into).collect())
+        Self::Array(arr.into_iter().map(Into::into).collect())
     }
 }
 
@@ -309,7 +309,7 @@ mod tests {
         assert!(!OwnedValue::Bool(false).is_truthy());
         assert!(OwnedValue::Bool(true).is_truthy());
         assert!(OwnedValue::Int(0).is_truthy()); // 0 is truthy in jq!
-        assert!(OwnedValue::String("".into()).is_truthy()); // "" is truthy in jq!
+        assert!(OwnedValue::String(String::new()).is_truthy()); // "" is truthy in jq!
         assert!(OwnedValue::Array(vec![]).is_truthy()); // [] is truthy in jq!
     }
 
@@ -319,7 +319,7 @@ mod tests {
         assert_eq!(OwnedValue::Bool(true).type_name(), "boolean");
         assert_eq!(OwnedValue::Int(42).type_name(), "number");
         assert_eq!(OwnedValue::Float(2.5).type_name(), "number");
-        assert_eq!(OwnedValue::String("".into()).type_name(), "string");
+        assert_eq!(OwnedValue::String(String::new()).type_name(), "string");
         assert_eq!(OwnedValue::Array(vec![]).type_name(), "array");
         assert_eq!(OwnedValue::Object(IndexMap::new()).type_name(), "object");
     }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -370,4 +370,106 @@ mod tests {
             OwnedValue::String("hello".into())
         );
     }
+
+    #[test]
+    fn test_collection_constructors() {
+        assert_eq!(OwnedValue::array(), OwnedValue::Array(vec![]));
+        assert_eq!(
+            OwnedValue::array_from(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
+            OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
+        );
+        assert_eq!(OwnedValue::object(), OwnedValue::Object(IndexMap::new()));
+        let obj = OwnedValue::object_from([("a".to_string(), OwnedValue::Int(1))]);
+        assert_eq!(obj.as_object().unwrap().get("a"), Some(&OwnedValue::Int(1)));
+    }
+
+    #[test]
+    fn test_is_null() {
+        assert!(OwnedValue::Null.is_null());
+        assert!(!OwnedValue::Bool(false).is_null());
+        assert!(!OwnedValue::Int(0).is_null());
+    }
+
+    #[test]
+    fn test_as_bool() {
+        assert_eq!(OwnedValue::Bool(true).as_bool(), Some(true));
+        assert_eq!(OwnedValue::Bool(false).as_bool(), Some(false));
+        assert_eq!(OwnedValue::Int(1).as_bool(), None);
+        assert_eq!(OwnedValue::Null.as_bool(), None);
+    }
+
+    #[test]
+    fn test_as_i64() {
+        assert_eq!(OwnedValue::Int(42).as_i64(), Some(42));
+        // A float with an integral value converts to i64...
+        assert_eq!(OwnedValue::Float(3.0).as_i64(), Some(3));
+        // ...but a fractional float does not.
+        assert_eq!(OwnedValue::Float(3.5).as_i64(), None);
+        assert_eq!(OwnedValue::String("3".into()).as_i64(), None);
+    }
+
+    #[test]
+    fn test_as_f64() {
+        assert_eq!(OwnedValue::Int(42).as_f64(), Some(42.0));
+        assert_eq!(OwnedValue::Float(2.5).as_f64(), Some(2.5));
+        assert_eq!(OwnedValue::Bool(true).as_f64(), None);
+    }
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(OwnedValue::String("hi".into()).as_str(), Some("hi"));
+        assert_eq!(OwnedValue::Int(1).as_str(), None);
+    }
+
+    #[test]
+    fn test_as_array_and_mut() {
+        let mut v = OwnedValue::Array(vec![OwnedValue::Int(1)]);
+        assert_eq!(v.as_array(), Some(&vec![OwnedValue::Int(1)]));
+        v.as_array_mut().unwrap().push(OwnedValue::Int(2));
+        assert_eq!(
+            v,
+            OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
+        );
+        assert_eq!(OwnedValue::Null.as_array(), None);
+        assert_eq!(OwnedValue::Null.as_array_mut(), None);
+    }
+
+    #[test]
+    fn test_as_object_and_mut() {
+        let mut map = IndexMap::new();
+        map.insert("a".to_string(), OwnedValue::Int(1));
+        let mut v = OwnedValue::Object(map);
+        assert_eq!(v.as_object().unwrap().len(), 1);
+        v.as_object_mut()
+            .unwrap()
+            .insert("b".to_string(), OwnedValue::Int(2));
+        assert_eq!(v.as_object().unwrap().len(), 2);
+        assert_eq!(OwnedValue::Int(1).as_object(), None);
+        assert_eq!(OwnedValue::Int(1).as_object_mut(), None);
+    }
+
+    #[test]
+    fn test_from_primitives() {
+        assert_eq!(OwnedValue::from(true), OwnedValue::Bool(true));
+        assert_eq!(OwnedValue::from(7i64), OwnedValue::Int(7));
+        assert_eq!(OwnedValue::from(1.5f64), OwnedValue::Float(1.5));
+        assert_eq!(
+            OwnedValue::from(String::from("s")),
+            OwnedValue::String("s".into())
+        );
+        assert_eq!(OwnedValue::from("s"), OwnedValue::String("s".into()));
+    }
+
+    #[test]
+    fn test_from_vec() {
+        let v: OwnedValue = vec![1i64, 2, 3].into();
+        assert_eq!(
+            v,
+            OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+                OwnedValue::Int(3)
+            ])
+        );
+    }
 }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -520,13 +520,13 @@ pub struct JsonCursor<'a, W = Vec<u64>> {
 }
 
 // Manual Clone/Copy impl since W is only used through a reference
-impl<'a, W> Clone for JsonCursor<'a, W> {
+impl<W> Clone for JsonCursor<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for JsonCursor<'a, W> {}
+impl<W> Copy for JsonCursor<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
     /// Create a cursor at a specific BP position.
@@ -590,7 +590,7 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
     ///
     /// Returns `None` if this position has no children (is a leaf or close paren).
     #[inline]
-    pub fn first_child(&self) -> Option<JsonCursor<'a, W>> {
+    pub fn first_child(&self) -> Option<Self> {
         let new_pos = self.index.bp().first_child(self.bp_pos)?;
         Some(JsonCursor {
             text: self.text,
@@ -603,7 +603,7 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
     ///
     /// Returns `None` if this is the last sibling.
     #[inline]
-    pub fn next_sibling(&self) -> Option<JsonCursor<'a, W>> {
+    pub fn next_sibling(&self) -> Option<Self> {
         let new_pos = self.index.bp().next_sibling(self.bp_pos)?;
         Some(JsonCursor {
             text: self.text,
@@ -616,7 +616,7 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
     ///
     /// Returns `None` if this is the root.
     #[inline]
-    pub fn parent(&self) -> Option<JsonCursor<'a, W>> {
+    pub fn parent(&self) -> Option<Self> {
         let new_pos = self.index.bp().parent(self.bp_pos)?;
         Some(JsonCursor {
             text: self.text,
@@ -806,7 +806,7 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
     /// - The offset doesn't correspond to a valid node
     ///
     /// This enables position-based navigation in jq queries via `at_offset(n)`.
-    pub fn cursor_at_offset(&self, offset: usize) -> Option<JsonCursor<'a, W>> {
+    pub fn cursor_at_offset(&self, offset: usize) -> Option<Self> {
         if offset >= self.text.len() {
             return None;
         }
@@ -876,7 +876,7 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
     /// - The position doesn't correspond to a valid node
     ///
     /// This enables position-based navigation in jq queries via `at_position(line; col)`.
-    pub fn cursor_at_position(&self, line: usize, col: usize) -> Option<JsonCursor<'a, W>> {
+    pub fn cursor_at_position(&self, line: usize, col: usize) -> Option<Self> {
         // Convert line/column to byte offset
         let offset = self.index.to_offset(line, col)?;
 
@@ -899,13 +899,13 @@ pub struct JsonChildren<'a, W = Vec<u64>> {
     current: Option<JsonCursor<'a, W>>,
 }
 
-impl<'a, W> Clone for JsonChildren<'a, W> {
+impl<W> Clone for JsonChildren<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for JsonChildren<'a, W> {}
+impl<W> Copy for JsonChildren<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> Iterator for JsonChildren<'a, W> {
     type Item = JsonCursor<'a, W>;
@@ -968,13 +968,13 @@ pub struct JsonFields<'a, W = Vec<u64>> {
 }
 
 // Manual Clone/Copy impl since JsonCursor is Copy
-impl<'a, W> Clone for JsonFields<'a, W> {
+impl<W> Clone for JsonFields<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for JsonFields<'a, W> {}
+impl<W> Copy for JsonFields<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// Create a new JsonFields from an object cursor.
@@ -993,7 +993,7 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// Get the first field and the remaining fields.
     ///
     /// Returns `None` if there are no more fields.
-    pub fn uncons(&self) -> Option<(JsonField<'a, W>, JsonFields<'a, W>)> {
+    pub fn uncons(&self) -> Option<(JsonField<'a, W>, Self)> {
         let key_cursor = self.key_cursor?;
 
         // Next sibling of key is the value
@@ -1052,13 +1052,13 @@ pub struct JsonField<'a, W = Vec<u64>> {
 }
 
 // Manual Clone/Copy impl since JsonCursor is Copy
-impl<'a, W> Clone for JsonField<'a, W> {
+impl<W> Clone for JsonField<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for JsonField<'a, W> {}
+impl<W> Copy for JsonField<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> JsonField<'a, W> {
     /// Get the field key (always a string).
@@ -1105,13 +1105,13 @@ pub struct JsonElements<'a, W = Vec<u64>> {
 }
 
 // Manual Clone/Copy impl since JsonCursor is Copy
-impl<'a, W> Clone for JsonElements<'a, W> {
+impl<W> Clone for JsonElements<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for JsonElements<'a, W> {}
+impl<W> Copy for JsonElements<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> JsonElements<'a, W> {
     /// Create a new JsonElements from an array cursor.
@@ -1130,7 +1130,7 @@ impl<'a, W: AsRef<[u64]>> JsonElements<'a, W> {
     /// Get the first element and the remaining elements.
     ///
     /// Returns `None` if there are no more elements.
-    pub fn uncons(&self) -> Option<(StandardJson<'a, W>, JsonElements<'a, W>)> {
+    pub fn uncons(&self) -> Option<(StandardJson<'a, W>, Self)> {
         let element_cursor = self.element_cursor?;
 
         let rest = JsonElements {
@@ -1145,7 +1145,7 @@ impl<'a, W: AsRef<[u64]>> JsonElements<'a, W> {
     ///
     /// This is like `uncons` but returns the cursor instead of the value.
     /// Useful for lazy evaluation where you want to defer calling `value()`.
-    pub fn uncons_cursor(&self) -> Option<(JsonCursor<'a, W>, JsonElements<'a, W>)> {
+    pub fn uncons_cursor(&self) -> Option<(JsonCursor<'a, W>, Self)> {
         let element_cursor = self.element_cursor?;
 
         let rest = JsonElements {
@@ -1474,10 +1474,10 @@ pub enum JsonError {
 impl core::fmt::Display for JsonError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            JsonError::InvalidUtf8 => write!(f, "invalid UTF-8 in string"),
-            JsonError::InvalidNumber => write!(f, "invalid number format"),
-            JsonError::InvalidEscape => write!(f, "invalid escape sequence in string"),
-            JsonError::InvalidUnicodeEscape => write!(f, "invalid unicode escape sequence"),
+            Self::InvalidUtf8 => write!(f, "invalid UTF-8 in string"),
+            Self::InvalidNumber => write!(f, "invalid number format"),
+            Self::InvalidEscape => write!(f, "invalid escape sequence in string"),
+            Self::InvalidUnicodeEscape => write!(f, "invalid unicode escape sequence"),
         }
     }
 }
@@ -1705,9 +1705,9 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for JsonElements<'a, W> {
 // ============================================================================
 
 /// Stream a JSON value as YAML.
-fn stream_json_as_yaml<'a, W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
+fn stream_json_as_yaml<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
     out: &mut Out,
-    value: StandardJson<'a, W>,
+    value: StandardJson<'_, W>,
     current_indent: usize,
     indent_spaces: usize,
 ) -> core::fmt::Result {
@@ -1717,7 +1717,7 @@ fn stream_json_as_yaml<'a, W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
         StandardJson::Number(n) => {
             // Try integer first, then float
             if let Ok(i) = n.as_i64() {
-                write!(out, "{}", i)
+                write!(out, "{i}")
             } else if let Ok(f) = n.as_f64() {
                 if f.is_nan() {
                     out.write_str(".nan")
@@ -1728,7 +1728,7 @@ fn stream_json_as_yaml<'a, W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
                         out.write_str("-.inf")
                     }
                 } else {
-                    write!(out, "{}", f)
+                    write!(out, "{f}")
                 }
             } else {
                 out.write_str("null")
@@ -2045,7 +2045,7 @@ mod tests {
 
     #[test]
     fn test_empty_object() {
-        let json = br#"{}"#;
+        let json = br"{}";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2059,7 +2059,7 @@ mod tests {
 
     #[test]
     fn test_empty_array() {
-        let json = br#"[]"#;
+        let json = br"[]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2228,7 +2228,7 @@ mod tests {
 
     #[test]
     fn test_array_single_element() {
-        let json = br#"[42]"#;
+        let json = br"[42]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2250,7 +2250,7 @@ mod tests {
 
     #[test]
     fn test_array_multiple_elements() {
-        let json = br#"[1, 2, 3]"#;
+        let json = br"[1, 2, 3]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2387,7 +2387,7 @@ mod tests {
     #[test]
     fn test_immutable_iteration() {
         // Test that iteration is truly immutable - we can iterate multiple times
-        let json = br#"[1, 2, 3]"#;
+        let json = br"[1, 2, 3]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2749,7 +2749,7 @@ mod tests {
 
     #[test]
     fn test_json_elements_iterator() {
-        let json = br#"[1, 2, 3, 4, 5]"#;
+        let json = br"[1, 2, 3, 4, 5]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2771,7 +2771,7 @@ mod tests {
 
     #[test]
     fn test_iterator_empty_object() {
-        let json = br#"{}"#;
+        let json = br"{}";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2784,7 +2784,7 @@ mod tests {
 
     #[test]
     fn test_iterator_empty_array() {
-        let json = br#"[]"#;
+        let json = br"[]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2834,7 +2834,7 @@ mod tests {
 
     #[test]
     fn test_is_container_array() {
-        let json = br#"[1, 2, 3]"#;
+        let json = br"[1, 2, 3]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
         assert!(root.is_container());
@@ -2842,7 +2842,7 @@ mod tests {
 
     #[test]
     fn test_is_container_empty_object() {
-        let json = br#"{}"#;
+        let json = br"{}";
         let index = JsonIndex::build(json);
         let root = index.root(json);
         // Empty containers have no children, so is_container returns false
@@ -2851,7 +2851,7 @@ mod tests {
 
     #[test]
     fn test_is_container_empty_array() {
-        let json = br#"[]"#;
+        let json = br"[]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
         // Empty containers have no children, so is_container returns false
@@ -2883,7 +2883,7 @@ mod tests {
 
     #[test]
     fn test_children_array() {
-        let json = br#"[1, 2, 3]"#;
+        let json = br"[1, 2, 3]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -2922,7 +2922,7 @@ mod tests {
 
     #[test]
     fn test_children_empty() {
-        let json = br#"[]"#;
+        let json = br"[]";
         let index = JsonIndex::build(json);
         let root = index.root(json);
 
@@ -3073,8 +3073,7 @@ mod tests {
             assert_eq!(
                 result,
                 Some(offset),
-                "Round-trip failed for offset {}",
-                offset
+                "Round-trip failed for offset {offset}"
             );
         }
     }

--- a/src/json/locate.rs
+++ b/src/json/locate.rs
@@ -157,9 +157,9 @@ impl PathComponent {
     /// Format as a jq path component.
     fn to_jq_string(&self) -> String {
         match self {
-            PathComponent::Index(i) => format!("[{}]", i),
-            PathComponent::DotKey(k) => format!(".{}", k),
-            PathComponent::BracketKey(k) => format!("[\"{}\"]", escape_jq_string(k)),
+            Self::Index(i) => format!("[{i}]"),
+            Self::DotKey(k) => format!(".{k}"),
+            Self::BracketKey(k) => format!("[\"{}\"]", escape_jq_string(k)),
         }
     }
 }
@@ -350,7 +350,7 @@ fn find_key_for_value<W: AsRef<[u64]>>(
 /// Extract the key string from a key cursor.
 fn extract_key_string<W: AsRef<[u64]>>(cursor: JsonCursor<'_, W>, _text: &[u8]) -> Option<String> {
     match cursor.value() {
-        StandardJson::String(s) => s.as_str().ok().map(|cow| cow.into_owned()),
+        StandardJson::String(s) => s.as_str().ok().map(alloc::borrow::Cow::into_owned),
         _ => None,
     }
 }
@@ -660,7 +660,7 @@ mod tests {
 
     #[test]
     fn test_locate_array_indices() {
-        let json = br#"[1, 2, 3]"#;
+        let json = br"[1, 2, 3]";
         let index = JsonIndex::build(json);
 
         // At array
@@ -751,7 +751,7 @@ mod tests {
             if i > 0 {
                 json.push(',');
             }
-            json.push_str(&format!("\"item{}\"", i));
+            json.push_str(&format!("\"item{i}\""));
         }
         json.push_str("]}");
 

--- a/src/json/pfsm_tables.rs
+++ b/src/json/pfsm_tables.rs
@@ -138,20 +138,20 @@ impl PfsmState {
 
     /// Extract the next state from a transition table entry
     #[inline]
-    pub const fn extract_next_state(table_entry: u32, current_state: PfsmState) -> PfsmState {
+    pub const fn extract_next_state(table_entry: u32, current_state: Self) -> Self {
         let byte = ((table_entry >> current_state.byte_offset()) & 0xFF) as u8;
         match byte {
-            0 => PfsmState::InJson,
-            1 => PfsmState::InString,
-            2 => PfsmState::InEscape,
-            3 => PfsmState::InValue,
-            _ => PfsmState::InJson, // Shouldn't happen
+            0 => Self::InJson,
+            1 => Self::InString,
+            2 => Self::InEscape,
+            3 => Self::InValue,
+            _ => Self::InJson, // Shouldn't happen
         }
     }
 
     /// Extract phi bits (IB/OP/CL) from a phi table entry
     #[inline]
-    pub const fn extract_phi(table_entry: u32, current_state: PfsmState) -> u8 {
+    pub const fn extract_phi(table_entry: u32, current_state: Self) -> u8 {
         ((table_entry >> current_state.byte_offset()) & 0xFF) as u8
     }
 }

--- a/src/json/simd/avx2.rs
+++ b/src/json/simd/avx2.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 AVX2 SIMD intrinsics
 //! AVX2-accelerated JSON semi-indexing for x86_64.
 //!
 //! Processes 32 bytes at a time using x86_64 AVX2 SIMD instructions.
@@ -240,7 +241,7 @@ unsafe fn build_semi_index_standard_avx2(json: &[u8]) -> SemiIndex {
 
         // Process 32-byte chunks
         while offset + 32 <= json.len() {
-            let chunk = _mm256_loadu_si256(json.as_ptr().add(offset) as *const __m256i);
+            let chunk = _mm256_loadu_si256(json.as_ptr().add(offset).cast::<__m256i>());
             let class = classify_chars(chunk);
             state =
                 process_chunk_standard(class, state, &mut ib, &mut bp, &json[offset..offset + 32]);
@@ -254,7 +255,7 @@ unsafe fn build_semi_index_standard_avx2(json: &[u8]) -> SemiIndex {
             let remaining = json.len() - offset;
             padded[..remaining].copy_from_slice(&json[offset..]);
 
-            let chunk = _mm256_loadu_si256(padded.as_ptr() as *const __m256i);
+            let chunk = _mm256_loadu_si256(padded.as_ptr().cast::<__m256i>());
             let class = classify_chars(chunk);
             state = process_chunk_standard(class, state, &mut ib, &mut bp, &json[offset..]);
         }
@@ -364,7 +365,7 @@ unsafe fn build_semi_index_simple_avx2(json: &[u8]) -> SimpleSemiIndex {
 
         // Process 32-byte chunks
         while offset + 32 <= json.len() {
-            let chunk = _mm256_loadu_si256(json.as_ptr().add(offset) as *const __m256i);
+            let chunk = _mm256_loadu_si256(json.as_ptr().add(offset).cast::<__m256i>());
             let class = classify_chars(chunk);
             state =
                 process_chunk_simple(class, state, &mut ib, &mut bp, &json[offset..offset + 32]);
@@ -378,7 +379,7 @@ unsafe fn build_semi_index_simple_avx2(json: &[u8]) -> SimpleSemiIndex {
             let remaining = json.len() - offset;
             padded[..remaining].copy_from_slice(&json[offset..]);
 
-            let chunk = _mm256_loadu_si256(padded.as_ptr() as *const __m256i);
+            let chunk = _mm256_loadu_si256(padded.as_ptr().cast::<__m256i>());
             let class = classify_chars(chunk);
             state = process_chunk_simple(class, state, &mut ib, &mut bp, &json[offset..]);
         }
@@ -421,7 +422,7 @@ mod tests {
 
         unsafe {
             let input = br#"{"hello":123}               "#; // 32 bytes
-            let chunk = _mm256_loadu_si256(input.as_ptr() as *const __m256i);
+            let chunk = _mm256_loadu_si256(input.as_ptr().cast::<__m256i>());
             let class = classify_chars(chunk);
 
             // Position 0 is '{', position 12 is '}'

--- a/src/json/simd/bmi2.rs
+++ b/src/json/simd/bmi2.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 BMI2 (PDEP/PEXT) intrinsics
 //! BMI2 bit manipulation helpers for x86_64.
 //!
 //! BMI2 provides PDEP (parallel bit deposit) and PEXT (parallel bit extract)
@@ -246,9 +247,7 @@ mod tests {
                 assert_eq!(
                     pext_u64(src, mask),
                     pext_u64_fallback(src, mask),
-                    "PEXT mismatch for src={:#x}, mask={:#x}",
-                    src,
-                    mask
+                    "PEXT mismatch for src={src:#x}, mask={mask:#x}"
                 );
             }
         }
@@ -271,9 +270,7 @@ mod tests {
                 assert_eq!(
                     pdep_u64(src, mask),
                     pdep_u64_fallback(src, mask),
-                    "PDEP mismatch for src={:#x}, mask={:#x}",
-                    src,
-                    mask
+                    "PDEP mismatch for src={src:#x}, mask={mask:#x}"
                 );
             }
         }

--- a/src/json/simd/mod.rs
+++ b/src/json/simd/mod.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // runtime SIMD feature dispatch
 //! SIMD-accelerated JSON semi-indexing.
 //!
 //! This module provides vectorized implementations of JSON semi-indexing

--- a/src/json/simd/neon.rs
+++ b/src/json/simd/neon.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ARM64 NEON SIMD intrinsics
 //! NEON-accelerated JSON semi-indexing for ARM64.
 //!
 //! Processes 16 bytes at a time using ARM NEON SIMD instructions.

--- a/src/json/simd/sse42.rs
+++ b/src/json/simd/sse42.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 SSE4.2 SIMD intrinsics
 //! SSE4.2-accelerated JSON semi-indexing for x86_64.
 //!
 //! Processes 16 bytes at a time using x86_64 SSE4.2 PCMPISTRI instructions.
@@ -230,7 +231,7 @@ unsafe fn build_semi_index_standard_sse42(json: &[u8]) -> SemiIndex {
         let mut offset = 0;
 
         while offset + 16 <= json.len() {
-            let chunk = _mm_loadu_si128(json.as_ptr().add(offset) as *const __m128i);
+            let chunk = _mm_loadu_si128(json.as_ptr().add(offset).cast::<__m128i>());
             let class = classify_chars(chunk);
             state =
                 process_chunk_standard(class, state, &mut ib, &mut bp, &json[offset..offset + 16]);
@@ -242,7 +243,7 @@ unsafe fn build_semi_index_standard_sse42(json: &[u8]) -> SemiIndex {
             let remaining = json.len() - offset;
             padded[..remaining].copy_from_slice(&json[offset..]);
 
-            let chunk = _mm_loadu_si128(padded.as_ptr() as *const __m128i);
+            let chunk = _mm_loadu_si128(padded.as_ptr().cast::<__m128i>());
             let class = classify_chars(chunk);
             state = process_chunk_standard(class, state, &mut ib, &mut bp, &json[offset..]);
         }
@@ -334,7 +335,7 @@ unsafe fn build_semi_index_simple_sse42(json: &[u8]) -> SimpleSemiIndex {
         let mut offset = 0;
 
         while offset + 16 <= json.len() {
-            let chunk = _mm_loadu_si128(json.as_ptr().add(offset) as *const __m128i);
+            let chunk = _mm_loadu_si128(json.as_ptr().add(offset).cast::<__m128i>());
             let class = classify_chars(chunk);
             state =
                 process_chunk_simple(class, state, &mut ib, &mut bp, &json[offset..offset + 16]);
@@ -346,7 +347,7 @@ unsafe fn build_semi_index_simple_sse42(json: &[u8]) -> SimpleSemiIndex {
             let remaining = json.len() - offset;
             padded[..remaining].copy_from_slice(&json[offset..]);
 
-            let chunk = _mm_loadu_si128(padded.as_ptr() as *const __m128i);
+            let chunk = _mm_loadu_si128(padded.as_ptr().cast::<__m128i>());
             let class = classify_chars(chunk);
             state = process_chunk_simple(class, state, &mut ib, &mut bp, &json[offset..]);
         }

--- a/src/json/simd/sve2.rs
+++ b/src/json/simd/sve2.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ARM64 SVE2 SIMD intrinsics
 //! SVE2-accelerated JSON semi-indexing for ARM64.
 //!
 //! Uses SVE2 instructions to classify JSON structural characters in parallel.

--- a/src/json/simd/x86.rs
+++ b/src/json/simd/x86.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 SSE2 SIMD intrinsics
 //! SSE2-accelerated JSON semi-indexing for x86_64.
 //!
 //! Processes 16 bytes at a time using x86_64 SSE2 SIMD instructions.
@@ -247,7 +248,7 @@ unsafe fn build_semi_index_standard_sse2(json: &[u8]) -> SemiIndex {
 
         // Process 16-byte chunks
         while offset + 16 <= json.len() {
-            let chunk = _mm_loadu_si128(json.as_ptr().add(offset) as *const __m128i);
+            let chunk = _mm_loadu_si128(json.as_ptr().add(offset).cast::<__m128i>());
             let class = classify_chars(chunk);
             state =
                 process_chunk_standard(class, state, &mut ib, &mut bp, &json[offset..offset + 16]);
@@ -261,7 +262,7 @@ unsafe fn build_semi_index_standard_sse2(json: &[u8]) -> SemiIndex {
             let remaining = json.len() - offset;
             padded[..remaining].copy_from_slice(&json[offset..]);
 
-            let chunk = _mm_loadu_si128(padded.as_ptr() as *const __m128i);
+            let chunk = _mm_loadu_si128(padded.as_ptr().cast::<__m128i>());
             let class = classify_chars(chunk);
             state = process_chunk_standard(class, state, &mut ib, &mut bp, &json[offset..]);
         }
@@ -371,7 +372,7 @@ unsafe fn build_semi_index_simple_sse2(json: &[u8]) -> SimpleSemiIndex {
 
         // Process 16-byte chunks
         while offset + 16 <= json.len() {
-            let chunk = _mm_loadu_si128(json.as_ptr().add(offset) as *const __m128i);
+            let chunk = _mm_loadu_si128(json.as_ptr().add(offset).cast::<__m128i>());
             let class = classify_chars(chunk);
             state =
                 process_chunk_simple(class, state, &mut ib, &mut bp, &json[offset..offset + 16]);
@@ -385,7 +386,7 @@ unsafe fn build_semi_index_simple_sse2(json: &[u8]) -> SimpleSemiIndex {
             let remaining = json.len() - offset;
             padded[..remaining].copy_from_slice(&json[offset..]);
 
-            let chunk = _mm_loadu_si128(padded.as_ptr() as *const __m128i);
+            let chunk = _mm_loadu_si128(padded.as_ptr().cast::<__m128i>());
             let class = classify_chars(chunk);
             state = process_chunk_simple(class, state, &mut ib, &mut bp, &json[offset..]);
         }
@@ -424,7 +425,7 @@ mod tests {
     fn test_classify_chars() {
         unsafe {
             let input = br#"{"hello":123}   "#;
-            let chunk = _mm_loadu_si128(input.as_ptr() as *const __m128i);
+            let chunk = _mm_loadu_si128(input.as_ptr().cast::<__m128i>());
             let class = classify_chars(chunk);
 
             // Position 0 is '{', position 12 is '}'
@@ -449,7 +450,7 @@ mod tests {
     fn test_classify_chars_alphabetic() {
         unsafe {
             let input = b"abcdefghABCDEFGH";
-            let chunk = _mm_loadu_si128(input.as_ptr() as *const __m128i);
+            let chunk = _mm_loadu_si128(input.as_ptr().cast::<__m128i>());
             let class = classify_chars(chunk);
 
             // All positions should be value_chars (alphabetic)
@@ -461,7 +462,7 @@ mod tests {
     fn test_classify_chars_special() {
         unsafe {
             let input = b".-+truefalsennul";
-            let chunk = _mm_loadu_si128(input.as_ptr() as *const __m128i);
+            let chunk = _mm_loadu_si128(input.as_ptr().cast::<__m128i>());
             let class = classify_chars(chunk);
 
             // Position 0: '.', 1: '-', 2: '+'
@@ -474,8 +475,7 @@ mod tests {
                 assert_ne!(
                     class.value_chars & (1 << i),
                     0,
-                    "Alphabetic at position {}",
-                    i
+                    "Alphabetic at position {i}"
                 );
             }
         }

--- a/src/json/simple_light.rs
+++ b/src/json/simple_light.rs
@@ -387,7 +387,7 @@ pub struct StructuralPositions<'a, W = Vec<u64>> {
     k: usize,
 }
 
-impl<'a, W: AsRef<[u64]>> Iterator for StructuralPositions<'a, W> {
+impl<W: AsRef<[u64]>> Iterator for StructuralPositions<'_, W> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -405,7 +405,7 @@ pub struct Children<'a, W = Vec<u64>> {
     end_idx: usize,
 }
 
-impl<'a, W: AsRef<[u64]>> Iterator for Children<'a, W> {
+impl<W: AsRef<[u64]>> Iterator for Children<'_, W> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -583,7 +583,7 @@ mod tests {
 
     #[test]
     fn test_structural_positions_iterator() {
-        let json = br#"[1,2,3]"#;
+        let json = br"[1,2,3]";
         let index = SimpleJsonIndex::build(json);
 
         let positions: Vec<_> = index.structural_positions(json).collect();

--- a/src/json/standard.rs
+++ b/src/json/standard.rs
@@ -516,9 +516,9 @@ mod tests {
             let pfsm = build_semi_index(json);
             let scalar = build_semi_index_scalar(json);
             let label = core::str::from_utf8(json);
-            assert_eq!(scalar.ib, pfsm.ib, "IB mismatch for {:?}", label);
-            assert_eq!(scalar.bp, pfsm.bp, "BP mismatch for {:?}", label);
-            assert_eq!(scalar.state, pfsm.state, "state mismatch for {:?}", label);
+            assert_eq!(scalar.ib, pfsm.ib, "IB mismatch for {label:?}");
+            assert_eq!(scalar.bp, pfsm.bp, "BP mismatch for {label:?}");
+            assert_eq!(scalar.state, pfsm.state, "state mismatch for {label:?}");
         }
     }
 

--- a/src/json/standard.rs
+++ b/src/json/standard.rs
@@ -139,10 +139,10 @@ fn is_value_char(c: u8) -> bool {
 struct Phi(u8);
 
 impl Phi {
-    const NONE: Phi = Phi(0b000);
-    const CLOSE: Phi = Phi(0b001);
-    const OPEN: Phi = Phi(0b110);
-    const LEAF: Phi = Phi(0b111); // open + close + interest
+    const NONE: Self = Self(0b000);
+    const CLOSE: Self = Self(0b001);
+    const OPEN: Self = Self(0b110);
+    const LEAF: Self = Self(0b111); // open + close + interest
 
     #[inline]
     fn ib(self) -> bool {

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -92,33 +92,32 @@ impl fmt::Display for ValidationErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnexpectedCharacter { expected, found } => {
-                write!(f, "expected {}, found {:?}", expected, found)
+                write!(f, "expected {expected}, found {found:?}")
             }
             Self::UnexpectedEof { expected } => {
-                write!(f, "unexpected end of input, expected {}", expected)
+                write!(f, "unexpected end of input, expected {expected}")
             }
             Self::TrailingContent => write!(f, "trailing content after JSON value"),
             Self::UnclosedString => write!(f, "unclosed string"),
             Self::InvalidEscape { sequence } => {
-                write!(f, "invalid escape sequence '\\{}'", sequence)
+                write!(f, "invalid escape sequence '\\{sequence}'")
             }
             Self::InvalidUnicodeEscape { reason } => {
-                write!(f, "invalid unicode escape: {}", reason)
+                write!(f, "invalid unicode escape: {reason}")
             }
             Self::UnpairedSurrogate { codepoint } => {
-                write!(f, "unpaired surrogate \\u{:04X}", codepoint)
+                write!(f, "unpaired surrogate \\u{codepoint:04X}")
             }
             Self::ControlCharacter { byte } => {
-                write!(f, "unescaped control character 0x{:02X}", byte)
+                write!(f, "unescaped control character 0x{byte:02X}")
             }
             Self::LeadingZero => write!(f, "leading zeros not allowed in numbers"),
             Self::LeadingPlus => write!(f, "leading plus sign not allowed in numbers"),
-            Self::InvalidNumber { reason } => write!(f, "invalid number: {}", reason),
+            Self::InvalidNumber { reason } => write!(f, "invalid number: {reason}"),
             Self::InvalidKeyword { found } => {
                 write!(
                     f,
-                    "invalid keyword '{}' (expected null, true, or false)",
-                    found
+                    "invalid keyword '{found}' (expected null, true, or false)"
                 )
             }
             Self::InvalidUtf8 => write!(f, "invalid UTF-8 sequence"),
@@ -194,8 +193,8 @@ impl<'a> Validator<'a> {
             Some(b'{') => self.validate_object(),
             Some(b'[') => self.validate_array(),
             Some(b'"') => self.validate_string(),
-            Some(b'-') | Some(b'0'..=b'9') => self.validate_number(),
-            Some(b't') | Some(b'f') | Some(b'n') => self.validate_keyword(),
+            Some(b'-' | b'0'..=b'9') => self.validate_number(),
+            Some(b't' | b'f' | b'n') => self.validate_keyword(),
             Some(b'+') => Err(self.error(ValidationErrorKind::LeadingPlus)),
             Some(c) => Err(self.error(ValidationErrorKind::UnexpectedCharacter {
                 expected: "JSON value",
@@ -223,7 +222,7 @@ impl<'a> Validator<'a> {
             if self.peek() != Some(b'"') {
                 return Err(self.error(ValidationErrorKind::UnexpectedCharacter {
                     expected: "string key",
-                    found: self.peek().map(|b| b as char).unwrap_or('\0'),
+                    found: self.peek().map_or('\0', |b| b as char),
                 }));
             }
             self.validate_string()?;
@@ -233,7 +232,7 @@ impl<'a> Validator<'a> {
             if self.peek() != Some(b':') {
                 return Err(self.error(ValidationErrorKind::UnexpectedCharacter {
                     expected: "':'",
-                    found: self.peek().map(|b| b as char).unwrap_or('\0'),
+                    found: self.peek().map_or('\0', |b| b as char),
                 }));
             }
             self.advance();
@@ -1046,8 +1045,7 @@ mod tests {
             let err = validate(input.as_bytes()).unwrap_err();
             assert!(
                 matches!(err.kind, ValidationErrorKind::ControlCharacter { byte: b } if b == byte),
-                "Control char 0x{:02X} should be rejected",
-                byte
+                "Control char 0x{byte:02X} should be rejected"
             );
         }
     }
@@ -1136,8 +1134,7 @@ mod tests {
             let err = validate(&input).unwrap_err();
             assert!(
                 matches!(err.kind, ValidationErrorKind::InvalidUtf8),
-                "Lead byte 0x{:02X} should be rejected",
-                lead
+                "Lead byte 0x{lead:02X} should be rejected"
             );
         }
     }

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -1320,4 +1320,80 @@ mod tests {
         s.push('"');
         assert!(validate(s.as_bytes()).is_ok());
     }
+
+    #[test]
+    fn test_validation_error_kind_display() {
+        assert_eq!(
+            ValidationErrorKind::UnexpectedCharacter {
+                expected: "','",
+                found: '}'
+            }
+            .to_string(),
+            "expected ',', found '}'"
+        );
+        assert_eq!(
+            ValidationErrorKind::UnexpectedEof { expected: "value" }.to_string(),
+            "unexpected end of input, expected value"
+        );
+        assert_eq!(
+            ValidationErrorKind::TrailingContent.to_string(),
+            "trailing content after JSON value"
+        );
+        assert_eq!(
+            ValidationErrorKind::UnclosedString.to_string(),
+            "unclosed string"
+        );
+        assert_eq!(
+            ValidationErrorKind::InvalidEscape { sequence: 'x' }.to_string(),
+            "invalid escape sequence '\\x'"
+        );
+        assert_eq!(
+            ValidationErrorKind::InvalidUnicodeEscape { reason: "bad hex" }.to_string(),
+            "invalid unicode escape: bad hex"
+        );
+        assert_eq!(
+            ValidationErrorKind::UnpairedSurrogate { codepoint: 0xD800 }.to_string(),
+            "unpaired surrogate \\uD800"
+        );
+        assert_eq!(
+            ValidationErrorKind::ControlCharacter { byte: 0x01 }.to_string(),
+            "unescaped control character 0x01"
+        );
+        assert_eq!(
+            ValidationErrorKind::LeadingZero.to_string(),
+            "leading zeros not allowed in numbers"
+        );
+        assert_eq!(
+            ValidationErrorKind::LeadingPlus.to_string(),
+            "leading plus sign not allowed in numbers"
+        );
+        assert_eq!(
+            ValidationErrorKind::InvalidNumber {
+                reason: "no digits"
+            }
+            .to_string(),
+            "invalid number: no digits"
+        );
+        assert_eq!(
+            ValidationErrorKind::InvalidKeyword {
+                found: "nul".to_string()
+            }
+            .to_string(),
+            "invalid keyword 'nul' (expected null, true, or false)"
+        );
+        assert_eq!(
+            ValidationErrorKind::InvalidUtf8.to_string(),
+            "invalid UTF-8 sequence"
+        );
+    }
+
+    #[test]
+    fn test_missing_colon_in_object() {
+        // Triggers the object-key colon error path.
+        let err = validate(br#"{"a" 1}"#).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::UnexpectedCharacter { .. }
+        ));
+    }
 }

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -2050,7 +2050,7 @@ impl<W: AsRef<[u64]>, S: SelectSupport> BalancedParens<W, S> {
                 }
 
                 State::CheckL0 => {
-                    debug_assert!(pos % 64 == 0);
+                    debug_assert_eq!(pos % 64, 0);
 
                     let word_idx = pos / 64;
                     if word_idx >= self.l0_min_excess.len() {
@@ -2071,7 +2071,7 @@ impl<W: AsRef<[u64]>, S: SelectSupport> BalancedParens<W, S> {
                 }
 
                 State::CheckL1 => {
-                    debug_assert!(pos % 64 == 0);
+                    debug_assert_eq!(pos % 64, 0);
 
                     let l1_idx = pos / (64 * FACTOR_L1);
                     if l1_idx >= self.l1_min_excess.len() {

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // unchecked indexing + SSE4.1 intrinsics on hot BP-navigation paths
 //! Balanced parentheses operations for succinct tree navigation.
 //!
 //! This module provides efficient operations on balanced parentheses (BP) sequences,
@@ -65,7 +66,7 @@ pub struct NoSelect;
 impl SelectSupport for NoSelect {
     #[inline]
     fn build(_words: &[u64], _total_ones: usize) -> Self {
-        NoSelect
+        Self
     }
 
     #[inline]
@@ -87,7 +88,7 @@ pub struct WithSelect {
 impl SelectSupport for WithSelect {
     fn build(words: &[u64], total_ones: usize) -> Self {
         // Use default sample rate of 256 for ~3% overhead
-        WithSelect {
+        Self {
             select_idx: SelectIndex::build(words, total_ones, 256),
         }
     }
@@ -557,12 +558,12 @@ unsafe fn build_l1_index_sse41_impl(
         while i + 8 <= end {
             // Load 8 min_excess values (i8) and widen to i16
             let min_ptr = l0_min_excess.as_ptr().add(i);
-            let min_i8 = _mm_loadl_epi64(min_ptr as *const __m128i); // Load 8 bytes into low 64 bits
+            let min_i8 = _mm_loadl_epi64(min_ptr.cast::<__m128i>()); // Load 8 bytes into low 64 bits
             let min_lo = _mm_cvtepi8_epi16(min_i8); // Sign-extend i8 -> i16
 
             // Load 8 word_excess values (i16)
             let excess_ptr = l0_word_excess.as_ptr().add(i);
-            let excess = _mm_loadu_si128(excess_ptr as *const __m128i);
+            let excess = _mm_loadu_si128(excess_ptr.cast::<__m128i>());
 
             // Compute prefix sum of excess using parallel prefix pattern
             // SSE doesn't have VEXT, so we use shuffles and shifts
@@ -678,11 +679,11 @@ unsafe fn build_l2_index_sse41_impl(
         while i + 8 <= end {
             // Load 8 min_excess values (i16)
             let min_ptr = l1_min_excess.as_ptr().add(i);
-            let min_vals = _mm_loadu_si128(min_ptr as *const __m128i);
+            let min_vals = _mm_loadu_si128(min_ptr.cast::<__m128i>());
 
             // Load 8 block_excess values (i16)
             let excess_ptr = l1_block_excess.as_ptr().add(i);
-            let excess = _mm_loadu_si128(excess_ptr as *const __m128i);
+            let excess = _mm_loadu_si128(excess_ptr.cast::<__m128i>());
 
             // Compute prefix sum using parallel prefix pattern
             let shifted1 = _mm_slli_si128(excess, 2);
@@ -2715,7 +2716,7 @@ mod tests {
         for p in [0, 1, 3] {
             let close = bp.find_close(p).unwrap();
             let open = bp.find_open(close).unwrap();
-            assert_eq!(open, p, "roundtrip failed for position {}", p);
+            assert_eq!(open, p, "roundtrip failed for position {p}");
         }
     }
 
@@ -2730,7 +2731,7 @@ mod tests {
             if bp.is_open(p) {
                 let bp_result = bp.find_close(p);
                 let linear_result = find_close(&words, len, p);
-                assert_eq!(bp_result, linear_result, "mismatch at position {}", p);
+                assert_eq!(bp_result, linear_result, "mismatch at position {p}");
             }
         }
     }
@@ -2859,13 +2860,12 @@ mod tests {
         let bp_result = bp.find_close(p);
 
         // First, make sure we're testing an open position
-        assert!(bp.is_open(p), "Position {} should be open", p);
+        assert!(bp.is_open(p), "Position {p} should be open");
 
         // The results should match
         assert_eq!(
             bp_result, linear_result,
-            "find_close({}) mismatch: accelerated={:?}, linear={:?}",
-            p, bp_result, linear_result
+            "find_close({p}) mismatch: accelerated={bp_result:?}, linear={linear_result:?}"
         );
     }
 
@@ -2942,8 +2942,7 @@ mod tests {
             let linear_result = find_close(&words, len, p);
             assert_eq!(
                 bp_result, linear_result,
-                "L1 boundary: find_close({}) mismatch",
-                p
+                "L1 boundary: find_close({p}) mismatch"
             );
         }
     }
@@ -3258,9 +3257,7 @@ mod tests {
                 assert_eq!(
                     v1.rank1(p),
                     v2.rank1(p),
-                    "rank1({}) mismatch for pattern {:?}",
-                    p,
-                    words
+                    "rank1({p}) mismatch for pattern {words:?}"
                 );
             }
         }
@@ -3284,9 +3281,7 @@ mod tests {
                     assert_eq!(
                         v1.find_close(p),
                         v2.find_close(p),
-                        "find_close({}) mismatch for pattern {:?}",
-                        p,
-                        words
+                        "find_close({p}) mismatch for pattern {words:?}"
                     );
                 }
             }
@@ -3328,8 +3323,7 @@ mod tests {
             assert_eq!(
                 v1.rank1(p),
                 v2.rank1(p),
-                "rank1({}) mismatch on large bitvector",
-                p
+                "rank1({p}) mismatch on large bitvector"
             );
         }
 
@@ -3426,13 +3420,11 @@ mod tests {
 
         assert_eq!(
             scalar_min, sse41_min,
-            "L1 min_excess mismatch: scalar={:?}, sse41={:?}",
-            scalar_min, sse41_min
+            "L1 min_excess mismatch: scalar={scalar_min:?}, sse41={sse41_min:?}"
         );
         assert_eq!(
             scalar_excess, sse41_excess,
-            "L1 block_excess mismatch: scalar={:?}, sse41={:?}",
-            scalar_excess, sse41_excess
+            "L1 block_excess mismatch: scalar={scalar_excess:?}, sse41={sse41_excess:?}"
         );
     }
 
@@ -3457,13 +3449,11 @@ mod tests {
 
         assert_eq!(
             scalar_min, sse41_min,
-            "L1 min_excess mismatch for {} blocks",
-            num_l1
+            "L1 min_excess mismatch for {num_l1} blocks"
         );
         assert_eq!(
             scalar_excess, sse41_excess,
-            "L1 block_excess mismatch for {} blocks",
-            num_l1
+            "L1 block_excess mismatch for {num_l1} blocks"
         );
     }
 
@@ -3554,13 +3544,11 @@ mod tests {
 
         assert_eq!(
             scalar_min, sse41_min,
-            "L2 min_excess mismatch: scalar={:?}, sse41={:?}",
-            scalar_min, sse41_min
+            "L2 min_excess mismatch: scalar={scalar_min:?}, sse41={sse41_min:?}"
         );
         assert_eq!(
             scalar_excess, sse41_excess,
-            "L2 block_excess mismatch: scalar={:?}, sse41={:?}",
-            scalar_excess, sse41_excess
+            "L2 block_excess mismatch: scalar={scalar_excess:?}, sse41={sse41_excess:?}"
         );
     }
 
@@ -3590,8 +3578,7 @@ mod tests {
                 let expected = len - 1 - i;
                 assert_eq!(
                     close, expected,
-                    "find_close({}) = {}, expected {}",
-                    i, close, expected
+                    "find_close({i}) = {close}, expected {expected}"
                 );
             }
         }
@@ -3723,13 +3710,11 @@ mod tests {
 
             assert_eq!(
                 scalar_min, sse41_min,
-                "L1 min_excess mismatch for pattern {}",
-                pattern_idx
+                "L1 min_excess mismatch for pattern {pattern_idx}"
             );
             assert_eq!(
                 scalar_excess, sse41_excess,
-                "L1 block_excess mismatch for pattern {}",
-                pattern_idx
+                "L1 block_excess mismatch for pattern {pattern_idx}"
             );
         }
     }

--- a/src/util/broadword.rs
+++ b/src/util/broadword.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // dispatches to PDEP/BDEP intrinsics for select-in-word
 //! Broadword (SWAR) algorithms for bit manipulation.
 //!
 //! These algorithms operate on 64-bit words using SIMD-within-a-register techniques,
@@ -191,7 +192,7 @@ mod tests {
     fn test_select_in_word_all_ones() {
         let word = u64::MAX;
         for k in 0..64 {
-            assert_eq!(select_in_word(word, k), k, "k={}", k);
+            assert_eq!(select_in_word(word, k), k, "k={k}");
         }
         assert_eq!(select_in_word(word, 64), 64);
     }
@@ -233,9 +234,7 @@ mod tests {
                 assert_eq!(
                     select_in_word(word, k),
                     select_in_word_broadword(word, k),
-                    "word={:#x}, k={}",
-                    word,
-                    k
+                    "word={word:#x}, k={k}"
                 );
             }
         }
@@ -248,10 +247,10 @@ mod tests {
             let pop = word.count_ones();
             for k in 0..pop {
                 let pos = select_in_word(word, k);
-                assert!(pos < 64, "word={:#x}, k={}", word, k);
+                assert!(pos < 64, "word={word:#x}, k={k}");
                 // Verify this is actually the k-th bit
                 let bits_before = (word & ((1 << pos) - 1)).count_ones();
-                assert_eq!(bits_before, k, "word={:#x}, k={}, pos={}", word, k, pos);
+                assert_eq!(bits_before, k, "word={word:#x}, k={k}, pos={pos}");
                 // Verify bit is set
                 assert!((word >> pos) & 1 == 1);
             }

--- a/src/util/broadword.rs
+++ b/src/util/broadword.rs
@@ -252,7 +252,7 @@ mod tests {
                 let bits_before = (word & ((1 << pos) - 1)).count_ones();
                 assert_eq!(bits_before, k, "word={word:#x}, k={k}, pos={pos}");
                 // Verify bit is set
-                assert!((word >> pos) & 1 == 1);
+                assert_eq!((word >> pos) & 1, 1);
             }
             // Beyond popcount should return 64
             assert_eq!(select_in_word(word, pop), 64);

--- a/src/util/simd/mod.rs
+++ b/src/util/simd/mod.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // runtime SIMD feature dispatch
 //! SIMD-accelerated operations.
 //!
 //! This module provides platform-specific SIMD implementations for
@@ -106,8 +107,7 @@ mod tests {
             assert_eq!(
                 popcount_512(&data),
                 popcount_512_scalar(&data),
-                "pattern={:#04x}",
-                pattern
+                "pattern={pattern:#04x}"
             );
         }
     }

--- a/src/util/simd/neon.rs
+++ b/src/util/simd/neon.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ARM64 NEON SIMD intrinsics
 //! ARM NEON SIMD implementations.
 //!
 //! These implementations use NEON intrinsics for accelerated bit operations

--- a/src/util/simd/sve2.rs
+++ b/src/util/simd/sve2.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ARM64 SVE2 SIMD intrinsics
 //! SVE2-accelerated operations for ARM64.
 //!
 //! This module provides SVE2 implementations for performance-critical operations,
@@ -157,7 +158,7 @@ pub unsafe fn toggle64_sve2(carry: u64, quote_mask: u64) -> (u64, u64) {
     let (result, overflow) = shifted.overflowing_add(comp_w);
 
     // New carry depends on overflow
-    let new_carry = if overflow { 1 } else { 0 };
+    let new_carry = u64::from(overflow);
 
     (result, new_carry)
 }
@@ -210,7 +211,7 @@ pub unsafe fn select_in_word_bdep(x: u64, k: u32) -> u32 {
     if scattered == 0 {
         return 64;
     }
-    63 - scattered.leading_zeros()
+    scattered.ilog2()
 }
 
 /// Check if SVE2-BITPERM is available at runtime.
@@ -376,7 +377,7 @@ mod tests {
             let comp_w = !quote_mask;
             let shifted = (addend << 1) | c;
             let (result, overflow) = shifted.overflowing_add(comp_w);
-            let new_carry = if overflow { 1 } else { 0 };
+            let new_carry = u64::from(overflow);
 
             (result, new_carry)
         }
@@ -402,13 +403,11 @@ mod tests {
 
                     assert_eq!(
                         sve2_mask, ref_mask,
-                        "Mask mismatch for quote_mask={:#x}, carry={}",
-                        quote_mask, carry
+                        "Mask mismatch for quote_mask={quote_mask:#x}, carry={carry}"
                     );
                     assert_eq!(
                         sve2_carry, ref_carry,
-                        "Carry mismatch for quote_mask={:#x}, carry={}",
-                        quote_mask, carry
+                        "Carry mismatch for quote_mask={quote_mask:#x}, carry={carry}"
                     );
                 }
             }
@@ -450,7 +449,7 @@ mod tests {
         unsafe {
             let word = u64::MAX;
             for k in 0..64 {
-                assert_eq!(select_in_word_bdep(word, k), k, "k={}", k);
+                assert_eq!(select_in_word_bdep(word, k), k, "k={k}");
             }
             assert_eq!(select_in_word_bdep(word, 64), 64);
         }
@@ -499,8 +498,7 @@ mod tests {
                     let ctz_result = select_ctz(word, k);
                     assert_eq!(
                         bdep_result, ctz_result,
-                        "Mismatch for word={:#x}, k={}",
-                        word, k
+                        "Mismatch for word={word:#x}, k={k}"
                     );
                 }
             }

--- a/src/util/simd/x86.rs
+++ b/src/util/simd/x86.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 POPCNT/BMI2 intrinsics
 //! x86/x86_64 SIMD implementations.
 //!
 //! These implementations use POPCNT, BMI2, and other x86 instructions for
@@ -121,7 +122,7 @@ pub unsafe fn select_in_word_pdep(x: u64, k: u32) -> u32 {
     if scattered == 0 {
         return 64;
     }
-    63 - scattered.leading_zeros()
+    scattered.ilog2()
 }
 
 /// Check if the CPU has fast BMI2 support.
@@ -293,7 +294,7 @@ mod tests {
         unsafe {
             let word = u64::MAX;
             for k in 0..64 {
-                assert_eq!(select_in_word_pdep(word, k), k, "k={}", k);
+                assert_eq!(select_in_word_pdep(word, k), k, "k={k}");
             }
             assert_eq!(select_in_word_pdep(word, 64), 64);
         }
@@ -325,7 +326,7 @@ mod tests {
             // Dense: lower 32 bits set
             let word = 0xFFFF_FFFFu64;
             for k in 0..32 {
-                assert_eq!(select_in_word_pdep(word, k), k, "k={}", k);
+                assert_eq!(select_in_word_pdep(word, k), k, "k={k}");
             }
             assert_eq!(select_in_word_pdep(word, 32), 64);
         }
@@ -376,8 +377,7 @@ mod tests {
                     let ctz_result = select_ctz(word, k);
                     assert_eq!(
                         pdep_result, ctz_result,
-                        "Mismatch for word={:#x}, k={}",
-                        word, k
+                        "Mismatch for word={word:#x}, k={k}"
                     );
                 }
             }
@@ -416,8 +416,7 @@ mod tests {
                     let ctz_result = select_ctz(word, k);
                     assert_eq!(
                         pdep_result, ctz_result,
-                        "Mismatch for word={:#x}, k={}",
-                        word, k
+                        "Mismatch for word={word:#x}, k={k}"
                     );
                 }
             }
@@ -428,7 +427,7 @@ mod tests {
     fn test_has_fast_bmi2_detection() {
         // This test just ensures the function runs without panicking
         let result = has_fast_bmi2();
-        eprintln!("has_fast_bmi2() = {}", result);
+        eprintln!("has_fast_bmi2() = {result}");
 
         // If BMI2 is not supported, result must be false
         if !is_x86_feature_detected!("bmi2") {

--- a/src/util/table.rs
+++ b/src/util/table.rs
@@ -48,8 +48,8 @@ mod tests {
         // Single bit set at each position
         for pos in 0..8 {
             let byte = 1u8 << pos;
-            assert_eq!(select_in_byte(byte, 0), pos, "byte={:08b}", byte);
-            assert_eq!(select_in_byte(byte, 1), 8, "byte={:08b}, k=1", byte);
+            assert_eq!(select_in_byte(byte, 0), pos, "byte={byte:08b}");
+            assert_eq!(select_in_byte(byte, 1), 8, "byte={byte:08b}, k=1");
         }
     }
 
@@ -88,10 +88,7 @@ mod tests {
                 // Verify the k-th bit is actually set at position pos
                 assert!(
                     (byte >> pos) & 1 == 1,
-                    "byte={:08b}, k={}, pos={}",
-                    byte,
-                    k,
-                    pos
+                    "byte={byte:08b}, k={k}, pos={pos}"
                 );
             }
             // Verify positions beyond popcount return 8
@@ -99,9 +96,7 @@ mod tests {
                 assert_eq!(
                     SELECT_IN_BYTE_TABLE[(byte as usize) * 8 + k as usize],
                     8,
-                    "byte={:08b}, k={}",
-                    byte,
-                    k
+                    "byte={byte:08b}, k={k}"
                 );
             }
         }

--- a/src/util/table.rs
+++ b/src/util/table.rs
@@ -86,10 +86,7 @@ mod tests {
             for k in 0..pop {
                 let pos = SELECT_IN_BYTE_TABLE[(byte as usize) * 8 + k as usize];
                 // Verify the k-th bit is actually set at position pos
-                assert!(
-                    (byte >> pos) & 1 == 1,
-                    "byte={byte:08b}, k={k}, pos={pos}"
-                );
+                assert!((byte >> pos) & 1 == 1, "byte={byte:08b}, k={k}, pos={pos}");
             }
             // Verify positions beyond popcount return 8
             for k in pop..8 {

--- a/src/yaml/advance_positions.rs
+++ b/src/yaml/advance_positions.rs
@@ -70,9 +70,9 @@ impl OpenPositions {
         let is_monotonic = positions.windows(2).all(|w| w[0] <= w[1]);
 
         if is_monotonic {
-            OpenPositions::Compact(AdvancePositions::build_unchecked(positions, text_len))
+            Self::Compact(AdvancePositions::build_unchecked(positions, text_len))
         } else {
-            OpenPositions::Dense(positions.to_vec())
+            Self::Dense(positions.to_vec())
         }
     }
 
@@ -80,8 +80,8 @@ impl OpenPositions {
     #[inline]
     pub fn len(&self) -> usize {
         match self {
-            OpenPositions::Compact(ap) => ap.len(),
-            OpenPositions::Dense(v) => v.len(),
+            Self::Compact(ap) => ap.len(),
+            Self::Dense(v) => v.len(),
         }
     }
 
@@ -89,8 +89,8 @@ impl OpenPositions {
     #[inline]
     pub fn is_empty(&self) -> bool {
         match self {
-            OpenPositions::Compact(ap) => ap.is_empty(),
-            OpenPositions::Dense(v) => v.is_empty(),
+            Self::Compact(ap) => ap.is_empty(),
+            Self::Dense(v) => v.is_empty(),
         }
     }
 
@@ -98,8 +98,8 @@ impl OpenPositions {
     #[inline]
     pub fn get(&self, open_idx: usize) -> Option<u32> {
         match self {
-            OpenPositions::Compact(ap) => ap.get(open_idx),
-            OpenPositions::Dense(v) => v.get(open_idx).copied(),
+            Self::Compact(ap) => ap.get(open_idx),
+            Self::Dense(v) => v.get(open_idx).copied(),
         }
     }
 
@@ -108,8 +108,8 @@ impl OpenPositions {
     /// Returns `None` if no node starts at this position.
     pub fn find_last_open_at_text_pos(&self, text_pos: usize) -> Option<usize> {
         match self {
-            OpenPositions::Compact(ap) => ap.find_last_open_at_text_pos(text_pos),
-            OpenPositions::Dense(v) => {
+            Self::Compact(ap) => ap.find_last_open_at_text_pos(text_pos),
+            Self::Dense(v) => {
                 // Binary search for non-compact storage
                 let text_pos_u32 = text_pos as u32;
                 let search_result = v.binary_search(&text_pos_u32);
@@ -132,15 +132,15 @@ impl OpenPositions {
     /// Returns the heap memory usage in bytes.
     pub fn heap_size(&self) -> usize {
         match self {
-            OpenPositions::Compact(ap) => ap.heap_size(),
-            OpenPositions::Dense(v) => v.len() * 4,
+            Self::Compact(ap) => ap.heap_size(),
+            Self::Dense(v) => v.len() * 4,
         }
     }
 
     /// Returns true if using compact (Advance Index) storage.
     #[inline]
     pub fn is_compact(&self) -> bool {
-        matches!(self, OpenPositions::Compact(_))
+        matches!(self, Self::Compact(_))
     }
 }
 
@@ -707,7 +707,7 @@ impl AdvancePositions {
     }
 }
 
-impl<'a> AdvancePositionsCursor<'a> {
+impl AdvancePositionsCursor<'_> {
     /// Returns the current text position, or `None` if exhausted.
     #[inline]
     pub fn current(&self) -> Option<u32> {
@@ -873,7 +873,7 @@ mod tests {
 
         // Test random access
         for (i, &expected) in positions.iter().enumerate() {
-            assert_eq!(ap.get(i), Some(expected), "get({}) failed", i);
+            assert_eq!(ap.get(i), Some(expected), "get({i}) failed");
         }
 
         // Test cursor iteration
@@ -895,7 +895,7 @@ mod tests {
 
         // Test random access
         for (i, &expected) in positions.iter().enumerate() {
-            assert_eq!(ap.get(i), Some(expected), "get({}) failed", i);
+            assert_eq!(ap.get(i), Some(expected), "get({i}) failed");
         }
 
         // Test cursor iteration
@@ -939,8 +939,7 @@ mod tests {
             assert_eq!(
                 cursor.current(),
                 Some(expected),
-                "cursor_from({}) failed",
-                i
+                "cursor_from({i}) failed"
             );
         }
 
@@ -992,9 +991,7 @@ mod tests {
         // Should achieve meaningful compression
         assert!(
             ap_size < vec_size,
-            "AdvancePositions {} should be smaller than Vec<u32> {}",
-            ap_size,
-            vec_size
+            "AdvancePositions {ap_size} should be smaller than Vec<u32> {vec_size}"
         );
     }
 

--- a/src/yaml/advance_positions.rs
+++ b/src/yaml/advance_positions.rs
@@ -936,11 +936,7 @@ mod tests {
         for (i, &expected) in positions.iter().enumerate() {
             let cursor = ap.cursor_from(i);
             assert_eq!(cursor.index(), i);
-            assert_eq!(
-                cursor.current(),
-                Some(expected),
-                "cursor_from({i}) failed"
-            );
+            assert_eq!(cursor.current(), Some(expected), "cursor_from({i}) failed");
         }
 
         // cursor_from past end

--- a/src/yaml/end_positions.rs
+++ b/src/yaml/end_positions.rs
@@ -143,14 +143,14 @@ impl EndPositions {
     /// of the non-zero entries.
     pub fn build(positions: &[u32], text_len: usize) -> Self {
         if positions.is_empty() {
-            return EndPositions::Compact(Box::new(CompactEndPositions::empty(text_len)));
+            return Self::Compact(Box::new(CompactEndPositions::empty(text_len)));
         }
 
         // Single-pass build with inline monotonicity check and zero-filling.
         // Returns None if non-zero positions are not monotonically non-decreasing.
         match CompactEndPositions::try_build(positions, text_len) {
-            Some(compact) => EndPositions::Compact(Box::new(compact)),
-            None => EndPositions::Dense(positions.to_vec()),
+            Some(compact) => Self::Compact(Box::new(compact)),
+            None => Self::Dense(positions.to_vec()),
         }
     }
 
@@ -167,8 +167,8 @@ impl EndPositions {
     #[inline]
     pub fn get(&self, open_idx: usize) -> Option<usize> {
         match self {
-            EndPositions::Compact(c) => c.get(open_idx),
-            EndPositions::Dense(v) => v
+            Self::Compact(c) => c.get(open_idx),
+            Self::Dense(v) => v
                 .get(open_idx)
                 .map(|&pos| pos as usize)
                 .filter(|&pos| pos > 0),
@@ -179,8 +179,8 @@ impl EndPositions {
     #[cfg(test)]
     pub fn heap_size(&self) -> usize {
         match self {
-            EndPositions::Compact(c) => c.heap_size(),
-            EndPositions::Dense(v) => v.len() * 4,
+            Self::Compact(c) => c.heap_size(),
+            Self::Dense(v) => v.len() * 4,
         }
     }
 
@@ -188,7 +188,7 @@ impl EndPositions {
     #[cfg(test)]
     #[inline]
     pub fn is_compact(&self) -> bool {
-        matches!(self, EndPositions::Compact(_))
+        matches!(self, Self::Compact(_))
     }
 }
 
@@ -516,7 +516,7 @@ mod tests {
         let ep = EndPositions::build(&positions, 100);
         assert!(ep.is_compact());
         for i in 0..5 {
-            assert_eq!(ep.get(i), None, "get({}) should be None", i);
+            assert_eq!(ep.get(i), None, "get({i}) should be None");
         }
     }
 
@@ -575,7 +575,7 @@ mod tests {
         assert!(ep.is_compact());
 
         for (i, &expected) in positions.iter().enumerate() {
-            assert_eq!(ep.get(i), Some(expected as usize), "get({}) failed", i);
+            assert_eq!(ep.get(i), Some(expected as usize), "get({i}) failed");
         }
     }
 
@@ -625,9 +625,7 @@ mod tests {
         // Should achieve meaningful compression
         assert!(
             ep_size < vec_size,
-            "EndPositions {} should be smaller than Vec<u32> {}",
-            ep_size,
-            vec_size
+            "EndPositions {ep_size} should be smaller than Vec<u32> {vec_size}"
         );
 
         // Verify scalar values are correct
@@ -637,10 +635,7 @@ mod tests {
                 assert_eq!(
                     got,
                     Some(expected as usize),
-                    "get({}) failed: expected {}, got {:?}",
-                    i,
-                    expected,
-                    got
+                    "get({i}) failed: expected {expected}, got {got:?}"
                 );
             }
             // Containers may return Some(prev_value) or None — don't check
@@ -700,7 +695,7 @@ mod tests {
         for (i, &expected) in positions.iter().enumerate() {
             let got = ep.get(i);
             if expected > 0 {
-                assert_eq!(got, Some(expected as usize), "get({}) failed", i);
+                assert_eq!(got, Some(expected as usize), "get({i}) failed");
             }
             // Containers may return Some(prev_value) or None
         }
@@ -711,15 +706,15 @@ mod tests {
         // Generate a realistic YAML structure and measure EndPositions savings
         let mut yaml = String::new();
         for i in 0..500 {
-            yaml.push_str(&format!("key_{}: value_{}\n", i, i));
+            yaml.push_str(&format!("key_{i}: value_{i}\n"));
         }
         yaml.push_str("nested:\n");
         for i in 0..200 {
-            yaml.push_str(&format!("  sub_{}: sub_val_{}\n", i, i));
+            yaml.push_str(&format!("  sub_{i}: sub_val_{i}\n"));
         }
         yaml.push_str("list:\n");
         for i in 0..300 {
-            yaml.push_str(&format!("  - item_{}\n", i));
+            yaml.push_str(&format!("  - item_{i}\n"));
         }
 
         let semi = super::super::parser::build_semi_index(yaml.as_bytes()).unwrap();
@@ -744,7 +739,7 @@ mod tests {
         for (i, &expected) in semi.bp_to_text_end.iter().enumerate() {
             let got = ep.get(i);
             if expected > 0 {
-                assert_eq!(got, Some(expected as usize), "open {} mismatch", i);
+                assert_eq!(got, Some(expected as usize), "open {i} mismatch");
             }
             // Containers (expected == 0) may return Some(prev_value) or None
         }

--- a/src/yaml/error.rs
+++ b/src/yaml/error.rs
@@ -133,36 +133,33 @@ pub enum YamlError {
 impl fmt::Display for YamlError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            YamlError::InvalidIndentation {
+            Self::InvalidIndentation {
                 line,
                 expected,
                 found,
             } => {
                 write!(
                     f,
-                    "invalid indentation at line {}: expected {} spaces, found {}",
-                    line, expected, found
+                    "invalid indentation at line {line}: expected {expected} spaces, found {found}"
                 )
             }
-            YamlError::TabIndentation { line, offset } => {
+            Self::TabIndentation { line, offset } => {
                 write!(
                     f,
-                    "tab character used for indentation at line {} (offset {})",
-                    line, offset
+                    "tab character used for indentation at line {line} (offset {offset})"
                 )
             }
-            YamlError::UnexpectedCharacter {
+            Self::UnexpectedCharacter {
                 offset,
                 char,
                 context,
             } => {
                 write!(
                     f,
-                    "unexpected character '{}' at offset {}: {}",
-                    char, offset, context
+                    "unexpected character '{char}' at offset {offset}: {context}"
                 )
             }
-            YamlError::UnclosedQuote {
+            Self::UnclosedQuote {
                 start_offset,
                 quote_type,
             } => {
@@ -177,65 +174,54 @@ impl fmt::Display for YamlError {
                     start_offset
                 )
             }
-            YamlError::InvalidEscape { offset, sequence } => {
-                write!(
-                    f,
-                    "invalid escape sequence '{}' at offset {}",
-                    sequence, offset
-                )
+            Self::InvalidEscape { offset, sequence } => {
+                write!(f, "invalid escape sequence '{sequence}' at offset {offset}")
             }
-            YamlError::InvalidUtf8 { offset } => {
-                write!(f, "invalid UTF-8 sequence at offset {}", offset)
+            Self::InvalidUtf8 { offset } => {
+                write!(f, "invalid UTF-8 sequence at offset {offset}")
             }
             #[allow(deprecated)]
             // STYLE-0004: Display arm for a deprecated error variant kept for back-compat
-            YamlError::MultiDocumentNotSupported { offset } => {
+            Self::MultiDocumentNotSupported { offset } => {
                 write!(
                     f,
-                    "multi-document YAML not supported (found `---` at offset {})",
-                    offset
+                    "multi-document YAML not supported (found `---` at offset {offset})"
                 )
             }
             #[allow(deprecated)]
             // STYLE-0004: Display arm for a deprecated error variant kept for back-compat
-            YamlError::FlowStyleNotSupported { offset, char } => {
+            Self::FlowStyleNotSupported { offset, char } => {
+                write!(f, "flow style '{char}' not supported at offset {offset}")
+            }
+            Self::InvalidAnchorName { offset, reason } => {
+                write!(f, "invalid anchor name at offset {offset}: {reason}")
+            }
+            Self::DuplicateAnchor { offset, name } => {
                 write!(
                     f,
-                    "flow style '{}' not supported at offset {}",
-                    char, offset
+                    "duplicate anchor '{name}' at offset {offset} (previously defined)"
                 )
             }
-            YamlError::InvalidAnchorName { offset, reason } => {
-                write!(f, "invalid anchor name at offset {}: {}", offset, reason)
+            Self::ExplicitKeyNotSupported { offset } => {
+                write!(f, "explicit keys (?) not supported at offset {offset}")
             }
-            YamlError::DuplicateAnchor { offset, name } => {
-                write!(
-                    f,
-                    "duplicate anchor '{}' at offset {} (previously defined)",
-                    name, offset
-                )
+            Self::TagNotSupported { offset } => {
+                write!(f, "tags (!) not supported at offset {offset}")
             }
-            YamlError::ExplicitKeyNotSupported { offset } => {
-                write!(f, "explicit keys (?) not supported at offset {}", offset)
-            }
-            YamlError::TagNotSupported { offset } => {
-                write!(f, "tags (!) not supported at offset {}", offset)
-            }
-            YamlError::EmptyInput => {
+            Self::EmptyInput => {
                 write!(f, "empty input")
             }
-            YamlError::ColonWithoutSpace { offset } => {
+            Self::ColonWithoutSpace { offset } => {
                 write!(
                     f,
-                    "colon at offset {} must be followed by space or newline",
-                    offset
+                    "colon at offset {offset} must be followed by space or newline"
                 )
             }
-            YamlError::KeyWithoutValue { offset, line } => {
-                write!(f, "key without value at line {} (offset {})", line, offset)
+            Self::KeyWithoutValue { offset, line } => {
+                write!(f, "key without value at line {line} (offset {offset})")
             }
-            YamlError::UnexpectedEof { context } => {
-                write!(f, "unexpected end of input: {}", context)
+            Self::UnexpectedEof { context } => {
+                write!(f, "unexpected end of input: {context}")
             }
         }
     }

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -500,7 +500,9 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     #[inline]
     pub fn get_alias_anchor_name(&self, bp_pos: usize) -> Option<&str> {
         let target_bp_pos = self.aliases.get(&bp_pos)?;
-        self.bp_to_anchor.get(target_bp_pos).map(alloc::string::String::as_str)
+        self.bp_to_anchor
+            .get(target_bp_pos)
+            .map(alloc::string::String::as_str)
     }
 
     /// Get the BP position of an anchor by name.
@@ -516,7 +518,9 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// Returns `None` if the position does not have an anchor.
     #[inline]
     pub fn get_anchor_name(&self, bp_pos: usize) -> Option<&str> {
-        self.bp_to_anchor.get(&bp_pos).map(alloc::string::String::as_str)
+        self.bp_to_anchor
+            .get(&bp_pos)
+            .map(alloc::string::String::as_str)
     }
 
     /// Resolve an alias at the given BP position to a cursor pointing to

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -500,7 +500,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     #[inline]
     pub fn get_alias_anchor_name(&self, bp_pos: usize) -> Option<&str> {
         let target_bp_pos = self.aliases.get(&bp_pos)?;
-        self.bp_to_anchor.get(target_bp_pos).map(|s| s.as_str())
+        self.bp_to_anchor.get(target_bp_pos).map(alloc::string::String::as_str)
     }
 
     /// Get the BP position of an anchor by name.
@@ -516,7 +516,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// Returns `None` if the position does not have an anchor.
     #[inline]
     pub fn get_anchor_name(&self, bp_pos: usize) -> Option<&str> {
-        self.bp_to_anchor.get(&bp_pos).map(|s| s.as_str())
+        self.bp_to_anchor.get(&bp_pos).map(alloc::string::String::as_str)
     }
 
     /// Resolve an alias at the given BP position to a cursor pointing to
@@ -768,9 +768,8 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             // No newline markers means single-line document
             if line == 1 {
                 return Some(column - 1);
-            } else {
-                return None;
             }
+            return None;
         }
 
         // Line 1 starts at offset 0
@@ -930,8 +929,7 @@ mod tests {
             assert_eq!(
                 result,
                 Some(offset),
-                "Round-trip failed for offset {}",
-                offset
+                "Round-trip failed for offset {offset}"
             );
         }
     }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // from_utf8_unchecked on validated UTF-8 in the transcoder
 #![allow(clippy::items_after_test_module)] // STYLE-0004: helper items intentionally follow `mod tests` in this file
 //! YamlCursor - Lazy YAML navigation using the semi-index.
 //!
@@ -34,13 +35,13 @@ pub struct YamlCursor<'a, W = Vec<u64>> {
     bp_pos: usize,
 }
 
-impl<'a, W> Clone for YamlCursor<'a, W> {
+impl<W> Clone for YamlCursor<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for YamlCursor<'a, W> {}
+impl<W> Copy for YamlCursor<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// Create a new cursor at the given BP position.
@@ -89,7 +90,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
 
     /// Navigate to the first child.
     #[inline]
-    pub fn first_child(&self) -> Option<YamlCursor<'a, W>> {
+    pub fn first_child(&self) -> Option<Self> {
         let new_pos = self.index.bp().first_child(self.bp_pos)?;
         Some(YamlCursor {
             text: self.text,
@@ -100,7 +101,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
 
     /// Navigate to the next sibling.
     #[inline]
-    pub fn next_sibling(&self) -> Option<YamlCursor<'a, W>> {
+    pub fn next_sibling(&self) -> Option<Self> {
         let new_pos = self.index.bp().next_sibling(self.bp_pos)?;
         Some(YamlCursor {
             text: self.text,
@@ -111,7 +112,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
 
     /// Navigate to the parent.
     #[inline]
-    pub fn parent(&self) -> Option<YamlCursor<'a, W>> {
+    pub fn parent(&self) -> Option<Self> {
         let new_pos = self.index.bp().parent(self.bp_pos)?;
         Some(YamlCursor {
             text: self.text,
@@ -163,9 +164,8 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             // Determine if mapping or sequence using the TY bits
             if self.index.is_sequence_at_bp(self.bp_pos) {
                 return YamlValue::Sequence(YamlElements::from_sequence_cursor(*self));
-            } else {
-                return YamlValue::Mapping(YamlFields::from_mapping_cursor(*self));
             }
+            return YamlValue::Mapping(YamlFields::from_mapping_cursor(*self));
         }
 
         // Check for alias (only for non-container nodes)
@@ -960,10 +960,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // Continuation line (in flow context, any non-delimiter continues)
                             end = empty_lines_end;
                             break;
-                        } else {
-                            // Not indented enough - scalar ends before this
-                            return line_end;
                         }
+                        // Not indented enough - scalar ends before this
+                        return line_end;
                     }
                 }
             }
@@ -1753,7 +1752,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// Note: For consistency with how yq evaluates expressions, if the offset
     /// lands on the document root sequence wrapper in a single-document file,
     /// this returns the document content instead of the wrapper.
-    pub fn cursor_at_offset(&self, offset: usize) -> Option<YamlCursor<'a, W>> {
+    pub fn cursor_at_offset(&self, offset: usize) -> Option<Self> {
         if offset >= self.text.len() {
             return None;
         }
@@ -1806,7 +1805,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// - The position doesn't correspond to a valid node
     ///
     /// This enables position-based navigation in jq queries via `at_position(line; col)`.
-    pub fn cursor_at_position(&self, line: usize, col: usize) -> Option<YamlCursor<'a, W>> {
+    pub fn cursor_at_position(&self, line: usize, col: usize) -> Option<Self> {
         // Convert line/column to byte offset
         let offset = self.index.to_offset(line, col, self.text)?;
 
@@ -2999,11 +2998,11 @@ fn stream_yaml_scalar_as_json<Out: core::fmt::Write>(
                     }
                     b'0'..=b'9' => {
                         if let Ok(n) = str_val.parse::<i64>() {
-                            return write!(out, "{}", n);
+                            return write!(out, "{n}");
                         }
                         if let Ok(f) = str_val.parse::<f64>() {
                             if !f.is_nan() && !f.is_infinite() {
-                                return write!(out, "{}", f);
+                                return write!(out, "{f}");
                             }
                         }
                     }
@@ -3013,21 +3012,21 @@ fn stream_yaml_scalar_as_json<Out: core::fmt::Write>(
         }
         b'0'..=b'9' => {
             if let Ok(n) = str_val.parse::<i64>() {
-                return write!(out, "{}", n);
+                return write!(out, "{n}");
             }
             if let Ok(f) = str_val.parse::<f64>() {
                 if !f.is_nan() && !f.is_infinite() {
-                    return write!(out, "{}", f);
+                    return write!(out, "{f}");
                 }
             }
         }
         b'+' if bytes.len() > 1 && bytes[1].is_ascii_digit() => {
             if let Ok(n) = str_val.parse::<i64>() {
-                return write!(out, "{}", n);
+                return write!(out, "{n}");
             }
             if let Ok(f) = str_val.parse::<f64>() {
                 if !f.is_nan() && !f.is_infinite() {
-                    return write!(out, "{}", f);
+                    return write!(out, "{f}");
                 }
             }
         }
@@ -3047,13 +3046,13 @@ pub struct YamlChildren<'a, W = Vec<u64>> {
     current: Option<YamlCursor<'a, W>>,
 }
 
-impl<'a, W> Clone for YamlChildren<'a, W> {
+impl<W> Clone for YamlChildren<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for YamlChildren<'a, W> {}
+impl<W> Copy for YamlChildren<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> Iterator for YamlChildren<'a, W> {
     type Item = YamlCursor<'a, W>;
@@ -3103,13 +3102,13 @@ pub struct YamlFields<'a, W = Vec<u64>> {
     key_cursor: Option<YamlCursor<'a, W>>,
 }
 
-impl<'a, W> Clone for YamlFields<'a, W> {
+impl<W> Clone for YamlFields<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for YamlFields<'a, W> {}
+impl<W> Copy for YamlFields<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
     /// Create a new YamlFields from a mapping cursor.
@@ -3126,7 +3125,7 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
     }
 
     /// Get the first field and the remaining fields.
-    pub fn uncons(&self) -> Option<(YamlField<'a, W>, YamlFields<'a, W>)> {
+    pub fn uncons(&self) -> Option<(YamlField<'a, W>, Self)> {
         let key_cursor = self.key_cursor?;
         let value_cursor = key_cursor.next_sibling()?;
 
@@ -3178,13 +3177,13 @@ pub struct YamlField<'a, W = Vec<u64>> {
     value_cursor: YamlCursor<'a, W>,
 }
 
-impl<'a, W> Clone for YamlField<'a, W> {
+impl<W> Clone for YamlField<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for YamlField<'a, W> {}
+impl<W> Copy for YamlField<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> YamlField<'a, W> {
     /// Get the field key.
@@ -3217,13 +3216,13 @@ pub struct YamlElements<'a, W = Vec<u64>> {
     element_cursor: Option<YamlCursor<'a, W>>,
 }
 
-impl<'a, W> Clone for YamlElements<'a, W> {
+impl<W> Clone for YamlElements<'_, W> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, W> Copy for YamlElements<'a, W> {}
+impl<W> Copy for YamlElements<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
     /// Create a new YamlElements from a sequence cursor.
@@ -3243,7 +3242,7 @@ impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
     ///
     /// This returns the cursor directly, which is useful when you need to
     /// call cursor methods like `to_json()` without going through YamlValue.
-    pub fn uncons_cursor(&self) -> Option<(YamlCursor<'a, W>, YamlElements<'a, W>)> {
+    pub fn uncons_cursor(&self) -> Option<(YamlCursor<'a, W>, Self)> {
         let element_cursor = self.element_cursor?;
 
         let rest = YamlElements {
@@ -3276,7 +3275,7 @@ impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
     }
 
     /// Get the first element and the remaining elements.
-    pub fn uncons(&self) -> Option<(YamlValue<'a, W>, YamlElements<'a, W>)> {
+    pub fn uncons(&self) -> Option<(YamlValue<'a, W>, Self)> {
         let element_cursor = self.element_cursor?;
 
         let rest = YamlElements {
@@ -3631,9 +3630,8 @@ impl<'a> YamlString<'a> {
                             }
                         }
                         return (content_start, end);
-                    } else {
-                        return (content_start, content_start);
                     }
+                    return (content_start, content_start);
                 }
             }
         };
@@ -3765,9 +3763,8 @@ impl<'a> YamlString<'a> {
                     .is_some_and(|slice| slice.contains(&b':'));
                 if has_colon {
                     return line_indent + 2;
-                } else {
-                    return line_indent;
                 }
+                return line_indent;
             }
         }
 
@@ -3856,8 +3853,8 @@ pub enum YamlStringError {
 impl core::fmt::Display for YamlStringError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            YamlStringError::InvalidUtf8 => write!(f, "invalid UTF-8 in string"),
-            YamlStringError::InvalidEscape => write!(f, "invalid escape sequence"),
+            Self::InvalidUtf8 => write!(f, "invalid UTF-8 in string"),
+            Self::InvalidEscape => write!(f, "invalid escape sequence"),
         }
     }
 }
@@ -4208,11 +4205,10 @@ fn fold_plain_line_break(
             if line_indent > base_indent {
                 // Valid continuation - position is after the indentation
                 break;
-            } else {
-                // This shouldn't happen if find_plain_scalar_end worked correctly
-                // but handle it gracefully
-                break;
             }
+            // This shouldn't happen if find_plain_scalar_end worked correctly
+            // but handle it gracefully
+            break;
         }
     }
 
@@ -4248,12 +4244,12 @@ fn parse_hex(hex: &[u8]) -> Result<u32, YamlStringError> {
 }
 
 /// Decode a literal block scalar (preserves newlines).
-fn decode_block_literal<'a>(
-    text: &'a [u8],
+fn decode_block_literal(
+    text: &[u8],
     indicator_pos: usize,
     chomping: ChompingIndicator,
     explicit_indent: Option<u8>,
-) -> Result<Cow<'a, str>, YamlStringError> {
+) -> Result<Cow<'_, str>, YamlStringError> {
     let (content_start, content_end) =
         YamlString::find_block_content_range(text, indicator_pos, chomping, explicit_indent);
 
@@ -4351,12 +4347,12 @@ fn decode_block_literal<'a>(
 }
 
 /// Decode a folded block scalar (folds newlines to spaces).
-fn decode_block_folded<'a>(
-    text: &'a [u8],
+fn decode_block_folded(
+    text: &[u8],
     indicator_pos: usize,
     chomping: ChompingIndicator,
     explicit_indent: Option<u8>,
-) -> Result<Cow<'a, str>, YamlStringError> {
+) -> Result<Cow<'_, str>, YamlStringError> {
     let (content_start, content_end) =
         YamlString::find_block_content_range(text, indicator_pos, chomping, explicit_indent);
 
@@ -4543,8 +4539,8 @@ pub enum YamlNumberError {
 impl core::fmt::Display for YamlNumberError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            YamlNumberError::InvalidUtf8 => write!(f, "invalid UTF-8 in number"),
-            YamlNumberError::InvalidNumber => write!(f, "invalid number format"),
+            Self::InvalidUtf8 => write!(f, "invalid UTF-8 in number"),
+            Self::InvalidNumber => write!(f, "invalid number format"),
         }
     }
 }
@@ -4667,7 +4663,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
             }
             YamlValue::Alias { target, .. } => {
                 // Resolve alias and check target
-                target.map(|t| t.value().is_null()).unwrap_or(true) // Unresolved alias treated as null
+                target.map_or(true, |t| t.value().is_null()) // Unresolved alias treated as null
             }
             _ => false,
         }
@@ -4776,9 +4772,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
             }
             YamlValue::Mapping(_) => "object",
             YamlValue::Sequence(_) => "array",
-            YamlValue::Alias { target, .. } => {
-                target.map(|t| t.value().type_name()).unwrap_or("null")
-            }
+            YamlValue::Alias { target, .. } => target.map_or("null", |t| t.value().type_name()),
             YamlValue::Error(_) => "error",
         }
     }
@@ -5044,18 +5038,13 @@ mod tests {
 
     /// Helper to get the first document from the root document array.
     /// All YAML documents are wrapped in a virtual root sequence.
-    fn first_doc<'a, W: AsRef<[u64]> + core::fmt::Debug>(
-        root: YamlCursor<'a, W>,
-    ) -> YamlValue<'a, W> {
+    fn first_doc<W: AsRef<[u64]> + core::fmt::Debug>(root: YamlCursor<'_, W>) -> YamlValue<'_, W> {
         match root.value() {
             YamlValue::Sequence(elements) => elements
                 .into_iter()
                 .next()
                 .expect("expected at least one document"),
-            other => panic!(
-                "expected root to be document array (sequence), got {:?}",
-                other
-            ),
+            other => panic!("expected root to be document array (sequence), got {other:?}"),
         }
     }
 
@@ -5070,7 +5059,7 @@ mod tests {
             YamlValue::Mapping(fields) => {
                 assert!(!fields.is_empty());
             }
-            other => panic!("expected mapping, got {:?}", other),
+            other => panic!("expected mapping, got {other:?}"),
         }
     }
 
@@ -5578,8 +5567,7 @@ mod tests {
                 let decoded = s.as_str().unwrap();
                 assert!(
                     decoded.contains("Line 1") && decoded.contains("Line 2"),
-                    "block literal should contain both lines, got: {:?}",
-                    decoded
+                    "block literal should contain both lines, got: {decoded:?}"
                 );
             } else {
                 panic!("expected string for text");
@@ -5601,8 +5589,7 @@ mod tests {
                 let decoded = s.as_str().unwrap();
                 assert!(
                     decoded.contains("First part") && decoded.contains("second part"),
-                    "block folded should contain both parts, got: {:?}",
-                    decoded
+                    "block folded should contain both parts, got: {decoded:?}"
                 );
             } else {
                 panic!("expected string for text");
@@ -5639,15 +5626,14 @@ mod tests {
 
         if let YamlValue::Sequence(elements) = first_doc(root) {
             let items: Vec<_> = elements.collect();
-            assert_eq!(items.len(), 2, "expected 2 items, got items: {:?}", items);
+            assert_eq!(items.len(), 2, "expected 2 items, got items: {items:?}");
 
             // First item is block literal
             if let YamlValue::String(s) = &items[0] {
                 let decoded = s.as_str().unwrap();
                 assert!(
                     decoded.contains("item"),
-                    "first item should contain 'item', got: {:?}",
-                    decoded
+                    "first item should contain 'item', got: {decoded:?}"
                 );
             } else {
                 panic!("expected string for first item, got: {:?}", items[0]);
@@ -5843,9 +5829,8 @@ mod tests {
                                 assert_eq!(anchor_name, "n");
                                 assert!(target.is_some());
                                 return;
-                            } else {
-                                panic!("expected alias for greeting");
                             }
+                            panic!("expected alias for greeting");
                         }
                     }
                 }
@@ -5950,9 +5935,8 @@ mod tests {
                             // Target should be None because anchor doesn't exist
                             assert!(target.is_none(), "undefined alias should not resolve");
                             return;
-                        } else {
-                            panic!("expected alias for bad");
                         }
+                        panic!("expected alias for bad");
                     }
                 }
             }
@@ -5978,14 +5962,13 @@ mod tests {
                     if k.as_str().unwrap() == "items" {
                         if let YamlValue::Sequence(elements) = val {
                             let items: Vec<_> = elements.collect();
-                            assert_eq!(items.len(), 2, "expected 2 items, got: {:?}", items);
+                            assert_eq!(items.len(), 2, "expected 2 items, got: {items:?}");
                             if let YamlValue::String(s) = &items[0] {
                                 assert_eq!(&*s.as_str().unwrap(), "one");
                             }
                             return;
-                        } else {
-                            panic!("expected sequence for items, got: {:?}", val);
                         }
+                        panic!("expected sequence for items, got: {val:?}");
                     }
                 }
             }
@@ -6265,12 +6248,12 @@ mod tests {
             YamlValue::Mapping(fields) => {
                 // For mappings, extract all string values and compare
                 let mut pairs = Vec::new();
-                for field in fields.into_iter() {
+                for field in fields {
                     if let YamlValue::String(k) = field.key() {
                         if let YamlValue::String(v) = field.value() {
                             let key_str = k.as_str().unwrap();
                             let val_str = v.as_str().unwrap();
-                            pairs.push(format!("\"{}\":\"{}\"", key_str, val_str));
+                            pairs.push(format!("\"{key_str}\":\"{val_str}\""));
                         }
                     }
                 }
@@ -6285,8 +6268,7 @@ mod tests {
     fn json_string_to_rust_string(json: &str) -> String {
         assert!(
             json.starts_with('"') && json.ends_with('"'),
-            "not a JSON string: {}",
-            json
+            "not a JSON string: {json}"
         );
         let inner = &json[1..json.len() - 1];
         let mut result = String::new();
@@ -6317,7 +6299,7 @@ mod tests {
                             result.push(char::from_u32(codepoint).unwrap());
                         }
                     }
-                    Some(c) => panic!("unknown escape: \\{}", c),
+                    Some(c) => panic!("unknown escape: \\{c}"),
                     None => panic!("trailing backslash"),
                 }
             } else {
@@ -6334,8 +6316,7 @@ mod tests {
         let decoded_value = json_string_to_rust_string(decoded);
         assert_eq!(
             transcoded_value, decoded_value,
-            "{}: JSON strings decode to different values.\n  transcoded JSON: {}\n  decoded JSON: {}\n  transcoded value: {:?}\n  decoded value: {:?}",
-            context, transcoded, decoded, transcoded_value, decoded_value
+            "{context}: JSON strings decode to different values.\n  transcoded JSON: {transcoded}\n  decoded JSON: {decoded}\n  transcoded value: {transcoded_value:?}\n  decoded value: {decoded_value:?}"
         );
     }
 
@@ -6691,8 +6672,7 @@ mod tests {
         // Should contain "line one line two" (folded)
         assert!(
             transcoded.contains("line one line two"),
-            "got: {}",
-            transcoded
+            "got: {transcoded}"
         );
     }
 
@@ -6704,8 +6684,7 @@ mod tests {
         // Should contain "line one\nline two" (empty line becomes newline)
         assert!(
             transcoded.contains("line one\\nline two"),
-            "got: {}",
-            transcoded
+            "got: {transcoded}"
         );
     }
 
@@ -6717,8 +6696,7 @@ mod tests {
         // Should contain "line one line two" (folded)
         assert!(
             transcoded.contains("line one line two"),
-            "got: {}",
-            transcoded
+            "got: {transcoded}"
         );
     }
 
@@ -6728,7 +6706,7 @@ mod tests {
         let yaml = b"key: 'it''s\n  working'";
         let transcoded = get_json_via_transcode(yaml);
         // Should contain "it's working"
-        assert!(transcoded.contains("it's working"), "got: {}", transcoded);
+        assert!(transcoded.contains("it's working"), "got: {transcoded}");
     }
 
     // =========================================================================

--- a/src/yaml/locate.rs
+++ b/src/yaml/locate.rs
@@ -32,9 +32,9 @@ impl PathComponent {
     /// Format as a jq path component.
     fn to_jq_string(&self) -> String {
         match self {
-            PathComponent::Index(i) => format!("[{}]", i),
-            PathComponent::DotKey(k) => format!(".{}", k),
-            PathComponent::BracketKey(k) => format!("[\"{}\"]", escape_jq_string(k)),
+            Self::Index(i) => format!("[{i}]"),
+            Self::DotKey(k) => format!(".{k}"),
+            Self::BracketKey(k) => format!("[\"{}\"]", escape_jq_string(k)),
         }
     }
 }
@@ -176,7 +176,7 @@ fn find_key_for_value<W: AsRef<[u64]>>(
 /// Extract the key string from a key cursor.
 fn extract_key_string<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Option<String> {
     match cursor.value() {
-        YamlValue::String(s) => s.as_str().ok().map(|cow| cow.into_owned()),
+        YamlValue::String(s) => s.as_str().ok().map(alloc::borrow::Cow::into_owned),
         _ => None,
     }
 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -531,11 +531,11 @@ impl<'a> Parser<'a> {
     fn looks_like_mapping_entry(&self) -> bool {
         // If we're at a flow structure, it's not a compact mapping
         match self.peek() {
-            Some(b'{') | Some(b'[') => return false,
+            Some(b'{' | b'[') => return false,
             // Empty key: `:` at start followed by whitespace/newline/EOF
             Some(b':') => {
                 let next = self.peek_at(1);
-                if matches!(next, Some(b' ') | Some(b'\t') | Some(b'\n') | None) {
+                if matches!(next, Some(b' ' | b'\t' | b'\n') | None) {
                     return true;
                 }
                 // Colon not followed by whitespace - continue checking
@@ -577,7 +577,7 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                return matches!(next, Some(b' ') | Some(b'\t') | Some(b'\n') | None);
+                return matches!(next, Some(b' ' | b'\t' | b'\n') | None);
             }
             return false;
         }
@@ -594,7 +594,7 @@ impl<'a> Parser<'a> {
                         None
                     };
                     match next {
-                        Some(b' ') | Some(b'\t') | Some(b'\n') | None => return true,
+                        Some(b' ' | b'\t' | b'\n') | None => return true,
                         _ => i += 1, // Colon not followed by whitespace, continue
                     }
                 }
@@ -632,11 +632,10 @@ impl<'a> Parser<'a> {
                         self.skip_to_eol();
                     }
                     continue;
-                } else {
-                    // Non-empty content - back up
-                    self.pos = start;
-                    break;
                 }
+                // Non-empty content - back up
+                self.pos = start;
+                break;
             } else {
                 break;
             }
@@ -714,8 +713,8 @@ impl<'a> Parser<'a> {
         let mut i = 0;
         loop {
             match self.peek_at(i) {
-                Some(b' ') | Some(b'\t') => i += 1,
-                Some(b'\n') | Some(b'\r') | Some(b'#') | None => return false,
+                Some(b' ' | b'\t') => i += 1,
+                Some(b'\n' | b'\r' | b'#') | None => return false,
                 _ => return true,
             }
         }
@@ -729,7 +728,7 @@ impl<'a> Parser<'a> {
         }
 
         match self.peek() {
-            Some(b'|') | Some(b'>') => {
+            Some(b'|' | b'>') => {
                 // Block scalar
                 self.parse_block_scalar(0)?;
             }
@@ -749,7 +748,7 @@ impl<'a> Parser<'a> {
                 self.set_bp_text_end(self.pos);
                 self.write_bp_close();
             }
-            Some(b'[') | Some(b'{') => {
+            Some(b'[' | b'{') => {
                 // Flow collection
                 self.parse_value(0)?;
             }
@@ -998,7 +997,7 @@ impl<'a> Parser<'a> {
                     // Empty line - skip it and continue
                     self.advance(); // Skip current \n
                                     // Skip to end of empty line
-                    while matches!(self.peek(), Some(b' ') | Some(b'\t')) {
+                    while matches!(self.peek(), Some(b' ' | b'\t')) {
                         self.advance();
                     }
                     continue;
@@ -1010,7 +1009,7 @@ impl<'a> Parser<'a> {
                     // Continue to next line - this is a valid continuation
                     self.advance(); // Skip \n
                                     // Skip leading whitespace (tabs are content, but we're at the scalar's level)
-                    while matches!(self.peek(), Some(b' ') | Some(b'\t')) {
+                    while matches!(self.peek(), Some(b' ' | b'\t')) {
                         self.advance();
                     }
                     continue;
@@ -1045,7 +1044,7 @@ impl<'a> Parser<'a> {
                 // Continue to next line
                 self.advance(); // Skip \n
                                 // Skip leading whitespace
-                while matches!(self.peek(), Some(b' ') | Some(b'\t')) {
+                while matches!(self.peek(), Some(b' ' | b'\t')) {
                     self.advance();
                 }
             } else {
@@ -1252,7 +1251,7 @@ impl<'a> Parser<'a> {
         if self.peek() == Some(b'-')
             && matches!(
                 self.peek_at(1),
-                Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') | None
+                Some(b' ' | b'\t' | b'\n' | b'\r') | None
             )
         {
             // Nested sequence - the item value is another sequence.
@@ -1322,7 +1321,7 @@ impl<'a> Parser<'a> {
         if self.peek() != Some(b':') {
             return Err(YamlError::UnexpectedCharacter {
                 offset: self.pos,
-                char: self.peek().map(|b| b as char).unwrap_or('\0'),
+                char: self.peek().map_or('\0', |b| b as char),
                 context: "expected ':' after key in compact mapping",
             });
         }
@@ -1352,7 +1351,7 @@ impl<'a> Parser<'a> {
                 let is_sequence_indicator = matches!(self.peek(), Some(b'-'))
                     && matches!(
                         self.peek_at(1),
-                        Some(b' ') | Some(b'\t') | Some(b'\n') | None
+                        Some(b' ' | b'\t' | b'\n') | None
                     );
                 self.pos = saved_pos;
 
@@ -1438,7 +1437,7 @@ impl<'a> Parser<'a> {
         let key_end = if self.peek() == Some(b':') {
             // Empty key - check that it's followed by proper terminator
             let next = self.peek_at(1);
-            if matches!(next, Some(b' ') | Some(b'\t') | Some(b'\n') | None) {
+            if matches!(next, Some(b' ' | b'\t' | b'\n') | None) {
                 // Empty key case - key length is 0, don't advance yet
                 self.pos
             } else {
@@ -1484,7 +1483,7 @@ impl<'a> Parser<'a> {
         if self.peek() != Some(b':') {
             return Err(YamlError::UnexpectedCharacter {
                 offset: self.pos,
-                char: self.peek().map(|b| b as char).unwrap_or('\0'),
+                char: self.peek().map_or('\0', |b| b as char),
                 context: "expected ':' after key",
             });
         }
@@ -1526,7 +1525,7 @@ impl<'a> Parser<'a> {
             let is_sequence_indicator = matches!(next_char, Some(b'-'))
                 && matches!(
                     self.peek_at(1),
-                    Some(b' ') | Some(b'\t') | Some(b'\n') | None
+                    Some(b' ' | b'\t' | b'\n') | None
                 );
             self.pos = saved_pos;
 
@@ -1555,19 +1554,19 @@ impl<'a> Parser<'a> {
                 Some(b'-')
                     if matches!(
                         self.peek_at(1),
-                        Some(b' ') | Some(b'\t') | Some(b'\n') | None
+                        Some(b' ' | b'\t' | b'\n') | None
                     ) =>
                 {
                     // Sequence - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
                 }
-                Some(b'?') if matches!(self.peek_at(1), Some(b' ') | Some(b'\n') | None) => {
+                Some(b'?') if matches!(self.peek_at(1), Some(b' ' | b'\n') | None) => {
                     // Explicit key - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
                 }
-                Some(b'{') | Some(b'[') | Some(b'|') | Some(b'>') => {
+                Some(b'{' | b'[' | b'|' | b'>') => {
                     // Flow/block structure - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
@@ -1577,7 +1576,7 @@ impl<'a> Parser<'a> {
                     self.pos = saved_pos;
                     return Ok(());
                 }
-                Some(b'&') | Some(b'*') => {
+                Some(b'&' | b'*') => {
                     // Anchor or alias on its own line - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
@@ -1639,7 +1638,7 @@ impl<'a> Parser<'a> {
                     // Skip past indent spaces to check what follows (SIMD accelerated)
                     self.skip_spaces_simd();
                     matches!(self.peek(), Some(b'-'))
-                        && matches!(self.peek_at(1), Some(b' ') | Some(b'\n') | None)
+                        && matches!(self.peek_at(1), Some(b' ' | b'\n') | None)
                 };
                 // Restore position after checking
                 self.pos = pos_before_check;
@@ -1673,7 +1672,7 @@ impl<'a> Parser<'a> {
                 Some(b'{') => {
                     self.parse_flow_mapping()?;
                 }
-                Some(b'|') | Some(b'>') => {
+                Some(b'|' | b'>') => {
                     // Block scalar - handles its own BP
                     self.parse_block_scalar(indent)?;
                 }
@@ -1762,7 +1761,7 @@ impl<'a> Parser<'a> {
                     && (next_indent == indent)
                     && matches!(
                         self.input.get(saved_pos + next_indent + 1).copied(),
-                        Some(b' ') | Some(b'\t') | Some(b'\n') | None
+                        Some(b' ' | b'\t' | b'\n') | None
                     )
                 {
                     // `: value` at same indent - empty key (null), value follows
@@ -1801,7 +1800,7 @@ impl<'a> Parser<'a> {
             Some(b'-')
                 if matches!(
                     self.peek_at(1),
-                    Some(b' ') | Some(b'\n') | Some(b'\r') | None
+                    Some(b' ' | b'\n' | b'\r') | None
                 ) =>
             {
                 // Sequence as key - open key node and let sequence parsing continue
@@ -1838,7 +1837,7 @@ impl<'a> Parser<'a> {
                 self.parse_flow_mapping()?;
                 self.write_bp_close();
             }
-            Some(b'|') | Some(b'>') => {
+            Some(b'|' | b'>') => {
                 // Block scalar as key
                 self.parse_block_scalar(indent)?;
             }
@@ -1903,7 +1902,7 @@ impl<'a> Parser<'a> {
             Some(b'-')
                 if matches!(
                     self.peek_at(1),
-                    Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') | None
+                    Some(b' ' | b'\t' | b'\n' | b'\r') | None
                 ) =>
             {
                 // Sequence as value
@@ -1932,7 +1931,7 @@ impl<'a> Parser<'a> {
             Some(b'{') => {
                 self.parse_flow_mapping()?;
             }
-            Some(b'|') | Some(b'>') => {
+            Some(b'|' | b'>') => {
                 self.parse_block_scalar(indent)?;
             }
             Some(b'"') => {
@@ -2024,7 +2023,7 @@ impl<'a> Parser<'a> {
                 // Flow mapping
                 self.parse_flow_mapping()?;
             }
-            Some(b'|') | Some(b'>') => {
+            Some(b'|' | b'>') => {
                 // Block scalar - handles its own BP
                 self.parse_block_scalar(min_indent)?;
             }
@@ -2156,7 +2155,7 @@ impl<'a> Parser<'a> {
                     // In flow context, colon must be followed by space, or flow indicator
                     return matches!(
                         next,
-                        Some(b' ') | Some(b'\t') | Some(b',') | Some(b']') | Some(b'}') | None
+                        Some(b' ' | b'\t' | b',' | b']' | b'}') | None
                     );
                 }
                 _ => i += 1,
@@ -2170,7 +2169,7 @@ impl<'a> Parser<'a> {
         self.peek() == Some(b'?')
             && matches!(
                 self.peek_at(1),
-                Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') | None
+                Some(b' ' | b'\t' | b'\n' | b'\r') | None
             )
     }
 
@@ -2203,7 +2202,7 @@ impl<'a> Parser<'a> {
                 // Don't consume anything, write empty node
                 self.pos
             }
-            Some(b',') | Some(b']') | Some(b'}') => {
+            Some(b',' | b']' | b'}') => {
                 // Empty key (null) - ? followed by terminator
                 self.pos
             }
@@ -2221,7 +2220,7 @@ impl<'a> Parser<'a> {
             self.skip_flow_whitespace();
 
             // Parse value (if present before , or ])
-            if !matches!(self.peek(), Some(b',') | Some(b']') | Some(b'}') | None) {
+            if !matches!(self.peek(), Some(b',' | b']' | b'}') | None) {
                 self.set_ib();
                 self.write_bp_open();
                 match self.peek() {
@@ -2291,7 +2290,7 @@ impl<'a> Parser<'a> {
         if self.peek() != Some(b':') {
             return Err(YamlError::UnexpectedCharacter {
                 offset: self.pos,
-                char: self.peek().map(|b| b as char).unwrap_or('\0'),
+                char: self.peek().map_or('\0', |b| b as char),
                 context: "expected ':' in implicit flow mapping entry",
             });
         }
@@ -2299,7 +2298,7 @@ impl<'a> Parser<'a> {
         self.skip_flow_whitespace();
 
         // Parse value (if present before , or ])
-        if !matches!(self.peek(), Some(b',') | Some(b']') | Some(b'}') | None) {
+        if !matches!(self.peek(), Some(b',' | b']' | b'}') | None) {
             self.set_ib();
             self.write_bp_open();
             let val_end = match self.peek() {
@@ -2356,7 +2355,7 @@ impl<'a> Parser<'a> {
                 if self.peek() != Some(b',') {
                     return Err(YamlError::UnexpectedCharacter {
                         offset: self.pos,
-                        char: self.peek().map(|b| b as char).unwrap_or('\0'),
+                        char: self.peek().map_or('\0', |b| b as char),
                         context: "expected ',' or ']' in flow sequence",
                     });
                 }
@@ -2450,7 +2449,7 @@ impl<'a> Parser<'a> {
                 if self.peek() != Some(b',') {
                     return Err(YamlError::UnexpectedCharacter {
                         offset: self.pos,
-                        char: self.peek().map(|b| b as char).unwrap_or('\0'),
+                        char: self.peek().map_or('\0', |b| b as char),
                         context: "expected ',' or '}' in flow mapping",
                     });
                 }
@@ -2508,7 +2507,7 @@ impl<'a> Parser<'a> {
                         }
                     }
                 }
-            } else if matches!(self.peek(), Some(b',') | Some(b'}')) {
+            } else if matches!(self.peek(), Some(b',' | b'}')) {
                 // Key without colon/value - emit empty value (implicit null)
                 self.set_ib();
                 self.write_bp_open();
@@ -2517,7 +2516,7 @@ impl<'a> Parser<'a> {
             } else {
                 return Err(YamlError::UnexpectedCharacter {
                     offset: self.pos,
-                    char: self.peek().map(|b| b as char).unwrap_or('\0'),
+                    char: self.peek().map_or('\0', |b| b as char),
                     context: "expected ':', ',' or '}' after key in flow mapping",
                 });
             }
@@ -2565,7 +2564,7 @@ impl<'a> Parser<'a> {
                 Some(b'{') => {
                     self.parse_flow_mapping()?;
                 }
-                Some(b':') | Some(b',') | Some(b'}') => {
+                Some(b':' | b',' | b'}') => {
                     // Empty key (null) - don't consume anything
                 }
                 _ => {
@@ -2639,7 +2638,7 @@ impl<'a> Parser<'a> {
                         self.advance();
                     }
                     // Skip leading whitespace
-                    while matches!(self.peek(), Some(b' ') | Some(b'\t')) {
+                    while matches!(self.peek(), Some(b' ' | b'\t')) {
                         self.advance();
                     }
                 }
@@ -2769,7 +2768,7 @@ impl<'a> Parser<'a> {
                         self.advance();
                     }
                     // Skip leading whitespace
-                    while matches!(self.peek(), Some(b' ') | Some(b'\t')) {
+                    while matches!(self.peek(), Some(b' ' | b'\t')) {
                         self.advance();
                     }
                 }
@@ -2817,14 +2816,7 @@ impl<'a> Parser<'a> {
                     let next = self.peek_at(1);
                     if matches!(
                         next,
-                        Some(b' ')
-                            | Some(b'\t')
-                            | Some(b'\n')
-                            | Some(b'\r')
-                            | Some(b',')
-                            | Some(b'}')
-                            | Some(b']')
-                            | None
+                        Some(b' ' | b'\t' | b'\n' | b'\r' | b',' | b'}' | b']') | None
                     ) {
                         break;
                     }
@@ -2876,7 +2868,7 @@ impl<'a> Parser<'a> {
                         self.advance();
                     }
                     // Skip leading whitespace
-                    while matches!(self.peek(), Some(b' ') | Some(b'\t')) {
+                    while matches!(self.peek(), Some(b' ' | b'\t')) {
                         self.advance();
                     }
                 }
@@ -2899,14 +2891,7 @@ impl<'a> Parser<'a> {
                                 };
                                 if matches!(
                                     after_colon,
-                                    Some(b' ')
-                                        | Some(b'\t')
-                                        | Some(b'\n')
-                                        | Some(b'\r')
-                                        | Some(b',')
-                                        | Some(b'}')
-                                        | Some(b']')
-                                        | None
+                                    Some(b' ' | b'\t' | b'\n' | b'\r' | b',' | b'}' | b']') | None
                                 ) {
                                     // Whitespace before `: ` - stop here
                                     break;
@@ -2958,7 +2943,7 @@ impl<'a> Parser<'a> {
             _ => {
                 return Err(YamlError::UnexpectedCharacter {
                     offset: self.pos,
-                    char: self.peek().map(|b| b as char).unwrap_or('\0'),
+                    char: self.peek().map_or('\0', |b| b as char),
                     context: "expected block scalar indicator (| or >)",
                 });
             }
@@ -3427,12 +3412,12 @@ impl<'a> Parser<'a> {
             Err(YamlError::TabIndentation { .. }) => {
                 // Tabs found - check if this leads to a flow structure
                 // Skip all leading whitespace (tabs and spaces)
-                while matches!(self.peek(), Some(b' ') | Some(b'\t')) {
+                while matches!(self.peek(), Some(b' ' | b'\t')) {
                     self.advance();
                 }
                 // If it's a flow structure, that's allowed
                 match self.peek() {
-                    Some(b'{') | Some(b'[') => {
+                    Some(b'{' | b'[') => {
                         self.close_deeper_indents(0);
                         self.parse_value(0)?;
                         // Move to next line if we haven't already
@@ -3464,7 +3449,7 @@ impl<'a> Parser<'a> {
             Some(b'-')
                 if matches!(
                     self.peek_at(1),
-                    Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') | None
+                    Some(b' ' | b'\t' | b'\n' | b'\r') | None
                 ) =>
             {
                 self.parse_sequence_item(indent)?;
@@ -3472,7 +3457,7 @@ impl<'a> Parser<'a> {
             Some(b'?')
                 if matches!(
                     self.peek_at(1),
-                    Some(b' ') | Some(b'\n') | Some(b'\r') | None
+                    Some(b' ' | b'\n' | b'\r') | None
                 ) =>
             {
                 // Explicit key indicator
@@ -3481,7 +3466,7 @@ impl<'a> Parser<'a> {
             Some(b':')
                 if matches!(
                     self.peek_at(1),
-                    Some(b' ') | Some(b'\n') | Some(b'\r') | None
+                    Some(b' ' | b'\n' | b'\r') | None
                 ) =>
             {
                 // Explicit value indicator (value for previous explicit key)
@@ -3495,7 +3480,7 @@ impl<'a> Parser<'a> {
                 // Empty line
                 self.advance();
             }
-            Some(b'{') | Some(b'[') => {
+            Some(b'{' | b'[') => {
                 // Flow mapping or sequence at document root
                 self.close_deeper_indents(indent);
                 self.parse_value(indent)?;
@@ -3558,13 +3543,13 @@ impl<'a> Parser<'a> {
                         Some(b'-')
                             if matches!(
                                 self.peek_at(1),
-                                Some(b' ') | Some(b'\t') | Some(b'\n') | None
+                                Some(b' ' | b'\t' | b'\n') | None
                             ) =>
                         {
                             // Anchor before block sequence on same line
                             self.parse_sequence_item(indent)?;
                         }
-                        Some(b'{') | Some(b'[') => {
+                        Some(b'{' | b'[') => {
                             // Anchor before flow collection
                             self.parse_value(indent)?;
                         }
@@ -3727,21 +3712,21 @@ mod tests {
     fn test_flow_sequence() {
         let yaml = b"items: [1, 2, 3]";
         let result = build_semi_index(yaml);
-        assert!(result.is_ok(), "Flow sequence should parse: {:?}", result);
+        assert!(result.is_ok(), "Flow sequence should parse: {result:?}");
     }
 
     #[test]
     fn test_flow_mapping() {
         let yaml = b"person: {name: Alice, age: 30}";
         let result = build_semi_index(yaml);
-        assert!(result.is_ok(), "Flow mapping should parse: {:?}", result);
+        assert!(result.is_ok(), "Flow mapping should parse: {result:?}");
     }
 
     #[test]
     fn test_flow_nested() {
         let yaml = b"data: {users: [{name: Alice}, {name: Bob}]}";
         let result = build_semi_index(yaml);
-        assert!(result.is_ok(), "Nested flow should parse: {:?}", result);
+        assert!(result.is_ok(), "Nested flow should parse: {result:?}");
     }
 
     #[test]
@@ -3750,8 +3735,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Flow with strings should parse: {:?}",
-            result
+            "Flow with strings should parse: {result:?}"
         );
     }
 
@@ -3761,8 +3745,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Flow with trailing comma should parse: {:?}",
-            result
+            "Flow with trailing comma should parse: {result:?}"
         );
     }
 
@@ -3772,8 +3755,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Empty flow sequence should parse: {:?}",
-            result
+            "Empty flow sequence should parse: {result:?}"
         );
     }
 
@@ -3783,8 +3765,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Empty flow mapping should parse: {:?}",
-            result
+            "Empty flow mapping should parse: {result:?}"
         );
     }
 
@@ -3814,14 +3795,14 @@ mod tests {
     fn test_block_literal_basic() {
         let yaml = b"text: |\n  line1\n  line2\n";
         let result = build_semi_index(yaml);
-        assert!(result.is_ok(), "Block literal should parse: {:?}", result);
+        assert!(result.is_ok(), "Block literal should parse: {result:?}");
     }
 
     #[test]
     fn test_block_folded_basic() {
         let yaml = b"text: >\n  line1\n  line2\n";
         let result = build_semi_index(yaml);
-        assert!(result.is_ok(), "Block folded should parse: {:?}", result);
+        assert!(result.is_ok(), "Block folded should parse: {result:?}");
     }
 
     #[test]
@@ -3830,8 +3811,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block literal strip should parse: {:?}",
-            result
+            "Block literal strip should parse: {result:?}"
         );
     }
 
@@ -3841,8 +3821,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block literal keep should parse: {:?}",
-            result
+            "Block literal keep should parse: {result:?}"
         );
     }
 
@@ -3852,8 +3831,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block folded strip should parse: {:?}",
-            result
+            "Block folded strip should parse: {result:?}"
         );
     }
 
@@ -3863,8 +3841,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block folded keep should parse: {:?}",
-            result
+            "Block folded keep should parse: {result:?}"
         );
     }
 
@@ -3874,8 +3851,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block with explicit indent should parse: {:?}",
-            result
+            "Block with explicit indent should parse: {result:?}"
         );
     }
 
@@ -3885,8 +3861,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block with explicit indent and chomping should parse: {:?}",
-            result
+            "Block with explicit indent and chomping should parse: {result:?}"
         );
     }
 
@@ -3896,8 +3871,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Empty block scalar should parse: {:?}",
-            result
+            "Empty block scalar should parse: {result:?}"
         );
     }
 
@@ -3907,8 +3881,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block scalar in sequence should parse: {:?}",
-            result
+            "Block scalar in sequence should parse: {result:?}"
         );
     }
 
@@ -3918,8 +3891,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block with nested indent should parse: {:?}",
-            result
+            "Block with nested indent should parse: {result:?}"
         );
     }
 
@@ -3929,8 +3901,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Multiple block scalars should parse: {:?}",
-            result
+            "Multiple block scalars should parse: {result:?}"
         );
     }
 
@@ -3940,8 +3911,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "Block scalar with comment should parse: {:?}",
-            result
+            "Block scalar with comment should parse: {result:?}"
         );
     }
 
@@ -3967,8 +3937,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "explicit document start should parse: {:?}",
-            result
+            "explicit document start should parse: {result:?}"
         );
     }
 
@@ -3977,7 +3946,7 @@ mod tests {
         // Two documents separated by `---`
         let yaml = b"---\nname: Alice\n---\nname: Bob";
         let result = build_semi_index(yaml);
-        assert!(result.is_ok(), "two documents should parse: {:?}", result);
+        assert!(result.is_ok(), "two documents should parse: {result:?}");
     }
 
     #[test]
@@ -3987,8 +3956,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "document with end marker should parse: {:?}",
-            result
+            "document with end marker should parse: {result:?}"
         );
     }
 
@@ -3999,8 +3967,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "document end at EOF should parse: {:?}",
-            result
+            "document end at EOF should parse: {result:?}"
         );
     }
 
@@ -4011,8 +3978,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "mixed document types should parse: {:?}",
-            result
+            "mixed document types should parse: {result:?}"
         );
     }
 
@@ -4021,7 +3987,7 @@ mod tests {
         // Empty content between document markers
         let yaml = b"---\n---\nname: Alice";
         let result = build_semi_index(yaml);
-        assert!(result.is_ok(), "empty document should parse: {:?}", result);
+        assert!(result.is_ok(), "empty document should parse: {result:?}");
     }
 
     #[test]
@@ -4031,8 +3997,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "quoted document marker should parse: {:?}",
-            result
+            "quoted document marker should parse: {result:?}"
         );
     }
 
@@ -4040,7 +4005,7 @@ mod tests {
     fn test_three_documents() {
         let yaml = b"---\na: 1\n---\nb: 2\n---\nc: 3";
         let result = build_semi_index(yaml);
-        assert!(result.is_ok(), "three documents should parse: {:?}", result);
+        assert!(result.is_ok(), "three documents should parse: {result:?}");
     }
 
     #[test]
@@ -4050,8 +4015,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "question mark in value should parse: {:?}",
-            result
+            "question mark in value should parse: {result:?}"
         );
     }
 
@@ -4062,8 +4026,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "question mark in key should parse: {:?}",
-            result
+            "question mark in key should parse: {result:?}"
         );
     }
 
@@ -4074,8 +4037,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "question mark in flow key should parse: {:?}",
-            result
+            "question mark in flow key should parse: {result:?}"
         );
     }
 
@@ -4086,8 +4048,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "question mark in flow value should parse: {:?}",
-            result
+            "question mark in flow value should parse: {result:?}"
         );
     }
 
@@ -4098,8 +4059,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "question marks test should parse: {:?}",
-            result
+            "question marks test should parse: {result:?}"
         );
     }
 
@@ -4110,8 +4070,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "compact mapping in sequence should parse: {:?}",
-            result
+            "compact mapping in sequence should parse: {result:?}"
         );
     }
 
@@ -4122,8 +4081,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "flow mapping in sequence should parse: {:?}",
-            result
+            "flow mapping in sequence should parse: {result:?}"
         );
     }
 
@@ -4134,8 +4092,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "double colon plain scalar should parse: {:?}",
-            result
+            "double colon plain scalar should parse: {result:?}"
         );
     }
 
@@ -4146,8 +4103,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "quoted key mapping should parse: {:?}",
-            result
+            "quoted key mapping should parse: {result:?}"
         );
     }
 
@@ -4158,8 +4114,7 @@ mod tests {
         let result = build_semi_index(yaml);
         assert!(
             result.is_ok(),
-            "empty key in flow sequence should parse: {:?}",
-            result
+            "empty key in flow sequence should parse: {result:?}"
         );
     }
 
@@ -4197,19 +4152,18 @@ mod tests {
                     eprintln!("  key.is_null() = {:?}", key_val.is_null());
                     count += 1;
                 }
-                eprintln!("Field count: {}", count);
+                eprintln!("Field count: {count}");
                 assert!(
                     count > 0,
-                    "mapping should have at least one field, but has {}",
-                    count
+                    "mapping should have at least one field, but has {count}"
                 );
 
                 // Now test to_owned conversion
                 eprintln!("\n=== Testing to_owned conversion ===");
                 let owned = to_owned(&doc_cursor.value());
-                eprintln!("to_owned result: {:?}", owned);
+                eprintln!("to_owned result: {owned:?}");
             }
-            other => panic!("expected mapping, got {:?}", other),
+            other => panic!("expected mapping, got {other:?}"),
         }
     }
 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1249,10 +1249,7 @@ impl<'a> Parser<'a> {
 
         // Check for nested sequence: `- - item` (sequence item containing a sequence)
         if self.peek() == Some(b'-')
-            && matches!(
-                self.peek_at(1),
-                Some(b' ' | b'\t' | b'\n' | b'\r') | None
-            )
+            && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None)
         {
             // Nested sequence - the item value is another sequence.
             // Use the actual column position of the nested `-` as the indent.
@@ -1349,10 +1346,7 @@ impl<'a> Parser<'a> {
                 let saved_pos = self.pos;
                 self.advance_by(next_indent);
                 let is_sequence_indicator = matches!(self.peek(), Some(b'-'))
-                    && matches!(
-                        self.peek_at(1),
-                        Some(b' ' | b'\t' | b'\n') | None
-                    );
+                    && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n') | None);
                 self.pos = saved_pos;
 
                 if next_indent < indent || (next_indent == indent && !is_sequence_indicator) {
@@ -1523,10 +1517,7 @@ impl<'a> Parser<'a> {
             self.advance_by(next_indent);
             let next_char = self.peek();
             let is_sequence_indicator = matches!(next_char, Some(b'-'))
-                && matches!(
-                    self.peek_at(1),
-                    Some(b' ' | b'\t' | b'\n') | None
-                );
+                && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n') | None);
             self.pos = saved_pos;
 
             if next_indent < indent {
@@ -1551,12 +1542,7 @@ impl<'a> Parser<'a> {
 
             // Check if this is a nested structure or a plain scalar value
             match self.peek() {
-                Some(b'-')
-                    if matches!(
-                        self.peek_at(1),
-                        Some(b' ' | b'\t' | b'\n') | None
-                    ) =>
-                {
+                Some(b'-') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n') | None) => {
                     // Sequence - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
@@ -1797,12 +1783,7 @@ impl<'a> Parser<'a> {
 
         // Parse the key value inline
         match self.peek() {
-            Some(b'-')
-                if matches!(
-                    self.peek_at(1),
-                    Some(b' ' | b'\n' | b'\r') | None
-                ) =>
-            {
+            Some(b'-') if matches!(self.peek_at(1), Some(b' ' | b'\n' | b'\r') | None) => {
                 // Sequence as key - open key node and let sequence parsing continue
                 // The key will be a sequence
                 self.write_bp_open();
@@ -1899,12 +1880,7 @@ impl<'a> Parser<'a> {
 
         // Parse the value
         match self.peek() {
-            Some(b'-')
-                if matches!(
-                    self.peek_at(1),
-                    Some(b' ' | b'\t' | b'\n' | b'\r') | None
-                ) =>
-            {
+            Some(b'-') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) => {
                 // Sequence as value
                 self.write_bp_open();
                 self.write_ty(true); // sequence
@@ -2153,10 +2129,7 @@ impl<'a> Parser<'a> {
                         None
                     };
                     // In flow context, colon must be followed by space, or flow indicator
-                    return matches!(
-                        next,
-                        Some(b' ' | b'\t' | b',' | b']' | b'}') | None
-                    );
+                    return matches!(next, Some(b' ' | b'\t' | b',' | b']' | b'}') | None);
                 }
                 _ => i += 1,
             }
@@ -2167,10 +2140,7 @@ impl<'a> Parser<'a> {
     /// Check if we're looking at an explicit key indicator `?` in flow context
     fn looks_like_explicit_flow_key(&self) -> bool {
         self.peek() == Some(b'?')
-            && matches!(
-                self.peek_at(1),
-                Some(b' ' | b'\t' | b'\n' | b'\r') | None
-            )
+            && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None)
     }
 
     /// Parse an explicit mapping entry in flow context: `? key : value`
@@ -3446,29 +3416,14 @@ impl<'a> Parser<'a> {
 
         // Check what kind of content this is
         match self.peek() {
-            Some(b'-')
-                if matches!(
-                    self.peek_at(1),
-                    Some(b' ' | b'\t' | b'\n' | b'\r') | None
-                ) =>
-            {
+            Some(b'-') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) => {
                 self.parse_sequence_item(indent)?;
             }
-            Some(b'?')
-                if matches!(
-                    self.peek_at(1),
-                    Some(b' ' | b'\n' | b'\r') | None
-                ) =>
-            {
+            Some(b'?') if matches!(self.peek_at(1), Some(b' ' | b'\n' | b'\r') | None) => {
                 // Explicit key indicator
                 self.parse_explicit_key(indent)?;
             }
-            Some(b':')
-                if matches!(
-                    self.peek_at(1),
-                    Some(b' ' | b'\n' | b'\r') | None
-                ) =>
-            {
+            Some(b':') if matches!(self.peek_at(1), Some(b' ' | b'\n' | b'\r') | None) => {
                 // Explicit value indicator (value for previous explicit key)
                 self.parse_explicit_value(indent)?;
             }
@@ -3541,10 +3496,7 @@ impl<'a> Parser<'a> {
                             // Anchor with value on next line - will be parsed in next iteration
                         }
                         Some(b'-')
-                            if matches!(
-                                self.peek_at(1),
-                                Some(b' ' | b'\t' | b'\n') | None
-                            ) =>
+                            if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n') | None) =>
                         {
                             // Anchor before block sequence on same line
                             self.parse_sequence_item(indent)?;
@@ -3733,10 +3685,7 @@ mod tests {
     fn test_flow_with_strings() {
         let yaml = b"items: [\"hello\", 'world', plain]";
         let result = build_semi_index(yaml);
-        assert!(
-            result.is_ok(),
-            "Flow with strings should parse: {result:?}"
-        );
+        assert!(result.is_ok(), "Flow with strings should parse: {result:?}");
     }
 
     #[test]
@@ -3839,10 +3788,7 @@ mod tests {
     fn test_block_folded_keep() {
         let yaml = b"text: >+\n  content\n\n";
         let result = build_semi_index(yaml);
-        assert!(
-            result.is_ok(),
-            "Block folded keep should parse: {result:?}"
-        );
+        assert!(result.is_ok(), "Block folded keep should parse: {result:?}");
     }
 
     #[test]

--- a/src/yaml/simd/neon.rs
+++ b/src/yaml/simd/neon.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ARM64 NEON SIMD intrinsics
 //! NEON-accelerated string scanning for YAML parsing on ARM64.
 //!
 //! Uses 128-bit NEON vectors to process 16 bytes at a time.
@@ -605,8 +606,7 @@ unsafe fn find_json_escape_neon_impl(bytes: &[u8], start: usize) -> usize {
     }
 
     // Handle remaining bytes with scalar fallback
-    for i in offset..data_len {
-        let b = data[i];
+    for (i, &b) in data.iter().enumerate().skip(offset) {
         if b == b'"' || b == b'\\' || b < 0x20 {
             return start + i;
         }
@@ -1114,8 +1114,7 @@ mod tests {
             assert_eq!(
                 find_json_escape_neon(&input, 0),
                 25,
-                "Failed for control char 0x{:02x}",
-                ctrl
+                "Failed for control char 0x{ctrl:02x}"
             );
         }
     }
@@ -1182,8 +1181,7 @@ mod tests {
             let neon = find_json_escape_neon(input, start);
             assert_eq!(
                 scalar, neon,
-                "Mismatch at offset {}: scalar={}, neon={}",
-                start, scalar, neon
+                "Mismatch at offset {start}: scalar={scalar}, neon={neon}"
             );
         }
     }

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // x86_64 SSE2/AVX2 SIMD intrinsics
 //! x86_64 SIMD-accelerated string scanning for YAML parsing.
 //!
 //! Uses SSE2 (baseline, 16 bytes) with optional AVX2 (32 bytes) when available.
@@ -62,7 +63,7 @@ pub fn classify_yaml_chars(input: &[u8], offset: usize) -> Option<YamlCharClass>
 #[cfg(any(test, feature = "std"))]
 #[target_feature(enable = "avx2")]
 unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass {
-    let chunk = _mm256_loadu_si256(input.as_ptr().add(offset) as *const __m256i);
+    let chunk = _mm256_loadu_si256(input.as_ptr().add(offset).cast::<__m256i>());
 
     // Create comparison vectors for each character
     let v_newline = _mm256_set1_epi8(b'\n' as i8);
@@ -99,7 +100,7 @@ unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass
 /// SSE2 implementation of character classification (16 bytes at a time).
 #[target_feature(enable = "sse2")]
 unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass {
-    let chunk = _mm_loadu_si128(input.as_ptr().add(offset) as *const __m128i);
+    let chunk = _mm_loadu_si128(input.as_ptr().add(offset).cast::<__m128i>());
 
     // Create comparison vectors for each character
     let v_newline = _mm_set1_epi8(b'\n' as i8);
@@ -157,7 +158,7 @@ unsafe fn find_newline_sse2(input: &[u8], start: usize) -> Option<usize> {
     let newline_vec = _mm_set1_epi8(b'\n' as i8);
 
     while offset + 16 <= len {
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
         let matches = _mm_cmpeq_epi8(chunk, newline_vec);
         let mask = _mm_movemask_epi8(matches) as u32;
 
@@ -182,7 +183,7 @@ unsafe fn find_newline_avx2(input: &[u8], start: usize) -> Option<usize> {
     let newline_vec = _mm256_set1_epi8(b'\n' as i8);
 
     while offset + 32 <= len {
-        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset) as *const __m256i);
+        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset).cast::<__m256i>());
         let matches = _mm256_cmpeq_epi8(chunk, newline_vec);
         let mask = _mm256_movemask_epi8(matches) as u32;
 
@@ -196,7 +197,7 @@ unsafe fn find_newline_avx2(input: &[u8], start: usize) -> Option<usize> {
     // Handle remaining bytes with SSE2
     if offset + 16 <= len {
         let newline_vec_sse = _mm_set1_epi8(b'\n' as i8);
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
         let matches = _mm_cmpeq_epi8(chunk, newline_vec_sse);
         let mask = _mm_movemask_epi8(matches) as u32;
 
@@ -264,7 +265,7 @@ unsafe fn find_quote_or_escape_sse2(input: &[u8], start: usize, end: usize) -> O
     let backslash_vec = _mm_set1_epi8(b'\\' as i8);
 
     while offset + 16 <= len {
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
 
         // Compare against both targets
         let quotes = _mm_cmpeq_epi8(chunk, quote_vec);
@@ -299,7 +300,7 @@ unsafe fn find_single_quote_sse2(input: &[u8], start: usize, end: usize) -> Opti
     let quote_vec = _mm_set1_epi8(b'\'' as i8);
 
     while offset + 16 <= len {
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
 
         // Compare against single quote
         let matches = _mm_cmpeq_epi8(chunk, quote_vec);
@@ -333,7 +334,7 @@ unsafe fn find_quote_or_escape_avx2(input: &[u8], start: usize, end: usize) -> O
     let backslash_vec = _mm256_set1_epi8(b'\\' as i8);
 
     while offset + 32 <= len {
-        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset) as *const __m256i);
+        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset).cast::<__m256i>());
 
         // Compare against both targets
         let quotes = _mm256_cmpeq_epi8(chunk, quote_vec);
@@ -357,7 +358,7 @@ unsafe fn find_quote_or_escape_avx2(input: &[u8], start: usize, end: usize) -> O
         let quote_vec_sse = _mm_set1_epi8(b'"' as i8);
         let backslash_vec_sse = _mm_set1_epi8(b'\\' as i8);
 
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
         let quotes = _mm_cmpeq_epi8(chunk, quote_vec_sse);
         let backslashes = _mm_cmpeq_epi8(chunk, backslash_vec_sse);
         let matches = _mm_or_si128(quotes, backslashes);
@@ -386,7 +387,7 @@ unsafe fn find_single_quote_avx2(input: &[u8], start: usize, end: usize) -> Opti
     let quote_vec = _mm256_set1_epi8(b'\'' as i8);
 
     while offset + 32 <= len {
-        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset) as *const __m256i);
+        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset).cast::<__m256i>());
 
         // Compare against single quote
         let matches = _mm256_cmpeq_epi8(chunk, quote_vec);
@@ -405,7 +406,7 @@ unsafe fn find_single_quote_avx2(input: &[u8], start: usize, end: usize) -> Opti
     if offset + 16 <= len {
         let quote_vec_sse = _mm_set1_epi8(b'\'' as i8);
 
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
         let matches = _mm_cmpeq_epi8(chunk, quote_vec_sse);
         let mask = _mm_movemask_epi8(matches) as u32;
 
@@ -447,7 +448,7 @@ unsafe fn count_leading_spaces_sse2(input: &[u8], start: usize) -> usize {
 
     // Process 16-byte chunks
     while offset + 16 <= len {
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
 
         // Compare against space
         let matches = _mm_cmpeq_epi8(chunk, space_vec);
@@ -478,7 +479,7 @@ unsafe fn count_leading_spaces_avx2(input: &[u8], start: usize) -> usize {
 
     // Process 32-byte chunks
     while offset + 32 <= len {
-        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset) as *const __m256i);
+        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset).cast::<__m256i>());
 
         // Compare against space
         let matches = _mm256_cmpeq_epi8(chunk, space_vec);
@@ -497,7 +498,7 @@ unsafe fn count_leading_spaces_avx2(input: &[u8], start: usize) -> usize {
     // Handle remaining bytes (16-31 bytes) with SSE2
     if offset + 16 <= len {
         let space_vec_sse = _mm_set1_epi8(b' ' as i8);
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
         let matches = _mm_cmpeq_epi8(chunk, space_vec_sse);
         let mask = _mm_movemask_epi8(matches) as u32;
 
@@ -547,7 +548,7 @@ unsafe fn find_block_scalar_end_avx2(input: &[u8], start: usize, min_indent: usi
 
     // Process in 32-byte chunks, looking for newlines
     while pos + 32 < input.len() {
-        let chunk = _mm256_loadu_si256(input.as_ptr().add(pos) as *const __m256i);
+        let chunk = _mm256_loadu_si256(input.as_ptr().add(pos).cast::<__m256i>());
         let nl_matches = _mm256_cmpeq_epi8(chunk, newline_vec);
         let mut nl_mask = _mm256_movemask_epi8(nl_matches) as u32;
 
@@ -568,7 +569,7 @@ unsafe fn find_block_scalar_end_avx2(input: &[u8], start: usize, min_indent: usi
                 // Use SIMD to count spaces
                 if remaining >= 32 {
                     let next_chunk =
-                        _mm256_loadu_si256(input.as_ptr().add(line_start) as *const __m256i);
+                        _mm256_loadu_si256(input.as_ptr().add(line_start).cast::<__m256i>());
                     let space_matches = _mm256_cmpeq_epi8(next_chunk, space_vec);
                     let space_mask = _mm256_movemask_epi8(space_matches) as u32;
 
@@ -620,7 +621,7 @@ unsafe fn find_block_scalar_end_sse2(input: &[u8], start: usize, min_indent: usi
 
     // Process in 16-byte chunks
     while pos + 16 < input.len() {
-        let chunk = _mm_loadu_si128(input.as_ptr().add(pos) as *const __m128i);
+        let chunk = _mm_loadu_si128(input.as_ptr().add(pos).cast::<__m128i>());
         let nl_matches = _mm_cmpeq_epi8(chunk, newline_vec);
         let mut nl_mask = _mm_movemask_epi8(nl_matches) as u32;
 
@@ -639,7 +640,7 @@ unsafe fn find_block_scalar_end_sse2(input: &[u8], start: usize, min_indent: usi
 
                 if remaining >= 16 {
                     let next_chunk =
-                        _mm_loadu_si128(input.as_ptr().add(line_start) as *const __m128i);
+                        _mm_loadu_si128(input.as_ptr().add(line_start).cast::<__m128i>());
                     let space_matches = _mm_cmpeq_epi8(next_chunk, space_vec);
                     let space_mask = _mm_movemask_epi8(space_matches) as u32;
 
@@ -743,7 +744,7 @@ unsafe fn parse_anchor_name_avx2(input: &[u8], start: usize) -> usize {
 
     // Process 32 bytes at a time with AVX2
     while pos + 32 <= end {
-        let chunk = _mm256_loadu_si256(input.as_ptr().add(pos) as *const __m256i);
+        let chunk = _mm256_loadu_si256(input.as_ptr().add(pos).cast::<__m256i>());
 
         // Check for all terminator types
         let is_space = _mm256_cmpeq_epi8(chunk, space);
@@ -844,7 +845,7 @@ unsafe fn find_json_escape_avx2(input: &[u8], start: usize) -> Option<usize> {
 
     // Process 32 bytes at a time with AVX2
     while offset + 32 <= data_len {
-        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset) as *const __m256i);
+        let chunk = _mm256_loadu_si256(data.as_ptr().add(offset).cast::<__m256i>());
 
         // Check for quote
         let is_quote = _mm256_cmpeq_epi8(chunk, quote_vec);
@@ -880,7 +881,7 @@ unsafe fn find_json_escape_avx2(input: &[u8], start: usize) -> Option<usize> {
         let backslash_vec_sse = _mm_set1_epi8(b'\\' as i8);
         let control_threshold_sse = _mm_set1_epi8(0x20);
 
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
 
         let is_quote = _mm_cmpeq_epi8(chunk, quote_vec_sse);
         let is_backslash = _mm_cmpeq_epi8(chunk, backslash_vec_sse);
@@ -896,8 +897,7 @@ unsafe fn find_json_escape_avx2(input: &[u8], start: usize) -> Option<usize> {
     }
 
     // Handle remaining bytes (< 16) with scalar
-    for i in offset..data_len {
-        let b = data[i];
+    for (i, &b) in data.iter().enumerate().skip(offset) {
         if b == b'"' || b == b'\\' || b < 0x20 {
             return Some(i);
         }
@@ -924,7 +924,7 @@ unsafe fn find_json_escape_sse2(input: &[u8], start: usize) -> Option<usize> {
 
     // Process 16 bytes at a time with SSE2
     while offset + 16 <= data_len {
-        let chunk = _mm_loadu_si128(data.as_ptr().add(offset) as *const __m128i);
+        let chunk = _mm_loadu_si128(data.as_ptr().add(offset).cast::<__m128i>());
 
         let is_quote = _mm_cmpeq_epi8(chunk, quote_vec);
         let is_backslash = _mm_cmpeq_epi8(chunk, backslash_vec);
@@ -941,8 +941,7 @@ unsafe fn find_json_escape_sse2(input: &[u8], start: usize) -> Option<usize> {
     }
 
     // Handle remaining bytes with scalar
-    for i in offset..data_len {
-        let b = data[i];
+    for (i, &b) in data.iter().enumerate().skip(offset) {
         if b == b'"' || b == b'\\' || b < 0x20 {
             return Some(i);
         }
@@ -1368,8 +1367,7 @@ mod tests {
             assert_eq!(
                 find_json_escape_x86(&input, 0),
                 Some(3),
-                "Control char 0x{:02x} not detected",
-                b
+                "Control char 0x{b:02x} not detected"
             );
         }
 

--- a/tests/binary_tests.rs
+++ b/tests/binary_tests.rs
@@ -113,7 +113,7 @@ fn test_large_json_roundtrip() {
     let json = format!(
         r#"{{"items":[{}]}}"#,
         (0..1000)
-            .map(|i| format!(r#"{{"id":{},"name":"item{}"}}"#, i, i))
+            .map(|i| format!(r#"{{"id":{i},"name":"item{i}"}}"#))
             .collect::<Vec<_>>()
             .join(",")
     );
@@ -156,7 +156,7 @@ fn test_deeply_nested_json() {
     let depth = 50;
     let opens: String = "[".repeat(depth);
     let closes: String = "]".repeat(depth);
-    let json = format!("{}1{}", opens, closes);
+    let json = format!("{opens}1{closes}");
 
     let semi = standard::build_semi_index(json.as_bytes());
 

--- a/tests/bitread_tests.rs
+++ b/tests/bitread_tests.rs
@@ -53,7 +53,7 @@ fn test_rank1_pattern_10010010() {
     // rank1 over [0..8] should be 0,1,1,1,2,2,2,3,3
     let expected = [0, 1, 1, 1, 2, 2, 2, 3, 3];
     for (i, &exp) in expected.iter().enumerate() {
-        assert_eq!(bv.rank1(i), exp, "rank1({}) mismatch", i);
+        assert_eq!(bv.rank1(i), exp, "rank1({i}) mismatch");
     }
 }
 
@@ -68,7 +68,7 @@ fn test_rank1_pattern_11011010_00000000() {
     // rank1 over [0..16]
     let expected = [0, 1, 2, 2, 3, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
     for (i, &exp) in expected.iter().enumerate() {
-        assert_eq!(bv.rank1(i), exp, "rank1({}) mismatch", i);
+        assert_eq!(bv.rank1(i), exp, "rank1({i}) mismatch");
     }
 }
 
@@ -83,7 +83,7 @@ fn test_rank1_pattern_11011010_10000000() {
     // rank1 over [0..16]
     let expected = [0, 1, 2, 2, 3, 4, 4, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6];
     for (i, &exp) in expected.iter().enumerate() {
-        assert_eq!(bv.rank1(i), exp, "rank1({}) mismatch", i);
+        assert_eq!(bv.rank1(i), exp, "rank1({i}) mismatch");
     }
 }
 
@@ -181,18 +181,12 @@ fn test_roundtrip_various_patterns() {
             let pos = bv.select1(k).unwrap();
             assert!(
                 bv.get(pos),
-                "pattern '{}': select1({}) = {} but bit is not set",
-                pattern,
-                k,
-                pos
+                "pattern '{pattern}': select1({k}) = {pos} but bit is not set"
             );
             assert_eq!(
                 bv.rank1(pos + 1),
                 k + 1,
-                "pattern '{}': rank1(select1({}) + 1) != {} + 1",
-                pattern,
-                k,
-                k
+                "pattern '{pattern}': rank1(select1({k}) + 1) != {k} + 1"
             );
         }
     }
@@ -214,7 +208,7 @@ fn test_long_alternating_pattern() {
     // rank1 at position x should be (x-1)/2 + 1 for x > 0
     for x in 1..=4096 {
         let expected = (x - 1) / 2 + 1;
-        assert_eq!(bv.rank1(x), expected, "rank1({}) mismatch", x);
+        assert_eq!(bv.rank1(x), expected, "rank1({x}) mismatch");
     }
 }
 
@@ -234,7 +228,7 @@ fn test_long_sparse_pattern() {
 
     // select1(k) should be k * 64
     for k in 0..64 {
-        assert_eq!(bv.select1(k), Some(k * 64), "select1({}) mismatch", k);
+        assert_eq!(bv.select1(k), Some(k * 64), "select1({k}) mismatch");
     }
 }
 

--- a/tests/bp_coverage_tests.rs
+++ b/tests/bp_coverage_tests.rs
@@ -183,9 +183,7 @@ mod excess_tests {
                 assert_eq!(
                     bp.excess(p),
                     expected,
-                    "excess({}) mismatch for words={:?}",
-                    p,
-                    words
+                    "excess({p}) mismatch for words={words:?}"
                 );
             }
         }
@@ -221,8 +219,7 @@ mod excess_tests {
                 assert_eq!(
                     bp.depth(p).unwrap() as i32,
                     bp.excess(p),
-                    "depth != excess at open position {}",
-                    p
+                    "depth != excess at open position {p}"
                 );
             }
         }
@@ -323,10 +320,7 @@ mod min_excess_tests {
             // min_excess should be <= total_excess (can't go below minimum)
             assert!(
                 min <= total,
-                "min_excess > total_excess for word={:#x}: min={}, total={}",
-                word,
-                min,
-                total
+                "min_excess > total_excess for word={word:#x}: min={min}, total={total}"
             );
 
             // min_excess should be <= 0 or the minimum running excess
@@ -361,8 +355,7 @@ mod find_close_in_word_tests {
             let naive = naive_find_close_in_word(word, p);
             assert_eq!(
                 result, naive,
-                "find_close_in_word({:#x}, {}) mismatch: got {:?}, expected {:?}",
-                word, p, result, naive
+                "find_close_in_word({word:#x}, {p}) mismatch: got {result:?}, expected {naive:?}"
             );
         }
     }
@@ -376,8 +369,7 @@ mod find_close_in_word_tests {
                 let naive = naive_find_close_in_word(word, p);
                 assert_eq!(
                     result, naive,
-                    "find_close_in_word({:#x}, {}) mismatch",
-                    word, p
+                    "find_close_in_word({word:#x}, {p}) mismatch"
                 );
             }
         }
@@ -439,8 +431,7 @@ mod find_close_in_word_tests {
             let naive = naive_find_unmatched_close_in_word(word);
             assert_eq!(
                 result, naive,
-                "find_unmatched_close_in_word({:#x}) mismatch: got {}, expected {}",
-                word, result, naive
+                "find_unmatched_close_in_word({word:#x}) mismatch: got {result}, expected {naive}"
             );
         }
     }
@@ -466,8 +457,7 @@ mod cross_verification_tests {
                 let linear_result = find_close(&words, len, p);
                 assert_eq!(
                     bp_result, linear_result,
-                    "find_close({}) mismatch at len={}",
-                    p, len
+                    "find_close({p}) mismatch at len={len}"
                 );
             }
 
@@ -477,8 +467,7 @@ mod cross_verification_tests {
                 let linear_result = find_open(&words, len, p);
                 assert_eq!(
                     bp_result, linear_result,
-                    "find_open({}) mismatch at len={}",
-                    p, len
+                    "find_open({p}) mismatch at len={len}"
                 );
             }
 
@@ -488,8 +477,7 @@ mod cross_verification_tests {
                 let linear_result = enclose(&words, len, p);
                 assert_eq!(
                     bp_result, linear_result,
-                    "enclose({}) mismatch at len={}",
-                    p, len
+                    "enclose({p}) mismatch at len={len}"
                 );
             }
 
@@ -498,8 +486,7 @@ mod cross_verification_tests {
             let naive_exc = naive_excess(&words, len, p);
             assert_eq!(
                 bp_excess, naive_exc,
-                "excess({}) mismatch at len={}",
-                p, len
+                "excess({p}) mismatch at len={len}"
             );
         }
     }
@@ -570,7 +557,7 @@ mod cross_verification_tests {
                 if bp.is_open(p) {
                     let bp_result = bp.find_close(p);
                     let linear_result = find_close(&words, len, p);
-                    assert_eq!(bp_result, linear_result, "find_close({}) mismatch", p);
+                    assert_eq!(bp_result, linear_result, "find_close({p}) mismatch");
                 }
             }
         }
@@ -596,8 +583,7 @@ mod cross_verification_tests {
                 let linear_result = find_close(&words, len, p);
                 assert_eq!(
                     bp_result, linear_result,
-                    "find_close({}) mismatch at large scale",
-                    p
+                    "find_close({p}) mismatch at large scale"
                 );
             }
         }
@@ -630,10 +616,7 @@ mod inverse_tests {
                         assert_eq!(
                             open,
                             Some(p),
-                            "find_open(find_close({})) != {} for close={}",
-                            p,
-                            p,
-                            close
+                            "find_open(find_close({p})) != {p} for close={close}"
                         );
                     }
                 }
@@ -673,8 +656,7 @@ mod inverse_tests {
                     assert_eq!(
                         size,
                         (close - p) / 2,
-                        "subtree_size formula failed at {}",
-                        p
+                        "subtree_size formula failed at {p}"
                     );
                 }
             }
@@ -748,9 +730,7 @@ mod depth_subtree_tests {
             assert_eq!(
                 bp.depth(i),
                 Some(expected),
-                "depth({}) should be {}",
-                i,
-                expected
+                "depth({i}) should be {expected}"
             );
         }
     }

--- a/tests/bp_coverage_tests.rs
+++ b/tests/bp_coverage_tests.rs
@@ -367,10 +367,7 @@ mod find_close_in_word_tests {
             for p in 0..16u32 {
                 let result = find_close_in_word(word, p);
                 let naive = naive_find_close_in_word(word, p);
-                assert_eq!(
-                    result, naive,
-                    "find_close_in_word({word:#x}, {p}) mismatch"
-                );
+                assert_eq!(result, naive, "find_close_in_word({word:#x}, {p}) mismatch");
             }
         }
     }
@@ -484,10 +481,7 @@ mod cross_verification_tests {
             // excess
             let bp_excess = bp.excess(p);
             let naive_exc = naive_excess(&words, len, p);
-            assert_eq!(
-                bp_excess, naive_exc,
-                "excess({p}) mismatch at len={len}"
-            );
+            assert_eq!(bp_excess, naive_exc, "excess({p}) mismatch at len={len}");
         }
     }
 
@@ -653,11 +647,7 @@ mod inverse_tests {
         for p in 0..6 {
             if bp.is_open(p) {
                 if let (Some(size), Some(close)) = (bp.subtree_size(p), bp.find_close(p)) {
-                    assert_eq!(
-                        size,
-                        (close - p) / 2,
-                        "subtree_size formula failed at {p}"
-                    );
+                    assert_eq!(size, (close - p) / 2, "subtree_size formula failed at {p}");
                 }
             }
         }

--- a/tests/bp_properties.rs
+++ b/tests/bp_properties.rs
@@ -401,8 +401,7 @@ mod edge_cases {
                     assert_eq!(
                         bp.find_open(close),
                         Some(p),
-                        "roundtrip failed at open position {}",
-                        p
+                        "roundtrip failed at open position {p}"
                     );
                 }
             }

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -29,7 +29,7 @@ fn run_cli(args: &[&str]) -> Result<String> {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("Command failed: {}", stderr);
+            anyhow::bail!("Command failed: {stderr}");
         }
 
         return Ok(String::from_utf8(output.stdout)?);

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -148,7 +148,7 @@ fn test_nested_field_access() -> Result<()> {
 
 #[test]
 fn test_array_index() -> Result<()> {
-    let (output, code) = run_jq_stdin(".[1]", r#"[10,20,30]"#, &[])?;
+    let (output, code) = run_jq_stdin(".[1]", r"[10,20,30]", &[])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "20");
     Ok(())
@@ -156,7 +156,7 @@ fn test_array_index() -> Result<()> {
 
 #[test]
 fn test_array_iteration() -> Result<()> {
-    let (output, code) = run_jq_stdin(".[]", r#"[1,2,3]"#, &[])?;
+    let (output, code) = run_jq_stdin(".[]", r"[1,2,3]", &[])?;
     assert_eq!(code, 0);
     assert_eq!(output, "1\n2\n3\n");
     Ok(())
@@ -595,7 +595,7 @@ fn test_multiple_file_inputs() -> Result<()> {
 
 #[test]
 fn test_builtin_length() -> Result<()> {
-    let (output, code) = run_jq_stdin("length", r#"[1,2,3,4,5]"#, &[])?;
+    let (output, code) = run_jq_stdin("length", r"[1,2,3,4,5]", &[])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "5");
     Ok(())
@@ -611,7 +611,7 @@ fn test_builtin_keys() -> Result<()> {
 
 #[test]
 fn test_builtin_map() -> Result<()> {
-    let (output, code) = run_jq_stdin("map(. * 2)", r#"[1,2,3]"#, &["-c"])?;
+    let (output, code) = run_jq_stdin("map(. * 2)", r"[1,2,3]", &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "[2,4,6]");
     Ok(())
@@ -619,7 +619,7 @@ fn test_builtin_map() -> Result<()> {
 
 #[test]
 fn test_builtin_select() -> Result<()> {
-    let (output, code) = run_jq_stdin(".[] | select(. > 2)", r#"[1,2,3,4,5]"#, &[])?;
+    let (output, code) = run_jq_stdin(".[] | select(. > 2)", r"[1,2,3,4,5]", &[])?;
     assert_eq!(code, 0);
     assert_eq!(output, "3\n4\n5\n");
     Ok(())
@@ -640,7 +640,7 @@ fn test_builtin_type() -> Result<()> {
 #[test]
 fn test_object_construction() -> Result<()> {
     let (output, code) = run_jq_stdin(
-        r#"{name: .user, id: .id}"#,
+        r"{name: .user, id: .id}",
         r#"{"user":"Alice","id":42}"#,
         &["-c"],
     )?;
@@ -683,7 +683,7 @@ fn test_try_catch() -> Result<()> {
 
 #[test]
 fn test_reduce() -> Result<()> {
-    let (output, code) = run_jq_stdin("reduce .[] as $x (0; . + $x)", r#"[1,2,3,4,5]"#, &[])?;
+    let (output, code) = run_jq_stdin("reduce .[] as $x (0; . + $x)", r"[1,2,3,4,5]", &[])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "15");
     Ok(())
@@ -758,7 +758,7 @@ fn test_ascii_output() -> Result<()> {
     // Test that --ascii-output escapes non-ASCII characters
     let (output, _) = run_jq_stdin(".", r#"{"name":"世界"}"#, &["-c", "-a"])?;
     // Chinese characters should be escaped as \uXXXX
-    assert!(output.contains(r#"\u4e16\u754c"#));
+    assert!(output.contains(r"\u4e16\u754c"));
     assert!(!output.contains("世界"));
     Ok(())
 }
@@ -768,7 +768,7 @@ fn test_ascii_output_emoji() -> Result<()> {
     // Test that emoji (outside BMP) are escaped as surrogate pairs
     let (output, _) = run_jq_stdin(".", r#"{"emoji":"🌍"}"#, &["-c", "-a"])?;
     // Earth emoji U+1F30D should be encoded as surrogate pair
-    assert!(output.contains(r#"\ud83c\udf0d"#));
+    assert!(output.contains(r"\ud83c\udf0d"));
     assert!(!output.contains("🌍"));
     Ok(())
 }
@@ -859,7 +859,7 @@ fn test_number_formatting_field_access() -> Result<()> {
 #[test]
 fn test_number_formatting_array_iteration() -> Result<()> {
     // Test number formatting preserved through array iteration with --preserve-input
-    let (output, code) = run_jq_stdin(".[]", r#"[1e100, 2e-100]"#, &["-c", "--preserve-input"])?;
+    let (output, code) = run_jq_stdin(".[]", r"[1e100, 2e-100]", &["-c", "--preserve-input"])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "1e100\n2e-100");
     Ok(())
@@ -1151,8 +1151,7 @@ fn test_include_directive() -> Result<()> {
 
     assert!(
         !stderr.contains("compile error"),
-        "Should parse include directive without error: {}",
-        stderr
+        "Should parse include directive without error: {stderr}"
     );
     assert_eq!(stdout.trim(), "42", "21 | double should equal 42");
     Ok(())
@@ -1189,8 +1188,7 @@ fn test_import_directive() -> Result<()> {
 
     assert!(
         !stderr.contains("compile error"),
-        "Should parse import directive without error: {}",
-        stderr
+        "Should parse import directive without error: {stderr}"
     );
     assert_eq!(stdout.trim(), "30", "10 | m::triple should equal 30");
     Ok(())
@@ -1251,8 +1249,7 @@ fn test_jq_library_path_env() -> Result<()> {
 
     assert!(
         !stderr.contains("compile error"),
-        "Should parse include directive without error: {}",
-        stderr
+        "Should parse include directive without error: {stderr}"
     );
     assert_eq!(stdout.trim(), "20", "5 | quadruple should equal 20");
     Ok(())
@@ -1282,8 +1279,7 @@ fn test_module_not_found_error() -> Result<()> {
     // Should produce a module error
     assert!(
         stderr.contains("module") && stderr.contains("not found"),
-        "Should report module not found error: {}",
-        stderr
+        "Should report module not found error: {stderr}"
     );
     Ok(())
 }
@@ -1313,8 +1309,7 @@ fn test_namespaced_call_parse() -> Result<()> {
     // Not a compile error, but an eval error
     assert!(
         !stderr.contains("compile error"),
-        "Should parse namespaced call without compile error: {}",
-        stderr
+        "Should parse namespaced call without compile error: {stderr}"
     );
     Ok(())
 }
@@ -1350,8 +1345,7 @@ fn test_home_jq_file_autoload() -> Result<()> {
     // Should successfully execute the function
     assert!(
         !stderr.contains("compile error"),
-        "Should not have compile error: {}",
-        stderr
+        "Should not have compile error: {stderr}"
     );
 
     // The function should multiply by 100
@@ -1394,8 +1388,7 @@ fn test_home_jq_dir_search_path() -> Result<()> {
 
     assert!(
         !stderr.contains("compile error") && !stderr.contains("module error"),
-        "Should find module in ~/.jq directory: {}",
-        stderr
+        "Should find module in ~/.jq directory: {stderr}"
     );
     assert_eq!(stdout.trim(), "1007", "7 | home_func should equal 1007");
     Ok(())
@@ -1433,8 +1426,7 @@ fn test_import_with_namespace() -> Result<()> {
     // Should not have errors
     assert!(
         !stderr.contains("compile error") && !stderr.contains("module error"),
-        "Should import module and use namespaced function: {}",
-        stderr
+        "Should import module and use namespaced function: {stderr}"
     );
 
     // Should output 10 (5 * 2)
@@ -1546,11 +1538,11 @@ fn test_seq_ignores_parse_errors() -> Result<()> {
     // Should only see outputs from valid JSON (1 and 2), not the invalid segment
     let output_str = String::from_utf8(output)?;
     assert!(
-        output_str.contains("1"),
+        output_str.contains('1'),
         "Should have output from first valid value"
     );
     assert!(
-        output_str.contains("2"),
+        output_str.contains('2'),
         "Should have output from second valid value"
     );
     Ok(())
@@ -1559,7 +1551,7 @@ fn test_seq_ignores_parse_errors() -> Result<()> {
 #[test]
 fn test_seq_multiple_outputs() -> Result<()> {
     // Each output from iterator should get RS prefix
-    let (output, code) = run_jq_binary_stdin(".[]", br#"[1,2,3]"#, &["--seq"])?;
+    let (output, code) = run_jq_binary_stdin(".[]", br"[1,2,3]", &["--seq"])?;
     assert_eq!(code, 0);
 
     // Count RS characters - should be 3 (one per output)

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -18,7 +18,11 @@ fn full_outputs(json: &[u8], filter: &str) -> Vec<String> {
     let cursor = index.root(json);
     let expr = parse(filter).expect("parse failed");
     let result: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
-    result.collect_owned().iter().map(succinctly::jq::OwnedValue::to_json).collect()
+    result
+        .collect_owned()
+        .iter()
+        .map(succinctly::jq::OwnedValue::to_json)
+        .collect()
 }
 
 /// Outputs of the generic evaluator (`src/jq/eval_generic.rs`, the CLI path).
@@ -27,7 +31,11 @@ fn generic_outputs(json: &[u8], filter: &str) -> Vec<String> {
     let cursor = index.root(json);
     let expr = parse(filter).expect("parse failed");
     let result = eval_generic::eval_with_cursor(&expr, cursor);
-    result.collect_owned().iter().map(succinctly::jq::OwnedValue::to_json).collect()
+    result
+        .collect_owned()
+        .iter()
+        .map(succinctly::jq::OwnedValue::to_json)
+        .collect()
 }
 
 fn as_strs(v: &[String]) -> Vec<&str> {

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -18,7 +18,7 @@ fn full_outputs(json: &[u8], filter: &str) -> Vec<String> {
     let cursor = index.root(json);
     let expr = parse(filter).expect("parse failed");
     let result: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
-    result.collect_owned().iter().map(|v| v.to_json()).collect()
+    result.collect_owned().iter().map(succinctly::jq::OwnedValue::to_json).collect()
 }
 
 /// Outputs of the generic evaluator (`src/jq/eval_generic.rs`, the CLI path).
@@ -27,7 +27,7 @@ fn generic_outputs(json: &[u8], filter: &str) -> Vec<String> {
     let cursor = index.root(json);
     let expr = parse(filter).expect("parse failed");
     let result = eval_generic::eval_with_cursor(&expr, cursor);
-    result.collect_owned().iter().map(|v| v.to_json()).collect()
+    result.collect_owned().iter().map(succinctly::jq::OwnedValue::to_json).collect()
 }
 
 fn as_strs(v: &[String]) -> Vec<&str> {
@@ -71,22 +71,22 @@ fn assert_divergence(json: &[u8], filter: &str, full_expected: &[&str], generic_
 #[test]
 fn test_parity_values_builtin() {
     // `values` drops null inputs.
-    assert_parity(br#"[1,null,2,null,3]"#, "[.[] | values]");
+    assert_parity(br"[1,null,2,null,3]", "[.[] | values]");
     assert_parity(br#"{"a":1,"b":null,"c":3}"#, "[.[] | values]");
 }
 
 #[test]
 fn test_parity_first_last() {
-    assert_parity(br#"[10,20,30]"#, "first(.[])");
-    assert_parity(br#"[10,20,30]"#, "last(.[])");
-    assert_parity(br#"[10,20,30]"#, "first");
-    assert_parity(br#"[10,20,30]"#, "last");
+    assert_parity(br"[10,20,30]", "first(.[])");
+    assert_parity(br"[10,20,30]", "last(.[])");
+    assert_parity(br"[10,20,30]", "first");
+    assert_parity(br"[10,20,30]", "last");
 }
 
 #[test]
 fn test_parity_first_last_empty() {
-    assert_parity(br#"[]"#, "first(.[])");
-    assert_parity(br#"[]"#, "last(.[])");
+    assert_parity(br"[]", "first(.[])");
+    assert_parity(br"[]", "last(.[])");
 }
 
 #[test]
@@ -110,6 +110,6 @@ fn test_out_of_bounds_index_diverges_161_162() {
     // The FULL evaluator matches; the generic (CLI) path yields NO output --
     // bug #161/#162.
     for filter in [".[5]", ".[-5]", ".[100]"] {
-        assert_divergence(br#"[1,2,3]"#, filter, &["null"], &[]);
+        assert_divergence(br"[1,2,3]", filter, &["null"], &[]);
     }
 }

--- a/tests/jq_numeric_equality_tests.rs
+++ b/tests/jq_numeric_equality_tests.rs
@@ -24,7 +24,7 @@ fn full_outputs(json: &[u8], filter: &str) -> Vec<String> {
     let cursor = index.root(json);
     let expr = parse(filter).expect("parse failed");
     let result: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
-    result.collect_owned().iter().map(|v| v.to_json()).collect()
+    result.collect_owned().iter().map(succinctly::jq::OwnedValue::to_json).collect()
 }
 
 /// Convenience: assert the filter produces exactly one output and return it.
@@ -59,7 +59,7 @@ fn test_eq_int_vs_float_diverges_156() {
 fn test_unique_dedups_int_and_float() {
     // `unique` sorts with the ordering-based comparison, which treats 1 and
     // 1.0 as equal -> a single element. This already matches jq.
-    assert_eq!(one(br#"[1,1.0]"#, "unique"), "[1]");
+    assert_eq!(one(br"[1,1.0]", "unique"), "[1]");
 }
 
 #[test]
@@ -68,17 +68,17 @@ fn test_difference_int_float_diverges_156() {
     // The FULL evaluator compares Int(1) != Float(1.0), so 1.0 is NOT removed.
     // This ALSO diverges from the generic/CLI path (which yields `[2,3]`) — see
     // the evaluator-parity tests, which pin that drift explicitly.
-    assert_eq!(one(br#"[1.0,2,3]"#, ". - [1]"), "[1,2,3]");
+    assert_eq!(one(br"[1.0,2,3]", ". - [1]"), "[1,2,3]");
 }
 
 #[test]
 fn test_contains_int_float_diverges_156() {
     // jq: `[1,2,3] | contains([1.0])` is `true`; succinctly currently `false`.
-    assert_eq!(one(br#"[1,2,3]"#, "contains([1.0])"), "false");
+    assert_eq!(one(br"[1,2,3]", "contains([1.0])"), "false");
 }
 
 #[test]
 fn test_index_int_float_diverges_156() {
     // jq: `[2,1,3] | index(1.0)` is `1`; succinctly currently `null`.
-    assert_eq!(one(br#"[2,1,3]"#, "index(1.0)"), "null");
+    assert_eq!(one(br"[2,1,3]", "index(1.0)"), "null");
 }

--- a/tests/jq_numeric_equality_tests.rs
+++ b/tests/jq_numeric_equality_tests.rs
@@ -24,7 +24,11 @@ fn full_outputs(json: &[u8], filter: &str) -> Vec<String> {
     let cursor = index.root(json);
     let expr = parse(filter).expect("parse failed");
     let result: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
-    result.collect_owned().iter().map(succinctly::jq::OwnedValue::to_json).collect()
+    result
+        .collect_owned()
+        .iter()
+        .map(succinctly::jq::OwnedValue::to_json)
+        .collect()
 }
 
 /// Convenience: assert the filter produces exactly one output and return it.

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -62,7 +62,7 @@ fn test_identity_object() {
 
 #[test]
 fn test_identity_array() {
-    query!(br#"[1, 2, 3]"#, ".", QueryResult::OneCursor(_) => {});
+    query!(br"[1, 2, 3]", ".", QueryResult::OneCursor(_) => {});
 }
 
 #[test]
@@ -124,7 +124,7 @@ fn test_field_missing_returns_null() {
 
 #[test]
 fn test_field_on_non_object_error() {
-    query!(br#"[1, 2, 3]"#, ".foo",
+    query!(br"[1, 2, 3]", ".foo",
         QueryResult::Error(e) => {
             assert!(e.message.contains("object"), "expected type error");
         }
@@ -151,7 +151,7 @@ fn test_field_with_underscore() {
 
 #[test]
 fn test_index_first() {
-    query!(br#"[10, 20, 30]"#, ".[0]",
+    query!(br"[10, 20, 30]", ".[0]",
         QueryResult::One(StandardJson::Number(n)) => {
             assert_eq!(n.as_i64().unwrap(), 10);
         }
@@ -160,7 +160,7 @@ fn test_index_first() {
 
 #[test]
 fn test_index_last() {
-    query!(br#"[10, 20, 30]"#, ".[2]",
+    query!(br"[10, 20, 30]", ".[2]",
         QueryResult::One(StandardJson::Number(n)) => {
             assert_eq!(n.as_i64().unwrap(), 30);
         }
@@ -169,12 +169,12 @@ fn test_index_last() {
 
 #[test]
 fn test_index_negative() {
-    query!(br#"[10, 20, 30, 40]"#, ".[-1]",
+    query!(br"[10, 20, 30, 40]", ".[-1]",
         QueryResult::One(StandardJson::Number(n)) => {
             assert_eq!(n.as_i64().unwrap(), 40);
         }
     );
-    query!(br#"[10, 20, 30, 40]"#, ".[-2]",
+    query!(br"[10, 20, 30, 40]", ".[-2]",
         QueryResult::One(StandardJson::Number(n)) => {
             assert_eq!(n.as_i64().unwrap(), 30);
         }
@@ -184,7 +184,7 @@ fn test_index_negative() {
 #[test]
 fn test_index_out_of_bounds_returns_null() {
     // jq returns null for out-of-bounds array access (not an error)
-    query!(br#"[1, 2, 3]"#, ".[10]",
+    query!(br"[1, 2, 3]", ".[10]",
         QueryResult::One(StandardJson::Null) => {}
     );
 }
@@ -192,7 +192,7 @@ fn test_index_out_of_bounds_returns_null() {
 #[test]
 fn test_index_negative_out_of_bounds_returns_null() {
     // jq returns null for negative out-of-bounds array access (not an error)
-    query!(br#"[1, 2, 3]"#, ".[-10]",
+    query!(br"[1, 2, 3]", ".[-10]",
         QueryResult::One(StandardJson::Null) => {}
     );
 }
@@ -228,7 +228,7 @@ fn test_index_on_non_array_error() {
 
 #[test]
 fn test_iterate_array() {
-    query!(br#"[1, 2, 3, 4, 5]"#, ".[]",
+    query!(br"[1, 2, 3, 4, 5]", ".[]",
         QueryResult::Many(values) => {
             assert_eq!(values.len(), 5);
         }
@@ -250,7 +250,7 @@ fn test_iterate_object_values() {
 
 #[test]
 fn test_iterate_empty_array() {
-    query!(br#"[]"#, ".[]",
+    query!(br"[]", ".[]",
         QueryResult::Many(values) => {
             assert!(values.is_empty());
         }
@@ -259,7 +259,7 @@ fn test_iterate_empty_array() {
 
 #[test]
 fn test_iterate_empty_object() {
-    query!(br#"{}"#, ".[]",
+    query!(br"{}", ".[]",
         QueryResult::Many(values) => {
             assert!(values.is_empty());
         }
@@ -281,7 +281,7 @@ fn test_iterate_on_scalar_error() {
 
 #[test]
 fn test_slice_range() {
-    query!(br#"[0, 1, 2, 3, 4, 5]"#, ".[1:4]",
+    query!(br"[0, 1, 2, 3, 4, 5]", ".[1:4]",
         QueryResult::Many(values) => {
             assert_eq!(values.len(), 3);
         }
@@ -290,7 +290,7 @@ fn test_slice_range() {
 
 #[test]
 fn test_slice_from_start() {
-    query!(br#"[0, 1, 2, 3, 4]"#, ".[:2]",
+    query!(br"[0, 1, 2, 3, 4]", ".[:2]",
         QueryResult::Many(values) => {
             assert_eq!(values.len(), 2);
         }
@@ -299,7 +299,7 @@ fn test_slice_from_start() {
 
 #[test]
 fn test_slice_to_end() {
-    query!(br#"[0, 1, 2, 3, 4]"#, ".[3:]",
+    query!(br"[0, 1, 2, 3, 4]", ".[3:]",
         QueryResult::Many(values) => {
             assert_eq!(values.len(), 2); // indices 3, 4
         }
@@ -308,7 +308,7 @@ fn test_slice_to_end() {
 
 #[test]
 fn test_slice_negative_indices() {
-    query!(br#"[0, 1, 2, 3, 4, 5]"#, ".[-3:-1]",
+    query!(br"[0, 1, 2, 3, 4, 5]", ".[-3:-1]",
         QueryResult::Many(values) => {
             assert_eq!(values.len(), 2); // indices 3, 4 (elements 3, 4)
         }
@@ -317,7 +317,7 @@ fn test_slice_negative_indices() {
 
 #[test]
 fn test_slice_empty_result() {
-    query!(br#"[0, 1, 2]"#, ".[5:10]",
+    query!(br"[0, 1, 2]", ".[5:10]",
         QueryResult::Many(values) => {
             assert!(values.is_empty());
         }
@@ -384,7 +384,7 @@ fn test_optional_field_present() {
 #[test]
 fn test_optional_index_out_of_bounds_returns_null() {
     // jq returns null for optional out-of-bounds (not empty)
-    query!(br#"[1, 2, 3]"#, ".[10]?",
+    query!(br"[1, 2, 3]", ".[10]?",
         QueryResult::One(StandardJson::Null) => {}
     );
 }
@@ -492,7 +492,7 @@ fn test_lenient_missing_field_optional_returns_null() {
 
 #[test]
 fn test_lenient_many() {
-    query_lenient!(br#"[1, 2, 3]"#, ".[]", len == 3);
+    query_lenient!(br"[1, 2, 3]", ".[]", len == 3);
 }
 
 // =============================================================================
@@ -548,7 +548,7 @@ fn test_whitespace_in_expression() {
 
 #[test]
 fn test_deeply_nested_arrays() {
-    query!(br#"[[[[1]]]]"#, ".[0][0][0][0]",
+    query!(br"[[[[1]]]]", ".[0][0][0][0]",
         QueryResult::One(StandardJson::Number(n)) => {
             assert_eq!(n.as_i64().unwrap(), 1);
         }
@@ -679,8 +679,8 @@ fn test_now_returns_timestamp() {
             // Verify it's a reasonable timestamp (after 2024-01-01 and not too far in the future)
             let jan_2024 = 1704067200.0; // 2024-01-01 00:00:00 UTC
             let jan_2100 = 4102444800.0; // 2100-01-01 00:00:00 UTC
-            assert!(ts > jan_2024, "timestamp {} should be after 2024-01-01", ts);
-            assert!(ts < jan_2100, "timestamp {} should be before 2100-01-01", ts);
+            assert!(ts > jan_2024, "timestamp {ts} should be after 2024-01-01");
+            assert!(ts < jan_2100, "timestamp {ts} should be before 2100-01-01");
         }
     );
 }
@@ -691,7 +691,7 @@ fn test_now_ignores_input() {
     query!(br#"{"foo": "bar"}"#, "now",
         QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
             let jan_2024 = 1704067200.0;
-            assert!(ts > jan_2024, "timestamp {} should be after 2024-01-01", ts);
+            assert!(ts > jan_2024, "timestamp {ts} should be after 2024-01-01");
         }
     );
 }
@@ -732,7 +732,7 @@ fn test_has_on_object_missing() {
 
 #[test]
 fn test_has_on_array() {
-    query!(br#"[1, 2, 3]"#, "has(1)",
+    query!(br"[1, 2, 3]", "has(1)",
         QueryResult::Owned(OwnedValue::Bool(b)) => {
             assert!(b);
         }
@@ -741,7 +741,7 @@ fn test_has_on_array() {
 
 #[test]
 fn test_has_on_array_out_of_bounds() {
-    query!(br#"[1, 2, 3]"#, "has(10)",
+    query!(br"[1, 2, 3]", "has(10)",
         QueryResult::Owned(OwnedValue::Bool(b)) => {
             assert!(!b);
         }
@@ -947,7 +947,7 @@ fn test_integer_addition_overflow_converts_to_float() {
     query!(b"null", "9223372036854775807 + 1",
         QueryResult::Owned(OwnedValue::Float(f)) => {
             // jq converts to float, so result is approximately 9.22e18
-            assert!(f > 9e18, "expected large positive float, got {}", f);
+            assert!(f > 9e18, "expected large positive float, got {f}");
         }
     );
 }
@@ -958,7 +958,7 @@ fn test_integer_multiplication_overflow_converts_to_float() {
     query!(b"null", "9223372036854775807 * 2",
         QueryResult::Owned(OwnedValue::Float(f)) => {
             // jq converts to float, so result is approximately 1.84e19
-            assert!(f > 1e19, "expected large positive float, got {}", f);
+            assert!(f > 1e19, "expected large positive float, got {f}");
         }
     );
 }
@@ -968,7 +968,7 @@ fn test_integer_subtraction_overflow_converts_to_float() {
     // jq: -9223372036854775808 - 1 => -9223372036854776000 (float)
     query!(b"null", "-9223372036854775808 - 1",
         QueryResult::Owned(OwnedValue::Float(f)) => {
-            assert!(f < -9e18, "expected large negative float, got {}", f);
+            assert!(f < -9e18, "expected large negative float, got {f}");
         }
     );
 }
@@ -1060,8 +1060,8 @@ fn test_split_empty_delimiter() {
             let expected = ["h", "e", "l", "l", "o"];
             for (i, (actual, exp)) in arr.iter().zip(expected.iter()).enumerate() {
                 match actual {
-                    OwnedValue::String(s) => assert_eq!(s, *exp, "element {} mismatch", i),
-                    _ => panic!("expected string at index {}", i),
+                    OwnedValue::String(s) => assert_eq!(s, *exp, "element {i} mismatch"),
+                    _ => panic!("expected string at index {i}"),
                 }
             }
         }
@@ -1073,7 +1073,7 @@ fn test_split_empty_delimiter_on_empty_string() {
     // jq: "" | split("") => []
     query!(br#""""#, r#"split("")"#,
         QueryResult::Owned(OwnedValue::Array(arr)) => {
-            assert!(arr.is_empty(), "split(\"\") on empty string should return [], got {:?}", arr);
+            assert!(arr.is_empty(), "split(\"\") on empty string should return [], got {arr:?}");
         }
     );
 }
@@ -1112,7 +1112,7 @@ fn test_csv_quotes_fields_with_comma() {
     query!(br#"["a", "b,c"]"#, "@csv",
         QueryResult::Owned(OwnedValue::String(s)) => {
             // Must contain quoted "b,c"
-            assert!(s.contains("\"b,c\""), "comma in field should be quoted: {}", s);
+            assert!(s.contains("\"b,c\""), "comma in field should be quoted: {s}");
         }
     );
 }
@@ -1123,7 +1123,7 @@ fn test_csv_escapes_quotes() {
     query!(br#"["a\"b"]"#, "@csv",
         QueryResult::Owned(OwnedValue::String(s)) => {
             // Quote in field should be doubled
-            assert!(s.contains("\"\""), "quote in field should be doubled: {}", s);
+            assert!(s.contains("\"\""), "quote in field should be doubled: {s}");
         }
     );
 }

--- a/tests/json_indexing_tests.rs
+++ b/tests/json_indexing_tests.rs
@@ -157,7 +157,7 @@ mod simple_cursor {
             if i > 0 {
                 json.push(b',');
             }
-            json.extend_from_slice(format!("{}", i).as_bytes());
+            json.extend_from_slice(format!("{i}").as_bytes());
         }
         json.push(b']');
 
@@ -302,9 +302,9 @@ mod standard_cursor {
             if i > 0 {
                 json.push(b',');
             }
-            json.extend_from_slice(format!(r#"{{"id":{},"value":"item{}"}}"#, i, i).as_bytes());
+            json.extend_from_slice(format!(r#"{{"id":{i},"value":"item{i}"}}"#).as_bytes());
         }
-        json.extend_from_slice(br#"]}"#);
+        json.extend_from_slice(br"]}");
 
         let semi = standard::build_semi_index(&json);
         assert_eq!(semi.state, standard::State::InJson);
@@ -386,7 +386,7 @@ mod simd_comparison {
     #[test]
     fn test_simd_nested() {
         compare_results(br#"{"a":{"b":{"c":1}}}"#);
-        compare_results(br#"[[[1,2],[3,4]],[[5,6]]]"#);
+        compare_results(br"[[[1,2],[3,4]],[[5,6]]]");
         compare_results(br#"{"a":[1,{"b":2}]}"#);
     }
 
@@ -846,7 +846,7 @@ mod locate_exhaustive {
     fn test_locate_deep_nesting_20() {
         let mut json = Vec::new();
         for i in 0..20 {
-            json.extend(format!(r#"{{"level{}":"v{}","n":"#, i, i).as_bytes());
+            json.extend(format!(r#"{{"level{i}":"v{i}","n":"#).as_bytes());
         }
         json.extend(br#""bottom""#);
         json.resize(json.len() + 20, b'}');
@@ -862,8 +862,7 @@ mod locate_exhaustive {
             }
             json.extend(
                 format!(
-                    r#"{{"id":{},"name":"user{}","tags":["a","b"],"meta":{{"x":{}}}}}"#,
-                    i, i, i
+                    r#"{{"id":{i},"name":"user{i}","tags":["a","b"],"meta":{{"x":{i}}}}}"#
                 )
                 .as_bytes(),
             );
@@ -882,7 +881,7 @@ mod locate_exhaustive {
             }
             // Varying length strings
             let s = "x".repeat(i % 50 + 1);
-            json.extend(format!(r#""{}""#, s).as_bytes());
+            json.extend(format!(r#""{s}""#).as_bytes());
         }
         json.extend(b"]}");
         test_all_offsets(&json, "String-heavy (200 strings)");

--- a/tests/json_indexing_tests.rs
+++ b/tests/json_indexing_tests.rs
@@ -861,10 +861,8 @@ mod locate_exhaustive {
                 json.push(b',');
             }
             json.extend(
-                format!(
-                    r#"{{"id":{i},"name":"user{i}","tags":["a","b"],"meta":{{"x":{i}}}}}"#
-                )
-                .as_bytes(),
+                format!(r#"{{"id":{i},"name":"user{i}","tags":["a","b"],"meta":{{"x":{i}}}}}"#)
+                    .as_bytes(),
             );
         }
         json.extend(b"]}");

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -96,7 +96,7 @@ fn run_validate_file(file_path: &str, extra_args: &[&str]) -> Result<(String, St
 #[test]
 fn test_valid_json_exit_code_0() -> Result<()> {
     let (stdout, stderr, exit_code) = run_validate_stdin(r#"{"key": "value"}"#, &[])?;
-    assert_eq!(exit_code, 0, "stdout: {}, stderr: {}", stdout, stderr);
+    assert_eq!(exit_code, 0, "stdout: {stdout}, stderr: {stderr}");
     assert!(stdout.is_empty(), "stdout should be empty for valid JSON");
     Ok(())
 }
@@ -158,8 +158,7 @@ fn test_quiet_mode_no_output() -> Result<()> {
         .join("\n");
     assert!(
         app_stderr.is_empty(),
-        "stderr should be empty in quiet mode, got: {}",
-        app_stderr
+        "stderr should be empty in quiet mode, got: {app_stderr}"
     );
     Ok(())
 }
@@ -363,7 +362,7 @@ fn test_file_input_valid() -> Result<()> {
     file.flush()?;
 
     let (stdout, stderr, exit_code) = run_validate_file(file.path().to_str().unwrap(), &[])?;
-    assert_eq!(exit_code, 0, "stdout: {}, stderr: {}", stdout, stderr);
+    assert_eq!(exit_code, 0, "stdout: {stdout}, stderr: {stderr}");
     Ok(())
 }
 
@@ -499,8 +498,7 @@ fn test_alignment_single_digit_line() -> Result<()> {
     // Verify the error is on line 9
     assert!(
         stderr.contains(":9:"),
-        "Error should be on line 9, got:\n{}",
-        stderr
+        "Error should be on line 9, got:\n{stderr}"
     );
 
     // Verify pipe alignment: all '|' should be at the same column
@@ -513,8 +511,7 @@ fn test_alignment_single_digit_line() -> Result<()> {
     for col in &pipe_cols {
         assert_eq!(
             *col, first_col,
-            "All pipes should be at the same column, got {:?}",
-            pipe_cols
+            "All pipes should be at the same column, got {pipe_cols:?}"
         );
     }
     Ok(())
@@ -531,8 +528,7 @@ fn test_alignment_double_digit_line() -> Result<()> {
     // Verify the error is on line 10
     assert!(
         stderr.contains(":10:"),
-        "Error should be on line 10, got:\n{}",
-        stderr
+        "Error should be on line 10, got:\n{stderr}"
     );
 
     // Verify pipe alignment
@@ -545,8 +541,7 @@ fn test_alignment_double_digit_line() -> Result<()> {
     for col in &pipe_cols {
         assert_eq!(
             *col, first_col,
-            "All pipes should be at the same column, got {:?}",
-            pipe_cols
+            "All pipes should be at the same column, got {pipe_cols:?}"
         );
     }
     Ok(())
@@ -563,8 +558,7 @@ fn test_alignment_triple_digit_line() -> Result<()> {
     // Verify the error is on line 999
     assert!(
         stderr.contains(":999:"),
-        "Error should be on line 999, got:\n{}",
-        stderr
+        "Error should be on line 999, got:\n{stderr}"
     );
 
     // Verify pipe alignment
@@ -577,8 +571,7 @@ fn test_alignment_triple_digit_line() -> Result<()> {
     for col in &pipe_cols {
         assert_eq!(
             *col, first_col,
-            "All pipes should be at the same column, got {:?}",
-            pipe_cols
+            "All pipes should be at the same column, got {pipe_cols:?}"
         );
     }
     Ok(())
@@ -595,8 +588,7 @@ fn test_alignment_four_digit_line() -> Result<()> {
     // Verify the error is on line 1000
     assert!(
         stderr.contains(":1000:"),
-        "Error should be on line 1000, got:\n{}",
-        stderr
+        "Error should be on line 1000, got:\n{stderr}"
     );
 
     // Verify pipe alignment
@@ -609,8 +601,7 @@ fn test_alignment_four_digit_line() -> Result<()> {
     for col in &pipe_cols {
         assert_eq!(
             *col, first_col,
-            "All pipes should be at the same column, got {:?}",
-            pipe_cols
+            "All pipes should be at the same column, got {pipe_cols:?}"
         );
     }
     Ok(())

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -299,14 +299,14 @@ fn test_100k_bits_random_pattern() {
     // Sample some rank queries
     for i in (0..102400).step_by(1000) {
         let expected = naive_rank1(&words, 102400, i);
-        assert_eq!(bv.rank1(i), expected, "rank1({}) mismatch", i);
+        assert_eq!(bv.rank1(i), expected, "rank1({i}) mismatch");
     }
 
     // Sample some select queries
     let ones = bv.count_ones();
     for k in (0..ones).step_by(1000) {
         let expected = naive_select1(&words, 102400, k);
-        assert_eq!(bv.select1(k), expected, "select1({}) mismatch", k);
+        assert_eq!(bv.select1(k), expected, "select1({k}) mismatch");
     }
 }
 
@@ -358,7 +358,7 @@ fn test_many_blocks() {
     for block in 0..16 {
         let pos = block * 512;
         let expected = block * 8; // 8 ones per block
-        assert_eq!(bv.rank1(pos), expected, "rank1({}) at block {}", pos, block);
+        assert_eq!(bv.rank1(pos), expected, "rank1({pos}) at block {block}");
     }
 }
 
@@ -376,7 +376,7 @@ fn test_word_boundaries_rank() {
     for word_idx in 0..16 {
         let pos = word_idx * 64;
         let expected = word_idx * 8;
-        assert_eq!(bv.rank1(pos), expected, "rank1({}) at word boundary", pos);
+        assert_eq!(bv.rank1(pos), expected, "rank1({pos}) at word boundary");
     }
 }
 
@@ -391,8 +391,7 @@ fn test_word_boundaries_select() {
         assert_eq!(
             bv.select1(k),
             Some(expected),
-            "select1({}) at word boundary",
-            k
+            "select1({k}) at word boundary"
         );
     }
 }
@@ -889,7 +888,7 @@ proptest! {
         for l1_block in 0..(len / 2048) {
             let boundary = l1_block * 2048;
             // Test positions around boundary
-            for offset in [0, 1, 31, 32, 33, 63, 64, 65].iter() {
+            for offset in &[0, 1, 31, 32, 33, 63, 64, 65] {
                 let p = boundary.saturating_add(*offset);
                 if p < len && bp.is_open(p) {
                     let bp_result = bp.find_close(p);
@@ -913,7 +912,7 @@ proptest! {
         for l2_block in 0..(len / 65536).max(1) {
             let boundary = l2_block * 65536;
             // Test positions around boundary
-            for offset in [0, 1, 63, 64, 65, 2047, 2048, 2049].iter() {
+            for offset in &[0, 1, 63, 64, 65, 2047, 2048, 2049] {
                 let p = boundary.saturating_add(*offset);
                 if p < len && bp.is_open(p) {
                     let bp_result = bp.find_close(p);
@@ -957,9 +956,7 @@ fn test_large_deeply_nested() {
         assert_eq!(
             bp.find_close(i),
             Some(expected_close),
-            "find_close({}) should be {}",
-            i,
-            expected_close
+            "find_close({i}) should be {expected_close}"
         );
     }
 
@@ -996,9 +993,7 @@ fn test_large_flat_sequence() {
             assert_eq!(
                 bp.find_close(p),
                 Some(p + 1),
-                "find_close({}) at block {} boundary",
-                p,
-                block
+                "find_close({p}) at block {block} boundary"
             );
         }
     }
@@ -1059,8 +1054,7 @@ fn test_large_mixed_structure() {
             let linear_result = find_close(&words, len, p);
             assert_eq!(
                 bp_result, linear_result,
-                "find_close({}) mismatch in mixed structure",
-                p
+                "find_close({p}) mismatch in mixed structure"
             );
         }
     }
@@ -1073,8 +1067,7 @@ fn test_large_mixed_structure() {
             let linear_result = find_close(&words, len, boundary);
             assert_eq!(
                 bp_result, linear_result,
-                "find_close({}) mismatch at L1 boundary",
-                boundary
+                "find_close({boundary}) mismatch at L1 boundary"
             );
         }
     }
@@ -1100,8 +1093,7 @@ fn test_million_bit_random() {
         let linear_result = find_close(&words, len, p);
         assert_eq!(
             bp_result, linear_result,
-            "find_close({}) mismatch in 1M bit test",
-            p
+            "find_close({p}) mismatch in 1M bit test"
         );
     }
 }

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -39,15 +39,14 @@ mod bitvec_serde {
 
         // Verify rank/select still work correctly
         for i in 0..bv.len() {
-            assert_eq!(restored.rank1(i), bv.rank1(i), "rank1 mismatch at {}", i);
+            assert_eq!(restored.rank1(i), bv.rank1(i), "rank1 mismatch at {i}");
         }
 
         for k in 0..bv.count_ones() {
             assert_eq!(
                 restored.select1(k),
                 bv.select1(k),
-                "select1 mismatch at {}",
-                k
+                "select1 mismatch at {k}"
             );
         }
     }
@@ -310,8 +309,7 @@ mod compact_serde {
                 assert_eq!(
                     restored.find_close(p),
                     bp.find_close(p),
-                    "find_close mismatch at {}",
-                    p
+                    "find_close mismatch at {p}"
                 );
             }
         }

--- a/tests/simd_level_tests.rs
+++ b/tests/simd_level_tests.rs
@@ -35,24 +35,24 @@ mod x86_simd_levels {
 
             // SSE2 (always available on x86_64)
             let sse2 = json::simd::x86::build_semi_index_standard(json);
-            assert_eq!(sse2.ib, scalar.ib, "{}: SSE2 IB mismatch", name);
-            assert_eq!(sse2.bp, scalar.bp, "{}: SSE2 BP mismatch", name);
-            assert_eq!(sse2.state, scalar.state, "{}: SSE2 state mismatch", name);
+            assert_eq!(sse2.ib, scalar.ib, "{name}: SSE2 IB mismatch");
+            assert_eq!(sse2.bp, scalar.bp, "{name}: SSE2 BP mismatch");
+            assert_eq!(sse2.state, scalar.state, "{name}: SSE2 state mismatch");
 
             // SSE4.2 (if supported)
             if is_x86_feature_detected!("sse4.2") {
                 let sse42 = json::simd::sse42::build_semi_index_standard(json);
-                assert_eq!(sse42.ib, scalar.ib, "{}: SSE4.2 IB mismatch", name);
-                assert_eq!(sse42.bp, scalar.bp, "{}: SSE4.2 BP mismatch", name);
-                assert_eq!(sse42.state, scalar.state, "{}: SSE4.2 state mismatch", name);
+                assert_eq!(sse42.ib, scalar.ib, "{name}: SSE4.2 IB mismatch");
+                assert_eq!(sse42.bp, scalar.bp, "{name}: SSE4.2 BP mismatch");
+                assert_eq!(sse42.state, scalar.state, "{name}: SSE4.2 state mismatch");
             }
 
             // AVX2 (if supported)
             if is_x86_feature_detected!("avx2") {
                 let avx2 = json::simd::avx2::build_semi_index_standard(json);
-                assert_eq!(avx2.ib, scalar.ib, "{}: AVX2 IB mismatch", name);
-                assert_eq!(avx2.bp, scalar.bp, "{}: AVX2 BP mismatch", name);
-                assert_eq!(avx2.state, scalar.state, "{}: AVX2 state mismatch", name);
+                assert_eq!(avx2.ib, scalar.ib, "{name}: AVX2 IB mismatch");
+                assert_eq!(avx2.bp, scalar.bp, "{name}: AVX2 BP mismatch");
+                assert_eq!(avx2.state, scalar.state, "{name}: AVX2 state mismatch");
             }
         }
     }
@@ -65,24 +65,24 @@ mod x86_simd_levels {
 
             // SSE2 (always available on x86_64)
             let sse2 = json::simd::x86::build_semi_index_simple(json);
-            assert_eq!(sse2.ib, scalar.ib, "{}: SSE2 IB mismatch", name);
-            assert_eq!(sse2.bp, scalar.bp, "{}: SSE2 BP mismatch", name);
-            assert_eq!(sse2.state, scalar.state, "{}: SSE2 state mismatch", name);
+            assert_eq!(sse2.ib, scalar.ib, "{name}: SSE2 IB mismatch");
+            assert_eq!(sse2.bp, scalar.bp, "{name}: SSE2 BP mismatch");
+            assert_eq!(sse2.state, scalar.state, "{name}: SSE2 state mismatch");
 
             // SSE4.2 (if supported)
             if is_x86_feature_detected!("sse4.2") {
                 let sse42 = json::simd::sse42::build_semi_index_simple(json);
-                assert_eq!(sse42.ib, scalar.ib, "{}: SSE4.2 IB mismatch", name);
-                assert_eq!(sse42.bp, scalar.bp, "{}: SSE4.2 BP mismatch", name);
-                assert_eq!(sse42.state, scalar.state, "{}: SSE4.2 state mismatch", name);
+                assert_eq!(sse42.ib, scalar.ib, "{name}: SSE4.2 IB mismatch");
+                assert_eq!(sse42.bp, scalar.bp, "{name}: SSE4.2 BP mismatch");
+                assert_eq!(sse42.state, scalar.state, "{name}: SSE4.2 state mismatch");
             }
 
             // AVX2 (if supported)
             if is_x86_feature_detected!("avx2") {
                 let avx2 = json::simd::avx2::build_semi_index_simple(json);
-                assert_eq!(avx2.ib, scalar.ib, "{}: AVX2 IB mismatch", name);
-                assert_eq!(avx2.bp, scalar.bp, "{}: AVX2 BP mismatch", name);
-                assert_eq!(avx2.state, scalar.state, "{}: AVX2 state mismatch", name);
+                assert_eq!(avx2.ib, scalar.ib, "{name}: AVX2 IB mismatch");
+                assert_eq!(avx2.bp, scalar.bp, "{name}: AVX2 BP mismatch");
+                assert_eq!(avx2.state, scalar.state, "{name}: AVX2 state mismatch");
             }
         }
     }
@@ -95,23 +95,21 @@ mod x86_simd_levels {
 
             if is_x86_feature_detected!("sse4.2") {
                 let sse42 = json::simd::sse42::build_semi_index_standard(json);
-                assert_eq!(sse42.ib, sse2.ib, "{}: SSE4.2 vs SSE2 IB mismatch", name);
-                assert_eq!(sse42.bp, sse2.bp, "{}: SSE4.2 vs SSE2 BP mismatch", name);
+                assert_eq!(sse42.ib, sse2.ib, "{name}: SSE4.2 vs SSE2 IB mismatch");
+                assert_eq!(sse42.bp, sse2.bp, "{name}: SSE4.2 vs SSE2 BP mismatch");
                 assert_eq!(
                     sse42.state, sse2.state,
-                    "{}: SSE4.2 vs SSE2 state mismatch",
-                    name
+                    "{name}: SSE4.2 vs SSE2 state mismatch"
                 );
             }
 
             if is_x86_feature_detected!("avx2") {
                 let avx2 = json::simd::avx2::build_semi_index_standard(json);
-                assert_eq!(avx2.ib, sse2.ib, "{}: AVX2 vs SSE2 IB mismatch", name);
-                assert_eq!(avx2.bp, sse2.bp, "{}: AVX2 vs SSE2 BP mismatch", name);
+                assert_eq!(avx2.ib, sse2.ib, "{name}: AVX2 vs SSE2 IB mismatch");
+                assert_eq!(avx2.bp, sse2.bp, "{name}: AVX2 vs SSE2 BP mismatch");
                 assert_eq!(
                     avx2.state, sse2.state,
-                    "{}: AVX2 vs SSE2 state mismatch",
-                    name
+                    "{name}: AVX2 vs SSE2 state mismatch"
                 );
             }
         }
@@ -124,23 +122,21 @@ mod x86_simd_levels {
 
             if is_x86_feature_detected!("sse4.2") {
                 let sse42 = json::simd::sse42::build_semi_index_simple(json);
-                assert_eq!(sse42.ib, sse2.ib, "{}: SSE4.2 vs SSE2 IB mismatch", name);
-                assert_eq!(sse42.bp, sse2.bp, "{}: SSE4.2 vs SSE2 BP mismatch", name);
+                assert_eq!(sse42.ib, sse2.ib, "{name}: SSE4.2 vs SSE2 IB mismatch");
+                assert_eq!(sse42.bp, sse2.bp, "{name}: SSE4.2 vs SSE2 BP mismatch");
                 assert_eq!(
                     sse42.state, sse2.state,
-                    "{}: SSE4.2 vs SSE2 state mismatch",
-                    name
+                    "{name}: SSE4.2 vs SSE2 state mismatch"
                 );
             }
 
             if is_x86_feature_detected!("avx2") {
                 let avx2 = json::simd::avx2::build_semi_index_simple(json);
-                assert_eq!(avx2.ib, sse2.ib, "{}: AVX2 vs SSE2 IB mismatch", name);
-                assert_eq!(avx2.bp, sse2.bp, "{}: AVX2 vs SSE2 BP mismatch", name);
+                assert_eq!(avx2.ib, sse2.ib, "{name}: AVX2 vs SSE2 IB mismatch");
+                assert_eq!(avx2.bp, sse2.bp, "{name}: AVX2 vs SSE2 BP mismatch");
                 assert_eq!(
                     avx2.state, sse2.state,
-                    "{}: AVX2 vs SSE2 state mismatch",
-                    name
+                    "{name}: AVX2 vs SSE2 state mismatch"
                 );
             }
         }
@@ -175,13 +171,13 @@ mod x86_simd_levels {
             let scalar = json::standard::build_semi_index(json);
             let sse2 = json::simd::x86::build_semi_index_standard(json);
 
-            assert_eq!(sse2.ib, scalar.ib, "{}: SSE2 IB mismatch", name);
-            assert_eq!(sse2.bp, scalar.bp, "{}: SSE2 BP mismatch", name);
+            assert_eq!(sse2.ib, scalar.ib, "{name}: SSE2 IB mismatch");
+            assert_eq!(sse2.bp, scalar.bp, "{name}: SSE2 BP mismatch");
 
             if is_x86_feature_detected!("avx2") {
                 let avx2 = json::simd::avx2::build_semi_index_standard(json);
-                assert_eq!(avx2.ib, scalar.ib, "{}: AVX2 IB mismatch", name);
-                assert_eq!(avx2.bp, scalar.bp, "{}: AVX2 BP mismatch", name);
+                assert_eq!(avx2.ib, scalar.ib, "{name}: AVX2 IB mismatch");
+                assert_eq!(avx2.bp, scalar.bp, "{name}: AVX2 BP mismatch");
             }
         }
     }

--- a/tests/yaml_test_suite.rs
+++ b/tests/yaml_test_suite.rs
@@ -12,7 +12,7 @@ use succinctly::yaml::{YamlIndex, YamlValue};
 
 /// Helper to convert YAML to JSON string for comparison.
 fn yaml_to_json(yaml: &[u8]) -> Result<String, String> {
-    let index = YamlIndex::build(yaml).map_err(|e| format!("{}", e))?;
+    let index = YamlIndex::build(yaml).map_err(|e| format!("{e}"))?;
     let root = index.root(yaml);
 
     // Get first document
@@ -30,7 +30,7 @@ fn yaml_to_json(yaml: &[u8]) -> Result<String, String> {
 
 /// Helper to convert multi-document YAML to JSON strings (one per doc).
 fn yaml_to_json_all(yaml: &[u8]) -> Result<String, String> {
-    let index = YamlIndex::build(yaml).map_err(|e| format!("{}", e))?;
+    let index = YamlIndex::build(yaml).map_err(|e| format!("{e}"))?;
     let root = index.root(yaml);
 
     // Get all documents
@@ -65,7 +65,7 @@ fn value_to_json<W: AsRef<[u64]>>(value: &YamlValue<'_, W>) -> String {
                         }
                         if let Ok(f) = s.parse::<f64>() {
                             if !f.is_nan() && !f.is_infinite() {
-                                return format!("{}", f);
+                                return format!("{f}");
                             }
                         }
                     }
@@ -123,7 +123,7 @@ fn value_to_json<W: AsRef<[u64]>>(value: &YamlValue<'_, W>) -> String {
                     .replace('\n', "\\n")
                     .replace('\r', "\\r")
                     .replace('\t', "\\t");
-                entries.push(format!("\"{}\": {}", escaped_key, val));
+                entries.push(format!("\"{escaped_key}\": {val}"));
             }
             format!("{{{}}}", entries.join(", "))
         }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -114,8 +114,7 @@ fn has_system_yq() -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .is_ok_and(|s| s.success())
 }
 
 /// Compare succinctly yq output with system yq output
@@ -152,7 +151,7 @@ fn test_quoted_leading_zero_preserved() -> Result<()> {
 
 #[test]
 fn test_unquoted_number_as_number() -> Result<()> {
-    let yaml = r#"count: 123"#;
+    let yaml = r"count: 123";
     let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
 
     assert_eq!(code, 0);
@@ -179,7 +178,7 @@ code: "007"
 
 #[test]
 fn test_single_quoted_string_preserved() -> Result<()> {
-    let yaml = r#"version: '2.0'"#;
+    let yaml = r"version: '2.0'";
     let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
 
     assert_eq!(code, 0);
@@ -232,7 +231,7 @@ codes:
 
 #[test]
 fn test_output_format_equals_syntax() -> Result<()> {
-    let yaml = r#"test: true"#;
+    let yaml = r"test: true";
     let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
 
     assert_eq!(code, 0);
@@ -242,19 +241,19 @@ fn test_output_format_equals_syntax() -> Result<()> {
 
 #[test]
 fn test_output_format_space_syntax() -> Result<()> {
-    let yaml = r#"test: true"#;
+    let yaml = r"test: true";
     let (output, code) = run_yq_stdin(".", yaml, &["-o", "json"])?;
 
     assert_eq!(code, 0);
     // Default format is pretty-printed, so check for field presence
     assert!(output.contains(r#""test""#));
-    assert!(output.contains(r#"true"#));
+    assert!(output.contains(r"true"));
     Ok(())
 }
 
 #[test]
 fn test_indent_equals_syntax() -> Result<()> {
-    let yaml = r#"a: 1"#;
+    let yaml = r"a: 1";
     let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
 
     assert_eq!(code, 0);
@@ -264,7 +263,7 @@ fn test_indent_equals_syntax() -> Result<()> {
 
 #[test]
 fn test_indent_space_syntax() -> Result<()> {
-    let yaml = r#"a: 1"#;
+    let yaml = r"a: 1";
     let (output, code) = run_yq_stdin(".", yaml, &["-o", "json", "-I", "0"])?;
 
     assert_eq!(code, 0);
@@ -349,7 +348,7 @@ fn test_file_input_type_preservation() -> Result<()> {
     let mut temp_file = NamedTempFile::new()?;
     writeln!(temp_file, r#"version: "1.0""#)?;
     writeln!(temp_file, r#"id: "001""#)?;
-    writeln!(temp_file, r#"count: 123"#)?;
+    writeln!(temp_file, r"count: 123")?;
 
     let path = temp_file.path().to_str().unwrap();
     let (output, code) = run_yq_file(".", path, &["-o=json", "-I=0"])?;
@@ -364,7 +363,7 @@ fn test_file_input_type_preservation() -> Result<()> {
 fn test_file_input_field_selection() -> Result<()> {
     let mut temp_file = NamedTempFile::new()?;
     writeln!(temp_file, r#"version: "2.5.1""#)?;
-    writeln!(temp_file, r#"build: 999"#)?;
+    writeln!(temp_file, r"build: 999")?;
 
     let path = temp_file.path().to_str().unwrap();
     let (output, code) = run_yq_file(".version", path, &["-o=json", "-I=0"])?;
@@ -511,16 +510,16 @@ fn test_yaml_output_format() -> Result<()> {
 
 #[test]
 fn test_compact_json_output() -> Result<()> {
-    let yaml = r#"
+    let yaml = r"
 a: 1
 b: 2
 c: 3
-"#;
+";
     let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
 
     assert_eq!(code, 0);
     // Compact output should not have newlines between fields
-    assert!(!output.trim().contains("\n"));
+    assert!(!output.trim().contains('\n'));
     Ok(())
 }
 
@@ -1011,14 +1010,12 @@ fn test_yaml_merge_key_expansion() -> Result<()> {
     // Should have both 'a' from merge and 'b' from item
     assert!(
         output.contains("\"a\"") && output.contains("\"b\""),
-        "merge key should expand anchor: got {}",
-        output
+        "merge key should expand anchor: got {output}"
     );
     // Should NOT have literal << key
     assert!(
         !output.contains("\"<<\""),
-        "merge key << should be expanded, not literal: {}",
-        output
+        "merge key << should be expanded, not literal: {output}"
     );
     Ok(())
 }
@@ -1032,8 +1029,7 @@ fn test_yaml_merge_key_override() -> Result<()> {
     assert_eq!(exit_code, 0);
     assert!(
         output.contains("override"),
-        "item's value should override anchor: got {}",
-        output
+        "item's value should override anchor: got {output}"
     );
     Ok(())
 }
@@ -1104,13 +1100,11 @@ fn test_multi_doc_select_first() -> Result<()> {
     assert_eq!(exit_code, 0);
     assert!(
         output.contains("a:"),
-        "should output first document: {}",
-        output
+        "should output first document: {output}"
     );
     assert!(
         !output.contains("b:"),
-        "should not include second document: {}",
-        output
+        "should not include second document: {output}"
     );
     Ok(())
 }
@@ -1122,13 +1116,11 @@ fn test_multi_doc_select_second() -> Result<()> {
     assert_eq!(exit_code, 0);
     assert!(
         output.contains("b:"),
-        "should output second document: {}",
-        output
+        "should output second document: {output}"
     );
     assert!(
         !output.contains("a:"),
-        "should not include first document: {}",
-        output
+        "should not include first document: {output}"
     );
     Ok(())
 }
@@ -1158,8 +1150,7 @@ fn test_unquoted_number_becomes_number() -> Result<()> {
     let trimmed = output.trim();
     assert!(
         trimmed == "1" || trimmed == "1.0",
-        "unquoted number should be numeric: {}",
-        trimmed
+        "unquoted number should be numeric: {trimmed}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Description

Gives `succinctly` an **explicit, enforced lint policy**. Adds a Cargo `[lints]`
section that:

1. Declares an explicit **unsafe policy** — `unsafe_code = "deny"` at the crate
   root, with a localized `#![allow(unsafe_code)]` (each carrying a rationale) on
   the handful of SIMD / popcount / balanced-parens / binary-serialization
   modules that legitimately need it. Introducing `unsafe` anywhere else is now a
   deliberate, reviewed change rather than an accident.
2. Opts the whole crate into clippy's strict groups — `all` + `pedantic` +
   `nursery` at `warn` — with a **curated allow-list** where every entry has a
   one-line rationale and is meant to be peeled back over time.

Then applies the code changes needed to make `cargo clippy --all-targets
--all-features -- -D warnings` (the existing CI gate) pass, plus `cargo fmt`.

Before this, the crate enforced only clippy's default set and had **no unsafe
policy at all** — despite being an `unsafe`/SIMD-heavy crate. This mirrors (and,
for unsafe, adapts) the stance of the sibling `omni-dev` project.

## Type of Change
- [x] Refactoring (no functional changes)

## Related Issue
Closes #205

## Changes Made

**`Cargo.toml` — new `[lints]` section**
- `[lints.rust]`: `unsafe_code = "deny"`.
- `[lints.clippy]`: `all` / `pedantic` / `nursery` at `warn` (`priority = -1`),
  followed by a curated allow-list grouped by theme (numeric casts, API/doc
  surface, perf-crate idioms, subjective style, and the noisier nursery lints),
  each `allow` documented with why.

**Per-module unsafe opt-in**
- `#![allow(unsafe_code)]` with a rationale on the 27 files that use `unsafe`
  (x86 AVX2/SSE/BMI2 **and** ARM NEON/SVE2 SIMD, popcount, balanced-parens,
  mmap-based binary (de)serialization).

**Lint fixes to reach green (mechanical / behaviour-preserving)**
- ~3,000 auto-fixed lints: `uninlined_format_args`, `use_self`,
  `elidable_lifetime_names`, `map_unwrap_or` → `map_or`,
  `redundant_closure_for_method_calls`, `ptr_as_ptr` → `.cast()`,
  `semicolon_if_nothing_returned`, `needless_raw_string_hashes`,
  `unnested_or_patterns`, `manual_assert_eq` → `assert_eq!`/`debug_assert_eq!`, …
- Hand-fixed the non-autofixable ones (`redundant_else`,
  `needless_range_loop` → iterator form, a stray `ptr_as_ptr` in the AVX-512
  popcount path).
- Converted a few autofix-introduced `std::` paths to `alloc::` so the crate
  still builds under `no_std`.
- A handful of lints are intentionally **allowed** (with rationales in
  `Cargo.toml`) rather than fixed: e.g. `comparison_chain` in the
  benchmark-tuned cursor `get()` hot paths, `doc_link_with_quotes` (false
  positives on markdown citation links / jq code examples), `manual_let_else`
  (clippy declines to autofix; explicit `match` is clearer at error-mapping
  sites).

## Testing

**Automated Testing:**
- [x] All existing tests pass (CI: Test + Coverage green on x86_64 and ARM64)

**Manual Testing:**
- [x] Tested on x86_64
- [x] Tested on aarch64/ARM

### Verification performed locally (Rust 1.97.0, both `aarch64-apple-darwin` and `x86_64-apple-darwin`)
```bash
cargo clippy --target <arch> --all-targets --all-features -- -D warnings   # PASS
cargo clippy --target <arch> --all-targets                -- -D warnings   # PASS (default features)
cargo fmt --check                                                          # clean
cargo build --no-default-features --lib                                    # no_std still builds
```
The x86 (CI-linted) SIMD paths were verified by cross-targeting
`x86_64-apple-darwin`, since CI's `--all-features` build actually compiles the
scalar/portable overrides rather than the real x86 SIMD.

## Performance Impact
- [x] No performance impact — all changes are formatting, lint-compliance, or
  semantically-equivalent rewrites. Hot code (SIMD kernels, the cursor `get()`
  methods) was deliberately left structurally unchanged (see the `allow`
  rationales).

## Additional Notes

**The allow-list is scaffolding, not a verdict.** It exists so the strict groups
can be turned on today without a multi-thousand-line rewrite; the intent is to
peel entries back in focused follow-ups.

**Pre-existing issues surfaced but *not* addressed here** (independent of this
PR — CI never builds these feature combos, so they were already latent; fixing
them is out of scope for a lint-config chore and warrants separate issues):
- `--features simd` on **x86** uses AVX-512 intrinsics (`_mm512_popcnt_epi64`,
  …) that were stabilized in **Rust 1.89**, but the crate's declared **MSRV is
  1.73** — so `simd` doesn't actually build on its stated MSRV on x86.
- `--features broadword-yaml` on **ARM** has a pre-existing missing-`else`
  compile error (`E0317`) in `src/yaml/simd/mod.rs`.
