### PR TITLE
ci(ci, docs): trigger CI on merge_group ahead of enabling the merge queue

### DIFF
--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -5,6 +5,12 @@ on:
     # labeled/unlabeled are NOT default pull_request activity types; include them
     # so this check re-runs the moment the do_not_merge label is toggled.
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  # Merge-queue leg (#310). "Do Not Merge" is a required context, so it must also
+  # report on the `gh-readonly-queue/main/*` builds or queued PRs would hang on it
+  # until the queue times out and drops them. No logic change is needed — see the
+  # step comment below.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -18,6 +24,12 @@ jobs:
       # The `if` guards the STEP, not the job: the job always runs and reports a
       # status (green when the label is absent), so a PR can never sit forever
       # "pending" on a required check that never ran.
+      #
+      # This is also what makes the job correct on `merge_group` (#310): that
+      # event carries no `github.event.pull_request`, so the guard is false, the
+      # step is skipped, and the job still reports success on the required
+      # context. The label therefore gates queue *entry* only — labelling a PR
+      # that is already in the queue will not evict it.
       - name: Fail if labeled do_not_merge
         if: contains(github.event.pull_request.labels.*.name, 'do_not_merge')
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Merge-queue leg (#310). `merge_group` is a distinct event from
+  # `push`/`pull_request`: when a PR is queued, GitHub builds a throwaway
+  # `gh-readonly-queue/main/*` ref (the PR replayed onto the latest `main`) and
+  # expects the required contexts to report *there*. Without this trigger a
+  # queued PR would hang on all six required checks until the queue's
+  # `check_response_timeout_minutes` elapsed and then be dropped — so this must
+  # be on `main` *before* the `merge_queue` rule is added to ruleset 11913990.
+  # `checks_requested` is the only activity type today; pinning it keeps the
+  # workflow specific if more are added later.
+  merge_group:
+    types: [checks_requested]
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,10 +27,13 @@ jobs:
   # in seconds without deadlocking branch protection. A single gate is the source
   # of truth for the split — no twin `ci-skip.yml` whose stub job names must be
   # hand-mirrored against this matrix (which would silently rot when the matrix or
-  # protection set changes). Non-PR events (main pushes) always take the full
-  # path. No markdown is `include_str!`-compiled here, but the doc set still
-  # scopes `*.md` to the repo root only — never `**/*.md` — so anything not
-  # explicitly a doc runs full CI (fail-safe).
+  # protection set changes). Non-PR events (main pushes, merge-queue builds)
+  # always take the full path — on a `merge_group` event the `paths-filter` step
+  # self-skips and `decide` sets `code=true`, so whatever is about to become
+  # `main` always gets the full required matrix (#310). No markdown is
+  # `include_str!`-compiled here, but the doc set still scopes `*.md` to the repo
+  # root only — never `**/*.md` — so anything not explicitly a doc runs full CI
+  # (fail-safe).
   gate:
     name: Gate
     runs-on: ubuntu-latest
@@ -303,11 +317,13 @@ jobs:
   # above stays on `stable` so we don't triple CI minutes. `beta` gates CI;
   # `nightly` is advisory (`continue-on-error`) because it is the flakiest. Not a
   # required status context, so it skips wholesale on the docs-only fast path
-  # (job-level `if`, like bench/coverage) rather than run-and-skip-steps.
+  # (job-level `if`, like bench/coverage) rather than run-and-skip-steps. Also
+  # skipped on `merge_group` (#310): it is advisory, not required, so running it
+  # per queue entry would just add latency to every merge without gating it.
   test-x86-upstream:
     name: Test (x86_64) (${{ matrix.rust }})
     needs: gate
-    if: needs.gate.outputs.code == 'true'
+    if: needs.gate.outputs.code == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false                                   # beta breakage must not cancel nightly
@@ -357,10 +373,12 @@ jobs:
       - name: Check no_std compatibility
         run: cargo check --no-default-features
 
+  # Skipped on `merge_group` (#310): a 3-arch `cargo bench` fan-out is far too
+  # slow to run per queue entry, and it gates nothing.
   bench:
     name: Bench (${{ matrix.name }})
     needs: gate
-    if: needs.gate.outputs.code == 'true'
+    if: needs.gate.outputs.code == 'true' && github.event_name != 'merge_group'
     strategy:
       matrix:
         include:
@@ -492,10 +510,14 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  # Skipped on `merge_group` (#310): this posts a sticky *PR* comment and needs
+  # `pull-requests: write`, but a merge-group build has no associated PR
+  # (`github.event.pull_request` is absent), so it could only error or no-op.
+  # Patch coverage is reported on the PR before it is ever queued.
   coverage:
     name: Coverage (${{ matrix.name }})
     needs: gate
-    if: needs.gate.outputs.code == 'true'
+    if: needs.gate.outputs.code == 'true' && github.event_name != 'merge_group'
     strategy:
       fail-fast: false
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,12 @@ Requires Intel Ice Lake+ or AMD Zen 4+.
 
 6. **Address review feedback**: Make requested changes and push updates
 
-7. **Merge**: Once approved, your PR will be merged
+7. **Merge**: Once approved and green, use **"Merge when ready"** to add the PR to
+   the merge queue. The queue replays your commits onto the current `main` and
+   re-runs CI on that combination before merging, so a PR that was green in
+   isolation can't silently break `main` by racing another merge. You don't need
+   to update your branch first — the queue does that for you. Merges are done by
+   **rebase**: your commits are replayed onto `main` with no merge commit.
 
 ## Architecture Guidelines
 


### PR DESCRIPTION
Part 1 of #310 — the workflow half. **This does not enable the merge queue**; it makes the queue safe to enable.

## Why this must land first

A merge queue tests each queued PR on a throwaway `gh-readonly-queue/main/*` ref via the **`merge_group`** event, which is separate from `push` and `pull_request`. No workflow in this repo triggered on it. GitHub's docs are explicit that CI must report on merge group events *before* you require a queue — otherwise every queued PR sits pending on all six required contexts, hits `check_response_timeout_minutes`, and is dropped. That would break all merging.

The six required contexts on ruleset `11913990` ("Protect main branch"):

| Context              | Workflow          | Job              |
|----------------------|-------------------|------------------|
| `Test (x86_64)`      | `ci.yml`          | `test-x86`       |
| `Test (ARM64)`       | `ci.yml`          | `test-arm`       |
| `Test (macOS ARM64)` | `ci.yml`          | `test-macos-arm` |
| `Clippy`             | `ci.yml`          | `clippy`         |
| `Format`             | `ci.yml`          | `fmt`            |
| `Do Not Merge`       | `block-merge.yml` | `do-not-merge`   |

## What changed

- **`ci.yml` / `block-merge.yml`** — added the `merge_group` trigger (`types: [checks_requested]`) so all six contexts report on merge-group builds.
- **`ci.yml`** — `bench`, `coverage` and `test-x86-upstream` now carry `&& github.event_name != 'merge_group'`. None are required contexts: `bench` is a 3-arch `cargo bench` fan-out (far too slow per queue entry), `coverage` posts a sticky *PR* comment and needs `pull-requests: write` but a merge group has no PR, and the beta/nightly leg is advisory only. `docs`, `yq-drift`, `jq-drift` and `skill-casing` still run — cheap, and they give extra signal on the merged combination.
- **`CONTRIBUTING.md`** — the PR process now describes merging via **"Merge when ready"**.

## What deliberately did not change

- **`gate`** — on a `merge_group` event `github.event_name != 'pull_request'`, so the `paths-filter` step self-skips and `decide` sets `code=true`. The full required matrix runs on whatever is about to become `main`, which is what we want.
- **`block-merge.yml` logic** — the `do_not_merge` check guards the *step*, not the job. `github.event.pull_request` is absent on `merge_group`, so the guard is false, the step skips, and the job still reports **success** on the required context. Accepted consequence: the label gates queue *entry* only — labelling a PR that is already queued will not evict it.
- **PR-time behaviour** — the skips are `merge_group`-only. `bench`, `coverage` and the upstream leg still run on this and every other PR.

## Verification

- All six workflow files parse; both changed files carry `merge_group: {types: [checks_requested]}`; the five required `ci.yml` jobs still have no job-level `if` (so they always report), and only the three intended jobs gained the `merge_group` exclusion. `actionlint` was not available locally.
- On this PR: confirm the six required contexts report as before and that `bench` / `coverage` / `test-x86-upstream` still run.
- No `merge_group` runs will appear yet — expected, the queue isn't on.

## Follow-up (Part 2, after this merges)

Add a `merge_queue` rule to ruleset `11913990` with `merge_method: REBASE`, and set `strict_required_status_checks_policy` to `false` in the same update — the queue builds against the latest `main`, so "require branches up to date" becomes redundant and would otherwise keep forcing manual rebases before queueing. Then verify end-to-end with a throwaway PR through "Merge when ready" (Part 3 of #310).

Refs #310