### PR TITLE
fix(simd): make NEON nibble classifier byte-exact

### DIFF
--- a/.claude/skills/simd-optimization/SKILL.md
+++ b/.claude/skills/simd-optimization/SKILL.md
@@ -112,6 +112,24 @@ unsafe fn unsigned_le(a: __m128i, b: __m128i) -> __m128i {
 }
 ```
 
+## Nibble Lookup Tables Must Be Exact (#186)
+
+`lo_table[byte & 0xF] & hi_table[byte >> 4]` classifies each bit plane as the
+Cartesian product {lo nibbles} × {hi nibbles} it is set for. A byte set is
+encoded exactly only as a union of such products, **one bit plane per
+product**:
+
+- `A-Z` (0x41-0x5A) spans two hi nibbles → needs two planes
+  (`{1..F}×{4}` and `{0..A}×{5}`). One shared "uppercase" plane matches all
+  of `0x40-0x5F`, over-matching `@ \ ^ _`.
+- `{',' ':'}` is not a product ({A,C} × {2,3} also contains `*` and `<`) →
+  needs a plane per character.
+
+Over-matches hide on valid input (the extra bytes are invalid JSON there) and
+surface as cross-backend index divergence on fuzzed/malformed input. Verify
+tables with an exhaustive 256-byte test against the scalar predicate (see
+`json/simd/neon.rs` table tests).
+
 ## Testing Strategy
 
 **Problem**: Runtime dispatch only tests highest available SIMD level.
@@ -173,6 +191,7 @@ cargo bench --bench json_simd
 4. **Consider architecture** - Zen 4 splits AVX-512, future Zen 5 may not
 5. **Amdahl's Law always wins** - Optimize what matters (the slow 80%)
 6. **Remove failed optimizations** - Slower code creates technical debt
+7. **Nibble tables: one bit plane per Cartesian product** - Shared planes over-match boundary bytes (#186)
 
 ## See Also
 

--- a/docs/optimizations/lookup-tables.md
+++ b/docs/optimizations/lookup-tables.md
@@ -158,6 +158,13 @@ fn classify_chars_nibble(chars: uint8x16_t) -> uint8x16_t {
 **Benefit**: Replaces 13 comparison operations with 2 lookups + 1 AND.
 **Result**: 2-6% speedup in JSON parsing.
 
+**Exactness caveat (#186)**: each bit plane of the AND matches exactly the
+Cartesian product {lo nibbles} × {hi nibbles} it is set for in the two
+tables. Encode one bit plane per product — a plane shared across products
+(e.g. one "uppercase" bit for hi nibbles 4 and 5) matches the full product
+`0x40-0x5F` and misclassifies boundary bytes like `@ \ ^ _`. Exhaustive
+256-byte table tests in `json/simd/neon.rs` enforce exactness.
+
 ### AVX2 vpshufb
 
 Similar technique on x86:
@@ -304,7 +311,7 @@ fn main() {
 | BYTE_FIND_CLOSE         | 4 KB    | `trees/bp.rs`         | BP find-close per byte     |
 | TRANSITION_TABLE        | 1 KB    | `json/pfsm_tables.rs` | PFSM state transitions     |
 | PHI_TABLE               | 1 KB    | `json/pfsm_tables.rs` | PFSM output generation     |
-| Nibble tables (NEON)    | 32 B    | `json/simd/neon.rs`   | Character classification   |
+| Nibble tables (NEON)    | 64 B    | `json/simd/neon.rs`   | Structural + value classes |
 
 **Total**: ~9 KB of lookup tables
 

--- a/docs/optimizations/simd.md
+++ b/docs/optimizations/simd.md
@@ -194,6 +194,14 @@ unsafe fn nibble_classify(chars: uint8x16_t) -> uint8x16_t {
 
 **Result**: Replaces 13 comparisons with 6 operations.
 
+**Exactness caveat (#186)**: each bit plane of `lo_table[lo] & hi_table[hi]`
+matches exactly the Cartesian product {lo nibbles} × {hi nibbles} it is set
+for. A byte set that is not such a product (e.g. `,`+`:`, or a range like
+`A-Z` that spans two hi nibbles) needs one bit plane per product — sharing a
+plane over-matches neighbouring bytes (`@ \ ^ _` for a shared "uppercase"
+plane) and silently diverges from backends using exact range compares.
+Exhaustive 256-byte table tests in `json/simd/neon.rs` enforce this.
+
 ### NEON PMULL for Prefix XOR (2026-01-22)
 
 Carryless multiplication computes prefix XOR in O(1) instead of O(log n):

--- a/docs/parsing/json.md
+++ b/docs/parsing/json.md
@@ -193,6 +193,11 @@ unsafe fn classify_neon(chunk: &[u8; 16]) -> Masks {
 
 This replaces 12+ comparisons with 2 lookups + 1 AND.
 
+Each bit plane of the AND matches exactly a Cartesian product
+{lo nibbles} × {hi nibbles}, so every character class gets one bit plane per
+product it decomposes into; sharing a plane over-matches boundary bytes and
+diverges from the other backends on invalid JSON (#186).
+
 See [simd.md](../optimizations/simd.md) for SIMD technique details.
 
 ---

--- a/src/json/simd/neon.rs
+++ b/src/json/simd/neon.rs
@@ -13,15 +13,20 @@ use crate::json::standard::{SemiIndex, State};
 use crate::json::BitWriter;
 
 // Nibble lookup tables for character classification.
-// Each byte in the result has bit flags indicating character class:
-//   Bit 0: opens ({ [)
-//   Bit 1: closes (} ])
-//   Bit 2: delims (, :)
-//   Bit 3: quote (")
-//   Bit 4: backslash (\)
 //
-// The tables are designed so that lo_table[lo_nibble] & hi_table[hi_nibble]
-// produces the correct flags for each ASCII character.
+// A byte's class is `lo_table[byte & 0x0F] & hi_table[byte >> 4]`, so each bit
+// plane matches exactly the Cartesian product {lo nibbles} x {hi nibbles} it is
+// set for in the two tables. A bit plane therefore encodes a byte set exactly
+// only if that set IS such a product; byte sets that aren't (like {, :}) need
+// one bit plane per product, or the classifier accepts extra bytes and the
+// index diverges from the scalar/x86 backends on invalid JSON (#186).
+//
+//   Bit 0: opens ({ [)      = {B} x {5,7}
+//   Bit 1: closes (} ])     = {D} x {5,7}
+//   Bit 2: comma (,)        = {C} x {2}
+//   Bit 3: quote (")        = {2} x {2}
+//   Bit 4: backslash (\)    = {C} x {5}
+//   Bit 5: colon (:)        = {A} x {3}
 
 /// Low nibble lookup table (indexed by byte & 0x0F)
 const LO_NIBBLE_TABLE: [u8; 16] = [
@@ -35,7 +40,7 @@ const LO_NIBBLE_TABLE: [u8; 16] = [
     0x00, // 7
     0x00, // 8
     0x00, // 9
-    0x04, // A: colon (:) has lo=A
+    0x20, // A: colon (:) has lo=A (bit 5)
     0x01, // B: opens ({ [) have lo=B
     0x14, // C: comma (,) has lo=C (bit 2), backslash (\) has lo=C (bit 4)
     0x02, // D: closes (} ]) have lo=D
@@ -48,7 +53,7 @@ const HI_NIBBLE_TABLE: [u8; 16] = [
     0x00, // 0
     0x00, // 1
     0x0C, // 2: comma (,) and quote (") have hi=2 (bits 2,3)
-    0x04, // 3: colon (:) has hi=3 (bit 2)
+    0x20, // 3: colon (:) has hi=3 (bit 5)
     0x00, // 4
     0x13, // 5: [ ] \ have hi=5 (bits 0,1,4)
     0x00, // 6
@@ -66,55 +71,60 @@ const HI_NIBBLE_TABLE: [u8; 16] = [
 // Classification result bit flags
 const FLAG_OPEN: u8 = 0x01;
 const FLAG_CLOSE: u8 = 0x02;
-const FLAG_DELIM: u8 = 0x04;
+const FLAG_COMMA: u8 = 0x04;
 const FLAG_QUOTE: u8 = 0x08;
 const FLAG_BACKSLASH: u8 = 0x10;
+const FLAG_COLON: u8 = 0x20;
+// Comma and colon need separate bit planes: a shared plane would match the
+// full product {A,C} x {2,3}, wrongly including '*' (0x2A) and '<' (0x3C).
+const DELIM_MASK: u8 = FLAG_COMMA | FLAG_COLON;
 
 // Value character detection lookup tables.
-// These use a different encoding than structural chars because value chars
-// include ranges (0-9, A-Z, a-z) that don't map cleanly to nibble AND.
+// A byte is a value char if `VALUE_LO_TABLE[lo] & VALUE_HI_TABLE[hi]` is
+// non-zero. The target set (matching scalar `standard::is_value_char`:
+// 0-9 A-Z a-z + - .) is not a single {lo} x {hi} product, so each bit plane
+// covers exactly one product; the whole-byte non-zero test then matches
+// exactly their union. Sharing a plane across hi nibbles (e.g. one
+// "uppercase" bit for hi=4 and hi=5) would cover the full product
+// {all lo} x {4,5} = 0x40-0x5F and misclassify `@ \ ^ _` (#186).
 //
-// Strategy: Use bit flags that indicate character classes, then AND the
-// lo and hi results. A character is a value char if the AND result has
-// any bit set in the VALUE_CHAR_MASK.
-//
-// Encoding:
-//   Bit 0: Could be digit (hi=3 with lo=0-9)
-//   Bit 1: Could be uppercase (hi=4 with lo=1-F, or hi=5 with lo=0-A)
-//   Bit 2: Could be lowercase (hi=6 with lo=1-F, or hi=7 with lo=0-A)
-//   Bit 3: Could be punct +/- (hi=2 with lo=B,D)
-//   Bit 4: Could be period (hi=2 with lo=E)
+//   Bit 0: digits 0-9 (0x30-0x39)    = {0..9} x {3}
+//   Bit 1: uppercase A-O (0x41-0x4F) = {1..F} x {4}
+//   Bit 2: uppercase P-Z (0x50-0x5A) = {0..A} x {5}
+//   Bit 3: lowercase a-o (0x61-0x6F) = {1..F} x {6}
+//   Bit 4: lowercase p-z (0x70-0x7A) = {0..A} x {7}
+//   Bit 5: punct + - . (0x2B/2D/2E)  = {B,D,E} x {2}
 
 /// Low nibble lookup for value chars
 const VALUE_LO_TABLE: [u8; 16] = [
-    0x07, // 0: digit, upper (0x50), lower (0x70)
-    0x07, // 1: digit, upper (0x41, 0x51), lower (0x61, 0x71)
-    0x07, // 2: digit, upper (0x42, 0x52), lower (0x62, 0x72)
-    0x07, // 3: digit, upper (0x43, 0x53), lower (0x63, 0x73)
-    0x07, // 4: digit, upper (0x44, 0x54), lower (0x64, 0x74)
-    0x07, // 5: digit, upper (0x45, 0x55), lower (0x65, 0x75)
-    0x07, // 6: digit, upper (0x46, 0x56), lower (0x66, 0x76)
-    0x07, // 7: digit, upper (0x47, 0x57), lower (0x67, 0x77)
-    0x07, // 8: digit, upper (0x48, 0x58), lower (0x68, 0x78)
-    0x07, // 9: digit, upper (0x49, 0x59), lower (0x69, 0x79)
-    0x06, // A: upper (0x4A, 0x5A), lower (0x6A, 0x7A) - NOT digit
-    0x0E, // B: upper (0x4B), lower (0x6B), punct '+' (0x2B)
-    0x06, // C: upper (0x4C), lower (0x6C)
-    0x0E, // D: upper (0x4D), lower (0x6D), punct '-' (0x2D)
-    0x16, // E: upper (0x4E), lower (0x6E), period '.' (0x2E)
-    0x06, // F: upper (0x4F), lower (0x6F)
+    0x15, // 0: digit, upper P-Z (0x50), lower p-z (0x70)
+    0x1F, // 1: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1F, // 2: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1F, // 3: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1F, // 4: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1F, // 5: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1F, // 6: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1F, // 7: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1F, // 8: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1F, // 9: digit, upper A-O/P-Z, lower a-o/p-z
+    0x1E, // A: upper A-O/P-Z (0x4A, 0x5A), lower a-o/p-z (0x6A, 0x7A) - NOT digit
+    0x2A, // B: upper A-O (0x4B), lower a-o (0x6B), punct '+' (0x2B)
+    0x0A, // C: upper A-O (0x4C), lower a-o (0x6C)
+    0x2A, // D: upper A-O (0x4D), lower a-o (0x6D), punct '-' (0x2D)
+    0x2A, // E: upper A-O (0x4E), lower a-o (0x6E), punct '.' (0x2E)
+    0x0A, // F: upper A-O (0x4F), lower a-o (0x6F)
 ];
 
 /// High nibble lookup for value chars
 const VALUE_HI_TABLE: [u8; 16] = [
     0x00, // 0: nothing
     0x00, // 1: nothing
-    0x18, // 2: punct (+,-) and period (.)
+    0x20, // 2: punct (+ - .)
     0x01, // 3: digits
     0x02, // 4: uppercase A-O (0x41-0x4F)
-    0x02, // 5: uppercase P-Z (0x50-0x5A)
-    0x04, // 6: lowercase a-o (0x61-0x6F)
-    0x04, // 7: lowercase p-z (0x70-0x7A)
+    0x04, // 5: uppercase P-Z (0x50-0x5A)
+    0x08, // 6: lowercase a-o (0x61-0x6F)
+    0x10, // 7: lowercase p-z (0x70-0x7A)
     0x00, // 8: nothing
     0x00, // 9: nothing
     0x00, // A: nothing
@@ -239,7 +249,7 @@ unsafe fn classify_chars(chunk: uint8x16_t) -> CharClass {
         // vtstq_u8 returns 0xFF if (a & b) != 0, else 0x00
         let flag_open_vec = vdupq_n_u8(FLAG_OPEN);
         let flag_close_vec = vdupq_n_u8(FLAG_CLOSE);
-        let flag_delim_vec = vdupq_n_u8(FLAG_DELIM);
+        let flag_delim_vec = vdupq_n_u8(DELIM_MASK);
         let flag_quote_vec = vdupq_n_u8(FLAG_QUOTE);
         let flag_backslash_vec = vdupq_n_u8(FLAG_BACKSLASH);
 
@@ -822,6 +832,58 @@ mod tests {
         (0..n)
             .map(|i| if get_bit(words, i) { '1' } else { '0' })
             .collect()
+    }
+
+    /// The nibble-AND value tables must reproduce the scalar
+    /// `standard::is_value_char` predicate for every byte value; any
+    /// over-match diverges the NEON index from all other backends on
+    /// invalid JSON (#186).
+    #[test]
+    fn test_value_tables_match_scalar_predicate() {
+        for b in 0..=255u8 {
+            let classified =
+                VALUE_LO_TABLE[(b & 0x0F) as usize] & VALUE_HI_TABLE[(b >> 4) as usize];
+            let expected = b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.');
+            assert_eq!(
+                classified != 0,
+                expected,
+                "byte 0x{b:02X} misclassified as value char"
+            );
+        }
+    }
+
+    /// Each structural bit plane must match its exact byte set for every
+    /// byte value; a plane covering a larger nibble product than its class
+    /// (e.g. delim matching '*'/'<') diverges the NEON index from all other
+    /// backends on invalid JSON (#186).
+    #[test]
+    fn test_structural_tables_match_exact_byte_sets() {
+        for b in 0..=255u8 {
+            let classified =
+                LO_NIBBLE_TABLE[(b & 0x0F) as usize] & HI_NIBBLE_TABLE[(b >> 4) as usize];
+            let cases = [
+                (
+                    "open",
+                    classified & FLAG_OPEN != 0,
+                    matches!(b, b'{' | b'['),
+                ),
+                (
+                    "close",
+                    classified & FLAG_CLOSE != 0,
+                    matches!(b, b'}' | b']'),
+                ),
+                (
+                    "delim",
+                    classified & DELIM_MASK != 0,
+                    matches!(b, b',' | b':'),
+                ),
+                ("quote", classified & FLAG_QUOTE != 0, b == b'"'),
+                ("backslash", classified & FLAG_BACKSLASH != 0, b == b'\\'),
+            ];
+            for (class, got, expected) in cases {
+                assert_eq!(got, expected, "byte 0x{b:02X} misclassified as {class}");
+            }
+        }
     }
 
     #[test]

--- a/tests/simd_level_tests.rs
+++ b/tests/simd_level_tests.rs
@@ -1,31 +1,53 @@
+#![allow(unsafe_code)]
+// SVE2 build functions are `unsafe fn` (require runtime
+// feature detection); every call site here is gated on `sve2::has_sve2()`.
 //! Cross-level SIMD testing to ensure all instruction set levels work correctly.
 //!
-//! This test suite explicitly tests all SIMD levels (SSE2, SSE4.2, AVX2) and
-//! verifies they produce identical results. Unlike regular tests which use
-//! runtime dispatch to select the best level, these tests force-test each
-//! specific level regardless of what the CPU supports.
+//! This test suite explicitly tests all SIMD levels (SSE2, SSE4.2, AVX2 on
+//! x86_64; NEON, SVE2 on aarch64) and verifies they produce identical results.
+//! Unlike regular tests which use runtime dispatch to select the best level,
+//! these tests force-test each specific level regardless of what the CPU
+//! supports.
+
+/// Test data: various JSON inputs to test.
+///
+/// Includes invalid JSON: all backends must produce identical indexes even on
+/// malformed input, otherwise the same fuzz case indexes differently per
+/// architecture (#186).
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+fn test_cases() -> Vec<(&'static str, &'static [u8])> {
+    vec![
+        ("empty object", b"{}"),
+        ("empty array", b"[]"),
+        ("simple object", br#"{"a":"b"}"#),
+        ("simple array", b"[1,2,3]"),
+        ("nested", br#"{"a":{"b":1},"c":[2,3]}"#),
+        ("escaped", br#"{"key":"val\"ue"}"#),
+        ("numbers", br#"{"int":123,"float":45.67,"sci":1e-5}"#),
+        ("whitespace", b"{  \"a\"  :  1  }"),
+        (
+            "long",
+            br#"{"name":"value","number":12345,"array":[1,2,3],"nested":{"x":"y"}}"#,
+        ),
+        // Bytes adjacent to the value-char ranges (0-9 A-Z a-z + - .), which a
+        // range-endpoint bug would misclassify as value chars (#186).
+        ("invalid value boundary bytes", b"[@\\^_`|~\x7F]"),
+        // Bytes sharing nibbles with ',' (0x2C) and ':' (0x3A).
+        ("invalid delim boundary bytes", b"[*<]"),
+        // Same boundary bytes straddling the 16B and 32B chunk boundaries:
+        // '@' at offset 15, '`' at 16, '|' at 31, '~' at 32.
+        (
+            "invalid boundary bytes straddling chunks",
+            b"[              @`              |~]",
+        ),
+    ]
+}
 
 #[cfg(target_arch = "x86_64")]
 mod x86_simd_levels {
     use succinctly::json;
 
-    /// Test data: various JSON inputs to test
-    fn test_cases() -> Vec<(&'static str, &'static [u8])> {
-        vec![
-            ("empty object", b"{}"),
-            ("empty array", b"[]"),
-            ("simple object", br#"{"a":"b"}"#),
-            ("simple array", b"[1,2,3]"),
-            ("nested", br#"{"a":{"b":1},"c":[2,3]}"#),
-            ("escaped", br#"{"key":"val\"ue"}"#),
-            ("numbers", br#"{"int":123,"float":45.67,"sci":1e-5}"#),
-            ("whitespace", b"{  \"a\"  :  1  }"),
-            (
-                "long",
-                br#"{"name":"value","number":12345,"array":[1,2,3],"nested":{"x":"y"}}"#,
-            ),
-        ]
-    }
+    use super::test_cases;
 
     /// Detection guard for SSE4.2; emits a visible `SKIPPED` line when
     /// unavailable so a fully-skipped level doesn't read as green (#193).
@@ -207,6 +229,222 @@ mod x86_simd_levels {
                 let avx2 = json::simd::avx2::build_semi_index_standard(json);
                 assert_eq!(avx2.ib, scalar.ib, "{name}: AVX2 IB mismatch");
                 assert_eq!(avx2.bp, scalar.bp, "{name}: AVX2 BP mismatch");
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64_simd_levels {
+    use succinctly::json;
+
+    use super::test_cases;
+
+    /// Detection guard for SVE2; emits a visible `SKIPPED` line when
+    /// unavailable so a fully-skipped level doesn't read as green (#193).
+    fn has_sve2() -> bool {
+        let available = json::simd::sve2::has_sve2();
+        if !available {
+            eprintln!("SKIPPED simd level [sve2]: sve2 not detected (see #193)");
+        }
+        available
+    }
+
+    #[test]
+    fn test_all_simd_levels_match_scalar_standard() {
+        let run_sve2 = has_sve2();
+        for (name, json_bytes) in test_cases() {
+            // Scalar reference
+            let scalar = json::standard::build_semi_index(json_bytes);
+
+            // NEON (always available on aarch64)
+            let neon = json::simd::neon::build_semi_index_standard(json_bytes);
+            assert_eq!(neon.ib, scalar.ib, "{name}: NEON IB mismatch");
+            assert_eq!(neon.bp, scalar.bp, "{name}: NEON BP mismatch");
+            assert_eq!(neon.state, scalar.state, "{name}: NEON state mismatch");
+
+            // SVE2 (if supported)
+            if run_sve2 {
+                let sve2 = unsafe { json::simd::sve2::build_semi_index_standard(json_bytes) };
+                assert_eq!(sve2.ib, scalar.ib, "{name}: SVE2 IB mismatch");
+                assert_eq!(sve2.bp, scalar.bp, "{name}: SVE2 BP mismatch");
+                assert_eq!(sve2.state, scalar.state, "{name}: SVE2 state mismatch");
+            }
+        }
+    }
+
+    #[test]
+    fn test_all_simd_levels_match_scalar_simple() {
+        let run_sve2 = has_sve2();
+        for (name, json_bytes) in test_cases() {
+            // Scalar reference
+            let scalar = json::simple::build_semi_index(json_bytes);
+
+            // NEON (always available on aarch64)
+            let neon = json::simd::neon::build_semi_index_simple(json_bytes);
+            assert_eq!(neon.ib, scalar.ib, "{name}: NEON IB mismatch");
+            assert_eq!(neon.bp, scalar.bp, "{name}: NEON BP mismatch");
+            assert_eq!(neon.state, scalar.state, "{name}: NEON state mismatch");
+
+            // SVE2 (if supported)
+            if run_sve2 {
+                let sve2 = unsafe { json::simd::sve2::build_semi_index_simple(json_bytes) };
+                assert_eq!(sve2.ib, scalar.ib, "{name}: SVE2 IB mismatch");
+                assert_eq!(sve2.bp, scalar.bp, "{name}: SVE2 BP mismatch");
+                assert_eq!(sve2.state, scalar.state, "{name}: SVE2 state mismatch");
+            }
+        }
+    }
+}
+
+/// Exhaustive per-byte differential guard (#186).
+///
+/// Every byte value 0..=255, embedded in several contexts (bare, mid-chunk,
+/// straddling the 16B and 32B chunk boundaries, inside strings, escaped), must
+/// produce exactly the scalar index on every available SIMD backend — including
+/// on invalid JSON. Divergence on invalid input means the same fuzz case
+/// indexes differently per architecture.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+mod per_byte_differential {
+    use succinctly::json;
+
+    /// Contexts in which each byte is embedded before indexing.
+    fn contexts(b: u8) -> Vec<(&'static str, Vec<u8>)> {
+        let at_offset = |len: usize, offset: usize| {
+            let mut v = vec![b' '; len];
+            v[offset] = b;
+            v
+        };
+        vec![
+            ("bare byte", vec![b]),
+            ("mid chunk", at_offset(17, 8)),
+            ("before 16B boundary", at_offset(33, 15)),
+            ("at 16B boundary", at_offset(33, 16)),
+            ("before 32B boundary", at_offset(48, 31)),
+            ("at 32B boundary", at_offset(48, 32)),
+            ("inside string", vec![b'"', b, b'"']),
+            ("escaped in string", vec![b'"', b'\\', b, b'"']),
+            (
+                "as object value",
+                [br#"{"k":"#.as_slice(), &[b], b"}"].concat(),
+            ),
+        ]
+    }
+
+    type StandardBackend = (
+        &'static str,
+        Box<dyn Fn(&[u8]) -> json::standard::SemiIndex>,
+    );
+    type SimpleBackend = (&'static str, Box<dyn Fn(&[u8]) -> json::simple::SemiIndex>);
+
+    fn standard_backends() -> Vec<StandardBackend> {
+        let mut backends: Vec<StandardBackend> = Vec::new();
+        #[cfg(target_arch = "x86_64")]
+        {
+            backends.push(("sse2", Box::new(json::simd::x86::build_semi_index_standard)));
+            if is_x86_feature_detected!("sse4.2") {
+                backends.push((
+                    "sse4.2",
+                    Box::new(json::simd::sse42::build_semi_index_standard),
+                ));
+            }
+            if is_x86_feature_detected!("avx2") {
+                backends.push((
+                    "avx2",
+                    Box::new(json::simd::avx2::build_semi_index_standard),
+                ));
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            backends.push((
+                "neon",
+                Box::new(json::simd::neon::build_semi_index_standard),
+            ));
+            if json::simd::sve2::has_sve2() {
+                backends.push((
+                    "sve2",
+                    Box::new(|j: &[u8]| unsafe { json::simd::sve2::build_semi_index_standard(j) }),
+                ));
+            }
+        }
+        backends
+    }
+
+    fn simple_backends() -> Vec<SimpleBackend> {
+        let mut backends: Vec<SimpleBackend> = Vec::new();
+        #[cfg(target_arch = "x86_64")]
+        {
+            backends.push(("sse2", Box::new(json::simd::x86::build_semi_index_simple)));
+            if is_x86_feature_detected!("sse4.2") {
+                backends.push((
+                    "sse4.2",
+                    Box::new(json::simd::sse42::build_semi_index_simple),
+                ));
+            }
+            if is_x86_feature_detected!("avx2") {
+                backends.push(("avx2", Box::new(json::simd::avx2::build_semi_index_simple)));
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            backends.push(("neon", Box::new(json::simd::neon::build_semi_index_simple)));
+            if json::simd::sve2::has_sve2() {
+                backends.push((
+                    "sve2",
+                    Box::new(|j: &[u8]| unsafe { json::simd::sve2::build_semi_index_simple(j) }),
+                ));
+            }
+        }
+        backends
+    }
+
+    #[test]
+    fn test_every_byte_matches_scalar_standard() {
+        let backends = standard_backends();
+        for b in 0..=255u8 {
+            for (ctx, input) in contexts(b) {
+                let scalar = json::standard::build_semi_index(&input);
+                for (level, build) in &backends {
+                    let simd = build(&input);
+                    assert_eq!(
+                        simd.ib, scalar.ib,
+                        "byte 0x{b:02X} [{ctx}]: {level} IB mismatch"
+                    );
+                    assert_eq!(
+                        simd.bp, scalar.bp,
+                        "byte 0x{b:02X} [{ctx}]: {level} BP mismatch"
+                    );
+                    assert_eq!(
+                        simd.state, scalar.state,
+                        "byte 0x{b:02X} [{ctx}]: {level} state mismatch"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_every_byte_matches_scalar_simple() {
+        let backends = simple_backends();
+        for b in 0..=255u8 {
+            for (ctx, input) in contexts(b) {
+                let scalar = json::simple::build_semi_index(&input);
+                for (level, build) in &backends {
+                    let simd = build(&input);
+                    assert_eq!(
+                        simd.ib, scalar.ib,
+                        "byte 0x{b:02X} [{ctx}]: {level} IB mismatch"
+                    );
+                    assert_eq!(
+                        simd.bp, scalar.bp,
+                        "byte 0x{b:02X} [{ctx}]: {level} BP mismatch"
+                    );
+                    assert_eq!(
+                        simd.state, scalar.state,
+                        "byte 0x{b:02X} [{ctx}]: {level} state mismatch"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #186

## Problem

NEON is the only JSON backend classifying characters with nibble-AND lookup tables; every other backend (scalar, PFSM, SSE2, SSE4.2, AVX2, SVE2) uses exact range checks. A nibble-AND bit plane matches exactly the Cartesian product {lo nibbles} × {hi nibbles} it is set for, and the old encoding shared planes across products, so two classifiers over-matched:

- **Value tables** (standard cursor): the shared "uppercase"/"lowercase" planes covered all of `0x40-0x5F`/`0x60-0x7F`, wrongly flagging ``@ \ ^ _ ` | ~ DEL`` as value chars.
- **Structural tables** (simple cursor): the single delim plane covered `{A,C} × {2,3}`, wrongly flagging `*` (0x2A) and `<` (0x3C) as delims. (The issue attributed both sets to the value tables; the simple path never reads `value_chars`.)

All of these bytes appear outside strings only in invalid JSON, so valid input was unaffected — but ARM built a differently-imbalanced BP than x86 for the same malformed input (fuzz/differential hazard).

## Fix

Constants-only re-encoding, one bit plane per exact Cartesian product: the value set (`0-9 A-Z a-z + - .`, matching `standard::is_value_char`) decomposes into 6 products; the delim flag splits into separate comma and colon planes tested through a two-bit mask. The emitted instruction sequence is unchanged (same `vqtbl1q_u8`/`vandq_u8`/`vtstq_u8` ops), so there is no performance impact to measure.

## Tests

- Exhaustive 256-byte in-module tests: nibble tables ≡ scalar predicates for every flag.
- `tests/simd_level_tests.rs`: new aarch64 module (NEON, and SVE2 when detected, vs scalar) mirroring the x86 module; invalid boundary-byte cases added to the shared test data (also exercised by the x86 legs); and an exhaustive per-byte differential test embedding every byte value in bare/mid-chunk/16B/32B-straddle/in-string/escaped contexts for both cursors on all available backends.
- Red→green verified on Apple Silicon: the new differential tests failed on NEON exactly for the #186 bytes before the fix, and pass after. Full suite + `clippy --all-targets --all-features -D warnings` clean.

## Docs

SIMD docs and the simd-optimization skill now record the exactness rule (one bit plane per Cartesian product), and the lookup-table inventory counts all four 16-byte NEON tables.