### PR TITLE
ci: add do-not-merge blocking workflow

### DIFF
--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -1,0 +1,25 @@
+name: Block Merge
+
+on:
+  pull_request:
+    # labeled/unlabeled are NOT default pull_request activity types; include them
+    # so this check re-runs the moment the do_not_merge label is toggled.
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  do-not-merge:
+    # "Do Not Merge" is the check-context name marked required in the main ruleset.
+    name: Do Not Merge
+    runs-on: ubuntu-latest
+    steps:
+      # The `if` guards the STEP, not the job: the job always runs and reports a
+      # status (green when the label is absent), so a PR can never sit forever
+      # "pending" on a required check that never ran.
+      - name: Fail if labeled do_not_merge
+        if: contains(github.event.pull_request.labels.*.name, 'do_not_merge')
+        run: |
+          echo "::error::PR is labeled 'do_not_merge' — merging is blocked until the label is removed."
+          exit 1


### PR DESCRIPTION
## Summary

Adds `.github/workflows/block-merge.yml` — a **Do Not Merge** status check that
fails while a PR carries the `do_not_merge` label, so the merge button is
disabled until the label is removed.

Implements [#234](https://github.com/rust-works/succinctly/issues/234).

## How it works

- Triggers on `opened, reopened, synchronize, labeled, unlabeled` — the
  `labeled`/`unlabeled` types (not defaults) make the check re-run within seconds
  when the label is toggled.
- The `if` guards the **step**, not the job, so the job always runs and reports a
  status (green when the label is absent). This avoids the "required check that
  never runs → PR stuck pending forever" trap.
- Uses `pull_request` (not `pull_request_target`), `contents: read`, and no
  checkout — the label comes straight from the event payload, so no repo code is
  executed.

## Rollout (done alongside this PR)

- [x] `do_not_merge` label created (`#B60205`, "Blocks merge while applied").
- [x] Workflow added (this PR).
- [ ] **Do Not Merge** added to the `Protect main branch` ruleset's required
      checks — done after this PR's check reports green, so no open PR gets stuck.
- [ ] End-to-end toggle verification on this PR.

Closes #234