### PR TITLE
docs(simd): document popcount strategies with measured benchmarks (#45)

### DIFF
--- a/.claude/skills/simd-optimization/SKILL.md
+++ b/.claude/skills/simd-optimization/SKILL.md
@@ -13,14 +13,14 @@ Patterns and learnings from SIMD optimization in this codebase.
 
 Two AVX-512 optimizations implemented with dramatically different results:
 
-### AVX512-VPOPCNTDQ: 5.2x Speedup (Compute-Bound)
+### AVX512-VPOPCNTDQ: ~5–9× vs a Baseline `count_ones()`, ≈1× Native (Compute-Bound)
 
 **Implementation**: `src/bits/popcount.rs`
 - Processes 8 u64 words (512 bits) in parallel
 - Hardware `_mm512_popcnt_epi64` instruction
-- **Result**: 96.8 GiB/s vs 18.5 GiB/s (scalar) = **5.2x faster**
+- **Result**: ~5–9× faster than a *baseline-build* `count_ones()` (which lowers to scalar broadword) — e.g. 96.8 GiB/s vs 18.5 GiB/s.
 
-**Why it wins**: Pure compute-bound, embarrassingly parallel, no dependencies
+**Why it wins — but only vs a baseline build**: Pure compute-bound and embarrassingly parallel, so explicit VPOPCNTDQ crushes scalar broadword. But compile with `-C target-cpu=native` and `count_ones()` auto-vectorizes to VPOPCNTDQ itself, reaching **≈1× parity** — the explicit path's remaining value is portable binaries that still reach VPOPCNTDQ via runtime `is_x86_feature_detected!` dispatch. Measured data: [Popcount Strategies](../../../docs/optimizations/simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones) (#45).
 
 ### AVX-512 JSON Parser: 7-17% Slower (Memory-Bound) - REMOVED
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -61,6 +61,7 @@ jobs:
             --exclude '^https://www\.cs\.cmu\.edu/'
             --exclude '^https://doi\.org/'
             --exclude '^https://no-color\.org/'
+            --exclude '^https://www\.reddit\.com/'
             '**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,6 +95,7 @@ jobs:
             --exclude '^https://www\.cs\.cmu\.edu/'
             --exclude '^https://doi\.org/'
             --exclude '^https://no-color\.org/'
+            --exclude '^https://www\.reddit\.com/'
             '**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -215,10 +215,12 @@ Comparison of `succinctly jq .` vs `jq .` for formatting/printing JSON files.
 
 | Platform             | Operation                    | Throughput | Speedup         |
 |----------------------|------------------------------|------------|-----------------|
-| **x86_64**           | Popcount (AVX-512 VPOPCNTDQ) | 96.8 GiB/s |  5.2x vs scalar |
+| **x86_64**           | Popcount (AVX-512 VPOPCNTDQ) | 96.8 GiB/s | 5.2x vs scalar† |
 | **ARM (M1 Max)**     | NEON JSON (string-heavy)     |  3.7 GiB/s | 1.69x vs scalar |
 | **ARM (Neoverse-V1)**| Popcount (NEON)              | 46.5 GiB/s |  N/A            |
 |                      | NEON movemask (parallel)     |  1.37 ns   | 2.5x vs serial  |
+
+† Popcount speedup is measured against a *baseline* build, where `count_ones()` lowers to scalar broadword. Compiled with `-C target-cpu=native`, `count_ones()` auto-vectorizes to VPOPCNTDQ and the explicit path drops to ≈1× (parity); the ~5–9× win holds only for baseline/portable builds. Full measured data: [Popcount Strategies](docs/optimizations/simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones) (#45).
 
 See [docs/benchmarks/rust-parsers.md](docs/benchmarks/rust-parsers.md), [docs/benchmarks/jq.md](docs/benchmarks/jq.md), and [docs/optimizations/history.md](docs/optimizations/history.md) for detailed benchmarks.
 

--- a/benches/popcount_strategies.rs
+++ b/benches/popcount_strategies.rs
@@ -1,17 +1,25 @@
 //! Detailed popcount strategy benchmarks.
 //!
-//! Compares performance across different popcount implementations:
-//! - Default: Rust's count_ones() (auto-vectorizes)
-//! - SIMD: Explicit SIMD intrinsics with AVX512-VPOPCNTDQ dispatch
-//! - Portable: Pure bitwise algorithm
+//! Compares performance across the three popcount implementations:
+//! - `scalar`: Rust's `count_ones()` — the default strategy; auto-vectorizes to
+//!   POPCNT on x86_64 and CNT on aarch64.
+//! - `portable`: pure broadword (SWAR) bitwise algorithm (`portable-popcount`).
+//! - `simd`: explicit SIMD intrinsics — AVX-512 VPOPCNTDQ dispatch on x86_64,
+//!   256-byte-unrolled NEON on aarch64.
 //!
-//! Run with:
+//! The `scalar` and `portable` arms are always measured; the `simd` arm is
+//! compiled only with `--features simd`. A single run therefore reports all
+//! three strategies side by side:
+//!
 //! - `cargo bench --bench popcount_strategies --features simd`
+//!
+//! Without `--features simd`, only `scalar` and `portable` are reported.
 
 #[cfg(feature = "simd")]
 use criterion::black_box;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
+use succinctly::popcount_word_portable;
 #[cfg(feature = "simd")]
 use succinctly::popcount_words;
 
@@ -57,7 +65,7 @@ fn bench_popcount_strategies(c: &mut Criterion) {
                 |b, words| b.iter(|| popcount_words(black_box(words))),
             );
 
-            // Always benchmark scalar as baseline
+            // Always benchmark scalar (default count_ones) as baseline
             group.bench_with_input(
                 BenchmarkId::new(format!("{size_name}/{pattern_name}"), "scalar"),
                 &words,
@@ -66,6 +74,21 @@ fn bench_popcount_strategies(c: &mut Criterion) {
                         let mut total = 0u32;
                         for &word in words {
                             total += word.count_ones();
+                        }
+                        total
+                    });
+                },
+            );
+
+            // Always benchmark the portable broadword algorithm for comparison
+            group.bench_with_input(
+                BenchmarkId::new(format!("{size_name}/{pattern_name}"), "portable"),
+                &words,
+                |b, words| {
+                    b.iter(|| {
+                        let mut total = 0u32;
+                        for &word in words {
+                            total += popcount_word_portable(word);
                         }
                         total
                     });
@@ -136,6 +159,16 @@ fn bench_throughput(c: &mut Criterion) {
             let mut total = 0u32;
             for word in &words {
                 total += word.count_ones();
+            }
+            total
+        });
+    });
+
+    group.bench_function("portable_1MB", |b| {
+        b.iter(|| {
+            let mut total = 0u32;
+            for &word in &words {
+                total += popcount_word_portable(word);
             }
             total
         });

--- a/docs/architecture/prior-art.md
+++ b/docs/architecture/prior-art.md
@@ -46,7 +46,7 @@ rising with bit density; see [../benchmarks/rust-succinct-libs.md](../benchmarks
 |--------------------------------------------------------------------------------------|--------------------|------|--------------------------------|
 | [Faster Population Counts Using AVX2 Instructions](https://arxiv.org/abs/1611.07612) | Mula, Kurz, Lemire | 2016 | Harley-Seal popcount algorithm |
 
-**Succinctly implementation**: [src/bits/popcount.rs](../../src/bits/popcount.rs) uses AVX-512 VPOPCNTDQ when available (5.2x speedup).
+**Succinctly implementation**: [src/bits/popcount.rs](../../src/bits/popcount.rs) uses AVX-512 VPOPCNTDQ when available — 5–9× faster than a baseline-build `count_ones()`, but ≈1× once `count_ones()` auto-vectorizes to VPOPCNTDQ under `-C target-cpu=native` (see [optimizations/simd.md](../optimizations/simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones)).
 
 ---
 

--- a/docs/optimizations/README.md
+++ b/docs/optimizations/README.md
@@ -35,14 +35,14 @@ This directory documents optimization techniques used in the succinctly library,
 | Byte Lookup Tables             | **11x**            | Lookup           | [lookup-tables.md](lookup-tables.md)                     |
 | BMI2 PDEP Toggle               | **10x**            | Bit manipulation | [bit-manipulation.md](bit-manipulation.md)               |
 | Lightweight DSV Index          | **5-9x**           | Cache/Memory     | [cache-memory.md](cache-memory.md)                       |
-| AVX-512 VPOPCNTDQ              | **5.2x**           | SIMD             | [simd.md](simd.md)                                      |
+| AVX-512 VPOPCNTDQ              | **5–9× / ≈1×**     | SIMD             | [simd.md](simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones) |
 | Exponential Search             | **3.1x**           | Access patterns  | [access-patterns.md](access-patterns.md)                 |
 | NEON VMINV L1 Building         | **2.8x**           | SIMD             | [simd.md](simd.md)                                      |
 | SSE4.1 PHMINPOSUW L1/L2       | **1-3%** (10M+)    | SIMD             | [simd.md](simd.md)                                      |
 | AVX2 JSON Parser               | **1.78x**          | SIMD             | [simd.md](simd.md)                                      |
 | PFSM Tables                    | **1.77x**          | State machines   | [state-machines.md](state-machines.md)                   |
 | NEON DSV Index                 | **1.8x**           | SIMD             | [simd.md](simd.md)                                      |
-| NEON 256B Popcount             | **1.15x**          | SIMD             | [simd.md](simd.md)                                      |
+| NEON 256B Popcount             | **1.6×** (M4 Pro)  | SIMD             | [simd.md](simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones) |
 | SIMD Unquoted Structural Skip  | **3-8%**           | SIMD             | [simd.md](simd.md)                                      |
 | Lazy line + direct indexing    | **2-6%**           | State machines   | [state-machines.md](state-machines.md)                   |
 | P12-A Build Mitigation         | **11-85%** (build) | Compact encoding | [end-positions.md](end-positions.md)                     |

--- a/docs/optimizations/bit-manipulation.md
+++ b/docs/optimizations/bit-manipulation.md
@@ -60,7 +60,13 @@ fn popcount_hw(x: u64) -> u32 {
 }
 ```
 
-**Rust**: Use `x.count_ones()` which compiles to `POPCNT` when available.
+**Rust**: Use `x.count_ones()`. It compiles to `POPCNT`/`VPOPCNTDQ` (x86) or `CNT` (ARM)
+only when the target enables the feature — `-C target-cpu=native`, or `+popcnt` on x86;
+`CNT` is always available on aarch64 — and falls back to the broadword sequence above
+otherwise. See
+[SIMD → Popcount Strategies](simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones)
+for a measured comparison of `count_ones()` against explicit SIMD popcount across build
+modes and array sizes (issue #45).
 
 ### Prior Art
 

--- a/docs/optimizations/history.md
+++ b/docs/optimizations/history.md
@@ -31,6 +31,8 @@ This document records all optimization attempts in the succinctly library, showi
 | O1 Sequential Cursor      | **3-13%** (yq identity queries, 1-100KB)    | All      | Deployed |
 | O2 Gap-Skip rank1         | **2-6%** (yq identity queries, nested/users) | All      | Deployed |
 
+> **Popcount build-flag caveat (#45):** The **AVX512-VPOPCNTDQ 5.2×** and **NEON 256-byte 1.10–1.15×** micro figures above are measured against a *baseline* build, where `count_ones()` stays scalar broadword. Under `-C target-cpu=native`, `count_ones()` auto-vectorizes and the x86 explicit path reaches **≈1× parity**; on Apple M4 Pro the NEON path re-measures at **1.56×**. Full measured data: [Popcount Strategies](simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones).
+
 **Total Successful**: 18 optimizations
 **Best Result**: Cumulative index (627x)
 
@@ -83,7 +85,7 @@ Parallel popcount of 8 u64 words (512 bits) using `_mm512_popcnt_epi64`.
 | 4KB (512 words)  | 342 ns  | 27.7 ns          | **+1135%**  |
 | 1MB (131K words) | 52.6 us | 10.1 us          | **+421%**   |
 
-**Throughput**: 96.8 GiB/s (AVX-512) vs 18.5 GiB/s (scalar) = **5.2x faster**
+**Throughput**: 96.8 GiB/s (AVX-512) vs 18.5 GiB/s (scalar, *baseline build*) = **5.2x faster** — but ≈1× once `count_ones()` auto-vectorizes to VPOPCNTDQ under `-C target-cpu=native` (see [Popcount Strategies](simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones), #45)
 
 **End-to-End Impact**: ~1-2% overall (Amdahl's Law - popcount is ~1.6% of total time)
 
@@ -354,7 +356,7 @@ Before implementing an optimization, ask:
 
 **x86_64 (Zen 4)**:
 - JSON parsing: ~2.4x faster (PFSM BMI2 vs scalar baseline)
-- Popcount: 5.2x faster (AVX512-VPOPCNTDQ vs scalar)
+- Popcount: 5.2x faster vs *baseline-build* scalar; ≈1× once `count_ones()` auto-vectorizes under `-C target-cpu=native` (#45)
 
 **ARM (Apple Silicon)**:
 - JSON parsing: 1.52x faster (NEON vs scalar)

--- a/docs/optimizations/simd-strategy.md
+++ b/docs/optimizations/simd-strategy.md
@@ -74,6 +74,7 @@ SIMD paths are selected via `#[cfg(target_arch)]` and Rust's `is_x86_feature_det
 ## See Also
 
 - [SIMD](simd.md) — detailed technique reference for each SIMD extension
+- [SIMD → Popcount Strategies](simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones) — measured explicit SIMD popcount vs auto-vectorized `count_ones()` across build modes (issue #45)
 - [Targets](targets.md) — CPU-specific build configurations
 
 ## Source & Docs

--- a/docs/optimizations/simd.md
+++ b/docs/optimizations/simd.md
@@ -83,7 +83,12 @@ unsafe fn popcount_avx512(words: &[u64; 8]) -> u64 {
 }
 ```
 
-**When AVX-512 wins**: Compute-bound operations like popcount (5.2x faster).
+**When AVX-512 wins**: Compute-bound operations like popcount — but *only against a
+baseline build*. Explicit VPOPCNTDQ is 5–9× faster than `count_ones()` when the latter is
+left as scalar broadword (default `cargo build`), yet drops to ≈1× once you compile with
+`-C target-cpu=native` and LLVM auto-vectorizes `count_ones()` to VPOPCNTDQ itself. See
+[Popcount Strategies](#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones) for
+the full measured data.
 
 **When AVX-512 loses**: Memory-bound operations like JSON parsing (7-17% slower) and YAML parsing (7% slower at 64B).
 
@@ -693,22 +698,159 @@ isolation but cause regression when integrated due to real-world data characteri
 
 ---
 
+## Popcount Strategies: Explicit SIMD vs Auto-Vectorized `count_ones()`
+
+*Measured for [issue #45](https://github.com/rust-works/succinctly/issues/45), raised on
+[r/rust](https://www.reddit.com/r/rust/comments/1qleizg/comment/o1f6w6c/): has explicit
+SIMD popcount actually been benchmarked against LLVM's auto-vectorized `count_ones()`?*
+
+The crate offers three popcount strategies for the `popcount_words()` hot path
+([`bits/popcount.rs`](../../src/bits/popcount.rs)), selected at compile time:
+
+| Strategy     | Feature flag                  | Implementation                                                            |
+|--------------|-------------------------------|---------------------------------------------------------------------------|
+| **default**  | *(none)*                      | `w.count_ones()` in a loop — LLVM lowers the `ctpop` intrinsic            |
+| **simd**     | `--features simd`             | explicit AVX-512 VPOPCNTDQ (x86, runtime-detected) / 256-byte-unrolled NEON (ARM) |
+| **portable** | `--features portable-popcount`| broadword SWAR (`popcount_word_portable`)                                 |
+
+The [`popcount_strategies`](../../benches/popcount_strategies.rs) benchmark measures all
+three in one run — the `scalar` (= default `count_ones()`) and `portable` arms are always
+present; the `simd` arm is compiled with `--features simd`.
+
+**Methodology.** Criterion, 100 samples, median times, `random` word pattern. Popcount is
+branchless and fixed-cost per word, so it is **data-independent**: across all six bit
+patterns (`zeros`…`random`) at 256 KiB the medians agree within noise (simd ≤ 0.6%, scalar
+≤ 2%). The axis that matters is **working-set size** (cache residency), not bit density.
+Two machines, two build modes each: **x86_64** = AMD Ryzen 9 7950X (Zen 4, AVX-512
+VPOPCNTDQ), Linux, rustc 1.97, pinned to one core; **aarch64** = Apple M4 Pro, macOS,
+rustc 1.96.
+
+### TL;DR
+
+- **On x86_64 it is a build-flag question, not a size question.** In a **default** build
+  `count_ones()` lowers to the *scalar broadword* sequence (byte-for-byte as fast as the
+  `portable` arm), and explicit AVX-512 is **5–9× faster**. Rebuild with
+  `-C target-cpu=native` (or `+avx512vpopcntdq`) and `count_ones()` auto-vectorizes to
+  VPOPCNTDQ, reaching **parity** with the explicit path (within ±15%, usually a hair
+  *faster*).
+- **On aarch64 explicit NEON always wins ~1.55–1.6×**, at every size and in every build
+  mode. `CNT` is baseline on ARM so `count_ones()` already vectorizes — but LLVM does not
+  reproduce the 256-byte-unrolled loop's *deferred horizontal reduction*.
+- **`portable-popcount` is never distinguishable from default `count_ones()`** on either
+  platform in any build — LLVM lowers both to the same instructions. It buys nothing
+  performance-wise; it exists only to force a pure-arithmetic lowering.
+
+### x86_64 — AMD Ryzen 9 7950X (Zen 4), `simd` = AVX-512 VPOPCNTDQ
+
+**Default build** (`cargo bench --bench popcount_strategies --features simd`).
+`count_ones()` compiles to broadword — note `count_ones() ≈ portable`:
+
+| Size    | `count_ones()` | simd     | portable | SIMD×    |
+|---------|----------------|----------|----------|----------|
+| 64 B    | 3.50 ns        | 1.83 ns  | 3.51 ns  | 1.9×     |
+| 512 B   | 25.6 ns        | 3.52 ns  | 25.5 ns  | 7.3×     |
+| 4 KiB   | 203 ns         | 22.5 ns  | 203 ns   | **9.0×** |
+| 32 KiB  | 1.61 µs        | 199 ns   | 1.61 µs  | 8.1×     |
+| 256 KiB | 12.9 µs        | 1.76 µs  | 12.9 µs  | 7.3×     |
+| 1 MiB   | 51.9 µs        | 8.74 µs  | 51.8 µs  | 5.9×     |
+| 10 MiB  | 521 µs         | 106 µs   | 520 µs   | 4.9×     |
+
+Throughput @ 1 MiB: simd **112.7 GiB/s**, `count_ones()`/portable 18.8 GiB/s.
+
+**`target-cpu=native` build** (`RUSTFLAGS="-C target-cpu=native" cargo bench …`).
+`count_ones()` now auto-vectorizes to VPOPCNTDQ and reaches parity:
+
+| Size    | `count_ones()` | simd     | portable | SIMD×             |
+|---------|----------------|----------|----------|-------------------|
+| 64 B    | 0.92 ns        | 1.10 ns  | 0.92 ns  | 0.83× (scalar wins) |
+| 512 B   | 3.23 ns        | 2.84 ns  | 3.23 ns  | 1.14×             |
+| 4 KiB   | 21.9 ns        | 23.0 ns  | 22.0 ns  | 0.95×             |
+| 32 KiB  | 159 ns         | 181 ns   | 160 ns   | 0.88×             |
+| 256 KiB | 1.79 µs        | 1.72 µs  | 1.78 µs  | 1.04×             |
+| 1 MiB   | 7.92 µs        | 8.24 µs  | 7.90 µs  | 0.96×             |
+| 10 MiB  | 109 µs         | 103 µs   | 109 µs   | 1.06×             |
+
+Throughput @ 1 MiB: `count_ones()` **126 GiB/s**, simd 122 GiB/s. Criterion's A/B delta
+between the two builds records `count_ones()` @ 1 MiB dropping **−85%** in time
+(18.8 → 126 GiB/s) — that is the switch from broadword to VPOPCNTDQ.
+
+### aarch64 — Apple M4 Pro, `simd` = 256-byte-unrolled NEON
+
+`CNT` is baseline on ARM, so the build mode barely matters (`native` matches the numbers
+below within ~2%). `count_ones() ≈ portable` again; the explicit NEON path is uniformly
+ahead:
+
+| Size    | `count_ones()` | simd     | portable | SIMD×  |
+|---------|----------------|----------|----------|--------|
+| 64 B    | 1.17 ns        | 0.95 ns  | 1.18 ns  | 1.24×  |
+| 512 B   | 7.40 ns        | 4.59 ns  | 7.40 ns  | 1.61×  |
+| 4 KiB   | 57.2 ns        | 36.0 ns  | 57.2 ns  | 1.59×  |
+| 32 KiB  | 457 ns         | 289 ns   | 457 ns   | 1.58×  |
+| 256 KiB | 3.76 µs        | 2.43 µs  | 3.77 µs  | 1.55×  |
+| 1 MiB   | 15.1 µs        | 9.69 µs  | 15.2 µs  | 1.56×  |
+| 10 MiB  | 154 µs         | 98.7 µs  | 155 µs   | 1.56×  |
+
+Throughput @ 1 MiB: simd **99.8 GiB/s**, `count_ones()`/portable 63.7 GiB/s.
+
+### Answers to the issue's questions
+
+1. **When does explicit SIMD beat `count_ones()`?**
+   - *x86_64*: only when the build does **not** enable the POPCNT/AVX-512 target features.
+     A default `cargo build`/`cargo bench` (baseline `x86-64-v1`) leaves `count_ones()` as
+     scalar broadword, and explicit AVX-512 wins 5–9×. Under `-C target-cpu=native` the
+     win vanishes (parity).
+   - *aarch64*: always, by ~1.55–1.6×, independent of build flags and array size — the
+     explicit loop's batched reduction is something the auto-vectorizer does not emit.
+2. **Is the `simd` feature worth the maintenance burden?**
+   - *x86_64*: as a *speed* feature, no — a `target-cpu=native` build gets the same
+     VPOPCNTDQ for free. Its remaining value is narrow but real: a **portable binary**
+     compiled for a baseline target still reaches VPOPCNTDQ through the runtime
+     `is_x86_feature_detected!` dispatch, which auto-vectorization cannot provide.
+   - *aarch64*: yes — the ~1.56× is real, unconditional, and not recovered by the compiler.
+3. **Where is the crossover (small vs large arrays)?**
+   - There is **no size crossover**. The ratio is essentially flat across 64 B → 10 MiB on
+     both platforms (it only sags on x86 at ≤ 512 B where loop/setup overhead dominates).
+     The real "crossover" on x86 is the *build flag*, not the input size.
+
+**Caveat.** These numbers isolate the popcount kernel over a contiguous `&[u64]`. In real
+rank/select index building, popcount is interleaved with loads, shifts and stores, so these
+ratios are an upper bound on what the strategy contributes end-to-end — consistent with
+this project's recurring "micro-benchmarks mislead" finding.
+
+### Reproduce
+
+```bash
+# All three arms in one report (scalar / simd / portable):
+cargo bench --bench popcount_strategies --features simd
+
+# Let count_ones() auto-vectorize to VPOPCNTDQ (x86) / native CNT (ARM):
+RUSTFLAGS="-C target-cpu=native" cargo bench --bench popcount_strategies --features simd
+```
+
+---
+
 ## Usage in Succinctly
 
 | SIMD Level | Location                | Purpose                  | Speedup |
 |------------|-------------------------|--------------------------|---------|
-| AVX-512    | `bits/popcount.rs`      | Parallel popcount        | 5.2x    |
+| AVX-512    | `bits/popcount.rs`      | Parallel popcount        | 5–9× / ≈1×‡ |
 | AVX2       | `json/simd/avx2.rs`     | JSON char classification | 1.78x   |
 | AVX2+BMI2  | `dsv/simd/bmi2.rs`      | DSV quote masking        | 10x     |
 | NEON       | `json/simd/neon.rs`     | ARM JSON parsing         | 1.11x   |
 | NEON       | `dsv/simd/neon.rs`      | ARM DSV parsing          | 1.8x    |
 | NEON       | `trees/bp.rs`           | BP L1/L2 index (VMINV)   | 2.8x (L1), 1-3% (L2) |
 | SSE4.1     | `trees/bp.rs`           | BP L1/L2 index (PHMINPOSUW) | 1-3% (10M+ nodes) |
-| NEON       | `bits/popcount.rs`      | 256-byte unrolling       | 1.15x   |
+| NEON       | `bits/popcount.rs`      | 256-byte unrolling       | 1.6×‡   |
 | NEON/AVX2  | `yaml/simd/`            | YAML unquoted structural | 3-8%    |
 | NEON       | `yaml/simd/neon.rs`     | Block scalar scanning    | 11-23%  |
 | NEON       | `yaml/simd/neon.rs`     | Anchor name scanning     | 3-6%    |
 | SVE2-BDEP  | `util/broadword.rs`     | select_in_word           | 5-17x (micro), 2-5% (e2e) |
+
+‡ Popcount speedups are **measured**, and depend on build flags. AVX-512 VPOPCNTDQ is 5–9×
+faster than a *baseline*-build `count_ones()` but ≈1× once `count_ones()` auto-vectorizes
+under `-C target-cpu=native`; the NEON 1.6× (Apple M4 Pro) holds regardless of build flags.
+Full data and methodology:
+[Popcount Strategies](#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones).
 
 ---
 

--- a/docs/plan/sve2-optimizations.md
+++ b/docs/plan/sve2-optimizations.md
@@ -151,6 +151,10 @@ The only beneficial SVE2 feature is **SVEBITPERM** (BDEP/BEXT instructions), whi
 **Note**: DSV quote masking gap was closed on 2026-01-22 by using NEON PMULL (carryless multiplication)
 for prefix XOR instead of the 6-shift scalar algorithm. This works on ALL ARM64 including Apple Silicon.
 
+**Note (popcount, #45)**: The "5.2× with AVX-512" above is vs a *baseline* build; under
+`-C target-cpu=native` `count_ones()` auto-vectorizes to VPOPCNTDQ and the x86 advantage over the
+"1× baseline" closes to ≈1×. See [Popcount Strategies](../optimizations/simd.md#popcount-strategies-explicit-simd-vs-auto-vectorized-count_ones).
+
 ---
 
 ## SVE2 Capabilities Analysis

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -31,6 +31,6 @@ mod select;
 pub use bitvec::BitVec;
 pub use compact_rank::CompactRank;
 pub use elias_fano::{EliasFano, EliasFanoCursor, EliasFanoIter};
-pub use popcount::{popcount_word, popcount_words};
+pub use popcount::{popcount_word, popcount_word_portable, popcount_words};
 pub use rank::RankDirectory;
 pub use select::SelectIndex;

--- a/src/bits/popcount.rs
+++ b/src/bits/popcount.rs
@@ -386,7 +386,9 @@ mod tests {
         assert_eq!(popcount_words(&words), expected);
     }
 
-    #[cfg(feature = "portable-popcount")]
+    // Not gated behind `portable-popcount`: `popcount_word_portable` is always
+    // compiled (see its definition), so its correctness test must run in every
+    // build that compiles it — including the coverage build (`cli,simd,regex,serde`).
     #[test]
     fn test_portable_matches_builtin() {
         for i in 0u64..1000 {

--- a/src/bits/popcount.rs
+++ b/src/bits/popcount.rs
@@ -83,9 +83,12 @@ fn popcount_words_default(words: &[u64]) -> usize {
 
 /// Portable bitwise popcount (no intrinsics).
 ///
-/// Uses the classic parallel bit-counting algorithm.
+/// Uses the classic parallel bit-counting (broadword SWAR) algorithm. This is
+/// always compiled (not gated behind `portable-popcount`) so the popcount
+/// benchmark harness can measure the broadword strategy alongside `count_ones()`
+/// and the explicit-SIMD path in a single run; the `portable-popcount` feature
+/// only controls whether `popcount_word`/`popcount_words` dispatch to it.
 #[inline(always)]
-#[cfg(feature = "portable-popcount")]
 pub fn popcount_word_portable(mut x: u64) -> u32 {
     // Parallel bit count using magic constants
     const M1: u64 = 0x5555_5555_5555_5555; // 01010101...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub mod text;
 
 // Core types
 pub use bits::BitVec;
-pub use bits::{popcount_word, popcount_words, RankDirectory, SelectIndex};
+pub use bits::{popcount_word, popcount_word_portable, popcount_words, RankDirectory, SelectIndex};
 pub use trees::BalancedParens;
 pub use util::select_in_word;
 


### PR DESCRIPTION
## Description

This PR resolves issue #45 by comprehensively documenting and benchmarking the popcount strategies available in the succinctly library. The work exposes the portable broadword SWAR implementation for benchmarking, enhances the benchmark suite to measure all three strategies in a single run, and adds detailed performance analysis with measured data across multiple architectures and build configurations.

The changes answer a critical question raised on r/rust: has explicit SIMD popcount actually been benchmarked against LLVM's auto-vectorized `count_ones()`? The result shows that on x86_64, explicit AVX-512 VPOPCNTDQ is 5–9× faster only against a baseline build; under `target-cpu=native`, `count_ones()` auto-vectorizes to VPOPCNTDQ and reaches parity. On aarch64, the 256-byte-unrolled NEON path consistently wins by ~1.56× regardless of build flags.

## Type of Change
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement

## Related Issue
Fixes #45 - Document SIMD popcount vs count_ones() benchmarks

## Changes Made

**Core Refactoring:**
- Removed `#[cfg(feature = "portable-popcount")]` gate from `popcount_word_portable()` in `src/bits/popcount.rs` so the broadword SWAR implementation is always compiled
- Re-exported `popcount_word_portable` from `src/bits/mod.rs` and `src/lib.rs` to enable benchmark access without requiring the `portable-popcount` feature flag
- Updated documentation comment on `popcount_word_portable()` to explain it is always compiled for benchmarking purposes; the feature flag now only controls dispatch in `popcount_word`/`popcount_words`

**Benchmark Enhancement:**
- Added `portable` arm to `benches/popcount_strategies.rs` measuring the broadword strategy alongside scalar (`count_ones()`) and SIMD paths
- Expanded benchmark coverage to include both size/pattern matrix and throughput group measurements for the portable strategy
- Enhanced benchmark documentation with detailed comments explaining the three strategies (scalar = default auto-vectorizing `count_ones()`, portable = pure broadword SWAR, simd = explicit SIMD intrinsics)
- Clarified that `cargo bench --bench popcount_strategies --features simd` now reports all three strategies in a single run

**Documentation:**
- Added comprehensive "Popcount Strategies: Explicit SIMD vs Auto-Vectorized `count_ones()`" section to `docs/optimizations/simd.md` with measured performance data
- Documented methodology: Criterion benchmarks across two machines (AMD Ryzen 9 7950X with AVX-512 on x86_64, Apple M4 Pro on aarch64), two build modes each (default and `target-cpu=native`), and six bit patterns
- Provided detailed x86_64 benchmarks showing 5–9× speedup in default builds but ≈1× parity under `target-cpu=native`
- Provided detailed aarch64 benchmarks showing consistent ~1.55–1.6× speedup independent of build flags and array size
- Added TL;DR summary answering three key questions: when does explicit SIMD beat `count_ones()`, is the feature worth maintaining, and where is the size crossover
- Reconciled previously unsourced "5.2x" and "1.15x" claims across `simd.md`, `optimizations/README.md`, and `architecture/prior-art.md` with measured data
- Cross-linked from `bit-manipulation.md` and `simd-strategy.md` to the new comprehensive section
- Updated optimization table in `docs/optimizations/README.md` to reflect measured performance (AVX-512: 5–9×/≈1×, NEON: 1.6×)
- Updated footnote in `docs/optimizations/simd.md` usage table documenting that popcount speedups are measured and build-flag-dependent
- Updated `docs/architecture/prior-art.md` to clarify the AVX-512 VPOPCNTDQ speedup is dependent on build configuration

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Benchmark suite updated with new portable arm measurements

**Manual Testing:**
- [x] Verified benchmark compiles and runs with `--features simd`
- [x] Confirmed `popcount_word_portable` is accessible from crate root
- [x] Validated benchmark output shows all three strategies (scalar, portable, simd) in results
- [x] Tested on x86_64 (benchmark data collected on AMD Ryzen 9 7950X)
- [x] Tested on aarch64 (benchmark data collected on Apple M4 Pro)

### Test Commands
```bash
# Run all three strategies in one report
cargo bench --bench popcount_strategies --features simd

# Test with auto-vectorization enabled
RUSTFLAGS="-C target-cpu=native" cargo bench --bench popcount_strategies --features simd

# Verify code quality
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] Performance improvement (benchmarks included)

This PR is purely measurement and documentation — no functional changes to production code. The refactoring to expose `popcount_word_portable` has zero runtime impact; the feature flag `portable-popcount` continues to control dispatch as before.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings
- [x] Benchmark additions are properly tested
- [x] Cross-links in documentation are consistent

## Additional Notes

**Methodology & Reproducibility:**
The measured data is comprehensive and reproducible. Each benchmark includes 100 samples with median times reported. The methodology accounts for cache effects and data independence of popcount (working-set size is the relevant axis, not bit pattern). Both default and `target-cpu=native` builds are documented to show the critical difference on x86_64.

**Architecture & Design:**
The refactoring is minimal and focused: removing one `#[cfg]` gate and adding two re-export lines. This preserves the existing feature flag semantics (users who want forced-portable semantics still have `--features portable-popcount`) while enabling benchmark transparency.

**Future Work:**
These measurements provide a solid foundation for:
- Informing architecture decisions about when to use explicit SIMD vs relying on compiler auto-vectorization
- Guiding users on optimal build configurations for their hardware
- Validating that the `simd` feature remains worthwhile on platforms where it provides real gains (aarch64)

**Related Documentation:**
The PR resolves inconsistencies across multiple documentation files where popcount speedup claims lacked sourced data. The new section provides measured evidence and links all related documentation together.