### PR TITLE
chore(ci): add Dependabot config for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(build)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    groups:
+      rust-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "ci"
+      - "dependencies"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Description

This PR adds automated dependency management for the repository by configuring Dependabot to monitor and update Cargo dependencies and GitHub Actions workflows. The configuration follows the established patterns from the sibling `omni-dev` project and ensures that security vulnerabilities and outdated dependencies are caught automatically through weekly update checks.

Dependabot will now create pull requests for dependency updates with appropriate labels and grouping strategies, allowing the team to review and merge updates in a controlled manner.

## Type of Change
- [x] CI/CD changes
- [x] Documentation update (configuration)

## Related Issue
Closes #148

## Changes Made

**Dependabot Configuration:**
- Added `.github/dependabot.yml` with automated dependency management settings
- Configured Cargo package ecosystem to check for updates on a weekly Monday schedule
- Set Cargo commit prefix to `chore(build)` (aligns with project's scope validation in `.omni-dev/scopes.yaml`)
- Grouped minor and patch Cargo updates into a single PR (rust-minor-patch group) to reduce noise
- Limited open Cargo PRs to 10 to prevent overwhelming the queue
- Configured GitHub Actions ecosystem with weekly Monday updates
- Set GitHub Actions commit prefix to `chore(ci)` (valid scope in project configuration)
- Limited open GitHub Actions PRs to 5
- Applied `dependencies` label to Cargo updates
- Applied `ci` and `dependencies` labels to GitHub Actions updates
- Intentionally excluded `bench-compare/` crate to preserve pinned versions for benchmark comparisons

**Labels:**
- Created `dependencies` label in the repository
- Created `ci` label in the repository

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Dependabot configuration is valid YAML syntax
- [x] No new warnings or errors generated

**Manual Testing:**
- [x] Verified `.github/dependabot.yml` structure against Dependabot documentation
- [x] Confirmed scopes `build` and `ci` exist in `.omni-dev/scopes.yaml`
- [x] Validated that configuration aligns with omni-dev reference implementation
- [x] Verified labels exist or are created in the repository

## Performance Impact
- [x] No performance impact

This is a configuration-only change with no runtime or build performance implications.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (Dependabot configuration)
- [x] My changes generate no new warnings
- [x] Configuration aligns with project standards and commit message scopes

## Additional Notes

**Rationale for Scope Selection:**
- `chore(build)` instead of `chore(deps)`: The project's commit message validation in `.omni-dev/scopes.yaml` defines `build` as the scope for `Cargo.toml`/`Cargo.lock` changes, ensuring Dependabot's own PRs pass the commit check.
- `chore(ci)` for GitHub Actions: Follows established project convention for workflow-related changes.

**Branch Pin Handling:**
- Rolling references like `dtolnay/rust-toolchain@stable` and `trufflesecurity/trufflehook@main` are not version-bumped by Dependabot's GitHub Actions ecosystem; this is expected behavior.

**First Run:**
- Merging this to the default branch automatically enables version updates. The first run can be verified under Insights → Dependency graph → Dependabot.

**Benchmark Stability:**
- The `bench-compare/` crate is deliberately excluded from Dependabot monitoring to keep third-party comparison-library versions (simd-json, sonic-rs, sucds, sux, vers-vecs) pinned, ensuring benchmark baselines remain comparable across runs.