### PR TITLE
test(jq): drop collect_map_pipe from jq golden known-failures

### DIFF
--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -22,7 +22,6 @@
 
 alt_multi_output   alternative   `//` inspects only the first output of its LHS — #160
 assign_rhs_root    assignment    compound-assign RHS evaluated against the sub-value, not the root — #159
-collect_map_pipe   iterator      `[.[] | f]` collects to `[]` (eval_pipe drops Owned/ManyOwned) — #295
 comma_in_index     parser        comma generator rejected inside index brackets — #155
 format_csv         format        @csv omits quotes on plain string fields; jq always quotes strings — #306
 index_oob_null     indexing      out-of-bounds array index errors instead of returning null — #307 (CLI path still errors despite closed #157)


### PR DESCRIPTION
## Problem

`jq_golden_conformance` (`tests/jq_golden_tests.rs`) is a two-sided check: a case that diverges from pinned jq must be listed in `tests/data/jq-golden-known-failures.txt`, **and** a listed case that now passes also fails the build.

Issue #295 was fixed in PR #304. That fix makes the `collect_map_pipe` golden case match pinned jq — but #304 landed without removing the case from the manifest. As a result the golden test now fails on `main` (commit 02951c49) and on every branch based on it, including dependabot PR #290:

```
1 case(s) now PASSING but still listed as known failures:
  collect_map_pipe
```

CI legs affected: Test (ARM64), Test (macOS ARM64), and the x86_64 test legs.

## Fix

Remove the stale `collect_map_pipe` line. The manifest now lists 7 of 41 divergences instead of 8; the case is exercised on every run and verified to match pinned jq.

## Verification

```
cargo test --features cli --test jq_golden_tests
# test known_failures_manifest_is_wellformed ... ok
# test jq_golden_conformance ... ok
```

Follow-up to #304 / #295.