### PR TITLE
fix(jq): return null for out-of-bounds array indices instead of error (#307)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -526,10 +526,10 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 };
                 match elements.get(actual_idx) {
                     Some(v) => GenericResult::One(v),
-                    None if optional => GenericResult::None,
-                    None => GenericResult::Error(EvalError::new(format!(
-                        "index {idx} out of bounds (length {len})"
-                    ))),
+                    // jq returns null for out-of-bounds array indices (positive
+                    // or negative), not an error. `.[n]` and `.[n]?` both yield
+                    // null since there is no error for `?` to suppress. See #307.
+                    None => GenericResult::Owned(OwnedValue::Null),
                 }
             } else if optional {
                 GenericResult::None

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -24,6 +24,5 @@ alt_multi_output   alternative   `//` inspects only the first output of its LHS 
 assign_rhs_root    assignment    compound-assign RHS evaluated against the sub-value, not the root — #159
 comma_in_index     parser        comma generator rejected inside index brackets — #155
 format_csv         format        @csv omits quotes on plain string fields; jq always quotes strings — #306
-index_oob_null     indexing      out-of-bounds array index errors instead of returning null — #307 (CLI path still errors despite closed #157)
 int_float_eq       equality      `1 == 1.0` is false (Int vs Float derived PartialEq) — #156
 try_catch_error    try-catch     catch runs on the input and discards the error value — #158

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -57,6 +57,10 @@ fn assert_parity(json: &[u8], filter: &str) {
 /// Assert the two evaluators currently DISAGREE, pinning both observed outputs.
 /// When the referenced fix aligns them, the `assert_ne!` fails, forcing whoever
 /// lands the fix to convert this into `assert_parity`.
+///
+/// Currently unused -- the last pinned divergence (#307) is now parity -- but
+/// retained as scaffolding for the next divergence this file needs to pin.
+#[allow(dead_code)]
 fn assert_divergence(json: &[u8], filter: &str, full_expected: &[&str], generic_expected: &[&str]) {
     let full = full_outputs(json, filter);
     let generic = generic_outputs(json, filter);
@@ -159,11 +163,12 @@ fn test_object_ordering_parity_162() {
 }
 
 #[test]
-fn test_out_of_bounds_index_diverges_161_162() {
+fn test_out_of_bounds_index_parity_307() {
     // jq: indexing an array out of bounds (positive or negative) yields `null`.
-    // The FULL evaluator matches; the generic (CLI) path yields NO output --
-    // bug #161/#162.
+    // Both evaluators now agree; the generic (CLI) path previously erred -- #307.
     for filter in [".[5]", ".[-5]", ".[100]"] {
-        assert_divergence(br"[1,2,3]", filter, &["null"], &[]);
+        assert_parity(br"[1,2,3]", filter);
     }
+    // The `?` variant also yields null (no error for `?` to suppress).
+    assert_parity(br"[1,2,3]", ".[10]?");
 }


### PR DESCRIPTION
## Description

This PR fixes issue #307 where out-of-bounds array indices were incorrectly returning errors instead of `null`. The jq specification requires that accessing an array with an out-of-bounds index (both positive and negative) returns `null`, not an error. Both the optional (`.[n]?`) and non-optional (`.[n]`) variants should return `null` since there is no error condition to suppress.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #307 - jq out of bounds array index returns error instead of null

## Changes Made

**Core Fix:**
- Modified `src/jq/eval_generic.rs` to return `null` for out-of-bounds array indices instead of raising an `EvalError`
- Changed the behavior in the array indexing logic to match jq semantics: both positive and negative out-of-bounds indices now yield `null`
- Added clarifying comments explaining that jq returns `null` for out-of-bounds access, with no error to suppress for the `?` variant

**Test Updates:**
- Removed `index_oob_null` from `tests/data/jq-golden-known-failures.txt` (no longer a known failure)
- Updated `test_out_of_bounds_index_diverges_161_162()` in `tests/jq_evaluator_parity_tests.rs` to `test_out_of_bounds_index_parity_307()`
- Changed test assertion from `assert_divergence()` to `assert_parity()` to verify both evaluators now agree
- Added test coverage for the optional variant `.[10]?` to ensure it also yields `null`
- Added `#[allow(dead_code)]` annotation to the now-unused `assert_divergence()` helper function with documentation

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Test updated to verify parity between full and generic evaluators
- [x] Test coverage added for both `.[n]` and `.[n]?` variants with out-of-bounds indices

**Manual Testing:**
- The fix handles positive out-of-bounds indices (e.g., `.[5]` on a 3-element array)
- The fix handles negative out-of-bounds indices (e.g., `.[-5]` on a 3-element array)
- The fix handles large indices (e.g., `.[100]` on a 3-element array)
- Optional variant with out-of-bounds index also returns `null` (e.g., `.[10]?`)

### Test Commands
```bash
cargo test test_out_of_bounds_index_parity_307
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

This fix aligns the generic (CLI) evaluator path with the full evaluator path and corrects the behavior to match the jq specification. Previously, the generic path would error on out-of-bounds array indices while the full path correctly returned `null`. Now both paths agree and return `null` in all cases, as jq does.

The `assert_divergence()` helper function is retained as scaffolding for future divergences between evaluators, but is annotated with `#[allow(dead_code)]` since the last known divergence (#307) has now been resolved.