### PR TITLE
ci(ci): pin jq-drift to actions/checkout@v7 like every other job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,7 +581,7 @@ jobs:
     if: needs.gate.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pinned jq
         run: |


### PR DESCRIPTION
`jq-drift` was the only job in `ci.yml` still on `actions/checkout@v4` — it landed in #300 after Dependabot had already bumped checkout v4 → v7, so it missed the sweep. All thirteen uses in the workflow are now `@v7`.

Also serves as the end-to-end verification PR for the merge queue enabled in #310 (Part 3): it will be merged via **"Merge when ready"** to confirm that the six required contexts report on a `gh-readonly-queue/main/*` build, that `bench` / `coverage` / `test-x86-upstream` stay skipped there, and that the queue merges by rebase.

Refs #310