### PR TITLE
fix(cli): stop yq --from-file dropping the input file

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1045,6 +1045,25 @@ fn contains_split_doc(expr: &Expr) -> bool {
     }
 }
 
+/// Get input files from arguments.
+fn get_input_files(args: &YqCommand) -> Vec<String> {
+    // When --from-file is used, the 'filter' field becomes the first input file
+    // because the filter comes from a file instead of command line
+    let mut files = Vec::new();
+
+    if args.from_file.is_some() {
+        // When --from-file is used, the first positional arg (if any) is an input file
+        if let Some(ref first_file) = args.filter {
+            files.push(first_file.clone());
+        }
+    }
+
+    // Add remaining files
+    files.extend(args.files.iter().cloned());
+
+    files
+}
+
 /// Main entry point for the yq command.
 pub fn run_yq(args: YqCommand) -> Result<i32> {
     // Handle --version
@@ -1066,6 +1085,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     } else {
         args.filter.clone().unwrap_or_else(|| ".".to_string())
     };
+
+    // Get input files (with --from-file, the filter positional is an input file)
+    let input_files = get_input_files(&args);
 
     // Validate flag compatibility
     if args.document.is_some() && args.raw_input {
@@ -1174,7 +1196,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }};
         }
 
-        if args.files.is_empty() {
+        if input_files.is_empty() {
             let yaml_bytes = read_stdin()?;
             let index = YamlIndex::build(&yaml_bytes)
                 .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
@@ -1219,7 +1241,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 }
             }
         } else {
-            for file_path in &args.files {
+            for file_path in &input_files {
                 let yaml_bytes = read_file(Path::new(file_path))?;
                 let index = YamlIndex::build(&yaml_bytes)
                     .map_err(|e| anyhow::anyhow!("YAML parse error in {file_path}: {e}"))?;
@@ -1280,11 +1302,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         }
     } else if args.raw_input {
         // Handle --raw-input: read each line as a string instead of parsing as YAML
-        let input_content = if args.files.is_empty() {
+        let input_content = if input_files.is_empty() {
             read_stdin_string()?
         } else {
             let mut content = String::new();
-            for file_path in &args.files {
+            for file_path in &input_files {
                 let file_content = std::fs::read_to_string(file_path)
                     .with_context(|| format!("failed to read file: {file_path}"))?;
                 content.push_str(&file_content);
@@ -1325,13 +1347,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         let mut all_docs: Vec<OwnedValue> = Vec::new();
 
         // Collect input sources
-        let input_sources: Vec<(Vec<u8>, InputFormat)> = if args.files.is_empty() {
+        let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
             let input_bytes = read_stdin()?;
             let format = resolve_input_format(args.input_format, None);
             vec![(input_bytes, format)]
         } else {
             let mut sources = Vec::new();
-            for file_path in &args.files {
+            for file_path in &input_files {
                 let path = Path::new(file_path);
                 let input_bytes = read_file(path)?;
                 let format = resolve_input_format(args.input_format, Some(path));
@@ -1369,12 +1391,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         }
     } else if args.inplace {
         // Handle --inplace: process each file and write back to it
-        if args.files.is_empty() {
+        if input_files.is_empty() {
             anyhow::bail!("--inplace requires at least one file argument");
         }
 
         let mut global_doc_index: usize = 0;
-        for file_path in &args.files {
+        for file_path in &input_files {
             let path = Path::new(file_path);
             let input_bytes = read_file(path)?;
             let format = resolve_input_format(args.input_format, Some(path));
@@ -1438,13 +1460,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // For JSON inputs, use the OwnedValue path
 
         // Collect input sources with their bytes and formats
-        let input_sources: Vec<(Vec<u8>, InputFormat)> = if args.files.is_empty() {
+        let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
             let input_bytes = read_stdin()?;
             let format = resolve_input_format(args.input_format, None);
             vec![(input_bytes, format)]
         } else {
             let mut sources = Vec::new();
-            for file_path in &args.files {
+            for file_path in &input_files {
                 let path = Path::new(file_path);
                 let input_bytes = read_file(path)?;
                 let format = resolve_input_format(args.input_format, Some(path));

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1079,3 +1079,142 @@ fn test_build_configuration_flag() -> Result<()> {
     assert!(stdout.contains("Features:"));
     Ok(())
 }
+
+// ============================================================================
+// From-File Filter Tests (#177)
+// ============================================================================
+
+/// Helper to run yq with --from-file and positional input files.
+///
+/// stdin is explicitly null so that a regression to reading stdin produces
+/// an empty-input error instead of hanging.
+fn run_yq_from_file(
+    filter_path: &str,
+    files: &[&str],
+    extra_args: &[&str],
+) -> Result<(String, i32)> {
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(extra_args)
+        .arg("--from-file")
+        .arg(filter_path)
+        .args(files)
+        .stdin(Stdio::null())
+        .output()?;
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    Ok((stdout, exit_code))
+}
+
+#[test]
+fn test_from_file_with_input_file() -> Result<()> {
+    // Regression test for #177: clap binds the input file positional to
+    // `filter`, and yq dropped it and read stdin instead.
+    let mut filter_file = NamedTempFile::new()?;
+    writeln!(filter_file, ".name")?;
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "name: Alice")?;
+    writeln!(input_file, "age: 30")?;
+
+    let (output, code) = run_yq_from_file(
+        filter_file.path().to_str().unwrap(),
+        &[input_file.path().to_str().unwrap()],
+        &[],
+    )?;
+
+    assert_eq!(code, 0);
+    assert_eq!(output, "Alice\n");
+    Ok(())
+}
+
+#[test]
+fn test_from_file_with_input_file_fast_path() -> Result<()> {
+    // Same as test_from_file_with_input_file, but -o=json -I=0 routes the
+    // query through the M2 streaming fast path's file loop.
+    let mut filter_file = NamedTempFile::new()?;
+    writeln!(filter_file, ".name")?;
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "name: Alice")?;
+
+    let (output, code) = run_yq_from_file(
+        filter_file.path().to_str().unwrap(),
+        &[input_file.path().to_str().unwrap()],
+        &["-o=json", "-I=0"],
+    )?;
+
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""Alice""#);
+    Ok(())
+}
+
+#[test]
+fn test_from_file_with_stdin() -> Result<()> {
+    // --from-file with no positional input file must still read stdin.
+    let mut filter_file = NamedTempFile::new()?;
+    writeln!(filter_file, ".name")?;
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("--from-file")
+        .arg(filter_file.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(b"name: Bob\n")?;
+    }
+
+    let output = cmd.wait_with_output()?;
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8(output.stdout)?, "Bob\n");
+    Ok(())
+}
+
+#[test]
+fn test_from_file_with_multiple_input_files() -> Result<()> {
+    let mut filter_file = NamedTempFile::new()?;
+    writeln!(filter_file, ".a")?;
+    let mut input_one = NamedTempFile::new()?;
+    writeln!(input_one, "a: 1")?;
+    let mut input_two = NamedTempFile::new()?;
+    writeln!(input_two, "a: 2")?;
+
+    let (output, code) = run_yq_from_file(
+        filter_file.path().to_str().unwrap(),
+        &[
+            input_one.path().to_str().unwrap(),
+            input_two.path().to_str().unwrap(),
+        ],
+        &[],
+    )?;
+
+    assert_eq!(code, 0);
+    assert_eq!(output, "---\n1\n---\n2\n");
+    Ok(())
+}
+
+#[test]
+fn test_inplace_from_file() -> Result<()> {
+    // Before #177, --inplace --from-file bailed with "requires at least one
+    // file argument" because the input file was swallowed by `filter`.
+    let mut filter_file = NamedTempFile::new()?;
+    writeln!(filter_file, ".name")?;
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "name: Alice")?;
+
+    let (output, code) = run_yq_from_file(
+        filter_file.path().to_str().unwrap(),
+        &[input_file.path().to_str().unwrap()],
+        &["-i"],
+    )?;
+
+    assert_eq!(code, 0);
+    assert_eq!(output, "");
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "Alice\n");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #177 — `succinctly yq --from-file q.jq d.yaml` ignored `d.yaml` and read stdin instead. Clap binds the first positional to `filter`, and `run_yq` never rerouted it into the input-file list once the filter came from `--from-file`.

The fix mirrors `jq_runner`'s existing `get_input_files`: when `--from-file` is set, the `filter` positional becomes the first input file, followed by the trailing `files`. All five input-selection branches in `run_yq` (M2 fast path, `--raw-input`, `--slurp`, `--inplace`, standard path) now consult the rerouted list; behavior is unchanged when `--from-file` is absent (`input_files == args.files`).

Side effect (matches mikefarah yq): `yq -i --from-file q.jq d.yaml` previously bailed with "requires at least one file argument"; it now edits `d.yaml` in place.

## Repro (before → after)

```
echo ".name" >q.jq; printf "name: Alice\n" >d.yaml
printf "" | syq --from-file q.jq d.yaml
# before: YAML parse error: empty input
# after:  Alice
```

## Tests

Five regression tests in `tests/yq_cli_tests.rs`: the issue repro on the standard path, the M2 streaming fast path (`-o=json -I=0`), stdin fallback with no positional, multiple input files (multi-doc `---` separators), and `--inplace --from-file` write-back.

- `cargo test --features cli`: all green (1338 lib + all integration suites)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean