### PR TITLE
fix(json): cap validator nesting depth to prevent stack-overflow DoS

### DIFF
--- a/src/bin/succinctly/json_validate.rs
+++ b/src/bin/succinctly/json_validate.rs
@@ -252,6 +252,9 @@ fn format_error_kind(kind: &ValidationErrorKind) -> String {
             format!("invalid keyword '{found}'")
         }
         ValidationErrorKind::InvalidUtf8 => "invalid UTF-8 sequence".to_string(),
+        ValidationErrorKind::NestingTooDeep { limit } => {
+            format!("nesting depth exceeds limit of {limit}")
+        }
     }
 }
 

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -86,6 +86,8 @@ pub enum ValidationErrorKind {
     InvalidKeyword { found: String },
     /// Invalid UTF-8 sequence.
     InvalidUtf8,
+    /// Container nesting depth exceeded the limit.
+    NestingTooDeep { limit: usize },
 }
 
 impl fmt::Display for ValidationErrorKind {
@@ -121,6 +123,9 @@ impl fmt::Display for ValidationErrorKind {
                 )
             }
             Self::InvalidUtf8 => write!(f, "invalid UTF-8 sequence"),
+            Self::NestingTooDeep { limit } => {
+                write!(f, "nesting depth exceeds limit of {limit}")
+            }
         }
     }
 }
@@ -143,6 +148,15 @@ impl fmt::Display for ValidationError {
 #[cfg(feature = "std")]
 impl std::error::Error for ValidationError {}
 
+/// Maximum nesting depth for containers (objects and arrays).
+///
+/// Bounds call-stack growth in the mutually recursive `validate_value` →
+/// `validate_object`/`validate_array` cycle so deeply nested input fails with
+/// [`ValidationErrorKind::NestingTooDeep`] instead of overflowing the stack.
+/// Matches the YAML parser's cap and keeps depth-100 documents (pinned by
+/// `tests/deep_nesting_valid_tests.rs`) valid.
+const MAX_NESTING_DEPTH: usize = 128;
+
 /// A strict JSON validator with position tracking.
 ///
 /// Uses recursive descent parsing to validate JSON according to RFC 8259.
@@ -151,6 +165,8 @@ pub struct Validator<'a> {
     offset: usize,
     line: usize,
     column: usize,
+    /// Current container nesting depth, capped at [`MAX_NESTING_DEPTH`].
+    nesting_depth: usize,
 }
 
 impl<'a> Validator<'a> {
@@ -161,6 +177,7 @@ impl<'a> Validator<'a> {
             offset: 0,
             line: 1,
             column: 1,
+            nesting_depth: 0,
         }
     }
 
@@ -206,8 +223,30 @@ impl<'a> Validator<'a> {
         }
     }
 
+    /// Enter a nested container, erroring past [`MAX_NESTING_DEPTH`].
+    ///
+    /// Callers must decrement `nesting_depth` when the container's frame
+    /// exits so sibling containers do not accumulate depth.
+    #[inline]
+    fn enter_nested(&mut self) -> Result<(), ValidationError> {
+        if self.nesting_depth >= MAX_NESTING_DEPTH {
+            return Err(self.error(ValidationErrorKind::NestingTooDeep {
+                limit: MAX_NESTING_DEPTH,
+            }));
+        }
+        self.nesting_depth += 1;
+        Ok(())
+    }
+
     /// Validate a JSON object.
     fn validate_object(&mut self) -> Result<(), ValidationError> {
+        self.enter_nested()?;
+        let result = self.validate_object_inner();
+        self.nesting_depth -= 1;
+        result
+    }
+
+    fn validate_object_inner(&mut self) -> Result<(), ValidationError> {
         self.advance(); // consume '{'
         self.skip_whitespace();
 
@@ -276,6 +315,13 @@ impl<'a> Validator<'a> {
 
     /// Validate a JSON array.
     fn validate_array(&mut self) -> Result<(), ValidationError> {
+        self.enter_nested()?;
+        let result = self.validate_array_inner();
+        self.nesting_depth -= 1;
+        result
+    }
+
+    fn validate_array_inner(&mut self) -> Result<(), ValidationError> {
         self.advance(); // consume '['
         self.skip_whitespace();
 
@@ -1273,6 +1319,65 @@ mod tests {
         assert!(validate(br#"{"a":{}}"#).is_ok());
     }
 
+    /// Issue #151: deeply nested input must return an error instead of
+    /// overflowing the stack. Passing at all is the proof — an overflow
+    /// would abort the test process.
+    #[test]
+    fn test_deep_array_errors_instead_of_aborting() {
+        let input = "[".repeat(20_000);
+        let err = validate(input.as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::NestingTooDeep { .. }
+        ));
+    }
+
+    #[test]
+    fn test_deep_object_errors_instead_of_aborting() {
+        let input = r#"{"a":"#.repeat(20_000);
+        let err = validate(input.as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::NestingTooDeep { .. }
+        ));
+    }
+
+    #[test]
+    fn test_deep_alternating_errors_instead_of_aborting() {
+        let input = r#"[{"a":"#.repeat(10_000);
+        let err = validate(input.as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::NestingTooDeep { .. }
+        ));
+    }
+
+    #[test]
+    fn test_nesting_at_cap_validates() {
+        let input = "[".repeat(MAX_NESTING_DEPTH) + &"]".repeat(MAX_NESTING_DEPTH);
+        assert!(validate(input.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn test_nesting_one_past_cap_errors() {
+        let input = "[".repeat(MAX_NESTING_DEPTH + 1) + &"]".repeat(MAX_NESTING_DEPTH + 1);
+        let err = validate(input.as_bytes()).unwrap_err();
+        assert_eq!(err.kind, ValidationErrorKind::NestingTooDeep { limit: 128 });
+        // The guard fires at the 129th '[', before it is consumed.
+        assert_eq!(err.position.offset, 128);
+        assert_eq!(err.position.column, 129);
+    }
+
+    /// Sibling containers at the same depth must not accumulate: the
+    /// counter is decremented when each container's frame exits, so three
+    /// siblings of depth 65 (195 containers total) stay under the cap.
+    #[test]
+    fn test_wide_but_shallow_nesting_validates() {
+        let element = "[".repeat(64) + &"]".repeat(64);
+        let input = format!("[{element},{element},{element}]");
+        assert!(validate(input.as_bytes()).is_ok());
+    }
+
     /// RFC 8259 Section 2: Whitespace handling.
     #[test]
     fn test_whitespace_edge_cases() {
@@ -1384,6 +1489,10 @@ mod tests {
         assert_eq!(
             ValidationErrorKind::InvalidUtf8.to_string(),
             "invalid UTF-8 sequence"
+        );
+        assert_eq!(
+            ValidationErrorKind::NestingTooDeep { limit: 128 }.to_string(),
+            "nesting depth exceeds limit of 128"
         );
     }
 

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -125,6 +125,20 @@ fn test_quiet_mode_no_output() -> Result<()> {
     Ok(())
 }
 
+/// Issue #151: deeply nested input must fail validation cleanly instead of
+/// aborting the process with a stack overflow (SIGABRT).
+#[test]
+fn test_deeply_nested_input_errors_instead_of_aborting() -> Result<()> {
+    let input = "[".repeat(20_000);
+    let (_, stderr, exit_code) = run_validate_stdin(&input, &[])?;
+    assert_eq!(exit_code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit"),
+        "stderr should report the nesting cap, got: {stderr}"
+    );
+    Ok(())
+}
+
 // ============================================================================
 // Valid JSON acceptance tests
 // ============================================================================


### PR DESCRIPTION
## Description

This PR fixes a critical stack overflow vulnerability in the JSON validator (issue #151) that could be triggered by deeply nested input. The validator's `validate_value` → `validate_object`/`validate_array` mutual recursion had no depth limit, allowing attacker-controlled input with 500k+ nested brackets to cause an uncatchable stack overflow and abort the process.

The fix mirrors the YAML validator fix from #257 by introducing a `nesting_depth` counter on the `Validator` struct, capped at `MAX_NESTING_DEPTH = 128`. The implementation wraps the recursion roots (`validate_object` and `validate_array`) with thin `enter_nested()` guards that check and increment the counter on entry, with decrement on exit. This ensures the limit is immune to early returns. A new `ValidationErrorKind::NestingTooDeep` variant surfaces errors through the error formatter for both the jq `--validate` CLI and the `json validate` API.

The fix maintains backward compatibility: depth-100 documents continue to validate successfully, honoring the contract pinned by `tests/deep_nesting_valid_tests.rs` (#242).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security improvement (prevents stack overflow DoS)
- [x] Test coverage improvement

## Related Issue
Fixes #151

## Changes Made

**Core Security Fix:**
- Added `nesting_depth: usize` field to `Validator` struct in `src/json/validate.rs` to track container nesting depth
- Defined `const MAX_NESTING_DEPTH: usize = 128` to cap recursion depth
- Implemented `enter_nested()` method that checks the depth limit before incrementing the counter
- Refactored `validate_object()` to wrap the recursive logic in `validate_object_inner()` with depth guards
- Refactored `validate_array()` to wrap the recursive logic in `validate_array_inner()` with depth guards
- Added `ValidationErrorKind::NestingTooDeep { limit: usize }` variant to the enum
- Implemented `Display` formatting for `NestingTooDeep` to show the nesting depth limit

**Error Handling:**
- Updated `src/bin/succinctly/json_validate.rs` to format `NestingTooDeep` errors in `format_error_kind()` function

**Test Coverage:**
- Added `test_deep_array_errors_instead_of_aborting()` to verify 20,000-deep array input returns error instead of stack overflow
- Added `test_deep_object_errors_instead_of_aborting()` to verify 20,000-deep object input returns error instead of stack overflow
- Added `test_deep_alternating_errors_instead_of_aborting()` to verify 10,000-deep alternating array/object input returns error
- Added `test_nesting_at_cap_validates()` to ensure documents at exactly MAX_NESTING_DEPTH (128) remain valid
- Added `test_nesting_one_past_cap_errors()` to verify error fires at depth 129 with correct position tracking
- Added `test_wide_but_shallow_nesting_validates()` to verify sibling containers at same depth don't accumulate (three 64-level siblings = 195 containers total)
- Updated `test_error_kind_display()` to verify `NestingTooDeep` error formatting
- Added integration test `test_deeply_nested_input_errors_instead_of_aborting()` in `tests/json_validate_tests.rs` to verify CLI reports nesting depth errors cleanly

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for deeply nested input scenarios (7 unit tests + 1 integration test)
- [x] Edge case tests verify the depth cap boundary conditions
- [x] Tests confirm sibling container behavior and counter decrement logic

**Manual Testing:**
- [x] Verified deeply nested input (20,000+ brackets) fails cleanly with `NestingTooDeep` error instead of aborting
- [x] Confirmed depth-100 documents still validate successfully
- [x] Tested alternating array/object nesting patterns
- [x] Verified error messages include the nesting limit

### Test Commands
```bash
cargo test --lib json::validate
cargo test test_deep_array_errors_instead_of_aborting
cargo test test_deep_object_errors_instead_of_aborting
cargo test test_nesting_at_cap_validates
cargo test test_nesting_one_past_cap_errors
cargo test test_wide_but_shallow_nesting_validates
cargo test test_deeply_nested_input_errors_instead_of_aborting
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Security Impact
- Prevents stack overflow attacks on the public `validate()` API
- Prevents stack overflow attacks via `json validate` and `--validate` CLI flags when processing attacker-controlled input
- Gracefully reports nesting depth errors instead of aborting the process
- Aligns with YAML validator security hardening (#257)

## Performance Impact
- [x] No performance impact (depth check is a single comparison and increment/decrement operations)
- Guard checks are `#[inline]` for zero-cost abstraction

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings
- [x] Security vulnerability is properly mitigated
- [x] Error messages clearly communicate the nesting limit

## Additional Notes

This fix prevents a critical Denial of Service vulnerability where deeply nested JSON input (reachable from both the library API and CLI) could crash the validator with a stack overflow. The solution is defensive, enforcing a reasonable nesting depth limit (128 levels) that accommodates legitimate use cases while preventing pathological inputs from consuming unbounded stack resources.

The implementation follows the established pattern from the YAML validator (#257), ensuring consistency across the codebase's handling of nesting depth validation.