### PR TITLE
fix(cli): jq -R -s slurps whole input as one string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `jq -R -s` now yields the entire input as a single string instead of an array of per-line strings, matching jq (#176)
+
 ## [0.7.0] - 2026-04-05
 
 ### Added

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1016,6 +1016,16 @@ fn get_inputs(args: &JqCommand) -> std::result::Result<Result<Vec<OwnedValue>>, 
         inputs
     };
 
+    // jq -R -s: the entire input (all files concatenated) becomes a single
+    // string; no line splitting and no array wrap.
+    if args.raw_input && args.slurp && args.input_dsv.is_none() {
+        let mut combined = String::new();
+        for (_, raw) in &raw_inputs {
+            combined.push_str(raw);
+        }
+        return Ok(Ok(vec![OwnedValue::String(combined)]));
+    }
+
     // Process based on input mode
     let mut values = Vec::new();
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -287,9 +287,65 @@ fn test_slurp() -> Result<()> {
 
 #[test]
 fn test_slurp_with_raw_input() -> Result<()> {
+    // jq -R -s: the entire input is one string, not an array of lines
     let (output, code) = run_jq_stdin(".", "a\nb\nc", &["-R", "-s", "-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#"["a","b","c"]"#);
+    assert_eq!(output.trim(), r#""a\nb\nc""#);
+    Ok(())
+}
+
+#[test]
+fn test_slurp_with_raw_input_preserves_trailing_newline() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "a\nb\n", &["-R", "-s", "-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""a\nb\n""#);
+    Ok(())
+}
+
+#[test]
+fn test_slurp_with_raw_input_raw_output() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "x\ny", &["-R", "-s", "-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "x\ny\n");
+    Ok(())
+}
+
+#[test]
+fn test_slurp_with_raw_input_empty_input() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "", &["-R", "-s", "-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""""#);
+    Ok(())
+}
+
+#[test]
+fn test_slurp_with_raw_input_multiple_files() -> Result<()> {
+    let mut file1 = NamedTempFile::new()?;
+    writeln!(file1, "a")?;
+
+    let mut file2 = NamedTempFile::new()?;
+    writeln!(file2, "b")?;
+
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--features",
+            "cli",
+            "--bin",
+            "succinctly",
+            "--",
+            "jq",
+        ])
+        .arg("-R")
+        .arg("-s")
+        .arg("-c")
+        .arg(".")
+        .arg(file1.path())
+        .arg(file2.path())
+        .output()?;
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout.trim(), r#""a\nb\n""#);
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #176

## Problem

jq's `-R -s` combination reads the **entire input as one string** — all files concatenated, trailing newlines preserved, no array wrapping. The CLI instead always line-split under `-R` and then array-wrapped under `-s`:

```
printf "a\nb\n" | sjq -Rs .   # before: ["a","b"]    after: "a\nb\n"  (matches jq)
```

## Fix

In `get_inputs` (`src/bin/succinctly/jq_runner.rs`), special-case `raw_input && slurp` to return a single `OwnedValue::String` of the concatenated raw inputs, bypassing both the line splitting and the slurp array wrap. Guarded on `input_dsv.is_none()` to preserve the existing `--input-dsv` precedence over `-R`. `-n` still short-circuits first, matching jq.

No other input path is affected: the DSV streaming path requires `!slurp`, and the lazy/identity fast path requires `!slurp && !raw_input`, so every `-R`/`-s` invocation goes through `get_inputs`.

## Tests

- `test_slurp_with_raw_input` asserted the buggy behavior and now expects the jq-correct single string
- New coverage: trailing-newline preservation, `-Rsr` raw output (byte-exact, untrimmed), empty input (`""`, not `[]`), and multi-file concatenation order
- Output verified byte-identical to system jq for `-Rs` and `-Rsr`
- Full `--features cli` suite and `cargo clippy --all-targets --all-features -- -D warnings` pass

## Out of scope

`yq_runner.rs` (~lines 1590-1605) has the same raw+slurp line-array pattern. That is a separate binary not covered by #176 (and mikefarah-yq flag semantics need their own check) — tracked in follow-up issue #271.
