### PR TITLE
fix(jq): compare objects by sorted keys then values in both evaluators

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1074,22 +1074,23 @@ fn compare_values(left: &OwnedValue, right: &OwnedValue) -> core::cmp::Ordering 
             a.len().cmp(&b.len())
         }
         (OwnedValue::Object(a), OwnedValue::Object(b)) => {
-            // Compare objects by sorted keys, then values
-            let mut a_keys: Vec<_> = a.keys().collect();
-            let mut b_keys: Vec<_> = b.keys().collect();
+            // jq compares the sorted key arrays first, then values in
+            // sorted-key order.
+            let mut a_keys: Vec<&String> = a.keys().collect();
+            let mut b_keys: Vec<&String> = b.keys().collect();
             a_keys.sort();
             b_keys.sort();
-
-            for (ak, bk) in a_keys.iter().zip(b_keys.iter()) {
-                match ak.cmp(bk) {
-                    Ordering::Equal => match compare_values(&a[*ak], &b[*bk]) {
-                        Ordering::Equal => continue,
-                        other => return other,
-                    },
+            match a_keys.cmp(&b_keys) {
+                Ordering::Equal => {}
+                other => return other,
+            }
+            for k in a_keys {
+                match compare_values(&a[k], &b[k]) {
+                    Ordering::Equal => continue,
                     other => return other,
                 }
             }
-            a.len().cmp(&b.len())
+            Ordering::Equal
         }
         _ => Ordering::Equal,
     }
@@ -13803,6 +13804,38 @@ mod tests {
     fn test_comparison_ge() {
         query!(br#"{"a": 2, "b": 2}"#, ".a >= .b",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+    }
+
+    #[test]
+    fn test_comparison_objects() {
+        // jq compares objects by [sorted keys] first, then values in
+        // sorted-key order. All expected values verified against real jq.
+        query!(b"null", r#"{"a":1} < {"a":2}"#,
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(b"null", r#"{"a":1} < {"b":1}"#,
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        // Key arrays decide before any values: ["a","b"] < ["a","c"] even
+        // though the value at the shared key "a" compares Greater.
+        query!(b"null", r#"{"a":2,"b":1} < {"a":1,"c":9}"#,
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        // Equal key sets fall through to values in sorted-key order.
+        query!(b"null", r#"{"a":1,"b":2} < {"a":1,"b":3}"#,
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        // A key array that is a strict prefix compares Less.
+        query!(b"null", r#"{"a":1} < {"a":1,"b":2}"#,
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        // Insertion order is irrelevant; these objects are equal.
+        query!(b"null", r#"{"b":1,"a":2} <= {"a":2,"b":1}"#,
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(b"null", r#"{"a":1,"b":2} < {"a":1}"#,
+            QueryResult::Owned(OwnedValue::Bool(false)) => {}
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -135,7 +135,7 @@ fn compare_values(left: &OwnedValue, right: &OwnedValue) -> Option<core::cmp::Or
         (OwnedValue::Int(a), OwnedValue::Float(b)) => (*a as f64).partial_cmp(b),
         (OwnedValue::Float(a), OwnedValue::Int(b)) => a.partial_cmp(&(*b as f64)),
         (OwnedValue::String(a), OwnedValue::String(b)) => Some(a.cmp(b)),
-        // Arrays and objects: compare element-wise (simplified)
+        // Arrays: compare element-wise, then by length
         (OwnedValue::Array(a), OwnedValue::Array(b)) => {
             for (ai, bi) in a.iter().zip(b.iter()) {
                 match compare_values(ai, bi) {
@@ -144,6 +144,25 @@ fn compare_values(left: &OwnedValue, right: &OwnedValue) -> Option<core::cmp::Or
                 }
             }
             Some(a.len().cmp(&b.len()))
+        }
+        // Objects: jq compares the sorted key arrays first, then values in
+        // sorted-key order.
+        (OwnedValue::Object(a), OwnedValue::Object(b)) => {
+            let mut a_keys: Vec<&String> = a.keys().collect();
+            let mut b_keys: Vec<&String> = b.keys().collect();
+            a_keys.sort();
+            b_keys.sort();
+            match a_keys.cmp(&b_keys) {
+                Ordering::Equal => {}
+                other => return Some(other),
+            }
+            for k in a_keys {
+                match compare_values(&a[k], &b[k]) {
+                    Some(Ordering::Equal) => continue,
+                    other => return other,
+                }
+            }
+            Some(Ordering::Equal)
         }
         _ => None,
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -764,6 +764,21 @@ fn test_conditional() -> Result<()> {
 }
 
 #[test]
+fn test_object_comparison_operators() -> Result<()> {
+    // Issue #162: object </> comparisons were always false in the CLI path.
+    // jq compares objects by sorted key arrays first, then values in key order.
+    let (output, code) = run_jq_stdin(r#"{"a":1} < {"a":2}"#, "null", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "true\n");
+
+    // Key arrays decide before any values: ["a","b"] < ["a","c"].
+    let (output, code) = run_jq_stdin(r#"{"a":2,"b":1} < {"a":1,"c":9}"#, "null", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "true\n");
+    Ok(())
+}
+
+#[test]
 fn test_try_catch() -> Result<()> {
     // jq returns null for .foo.bar when .foo is null (not an error)
     let (output, code) = run_jq_stdin(r#"try .foo.bar catch "error""#, r#"{"foo":null}"#, &["-r"])?;

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -98,17 +98,34 @@ fn test_parity_first_last_empty() {
 }
 
 #[test]
-fn test_object_ordering_diverges_157() {
-    // jq compares objects by [sorted keys], then by [values in key order].
-    // Every case below is `true` in jq, which the FULL evaluator matches; the
-    // generic (CLI) path always returns `false` -- bug #157.
-    for filter in [
-        r#"{"a":1} < {"a":2}"#,
-        r#"{"a":2} > {"a":1}"#,
-        r#"{"a":1} < {"b":1}"#,
-        r#"{"a":1,"b":2} < {"a":1,"b":3}"#,
+fn test_object_ordering_parity_162() {
+    // jq compares objects by [sorted keys] first, then by [values in key
+    // order]. Fixed by #162 in BOTH evaluators (eval_generic was missing the
+    // Object arm; eval.rs interleaved key and value comparison). Every
+    // expected value below is pinned against real jq, so the parity assertion
+    // can't lock in an agreed-upon wrong answer.
+    for (filter, expected) in [
+        (r#"{"a":1} < {"a":2}"#, "true"),
+        (r#"{"a":2} > {"a":1}"#, "true"),
+        (r#"{"a":1} < {"b":1}"#, "true"),
+        (r#"{"a":1,"b":2} < {"a":1,"b":3}"#, "true"),
+        // Key arrays decide before any values: ["a","b"] < ["a","c"] even
+        // though the value at the shared key "a" compares Greater.
+        (r#"{"a":2,"b":1} < {"a":1,"c":9}"#, "true"),
+        // Insertion order is irrelevant; these objects are equal.
+        (r#"{"b":1,"a":2} <= {"a":2,"b":1}"#, "true"),
+        (r#"{"a":1} >= {"a":1}"#, "true"),
+        // A key array that is a strict prefix compares Less.
+        (r#"{"a":1} < {"a":1,"b":2}"#, "true"),
+        (r#"{"a":1,"b":2} < {"a":1}"#, "false"),
     ] {
-        assert_divergence(b"null", filter, &["true"], &["false"]);
+        let full = full_outputs(b"null", filter);
+        assert_eq!(
+            as_strs(&full),
+            [expected],
+            "full evaluator disagrees with jq for `{filter}`"
+        );
+        assert_parity(b"null", filter);
     }
 }
 


### PR DESCRIPTION
Fixes #162

## Problem

`compare_values` in `src/jq/eval_generic.rs` (the CLI path) had no
`(Object, Object)` arm — it fell through to `_ => None`, so every object
`<`/`<=`/`>`/`>=` comparison returned `false`:

```bash
echo null | sjq '{"a":1} < {"a":2}'   # was: false   (jq: true)
```

## Fix

- **eval_generic.rs**: add the missing `(Object, Object)` arm implementing
  jq's semantics — compare the sorted key arrays first, then values in
  sorted-key order.
- **eval.rs**: the full evaluator's existing Object arm *interleaved* key and
  value comparison, which diverges from jq when key sets differ but an
  earlier shared-key value comparison fires first. Verified against real jq:
  `{"a":2,"b":1} < {"a":1,"c":9}` is `true` (keys `["a","b"] < ["a","c"]`
  decide before any values), but the interleaved code returned `false`.
  Fixed to the same keys-first algorithm; this also corrects object ordering
  in `sort`/`unique`/`min`/`max`/`group_by`, which all use this function.

## Tests

- `tests/jq_evaluator_parity_tests.rs`: converted the divergence pin to
  `test_object_ordering_parity_162`, asserting the full evaluator's output
  against jq-verified expectations *and* parity with the generic evaluator
  (so the two can't agree on a wrong answer). Added the interleaving edge
  case, insertion-order, prefix-keys, and `false` cases.
- `src/jq/eval.rs`: new `test_comparison_objects` unit test.
- `tests/jq_cli_tests.rs`: end-to-end CLI test of the issue's repro.

All expected values were verified against real jq before pinning.

## Note for #157

The parity test file had issue numbers crossed: the object-ordering test was
named `..._157` but is actually this issue (#162), and
`test_out_of_bounds_index_diverges_161_162` (left untouched here) is
actually #157's out-of-bounds bug. Whoever fixes #157 should convert that
test and can ignore its `162` suffix.