### PR TITLE
test(simd): implement comprehensive x86 SIMD test coverage and hard feature expectations for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,30 @@ jobs:
     name: Test (x86_64)
     needs: gate
     runs-on: ubuntu-latest
+    env:
+      # x86 SIMD CI leg (#193): the SIMD suites self-skip (with a visible
+      # `SKIPPED` line) when a CPU feature is missing, so this pins the runner
+      # contract — tests/simd_expectation_tests.rs fails the leg if any listed
+      # feature stops being detected, instead of the suites silently skipping.
+      # The SSE2 kernels don't need an AVX2-disabled config: the differential
+      # tests (tests/simd_level_tests.rs, tests/dsv_simd_differential_tests.rs,
+      # src/yaml/simd/x86.rs) call each kernel directly, so every level is
+      # exercised on this AVX2 runner. There is deliberately no x86 dispatch
+      # override (docs/reference/environment-variables.md).
+      SUCCINCTLY_EXPECT_SIMD: sse2,sse4.2,avx2,bmi2,popcnt
     steps:
       - uses: actions/checkout@v4
         if: needs.gate.outputs.code == 'true'
+
+      - name: Check CPU features (x86 SIMD)
+        if: needs.gate.outputs.code == 'true'
+        run: |
+          echo "=== CPU Info ==="
+          lscpu | grep -E "Model name|Architecture|CPU" || true
+          echo "=== x86 SIMD Detection (expecting $SUCCINCTLY_EXPECT_SIMD) ==="
+          for feature in sse2 sse4_2 avx2 bmi2 popcnt; do
+            if grep -qw "$feature" /proc/cpuinfo; then echo "$feature: supported"; else echo "$feature: not detected"; fi
+          done
 
       - name: Install Rust
         if: needs.gate.outputs.code == 'true'
@@ -252,6 +273,9 @@ jobs:
       matrix:
         rust: [beta, nightly]
     continue-on-error: ${{ matrix.rust == 'nightly' }}   # beta gates CI; nightly is advisory
+    env:
+      # Same x86 SIMD runner contract as test-x86 (#193).
+      SUCCINCTLY_EXPECT_SIMD: sse2,sse4.2,avx2,bmi2,popcnt
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -15,6 +15,7 @@ Every environment variable succinctly reads, what it accepts, and what it change
 | [`JQ_LIBRARY_PATH`](#jq_library_path)                     | `succinctly jq`                  | `:`-separated directories      | Only `-L` paths and `~/.jq`   |
 | [`HOME`](#home)                                           | `succinctly jq`                  | A directory path               | No `~/.jq` auto-loading       |
 | [`TZ`](#tz)                                               | Library (jq date builtins)       | POSIX `STDoffset[DST]`         | UTC                           |
+| [`SUCCINCTLY_EXPECT_SIMD`](#succinctly_expect_simd)       | Test suite (`cargo test`)        | Comma-separated CPU features   | Expectation check skipped     |
 
 Queries can also read **any** variable through the [`env` builtins](#reading-the-environment-from-a-query).
 
@@ -86,6 +87,34 @@ TZ=EST5EDT succinctly jq -nc '1700000000 | localtime' # [2023,10,14,17,13,20,2,3
 
 For anything requiring true local time, set an explicit numeric offset rather than a zone name, and
 change it yourself across DST boundaries.
+
+## Test-Only Variables
+
+### `SUCCINCTLY_EXPECT_SIMD`
+
+Read only by the test suite ([`tests/simd_expectation_tests.rs`](../../tests/simd_expectation_tests.rs));
+the library and CLI never look at it.
+
+Pins the set of CPU features a `cargo test` run is expected to detect. The SIMD test suites self-skip
+when the running CPU lacks a feature (printing a `SKIPPED` line), which keeps local runs green on any
+hardware — but on CI it would let a runner-fleet change silently skip entire suites. Setting this
+variable turns those soft skips into a hard failure: every listed feature must be runtime-detected or
+`test_expected_simd_features_are_detected` fails the run (#193).
+
+The value is a comma-separated list of runtime feature names:
+
+| Target    | Recognized names                          |
+|-----------|-------------------------------------------|
+| `x86_64`  | `sse2`, `sse4.2`, `avx2`, `bmi2`, `popcnt` |
+| `aarch64` | `neon`, `sve2`, `sve2-bitperm`             |
+
+Unknown names — including names for the *other* architecture — fail the test, so a typo cannot
+silently satisfy the expectation. Unset, the check is skipped entirely.
+
+```bash
+# What CI sets on the x86_64 test legs (.github/workflows/ci.yml)
+SUCCINCTLY_EXPECT_SIMD=sse2,sse4.2,avx2,bmi2,popcnt cargo test --test simd_expectation_tests
+```
 
 ## CLI Variables
 

--- a/src/dsv/simd/avx2.rs
+++ b/src/dsv/simd/avx2.rs
@@ -170,11 +170,7 @@ mod tests {
     /// Detection guard for the AVX2 backend; emits a visible `SKIPPED` line
     /// when unavailable so a fully-skipped run doesn't read as green (#193).
     fn has_avx2() -> bool {
-        let available = is_x86_feature_detected!("avx2");
-        if !available {
-            crate::util::simd::note_simd_skip("avx2");
-        }
-        available
+        crate::util::simd::note_simd_skip_unless(is_x86_feature_detected!("avx2"), "avx2")
     }
 
     #[test]

--- a/src/dsv/simd/avx2.rs
+++ b/src/dsv/simd/avx2.rs
@@ -167,9 +167,19 @@ fn prefix_xor(x: u64) -> u64 {
 mod tests {
     use super::*;
 
+    /// Detection guard for the AVX2 backend; emits a visible `SKIPPED` line
+    /// when unavailable so a fully-skipped run doesn't read as green (#193).
+    fn has_avx2() -> bool {
+        let available = is_x86_feature_detected!("avx2");
+        if !available {
+            crate::util::simd::note_simd_skip("avx2");
+        }
+        available
+    }
+
     #[test]
     fn test_simple_csv() {
-        if !is_x86_feature_detected!("avx2") {
+        if !has_avx2() {
             return;
         }
 
@@ -183,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_quoted_delimiter() {
-        if !is_x86_feature_detected!("avx2") {
+        if !has_avx2() {
             return;
         }
 
@@ -197,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_simd_matches_scalar() {
-        if !is_x86_feature_detected!("avx2") {
+        if !has_avx2() {
             return;
         }
 
@@ -213,7 +223,7 @@ mod tests {
 
     #[test]
     fn test_large_csv() {
-        if !is_x86_feature_detected!("avx2") {
+        if !has_avx2() {
             return;
         }
 
@@ -230,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_quoted_spanning_chunks() {
-        if !is_x86_feature_detected!("avx2") {
+        if !has_avx2() {
             return;
         }
 

--- a/src/dsv/simd/bmi2.rs
+++ b/src/dsv/simd/bmi2.rs
@@ -213,11 +213,10 @@ mod tests {
     /// Detection guard for the BMI2+AVX2 backend; emits a visible `SKIPPED`
     /// line when unavailable so a fully-skipped run doesn't read as green (#193).
     fn has_bmi2() -> bool {
-        let available = is_x86_feature_detected!("bmi2") && is_x86_feature_detected!("avx2");
-        if !available {
-            crate::util::simd::note_simd_skip("bmi2+avx2");
-        }
-        available
+        crate::util::simd::note_simd_skip_unless(
+            is_x86_feature_detected!("bmi2") && is_x86_feature_detected!("avx2"),
+            "bmi2+avx2",
+        )
     }
 
     #[test]

--- a/src/dsv/simd/bmi2.rs
+++ b/src/dsv/simd/bmi2.rs
@@ -210,14 +210,19 @@ unsafe fn toggle64_bmi2(carry: u64, w: u64) -> (u64, u64) {
 mod tests {
     use super::*;
 
+    /// Detection guard for the BMI2+AVX2 backend; emits a visible `SKIPPED`
+    /// line when unavailable so a fully-skipped run doesn't read as green (#193).
     fn has_bmi2() -> bool {
-        is_x86_feature_detected!("bmi2") && is_x86_feature_detected!("avx2")
+        let available = is_x86_feature_detected!("bmi2") && is_x86_feature_detected!("avx2");
+        if !available {
+            crate::util::simd::note_simd_skip("bmi2+avx2");
+        }
+        available
     }
 
     #[test]
     fn test_simple_csv() {
         if !has_bmi2() {
-            eprintln!("Skipping BMI2 test: CPU doesn't support BMI2");
             return;
         }
 

--- a/src/util/simd/mod.rs
+++ b/src/util/simd/mod.rs
@@ -58,12 +58,13 @@ pub fn popcount_512_scalar(data: &[u8; 64]) -> u32 {
 /// suites (and, absent emulation, SVE2) read as "passed" without asserting
 /// anything. Routing every skip through this helper makes the skips visible and
 /// countable (grep the test output for `SKIPPED`), so a fully-skipped SIMD suite
-/// no longer looks green. See #191; applied to the x86 sites in #193 and the
-/// remaining SVE2 sites in #194.
-// Used today only by the aarch64 SVE2 test modules; the x86 BMI2/AVX2/SSE2
-// sites adopt it in #193, so it is dead on x86-only builds until then.
+/// no longer looks green. See #191; wired into the x86 BMI2/AVX2/POPCNT sites
+/// (#193), with the remaining SVE2 sites tracked in #194.
+///
+/// CI additionally pins the expected feature set hard via the
+/// `SUCCINCTLY_EXPECT_SIMD` expectation test (`tests/simd_expectation_tests.rs`),
+/// so a runner that stops exposing a feature fails the leg instead of skipping.
 #[cfg(test)]
-#[allow(dead_code)] // STYLE-0005: test-only skip helper; dead on x86 builds until #193 wires it in
 pub(crate) fn note_simd_skip(feature: &str) {
     eprintln!("SKIPPED: SIMD test - CPU feature `{feature}` unavailable");
 }

--- a/src/util/simd/mod.rs
+++ b/src/util/simd/mod.rs
@@ -69,6 +69,20 @@ pub(crate) fn note_simd_skip(feature: &str) {
     eprintln!("SKIPPED: SIMD test - CPU feature `{feature}` unavailable");
 }
 
+/// Note a skip when `available` is false, passing the flag through.
+///
+/// Feature guards call this as a single always-executed expression, so the
+/// skip branch lives here — covered by its own test even on hardware that has
+/// every feature — rather than as a dead line in each guard that coverage on
+/// fully-featured CI runners can never reach (#193).
+#[cfg(test)]
+pub(crate) fn note_simd_skip_unless(available: bool, feature: &str) -> bool {
+    if !available {
+        note_simd_skip(feature);
+    }
+    available
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,6 +98,14 @@ mod tests {
         // Exercise the shared skip-visibility helper directly so it is covered
         // even on arches where no feature-gated SIMD test calls it (see #191).
         note_simd_skip("test-feature");
+    }
+
+    #[test]
+    fn test_note_simd_skip_unless_both_branches() {
+        // Both arms of the shared guard helper, so per-module feature guards
+        // stay fully covered even on hardware that has every feature (#193).
+        assert!(note_simd_skip_unless(true, "test-feature"));
+        assert!(!note_simd_skip_unless(false, "test-feature"));
     }
 
     #[test]

--- a/src/util/simd/x86.rs
+++ b/src/util/simd/x86.rs
@@ -215,11 +215,7 @@ mod tests {
     /// Detection guard for POPCNT; emits a visible `SKIPPED` line when
     /// unavailable so a fully-skipped run doesn't read as green (#193).
     fn has_popcnt() -> bool {
-        let available = is_x86_feature_detected!("popcnt");
-        if !available {
-            crate::util::simd::note_simd_skip("popcnt");
-        }
-        available
+        crate::util::simd::note_simd_skip_unless(is_x86_feature_detected!("popcnt"), "popcnt")
     }
 
     #[test]
@@ -265,11 +261,7 @@ mod tests {
     /// Detection guard for BMI2; emits a visible `SKIPPED` line when
     /// unavailable so a fully-skipped run doesn't read as green (#193).
     fn has_bmi2() -> bool {
-        let available = is_x86_feature_detected!("bmi2");
-        if !available {
-            crate::util::simd::note_simd_skip("bmi2");
-        }
-        available
+        crate::util::simd::note_simd_skip_unless(is_x86_feature_detected!("bmi2"), "bmi2")
     }
 
     #[test]

--- a/src/util/simd/x86.rs
+++ b/src/util/simd/x86.rs
@@ -212,9 +212,19 @@ fn detect_fast_bmi2() -> bool {
 mod tests {
     use super::*;
 
+    /// Detection guard for POPCNT; emits a visible `SKIPPED` line when
+    /// unavailable so a fully-skipped run doesn't read as green (#193).
+    fn has_popcnt() -> bool {
+        let available = is_x86_feature_detected!("popcnt");
+        if !available {
+            crate::util::simd::note_simd_skip("popcnt");
+        }
+        available
+    }
+
     #[test]
     fn test_popcount_512_popcnt() {
-        if !is_x86_feature_detected!("popcnt") {
+        if !has_popcnt() {
             return;
         }
 
@@ -234,7 +244,7 @@ mod tests {
 
     #[test]
     fn test_popcount_words_popcnt() {
-        if !is_x86_feature_detected!("popcnt") {
+        if !has_popcnt() {
             return;
         }
 
@@ -252,14 +262,19 @@ mod tests {
     // BMI2 select_in_word tests
     // -------------------------------------------------------------------------
 
+    /// Detection guard for BMI2; emits a visible `SKIPPED` line when
+    /// unavailable so a fully-skipped run doesn't read as green (#193).
     fn has_bmi2() -> bool {
-        is_x86_feature_detected!("bmi2")
+        let available = is_x86_feature_detected!("bmi2");
+        if !available {
+            crate::util::simd::note_simd_skip("bmi2");
+        }
+        available
     }
 
     #[test]
     fn test_select_in_word_pdep_basic() {
         if !has_bmi2() {
-            eprintln!("Skipping BMI2 test: CPU doesn't support BMI2");
             return;
         }
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5327,6 +5327,21 @@ mod tests {
     }
 
     #[test]
+    fn test_long_plain_scalar_does_not_swallow_next_line() {
+        // Regression for the SSE2 chunk-width bug found by the multibyte tests
+        // above (#193): `skip_unquoted_simd` assumed `classify_yaml_chars`
+        // scanned 32 bytes whenever 32 remained, but on non-AVX2 x86 the SSE2
+        // classifier only scans 16 — so the parser skipped past the newline of
+        // any plain scalar whose line ended in bytes 16..31 of the scan window
+        // and folded the next mapping entry into the value. Pure ASCII, so the
+        // failure is isolated to chunk-width accounting, not UTF-8 handling.
+        let yaml = b"a: love and peace forever more x\nb: x\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let json = index.root(yaml).to_json_document();
+        assert_eq!(json, r#"{"a":"love and peace forever more x","b":"x"}"#);
+    }
+
+    #[test]
     fn test_decode_double_quoted_space_escape() {
         let s = YamlString::DoubleQuoted {
             text: b"\"spaced\\ word\"",

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5268,6 +5268,64 @@ mod tests {
         assert!(out.contains("\"f\":1.5"), "got {out}");
     }
 
+    /// Values ≥ 16 bytes with multibyte UTF-8, long enough to enter the SIMD
+    /// escape scanners (`find_json_escape`), including the 32-byte AVX2 loop.
+    const MULTIBYTE_JSON_VALUES: &[&str] = &[
+        "love ♥ and peace ☮", // the original #230 repro value
+        "café au lait, s'il vous plaît",
+        "日本語のテキストはここにあります",
+        "emoji 😁 in a string long enough for a full chunk",
+    ];
+
+    fn multibyte_yaml() -> Vec<u8> {
+        format!(
+            "wanted: {}\nlatin: {}\ncjk: {}\nemoji: {}\n",
+            MULTIBYTE_JSON_VALUES[0],
+            MULTIBYTE_JSON_VALUES[1],
+            MULTIBYTE_JSON_VALUES[2],
+            MULTIBYTE_JSON_VALUES[3]
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn test_to_json_multibyte_survives_simd_escape_scan() {
+        // Regression test for the x86 signed-compare bug (#150/#230): the
+        // AVX2/SSE2 `find_json_escape` kernels misread bytes >= 0x80 as
+        // control characters, cutting multibyte UTF-8 mid-character (a panic
+        // in callers slicing on the index, or corrupt output). On x86 this
+        // drives the fixed kernels through the library `to_json()` /
+        // `to_json_document()` path end-to-end.
+        let yaml = multibyte_yaml();
+        let index = YamlIndex::build(&yaml).unwrap();
+        let json = index.root(&yaml).to_json_document();
+        for expect in MULTIBYTE_JSON_VALUES {
+            assert!(
+                json.contains(expect),
+                "multibyte content lost: {expect:?} not in {json}"
+            );
+        }
+
+        // `to_json` (with the document wrapper) takes the same escape path.
+        let wrapped = index.root(&yaml).to_json();
+        assert!(wrapped.contains(MULTIBYTE_JSON_VALUES[0]), "got {wrapped}");
+    }
+
+    #[test]
+    fn test_stream_json_multibyte_survives_simd_escape_scan() {
+        // Streaming counterpart of the test above (#150/#230).
+        let yaml = multibyte_yaml();
+        let index = YamlIndex::build(&yaml).unwrap();
+        let mut out = String::new();
+        index.root(&yaml).stream_json_document(&mut out).unwrap();
+        for expect in MULTIBYTE_JSON_VALUES {
+            assert!(
+                out.contains(expect),
+                "multibyte content lost: {expect:?} not in {out}"
+            );
+        }
+    }
+
     #[test]
     fn test_decode_double_quoted_space_escape() {
         let s = YamlString::DoubleQuoted {

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -399,13 +399,13 @@ impl<'a> Parser<'a> {
             let terminators = class.newlines | class.colons | class.hash;
 
             if terminators == 0 {
-                // No structural characters in this 32-byte chunk - safe to skip all
-                let chunk_size = if self.pos + 32 <= self.input.len() {
-                    32
-                } else {
-                    16
-                };
-                return Some(chunk_size);
+                // No structural characters in the classified chunk — skip
+                // exactly the bytes the classifier scanned (32 with AVX2, 16
+                // with SSE2). Deriving the width from input length alone
+                // assumed AVX2: after a 16-byte SSE2 classify it skipped 32,
+                // swallowing newlines/colons in bytes 16..31 on non-AVX2 CPUs
+                // (#193).
+                return Some(class.width);
             }
 
             // Found a potential terminator - find its position

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -1399,11 +1399,7 @@ mod tests {
     /// Detection guard for AVX2; emits a visible `SKIPPED` line when
     /// unavailable so a fully-skipped kernel doesn't read as green (#193).
     fn has_avx2() -> bool {
-        let available = is_x86_feature_detected!("avx2");
-        if !available {
-            crate::util::simd::note_simd_skip("avx2");
-        }
-        available
+        crate::util::simd::note_simd_skip_unless(is_x86_feature_detected!("avx2"), "avx2")
     }
 
     /// Multibyte UTF-8 cases sized to hit the SSE2 16-byte loop, the AVX2

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -1377,4 +1377,102 @@ mod tests {
         let input_space = b"abc def";
         assert_eq!(find_json_escape_x86(input_space, 0), None);
     }
+
+    // ========================================================================
+    // Per-kernel differential tests (#193)
+    //
+    // These call `find_json_escape_sse2` / `find_json_escape_avx2` directly
+    // rather than through `find_json_escape_x86`, so the SSE2 kernel is
+    // exercised even on AVX2 hardware — the dispatcher never reaches it on
+    // CI runners, and there is deliberately no x86 dispatch override. They
+    // are the tests that would have caught the signed-compare bug (#150/#230)
+    // on x86 regardless of which kernel the dispatcher picks.
+    // ========================================================================
+
+    /// Detection guard for AVX2; emits a visible `SKIPPED` line when
+    /// unavailable so a fully-skipped kernel doesn't read as green (#193).
+    fn has_avx2() -> bool {
+        let available = is_x86_feature_detected!("avx2");
+        if !available {
+            crate::util::simd::note_simd_skip("avx2");
+        }
+        available
+    }
+
+    /// Multibyte UTF-8 cases sized to hit the SSE2 16-byte loop, the AVX2
+    /// 32-byte main loop, its 16-byte SSE2 tail, and the scalar tails.
+    fn non_ascii_cases() -> Vec<&'static [u8]> {
+        vec![
+            "café au lait, s'il vous plaît".as_bytes(),
+            "love ♥ and peace ☮".as_bytes(), // the original #230 repro value
+            "日本語のテキストはここにあります".as_bytes(),
+            "emoji 😁 in a string long enough for a full chunk".as_bytes(),
+            "aaaaaaaaaaaaaaaa♥".as_bytes(), // multibyte right at the 16-byte boundary
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa😁".as_bytes(), // at the 32-byte boundary
+            "mixed \"quote\" and café and \\ backslash".as_bytes(),
+            "日本語 with a \n control in the middle of CJK 文字".as_bytes(),
+        ]
+    }
+
+    #[test]
+    fn test_find_json_escape_kernels_match_scalar_non_ascii() {
+        let run_avx2 = has_avx2();
+        for input in non_ascii_cases() {
+            for start in [0usize, 1, 3] {
+                let scalar = find_json_escape_scalar(input, start);
+                // SSE2 is x86_64 baseline, so the kernel is always callable.
+                let sse2 = unsafe { find_json_escape_sse2(input, start) };
+                assert_eq!(
+                    scalar,
+                    sse2,
+                    "SSE2 mismatch for {:?} at start {start}",
+                    String::from_utf8_lossy(input)
+                );
+                if run_avx2 {
+                    let avx2 = unsafe { find_json_escape_avx2(input, start) };
+                    assert_eq!(
+                        scalar,
+                        avx2,
+                        "AVX2 mismatch for {:?} at start {start}",
+                        String::from_utf8_lossy(input)
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_find_json_escape_sse2_exhaustive_bytes_match_scalar() {
+        // Every byte value at every position of a 40-byte buffer: two 16-byte
+        // SSE2 chunks plus the scalar tail. Bytes >= 0x80 are the ones the
+        // signed compare misclassified (#150/#230).
+        for byte in 0u8..=255 {
+            for pos in 0..40 {
+                let mut input = [b'a'; 40];
+                input[pos] = byte;
+                let scalar = find_json_escape_scalar(&input, 0);
+                let sse2 = unsafe { find_json_escape_sse2(&input, 0) };
+                assert_eq!(scalar, sse2, "SSE2 mismatch for byte 0x{byte:02x} at {pos}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_find_json_escape_avx2_exhaustive_bytes_match_scalar() {
+        if !has_avx2() {
+            return;
+        }
+
+        // 56-byte buffer: one 32-byte AVX2 chunk, one 16-byte SSE2 tail chunk,
+        // and an 8-byte scalar tail — every internal path of the kernel.
+        for byte in 0u8..=255 {
+            for pos in 0..56 {
+                let mut input = [b'a'; 56];
+                input[pos] = byte;
+                let scalar = find_json_escape_scalar(&input, 0);
+                let avx2 = unsafe { find_json_escape_avx2(&input, 0) };
+                assert_eq!(scalar, avx2, "AVX2 mismatch for byte 0x{byte:02x} at {pos}");
+            }
+        }
+    }
 }

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -31,6 +31,11 @@ pub struct YamlCharClass {
     pub backslashes: u32,
     /// Mask of bytes that are '#'
     pub hash: u32,
+    /// Number of bytes actually classified: 32 (AVX2) or 16 (SSE2). Only the
+    /// low `width` bits of each mask are meaningful. Callers must not assume
+    /// 32 bytes were scanned — deriving the width from input length alone
+    /// skipped structural bytes 16..31 on non-AVX2 CPUs (#193).
+    pub width: usize,
 }
 
 /// Classify YAML structural characters in a 32-byte chunk using AVX2.
@@ -94,6 +99,7 @@ unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass
         quotes_single: _mm256_movemask_epi8(eq_quote_single) as u32,
         backslashes: _mm256_movemask_epi8(eq_backslash) as u32,
         hash: _mm256_movemask_epi8(eq_hash) as u32,
+        width: 32,
     }
 }
 
@@ -131,6 +137,7 @@ unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass
         quotes_single: _mm_movemask_epi8(eq_quote_single) as u32,
         backslashes: _mm_movemask_epi8(eq_backslash) as u32,
         hash: _mm_movemask_epi8(eq_hash) as u32,
+        width: 16,
     }
 }
 

--- a/tests/dsv_simd_differential_tests.rs
+++ b/tests/dsv_simd_differential_tests.rs
@@ -123,11 +123,6 @@ fn assert_backends_match_scalar(
     }
 }
 
-/// Assert the carry-correct (prefix-xor) backends match scalar.
-fn assert_matches_scalar(label: &str, text: &[u8], config: &DsvConfig) {
-    assert_backends_match_scalar(&prefix_xor_backends(), label, text, config);
-}
-
 /// Build an input whose quoted span opens at byte `open`, is longer than one
 /// 64-byte chunk (so it always crosses a boundary), and swallows delimiters and
 /// newlines that must therefore be masked.
@@ -150,11 +145,14 @@ fn spanning_quote_input(open: usize) -> Vec<u8> {
 
 #[test]
 fn test_quote_at_every_offset_matches_scalar() {
+    // Detect backends once so a missing feature prints one SKIPPED line per
+    // test rather than one per assertion (#193).
+    let backends = prefix_xor_backends();
     let config = DsvConfig::default();
     // Opening quote at every byte offset across three 64-byte chunk boundaries.
     for open in 0..192usize {
         let text = spanning_quote_input(open);
-        assert_matches_scalar(&format!("open={open}"), &text, &config);
+        assert_backends_match_scalar(&backends, &format!("open={open}"), &text, &config);
     }
 }
 
@@ -164,6 +162,7 @@ fn test_bit63_carry_regression() {
     // delimiter at offset 64 (first bit of chunk 1) stays masked. Also check the
     // neighboring boundary bits 62/64 and the next boundary at 127/128. The
     // toggle64 backends fail this (#149) and are covered separately below.
+    let backends = prefix_xor_backends();
     let config = DsvConfig::default();
     for open in [62usize, 63, 64, 65, 126, 127, 128, 129] {
         let mut text = vec![b'a'; open + 80];
@@ -172,7 +171,7 @@ fn test_bit63_carry_regression() {
         text[open + 7] = b'\n'; // newline inside quotes -> masked
         text[open + 40] = b'"'; // closes the span in a later chunk
         text[open + 41] = b','; // real delimiter, outside quotes
-        assert_matches_scalar(&format!("boundary open={open}"), &text, &config);
+        assert_backends_match_scalar(&backends, &format!("boundary open={open}"), &text, &config);
     }
 }
 
@@ -181,6 +180,7 @@ fn test_random_csv_matches_scalar() {
     // Deterministic fuzz: randomized bytes over an alphabet of ordinary chars
     // plus every special byte used by the configs below (delimiters, newline,
     // quote, CR). Chunk-spanning quoted regions arise naturally.
+    let backends = prefix_xor_backends();
     let mut rng = ChaCha8Rng::seed_from_u64(0x9E37_79B9_7F4A_7C15);
     let alphabet = *b"ab,\t;\n\r\" ";
     let configs = [
@@ -195,7 +195,7 @@ fn test_random_csv_matches_scalar() {
             .map(|_| alphabet[rng.gen_range(0..alphabet.len())])
             .collect();
         let config = &configs[rng.gen_range(0..configs.len())];
-        assert_matches_scalar("fuzz", &text, config);
+        assert_backends_match_scalar(&backends, "fuzz", &text, config);
     }
 }
 

--- a/tests/simd_expectation_tests.rs
+++ b/tests/simd_expectation_tests.rs
@@ -1,0 +1,76 @@
+//! Hard assertion that the CPU features CI expects are actually detected.
+//!
+//! The SIMD test suites self-skip when a feature is missing (emitting a
+//! visible `SKIPPED` line — see `note_simd_skip`, #191/#193). That keeps local
+//! runs green on any hardware, but on CI it would let a runner-fleet change
+//! silently skip entire suites while the leg stays green. Setting
+//! `SUCCINCTLY_EXPECT_SIMD` pins the contract: every named feature must be
+//! runtime-detected or this test fails the leg.
+//!
+//! The value is a comma-separated feature list, e.g.
+//! `SUCCINCTLY_EXPECT_SIMD=sse2,sse4.2,avx2,bmi2,popcnt` on x86_64 or
+//! `SUCCINCTLY_EXPECT_SIMD=neon` on aarch64. Unset, the test is a no-op, so
+//! local `cargo test` behaves as before. Unknown names fail (a typo must not
+//! silently satisfy the expectation). See
+//! `docs/reference/environment-variables.md`.
+
+/// Runtime-detects `name` on the current target.
+///
+/// Returns `None` for names this target cannot detect, which the caller
+/// treats as a hard failure — the env var is set per CI job, so its contents
+/// must match the job's architecture.
+fn feature_detected(name: &str) -> Option<bool> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        Some(match name {
+            "sse2" => is_x86_feature_detected!("sse2"),
+            "sse4.2" => is_x86_feature_detected!("sse4.2"),
+            "avx2" => is_x86_feature_detected!("avx2"),
+            "bmi2" => is_x86_feature_detected!("bmi2"),
+            "popcnt" => is_x86_feature_detected!("popcnt"),
+            _ => return None,
+        })
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        Some(match name {
+            "neon" => std::arch::is_aarch64_feature_detected!("neon"),
+            "sve2" => std::arch::is_aarch64_feature_detected!("sve2"),
+            "sve2-bitperm" => std::arch::is_aarch64_feature_detected!("sve2-bitperm"),
+            _ => return None,
+        })
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        let _ = name;
+        None
+    }
+}
+
+#[test]
+fn test_expected_simd_features_are_detected() {
+    let Ok(expected) = std::env::var("SUCCINCTLY_EXPECT_SIMD") else {
+        eprintln!("SUCCINCTLY_EXPECT_SIMD unset: skipping SIMD feature expectation check");
+        return;
+    };
+
+    let mut missing = Vec::new();
+    let mut unknown = Vec::new();
+    for name in expected.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        match feature_detected(name) {
+            Some(true) => eprintln!("SIMD feature expectation met: `{name}` detected"),
+            Some(false) => missing.push(name),
+            None => unknown.push(name),
+        }
+    }
+
+    assert!(
+        unknown.is_empty(),
+        "SUCCINCTLY_EXPECT_SIMD lists features unknown on this target: {unknown:?}"
+    );
+    assert!(
+        missing.is_empty(),
+        "SUCCINCTLY_EXPECT_SIMD features not detected on this CPU: {missing:?} — \
+         the SIMD suites guarded by these features would silently self-skip (see #193)"
+    );
+}

--- a/tests/simd_level_tests.rs
+++ b/tests/simd_level_tests.rs
@@ -27,8 +27,30 @@ mod x86_simd_levels {
         ]
     }
 
+    /// Detection guard for SSE4.2; emits a visible `SKIPPED` line when
+    /// unavailable so a fully-skipped level doesn't read as green (#193).
+    fn has_sse42() -> bool {
+        let available = is_x86_feature_detected!("sse4.2");
+        if !available {
+            eprintln!("SKIPPED simd level [sse4.2]: sse4.2 not detected (see #193)");
+        }
+        available
+    }
+
+    /// Detection guard for AVX2; emits a visible `SKIPPED` line when
+    /// unavailable so a fully-skipped level doesn't read as green (#193).
+    fn has_avx2() -> bool {
+        let available = is_x86_feature_detected!("avx2");
+        if !available {
+            eprintln!("SKIPPED simd level [avx2]: avx2 not detected (see #193)");
+        }
+        available
+    }
+
     #[test]
     fn test_all_simd_levels_match_scalar_standard() {
+        let run_sse42 = has_sse42();
+        let run_avx2 = has_avx2();
         for (name, json) in test_cases() {
             // Scalar reference
             let scalar = json::standard::build_semi_index(json);
@@ -40,7 +62,7 @@ mod x86_simd_levels {
             assert_eq!(sse2.state, scalar.state, "{name}: SSE2 state mismatch");
 
             // SSE4.2 (if supported)
-            if is_x86_feature_detected!("sse4.2") {
+            if run_sse42 {
                 let sse42 = json::simd::sse42::build_semi_index_standard(json);
                 assert_eq!(sse42.ib, scalar.ib, "{name}: SSE4.2 IB mismatch");
                 assert_eq!(sse42.bp, scalar.bp, "{name}: SSE4.2 BP mismatch");
@@ -48,7 +70,7 @@ mod x86_simd_levels {
             }
 
             // AVX2 (if supported)
-            if is_x86_feature_detected!("avx2") {
+            if run_avx2 {
                 let avx2 = json::simd::avx2::build_semi_index_standard(json);
                 assert_eq!(avx2.ib, scalar.ib, "{name}: AVX2 IB mismatch");
                 assert_eq!(avx2.bp, scalar.bp, "{name}: AVX2 BP mismatch");
@@ -59,6 +81,8 @@ mod x86_simd_levels {
 
     #[test]
     fn test_all_simd_levels_match_scalar_simple() {
+        let run_sse42 = has_sse42();
+        let run_avx2 = has_avx2();
         for (name, json) in test_cases() {
             // Scalar reference
             let scalar = json::simple::build_semi_index(json);
@@ -70,7 +94,7 @@ mod x86_simd_levels {
             assert_eq!(sse2.state, scalar.state, "{name}: SSE2 state mismatch");
 
             // SSE4.2 (if supported)
-            if is_x86_feature_detected!("sse4.2") {
+            if run_sse42 {
                 let sse42 = json::simd::sse42::build_semi_index_simple(json);
                 assert_eq!(sse42.ib, scalar.ib, "{name}: SSE4.2 IB mismatch");
                 assert_eq!(sse42.bp, scalar.bp, "{name}: SSE4.2 BP mismatch");
@@ -78,7 +102,7 @@ mod x86_simd_levels {
             }
 
             // AVX2 (if supported)
-            if is_x86_feature_detected!("avx2") {
+            if run_avx2 {
                 let avx2 = json::simd::avx2::build_semi_index_simple(json);
                 assert_eq!(avx2.ib, scalar.ib, "{name}: AVX2 IB mismatch");
                 assert_eq!(avx2.bp, scalar.bp, "{name}: AVX2 BP mismatch");
@@ -89,11 +113,13 @@ mod x86_simd_levels {
 
     #[test]
     fn test_simd_levels_match_each_other_standard() {
+        let run_sse42 = has_sse42();
+        let run_avx2 = has_avx2();
         // This test ensures all SIMD levels produce identical results to each other
         for (name, json) in test_cases() {
             let sse2 = json::simd::x86::build_semi_index_standard(json);
 
-            if is_x86_feature_detected!("sse4.2") {
+            if run_sse42 {
                 let sse42 = json::simd::sse42::build_semi_index_standard(json);
                 assert_eq!(sse42.ib, sse2.ib, "{name}: SSE4.2 vs SSE2 IB mismatch");
                 assert_eq!(sse42.bp, sse2.bp, "{name}: SSE4.2 vs SSE2 BP mismatch");
@@ -103,7 +129,7 @@ mod x86_simd_levels {
                 );
             }
 
-            if is_x86_feature_detected!("avx2") {
+            if run_avx2 {
                 let avx2 = json::simd::avx2::build_semi_index_standard(json);
                 assert_eq!(avx2.ib, sse2.ib, "{name}: AVX2 vs SSE2 IB mismatch");
                 assert_eq!(avx2.bp, sse2.bp, "{name}: AVX2 vs SSE2 BP mismatch");
@@ -117,10 +143,12 @@ mod x86_simd_levels {
 
     #[test]
     fn test_simd_levels_match_each_other_simple() {
+        let run_sse42 = has_sse42();
+        let run_avx2 = has_avx2();
         for (name, json) in test_cases() {
             let sse2 = json::simd::x86::build_semi_index_simple(json);
 
-            if is_x86_feature_detected!("sse4.2") {
+            if run_sse42 {
                 let sse42 = json::simd::sse42::build_semi_index_simple(json);
                 assert_eq!(sse42.ib, sse2.ib, "{name}: SSE4.2 vs SSE2 IB mismatch");
                 assert_eq!(sse42.bp, sse2.bp, "{name}: SSE4.2 vs SSE2 BP mismatch");
@@ -130,7 +158,7 @@ mod x86_simd_levels {
                 );
             }
 
-            if is_x86_feature_detected!("avx2") {
+            if run_avx2 {
                 let avx2 = json::simd::avx2::build_semi_index_simple(json);
                 assert_eq!(avx2.ib, sse2.ib, "{name}: AVX2 vs SSE2 IB mismatch");
                 assert_eq!(avx2.bp, sse2.bp, "{name}: AVX2 vs SSE2 BP mismatch");
@@ -144,6 +172,7 @@ mod x86_simd_levels {
 
     #[test]
     fn test_chunk_boundary_conditions() {
+        let run_avx2 = has_avx2();
         // Test inputs that align with and cross SIMD chunk boundaries
 
         // Exactly 16 bytes (SSE2/SSE4.2 boundary)
@@ -174,7 +203,7 @@ mod x86_simd_levels {
             assert_eq!(sse2.ib, scalar.ib, "{name}: SSE2 IB mismatch");
             assert_eq!(sse2.bp, scalar.bp, "{name}: SSE2 BP mismatch");
 
-            if is_x86_feature_detected!("avx2") {
+            if run_avx2 {
                 let avx2 = json::simd::avx2::build_semi_index_standard(json);
                 assert_eq!(avx2.ib, scalar.ib, "{name}: AVX2 IB mismatch");
                 assert_eq!(avx2.bp, scalar.bp, "{name}: AVX2 BP mismatch");

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -929,3 +929,22 @@ fn test_unquoted_bool_becomes_bool() -> Result<()> {
     assert_eq!(output.trim(), "true");
     Ok(())
 }
+
+#[test]
+fn test_multibyte_value_survives_simd_escape_scan() -> Result<()> {
+    // Regression test for the x86 signed-compare bug (#150/#230): the AVX2/
+    // SSE2 `find_json_escape` kernels misread bytes >= 0x80 as control
+    // characters, so a >= 16-byte value with multibyte UTF-8 was cut
+    // mid-character. This is the original repro; the CLI path also covers
+    // the jq streaming caller (`stream_json_string`).
+    let input = "---\nwanted: love \u{2665} and peace \u{262e}\n";
+
+    let (output, exit_code) = run_yq_stdin(".wanted", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "love \u{2665} and peace \u{262e}");
+
+    let (json, exit_code) = run_yq_stdin(".wanted", input, &["-o", "json"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(json.trim(), "\"love \u{2665} and peace \u{262e}\"");
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR addresses issue #193 by implementing comprehensive SIMD test coverage infrastructure for x86 architectures. The work ensures that x86 SIMD test suites (AVX2, BMI2, SSE4.2, POPCNT) provide visible skip indicators when CPU features are unavailable, and adds a hard contract test that prevents silent feature degradation on CI runners.

### Problem Solved

Previously, x86 SIMD tests would silently self-skip on unsupported hardware without any visible indication, causing test suites to appear fully passing when they actually ran zero assertions. On CI, a runner-fleet change that removed a required CPU feature would go undetected. Additionally, per-kernel differential tests were missing for the YAML JSON escape scanners, and an SSE2 chunk-width accounting bug in the parser was lurking undetected on non-AVX2 hardware.

### Solution Overview

This PR implements a multi-layered approach:

1. **Visible Skip Indicators**: Routes all x86 SIMD guards through `note_simd_skip()` helper to emit visible `SKIPPED` lines instead of silent returns
2. **Hard Feature Expectations**: Adds `SUCCINCTLY_EXPECT_SIMD` environment variable test that fails CI if expected features become unavailable
3. **Per-Kernel Differential Tests**: Adds direct kernel calls to exercise SSE2 and AVX2 independently, catching issues regardless of dispatcher choices
4. **Bug Fix**: Corrects SSE2 chunk-width accounting in the unquoted-scalar fast path that was swallowing structural characters

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] CI/CD changes
- [x] Documentation update

## Related Issue
Fixes #193
Relates to #191, #150, #230

## Changes Made

**Test Infrastructure & Skip Visibility:**
- Created `note_simd_skip()` helper in `src/util/simd/mod.rs` to emit `SKIPPED` lines for unavailable CPU features
- Added `has_avx2()`, `has_bmi2()`, and `has_popcnt()` detection guards in `src/dsv/simd/avx2.rs`, `src/dsv/simd/bmi2.rs`, and `src/util/simd/x86.rs` that route through `note_simd_skip()`
- Removed `#[allow(dead_code)]` from `note_simd_skip()` now that x86 sites use it
- Updated `tests/simd_level_tests.rs` to detect backends once per test instead of per-assertion (eliminating 3200+ duplicate skip lines in differential fuzz tests)
- Updated `tests/dsv_simd_differential_tests.rs` to cache backend detection, reducing redundant feature checks

**Hard Expectation Test:**
- Added `tests/simd_expectation_tests.rs` with `test_expected_simd_features_are_detected()` that validates CPU features listed in `SUCCINCTLY_EXPECT_SIMD` environment variable
- Supports x86_64 features: `sse2`, `sse4.2`, `avx2`, `bmi2`, `popcnt`
- Supports aarch64 features: `neon`, `sve2`, `sve2-bitperm`
- Unknown feature names fail the test (prevents silent typos)

**Per-Kernel Differential Tests:**
- Added exhaustive per-kernel tests in `src/yaml/simd/x86.rs` that call `find_json_escape_sse2()` and `find_json_escape_avx2()` directly
- Added byte-by-byte exhaustive sweep tests for both SSE2 (40-byte buffer) and AVX2 (56-byte buffer) kernels
- Added multibyte UTF-8 regression tests in `src/yaml/light.rs` for `to_json()`, `to_json_document()`, and streaming paths
- Added yq CLI regression test in `tests/yq_cli_tests.rs` for the original #230 repro case

**Parser Bug Fix:**
- Modified `YamlCharClass` struct in `src/yaml/simd/x86.rs` to include `width` field reporting classified bytes (32 for AVX2, 16 for SSE2)
- Updated `classify_yaml_chars_avx2()` and `classify_yaml_chars_sse2()` to set the width field
- Fixed `skip_unquoted_simd()` in `src/yaml/parser.rs` to skip exactly the classified width instead of assuming 32 bytes
- Added regression test in `src/yaml/light.rs` for the plain-scalar folding bug

**Documentation:**
- Documented `SUCCINCTLY_EXPECT_SIMD` in `docs/reference/environment-variables.md` with per-target feature names and CI usage example
- Added comprehensive comments explaining the skip visibility and expectation contract

**CI Configuration:**
- Added `SUCCINCTLY_EXPECT_SIMD=sse2,sse4.2,avx2,bmi2,popcnt` environment variable to x86_64 test jobs in `.github/workflows/ci.yml`
- Added CPU feature detection step that prints available features at job start
- Applied same expectation to both stable and beta/nightly test jobs

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New skip visibility tests in all SIMD modules
- [x] New hard expectation test validates CI runner feature contract
- [x] Per-kernel differential tests for YAML escape scanners (exhaustive byte sweeps + multibyte UTF-8)
- [x] Regression tests for SSE2 parser chunk-width bug
- [x] yq CLI regression test for multibyte content
- [x] Verified on x86_64 (stable), aarch64 (neon/sve2 feature detection), and Rosetta 2

**Manual Testing:**
- [x] Tested on x86_64 with AVX2
- [x] Tested on aarch64 with NEON
- [x] Tested on Rosetta 2 (x86 without AVX2) — exposed the parser SSE2 bug
- [x] Verified skip lines appear in test output when features unavailable
- [x] Verified `SUCCINCTLY_EXPECT_SIMD` fails when features are missing
- [x] Verified `SUCCINCTLY_EXPECT_SIMD` fails when unknown feature names are used

### Test Commands
```bash
# Run all tests
cargo test

# Run SIMD-specific tests
cargo test simd

# Run parser tests
cargo test yaml

# Test feature expectation (with AVX2)
SUCCINCTLY_EXPECT_SIMD=sse2,sse4.2,avx2,bmi2,popcnt cargo test simd_expectation

# Verify no warnings
cargo clippy --all-targets --all-features -- -D warnings

# Check formatting
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
  - Skip detection happens only during test initialization, not in hot paths
  - Backend caching in differential tests reduces redundant feature checks
  - Parser bug fix improves correctness with no overhead change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings
- [x] CI configuration updated with feature expectations

## Additional Notes

### Why This Matters for CI

GitHub's x86_64 runners always have AVX2 available, so the dispatcher never reaches the SSE2 kernel in CI. Without per-kernel differential tests, the SSE2 code path remained untested by CI and the chunk-width bug went undetected for a long time. By adding exhaustive per-kernel tests (byte-by-byte sweeps), we now catch regressions in both code paths regardless of CPU capabilities. The hard expectation test adds a second line of defense: if a runner-fleet change removes a required feature, the leg fails instead of silently skipping.

### Architecture-Specific Notes

- **x86_64**: Tests exercise SSE2 (baseline), SSE4.2, AVX2, BMI2, and POPCNT paths
- **aarch64**: Tests exercise NEON (baseline) and SVE2 paths (if available)
- **Other targets**: SIMD tests are no-ops (scalar paths only)

The expectation test confirms the CI environment matches what the code was compiled and tested for, preventing silent regressions from infrastructure changes.

---

## Post-rebase verification findings (2026-07-19)

### Verified on genuine x86 hardware

Ran the branch (Rust content identical to PR head `5b5c8b49`; local `89e09b34` differs only by the #246 links.yml/.gitignore base commits) on an **AMD Ryzen 9 7950X** (Zen 4 — real AVX2/BMI2/AVX-512), in a dedicated worktree with the SHA asserted before testing:

- **27/27 test suites green** on default features, `--features simd`, and `--features portable-popcount`; cli-gated `yq_cli_tests` + `yq_golden_tests` green.
- **Zero `SKIPPED` lines** with `SUCCINCTLY_EXPECT_SIMD=sse2,sse4.2,avx2,bmi2,popcnt` — every SIMD test asserted rather than skipped, and the expectation test reported all five features detected.

### New finding: #149 confirmed on genuine BMI2 hardware

Running the `#[ignore]`d repro on the 7950X:

```
cargo test --test dsv_simd_differential_tests -- --ignored
```

fails at exactly **`bmi2/open=63`** (“index differs from scalar”) — the first hardware confirmation that the toggle64 PDEP bit-63 carry bug (#149) is real and that this PR’s differential detects it. Un-ignoring that test after #149’s fix will therefore be a meaningful gate, not a formality.

### Rosetta 2 as the missing “AVX2-disabled” configuration

Rosetta 2 on this dev host exposes SSE2/SSE4.2/POPCNT but **not** AVX2/BMI2 — the only environment available that exercises the x86 SSE2 *dispatch* branches (CI runners all have AVX2). That is how the `skip_unquoted_simd` chunk-width bug in this PR’s fix commit was found: the multibyte `to_json()` tests failed there on **pure-ASCII** long scalars, isolating the fault to chunk-width accounting rather than UTF-8 handling. After the fix, the affected suites pass under Rosetta with visible `SKIPPED … [avx2]/[bmi2]` lines for the guarded kernels.

### Review note: overlapping CI steps after the #192 rebase

The rebase onto #192’s scaffolding leaves `test-x86` with two CPU-feature steps: this PR’s log-only **“Check CPU features (x86 SIMD)”** and #192’s enforcing **“Verify SIMD CPU features (BMI2 + AVX2)”**. The log-only step is now redundant and can be dropped in a follow-up (or on this branch before merge). The `SUCCINCTLY_EXPECT_SIMD` test is **not** redundant with #192’s shell check: it enforces through the same `is_x86_feature_detected!` path the tests actually use (a `/proc/cpuinfo` grep can disagree with Rust’s detection), covers all five listed features rather than just AVX2/BMI2, and also works on the ARM legs and in local runs.
