### PR TITLE
ci(ci): make links check self-heal transient flakes (#243)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,12 +24,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Successful results are reused across runs (max-cache-age 1d), so a
+      # retry or re-run only re-checks links that actually failed. lychee
+      # never caches failures, so a flake can't stick.
+      - name: Restore lychee cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
       - name: Check markdown links
+        id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
+          # Don't fail yet; the retry step below decides the job outcome.
+          fail: false
           args: >-
             --verbose
             --no-progress
+            --cache
+            --max-cache-age 1d
+            --max-retries 3
+            --retry-wait-time 2
             --accept 100..=399
             --exclude-path ./target
             --exclude-path ./data
@@ -48,5 +65,44 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fail if broken links found
-        run: exit ${{ steps.lychee.outputs.exit_code }}
+      # Self-heal transient flakes: the first attempt cached every successful
+      # link, so this re-checks only the links that just failed. lychee does
+      # not retry connect-phase resets internally, so a second in-job attempt
+      # is the only way to heal them without re-running the whole job.
+      - name: Retry links that failed the first attempt
+        if: steps.lychee.outputs.exit_code != '0'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --max-retries 3
+            --retry-wait-time 2
+            --accept 100..=399
+            --exclude-path ./target
+            --exclude-path ./data
+            --exclude '^https://crates\.io/crates/'
+            --exclude '^https://docs\.rs/'
+            --exclude '^https://www\.intel\.com/'
+            --exclude '^https://dl\.acm\.org/'
+            --exclude '^https://lib\.rs/'
+            --exclude '^https://developer\.arm\.com/'
+            --exclude '^https://www\.agner\.org/'
+            --exclude '^https://github\.com/rust-works/succinctly/compare/v'
+            --exclude '^https://www\.cs\.cmu\.edu/'
+            --exclude '^https://doi\.org/'
+            --exclude '^https://no-color\.org/'
+            '**/*.md'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # actions/cache's automatic post-save is skipped on job failure; save
+      # explicitly so successes from a failing run still make the next run cheap.
+      - name: Save lychee cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ data/bench/results/
 # Build artifacts
 *.rlib
 libtest_no_std.rlib
+
+# lychee link-checker cache (written by `lychee --cache`, persisted in CI)
+.lycheecache


### PR DESCRIPTION
Fixes #243

## Problem

The required `Links` job re-checks ~100+ external URLs on every PR; a single transient network reset (PR #242, run 29673029550: `Connection reset by peer` on a link that was green two minutes earlier) reddens the job.

## Why not just the proposed flags

Verified against lychee v0.24.2 source (the version `lychee-action@v2` pins):

- `--max-retries` **already defaults to 3** (`--retry-wait-time` to 1s, exponential backoff), so the incident failed *despite* retries.
- lychee **never retries connect-phase errors** (`is_connect() -> false` in `lychee-lib/src/retry.rs`, unchanged on master) — the likely class of the incident. No retry-count flag can heal those.

## What this does instead

- **In-job second attempt on failure**: lychee writes `.lycheecache` even when links fail, and **never caches failures** (both store and load skip error entries). So a conditional second lychee step re-checks *only* the links that just failed — healing every transient error class, including non-retried connect resets, in seconds instead of a whole-job re-run.
- **Cache persisted across runs** via split `actions/cache/restore` + `actions/cache/save` (`if: always()`, so successes from a failing run still persist). `--max-cache-age 1d` keeps the weekly cron's link-rot signal intact (7-day-old entries are stale and re-checked).
- **Flags from the issue** (`--max-retries 3 --retry-wait-time 2 --cache`) are passed explicitly: 3 pins the upstream default, wait-time 2 doubles backoff (2s/4s/8s) for the error classes lychee *does* retry.
- **Removed the no-op `Fail if broken links found` step** (referenced `steps.lychee.outputs.exit_code` with no `id: lychee`; the action's `fail: true` default already fails the job). The first attempt now sets `fail: false` and the retry step decides the job.
- `.gitignore`: added `.lycheecache`.

## Acceptance criteria

- [x] `links.yml` passes `--max-retries`, `--retry-wait-time`, and `--cache` to lychee
- [x] A transient single-link reset no longer fails the job on the first attempt (in-job retry re-checks only the failed link)
- [x] Internal/relative-link breakage still caught (real breakage isn't cached as success; the retry re-checks it and fails the job)

## Verification

- `links.yml` is in its own `paths:` filter, so this PR's own `Links` run exercises the new workflow — expect: restore runs, lychee green, retry **skipped**, save runs.
- Job name `Check Links` unchanged (required-check name preserved).