### PR TITLE
test(yaml): CI-executable regression guard for the x86 SSE2 classify/skip-width path (#247)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,18 @@ jobs:
       # `SKIPPED` line) when a CPU feature is missing, so this pins the runner
       # contract — tests/simd_expectation_tests.rs fails the leg if any listed
       # feature stops being detected, instead of the suites silently skipping.
-      # The SSE2 kernels don't need an AVX2-disabled config: the differential
-      # tests (tests/simd_level_tests.rs, tests/dsv_simd_differential_tests.rs,
-      # src/yaml/simd/x86.rs) call each kernel directly, so every level is
-      # exercised on this AVX2 runner. There is deliberately no x86 dispatch
-      # override (docs/reference/environment-variables.md).
+      # Coverage is two-layered on this AVX2 runner:
+      #  - Kernel correctness: the differential tests (tests/simd_level_tests.rs,
+      #    tests/dsv_simd_differential_tests.rs, src/yaml/simd/x86.rs) call each
+      #    kernel directly, so every kernel level is exercised regardless of
+      #    dispatch.
+      #  - Caller integration: kernel-direct tests cannot catch caller-side
+      #    bugs like the classify/skip-width accounting (#231), so the
+      #    "SSE2-clamped dispatch" step below re-runs the suite with
+      #    SUCCINCTLY_SIMD=sse2 (docs/reference/environment-variables.md),
+      #    forcing the yaml parser through the real 16-byte SSE2 dispatch
+      #    path (#247). The clamp affects dispatch only, not detection, so
+      #    this expectation still holds in that step.
       SUCCINCTLY_EXPECT_SIMD: sse2,sse4.2,avx2,bmi2,popcnt
     steps:
       - uses: actions/checkout@v4
@@ -132,6 +139,18 @@ jobs:
       - name: Run tests
         if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose
+
+      # Re-run the suite with yaml x86 dispatch clamped to SSE2 (#247): the
+      # parser and the light.rs regression tests then genuinely execute the
+      # 16-byte classify path, so a reintroduced length-derived skip width
+      # (#231) fails here instead of sailing through on AVX2 dispatch. Same
+      # features as "Run tests", so this reuses the build and costs only
+      # execution time. The in-lib contract test
+      # (test_succinctly_simd_env_contract) fails this step if the clamp ever
+      # stops applying or the value here is typo'd.
+      - name: Run tests (SSE2-clamped dispatch)
+        if: needs.gate.outputs.code == 'true'
+        run: SUCCINCTLY_SIMD=sse2 cargo test --verbose
 
       - name: Run tests (simd feature)
         if: needs.gate.outputs.code == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,18 @@ What each CI runner exercises for real:
 | `ubuntu-24.04-arm` (Test ARM) | Neoverse-N2   | NEON, **SVE2-BITPERM** (BDEP/BEXT)     |
 | `macos-latest` (Test macOS)   | Apple Silicon | NEON                                   |
 
+Kernel-direct differential tests (`tests/simd_level_tests.rs`,
+`tests/dsv_simd_differential_tests.rs`, `src/yaml/simd/x86.rs`) exercise every
+kernel *level* on the AVX2 runner, but they cannot catch caller-side dispatch
+bugs — e.g. the classify/skip-width accounting (#231), where the parser
+consumed a 16-byte SSE2 result as if 32 bytes had been scanned. For that, the
+x86 leg **re-runs the whole suite with `SUCCINCTLY_SIMD=sse2`** (the
+"SSE2-clamped dispatch" step, #247), forcing the yaml parser through the real
+16-byte dispatch path; an in-lib contract test
+(`test_succinctly_simd_env_contract`) fails the step if the clamp stops
+applying. See
+[docs/reference/environment-variables.md](docs/reference/environment-variables.md#succinctly_simd).
+
 **Not covered by routine CI: AVX-512.** The standard x86 runners are Zen 3
 (EPYC 7763), which has no `avx512f`/`avx512vpopcntdq`, so the AVX-512 paths
 (`src/util/simd/x86.rs` `avx512f` branch, `src/bits/popcount.rs` VPOPCNTDQ)

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -658,7 +658,7 @@ A command-line flag always beats an environment variable.
 Queries can read any variable via `env`, `$ENV`, `env(NAME)` and `strenv(NAME)`.
 
 See [Environment Variables](../reference/environment-variables.md) for accepted values, precedence,
-and the library-only `SUCCINCTLY_SVE2`.
+and the library-only `SUCCINCTLY_SIMD` and `SUCCINCTLY_SVE2`.
 
 ---
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -8,6 +8,7 @@ Every environment variable succinctly reads, what it accepts, and what it change
 
 | Variable                                                  | Applies to                       | Accepted values                | When unset                    |
 |-----------------------------------------------------------|----------------------------------|--------------------------------|-------------------------------|
+| [`SUCCINCTLY_SIMD`](#succinctly_simd)                     | Library (YAML parsing, x86_64)   | `scalar`/`sse2`/`sse4.2`/`avx2`| Best detected level           |
 | [`SUCCINCTLY_SVE2`](#succinctly_sve2)                     | Library (JSON indexing, ARM)     | Exactly `1`                    | NEON kernels                  |
 | [`SUCCINCTLY_PRESERVE_INPUT`](#succinctly_preserve_input) | `succinctly jq`                  | `1` or `true`                  | jq-compatible formatting      |
 | [`NO_COLOR`](#no_color)                                   | `succinctly jq`, `succinctly yq` | Any non-empty value            | Color if stdout is a terminal |
@@ -24,6 +25,44 @@ Precedence rule of thumb: an explicit command-line flag always beats an environm
 ## Library Variables
 
 These affect the `succinctly` library itself, so they apply to anything built on it, not just the CLI.
+
+### `SUCCINCTLY_SIMD`
+
+Clamps the x86_64 **YAML** SIMD dispatch to a lower instruction-set level than the CPU supports.
+`SUCCINCTLY_SIMD=sse2` makes the YAML parser use the 16-byte SSE2 kernels even on an AVX2 machine.
+
+This is a **clamp, not a selector**: it can only lower the dispatch level, never raise it.
+Requesting a level the CPU does not support would mean executing undetected instructions, which is
+undefined behaviour, so values at or above the detected level are simply no-ops.
+
+Reasons to set it:
+
+- **CI regression coverage** ([#247](https://github.com/rust-works/succinctly/issues/247)): the
+  x86 CI leg re-runs the test suite with `SUCCINCTLY_SIMD=sse2`, so the SSE2 classify/skip-width
+  path (the [#231](https://github.com/rust-works/succinctly/issues/231) bug class) executes for
+  real on AVX2 runners. An in-lib contract test fails loudly if the variable is set to an
+  unrecognized value or the clamp stops applying.
+- A/B benchmarking the SSE2 path against AVX2 on the same machine.
+
+Accepted values (case-insensitive, surrounding whitespace ignored):
+
+| Value                             | Effect on x86_64 YAML dispatch                                 |
+|-----------------------------------|----------------------------------------------------------------|
+| `scalar`, `sse2`, `sse42`/`sse4.2`| 16-byte SSE2 kernels (SSE2 is the x86_64 baseline)             |
+| `avx2`, empty                     | No clamp — best detected level, same as unset                  |
+| Anything else                     | Ignored at runtime; the test-suite contract test fails on it   |
+
+Note that `scalar` still runs the SSE2 kernels: scalar YAML parsing is a compile-time choice
+(`--features scalar-yaml`), not a runtime dispatch level, and SSE2 is unconditionally available on
+x86_64.
+
+Scope worth knowing: it clamps **YAML parsing on x86_64 only**
+([`src/yaml/simd/x86.rs`](../../src/yaml/simd/x86.rs)). JSON, DSV, popcount, and balanced-parens
+dispatch are unaffected (extending the clamp to those sites is tracked as follow-up to #247), and
+`aarch64` never reads it. Requires the `std` feature; `no_std` builds compile straight to SSE2
+dispatch with no AVX2 path at all.
+
+The value is read **once per process**, on first use, and cached. Changing it mid-run has no effect.
 
 ### `SUCCINCTLY_SVE2`
 
@@ -50,13 +89,14 @@ It takes effect only when **all** of the following hold; otherwise it is silentl
 | Requirement                    | Otherwise                                                                    |
 |--------------------------------|------------------------------------------------------------------------------|
 | Value is exactly `1`           | `true`, `yes`, `TRUE`, `0` and empty all mean "unset" — no error, no warning |
-| Target is `aarch64`            | Ignored on x86_64, which dispatches AVX2 > SSE4.2 > SSE2 with no override    |
+| Target is `aarch64`            | Ignored on x86_64 (whose YAML dispatch has its own [`SUCCINCTLY_SIMD`](#succinctly_simd) clamp) |
 | CPU reports the `sve2` feature | Falls back to NEON                                                           |
 | Built with the `std` feature   | `no_std` builds compile straight to NEON, with no dispatch                   |
 
 Scope worth knowing: it switches **JSON index building only** ([`src/json/simd/mod.rs`](../../src/json/simd/mod.rs)).
-YAML has no equivalent override, and DSV and broadword select use the *different* `sve2-bitperm`
-feature unconditionally — so "SVE2" is opt-in for JSON but always-on elsewhere when the CPU supports it.
+YAML's own dispatch override is the x86-only [`SUCCINCTLY_SIMD`](#succinctly_simd) clamp, and DSV
+and broadword select use the *different* `sve2-bitperm` feature unconditionally — so "SVE2" is
+opt-in for JSON but always-on elsewhere when the CPU supports it.
 
 The value is read **once per process**, on first use, and cached. Changing it mid-run has no effect.
 

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -7,6 +7,52 @@
 use core::arch::x86_64::*;
 
 // ============================================================================
+// Dispatch clamp (SUCCINCTLY_SIMD)
+// ============================================================================
+
+/// Parsed `SUCCINCTLY_SIMD` value: does it clamp x86 dispatch below AVX2?
+///
+/// - `Some(true)` — a recognized level below AVX2 (`scalar`, `sse2`, `sse42`,
+///   `sse4.2`): use the 16-byte SSE2 kernels. (`scalar` still means SSE2 here;
+///   scalar YAML parsing is compile-time only, via `--features scalar-yaml`.)
+/// - `Some(false)` — recognized no-op (`avx2`, empty): keep detected dispatch.
+/// - `None` — unrecognized. The runtime ignores it (no clamp), but the
+///   `test_succinctly_simd_env_contract` test fails loudly on it so a typo in
+///   a CI leg cannot silently un-clamp the suite.
+#[cfg(any(test, feature = "std"))]
+fn parse_simd_clamp(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "scalar" | "sse2" | "sse42" | "sse4.2" => Some(true),
+        "avx2" | "" => Some(false),
+        _ => None,
+    }
+}
+
+/// Whether `SUCCINCTLY_SIMD` requests clamping dispatch below AVX2.
+#[cfg(any(test, feature = "std"))]
+fn clamp_below_avx2() -> bool {
+    std::env::var("SUCCINCTLY_SIMD").is_ok_and(|v| parse_simd_clamp(&v) == Some(true))
+}
+
+/// Whether the 32-byte AVX2 kernels should be dispatched.
+///
+/// Combines runtime detection with the clamp-down-only `SUCCINCTLY_SIMD`
+/// override: `SUCCINCTLY_SIMD=sse2` forces the 16-byte SSE2 kernels even on an
+/// AVX2 CPU, which is how CI executes the SSE2 classify/skip-width path on
+/// AVX2 runners (#247). Clamping can only lower the level, never raise it —
+/// dispatching an undetected feature would be undefined behaviour.
+///
+/// Cached per STYLE-0003 (see `use_sve2`, `src/json/simd/mod.rs`): dispatch is
+/// on the per-chunk hot path, so the env var is read once per process;
+/// mutating it mid-run has no effect.
+#[cfg(any(test, feature = "std"))]
+#[inline]
+fn avx2_enabled() -> bool {
+    static AVX2: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *AVX2.get_or_init(|| is_x86_feature_detected!("avx2") && !clamp_below_avx2())
+}
+
+// ============================================================================
 // Multi-Character Classification (P0 Optimization)
 // ============================================================================
 
@@ -51,7 +97,7 @@ pub fn classify_yaml_chars(input: &[u8], offset: usize) -> Option<YamlCharClass>
 
     #[cfg(any(test, feature = "std"))]
     {
-        if offset + 32 <= input.len() && is_x86_feature_detected!("avx2") {
+        if offset + 32 <= input.len() && avx2_enabled() {
             return Some(unsafe { classify_yaml_chars_avx2(input, offset) });
         }
     }
@@ -148,7 +194,7 @@ unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass
 pub fn find_newline_x86(input: &[u8], start: usize) -> Option<usize> {
     #[cfg(any(test, feature = "std"))]
     {
-        if is_x86_feature_detected!("avx2") {
+        if avx2_enabled() {
             return unsafe { find_newline_avx2(input, start) };
         }
     }
@@ -230,7 +276,7 @@ pub fn find_quote_or_escape_x86(input: &[u8], start: usize, end: usize) -> Optio
     // Runtime dispatch to best available implementation
     #[cfg(any(test, feature = "std"))]
     {
-        if is_x86_feature_detected!("avx2") {
+        if avx2_enabled() {
             // SAFETY: We just checked for AVX2 support
             return unsafe { find_quote_or_escape_avx2(input, start, end) };
         }
@@ -248,7 +294,7 @@ pub fn find_single_quote_x86(input: &[u8], start: usize, end: usize) -> Option<u
     // Runtime dispatch to best available implementation
     #[cfg(any(test, feature = "std"))]
     {
-        if is_x86_feature_detected!("avx2") {
+        if avx2_enabled() {
             // SAFETY: We just checked for AVX2 support
             return unsafe { find_single_quote_avx2(input, start, end) };
         }
@@ -435,7 +481,7 @@ pub fn count_leading_spaces_x86(input: &[u8], start: usize) -> usize {
     // Runtime dispatch to best available implementation
     #[cfg(any(test, feature = "std"))]
     {
-        if is_x86_feature_detected!("avx2") {
+        if avx2_enabled() {
             // SAFETY: We just checked for AVX2 support
             return unsafe { count_leading_spaces_avx2(input, start) };
         }
@@ -536,7 +582,7 @@ pub fn find_block_scalar_end(input: &[u8], start: usize, min_indent: usize) -> O
 
     #[cfg(any(test, feature = "std"))]
     {
-        if is_x86_feature_detected!("avx2") {
+        if avx2_enabled() {
             return Some(unsafe { find_block_scalar_end_avx2(input, start, min_indent) });
         }
     }
@@ -981,7 +1027,7 @@ fn find_json_escape_scalar(input: &[u8], start: usize) -> Option<usize> {
 pub fn find_json_escape_x86(input: &[u8], start: usize) -> Option<usize> {
     #[cfg(any(test, feature = "std"))]
     {
-        if is_x86_feature_detected!("avx2") {
+        if avx2_enabled() {
             return unsafe { find_json_escape_avx2(input, start) };
         }
     }
@@ -998,7 +1044,7 @@ pub fn parse_anchor_name(input: &[u8], start: usize) -> usize {
     if start + 16 <= input.len() {
         #[cfg(any(test, feature = "std"))]
         {
-            if is_x86_feature_detected!("avx2") {
+            if avx2_enabled() {
                 return unsafe { parse_anchor_name_avx2(input, start) };
             }
         }
@@ -1390,10 +1436,12 @@ mod tests {
     //
     // These call `find_json_escape_sse2` / `find_json_escape_avx2` directly
     // rather than through `find_json_escape_x86`, so the SSE2 kernel is
-    // exercised even on AVX2 hardware — the dispatcher never reaches it on
-    // CI runners, and there is deliberately no x86 dispatch override. They
-    // are the tests that would have caught the signed-compare bug (#150/#230)
-    // on x86 regardless of which kernel the dispatcher picks.
+    // exercised even on AVX2 hardware regardless of dispatch. They deliberately
+    // bypass the `SUCCINCTLY_SIMD` clamp (#247) by guarding on raw feature
+    // detection: under the SSE2-clamped CI step the AVX2 *kernels* must still
+    // be differentially tested even though the *dispatcher* never picks them.
+    // They are the tests that would have caught the signed-compare bug
+    // (#150/#230) on x86 regardless of which kernel the dispatcher picks.
     // ========================================================================
 
     /// Detection guard for AVX2; emits a visible `SKIPPED` line when
@@ -1475,6 +1523,162 @@ mod tests {
                 let scalar = find_json_escape_scalar(&input, 0);
                 let avx2 = unsafe { find_json_escape_avx2(&input, 0) };
                 assert_eq!(scalar, avx2, "AVX2 mismatch for byte 0x{byte:02x} at {pos}");
+            }
+        }
+    }
+
+    // ========================================================================
+    // SUCCINCTLY_SIMD dispatch clamp (#247)
+    // ========================================================================
+
+    #[test]
+    fn test_parse_simd_clamp_values() {
+        // Recognized levels below AVX2 clamp (whitespace/case-insensitive).
+        for v in ["scalar", "sse2", "sse42", "sse4.2", " SSE2 ", "Sse4.2"] {
+            assert_eq!(parse_simd_clamp(v), Some(true), "{v:?} should clamp");
+        }
+        // Recognized no-ops.
+        for v in ["avx2", "AVX2", ""] {
+            assert_eq!(parse_simd_clamp(v), Some(false), "{v:?} should be a no-op");
+        }
+        // Unrecognized values parse to None (runtime ignores; contract test
+        // fails loudly when the env var is actually set to one of these).
+        for v in ["banana", "neon", "1", "sse", "avx512"] {
+            assert_eq!(parse_simd_clamp(v), None, "{v:?} should be unrecognized");
+        }
+    }
+
+    /// Contract test for the `SUCCINCTLY_SIMD` clamp, in the spirit of
+    /// `SUCCINCTLY_EXPECT_SIMD` (#192): when a CI leg sets the variable, the
+    /// dispatcher must observably honor it, and a typo'd value must fail the
+    /// leg instead of silently un-clamping the suite. Reads the environment
+    /// only — never sets it — so it is race-free across test threads.
+    #[test]
+    fn test_succinctly_simd_env_contract() {
+        let buf = [b'a'; 64];
+        let width = classify_yaml_chars(&buf, 0).unwrap().width;
+
+        match std::env::var("SUCCINCTLY_SIMD") {
+            Ok(v) => match parse_simd_clamp(&v) {
+                Some(true) => {
+                    assert!(!avx2_enabled(), "SUCCINCTLY_SIMD={v} must clamp dispatch");
+                    assert_eq!(width, 16, "SUCCINCTLY_SIMD={v} must force 16-byte classify");
+                }
+                Some(false) => assert_eq!(
+                    width,
+                    if is_x86_feature_detected!("avx2") {
+                        32
+                    } else {
+                        16
+                    }
+                ),
+                None => panic!(
+                    "SUCCINCTLY_SIMD={v:?} is not a recognized level \
+                     (scalar|sse2|sse42|sse4.2|avx2) — fix the caller so the \
+                     clamp actually applies"
+                ),
+            },
+            Err(_) => assert_eq!(
+                width,
+                if is_x86_feature_detected!("avx2") {
+                    32
+                } else {
+                    16
+                },
+                "unclamped dispatch must classify at the detected width"
+            ),
+        }
+    }
+
+    /// All eight mask channels of a `YamlCharClass`, paired with names for
+    /// assertion messages.
+    fn classify_channels(class: &YamlCharClass) -> [(u32, &'static str); 8] {
+        [
+            (class.newlines, "newlines"),
+            (class.colons, "colons"),
+            (class.hyphens, "hyphens"),
+            (class.spaces, "spaces"),
+            (class.quotes_double, "quotes_double"),
+            (class.quotes_single, "quotes_single"),
+            (class.backslashes, "backslashes"),
+            (class.hash, "hash"),
+        ]
+    }
+
+    /// Per-kernel differential sweep for the classify path (#247, option 2 of
+    /// the issue): a lone structural byte at every position 0..40 of an
+    /// otherwise-inert buffer, asserted against both kernels directly. The
+    /// 16..31 window is exactly where the length-derived skip width swallowed
+    /// terminators after a 16-byte SSE2 classify (#231).
+    #[test]
+    fn test_classify_kernels_differential_terminator_sweep() {
+        let structural: [(u8, usize); 8] = [
+            (b'\n', 0),
+            (b':', 1),
+            (b'-', 2),
+            (b' ', 3),
+            (b'"', 4),
+            (b'\'', 5),
+            (b'\\', 6),
+            (b'#', 7),
+        ];
+        let run_avx2 = has_avx2();
+
+        for &(byte, channel) in &structural {
+            for pos in 0..40usize {
+                let mut buf = [b'a'; 48];
+                buf[pos] = byte;
+
+                // SSE2 kernel at offset 0: sees bytes 0..16 only.
+                let sse2 = unsafe { classify_yaml_chars_sse2(&buf, 0) };
+                assert_eq!(sse2.width, 16, "SSE2 must report a 16-byte width");
+                for (i, (mask, name)) in classify_channels(&sse2).iter().enumerate() {
+                    let expected = if i == channel && pos < 16 {
+                        1u32 << pos
+                    } else {
+                        0
+                    };
+                    assert_eq!(
+                        *mask, expected,
+                        "SSE2@0 {name} mask for 0x{byte:02x} at {pos}"
+                    );
+                }
+
+                // SSE2 kernel at offset 16: covers the #231 window 16..31.
+                let sse2_hi = unsafe { classify_yaml_chars_sse2(&buf, 16) };
+                for (i, (mask, name)) in classify_channels(&sse2_hi).iter().enumerate() {
+                    let expected = if i == channel && (16..32).contains(&pos) {
+                        1u32 << (pos - 16)
+                    } else {
+                        0
+                    };
+                    assert_eq!(
+                        *mask, expected,
+                        "SSE2@16 {name} mask for 0x{byte:02x} at {pos}"
+                    );
+                }
+
+                if run_avx2 {
+                    let avx2 = unsafe { classify_yaml_chars_avx2(&buf, 0) };
+                    assert_eq!(avx2.width, 32, "AVX2 must report a 32-byte width");
+                    let sse2_lo = classify_channels(&sse2);
+                    for (i, (mask, name)) in classify_channels(&avx2).iter().enumerate() {
+                        let expected = if i == channel && pos < 32 {
+                            1u32 << pos
+                        } else {
+                            0
+                        };
+                        assert_eq!(
+                            *mask, expected,
+                            "AVX2 {name} mask for 0x{byte:02x} at {pos}"
+                        );
+                        assert_eq!(
+                            *mask & 0xFFFF,
+                            sse2_lo[i].0,
+                            "AVX2 low 16 bits must equal SSE2 ({name}, 0x{byte:02x} at {pos})"
+                        );
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #247.

## What

Makes the x86 SSE2 classify/skip-width path (#231's bug class) actually execute on CI, per the recommendation on #247:

- **`SUCCINCTLY_SIMD` clamp-down dispatch override** (`src/yaml/simd/x86.rs`): all eight AVX2 dispatch sites now route through a cached `avx2_enabled()`; `SUCCINCTLY_SIMD=sse2` (also `scalar`/`sse42`/`sse4.2`) forces the 16-byte SSE2 kernels on an AVX2 CPU. Clamp-down only — the variable can never enable an undetected feature (that would be UB). Modeled on the existing `SUCCINCTLY_SVE2` OnceLock pattern (STYLE-0003).
- **CI step** `Run tests (SSE2-clamped dispatch)`: re-runs the suite with `SUCCINCTLY_SIMD=sse2` on the x86 leg (reuses the build; costs only run time). The existing `light.rs` regression tests then genuinely execute at width 16, so a reintroduced length-derived skip width fails CI.
- **Contract test** `test_succinctly_simd_env_contract` (same philosophy as `SUCCINCTLY_EXPECT_SIMD`, #192): asserts the dispatcher observably honors the variable and panics on unrecognized values — a typo'd CI leg fails loudly instead of silently un-clamping.
- **Differential sweep** `test_classify_kernels_differential_terminator_sweep` (issue option 2): every structural byte at positions 0..40 against both classify kernels directly, covering the 16..31 window where #231 swallowed terminators. Kernel-direct tests keep guarding on raw detection, so AVX2 kernels stay tested even under the clamped step.
- **Comment/doc fixes**: the `ci.yml` env-block comment no longer claims "every level is exercised" / "deliberately no x86 dispatch override"; `environment-variables.md`, the CLI guide, and CONTRIBUTING's "SIMD CI coverage" section document the new variable and the two-layer coverage model.

Scope note (per #247 discussion): the clamp covers **YAML x86 dispatch only**. Extending it to json/dsv/popcount/bp (or centralizing a `SimdLevel`) is deferred follow-up.

## How tested

- Native aarch64: full suite green (clamp code not compiled — no cross-arch impact).
- Rosetta (`x86_64-apple-darwin`): full suite green both unclamped and with `SUCCINCTLY_SIMD=sse2`; `SUCCINCTLY_SIMD=banana` makes the contract test panic naming the value.
- **Test-the-test**: temporarily reintroduced the #231 length-derived width in `parser.rs` — under SSE2 dispatch exactly `test_long_plain_scalar_does_not_swallow_next_line`, `test_to_json_multibyte_survives_simd_escape_scan`, and `test_stream_json_multibyte_survives_simd_escape_scan` fail; reverted.
- Note: this host's Rosetta reports no AVX2 (`hw.optional.avx2_0: 0`), so the "clamp overrides detected AVX2" half is proven by this PR's own x86 CI leg — the clamped step's contract test asserts `!avx2_enabled()` + `width == 16` on a machine where AVX2 *is* detected. That's the leg to watch.
- `cargo clippy --all-targets --all-features -D warnings` **and** default-features clippy on the x86 target (CI's `--all-features` clippy enables `scalar-yaml`, which compiles `x86.rs` out — flagged during planning); `cargo doc --all-features` with `-D warnings`; `cargo check --no-default-features` on both arches (one pre-existing unrelated dead-code warning in `sve2.rs`); `cargo fmt --check`.

Refs #231, #193, #245.
