### PR TITLE
fix(jq): fix array slice semantics and add full slice `[:]` support

### DIFF
--- a/docs/plan/jq.md
+++ b/docs/plan/jq.md
@@ -18,7 +18,7 @@ Support basic jq path syntax for navigating JSON:
 | `.foo.bar` | Chained field access | Compose cursor navigation               |
 | `.[]`      | Iterate all elements | `JsonElements` / `JsonFields` iterators |
 | `.foo[]`   | Field then iterate   | Compose field access + iteration        |
-| `.[2:5]`   | Array slice          | Iterate with skip/take                  |
+| `.[2:5]`   | Array slice          | Single sub-array via skip/take          |
 
 ### Phase 2: Filters and Conditionals
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -290,8 +290,16 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
         Expr::Slice { start, end } => match value {
             StandardJson::Array(elements) => {
-                let results = slice_elements::<W>(elements, *start, *end);
-                QueryResult::Many(results)
+                // Fast path: full slice [:] / [0:] returns the original array unchanged
+                if matches!(start, None | Some(0)) && end.is_none() {
+                    return QueryResult::One(value);
+                }
+                // jq array slicing yields a single sub-array, not a stream of elements
+                let items: Vec<OwnedValue> = slice_elements::<W>(elements, *start, *end)
+                    .iter()
+                    .map(to_owned)
+                    .collect();
+                QueryResult::Owned(OwnedValue::Array(items))
             }
             // jq returns null for slice on null
             StandardJson::Null => QueryResult::One(StandardJson::Null),
@@ -13597,21 +13605,33 @@ mod tests {
 
     #[test]
     fn test_slice() {
+        // jq array slicing yields a single sub-array, not a stream of elements.
         query!(br"[0, 1, 2, 3, 4, 5]", ".[1:4]",
-            QueryResult::Many(values) => {
-                assert_eq!(values.len(), 3);
+            QueryResult::Owned(OwnedValue::Array(values)) => {
+                assert_eq!(
+                    values,
+                    vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]
+                );
             }
         );
 
         query!(br"[0, 1, 2, 3, 4, 5]", ".[2:]",
-            QueryResult::Many(values) => {
-                assert_eq!(values.len(), 4); // 2, 3, 4, 5
+            QueryResult::Owned(OwnedValue::Array(values)) => {
+                assert_eq!(
+                    values,
+                    vec![
+                        OwnedValue::Int(2),
+                        OwnedValue::Int(3),
+                        OwnedValue::Int(4),
+                        OwnedValue::Int(5)
+                    ]
+                );
             }
         );
 
         query!(br"[0, 1, 2, 3, 4, 5]", ".[:2]",
-            QueryResult::Many(values) => {
-                assert_eq!(values.len(), 2); // 0, 1
+            QueryResult::Owned(OwnedValue::Array(values)) => {
+                assert_eq!(values, vec![OwnedValue::Int(0), OwnedValue::Int(1)]);
             }
         );
     }

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -613,9 +613,12 @@ impl<'a> Parser<'a> {
             self.skip_ws();
 
             if self.peek() == Some(']') {
-                // `[:]` - full slice (same as iterate)
+                // `[:]` - full slice, returns the whole array as a single value
                 self.next();
-                return Ok(Expr::Iterate);
+                return Ok(Expr::Slice {
+                    start: None,
+                    end: None,
+                });
             }
 
             // `[:n]` - slice from start to n
@@ -4057,6 +4060,14 @@ mod tests {
             Expr::Slice {
                 start: None,
                 end: Some(3)
+            }
+        );
+        // `[:]` is a full slice (returns the whole array), not an iterate
+        assert_eq!(
+            parse(".[:]").unwrap(),
+            Expr::Slice {
+                start: None,
+                end: None
             }
         );
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -205,6 +205,14 @@ fn test_array_slice_out_of_range_is_empty_array() -> Result<()> {
 }
 
 #[test]
+fn test_full_array_slice_returns_whole_array() -> Result<()> {
+    let (output, code) = run_jq_stdin(".[:]", r"[0,1,2,3,4]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[0,1,2,3,4]\n");
+    Ok(())
+}
+
+#[test]
 fn test_string_slice_unchanged() -> Result<()> {
     let (output, code) = run_jq_stdin(".[1:3]", r#""hello""#, &["-c"])?;
     assert_eq!(code, 0);

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -162,6 +162,56 @@ fn test_array_iteration() -> Result<()> {
     Ok(())
 }
 
+// Array slicing yields a single sub-array, not a stream of elements (issue #154).
+
+#[test]
+fn test_array_slice_returns_single_array() -> Result<()> {
+    let (output, code) = run_jq_stdin(".[2:4]", r"[0,1,2,3,4]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[2,3]\n");
+    Ok(())
+}
+
+#[test]
+fn test_array_slice_construction_nests() -> Result<()> {
+    let (output, code) = run_jq_stdin("[.[2:4]]", r"[0,1,2,3,4]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[[2,3]]\n");
+    Ok(())
+}
+
+#[test]
+fn test_array_slice_then_iterate_streams() -> Result<()> {
+    let (output, code) = run_jq_stdin(".[2:4][]", r"[0,1,2,3,4]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "2\n3\n");
+    Ok(())
+}
+
+#[test]
+fn test_array_slice_piped_to_length() -> Result<()> {
+    let (output, code) = run_jq_stdin(".[2:4] | length", r"[0,1,2,3,4]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "2\n");
+    Ok(())
+}
+
+#[test]
+fn test_array_slice_out_of_range_is_empty_array() -> Result<()> {
+    let (output, code) = run_jq_stdin(".[5:10]", r"[0,1,2,3,4]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[]\n");
+    Ok(())
+}
+
+#[test]
+fn test_string_slice_unchanged() -> Result<()> {
+    let (output, code) = run_jq_stdin(".[1:3]", r#""hello""#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "\"el\"\n");
+    Ok(())
+}
+
 #[test]
 fn test_arithmetic() -> Result<()> {
     let (output, code) = run_jq_null("1 + 2 * 3", &[])?;

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -411,6 +411,15 @@ fn test_slice_single_element_stays_array() {
     );
 }
 
+#[test]
+fn test_full_slice_returns_whole_array() {
+    // `.[:]` is a full slice returning the whole array as a single value,
+    // taking the fast path that returns the original borrowed value.
+    query!(br"[0, 1, 2]", ".[:]",
+        QueryResult::One(StandardJson::Array(_)) => {}
+    );
+}
+
 // =============================================================================
 // Optional tests
 // =============================================================================

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -281,9 +281,13 @@ fn test_iterate_on_scalar_error() {
 
 #[test]
 fn test_slice_range() {
+    // jq array slicing yields a single sub-array, not a stream (issue #154).
     query!(br"[0, 1, 2, 3, 4, 5]", ".[1:4]",
-        QueryResult::Many(values) => {
-            assert_eq!(values.len(), 3);
+        QueryResult::Owned(OwnedValue::Array(values)) => {
+            assert_eq!(
+                values,
+                vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]
+            );
         }
     );
 }
@@ -291,8 +295,8 @@ fn test_slice_range() {
 #[test]
 fn test_slice_from_start() {
     query!(br"[0, 1, 2, 3, 4]", ".[:2]",
-        QueryResult::Many(values) => {
-            assert_eq!(values.len(), 2);
+        QueryResult::Owned(OwnedValue::Array(values)) => {
+            assert_eq!(values, vec![OwnedValue::Int(0), OwnedValue::Int(1)]);
         }
     );
 }
@@ -300,8 +304,8 @@ fn test_slice_from_start() {
 #[test]
 fn test_slice_to_end() {
     query!(br"[0, 1, 2, 3, 4]", ".[3:]",
-        QueryResult::Many(values) => {
-            assert_eq!(values.len(), 2); // indices 3, 4
+        QueryResult::Owned(OwnedValue::Array(values)) => {
+            assert_eq!(values, vec![OwnedValue::Int(3), OwnedValue::Int(4)]);
         }
     );
 }
@@ -309,16 +313,17 @@ fn test_slice_to_end() {
 #[test]
 fn test_slice_negative_indices() {
     query!(br"[0, 1, 2, 3, 4, 5]", ".[-3:-1]",
-        QueryResult::Many(values) => {
-            assert_eq!(values.len(), 2); // indices 3, 4 (elements 3, 4)
+        QueryResult::Owned(OwnedValue::Array(values)) => {
+            assert_eq!(values, vec![OwnedValue::Int(3), OwnedValue::Int(4)]);
         }
     );
 }
 
 #[test]
 fn test_slice_empty_result() {
+    // Out-of-range slice yields an empty array, not an empty stream.
     query!(br"[0, 1, 2]", ".[5:10]",
-        QueryResult::Many(values) => {
+        QueryResult::Owned(OwnedValue::Array(values)) => {
             assert!(values.is_empty());
         }
     );
@@ -356,6 +361,52 @@ fn test_slice_on_string_to_end() {
     query!(br#""hello""#, ".[3:]",
         QueryResult::Owned(OwnedValue::String(s)) => {
             assert_eq!(s, "lo");
+        }
+    );
+}
+
+#[test]
+fn test_slice_piped_to_length() {
+    // A slice is a single array, so `length` sees the array (issue #154).
+    query!(br"[0, 1, 2, 3, 4]", ".[1:4] | length",
+        QueryResult::Owned(OwnedValue::Int(n)) => {
+            assert_eq!(n, 3);
+        }
+    );
+}
+
+#[test]
+fn test_slice_piped_to_index() {
+    query!(br"[0, 1, 2, 3, 4]", ".[1:4] | .[0]",
+        QueryResult::Owned(OwnedValue::Int(n)) => {
+            assert_eq!(n, 1);
+        }
+    );
+}
+
+#[test]
+fn test_slice_array_construction_nests() {
+    // `[.[1:4]]` wraps the sub-array, producing a nested array.
+    query!(br"[0, 1, 2, 3, 4]", "[.[1:4]]",
+        QueryResult::Owned(OwnedValue::Array(outer)) => {
+            assert_eq!(
+                outer,
+                vec![OwnedValue::Array(vec![
+                    OwnedValue::Int(1),
+                    OwnedValue::Int(2),
+                    OwnedValue::Int(3),
+                ])]
+            );
+        }
+    );
+}
+
+#[test]
+fn test_slice_single_element_stays_array() {
+    // A one-element slice must remain an array, not collapse to the element.
+    query!(br"[0, 1, 2, 3, 4]", "[.[]] | .[1:2]",
+        QueryResult::Owned(OwnedValue::Array(values)) => {
+            assert_eq!(values, vec![OwnedValue::Int(1)]);
         }
     );
 }


### PR DESCRIPTION
## Description

This PR fixes array slicing behavior in jq to return a single sub-array instead of streaming individual elements, ensuring consistency with standard jq semantics. Additionally, it extends array slice syntax to support the `[:]` notation as a full array slice that returns the whole array.

The fix addresses issue #154 where `.[2:4]` on `[0,1,2,3,4]` incorrectly produced a stream of elements `2
3` instead of the single array `[2,3]`. Now array slicing consistently returns one array value, matching jq's expected behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #154

## Changes Made

**Core Implementation (src/jq/eval.rs):**
- Modified `Expr::Slice` array arm to collect sliced elements into a single `OwnedValue::Array` instead of returning `QueryResult::Many`
- Implemented fast path for full slices (`.[0:]` and `.[:])` that returns the original array unchanged without allocation
- Ensured string slicing remains unaffected by these changes

**Parser Enhancement (src/jq/parser.rs):**
- Updated parser to recognize `[:]` as `Expr::Slice { start: None, end: None }` instead of `Expr::Iterate`
- This makes `.[:]` return the whole array as a single value, consistent with `.[0:]` behavior
- Added parser test to verify `[:]` parsing produces correct slice expression

**Test Coverage:**
- Updated existing unit tests in `tests/jq_tests.rs` to assert single array results instead of streams:
  - `test_slice_range`: Updated to expect `QueryResult::Owned(OwnedValue::Array)` with verified contents
  - `test_slice_from_start`, `test_slice_to_end`, `test_slice_negative_indices`: Updated to verify array contents
  - `test_slice_empty_result`: Updated to expect empty array instead of empty stream

- Added comprehensive new tests in `tests/jq_tests.rs`:
  - `test_slice_piped_to_length`: Verifies slice result works with `length` filter
  - `test_slice_piped_to_index`: Verifies indexing into slice result
  - `test_slice_array_construction_nests`: Verifies `[.[1:4]]` produces nested array
  - `test_slice_single_element_stays_array`: Verifies single-element slices remain arrays
  - `test_full_slice_returns_whole_array`: Verifies `.[:]` returns original borrowed array via fast path

- Added comprehensive CLI tests in `tests/jq_cli_tests.rs`:
  - `test_array_slice_returns_single_array`: Verifies `.[2:4]` returns `[2,3]` not stream
  - `test_array_slice_construction_nests`: Verifies `[.[2:4]]` produces `[[2,3]]`
  - `test_array_slice_then_iterate_streams`: Verifies `.[2:4][]` streams elements from result
  - `test_array_slice_piped_to_length`: Verifies piping slice to `length` works correctly
  - `test_array_slice_out_of_range_is_empty_array`: Verifies out-of-range slices produce empty array
  - `test_string_slice_unchanged`: Verifies string slicing behavior unaffected
  - `test_full_array_slice_returns_whole_array`: Verifies `.[:]` returns full array

**Documentation (docs/plan/jq.md):**
- Updated array slice documentation from "Iterate with skip/take" to "Single sub-array via skip/take" to reflect correct semantic

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for array slice functionality and edge cases
- [x] Comprehensive regression tests for slice-then-pipe, array construction, and single-element slices
- [x] Tests verify consistency with standard jq semantics

**Manual Testing Examples:**
```bash
# Basic slice returns single array
echo '[0,1,2,3,4]' | cargo run -- -c '.[2:4]'      # Returns: [2,3]

# Array construction wraps the result
echo '[0,1,2,3,4]' | cargo run -- -c '[.[2:4]]'    # Returns: [[2,3]]

# Iteration streams elements from the array
echo '[0,1,2,3,4]' | cargo run -- -c '.[2:4][]'    # Returns: 2\n3

# Piping to length works correctly
echo '[0,1,2,3,4]' | cargo run -- -c '.[2:4] | length'  # Returns: 2

# Full slice returns whole array
echo '[0,1,2,3,4]' | cargo run -- -c '.[:]'        # Returns: [0,1,2,3,4]

# String slicing unaffected
echo '"hello"' | cargo run -- -c '.[1:3]'          # Returns: "el"
```

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact for typical operations
- [x] Fast path optimization for full slices avoids unnecessary allocation
- [x] Collecting slice elements into array is minimal overhead vs. streaming

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Semantic Alignment:**
This PR aligns succinctly's jq implementation with standard jq semantics where array slicing produces a single array value rather than a stream. This is a fundamental correction that makes pipes and array operations work as expected.

**Extension:**
The `[:]` full slice syntax is a succinctly extension (standard jq rejects it), but it provides useful consistency with other slice forms and enables convenient operations like `.[:]` for non-destructive array copying through the fast path.

**Backward Compatibility:**
Code that relied on array slicing producing streams will need updates. However, the previous behavior was incorrect relative to jq semantics, so this is a necessary fix rather than a breaking change.