### PR TITLE
perf(simd): use lightweight index in DSV SSE2 backend

### DIFF
--- a/src/dsv/config.rs
+++ b/src/dsv/config.rs
@@ -13,8 +13,6 @@ pub struct DsvConfig {
     pub quote_char: u8,
     /// Record delimiter (default: b'\n')
     pub newline: u8,
-    /// Select sample rate for BitVec (default: 256)
-    pub select_sample_rate: u32,
 }
 
 impl Default for DsvConfig {
@@ -23,7 +21,6 @@ impl Default for DsvConfig {
             delimiter: b',',
             quote_char: b'"',
             newline: b'\n',
-            select_sample_rate: 256,
         }
     }
 }
@@ -59,12 +56,6 @@ impl DsvConfig {
     /// Set the quote character.
     pub fn with_quote_char(mut self, quote_char: u8) -> Self {
         self.quote_char = quote_char;
-        self
-    }
-
-    /// Set the select sample rate for the index.
-    pub fn with_select_sample_rate(mut self, rate: u32) -> Self {
-        self.select_sample_rate = rate;
         self
     }
 }

--- a/src/dsv/index.rs
+++ b/src/dsv/index.rs
@@ -1,7 +1,6 @@
 //! Semi-index for DSV data.
 
 use super::index_lightweight::DsvIndexLightweight;
-use crate::bits::BitVec;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -26,14 +25,6 @@ pub struct DsvIndex {
 impl DsvIndex {
     /// Create a new DsvIndex from lightweight index.
     pub fn new_lightweight(inner: DsvIndexLightweight) -> Self {
-        Self { inner }
-    }
-
-    /// Create a new DsvIndex from BitVec (legacy API).
-    pub fn new(markers: BitVec, newlines: BitVec, text_len: usize) -> Self {
-        let markers_words = markers.words().to_vec();
-        let newlines_words = newlines.words().to_vec();
-        let inner = DsvIndexLightweight::new(markers_words, newlines_words, text_len);
         Self { inner }
     }
 

--- a/src/dsv/simd/sse2.rs
+++ b/src/dsv/simd/sse2.rs
@@ -7,17 +7,18 @@
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+use alloc::vec;
+
 use super::super::config::DsvConfig;
 use super::super::index::DsvIndex;
-use crate::bits::BitVec;
+use super::super::index_lightweight::DsvIndexLightweight;
 use crate::json::BitWriter;
-use crate::Config;
 
 /// Build a DsvIndex using SSE2 SIMD acceleration.
 #[cfg(target_arch = "x86_64")]
 pub fn build_index_simd(text: &[u8], config: &DsvConfig) -> DsvIndex {
     if text.is_empty() {
-        return DsvIndex::new(BitVec::new(), BitVec::new(), 0);
+        return DsvIndex::new_lightweight(DsvIndexLightweight::new(vec![], vec![], 0));
     }
 
     // SAFETY: SSE2 is mandatory on x86_64
@@ -78,15 +79,8 @@ unsafe fn build_index_sse2(text: &[u8], config: &DsvConfig) -> DsvIndex {
     let markers_words = markers_writer.finish();
     let newlines_words = newlines_writer.finish();
 
-    let bit_config = Config {
-        select_sample_rate: config.select_sample_rate,
-    };
-
-    DsvIndex::new(
-        BitVec::with_config(markers_words, text.len(), bit_config.clone()),
-        BitVec::with_config(newlines_words, text.len(), bit_config),
-        text.len(),
-    )
+    let lightweight = DsvIndexLightweight::new(markers_words, newlines_words, text.len());
+    DsvIndex::new_lightweight(lightweight)
 }
 
 /// Process a 64-byte chunk and return (markers, newlines, new_in_quote).


### PR DESCRIPTION
## Summary

Fixes #183, plus the natural cleanup it exposes.

**Commit 1 — `perf(simd)`:** The SSE2 DSV backend was the only backend still constructing its index via the legacy `DsvIndex::new(BitVec::with_config(...), ...)` path. `BitVec::with_config` builds full rank/select directories, but `DsvIndex::new` immediately discards them, extracting only the raw words into a `DsvIndexLightweight` (plus an extra word-vector copy). SSE2 now uses `DsvIndexLightweight::new` + `DsvIndex::new_lightweight`, matching AVX2, NEON, BMI2, SVE2, and the portable parser. Output is functionally identical; the wasted rank/select build and the extra copy are gone.

**Commit 2 — `refactor(simd)!`:** With SSE2 switched over, the legacy `DsvIndex::new` had **zero** remaining callers — the coverage report confirmed `src/dsv/index.rs:33-38` was now fully unhit dead code. `DsvConfig::select_sample_rate` also lost its last reader (SSE2 was the only consumer). Both are removed, so all DSV backends now build indexes exclusively via `new_lightweight`.

## Breaking changes

Removed from the public API (pre-1.0):

- `DsvIndex::new(markers, newlines, text_len)` → use `DsvIndex::new_lightweight(DsvIndexLightweight::new(...))`.
- `DsvConfig::select_sample_rate` field + `DsvConfig::with_select_sample_rate(rate)` → no replacement; the select sample rate never affected the lightweight index that every backend now produces.

## Verification

- `cargo test --target x86_64-apple-darwin --lib dsv` — 53 dsv tests pass, including the SSE2-only `test_simd_matches_scalar` / `test_quoted_spanning_chunks` module tests (SSE2 is `#[cfg(target_arch = "x86_64")]`, exercised via the x86_64 target under Rosetta on an aarch64 host).
- `cargo test` (native aarch64) + `serde_tests` — full suites green.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean on the changed files (both targets).

## Coverage note

The bot's `-0.08pp` total is measurement noise from `src/bits/popcount.rs` (an unchanged, CPU-conditional file whose exercised popcount path varies per runner) — not attributable to this PR. This PR's own diff removed the previously-uncovered dead code rather than adding any.