### PR TITLE
test(lib): add deterministic coverage test for L2 block boundary traversal

### DIFF
--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -2614,6 +2614,67 @@ mod tests {
         assert_eq!(bp.enclose(33000), Some(32999));
     }
 
+    /// Build `(` + `pairs` copies of `()` + `)`: one outer pair wrapping a long
+    /// flat run of balanced pairs. Total length is `2 + 2 * pairs`, the nesting
+    /// depth never exceeds 2, and the running excess stays in `[1, 2]` across the
+    /// whole interior — it only returns to 0 at the final close. That keeps the
+    /// index counters far from the i16 ceiling (#188) while forcing `find_close`
+    /// from position 0 to traverse the entire sequence.
+    fn wrapped_flat_pairs(pairs: usize) -> (Vec<u64>, usize) {
+        let total = 2 + 2 * pairs;
+        let mut words = vec![0u64; total.div_ceil(64)];
+        // Outer open at position 0.
+        words[0] |= 1;
+        // Interior pair `i` opens at the odd position `1 + 2*i`; its close (an
+        // even position) is left as a 0 bit. The outer close at `total - 1` is
+        // likewise a 0 bit.
+        for i in 0..pairs {
+            let open = 1 + 2 * i;
+            words[open / 64] |= 1u64 << (open % 64);
+        }
+        (words, total)
+    }
+
+    #[test]
+    fn test_find_close_crosses_l2_block_boundary() {
+        // Coverage stabilizer for issue #220: deterministically exercise the L2
+        // hierarchical-navigation branches (`State::CheckL2` / `State::FromL2`)
+        // of `find_close_from`, instead of relying on proptest randomly drawing
+        // an input large enough to span a full L2 block (the source of the
+        // flaky covered/uncovered flip on unrelated PRs).
+        //
+        // One L2 block spans 64 * FACTOR_L1 * FACTOR_L2 parens. Build a sequence
+        // several L2 blocks long whose excess never drops to 0 until the very
+        // end, so `find_close(0)` must skip whole L2 blocks to reach the match —
+        // driving the scan through the L2 states on every run.
+        const L2_SPAN: usize = 64 * FACTOR_L1 * FACTOR_L2;
+        assert_eq!(L2_SPAN, 65_536);
+
+        let (words, len) = wrapped_flat_pairs(100_000);
+        assert!(
+            len > 3 * L2_SPAN,
+            "input must cross multiple L2 boundaries: len={len}, L2_SPAN={L2_SPAN}"
+        );
+
+        let bp = BalancedParens::new(words.clone(), len);
+
+        // The outer open matches the very last close, having skipped every
+        // interior L2 block along the way.
+        assert_eq!(bp.find_close(0), Some(len - 1));
+
+        // Accelerated result matches the linear-scan reference for opens sampled
+        // across multiple L2 blocks (the outer pair plus interior pairs whose
+        // close sits one position later).
+        for p in [0usize, 1, L2_SPAN + 1, 2 * L2_SPAN + 1, len - 3] {
+            assert!(bp.is_open(p), "sampled position {p} should be open");
+            assert_eq!(
+                bp.find_close(p),
+                find_close(&words, len, p),
+                "find_close({p}) mismatch: accelerated vs linear scan"
+            );
+        }
+    }
+
     #[test]
     fn test_word_min_excess() {
         // "()" = 0b01 - open at 0, close at 1


### PR DESCRIPTION
## Description

Adds a deterministic unit test that **always** exercises the L2
hierarchical-navigation branches (`State::CheckL2` / `State::FromL2`) of
`BalancedParens::find_close_from` in `src/trees/bp.rs`.

These branches only execute when a balanced-parens sequence spans a full L2
block — `64 · FACTOR_L1 · FACTOR_L2 = 64 · 32 · 32 = 65,536` parens. Today they
are reached only incidentally, by an **unseeded** proptest that draws a
variable-size input (`bp_very_large_random_words` / `bp_very_large_next_sibling`
in `tests/property_tests.rs`, `vec(any::<u64>(), 1..16384)` under
`with_cases(5)`). Only some runs draw an input large enough — and a random
position that traverses an L2 boundary — so the ~16 L2 lines flip
`covered → uncovered` between runs. That produces a recurring red "indirect
coverage change" from the coverage bot on PRs that don't touch this code at all
(e.g. the docs-only #213).

The new test pins that coverage down **without touching the fuzzer**: it builds
`( ()()…() )` — one outer pair wrapping 100,000 flat pairs (200,002 parens,
> 3 L2 blocks) — so the running excess stays in `[1, 2]` until the final close
and `find_close(0)` must skip whole L2 blocks to reach the match, driving the L2
states on every run. The flat, depth-2 shape keeps the index counters far from
the i16 ceiling (#188).

No global proptest RNG seed is pinned, so fuzzing breadth is preserved.

## Type of Change
- [x] Test coverage improvement

## Related Issue
Fixes #220

## Changes Made
- Add `test_find_close_crosses_l2_block_boundary` in `src/trees/bp.rs`, asserting
  `find_close` / `find_close_from` on a ≥ 65,536-paren input and cross-checking
  the accelerated result against the linear-scan reference at positions sampled
  across multiple L2 blocks.
- Add a `wrapped_flat_pairs(pairs)` test helper that builds one outer pair
  wrapping a long flat run of `()` pairs.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

Coverage verified: running the new test in isolation covers the L2 main-path
lines (`src/trees/bp.rs` ~2096–2154) that previously flipped. The only lines
left uncovered in that region are the unreachable early-`return None` /
`return Some` edge cases, which require *unbalanced* input that `find_close` from
a valid open never produces — so they are consistently uncovered and were never
part of the flip.

**Manual Testing:**
- [x] Tested on aarch64/ARM (Apple Silicon, macOS)
- [ ] Tested on x86_64 (n/a — architecture-independent index-navigation logic)

### Test Commands
```bash
cargo test --lib trees::bp::tests::test_find_close_crosses_l2_block_boundary
cargo test --lib trees::bp
cargo fmt -- --check
```

## Performance Impact
- [x] No performance impact (test-only change; no library code modified)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed (n/a — test-only)
- [x] My changes generate no new warnings

## Additional Notes

**Root-cause correction.** The flaky L2 coverage does **not** originate from
`tests/bp_properties.rs` as the issue hypothesized — that generator caps at 500
nodes (≤ 1,000 parens) and can never reach the 65,536-paren L2 threshold. The
actual source is the unseeded `bp_very_large_random_words` /
`bp_very_large_next_sibling` proptests in `tests/property_tests.rs:819-868`. The
fix — a deterministic test that pins the L2 coverage — is correct regardless of
which test happens to be the incidental source.

A pre-existing `clippy::needless_range_loop` warning at `src/trees/bp.rs:608` is
present on `main` (unrelated to this change) and is intentionally left untouched
to keep this PR test-only.

---
## 📝 Commit Summary
*This section was automatically generated based on commit analysis*

### Commits in this PR:
- `a7fa78a7` test(lib): add deterministic coverage test for L2 block boundary traversal

**Files changed:** 1 files
