### PR TITLE
fix(jq): truncate float operands in modulo and thread eval semantics through generic evaluator

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -10,7 +10,7 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::DocumentCursor;
-use succinctly::jq::eval_generic::{eval_with_cursor, to_owned, GenericResult};
+use succinctly::jq::eval_generic::{eval_with_cursor_using, to_owned, GenericResult};
 use succinctly::jq::{self, Builtin, Expr, OwnedValue, QueryResult, YqSemantics};
 use succinctly::json::light::StandardJson;
 use succinctly::json::JsonIndex;
@@ -317,7 +317,7 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     cursor: YamlCursor<'_, W>,
     expr: &Expr,
 ) -> Result<Vec<OwnedValue>> {
-    let result = eval_with_cursor(expr, cursor);
+    let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
 
     // Convert GenericResult to Vec<OwnedValue>
     match result {
@@ -1153,7 +1153,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         }
                     } else {
                         // M2 YAML path: evaluate and stream YAML results
-                        let result = eval_with_cursor(&program.expr, $cursor);
+                        let result = eval_with_cursor_using::<YqSemantics, _>(&program.expr, $cursor);
                         let will_output = !matches!(
                             &result,
                             GenericResult::None | GenericResult::Break(_)
@@ -1180,7 +1180,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         }
                     } else {
                         // M2 path: evaluate and stream results
-                        let result = eval_with_cursor(&program.expr, $cursor);
+                        let result = eval_with_cursor_using::<YqSemantics, _>(&program.expr, $cursor);
                         let stats = result
                             .stream_json(&mut FmtWriter($writer), |w| w.write_str("\n"))
                             .map_err(|_| anyhow::anyhow!("Write error"))?;

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27,6 +27,8 @@ pub trait EvalSemantics: Copy + Default {
     const DIV_BY_ZERO_IS_INFINITY: bool;
     /// If true, has(-1) on arrays checks if abs(idx) <= len (yq). If false, only non-negative (jq).
     const NEGATIVE_INDEX_IN_HAS: bool;
+    /// If true, `%` truncates float operands to integers (jq). If false, float modulo (yq).
+    const MOD_TRUNCATES_FLOATS: bool;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -41,6 +43,7 @@ impl EvalSemantics for JqSemantics {
     const OVERFLOW_WRAPS: bool = false;
     const DIV_BY_ZERO_IS_INFINITY: bool = false;
     const NEGATIVE_INDEX_IN_HAS: bool = false;
+    const MOD_TRUNCATES_FLOATS: bool = true;
 }
 
 /// yq-compatible evaluation semantics.
@@ -55,6 +58,7 @@ impl EvalSemantics for YqSemantics {
     const OVERFLOW_WRAPS: bool = true;
     const DIV_BY_ZERO_IS_INFINITY: bool = true;
     const NEGATIVE_INDEX_IN_HAS: bool = true;
+    const MOD_TRUNCATES_FLOATS: bool = false;
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
@@ -978,35 +982,42 @@ fn arith_mod<S: EvalSemantics>(
                     Err(EvalError::new("modulo by zero"))
                 }
             } else {
-                Ok(OwnedValue::Int(a % b))
+                Ok(OwnedValue::Int(a.wrapping_rem(b)))
             }
         }
-        (OwnedValue::Float(a), OwnedValue::Float(b)) => {
-            if b == 0.0 && !S::DIV_BY_ZERO_IS_INFINITY {
-                Err(EvalError::new("modulo by zero"))
-            } else {
-                Ok(OwnedValue::Float(a % b))
-            }
-        }
-        (OwnedValue::Int(a), OwnedValue::Float(b)) => {
-            if b == 0.0 && !S::DIV_BY_ZERO_IS_INFINITY {
-                Err(EvalError::new("modulo by zero"))
-            } else {
-                Ok(OwnedValue::Float(a as f64 % b))
-            }
-        }
-        (OwnedValue::Float(a), OwnedValue::Int(b)) => {
-            if b == 0 && !S::DIV_BY_ZERO_IS_INFINITY {
-                Err(EvalError::new("modulo by zero"))
-            } else {
-                Ok(OwnedValue::Float(a % b as f64))
-            }
-        }
+        (OwnedValue::Float(a), OwnedValue::Float(b)) => mod_floats::<S>(a, b),
+        (OwnedValue::Int(a), OwnedValue::Float(b)) => mod_floats::<S>(a as f64, b),
+        (OwnedValue::Float(a), OwnedValue::Int(b)) => mod_floats::<S>(a, b as f64),
         (a, b) => Err(EvalError::new(format!(
             "cannot compute modulo of {} and {}",
             a.type_name(),
             b.type_name()
         ))),
+    }
+}
+
+/// Modulo where at least one operand is a float.
+///
+/// jq truncates both operands to integers (`intmax_t`), so `10.5 % 3 == 1` and
+/// `5 % 0.5` errors because the divisor truncates to zero. yq performs float
+/// modulo, returning NaN for a zero divisor.
+fn mod_floats<S: EvalSemantics>(a: f64, b: f64) -> Result<OwnedValue, EvalError> {
+    if S::MOD_TRUNCATES_FLOATS {
+        if a.is_nan() || b.is_nan() {
+            return Ok(OwnedValue::Float(f64::NAN));
+        }
+        // `as` truncates toward zero and saturates, matching jq's intmax_t cast.
+        let (ai, bi) = (a as i64, b as i64);
+        if bi == 0 {
+            Err(EvalError::new("modulo by zero"))
+        } else {
+            // wrapping_rem: i64::MIN % -1 must not panic.
+            Ok(OwnedValue::Int(ai.wrapping_rem(bi)))
+        }
+    } else if b == 0.0 && !S::DIV_BY_ZERO_IS_INFINITY {
+        Err(EvalError::new("modulo by zero"))
+    } else {
+        Ok(OwnedValue::Float(a % b))
     }
 }
 
@@ -13636,6 +13647,48 @@ mod tests {
     }
 
     #[test]
+    fn test_arithmetic_mod_float_truncates() {
+        // jq truncates both operands to integers: 10.5 % 3 == 1
+        query!(br#"{"a": 10.5, "b": 3}"#, ".a % .b",
+            QueryResult::Owned(OwnedValue::Int(1)) => {}
+        );
+
+        // Float % Float: 10.9 % 3.9 == 10 % 3 == 1
+        query!(br#"{"a": 10.9, "b": 3.9}"#, ".a % .b",
+            QueryResult::Owned(OwnedValue::Int(1)) => {}
+        );
+
+        // Truncation is toward zero, not floor: -7.5 % 2 == -7 % 2 == -1
+        query!(br#"{"a": -7.5, "b": 2}"#, ".a % .b",
+            QueryResult::Owned(OwnedValue::Int(-1)) => {}
+        );
+    }
+
+    #[test]
+    fn test_arithmetic_mod_float_divisor_truncates_to_zero() {
+        // jq: 5 % 0.5 errors because the divisor truncates to 0
+        query!(br#"{"a": 5, "b": 0.5}"#, ".a % .b",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    #[test]
+    fn test_arithmetic_mod_nan_and_infinite() {
+        // jq: a NaN operand yields NaN (serialized as null), not an error
+        query!(b"null", "nan % 2",
+            QueryResult::Owned(OwnedValue::Float(n)) if n.is_nan() => {}
+        );
+        query!(b"null", "2 % nan",
+            QueryResult::Owned(OwnedValue::Float(n)) if n.is_nan() => {}
+        );
+
+        // jq: infinite saturates to i64::MAX, so infinite % 3 == 1
+        query!(b"null", "infinite % 3",
+            QueryResult::Owned(OwnedValue::Int(1)) => {}
+        );
+    }
+
+    #[test]
     fn test_arithmetic_precedence() {
         // 2 + 3 * 4 = 2 + 12 = 14
         query!(br"{}", "2 + 3 * 4",
@@ -16657,6 +16710,17 @@ mod tests {
     fn test_compound_assign_mod() {
         // Compound modulo: .a %= 3
         query!(br#"{"a": 10}"#, r".a %= 3",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                let a = obj.get("a").unwrap();
+                assert_eq!(*a, OwnedValue::Int(1));
+            }
+        );
+    }
+
+    #[test]
+    fn test_compound_assign_mod_float_truncates() {
+        // jq truncates float operands: 10.5 %= 3 leaves 10 % 3 == 1
+        query!(br#"{"a": 10.5}"#, r".a %= 3",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 let a = obj.get("a").unwrap();
                 assert_eq!(*a, OwnedValue::Int(1));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 use indexmap::IndexMap;
 
 use super::document::{DocumentCursor, DocumentElements, DocumentFields, DocumentValue};
-use super::eval::{eval as full_eval, EvalError, JqSemantics, QueryResult};
+use super::eval::{eval as full_eval, EvalError, EvalSemantics, JqSemantics, QueryResult};
 use super::expr::{Builtin, CompareOp, Expr, Literal};
 use super::value::OwnedValue;
 use crate::json::JsonIndex;
@@ -172,13 +172,16 @@ fn compare_values(left: &OwnedValue, right: &OwnedValue) -> Option<core::cmp::Or
 ///
 /// This converts the OwnedValue to JSON, evaluates using the full evaluator,
 /// and converts the result back to GenericResult.
-fn eval_on_owned<V: DocumentValue>(expr: &Expr, owned: OwnedValue) -> GenericResult<V> {
+fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    owned: OwnedValue,
+) -> GenericResult<V> {
     let json_str = owned.to_json();
     let json_bytes = json_str.as_bytes();
     let index = JsonIndex::build(json_bytes);
     let cursor = index.root(json_bytes);
 
-    match full_eval::<Vec<u64>, JqSemantics>(expr, cursor) {
+    match full_eval::<Vec<u64>, S>(expr, cursor) {
         QueryResult::One(v) => GenericResult::Owned(standard_json_to_owned(&v)),
         QueryResult::OneCursor(c) => GenericResult::Owned(standard_json_to_owned(&c.value())),
         QueryResult::Many(vs) => {
@@ -193,13 +196,13 @@ fn eval_on_owned<V: DocumentValue>(expr: &Expr, owned: OwnedValue) -> GenericRes
 }
 
 /// Evaluate an expression on multiple OwnedValues using the full evaluator.
-fn eval_on_many_owned<V: DocumentValue>(
+fn eval_on_many_owned<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     owned_values: Vec<OwnedValue>,
 ) -> GenericResult<V> {
     let mut results = Vec::new();
     for owned in owned_values {
-        match eval_on_owned::<V>(expr, owned) {
+        match eval_on_owned::<S, V>(expr, owned) {
             GenericResult::One(_) => unreachable!("eval_on_owned never returns One"),
             GenericResult::OneCursor(_) => unreachable!("eval_on_owned never returns OneCursor"),
             GenericResult::Many(_) => unreachable!("eval_on_owned never returns Many"),
@@ -449,21 +452,42 @@ impl<V: DocumentValue> GenericResult<V> {
 
 /// Evaluate an expression against a document value.
 ///
-/// This is the main entry point for generic evaluation.
+/// This is the main entry point for generic evaluation. It uses jq semantics;
+/// use [`eval_using`] to select yq semantics.
 pub fn eval<V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
-    eval_single(expr, value, false, None)
+    eval_using::<JqSemantics, V>(expr, value)
+}
+
+/// Evaluate an expression against a document value with explicit semantics.
+///
+/// Arithmetic that falls back to the full evaluator (division, modulo, overflow)
+/// follows `S`, so yq keeps yq numeric behavior instead of jq's.
+pub fn eval_using<S: EvalSemantics, V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
+    eval_single::<S, V>(expr, value, false, None)
 }
 
 /// Evaluate an expression against a cursor.
 ///
 /// This entry point preserves cursor position metadata, enabling
-/// `line` and `column` builtins to return actual values.
+/// `line` and `column` builtins to return actual values. It uses jq semantics;
+/// use [`eval_with_cursor_using`] to select yq semantics.
 pub fn eval_with_cursor<C: DocumentCursor>(expr: &Expr, cursor: C) -> GenericResult<C::Value> {
-    eval_single(expr, cursor.value(), false, Some(cursor))
+    eval_with_cursor_using::<JqSemantics, C>(expr, cursor)
+}
+
+/// Evaluate an expression against a cursor with explicit semantics.
+///
+/// Like [`eval_with_cursor`] but arithmetic follows `S` (jq vs yq), so yq's
+/// modulo/division/overflow behavior is preserved on the cursor path.
+pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
+    expr: &Expr,
+    cursor: C,
+) -> GenericResult<C::Value> {
+    eval_single::<S, C::Value>(expr, cursor.value(), false, Some(cursor))
 }
 
 /// Evaluate a single expression against a value with optional cursor context.
-fn eval_single<V: DocumentValue>(
+fn eval_single<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     value: V,
     optional: bool,
@@ -547,23 +571,25 @@ fn eval_single<V: DocumentValue>(
             }
         }
 
-        Expr::Optional(inner) => eval_single(inner, value, true, cursor),
+        Expr::Optional(inner) => eval_single::<S, _>(inner, value, true, cursor),
 
         Expr::Pipe(exprs) => {
             if exprs.is_empty() {
                 return GenericResult::One(value);
             }
 
-            let mut current = eval_single(&exprs[0], value, optional, cursor);
+            let mut current = eval_single::<S, _>(&exprs[0], value, optional, cursor);
 
             for expr in &exprs[1..] {
                 current = match current {
-                    GenericResult::One(v) => eval_single(expr, v, optional, None),
-                    GenericResult::OneCursor(c) => eval_single(expr, c.value(), optional, Some(c)),
+                    GenericResult::One(v) => eval_single::<S, _>(expr, v, optional, None),
+                    GenericResult::OneCursor(c) => {
+                        eval_single::<S, _>(expr, c.value(), optional, Some(c))
+                    }
                     GenericResult::Many(vs) => {
                         let mut results = Vec::new();
                         for v in vs {
-                            match eval_single(expr, v, optional, None) {
+                            match eval_single::<S, _>(expr, v, optional, None) {
                                 GenericResult::One(r) => results.push(to_owned(&r)),
                                 GenericResult::OneCursor(c) => results.push(to_owned(&c.value())),
                                 GenericResult::Many(rs) => {
@@ -586,11 +612,11 @@ fn eval_single<V: DocumentValue>(
                     GenericResult::Error(e) => return GenericResult::Error(e),
                     GenericResult::Owned(o) => {
                         // Continue piping from owned value via JSON round-trip
-                        eval_on_owned(expr, o)
+                        eval_on_owned::<S, _>(expr, o)
                     }
                     GenericResult::ManyOwned(os) => {
                         // Continue piping from owned values via JSON round-trip
-                        eval_on_many_owned(expr, os)
+                        eval_on_many_owned::<S, _>(expr, os)
                     }
                     GenericResult::Break(label) => return GenericResult::Break(label),
                 };
@@ -607,13 +633,13 @@ fn eval_single<V: DocumentValue>(
             Literal::String(s) => GenericResult::Owned(OwnedValue::String(s.clone())),
         },
 
-        Expr::Builtin(builtin) => eval_builtin(builtin, value, optional, cursor),
+        Expr::Builtin(builtin) => eval_builtin::<S, _>(builtin, value, optional, cursor),
 
         // Comparison operations - handle locally to preserve cursor context
         Expr::Compare { op, left, right } => {
             // Evaluate left and right with cursor context preserved
-            let left_result = eval_single(left, value.clone(), false, cursor);
-            let right_result = eval_single(right, value, false, cursor);
+            let left_result = eval_single::<S, _>(left, value.clone(), false, cursor);
+            let right_result = eval_single::<S, _>(right, value, false, cursor);
 
             // Convert results to OwnedValue for comparison
             let left_owned = match left_result {
@@ -707,7 +733,7 @@ fn eval_single<V: DocumentValue>(
             let cursor = index.root(json_bytes);
 
             // Evaluate using the full evaluator
-            match full_eval::<Vec<u64>, JqSemantics>(expr, cursor) {
+            match full_eval::<Vec<u64>, S>(expr, cursor) {
                 QueryResult::One(v) => {
                     // Convert StandardJson back to OwnedValue
                     GenericResult::Owned(standard_json_to_owned(&v))
@@ -729,7 +755,7 @@ fn eval_single<V: DocumentValue>(
 }
 
 /// Evaluate a builtin function.
-fn eval_builtin<V: DocumentValue>(
+fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
     builtin: &Builtin,
     value: V,
     optional: bool,
@@ -754,7 +780,7 @@ fn eval_builtin<V: DocumentValue>(
         Builtin::Select(cond) => {
             // Evaluate condition with cursor context preserved
             // This is critical for select(di == N) to work correctly
-            let cond_result = eval_single(cond, value.clone(), false, cursor);
+            let cond_result = eval_single::<S, _>(cond, value.clone(), false, cursor);
 
             // Helper to check if an OwnedValue is truthy
             let is_truthy = |v: &OwnedValue| -> bool {
@@ -1112,7 +1138,7 @@ fn eval_builtin<V: DocumentValue>(
         // Phase 23: Position-based navigation (succinctly extension)
         Builtin::AtOffset(offset_expr) => {
             // Evaluate the offset expression
-            let offset_result = eval_single(offset_expr, value.clone(), false, cursor);
+            let offset_result = eval_single::<S, _>(offset_expr, value.clone(), false, cursor);
             let offset = match offset_result {
                 GenericResult::Owned(OwnedValue::Int(i)) if i >= 0 => i as usize,
                 GenericResult::One(v) => match v.as_i64() {
@@ -1152,7 +1178,7 @@ fn eval_builtin<V: DocumentValue>(
 
         Builtin::AtPosition(line_expr, col_expr) => {
             // Evaluate the line expression
-            let line_result = eval_single(line_expr, value.clone(), false, cursor);
+            let line_result = eval_single::<S, _>(line_expr, value.clone(), false, cursor);
             let line = match line_result {
                 GenericResult::Owned(OwnedValue::Int(i)) if i > 0 => i as usize,
                 GenericResult::One(v) => match v.as_i64() {
@@ -1171,7 +1197,7 @@ fn eval_builtin<V: DocumentValue>(
             };
 
             // Evaluate the column expression
-            let col_result = eval_single(col_expr, value.clone(), false, cursor);
+            let col_result = eval_single::<S, _>(col_expr, value.clone(), false, cursor);
             let col = match col_result {
                 GenericResult::Owned(OwnedValue::Int(i)) if i > 0 => i as usize,
                 GenericResult::One(v) => match v.as_i64() {
@@ -1214,7 +1240,7 @@ fn eval_builtin<V: DocumentValue>(
         // For other builtins, fall back to full evaluator via JSON
         _ => {
             let owned = to_owned(&value);
-            eval_on_owned(&Expr::Builtin(builtin.clone()), owned)
+            eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned)
         }
     }
 }
@@ -1945,5 +1971,24 @@ mod tests {
         let expr = crate::jq::parse(".a | tonumber").unwrap();
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_error());
+    }
+
+    #[test]
+    fn test_arithmetic_semantics_are_threaded() {
+        // The generic evaluator delegates arithmetic to the full evaluator; the
+        // semantics parameter must reach that fallback so jq truncates float
+        // modulo (issue #164) while yq keeps float modulo.
+        use crate::jq::YqSemantics;
+
+        let expr = crate::jq::parse("10.5 % 3").unwrap();
+
+        let json = b"null";
+        let index = JsonIndex::build(json);
+
+        let jq_result = eval_using::<JqSemantics, _>(&expr, index.root(json).value());
+        assert_eq!(jq_result.into_owned(), Some(OwnedValue::Int(1)));
+
+        let yq_result = eval_using::<YqSemantics, _>(&expr, index.root(json).value());
+        assert_eq!(yq_result.into_owned(), Some(OwnedValue::Float(1.5)));
     }
 }

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -1002,6 +1002,23 @@ fn test_integer_modulo_by_zero_returns_error() {
 }
 
 #[test]
+fn test_float_modulo_truncates_operands_to_integers() {
+    // jq: 10.5 % 3 => 1 (both operands truncate to intmax_t)
+    query!(b"null", "10.5 % 3",
+        QueryResult::Owned(OwnedValue::Int(1)) => {}
+    );
+}
+
+#[test]
+fn test_float_modulo_divisor_truncating_to_zero_returns_error() {
+    // jq: 5 % 0.5 => error "cannot be divided (remainder) because the divisor is zero"
+    // (the divisor 0.5 truncates to 0)
+    query!(b"null", "5 % 0.5",
+        QueryResult::Error(_) => {}
+    );
+}
+
+#[test]
 fn test_integer_addition_overflow_converts_to_float() {
     // jq: 9223372036854775807 + 1 => 9223372036854776000 (float)
     query!(b"null", "9223372036854775807 + 1",

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1128,6 +1128,17 @@ fn test_colorized_json_output_is_token_aware() -> Result<()> {
 }
 
 #[test]
+fn test_float_modulo_uses_float_semantics() -> Result<()> {
+    // yq (unlike jq) performs float modulo: 10.5 % 3 => 1.5.
+    // This guards against the jq integer-truncation fix (issue #164)
+    // leaking into yq's semantics.
+    let (output, exit_code) = run_yq_stdin("10.5 % 3", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "1.5");
+    Ok(())
+}
+
+#[test]
 fn test_build_configuration_flag() -> Result<()> {
     // --build-configuration prints diagnostics and exits successfully.
     let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
@@ -1503,5 +1514,22 @@ fn test_exit_status_no_stderr_message_when_truthy() -> Result<()> {
     let output = cmd.wait_with_output()?;
     assert_eq!(output.status.code(), Some(0));
     assert_eq!(String::from_utf8(output.stderr)?.trim(), "");
+    Ok(())
+}
+
+#[test]
+fn test_arithmetic_semantics_match_between_stdin_and_null_input() -> Result<()> {
+    // The stdin/file path (generic evaluator) and the -n path (full evaluator)
+    // must agree on yq numeric semantics. Before threading EvalSemantics through
+    // the generic evaluator, the stdin path silently used jq semantics.
+    for expr in ["10.5 % 3", "1 / 0", "7.5 % 2.5"] {
+        let (stdin_out, stdin_code) = run_yq_stdin(expr, "null", &["-o=json", "-I=0"])?;
+        let (null_out, null_code) = run_yq_stdin(expr, "", &["-n", "-o=json", "-I=0"])?;
+        assert_eq!(
+            (stdin_out.trim(), stdin_code),
+            (null_out.trim(), null_code),
+            "stdin vs -n disagree for `{expr}`",
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
## Description

This PR fixes jq's modulo operator to correctly truncate float operands to integers before computing the remainder, matching jq's behavior. Additionally, it threads evaluation semantics through the generic evaluator to ensure yq maintains its own float modulo semantics when processing YAML stdin/file paths.

### Root Cause

jq truncates both operands of `%` to `intmax_t` before taking the remainder, so `10.5 % 3` equals `1` (not `1.5`), and `5 % 0.5` errors because the divisor truncates to zero. The previous implementation applied IEEE float `%` whenever an operand was a float, yielding incorrect results like `1.5` and spurious `0.0` instead of proper error handling.

Additionally, the generic evaluator (used by yq's stdin/file path to preserve line/column metadata) hardcoded `JqSemantics` in its full-evaluator fallback, causing yq to silently apply jq's arithmetic semantics. This became apparent after the modulo fix, where yq's `10.5 % 3` would return `1` instead of the correct `1.5`.

### Solution

**Commit 1: Fix jq modulo truncation**
- Added `MOD_TRUNCATES_FLOATS` constant to `EvalSemantics` trait (true for jq, false for yq)
- Implemented shared `mod_floats()` helper function that:
  - Truncates float operands to `i64` (saturating, toward zero) for jq semantics
  - Errors on zero truncated divisor
  - Passes NaN through unchanged
  - Applies IEEE float modulo for yq semantics
- Hardened integer modulo with `wrapping_rem` to prevent `i64::MIN % -1` panic
- Added comprehensive tests covering truncation, edge cases (NaN, infinite), and divisor-truncates-to-zero scenarios

**Commit 2: Thread evaluation semantics through generic evaluator**
- Made `eval_single()`, `eval_builtin()`, and `on_owned` helpers generic over `EvalSemantics`
- Added `eval_using::<S, V>()` and `eval_with_cursor_using::<S, C>()` entry points
- Updated `yq_runner.rs` to use `YqSemantics` for stdin/file evaluation paths
- Kept `eval()` and `eval_with_cursor()` defaulting to `JqSemantics` for backward compatibility
- Added tests verifying arithmetic semantics consistency between stdin and `-n` paths

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #164 - jq modulo with float operands does not truncate

## Changes Made

**Core Arithmetic:**
- Modified `src/jq/eval.rs` to add `MOD_TRUNCATES_FLOATS` trait constant
- Implemented `mod_floats::<S>()` function handling both jq (truncate floats) and yq (float modulo) semantics
- Updated `arith_mod()` to route float arms through the shared helper and use `wrapping_rem` for integers

**Generic Evaluator Refactoring:**
- Made `eval_single::<S, V>()` generic over `EvalSemantics` in `src/jq/eval_generic.rs`
- Made `eval_builtin::<S, V>()` generic over `EvalSemantics`
- Made `eval_on_owned::<S, V>()` and `eval_on_many_owned::<S, V>()` generic over `EvalSemantics`
- Added public `eval_using::<S, V>()` and `eval_with_cursor_using::<S, C>()` entry points
- Updated `src/bin/succinctly/yq_runner.rs` to use `eval_with_cursor_using::<YqSemantics, _>()`

**Test Coverage:**
- Added `test_arithmetic_mod_float_truncates()` verifying `10.5 % 3 == 1` and truncation toward zero
- Added `test_arithmetic_mod_float_divisor_truncates_to_zero()` verifying error on zero truncated divisor
- Added `test_arithmetic_mod_nan_and_infinite()` verifying NaN pass-through and infinite saturation
- Added `test_compound_assign_mod_float_truncates()` for `%=` operator
- Added `test_arithmetic_semantics_are_threaded()` verifying jq vs yq semantics in generic evaluator
- Added `test_float_modulo_uses_float_semantics()` CLI test for yq float modulo behavior
- Added `test_arithmetic_semantics_match_between_stdin_and_null_input()` verifying consistency

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for float modulo truncation (8 new test cases)
- [x] Tests verify both jq and yq semantics are correctly applied
- [x] Integration tests confirm stdin and `-n` paths use matching semantics

**Test Commands**
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact - changes are correctness fixes with minimal overhead

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings
- [x] Backward compatibility maintained (jq semantics default unchanged)

## Additional Notes

**Behavioral Changes:**
- jq: `10.5 % 3` now returns `1` (was `1.5`)
- jq: `5 % 0.5` now errors (was `0.0`)
- yq: `10.5 % 3` still returns `1.5` (fixed regression from generic evaluator hardcoding)
- yq: stdin and `-n` paths now consistently apply yq float semantics

**No Breaking Changes:** The fix is purely corrective. jq behavior is now accurate to spec. yq stdin behavior is restored to expected float modulo semantics.

**Design Notes:** The `MOD_TRUNCATES_FLOATS` constant allows future semantics implementations to define their own behavior. NaN and infinite values are handled correctly per IEEE semantics.