### PR TITLE
fix(simd): derive toggle64 quote carry from quote parity, not adder overflow

### DIFF
--- a/docs/optimizations/bit-manipulation.md
+++ b/docs/optimizations/bit-manipulation.md
@@ -184,16 +184,21 @@ Used in DSV parsing to compute regions inside quotes:
 
 ```rust
 // src/dsv/simd/bmi2.rs
-fn toggle64_bmi2(quote_mask: u64, carry: u64) -> (u64, u64) {
+fn toggle64_bmi2(carry: u64, w: u64) -> (u64, u64) {
     // Scatter alternating 0/1 pattern to quote positions
-    let addend = _pdep_u64(0x5555_5555_5555_5555 << carry, quote_mask);
+    let c = carry & 0x1;
+    let addend = _pdep_u64(0x5555_5555_5555_5555 << c, w);
 
     // Use addition with carry propagation to fill between quotes
-    let comp = !quote_mask;
-    let shifted = (addend << 1) | carry;
-    let (result, overflow) = shifted.overflowing_add(comp);
+    let comp_w = !w;
+    let shifted = (addend << 1) | c;
+    let result = shifted.wrapping_add(comp_w);
 
-    (result ^ comp, overflow as u64)
+    // Carry for the next chunk is quote-count parity, NOT the adder's
+    // overflow: `addend << 1` drops an opener deposited at bit 63 (#149).
+    let new_carry = (w.count_ones() as u64 + c) & 1;
+
+    (result, new_carry)
 }
 ```
 

--- a/docs/optimizations/parallel-prefix.md
+++ b/docs/optimizations/parallel-prefix.md
@@ -99,16 +99,21 @@ BMI2's PDEP instruction enables efficient carry propagation:
 
 ```rust
 // src/dsv/simd/bmi2.rs
-fn toggle64_bmi2(quote_mask: u64, carry: u64) -> (u64, u64) {
+fn toggle64_bmi2(carry: u64, w: u64) -> (u64, u64) {
     // Scatter alternating pattern to quote positions
-    let addend = _pdep_u64(0x5555_5555_5555_5555 << carry, quote_mask);
+    let c = carry & 0x1;
+    let addend = _pdep_u64(0x5555_5555_5555_5555 << c, w);
 
-    // Use addition to propagate carries
-    let comp_mask = !quote_mask;
-    let shifted = (addend << 1) | carry;
-    let (result, overflow) = shifted.overflowing_add(comp_mask);
+    // Use addition to propagate carries (fills between quote pairs)
+    let comp_w = !w;
+    let shifted = (addend << 1) | c;
+    let result = shifted.wrapping_add(comp_w);
 
-    (result ^ comp_mask, overflow as u64)
+    // Carry for the next chunk is quote-count parity, NOT the adder's
+    // overflow: `addend << 1` drops an opener deposited at bit 63 (#149).
+    let new_carry = (w.count_ones() as u64 + c) & 1;
+
+    (result, new_carry)
 }
 ```
 

--- a/docs/parsing/dsv.md
+++ b/docs/parsing/dsv.md
@@ -126,19 +126,24 @@ See [parallel-prefix.md](../optimizations/parallel-prefix.md) for technique deta
 A 10x faster alternative using hardware PDEP instruction:
 
 ```rust
-unsafe fn toggle64_bmi2(quote_mask: u64, carry: u64) -> (u64, u64) {
+unsafe fn toggle64_bmi2(carry: u64, w: u64) -> (u64, u64) {
     const ODDS_MASK: u64 = 0x5555_5555_5555_5555;  // 0101...
 
     // Scatter alternating pattern to quote positions
     let c = carry & 0x1;
-    let addend = _pdep_u64(ODDS_MASK << c, quote_mask);
+    let addend = _pdep_u64(ODDS_MASK << c, w);
 
     // Use addition for carry propagation
-    let comp_mask = !quote_mask;
+    let comp_w = !w;
     let shifted = (addend << 1) | c;
-    let (result, overflow) = shifted.overflowing_add(comp_mask);
+    let result = shifted.wrapping_add(comp_w);
 
-    (result ^ comp_mask, overflow as u64)
+    // Quote state entering the next chunk = incoming state XOR quote-count
+    // parity. The adder's overflow is NOT a valid carry: `addend << 1` drops
+    // an opener deposited at bit 63, losing the carry (issue #149).
+    let new_carry = (w.count_ones() as u64 + c) & 1;
+
+    (result, new_carry)
 }
 ```
 
@@ -147,6 +152,8 @@ unsafe fn toggle64_bmi2(quote_mask: u64, carry: u64) -> (u64, u64) {
 1. **PDEP scatters bits**: Places alternating 0/1 pattern at quote positions
 2. **Addition propagates carries**: Fills regions between quotes
 3. **Result**: 1-bits where outside quotes, 0-bits where inside
+4. **Carry**: quote-count parity XOR incoming carry — the inside/outside state
+   entering the next 64-byte chunk (do not use the adder's overflow; see #149)
 
 ```
 quote_mask:     0b00100100  (quotes at 2, 5)
@@ -396,12 +403,12 @@ for chunk in data.chunks(64) {
     let (delim_mask, quote_mask, newline_mask) = classify_chunk(chunk);
 
     // Apply quote masking with carry from previous chunk
-    let (in_quote_mask, new_carry) = toggle64_bmi2(quote_mask, carry);
+    let (outside_quotes, new_carry) = toggle64_bmi2(carry, quote_mask);
     carry = new_carry;
 
     // Mask out delimiters inside quotes
-    let valid_delims = delim_mask & !in_quote_mask;
-    let valid_newlines = newline_mask & !in_quote_mask;
+    let valid_delims = delim_mask & outside_quotes;
+    let valid_newlines = newline_mask & outside_quotes;
 
     // Write to index
     markers.push(valid_delims | valid_newlines);

--- a/src/dsv/simd/bmi2.rs
+++ b/src/dsv/simd/bmi2.rs
@@ -197,11 +197,13 @@ unsafe fn toggle64_bmi2(carry: u64, w: u64) -> (u64, u64) {
     // effectively "filling" the regions between matched quote pairs.
     let comp_w = !w;
     let shifted = (addend << 1) | c;
-    let (result, overflow) = shifted.overflowing_add(comp_w);
+    let result = shifted.wrapping_add(comp_w);
 
-    // The new carry depends on whether addition overflowed
-    // and the final state of the quote parity
-    let new_carry = u64::from(overflow);
+    // Quote state after this chunk = incoming state XOR quote-count parity.
+    // The adder's carry-out cannot be used here: `addend << 1` drops a bit
+    // deposited at position 63, so a quote that opens at bit 63 never
+    // produces an overflow and the carry would be lost (#149).
+    let new_carry = (w.count_ones() as u64 + c) & 1;
 
     (result, new_carry)
 }
@@ -392,6 +394,86 @@ mod tests {
             let (_mask, carry) = toggle64_bmi2(0, 1);
             // After the quote, we're inside, so the mask should have 0s
             assert_eq!(carry, 1, "Odd quotes should set carry");
+
+            // #149 regression: a quote at bit 63 must still toggle the carry.
+            // The overflow-based carry lost an opener at bit 63 because
+            // `addend << 1` shifts the deposited bit out of the word.
+            let (mask, carry) = toggle64_bmi2(0, 1 << 63);
+            assert_eq!(carry, 1, "Opener at bit 63 must carry into next chunk");
+            assert_eq!(mask, !0u64 >> 1, "Bits 0..63 outside, bit 63 inside");
+            let (_mask, carry) = toggle64_bmi2(1, 1 << 63);
+            assert_eq!(carry, 0, "Closer at bit 63 must clear the carry");
+        }
+    }
+
+    #[test]
+    fn test_toggle64_matches_bit_serial_reference() {
+        if !has_bmi2() {
+            return;
+        }
+
+        // Independent bit-serial oracle: walk the word tracking an inside-quotes
+        // flag, exactly like the scalar DSV parser. A quote bit takes its
+        // post-toggle state — an opening quote reads as inside (0), a closing
+        // quote as outside (1). See the SVE2 twin of this test in
+        // `src/util/simd/sve2.rs` (#149).
+        fn toggle64_reference(carry: u64, quote_mask: u64) -> (u64, u64) {
+            let mut inside = carry & 1 == 1;
+            let mut outside_mask = 0u64;
+            for i in 0..64 {
+                if (quote_mask >> i) & 1 == 1 {
+                    inside = !inside;
+                }
+                if !inside {
+                    outside_mask |= 1 << i;
+                }
+            }
+            (outside_mask, u64::from(inside))
+        }
+
+        // Deterministic PRNG for wide mask coverage without a rand dependency.
+        fn splitmix64(state: &mut u64) -> u64 {
+            *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = *state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+
+        let mut patterns = vec![
+            0u64,
+            1,
+            0b11,
+            0b101,
+            0b1001,
+            0x8000_0000_0000_0000,
+            0xC000_0000_0000_0000,
+            0x8000_0000_0000_0001,
+            0xAAAA_AAAA_AAAA_AAAA,
+            0x5555_5555_5555_5555,
+            0xFF00_FF00_FF00_FF00,
+            !0u64,
+        ];
+        patterns.extend((0..64).map(|i| 1u64 << i));
+        let mut state = 0x149u64;
+        patterns.extend((0..512).map(|_| splitmix64(&mut state)));
+
+        for &quote_mask in &patterns {
+            for carry in [0u64, 1] {
+                unsafe {
+                    let (bmi2_mask, bmi2_carry) = toggle64_bmi2(carry, quote_mask);
+                    let (ref_mask, ref_carry) = toggle64_reference(carry, quote_mask);
+
+                    assert_eq!(
+                        bmi2_mask, ref_mask,
+                        "Mask mismatch for quote_mask={quote_mask:#x}, carry={carry}"
+                    );
+                    assert_eq!(
+                        bmi2_carry, ref_carry,
+                        "Carry mismatch for quote_mask={quote_mask:#x}, carry={carry}"
+                    );
+                }
+            }
         }
     }
 

--- a/src/dsv/simd/sve2.rs
+++ b/src/dsv/simd/sve2.rs
@@ -210,14 +210,7 @@ mod tests {
     use super::*;
 
     fn has_sve2() -> bool {
-        #[cfg(feature = "std")]
-        {
-            std::arch::is_aarch64_feature_detected!("sve2-bitperm")
-        }
-        #[cfg(not(feature = "std"))]
-        {
-            false
-        }
+        crate::util::simd::sve2::has_sve2_bitperm()
     }
 
     #[test]

--- a/src/util/simd/sve2.rs
+++ b/src/util/simd/sve2.rs
@@ -155,10 +155,13 @@ pub unsafe fn toggle64_sve2(carry: u64, quote_mask: u64) -> (u64, u64) {
     // Formula: ((addend << 1) | c) + !quote_mask
     let comp_w = !quote_mask;
     let shifted = (addend << 1) | c;
-    let (result, overflow) = shifted.overflowing_add(comp_w);
+    let result = shifted.wrapping_add(comp_w);
 
-    // New carry depends on overflow
-    let new_carry = u64::from(overflow);
+    // Quote state after this chunk = incoming state XOR quote-count parity.
+    // The adder's carry-out cannot be used here: `addend << 1` drops a bit
+    // deposited at position 63, so a quote that opens at bit 63 never
+    // produces an overflow and the carry would be lost (#149).
+    let new_carry = (quote_mask.count_ones() as u64 + c) & 1;
 
     (result, new_carry)
 }
@@ -352,48 +355,61 @@ mod tests {
     }
 
     #[test]
-    fn test_toggle64_matches_prefix_xor() {
+    fn test_toggle64_matches_bit_serial_reference() {
         if !has_sve2() {
             return;
         }
 
-        // Reference implementation using the same algorithm as toggle64_sve2/toggle64_bmi2
-        // but without BDEP (uses scalar PDEP-equivalent logic).
+        // Independent bit-serial oracle: walk the word tracking an inside-quotes
+        // flag, exactly like the scalar DSV parser. Deliberately NOT a scalar
+        // port of the BDEP/adder formula — the previous reference re-implemented
+        // that formula and so inherited its bit-63 carry bug (#149).
+        //
+        // Convention (matches the adder formula): a quote bit takes its
+        // post-toggle state — an opening quote reads as inside (0), a closing
+        // quote as outside (1).
         fn toggle64_reference(carry: u64, quote_mask: u64) -> (u64, u64) {
-            const ODDS_MASK: u64 = 0x5555_5555_5555_5555;
-            let c = carry & 0x1;
-
-            // Scalar PDEP equivalent: deposit alternating bits into quote positions
-            let mut addend = 0u64;
-            let mut src_bit = 0;
+            let mut inside = carry & 1 == 1;
+            let mut outside_mask = 0u64;
             for i in 0..64 {
                 if (quote_mask >> i) & 1 == 1 {
-                    let bit = (ODDS_MASK << c >> src_bit) & 1;
-                    addend |= bit << i;
-                    src_bit += 1;
+                    inside = !inside;
+                }
+                if !inside {
+                    outside_mask |= 1 << i;
                 }
             }
-
-            let comp_w = !quote_mask;
-            let shifted = (addend << 1) | c;
-            let (result, overflow) = shifted.overflowing_add(comp_w);
-            let new_carry = u64::from(overflow);
-
-            (result, new_carry)
+            (outside_mask, u64::from(inside))
         }
 
-        // Test various quote patterns
-        let patterns = [
+        // Deterministic PRNG for wide mask coverage without a rand dependency.
+        fn splitmix64(state: &mut u64) -> u64 {
+            *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = *state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+
+        // Fixed edge patterns (bit 63 is the #149 regression), every single-bit
+        // mask, and 512 pseudo-random masks.
+        let mut patterns = vec![
             0u64,
             1,
             0b11,
             0b101,
             0b1001,
             0x8000_0000_0000_0000,
+            0xC000_0000_0000_0000,
+            0x8000_0000_0000_0001,
             0xAAAA_AAAA_AAAA_AAAA,
             0x5555_5555_5555_5555,
             0xFF00_FF00_FF00_FF00,
+            !0u64,
         ];
+        patterns.extend((0..64).map(|i| 1u64 << i));
+        let mut state = 0x149u64;
+        patterns.extend((0..512).map(|_| splitmix64(&mut state)));
 
         for &quote_mask in &patterns {
             for carry in [0u64, 1] {

--- a/src/util/simd/sve2.rs
+++ b/src/util/simd/sve2.rs
@@ -241,14 +241,7 @@ mod tests {
     use super::*;
 
     fn has_sve2() -> bool {
-        #[cfg(feature = "std")]
-        {
-            std::arch::is_aarch64_feature_detected!("sve2-bitperm")
-        }
-        #[cfg(not(feature = "std"))]
-        {
-            false
-        }
+        super::has_sve2_bitperm()
     }
 
     #[test]

--- a/tests/dsv_simd_differential_tests.rs
+++ b/tests/dsv_simd_differential_tests.rs
@@ -69,12 +69,13 @@ fn toggle64_backends() -> Vec<(&'static str, Builder)> {
 
     #[cfg(target_arch = "aarch64")]
     {
-        // SVE2 is absent on Apple Silicon; validated under emulation (#194).
-        // NOTE: #194 should tighten this to the exact `sve2-bitperm` feature.
-        if std::arch::is_aarch64_feature_detected!("sve2") {
+        // SVE2-BITPERM is absent on Apple Silicon; runs on Neoverse CI (#194).
+        if std::arch::is_aarch64_feature_detected!("sve2-bitperm") {
             backends.push(("sve2", succinctly::dsv::simd::sve2::build_index_simd));
         } else {
-            eprintln!("SKIPPED dsv toggle64 differential [sve2]: sve2 not detected (see #194)");
+            eprintln!(
+                "SKIPPED dsv toggle64 differential [sve2]: sve2-bitperm not detected (see #194)"
+            );
         }
     }
 

--- a/tests/dsv_simd_differential_tests.rs
+++ b/tests/dsv_simd_differential_tests.rs
@@ -14,18 +14,18 @@
 //! The SIMD backends fall into two families:
 //!
 //! * **prefix-xor** (`neon`, `sse2`, `avx2`) — track quote state with a running
-//!   `in_quote` flag. These agree with scalar today, including at bit 63, and
-//!   are asserted directly.
-//! * **toggle64** (`bmi2` PDEP, `sve2` BDEP) — share a carry formula that drops
-//!   a quote at bit 63 (`(addend << 1)` loses the top bit), so they currently
-//!   DISAGREE with scalar at the chunk boundary. That is bug #149 (with #182);
-//!   the in-repo `toggle64_reference` re-implements the same buggy formula, so
-//!   the old unit test never caught it. Those backends are exercised only by the
-//!   `#[ignore]`d repro test at the bottom until #149 is fixed.
+//!   `in_quote` flag. These have always agreed with scalar, including at bit 63.
+//! * **toggle64** (`bmi2` PDEP, `sve2` BDEP) — historically derived the
+//!   chunk-boundary carry from the adder's overflow, which dropped a quote
+//!   opening at bit 63 (`addend << 1` loses the top bit) — bug #149 (with
+//!   #182). The carry now comes from quote-count parity, and these backends are
+//!   asserted against scalar exactly like the prefix-xor family, plus a named
+//!   #149 regression sweep at the bottom.
 //!
-//! On this aarch64 host the direct assertions run scalar vs NEON. On x86 CI they
-//! run scalar vs SSE2/AVX2. Absent CPU features print a `SKIPPED` line so a
-//! fully-skipped run does not read as "passed". See #193 (x86) / #194 (SVE2).
+//! On aarch64 hosts the direct assertions run scalar vs NEON (SVE2 where
+//! available). On x86 CI they run scalar vs SSE2/AVX2/BMI2. Absent CPU features
+//! print a `SKIPPED` line so a fully-skipped run does not read as "passed". See
+//! #193 (x86) / #194 (SVE2).
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -33,8 +33,8 @@ use succinctly::dsv::{build_index_scalar, DsvConfig, DsvIndex};
 
 type Builder = fn(&[u8], &DsvConfig) -> DsvIndex;
 
-/// Carry-correct SIMD backends for this target (prefix-xor family). These agree
-/// with the scalar reference today, including at the bit-63 chunk boundary.
+/// The prefix-xor family (running `in_quote` flag). These have always agreed
+/// with the scalar reference, including at the bit-63 chunk boundary.
 fn prefix_xor_backends() -> Vec<(&'static str, Builder)> {
     #[allow(unused_mut)]
     let mut backends: Vec<(&'static str, Builder)> = Vec::new();
@@ -59,10 +59,10 @@ fn prefix_xor_backends() -> Vec<(&'static str, Builder)> {
     backends
 }
 
-/// The `toggle64`-based backends (BMI2 PDEP / SVE2 BDEP). They share the carry
-/// formula that drops a quote at bit 63, so they currently DISAGREE with scalar
-/// at a chunk boundary — bug #149 (with #182). Exercised only by the ignored
-/// repro test until #149 is fixed.
+/// The `toggle64`-based backends (BMI2 PDEP / SVE2 BDEP). Their shared carry
+/// formula used to drop a quote opening at bit 63 (#149, with #182); the carry
+/// is now derived from quote-count parity and they must agree with scalar
+/// everywhere, like the prefix-xor family.
 fn toggle64_backends() -> Vec<(&'static str, Builder)> {
     #[allow(unused_mut)]
     let mut backends: Vec<(&'static str, Builder)> = Vec::new();
@@ -87,6 +87,13 @@ fn toggle64_backends() -> Vec<(&'static str, Builder)> {
         }
     }
 
+    backends
+}
+
+/// Every SIMD backend available on this host, both families.
+fn all_backends() -> Vec<(&'static str, Builder)> {
+    let mut backends = prefix_xor_backends();
+    backends.extend(toggle64_backends());
     backends
 }
 
@@ -147,7 +154,7 @@ fn spanning_quote_input(open: usize) -> Vec<u8> {
 fn test_quote_at_every_offset_matches_scalar() {
     // Detect backends once so a missing feature prints one SKIPPED line per
     // test rather than one per assertion (#193).
-    let backends = prefix_xor_backends();
+    let backends = all_backends();
     let config = DsvConfig::default();
     // Opening quote at every byte offset across three 64-byte chunk boundaries.
     for open in 0..192usize {
@@ -160,9 +167,9 @@ fn test_quote_at_every_offset_matches_scalar() {
 fn test_bit63_carry_regression() {
     // A quote at offset 63 (last bit of chunk 0) must set the carry so the
     // delimiter at offset 64 (first bit of chunk 1) stays masked. Also check the
-    // neighboring boundary bits 62/64 and the next boundary at 127/128. The
-    // toggle64 backends fail this (#149) and are covered separately below.
-    let backends = prefix_xor_backends();
+    // neighboring boundary bits 62/64 and the next boundary at 127/128. This is
+    // the exact case the toggle64 overflow carry used to get wrong (#149).
+    let backends = all_backends();
     let config = DsvConfig::default();
     for open in [62usize, 63, 64, 65, 126, 127, 128, 129] {
         let mut text = vec![b'a'; open + 80];
@@ -180,7 +187,7 @@ fn test_random_csv_matches_scalar() {
     // Deterministic fuzz: randomized bytes over an alphabet of ordinary chars
     // plus every special byte used by the configs below (delimiters, newline,
     // quote, CR). Chunk-spanning quoted regions arise naturally.
-    let backends = prefix_xor_backends();
+    let backends = all_backends();
     let mut rng = ChaCha8Rng::seed_from_u64(0x9E37_79B9_7F4A_7C15);
     let alphabet = *b"ab,\t;\n\r\" ";
     let configs = [
@@ -199,11 +206,12 @@ fn test_random_csv_matches_scalar() {
     }
 }
 
+/// Named regression sweep for #149: the toggle64 (BMI2 PDEP / SVE2 BDEP) carry
+/// formula used to drop a quote opening at bit 63, so bmi2/sve2 disagreed with
+/// scalar at the chunk boundary. Kept as a dedicated test (in addition to the
+/// `all_backends()` sweeps above) so a reintroduction fails with #149 in the
+/// test name.
 #[test]
-#[ignore = "blocked on #149: the toggle64 (BMI2 PDEP / SVE2 BDEP) carry formula \
-            drops a quote at bit 63, so bmi2/sve2 disagree with scalar at the \
-            chunk boundary. Un-ignore once #149 fixes toggle64; run with \
-            `--ignored` on an x86 (bmi2) or SVE2 (sve2) host to reproduce."]
 fn test_toggle64_backends_match_scalar_149() {
     let backends = toggle64_backends();
     if backends.is_empty() {


### PR DESCRIPTION
Closes #149.

## Problem

`toggle64_bmi2` (BMI2 PDEP, default x86_64 fast path) and `toggle64_sve2` (SVE2 BDEP, Graviton4/Neoverse fast path) derived the chunk-to-chunk quote carry from the overflow of `((addend << 1) | c) + !w`. A quote **opening at bit 63** has its deposited bit shifted out of the word by `addend << 1`, so the addition never overflows and the next 64-byte chunk starts outside quotes — delimiters and newlines inside a quoted field spanning the boundary leak out as real separators. Silent row/field corruption, no error.

Nuance vs. the issue text, established by simulation: only masks where the bit-63 quote is an *opener* diverge (~half of bit-63 masks); a closer at bit 63 happens to overflow correctly. The outside mask itself was always correct — only the carry-out was wrong.

## Fix

Derive the carry from quote-count parity — the state entering the next chunk is the incoming state XOR the parity of quotes seen:

```rust
let new_carry = (w.count_ones() as u64 + c) & 1;
```

This is exactly what the NEON/SSE2/AVX2 prefix-xor backends and the scalar parser already compute, so all five backends now share one carry definition.

## Tests

- The old `test_toggle64_matches_prefix_xor` validated against a scalar port of the **same buggy formula**, so it passed despite the bug. Replaced with an independent bit-serial oracle (walks the word with an `inside` flag, like the scalar parser), mirrored for both kernels, over fixed edge patterns (incl. bit 63), every single-bit mask, and 512 splitmix64 masks × both carries.
- `tests/dsv_simd_differential_tests.rs`: un-ignored `test_toggle64_backends_match_scalar_149` (quote at every offset 0..192 vs scalar) and folded the bmi2/sve2 backends into the offset sweep, bit-63 boundary cases, and 3000-case fuzz.
- Docs that reproduced the overflow formula (`docs/parsing/dsv.md`, `docs/optimizations/parallel-prefix.md`, `docs/optimizations/bit-manipulation.md`) now show the parity carry and had drifted signatures corrected.

## Verification

- Fixed formula (mask + carry) matches the bit-serial oracle over **2,000,152 simulated (mask, carry) pairs — 0 mismatches** (the buggy formula diverges on ~50% of bit-63 masks).
- Full native test suite green on aarch64 (1333 lib tests + all integration suites); differential tests green scalar-vs-NEON.
- x86_64 build compiles and runs under Rosetta: SSE2 differential green; BMI2 self-skips with a visible `SKIPPED` line (Rosetta doesn't expose BMI2), so the x86 CI leg is the executing backstop for the PDEP kernel. SVE2 likewise relies on the shared formula + oracle test (#194 tracks SVE2 execution coverage).
- `cargo clippy --all-targets --all-features -- -D warnings` clean for both aarch64 and x86_64 targets.