### PR TITLE
docs: document popcount.rs non-deterministic coverage behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,12 +240,35 @@ and asserts nothing; to validate SVE2 changes locally, run
 `qemu-aarch64 -cpu max` (SVE2 + BITPERM emulated at the 128-bit vector length
 of real Neoverse hardware) inside Docker.
 
-**Not covered by routine CI: AVX-512.** The standard x86 runners are Zen 3
-(EPYC 7763), which has no `avx512f`/`avx512vpopcntdq`, so the AVX-512 paths
-(`src/util/simd/x86.rs` `avx512f` branch, `src/bits/popcount.rs` VPOPCNTDQ)
-self-skip there. Validate changes to those paths off-CI — on AVX-512 hardware
-or under an emulator (e.g. QEMU `qemu-x86_64 -cpu max`) — and note how you
+**Not covered by routine CI: AVX-512.** The standard x86 runners usually draw
+Zen 3 (EPYC 7763) CPUs, which have no `avx512f`/`avx512vpopcntdq`, so the
+AVX-512 paths (`src/util/simd/x86.rs` `avx512f` branch,
+`src/bits/popcount.rs` VPOPCNTDQ) self-skip on most runs. The runner fleet is
+not CPU-homogeneous — an occasional host does have AVX-512 (the source of the
+coverage wobble described below) — but no run is guaranteed one, so treat the
+paths as uncovered. Validate changes to them off-CI — on AVX-512 hardware or
+under an emulator (e.g. QEMU `qemu-x86_64 -cpu max`) — and note how you
 tested in the PR.
+
+Because the AVX-512 gate is a runtime CPU check, not a `#[cfg]`, the ~30
+executable lines behind the VPOPCNTDQ dispatch in `src/bits/popcount.rs` are
+still *compiled* under `--features cli,simd,regex,serde` and counted in the
+coverage denominator — but only *executed* on a runner whose CPU has
+`avx512vpopcntdq`. The coverage job is also `ubuntu-latest` with no guaranteed
+VPOPCNTDQ (`SUCCINCTLY_EXPECT_SIMD` intentionally omits it — see the note in
+[docs/reference/environment-variables.md](docs/reference/environment-variables.md#succinctly_expect_simd)),
+so **`src/bits/popcount.rs` reports a non-deterministic x86 coverage number**:
+~93% when the run happens to draw a VPOPCNTDQ-capable host, ~66% when it
+doesn't — a ±~26pp swing driven purely by which CPU the run landed on, not by
+any code change. This is expected, not a regression. The coverage bot
+quarantines it into the "N unchanged file(s) also moved (not attributed to this
+PR)" section, it doesn't count against patch coverage on PRs that leave the
+file untouched, and the
+`fail-under-lines` gate has ~19pp of headroom over the ~74.5% total, so the
+wobble can't trip the build. If you see `popcount.rs` move by ±26pp on an
+otherwise-unrelated PR (e.g. a dependabot bump), that's this — no need to
+re-triage it. Tracked in #302; the kernel's correctness is still validated on
+capable hardware by the two host-gated tests in `popcount.rs`.
 
 ### Unsafe Code
 


### PR DESCRIPTION
## Description

This PR documents the non-deterministic coverage behavior of `src/bits/popcount.rs` to help future contributors understand why this file's coverage metrics fluctuate significantly across CI runs.

The AVX-512 VPOPCNTDQ instruction set check in `popcount.rs` is a runtime CPU feature detection, not a compile-time feature gate. This means the ~30 lines of AVX-512-specific code are compiled when the project's features include `simd`, but only executed on runners with actual VPOPCNTDQ-capable hardware. Since CI runners vary in their CPU capabilities, the coverage for this file ranges from ~66% to ~93% depending on which host the job runs on—a ±26 percentage point swing that has nothing to do with code changes.

This documentation clarifies that the coverage fluctuation is expected behavior, not a regression, and explains how the coverage reporting system quarantines the variance and prevents it from affecting patch coverage gates.

## Type of Change
- [x] Documentation update

## Related Issue
Fixes #302 - Explain non-deterministic popcount.rs coverage swings

## Changes Made

**Documentation Updates:**
- Added comprehensive explanation to `CONTRIBUTING.md` documenting why `src/bits/popcount.rs` exhibits ±26 percentage point coverage variance across CI runs
- Explained that the variance is caused by runtime CPU feature detection (VPOPCNTDQ) rather than code changes
- Noted that the coverage bot quarantines this file and it never counts against patch coverage
- Clarified that the `fail-under-lines` gate has sufficient headroom (~19pp) to tolerate the coverage wobble
- Referenced the existing host-gated tests in `popcount.rs` that validate correctness on capable hardware

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] No new tests required (documentation-only change)

**Manual Testing:**
- [x] Verified documentation is clear and accurate
- [x] Confirmed references to existing systems (coverage bot, fail-under-lines gate) are correct

## Performance Impact
- [x] No performance impact (documentation-only change)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my documentation
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

This documentation addresses a common source of confusion for CI maintainers and contributors. By explaining the root cause of the coverage variance upfront, future CI flaps in `popcount.rs` coverage won't trigger unnecessary investigations or re-triage efforts. The explanation emphasizes that the correctness of the AVX-512 optimizations is still validated on capable hardware through the existing host-gated tests.