### PR TITLE
Fix silently-truncating u32/i16 counters in structural indices (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   new `YamlError::AliasCycle` variant instead of aborting with a stack overflow when the
   value is materialized (#153). Matches `yq`, which fails at decode time on the same
   input. Note: exhaustive `match`es on `YamlError` need a new arm.
+- **BalancedParens L2 excess overflow** (#188): the per-L2-block excess
+  counters were `i16` and overflowed at nesting depth > 32,767 (debug panic /
+  silent wrap in release). Widened to `i32` across the scalar, NEON, and
+  SSE4.1 build paths; deep nesting is no longer bounded by the index.
+- **BalancedParens stray-bit over-count** (#188): constructors did not mask
+  1-bits above `len` in the final partial word, inflating
+  `total_ones`/`rank1`/`select1`. Owned constructors now canonicalize the
+  final word in place; borrowed (`from_words*`, mmap) paths mask on read.
+- **SelectIndex sample overflow** (#188): `SampleEntry` counters were `u32`
+  and wrapped past 2^32 set bits (~512 MB of ones); widened to `u64`.
+
+### Changed
+
+- **4 GiB input ceilings enforced** (#188): instead of silently truncating
+  `u32` counters, builds now fail loudly for inputs over `u32::MAX` bytes —
+  `YamlIndex::build` returns the new `YamlError::InputTooLarge` variant
+  (minor API addition: exhaustive matches on `YamlError` gain an arm), while
+  `JsonIndex` and `DsvIndexLightweight` constructors panic with a documented
+  message. `BalancedParens` constructors assert a `u32::MAX`-bit ceiling.
+  See [docs/reference/limits.md](docs/reference/limits.md).
+- **SelectIndex sample entries doubled** from 8 to 16 bytes (one entry per
+  `sample_rate` set bits; ~6% of set-bit count at the default rate 256, up
+  from ~3%). Serialized (`serde`) representations of `BitVec`,
+  `BalancedParens`, and `SelectIndex` change accordingly.
 
 ## [0.7.0] - 2026-04-05
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -18,6 +18,12 @@ Language and feature reference documentation for succinctly.
 |---------------------------------------------------|---------------------------------|
 | [Environment Variables](environment-variables.md) | Every variable succinctly reads |
 
+## Limits
+
+| Document                    | Description                                 |
+|-----------------------------|---------------------------------------------|
+| [Input Size Limits](limits.md) | Enforced input ceilings and widened counters |
+
 ## See Also
 
 - [CLI Guide](../guides/cli.md) - Command-line tool reference

--- a/docs/reference/limits.md
+++ b/docs/reference/limits.md
@@ -1,0 +1,48 @@
+# Input Size Limits
+
+[Home](../../) > [Docs](../) > Limits
+
+Structural indices store counters in narrow integer types where the memory
+cost of widening would be significant. Since [#188](https://github.com/rust-works/succinctly/issues/188),
+every such ceiling is validated at build time and fails loudly instead of
+silently truncating.
+
+## Enforced Ceilings
+
+| Structure                        | Ceiling                        | On violation                              | Why not widen?                                          |
+|----------------------------------|--------------------------------|-------------------------------------------|---------------------------------------------------------|
+| `JsonIndex::build`/`from_parts`  | `u32::MAX` bytes (< 4 GiB)     | Panic (documented)                        | IB rank array is ~6.25% of input; u64 doubles it        |
+| `YamlIndex::build`               | `u32::MAX` bytes (< 4 GiB)     | `Err(YamlError::InputTooLarge)`           | Text positions stored as u32 throughout the semi-index  |
+| `DsvIndexLightweight::new`       | `u32::MAX` bytes (< 4 GiB)     | Panic (documented)                        | Two rank arrays are ~12.5% of input combined            |
+| `BalancedParens` constructors    | `u32::MAX` bits                | Panic (documented)                        | `rank_l1` stores absolute cumulative rank as u32        |
+
+The `BalancedParens` ceiling acts as a backstop for pathological JSON/YAML
+that emits more BP bits than input bytes: such inputs can exceed the BP
+ceiling before the byte ceiling, and the constructor assert catches them with
+a clear message.
+
+## Widened Counters (no ceiling)
+
+| Structure                        | Change                          | Reason                                                       |
+|----------------------------------|---------------------------------|--------------------------------------------------------------|
+| `BalancedParens` L2 excess       | `i16` → `i32`                   | Nesting depth > 32767 is realistic; widening costs ~nothing  |
+| `SelectIndex` sample entries     | `u32` → `u64`                   | > 2^32 set bits (~512 MB of ones) is within `huge-tests`     |
+
+Nesting depth is therefore no longer bounded by the index (previously
+~32,767); `BitVec`/`SelectIndex` support bitvectors past 2^32 set bits.
+
+## Practical Notes
+
+- The CLI tools (`sjq`, `syq`, DSV input) inherit these limits: a > 4 GiB
+  input file fails with the corresponding error or panic message rather than
+  producing wrong results.
+- All ceilings are per-document. Multi-document YAML streams are bounded by
+  the total input passed to a single `YamlIndex::build` call.
+- The design decision (widen cheap counters, validate ceilings on hot
+  arrays) is recorded in [#188](https://github.com/rust-works/succinctly/issues/188).
+
+## See Also
+
+- [BalancedParens](../architecture/balanced-parens.md) — rank directory and excess index internals
+- [BitVec](../architecture/bitvec.md) — rank/select directories
+- [Semi-indexing](../architecture/semi-indexing.md) — why indices track text positions

--- a/src/bits/select.rs
+++ b/src/bits/select.rs
@@ -13,13 +13,19 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_SAMPLE_RATE: u32 = 256;
 
 /// Sample entry storing word index and cumulative count before that word.
+///
+/// Both fields are `u64`, not `u32`: bitvectors past 2^32 set bits (~512 MB of
+/// ones — within the advertised `huge-tests` tier) previously wrapped
+/// `cumulative_before`, and past 2^32 words `word_idx` too (#188). The samples
+/// array holds one entry per `sample_rate` set bits, so the widening cost is
+/// negligible.
 #[derive(Clone, Copy, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct SampleEntry {
     /// Word index containing the sample point.
-    word_idx: u32,
+    word_idx: u64,
     /// Cumulative count of ones before this word (not including this word).
-    cumulative_before: u32,
+    cumulative_before: u64,
 }
 
 /// Sampled select index for accelerated select queries.
@@ -30,10 +36,10 @@ struct SampleEntry {
 ///
 /// # Space Overhead
 ///
-/// With sample rate k, overhead is approximately `8 / k` bytes per bit set.
-/// - Sample rate 64: ~12.5% overhead
-/// - Sample rate 256: ~3% overhead
-/// - Sample rate 512: ~1.5% overhead
+/// With sample rate k, overhead is approximately `16 / k` bytes per bit set.
+/// - Sample rate 64: ~25% overhead
+/// - Sample rate 256: ~6% overhead
+/// - Sample rate 512: ~3% overhead
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SelectIndex {
@@ -80,8 +86,8 @@ impl SelectIndex {
             // Check if any sample points fall within this word
             while next_sample < total_ones && count + pop > next_sample {
                 samples.push(SampleEntry {
-                    word_idx: word_idx as u32,
-                    cumulative_before: count as u32,
+                    word_idx: word_idx as u64,
+                    cumulative_before: count as u64,
                 });
                 next_sample += sample_rate as usize;
             }
@@ -228,5 +234,27 @@ mod tests {
         // Sample rate larger than total ones - only sample at 0
         assert_eq!(idx.jump_to(0), (0, 0));
         assert_eq!(idx.jump_to(15), (0, 15));
+    }
+
+    /// Regression test for #188: `cumulative_before` was u32 and wrapped past
+    /// 2^32 set bits. Needs ~800 MB RAM (512 MB of all-ones words plus the
+    /// sample array), hence the huge-tests gate.
+    #[test]
+    #[cfg(feature = "huge-tests")]
+    fn test_sample_entry_beyond_u32_max() {
+        let num_words = (u32::MAX as usize / 64) + 2;
+        let words = vec![u64::MAX; num_words];
+        let total_ones = num_words * 64;
+        assert!(total_ones > u32::MAX as usize);
+
+        let idx = SelectIndex::build(&words, total_ones, 256);
+
+        // All bits are ones, so the k-th 1-bit lives at bit position k and
+        // cumulative_before == start_word * 64 exactly.
+        let k = u32::MAX as usize + 1;
+        let (start_word, remaining) = idx.jump_to(k);
+        assert_eq!(start_word * 64 + remaining, k);
+        // The sample that answered this query sits beyond the old u32 range.
+        assert!(start_word as u64 * 64 > u64::from(u32::MAX));
     }
 }

--- a/src/dsv/index_lightweight.rs
+++ b/src/dsv/index_lightweight.rs
@@ -31,6 +31,11 @@ pub struct DsvIndexLightweight {
 
 /// Build cumulative rank array.
 /// Returns a vector where entry i = total 1-bits in words[0..i).
+///
+/// The `u32` accumulator is safe because `new` asserts
+/// `text_len <= u32::MAX` (#188), and set bits <= text_len. Widening both
+/// rank arrays to `u64` would double two hot per-word structures (~12.5% of
+/// input combined) for inputs the index cannot represent anyway.
 fn build_rank(words: &[u64]) -> Vec<u32> {
     let mut rank = Vec::with_capacity(words.len() + 1);
     let mut cumulative: u32 = 0;
@@ -44,7 +49,20 @@ fn build_rank(words: &[u64]) -> Vec<u32> {
 
 impl DsvIndexLightweight {
     /// Create a new lightweight index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `text_len` exceeds `u32::MAX` bytes (just under 4 GiB): the
+    /// cumulative rank arrays store counts as `u32` (#188). Larger inputs
+    /// would previously truncate silently. (The fields are `pub`, so a direct
+    /// struct literal can bypass this check; all crate builders funnel through
+    /// `new`.)
     pub fn new(markers: Vec<u64>, newlines: Vec<u64>, text_len: usize) -> Self {
+        assert!(
+            text_len as u64 <= u64::from(u32::MAX),
+            "DsvIndexLightweight supports inputs up to u32::MAX (4294967295) bytes; \
+             got {text_len} bytes (#188)"
+        );
         let markers_rank = build_rank(&markers);
         let newlines_rank = build_rank(&newlines);
 
@@ -235,5 +253,14 @@ mod tests {
         assert_eq!(index.markers_select1(1), Some(3));
         assert_eq!(index.markers_select1(2), Some(5));
         assert_eq!(index.markers_select1(3), Some(7));
+    }
+
+    #[test]
+    #[should_panic(expected = "up to u32::MAX")]
+    #[cfg(target_pointer_width = "64")]
+    fn test_text_len_guard_panics() {
+        // text_len is a plain parameter, so exercising the #188 guard needs no
+        // 4 GiB allocation.
+        let _ = DsvIndexLightweight::new(vec![], vec![], u32::MAX as usize + 1);
     }
 }

--- a/src/dsv/index_lightweight.rs
+++ b/src/dsv/index_lightweight.rs
@@ -59,7 +59,7 @@ impl DsvIndexLightweight {
     /// `new`.)
     pub fn new(markers: Vec<u64>, newlines: Vec<u64>, text_len: usize) -> Self {
         assert!(
-            text_len as u64 <= u64::from(u32::MAX),
+            u32::try_from(text_len).is_ok(),
             "DsvIndexLightweight supports inputs up to u32::MAX (4294967295) bytes; \
              got {text_len} bytes (#188)"
         );

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -79,6 +79,11 @@ pub struct JsonIndex<W = Vec<u64>> {
 
 /// Build cumulative popcount index for IB.
 /// Returns a vector where entry i = total 1-bits in words [0, i).
+///
+/// The `u32` accumulator is safe because every constructor asserts
+/// `ib_len <= u32::MAX` (#188), and set bits <= ib_len. Widening to `u64`
+/// would double a hot per-word array (~6.25% of input) for inputs the index
+/// cannot represent anyway.
 fn build_ib_rank(words: &[u64]) -> Vec<u32> {
     let mut rank = Vec::with_capacity(words.len() + 1);
     let mut cumulative: u32 = 0;
@@ -141,7 +146,18 @@ impl JsonIndex<Vec<u64>> {
     ///
     /// On supported platforms (aarch64, x86_64), this automatically uses
     /// SIMD-accelerated indexing for better performance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input exceeds `u32::MAX` bytes (just under 4 GiB): the
+    /// IB rank directory stores cumulative counts as `u32` (#188). Larger
+    /// inputs would previously truncate silently.
     pub fn build(json: &[u8]) -> Self {
+        assert!(
+            json.len() as u64 <= u64::from(u32::MAX),
+            "JsonIndex supports inputs up to u32::MAX (4294967295) bytes; got {} bytes (#188)",
+            json.len()
+        );
         #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
         let semi = crate::json::simd::build_semi_index_standard(json);
 
@@ -182,7 +198,18 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
     /// * `ib_len` - Number of valid bits in IB (typically == JSON text length)
     /// * `bp` - Balanced parentheses data
     /// * `bp_len` - Number of valid bits in BP
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ib_len` exceeds `u32::MAX` bits (#188): the IB rank
+    /// directory stores cumulative counts as `u32`. (Pathological JSON can
+    /// also push `bp_len` past `u32::MAX` first; `BalancedParens` asserts its
+    /// own ceiling.)
     pub fn from_parts(ib: W, ib_len: usize, bp: W, bp_len: usize) -> Self {
+        assert!(
+            ib_len as u64 <= u64::from(u32::MAX),
+            "JsonIndex supports inputs up to u32::MAX (4294967295) bytes; got {ib_len} bits (#188)"
+        );
         // Build cumulative popcount index for IB
         let ib_rank = build_ib_rank(ib.as_ref());
 
@@ -204,6 +231,11 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
     /// * `bp` - Balanced parentheses data
     /// * `bp_len` - Number of valid bits in BP
     /// * `newlines` - Newline position bitvector
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ib_len` exceeds `u32::MAX` bits (#188): the IB rank
+    /// directory stores cumulative counts as `u32`.
     pub fn from_parts_with_newlines(
         ib: W,
         ib_len: usize,
@@ -211,6 +243,10 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
         bp_len: usize,
         newlines: crate::bits::BitVec,
     ) -> Self {
+        assert!(
+            ib_len as u64 <= u64::from(u32::MAX),
+            "JsonIndex supports inputs up to u32::MAX (4294967295) bytes; got {ib_len} bits (#188)"
+        );
         let ib_rank = build_ib_rank(ib.as_ref());
 
         Self {
@@ -2033,6 +2069,15 @@ mod tests {
         let json = br#"{"a": 1}"#;
         let index = JsonIndex::build(json);
         assert!(!index.bp().is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "up to u32::MAX")]
+    #[cfg(target_pointer_width = "64")]
+    fn test_from_parts_len_guard_panics() {
+        // ib_len is a plain parameter, so exercising the #188 guard needs no
+        // 4 GiB allocation.
+        let _ = JsonIndex::from_parts(vec![], u32::MAX as usize + 1, vec![], 0);
     }
 
     #[test]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -154,7 +154,7 @@ impl JsonIndex<Vec<u64>> {
     /// inputs would previously truncate silently.
     pub fn build(json: &[u8]) -> Self {
         assert!(
-            json.len() as u64 <= u64::from(u32::MAX),
+            u32::try_from(json.len()).is_ok(),
             "JsonIndex supports inputs up to u32::MAX (4294967295) bytes; got {} bytes (#188)",
             json.len()
         );
@@ -207,7 +207,7 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
     /// own ceiling.)
     pub fn from_parts(ib: W, ib_len: usize, bp: W, bp_len: usize) -> Self {
         assert!(
-            ib_len as u64 <= u64::from(u32::MAX),
+            u32::try_from(ib_len).is_ok(),
             "JsonIndex supports inputs up to u32::MAX (4294967295) bytes; got {ib_len} bits (#188)"
         );
         // Build cumulative popcount index for IB
@@ -244,7 +244,7 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
         newlines: crate::bits::BitVec,
     ) -> Self {
         assert!(
-            ib_len as u64 <= u64::from(u32::MAX),
+            u32::try_from(ib_len).is_ok(),
             "JsonIndex supports inputs up to u32::MAX (4294967295) bytes; got {ib_len} bits (#188)"
         );
         let ib_rank = build_ib_rank(ib.as_ref());

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -1473,9 +1473,9 @@ pub struct BalancedParens<W = Vec<u64>, S: SelectSupport = NoSelect> {
     /// L2: Per-1024-word block min excess (relative to block start)
     ///
     /// `i32`, not `i16`: an L2 block spans 65536 bits, so block-relative excess
-    /// ranges over [-65536, 65536] and would wrap `i16` at nesting depth
-    /// > 32767 (#188). L0/L1 stay narrow because their spans bound the excess
-    /// to [-64, 64] and [-2048, 2048] respectively.
+    /// ranges over [-65536, 65536] and would wrap `i16` at nesting depth above
+    /// 32767 (#188). L0/L1 stay narrow because their spans bound the excess to
+    /// [-64, 64] and [-2048, 2048] respectively.
     l2_min_excess: Vec<i32>,
     /// L2: Per-1024-word block excess (total excess within this block)
     l2_block_excess: Vec<i32>,
@@ -1514,10 +1514,9 @@ fn build_bp_index(
 ) {
     // rank_l1 stores absolute cumulative rank as u32, so the structure cannot
     // represent more than u32::MAX bits (#188). Fail loudly instead of
-    // truncating. The comparison is via u64 so it stays meaningful on 32-bit
-    // targets.
+    // truncating. try_from keeps the check meaningful on 32-bit targets.
     assert!(
-        len as u64 <= u64::from(u32::MAX),
+        u32::try_from(len).is_ok(),
         "BalancedParens supports at most u32::MAX (4294967295) bits; got {len}. \
          The rank directory stores absolute cumulative counts as u32 (#188)"
     );
@@ -2725,7 +2724,7 @@ mod tests {
     fn test_from_words_ignores_stray_bits() {
         // Borrowed storage keeps the stray bits, but counting must not see
         // them (#188).
-        let words = vec![0b0011u64 | (u64::MAX << 4)];
+        let words = [0b0011u64 | (u64::MAX << 4)];
         let bp = BalancedParens::<_, NoSelect>::from_words(&words[..], 4);
         assert_eq!(
             bp.words()[0],
@@ -2742,7 +2741,7 @@ mod tests {
         // Two all-ones words with len = 68: 68 valid 1-bits plus 60 stray
         // 1-bits above len in the final word. select1 must resolve every valid
         // k and reject the rest despite the strays (#188).
-        let words = vec![u64::MAX, u64::MAX];
+        let words = [u64::MAX, u64::MAX];
         let bp = BalancedParens::<_, WithSelect>::from_words_with_select(&words[..], 68);
         assert_eq!(bp.total_ones(), 68);
         for k in 0..68 {

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -438,7 +438,7 @@ fn build_l2_index_neon(
     l1_min_excess: &[i16],
     l1_block_excess: &[i16],
     num_l2: usize,
-) -> (Vec<i16>, Vec<i16>) {
+) -> (Vec<i32>, Vec<i32>) {
     use core::arch::aarch64::*;
 
     let mut l2_min_excess = Vec::with_capacity(num_l2);
@@ -449,8 +449,14 @@ fn build_l2_index_neon(
     for block_idx in 0..num_l2 {
         let start = block_idx * FACTOR_L2;
         let end = (start + FACTOR_L2).min(num_l1);
-        let mut block_min: i16 = 0;
-        let mut running_excess: i16 = 0;
+        // i32: L2 block-relative excess spans [-65536, 65536], beyond i16
+        // (#188). The i16 SIMD lanes below stay chunk-relative and bounded:
+        // each L1 lane is in [-2048, 2048], so the 7-lane exclusive prefix is
+        // in [-14336, 14336], adjusted_min in [-16384, 14336], and the chunk
+        // sum in [-16384, 16384] — all within i16. Only the cross-chunk
+        // accumulation here is i32.
+        let mut block_min: i32 = 0;
+        let mut running_excess: i32 = 0;
 
         // Process 8 L1 blocks at a time with SIMD
         let mut i = start;
@@ -478,22 +484,19 @@ fn build_l2_index_neon(
                 let shifted4 = vextq_s16(vdupq_n_s16(0), sum2, 4);
                 let prefix_sum = vaddq_s16(sum2, shifted4);
 
-                // Add running_excess offset to prefix sum
-                let offset = vdupq_n_s16(running_excess);
-                let adjusted_prefix = vaddq_s16(prefix_sum, offset);
-
-                // We need exclusive prefix sum for min calculation
-                let exclusive_prefix = vextq_s16(offset, adjusted_prefix, 7);
+                // Zero-based exclusive prefix sum (chunk-relative; the
+                // running_excess offset is applied in scalar i32 below)
+                let exclusive_prefix = vextq_s16(vdupq_n_s16(0), prefix_sum, 7);
 
                 // Add to min_excess: min[i] + exclusive_prefix[i]
                 let adjusted_min = vaddq_s16(min_vals, exclusive_prefix);
 
-                // Find minimum using vminvq_s16
+                // Find chunk-relative minimum, then combine in i32
                 let chunk_min = vminvq_s16(adjusted_min);
-                block_min = block_min.min(chunk_min);
+                block_min = block_min.min(running_excess + i32::from(chunk_min));
 
                 // Update running excess with sum of all 8 values
-                running_excess += vaddvq_s16(excess);
+                running_excess += i32::from(vaddvq_s16(excess));
             }
             i += 8;
         }
@@ -502,8 +505,8 @@ fn build_l2_index_neon(
         while i < end {
             let l1_min = l1_min_excess[i];
             let l1_excess = l1_block_excess[i];
-            block_min = block_min.min(running_excess + l1_min);
-            running_excess += l1_excess;
+            block_min = block_min.min(running_excess + i32::from(l1_min));
+            running_excess += i32::from(l1_excess);
             i += 1;
         }
 
@@ -657,7 +660,7 @@ unsafe fn build_l2_index_sse41_impl(
     l1_min_excess: &[i16],
     l1_block_excess: &[i16],
     num_l2: usize,
-) -> (Vec<i16>, Vec<i16>) {
+) -> (Vec<i32>, Vec<i32>) {
     use core::arch::x86_64::*;
 
     let mut l2_min_excess = Vec::with_capacity(num_l2);
@@ -671,8 +674,14 @@ unsafe fn build_l2_index_sse41_impl(
     for block_idx in 0..num_l2 {
         let start = block_idx * FACTOR_L2;
         let end = (start + FACTOR_L2).min(num_l1);
-        let mut block_min: i16 = 0;
-        let mut running_excess: i16 = 0;
+        // i32: L2 block-relative excess spans [-65536, 65536], beyond i16
+        // (#188). The i16 SIMD lanes below stay chunk-relative and bounded:
+        // each L1 lane is in [-2048, 2048], so the 7-lane exclusive prefix is
+        // in [-14336, 14336], adjusted_min in [-16384, 14336], and the chunk
+        // sum in [-16384, 16384] — all within i16. Only the cross-chunk
+        // accumulation here is i32.
+        let mut block_min: i32 = 0;
+        let mut running_excess: i32 = 0;
 
         // Process 8 L1 blocks at a time with SIMD
         let mut i = start;
@@ -695,30 +704,27 @@ unsafe fn build_l2_index_sse41_impl(
             let shifted4 = _mm_slli_si128(sum2, 8);
             let prefix_sum = _mm_add_epi16(sum2, shifted4);
 
-            // Add running_excess offset
-            let offset = _mm_set1_epi16(running_excess);
-            let adjusted_prefix = _mm_add_epi16(prefix_sum, offset);
-
-            // Exclusive prefix sum
-            let exclusive_prefix = _mm_slli_si128(adjusted_prefix, 2);
-            let exclusive_prefix = _mm_insert_epi16(exclusive_prefix, running_excess as i32, 0);
+            // Zero-based exclusive prefix sum (chunk-relative; the shift pulls
+            // a zero into lane 0, and the running_excess offset is applied in
+            // scalar i32 below)
+            let exclusive_prefix = _mm_slli_si128(prefix_sum, 2);
 
             // Add to min_excess
             let adjusted_min = _mm_add_epi16(min_vals, exclusive_prefix);
 
-            // Find minimum with bias trick
+            // Find chunk-relative minimum with bias trick
             let biased = _mm_add_epi16(adjusted_min, bias);
             let minpos = _mm_minpos_epu16(biased);
             let biased_min = _mm_extract_epi16(minpos, 0) as i16;
             let chunk_min = biased_min.wrapping_add(i16::MIN);
 
-            block_min = block_min.min(chunk_min);
+            block_min = block_min.min(running_excess + i32::from(chunk_min));
 
             // Horizontal sum for running excess
             let sum_lo = _mm_add_epi16(excess, _mm_srli_si128(excess, 8));
             let sum_lo = _mm_add_epi16(sum_lo, _mm_srli_si128(sum_lo, 4));
             let sum_lo = _mm_add_epi16(sum_lo, _mm_srli_si128(sum_lo, 2));
-            running_excess += _mm_extract_epi16(sum_lo, 0) as i16;
+            running_excess += i32::from(_mm_extract_epi16(sum_lo, 0) as i16);
 
             i += 8;
         }
@@ -727,8 +733,8 @@ unsafe fn build_l2_index_sse41_impl(
         while i < end {
             let l1_min = l1_min_excess[i];
             let l1_excess = l1_block_excess[i];
-            block_min = block_min.min(running_excess + l1_min);
-            running_excess += l1_excess;
+            block_min = block_min.min(running_excess + i32::from(l1_min));
+            running_excess += i32::from(l1_excess);
             i += 1;
         }
 
@@ -745,7 +751,7 @@ fn build_l2_index_sse41(
     l1_min_excess: &[i16],
     l1_block_excess: &[i16],
     num_l2: usize,
-) -> (Vec<i16>, Vec<i16>) {
+) -> (Vec<i32>, Vec<i32>) {
     // SAFETY: We check for SSE4.1 support before calling
     unsafe { build_l2_index_sse41_impl(l1_min_excess, l1_block_excess, num_l2) }
 }
@@ -793,7 +799,7 @@ fn build_l2_index_scalar(
     l1_min_excess: &[i16],
     l1_block_excess: &[i16],
     num_l2: usize,
-) -> (Vec<i16>, Vec<i16>) {
+) -> (Vec<i32>, Vec<i32>) {
     let mut l2_min_excess = Vec::with_capacity(num_l2);
     let mut l2_block_excess = Vec::with_capacity(num_l2);
 
@@ -803,14 +809,15 @@ fn build_l2_index_scalar(
         let start = block_idx * FACTOR_L2;
         let end = (start + FACTOR_L2).min(num_l1);
 
-        let mut block_min: i16 = 0;
-        let mut running_excess: i16 = 0;
+        // i32: L2 block-relative excess spans [-65536, 65536] (#188).
+        let mut block_min: i32 = 0;
+        let mut running_excess: i32 = 0;
 
         for i in start..end {
             let l1_min = l1_min_excess[i];
             let l1_excess = l1_block_excess[i];
-            block_min = block_min.min(running_excess + l1_min);
-            running_excess += l1_excess;
+            block_min = block_min.min(running_excess + i32::from(l1_min));
+            running_excess += i32::from(l1_excess);
         }
 
         l2_min_excess.push(block_min);
@@ -1418,7 +1425,7 @@ const FACTOR_L2: usize = 32;
 /// Approximately 6-7% overhead:
 /// - L0: 2 bytes per word (min excess + word excess)
 /// - L1: 4 bytes per 32 words
-/// - L2: 4 bytes per 1024 words
+/// - L2: 8 bytes per 1024 words
 /// - Rank: ~1.5 bytes per 8 words
 ///
 /// # Example
@@ -1456,9 +1463,14 @@ pub struct BalancedParens<W = Vec<u64>, S: SelectSupport = NoSelect> {
     l1_block_excess: Vec<i16>,
 
     /// L2: Per-1024-word block min excess (relative to block start)
-    l2_min_excess: Vec<i16>,
+    ///
+    /// `i32`, not `i16`: an L2 block spans 65536 bits, so block-relative excess
+    /// ranges over [-65536, 65536] and would wrap `i16` at nesting depth
+    /// > 32767 (#188). L0/L1 stay narrow because their spans bound the excess
+    /// to [-64, 64] and [-2048, 2048] respectively.
+    l2_min_excess: Vec<i32>,
     /// L2: Per-1024-word block excess (total excess within this block)
-    l2_block_excess: Vec<i16>,
+    l2_block_excess: Vec<i32>,
 
     // --- Cumulative rank directory for O(1) rank1() ---
     /// Cumulative 1-bit count at the start of each 512-bit block (8 words)
@@ -1486,8 +1498,8 @@ fn build_bp_index(
     Vec<i16>,
     Vec<i16>,
     Vec<i16>,
-    Vec<i16>,
-    Vec<i16>,
+    Vec<i32>,
+    Vec<i32>,
     Vec<u32>,
     Vec<u64>,
     usize,
@@ -1600,14 +1612,15 @@ fn build_bp_index(
                 let start = block_idx * FACTOR_L2;
                 let end = (start + FACTOR_L2).min(num_l1);
 
-                let mut block_min: i16 = 0;
-                let mut running_excess: i16 = 0;
+                // i32: L2 block-relative excess spans [-65536, 65536] (#188).
+                let mut block_min: i32 = 0;
+                let mut running_excess: i32 = 0;
 
                 for i in start..end {
                     let l1_min = l1_min_excess[i];
                     let l1_excess = l1_block_excess[i];
-                    block_min = block_min.min(running_excess + l1_min);
-                    running_excess += l1_excess;
+                    block_min = block_min.min(running_excess + i32::from(l1_min));
+                    running_excess += i32::from(l1_excess);
                 }
 
                 l2_min_excess.push(block_min);
@@ -1630,14 +1643,15 @@ fn build_bp_index(
             let start = block_idx * FACTOR_L2;
             let end = (start + FACTOR_L2).min(num_l1);
 
-            let mut block_min: i16 = 0;
-            let mut running_excess: i16 = 0;
+            // i32: L2 block-relative excess spans [-65536, 65536] (#188).
+            let mut block_min: i32 = 0;
+            let mut running_excess: i32 = 0;
 
             for i in start..end {
                 let l1_min = l1_min_excess[i];
                 let l1_excess = l1_block_excess[i];
-                block_min = block_min.min(running_excess + l1_min);
-                running_excess += l1_excess;
+                block_min = block_min.min(running_excess + i32::from(l1_min));
+                running_excess += i32::from(l1_excess);
             }
 
             l2_min_excess.push(block_min);
@@ -2100,14 +2114,14 @@ impl<W: AsRef<[u64]>, S: SelectSupport> BalancedParens<W, S> {
                         return None;
                     }
 
-                    let min_e = self.l2_min_excess[l2_idx] as i32;
+                    let min_e = self.l2_min_excess[l2_idx];
                     if excess + min_e <= 0 {
                         state = State::CheckL1;
                     } else if pos < self.len {
                         if self.is_close(pos) && excess <= 1 {
                             return Some(pos);
                         }
-                        let l2_excess = self.l2_block_excess[l2_idx] as i32;
+                        let l2_excess = self.l2_block_excess[l2_idx];
                         excess += l2_excess;
                         pos += 64 * FACTOR_L1 * FACTOR_L2;
                         state = State::FromL2;
@@ -2597,16 +2611,11 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "blocked on #188: L1/L2 excess counters are i16 and overflow past \
-                32767-deep nesting (build panics in debug at bp.rs ~1639, \
-                silently wraps in release). Un-ignore once #188 widens the \
-                counters (including the SIMD build path); run with --ignored to \
-                reproduce the overflow today."]
     fn test_bp_nesting_beyond_i16_excess() {
-        // Overflow ceiling for #188 -- CONFIRMED failing today. Build a chain
-        // 40_000 deep (> i16::MAX) and require navigation to stay correct past
-        // the boundary; see test_bp_deep_nesting_navigation for the same
-        // assertions at a safe depth.
+        // Regression test for #188. Build a chain 40_000 deep (> i16::MAX) and
+        // require navigation to stay correct past the boundary; see
+        // test_bp_deep_nesting_navigation for the same assertions at a safe
+        // depth. The L2 excess counters are i32 so this no longer overflows.
         let depth = 40_000usize;
         let (words, len) = deeply_nested(depth);
         let bp = BalancedParens::new(words, len);
@@ -3550,6 +3559,62 @@ mod tests {
             scalar_excess, sse41_excess,
             "L2 block_excess mismatch: scalar={scalar_excess:?}, sse41={sse41_excess:?}"
         );
+    }
+
+    /// Words whose L2 excess exceeds i16::MAX: one full L2 block of opens
+    /// (excess +65536) followed by one full L2 block of closes (#188).
+    #[cfg(all(feature = "simd", any(target_arch = "x86_64", target_arch = "aarch64")))]
+    fn beyond_i16_l2_words() -> Vec<u64> {
+        let mut words = vec![u64::MAX; 1024];
+        words.extend(vec![0u64; 1024]);
+        words
+    }
+
+    #[test]
+    #[cfg(all(feature = "simd", target_arch = "x86_64"))]
+    fn test_sse41_l2_matches_scalar_beyond_i16() {
+        if !is_x86_feature_detected!("sse4.1") {
+            println!("SSE4.1 not available, skipping test");
+            return;
+        }
+
+        let words = beyond_i16_l2_words();
+        let num_words = words.len();
+        let (l0_min, l0_excess) = build_l0_index(&words, num_words * 64, num_words);
+        let num_l1 = num_words.div_ceil(FACTOR_L1);
+        let num_l2 = num_l1.div_ceil(FACTOR_L2);
+
+        let (l1_min, l1_excess) = build_l1_index_scalar(&l0_min, &l0_excess, num_l1);
+        let (scalar_min, scalar_excess) = build_l2_index_scalar(&l1_min, &l1_excess, num_l2);
+        let (sse41_min, sse41_excess) = build_l2_index_sse41(&l1_min, &l1_excess, num_l2);
+
+        // Verify actual values beyond the i16 range, not just SIMD/scalar agreement
+        assert_eq!(scalar_excess[0], 65536);
+        assert_eq!(scalar_excess[1], -65536);
+        assert_eq!(scalar_min[1], -65536);
+        assert_eq!(scalar_min, sse41_min);
+        assert_eq!(scalar_excess, sse41_excess);
+    }
+
+    #[test]
+    #[cfg(all(feature = "simd", target_arch = "aarch64"))]
+    fn test_neon_l2_matches_scalar_beyond_i16() {
+        let words = beyond_i16_l2_words();
+        let num_words = words.len();
+        let (l0_min, l0_excess) = build_l0_index(&words, num_words * 64, num_words);
+        let num_l1 = num_words.div_ceil(FACTOR_L1);
+        let num_l2 = num_l1.div_ceil(FACTOR_L2);
+
+        let (l1_min, l1_excess) = build_l1_index_scalar(&l0_min, &l0_excess, num_l1);
+        let (scalar_min, scalar_excess) = build_l2_index_scalar(&l1_min, &l1_excess, num_l2);
+        let (neon_min, neon_excess) = build_l2_index_neon(&l1_min, &l1_excess, num_l2);
+
+        // Verify actual values beyond the i16 range, not just SIMD/scalar agreement
+        assert_eq!(scalar_excess[0], 65536);
+        assert_eq!(scalar_excess[1], -65536);
+        assert_eq!(scalar_min[1], -65536);
+        assert_eq!(scalar_min, neon_min);
+        assert_eq!(scalar_excess, neon_excess);
     }
 
     /// Test that full BalancedParens construction with SSE4.1 produces correct results.

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -87,6 +87,14 @@ pub struct WithSelect {
 
 impl SelectSupport for WithSelect {
     fn build(words: &[u64], total_ones: usize) -> Self {
+        // INVARIANT: `total_ones` must count only the valid bits below `len`
+        // (build_bp_index masks the final partial word when counting, #188).
+        // Given that, stray 1-bits above `len` in the final word cannot skew
+        // the samples: every sample's cumulative_before sums only full words
+        // before its target word, and in select1 `remaining` stays below the
+        // masked popcount of the target word, so select_in_word never lands on
+        // a stray bit (the `result < len` check backstops the rest).
+        //
         // Use default sample rate of 256 for ~3% overhead
         Self {
             select_idx: SelectIndex::build(words, total_ones, 256),
@@ -1504,6 +1512,16 @@ fn build_bp_index(
     Vec<u64>,
     usize,
 ) {
+    // rank_l1 stores absolute cumulative rank as u32, so the structure cannot
+    // represent more than u32::MAX bits (#188). Fail loudly instead of
+    // truncating. The comparison is via u64 so it stays meaningful on 32-bit
+    // targets.
+    assert!(
+        len as u64 <= u64::from(u32::MAX),
+        "BalancedParens supports at most u32::MAX (4294967295) bits; got {len}. \
+         The rank directory stores absolute cumulative counts as u32 (#188)"
+    );
+
     if words.is_empty() || len == 0 {
         return (
             Vec::new(),
@@ -1667,6 +1685,17 @@ fn build_bp_index(
 
     let mut cumulative_rank: u64 = 0;
 
+    // Mask stray 1-bits above `len` in the final partial word when counting.
+    // Borrowed storage (`from_words` over mmap) cannot be masked in place, so
+    // count through a masked read instead; otherwise total_ones/rank1/select1
+    // over-count (#188). The excess indices are unaffected: build_l0_index
+    // already scans only the valid bits of the final word. rank_l2 packed
+    // offsets are written before each word's count is added and the partial
+    // word is the last word overall, so strays could only ever leak into
+    // cumulative_rank, fixed here.
+    let tail_bits = len % 64;
+    let last_word_idx = num_words - 1;
+
     for block_idx in 0..num_rank_blocks {
         let block_start = block_idx * WORDS_PER_RANK_BLOCK;
         let block_end = (block_start + WORDS_PER_RANK_BLOCK).min(num_words);
@@ -1683,7 +1712,11 @@ fn build_bp_index(
                 // Pack offset into 9 bits at position (i-1)*9
                 l2_packed |= (block_cumulative as u64) << ((i - 1) * 9);
             }
-            block_cumulative += words[word_idx].count_ones() as u16;
+            let mut word = words[word_idx];
+            if word_idx == last_word_idx && tail_bits != 0 {
+                word &= (1u64 << tail_bits) - 1;
+            }
+            block_cumulative += word.count_ones() as u16;
         }
 
         rank_l2.push(l2_packed);
@@ -1703,11 +1736,31 @@ fn build_bp_index(
     )
 }
 
+/// Clear bits at or above `len` in the final word (same canonicalization as
+/// `BitVec::with_config`), so stray 1-bits cannot skew counting (#188).
+fn mask_final_word_in_place(words: &mut [u64], len: usize) {
+    if len % 64 != 0 {
+        if let Some(last) = words.last_mut() {
+            *last &= (1u64 << (len % 64)) - 1;
+        }
+    }
+}
+
 impl BalancedParens<Vec<u64>, NoSelect> {
     /// Build from an owned bitvector representing balanced parentheses.
     ///
     /// Creates a BalancedParens without select support (default for JSON).
-    pub fn new(words: Vec<u64>, len: usize) -> Self {
+    ///
+    /// Bits at or above `len` in the final word are cleared (as in
+    /// [`BitVec::with_config`](crate::bits::BitVec::with_config)), so stray
+    /// 1-bits cannot skew `total_ones`/`rank1`/`select1` (#188).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds `u32::MAX` bits (#188): the rank directory
+    /// stores absolute cumulative counts as `u32`.
+    pub fn new(mut words: Vec<u64>, len: usize) -> Self {
+        mask_final_word_in_place(&mut words, len);
         let (
             l0_min_excess,
             l0_word_excess,
@@ -1741,7 +1794,16 @@ impl BalancedParens<Vec<u64>, WithSelect> {
     /// Build from an owned bitvector with select support enabled.
     ///
     /// Creates a BalancedParens with O(1) select1 support (for YAML).
-    pub fn new_with_select(words: Vec<u64>, len: usize) -> Self {
+    ///
+    /// Bits at or above `len` in the final word are cleared, so stray 1-bits
+    /// cannot skew `total_ones`/`rank1`/`select1` (#188).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds `u32::MAX` bits (#188): the rank directory
+    /// stores absolute cumulative counts as `u32`.
+    pub fn new_with_select(mut words: Vec<u64>, len: usize) -> Self {
+        mask_final_word_in_place(&mut words, len);
         let (
             l0_min_excess,
             l0_word_excess,
@@ -1778,6 +1840,15 @@ impl<W: AsRef<[u64]>> BalancedParens<W, NoSelect> {
     ///
     /// Creates a BalancedParens without select support (default for JSON).
     /// This is useful for borrowed data, e.g., from mmap.
+    ///
+    /// The storage is not mutated: stray 1-bits at or above `len` in the final
+    /// word are ignored when counting (masked on read), so they cannot skew
+    /// `total_ones`/`rank1`/`select1` (#188).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds `u32::MAX` bits (#188): the rank directory
+    /// stores absolute cumulative counts as `u32`.
     pub fn from_words(words: W, len: usize) -> Self {
         let (
             l0_min_excess,
@@ -1813,6 +1884,15 @@ impl<W: AsRef<[u64]>> BalancedParens<W, WithSelect> {
     ///
     /// Creates a BalancedParens with O(1) select1 support (for YAML).
     /// This is useful for borrowed data, e.g., from mmap.
+    ///
+    /// The storage is not mutated: stray 1-bits at or above `len` in the final
+    /// word are ignored when counting (masked on read), so they cannot skew
+    /// `total_ones`/`rank1`/`select1` (#188).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds `u32::MAX` bits (#188): the rank directory
+    /// stores absolute cumulative counts as `u32`.
     pub fn from_words_with_select(words: W, len: usize) -> Self {
         let (
             l0_min_excess,
@@ -1958,6 +2038,11 @@ impl<W: AsRef<[u64]>, S: SelectSupport> BalancedParens<W, S> {
     }
 
     /// Fallback slow rank1 for edge cases.
+    ///
+    /// Safe against stray 1-bits above `len` in the final word: `rank1` clamps
+    /// `p` to `len` before calling, so the full-word loop below only covers
+    /// words strictly before the partial word, which is always counted through
+    /// the `bit_idx` mask (#188).
     fn rank1_slow(&self, p: usize) -> usize {
         let words = self.words.as_ref();
         let word_idx = p / 64;
@@ -2622,6 +2707,58 @@ mod tests {
         assert_eq!(bp.excess(depth - 1), depth as i32);
         assert_eq!(bp.find_close(32767), Some(len - 1 - 32767));
         assert_eq!(bp.enclose(33000), Some(32999));
+    }
+
+    #[test]
+    fn test_new_masks_stray_bits_in_final_word() {
+        // "(())" (bits 0011) plus 60 stray 1-bits above len; new() must clear
+        // them (#188).
+        let word = 0b0011u64 | (u64::MAX << 4);
+        let bp = BalancedParens::new(vec![word], 4);
+        assert_eq!(bp.words()[0], 0b0011);
+        assert_eq!(bp.total_ones(), 2);
+        assert_eq!(bp.rank1(4), 2);
+        assert_eq!(bp.find_close(0), Some(3));
+    }
+
+    #[test]
+    fn test_from_words_ignores_stray_bits() {
+        // Borrowed storage keeps the stray bits, but counting must not see
+        // them (#188).
+        let words = vec![0b0011u64 | (u64::MAX << 4)];
+        let bp = BalancedParens::<_, NoSelect>::from_words(&words[..], 4);
+        assert_eq!(
+            bp.words()[0],
+            words[0],
+            "borrowed words must not be mutated"
+        );
+        assert_eq!(bp.total_ones(), 2);
+        assert_eq!(bp.rank1(4), 2);
+        assert_eq!(bp.find_close(0), Some(3));
+    }
+
+    #[test]
+    fn test_from_words_with_select_stray_bits() {
+        // Two all-ones words with len = 68: 68 valid 1-bits plus 60 stray
+        // 1-bits above len in the final word. select1 must resolve every valid
+        // k and reject the rest despite the strays (#188).
+        let words = vec![u64::MAX, u64::MAX];
+        let bp = BalancedParens::<_, WithSelect>::from_words_with_select(&words[..], 68);
+        assert_eq!(bp.total_ones(), 68);
+        for k in 0..68 {
+            assert_eq!(bp.select1(k), Some(k), "select1({k})");
+        }
+        assert_eq!(bp.select1(68), None);
+        assert_eq!(bp.select1(69), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "at most u32::MAX")]
+    #[cfg(target_pointer_width = "64")]
+    fn test_bp_len_guard_panics() {
+        // The guard precedes the empty-words early return, so no allocation is
+        // needed to exercise it (#188).
+        let _ = BalancedParens::<_, NoSelect>::from_words(Vec::<u64>::new(), u32::MAX as usize + 1);
     }
 
     /// Build `(` + `pairs` copies of `()` + `)`: one outer pair wrapping a long

--- a/src/yaml/error.rs
+++ b/src/yaml/error.rs
@@ -144,6 +144,15 @@ pub enum YamlError {
         /// The configured depth limit
         limit: usize,
     },
+
+    /// Input exceeds the maximum indexable size (`u32::MAX` bytes).
+    ///
+    /// Text positions are stored as `u32` in the semi-index (#188), so larger
+    /// inputs would silently truncate offsets instead of failing cleanly.
+    InputTooLarge {
+        /// Actual input length in bytes
+        len: usize,
+    },
 }
 
 impl fmt::Display for YamlError {
@@ -249,6 +258,12 @@ impl fmt::Display for YamlError {
                 write!(
                     f,
                     "nesting depth exceeds limit of {limit} at offset {offset}"
+                )
+            }
+            Self::InputTooLarge { len } => {
+                write!(
+                    f,
+                    "input too large: {len} bytes exceeds the u32::MAX-byte (4 GiB) indexing limit"
                 )
             }
         }
@@ -413,6 +428,15 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "unexpected end of input: while parsing flow sequence"
+        );
+    }
+
+    #[test]
+    fn test_input_too_large_display() {
+        let err = YamlError::InputTooLarge { len: 5_000_000_000 };
+        assert_eq!(
+            err.to_string(),
+            "input too large: 5000000000 bytes exceeds the u32::MAX-byte (4 GiB) indexing limit"
         );
     }
 

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -135,6 +135,12 @@ impl YamlIndex<Vec<u64>> {
     ///
     /// The newline index for line/column lookup is built lazily on first
     /// call to `to_line_column()` or `to_offset()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`YamlError::InputTooLarge`] for inputs over `u32::MAX` bytes
+    /// (just under 4 GiB): the semi-index stores text positions as `u32`
+    /// (#188). Other variants report malformed YAML.
     pub fn build(yaml: &[u8]) -> Result<Self, YamlError> {
         let semi = build_semi_index(yaml)?;
 

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3616,7 +3616,24 @@ impl<'a> Parser<'a> {
 }
 
 /// Build a semi-index from YAML input.
+///
+/// # Errors
+///
+/// Returns [`YamlError::InputTooLarge`] for inputs over `u32::MAX` bytes
+/// (just under 4 GiB): the semi-index stores text positions as `u32` (#188).
+/// Other variants report malformed YAML. (Pathological YAML can also push the
+/// BP bit count past `u32::MAX` before the text does; `BalancedParens`
+/// asserts its own ceiling as a loud backstop.)
 pub fn build_semi_index(input: &[u8]) -> Result<SemiIndex, YamlError> {
+    // Text positions (bp_to_text/bp_to_text_end and the select samples and
+    // rank arrays derived from them) are stored as u32, so inputs past
+    // u32::MAX bytes would silently truncate offsets (#188). Every position
+    // written is <= input.len() (including the input.len() sentinel for null
+    // nodes, an exact fit at the maximum), so this single guard makes all
+    // downstream u32 casts safe.
+    if input.len() as u64 > u64::from(u32::MAX) {
+        return Err(YamlError::InputTooLarge { len: input.len() });
+    }
     let mut parser = Parser::new(input);
     parser.parse()
 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3631,7 +3631,7 @@ pub fn build_semi_index(input: &[u8]) -> Result<SemiIndex, YamlError> {
     // written is <= input.len() (including the input.len() sentinel for null
     // nodes, an exact fit at the maximum), so this single guard makes all
     // downstream u32 casts safe.
-    if input.len() as u64 > u64::from(u32::MAX) {
+    if u32::try_from(input.len()).is_err() {
         return Err(YamlError::InputTooLarge { len: input.len() });
     }
     let mut parser = Parser::new(input);


### PR DESCRIPTION
Closes #188.

## Approach

One shared decision across all six checklist sites: **widen** counters whose overflow is realistically reachable and cheap to fix, **validate a documented ceiling** where overflow needs >4 GiB input and widening would double hot per-word arrays (6-25% of input) in a library whose headline is ~3-6% overhead.

## Per-checklist-item disposition

| Issue item | Disposition |
|---|---|
| `bp.rs` L2 min/total-excess + `running_excess` are `i16` | **Widened to `i32`** in scalar, NEON, and SSE4.1 build paths. The i16 SIMD lanes stay chunk-relative (provably bounded ±16384); only cross-chunk accumulation and storage widen. |
| `select.rs` `SampleEntry.cumulative_before: u32` | **Widened to `u64`** (both fields). Sampled structure — one entry per 256 set bits — so cost is negligible; >2^32 ones is within the advertised `huge-tests` tier. |
| `bp.rs` `rank_l1: Vec<u32>` absolute rank | **Guarded**: `build_bp_index` asserts `len <= u32::MAX` bits. Since `total_ones <= len`, every u32 push is exact. Also acts as the loud backstop for pathological JSON/YAML BP lengths. |
| `json/light.rs` `ib_rank` + `k as u32` | **Guarded**: `build`/`from_parts`/`from_parts_with_newlines` assert input/`ib_len` ≤ `u32::MAX` with `# Panics` docs. Widening would double a hot array (~6.25% of input). |
| `yaml/parser.rs` `text_pos as u32` | **Guarded**: `build_semi_index` returns new `YamlError::InputTooLarge` for inputs > `u32::MAX` bytes (build already returned `Result`; propagates through CLI unchanged). Every stored position is ≤ `input.len()`, so one guard covers all downstream u32s. |
| `dsv/index_lightweight.rs` rank arrays | **Guarded**: `new` asserts `text_len <= u32::MAX`. Widening would double two hot arrays (~12.5% of input) and change the serde format. |
| Constructor hygiene: unmasked final partial word | **Fixed**: owned constructors mask in place (mirroring `BitVec::with_config`); borrowed/mmap `from_words*` paths mask on read while counting, keeping zero-copy. |

## Tests

- Un-ignored `test_bp_nesting_beyond_i16_excess` (depth 40,000) — the direct #188 reproduction, now passing.
- New SSE4.1/NEON-vs-scalar L2 parity tests at excess ±65,536, asserting the actual beyond-i16 values.
- Stray-bit masking tests for `new`/`from_words`/`from_words_with_select` (rank/select correctness with all-ones tails).
- Cheap `#[should_panic]` guard tests for BP/JSON/DSV (length parameters, no 4 GiB allocations) and a `YamlError::InputTooLarge` Display test.
- First real consumer of the `huge-tests` feature: `test_sample_entry_beyond_u32_max` (~800 MB, `jump_to` past 2^32 ones) — passes in release.

## Notes

- `YamlError` gains a variant — a minor break for exhaustive matches (none in-crate outside its own Display); noted in CHANGELOG.
- serde formats change where widened fields serialize (`SelectIndex` via `BitVec`/`WithSelect`, BP L2 arrays); `serde_json` roundtrip tests pass, no versioning scheme exists.
- New docs page: `docs/reference/limits.md`.

## Verification

- `cargo fmt --check`, `cargo test` (default, `simd`, `cli`), `cargo test --features serde --test serde_tests`, `cargo test --features huge-tests --release` (select regression), `cargo clippy --all-targets --all-features -- -D warnings`, `./scripts/build.sh` — all green locally (Apple Silicon; SSE4.1 parity test runs on the CI x86 leg).