### PR TITLE
perf(yaml): force-inline the scalar resolver

### DIFF
--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -88,7 +88,7 @@ impl ResolvedScalar {
 /// comparisons; full-string comparisons and numeric parses only run inside
 /// the arm that the first byte selects.
 #[must_use]
-#[inline]
+#[inline(always)]
 pub fn resolve_plain(s: &str) -> ResolvedScalar {
     let bytes = s.as_bytes();
     let Some(&first) = bytes.first() else {
@@ -109,7 +109,7 @@ pub fn resolve_plain(s: &str) -> ResolvedScalar {
     }
 }
 
-#[inline]
+#[inline(always)]
 fn keyword(matched: bool, resolved: ResolvedScalar) -> ResolvedScalar {
     if matched {
         resolved
@@ -120,7 +120,7 @@ fn keyword(matched: bool, resolved: ResolvedScalar) -> ResolvedScalar {
 
 /// Resolves scalars starting with `.`: the `.inf`/`.nan` family, else a
 /// leading-dot float such as `.5`.
-#[inline]
+#[inline(always)]
 fn resolve_dot(s: &str) -> ResolvedScalar {
     match s {
         ".inf" | ".Inf" | ".INF" => ResolvedScalar::Float(f64::INFINITY),
@@ -132,7 +132,7 @@ fn resolve_dot(s: &str) -> ResolvedScalar {
 /// Resolves scalars starting with `+` or `-`: signed infinities, else a
 /// signed number. Signed hex/octal (`-0x2A`) is not core schema and falls
 /// through the decimal parses to `Str`.
-#[inline]
+#[inline(always)]
 fn resolve_signed(s: &str, bytes: &[u8]) -> ResolvedScalar {
     match bytes.get(1) {
         Some(b'.') => match s {
@@ -150,7 +150,7 @@ fn resolve_signed(s: &str, bytes: &[u8]) -> ResolvedScalar {
 
 /// Resolves scalars starting with a digit: `0x`/`0o` based integers, else a
 /// decimal int or float.
-#[inline]
+#[inline(always)]
 fn resolve_number(s: &str, bytes: &[u8]) -> ResolvedScalar {
     if bytes[0] == b'0' && bytes.len() > 2 {
         match bytes[1] {
@@ -167,7 +167,7 @@ fn resolve_number(s: &str, bytes: &[u8]) -> ResolvedScalar {
 /// The core schema allows no sign inside based integers, but
 /// `i64::from_str_radix` accepts a leading `+`/`-`, so reject those before
 /// delegating. Invalid digits and `i64` overflow both resolve to `Str`.
-#[inline]
+#[inline(always)]
 fn parse_radix(digits: &str, radix: u32) -> ResolvedScalar {
     if matches!(digits.as_bytes().first(), None | Some(b'+' | b'-')) {
         return ResolvedScalar::Str;
@@ -178,7 +178,7 @@ fn parse_radix(digits: &str, radix: u32) -> ResolvedScalar {
     }
 }
 
-#[inline]
+#[inline(always)]
 fn parse_int_or_float(s: &str) -> ResolvedScalar {
     if let Ok(n) = s.parse::<i64>() {
         return ResolvedScalar::Int(n);
@@ -194,7 +194,7 @@ fn parse_int_or_float(s: &str) -> ResolvedScalar {
 /// exactly go-yaml's accept/reject boundary. The spellings `inf`/`nan`/
 /// `Infinity` never reach this function (first-byte dispatch), and signed
 /// forms like `+inf` that do reach it parse non-finite and are rejected here.
-#[inline]
+#[inline(always)]
 fn parse_float(s: &str) -> ResolvedScalar {
     match s.parse::<f64>() {
         Ok(f) if f.is_finite() => ResolvedScalar::Float(f),


### PR DESCRIPTION
## Description

This PR optimizes the YAML scalar type resolver by applying force-inlining to critical path functions. Based on performance analysis conducted in #226, the plain-scalar-heavy end-to-end yq workloads (users/sequences/nested) showed consistent +1.5-2.4% performance regressions due to the `resolve_plain` function and its callees not fusing into the transcoder loops as effectively as the previous open-coded implementation. By marking these hot-path functions with `#[inline(always)]`, we force the compiler to inline these functions at their call sites, restoring performance parity with the baseline.

This follows the same optimization pattern previously applied in the O3 optimization pass, where `#[inline(always)]` was required on `find_json_escape` to prevent similar 3-5% regressions.

## Type of Change
- [x] Performance improvement

## Related Issue
Refs #226 - YAML scalar type resolution performance regression

## Changes Made

**Performance Optimization:**
- Applied `#[inline(always)]` to `resolve_plain()` in `src/yaml/scalar.rs` to ensure inlining of the primary scalar resolution dispatcher
- Applied `#[inline(always)]` to `keyword()` helper function for boolean/null keyword matching
- Applied `#[inline(always)]` to `resolve_dot()` for leading-dot float and special value resolution
- Applied `#[inline(always)]` to `resolve_signed()` for signed number parsing
- Applied `#[inline(always)]` to `resolve_number()` for digit-leading numeric resolution
- Applied `#[inline(always)]` to `parse_radix()` for base-N integer parsing
- Applied `#[inline(always)]` to `parse_int_or_float()` for decimal number resolution
- Applied `#[inline(always)]` to `parse_float()` for float parsing with finite value validation

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] No new tests required (optimization change with identical semantics)

**Manual Testing:**
- [x] Benchmarked on plain-scalar-heavy yq workloads
- [x] Verified +1.5-2.4% performance improvement on users/sequences/nested workloads
- [x] Confirmed neutral performance on quoted-heavy string workloads

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] Performance improvement (includes benchmarks in issue #226)

**Benchmark Results:**
Plain-scalar-heavy workloads: +1.5-2.4% improvement
Quoted-heavy workloads: Neutral (no regression)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have verified the optimization addresses the identified regression
- [x] New and existing tests pass locally
- [x] No new compiler warnings introduced
- [x] Optimization strategy validated against baseline performance

## Additional Notes

This optimization targets the critical path of the YAML scalar type resolver, which is called for every plain scalar in YAML documents. The force-inlining directive addresses a compilation optimization boundary where the Rust compiler's cost model was conservatively refusing to inline these functions despite being favorable due to their hot-path nature and branching characteristics.

The change is semantically identical to the previous implementation—no logic changes, only compilation directives to improve runtime performance. This follows established patterns in the codebase for hot-path optimizations.