### PR TITLE
fix(jq): fall back to float for integer literals beyond i64 range

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -330,9 +330,12 @@ impl<'a> Parser<'a> {
                 .map(Literal::Float)
                 .map_err(|_| ParseError::new("invalid number", start))
         } else {
+            // Integer literal; on i64 overflow fall back to float like jq,
+            // which represents all numbers as doubles.
             num_str
                 .parse::<i64>()
                 .map(Literal::Int)
+                .or_else(|_| num_str.parse::<f64>().map(Literal::Float))
                 .map_err(|_| ParseError::new("invalid number", start))
         }
     }
@@ -4179,6 +4182,37 @@ mod tests {
         assert_eq!(
             parse("\"hello\\nworld\"").unwrap(),
             Expr::Literal(Literal::String("hello\nworld".into()))
+        );
+    }
+
+    #[test]
+    fn test_large_integer_literal_falls_back_to_float() {
+        // Literals beyond i64 range degrade to floats like jq (issue #166).
+        assert_eq!(
+            parse("9999999999999999999").unwrap(),
+            Expr::Literal(Literal::Float(1e19))
+        );
+        assert_eq!(
+            parse("-9999999999999999999").unwrap(),
+            Expr::Literal(Literal::Float(-1e19))
+        );
+        // One past the boundary in each direction.
+        assert_eq!(
+            parse("9223372036854775808").unwrap(),
+            Expr::Literal(Literal::Float(9.223372036854776e18))
+        );
+        assert_eq!(
+            parse("-9223372036854775809").unwrap(),
+            Expr::Literal(Literal::Float(-9.223372036854776e18))
+        );
+        // Boundary values stay exact integers.
+        assert_eq!(
+            parse("9223372036854775807").unwrap(),
+            Expr::Literal(Literal::Int(i64::MAX))
+        );
+        assert_eq!(
+            parse("-9223372036854775808").unwrap(),
+            Expr::Literal(Literal::Int(i64::MIN))
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1174,6 +1174,16 @@ fn test_jq_compat_default() -> Result<()> {
 }
 
 #[test]
+fn test_large_integer_literal_prints_like_jq() -> Result<()> {
+    // Integer literals beyond i64 degrade to floats like jq (issue #166):
+    // jq -n '9999999999999999999' => 10000000000000000000
+    let (output, code) = run_jq_stdin("9999999999999999999", "null", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "10000000000000000000");
+    Ok(())
+}
+
+#[test]
 fn test_args_positional() -> Result<()> {
     // Test --args: positional args become $ARGS.positional
     // Note: Use pipe syntax since parser doesn't support $VAR.field directly

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -1101,6 +1101,16 @@ fn test_length_of_i64_min_falls_back_to_float() {
     );
 }
 
+#[test]
+fn test_large_integer_literal_evaluates_to_float() {
+    // jq: 9999999999999999999 => 10000000000000000000 (float; issue #166)
+    query!(b"null", "9999999999999999999",
+        QueryResult::Owned(OwnedValue::Float(f)) => {
+            assert_eq!(f, 1e19, "expected literal to degrade to 1e19, got {f}");
+        }
+    );
+}
+
 // =============================================================================
 // Compatibility tests - has()/in() with negative indices
 // =============================================================================


### PR DESCRIPTION
Fixes #166

## Problem

Integer literals in jq programs were parsed with `parse::<i64>()` in `parse_number_literal`, and any overflow became a parse error:

```
echo null | sjq "9999999999999999999"   # => parse error
```

Real jq degrades the literal to a double instead of failing.

## Fix

On i64 parse failure, fall back to `parse::<f64>()` → `Literal::Float`. The digit string is pre-validated by the lexer loop, so the only way the i64 parse fails is overflow — the fallback cannot change behavior for valid i64 literals. Runtime arithmetic already models jq's overflow→float semantics, so the float literal is first-class downstream.

```
echo null | sjq "9999999999999999999"   # => 10000000000000000000
```

## Behavior notes

- `9223372036854775807` / `-9223372036854775808` (i64 boundaries) still parse as exact `Int`; one past the boundary degrades to the nearest f64.
- Output matches jq 1.6 semantics (exact f64 value in positional notation). jq 1.7 additionally preserves the literal's original source digits (prints `9999999999999999999` verbatim); that literal-preservation pipeline exists here only for input JSON (`RawNumber`), not program literals, and is out of scope.
- `parse_integer` (array/slice indices) intentionally stays i64-only.

## Tests

- Unit: `test_large_integer_literal_falls_back_to_float` (parser AST: overflow → `Float`, boundaries stay `Int`)
- Integration: `test_large_integer_literal_evaluates_to_float` (evaluates to `OwnedValue::Float(1e19)`)
- CLI: `test_large_integer_literal_prints_like_jq` (prints `10000000000000000000`)

`cargo test --features cli --lib --test jq_tests --test jq_cli_tests`: 1185 + 79 + 119 passed, 0 failed.

Note: `cargo clippy --all-targets --all-features -- -D warnings` fails with 17 pre-existing `unnecessary_cast` warnings in `src/jq/eval.rs`, `src/yaml/light.rs`, and `src/bin/succinctly/jq_runner.rs` (new stable clippy 1.97) — none in files touched by this PR; main is affected equally.