### PR TITLE
fix(cli): reject size values that overflow in parse_size instead of panicking

### DIFF
--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1050,8 +1050,11 @@ fn parse_size(s: &str) -> Result<usize, String> {
     num_str
         .trim()
         .parse::<usize>()
-        .map(|n| n * unit)
         .map_err(|_| format!("Invalid number in size: '{s}'"))
+        .and_then(|n| {
+            n.checked_mul(unit)
+                .ok_or_else(|| format!("Size too large: '{s}'"))
+        })
 }
 
 /// Multi-call binary support: detect if invoked via a known alias name.
@@ -2138,5 +2141,10 @@ mod tests {
         assert!(parse_size("abc").is_err());
         assert!(parse_size("1tb").is_err());
         assert!(parse_size("").is_err());
+
+        // Overflow: rejected cleanly instead of wrapping (issue #179)
+        assert!(parse_size("99999999999gb").is_err());
+        assert!(parse_size(&format!("{}kb", usize::MAX)).is_err());
+        assert_eq!(parse_size(&format!("{}b", usize::MAX)).unwrap(), usize::MAX);
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the `parse_size` function where extremely large size values (e.g., `99999999999gb`) would cause an integer overflow. In release builds, the unchecked multiplication would silently wrap around to a small value, which the generator would later reject with a panic: "capacity overflow". This PR replaces the unchecked multiply with `checked_mul`, which safely detects overflow and returns a clean error that clap surfaces as a normal invalid-value message.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #179

## Changes Made

**Core Fix:**
- Modified `parse_size` function in `src/bin/succinctly/main.rs` to use `checked_mul` instead of unchecked multiplication
- Changed the error chain to use `and_then` for proper overflow detection
- Returns descriptive error message "Size too large" for overflow cases

**Test Coverage:**
- Added test for `parse_size("99999999999gb")` to verify overflow rejection
- Added test for `parse_size(&format!("{}kb", usize::MAX))` to test boundary conditions
- Added test for `parse_size(&format!("{}b", usize::MAX))` to verify maximum valid value acceptance
- All new tests document that overflow is now rejected cleanly (issue #179)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for overflow boundary conditions

**Manual Testing:**
- [x] Tested on x86_64

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The `checked_mul` operation has negligible performance overhead and only affects the error path during size parsing.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

This fix prevents a potential crash when users provide extremely large size values to the CLI. The error is now handled gracefully at parse time rather than deferring to a panic during generation, improving the user experience and making the application more robust.