### PR TITLE
docs(docs): record measured seq_items elimination trade-off as O4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,3 +616,10 @@ For detailed documentation on optimization techniques used in this project, see 
   - **16-byte threshold + `#[inline(always)]`**: Both required to prevent regression (threshold alone still caused 3-5% regression)
   - Best for: YAML with long string values (logs, templates, embedded content)
   - See [docs/parsing/yaml.md#o3-simd-escape-scanning-for-json-output--accepted-](docs/parsing/yaml.md#o3-simd-escape-scanning-for-json-output--accepted-) for full analysis
+- ✅ O4 (seq_items Bitvector Elimination): **−12.5% build peak memory, 2-6% faster builds**, issues #75/#104/#106
+  - Removed the stored `seq_items` bitvector; seq-item wrappers are derived from text (`-` + whitespace/EOI)
+  - Branchless `matches!` derivation at both detection sites recovers the 7-15% query regression #106 found in the naive form
+  - **Measured** (Apple M5 Max, c090e7f6 vs 2a41c2f5): build peak 2.00× → 1.75× of input (−L/4 transient scratch), retained index −3-5% (19-41 KB/MB), all 44 yaml_bench benchmarks improved or neutral, yq query side neutral-or-better (worst +1.8% noise, best −10.7%)
+  - Outputs byte-identical pre↔post on all 80 yq A/B configurations
+  - Key insight: derive, don't store, what the text already encodes; transient build allocations can dwarf the retained structure (2-bit-per-byte scratch was 6-13× the stored bitvector)
+  - See [docs/parsing/yaml.md#o4-seq_items-bitvector-elimination--accepted-](docs/parsing/yaml.md#o4-seq_items-bitvector-elimination--accepted-) for full analysis

--- a/docs/adrs/adr-0000.md
+++ b/docs/adrs/adr-0000.md
@@ -9,7 +9,7 @@
 Succinctly has accumulated a substantial body of design decisions — the choice of
 semi-indexing over DOM parsing, the PFSM JSON parser, the YAML oracle, and a long series of
 optimizations that were tried and either accepted or rejected. Until now these decisions have
-been recorded **informally**: in the P1–P12 / O1–O3 "accepted/rejected optimization" log
+been recorded **informally**: in the P1–P12 / O1–O4 "accepted/rejected optimization" log
 inside [CLAUDE.md](../../CLAUDE.md), in the narrative optimization journey in
 [parsing/yaml.md](../parsing/yaml.md), and in [optimizations/](../optimizations/).
 

--- a/docs/benchmarks/inventory.md
+++ b/docs/benchmarks/inventory.md
@@ -538,6 +538,12 @@ YAML parsing implementation and optimization benchmark results.
   - escape_scan/control_chars (tab character detection)
   - escape_scan/realistic (escape every ~20 chars, 64B-2048B)
 
+##### O4: seq_items Bitvector Elimination - ACCEPTED ✅
+- Issues #75/#104/#106: text-derived seq-item detection replaces stored bitvector
+- Memory A/B (tracking-allocator probe, Apple M5 Max): build peak −12.5% (2.00× → 1.75× input), retained index −3-5% (19-41 KB per MB)
+- yaml_bench criterion A/B: all 44 benchmarks improved or neutral (−2 to −6% typical)
+- dev bench yq A/B via --binary swap: neutral-or-better, outputs byte-identical pre↔post (80 configs)
+
 #### Optimization Phases (Rejected)
 
 ##### P1: YFSM (YAML Finite State Machine) - REJECTED ❌

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ Full data: [benchmarks/](benchmarks/)
 The project documents both successes and failures in optimization:
 
 - [optimizations/](optimizations/) — 11 technique guides (SIMD, cache, bit manipulation, etc.)
-- [parsing/yaml.md](parsing/yaml.md) — Detailed P0-P12 + O1-O3 optimization journey with benchmarks
+- [parsing/yaml.md](parsing/yaml.md) — Detailed P0-P12 + O1-O4 optimization journey with benchmarks
 - [optimizations/history.md](optimizations/history.md) — Why AVX-512 was removed, and other lessons
 - [adrs/](adrs/) — Architecture Decision Records for the rejected optimizations (P2.6/P2.8/P3/P5/P6/P7/P8) and the core design choices
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -91,7 +91,7 @@ Tracks updates to the knowledge wiki pages in `docs/`.
 - [bitvec.md](architecture/bitvec.md) — BitVec rank/select, Poppy structure, SIMD popcount
 - [balanced-parens.md](architecture/balanced-parens.md) — BP tree encoding, RangeMin, generic SelectSupport
 - [json-index.md](parsing/json-index.md) — JSON semi-indexing, PFSM, SIMD classification pipeline
-- [yaml-index.md](parsing/yaml-index.md) — YAML oracle parser, virtual brackets, P0-P12/O1-O3 optimization history
+- [yaml-index.md](parsing/yaml-index.md) — YAML oracle parser, virtual brackets, P0-P12/O1-O4 optimization history
 - [dsv-index.md](parsing/dsv-index.md) — DSV quote handling, prefix XOR, BMI2 toggle
 - [jq-evaluator.md](reference/jq-evaluator.md) — jq parser/evaluator, JqSemantics vs YqSemantics, supported syntax
 - [simd-strategy.md](optimizations/simd-strategy.md) — Per-module SIMD usage, platform support, lessons learned

--- a/docs/optimizations/history.md
+++ b/docs/optimizations/history.md
@@ -613,6 +613,28 @@ The IB cursor state (`ib_word_idx`, `ib_ones_before`) remains valid after the ra
 
 **Files**: [src/yaml/end_positions.rs](../../src/yaml/end_positions.rs), [src/yaml/advance_positions.rs](../../src/yaml/advance_positions.rs)
 
+### ✅ O4 seq_items Bitvector Elimination (July 2026)
+
+**Status**: Implemented and measured — [issue #75](https://github.com/rust-works/succinctly/issues/75), [PR #104](https://github.com/rust-works/succinctly/pull/104), [issue #106](https://github.com/rust-works/succinctly/issues/106)
+
+**Problem**: `YamlIndex` stored a `seq_items` bitvector marking sequence-item wrapper nodes. The parser pre-allocated its backing store at 2 bits per input byte (worst-case BP length), marked bits during parsing, and truncated + shrank it at finish — all to store a property that is derivable from the text (a `-` followed by whitespace or end-of-input).
+
+**Technique**: Remove the bitvector and derive `is_seq_item` from the text at both detection sites (`YamlIndex::is_seq_item`, `LightCursor::value`). The naive nested-branch derivation regressed queries 7–15% (#106); the shipped form is a branchless `matches!` with end-of-input folded into the whitespace class.
+
+**Benchmark Results** (Apple M5 Max, `c090e7f6` vs `2a41c2f5`, sequential quiesced A/B):
+
+| Measure                        | Result                                              |
+|--------------------------------|-----------------------------------------------------|
+| yaml_bench (44 benchmarks)     | All improved or neutral; −2 to −6% typical, no regressions |
+| Build peak memory              | **−12.5%** (2.00× → 1.75× of input; −L/4 transient) |
+| Retained index memory          | **−3 to −5%** (19–41 KB per MB of input)            |
+| yq query side (`dev bench yq`) | Neutral-or-better (worst +1.8% noise, best −10.7%)  |
+| Output correctness             | Byte-identical pre↔post on all 80 configurations    |
+
+**Key insight**: Derive, don't store, what the text already encodes — and beware that transient build allocations can dwarf the retained structure (the 2-bit-per-byte scratch was 6–13× the stored bitvector). Full analysis in [parsing/yaml.md O4](../parsing/yaml.md#o4-seq_items-bitvector-elimination--accepted-).
+
+**Files**: [src/yaml/parser.rs](../../src/yaml/parser.rs), [src/yaml/index.rs](../../src/yaml/index.rs), [src/yaml/light.rs](../../src/yaml/light.rs), [src/yaml/locate.rs](../../src/yaml/locate.rs)
+
 ---
 
 ## Future Optimization Opportunities
@@ -660,4 +682,4 @@ See [docs/plan/sve2-optimizations.md](../plan/sve2-optimizations.md#future-neon-
 
 ---
 
-*Last Updated: 2026-01-28*
+*Last Updated: 2026-07-19*

--- a/docs/parsing/yaml-index.md
+++ b/docs/parsing/yaml-index.md
@@ -60,7 +60,7 @@ This eliminated the `OwnedValue` intermediate representation, yielding a **2.3x 
 
 ## Optimization Journey
 
-YAML parsing has an extensive documented optimization history (P0-P12, O1-O3):
+YAML parsing has an extensive documented optimization history (P0-P12, O1-O4):
 
 | Phase | Result          | Technique                                    |
 |-------|-----------------|----------------------------------------------|
@@ -73,6 +73,7 @@ YAML parsing has an extensive documented optimization history (P0-P12, O1-O3):
 | P12   | +20-25%         | Advance index (memory-efficient bp_to_text)  |
 | O1    | +3-13%          | Sequential cursor for AdvancePositions       |
 | O3    | 4-12x micro     | SIMD escape scanning (NEON)                  |
+| O4    | −12.5% peak mem | seq_items elimination (text-derived detection)|
 
 **Rejected** (with documented reasons): P2.6 (prefetching), P2.8 (threshold tuning), P3 (branchless), P5-P8 (various), all documented in [yaml.md](yaml.md).
 

--- a/docs/parsing/yaml-succinct.md
+++ b/docs/parsing/yaml-succinct.md
@@ -127,6 +127,13 @@ The `CompactRank` two-level directory uses ~3.5% overhead per bitmap
 (L1: one `u32` per 128 words + L2: one `u16` per 8 words), meeting the 5%
 target. This replaced the earlier `Vec<u32>` approach (50% overhead).
 
+The same budget-driven reasoning cut the other way for `seq_items`: since the
+sequence-item property is derivable from the text (`-` + whitespace), storing it
+was pure overhead and the bitvector was eliminated outright (issues #75/#104).
+Measured saving: 19–41 KB retained per MB of input (3–5% of the index) plus a
+2-bit-per-byte transient build allocation (−12.5% build peak). See
+[yaml.md O4](yaml.md#o4-seq_items-bitvector-elimination--accepted-).
+
 ## Current derived index structures
 
 Every raw bitmap that needs O(1) rank queries gets a two-level `CompactRank`

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -3747,6 +3747,11 @@ Profiling the end-to-end pipeline on 1MB YAML files reveals:
 sequence-item wrappers are now detected directly from the text (a `-` followed by
 whitespace or end-of-input), so there is no `seq_items` structure left to index.
 
+**Measured impact of the elimination** (see [O4](#o4-seq_items-bitvector-elimination--accepted-)
+for full analysis): build peak memory −12.5% (2.00× → 1.75× of input), retained index
+−3–5% (19–41 KB per MB of input), builds 2–6% faster across yaml_bench, query side
+neutral-or-better with the #106 branchless derivation.
+
 ### Opportunity 3: Pack `is_container` Flag into `bp_to_text`
 
 **Current**: Separate bitvector lookup per node.
@@ -3842,7 +3847,7 @@ for (start, end) in structural_segments {
 | 4. String boundaries       | Medium | High   | **P1**   | ✓ Done  |
 | 3. Pack flag in bp_to_text | Low    | Low    | **P2**   | Pending |
 | 5. SIMD JSON escaping      | Medium | Medium | **P2**   | Pending |
-| 2. `seq_items_rank`        | n/a    | n/a    | n/a      | Obsolete|
+| 2. `seq_items_rank`        | n/a    | n/a    | n/a      | Obsolete (O4)|
 | 6. Streaming identity      | High   | High   | **P3**   | Pending |
 
 ### Detailed Bottleneck Analysis
@@ -4639,6 +4644,161 @@ Key optimizations:
 - `src/yaml/light.rs` — Integrated `find_json_escape()` into `write_json_string()`
 - `src/yaml/mod.rs` — Made `simd` module public for benchmark access
 - `benches/yaml_transcode_micro.rs` — Added 5 escape scanning benchmark groups
+
+---
+
+## O4: seq_items Bitvector Elimination — Accepted ✅
+
+**Issues**: [#75](https://github.com/rust-works/succinctly/issues/75) (proposal + memory estimate),
+[#104](https://github.com/rust-works/succinctly/pull/104) (implementation PR),
+[#106](https://github.com/rust-works/succinctly/issues/106) (query-side regression + branchless mitigation)
+
+### Problem
+
+`YamlIndex` stored a `seq_items` bitvector marking which BP positions are sequence-item
+wrapper nodes. The parser pre-allocated the backing `seq_item_words` at **2 bits per input
+byte** (`vec![0u64; input.len().div_ceil(32)]`, sized for the worst-case BP length), set bits
+via `mark_seq_item()` during parsing, then truncated to the actual BP word count and
+`shrink_to_fit()` at finish. Queries answered `is_seq_item()` with an O(1) bit test.
+
+The stored bit is redundant: a node is a sequence-item wrapper **iff** its text position
+starts with a `-` followed by whitespace (or end of input). The text already encodes the
+answer.
+
+### Solution
+
+1. Remove the `seq_items` field and all build/mark/truncate plumbing (`5cf299a0`).
+2. Derive the answer from text at the two detection sites — `YamlIndex::is_seq_item()`
+   ([src/yaml/index.rs](../../src/yaml/index.rs)) and the inlined check in the
+   `LightCursor::value()` hot path ([src/yaml/light.rs](../../src/yaml/light.rs)).
+3. The naive nested-branch form caused a **7–15% query-side regression** (#106). The fix
+   (`4736f040`) is a branchless `matches!` with end-of-input folded into the whitespace
+   class:
+
+```rust
+// Branchless form (see #106): a `-` at end of input is a seq_item, so a
+// missing next byte is treated as whitespace via `unwrap_or(b' ')`.
+text_pos < text.len()
+    && text[text_pos] == b'-'
+    && matches!(
+        text.get(text_pos + 1).copied().unwrap_or(b' '),
+        b' ' | b'\t' | b'\n' | b'\r'
+    )
+```
+
+### Memory Analysis
+
+**Formula** (L = input bytes, B = BP bit length ≈ 2 bits per node):
+- **Transient build allocation (removed)**: `8·ceil(L/32)` bytes ≈ **L/4** (2 bits per input byte)
+- **Retained after build (removed)**: `8·ceil(B/64)` bytes ≈ **B/8** (2 bits per node after truncate + shrink)
+
+**Measured** (tracking-allocator probe around `YamlIndex::build()`, Apple M5 Max,
+baseline `c090e7f6` vs `2a41c2f5`):
+
+| File               | Peak before | Peak after  | Δ peak                | Retained before | Retained after | Δ retained           |
+|--------------------|-------------|-------------|-----------------------|-----------------|----------------|----------------------|
+| comprehensive/1mb  | 2,097,760 B | 1,835,576 B | **−262,184 (−12.5%)** | 681,512 B       | 654,568 B      | **−26,944  (−4.0%)** |
+| comprehensive/10mb | 20.97 MB    | 18.35 MB    | **−2.62 MB (−12.5%)** | 6,738,070 B     | 6,481,414 B    | **−256,656 (−3.8%)** |
+| sequences/1mb      | 3,146,088 B | 2,883,936 B | **−262,152  (−8.3%)** | 760,234 B       | 719,578 B      | **−40,656  (−5.3%)** |
+| users/1mb          | 2,097,688 B | 1,835,512 B | **−262,176 (−12.5%)** | 700,997 B       | 670,829 B      | **−30,168  (−4.3%)** |
+| nested/1mb         | 2,097,488 B | 1,835,336 B | **−262,152 (−12.5%)** | 635,411 B       | 616,395 B      | **−19,016  (−3.0%)** |
+
+The peak delta matches the formula exactly (predicted L/4 = 262,180 B for comprehensive/1mb
+vs 262,184 measured). Build peak drops from **2.00× to 1.75×** input on comprehensive
+(3.00× → 2.75× on sequences); `bench-compare`'s `yaml_peak_memory` group corroborates the
+same ratios independently.
+
+**Versus the #75 estimate** (~125 KB/MB, ~12% of index): that estimate assumed the retained
+bitvector was 1 bit per *text byte*. In reality the stored copy was truncated to BP length
+(2 bits per *node*), so the retained saving is **19–41 KB per MB of input (3–5% of the
+index)** depending on node density — while the *transient* saving is much larger than the
+estimate: **256 KB per MB (12.5% of build peak)**. The estimate sat between the two real
+numbers.
+
+### Benchmark Results
+
+#### yaml_bench — build path (Apple M5 Max, criterion `--baseline` A/B)
+
+**All 44 benchmarks improved or stayed neutral; no significant regressions** (worst case
++0.56%, flagged by criterion as within noise). Notable improvements:
+
+| Benchmark                    | Change      | Benchmark                    | Change      |
+|------------------------------|-------------|------------------------------|-------------|
+| simple_kv/10                 | **−10.5%**  | large/100kb                  | **−5.0%**   |
+| simple_kv/1000               | **−6.0%**   | large/1mb                    | **−3.6%**   |
+| simple_kv/10000              | **−5.1%**   | long_strings/double/64b      | **−8.6%**   |
+| sequences/100                | **−5.2%**   | quoted/single/10             | **−7.6%**   |
+| nested/d5_w2                 | **−5.1%**   | anchors/10                   | **−14.6%**  |
+| nested/d10_w2                | **−3.3%**   | block_scalars/long_100x100   | **−3.8%**   |
+
+The build win comes from eliminating the upfront zero-fill of the 2-bit-per-byte scratch
+vector plus the truncate/shrink (realloc) at finish — the same class of win as P12-A.
+
+#### dev bench yq — query path (Apple M5 Max, system yq v4.53.3)
+
+Method: one harness, two binaries via `--binary` (baseline `c090e7f6` build vs PR build),
+identical data files. Patterns sequences/users/nested/comprehensive × 1kb–10mb × queries
+`.` `.[0]` `.[]` `length`. **Correctness**: succinctly's output hashes were byte-identical
+pre↔post on all 80 configurations.
+
+The harness's default 3-run medians showed process-spawn artifacts swinging **both**
+directions (−42% to +48%) on `.[]`; every outlier was re-measured with 9 runs
+(trimmed median):
+
+| Case                       | Before   | After    | Δ          |
+|----------------------------|----------|----------|------------|
+| users/1kb `.[]`            | 3.49 ms  | 3.12 ms  | **−10.7%** |
+| users/10kb `.[]`           | 3.25 ms  | 3.09 ms  | **−4.8%**  |
+| users/1mb `.[]`            | 16.03 ms | 16.09 ms | +0.4%      |
+| comprehensive/1mb `.[]`    | 14.86 ms | 14.86 ms | ±0.0%      |
+| sequences/1mb `.[]`        | 16.07 ms | 15.65 ms | **−2.6%**  |
+| sequences/10mb `.[]`       | 123.4 ms | 121.8 ms | −1.3%      |
+| nested/10mb `.[]`          | 80.9 ms  | 78.0 ms  | **−3.6%**  |
+| sequences/1mb `length`     | 6.69 ms  | 6.49 ms  | −2.9%      |
+| users/1mb `length`         | 5.18 ms  | 5.27 ms  | +1.7%      |
+| nested/10kb `.[]`          | 3.13 ms  | 3.18 ms  | +1.8%      |
+
+**Verdict**: neutral-or-better across the board (worst +1.8%, within run-to-run noise;
+full-matrix median −2.3%). The #106 branchless mitigation fully recovers the cost of the
+removed O(1) bit test.
+
+### Trade-offs
+
+**Benefits:**
+- ✅ **2–6% faster index builds** across all yaml_bench groups (up to −10% on small inputs)
+- ✅ **−12.5% build peak memory** (−0.25× input: the transient 2-bit-per-byte scratch vector)
+- ✅ **−3–5% retained index memory** (19–41 KB per MB of input)
+- ✅ Less parser plumbing (no `mark_seq_item`/truncate/shrink bookkeeping)
+
+**Costs:**
+- ⚠️ `is_seq_item` now costs two text-byte loads + compares instead of one bit test —
+  measured neutral end-to-end, but only in the branchless form (#106)
+- ⚠️ Detection semantics now tied to text shape (`-` + whitespace/EOI) rather than parser
+  state; covered by `test_is_seq_item_derived_from_text` and
+  `test_is_seq_item_ignores_dash_without_space`
+
+### Key Learnings
+
+1. **Derive, don't store, what the text already encodes** — eliminating a structure beats
+   compressing it (echoes P9's "eliminating phases beats optimizing them").
+2. **Peak ≠ retained**: the transient build scratch (2 bits/byte) was 6–13× larger than the
+   retained structure it produced. Estimates that only consider the stored form (#75) can
+   miss the bigger win.
+3. **Branch shape matters more than instruction count** on the query path: the naive
+   nested-branch derivation regressed 7–15% (#106); the branchless `matches!` form is
+   neutral-or-better.
+4. **3-run process-spawn medians can swing ±40% in both directions** — re-measure outliers
+   (more runs, trimmed medians) before believing either regressions *or* improvements.
+
+### Files Modified
+
+- `src/yaml/parser.rs` — removed `seq_item_words` allocation, `mark_seq_item()`, and the
+  truncate/shrink handoff
+- `src/yaml/index.rs` — removed the `seq_items` field and dead `count_seq_items_before()`;
+  `is_seq_item(text, bp_pos)` is now text-derived and branchless
+- `src/yaml/light.rs` — `LightCursor::value()` reordered (`is_container` first) with the
+  inline branchless seq-item check
+- `src/yaml/locate.rs` — caller updated to pass `text`
 
 ---
 

--- a/docs/plan/yaml-index-post-compactrank.md
+++ b/docs/plan/yaml-index-post-compactrank.md
@@ -18,7 +18,6 @@ remaining optimization opportunities.
 | `ib_rank`             | CompactRank              | ~3.5% of ib         | Two-level directory                  |
 | `bp`                  | BalancedParens+Select    | ~2B/8 + indices     | B = BP length                        |
 | `ty`                  | bitmap                   | T/8 bytes           | T = container count                  |
-| `seq_items`           | bitmap                   | B/8 bytes           | 1 bit/BP position                    |
 | `containers`          | bitmap                   | B/8 bytes           | 1 bit/BP position                    |
 | `containers_rank`     | CompactRank              | ~3.5% of containers |                                      |
 | `open_positions`      | AdvancePositions         | ~1.1N bytes         | N = BP opens (compact)               |
@@ -29,6 +28,11 @@ remaining optimization opportunities.
 | `aliases`             | BTreeMap<usize, usize>   | variable            | Alias references                     |
 
 Where L = text length, B = BP length (~2N), N = BP opens, T = container count.
+
+> **Update (2026-07)**: the `seq_items` bitmap (B/8 bytes, originally listed here) was
+> eliminated in [#104](https://github.com/rust-works/succinctly/pull/104) — sequence
+> items are now derived from the text. See
+> [parsing/yaml.md O4](../parsing/yaml.md#o4-seq_items-bitvector-elimination--accepted-).
 
 For typical YAML with N ≈ L/7.5:
 
@@ -170,10 +174,14 @@ pattern as `OpenPositions`.
 
 ---
 
-## Opportunity 2: Remove Dead Code — `count_seq_items_before()`
+## Opportunity 2: Remove Dead Code — `count_seq_items_before()` ✓ DONE (#104)
 
 **Impact: Low (code cleanliness)**
 **Effort: Trivial**
+
+**Status**: Done. `count_seq_items_before()` was removed along with the whole
+`seq_items` bitvector in [#104](https://github.com/rust-works/succinctly/pull/104)
+([O4](../parsing/yaml.md#o4-seq_items-bitvector-elimination--accepted-)).
 
 ### Problem
 
@@ -267,6 +275,10 @@ ib_scalar_rank(pos) = ib_words_rank(pos) - containers_rank(pos) - seq_items_rank
 ```
 
 This eliminates one L/8-byte bitmap and its CompactRank index.
+
+> **Update (2026-07)**: `seq_items` no longer exists (#104), so this derivation no
+> longer applies as written — a `seq_items_rank` would have to be recomputed from
+> text-derived detection, changing this opportunity's cost/benefit.
 
 ### Why this is hard
 
@@ -390,7 +402,7 @@ any remaining unnecessary clones during `SemiIndex` construction.
 | #  | Opportunity                        | Type        | Impact  | Effort  | Depends on  |
 |----|------------------------------------|-------------|---------|---------|-------------|
 | 1  | `bp_to_text_end` compression       | Memory      | High    | Medium  | —           |
-| 2  | Remove dead `count_seq_items_before`| Cleanup    | Low     | Trivial | —           |
+| 2  | Remove dead `count_seq_items_before`| Cleanup    | Low     | Trivial | ✓ Done #104 |
 | 3  | IB select samples                  | Performance | Medium  | Low     | —           |
 | 5  | Remove trivial wrappers            | Cleanup     | Negl.   | Trivial | —           |
 | 7  | Parser clone avoidance             | Build perf  | Medium  | Low     | In progress |

--- a/docs/plan/yq-memory-optimization.md
+++ b/docs/plan/yq-memory-optimization.md
@@ -33,7 +33,7 @@ The succinct data structures are working as designed:
 | `ty` (type bits)           | M/8 bytes        | Container type markers     |
 | **`bp_to_text`**           | **M × 4 bytes**  | BP→text offset mapping     |
 | **`bp_to_text_end`**       | **M × 4 bytes**  | Scalar end positions       |
-| `seq_items`, `containers`  | M/8 bytes each   | Marker bits                |
+| `containers`               | M/8 bytes        | Marker bits (`seq_items` eliminated in #104/O4) |
 | `newlines` (BitVec)        | N/8 + indices    | Line/column lookup         |
 
 Where:
@@ -121,7 +121,7 @@ Vec<u8> ────────────────────────
   ▼
 YamlIndex::build()
   │
-  ├─ ib, bp, ty, seq_items, containers ──────── [~0.2× input size]
+  ├─ ib, bp, ty, containers ─────────────────── [~0.2× input size]
   ├─ bp_to_text, bp_to_text_end ─────────────── [~0.8× input size]
   └─ rank indices, newlines ─────────────────── [~0.1× input size]
   │                                              ─────────────────


### PR DESCRIPTION
## Summary

Completes the post-merge follow-up from #104 ([tracking comment](https://github.com/rust-works/succinctly/pull/104#issuecomment-5012946487)): the memory/CPU trade-off of the `seq_items` bitvector elimination is now **measured end-to-end** and recorded in the docs as **O4**, replacing the qualitative claims.

**Method**: sequential, exclusive-CPU A/B on a quiesced Apple M5 Max. Baseline `c090e7f6` (pre-#104 main) vs `2a41c2f5` (the #104 merge). Identical input files both sides; succinctly output hashes byte-identical pre↔post on all 80 yq configurations.

## Measured results

**Build path — `yaml_bench` (criterion `--save-baseline`/`--baseline` A/B):**
- All 44 benchmarks improved or neutral; zero significant regressions (worst +0.56%, within noise)
- Typical −2 to −6% (simple_kv/10000 −5.1%, large/1mb −3.6%, sequences/100 −5.2%)

**Memory — tracking-allocator probe around `YamlIndex::build()` (corroborated by bench-compare `yaml_peak_memory`):**
- Build **peak −12.5%**: 2.00× → 1.75× of input (sequences: 3.00× → 2.75×). Delta matches the eliminated transient `seq_item_words` scratch (2 bits/input byte = L/4) to within 4 bytes
- **Retained index −3 to −5%** (19–41 KB per MB of input) — the stored bitvector was 2 bits/node after truncation
- #75's ~125 KB/MB estimate assumed 1 bit/text byte retained; the real retained saving is smaller, the transient saving larger

**Query path — `dev bench yq`, one harness + `--binary` swap (system yq v4.53.3):**
- Neutral-or-better: worst +1.8% (noise), best −10.7% (`users/1kb .[]`); full-matrix median −2.3%
- The 3-run harness medians showed ±30–48% two-sided process-spawn artifacts on `.[]`; every outlier re-measured with 9-run trimmed medians
- Confirms the #106 branchless mitigation fully recovers the removed O(1) bit test

## Docs changes

- New **O4 section** in `docs/parsing/yaml.md` (P12/O3 template: problem, solution, memory analysis with formula + measured, benchmark tables, trade-offs, learnings)
- Qualitative claims replaced with measured numbers: `yaml.md` Opportunity 2 note + priority row, `yaml-succinct.md` memory-budget section
- O4 entries added to `docs/optimizations/history.md` and `docs/benchmarks/inventory.md`; P/O enumerations bumped in `yaml-index.md`, `index.md`, `log.md`, `adr-0000.md`; CLAUDE.md O4 bullet
- Stale `seq_items` references fixed in `docs/plan/yaml-index-post-compactrank.md` (incl. Opportunity 2 → Done) and `docs/plan/yq-memory-optimization.md`

Refs #75, #104, #106
