### PR TITLE
test(test): add comprehensive refactor guard tests and SIMD CI verification (#192)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,26 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      # The x86 SIMD tests (BMI2, AVX2) self-skip when the feature is absent,
+      # which reads as a silent pass. Fail loudly if this runner can't actually
+      # exercise them, so an all-skipped SIMD suite never looks green (#192).
+      # NOTE: AVX-512 is intentionally NOT required — the standard x86 runners
+      # (Zen 3 EPYC) lack it, so those paths are validated off routine CI. See
+      # CONTRIBUTING.md ("SIMD CI coverage").
+      - name: Verify SIMD CPU features (BMI2 + AVX2)
+        if: needs.gate.outputs.code == 'true'
+        run: |
+          echo "=== CPU Info ==="
+          lscpu | grep -E "Model name|Architecture|Flags" || true
+          missing=""
+          grep -qw avx2 /proc/cpuinfo || missing="$missing avx2"
+          grep -qw bmi2 /proc/cpuinfo || missing="$missing bmi2"
+          if [ -n "$missing" ]; then
+            echo "::error::x86 runner is missing CPU feature(s):$missing — the BMI2/AVX2 SIMD tests would self-skip. See CONTRIBUTING.md (SIMD CI coverage)."
+            exit 1
+          fi
+          echo "BMI2 + AVX2 present: SIMD tests will assert, not skip."
+
       - name: Build
         if: needs.gate.outputs.code == 'true'
         run: cargo build --verbose
@@ -128,14 +148,20 @@ jobs:
             target/
           key: ${{ runner.os }}-arm64-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check CPU features (SVE2)
+      # The aarch64 SVE2 tests self-skip (emitting a `SKIPPED: SIMD test` marker
+      # via note_simd_skip) when sve2-bitperm is absent. The ubuntu-24.04-arm
+      # runner (Neoverse-N2) provides it, so require it here: an all-skipped SVE2
+      # suite must never read as green (#192). NEON is always present on aarch64.
+      - name: Verify SIMD CPU features (NEON + SVE2-BITPERM)
         if: needs.gate.outputs.code == 'true'
         run: |
           echo "=== CPU Info ==="
           lscpu | grep -E "Model name|Architecture|CPU|Flags" || true
-          echo "=== SVE/SVE2 Detection ==="
-          if grep -q sve2 /proc/cpuinfo 2>/dev/null; then echo "SVE2: supported"; else echo "SVE2: not detected"; fi
-          if grep -q svebitperm /proc/cpuinfo 2>/dev/null; then echo "SVE2-BITPERM: supported"; else echo "SVE2-BITPERM: not detected"; fi
+          if ! grep -qw svebitperm /proc/cpuinfo; then
+            echo "::error::ARM runner lacks SVE2-BITPERM — the SVE2 BDEP/BEXT tests would self-skip. See CONTRIBUTING.md (SIMD CI coverage)."
+            exit 1
+          fi
+          echo "NEON (always on aarch64) + SVE2-BITPERM present: SIMD tests will assert, not skip."
 
       - name: Build
         if: needs.gate.outputs.code == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,31 @@ Requires Intel Ice Lake+ or AMD Zen 4+.
 - Test on both x86_64 and aarch64 if possible
 - Document the expected speedup
 
+#### SIMD CI coverage
+
+SIMD unit tests self-skip when the host CPU lacks the required feature (an
+early `return`, sometimes emitting a `SKIPPED: SIMD test` marker via
+`note_simd_skip`). A fully-skipped suite would otherwise read as a green pass,
+so each test job **asserts its runner actually has the features** (the
+"Verify SIMD CPU features" steps in `.github/workflows/ci.yml`) and fails
+loudly if not.
+
+What each CI runner exercises for real:
+
+| Runner                        | CPU           | Backends asserted in CI                |
+|-------------------------------|---------------|----------------------------------------|
+| `ubuntu-latest` (Test x86_64) | AMD EPYC 7763 | POPCNT, SSE4.1/4.2, **BMI2**, **AVX2** |
+| `ubuntu-24.04-arm` (Test ARM) | Neoverse-N2   | NEON, **SVE2-BITPERM** (BDEP/BEXT)     |
+| `macos-latest` (Test macOS)   | Apple Silicon | NEON                                   |
+
+**Not covered by routine CI: AVX-512.** The standard x86 runners are Zen 3
+(EPYC 7763), which has no `avx512f`/`avx512vpopcntdq`, so the AVX-512 paths
+(`src/util/simd/x86.rs` `avx512f` branch, `src/bits/popcount.rs` VPOPCNTDQ)
+self-skip there. Validate changes to those paths off-CI — on AVX-512 hardware
+or under an emulator (e.g. QEMU `qemu-x86_64 -cpu max`) — and note how you
+tested in the PR. (SVE2 *is* covered: the Neoverse-N2 ARM runner provides
+`sve2-bitperm`.)
+
 ### Unsafe Code
 
 - Minimize `unsafe` blocks

--- a/tests/cli_characterization_tests.rs
+++ b/tests/cli_characterization_tests.rs
@@ -1,0 +1,222 @@
+//! Characterization snapshots for jq/yq/dsv CLI query output (#192).
+//!
+//! These are behavior-preserving guards for the pure-refactor issues: they
+//! snapshot the *current* CLI query output over a small representative
+//! JSON/YAML/DSV corpus so each refactor becomes a "snapshots unchanged" review:
+//!
+//! - #181 jq_runner/yq_runner consolidation  -> jq + yq query output
+//! - #183 DSV SSE2 path                       -> `--input-dsv` query output
+//! - #184 dead JSON SIMD removal              -> jq query output
+//! - #185 YAML SIMD scalar-helper dedup       -> yq query output
+//!
+//! The existing `cli_golden_tests.rs` only snapshots `json generate` + help
+//! output; those don't exercise the query path these refactors touch.
+//!
+//! Cross-backend structural equivalence (scalar vs SSE2/AVX2/BMI2/NEON/SVE2) is
+//! covered separately by `dsv_simd_differential_tests.rs`; here we lock the
+//! end-to-end CLI output, which is what the refactors must preserve.
+//!
+//! Run with: cargo test --features cli --test cli_characterization_tests
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use anyhow::Result;
+
+/// Maximum retries for `cargo run` commands that fail with exit code 101.
+/// Handles flaky failures from cargo lock contention when tests run in parallel
+/// (same rationale as the other CLI integration tests).
+const MAX_CARGO_RETRIES: u32 = 3;
+
+/// Run `succinctly <args>` with `stdin` piped in, returning captured stdout.
+///
+/// Goes through the real binary (via `cargo run`) rather than the library so the
+/// snapshot reflects exactly what a user sees. Bails with stderr on failure so a
+/// broken query is a loud test error, not a silently-empty snapshot.
+fn run(args: &[&str], stdin: &str) -> Result<String> {
+    for attempt in 0..MAX_CARGO_RETRIES {
+        let mut cmd = Command::new("cargo")
+            .args(["run", "--features", "cli", "--bin", "succinctly", "--"])
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        if let Some(mut sin) = cmd.stdin.take() {
+            sin.write_all(stdin.as_bytes())?;
+        }
+
+        let output = cmd.wait_with_output()?;
+        let exit_code = output.status.code().unwrap_or(-1);
+
+        // Exit code 101 often indicates cargo lock contention; retry.
+        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
+            continue;
+        }
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("`succinctly {}` failed: {stderr}", args.join(" "));
+        }
+
+        return Ok(String::from_utf8(output.stdout)?);
+    }
+    unreachable!()
+}
+
+// ---------------------------------------------------------------------------
+// Corpus (small, inline, stable — matches the convention in jq_cli_tests.rs).
+// ---------------------------------------------------------------------------
+
+const JSON_USERS: &str =
+    r#"{"users":[{"name":"Alice","age":30},{"name":"Bob","age":25}],"active":true}"#;
+
+const JSON_NESTED: &str = r#"{"a":{"b":{"c":[1,2,3]}}}"#;
+
+const YAML_CONFIG: &str = "\
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo
+spec:
+  containers:
+    - name: web
+      image: nginx
+    - name: sidecar
+      image: envoy
+";
+
+/// Exercises type preservation: quoted `\"1.0\"` stays a string while bare
+/// scalars become bool/int/float/null.
+const YAML_TYPES: &str = "\
+version: \"1.0\"
+enabled: true
+count: 42
+ratio: 3.14
+missing: null
+";
+
+const CSV_PEOPLE: &str = "name,age\nAlice,30\nBob,25\n";
+
+// ---------------------------------------------------------------------------
+// JSON / jq  (guards #181, #184)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jq_users_identity() -> Result<()> {
+    insta::assert_snapshot!("jq_users_identity", run(&["jq", "."], JSON_USERS)?);
+    Ok(())
+}
+
+#[test]
+fn jq_users_compact() -> Result<()> {
+    insta::assert_snapshot!("jq_users_compact", run(&["jq", "-c", "."], JSON_USERS)?);
+    Ok(())
+}
+
+#[test]
+fn jq_users_names_raw() -> Result<()> {
+    insta::assert_snapshot!(
+        "jq_users_names_raw",
+        run(&["jq", "-r", ".users[].name"], JSON_USERS)?
+    );
+    Ok(())
+}
+
+#[test]
+fn jq_users_length() -> Result<()> {
+    insta::assert_snapshot!(
+        "jq_users_length",
+        run(&["jq", ".users | length"], JSON_USERS)?
+    );
+    Ok(())
+}
+
+#[test]
+fn jq_users_csv() -> Result<()> {
+    insta::assert_snapshot!(
+        "jq_users_csv",
+        run(&["jq", "-r", ".users[] | [.name, .age] | @csv"], JSON_USERS)?
+    );
+    Ok(())
+}
+
+#[test]
+fn jq_nested_path() -> Result<()> {
+    insta::assert_snapshot!("jq_nested_path", run(&["jq", "-c", ".a.b.c"], JSON_NESTED)?);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// YAML / yq  (guards #181, #185)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn yq_config_identity() -> Result<()> {
+    insta::assert_snapshot!("yq_config_identity", run(&["yq", "."], YAML_CONFIG)?);
+    Ok(())
+}
+
+#[test]
+fn yq_config_to_json() -> Result<()> {
+    insta::assert_snapshot!(
+        "yq_config_to_json",
+        run(&["yq", "-o", "json", "."], YAML_CONFIG)?
+    );
+    Ok(())
+}
+
+#[test]
+fn yq_config_container_names() -> Result<()> {
+    insta::assert_snapshot!(
+        "yq_config_container_names",
+        run(&["yq", ".spec.containers[].name"], YAML_CONFIG)?
+    );
+    Ok(())
+}
+
+#[test]
+fn yq_types_to_json() -> Result<()> {
+    insta::assert_snapshot!(
+        "yq_types_to_json",
+        run(&["yq", "-o", "json", "."], YAML_TYPES)?
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// DSV  (guards #183). `--input-dsv` yields a stream of row-arrays.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dsv_rows() -> Result<()> {
+    insta::assert_snapshot!(
+        "dsv_rows",
+        run(&["jq", "--input-dsv", ",", "-c", "."], CSV_PEOPLE)?
+    );
+    Ok(())
+}
+
+#[test]
+fn dsv_col0_raw() -> Result<()> {
+    insta::assert_snapshot!(
+        "dsv_col0_raw",
+        run(&["jq", "--input-dsv", ",", "-r", ".[0]"], CSV_PEOPLE)?
+    );
+    Ok(())
+}
+
+#[test]
+fn dsv_select_row() -> Result<()> {
+    insta::assert_snapshot!(
+        "dsv_select_row",
+        run(
+            &["jq", "--input-dsv", ",", "-c", "select(.[0] == \"Alice\")"],
+            CSV_PEOPLE
+        )?
+    );
+    Ok(())
+}

--- a/tests/deep_nesting_valid_tests.rs
+++ b/tests/deep_nesting_valid_tests.rs
@@ -1,0 +1,99 @@
+//! Guard tests: deeply-nested but *valid* documents must keep parsing (#192).
+//!
+//! The DoS fixes #151 (JSON validator), #152 (YAML flow parser) and #153 (YAML
+//! alias cycles) add depth caps / cycle guards to stop pathological input from
+//! aborting the process. These tests lock in the other side of that fix — that a
+//! genuinely-valid, real-world-depth document is **not** over-rejected once the
+//! caps land. They are green on `main` today (no cap exists yet) and must stay
+//! green after the fixes.
+//!
+//! `VALID_DEPTH` is deliberately kept well below the ~128 depth cap #151/#152
+//! propose, so a correctly-sized cap never trips these guards. If you lower the
+//! cap below this, that is a deliberate decision to reject documents this deep —
+//! update the constant and say why.
+//!
+//! Run with: cargo test --features cli --test deep_nesting_valid_tests
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use anyhow::Result;
+
+const MAX_CARGO_RETRIES: u32 = 3;
+
+/// A real-but-deep nesting depth: deeper than typical documents (~30-50 levels),
+/// yet comfortably under the ~128-level DoS cap proposed in #151/#152.
+const VALID_DEPTH: usize = 100;
+
+/// Run `succinctly <args>` with `stdin` piped in; return `(stdout, exit_code)`.
+fn run(args: &[&str], stdin: &str) -> Result<(String, i32)> {
+    for attempt in 0..MAX_CARGO_RETRIES {
+        let mut cmd = Command::new("cargo")
+            .args(["run", "--features", "cli", "--bin", "succinctly", "--"])
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        if let Some(mut sin) = cmd.stdin.take() {
+            sin.write_all(stdin.as_bytes())?;
+        }
+
+        let output = cmd.wait_with_output()?;
+        let exit_code = output.status.code().unwrap_or(-1);
+
+        // Exit code 101 often indicates cargo lock contention; retry.
+        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
+            continue;
+        }
+
+        let stdout = String::from_utf8(output.stdout)?;
+        return Ok((stdout, exit_code));
+    }
+    unreachable!()
+}
+
+/// `[[[ … ]]]` nested `depth` levels deep with an empty innermost array.
+fn nested_json(depth: usize) -> String {
+    format!("{}{}", "[".repeat(depth), "]".repeat(depth))
+}
+
+/// Guards #151: the JSON validator must accept a valid, deeply-nested document
+/// (the DoS fix caps *pathological* depth, not real documents).
+#[test]
+fn json_validate_accepts_deep_valid_document() -> Result<()> {
+    let (_, code) = run(&["json", "validate"], &nested_json(VALID_DEPTH))?;
+    assert_eq!(
+        code, 0,
+        "json validate should accept depth-{VALID_DEPTH} JSON"
+    );
+    Ok(())
+}
+
+/// Guards #152: the YAML flow parser must accept a valid, deeply-nested flow
+/// collection (`a: [[[ … ]]]`), the shape whose pathological form aborts today.
+#[test]
+fn yaml_flow_parser_accepts_deep_valid_document() -> Result<()> {
+    let yaml = format!("a: {}", nested_json(VALID_DEPTH));
+    let (out, code) = run(&["yq", "-o", "json", ".a"], &yaml)?;
+    assert_eq!(code, 0, "yq should accept depth-{VALID_DEPTH} flow YAML");
+    assert!(
+        out.contains('['),
+        "expected nested-array JSON output, got: {out:?}"
+    );
+    Ok(())
+}
+
+/// Guards #153: a valid, *acyclic* anchor/alias must still resolve after the
+/// cycle-detection fix (which should reject only self-referential anchors).
+#[test]
+fn yaml_valid_alias_still_resolves() -> Result<()> {
+    let (out, code) = run(&["yq", "-o", "json", ".b"], "a: &x [1, 2]\nb: *x\n")?;
+    assert_eq!(code, 0, "yq should resolve a valid alias");
+    let compact: String = out.split_whitespace().collect();
+    assert_eq!(compact, "[1,2]", "alias .b should resolve to [1, 2]");
+    Ok(())
+}

--- a/tests/snapshots/cli_characterization_tests__dsv_col0_raw.snap
+++ b/tests/snapshots/cli_characterization_tests__dsv_col0_raw.snap
@@ -1,0 +1,7 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \"--input-dsv\", \",\", \"-r\", \".[0]\"], CSV_PEOPLE)?"
+---
+name
+Alice
+Bob

--- a/tests/snapshots/cli_characterization_tests__dsv_rows.snap
+++ b/tests/snapshots/cli_characterization_tests__dsv_rows.snap
@@ -1,0 +1,7 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \"--input-dsv\", \",\", \"-c\", \".\"], CSV_PEOPLE)?"
+---
+["name","age"]
+["Alice","30"]
+["Bob","25"]

--- a/tests/snapshots/cli_characterization_tests__dsv_select_row.snap
+++ b/tests/snapshots/cli_characterization_tests__dsv_select_row.snap
@@ -1,0 +1,5 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \"--input-dsv\", \",\", \"-c\", \"select(.[0] == \\\"Alice\\\")\"],\nCSV_PEOPLE)?"
+---
+["Alice","30"]

--- a/tests/snapshots/cli_characterization_tests__jq_nested_path.snap
+++ b/tests/snapshots/cli_characterization_tests__jq_nested_path.snap
@@ -1,0 +1,5 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \"-c\", \".a.b.c\"], JSON_NESTED)?"
+---
+[1,2,3]

--- a/tests/snapshots/cli_characterization_tests__jq_users_compact.snap
+++ b/tests/snapshots/cli_characterization_tests__jq_users_compact.snap
@@ -1,0 +1,5 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \"-c\", \".\"], JSON_USERS)?"
+---
+{"users":[{"name":"Alice","age":30},{"name":"Bob","age":25}],"active":true}

--- a/tests/snapshots/cli_characterization_tests__jq_users_csv.snap
+++ b/tests/snapshots/cli_characterization_tests__jq_users_csv.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \"-r\", \".users[] | [.name, .age] | @csv\"], JSON_USERS)?"
+---
+Alice,30
+Bob,25

--- a/tests/snapshots/cli_characterization_tests__jq_users_identity.snap
+++ b/tests/snapshots/cli_characterization_tests__jq_users_identity.snap
@@ -1,0 +1,17 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \".\"], JSON_USERS)?"
+---
+{
+  "users": [
+    {
+      "name": "Alice",
+      "age": 30
+    },
+    {
+      "name": "Bob",
+      "age": 25
+    }
+  ],
+  "active": true
+}

--- a/tests/snapshots/cli_characterization_tests__jq_users_length.snap
+++ b/tests/snapshots/cli_characterization_tests__jq_users_length.snap
@@ -1,0 +1,5 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \".users | length\"], JSON_USERS)?"
+---
+2

--- a/tests/snapshots/cli_characterization_tests__jq_users_names_raw.snap
+++ b/tests/snapshots/cli_characterization_tests__jq_users_names_raw.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"jq\", \"-r\", \".users[].name\"], JSON_USERS)?"
+---
+Alice
+Bob

--- a/tests/snapshots/cli_characterization_tests__yq_config_container_names.snap
+++ b/tests/snapshots/cli_characterization_tests__yq_config_container_names.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"yq\", \".spec.containers[].name\"], YAML_CONFIG)?"
+---
+web
+sidecar

--- a/tests/snapshots/cli_characterization_tests__yq_config_identity.snap
+++ b/tests/snapshots/cli_characterization_tests__yq_config_identity.snap
@@ -1,0 +1,16 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"yq\", \".\"], YAML_CONFIG)?"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo
+spec:
+  containers:
+    -
+      name: web
+      image: nginx
+    -
+      name: sidecar
+      image: envoy

--- a/tests/snapshots/cli_characterization_tests__yq_config_to_json.snap
+++ b/tests/snapshots/cli_characterization_tests__yq_config_to_json.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"yq\", \"-o\", \"json\", \".\"], YAML_CONFIG)?"
+---
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "demo"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "web",
+        "image": "nginx"
+      },
+      {
+        "name": "sidecar",
+        "image": "envoy"
+      }
+    ]
+  }
+}

--- a/tests/snapshots/cli_characterization_tests__yq_types_to_json.snap
+++ b/tests/snapshots/cli_characterization_tests__yq_types_to_json.snap
@@ -1,0 +1,11 @@
+---
+source: tests/cli_characterization_tests.rs
+expression: "run(&[\"yq\", \"-o\", \"json\", \".\"], YAML_TYPES)?"
+---
+{
+  "version": "1.0",
+  "enabled": true,
+  "count": 42,
+  "ratio": 3.14,
+  "missing": null
+}


### PR DESCRIPTION
## Description

This PR establishes comprehensive test scaffolding and CI infrastructure to prevent behavior regressions across four major refactoring initiatives (#181, #183, #184, #185). It adds characterization snapshot tests for jq/yq/dsv query paths, validates deeply-nested JSON/YAML parsing against DoS safeguards, and hardens CI checks to ensure SIMD test features are actually available on the runner.

## Type of Change
- [x] Test coverage improvement
- [x] CI/CD changes
- [x] Documentation update

## Related Issue
Fixes #192 - Land the green test scaffolding CI arch

Related to:
- #181 jq_runner/yq_runner consolidation
- #183 DSV SSE2 path
- #184 dead JSON SIMD removal
- #185 YAML SIMD scalar-helper dedup
- #151 JSON validator depth cap
- #152 YAML flow parser depth cap
- #153 YAML alias cycle guard

## Changes Made

**Characterization Snapshot Tests (`tests/cli_characterization_tests.rs`)**
- Added 13 snapshot tests covering jq/yq/dsv query output over representative JSON/YAML/DSV corpus
- jq tests: identity, compact (-c), raw output (-r), length, @csv formatting, nested path queries
- yq tests: identity, JSON output (-o json), field selection, type preservation
- dsv tests: row-stream output, column selection (-r), row filtering (select)
- Tests exercise the exact query paths touched by refactors #181, #183, #184, #185
- Uses `insta` snapshot framework with retry logic (up to 3 attempts) for cargo lock contention
- Created 13 corresponding snapshot files documenting current CLI behavior

**Deep Nesting Validation Tests (`tests/deep_nesting_valid_tests.rs`)**
- Added guard tests for JSON validator (fixes #151), YAML flow parser (#152), and alias resolution (#153)
- `json_validate_accepts_deep_valid_document`: validates depth-100 nested JSON structure is accepted
- `yaml_flow_parser_accepts_deep_valid_document`: validates depth-100 nested flow collections are accepted
- `yaml_valid_alias_still_resolves`: validates acyclic anchor/alias resolution works correctly
- Tests ensure DoS depth caps reject only pathological input, not real-world-depth documents
- Depth kept at 100 levels, well below the ~128-level cap proposed in #151/#152

**CI Feature Verification (`.github/workflows/ci.yml`)**
- Added "Verify SIMD CPU features (BMI2 + AVX2)" check for x86_64 runner
  - Checks `/proc/cpuinfo` for required avx2 and bmi2 flags
  - Prints CPU model, architecture, and flags for debugging
  - Fails loudly with actionable error if either feature is missing
  - Prevents silent-pass scenario where all SIMD tests self-skip
- Enhanced "Verify SIMD CPU features (NEON + SVE2-BITPERM)" check for ARM runner
  - Replaces echo-only SVE2 probe with explicit svebitperm requirement
  - Requires SVE2-BITPERM (BDEP/BEXT instructions) on aarch64 runners
  - Confirms NEON (always present on aarch64) + SVE2-BITPERM for SIMD test execution

**Documentation (`CONTRIBUTING.md`)**
- Added "SIMD CI coverage" section with clear mapping of runner capabilities
- Table showing:
  - ubuntu-latest (x86_64, AMD EPYC 7763): POPCNT, SSE4.1/4.2, **BMI2**, **AVX2**
  - ubuntu-24.04-arm (ARM, Neoverse-N2): NEON, **SVE2-BITPERM**
  - macos-latest (Apple Silicon): NEON
- Explicitly documents that AVX-512 is **not** covered by routine CI (Zen 3 EPYC lacks avx512f/avx512vpopcntdq)
- Provides guidance for validating AVX-512 paths off-CI (hardware or QEMU emulation)
- Clarifies that SVE2 *is* covered by CI despite historical misconception

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New characterization snapshot tests added for jq/yq/dsv query paths (13 tests)
- [x] New deep-nesting validation tests added for JSON/YAML safety guards (3 tests)
- [x] CI feature verification integrated into workflow

**Manual Testing:**
- [x] Snapshot tests verified on development machine
- [x] Deep nesting tests verified on development machine
- [x] CI workflow changes staged for GitHub Actions validation

### Test Commands
```bash
# Run all characterization tests
cargo test --features cli --test cli_characterization_tests

# Run deep nesting validation tests
cargo test --features cli --test deep_nesting_valid_tests

# Run full test suite
cargo test --features cli

# Lint and formatting checks
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

Test additions only; no changes to runtime code paths. Snapshot tests run through `cargo run` which involves compilation overhead, but this is test infrastructure not affecting production performance.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Test Architecture Rationale:**
- Characterization snapshots lock query behavior across refactors that don't change what users see — purely internal consolidations and optimizations become "snapshots unchanged" reviews
- Existing `cli_golden_tests.rs` only covers `json generate` + help output, never exercising the query paths these refactors touch
- Cross-backend structural equivalence (scalar vs SIMD variants) remains covered by separate `dsv_simd_differential_tests.rs`
- This PR adds end-to-end CLI output validation, which is what refactors must preserve

**CI Feature Verification Purpose:**
- SIMD unit tests self-skip early when CPU features are absent, reading as "all pass" for a fully-skipped suite
- New verification steps ensure each CI runner has the features it's meant to exercise, failing loudly if not
- Prevents accidentally merging changes that appear to have passing tests but actually had all SIMD tests skipped

**Future Work:**
- Per-site SKIPPED-marker wiring and more granular test reporting planned for #193/#194
- AVX-512 validation recommendations provided for off-CI testing