### PR TITLE
fix(bitvec): clamp rank0 at bitvector length for out-of-range positions

### DIFF
--- a/src/bits/bitvec.rs
+++ b/src/bits/bitvec.rs
@@ -218,6 +218,15 @@ impl RankSelect for BitVec {
         dir_rank + partial
     }
 
+    /// Count 0-bits in positions `[0, i)`.
+    ///
+    /// Returns 0 if `i == 0`, and `len() - count_ones()` if `i >= len`,
+    /// consistent with `rank1`'s clamping.
+    #[inline]
+    fn rank0(&self, i: usize) -> usize {
+        i.min(self.len) - self.rank1(i)
+    }
+
     /// Find position of the k-th 1-bit (0-indexed).
     ///
     /// Returns `None` if there are fewer than `k+1` ones.
@@ -359,6 +368,16 @@ mod tests {
     fn test_rank1_beyond_len() {
         let bv = BitVec::from_words(vec![u64::MAX], 64);
         assert_eq!(bv.rank1(100), 64);
+    }
+
+    #[test]
+    fn test_rank0_beyond_len() {
+        let bv = BitVec::from_words(vec![u64::MAX], 64);
+        assert_eq!(bv.rank0(64), 0);
+        assert_eq!(bv.rank0(100), 0); // clamped: no 0-bits exist (issue #187)
+
+        let bv = BitVec::from_words(vec![0b0100_1101], 8);
+        assert_eq!(bv.rank0(100), 4); // len - count_ones = 8 - 4
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,10 @@ pub trait RankSelect {
 
     /// Count 0-bits in positions `[0, i)`.
     ///
-    /// Default implementation: `i - rank1(i)`
+    /// Default implementation: `i - rank1(i)`. This is only correct while
+    /// `rank1(i)` counts exactly `i` positions; implementations whose `rank1`
+    /// clamps `i` to the bitvector length (like `BitVec`) must override this
+    /// to clamp `i` as well.
     #[inline]
     fn rank0(&self, i: usize) -> usize {
         i - self.rank1(i)
@@ -161,5 +164,39 @@ impl Default for Config {
         Self {
             select_sample_rate: 256,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RankSelect;
+
+    /// Minimal implementer that keeps the trait's default `rank0`
+    /// (unlike `BitVec`, which overrides it to clamp at the length).
+    struct WordRank(u64);
+
+    impl RankSelect for WordRank {
+        fn rank1(&self, i: usize) -> usize {
+            let mask = if i >= 64 { u64::MAX } else { (1u64 << i) - 1 };
+            (self.0 & mask).count_ones() as usize
+        }
+
+        fn select1(&self, k: usize) -> Option<usize> {
+            (0..64).filter(|b| (self.0 >> b) & 1 == 1).nth(k)
+        }
+    }
+
+    #[test]
+    fn default_rank0_counts_zeros() {
+        let w = WordRank(0b0100_1101); // bits set at 0, 2, 3, 6
+        assert_eq!(w.rank0(0), 0);
+        assert_eq!(w.rank0(4), 1); // 4 - rank1(4) = 4 - 3
+        assert_eq!(w.rank0(8), 4); // 8 - rank1(8) = 8 - 4
+
+        // Sanity-check the rest of the impl so the whole implementer is exercised.
+        assert_eq!(w.rank1(4), 3);
+        assert_eq!(w.select1(0), Some(0));
+        assert_eq!(w.select1(3), Some(6));
+        assert_eq!(w.select1(4), None);
     }
 }

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -19,6 +19,17 @@ proptest! {
         }
     }
 
+    /// rank0(i) is clamped at len: for i >= len it equals len - count_ones (issue #187)
+    #[test]
+    fn prop_rank0_beyond_len_clamped(
+        words in prop::collection::vec(any::<u64>(), 1..50),
+        extra in 0usize..1024
+    ) {
+        let len = words.len() * 64;
+        let bv = BitVec::from_words(words, len);
+        prop_assert_eq!(bv.rank0(len + extra), len - bv.count_ones());
+    }
+
     /// rank1 is monotonically increasing
     #[test]
     fn prop_rank_monotonic(

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -38,6 +38,17 @@ proptest! {
         prop_assert_eq!(bv.rank0(i) + bv.rank1(i), i);
     }
 
+    /// rank0(i) is clamped at len: for i >= len it equals len - count_ones (issue #187)
+    #[test]
+    fn rank0_beyond_len_is_clamped(
+        words in prop::collection::vec(any::<u64>(), 1..20),
+        extra in 0usize..1024
+    ) {
+        let len = words.len() * 64;
+        let bv = BitVec::from_words(words, len);
+        prop_assert_eq!(bv.rank0(len + extra), len - bv.count_ones());
+    }
+
     /// rank1 is monotonically non-decreasing
     #[test]
     fn rank1_is_monotonic(


### PR DESCRIPTION
## Summary

`BitVec` inherited the `RankSelect` trait default `rank0(i) = i - rank1(i)`, which has no clamp, while `BitVec::rank1` clamps `i >= len` to `ones_count`. For `i > len` the pair was inconsistent and `rank0` over-counted:

```rust
BitVec::from_words(vec![u64::MAX], 64).rank0(100)  // returned 36; correct: 0
```

## Changes

- Override `rank0` in `impl RankSelect for BitVec` as `i.min(self.len) - self.rank1(i)` so both ranks clamp consistently (`i >= len` now returns `len - count_ones()`).
- Document the trait default's assumption in `src/lib.rs`: implementations whose `rank1` clamps at the bitvector length must override `rank0` to clamp as well.
- Add `test_rank0_beyond_len` unit test next to the existing `test_rank1_beyond_len`.
- Add beyond-len clamping property tests to both `tests/property_tests.rs` and `tests/properties.rs` (the existing rank-sum properties only exercised `i <= len`, which is why this slipped through).

No behavior change for in-range callers (`i <= len`); all existing `.rank0(` call sites are tests with in-range arguments.

## Testing

- `cargo test` — full suite green (1334 lib tests + all integration/property tests, 0 failures)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt -- --check` — clean

Closes #187