### PR TITLE
feat(bench): add succinct library comparison benchmarks and ADR-0011

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ use succinctly::jq::{parse, eval};
 
 | Structure         | Description                            | Performance (x86_64 Zen 4) |
 |-------------------|----------------------------------------|----------------------------|
-| **BitVec**        | O(1) rank, O(log n) select             | ~3-4% overhead             |
+| **BitVec**        | O(1) rank, O(log n) select             | ~28-48% overhead           |
 | **BalancedParens**| Succinct tree navigation               | ~6% overhead               |
 | **JsonIndex**     | JSON semi-indexing with PFSM parser    | ~880 MiB/s                 |
 | **YamlIndex**     | YAML semi-indexing with oracle parser  | ~250-400 MiB/s             |
@@ -327,6 +327,7 @@ cargo test
 | [docs/benchmarks/jq.md](docs/benchmarks/jq.md)                    | JSON jq benchmark results            |
 | [docs/benchmarks/yq.md](docs/benchmarks/yq.md)                    | YAML yq benchmark results            |
 | [docs/benchmarks/dsv.md](docs/benchmarks/dsv.md)                  | DSV input performance benchmarks     |
+| [docs/adrs/adr-0011.md](docs/adrs/adr-0011.md)                    | Why rank/select is built in-crate    |
 
 ## Performance Summary
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Succinctly provides space-efficient data structures with fast rank and select op
 
 ## Features
 
-- **Bitvector with O(1) rank and O(log n) select** - Poppy-style 3-level directory with ~3% space overhead
+- **Bitvector with O(1) rank and O(log n) select** - Poppy-style 3-level directory, tuned for query speed over compactness (~28-48% overhead)
 - **Balanced parentheses for tree navigation** - RangeMin structure with O(1) operations and ~6% overhead
 - **JSON semi-indexing with SIMD acceleration** - Up to 880 MiB/s throughput on x86_64 (AMD Zen 4) with table-driven PFSM parser
 - **YAML semi-indexing** - Complete YAML 1.2 parser with anchor/alias resolution (~250-400 MiB/s)
@@ -308,7 +308,7 @@ succinctly
 
 ### Core Data Structures
 
-- **`bits::BitVec`** - Bitvector with 3-level Poppy-style rank directory (~3% overhead) and sampled select index (~1-3% overhead)
+- **`bits::BitVec`** - Bitvector with 3-level Poppy-style rank directory (~25% overhead) and sampled select index; ~28-48% resident overhead in total, rising with bit density ([benchmarks](docs/benchmarks/rust-succinct-libs.md))
 - **`trees::BalancedParens`** - Hierarchical min-excess structure for O(1) tree navigation (~6% overhead)
 - **`json::JsonIndex`** - Semi-index combining Interest Bits (IB) and Balanced Parentheses (BP) for fast JSON navigation
 - **`yaml::YamlIndex`** - YAML semi-index with anchor/alias resolution and multi-document support

--- a/bench-compare/Cargo.lock
+++ b/bench-compare/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +30,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambassador"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3d4da7fddbc6567cbd7b5c30364f91313701b1857ab5b925eb3acf06162eed"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
 
 [[package]]
 name = "anes"
@@ -36,16 +60,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arbitrary-chunks"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad8689a486416c401ea15715a4694de30054248ec627edbf31f49cb64ee4086"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "atomic-primitive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271062a944c5d07aedd64f32126d991174d4313c2080f36a21503d575b0567bf"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-pseudorand"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2097358495d244a0643746f4d13eedba4608137008cf9dec54e53a3b700115a6"
+dependencies = [
+ "chiapos-chacha8",
+ "nanorand",
+]
 
 [[package]]
 name = "bumpalo"
@@ -70,7 +184,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -86,10 +200,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chiapos-chacha8"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f8be573a85f6c2bc1b8e43834c07e32f95e489b914bf856c0549c3c269cd0a"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "ciborium"
@@ -144,6 +290,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +325,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -176,7 +346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -211,16 +390,162 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_setters"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e6f6fa1f03c14ae082120b84b3c7fbd7b8588d924cf2d7c3daf9afd49df8b9"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "dsi-progress-logger"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa66984aaf46be4aa18df96e29fe354845cc4255e148bbfda92e73aea7cb0399"
+dependencies = [
+ "log",
+ "num-format",
+ "pluralizer",
+ "sysinfo",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "faststr"
@@ -235,6 +560,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +583,18 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "getrandom"
@@ -254,6 +607,18 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -292,12 +657,47 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "impl-tools"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae314a99afb5821e2fda288387546d4a04aace674551e854e6216b892ec3208"
+dependencies = [
+ "autocfg",
+ "impl-tools-lib",
+ "proc-macro-error2",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "impl-tools-lib"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
 
 [[package]]
 name = "indexmap"
@@ -321,6 +721,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,10 +736,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -350,12 +817,51 @@ name = "json-parser-bench"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "rand 0.8.7",
+ "rand_chacha",
  "serde_json",
  "serde_yaml",
  "simd-json",
  "sonic-rs",
- "succinctly",
+ "succinctly 0.7.0",
+ "sucds",
+ "sux",
  "tracking-allocator",
+ "vers-vecs",
+]
+
+[[package]]
+name = "lambert_w"
+version = "1.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f0846ee4f0299ca4c5b9ca06ff55cf88b3430a763bf591474cc734479c9b24"
+dependencies = [
+ "num-complex",
+ "num-traits",
+]
+
+[[package]]
+name = "lender"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeed4888de4544bf3ba2e111326978dbcc37f57bf2c7d6a6a78ed6c01f77ef93"
+dependencies = [
+ "aliasable",
+ "fallible-iterator",
+ "lender-derive",
+ "maybe-dangling",
+ "stable_try_trait_v2",
+]
+
+[[package]]
+name = "lender-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d074a297c82222d442171bad4f392fef93d35fb31e24a115f605a0c907ce0af9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -371,10 +877,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "maybe-dangling"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59dbb09ed53f8e4f314e353dc6c1853ae5b4c480a668a422657804a544ea9f65"
+
+[[package]]
+name = "mem_dbg"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ef2d80bfa14894b6d5a3ff537e7e9a908dbf4c95de8a5b8ad2a473301676e6"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.16.1",
+ "mem_dbg-derive",
+]
+
+[[package]]
+name = "mem_dbg-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73acd151c6ce84a41d8d6fb0958d9a3d5a18d649ad5a85ad5b719439af8ad257"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "munge"
@@ -393,8 +949,48 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
+
+[[package]]
+name = "nanorand"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
+name = "num-primitive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0178502a58a2514f927965f80216c0ea2533b5364061544ea8e09b79343d4183"
 
 [[package]]
 name = "num-traits"
@@ -406,10 +1002,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -418,10 +1039,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "partition"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947f833aaa585cf12b8ec7c0476c98784c49f33b861376ffc84ed92adebf2aba"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -452,6 +1085,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,7 +1165,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -490,6 +1178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rancor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +1191,53 @@ checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
 dependencies = [
  "ptr_meta",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -519,6 +1260,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdst"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7970b4e577b76a96d5e56b5f6662b66d1a4e1f5bb026ee118fc31b373c2752"
+dependencies = [
+ "arbitrary-chunks",
+ "block-pseudorand",
+ "criterion",
+ "partition",
+ "rayon",
+ "tikv-jemallocator",
+ "voracious_radix_sort",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,7 +1291,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -599,7 +1355,20 @@ checksum = "7f6dffea3c91fa91a3c0fc8a061b0e27fef25c6304728038a6d6bcb1c58ba9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -650,7 +1419,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -680,12 +1449,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd-json"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "halfbrown",
  "ref-cast",
  "serde",
@@ -739,12 +1520,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_try_trait_v2"
+version = "1.75.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4e48411f4db8ccca0470bfb67e3bb821af4227d455aa147917d8d109be0d13"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "succinctly"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efed1dfd86bb1bafeba986d5cb77f0f38924438b833c5cc3977a2afbd7e26536"
 dependencies = [
  "bytemuck",
  "indexmap",
  "libm",
+]
+
+[[package]]
+name = "succinctly"
+version = "0.7.0"
+dependencies = [
+ "bytemuck",
+ "indexmap",
+ "libm",
+]
+
+[[package]]
+name = "sucds"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd324eaa05be64f105ea5269bb8aabd70e5dd57fa5c673b167f451b07d6c0dcd"
+dependencies = [
+ "anyhow",
+ "num-traits",
+]
+
+[[package]]
+name = "sux"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7bb0732ef419ea39063a3f345cd5feea30765842354d52d709e28fb04cceec"
+dependencies = [
+ "ambassador",
+ "anyhow",
+ "arbitrary-chunks",
+ "arrayvec",
+ "atomic-primitive",
+ "bitflags 2.13.0",
+ "crossbeam-channel",
+ "derivative",
+ "derive_setters",
+ "dsi-progress-logger",
+ "env_logger",
+ "fallible-iterator",
+ "flate2",
+ "impl-tools",
+ "itertools 0.14.0",
+ "jiff",
+ "lambert_w",
+ "lender",
+ "libc",
+ "log",
+ "mem_dbg",
+ "num-primitive",
+ "rand 0.10.2",
+ "rayon",
+ "rdst",
+ "succinctly 0.6.0",
+ "sync-cell-slice",
+ "tempfile",
+ "thiserror",
+ "thread-priority",
+ "value-traits",
+ "xxhash-rust",
+ "zerocopy",
+ "zstd",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -756,6 +1623,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync-cell-slice"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84d5335e8ec011a812fc9f8a1b87608629338b0b3dbd58a6ec306dc7d340d20"
+
+[[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -775,7 +1675,41 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "thread-priority"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2e834949be5111506bb252643498af1514f600d9e1dceedaa42afae155b67f"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -854,6 +1788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,10 +1816,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-traits"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e73c7053d8fa8e9c3c6b16c32d079ed5642a7156514820486a9c4e109cf48d"
+dependencies = [
+ "value-traits-derive",
+]
+
+[[package]]
+name = "value-traits-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d301d1ee4b3eced3e73aa5740a303c7e068f1d4450c5dae4c8cf6bfa266954f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "vers-vecs"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0435d0e97f854c537ab74e86072e1389c73251eba2cf46069edadd72d0e860"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "voracious_radix_sort"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446e7ffcb6c27a71d05af7e51ef2ee5b71c48424b122a832f2439651e1914899"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "walkdir"
@@ -929,7 +1904,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
  "wasm-bindgen-shared",
 ]
 
@@ -953,6 +1928,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,10 +1953,191 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "windows-sys"
@@ -973,8 +2145,32 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
 
 [[package]]
 name = "zerocopy"
@@ -993,7 +2189,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1001,3 +2197,31 @@ name = "zmij"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/bench-compare/Cargo.toml
+++ b/bench-compare/Cargo.toml
@@ -10,8 +10,18 @@ serde_json = "1.0"
 simd-json = "0.14"
 sonic-rs = "0.3"
 serde_yaml = "0.9"
-succinctly = { path = ".." }
+succinctly = { path = "..", features = ["simd"] }
 tracking-allocator = "0.4"
+
+# Succinct rank/select crates, compared against succinctly's BitVec in succinct_libs.
+# Each is given its best-available acceleration so the comparison is like-for-like:
+# succinctly's `simd` selects NEON/AVX-512 popcount, vers-vecs' `simd` its AVX-512 select,
+# sucds' `intrinsics` its broadword helpers. sux has no equivalent feature.
+rand = "0.8"
+rand_chacha = "0.3"
+sucds = { version = "0.8", features = ["intrinsics"] }
+sux = "0.14"
+vers-vecs = { version = "1.10", features = ["simd"] }
 
 [[bench]]
 name = "json_parsers"
@@ -19,4 +29,8 @@ harness = false
 
 [[bench]]
 name = "yaml_parsers"
+harness = false
+
+[[bench]]
+name = "succinct_libs"
 harness = false

--- a/bench-compare/benches/succinct_libs.rs
+++ b/bench-compare/benches/succinct_libs.rs
@@ -1,0 +1,445 @@
+//! Benchmark comparing succinctly's `BitVec` against other Rust succinct-structure crates.
+//!
+//! Compares rank/select structures that carry both a rank index and a select index:
+//!
+//! - **succinctly**: `BitVec` (3-level `RankDirectory` + sampled `SelectIndex`)
+//! - **vers-vecs**: `RsVec`
+//! - **sucds**: `Rank9Sel`
+//! - **sux**: `SelectAdapt<Rank9<AddNumBits<BitVec>>>`
+//!
+//! Every structure is built from the same seeded random words, so all four see identical
+//! bits. Each builder takes `&[u64]` and returns a fully owned structure, which keeps the
+//! construction and memory comparison apples-to-apples: no crate is charged for, or
+//! credited with, borrowing the caller's buffer.
+//!
+//! Note that both succinctly (`BitVec::from_words`) and vers-vecs (`BitVec::from_vec`)
+//! additionally accept an owned `Vec<u64>` by move, which is free. sucds and sux have no
+//! bulk-word constructor and must be filled per bit; that cost is real and is what the
+//! `construction` group measures for them.
+//!
+//! Run from the bench-compare directory:
+//! ```bash
+//! cargo bench --bench succinct_libs
+//! ```
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+// ============================================================================
+// Resident Memory Tracking Allocator
+// ============================================================================
+
+struct TrackingAllocator {
+    current: AtomicUsize,
+}
+
+impl TrackingAllocator {
+    const fn new() -> Self {
+        Self {
+            current: AtomicUsize::new(0),
+        }
+    }
+
+    fn reset(&self) {
+        self.current.store(0, Ordering::SeqCst);
+    }
+
+    /// Bytes currently held. Read while a structure is alive, this is its resident size.
+    fn current(&self) -> usize {
+        self.current.load(Ordering::SeqCst)
+    }
+}
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            self.current.fetch_add(layout.size(), Ordering::SeqCst);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.current.fetch_sub(layout.size(), Ordering::SeqCst);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            let old_size = layout.size();
+            if new_size > old_size {
+                self.current
+                    .fetch_add(new_size - old_size, Ordering::SeqCst);
+            } else {
+                self.current
+                    .fetch_sub(old_size - new_size, Ordering::SeqCst);
+            }
+        }
+        new_ptr
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator = TrackingAllocator::new();
+
+// ============================================================================
+// Test Data
+// ============================================================================
+
+/// Sizes in bits. Matches `benches/rank_select.rs` in the main crate.
+const SIZES: &[usize] = &[1_000_000, 10_000_000];
+
+/// Fraction of set bits.
+const DENSITIES: &[f64] = &[0.1, 0.5, 0.9];
+
+/// Generate random words with the given density of set bits.
+///
+/// Mirrors `generate_bitvec` in `benches/rank_select.rs` so results are comparable.
+fn generate_words(size: usize, density: f64, seed: u64) -> Vec<u64> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let word_count = size.div_ceil(64);
+    let mut words = Vec::with_capacity(word_count);
+
+    let threshold = (density * u64::MAX as f64) as u64;
+    for _ in 0..word_count {
+        let mut word = 0u64;
+        for bit in 0..64 {
+            if rng.r#gen::<u64>() < threshold {
+                word |= 1 << bit;
+            }
+        }
+        words.push(word);
+    }
+    words
+}
+
+/// Generate random query positions.
+fn generate_queries(count: usize, max: usize, seed: u64) -> Vec<usize> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    (0..count).map(|_| rng.gen_range(0..max)).collect()
+}
+
+fn bit_at(words: &[u64], i: usize) -> bool {
+    words[i / 64] >> (i % 64) & 1 == 1
+}
+
+// ============================================================================
+// Per-Crate Builders
+//
+// Each takes a borrowed slice and returns a fully owned rank+select structure.
+// ============================================================================
+
+fn build_succinctly(words: &[u64], len: usize) -> succinctly::BitVec {
+    succinctly::BitVec::from_words(words.to_vec(), len)
+}
+
+fn build_vers(words: &[u64], _len: usize) -> vers_vecs::RsVec {
+    vers_vecs::RsVec::from_bit_vec(vers_vecs::BitVec::from_vec(words.to_vec()))
+}
+
+fn build_sucds(words: &[u64], len: usize) -> sucds::bit_vectors::Rank9Sel {
+    use sucds::bit_vectors::Build;
+    // sucds has no bulk-word constructor; per-bit is the only public path.
+    sucds::bit_vectors::Rank9Sel::build_from_bits(
+        (0..len).map(|i| bit_at(words, i)),
+        true,
+        true,
+        true,
+    )
+    .expect("sucds build failed")
+}
+
+type SuxRankSel = sux::rank_sel::SelectAdapt<
+    sux::rank_sel::Rank9<sux::traits::AddNumBits<sux::bits::BitVec<Vec<usize>>>>,
+>;
+
+fn build_sux(words: &[u64], len: usize) -> SuxRankSel {
+    use sux::traits::BitVecOpsMut;
+    let mut bv = sux::bits::BitVec::<Vec<usize>>::new(len);
+    for i in 0..len {
+        bv.set(i, bit_at(words, i));
+    }
+    sux::rank_sel::SelectAdapt::new(sux::rank_sel::Rank9::new(sux::traits::AddNumBits::from(bv)))
+}
+
+// ============================================================================
+// Benchmarks
+// ============================================================================
+
+fn label(size: usize, density: f64) -> String {
+    format!("{:.0}M/{:.0}%", size as f64 / 1e6, density * 100.0)
+}
+
+fn bench_construction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("construction");
+
+    for &size in SIZES {
+        for &density in DENSITIES {
+            let words = generate_words(size, density, 42);
+            let id = label(size, density);
+
+            group.bench_with_input(BenchmarkId::new("succinctly", &id), &words, |b, w| {
+                b.iter(|| build_succinctly(black_box(w), size));
+            });
+            group.bench_with_input(BenchmarkId::new("vers-vecs", &id), &words, |b, w| {
+                b.iter(|| build_vers(black_box(w), size));
+            });
+            group.bench_with_input(BenchmarkId::new("sucds", &id), &words, |b, w| {
+                b.iter(|| build_sucds(black_box(w), size));
+            });
+            group.bench_with_input(BenchmarkId::new("sux", &id), &words, |b, w| {
+                b.iter(|| build_sux(black_box(w), size));
+            });
+        }
+    }
+    group.finish();
+}
+
+fn bench_rank(c: &mut Criterion) {
+    use succinctly::RankSelect;
+    use sucds::bit_vectors::Rank;
+    use sux::traits::Rank as SuxRank;
+
+    let mut group = c.benchmark_group("rank1");
+
+    for &size in SIZES {
+        for &density in DENSITIES {
+            let words = generate_words(size, density, 42);
+            let queries = generate_queries(10_000, size, 123);
+            let id = label(size, density);
+
+            let succ = build_succinctly(&words, size);
+            group.bench_with_input(BenchmarkId::new("succinctly", &id), &queries, |b, qs| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &q in qs {
+                        sum += succ.rank1(black_box(q));
+                    }
+                    sum
+                });
+            });
+            drop(succ);
+
+            let vers = build_vers(&words, size);
+            group.bench_with_input(BenchmarkId::new("vers-vecs", &id), &queries, |b, qs| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &q in qs {
+                        sum += vers.rank1(black_box(q));
+                    }
+                    sum
+                });
+            });
+            drop(vers);
+
+            let sucds_bv = build_sucds(&words, size);
+            group.bench_with_input(BenchmarkId::new("sucds", &id), &queries, |b, qs| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &q in qs {
+                        sum += sucds_bv.rank1(black_box(q)).unwrap_or(0);
+                    }
+                    sum
+                });
+            });
+            drop(sucds_bv);
+
+            let sux_bv = build_sux(&words, size);
+            group.bench_with_input(BenchmarkId::new("sux", &id), &queries, |b, qs| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &q in qs {
+                        sum += sux_bv.rank(black_box(q));
+                    }
+                    sum
+                });
+            });
+            drop(sux_bv);
+        }
+    }
+    group.finish();
+}
+
+fn bench_select(c: &mut Criterion) {
+    use succinctly::RankSelect;
+    use sucds::bit_vectors::Select;
+    use sux::traits::Select as SuxSelect;
+
+    let mut group = c.benchmark_group("select1");
+
+    for &size in SIZES {
+        for &density in DENSITIES {
+            let words = generate_words(size, density, 42);
+            let ones: usize = words.iter().map(|w| w.count_ones() as usize).sum();
+            if ones == 0 {
+                continue;
+            }
+            let queries = generate_queries(10_000, ones, 123);
+            let id = label(size, density);
+
+            let succ = build_succinctly(&words, size);
+            group.bench_with_input(BenchmarkId::new("succinctly", &id), &queries, |b, qs| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &q in qs {
+                        if let Some(p) = succ.select1(black_box(q)) {
+                            sum += p;
+                        }
+                    }
+                    sum
+                });
+            });
+            drop(succ);
+
+            let vers = build_vers(&words, size);
+            group.bench_with_input(BenchmarkId::new("vers-vecs", &id), &queries, |b, qs| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &q in qs {
+                        sum += vers.select1(black_box(q));
+                    }
+                    sum
+                });
+            });
+            drop(vers);
+
+            let sucds_bv = build_sucds(&words, size);
+            group.bench_with_input(BenchmarkId::new("sucds", &id), &queries, |b, qs| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &q in qs {
+                        sum += sucds_bv.select1(black_box(q)).unwrap_or(0);
+                    }
+                    sum
+                });
+            });
+            drop(sucds_bv);
+
+            let sux_bv = build_sux(&words, size);
+            group.bench_with_input(BenchmarkId::new("sux", &id), &queries, |b, qs| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &q in qs {
+                        sum += sux_bv.select(black_box(q)).unwrap_or(0);
+                    }
+                    sum
+                });
+            });
+            drop(sux_bv);
+        }
+    }
+    group.finish();
+}
+
+/// Assert all four structures answer rank1/select1 identically before timing them.
+///
+/// A benchmark of structures that disagree measures nothing, so this guards the rest of
+/// the file. It also pins down the API differences worth knowing: vers-vecs `select1`
+/// returns `usize` where succinctly and sucds return `Option`, and sux names the
+/// operations `rank`/`select`.
+fn verify_agreement(_c: &mut Criterion) {
+    use succinctly::RankSelect;
+    use sucds::bit_vectors::{Rank, Select};
+    use sux::traits::{Rank as SuxRank, Select as SuxSelect};
+
+    let size = 100_000;
+    let words = generate_words(size, 0.3, 7);
+    let ones: usize = words.iter().map(|w| w.count_ones() as usize).sum();
+
+    let succ = build_succinctly(&words, size);
+    let vers = build_vers(&words, size);
+    let sucds_bv = build_sucds(&words, size);
+    let sux_bv = build_sux(&words, size);
+
+    for i in (0..size).step_by(997) {
+        let expected = succ.rank1(i);
+        assert_eq!(vers.rank1(i), expected, "vers-vecs rank1({i})");
+        assert_eq!(sucds_bv.rank1(i), Some(expected), "sucds rank1({i})");
+        assert_eq!(sux_bv.rank(i), expected, "sux rank({i})");
+    }
+
+    for k in (0..ones).step_by(499) {
+        let expected = succ.select1(k).expect("succinctly select1");
+        assert_eq!(vers.select1(k), expected, "vers-vecs select1({k})");
+        assert_eq!(sucds_bv.select1(k), Some(expected), "sucds select1({k})");
+        assert_eq!(sux_bv.select(k), Some(expected), "sux select({k})");
+    }
+
+    println!("\nverify: all four libraries agree on rank1/select1 over {size} bits");
+}
+
+/// Report resident bytes per structure and the overhead over the raw bits.
+///
+/// This prints rather than times: it is the space half of the comparison, and the
+/// numbers it emits are what `docs/benchmarks/rust-succinct-libs.md` records.
+fn report_memory(_c: &mut Criterion) {
+    println!("\n{:=^78}", " Resident Size (rank + select structure) ");
+    println!(
+        "{:<14} {:<10} {:>12} {:>12} {:>12}",
+        "size/density", "library", "raw KiB", "resident KiB", "overhead"
+    );
+    println!("{:-<78}", "");
+
+    for &size in SIZES {
+        for &density in DENSITIES {
+            let words = generate_words(size, density, 42);
+            let raw = size.div_ceil(8);
+            let id = label(size, density);
+
+            let measure = |name: &str, resident: usize| {
+                let overhead = (resident as f64 - raw as f64) / raw as f64 * 100.0;
+                println!(
+                    "{:<14} {:<10} {:>12.1} {:>12.1} {:>11.1}%",
+                    id,
+                    name,
+                    raw as f64 / 1024.0,
+                    resident as f64 / 1024.0,
+                    overhead
+                );
+            };
+
+            ALLOCATOR.reset();
+            let s = build_succinctly(&words, size);
+            let r = ALLOCATOR.current();
+            black_box(&s);
+            drop(s);
+            measure("succinctly", r);
+
+            ALLOCATOR.reset();
+            let s = build_vers(&words, size);
+            let r = ALLOCATOR.current();
+            black_box(&s);
+            drop(s);
+            measure("vers-vecs", r);
+
+            ALLOCATOR.reset();
+            let s = build_sucds(&words, size);
+            let r = ALLOCATOR.current();
+            black_box(&s);
+            drop(s);
+            measure("sucds", r);
+
+            ALLOCATOR.reset();
+            let s = build_sux(&words, size);
+            let r = ALLOCATOR.current();
+            black_box(&s);
+            drop(s);
+            measure("sux", r);
+        }
+    }
+    println!("{:=<78}\n", "");
+}
+
+criterion_group!(
+    benches,
+    verify_agreement,
+    bench_construction,
+    bench_rank,
+    bench_select,
+    report_memory
+);
+criterion_main!(benches);

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -37,6 +37,7 @@ by Michael Nygard.
 | [ADR-0008](adr-0008.md) | ✅ Accepted | 2026-07-12 | Reject BMI2 Quote-Indexing for YAML (P6)               |
 | [ADR-0009](adr-0009.md) | ✅ Accepted | 2026-07-12 | Reject a Parse-Time Newline Index (P7)                 |
 | [ADR-0010](adr-0010.md) | ✅ Accepted | 2026-07-12 | Reject AVX-512 SIMD Variants (P8)                      |
+| [ADR-0011](adr-0011.md) | ✅ Accepted | 2026-07-15 | Custom Succinct Structures over Existing Rust Crates   |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0011.md
+++ b/docs/adrs/adr-0011.md
@@ -1,0 +1,113 @@
+# ADR-0011: Custom Succinct Structures over Existing Rust Crates
+
+## Status
+
+✅ Accepted
+
+## Context
+
+Succinctly implements its own bitvector (`BitVec` with a 3-level `RankDirectory` and a sampled
+`SelectIndex`), its own balanced-parentheses tree, and its own SIMD popcount. Several Rust crates
+already provide rank/select, which prompts a reasonable question — raised on Reddit and recorded as
+[issue #47](https://github.com/rust-works/succinctly/issues/47): were they evaluated, what ruled them
+out, and did anyone benchmark them?
+
+Until now the repository could not answer. [architecture/prior-art.md](../architecture/prior-art.md)
+listed two crates with no rationale, and four others (`fid`, `bio`, `sucds`, `sux`) were unmentioned.
+No build-vs-buy reasoning existed anywhere, and no comparative benchmark had been run.
+
+**This record is retrospective.** The code predates it, and to the extent the original decision was
+reasoned through, that reasoning was never written down — so the honest answer to "were these
+libraries evaluated first?" is *not on record*. The evaluation below was carried out now, against the
+crates as they stand in July 2026, and it is deliberately reported as it came out rather than as a
+defence of the existing code. Where the evidence undercuts the status quo, it says so.
+
+The candidates are `succinct`, `vers-vecs`, `fid`, and `bio` (named in the issue), plus `sucds` and
+`sux`, which the issue missed but which are the two strongest: `sucds` is the only one advertising
+`no_std`, and `sux` is from Vigna, author of the broadword paper this project already cites.
+
+## Decision
+
+We will **implement succinct structures in-crate** rather than depend on an existing rank/select
+library.
+
+Three requirements drive this, each verified rather than assumed:
+
+1. **`no_std`, which no candidate satisfies.** Succinctly is `no_std` when built without default
+   features ([src/lib.rs](../../src/lib.rs)), and CI enforces it — `cargo check --no-default-features`
+   runs on two legs of [ci.yml](../../.github/workflows/ci.yml). `succinct`, `fid`, `bio`, `vers-vecs`,
+   and `sux` are all std-only. `sucds` declares `#![cfg_attr(not(feature = "std"), no_std)]`, but the
+   attribute is vestigial as of 0.8.3: building it with `default-features = false` fails with ~141
+   errors, because `bit_vectors/rank9sel.rs` and `serial.rs` unconditionally `use std::io::{Read,
+   Write}` and the crate has no `alloc` plumbing. **All six are unusable from succinctly's `no_std`
+   core.**
+2. **Balanced-parentheses tree navigation, which none provide.** The semi-index (ADR-0001) needs
+   `find_close`, `find_open`, `enclose`, `parent`, `first_child`, `next_sibling`, `depth`, and
+   `subtree_size` over a min-excess index ([src/trees/bp.rs](../../src/trees/bp.rs)). These crates
+   supply rank/select over a bitvector; the tree layer would have to be written regardless.
+3. **Select with a caller-supplied hint.** `JsonIndex::ib_select1_from(k, hint)` gallops from a hint
+   word, giving O(log d) in the distance rather than O(log n) for the sequential access that dominates
+   iteration — the implementation documents ~3.3x sequential against a ~37% penalty on random access
+   ([src/json/light.rs](../../src/json/light.rs)). No candidate exposes a select that accepts a caller
+   hint. (sucds' "hinted selection" is Vigna's internal darray hint, not a caller-supplied one.)
+
+Requirement 1 alone is decisive today; 2 and 3 mean that adopting a crate would shrink the custom
+surface rather than remove it.
+
+Measured comparisons: [benchmarks/rust-succinct-libs.md](../benchmarks/rust-succinct-libs.md).
+
+## Consequences
+
+**Positive:**
+
+- The core `bits`/`trees` path stays `alloc`-only and `no_std`-clean, which CI keeps honest.
+- The BP tree, the parser-coupled indices, and the hinted-select paths can be co-designed with the
+  parsers instead of layered over a foreign API.
+- `BalancedParens<W, S>` can be generic over storage (`W: AsRef<[u64]>`) so a tree can be built over
+  borrowed or memory-mapped words, and over `SelectSupport` (`NoSelect` is a ZST) so JSON pays nothing
+  for a select index that only YAML needs. `vers-vecs::RsVec` and the others own their storage and
+  always build both indices.
+
+**Negative / trade-offs:**
+
+- **The general-purpose `BitVec` is not justified by these arguments, and the benchmarks do not rescue
+  it.** It wins no measured category on ARM64: `sux` is 1.5-1.7x faster at rank *and* roughly 3-4x
+  faster at select at comparable space, and `vers-vecs` is 5-8x more compact and up to 1.31x faster to
+  build. (Those measurements are ARM64-only; succinctly's x86_64 popcount is AVX-512-gated and
+  untested, as is vers-vecs' AVX-512 select. The space figures are exact and platform-independent; the
+  `select1` ratios are noisy — see the benchmark page.) Requirements
+  2 and 3 are about `BalancedParens` and `JsonIndex`, neither of which uses `BitVec` — both bypass it
+  for a plain `Vec<u64>` plus cumulative-rank `Vec<u32>`. `BitVec` survives only in auxiliary newline
+  indices and at the DSV API boundary. Its use there is a candidate for replacement, tracked in
+  [issue #228](https://github.com/rust-works/succinctly/issues/228); only requirement 1 currently keeps
+  it in-crate.
+- **The space cost is real and was previously misdocumented.** The rank directory spends 128 bits per
+  512 bits of data (~25%) and the sampled select index grows with density, so a full `BitVec` measures
+  27.5-47.5% resident overhead. Four documents claimed ~3%, which is the Poppy *paper's* figure, not
+  this implementation's; they have been corrected. Anyone citing succinctly's compactness against these
+  crates would have been citing a number that was never true of this code.
+- `CacheAlignedL1L2` and its builder cost roughly 270 lines of hand-rolled allocation machinery, with 16
+  `unsafe` sites, a manual `Drop`, and an `unsafe impl Send/Sync`
+  ([src/bits/rank.rs](../../src/bits/rank.rs)), all to buy 64-byte alignment. No in-repo benchmark
+  isolates aligned-vs-unaligned L1L2, so that specific trade remains unquantified.
+- Every structure here is ours to maintain, test across x86_64/ARM64, and fix. The crates would have
+  amortised that across their users.
+
+**Alternatives considered and rejected:**
+
+- **vers-vecs** (1.10.1) — the strongest on measurements: 5-8x more compact than `BitVec` and faster to
+  build, and it offers the same zero-copy `BitVec::from_vec(Vec<u64>)` construction succinctly relies on
+  for SIMD-produced masks. Rejected on `no_std` only. Its rank is ~2x slower than succinctly's.
+- **sux** (0.14.0) — fastest queries measured, at space comparable to `BitVec`. Rejected on `no_std`
+  only.
+- **sucds** (0.8.3) — the only candidate advertising `no_std`; rejected because that support does not
+  compile (see Decision). Otherwise a close fit, and worth revisiting if upstream repairs it.
+- **succinct** (0.5.2) — last published August 2019; unmaintained.
+- **fid** (0.1.7) — repository archived February 2025.
+- **bio** (4.0.1) — a bioinformatics toolkit whose rank/select is incidental; adopting it means adopting
+  ~30 direct dependencies for one data structure.
+- **sdsl-lite** — C++, so not a candidate for a pure-Rust `no_std` crate.
+
+This ADR should be revisited if succinctly drops the `no_std` requirement, or if `sucds` fixes its
+`no_std` build — in either case, requirement 1 disappears and only the BP tree and hinted-select
+arguments remain, neither of which covers `BitVec`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -14,7 +14,7 @@ one-page top-level overview and orientation, start at the root
 | [BitVec](bitvec.md) | Bit vector with O(1) rank and O(log n) select |
 | [Balanced Parentheses](balanced-parens.md) | Succinct tree encoding |
 | [Semi-Indexing](semi-indexing.md) | JSON/YAML/DSV parsing approach |
-| [Prior Art](prior-art.md) | Academic foundations and haskell-works heritage |
+| [Prior Art](prior-art.md) | Academic foundations, haskell-works heritage, and the Rust crates evaluated |
 
 ## Module Structure
 

--- a/docs/architecture/bitvec.md
+++ b/docs/architecture/bitvec.md
@@ -72,17 +72,22 @@ For n bits:
 - Superblock index: n/512 * 64 = n/8 bits (12.5%)
 - Block index: n/64 * 16 = n/4 bits (25%)
 
-Wait, that's too much! We optimize:
+The block index is packed to bring that down:
 
 ### Optimized Block Index
 - Store relative counts within superblock
 - 8 blocks per superblock, max count 64 each
 - Pack into u16 (max 512 total)
 
-Actual overhead:
+Actual overhead of the rank directory:
 - Superblock: n/512 * 64 bits = 0.125n bits
 - Block: n/64 * 9 bits = 0.14n bits
-- Total: ~3-4% overhead
+- Total: ~0.265n bits, i.e. **~25% overhead** — 128 bits of metadata per 512 bits of data
+
+This is a deliberate trade of space for query speed, and is *not* the ~3% of a compact Poppy index;
+see the note in [src/bits/rank.rs](../../src/bits/rank.rs). The sampled `SelectIndex` adds an entry per
+256 set bits on top, so a full `BitVec` measures **27.5-47.5%** resident overhead, rising with bit
+density ([../benchmarks/rust-succinct-libs.md](../benchmarks/rust-succinct-libs.md)).
 
 ## SIMD Optimization
 

--- a/docs/architecture/prior-art.md
+++ b/docs/architecture/prior-art.md
@@ -10,35 +10,40 @@ This document records the academic papers, prior implementations, and key refere
 
 ### Rank and Select
 
-| Paper | Authors | Year | Contribution |
-|-------|---------|------|--------------|
-| [Broadword Implementation of Rank/Select Queries](https://vigna.di.unimi.it/ftp/papers/Broadword.pdf) | Vigna | 2008 | Broadword algorithms for 64-bit operations |
-| [Space-Efficient, High-Performance Rank & Select](https://www.cs.cmu.edu/~dga/papers/zhou-sea2013.pdf) | Zhou, Andersen, Kaminsky | 2013 | Poppy structure with 3% overhead |
+| Paper                                                                                                  | Authors                  | Year | Contribution                               |
+|--------------------------------------------------------------------------------------------------------|--------------------------|------|--------------------------------------------|
+| [Broadword Implementation of Rank/Select Queries](https://vigna.di.unimi.it/ftp/papers/Broadword.pdf)  | Vigna                    | 2008 | Broadword algorithms for 64-bit operations |
+| [Space-Efficient, High-Performance Rank & Select](https://www.cs.cmu.edu/~dga/papers/zhou-sea2013.pdf) | Zhou, Andersen, Kaminsky | 2013 | Poppy structure with 3% overhead           |
 
-**Succinctly implementation**: [src/bits/](../../src/bits/) implements Poppy-style 3-level rank directory with ~3% space overhead.
+**Succinctly implementation**: [src/bits/](../../src/bits/) implements a Poppy-*style* 3-level rank directory. It
+borrows Poppy's L0/L1/L2 shape but not its space bound: the 3% figure above is the paper's, and succinctly's
+directory instead spends 128 bits of metadata per 512 bits of data (~25%), deliberately trading space for query
+speed — see the note in [src/bits/rank.rs](../../src/bits/rank.rs) and [bitvec.md](bitvec.md#space-analysis).
+Measured resident overhead for a full `BitVec` (rank directory *and* sampled select index) is **27.5–47.5%**,
+rising with bit density; see [../benchmarks/rust-succinct-libs.md](../benchmarks/rust-succinct-libs.md).
 
 ### Balanced Parentheses
 
-| Paper | Authors | Year | Contribution |
-|-------|---------|------|--------------|
-| Fully-Functional Succinct Trees | Sadakane & Navarro | 2010 | RangeMin structure for O(1) tree navigation |
-| Optimal Succinctness for Parentheses | Navarro & Sadakane | 2014 | Space-optimal BP representation |
+| Paper                                | Authors            | Year | Contribution                                |
+|--------------------------------------|--------------------|------|---------------------------------------------|
+| Fully-Functional Succinct Trees      | Sadakane & Navarro | 2010 | RangeMin structure for O(1) tree navigation |
+| Optimal Succinctness for Parentheses | Navarro & Sadakane | 2014 | Space-optimal BP representation             |
 
 **Succinctly implementation**: [src/trees/bp.rs](../../src/trees/bp.rs) implements hierarchical RangeMin with ~6% overhead.
 
 ### JSON Semi-Indexing
 
-| Paper | Authors | Year | Contribution |
-|-------|---------|------|--------------|
-| [Parsing Gigabytes of JSON per Second](https://arxiv.org/abs/1902.08318) | Langdale & Lemire | 2019 | SIMD-accelerated JSON parsing (simdjson) |
-| [Data-Parallel Finite-State Machines](https://www.microsoft.com/en-us/research/publication/data-parallel-finite-state-machines/) | Mytkowicz et al. | 2014 | PFSM for parallel parsing |
+| Paper                                                                                                                            | Authors           | Year | Contribution                             |
+|----------------------------------------------------------------------------------------------------------------------------------|-------------------|------|------------------------------------------|
+| [Parsing Gigabytes of JSON per Second](https://arxiv.org/abs/1902.08318)                                                         | Langdale & Lemire | 2019 | SIMD-accelerated JSON parsing (simdjson) |
+| [Data-Parallel Finite-State Machines](https://www.microsoft.com/en-us/research/publication/data-parallel-finite-state-machines/) | Mytkowicz et al.  | 2014 | PFSM for parallel parsing                |
 
 **Succinctly implementation**: [src/json/](../../src/json/) uses PFSM with table-driven state machine, achieving ~700 MiB/s throughput.
 
 ### Bit Manipulation
 
-| Paper | Authors | Year | Contribution |
-|-------|---------|------|--------------|
+| Paper                                                                                | Authors            | Year | Contribution                   |
+|--------------------------------------------------------------------------------------|--------------------|------|--------------------------------|
 | [Faster Population Counts Using AVX2 Instructions](https://arxiv.org/abs/1611.07612) | Mula, Kurz, Lemire | 2016 | Harley-Seal popcount algorithm |
 
 **Succinctly implementation**: [src/bits/popcount.rs](../../src/bits/popcount.rs) uses AVX-512 VPOPCNTDQ when available (5.2x speedup).
@@ -51,13 +56,13 @@ Succinctly is a Rust reimplementation of techniques from the [haskell-works](htt
 
 ### Core Packages
 
-| Haskell Package | Succinctly Module | Purpose |
-|-----------------|-------------------|---------|
-| [hw-rankselect](https://github.com/haskell-works/hw-rankselect) | `src/bits/` | Rank/select data structures |
-| [hw-balancedparens](https://github.com/haskell-works/hw-balancedparens) | `src/trees/` | Balanced parentheses operations |
-| [hw-json](https://github.com/haskell-works/hw-json) | `src/json/` | JSON semi-indexing |
-| [hw-json-simd](https://github.com/haskell-works/hw-json-simd) | `src/json/pfsm*.rs` | SIMD-accelerated JSON parser |
-| [hw-dsv](https://github.com/haskell-works/hw-dsv) | `src/dsv/` | DSV/CSV parsing |
+| Haskell Package                                                         | Succinctly Module   | Purpose                         |
+|-------------------------------------------------------------------------|---------------------|---------------------------------|
+| [hw-rankselect](https://github.com/haskell-works/hw-rankselect)         | `src/bits/`         | Rank/select data structures     |
+| [hw-balancedparens](https://github.com/haskell-works/hw-balancedparens) | `src/trees/`        | Balanced parentheses operations |
+| [hw-json](https://github.com/haskell-works/hw-json)                     | `src/json/`         | JSON semi-indexing              |
+| [hw-json-simd](https://github.com/haskell-works/hw-json-simd)           | `src/json/pfsm*.rs` | SIMD-accelerated JSON parser    |
+| [hw-dsv](https://github.com/haskell-works/hw-dsv)                       | `src/dsv/`          | DSV/CSV parsing                 |
 
 ### Key Concepts Ported
 
@@ -68,23 +73,23 @@ Succinctly is a Rust reimplementation of techniques from the [haskell-works](htt
 
 ### Differences from Haskell Implementation
 
-| Aspect | Haskell | Rust |
-|--------|---------|------|
-| Memory model | GC-managed | Zero-copy, no_std compatible |
-| SIMD | FFI to C | Native intrinsics via `std::arch` |
-| ARM support | Limited (disabled) | Full NEON implementation |
-| Streaming | Lazy evaluation | Explicit iterators |
+| Aspect       | Haskell            | Rust                              |
+|--------------|--------------------|-----------------------------------|
+| Memory model | GC-managed         | Zero-copy, no_std compatible      |
+| SIMD         | FFI to C           | Native intrinsics via `std::arch` |
+| ARM support  | Limited (disabled) | Full NEON implementation          |
+| Streaming    | Lazy evaluation    | Explicit iterators                |
 
 ### ARM/NEON Portability
 
 The Haskell packages disable SIMD on ARM (`base < 0` constraint). Succinctly provides full ARM support:
 
-| x86_64 Instruction | ARM/NEON Equivalent | Notes |
-|--------------------|---------------------|-------|
-| `_mm256_cmpeq_epi8` | `vceqq_u8` (128-bit) | Process 16 bytes vs 32 |
-| `_mm256_movemask_epi8` | Manual extraction | Multi-instruction sequence |
-| `_pdep_u64` | Software emulation | No ARM equivalent |
-| `_pext_u64` | Software emulation | No ARM equivalent |
+| x86_64 Instruction     | ARM/NEON Equivalent  | Notes                      |
+|------------------------|----------------------|----------------------------|
+| `_mm256_cmpeq_epi8`    | `vceqq_u8` (128-bit) | Process 16 bytes vs 32     |
+| `_mm256_movemask_epi8` | Manual extraction    | Multi-instruction sequence |
+| `_pdep_u64`            | Software emulation   | No ARM equivalent          |
+| `_pext_u64`            | Software emulation   | No ARM equivalent          |
 
 ---
 
@@ -92,22 +97,37 @@ The Haskell packages disable SIMD on ARM (`base < 0` constraint). Succinctly pro
 
 ### JSON Parsers
 
-| Project | Language | Technique | Performance |
-|---------|----------|-----------|-------------|
-| [simdjson](https://github.com/simdjson/simdjson) | C++ | SIMD + tape | >2 GB/s |
-| [simd-json](https://github.com/simd-lite/simd-json) | Rust | simdjson port | ~1 GB/s |
-| [sonic-rs](https://github.com/cloudwego/sonic-rs) | Rust | SIMD + LazyValue | ~800 MiB/s |
-| succinctly | Rust | Semi-indexing | ~700 MiB/s |
+| Project                                             | Language | Technique        | Performance |
+|-----------------------------------------------------|----------|------------------|-------------|
+| [simdjson](https://github.com/simdjson/simdjson)    | C++      | SIMD + tape      | >2 GB/s     |
+| [simd-json](https://github.com/simd-lite/simd-json) | Rust     | simdjson port    | ~1 GB/s     |
+| [sonic-rs](https://github.com/cloudwego/sonic-rs)   | Rust     | SIMD + LazyValue | ~800 MiB/s  |
+| succinctly                                          | Rust     | Semi-indexing    | ~700 MiB/s  |
 
 **Succinctly's advantage**: 18-46x less memory than DOM parsers due to lazy evaluation.
 
 ### Succinct Data Structure Libraries
 
-| Library | Language | Focus |
-|---------|----------|-------|
-| [sdsl-lite](https://github.com/simongog/sdsl-lite) | C++ | Comprehensive succinct DS |
-| [succinct](https://crates.io/crates/succinct) | Rust | Basic rank/select |
-| [vers-vecs](https://crates.io/crates/vers-vecs) | Rust | Fast pure-Rust rank/select |
+Succinctly implements its own rank/select rather than depending on one of these. The reasoning, and the
+benchmarks behind it, are recorded in [ADR-0011](../adrs/adr-0011.md) — including the cases where an existing
+crate would have served. Measured comparisons live in
+[../benchmarks/rust-succinct-libs.md](../benchmarks/rust-succinct-libs.md).
+
+| Library                                            | Language | `no_std` | Latest | Assessment                                                                        |
+|----------------------------------------------------|----------|----------|--------|-----------------------------------------------------------------------------------|
+| [sdsl-lite](https://github.com/simongog/sdsl-lite) | C++      | n/a      | —      | Comprehensive succinct DS; C++, so not a candidate for a pure-Rust `no_std` crate |
+| [succinct](https://crates.io/crates/succinct)      | Rust     | No       | 0.5.2  | Basic rank/select; last published 2019, effectively unmaintained                  |
+| [fid](https://crates.io/crates/fid)                | Rust     | No       | 0.1.7  | Fully Indexable Dictionary; repository archived February 2025                     |
+| [bio](https://crates.io/crates/bio)                | Rust     | No       | 4.0.1  | Bioinformatics toolkit; rank/select incidental, ~30 direct dependencies           |
+| [vers-vecs](https://crates.io/crates/vers-vecs)    | Rust     | No       | 1.10.1 | **Smallest measured** (5-8x more compact than `BitVec`) and fastest to build      |
+| [sucds](https://crates.io/crates/sucds)            | Rust     | Declared | 0.8.3  | Declares `no_std`, but does not build without `std` — see note below              |
+| [sux](https://crates.io/crates/sux)                | Rust     | No       | 0.14.0 | From Vigna; **fastest queries measured** — beats `BitVec` at rank and select      |
+
+**On sucds and `no_std`**: sucds is the only candidate that advertises `no_std` support, via
+`#![cfg_attr(not(feature = "std"), no_std)]` in its `lib.rs`. That attribute is vestigial as of 0.8.3: building
+with `default-features = false` fails with ~141 errors, because `bit_vectors/rank9sel.rs` and `serial.rs`
+unconditionally `use std::io::{Read, Write}` and the crate has no `alloc` plumbing. Every crate in this table is
+therefore unusable from succinctly's `no_std` core.
 
 ---
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -17,15 +17,16 @@ The benchmarks below compare succinctly against DOM-based tools (jq, yq, serde_j
 
 ## Benchmark Results
 
-| Benchmark                                 | Description                          | Key Finding                                      |
-|-------------------------------------------|--------------------------------------|--------------------------------------------------|
-| [jq](jq.md)                               | succinctly jq vs system jq           | 1.1-2.3x faster across platforms                 |
-| [yq](yq.md)                               | succinctly yq vs system yq           | 4.5-11x faster (Graviton 4), 7-25x (x86_64)      |
-| [JSON Validation](json-validate.md)       | RFC 8259 strict validation           | 530-1800 MiB/s (up to 1.8 GiB/s on nested)       |
-| [Rust JSON Parsers](rust-parsers.md)      | vs serde_json, sonic-rs, simd-json   | Competitive with specialized parsers             |
-| [Rust YAML Parsers](rust-yaml-parsers.md) | vs serde_yaml                        | 8-14x faster parsing, 10-39x less memory         |
-| [Cross-Language](cross-language.md)       | Multi-language parser comparison     | Best-in-class for semi-indexing                  |
-| [DSV](dsv.md)                             | CSV/TSV parsing performance          | 85-1676 MiB/s (API)                              |
+| Benchmark                                        | Description                          | Key Finding                                    |
+|--------------------------------------------------|--------------------------------------|------------------------------------------------|
+| [jq](jq.md)                                      | succinctly jq vs system jq           | 1.1-2.3x faster across platforms               |
+| [yq](yq.md)                                      | succinctly yq vs system yq           | 4.5-11x faster (Graviton 4), 7-25x (x86_64)    |
+| [JSON Validation](json-validate.md)              | RFC 8259 strict validation           | 530-1800 MiB/s (up to 1.8 GiB/s on nested)     |
+| [Rust JSON Parsers](rust-parsers.md)             | vs serde_json, sonic-rs, simd-json   | Competitive with specialized parsers           |
+| [Rust YAML Parsers](rust-yaml-parsers.md)        | vs serde_yaml                        | 8-14x faster parsing, 10-39x less memory       |
+| [Rust Succinct Libraries](rust-succinct-libs.md) | rank/select vs vers-vecs, sucds, sux | Faster rank than vers-vecs, but 5-8x the space |
+| [Cross-Language](cross-language.md)              | Multi-language parser comparison     | Best-in-class for semi-indexing                |
+| [DSV](dsv.md)                                    | CSV/TSV parsing performance          | 85-1676 MiB/s (API)                            |
 
 ## Methodology
 

--- a/docs/benchmarks/inventory.md
+++ b/docs/benchmarks/inventory.md
@@ -6,18 +6,19 @@ This document provides a comprehensive index of all benchmark reports in the pro
 
 ## Overview
 
-The project contains **8 main benchmark documentation files** with approximately **160+ distinct benchmark report sections**, plus **6 core/internal benchmark suites**.
+The project contains **9 main benchmark documentation files** with approximately **160+ distinct benchmark report sections**, plus **6 core/internal benchmark suites**.
 
-| File                                         | Description                                | Sections |
-|----------------------------------------------|--------------------------------------------|----------|
-| [jq.md](jq.md)                               | JSON query performance vs system jq        | ~40      |
-| [yq.md](yq.md)                               | YAML query performance vs system yq        | ~35      |
-| [json-validate.md](json-validate.md)         | JSON validation (RFC 8259) throughput      | ~12      |
-| [dsv.md](dsv.md)                             | CSV/TSV parsing performance                | ~8       |
-| [cross-language.md](cross-language.md)       | Multi-parser JSON comparison               | ~15      |
-| [rust-parsers.md](rust-parsers.md)           | Rust JSON parser comparison (x86_64 + ARM) | ~20      |
-| [rust-yaml-parsers.md](rust-yaml-parsers.md) | Rust YAML parser comparison (x86_64 + ARM) | ~16      |
-| [../parsing/yaml.md](../parsing/yaml.md)     | YAML optimization phases                   | ~15      |
+| File                                           | Description                                 | Sections |
+|------------------------------------------------|---------------------------------------------|----------|
+| [jq.md](jq.md)                                 | JSON query performance vs system jq         | ~40      |
+| [yq.md](yq.md)                                 | YAML query performance vs system yq         | ~35      |
+| [json-validate.md](json-validate.md)           | JSON validation (RFC 8259) throughput       | ~12      |
+| [dsv.md](dsv.md)                               | CSV/TSV parsing performance                 | ~8       |
+| [cross-language.md](cross-language.md)         | Multi-parser JSON comparison                | ~15      |
+| [rust-parsers.md](rust-parsers.md)             | Rust JSON parser comparison (x86_64 + ARM)  | ~20      |
+| [rust-yaml-parsers.md](rust-yaml-parsers.md)   | Rust YAML parser comparison (x86_64 + ARM)  | ~16      |
+| [rust-succinct-libs.md](rust-succinct-libs.md) | Rust rank/select library comparison (ARM64) | ~4       |
+| [../parsing/yaml.md](../parsing/yaml.md)       | YAML optimization phases                    | ~15      |
 
 ---
 

--- a/docs/benchmarks/rust-succinct-libs.md
+++ b/docs/benchmarks/rust-succinct-libs.md
@@ -1,0 +1,189 @@
+# Rust Succinct Library Comparison
+
+[Home](../../) > [Docs](../) > [Benchmarks](./) > Rust Succinct Libraries
+
+Benchmark comparison of succinctly's `BitVec` rank/select against the other maintained pure-Rust
+succinct-structure crates.
+
+**Platform**: ARM64 (Apple M5 Max, 18 cores, 128 GB), macOS 26.5.2, rustc 1.97.0
+**Date**: 2026-07-15
+
+> **Why this page exists**: [issue #47](https://github.com/rust-works/succinctly/issues/47) asked whether
+> existing crates were evaluated before succinctly built its own rank/select, and whether anyone had
+> benchmarked them. This page is the measurement; [ADR-0011](../adrs/adr-0011.md) is the decision it informs.
+> The short version: **succinctly's `BitVec` is not the fastest structure here, and it is far from the
+> smallest.** It is kept for reasons that these benchmarks do not measure.
+
+## Libraries Compared
+
+Each library is given its best-available acceleration, so no crate is measured with a fast path switched
+off:
+
+| Library        | Version | Features enabled | Structure benchmarked                              |
+|----------------|---------|------------------|----------------------------------------------------|
+| **succinctly** | 0.7.0   | `simd`           | `BitVec` (3-level `RankDirectory` + `SelectIndex`) |
+| **vers-vecs**  | 1.10.1  | `simd`           | `RsVec`                                            |
+| **sucds**      | 0.8.3   | `intrinsics`     | `Rank9Sel`                                         |
+| **sux**        | 0.14.0  | (none relevant)  | `SelectAdapt<Rank9<AddNumBits<BitVec>>>`           |
+
+### Not benchmarked, and why
+
+Three of the crates named in issue #47 are excluded. They are ruled out on maintenance or dependency
+grounds *before* performance becomes relevant, so benchmarking them would pad the tables without
+informing the decision:
+
+| Library    | Version | Reason for exclusion                                                             |
+|------------|---------|----------------------------------------------------------------------------------|
+| `succinct` | 0.5.2   | Last published August 2019; effectively unmaintained                             |
+| `fid`      | 0.1.7   | Repository archived February 2025                                                |
+| `bio`      | 4.0.1   | Bioinformatics toolkit; rank/select incidental, ~30 direct dependencies to adopt |
+
+## Limitations
+
+**These results are ARM64-only, and that matters more than usual here** — several of the fastest paths in
+this comparison are x86_64-specific and therefore never executed:
+
+- **succinctly's x86_64 popcount acceleration is AVX-512 VPOPCNTDQ** (`popcount_words_x86` in
+  [src/bits/popcount.rs](../../src/bits/popcount.rs)); there is no AVX2 variant. On ARM64 the `simd`
+  feature selects the NEON path instead. The x86_64 path is untested by this page.
+- **vers-vecs' SIMD select is gated on `x86_64` + `avx512vl` + `avx512bw`**. On ARM64 its `simd` feature
+  is a no-op, so its select ran on the scalar fallback. On an AVX-512 machine its select numbers below
+  could improve substantially.
+- **sucds' `intrinsics`** is arch-neutral (`count_ones`/`trailing_zeros`), so it is unaffected by
+  platform.
+
+Treat the **placings as ARM64 findings, not universal ones.** Reproducing this on x86_64 (Zen 4, where
+the project already documents other benchmarks) is a genuine gap; the `select1` ordering in particular
+should not be assumed to carry over.
+
+**Run-to-run variance**: `select1` is memory-bound and noisy on this machine — repeated runs moved
+individual cells by up to ~40% (succinctly at 1M/50% measured 125 µs, 181 µs, and 175 µs across three
+runs). The *placings* were stable across all three, but do not read the `select1` ratios as precise.
+`rank1`, `construction`, and resident size were all stable or exact.
+
+## Methodology
+
+All four structures are built from the **same seeded random words** (`ChaCha8Rng`, fixed seed), so every
+library sees identical bits. Each builder takes `&[u64]` and returns a fully owned rank+select structure:
+no library is charged for, or credited with, borrowing the caller's buffer.
+
+The benchmark asserts all four libraries **agree on every `rank1`/`select1` answer** before timing them —
+a comparison of structures that disagree would measure nothing. See `verify_agreement` in
+[bench-compare/benches/succinct_libs.rs](../../bench-compare/benches/succinct_libs.rs).
+
+Sizes and densities mirror [benches/rank_select.rs](../../benches/rank_select.rs) so numbers are comparable
+with the in-crate rank/select benchmarks. Query benchmarks issue 10,000 random positions per iteration.
+
+**Fairness caveat on construction**: succinctly (`BitVec::from_words`) and vers-vecs (`BitVec::from_vec`)
+both accept an owned `Vec<u64>` by move. sucds and sux have **no bulk-word constructor** and must be filled
+one bit at a time. Their construction numbers below reflect that API limitation, not an algorithmic deficit.
+
+## Results
+
+### Resident size (rank + select structure)
+
+Measured with a tracking global allocator, read while the structure is alive. Overhead is over the raw
+bits. These figures are deterministic — identical across every run.
+
+| Size / density | succinctly | vers-vecs | sucds | sux   |
+|----------------|------------|-----------|-------|-------|
+| 1M / 10%       | 27.5%      | **5.6%**  | 36.1% | 36.3% |
+| 1M / 50%       | 37.5%      | **4.7%**  | 36.1% | 39.1% |
+| 1M / 90%       | 47.5%      | **5.6%**  | 36.1% | 37.7% |
+| 10M / 10%      | 27.5%      | **6.5%**  | 99.0% | 36.3% |
+| 10M / 50%      | 37.5%      | **5.2%**  | 99.0% | 32.0% |
+| 10M / 90%      | 47.5%      | **6.5%**  | 99.0% | 37.7% |
+
+**vers-vecs is 5-8x more compact than succinctly.** Two things drive succinctly's number: the rank
+directory spends 128 bits of metadata per 512 bits of data (~25% by design — see
+[src/bits/rank.rs](../../src/bits/rank.rs)), and the sampled `SelectIndex` adds an entry per 256 set bits,
+which is why succinctly's overhead **climbs with density** (27.5% → 47.5%) where the others stay flat.
+
+This is the strongest result on the page: it is exact, platform-independent, and not subject to the
+variance that affects the timings.
+
+### Construction (build the full rank+select structure)
+
+| Size / density | succinctly | vers-vecs    | sucds    | sux      |
+|----------------|------------|--------------|----------|----------|
+| 1M / 10%       | 21.5 µs    | **19.9 µs**  | 735.5 µs | 1.66 ms  |
+| 1M / 50%       | 24.0 µs    | **19.7 µs**  | 757.1 µs | 3.13 ms  |
+| 1M / 90%       | 25.0 µs    | **20.1 µs**  | 735.5 µs | 1.69 ms  |
+| 10M / 10%      | 212.4 µs   | **209.8 µs** | 7.47 ms  | 17.29 ms |
+| 10M / 50%      | 242.7 µs   | **215.3 µs** | 7.58 ms  | 29.81 ms |
+| 10M / 90%      | 249.9 µs   | **191.3 µs** | 7.76 ms  | 16.79 ms |
+
+vers-vecs builds **1.0-1.31x faster** than succinctly (the two are near-parity at 10M/10%). sucds and sux
+are 30-120x slower here, but per the caveat above that is their missing bulk-word constructor, not their
+algorithms.
+
+### rank1 (10,000 random queries)
+
+| Size / density | succinctly | vers-vecs | sucds   | sux         |
+|----------------|------------|-----------|---------|-------------|
+| 1M / 10%       | 14.6 µs    | 33.5 µs   | 16.3 µs | **9.2 µs**  |
+| 1M / 50%       | 14.9 µs    | 34.0 µs   | 16.0 µs | **9.0 µs**  |
+| 1M / 90%       | 14.2 µs    | 32.6 µs   | 16.8 µs | **9.1 µs**  |
+| 10M / 10%      | 16.2 µs    | 30.4 µs   | 16.3 µs | **10.1 µs** |
+| 10M / 50%      | 16.0 µs    | 30.0 µs   | 16.1 µs | **10.6 µs** |
+| 10M / 90%      | 17.9 µs    | 32.6 µs   | 17.9 µs | **10.8 µs** |
+
+This is succinctly's best showing, and the most stable timing on the page. It is **~1.8-2.3x faster than
+vers-vecs** and level with sucds — the cache-aligned directory is buying the query speed it was designed
+to buy. But **sux is 1.5-1.7x faster still**, at comparable space.
+
+### select1 (10,000 random queries)
+
+Read the ordering, not the ratios — see the variance note under [Limitations](#limitations).
+
+| Size / density | succinctly | vers-vecs | sucds    | sux         |
+|----------------|------------|-----------|----------|-------------|
+| 1M / 10%       | 195.9 µs   | 174.4 µs  | 122.2 µs | **55.9 µs** |
+| 1M / 50%       | 181.0 µs   | 372.2 µs  | 79.7 µs  | **55.8 µs** |
+| 1M / 90%       | 240.2 µs   | 554.1 µs  | 70.8 µs  | **69.3 µs** |
+| 10M / 10%      | 278.3 µs   | 182.9 µs  | 139.7 µs | **70.2 µs** |
+| 10M / 50%      | 279.8 µs   | 382.1 µs  | 90.3 µs  | **78.7 µs** |
+| 10M / 90%      | 276.7 µs   | 575.6 µs  | 83.6 µs  | **63.0 µs** |
+
+succinctly's select is O(log n) by construction (sample every 256 ones, then search), so losing here is
+expected rather than surprising. **sux is roughly 3-4x faster** and sucds 1.6-3.4x faster; both keep select
+near-flat across density where succinctly's and vers-vecs' degrade. vers-vecs is the only library that is
+*worse* than succinctly here, and only at 50-90% density — but on ARM64 its SIMD select path does not
+exist, so this is the cell most likely to change on x86_64.
+
+## Summary
+
+| Dimension    | Winner        | succinctly's placing                      |
+|--------------|---------------|-------------------------------------------|
+| Space        | **vers-vecs** | 4th of 4 at high density (5-8x vers-vecs) |
+| Construction | **vers-vecs** | 2nd of 4                                  |
+| rank1        | **sux**       | 2nd of 4                                  |
+| select1      | **sux**       | 3rd of 4                                  |
+
+succinctly's `BitVec` wins no category on ARM64. `sux` is faster at both rank and select at comparable
+space; `vers-vecs` is far smaller and faster to build. On these measurements alone, a third-party crate
+would be the better choice.
+
+**The reason succinctly nevertheless implements its own is not on this page**: it is `no_std` (CI-enforced,
+and not satisfied by any of these crates), plus structures none of them provide — balanced-parentheses tree
+navigation and hinted select. See [ADR-0011](../adrs/adr-0011.md) for the full argument, including where it
+does not hold.
+
+## Reproducing Benchmarks
+
+```bash
+# From the repository root
+succinctly bench run succinct_libs
+
+# Or directly
+cd bench-compare
+cargo bench --bench succinct_libs
+```
+
+Feature selection is pinned in `bench-compare/Cargo.toml` (see [Libraries Compared](#libraries-compared)),
+so the command above reproduces the configuration measured here. The resident-size table is printed by the
+benchmark itself, after the criterion groups.
+
+Per [STYLE-0008](../STYLE_GUIDE.md), these numbers are regenerated rather than hand-edited, and are labelled
+with the CPU they were measured on. **An x86_64 run is outstanding** and would be a genuine addition — it is
+the only way to exercise succinctly's AVX-512 popcount and vers-vecs' AVX-512 select.

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,8 @@ the YAML equivalent is planned.
 Where this knowledge map explains *how* succinctly works today, the
 [Architecture Decision Records](adrs/README.md) record *why* it is shaped that way — and which
 approaches were considered and **rejected**. The corpus covers the core choices (semi-indexing
-over DOM parsing, the PFSM JSON parser, the YAML oracle) and the rejected optimizations
+over DOM parsing, the PFSM JSON parser, the YAML oracle, building succinct structures in-crate
+rather than depending on an existing rank/select library) and the rejected optimizations
 (software prefetching, SIMD threshold tuning, branchless classification, flow-collection SIMD,
 BMI2 quote-indexing, parse-time newline index, AVX-512), each as a stable, citable record. See
 [adrs/README.md](adrs/README.md) for the inventory.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2,6 +2,25 @@
 
 Tracks updates to the knowledge wiki pages in `docs/`.
 
+## 2026-07-15 — Rust succinct-library evaluation (issue #47)
+
+**Sources ingested:**
+- crates.io + GitHub metadata for `succinct`, `vers-vecs`, `fid`, `bio`, `sucds`, `sux` — versions,
+  maintenance status, `no_std` support (verified by compiling, not by reading the attribute)
+- `src/bits/` — `bitvec.rs`, `rank.rs`, `select.rs`, `popcount.rs`; the ~25% overhead note at `rank.rs:352-354`
+- `src/trees/bp.rs`, `src/json/light.rs`, `src/dsv/index.rs` — coupling that a generic crate cannot supply
+- New measurements from `bench-compare/benches/succinct_libs.rs` (Apple M5 Max)
+
+**Pages created:**
+- [adr-0011.md](adrs/adr-0011.md) — why succinct structures are built in-crate rather than taken from a crate
+- [rust-succinct-libs.md](benchmarks/rust-succinct-libs.md) — rank/select vs vers-vecs, sucds, sux
+
+**Pages corrected:**
+- [prior-art.md](architecture/prior-art.md), `CLAUDE.md`, `README.md`,
+  [hierarchical-structures.md](optimizations/hierarchical-structures.md) — all claimed the rank directory costs
+  ~3% space. That is the Poppy *paper's* figure; succinctly's directory costs ~25% by design
+  (`src/bits/rank.rs:352-354`), and a full `BitVec` measures 27.5–47.5% resident. Corrected throughout.
+
 ## 2026-07-15 — YAML Test Suite conformance (issue #49)
 
 **Sources ingested:**

--- a/docs/optimizations/cache-memory.md
+++ b/docs/optimizations/cache-memory.md
@@ -378,13 +378,13 @@ struct Counters {
 
 ## Usage in Succinctly
 
-| Technique              | Location           | Purpose                    | Impact       |
-|------------------------|--------------------|----------------------------|--------------|
-| Cache-aligned L1L2     | `bits/rank.rs`     | Rank directory             | 3-4% faster  |
-| Packed u128 entries    | `bits/rank.rs`     | Reduce memory footprint    | 3% overhead  |
-| Dual select methods    | `bits/select.rs`   | Adapt to access pattern    | 3.1x seq     |
-| Lightweight index      | `dsv/index_*.rs`   | Simpler = cache-friendly   | 5-9x faster  |
-| Zero-copy iteration    | `json/light.rs`    | Avoid allocations          | Varies       |
+| Technique              | Location           | Purpose                    | Impact        |
+|------------------------|--------------------|----------------------------|---------------|
+| Cache-aligned L1L2     | `bits/rank.rs`     | Rank directory             | 3-4% faster   |
+| Packed u128 entries    | `bits/rank.rs`     | Reduce memory footprint    | ~25% overhead |
+| Dual select methods    | `bits/select.rs`   | Adapt to access pattern    | 3.1x seq      |
+| Lightweight index      | `dsv/index_*.rs`   | Simpler = cache-friendly   | 5-9x faster   |
+| Zero-copy iteration    | `json/light.rs`    | Avoid allocations          | Varies        |
 
 **Key insight from DSV optimization**: The "heavyweight" BitVec with 3-level RankDirectory was 5-9x slower than a simple cumulative array despite being theoretically optimal. Cache behavior matters more than asymptotic complexity for practical sizes.
 

--- a/docs/optimizations/hierarchical-structures.md
+++ b/docs/optimizations/hierarchical-structures.md
@@ -448,8 +448,9 @@ Sometimes simpler structures outperform theoretically optimal ones.
 ```
 3-level RankDirectory + SelectIndex + storage
 - O(1) rank, O(log n + k) select
-- ~3% overhead for rank
-- ~3% overhead for select
+- ~25% overhead for rank (128 bits of metadata per 512 bits of data)
+- select overhead scales with the number of ones (sampled every 256)
+- ~28-48% resident overhead in total, rising with bit density
 - Complex access patterns
 ```
 

--- a/src/bin/succinctly/bench_runner/registry.rs
+++ b/src/bin/succinctly/bench_runner/registry.rs
@@ -327,6 +327,15 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         cli_subcommand: None,
         working_dir: "bench-compare",
     },
+    BenchmarkInfo {
+        name: "succinct_libs",
+        description: "Cross-library rank/select comparison (vers-vecs, sucds, sux)",
+        category: BenchmarkCategory::CrossParser,
+        bench_type: BenchmarkType::CrossParser,
+        criterion_name: Some("succinct_libs"),
+        cli_subcommand: None,
+        working_dir: "bench-compare",
+    },
 ];
 
 /// Filter benchmarks by category.


### PR DESCRIPTION
## Description

This PR addresses issue #47 by adding comprehensive benchmarking and documentation for succinctly's rank/select implementation against other maintained Rust succinct-structure crates (vers-vecs, sucds, and sux). The work includes both empirical measurements and an Architecture Decision Record (ADR-0011) that records the build-vs-buy reasoning behind implementing custom succinct structures in-crate rather than depending on existing libraries.

Prior to this PR, the repository could not answer whether existing crates were evaluated or benchmarked. The documentation incorrectly claimed ~3% space overhead for the rank directory (the Poppy paper's figure, not this implementation's). This PR corrects the record with measured data and honest assessment of trade-offs.

## Type of Change
- [x] New feature (non-breaking change which adds functionality) — `succinct_libs` benchmark suite
- [x] Documentation update — ADR-0011, benchmark page, corrected space overhead claims
- [x] Test coverage improvement — comparison verification in benchmark

## Related Issue
Fixes #47 — "Evaluate existing succinct crates and benchmark against them"

## Changes Made

**Benchmark Implementation:**
- Added `bench-compare/benches/succinct_libs.rs` with comprehensive rank/select comparison across four libraries
- Implemented `TrackingAllocator` for precise resident-size measurement
- Created `verify_agreement` test ensuring all four libraries agree on rank1/select1 answers before timing
- Benchmarks test construction, rank1 (10,000 random queries), select1, and resident memory across 1M-10M bits at 10/50/90% density
- Added `succinct_libs` benchmark to registry in `src/bin/succinctly/bench_runner/registry.rs`
- Updated `bench-compare/Cargo.toml` with dependencies: `vers-vecs`, `sucds`, `sux`, `rand`, `rand_chacha` (all pinned for reproducibility)
- Updated `bench-compare/Cargo.toml` to enable `simd` feature for succinctly and vers-vecs

**Documentation:**
- Created `docs/adrs/adr-0011.md` — Architecture Decision Record documenting why succinct structures are built in-crate
  - Records three requirements: `no_std` support (no existing crate satisfies), balanced-parentheses tree navigation (none provide), hinted select (none expose)
  - Honestly reports that BitVec wins no measured category on ARM64: sux is 1.5-1.7x faster at rank/select, vers-vecs is 5-8x more compact and faster to build
  - Documents why BitVec is kept despite losing: only `no_std` requirement currently holds; BalancedParens and JsonIndex bypass BitVec entirely
  - Lists alternatives evaluated and rejected (vers-vecs, sux, sucds, succinct, fid, bio) with rationale
- Created `docs/benchmarks/rust-succinct-libs.md` — benchmark results and methodology
  - Platforms: ARM64 only (Apple M5 Max); flags x86_64 run as outstanding
  - Resident size table: vers-vecs 5-8x more compact; succinctly 27.5-47.5% overhead rising with density
  - Construction: vers-vecs 1.0-1.31x faster
  - rank1: succinctly 1.8-2.3x faster than vers-vecs, but sux 1.5-1.7x faster than succinctly
  - select1: sux 3-4x faster; marked as noisy (~40% variance in individual cells)
  - Documents fairness caveat: sucds/sux lack bulk-word constructor, must fill per-bit
- Updated `docs/adrs/README.md` to add ADR-0011 entry
- Updated `docs/architecture/README.md` — noted Prior Art now includes Rust crates evaluated
- Corrected `docs/architecture/bitvec.md` — rank directory overhead documented as ~25% (128 bits per 512 bits), not ~3%; full BitVec 27.5-47.5% resident
- Comprehensively updated `docs/architecture/prior-art.md`
  - Clarified Poppy paper claims 3% but succinctly's directory costs ~25% by design
  - Added table of Rust succinct libraries with versions, `no_std` status, and assessments
  - Documented sucds `no_std` attribute is vestigial in 0.8.3 — builds fail with ~141 errors
  - Cross-referenced ADR-0011 and benchmark page
- Updated `docs/benchmarks/README.md` — added rust-succinct-libs row to benchmark table
- Updated `docs/benchmarks/inventory.md` — added rust-succinct-libs.md (4 sections)
- Updated `docs/log.md` with 2026-07-15 entry documenting sources ingested and corrections made
- Updated `docs/optimizations/cache-memory.md` — rank directory overhead corrected from 3% to ~25%
- Updated `docs/optimizations/hierarchical-structures.md` — rank/select overhead corrected to reflect actual measurements
- Updated `CLAUDE.md` — BitVec performance summary corrected from ~3-4% to ~28-48% overhead
- Updated `README.md` — corrected feature claims from "~3% space overhead" to "tuned for query speed over compactness (~28-48% overhead)"
- Updated README core structures documentation with link to benchmark results

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New benchmark suite added with verification step (`verify_agreement` ensures all four libraries agree on rank1/select1 answers)
- [x] Benchmark registered and accessible via `bench run succinct_libs` command

**Manual Testing:**
- [x] Benchmarks tested on ARM64 (Apple M5 Max)
- [x] `cargo test` passes with all benchmarks
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied

### Test Commands
```bash
# Run the new benchmark suite
cd bench-compare
cargo bench --bench succinct_libs

# Or via the bench runner
succinctly bench run succinct_libs

# Verify all tests pass
cargo test --all

# Check code quality
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact to main crate (benchmarks are in `bench-compare` standalone crate)
- Benchmark findings documented: succinctly's BitVec trades space for query speed; loses on space (vers-vecs 5-8x better), loses on select (sux 3-4x faster), competitive on rank, faster to build than sux/sucds

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added comprehensive documentation explaining the decision
- [x] Benchmark code includes verification logic (`verify_agreement`)
- [x] New and existing tests pass locally
- [x] Documentation is complete and accurate (corrected prior misstated overhead figures)
- [x] No new warnings generated

## Additional Notes

**Honest Assessment**: This PR deliberately reports findings as they came out rather than as a defense of the existing code. The measurements show BitVec loses on space and select performance but wins on rank speed (among the measured libraries). The decision to keep it in-crate is justified by three requirements: `no_std` (which no external crate satisfies), balanced-parentheses tree navigation, and hinted select — only the first currently applies to BitVec itself. The code acknowledges that BalancedParens and JsonIndex bypass BitVec entirely, making its use a candidate for replacement (tracked in issue #228).

**Platform Limitations**: Results are ARM64-only (Apple M5 Max). Succinctly's x86_64 popcount is AVX-512 VPOPCNTDQ-gated and untested here. Vers-vecs' SIMD select is also AVX-512-gated, so an x86_64 run could change the placings and is flagged as outstanding. The resident-size measurements are deterministic and platform-independent.

**Space Overhead Corrections**: Four documents claimed ~3% overhead for the rank directory. That is the Poppy paper's figure, not succinctly's implementation. All instances have been corrected to the measured value: ~25% for the rank directory alone, 27.5-47.5% for the full BitVec with select index (rising with density). This was an arithmetic error in bitvec.md that propagated through the docs.

**Future Work**: ADR-0011 recommends revisiting this decision if the `no_std` requirement is dropped or if sucds fixes its `no_std` build. The benchmark provides a stable baseline for that future evaluation.