### PR TITLE
ci(ci): gate golden drift jobs per-step so they always report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,16 +551,22 @@ jobs:
   # Drift detector for the yq golden fixtures (tests/data/yq-golden/): the
   # goldens are frozen oracle output, so this is the one job that re-checks
   # them against the pinned mikefarah/yq. Unlike the pre-#227 comparison
-  # tests, a missing or wrong-version yq fails here — it cannot skip.
+  # tests, a missing or wrong-version yq fails the check — it cannot silently
+  # self-skip when it runs. The gate is applied per-STEP (not as a job-level
+  # `if`) so that on the docs-only fast path every step skips but the job still
+  # reports a genuine `success` rather than a `skipped` conclusion whose
+  # branch-protection semantics vary — matching the required Test/Clippy/Format
+  # jobs above, so this context is safe to mark required.
   yq-drift:
     name: yq golden drift check
     needs: gate
-    if: needs.gate.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        if: needs.gate.outputs.code == 'true'
 
       - name: Install pinned yq
+        if: needs.gate.outputs.code == 'true'
         run: |
           V="$(cat tests/data/yq-golden/YQ_VERSION)"
           curl -fsSL "https://github.com/mikefarah/yq/releases/download/${V}/yq_linux_amd64" \
@@ -569,21 +575,24 @@ jobs:
           yq --version | grep -F "version ${V}"
 
       - name: Verify goldens against pinned yq
+        if: needs.gate.outputs.code == 'true'
         run: ./scripts/sync-yq-golden.sh --check
 
   # Drift detector for the jq golden fixtures (tests/data/jq-golden/): the
   # goldens are frozen oracle output, so this is the one job that re-checks
-  # them against the pinned jqlang/jq. A missing or wrong-version jq fails
-  # here — it cannot skip. Sibling of yq-drift above (#300 mirrors #227).
+  # them against the pinned jqlang/jq. A missing or wrong-version jq fails the
+  # check — it cannot silently self-skip when it runs. Per-STEP gate for the
+  # same required-context-safe reason as yq-drift above (#300 mirrors #227).
   jq-drift:
     name: jq golden drift check
     needs: gate
-    if: needs.gate.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        if: needs.gate.outputs.code == 'true'
 
       - name: Install pinned jq
+        if: needs.gate.outputs.code == 'true'
         run: |
           V="$(cat tests/data/jq-golden/JQ_VERSION)"
           curl -fsSL "https://github.com/jqlang/jq/releases/download/${V}/jq-linux-amd64" \
@@ -592,4 +601,5 @@ jobs:
           jq --version | grep -F "${V}"
 
       - name: Verify goldens against pinned jq
+        if: needs.gate.outputs.code == 'true'
         run: ./scripts/sync-jq-golden.sh --check


### PR DESCRIPTION
Tier 2 of the required-checks cleanup (follow-up to #310). Prepares `yq golden drift check` and `jq golden drift check` to be marked **required** on the main ruleset.

## Problem

Both jobs used a **job-level** `if: needs.gate.outputs.code == 'true'`. On the docs-only fast path (`gate` sets `code=false` for `*.md` / `docs/**` / `.claude/skills/**`-only PRs) the entire job is skipped, so its status context is never reported. That's harmless while the jobs are advisory — but a *required* context that resolves to `skipped` has branch-protection semantics that vary and can leave a PR pending indefinitely. This is exactly why the required `Test` / `Clippy` / `Format` jobs push the gate down to each **step** instead, so the job always runs and reports a genuine `success`.

## Change

Move the gate from the job level to each step in both drift jobs (no other change):

- On a code PR, a `main` push, or a `merge_group` build — `gate` sets `code=true`, so every step runs exactly as before.
- On a docs-only fast-path PR — every step skips, but the job reports a real `success` instead of `skipped`.

## Why this doesn't change queue behaviour

These jobs already trigger and report on `merge_group` (that landed in #310). This PR only fixes their fast-path reporting, which is the remaining blocker to requiring them.

## Follow-up (after merge)

Add `Documentation`… already required; then add `yq golden drift check` and `jq golden drift check` to the required contexts on ruleset `11913990` — a ruleset-only change, no further workflow edits.

## Verification

- YAML parses; both drift jobs now have no job-level `if` and all three steps carry `if: needs.gate.outputs.code == 'true'`.
- All `actions/checkout` uses remain `@v7`.
- On this PR (a `.github`-only change → full path), both drift checks run and report as before.

Refs #310