### PR TITLE
fix(jq): enable regex builtins in CLI and fix test/1 regex semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ echo '{"data": {"nested": {"value": 42}}}' | succinctly jq 'at_offset(9) | .nest
 | `simd`              | Explicit SIMD intrinsics                  |
 | `portable-popcount` | Portable bitwise popcount                 |
 | `serde`             | Serde serialize/deserialize support       |
-| `regex`             | Regex builtins in jq (test, match, sub)   |
+| `regex`             | Regex builtins in jq (included in `cli`)  |
 | `cli`               | CLI tool (jq, yq, locate, generators)     |
 | `bench-runner`      | Unified benchmark runner (bench list/run) |
 | `large-tests`       | 1GB bitvector tests                       |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ portable-popcount = []
 serde = ["dep:serde"]
 
 # CLI tool features
-cli = ["std", "clap", "rand", "rand_chacha", "anyhow", "serde_json", "memmap2", "md5", "serde", "ctrlc"]
+cli = ["std", "clap", "rand", "rand_chacha", "anyhow", "serde_json", "memmap2", "md5", "serde", "ctrlc", "regex"]
 
 # Enable regex support in jq query language
 regex = ["dep:regex"]

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ See [docs/benchmarks/rust-parsers.md](docs/benchmarks/rust-parsers.md), [docs/be
 | `std`   | Enable std library (default, required for runtime CPU detection) |
 | `serde` | Enable serialization/deserialization support                     |
 | `cli`   | Build the CLI tool                                               |
-| `regex` | Enable regex support in jq queries                               |
+| `regex` | Enable regex support in jq queries (included in `cli`)           |
 
 ### Test Features
 

--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -112,9 +112,9 @@ The implementation covers ~95% of jq functionality and is production-ready.
 - [x] `explode` / `implode`
 - [x] `utf8bytelength`
 - [x] `indices(s)` / `index(s)` / `rindex(s)`
-- [x] `test(re)` (substring without regex feature)
+- [x] `test(re)` (regex with `regex` feature; substring fallback without)
 
-### Regular Expressions (with `regex` feature)
+### Regular Expressions (with `regex` feature, included in `cli`)
 - [x] `match(re)` / `match(re; flags)`
 - [x] `capture(re)`
 - [x] `scan(re)`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1459,6 +1459,9 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Phase 6: Additional String Functions
         Builtin::Explode => builtin_explode::<W>(value, optional),
         Builtin::Implode => builtin_implode::<W>(value, optional),
+        #[cfg(feature = "regex")]
+        Builtin::Test(re) => builtin_test_regex::<W, S>(re, value, optional),
+        #[cfg(not(feature = "regex"))]
         Builtin::Test(re) => builtin_test::<W, S>(re, value, optional),
         Builtin::Indices(s) => builtin_indices::<W, S>(s, value, optional),
         Builtin::Index(s) => builtin_index::<W, S>(s, value, optional),
@@ -4217,7 +4220,8 @@ fn builtin_implode<W: Clone + AsRef<[u64]>>(
     }
 }
 
-/// Builtin: test(re) - test if string matches (basic substring matching)
+/// Builtin: test(re) - test if string matches (substring fallback without regex feature)
+#[cfg(not(feature = "regex"))]
 fn builtin_test<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
     value: StandardJson<'a, W>,
@@ -4521,6 +4525,42 @@ fn build_regex(pattern: &str, flags: Option<&str>) -> Result<regex::Regex, EvalE
     }
 
     regex::Regex::new(&pattern).map_err(|e| EvalError::new(format!("invalid regex: {e}")))
+}
+
+/// Builtin: test(re) - test if string matches the regex
+#[cfg(feature = "regex")]
+fn builtin_test_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    re_expr: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    // Evaluate the pattern
+    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
+        Ok(OwnedValue::String(s)) => s,
+        Ok(_) if optional => return QueryResult::None,
+        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "pattern")),
+        Err(e) => return QueryResult::Error(e),
+    };
+
+    // Get the input string
+    let input = match &value {
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => cow.into_owned(),
+            Err(_) if optional => return QueryResult::None,
+            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+        },
+        _ if optional => return QueryResult::None,
+        _ => return QueryResult::Error(EvalError::type_error("string", type_name(&value))),
+    };
+
+    // Build regex and test for a match
+    let re = match build_regex(&pattern, None) {
+        Ok(r) => r,
+        Err(_e) if optional => return QueryResult::None,
+        Err(e) => return QueryResult::Error(e),
+    };
+
+    QueryResult::Owned(OwnedValue::Bool(re.is_match(&input)))
 }
 
 /// Builtin: match(re) or match(re; flags) - return match object
@@ -15283,6 +15323,30 @@ mod tests {
     // =========================================================================
     // Phase 7: Regex Functions (requires "regex" feature)
     // =========================================================================
+
+    #[cfg(feature = "regex")]
+    #[test]
+    fn test_regex_test() {
+        // The #167 repro: character classes must match with regex semantics
+        query!(br#""abc123""#, r#"test("[0-9]+")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b);
+            }
+        );
+
+        // Metacharacter case a substring match would get wrong
+        query!(br#""abc""#, r#"test("a.c")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b);
+            }
+        );
+
+        query!(br#""abc""#, r#"test("[0-9]+")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(!b);
+            }
+        );
+    }
 
     #[cfg(feature = "regex")]
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1898,3 +1898,40 @@ fn test_seq_with_slurp() -> Result<()> {
     assert_eq!(rest.trim(), "6");
     Ok(())
 }
+
+// =============================================================================
+// Regex builtins (regression tests for #167 - cli feature must bundle regex)
+// =============================================================================
+
+#[test]
+fn test_regex_test_available_in_cli() -> Result<()> {
+    // The #167 repro: must use regex semantics, not substring matching
+    let (output, code) = run_jq_stdin(r#"test("[0-9]+")"#, r#""abc123""#, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "true");
+
+    let (output, code) = run_jq_stdin(r#"test("[0-9]+")"#, r#""abc""#, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "false");
+    Ok(())
+}
+
+#[test]
+fn test_regex_gsub_available_in_cli() -> Result<()> {
+    let (output, code) = run_jq_stdin(r#"gsub("[0-9]"; "X")"#, r#""a1b2""#, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""aXbX""#);
+    Ok(())
+}
+
+#[test]
+fn test_regex_capture_available_in_cli() -> Result<()> {
+    let (output, code) = run_jq_stdin(
+        r#"capture("(?<word>[a-z]+)") | .word"#,
+        r#""hello123""#,
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""hello""#);
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR resolves issue #167 by fixing jq regex builtins to work correctly in the shipped CLI. The changes include three main components:

1. **Regex semantics for `test/1`**: The `test()` builtin now dispatches to proper regex-based matching when the regex feature is enabled, instead of always using substring matching. Patterns like `[0-9]+` now correctly match numeric sequences.

2. **Bundling regex into the CLI feature**: The `cli` feature now explicitly includes the `regex` feature dependency, ensuring all jq regex builtins (test, match, sub, gsub, scan, splits, capture) are available in the shipped binary.

3. **Comprehensive test coverage**: Added end-to-end CLI regression tests and updated documentation to clarify that regex support is included in the cli feature.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #167

## Changes Made

**Core Implementation:**
- Modified `src/jq/eval.rs` to dispatch `Builtin::Test` to a new `builtin_test_regex()` function when the regex feature is enabled, while maintaining the substring fallback behavior for builds without regex
- Implemented `builtin_test_regex()` that uses the existing `build_regex()` helper to properly evaluate regex patterns with full jq regex semantics
- Updated `Cargo.toml` to include `regex` in the `cli` feature definition

**Testing:**
- Added unit test `test_regex_test()` covering the #167 repro case (`[0-9]+` matching), metacharacter matching (`a.c`), and negative cases
- Added three CLI regression tests in `tests/jq_cli_tests.rs`:
  - `test_regex_test_available_in_cli()`: Validates `test()` with character classes
  - `test_regex_gsub_available_in_cli()`: Validates global substitution
  - `test_regex_capture_available_in_cli()`: Validates named group capture

**Documentation:**
- Updated `CLAUDE.md`, `README.md`, and `docs/reference/jq-language.md` to clarify that the `regex` feature is included in the `cli` feature
- Clarified that `test(re)` uses regex semantics with the regex feature and substring fallback without

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New unit tests added for regex semantics verification
- [x] New CLI integration tests added for end-to-end validation
- [x] Regression tests confirm #167 repro case now passes

**Test Commands:**
```bash
cargo test
cargo test --features cli
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The regex dispatch is compile-time conditional and only affects behavior when the feature is enabled.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

This fix ensures the shipped CLI binary correctly implements jq regex semantics for all regex builtins. Previously, even with the regex crate available, the `test()` builtin was incorrectly using substring matching instead of proper regex pattern matching. The fix maintains backward compatibility for builds without the regex feature by preserving the substring fallback behavior.