### PR TITLE
feat(lib): add feature detection indirection layer for dispatcher fallback arm testing

### DIFF
--- a/src/dsv/simd/mod.rs
+++ b/src/dsv/simd/mod.rs
@@ -57,7 +57,7 @@ pub mod sse2;
 #[cfg(all(target_arch = "aarch64", feature = "std"))]
 pub fn build_index_simd(text: &[u8], config: &super::DsvConfig) -> super::DsvIndex {
     // Check for SVE2-BITPERM (fastest path on ARM)
-    if is_aarch64_feature_detected!("sve2-bitperm") {
+    if detect_sve2() {
         return sve2::build_index_simd(text, config);
     }
 
@@ -82,12 +82,12 @@ pub use neon::build_index_simd;
 #[cfg(all(target_arch = "x86_64", any(test, feature = "std")))]
 pub fn build_index_simd(text: &[u8], config: &super::DsvConfig) -> super::DsvIndex {
     // Check for BMI2 + AVX2 (fastest path)
-    if is_x86_feature_detected!("bmi2") && is_x86_feature_detected!("avx2") {
+    if detect_bmi2() && detect_avx2() {
         return bmi2::build_index_simd(text, config);
     }
 
     // Fall back to AVX2 with prefix_xor
-    if is_x86_feature_detected!("avx2") {
+    if detect_avx2() {
         return avx2::build_index_simd(text, config);
     }
 
@@ -106,4 +106,230 @@ pub use sse2::build_index_simd;
 #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
 pub fn build_index_simd(text: &[u8], config: &super::DsvConfig) -> super::DsvIndex {
     super::parser::build_index(text, config)
+}
+
+// ============================================================================
+// Feature detection (indirection point for the dispatcher fallback-arm tests)
+// ============================================================================
+//
+// The dispatchers above call these instead of `is_*_feature_detected!` directly.
+// In production each is a straight CPU probe. Under `cfg(test)` each also
+// consults a thread-local mask (see `test_dispatch`) so a test can drive the
+// dispatcher through its lower arms without depending on the host CPU — the arm
+// selection in `mod.rs` is otherwise never exercised end-to-end, because every
+// runner reports the fastest backend and the fallbacks never run (#283).
+
+#[cfg(all(target_arch = "x86_64", feature = "std", not(test)))]
+#[inline]
+fn detect_bmi2() -> bool {
+    is_x86_feature_detected!("bmi2")
+}
+
+#[cfg(all(target_arch = "x86_64", feature = "std", not(test)))]
+#[inline]
+fn detect_avx2() -> bool {
+    is_x86_feature_detected!("avx2")
+}
+
+#[cfg(all(target_arch = "x86_64", test))]
+#[inline]
+fn detect_bmi2() -> bool {
+    is_x86_feature_detected!("bmi2") && !test_dispatch::is_disabled(test_dispatch::BMI2)
+}
+
+#[cfg(all(target_arch = "x86_64", test))]
+#[inline]
+fn detect_avx2() -> bool {
+    is_x86_feature_detected!("avx2") && !test_dispatch::is_disabled(test_dispatch::AVX2)
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "std", not(test)))]
+#[inline]
+fn detect_sve2() -> bool {
+    is_aarch64_feature_detected!("sve2-bitperm")
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "std", test))]
+#[inline]
+fn detect_sve2() -> bool {
+    is_aarch64_feature_detected!("sve2-bitperm") && !test_dispatch::is_disabled(test_dispatch::SVE2)
+}
+
+// ============================================================================
+// Test-only hook to exercise the dispatcher fallback arms (#283)
+// ============================================================================
+
+/// Test-only hook that forces the runtime dispatcher down its fallback arms.
+///
+/// The dispatcher always selects the fastest backend the host CPU supports, so
+/// on any given runner its lower arms never execute (#283). This hook lets a
+/// test mask off detected features for the current thread, so the dispatcher
+/// falls through to a lower backend and the arm-selection logic in `mod.rs` is
+/// actually covered.
+///
+/// Invariant: the mask can only *remove* a feature the host has — never add one
+/// it lacks. So the dispatcher can never route to a `#[target_feature]` backend
+/// on a CPU without that feature (which would be undefined behavior); a backend
+/// is reachable here only when the host genuinely supports it.
+#[cfg(all(
+    test,
+    any(target_arch = "x86_64", all(target_arch = "aarch64", feature = "std"))
+))]
+mod test_dispatch {
+    use core::cell::Cell;
+
+    #[cfg(target_arch = "x86_64")]
+    pub(super) const BMI2: u8 = 1 << 0;
+    #[cfg(target_arch = "x86_64")]
+    pub(super) const AVX2: u8 = 1 << 1;
+    #[cfg(target_arch = "aarch64")]
+    pub(super) const SVE2: u8 = 1 << 2;
+
+    std::thread_local! {
+        /// Bitmask of features masked off for the current thread.
+        static DISABLED: Cell<u8> = const { Cell::new(0) };
+    }
+
+    /// Whether `flag` is currently masked off on this thread.
+    pub(super) fn is_disabled(flag: u8) -> bool {
+        DISABLED.with(|d| d.get() & flag != 0)
+    }
+
+    /// RAII guard that masks off `flags` until dropped, restoring the previous
+    /// mask. Thread-local and scoped, so parallel tests don't interfere.
+    #[must_use = "the mask is only active while the guard is alive"]
+    pub(super) struct MaskGuard {
+        prev: u8,
+    }
+
+    /// Mask off `flags` for the current thread until the returned guard drops.
+    pub(super) fn mask(flags: u8) -> MaskGuard {
+        DISABLED.with(|d| {
+            let prev = d.get();
+            d.set(prev | flags);
+            MaskGuard { prev }
+        })
+    }
+
+    impl Drop for MaskGuard {
+        fn drop(&mut self) {
+            DISABLED.with(|d| d.set(self.prev));
+        }
+    }
+}
+
+#[cfg(all(
+    test,
+    any(target_arch = "x86_64", all(target_arch = "aarch64", feature = "std"))
+))]
+mod tests {
+    use super::build_index_simd;
+    use crate::dsv::{build_index_scalar, DsvConfig, DsvIndex};
+
+    /// Cumulative marker/newline rank at every position — a padding-insensitive
+    /// signature of an index (same idea as the cross-backend differential
+    /// tests): two indices share a signature iff they mark the same bytes.
+    fn index_sig(idx: &DsvIndex, len: usize) -> (Vec<usize>, Vec<usize>) {
+        (
+            (0..=len).map(|i| idx.markers_rank1(i)).collect(),
+            (0..=len).map(|i| idx.newlines_rank1(i)).collect(),
+        )
+    }
+
+    /// Representative CSVs: plain, a delimiter and a newline inside quotes, a
+    /// quoted span crossing a 64-byte chunk boundary, and empty.
+    fn cases() -> Vec<(&'static str, Vec<u8>)> {
+        let mut spanning = Vec::new();
+        spanning.extend_from_slice(b"aaa,\"");
+        spanning.extend_from_slice(&[b'x'; 80]); // quoted run longer than one 64-byte chunk
+        spanning.extend_from_slice(b",\n"); // delimiter + newline swallowed by the quotes
+        spanning.extend_from_slice(b"\"\nbbb,ccc\n");
+        vec![
+            ("plain", b"a,b,c\n1,2,3\n".to_vec()),
+            ("quoted_delimiter", b"\"a,b\",c\n\"d,e\",f\n".to_vec()),
+            ("quoted_newline", b"\"line1\nline2\",x\ny,z\n".to_vec()),
+            ("chunk_spanning_quote", spanning),
+            ("empty", Vec::new()),
+        ]
+    }
+
+    /// Drive the x86_64 dispatcher through every arm it can reach on this host
+    /// and assert each agrees with the scalar reference. On a modern CI runner
+    /// (BMI2 + AVX2) this covers all three arms of `build_index_simd`; the
+    /// masking only ever downgrades, so it never calls an unsupported backend.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn dispatch_covers_x86_arms() {
+        use super::test_dispatch::{mask, AVX2, BMI2};
+
+        let has_bmi2 = std::arch::is_x86_feature_detected!("bmi2");
+        let has_avx2 = std::arch::is_x86_feature_detected!("avx2");
+        let config = DsvConfig::default();
+
+        for (label, text) in cases() {
+            let want = index_sig(&build_index_scalar(&text, &config), text.len());
+
+            // Top arm: BMI2 + AVX2. Reachable only when the host has both.
+            if has_bmi2 && has_avx2 {
+                let got = build_index_simd(&text, &config);
+                assert_eq!(index_sig(&got, text.len()), want, "bmi2 arm / {label}");
+            }
+
+            // Middle arm: AVX2 prefix_xor. Mask BMI2 off; needs host AVX2.
+            if has_avx2 {
+                let _guard = mask(BMI2);
+                let got = build_index_simd(&text, &config);
+                assert_eq!(index_sig(&got, text.len()), want, "avx2 arm / {label}");
+            }
+
+            // Bottom arm: SSE2 baseline. Mask BMI2 + AVX2 off; SSE2 is universal.
+            {
+                let _guard = mask(BMI2 | AVX2);
+                let got = build_index_simd(&text, &config);
+                assert_eq!(index_sig(&got, text.len()), want, "sse2 arm / {label}");
+            }
+        }
+
+        if !has_bmi2 {
+            eprintln!("SKIPPED dsv dispatch [bmi2 arm]: bmi2 not detected (#283, see #193)");
+        }
+        if !has_avx2 {
+            eprintln!("SKIPPED dsv dispatch [avx2 arm]: avx2 not detected (#283, see #193)");
+        }
+    }
+
+    /// Drive the aarch64 dispatcher through every arm it can reach on this host
+    /// and assert each agrees with the scalar reference. NEON is mandatory so
+    /// its arm always runs; the SVE2 arm runs only on an `sve2-bitperm` host.
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
+    #[test]
+    fn dispatch_covers_aarch64_arms() {
+        use super::test_dispatch::{mask, SVE2};
+
+        let has_sve2 = std::arch::is_aarch64_feature_detected!("sve2-bitperm");
+        let config = DsvConfig::default();
+
+        for (label, text) in cases() {
+            let want = index_sig(&build_index_scalar(&text, &config), text.len());
+
+            // Top arm: SVE2-BITPERM. Reachable only on a host that has it.
+            if has_sve2 {
+                let got = build_index_simd(&text, &config);
+                assert_eq!(index_sig(&got, text.len()), want, "sve2 arm / {label}");
+            }
+
+            // Fallback arm: NEON (mandatory on aarch64). Mask SVE2 off.
+            {
+                let _guard = mask(SVE2);
+                let got = build_index_simd(&text, &config);
+                assert_eq!(index_sig(&got, text.len()), want, "neon arm / {label}");
+            }
+        }
+
+        if !has_sve2 {
+            eprintln!(
+                "SKIPPED dsv dispatch [sve2 arm]: sve2-bitperm not detected (#283, see #194)"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Description

This PR adds a feature detection indirection layer to the DSV SIMD dispatcher, enabling comprehensive testing of dispatcher fallback arms. Previously, the dispatcher always selected the fastest backend available on the host CPU, leaving lower fallback arms untested on any given runner (#283). This change introduces thread-local feature masking specifically for tests, allowing tests to temporarily disable detected features and verify that all reachable backend paths work correctly and consistently with the scalar reference implementation.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #283

## Changes Made

**Feature Detection Indirection:**
- Extracted CPU feature detection into inline wrapper functions: `detect_bmi2()`, `detect_avx2()` (x86_64) and `detect_sve2()` (aarch64)
- Production builds call CPU detection directly via `is_*_feature_detected!` macros
- Test builds additionally consult a thread-local feature mask that can suppress detected features
- Updated dispatcher calls in `build_index_simd()` to use the new wrapper functions instead of direct macro calls

**Test-Only Dispatch Hook:**
- Added `test_dispatch` module with thread-local `DISABLED` cell tracking masked-off features per thread
- Implemented per-feature flag constants: `BMI2`, `AVX2` (x86_64) and `SVE2` (aarch64)
- Added `is_disabled(flag)` function to check if a feature is masked for the current thread
- Implemented `MaskGuard` RAII struct that masks features until dropped, preserving previous state
- Added `mask(flags)` function to temporarily disable features for test scope

**Comprehensive Dispatcher Coverage Tests:**
- Added `dispatch_covers_x86_arms()` test that exercises all three x86_64 dispatcher arms (BMI2+AVX2, AVX2 prefix_xor, and SSE2 baseline) by masking features appropriately
- Added `dispatch_covers_aarch64_arms()` test that verifies both SVE2 and NEON arms on applicable hosts
- Tests validate each backend against the scalar reference using a padding-insensitive signature (marker and newline rank checksums)
- Test cases cover representative CSV scenarios: plain data, quoted delimiters, quoted newlines, chunk-spanning quotes, and empty input
- Tests include skip messages for arms that cannot be tested due to host CPU limitations

**Test Safety Guarantees:**
- Masking is thread-local and scoped via RAII, preventing interference between parallel tests
- Invariant maintained: the mask can only *remove* detected features, never add missing ones
- Ensures the dispatcher can never route to a `#[target_feature]` backend on a CPU lacking that feature

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for dispatcher coverage on x86_64 and aarch64
- [x] Tests exercise all reachable backend arms with representative CSV inputs
- [x] Tests verify consistency between backends using differential testing approach

**Manual Testing:**
- [x] Tested on x86_64 with BMI2 + AVX2 (covers all three dispatcher arms)
- [x] Tested on aarch64 with SVE2 support (covers both SVE2 and NEON arms)

### Test Commands
```bash
cargo test dsv
cargo test dispatch_covers
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

Production builds are unaffected: feature detection remains a direct CPU probe with no additional overhead. Test builds add only a thread-local check, negligible compared to test execution time.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fallback arm selection logic works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings
- [x] Thread-local feature masking is properly scoped via RAII
- [x] All dispatcher arms are exercised on capable hosts

## Additional Notes

**Design Rationale:**
The dispatcher selection logic in `mod.rs` was previously untested end-to-end because every runner reports the fastest backend the CPU supports, leaving lower fallback arms dead code. By introducing a test-only hook that masks off features at runtime, we can drive the dispatcher through all reachable paths without special hardware or CI modifications.

**Coverage Details:**
- On a modern x86_64 runner with BMI2 + AVX2, all three dispatcher arms are now exercised
- On aarch64 runners, both SVE2 and NEON arms are verified where applicable
- Tests skip unreachable arms on limited hardware but still verify all available backends

**Future Enhancements:**
The feature masking infrastructure can be extended to support additional SIMD backends (e.g., SSE4.2, AVX512) as new optimizations are added to the dispatcher.