### PR TITLE
ci: exclude no-color.org from link checker

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -43,6 +43,7 @@ jobs:
             --exclude '^https://github\.com/rust-works/succinctly/compare/v'
             --exclude '^https://www\.cs\.cmu\.edu/'
             --exclude '^https://doi\.org/'
+            --exclude '^https://no-color\.org/'
             '**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR excludes `https://no-color.org/` from the link checker workflow to prevent timeout issues during automated link validation checks. The no-color.org domain is known to cause timeouts in the GitHub Actions link checker, disrupting the CI pipeline.

## Type of Change
- [x] CI/CD changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Added `--exclude '^https://no-color\.org/'` to the excluded domains list in `.github/workflows/links.yml`
- This prevents the link checker from attempting to validate the no-color.org domain, which was causing workflow timeouts

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Link checker workflow will no longer timeout on no-color.org domain

**Manual Testing:**
- [x] Verified the exclusion pattern matches the no-color.org domain correctly
- [x] Confirmed the workflow configuration remains valid YAML

## Performance Impact
- [x] Performance improvement (eliminated timeout delays in link checking workflow)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] The workflow configuration is valid

## Additional Notes

This is a targeted fix to resolve CI pipeline disruptions. The no-color.org domain is part of the no-color initiative (https://no-color.org) but is not critical to validate as part of the project's documentation links. By excluding it, we maintain a reliable and consistent CI experience without sacrificing link validation for the project's actual dependencies and references.