### PR TITLE
fix(lib): select1 underflow on zero-marker words in lightweight DSV index

### DIFF
--- a/src/dsv/cursor.rs
+++ b/src/dsv/cursor.rs
@@ -396,6 +396,47 @@ mod tests {
         assert_eq!(row.get(3), None);
     }
 
+    /// Issue #196: a field spanning a full 64-byte word leaves that word with
+    /// zero markers, producing duplicate cumulative rank entries that made
+    /// select1 underflow during field navigation.
+    #[test]
+    fn test_field_navigation_across_zero_marker_word_regression_196() {
+        // Markers at 0, 128, 129; word 1 (bytes 64..128) has none.
+        let mut csv = vec![b'a'; 130];
+        csv[0] = b',';
+        csv[128] = b',';
+        csv[129] = b'\n';
+        let config = DsvConfig::default();
+        let index = build_index(&csv, &config);
+
+        let mut cursor = DsvCursor::new(&csv, &index);
+        assert_eq!(cursor.current_field(), b"");
+        assert!(cursor.next_field());
+        assert_eq!(cursor.current_field(), &csv[1..128]);
+        assert!(cursor.next_field());
+        assert_eq!(cursor.current_field(), b"");
+        assert!(!cursor.next_field());
+    }
+
+    /// Issue #196: same underflow through goto_row when a row spans a full
+    /// 64-byte word without newlines.
+    #[test]
+    fn test_goto_row_across_zero_newline_word_regression_196() {
+        // Newlines at 1 and 131; word 1 (bytes 64..128) has none.
+        let mut csv = vec![b'a'; 132];
+        csv[0] = b'x';
+        csv[1] = b'\n';
+        csv[131] = b'\n';
+        let config = DsvConfig::default();
+        let index = build_index(&csv, &config);
+
+        let mut cursor = DsvCursor::new(&csv, &index);
+        assert!(cursor.goto_row(1));
+        assert_eq!(cursor.position(), 2);
+        assert_eq!(cursor.current_field(), &csv[2..131]);
+        assert!(!cursor.goto_row(2)); // text ends after row 1
+    }
+
     #[test]
     fn test_strip_quotes() {
         assert_eq!(strip_quotes(b"\"hello\""), b"hello");

--- a/src/dsv/index_lightweight.rs
+++ b/src/dsv/index_lightweight.rs
@@ -109,12 +109,12 @@ impl DsvIndexLightweight {
             return None;
         }
 
-        // Binary search to find the word containing the k-th bit
-        let target_rank = (k + 1) as u32;
-        let word_idx = match self.markers_rank.binary_search(&target_rank) {
-            Ok(idx) => idx.saturating_sub(1),
-            Err(idx) => idx.saturating_sub(1),
-        };
+        // Find the word containing the k-th bit: the last word whose
+        // cumulative rank is <= k. partition_point is duplicate-stable, unlike
+        // binary_search, which returns an arbitrary index among the equal
+        // entries produced by zero-marker words (issue #196). rank[0] == 0, so
+        // the partition point is always >= 1.
+        let word_idx = self.markers_rank.partition_point(|&r| r as usize <= k) - 1;
 
         if word_idx >= self.markers.len() {
             return None;
@@ -168,11 +168,8 @@ impl DsvIndexLightweight {
             return None;
         }
 
-        let target_rank = (k + 1) as u32;
-        let word_idx = match self.newlines_rank.binary_search(&target_rank) {
-            Ok(idx) => idx.saturating_sub(1),
-            Err(idx) => idx.saturating_sub(1),
-        };
+        // See markers_select1: duplicate-stable word lookup (issue #196).
+        let word_idx = self.newlines_rank.partition_point(|&r| r as usize <= k) - 1;
 
         if word_idx >= self.newlines.len() {
             return None;
@@ -262,5 +259,40 @@ mod tests {
         // text_len is a plain parameter, so exercising the #188 guard needs no
         // 4 GiB allocation.
         let _ = DsvIndexLightweight::new(vec![], vec![], u32::MAX as usize + 1);
+    }
+
+    /// Issue #196: a word with zero markers produces duplicate entries in the
+    /// cumulative rank array, and select1 must still find the right word.
+    #[test]
+    fn test_select1_zero_marker_word_regression_196() {
+        let markers = vec![0b1u64, 0, 0b11];
+        let newlines = vec![0b1u64, 0, 0b10];
+        let index = DsvIndexLightweight::new(markers, newlines, 192);
+
+        assert_eq!(index.markers_rank, vec![0, 1, 1, 3]);
+        assert_eq!(index.markers_select1(0), Some(0));
+        assert_eq!(index.markers_select1(1), Some(128));
+        assert_eq!(index.markers_select1(2), Some(129));
+        assert_eq!(index.markers_select1(3), None);
+
+        assert_eq!(index.newlines_rank, vec![0, 1, 1, 2]);
+        assert_eq!(index.newlines_select1(0), Some(0));
+        assert_eq!(index.newlines_select1(1), Some(129));
+        assert_eq!(index.newlines_select1(2), None);
+    }
+
+    #[test]
+    fn test_select1_leading_zero_word() {
+        let markers = vec![0u64, 0b101];
+        let newlines = vec![0u64, 0b10];
+        let index = DsvIndexLightweight::new(markers, newlines, 128);
+
+        assert_eq!(index.markers_rank, vec![0, 0, 2]);
+        assert_eq!(index.markers_select1(0), Some(64));
+        assert_eq!(index.markers_select1(1), Some(66));
+        assert_eq!(index.markers_select1(2), None);
+
+        assert_eq!(index.newlines_select1(0), Some(65));
+        assert_eq!(index.newlines_select1(1), None);
     }
 }

--- a/tests/dsv_select_tests.rs
+++ b/tests/dsv_select_tests.rs
@@ -1,0 +1,82 @@
+//! Regression and property tests for DSV lightweight select1 (issue #196).
+//!
+//! `markers_select1`/`newlines_select1` underflowed (`k - rank_before`) when a
+//! 64-bit word contained no markers: the cumulative rank array then holds
+//! duplicate values, and `binary_search` returns an arbitrary index among
+//! equal elements, which can land one word past the one containing the k-th
+//! bit.
+
+use proptest::prelude::*;
+use succinctly::dsv::{build_index_scalar, DsvConfig};
+
+/// Positions of set bits in `words`, restricted to `[0, len)`.
+fn set_bit_positions(words: &[u64], len: usize) -> Vec<usize> {
+    let mut out = Vec::new();
+    for (w, &word) in words.iter().enumerate() {
+        let mut bits = word;
+        while bits != 0 {
+            let pos = w * 64 + bits.trailing_zeros() as usize;
+            if pos < len {
+                out.push(pos);
+            }
+            bits &= bits - 1;
+        }
+    }
+    out
+}
+
+/// The exact reproducer from issue #196: marker in word 0, marker-free word 1,
+/// markers in word 2, yielding `markers_rank == [0, 1, 1, 3]`.
+#[test]
+fn select1_zero_marker_word_reproducer_196() {
+    let mut text = vec![b'a'; 130];
+    text[0] = b',';
+    text[128] = b',';
+    text[129] = b'\n';
+    let idx = build_index_scalar(&text, &DsvConfig::default());
+
+    assert_eq!(idx.markers_select1(0), Some(0));
+    assert_eq!(idx.markers_select1(1), Some(128));
+    assert_eq!(idx.markers_select1(2), Some(129));
+    assert_eq!(idx.markers_select1(3), None);
+
+    assert_eq!(idx.newlines_select1(0), Some(129));
+    assert_eq!(idx.newlines_select1(1), None);
+}
+
+proptest! {
+    /// select1 agrees with a naive scan of the index's bit words, and
+    /// round-trips through rank1, on texts biased toward long marker-free
+    /// runs (so zero-marker words are common).
+    #[test]
+    fn select1_matches_naive_scan_and_rank1_roundtrip(
+        text in prop::collection::vec(
+            prop_oneof![
+                100 => Just(b'a'),
+                1 => Just(b','),
+                1 => Just(b'\n'),
+                1 => Just(b'"'),
+            ],
+            0..512,
+        )
+    ) {
+        let idx = build_index_scalar(&text, &DsvConfig::default());
+        let lw = idx.as_lightweight();
+
+        let markers = set_bit_positions(&lw.markers, text.len());
+        prop_assert_eq!(idx.marker_count(), markers.len());
+        for (k, &pos) in markers.iter().enumerate() {
+            prop_assert_eq!(idx.markers_select1(k), Some(pos));
+            prop_assert_eq!(idx.markers_rank1(pos + 1), k + 1);
+        }
+        prop_assert_eq!(idx.markers_select1(markers.len()), None);
+
+        let newlines = set_bit_positions(&lw.newlines, text.len());
+        prop_assert_eq!(idx.row_count(), newlines.len());
+        for (k, &pos) in newlines.iter().enumerate() {
+            prop_assert_eq!(idx.newlines_select1(k), Some(pos));
+            prop_assert_eq!(idx.newlines_rank1(pos + 1), k + 1);
+        }
+        prop_assert_eq!(idx.newlines_select1(newlines.len()), None);
+    }
+}


### PR DESCRIPTION
Fixes #196.

## Problem

`DsvIndexLightweight::markers_select1` and `newlines_select1` located the word containing the k-th set bit with `slice::binary_search` on the cumulative rank array. Any 64-bit word with zero markers produces **duplicate** entries in that array, and `binary_search` returns an *arbitrary* index among equal elements — when it lands on the higher duplicate, `word_idx` points one word too far, `rank_before` becomes `k + 1`, and `k - rank_before` underflows: `attempt to subtract with overflow` panic in debug, silently wrong position in release.

Reachable from ordinary `DsvCursor`/`DsvRows` navigation (`next_field`, `next_row`, `goto_row`, `current_field`) whenever a field or row spans a full 64-byte word.

## Fix

Replace the lookup in both functions with a duplicate-stable `partition_point` — the last word whose cumulative rank is `<= k`:

```rust
let word_idx = self.markers_rank.partition_point(|&r| r as usize <= k) - 1;
```

`rank[0] == 0` guarantees the partition point is ≥ 1, so the `- 1` cannot underflow; the existing `k >= total_ones` early-return guarantees the result is in bounds.

## Tests (written first; all panicked at `index_lightweight.rs:107`/`:164` pre-fix)

- **Unit** (`src/dsv/index_lightweight.rs`): hand-built words with a zero-marker middle word (`markers_rank == [0, 1, 1, 3]`) asserting exact positions for every k, plus a leading-zero-word case.
- **Cursor** (`src/dsv/cursor.rs`): field navigation across a 64-byte marker gap, and `goto_row` across a 64-byte newline gap.
- **Integration** (`tests/dsv_select_tests.rs`, new): the issue's exact 130-byte reproducer, plus a proptest checking `select1` against a naive bit scan and the `rank1` round-trip on texts biased toward long marker-free runs.

## Verification

- Full `cargo test` suite green (3 unrelated `jq_cli_tests` flakes — that harness shells out to `cargo run` per test and documents its own lock-contention flakiness; all 3 pass when re-run, and the file has zero DSV references).
- `cargo test --features simd` for the dsv lib/integration/differential targets green.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.