### PR TITLE
feat(cli): implement yq-compatible JSON control-character escaping

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -18,8 +18,8 @@ use succinctly::json::JsonIndex;
 
 use super::JqCommand;
 use crate::output::{
-    self, escape_json_string, escape_json_string_ascii, exit_codes, ColorScheme, FloatStyle,
-    JsonFormatOpts,
+    self, escape_json_string, escape_json_string_ascii, exit_codes, ColorScheme, ControlEscape,
+    FloatStyle, JsonFormatOpts,
 };
 
 /// Evaluation context for passing variables to the jq evaluator.
@@ -2078,6 +2078,7 @@ fn format_json(value: &OwnedValue, config: &OutputConfig) -> String {
         sort_keys: config.sort_keys,
         ascii: config.ascii_output,
         float_style: FloatStyle::Shortest,
+        control_escape: ControlEscape::Jq,
     };
     let json = output::format_json(value, &opts);
 

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -127,6 +127,78 @@ pub fn escape_json_string_ascii(s: &str) -> String {
     result
 }
 
+/// Escape special characters in a JSON string using yq's control-char rules.
+///
+/// Matches `mikefarah/yq`: only `"`, `\`, and C0 controls (`< 0x20`) are
+/// escaped — with `\t`/`\n`/`\r` short forms and `\u00xx` for the rest. Unlike
+/// [`escape_json_string`] (jq style), backspace/form-feed stay as
+/// `\u0008`/`\u000c` (not `\b`/`\f`), and DEL (`0x7f`) plus the C1 controls
+/// (`0x80..=0x9f`) are emitted raw. Returns the body without surrounding quotes.
+pub fn escape_json_string_yq(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => result.push_str("\\\""),
+            '\\' => result.push_str("\\\\"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                result.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => result.push(c),
+        }
+    }
+    result
+}
+
+/// yq-style escaping (see [`escape_json_string_yq`]) that also escapes
+/// non-ASCII as `\uXXXX`, for yq's ASCII output mode.
+///
+/// Returns the escaped body without surrounding quotes; callers add them.
+pub fn escape_json_string_ascii_yq(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => result.push_str("\\\""),
+            '\\' => result.push_str("\\\\"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                result.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c if !c.is_ascii() => {
+                // Escape non-ASCII characters as \uXXXX
+                // For characters outside BMP, use surrogate pairs
+                let code = c as u32;
+                if code <= 0xFFFF {
+                    result.push_str(&format!("\\u{code:04x}"));
+                } else {
+                    // Surrogate pair for characters above U+FFFF
+                    let adjusted = code - 0x10000;
+                    let high = 0xD800 + (adjusted >> 10);
+                    let low = 0xDC00 + (adjusted & 0x3FF);
+                    result.push_str(&format!("\\u{high:04x}\\u{low:04x}"));
+                }
+            }
+            c => result.push(c),
+        }
+    }
+    result
+}
+
+/// Which tool's control-character escaping convention [`format_json`] uses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ControlEscape {
+    /// jq style: `\b`/`\f` short escapes, DEL and C1 controls escaped as
+    /// `\u00xx`. See [`escape_json_string`].
+    Jq,
+    /// yq style: backspace/form-feed as `\u0008`/`\u000c`, DEL and C1 controls
+    /// left raw. See [`escape_json_string_yq`].
+    Yq,
+}
+
 /// How to render finite floats with no fractional part.
 #[derive(Clone, Copy, Debug)]
 pub enum FloatStyle {
@@ -146,6 +218,18 @@ pub struct JsonFormatOpts<'a> {
     pub ascii: bool,
     /// Rendering of whole floats.
     pub float_style: FloatStyle,
+    /// Control-character escaping convention (jq vs yq).
+    pub control_escape: ControlEscape,
+}
+
+/// Escape a JSON string body per the opts' control-escape style and ASCII mode.
+fn escape_json_body(s: &str, opts: &JsonFormatOpts) -> String {
+    match (opts.control_escape, opts.ascii) {
+        (ControlEscape::Jq, false) => escape_json_string(s),
+        (ControlEscape::Jq, true) => escape_json_string_ascii(s),
+        (ControlEscape::Yq, false) => escape_json_string_yq(s),
+        (ControlEscape::Yq, true) => escape_json_string_ascii_yq(s),
+    }
 }
 
 /// Format a value as JSON text (compact or pretty, per `opts`).
@@ -191,11 +275,7 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
             }
         }
         OwnedValue::String(s) => {
-            if opts.ascii {
-                format!("\"{}\"", escape_json_string_ascii(s))
-            } else {
-                format!("\"{}\"", escape_json_string(s))
-            }
+            format!("\"{}\"", escape_json_body(s, opts))
         }
         OwnedValue::Array(arr) => {
             if arr.is_empty() {
@@ -231,11 +311,7 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 let items: Vec<String> = entries
                     .iter()
                     .map(|(k, v)| {
-                        let key = if opts.ascii {
-                            escape_json_string_ascii(k)
-                        } else {
-                            escape_json_string(k)
-                        };
+                        let key = escape_json_body(k, opts);
                         format!("\"{}\":{}", key, format_json_impl(v, opts, level + 1))
                     })
                     .collect();
@@ -244,11 +320,7 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 let items: Vec<String> = entries
                     .iter()
                     .map(|(k, v)| {
-                        let key = if opts.ascii {
-                            escape_json_string_ascii(k)
-                        } else {
-                            escape_json_string(k)
-                        };
+                        let key = escape_json_body(k, opts);
                         format!(
                             "\"{}\":{}{}",
                             key,
@@ -647,6 +719,7 @@ mod tests {
             sort_keys: true,
             ascii: false,
             float_style: FloatStyle::Shortest,
+            control_escape: ControlEscape::Jq,
         };
         assert_eq!(format_json(&value, &opts), r#"{"a":2,"z":1}"#);
     }
@@ -659,6 +732,7 @@ mod tests {
             sort_keys: false,
             ascii: false,
             float_style,
+            control_escape: ControlEscape::Jq,
         };
         assert_eq!(format_json(&value, &opts(FloatStyle::Shortest)), "1");
         assert_eq!(
@@ -703,12 +777,45 @@ mod tests {
     }
 
     #[test]
+    fn test_escape_json_string_yq_matches_mikefarah_yq() {
+        // Backspace/form-feed use the long \u00xx form (NOT jq's \b/\f) — #262.
+        assert_eq!(escape_json_string_yq("\x08\x0C"), "\\u0008\\u000c");
+        // \t/\n/\r keep their short forms.
+        assert_eq!(escape_json_string_yq("\t\n\r"), "\\t\\n\\r");
+        // Quotes/backslashes escape as usual.
+        assert_eq!(escape_json_string_yq("a\"\\b"), "a\\\"\\\\b");
+        // Other C0 controls fall back to \u00xx.
+        assert_eq!(
+            escape_json_string_yq("\x00\x07\x0b\x1b"),
+            "\\u0000\\u0007\\u000b\\u001b"
+        );
+        // DEL (0x7f) and C1 controls (0x80..=0x9f) are emitted RAW, like yq.
+        assert_eq!(escape_json_string_yq("\u{7f}"), "\u{7f}");
+        assert_eq!(escape_json_string_yq("\u{85}"), "\u{85}");
+        assert_eq!(escape_json_string_yq("\u{80}\u{9f}"), "\u{80}\u{9f}");
+        // Printable ASCII and non-ASCII pass through unescaped.
+        assert_eq!(escape_json_string_yq("café"), "café");
+    }
+
+    #[test]
+    fn test_escape_json_string_ascii_yq_escapes_non_ascii() {
+        // Same control-char rules as escape_json_string_yq...
+        assert_eq!(escape_json_string_ascii_yq("\x08\x0C"), "\\u0008\\u000c");
+        assert_eq!(escape_json_string_ascii_yq("\u{7f}"), "\u{7f}"); // DEL stays raw (ASCII)
+                                                                     // ...but non-ASCII (including C1) escapes as \uXXXX.
+        assert_eq!(escape_json_string_ascii_yq("\u{85}"), "\\u0085");
+        assert_eq!(escape_json_string_ascii_yq("é"), "\\u00e9");
+        assert_eq!(escape_json_string_ascii_yq("😀"), "\\ud83d\\ude00");
+    }
+
+    #[test]
     fn test_format_json_non_finite_floats_are_null() {
         let opts = JsonFormatOpts {
             indent: "",
             sort_keys: false,
             ascii: false,
             float_style: FloatStyle::PreserveWholeFloat,
+            control_escape: ControlEscape::Jq,
         };
         assert_eq!(format_json(&OwnedValue::Float(f64::NAN), &opts), "null");
         assert_eq!(
@@ -724,6 +831,7 @@ mod tests {
             sort_keys: false,
             ascii: false,
             float_style: FloatStyle::Shortest,
+            control_escape: ControlEscape::Jq,
         };
         assert_eq!(format_json(&OwnedValue::Array(vec![]), &pretty), "[]");
         assert_eq!(
@@ -745,6 +853,7 @@ mod tests {
             sort_keys: false,
             ascii: true,
             float_style: FloatStyle::Shortest,
+            control_escape: ControlEscape::Jq,
         };
         assert_eq!(
             format_json(&value, &opts),

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -799,6 +799,11 @@ mod tests {
 
     #[test]
     fn test_escape_json_string_ascii_yq_escapes_non_ascii() {
+        // Quote/backslash and the \n/\r/\t short forms escape as usual.
+        assert_eq!(
+            escape_json_string_ascii_yq("a\"\\b\n\r\t"),
+            "a\\\"\\\\b\\n\\r\\t"
+        );
         // Same control-char rules as escape_json_string_yq...
         assert_eq!(escape_json_string_ascii_yq("\x08\x0C"), "\\u0008\\u000c");
         assert_eq!(escape_json_string_ascii_yq("\u{7f}"), "\u{7f}"); // DEL stays raw (ASCII)
@@ -806,6 +811,29 @@ mod tests {
         assert_eq!(escape_json_string_ascii_yq("\u{85}"), "\\u0085");
         assert_eq!(escape_json_string_ascii_yq("é"), "\\u00e9");
         assert_eq!(escape_json_string_ascii_yq("😀"), "\\ud83d\\ude00");
+    }
+
+    #[test]
+    fn test_format_json_yq_ascii_routes_through_ascii_yq_escaper() {
+        // yq control-escape + ASCII mode escapes both keys and values via
+        // escape_json_string_ascii_yq: BS -> \u0008 (long form), C1/non-ASCII
+        // -> \uXXXX. Exercises the (Yq, ascii) dispatch arm in format_json.
+        let mut obj = IndexMap::new();
+        obj.insert(
+            "ké".to_string(),
+            OwnedValue::String("a\x08\u{85}é".to_string()),
+        );
+        let opts = JsonFormatOpts {
+            indent: "",
+            sort_keys: false,
+            ascii: true,
+            float_style: FloatStyle::Shortest,
+            control_escape: ControlEscape::Yq,
+        };
+        assert_eq!(
+            format_json(&OwnedValue::Object(obj), &opts),
+            r#"{"k\u00e9":"a\u0008\u0085\u00e9"}"#
+        );
     }
 
     #[test]

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -17,7 +17,7 @@ use succinctly::json::JsonIndex;
 use succinctly::yaml::{resolve_plain, ResolvedScalar, YamlCursor, YamlIndex, YamlValue};
 
 use super::{InputFormat, OutputFormat, YqCommand};
-use crate::output::{self, exit_codes, ColorScheme, FloatStyle, JsonFormatOpts};
+use crate::output::{self, exit_codes, ColorScheme, ControlEscape, FloatStyle, JsonFormatOpts};
 
 /// Adapter to use `std::io::Write` with `core::fmt::Write` methods.
 /// This enables streaming JSON output without intermediate String allocation.
@@ -451,21 +451,30 @@ fn output_value<W: Write>(writer: &mut W, value: &OwnedValue, config: &OutputCon
         return Ok(());
     }
 
-    // JSON output format
-    let json_str = if config.compact {
-        value.to_json()
-    } else {
-        // Custom pretty-printing with configurable indent
-        output::format_json(
-            value,
-            &JsonFormatOpts {
-                indent: &config.indent_str,
-                sort_keys: config.sort_keys,
-                ascii: config.ascii_output,
-                float_style: FloatStyle::PreserveWholeFloat,
+    // JSON output format. Both compact and pretty route through the shared
+    // formatter with yq's control-char escaping so the two agree byte-for-byte
+    // on control characters — `\u0008`/`\u000c` (not jq's `\b`/`\f`) and raw
+    // DEL/C1 controls — matching `mikefarah/yq` and the M2 streaming fast path
+    // (#262). Compact keeps jq-shortest floats (e.g. `1`) to match the streaming
+    // path; pretty preserves whole floats (e.g. `1.0`).
+    let json_str = output::format_json(
+        value,
+        &JsonFormatOpts {
+            indent: if config.compact {
+                ""
+            } else {
+                &config.indent_str
             },
-        )
-    };
+            sort_keys: config.sort_keys,
+            ascii: config.ascii_output,
+            float_style: if config.compact {
+                FloatStyle::Shortest
+            } else {
+                FloatStyle::PreserveWholeFloat
+            },
+            control_escape: ControlEscape::Yq,
+        },
+    );
 
     if config.use_color {
         write!(

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1642,3 +1642,39 @@ fn test_arithmetic_semantics_match_between_stdin_and_null_input() -> Result<()> 
     }
     Ok(())
 }
+
+/// #262: yq JSON control-char escaping must be identical across all three yq
+/// output paths — pretty (`-o json`), the compact M2 streaming fast path, and
+/// the compact DOM formatter (`OwnedValue`) — and must match `mikefarah/yq`:
+/// backspace/form-feed as `\u0008`/`\u000c` (NOT jq's `\b`/`\f`), C1 controls
+/// left raw, other C0 controls as `\u00xx`.
+#[test]
+fn test_yq_json_control_char_escaping_consistent_across_paths() -> Result<()> {
+    // s = "a<BS>b<FF>c<U+0085>d<NUL>e" via YAML double-quoted escapes
+    // (\b, \f, \x85 = C1 NEL, \x00 = NUL).
+    let yaml = "s: \"a\\bb\\fc\\x85d\\x00e\"\n";
+    // yq re-emits BS/FF as \u0008/\u000c, leaves the C1 (U+0085) byte raw,
+    // and escapes NUL as \u0000.
+    let expected = "\"a\\u0008b\\u000cc\u{85}d\\u0000e\"";
+
+    // Compact streaming fast path: `.s` is M2-streamable.
+    let (stream, code) = run_yq_stdin(".s", yaml, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stream.trim(), expected, "compact streaming path");
+
+    // Compact DOM path: `.s + ""` is not streamable, so it routes through the
+    // OwnedValue formatter.
+    let (dom, code) = run_yq_stdin(".s + \"\"", yaml, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(dom.trim(), expected, "compact DOM path");
+
+    // Pretty path: a bare scalar has no indentation, so its bytes equal compact.
+    let (pretty, code) = run_yq_stdin(".s", yaml, &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty.trim(), expected, "pretty path");
+
+    // Mutual consistency is the core guarantee (#262).
+    assert_eq!(stream.trim(), dom.trim(), "streaming vs DOM");
+    assert_eq!(stream.trim(), pretty.trim(), "streaming vs pretty");
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR resolves issue #262 by implementing yq-compatible JSON control-character escaping across all yq output paths. The changes ensure byte-for-byte consistency between the pretty printer, compact streaming fast path, and compact DOM formatter when handling special characters like backspace, form-feed, and C0/C1 control characters.

Previously, different output paths used inconsistent escaping conventions. This PR unifies them by introducing a `ControlEscape` enum that distinguishes between jq-style escaping (using short forms like `\b` and `\f` for backspace/form-feed) and yq-style escaping (using Unicode escapes `\u0008` and `\u000c` instead). All yq output now routes through the shared formatter with `ControlEscape::Yq` to guarantee consistency with the reference implementation `mikefarah/yq`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issue
Fixes #262

## Changes Made

**Core Implementation:**
- Added `ControlEscape` enum in `output.rs` with `Jq` and `Yq` variants to distinguish control-character escaping conventions
- Implemented `escape_json_string_yq()` function that follows yq rules: backspace/form-feed emitted as `\u0008`/`\u000c` (not `\b`/`\f`), DEL and C1 controls emitted raw, other C0 controls as `\u00xx`
- Implemented `escape_json_string_ascii_yq()` function for yq's ASCII output mode with non-ASCII characters escaped as `\uXXXX` and surrogate pair support for characters above U+FFFF
- Added `control_escape` field to `JsonFormatOpts` struct to parameterize escaping behavior
- Unified compact and pretty output paths in `yq_runner.rs` to use the shared `format_json()` function with `ControlEscape::Yq`, eliminating the previous dual-path approach
- Updated `jq_runner.rs` to specify `ControlEscape::Jq` in format options

**Refactoring:**
- Created helper function `escape_json_body()` in `output.rs` to centralize escaping logic based on both `control_escape` mode and ASCII output setting
- Refactored string formatting in `format_json_impl()` to use the new `escape_json_body()` function for consistency across key and value handling

**Testing:**
- Added comprehensive unit tests `test_escape_json_string_yq_matches_mikefarah_yq()` validating yq-style escaping behavior for control characters
- Added unit test `test_escape_json_string_ascii_yq_escapes_non_ascii()` for yq ASCII mode with non-ASCII escaping and surrogate pair handling
- Added integration test `test_yq_json_control_char_escaping_consistent_across_paths()` that validates all three yq output paths (compact streaming, compact DOM, and pretty) produce identical byte-for-byte output matching yq's control-character handling
- Updated existing tests to include `control_escape: ControlEscape::Jq` in format options

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for yq control-character escaping behavior
- [x] Integration test validates consistency across all three output paths (streaming, DOM, pretty)

**Manual Testing:**
- [x] Tested YAML input with mixed C0, C1, and special control characters
- [x] Verified compact streaming path matches compact DOM formatter
- [x] Verified pretty formatter output matches compact output for control-character encoding
- [x] Confirmed output byte-for-byte matches `mikefarah/yq` behavior

### Test Commands
```bash
cargo test
cargo test yq_cli_tests::test_yq_json_control_char_escaping_consistent_across_paths -- --nocapture
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The refactoring unifies code paths and centralizes escaping logic, which may slightly improve cache locality. No algorithmic changes or additional allocations were introduced.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

**Design Rationale:**
The solution parameterizes escaping behavior via `ControlEscape` enum rather than hardcoding tool-specific logic, allowing future tools with different conventions to be supported. Both jq and yq output now use the same shared `format_json()` formatter, ensuring consistency and reducing maintenance burden.

**Compatibility:**
This is backward compatible for jq output (which continues using `ControlEscape::Jq`) and fixes yq output to match the reference implementation, eliminating the inconsistency documented in #262.