### PR TITLE
feat(yaml): implement opt-in strict YAML validator with CLI support and conformance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in strict YAML validation** (#223): a new `succinctly::yaml::validate`
+  pass, exposed as `succinctly yaml validate [FILES]...` and `syq --validate`,
+  that rejects invalid YAML. It mirrors `json validate` — a separate pass run
+  before indexing, so the default non-validating loader path is unchanged and
+  pays nothing. It rejects 59 of the 83 previously-accepted-but-invalid YAML
+  Test Suite cases (reject conformance 11/94 → 70/94) with no false positives on
+  the valid corpus; the remaining structurally-deep cases stay on record.
+
+### Removed
+
+- Removed four never-constructed `YamlError` variants — `InvalidEscape`,
+  `InvalidIndentation`, `ExplicitKeyNotSupported`, and `ColonWithoutSpace`
+  (#223). **Breaking**: exhaustive `match`es on the public `YamlError` lose four
+  arms. The opt-in validator's `YamlValidationError` is the real rejection
+  surface.
+
 ### Fixed
 
 - `jq -R -s` now yields the entire input as a single string instead of an array of per-line strings, matching jq (#176)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "succinctly"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "succinctly"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["John Ky <newhoggy@gmail.com>"]
 rust-version = "1.73.0"

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -27,18 +27,23 @@ path:
 | Dimension                              | Result              | Meaning                                        |
 |----------------------------------------|---------------------|------------------------------------------------|
 | **Load** (valid YAML, output compared) | **209/279 = 74.9%** | Parses and produces the JSON the suite expects |
-| **Reject** (invalid YAML, must fail)   | **11/94 = 11.7%**   | Correctly refuses malformed input              |
+| **Reject** (invalid YAML, must fail)   | **70/94 = 74.5%**   | Refused by the loader or the opt-in validator  |
 | **Parse** (valid YAML, no JSON form)   | **27/29 = 93.1%**   | Parses without error                           |
 
-The 155 non-passing cases are enumerated individually, with a category and reason, in
+The **Reject** figure is what the conformance harness rejects with the opt-in
+validator enabled (loader OR validator, see below). The *default non-validating
+loader alone* still rejects only 11/94 (11.7%) by design — the opt-in validator
+([#223](https://github.com/rust-works/succinctly/issues/223)) closes 59 more.
+
+The 96 non-passing cases are enumerated individually, with a category and reason, in
 [`tests/data/yaml-test-suite-known-failures.txt`](../../../tests/data/yaml-test-suite-known-failures.txt).
 That file is the machine-readable source of truth; the test asserts it matches reality
 exactly, so it cannot silently drift from this page.
 
-## Validation is out of scope by design
+## Validation: default loader vs. the opt-in validator
 
-**succinctly is a non-validating YAML loader.** It rejects 11 of the suite's 94 invalid
-documents; the other 83 are accepted and produce a value.
+**The default loader is non-validating by design.** `YamlIndex::build` rejects 11 of the
+suite's 94 invalid documents; the other 83 are accepted and produce a value.
 
 This follows from semi-indexing. The index records *structure* — where values start and
 end, and how they nest — not grammar conformance. The parser is a structure recognizer:
@@ -47,11 +52,21 @@ anything it does not recognize as scalar text. Checking the ~1200 productions of
 1.2 grammar is work it deliberately does not do, and that omission is a large part of why
 it is 5-10x faster than `yq`.
 
-If you need malformed YAML rejected, you need a validating parser. Passing untrusted or
-unverified YAML through succinctly and relying on a parse error to catch problems will
-not work.
+**When you need malformed YAML rejected, use the opt-in validator.**
+[`succinctly yaml validate`](../../guides/cli.md) / `syq --validate` runs a separate strict
+pass ([`src/yaml/validate.rs`](../../../src/yaml/validate.rs)) before indexing — mirroring
+`json validate` / `sjq --validate`, so the default path pays nothing. It rejects **59 of
+the 83** documents below with zero false positives on the valid corpus (a guardrail test,
+`validator_accepts_all_valid_cases`, enforces that). The conformance harness treats a
+must-fail case as handled if the loader *or* the validator rejects it, which is why the
+Reject figure above is 70/94 rather than 11/94.
 
-The 83 accepted-but-invalid documents break down as:
+The 24 documents the validator does not yet reject (marked `lax:*` in the manifest) need
+deeper structural analysis — cross-line anchor binding, block-scalar content indentation,
+flow multi-line implicit keys — and are tracked in
+[#223](https://github.com/rust-works/succinctly/issues/223).
+
+The 83 accepted-but-invalid documents (of which the validator now rejects 59) break down as:
 
 | Category           | Cases | What is not checked                          |
 |--------------------|-------|----------------------------------------------|
@@ -66,12 +81,12 @@ The 83 accepted-but-invalid documents break down as:
 | `lax:anchors`      | 6     | Anchor and alias rules                       |
 | `lax:comments`     | 5     | Comment placement                            |
 
-An opt-in validation mode is planned, mirroring the JSON side's existing
-`succinctly json validate` / `sjq --validate`. There, validation is a separate pass that
-runs before indexing, so the default path pays nothing for it — see
-[`src/json/validate.rs`](../../../src/json/validate.rs). The 83 cases above are its
-acceptance criteria. Tracked in
-[#223](https://github.com/rust-works/succinctly/issues/223).
+The opt-in validation mode now exists ([#223](https://github.com/rust-works/succinctly/issues/223)),
+mirroring the JSON side's `succinctly json validate` / `sjq --validate`. Validation is a
+separate pass run before indexing, so the default path pays nothing for it — see
+[`src/yaml/validate.rs`](../../../src/yaml/validate.rs). The 83 cases above were its
+acceptance criteria; it rejects 59 of them today (each `lax:*` line removed from the
+manifest is a case now rejected), with the 24 harder cases still tracked in #223.
 
 ### One exception: cyclic aliases are rejected
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -196,6 +196,69 @@ The validator enforces strict RFC 8259 compliance:
 
 ---
 
+### YAML Validation
+
+`succinctly` is a non-validating YAML loader by design (see
+[YAML limitations](../compliance/yaml/limitations.md)). `yaml validate` is the **opt-in**
+strict counterpart, mirroring `json validate`: a separate pass, run before indexing, that
+rejects invalid YAML. The default indexing path (`syq`, `YamlIndex::build`) is unaffected
+and still accepts the same input unless you ask for validation.
+
+```bash
+succinctly yaml validate [OPTIONS] [FILES...]
+```
+
+#### Options
+
+- `-q`, `--quiet`: Exit code only, no diagnostic output
+- `-C`, `--color`: Force color output even when not a TTY
+- `-M`, `--no-color`: Disable color output
+
+#### Exit Codes
+
+- `0`: All inputs are valid
+- `1`: At least one input is invalid
+- `2`: I/O error (file not found, permission denied, etc.)
+
+#### Examples
+
+```bash
+# Validate stdin
+echo 'a: b: c' | succinctly yaml validate
+
+# Validate a file (rustc-style caret diagnostics)
+succinctly yaml validate config.yaml
+
+# Exit code only, for scripts
+succinctly yaml validate --quiet config.yaml && echo "Valid"
+
+# Validate before querying, in one step (bails before producing output)
+syq --validate '.users[]' config.yaml
+```
+
+#### Validation Rules (YAML)
+
+The validator rejects the classes of malformed YAML below (the YAML Test Suite's `lax:*`
+cases). It is deliberately not a full grammar checker: anything it does not recognize as
+invalid, it accepts.
+
+- **Indentation & tabs** — indentation that matches no open block level; tabs used where
+  indentation is expected (`\t` before a mapping key or between block indicators).
+- **Structure & mappings** — a second root node after a block collection; a compact nested
+  mapping key (`a: b: c`); an inline block sequence after `:` (`key: - a`).
+- **Scalars & quoting** — invalid double-quoted escapes (`"\."`); trailing content after a
+  quoted scalar; a multi-line scalar used as an implicit key; invalid block-scalar headers
+  (`|0`, `|10`, `> text`).
+- **Flow collections** — leading/doubled commas, unbalanced or unclosed brackets, bare `-`
+  items, document markers inside a flow collection.
+- **Anchors** — an anchor immediately followed by an alias (`&a *b`) or a block indicator.
+- **Comments** — a `#` not separated from the preceding token by whitespace; a comment
+  interrupting a multi-line plain scalar.
+- **Documents & directives** — content after a `...` marker; a `%YAML` directive with no
+  following `---`, malformed, or duplicated; a document marker inside an open quoted scalar.
+
+---
+
 ## Examples
 
 ### Basic Generation
@@ -363,6 +426,7 @@ succinctly yq '.users[]' input.yaml
 - `-R, --raw-input`: Read each line as a string instead of parsing as YAML/JSON
 - `-s, --slurp`: Read all inputs into an array and use it as the single input value
 - `-p, --input-format <FORMAT>`: Input format: `auto` (default), `yaml`, `json`
+- `--validate`: Validate YAML strictly (opt-in) before processing; reports line:column errors and bails without producing output (see [YAML Validation](#yaml-validation))
 - `-i, --inplace`: Update the file in place
 - `--doc <N>`: Select specific document by 0-based index from multi-document stream
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,11 +103,11 @@ rather than asserted:
 
 - [compliance/yaml/limitations.md](compliance/yaml/limitations.md) — YAML Test Suite conformance (402 cases), unsupported features, and why validation is opt-in
 - [compliance/yaml/1.2.md](compliance/yaml/1.2.md) — YAML 1.2 scalar type resolution: the Norway problem, booleans, quoted numbers
-- [guides/cli.md](guides/cli.md) — JSON's strict RFC 8259 validation (`json validate`, `sjq --validate`)
+- [guides/cli.md](guides/cli.md) — strict validation for both formats: JSON's RFC 8259 (`json validate`, `sjq --validate`) and YAML's opt-in validator (`yaml validate`, `syq --validate`)
 
 Key point: both JSON and YAML semi-indexing are **non-validating by design** — the index
-records structure, not grammar conformance. JSON offers a separate opt-in validation pass;
-the YAML equivalent is planned.
+records structure, not grammar conformance. Each format offers a separate opt-in validation
+pass that runs before indexing, so the default path pays nothing for it.
 
 ## Architecture Decisions (ADRs)
 

--- a/docs/parsing/yaml-index.md
+++ b/docs/parsing/yaml-index.md
@@ -89,11 +89,13 @@ Key lesson: micro-benchmark wins frequently don't translate to end-to-end gains.
 ## Validation
 
 `YamlIndex` performs minimal validation during indexing (structural recognition only) and
-accepts many malformed documents — it rejects 11 of the YAML Test Suite's 94 invalid
-inputs. Unlike JSON, there is no strict mode yet; an opt-in validation pass mirroring
-`json validate` is planned. See [Known Limitations](../compliance/yaml/limitations.md)
-for measured conformance and the list of unsupported features (tags, `%YAML`/`%TAG`
-directives).
+accepts many malformed documents — `YamlIndex::build` rejects 11 of the YAML Test Suite's
+94 invalid inputs. When strict validation is needed, an opt-in pass
+([`src/yaml/validate.rs`](../../src/yaml/validate.rs), `succinctly yaml validate` /
+`syq --validate`) mirrors `json validate`: a separate pass before indexing that rejects
+59 more of those cases without affecting the default path. See
+[Known Limitations](../compliance/yaml/limitations.md) for measured conformance and the
+list of unsupported features (tags, `%YAML`/`%TAG` directives).
 
 ## Depends On
 

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -582,13 +582,15 @@ This separation keeps the index small and fast. A higher-level `YamlValue` type 
 
 ### 8. Error Handling
 
-> **Superseded.** This section recorded an intent that was never implemented, and the
-> "strict mode only" claim below is false. Measured against the YAML Test Suite, the
-> parser rejects 11 of 94 invalid documents (11.7%); several `YamlError` variants named
-> here — including `InvalidIndentation` — are never constructed anywhere in `src/`.
-> succinctly is a **non-validating loader**: the index records structure, not grammar
-> conformance. Validation is planned as an opt-in pass, mirroring `json validate`. See
-> [Known Limitations](../compliance/yaml/limitations.md#validation-is-out-of-scope-by-design)
+> **Superseded.** This section recorded an intent that was never implemented as described.
+> succinctly's default loader is **non-validating**: `YamlIndex::build` rejects only 11 of
+> the YAML Test Suite's 94 invalid documents (11.7%). The four `YamlError` variants that
+> were never constructed — including `InvalidIndentation` — have since been removed (#223).
+> Strict rejection is instead provided by an **opt-in** validator
+> ([`src/yaml/validate.rs`](../../src/yaml/validate.rs), `succinctly yaml validate` /
+> `syq --validate`), mirroring `json validate`: a separate pass before indexing with its
+> own `YamlValidationError`. See
+> [Known Limitations](../compliance/yaml/limitations.md#validation-default-loader-vs-the-opt-in-validator)
 > for the measurements and rationale. Retained below as a historical design note.
 
 **Decision** (not implemented): Strict mode only. Reject malformed YAML with clear error messages.

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -917,6 +917,11 @@ pub struct YqCommand {
     #[arg(short = 's', long)]
     pub slurp: bool,
 
+    /// Validate YAML strictly (opt-in) before processing. Reports line:column
+    /// errors and exits without producing output on the first violation.
+    #[arg(long)]
+    pub validate: bool,
+
     /// Input format type [auto, yaml, json] (default: auto)
     #[arg(
         short = 'p',

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -202,6 +202,8 @@ enum YamlSubcommand {
     Generate(GenerateYaml),
     /// Generate a suite of YAML files with various sizes and patterns
     GenerateSuite(GenerateYamlSuite),
+    /// Validate YAML files strictly (opt-in; mirrors `json validate`)
+    Validate(yaml_validate::ValidateArgs),
 }
 
 #[derive(Debug, Parser)]
@@ -1232,6 +1234,10 @@ fn main() -> Result<()> {
                 Ok(())
             }
             YamlSubcommand::GenerateSuite(args) => generate_yaml_suite(args),
+            YamlSubcommand::Validate(args) => {
+                let exit_code = yaml_validate::run(args)?;
+                std::process::exit(exit_code);
+            }
         },
         Command::Dev(dev_cmd) => match dev_cmd.command {
             DevSubcommand::Bench(bench_cmd) => match bench_cmd.command {
@@ -2103,6 +2109,7 @@ mod text_generators;
 mod text_validate;
 mod utf8_bench;
 mod yaml_generators;
+mod yaml_validate;
 mod yq_bench;
 mod yq_locate;
 mod yq_runner;

--- a/src/bin/succinctly/yaml_validate.rs
+++ b/src/bin/succinctly/yaml_validate.rs
@@ -1,0 +1,301 @@
+//! CLI handler for the `yaml validate` command.
+//!
+//! Mirrors `json validate` (see `json_validate.rs`) but for the opt-in YAML
+//! validator. Unlike the JSON handler, the error header is rendered straight
+//! from the error kind's `Display` impl rather than a hand-copied `match`, so
+//! there is a single source of truth for the message text.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::fs;
+use std::io::{self, IsTerminal, Read};
+use std::path::PathBuf;
+use succinctly::yaml::validate::{validate, YamlValidationError, YamlValidationErrorKind};
+
+/// Validate YAML files strictly (opt-in; the default loader does not validate).
+#[derive(Debug, Parser)]
+pub struct ValidateArgs {
+    /// Input files to validate (reads from stdin if none provided)
+    #[arg(trailing_var_arg = true)]
+    pub files: Vec<PathBuf>,
+
+    /// Quiet mode: exit code only, no output
+    #[arg(short, long)]
+    pub quiet: bool,
+
+    /// Force color output even when not a TTY
+    #[arg(short = 'C', long = "color")]
+    pub color: bool,
+
+    /// Disable color output
+    #[arg(short = 'M', long = "no-color")]
+    pub no_color: bool,
+}
+
+/// Exit codes for the validate command.
+pub mod exit_codes {
+    /// YAML is valid.
+    pub const SUCCESS: i32 = 0;
+    /// YAML is invalid (validation error).
+    pub const INVALID: i32 = 1;
+    /// I/O error (file not found, permission denied, etc.).
+    pub const IO_ERROR: i32 = 2;
+}
+
+/// ANSI color codes for error output.
+mod colors {
+    pub const RESET: &str = "\x1b[0m";
+    pub const ERROR: &str = "\x1b[1;31m"; // Bold red
+    pub const LOCATION: &str = "\x1b[1;34m"; // Bold blue
+    pub const LINE_NUM: &str = "\x1b[0;34m"; // Blue
+    pub const CARET: &str = "\x1b[1;32m"; // Bold green
+    pub const MESSAGE: &str = "\x1b[0;33m"; // Yellow
+}
+
+/// Color scheme that can be disabled.
+struct ColorScheme {
+    error: &'static str,
+    location: &'static str,
+    line_num: &'static str,
+    caret: &'static str,
+    message: &'static str,
+    reset: &'static str,
+}
+
+impl ColorScheme {
+    fn new(use_color: bool) -> Self {
+        if use_color {
+            Self {
+                error: colors::ERROR,
+                location: colors::LOCATION,
+                line_num: colors::LINE_NUM,
+                caret: colors::CARET,
+                message: colors::MESSAGE,
+                reset: colors::RESET,
+            }
+        } else {
+            Self {
+                error: "",
+                location: "",
+                line_num: "",
+                caret: "",
+                message: "",
+                reset: "",
+            }
+        }
+    }
+}
+
+/// Run the validate command.
+pub fn run(args: ValidateArgs) -> Result<i32> {
+    let use_color = if args.no_color {
+        false
+    } else if args.color {
+        true
+    } else {
+        io::stderr().is_terminal()
+    };
+
+    let scheme = ColorScheme::new(use_color);
+
+    if args.files.is_empty() {
+        let mut input = Vec::new();
+        io::stdin()
+            .read_to_end(&mut input)
+            .context("failed to read from stdin")?;
+
+        validate_input(&input, None, &args, &scheme)
+    } else {
+        let mut any_invalid = false;
+        let mut any_io_error = false;
+
+        for path in &args.files {
+            match fs::read(path) {
+                Ok(input) => {
+                    let filename = path.to_string_lossy();
+                    let result = validate_input(&input, Some(&filename), &args, &scheme)?;
+                    if result == exit_codes::INVALID {
+                        any_invalid = true;
+                    }
+                }
+                Err(e) => {
+                    any_io_error = true;
+                    if !args.quiet {
+                        eprintln!(
+                            "{}error{}: {}: {}",
+                            scheme.error,
+                            scheme.reset,
+                            path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        if any_io_error {
+            Ok(exit_codes::IO_ERROR)
+        } else if any_invalid {
+            Ok(exit_codes::INVALID)
+        } else {
+            Ok(exit_codes::SUCCESS)
+        }
+    }
+}
+
+/// Validate a single input and print errors.
+fn validate_input(
+    input: &[u8],
+    filename: Option<&str>,
+    args: &ValidateArgs,
+    scheme: &ColorScheme,
+) -> Result<i32> {
+    match validate(input) {
+        Ok(()) => Ok(exit_codes::SUCCESS),
+        Err(err) => {
+            if !args.quiet {
+                print_error(&err, input, filename, scheme);
+            }
+            Ok(exit_codes::INVALID)
+        }
+    }
+}
+
+/// Print a formatted error message with a rustc-style context snippet.
+fn print_error(
+    err: &YamlValidationError,
+    input: &[u8],
+    filename: Option<&str>,
+    scheme: &ColorScheme,
+) {
+    let pos = &err.position;
+
+    // Single source of truth for the message: the error kind's Display impl.
+    eprintln!("{}error{}: {}", scheme.error, scheme.reset, err.kind);
+
+    let location = match filename {
+        Some(f) => format!("{}:{}:{}", f, pos.line, pos.column),
+        None => format!("<stdin>:{}:{}", pos.line, pos.column),
+    };
+    eprintln!("  {}--> {}{}", scheme.location, location, scheme.reset);
+
+    if let Some(snippet) = get_error_snippet(input, pos.line, pos.column) {
+        let line_num_width = pos.line.to_string().len().max(3);
+        let blank_padding = " ".repeat(line_num_width + 2);
+
+        eprintln!("{}{}|{}", blank_padding, scheme.line_num, scheme.reset);
+        eprintln!(
+            " {}{:>width$}{} {}|{} {}",
+            scheme.line_num,
+            pos.line,
+            scheme.reset,
+            scheme.line_num,
+            scheme.reset,
+            snippet.line_content,
+            width = line_num_width
+        );
+
+        let padding = " ".repeat(snippet.caret_offset);
+        let carets = "^".repeat(snippet.caret_width.max(1));
+        eprintln!(
+            "{}{}|{} {}{}{}{}{}",
+            blank_padding,
+            scheme.line_num,
+            scheme.reset,
+            padding,
+            scheme.caret,
+            carets,
+            scheme.reset,
+            format_error_hint(&err.kind, scheme)
+        );
+    }
+
+    eprintln!();
+}
+
+/// A short, actionable hint for certain error kinds, shown after the caret.
+/// This is a hint only — the message itself comes from `Display` (see above).
+fn format_error_hint(kind: &YamlValidationErrorKind, scheme: &ColorScheme) -> String {
+    let hint = match kind {
+        YamlValidationErrorKind::InvalidEscape { .. } => Some("not a valid YAML escape"),
+        YamlValidationErrorKind::TabInIndentation => Some("use spaces, not tabs, to indent"),
+        YamlValidationErrorKind::NestedMappingKey => {
+            Some("a mapping value cannot itself be a mapping on one line")
+        }
+        YamlValidationErrorKind::MultilineImplicitKey => {
+            Some("an implicit key must fit on a single line")
+        }
+        YamlValidationErrorKind::UnexpectedFlowComma => Some("remove the extra comma"),
+        YamlValidationErrorKind::MisplacedDirective => {
+            Some("a directive must directly precede a `---` document start")
+        }
+        YamlValidationErrorKind::CommentNotSeparated => Some("put a space before `#`"),
+        _ => None,
+    };
+
+    match hint {
+        Some(h) => format!(" {}{}{}", scheme.message, h, scheme.reset),
+        None => String::new(),
+    }
+}
+
+/// Information about an error snippet.
+struct ErrorSnippet {
+    line_content: String,
+    caret_offset: usize,
+    caret_width: usize,
+}
+
+/// Extract a snippet of context around an error position.
+fn get_error_snippet(input: &[u8], line: usize, column: usize) -> Option<ErrorSnippet> {
+    let text = String::from_utf8_lossy(input);
+
+    let mut current_line = 1;
+    let mut line_start = 0;
+    for (i, ch) in text.char_indices() {
+        if current_line == line {
+            line_start = i;
+            break;
+        }
+        if ch == '\n' {
+            current_line += 1;
+        }
+    }
+
+    if current_line != line && line > 1 {
+        return None;
+    }
+
+    let line_end = text[line_start..]
+        .find('\n')
+        .map_or(text.len(), |i| line_start + i);
+    let line_content = &text[line_start..line_end];
+
+    let max_width = 80;
+    let (display_content, caret_offset) = if line_content.len() > max_width {
+        let error_col = column.saturating_sub(1);
+        if error_col < max_width / 2 {
+            let truncated = &line_content[..max_width.min(line_content.len())];
+            (format!("{truncated}..."), error_col)
+        } else if error_col >= line_content.len().saturating_sub(max_width / 2) {
+            let start = line_content.len().saturating_sub(max_width);
+            let truncated = &line_content[start..];
+            let pos_in_truncated = error_col.saturating_sub(start);
+            (format!("...{truncated}"), pos_in_truncated + 3)
+        } else {
+            let start = error_col.saturating_sub(max_width / 2);
+            let end = (start + max_width).min(line_content.len());
+            let truncated = &line_content[start..end];
+            let pos_in_truncated = error_col.saturating_sub(start);
+            (format!("...{truncated}..."), pos_in_truncated + 3)
+        }
+    } else {
+        (line_content.to_string(), column.saturating_sub(1))
+    };
+
+    Some(ErrorSnippet {
+        line_content: display_content,
+        caret_offset,
+        caret_width: 1,
+    })
+}

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -165,6 +165,54 @@ fn read_file(path: &Path) -> Result<Vec<u8>> {
     std::fs::read(path).with_context(|| format!("failed to read file: {}", path.display()))
 }
 
+/// When `--validate` is set and the resolved input format is YAML, run the
+/// opt-in strict validator (`succinctly::yaml::validate`) before indexing and,
+/// on the first violation, print a rustc-style diagnostic and return the exit
+/// code to bail with. Mirrors `sjq --validate` (`jq_runner::validate_json_input`);
+/// JSON input is left to jq-side validation.
+fn yaml_validate_guard(
+    input: &[u8],
+    format: InputFormat,
+    validate: bool,
+    filename: Option<&str>,
+) -> Option<i32> {
+    if !validate || !matches!(format, InputFormat::Yaml | InputFormat::Auto) {
+        return None;
+    }
+    match succinctly::yaml::validate::validate(input) {
+        Ok(()) => None,
+        Err(err) => {
+            print_yaml_validation_error(&err, input, filename);
+            Some(exit_codes::COMPILE_ERROR)
+        }
+    }
+}
+
+/// Print a YAML validation error with a line/column location and a caret snippet.
+fn print_yaml_validation_error(
+    err: &succinctly::yaml::validate::YamlValidationError,
+    input: &[u8],
+    filename: Option<&str>,
+) {
+    let pos = &err.position;
+    eprintln!("yq: validation error: {}", err.kind);
+    let location = filename.map_or_else(
+        || format!("<stdin>:{}:{}", pos.line, pos.column),
+        |f| format!("{}:{}:{}", f, pos.line, pos.column),
+    );
+    eprintln!("  --> {location}");
+
+    let text = String::from_utf8_lossy(input);
+    if let Some(line_content) = text.lines().nth(pos.line.saturating_sub(1)) {
+        let width = pos.line.to_string().len().max(3);
+        let pad = " ".repeat(width + 2);
+        eprintln!("{pad}|");
+        eprintln!(" {:>width$} | {}", pos.line, line_content, width = width);
+        eprintln!("{}| {}^", pad, " ".repeat(pos.column.saturating_sub(1)));
+    }
+    eprintln!();
+}
+
 /// Detect input format from file extension.
 fn detect_format_from_path(path: &Path) -> InputFormat {
     match path.extension().and_then(|e| e.to_str()) {
@@ -1262,6 +1310,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
         if input_files.is_empty() {
             let yaml_bytes = read_stdin()?;
+            let fmt = resolve_input_format(args.input_format, None);
+            if let Some(code) = yaml_validate_guard(&yaml_bytes, fmt, args.validate, None) {
+                return Ok(code);
+            }
             let index = YamlIndex::build(&yaml_bytes)
                 .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
             let root = index.root(&yaml_bytes);
@@ -1313,7 +1365,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }
         } else {
             for file_path in &input_files {
-                let yaml_bytes = read_file(Path::new(file_path))?;
+                let path = Path::new(file_path);
+                let yaml_bytes = read_file(path)?;
+                let fmt = resolve_input_format(args.input_format, Some(path));
+                if let Some(code) =
+                    yaml_validate_guard(&yaml_bytes, fmt, args.validate, Some(file_path))
+                {
+                    return Ok(code);
+                }
                 let index = YamlIndex::build(&yaml_bytes)
                     .map_err(|e| anyhow::anyhow!("YAML parse error in {file_path}: {e}"))?;
                 let root = index.root(&yaml_bytes);
@@ -1424,6 +1483,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
             let input_bytes = read_stdin()?;
             let format = resolve_input_format(args.input_format, None);
+            if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
+                return Ok(code);
+            }
             vec![(input_bytes, format)]
         } else {
             let mut sources = Vec::new();
@@ -1431,6 +1493,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 let path = Path::new(file_path);
                 let input_bytes = read_file(path)?;
                 let format = resolve_input_format(args.input_format, Some(path));
+                if let Some(code) =
+                    yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
+                {
+                    return Ok(code);
+                }
                 sources.push((input_bytes, format));
             }
             sources
@@ -1473,6 +1540,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             let path = Path::new(file_path);
             let input_bytes = read_file(path)?;
             let format = resolve_input_format(args.input_format, Some(path));
+            if let Some(code) =
+                yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
+            {
+                return Ok(code);
+            }
             let inputs = parse_input(&input_bytes, format)?;
 
             // Collect all output into a buffer
@@ -1535,6 +1607,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
             let input_bytes = read_stdin()?;
             let format = resolve_input_format(args.input_format, None);
+            if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
+                return Ok(code);
+            }
             vec![(input_bytes, format)]
         } else {
             let mut sources = Vec::new();
@@ -1542,6 +1617,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 let path = Path::new(file_path);
                 let input_bytes = read_file(path)?;
                 let format = resolve_input_format(args.input_format, Some(path));
+                if let Some(code) =
+                    yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
+                {
+                    return Ok(code);
+                }
                 sources.push((input_bytes, format));
             }
             sources

--- a/src/yaml/error.rs
+++ b/src/yaml/error.rs
@@ -11,16 +11,6 @@ use core::fmt;
 /// Errors that can occur during YAML parsing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum YamlError {
-    /// Inconsistent indentation (e.g., mixing 2-space and 4-space).
-    InvalidIndentation {
-        /// Line number (1-indexed)
-        line: usize,
-        /// Expected indentation level
-        expected: usize,
-        /// Actual indentation level found
-        found: usize,
-    },
-
     /// Tab character used for indentation (YAML forbids tabs).
     TabIndentation {
         /// Line number where tab was found
@@ -45,14 +35,6 @@ pub enum YamlError {
         start_offset: usize,
         /// The quote character (" or ')
         quote_type: char,
-    },
-
-    /// Invalid escape sequence in a double-quoted string.
-    InvalidEscape {
-        /// Byte offset of the backslash
-        offset: usize,
-        /// The invalid escape sequence
-        sequence: String,
     },
 
     /// Invalid UTF-8 sequence.
@@ -102,12 +84,6 @@ pub enum YamlError {
         name: String,
     },
 
-    /// Explicit key (`?`) not supported.
-    ExplicitKeyNotSupported {
-        /// Byte offset of the `?`
-        offset: usize,
-    },
-
     /// Tag not supported.
     TagNotSupported {
         /// Byte offset of the `!`
@@ -116,12 +92,6 @@ pub enum YamlError {
 
     /// Empty input.
     EmptyInput,
-
-    /// Colon found without following space (ambiguous).
-    ColonWithoutSpace {
-        /// Byte offset of the colon
-        offset: usize,
-    },
 
     /// Key without value in mapping.
     KeyWithoutValue {
@@ -158,16 +128,6 @@ pub enum YamlError {
 impl fmt::Display for YamlError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidIndentation {
-                line,
-                expected,
-                found,
-            } => {
-                write!(
-                    f,
-                    "invalid indentation at line {line}: expected {expected} spaces, found {found}"
-                )
-            }
             Self::TabIndentation { line, offset } => {
                 write!(
                     f,
@@ -198,9 +158,6 @@ impl fmt::Display for YamlError {
                     },
                     start_offset
                 )
-            }
-            Self::InvalidEscape { offset, sequence } => {
-                write!(f, "invalid escape sequence '{sequence}' at offset {offset}")
             }
             Self::InvalidUtf8 { offset } => {
                 write!(f, "invalid UTF-8 sequence at offset {offset}")
@@ -233,20 +190,11 @@ impl fmt::Display for YamlError {
                     "cyclic alias '{name}' at offset {offset} (anchor value contains itself)"
                 )
             }
-            Self::ExplicitKeyNotSupported { offset } => {
-                write!(f, "explicit keys (?) not supported at offset {offset}")
-            }
             Self::TagNotSupported { offset } => {
                 write!(f, "tags (!) not supported at offset {offset}")
             }
             Self::EmptyInput => {
                 write!(f, "empty input")
-            }
-            Self::ColonWithoutSpace { offset } => {
-                write!(
-                    f,
-                    "colon at offset {offset} must be followed by space or newline"
-                )
             }
             Self::KeyWithoutValue { offset, line } => {
                 write!(f, "key without value at line {line} (offset {offset})")
@@ -279,16 +227,6 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let err = YamlError::InvalidIndentation {
-            line: 5,
-            expected: 2,
-            found: 4,
-        };
-        assert_eq!(
-            err.to_string(),
-            "invalid indentation at line 5: expected 2 spaces, found 4"
-        );
-
         let err = YamlError::TabIndentation {
             line: 3,
             offset: 20,
@@ -335,15 +273,6 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_escape_display() {
-        let err = YamlError::InvalidEscape {
-            offset: 4,
-            sequence: "\\q".to_string(),
-        };
-        assert_eq!(err.to_string(), "invalid escape sequence '\\q' at offset 4");
-    }
-
-    #[test]
     fn test_invalid_utf8_display() {
         let err = YamlError::InvalidUtf8 { offset: 9 };
         assert_eq!(err.to_string(), "invalid UTF-8 sequence at offset 9");
@@ -386,15 +315,6 @@ mod tests {
     }
 
     #[test]
-    fn test_explicit_key_not_supported_display() {
-        let err = YamlError::ExplicitKeyNotSupported { offset: 6 };
-        assert_eq!(
-            err.to_string(),
-            "explicit keys (?) not supported at offset 6"
-        );
-    }
-
-    #[test]
     fn test_tag_not_supported_display() {
         let err = YamlError::TagNotSupported { offset: 8 };
         assert_eq!(err.to_string(), "tags (!) not supported at offset 8");
@@ -403,15 +323,6 @@ mod tests {
     #[test]
     fn test_empty_input_display() {
         assert_eq!(YamlError::EmptyInput.to_string(), "empty input");
-    }
-
-    #[test]
-    fn test_colon_without_space_display() {
-        let err = YamlError::ColonWithoutSpace { offset: 11 };
-        assert_eq!(
-            err.to_string(),
-            "colon at offset 11 must be followed by space or newline"
-        );
     }
 
     #[test]

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -71,6 +71,7 @@ mod locate;
 mod parser;
 mod scalar;
 pub mod simd;
+pub mod validate;
 
 pub use error::YamlError;
 pub use index::YamlIndex;

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -1,0 +1,1777 @@
+//! Strict, opt-in YAML validator.
+//!
+//! `succinctly` is a non-validating YAML loader by design: [`YamlIndex::build`]
+//! records structure, not grammar conformance, and accepts many malformed
+//! documents (see `docs/compliance/yaml/limitations.md`). This module is the
+//! opt-in counterpart, mirroring [`crate::json::validate`]: a separate pass, run
+//! *before* indexing, that rejects invalid YAML. The default indexing path does
+//! not link it and is structurally incapable of regressing because of it.
+//!
+//! Like the JSON validator this is a plain scalar scanner — `no_std`, with no
+//! allocation on the success path. It is **not** a full YAML grammar checker:
+//! it walks the document permissively and rejects only the specific classes of
+//! malformed input enumerated in issue #223 (the YAML Test Suite's `lax:*`
+//! cases). Everything it does not recognize as invalid, it accepts — the same
+//! philosophy as the loader, but with a rejection surface bolted on.
+//!
+//! [`YamlIndex::build`]: crate::yaml::YamlIndex::build
+//!
+//! # Example
+//!
+//! ```
+//! use succinctly::yaml::validate::validate;
+//!
+//! assert!(validate(b"a: 1\nb: 2\n").is_ok());
+//! assert!(validate(b"a: b: c\n").is_err()); // nested mapping key
+//! ```
+
+use core::fmt;
+
+/// Position information for error reporting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Position {
+    /// Byte offset (0-indexed).
+    pub offset: usize,
+    /// Line number (1-indexed).
+    pub line: usize,
+    /// Column number (1-indexed, in bytes not characters).
+    pub column: usize,
+}
+
+impl fmt::Display for Position {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "line {}, column {} (offset {})",
+            self.line, self.column, self.offset
+        )
+    }
+}
+
+/// Kinds of YAML validation errors, grouped by the grammar family they guard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum YamlValidationErrorKind {
+    // --- Scalars / quoting ---
+    /// Invalid escape sequence in a double-quoted string (e.g. `"\."`).
+    InvalidEscape { sequence: char },
+    /// A quoted scalar was not closed before end of input.
+    UnclosedQuote { quote: char },
+    /// Content appears immediately after a closing quote where a separator,
+    /// value indicator, or line break was required (e.g. `key2: "v" trailing`).
+    TrailingContentAfterScalar,
+    /// A multi-line scalar was used as an implicit mapping key.
+    MultilineImplicitKey,
+
+    // --- Block scalars ---
+    /// Block scalar indent indicator was `0` or more than one digit (`|0`, `|10`).
+    InvalidBlockScalarIndent,
+    /// Content or a glued comment followed a block scalar header on the same
+    /// line (`> text`, `>#comment`).
+    ContentAfterBlockScalarHeader,
+
+    // --- Comments ---
+    /// A `#` that starts a comment was not preceded by whitespace (glued to a
+    /// terminated token, e.g. `"v"#c` or `c,#c`).
+    CommentNotSeparated,
+
+    // --- Flow collections ---
+    /// A comma appeared where no item precedes it (leading or doubled comma).
+    UnexpectedFlowComma,
+    /// Two flow nodes were not separated by a comma.
+    MissingFlowSeparator,
+    /// A flow collection was not closed before end of input.
+    UnclosedFlow { bracket: char },
+    /// A closing bracket did not match the open one, or extra content followed
+    /// the top-level flow close.
+    UnbalancedFlow { found: char },
+
+    // --- Indentation / structure ---
+    /// A line's indentation matches no open block level.
+    BadIndentation,
+    /// A bare scalar followed a block collection, or a second root node
+    /// appeared at document level.
+    TrailingContent,
+    /// A second `:` value indicator appeared on one line (`a: b: c`).
+    NestedMappingKey,
+
+    // --- Tabs ---
+    /// A tab character was used where indentation is expected.
+    TabInIndentation,
+
+    // --- Anchors / aliases ---
+    /// An anchor was immediately followed by an alias (`&a *b`).
+    AnchorOnAlias,
+    /// An anchor was placed where it cannot bind to a following node.
+    MisplacedAnchor,
+
+    // --- Documents / directives ---
+    /// Non-comment content followed a `...` document-end marker on its line.
+    ContentAfterDocumentEnd,
+    /// A directive (`%YAML`/`%TAG`) appeared where it is not allowed.
+    MisplacedDirective,
+    /// A `%YAML`/`%TAG` directive was malformed.
+    InvalidDirective,
+    /// A second `%YAML` directive appeared for one document.
+    DuplicateYamlDirective,
+    /// A `---`/`...` document marker appeared inside an open quoted scalar.
+    DocumentMarkerInScalar,
+
+    // --- Generic (mirrors json/validate.rs) ---
+    /// Unexpected character in the given context.
+    UnexpectedCharacter {
+        /// What was expected.
+        expected: &'static str,
+        /// The character found.
+        found: char,
+    },
+    /// Unexpected end of input.
+    UnexpectedEof {
+        /// What was expected.
+        expected: &'static str,
+    },
+    /// Invalid UTF-8 sequence.
+    InvalidUtf8,
+    /// Container nesting depth exceeded the limit.
+    NestingTooDeep {
+        /// The configured limit.
+        limit: usize,
+    },
+}
+
+impl fmt::Display for YamlValidationErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEscape { sequence } => {
+                write!(f, "invalid escape sequence '\\{sequence}'")
+            }
+            Self::UnclosedQuote { quote } => write!(f, "unclosed {quote} quote"),
+            Self::TrailingContentAfterScalar => {
+                write!(f, "unexpected content after quoted scalar")
+            }
+            Self::MultilineImplicitKey => {
+                write!(f, "mapping key spans multiple lines")
+            }
+            Self::InvalidBlockScalarIndent => {
+                write!(f, "invalid block scalar indentation indicator")
+            }
+            Self::ContentAfterBlockScalarHeader => {
+                write!(f, "unexpected content after block scalar header")
+            }
+            Self::CommentNotSeparated => {
+                write!(f, "comment must be preceded by whitespace")
+            }
+            Self::UnexpectedFlowComma => write!(f, "unexpected ',' in flow collection"),
+            Self::MissingFlowSeparator => {
+                write!(f, "missing ',' between flow collection entries")
+            }
+            Self::UnclosedFlow { bracket } => write!(f, "unclosed flow collection '{bracket}'"),
+            Self::UnbalancedFlow { found } => {
+                write!(f, "unbalanced flow collection near '{found}'")
+            }
+            Self::BadIndentation => write!(f, "inconsistent indentation"),
+            Self::TrailingContent => write!(f, "unexpected content after block node"),
+            Self::NestedMappingKey => write!(f, "nested mapping key ('a: b: c')"),
+            Self::TabInIndentation => {
+                write!(f, "tab character used where indentation is expected")
+            }
+            Self::AnchorOnAlias => write!(f, "anchor immediately followed by an alias"),
+            Self::MisplacedAnchor => write!(f, "misplaced anchor"),
+            Self::ContentAfterDocumentEnd => {
+                write!(f, "content after document-end marker '...'")
+            }
+            Self::MisplacedDirective => write!(f, "misplaced directive"),
+            Self::InvalidDirective => write!(f, "invalid directive"),
+            Self::DuplicateYamlDirective => write!(f, "duplicate %YAML directive"),
+            Self::DocumentMarkerInScalar => {
+                write!(f, "document marker inside an open quoted scalar")
+            }
+            Self::UnexpectedCharacter { expected, found } => {
+                write!(f, "expected {expected}, found {found:?}")
+            }
+            Self::UnexpectedEof { expected } => {
+                write!(f, "unexpected end of input, expected {expected}")
+            }
+            Self::InvalidUtf8 => write!(f, "invalid UTF-8 sequence"),
+            Self::NestingTooDeep { limit } => {
+                write!(f, "nesting depth exceeds limit of {limit}")
+            }
+        }
+    }
+}
+
+/// A YAML validation error with position information.
+#[derive(Debug, Clone)]
+pub struct YamlValidationError {
+    /// The kind of error.
+    pub kind: YamlValidationErrorKind,
+    /// Position where the error occurred.
+    pub position: Position,
+}
+
+impl fmt::Display for YamlValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} at {}", self.kind, self.position)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for YamlValidationError {}
+
+/// Maximum flow-collection nesting depth. Matches the parser and JSON validator
+/// caps so deeply nested input fails cleanly instead of overflowing the stack.
+const MAX_NESTING_DEPTH: usize = 128;
+
+/// The structural kind of a block-context line, used for root-node consistency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineKind {
+    /// A sequence entry (`- x`).
+    Seq,
+    /// A mapping entry (`k: v`, `? k`, `: v`).
+    Map,
+    /// A plain or quoted scalar with no value indicator.
+    Scalar,
+}
+
+/// Validate YAML input strictly.
+///
+/// Returns `Ok(())` if the input passes the checks in this module, or an error
+/// with position information for the first violation found. See the module docs
+/// for what is and is not checked.
+///
+/// # Example
+///
+/// ```
+/// use succinctly::yaml::validate::validate;
+/// assert!(validate(b"- a\n- b\n").is_ok());
+/// assert!(validate(b"[ a, , b ]\n").is_err());
+/// ```
+pub fn validate(input: &[u8]) -> Result<(), YamlValidationError> {
+    Validator::new(input).validate()
+}
+
+/// A strict YAML validator with position tracking.
+pub struct Validator<'a> {
+    input: &'a [u8],
+    offset: usize,
+    line: usize,
+    column: usize,
+    /// Leading-space count of the physical line currently being scanned.
+    line_indent: usize,
+    /// Current flow-collection nesting depth, capped at [`MAX_NESTING_DEPTH`].
+    nesting_depth: usize,
+    /// True while inside a document body (after `---` or first content, until
+    /// `...` or a new `---`). A col-0 `%` is a directive only when this is false.
+    in_document: bool,
+    /// A directive was seen and no `---` has followed yet.
+    directive_pending: bool,
+    /// A `%YAML` directive was seen for the pending document (duplicate guard).
+    yaml_directive_seen: bool,
+    /// Kind of the current document's root node (set by its first indent-0
+    /// content line); a later indent-0 node of a different kind is a second
+    /// root. Reset at each document boundary.
+    root_kind: Option<LineKind>,
+    /// Open block-collection frames: the indentation column of each and its
+    /// kind. Used to detect dedents that land between levels and kind mismatches
+    /// at an established level. Fixed-size to keep the success path allocation-free.
+    frame_indent: [u32; MAX_NESTING_DEPTH],
+    frame_kind: [LineKind; MAX_NESTING_DEPTH],
+    frame_len: usize,
+    /// The current content line carried a trailing `# comment`.
+    line_had_comment: bool,
+    /// A root plain scalar was closed by a trailing comment; any further content
+    /// in the same document is a second root node (BS4K, EB22).
+    root_scalar_done: bool,
+}
+
+impl<'a> Validator<'a> {
+    /// Create a new validator for the given input.
+    pub fn new(input: &'a [u8]) -> Self {
+        Self {
+            input,
+            offset: 0,
+            line: 1,
+            column: 1,
+            line_indent: 0,
+            nesting_depth: 0,
+            in_document: false,
+            directive_pending: false,
+            yaml_directive_seen: false,
+            root_kind: None,
+            frame_indent: [0; MAX_NESTING_DEPTH],
+            frame_kind: [LineKind::Scalar; MAX_NESTING_DEPTH],
+            frame_len: 0,
+            line_had_comment: false,
+            root_scalar_done: false,
+        }
+    }
+
+    /// Validate the entire input.
+    pub fn validate(&mut self) -> Result<(), YamlValidationError> {
+        // A byte-oriented scan is enough for the lexical families (escapes,
+        // block-scalar headers, quotes, comments glued to tokens, tabs). It
+        // tracks just enough context to know when a `"`/`'`/`|`/`>`/`#` is
+        // significant versus scalar content. Structural families are layered on
+        // in later passes.
+        while self.offset < self.input.len() {
+            self.scan_line()?;
+        }
+        // A directive with no following `---` document start (9MMA `%YAML 1.2`).
+        if self.directive_pending {
+            return Err(self.error(YamlValidationErrorKind::MisplacedDirective));
+        }
+        Ok(())
+    }
+
+    /// Scan one physical line, dispatching on its first significant token.
+    fn scan_line(&mut self) -> Result<(), YamlValidationError> {
+        // Leading indentation (spaces only; tabs handled per-context later).
+        let start = self.offset;
+        self.skip_spaces();
+        self.line_indent = self.offset - start;
+
+        // At column 0, `%` begins a directive (only outside a document body) and
+        // `---`/`...` are document markers.
+        if self.line_indent == 0 {
+            if self.peek() == Some(b'%') && !self.in_document {
+                return self.handle_directive();
+            }
+            if let Some(marker) = self.doc_marker_char() {
+                return self.handle_document_marker(marker);
+            }
+        }
+
+        match self.peek() {
+            None => Ok(()),
+            Some(b'\n' | b'\r') => {
+                self.consume_line_break();
+                Ok(())
+            }
+            Some(b'#') => {
+                self.skip_to_line_end();
+                Ok(())
+            }
+            // A whitespace-only line (spaces and/or tabs) is blank; it carries no
+            // content and does not close the directive section (DK95/07).
+            _ if self.rest_of_line_is_blank() => {
+                self.skip_to_line_end();
+                self.consume_line_break();
+                Ok(())
+            }
+            // A tab in the leading indentation of a structural line (a mapping
+            // key or sequence item) is not valid indentation (DK95/06). A tab
+            // before a plain scalar value (DK95/00 `foo:\n \tbar`) is separation,
+            // not indentation, and is allowed.
+            Some(b'\t') if self.line_is_structural() => {
+                Err(self.error(YamlValidationErrorKind::TabInIndentation))
+            }
+            _ => {
+                // A directive must be followed by a `---` before any content.
+                if self.directive_pending {
+                    return Err(self.error(YamlValidationErrorKind::MisplacedDirective));
+                }
+                self.in_document = true;
+                self.check_root_kind()?;
+                self.check_block_indent()?;
+                let result = self.scan_content_line();
+                // A root plain scalar terminated by a trailing comment cannot be
+                // continued by a later line (BS4K, EB22).
+                if self.line_indent == 0
+                    && self.root_kind == Some(LineKind::Scalar)
+                    && self.line_had_comment
+                {
+                    self.root_scalar_done = true;
+                }
+                result
+            }
+        }
+    }
+
+    /// Track block indentation and reject dedents that land between open levels
+    /// (N4JP, DMG6, 4HVU) and kind mismatches at an established level (6S55). A
+    /// block sequence value legitimately sits at its mapping key's indentation,
+    /// so a same-indent sequence under a mapping is allowed.
+    fn check_block_indent(&mut self) -> Result<(), YamlValidationError> {
+        // Anchor/alias/tag property lines do not establish or test a frame.
+        if matches!(self.peek(), Some(b'&' | b'*' | b'!')) {
+            return Ok(());
+        }
+        let d = self.line_indent as u32;
+        let kind = self.line_kind();
+
+        // Dedent: drop deeper frames.
+        let mut popped = false;
+        while self.frame_len > 0 && self.frame_indent[self.frame_len - 1] > d {
+            self.frame_len -= 1;
+            popped = true;
+        }
+
+        if self.frame_len == 0 {
+            if matches!(kind, LineKind::Seq | LineKind::Map) {
+                self.push_frame(d, kind)?;
+            }
+            return Ok(());
+        }
+
+        let top_indent = self.frame_indent[self.frame_len - 1];
+        let top_kind = self.frame_kind[self.frame_len - 1];
+        if top_indent == d {
+            // Sibling at an established level.
+            match (top_kind, kind) {
+                // A block sequence value sits at its mapping key's indentation.
+                (LineKind::Map, LineKind::Seq) => self.push_frame(d, LineKind::Seq)?,
+                // A mapping key at the sequence's indent ends the sequence value
+                // and resumes the enclosing mapping (AZ63, 7ZZ5, S9E8).
+                (LineKind::Seq, LineKind::Map) => self.frame_len -= 1,
+                // A scalar where a sequence expects an item (6S55).
+                (LineKind::Seq, LineKind::Scalar) => {
+                    return Err(self.error(YamlValidationErrorKind::BadIndentation))
+                }
+                _ => {}
+            }
+        } else {
+            // `top_indent < d`: a deeper line.
+            if popped && matches!(kind, LineKind::Seq | LineKind::Map) {
+                // A dedent that stopped between two levels (N4JP, DMG6, 4HVU).
+                return Err(self.error(YamlValidationErrorKind::BadIndentation));
+            }
+            if matches!(kind, LineKind::Seq | LineKind::Map) {
+                self.push_frame(d, kind)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Push a block frame, capping nesting depth.
+    fn push_frame(&mut self, indent: u32, kind: LineKind) -> Result<(), YamlValidationError> {
+        if self.frame_len >= MAX_NESTING_DEPTH {
+            return Err(self.error(YamlValidationErrorKind::NestingTooDeep {
+                limit: MAX_NESTING_DEPTH,
+            }));
+        }
+        self.frame_indent[self.frame_len] = indent;
+        self.frame_kind[self.frame_len] = kind;
+        self.frame_len += 1;
+        Ok(())
+    }
+
+    /// At the document root (indent 0), enforce that every top-level node is
+    /// compatible with the root's kind. A mapping may carry same-indent
+    /// sequence values, so `root=Map` still accepts `Seq`; but a stray scalar
+    /// (236B, 7MNF, 9CWY), a mapping under a sequence (BD7L), or a mapping/
+    /// sequence after a plain scalar (G7JE) is a second root node.
+    fn check_root_kind(&mut self) -> Result<(), YamlValidationError> {
+        if self.line_indent != 0 {
+            return Ok(());
+        }
+        // A root scalar closed by a trailing comment admits no further content.
+        if self.root_scalar_done {
+            return Err(self.error(YamlValidationErrorKind::TrailingContent));
+        }
+        // Anchor/alias/tag properties (`&a`, `*a`, `!t`) attach to the node that
+        // follows; they do not themselves establish the root kind.
+        if matches!(self.peek(), Some(b'&' | b'*' | b'!')) {
+            return Ok(());
+        }
+        let kind = self.line_kind();
+        match self.root_kind {
+            None => self.root_kind = Some(kind),
+            Some(root) => {
+                let incompatible = match root {
+                    // A mapping's values may be same-indent sequences.
+                    LineKind::Map => kind == LineKind::Scalar,
+                    LineKind::Seq => kind != LineKind::Seq,
+                    LineKind::Scalar => kind != LineKind::Scalar,
+                };
+                if incompatible {
+                    return Err(self.error(YamlValidationErrorKind::TrailingContent));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Classify a block-context line (from the cursor, after leading indent) as
+    /// a sequence entry, a mapping entry, or a plain/quoted scalar. Quoted
+    /// regions are skipped so a `:` inside a quoted key is not miscounted.
+    fn line_kind(&self) -> LineKind {
+        let mut i = self.offset;
+        let first = self.input.get(i).copied();
+        // Sequence entry `-` / explicit key `?` / explicit value `:`.
+        if matches!(first, Some(b'-'))
+            && matches!(
+                self.input.get(i + 1),
+                None | Some(b' ' | b'\t' | b'\n' | b'\r')
+            )
+        {
+            return LineKind::Seq;
+        }
+        if matches!(first, Some(b'?' | b':'))
+            && matches!(
+                self.input.get(i + 1),
+                None | Some(b' ' | b'\t' | b'\n' | b'\r')
+            )
+        {
+            return LineKind::Map;
+        }
+        // Otherwise scan for a `:` value indicator outside quoted regions.
+        while let Some(&b) = self.input.get(i) {
+            match b {
+                b'\n' | b'\r' => break,
+                b'"' => {
+                    i += 1;
+                    while let Some(&c) = self.input.get(i) {
+                        i += 1;
+                        if c == b'\\' {
+                            i += 1;
+                        } else if c == b'"' || c == b'\n' || c == b'\r' {
+                            break;
+                        }
+                    }
+                }
+                b'\'' => {
+                    i += 1;
+                    while let Some(&c) = self.input.get(i) {
+                        if c == b'\'' {
+                            i += 1;
+                            if self.input.get(i) == Some(&b'\'') {
+                                i += 1;
+                                continue;
+                            }
+                            break;
+                        }
+                        if c == b'\n' || c == b'\r' {
+                            break;
+                        }
+                        i += 1;
+                    }
+                }
+                b'#' if i > self.offset && matches!(self.input.get(i - 1), Some(b' ' | b'\t')) => {
+                    break
+                }
+                b':' if matches!(
+                    self.input.get(i + 1),
+                    None | Some(b' ' | b'\t' | b'\n' | b'\r')
+                ) =>
+                {
+                    return LineKind::Map
+                }
+                _ => i += 1,
+            }
+        }
+        LineKind::Scalar
+    }
+
+    /// True if the current line (from the cursor, skipping leading whitespace)
+    /// is a structural node — a sequence item (`-` + whitespace) or a block
+    /// mapping entry (a `: ` value indicator before end of line) — rather than a
+    /// plain scalar. Used to decide whether a leading tab is illegal indentation.
+    fn line_is_structural(&self) -> bool {
+        let mut i = self.offset;
+        while matches!(self.input.get(i), Some(b' ' | b'\t')) {
+            i += 1;
+        }
+        // Sequence item: `-` followed by whitespace or end of line.
+        if self.input.get(i) == Some(&b'-')
+            && matches!(
+                self.input.get(i + 1),
+                None | Some(b' ' | b'\t' | b'\n' | b'\r')
+            )
+        {
+            return true;
+        }
+        // Mapping entry: a `:` value indicator somewhere on the line.
+        while let Some(&b) = self.input.get(i) {
+            match b {
+                b'\n' | b'\r' => return false,
+                b':' if matches!(
+                    self.input.get(i + 1),
+                    None | Some(b' ' | b'\t' | b'\n' | b'\r')
+                ) =>
+                {
+                    return true
+                }
+                _ => i += 1,
+            }
+        }
+        false
+    }
+
+    /// True if the line begins with a block indicator (`-`/`?`/`:`) whose
+    /// separating whitespace contains a tab and is followed by another block
+    /// indicator or a mapping key — a tab used as block indentation
+    /// (Y79Y/004-009). A tab before a plain scalar (Y79Y/010 `-\t-1`) is allowed.
+    fn tab_between_indicators(&self) -> bool {
+        let is_indicator = |i: usize| {
+            matches!(self.input.get(i), Some(b'-' | b'?' | b':'))
+                && matches!(
+                    self.input.get(i + 1),
+                    None | Some(b' ' | b'\t' | b'\n' | b'\r')
+                )
+        };
+        let mut i = self.offset;
+        loop {
+            if !is_indicator(i) {
+                return false;
+            }
+            // Scan the whitespace separating this indicator from the next token.
+            let mut j = i + 1;
+            let mut saw_tab = false;
+            while let Some(&b) = self.input.get(j) {
+                match b {
+                    b' ' => j += 1,
+                    b'\t' => {
+                        saw_tab = true;
+                        j += 1;
+                    }
+                    _ => break,
+                }
+            }
+            match self.input.get(j) {
+                None | Some(b'\n' | b'\r') => return false,
+                Some(_) if saw_tab => {
+                    // Tab separates the indicator from a nested block construct.
+                    return is_indicator(j) || self.mapping_key_at(j);
+                }
+                Some(_) if is_indicator(j) => {
+                    // Another indicator with no tab yet — keep looking.
+                    i = j;
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    /// True if the token starting at byte `i` forms a block mapping key, i.e. a
+    /// `: ` value indicator appears before the end of that line.
+    fn mapping_key_at(&self, mut i: usize) -> bool {
+        while let Some(&b) = self.input.get(i) {
+            match b {
+                b'\n' | b'\r' => return false,
+                b':' if matches!(
+                    self.input.get(i + 1),
+                    None | Some(b' ' | b'\t' | b'\n' | b'\r')
+                ) =>
+                {
+                    return true
+                }
+                _ => i += 1,
+            }
+        }
+        false
+    }
+
+    /// True if the remainder of the current line is only whitespace (spaces or
+    /// tabs) up to the next line break or end of input.
+    fn rest_of_line_is_blank(&self) -> bool {
+        let mut i = self.offset;
+        while let Some(b) = self.input.get(i) {
+            match b {
+                b' ' | b'\t' => i += 1,
+                b'\n' | b'\r' => return true,
+                _ => return false,
+            }
+        }
+        true
+    }
+
+    /// Handle a `%YAML`/`%TAG`/other directive line at column 0 (outside a
+    /// document body). Validates `%YAML` syntax and records that a document
+    /// start must follow.
+    fn handle_directive(&mut self) -> Result<(), YamlValidationError> {
+        self.advance(); // consume '%'
+        let name_start = self.offset;
+        while matches!(self.peek(), Some(b'A'..=b'Z' | b'a'..=b'z')) {
+            self.advance();
+        }
+        let is_yaml = &self.input[name_start..self.offset] == b"YAML";
+        if is_yaml {
+            if self.yaml_directive_seen {
+                // SF5V: two %YAML directives for one document.
+                return Err(self.error(YamlValidationErrorKind::DuplicateYamlDirective));
+            }
+            self.yaml_directive_seen = true;
+            self.validate_yaml_directive()?;
+        } else {
+            // %TAG and other directives are accepted permissively.
+            self.skip_to_line_end();
+        }
+        self.consume_line_break();
+        self.directive_pending = true;
+        Ok(())
+    }
+
+    /// Validate the tail of a `%YAML` directive: whitespace, a version token,
+    /// then only whitespace and an optional space-separated comment.
+    fn validate_yaml_directive(&mut self) -> Result<(), YamlValidationError> {
+        self.skip_spaces_and_tabs();
+        // Version token: digits and dots (`1.2`).
+        while matches!(self.peek(), Some(b'0'..=b'9' | b'.')) {
+            self.advance();
+        }
+        // MUS6/00: a `#` glued to the version (no separating space) is invalid.
+        if self.peek() == Some(b'#') {
+            return Err(self.error(YamlValidationErrorKind::InvalidDirective));
+        }
+        self.skip_spaces_and_tabs();
+        match self.peek() {
+            None | Some(b'\n' | b'\r' | b'#') => Ok(()),
+            // H7TQ: an extra word after the version.
+            Some(_) => Err(self.error(YamlValidationErrorKind::InvalidDirective)),
+        }
+    }
+
+    /// Handle a `---` or `...` document marker at column 0. `marker` is `'-'`
+    /// or `'.'`. For `---`, the document root may continue on the same line.
+    fn handle_document_marker(&mut self, marker: char) -> Result<(), YamlValidationError> {
+        self.advance();
+        self.advance();
+        self.advance(); // consume the three marker bytes
+
+        if marker == '.' {
+            // `...` document end. A directive with no `---` cannot be closed by
+            // `...` (B63P `%YAML 1.2\n...`).
+            if self.directive_pending {
+                return Err(self.error(YamlValidationErrorKind::MisplacedDirective));
+            }
+            self.skip_spaces_and_tabs();
+            match self.peek() {
+                None | Some(b'\n' | b'\r' | b'#') => {}
+                // 3HFZ: `... invalid` — non-comment content after the marker.
+                Some(_) => return Err(self.error(YamlValidationErrorKind::ContentAfterDocumentEnd)),
+            }
+            self.skip_to_line_end();
+            self.consume_line_break();
+            self.in_document = false;
+            self.directive_pending = false;
+            self.yaml_directive_seen = false;
+            self.root_kind = None;
+            self.root_scalar_done = false;
+            self.frame_len = 0;
+            Ok(())
+        } else {
+            // `---` document start; a document root node may follow on this line.
+            self.directive_pending = false;
+            self.in_document = true;
+            self.yaml_directive_seen = false;
+            // Content after `---` on this line is the root; the marker sits at
+            // column 0 but the node may be indented past it, so root-kind
+            // tracking (indent-0 only) does not apply to same-line `--- x`.
+            self.root_kind = None;
+            self.root_scalar_done = false;
+            self.frame_len = 0;
+            self.scan_content_line()
+        }
+    }
+
+    /// Scan the significant content of a line (after leading indent), consuming
+    /// scalars, flow collections, and comments to the line break.
+    fn scan_content_line(&mut self) -> Result<(), YamlValidationError> {
+        // A tab used as indentation between block indicators (Y79Y/004-009).
+        if self.tab_between_indicators() {
+            return Err(self.error(YamlValidationErrorKind::TabInIndentation));
+        }
+        self.line_had_comment = false;
+        let parent_indent = self.line_indent;
+        // A block-context line may hold at most one `: ` value indicator; a
+        // second means a compact nested mapping (`a: b: c`, ZCZ6 / ZL4Z). The
+        // check is suppressed on lines using anchors/aliases (`&`/`*`) or
+        // explicit key/value indicators (`?`/leading `:`), which legitimately
+        // carry multiple colons (anchor names may contain `:`; explicit keys
+        // take compact mapping values).
+        let mut seen_value_indicator = false;
+        let mut suppress_nested = self.peek() == Some(b':') && self.is_value_indicator();
+        // Walk tokens until the line break, honoring multi-line constructs.
+        loop {
+            match self.peek() {
+                None => return Ok(()),
+                Some(b'\n' | b'\r') => {
+                    self.consume_line_break();
+                    return Ok(());
+                }
+                Some(b'&') if self.at_quote_start() => {
+                    suppress_nested = true;
+                    self.scan_anchor()?;
+                }
+                Some(b'*') if self.at_quote_start() => {
+                    suppress_nested = true;
+                    self.scan_anchor_name();
+                }
+                Some(b'?') => {
+                    suppress_nested = true;
+                    self.advance();
+                }
+                Some(b'"') if self.at_quote_start() => {
+                    // A value scalar's continuation lines must be indented past
+                    // the key (QB6E); a key/root scalar imposes no minimum here.
+                    let min = if seen_value_indicator {
+                        self.line_indent + 1
+                    } else {
+                        0
+                    };
+                    let multiline = self.scan_double_quoted(min)?;
+                    self.check_after_block_quoted(multiline)?;
+                }
+                Some(b'\'') if self.at_quote_start() => {
+                    let min = if seen_value_indicator {
+                        self.line_indent + 1
+                    } else {
+                        0
+                    };
+                    let multiline = self.scan_single_quoted(min)?;
+                    self.check_after_block_quoted(multiline)?;
+                }
+                Some(b':') if self.is_value_indicator() => {
+                    if seen_value_indicator && !suppress_nested {
+                        return Err(self.error(YamlValidationErrorKind::NestedMappingKey));
+                    }
+                    seen_value_indicator = true;
+                    self.advance();
+                    // A block sequence indicator cannot follow `: ` inline on the
+                    // same line (5U3A `key: - a`); the sequence must be on its own
+                    // lines. `key: -1` (a scalar starting with `-`) is fine, and an
+                    // explicit value (`? k\n: - v`, suppressed) legitimately may.
+                    let mut k = self.offset;
+                    while matches!(self.input.get(k), Some(b' ' | b'\t')) {
+                        k += 1;
+                    }
+                    if !suppress_nested
+                        && self.input.get(k) == Some(&b'-')
+                        && matches!(self.input.get(k + 1), Some(b' ' | b'\t' | b'\n' | b'\r'))
+                    {
+                        return Err(self.error(YamlValidationErrorKind::TrailingContent));
+                    }
+                }
+                Some(b'[' | b'{') if self.at_quote_start() => {
+                    self.scan_flow()?;
+                    self.check_after_top_level_flow()?;
+                }
+                Some(b'|' | b'>') if self.at_block_scalar_header() => {
+                    self.scan_block_scalar_header()?;
+                    self.skip_block_scalar_body(parent_indent);
+                    return Ok(());
+                }
+                Some(b'#') if self.prev_is_space_or_line_start() => {
+                    self.line_had_comment = true;
+                    self.skip_to_line_end();
+                    return Ok(());
+                }
+                Some(_) => {
+                    self.advance();
+                }
+            }
+        }
+    }
+
+    /// True if a `:` at the cursor is a block mapping value indicator: it must
+    /// be followed by whitespace, a line break, or end of input. `a:b` (no
+    /// space) and `http://x` are plain-scalar content, not indicators.
+    fn is_value_indicator(&self) -> bool {
+        matches!(self.peek_at(1), None | Some(b' ' | b'\t' | b'\n' | b'\r'))
+    }
+
+    /// True if a `"`/`'` at the cursor begins a quoted scalar rather than being
+    /// content inside a plain scalar. A quoted scalar starts only where a node
+    /// can begin: at line start, after whitespace, or after a flow separator.
+    fn at_quote_start(&self) -> bool {
+        match self.offset.checked_sub(1).and_then(|i| self.input.get(i)) {
+            None => true,
+            Some(b' ' | b'\t' | b'\n' | b'\r') => true,
+            Some(b'[' | b'{' | b',') => true,
+            Some(_) => false,
+        }
+    }
+
+    /// Consume the body of a block scalar: blank lines and lines indented deeper
+    /// than the header's own line. Stops before the first line at or below the
+    /// parent indentation. Body content is accepted without further scanning.
+    fn skip_block_scalar_body(&mut self, parent_indent: usize) {
+        loop {
+            // At a line start: column is 1 here and on every rewind below.
+            let line_start = self.offset;
+            self.skip_spaces_and_tabs();
+            let indent = self.offset - line_start;
+            match self.peek() {
+                None => {
+                    self.offset = line_start;
+                    self.column = 1;
+                    return;
+                }
+                Some(b'\n' | b'\r') => {
+                    // Blank line (only whitespace) is always part of the body.
+                    self.consume_line_break();
+                }
+                _ if indent > parent_indent => {
+                    // A more-indented content line belongs to the block scalar.
+                    self.skip_to_line_end();
+                    self.consume_line_break();
+                }
+                _ => {
+                    // Line at or below parent indent ends the block scalar.
+                    self.offset = line_start;
+                    self.column = 1;
+                    return;
+                }
+            }
+        }
+    }
+
+    /// True if a `|`/`>` at the current position begins a block scalar header:
+    /// it must be followed (after optional modifiers) by end-of-line or a
+    /// space-separated comment. A `|`/`>` embedded in a plain scalar (`a|b`) is
+    /// not a header.
+    fn at_block_scalar_header(&self) -> bool {
+        // Must be preceded by whitespace or line start to be an indicator.
+        if !self.prev_is_space_or_line_start() {
+            return false;
+        }
+        let mut i = self.offset + 1;
+        // Skip up to two modifier bytes (digits / + / -).
+        let mut modifiers = 0;
+        while modifiers < 2 {
+            match self.input.get(i) {
+                Some(b'-' | b'+') => {
+                    i += 1;
+                    modifiers += 1;
+                }
+                Some(c) if c.is_ascii_digit() => {
+                    i += 1;
+                    modifiers += 1;
+                }
+                _ => break,
+            }
+        }
+        // After modifiers, only whitespace / comment / line break / EOF.
+        matches!(
+            self.input.get(i),
+            None | Some(b' ' | b'\t' | b'\n' | b'\r' | b'#')
+        )
+    }
+
+    /// Validate a block scalar header: `|`/`>` with optional chomping (`+`/`-`)
+    /// and a single non-zero indent digit, then only whitespace/comment/newline.
+    fn scan_block_scalar_header(&mut self) -> Result<(), YamlValidationError> {
+        self.advance(); // consume | or >
+
+        let mut saw_indent_digit = false;
+        // Up to two modifiers, order-independent (`|2-` or `|-2`).
+        loop {
+            match self.peek() {
+                Some(b'-' | b'+') => {
+                    self.advance();
+                }
+                Some(c) if c.is_ascii_digit() => {
+                    // Indent indicator must be a single digit in 1..=9.
+                    if c == b'0' || saw_indent_digit {
+                        return Err(self.error(YamlValidationErrorKind::InvalidBlockScalarIndent));
+                    }
+                    saw_indent_digit = true;
+                    self.advance();
+                }
+                _ => break,
+            }
+        }
+
+        // Only spaces/tabs, then an optional comment, then the line break.
+        self.skip_spaces_and_tabs();
+        match self.peek() {
+            None | Some(b'\n' | b'\r') => {
+                self.consume_line_break();
+                Ok(())
+            }
+            Some(b'#') => {
+                // A comment here is only valid if separated by whitespace, which
+                // skip_spaces_and_tabs already required (the header consumed at
+                // least the indicator, so column > indicator). `>#c` (no space)
+                // is rejected: nothing was skipped.
+                if !self.prev_is_space_or_line_start() {
+                    return Err(self.error(YamlValidationErrorKind::ContentAfterBlockScalarHeader));
+                }
+                self.skip_to_line_end();
+                Ok(())
+            }
+            Some(_) => Err(self.error(YamlValidationErrorKind::ContentAfterBlockScalarHeader)),
+        }
+    }
+
+    /// Enter a nested flow collection, erroring past [`MAX_NESTING_DEPTH`].
+    fn enter_nested(&mut self) -> Result<(), YamlValidationError> {
+        if self.nesting_depth >= MAX_NESTING_DEPTH {
+            return Err(self.error(YamlValidationErrorKind::NestingTooDeep {
+                limit: MAX_NESTING_DEPTH,
+            }));
+        }
+        self.nesting_depth += 1;
+        Ok(())
+    }
+
+    /// Scan a flow collection (`[...]` or `{...}`), entered on the open bracket.
+    /// Enforces comma well-formedness (no leading/doubled comma) and bracket
+    /// balance. May span multiple lines.
+    fn scan_flow(&mut self) -> Result<(), YamlValidationError> {
+        let open = self.peek().expect("scan_flow entered on a bracket");
+        let close = if open == b'[' { b']' } else { b'}' };
+        self.enter_nested()?;
+        self.advance(); // consume open bracket
+
+        // `expect_item` is true right after the open bracket or a comma: a comma
+        // in that state is a leading/doubled comma (9MAG, CTN5).
+        let mut expect_item = true;
+        loop {
+            self.skip_flow_ws()?;
+            match self.peek() {
+                None => {
+                    return Err(self.error(YamlValidationErrorKind::UnclosedFlow {
+                        bracket: open as char,
+                    }))
+                }
+                Some(c) if c == close => {
+                    self.advance();
+                    self.nesting_depth -= 1;
+                    return Ok(());
+                }
+                Some(c @ (b']' | b'}')) => {
+                    return Err(
+                        self.error(YamlValidationErrorKind::UnbalancedFlow { found: c as char })
+                    )
+                }
+                Some(b',') => {
+                    if expect_item {
+                        return Err(self.error(YamlValidationErrorKind::UnexpectedFlowComma));
+                    }
+                    self.advance();
+                    expect_item = true;
+                }
+                Some(b':') => {
+                    // Mapping value indicator; the value follows.
+                    self.advance();
+                    expect_item = false;
+                }
+                Some(b'[' | b'{') => {
+                    self.scan_flow()?;
+                    expect_item = false;
+                }
+                Some(b'"') => {
+                    self.scan_double_quoted(0)?;
+                    expect_item = false;
+                }
+                Some(b'\'') => {
+                    self.scan_single_quoted(0)?;
+                    expect_item = false;
+                }
+                // A bare `-` (block sequence indicator) is not a valid flow node
+                // (YJV2 `[-]`, G5U8 `[-, -]`). A `-` starting a scalar like `-1`
+                // is fine — only a `-` followed by a delimiter/space is bare.
+                Some(b'-')
+                    if matches!(
+                        self.peek_at(1),
+                        None | Some(b' ' | b'\t' | b'\n' | b'\r' | b',' | b']' | b'}')
+                    ) =>
+                {
+                    return Err(self.error(YamlValidationErrorKind::UnexpectedCharacter {
+                        expected: "flow node",
+                        found: '-',
+                    }))
+                }
+                Some(_) => {
+                    self.scan_flow_plain();
+                    expect_item = false;
+                }
+            }
+        }
+    }
+
+    /// Skip whitespace, line breaks, and comments between flow tokens. A `#`
+    /// glued to the previous token (no separating space) is rejected.
+    fn skip_flow_ws(&mut self) -> Result<(), YamlValidationError> {
+        loop {
+            // A `---`/`...` document marker at column 0 cannot appear inside a
+            // flow collection (N782 `[\n--- ,\n...\n]`).
+            if self.column == 1 {
+                if let Some(marker) = self.doc_marker_char() {
+                    return Err(self.error(YamlValidationErrorKind::UnexpectedCharacter {
+                        expected: "flow content",
+                        found: marker,
+                    }));
+                }
+            }
+            match self.peek() {
+                Some(b' ' | b'\t') => {
+                    self.advance();
+                }
+                Some(b'\n' | b'\r') => {
+                    self.consume_line_break();
+                    self.skip_spaces();
+                }
+                Some(b'#') => {
+                    if !self.prev_is_space_or_line_start() {
+                        return Err(self.error(YamlValidationErrorKind::CommentNotSeparated));
+                    }
+                    self.skip_to_line_end();
+                }
+                _ => return Ok(()),
+            }
+        }
+    }
+
+    /// Consume a plain scalar inside a flow collection, stopping before the next
+    /// flow delimiter (`,` `[` `]` `{` `}`), a `:` value indicator, a line break,
+    /// or a space-preceded comment.
+    fn scan_flow_plain(&mut self) {
+        loop {
+            match self.peek() {
+                None | Some(b'\n' | b'\r') => return,
+                Some(b',' | b'[' | b']' | b'{' | b'}') => return,
+                Some(b'#') if self.prev_is_space_or_line_start() => return,
+                Some(b':') => {
+                    // `:` ends the scalar only when it acts as a value indicator
+                    // (followed by whitespace, a flow delimiter, or end).
+                    match self.peek_at(1) {
+                        None | Some(b' ' | b'\t' | b'\n' | b'\r' | b',' | b']' | b'}') => return,
+                        _ => self.advance(),
+                    };
+                }
+                Some(_) => {
+                    self.advance();
+                }
+            }
+        }
+    }
+
+    /// After a top-level flow collection closes, only whitespace, a line break,
+    /// a space-separated comment, or a `:` value indicator (flow collection used
+    /// as a mapping key) may follow on the line. Anything else is trailing
+    /// content (4H7K `] ]`) or a glued comment (9JBA `]#`).
+    fn check_after_top_level_flow(&mut self) -> Result<(), YamlValidationError> {
+        // A glued comment (`]#...`) is a separation error.
+        if self.peek() == Some(b'#') {
+            return Err(self.error(YamlValidationErrorKind::CommentNotSeparated));
+        }
+        self.skip_spaces_and_tabs();
+        match self.peek() {
+            None | Some(b'\n' | b'\r' | b'#' | b':') => Ok(()),
+            Some(_) => Err(self.error(YamlValidationErrorKind::UnbalancedFlow { found: ']' })),
+        }
+    }
+
+    /// After a block-context quoted scalar closes, only whitespace, a line
+    /// break, a space-separated comment, or a `:` value indicator may follow.
+    /// A glued `#` (SU5Z), a bare word (Q4CL/JY7Z), or — when the scalar spanned
+    /// lines and is used as a key — the `:` itself (7LBH/D49Q/JKF3) is rejected.
+    fn check_after_block_quoted(&mut self, multiline: bool) -> Result<(), YamlValidationError> {
+        // A glued comment (`"v"#c`, no separating space) is a separation error.
+        if self.peek() == Some(b'#') {
+            return Err(self.error(YamlValidationErrorKind::CommentNotSeparated));
+        }
+        self.skip_spaces_and_tabs();
+        match self.peek() {
+            Some(b':') if multiline => {
+                Err(self.error(YamlValidationErrorKind::MultilineImplicitKey))
+            }
+            None | Some(b'\n' | b'\r' | b'#' | b':') => Ok(()),
+            Some(_) => Err(self.error(YamlValidationErrorKind::TrailingContentAfterScalar)),
+        }
+    }
+
+    /// Scan an anchor property (`&name`) and check its placement. An anchor may
+    /// not be immediately followed by an alias (`&a *b`, SR86/SU74) nor by a
+    /// block sequence indicator on the same line (`&a - x`, SY6V).
+    fn scan_anchor(&mut self) -> Result<(), YamlValidationError> {
+        self.scan_anchor_name(); // consumes `&`/`*` and the name
+        self.skip_spaces_and_tabs();
+        match self.peek() {
+            Some(b'*') => Err(self.error(YamlValidationErrorKind::AnchorOnAlias)),
+            Some(b'-') if matches!(self.peek_at(1), None | Some(b' ' | b'\t' | b'\n' | b'\r')) => {
+                Err(self.error(YamlValidationErrorKind::MisplacedAnchor))
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Consume an anchor or alias token: the `&`/`*` sigil and its name (any
+    /// non-whitespace, non-flow-indicator bytes; `:` is a legal name character).
+    fn scan_anchor_name(&mut self) {
+        self.advance(); // `&` or `*`
+        while !matches!(
+            self.peek(),
+            None | Some(b' ' | b'\t' | b'\n' | b'\r' | b',' | b'[' | b']' | b'{' | b'}')
+        ) {
+            self.advance();
+        }
+    }
+
+    /// Scan a double-quoted scalar, validating escape sequences. May span lines.
+    /// Returns `true` if the scalar spanned a line break. `min_cont_indent` is
+    /// the least indentation a non-blank continuation line may have (0 disables
+    /// the check); a value scalar's continuations must be indented past its key.
+    fn scan_double_quoted(&mut self, min_cont_indent: usize) -> Result<bool, YamlValidationError> {
+        let quote_char = '"';
+        self.advance(); // opening quote
+        let mut multiline = false;
+
+        loop {
+            match self.peek() {
+                None => {
+                    return Err(
+                        self.error(YamlValidationErrorKind::UnclosedQuote { quote: quote_char })
+                    )
+                }
+                Some(b'"') => {
+                    self.advance(); // closing quote
+                    return Ok(multiline);
+                }
+                Some(b'\\') => {
+                    self.scan_double_quoted_escape()?;
+                }
+                Some(b'\n' | b'\r') => {
+                    self.consume_line_break();
+                    // A `---`/`...` at column 0 ends the document; it cannot be
+                    // content of an open quoted scalar (5TRB).
+                    if self.doc_marker_char().is_some() {
+                        return Err(self.error(YamlValidationErrorKind::DocumentMarkerInScalar));
+                    }
+                    // Multi-line double-quoted: continuation lines are content.
+                    self.check_continuation_indent(min_cont_indent)?;
+                    multiline = true;
+                }
+                Some(_) => {
+                    self.advance();
+                }
+            }
+        }
+    }
+
+    /// After a line break inside a multi-line scalar, consume the leading spaces
+    /// and reject a non-blank continuation line indented less than `min` (QB6E).
+    fn check_continuation_indent(&mut self, min: usize) -> Result<(), YamlValidationError> {
+        let start = self.offset;
+        self.skip_spaces();
+        let indent = self.offset - start;
+        if min > 0 && indent < min && !matches!(self.peek(), None | Some(b'\n' | b'\r')) {
+            return Err(self.error(YamlValidationErrorKind::BadIndentation));
+        }
+        Ok(())
+    }
+
+    /// Validate one `\`-escape in a double-quoted scalar. Positioned on the `\`.
+    fn scan_double_quoted_escape(&mut self) -> Result<(), YamlValidationError> {
+        self.advance(); // consume backslash
+        let esc = match self.peek() {
+            None => return Err(self.error(YamlValidationErrorKind::UnclosedQuote { quote: '"' })),
+            Some(b) => b,
+        };
+        // Valid single-char escapes (mirrors src/yaml/light.rs escape table).
+        match esc {
+            b'n' | b'r' | b't' | b'\t' | b'"' | b'\\' | b'/' | b' ' | b'0' | b'a' | b'b' | b'v'
+            | b'f' | b'e' | b'N' | b'_' | b'L' | b'P' => {
+                self.advance();
+                Ok(())
+            }
+            b'\n' | b'\r' => {
+                // Escaped line break (line continuation).
+                self.consume_line_break();
+                self.skip_spaces();
+                Ok(())
+            }
+            b'x' => self.scan_hex_escape(2),
+            b'u' => self.scan_hex_escape(4),
+            b'U' => self.scan_hex_escape(8),
+            other => Err(self.error(YamlValidationErrorKind::InvalidEscape {
+                sequence: other as char,
+            })),
+        }
+    }
+
+    /// Validate `n` hex digits following `\x`/`\u`/`\U`. Positioned on `x`/`u`/`U`.
+    fn scan_hex_escape(&mut self, n: usize) -> Result<(), YamlValidationError> {
+        self.advance(); // consume x/u/U
+        for _ in 0..n {
+            match self.peek() {
+                Some(c) if c.is_ascii_hexdigit() => {
+                    self.advance();
+                }
+                _ => {
+                    return Err(self.error(YamlValidationErrorKind::InvalidEscape { sequence: 'x' }))
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Scan a single-quoted scalar. `''` is an escaped quote. May span lines.
+    /// Returns `true` if the scalar spanned a line break. `min_cont_indent` bounds
+    /// continuation-line indentation, as in [`Self::scan_double_quoted`].
+    fn scan_single_quoted(&mut self, min_cont_indent: usize) -> Result<bool, YamlValidationError> {
+        self.advance(); // opening quote
+        let mut multiline = false;
+
+        loop {
+            match self.peek() {
+                None => {
+                    return Err(self.error(YamlValidationErrorKind::UnclosedQuote { quote: '\'' }))
+                }
+                Some(b'\'') => {
+                    if self.peek_at(1) == Some(b'\'') {
+                        // Escaped quote.
+                        self.advance();
+                        self.advance();
+                    } else {
+                        self.advance(); // closing quote
+                        return Ok(multiline);
+                    }
+                }
+                Some(b'\n' | b'\r') => {
+                    self.consume_line_break();
+                    // A `---`/`...` at column 0 ends the document; it cannot be
+                    // content of an open quoted scalar (RXY3).
+                    if self.doc_marker_char().is_some() {
+                        return Err(self.error(YamlValidationErrorKind::DocumentMarkerInScalar));
+                    }
+                    self.check_continuation_indent(min_cont_indent)?;
+                    multiline = true;
+                }
+                Some(_) => {
+                    self.advance();
+                }
+            }
+        }
+    }
+
+    // ---- byte-level helpers ----
+
+    /// If the cursor is at a `---` or `...` document marker (three identical
+    /// bytes followed by whitespace, a line break, or end of input), return the
+    /// marker byte as a char; otherwise `None`. Assumes the cursor is at a line
+    /// start (column 1); the caller checks that.
+    fn doc_marker_char(&self) -> Option<char> {
+        let b = self.peek()?;
+        if (b == b'-' || b == b'.')
+            && self.peek_at(1) == Some(b)
+            && self.peek_at(2) == Some(b)
+            && matches!(self.peek_at(3), None | Some(b' ' | b'\t' | b'\n' | b'\r'))
+        {
+            Some(b as char)
+        } else {
+            None
+        }
+    }
+
+    /// Peek at the current byte.
+    #[inline]
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.offset).copied()
+    }
+
+    /// Peek `n` bytes ahead of the cursor.
+    #[inline]
+    fn peek_at(&self, n: usize) -> Option<u8> {
+        self.input.get(self.offset + n).copied()
+    }
+
+    /// True if the previous byte was a space/tab or we are at the line start.
+    #[inline]
+    fn prev_is_space_or_line_start(&self) -> bool {
+        match self.offset.checked_sub(1).and_then(|i| self.input.get(i)) {
+            None => true,
+            Some(b' ' | b'\t' | b'\n' | b'\r') => true,
+            Some(_) => false,
+        }
+    }
+
+    /// Advance one byte, tracking line/column.
+    #[inline]
+    fn advance(&mut self) -> Option<u8> {
+        let b = *self.input.get(self.offset)?;
+        self.offset += 1;
+        self.column += 1;
+        Some(b)
+    }
+
+    /// Consume a line break (`\n`, `\r`, or `\r\n`), resetting the column.
+    fn consume_line_break(&mut self) {
+        match self.peek() {
+            Some(b'\r') => {
+                self.offset += 1;
+                if self.peek() == Some(b'\n') {
+                    self.offset += 1;
+                }
+                self.line += 1;
+                self.column = 1;
+            }
+            Some(b'\n') => {
+                self.offset += 1;
+                self.line += 1;
+                self.column = 1;
+            }
+            _ => {}
+        }
+    }
+
+    /// Skip spaces (not tabs) at the cursor.
+    fn skip_spaces(&mut self) {
+        while self.peek() == Some(b' ') {
+            self.offset += 1;
+            self.column += 1;
+        }
+    }
+
+    /// Skip spaces and tabs at the cursor.
+    fn skip_spaces_and_tabs(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t')) {
+            self.offset += 1;
+            self.column += 1;
+        }
+    }
+
+    /// Skip everything up to (not including) the next line break.
+    fn skip_to_line_end(&mut self) {
+        while !matches!(self.peek(), None | Some(b'\n' | b'\r')) {
+            self.offset += 1;
+            self.column += 1;
+        }
+    }
+
+    /// Current position.
+    fn position(&self) -> Position {
+        Position {
+            offset: self.offset,
+            line: self.line,
+            column: self.column,
+        }
+    }
+
+    /// Build an error at the current position.
+    fn error(&self, kind: YamlValidationErrorKind) -> YamlValidationError {
+        YamlValidationError {
+            kind,
+            position: self.position(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::YamlValidationErrorKind::*;
+    use super::*;
+
+    fn kind(input: &[u8]) -> YamlValidationErrorKind {
+        validate(input).unwrap_err().kind
+    }
+
+    // ========================================================================
+    // Accept battery — valid YAML the validator must NOT reject. These include
+    // the corpus boundary cases that earlier iterations wrongly rejected, so a
+    // regression fails a *named* test rather than only the corpus scoreboard.
+    // ========================================================================
+
+    #[test]
+    fn accepts_basic_structures() {
+        assert!(validate(b"").is_ok());
+        assert!(validate(b"# just a comment\n").is_ok());
+        assert!(validate(b"a: 1\nb: 2\n").is_ok());
+        assert!(validate(b"- a\n- b\n").is_ok());
+        assert!(validate(b"key: \"value\"\n").is_ok());
+        assert!(validate(b"key: 'value'\n").is_ok());
+        assert!(validate(b"nested:\n  a: 1\n  b: 2\n").is_ok());
+    }
+
+    #[test]
+    fn accepts_same_indent_sequence_value() {
+        // A block sequence value may sit at its mapping key's indentation.
+        assert!(validate(b"one:\n- 2\n- 3\nfour: 5\n").is_ok()); // AZ63
+        assert!(validate(b"foo:\n- 42\nbar:\n  - 44\n").is_ok()); // RLU9
+        assert!(validate(b"nested sequences:\n- - - []\n- - - {}\nkey1: []\nkey2: {}\n").is_ok());
+    }
+
+    #[test]
+    fn accepts_explicit_keys_and_anchors() {
+        assert!(validate(b"? a\n: -\tb\n  -  -\tc\n     - d\n").is_ok()); // A2M4
+        assert!(validate(b"---\n?\n- a\n- b\n:\n- c\n- d\n").is_ok()); // 6PBE
+        assert!(validate(b"&sequence\n- a\n").is_ok()); // 3R3P
+        assert!(validate(b"key1: &a value\nkey2: *a\n").is_ok());
+        assert!(validate(b"---\nseq:\n &anchor\n- a\n- b\n").is_ok()); // SKE5
+    }
+
+    #[test]
+    fn accepts_multiline_and_folded_scalars() {
+        assert!(validate(b"a\nb\n c\nd\n\ne\n").is_ok()); // 9YRD plain multiline
+        assert!(validate(b"a: b\n c\nd:\n").is_ok()); // A984
+                                                      // Root multi-line double-quoted scalar folding at column 0.
+        assert!(validate(b"\"folded \nto a space,\nto a line feed\"\n").is_ok());
+        assert!(validate(b"key: \"a\n  b\n  c\"\n").is_ok()); // indented continuation
+    }
+
+    #[test]
+    fn accepts_tabs_as_separation() {
+        assert!(validate(b"-\t-1\n").is_ok()); // Y79Y/010: tab before a scalar
+        assert!(validate(b"- foo:\t bar\n- - baz\n  -\tbaz\n").is_ok()); // 6BCT
+        assert!(validate(b"foo:\n \tbar\n").is_ok()); // DK95/00: tab before scalar value
+        assert!(validate(b"\t{}\n").is_ok()); // Q5MG: tab before root node
+    }
+
+    #[test]
+    fn accepts_directives_and_document_markers() {
+        assert!(validate(b"%YAML 1.2\n---\nDocument\n... # Suffix\n").is_ok()); // RTP8
+        assert!(validate(b"Document\n---\n# Empty\n...\n%YAML 1.2\n---\nmatches %: 20\n").is_ok()); // 6ZKB
+        assert!(validate(b"---\nscalar\n%YAML 1.2\n").is_ok()); // XLQ9: %YAML as scalar content
+        assert!(validate(b"%YAML 1.2 # comment\n---\n").is_ok());
+    }
+
+    #[test]
+    fn accepts_flow_collections() {
+        assert!(validate(b"[a, b, c]\n").is_ok());
+        assert!(validate(b"[ a, b, c, ]\n").is_ok()); // trailing comma is valid
+        assert!(validate(b"{a: 1, b: 2}\n").is_ok());
+        assert!(validate(b"flow: [a,\n  b,\n  c]\n").is_ok());
+        assert!(validate(b"{\"foo\"\n: \"bar\"}\n").is_ok()); // 4MUZ quoted key over lines
+        assert!(validate(b"[-1, -2]\n").is_ok()); // '-' starting a scalar
+    }
+
+    // ========================================================================
+    // Reject battery — one representative per rule, tagged with its corpus id.
+    // ========================================================================
+
+    #[test]
+    fn rejects_invalid_escapes() {
+        assert!(matches!(
+            kind(b"---\n\"\\.\"\n"),
+            InvalidEscape { sequence: '.' }
+        )); // 55WF
+        assert!(matches!(
+            kind(b"---\ndouble: \"quoted \\' scalar\"\n"),
+            InvalidEscape { sequence: '\'' }
+        )); // HRE5
+    }
+
+    #[test]
+    fn accepts_valid_escapes() {
+        assert!(validate(b"a: \"tab\\tnl\\n hex \\x41 \\u0041 \\U00000041\"\n").is_ok());
+        assert!(validate(b"a: \"q \\\" s \\/ b \\\\ nbsp \\_ next \\N\"\n").is_ok());
+    }
+
+    #[test]
+    fn rejects_quoting_and_trailing_content() {
+        assert!(matches!(
+            kind(b"key: \"unterminated\n"),
+            UnclosedQuote { quote: '"' }
+        ));
+        assert!(matches!(
+            kind(b"key1: \"quoted1\"\nkey2: \"quoted2\" trailing content\n"),
+            TrailingContentAfterScalar
+        )); // Q4CL
+        assert!(matches!(kind(b"\"a\nb\": 1\n"), MultilineImplicitKey)); // 7LBH
+        assert!(matches!(kind(b"'a\nb': 1\n"), MultilineImplicitKey)); // D49Q
+    }
+
+    #[test]
+    fn rejects_block_scalar_headers() {
+        assert!(matches!(kind(b"--- |0\n"), InvalidBlockScalarIndent)); // 2G84/00
+        assert!(matches!(kind(b"--- |10\n"), InvalidBlockScalarIndent)); // 2G84/01
+        assert!(matches!(
+            kind(b"block: >#comment\n  scalar\n"),
+            ContentAfterBlockScalarHeader
+        )); // X4QW
+        assert!(matches!(
+            kind(b"---\nfolded: > first line\n  second line\n"),
+            ContentAfterBlockScalarHeader
+        )); // S4GJ
+    }
+
+    #[test]
+    fn accepts_valid_block_scalars() {
+        assert!(validate(b"a: |\n  text\n  more\n").is_ok());
+        assert!(validate(b"a: >2-\n  folded\n").is_ok());
+        assert!(validate(b"a: | # comment\n  text\nb: c\n").is_ok());
+    }
+
+    #[test]
+    fn rejects_flow_wellformedness() {
+        assert!(matches!(kind(b"---\n[ , a, b, c ]\n"), UnexpectedFlowComma)); // 9MAG
+        assert!(matches!(
+            kind(b"---\n[ a, b, c, , ]\n"),
+            UnexpectedFlowComma
+        )); // CTN5
+        assert!(matches!(
+            kind(b"---\n[ a, b, c ] ]\n"),
+            UnbalancedFlow { .. }
+        )); // 4H7K
+        assert!(matches!(
+            kind(b"---\n[ a, b, c,#invalid\n]\n"),
+            CommentNotSeparated
+        )); // CVW2
+        assert!(matches!(
+            kind(b"[-]\n"),
+            UnexpectedCharacter { found: '-', .. }
+        )); // YJV2
+        assert!(matches!(kind(b"[ a, b"), UnclosedFlow { bracket: '[' }));
+    }
+
+    #[test]
+    fn rejects_nested_mapping_keys() {
+        assert!(matches!(kind(b"a: b: c: d\n"), NestedMappingKey)); // ZCZ6
+        assert!(matches!(kind(b"---\na: 'b': c\n"), NestedMappingKey)); // ZL4Z
+    }
+
+    #[test]
+    fn rejects_bad_indentation() {
+        assert!(matches!(
+            kind(b"map:\n  key1: \"quoted1\"\n key2: \"bad indentation\"\n"),
+            BadIndentation
+        )); // N4JP
+        assert!(matches!(
+            kind(b"key:\n  ok: 1\n wrong: 2\n"),
+            BadIndentation
+        )); // DMG6
+        assert!(matches!(
+            kind(b"key:\n - bar\n - baz\n invalid\n"),
+            BadIndentation
+        )); // 6S55
+        assert!(matches!(
+            kind(b"---\nquoted: \"a\nb\nc\"\n"),
+            BadIndentation
+        )); // QB6E
+    }
+
+    #[test]
+    fn rejects_second_root_node() {
+        assert!(matches!(kind(b"foo:\n  bar\ninvalid\n"), TrailingContent)); // 236B
+        assert!(matches!(
+            kind(b"- item1\n- item2\ninvalid: x\n"),
+            TrailingContent
+        )); // BD7L
+        assert!(matches!(
+            kind(b"- item1\n- item2\ninvalid\n"),
+            TrailingContent
+        )); // TD5N
+        assert!(matches!(kind(b"a\nb: 1\nc\n d: 1\n"), TrailingContent)); // G7JE
+        assert!(matches!(kind(b"key: - a\n     - b\n"), TrailingContent)); // 5U3A
+        assert!(matches!(
+            kind(b"word1  # comment\nword2\n"),
+            TrailingContent
+        )); // BS4K
+    }
+
+    #[test]
+    fn rejects_tabs_in_indentation() {
+        assert!(matches!(kind(b"-\t-\n"), TabInIndentation)); // Y79Y/004
+        assert!(matches!(kind(b"?\tkey:\n"), TabInIndentation)); // Y79Y/008
+        assert!(matches!(
+            kind(b"foo:\n  a: 1\n  \tb: 2\n"),
+            TabInIndentation
+        )); // DK95/06
+    }
+
+    #[test]
+    fn rejects_anchor_placement() {
+        assert!(matches!(
+            kind(b"key1: &a value\nkey2: &b *a\n"),
+            AnchorOnAlias
+        )); // SR86
+        assert!(matches!(
+            kind(b"&anchor - sequence entry\n"),
+            MisplacedAnchor
+        )); // SY6V
+    }
+
+    #[test]
+    fn rejects_document_and_directive_errors() {
+        assert!(matches!(
+            kind(b"---\nkey: value\n... invalid\n"),
+            ContentAfterDocumentEnd
+        )); // 3HFZ
+        assert!(matches!(kind(b"%YAML 1.2\n"), MisplacedDirective)); // 9MMA
+        assert!(matches!(kind(b"%YAML 1.2\n...\n"), MisplacedDirective)); // B63P
+        assert!(matches!(kind(b"%YAML 1.2 foo\n---\n"), InvalidDirective)); // H7TQ
+        assert!(matches!(kind(b"%YAML 1.1#...\n---\n"), InvalidDirective)); // MUS6/00
+        assert!(matches!(
+            kind(b"%YAML 1.2\n%YAML 1.2\n---\n"),
+            DuplicateYamlDirective
+        )); // SF5V
+        assert!(matches!(
+            kind(b"---\n\"\n---\n\"\n"),
+            DocumentMarkerInScalar
+        )); // 5TRB
+    }
+
+    // ========================================================================
+    // Positions, nesting cap, and Display.
+    // ========================================================================
+
+    #[test]
+    fn reports_error_position() {
+        let err = validate(b"a: 1\nb: c: d\n").unwrap_err();
+        assert_eq!(err.position.line, 2);
+    }
+
+    #[test]
+    fn deep_flow_nesting_errors_instead_of_overflowing() {
+        let input = "[".repeat(20_000);
+        assert!(matches!(
+            validate(input.as_bytes()).unwrap_err().kind,
+            NestingTooDeep { .. }
+        ));
+    }
+
+    #[test]
+    fn deep_block_nesting_errors_instead_of_overflowing() {
+        // Each level indents one more space and opens a mapping.
+        let mut input = String::new();
+        for i in 0..20_000 {
+            for _ in 0..i {
+                input.push(' ');
+            }
+            input.push_str("k:\n");
+        }
+        assert!(matches!(
+            validate(input.as_bytes()).unwrap_err().kind,
+            NestingTooDeep { .. }
+        ));
+    }
+
+    #[test]
+    fn error_display_is_nonempty_for_all_kinds() {
+        let kinds = [
+            InvalidEscape { sequence: 'q' },
+            UnclosedQuote { quote: '"' },
+            TrailingContentAfterScalar,
+            MultilineImplicitKey,
+            InvalidBlockScalarIndent,
+            ContentAfterBlockScalarHeader,
+            CommentNotSeparated,
+            UnexpectedFlowComma,
+            MissingFlowSeparator,
+            UnclosedFlow { bracket: '[' },
+            UnbalancedFlow { found: ']' },
+            BadIndentation,
+            TrailingContent,
+            NestedMappingKey,
+            TabInIndentation,
+            AnchorOnAlias,
+            MisplacedAnchor,
+            ContentAfterDocumentEnd,
+            MisplacedDirective,
+            InvalidDirective,
+            DuplicateYamlDirective,
+            DocumentMarkerInScalar,
+            UnexpectedCharacter {
+                expected: "x",
+                found: 'y',
+            },
+            UnexpectedEof { expected: "x" },
+            InvalidUtf8,
+            NestingTooDeep { limit: 128 },
+        ];
+        for k in &kinds {
+            assert!(!k.to_string().is_empty());
+        }
+        // Full error Display includes the position.
+        let err = YamlValidationError {
+            kind: NestedMappingKey,
+            position: Position {
+                offset: 3,
+                line: 1,
+                column: 4,
+            },
+        };
+        assert!(err.to_string().contains("line 1"));
+    }
+}

--- a/tests/data/yaml-test-suite-known-failures.txt
+++ b/tests/data/yaml-test-suite-known-failures.txt
@@ -16,106 +16,76 @@
 #   lax:*       Invalid input that indexing accepts because it does not validate.
 #               This is a property of the default mode, not a defect: succinctly
 #               is a non-validating loader. Rejecting these is the job of the
-#               opt-in validation mode, mirroring `json validate`. -> #223
+#               opt-in validation mode (`succinctly yaml validate` /
+#               `syq --validate`), mirroring `json validate`. The harness treats a
+#               must-fail case as handled if the loader OR that validator rejects
+#               it, so the `lax:*` entries that remain here are the cases the
+#               validator does not yet reject (deeper structural analysis). -> #223
 #   scalars     Scalar content or block-scalar folding differs from the spec.
 #               Not yet individually triaged.
 #   structure   Document or block structure differs from the spec. Not yet
 #               individually triaged.
 
-236B      lax:mapping       mapping/key rules not validated — #223
 27NA      directives        %YAML/%TAG directive not recognized — #225
 2AUY      tags              tags (!) not supported — #224
 2CMS      lax:mapping       mapping/key rules not validated — #223
-2G84/00   lax:block-scalar  block scalar header not validated — #223
-2G84/01   lax:block-scalar  block scalar header not validated — #223
 2G84/03   scalars           scalar content/folding differs from spec
 2LFX      directives        %YAML/%TAG directive not recognized — #225
 2SXE      structure         document/block structure differs from spec
 2XXW      tags              tag shorthand emitted as scalar text — #224
 33X3      tags              tags (!) not supported — #224
 35KP      tags              tags (!) not supported — #224
-3HFZ      lax:documents     directive/document rules not validated — #223
-4H7K      lax:flow          flow syntax not validated — #223
-4HVU      lax:other         not validated — #223
 4JVG      lax:anchors       anchor/alias rules not validated — #223
 4Q9F      scalars           scalar content/folding differs from spec
 52DL      tags              tags (!) not supported — #224
-55WF      lax:quoting       quoting/escape rules not validated — #223
 565N      tags              tags (!) not supported — #224
 57H4      tags              tags (!) not supported — #224
 5LLU      lax:indentation   indentation not validated — #223
-5TRB      lax:documents     directive/document rules not validated — #223
 5TYM      tags              tags (!) not supported — #224
-5U3A      lax:mapping       mapping/key rules not validated — #223
-62EZ      lax:mapping       mapping/key rules not validated — #223
 6CK3      tags              tags (!) not supported — #224
 6JWB      tags              tags (!) not supported — #224
 6LVF      directives        %YAML/%TAG directive not recognized — #225
-6S55      lax:other         not validated — #223
 6WLZ      tags              tags (!) not supported — #224
 6XDY      structure         document/block structure differs from spec
 6ZKB      directives        %YAML/%TAG directive not recognized — #225
 735Y      tags              tags (!) not supported — #224
 74H7      tags              tags (!) not supported — #224
 7FWL      tags              tags (!) not supported — #224
-7LBH      lax:quoting       quoting/escape rules not validated — #223
-7MNF      lax:other         not validated — #223
 7T8X      scalars           scalar content/folding differs from spec
 7Z25      structure         document/block structure differs from spec
 8MK2      tags              tags (!) not supported — #224
 8XDJ      lax:comments      comment placement not validated — #223
 93WF      scalars           scalar content/folding differs from spec
 9C9N      lax:indentation   indentation not validated — #223
-9CWY      lax:mapping       mapping/key rules not validated — #223
 9DXL      directives        %YAML/%TAG directive not recognized — #225
-9JBA      lax:flow          flow syntax not validated — #223
 9KAX      tags              tags (!) not supported — #224
 9KBC      lax:mapping       mapping/key rules not validated — #223
-9MAG      lax:flow          flow syntax not validated — #223
-9MMA      lax:documents     directive/document rules not validated — #223
-9MQT/01   lax:other         not validated — #223
 9WXW      tags              tags (!) not supported — #224
 AVM7      scalars           scalar content/folding differs from spec
-B63P      lax:documents     directive/document rules not validated — #223
-BD7L      lax:mapping       mapping/key rules not validated — #223
 BEC7      directives        %YAML/%TAG directive not recognized — #225
 BF9H      lax:comments      comment placement not validated — #223
-BS4K      lax:comments      comment placement not validated — #223
 BU8L      tags              tag shorthand emitted as scalar text — #224
 C2SP      lax:flow          flow syntax not validated — #223
 C4HZ      tags              tags (!) not supported — #224
 CC74      directives        %YAML/%TAG directive not recognized — #225
-CTN5      lax:flow          flow syntax not validated — #223
 CUP7      tags              tags (!) not supported — #224
-CVW2      lax:comments      comment placement not validated — #223
 CXX2      lax:anchors       anchor/alias rules not validated — #223
-D49Q      lax:quoting       quoting/escape rules not validated — #223
 DK3J      scalars           scalar content/folding differs from spec
 DK4H      lax:mapping       mapping/key rules not validated — #223
 DK95/00   scalars           scalar content/folding differs from spec
-DK95/01   lax:tabs          tab handling not validated — #223
-DK95/06   lax:tabs          tab handling not validated — #223
 DK95/07   directives        %YAML/%TAG directive not recognized — #225
-DMG6      lax:other         not validated — #223
-EB22      lax:documents     directive/document rules not validated — #223
 EHF6      tags              tags (!) not supported — #224
 EW3V      lax:mapping       mapping/key rules not validated — #223
 F2C7      tags              tags (!) not supported — #224
 FH7J      tags              tags (!) not supported — #224
 FP8R      scalars           scalar content/folding differs from spec
 FTA2      structure         document/block structure differs from spec
-G5U8      lax:flow          flow syntax not validated — #223
-G7JE      lax:mapping       mapping/key rules not validated — #223
 G9HC      lax:indentation   indentation not validated — #223
 GT5M      lax:anchors       anchor/alias rules not validated — #223
-H7TQ      lax:documents     directive/document rules not validated — #223
 HMQ5      tags              tags (!) not supported — #224
-HRE5      lax:quoting       quoting/escape rules not validated — #223
 HU3P      lax:mapping       mapping/key rules not validated — #223
 J7PZ      tags              tag shorthand emitted as scalar text — #224
 JEF9/01   structure         document/block structure differs from spec
-JKF3      lax:quoting       quoting/escape rules not validated — #223
-JY7Z      lax:mapping       mapping/key rules not validated — #223
 K527      scalars           scalar content/folding differs from spec
 K54U      scalars           scalar content/folding differs from spec
 KS4U      lax:flow          flow syntax not validated — #223
@@ -124,34 +94,19 @@ L94M      tags              tag shorthand emitted as scalar text — #224
 LE5A      tags              tags (!) not supported — #224
 M5C3      scalars           scalar content/folding differs from spec
 M7A3      structure         bare document / `...` end-marker mis-parsed (both paths agree)
-MUS6/00   lax:documents     directive/document rules not validated — #223
 MUS6/01   lax:documents     directive/document rules not validated — #223
 MUS6/02   directives        %YAML/%TAG directive not recognized — #225
 MUS6/03   directives        %YAML/%TAG directive not recognized — #225
 MUS6/04   directives        %YAML/%TAG directive not recognized — #225
 MUS6/05   directives        %YAML/%TAG directive not recognized — #225
 MUS6/06   directives        %YAML/%TAG directive not recognized — #225
-N4JP      lax:indentation   indentation not validated — #223
-N782      lax:flow          flow syntax not validated — #223
-P2EQ      lax:other         not validated — #223
 P76L      directives        %YAML/%TAG directive not recognized — #225
 PUW8      structure         document/block structure differs from spec
-Q4CL      lax:quoting       quoting/escape rules not validated — #223
-QB6E      lax:indentation   indentation not validated — #223
 QLJ7      lax:documents     directive/document rules not validated — #223
-RHX7      lax:documents     directive/document rules not validated — #223
 RTP8      directives        %YAML/%TAG directive not recognized — #225
-RXY3      lax:documents     directive/document rules not validated — #223
-S4GJ      lax:block-scalar  block scalar header not validated — #223
 S4JQ      tags              tags (!) not supported — #224
 S98Z      lax:block-scalar  block scalar header not validated — #223
-SF5V      lax:documents     directive/document rules not validated — #223
-SR86      lax:anchors       anchor/alias rules not validated — #223
-SU5Z      lax:comments      comment placement not validated — #223
-SU74      lax:anchors       anchor/alias rules not validated — #223
-SY6V      lax:anchors       anchor/alias rules not validated — #223
 T833      lax:flow          flow syntax not validated — #223
-TD5N      lax:other         not validated — #223
 TS54      scalars           scalar content/folding differs from spec
 U3C3      tags              tags (!) not supported — #224
 U44R      lax:indentation   indentation not validated — #223
@@ -163,17 +118,7 @@ W4TN      directives        %YAML/%TAG directive not recognized — #225
 W5VH      structure         document/block structure differs from spec
 W9L4      lax:block-scalar  block scalar header not validated — #223
 WZ62      tags              tag shorthand emitted as scalar text — #224
-X4QW      lax:block-scalar  block scalar header not validated — #223
 Y79Y/003  lax:tabs          tab handling not validated — #223
-Y79Y/004  lax:tabs          tab handling not validated — #223
-Y79Y/005  lax:tabs          tab handling not validated — #223
-Y79Y/006  lax:tabs          tab handling not validated — #223
-Y79Y/007  lax:tabs          tab handling not validated — #223
-Y79Y/008  lax:tabs          tab handling not validated — #223
-Y79Y/009  lax:tabs          tab handling not validated — #223
-YJV2      lax:flow          flow syntax not validated — #223
 Z67P      tags              tags (!) not supported — #224
 Z9M4      tags              tags (!) not supported — #224
-ZCZ6      lax:mapping       mapping/key rules not validated — #223
-ZL4Z      lax:mapping       mapping/key rules not validated — #223
 ZVH3      lax:indentation   indentation not validated — #223

--- a/tests/snapshots/cli_golden_tests__version.snap
+++ b/tests/snapshots/cli_golden_tests__version.snap
@@ -2,4 +2,4 @@
 source: tests/cli_golden_tests.rs
 expression: output
 ---
-succinctly 0.7.0
+succinctly 0.8.0

--- a/tests/yaml_test_suite.rs
+++ b/tests/yaml_test_suite.rs
@@ -109,10 +109,19 @@ fn run_case(yaml: &str, expectation: &Expectation) -> Result<(), String> {
     match expectation {
         Expectation::MustFail => match produced {
             Err(_) => Ok(()),
-            Ok(docs) => Err(format!(
-                "accepted invalid input, produced {}",
-                docs.join(" ")
-            )),
+            // #223: the opt-in validator is the second line of defence. A
+            // must-fail case is handled correctly if EITHER the default loader
+            // (`YamlIndex::build`, above) or the strict validator rejects it.
+            Ok(docs) => {
+                if succinctly::yaml::validate::validate(yaml.as_bytes()).is_err() {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "accepted invalid input, produced {}",
+                        docs.join(" ")
+                    ))
+                }
+            }
         },
         Expectation::Parses => produced
             .map(|_| ())
@@ -292,5 +301,33 @@ fn known_failures_manifest_is_wellformed() {
     assert!(
         unknown.is_empty(),
         "manifest lists case IDs that are not in the corpus: {unknown:?}"
+    );
+}
+
+/// #223 false-positive guardrail: the opt-in validator must **accept** every
+/// valid corpus case (the ~236 loads/parses). Without this, the validator could
+/// "pass" the reject side of the conformance test simply by over-rejecting —
+/// e.g. wrongly rejecting the valid tag/directive documents the loader merely
+/// mishandles. The exceptions list is the escape hatch (ideally empty): a valid
+/// case the validator cannot yet accept goes here with an issue link, exactly
+/// as reject-side gaps go in the known-failures manifest.
+#[test]
+fn validator_accepts_all_valid_cases() {
+    const ACCEPT_EXCEPTIONS: &[&str] = &[];
+
+    let mut rejected = Vec::new();
+    for case in corpus() {
+        if case.fail || ACCEPT_EXCEPTIONS.contains(&case.id.as_str()) {
+            continue;
+        }
+        if let Err(e) = succinctly::yaml::validate::validate(case.yaml.as_bytes()) {
+            rejected.push(format!("  {}: {} — {e}", case.id, case.name));
+        }
+    }
+    assert!(
+        rejected.is_empty(),
+        "the validator rejected {} valid case(s):\n{}",
+        rejected.len(),
+        rejected.join("\n")
     );
 }

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -1,0 +1,152 @@
+//! Integration tests for the `succinctly yaml validate` CLI command.
+//!
+//! Run with: cargo test --features cli --test yaml_validate_tests
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+
+use anyhow::Result;
+use tempfile::NamedTempFile;
+
+/// Resolve the path to the pre-built `succinctly` CLI binary, building it once.
+/// Mirrors `tests/json_validate_tests.rs` — the integration harness is compiled
+/// without `cli`, so we build the binary and derive its path from this test
+/// executable's own location.
+fn succinctly_bin() -> &'static Path {
+    static BIN: OnceLock<PathBuf> = OnceLock::new();
+    BIN.get_or_init(|| {
+        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+        let output = Command::new(cargo)
+            .args(["build", "--features", "cli", "--bin", "succinctly"])
+            .output()
+            .expect("failed to spawn `cargo build`");
+        assert!(
+            output.status.success(),
+            "`cargo build --features cli --bin succinctly` failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let mut path = std::env::current_exe().expect("resolve current_exe");
+        path.pop();
+        if path.file_name().and_then(|s| s.to_str()) == Some("deps") {
+            path.pop();
+        }
+        path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
+        assert!(
+            path.is_file(),
+            "built `succinctly` binary not found at {}",
+            path.display()
+        );
+        path
+    })
+}
+
+fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
+    let mut cmd = Command::new(succinctly_bin())
+        .args(["yaml", "validate"])
+        .args(extra_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(input.as_bytes())?;
+    }
+    let output = cmd.wait_with_output()?;
+    Ok((
+        String::from_utf8(output.stdout)?,
+        String::from_utf8(output.stderr)?,
+        output.status.code().unwrap_or(-1),
+    ))
+}
+
+fn run_validate_file(path: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
+    let output = Command::new(succinctly_bin())
+        .args(["yaml", "validate"])
+        .args(extra_args)
+        .arg(path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    Ok((
+        String::from_utf8(output.stdout)?,
+        String::from_utf8(output.stderr)?,
+        output.status.code().unwrap_or(-1),
+    ))
+}
+
+#[test]
+fn valid_yaml_exits_zero() -> Result<()> {
+    let (stdout, stderr, code) = run_validate_stdin("a: 1\nb: 2\n", &[])?;
+    assert_eq!(code, 0, "stdout: {stdout}, stderr: {stderr}");
+    assert!(stdout.is_empty());
+    Ok(())
+}
+
+#[test]
+fn invalid_yaml_exits_one() -> Result<()> {
+    // Nested mapping key `a: b: c` — rejected by the validator, accepted by the
+    // default loader.
+    let (_, stderr, code) = run_validate_stdin("a: b: c: d\n", &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(stderr.contains("nested mapping key"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn quiet_mode_is_silent() -> Result<()> {
+    let (stdout, stderr, code) = run_validate_stdin("foo: |0\n", &["--quiet"])?;
+    assert_eq!(code, 1);
+    assert!(stdout.is_empty());
+    assert!(
+        stderr.is_empty(),
+        "stderr should be empty in quiet mode: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn error_output_has_rustc_style_caret() -> Result<()> {
+    let (_, stderr, code) = run_validate_stdin("---\n\"\\.\"\n", &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("error: invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("--> <stdin>:2:"),
+        "location line missing: {stderr}"
+    );
+    assert!(stderr.contains('^'), "caret missing: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn file_input_reports_filename_and_missing_file() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    write!(file, "key: - a\n     - b\n")?; // 5U3A: inline sequence after ':'
+    let path = file.path().to_str().unwrap();
+    let (_, stderr, code) = run_validate_file(path, &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains(path),
+        "filename should appear in output: {stderr}"
+    );
+
+    // Missing file → I/O error exit code 2.
+    let (_, _, code) = run_validate_file("/no/such/file.yaml", &["--no-color"])?;
+    assert_eq!(code, 2);
+    Ok(())
+}
+
+#[test]
+fn valid_file_exits_zero() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    write!(file, "users:\n  - name: Alice\n  - name: Bob\n")?;
+    let path = file.path().to_str().unwrap();
+    let (_, stderr, code) = run_validate_file(path, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    Ok(())
+}

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -185,7 +185,10 @@ fn yq_validate_passes_valid_yaml() -> Result<()> {
 fn yq_validate_rejects_invalid_yaml_before_output() -> Result<()> {
     let (stdout, stderr, code) = run_yq_validate_stdin("a: b: c: d\n", ".")?;
     assert_ne!(code, 0);
-    assert!(stdout.is_empty(), "no query output on validation failure: {stdout}");
+    assert!(
+        stdout.is_empty(),
+        "no query output on validation failure: {stdout}"
+    );
     assert!(stderr.contains("validation error"), "stderr: {stderr}");
     Ok(())
 }

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -150,3 +150,67 @@ fn valid_file_exits_zero() -> Result<()> {
     assert_eq!(code, 0, "stderr: {stderr}");
     Ok(())
 }
+
+// ============================================================================
+// `syq --validate` (the yq runner's opt-in validation flag).
+// ============================================================================
+
+fn run_yq_validate_stdin(input: &str, filter: &str) -> Result<(String, String, i32)> {
+    let mut cmd = Command::new(succinctly_bin())
+        .args(["yq", "--validate", filter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(input.as_bytes())?;
+    }
+    let output = cmd.wait_with_output()?;
+    Ok((
+        String::from_utf8(output.stdout)?,
+        String::from_utf8(output.stderr)?,
+        output.status.code().unwrap_or(-1),
+    ))
+}
+
+#[test]
+fn yq_validate_passes_valid_yaml() -> Result<()> {
+    let (stdout, stderr, code) = run_yq_validate_stdin("a: 1\nb: 2\n", ".a")?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "1");
+    Ok(())
+}
+
+#[test]
+fn yq_validate_rejects_invalid_yaml_before_output() -> Result<()> {
+    let (stdout, stderr, code) = run_yq_validate_stdin("a: b: c: d\n", ".")?;
+    assert_ne!(code, 0);
+    assert!(stdout.is_empty(), "no query output on validation failure: {stdout}");
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn yq_without_validate_accepts_the_same_invalid_yaml() -> Result<()> {
+    // The default loader is non-validating: the same input succeeds without
+    // `--validate`, proving the flag is opt-in.
+    let (_, _, code) = {
+        let mut cmd = Command::new(succinctly_bin())
+            .args(["yq", "."])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        if let Some(mut stdin) = cmd.stdin.take() {
+            stdin.write_all(b"a: b: c: d\n")?;
+        }
+        let output = cmd.wait_with_output()?;
+        (
+            String::from_utf8(output.stdout)?,
+            String::from_utf8(output.stderr)?,
+            output.status.code().unwrap_or(-1),
+        )
+    };
+    assert_eq!(code, 0);
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR implements a comprehensive opt-in strict YAML validator for the succinctly library, addressing issue #223. The validator provides a separate validation pass that runs before indexing, mirroring the existing JSON validation functionality (`json validate` / `sjq --validate`). The default non-validating loader path remains unchanged and incurs no performance penalty.

The implementation includes:
- A new `succinctly::yaml::validate` module with exhaustive validation of YAML grammar families
- CLI commands: `succinctly yaml validate` and `syq --validate` flags
- Integration tests covering all validation scenarios
- Documentation updates and conformance test improvements
- Version bump to 0.8.0 (breaking change due to removed `YamlError` variants)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (removal of four never-constructed `YamlError` variants)
- [x] Test coverage improvement
- [x] Documentation update
- [x] Refactoring (removal of dead code)

## Related Issue
Fixes #223 - Implement opt-in strict YAML validation

## Changes Made

**Core Validator Implementation:**
- Added `src/yaml/validate.rs` (1,777 lines): a `no_std`, allocation-free-on-success validator that rejects invalid YAML across nine grammar families (escapes, block-scalar headers, flow well-formedness, nested mapping keys, block indentation, tabs-as-indentation, anchor placement, directive/document placement, second root nodes)
- Implemented `validate()` function with position tracking (`YamlValidationError`, `Position`)
- Defined 23 specific error kinds in `YamlValidationErrorKind` enum with comprehensive `Display` implementations
- Added recursion depth cap (128) preventing stack overflow on pathologically nested input
- Measures 59 of 83 YAML Test Suite `lax:*` cases with zero false positives on ~300 valid corpus cases
- Includes 40+ unit tests covering accept/reject boundaries, error positions, nesting cap, and Display coverage

**Error Handling Refactoring:**
- Removed four never-constructed `YamlError` variants from `src/yaml/error.rs`: `InvalidEscape`, `InvalidIndentation`, `ExplicitKeyNotSupported`, `ColonWithoutSpace`
- Removed corresponding Display implementations and unit tests
- **Breaking change**: exhaustive `match`es on public `YamlError` lose four arms (mitigated by adding the validator as the real rejection surface)

**CLI Integration:**
- Added `succinctly yaml validate [FILES]...` subcommand with rustc-style caret diagnostics
- Implemented `--quiet`, `--color`, `--no-color` flags; exit codes: 0 (valid), 1 (invalid), 2 (I/O error)
- Added `--validate` flag to `syq` (yq command) for opt-in pre-indexing validation
- Color-coded error output with location headers and snippet context
- Per-error-kind hints (e.g., "use spaces, not tabs, to indent" for tab indentation)

**Testing & Conformance:**
- Added `tests/yaml_validate_tests.rs` (152 lines) with 9 integration tests covering valid/invalid input, quiet mode, caret formatting, file I/O, and `syq --validate` behavior
- Modified `tests/yaml_test_suite.rs` to recognize validator rejection as equivalent to loader rejection for conformance scoring
- Added `validator_accepts_all_valid_cases()` guardrail test (false-positive prevention) with empty exception list
- Updated `tests/data/yaml-test-suite-known-failures.txt`: deleted 59 `lax:*` entries now rejected by validator; reject conformance improved from 11/94 (11.7%) to 70/94 (74.5%)
- Remaining 24 structurally-deep `lax:*` cases tracked for future work

**Documentation:**
- Updated `CHANGELOG.md` with Added/Removed sections for the validator and breaking change
- Enhanced `docs/compliance/yaml/limitations.md` with validator details, conformance figures (209/279 load, 70/94 reject, 27/29 parse), and rules breakdown
- Added `docs/guides/cli.md` section "YAML Validation" documenting usage, options, exit codes, examples, and per-family rules
- Updated `docs/parsing/yaml-index.md` and `docs/parsing/yaml.md` to reference the opt-in validator
- Flipped "planned" language in `docs/index.md` to reflect shipped functionality

**Version & Snapshots:**
- Bumped `Cargo.toml` and `Cargo.lock` from 0.7.0 to 0.8.0 (breaking change justifies minor version bump per SemVer)
- Updated CLI golden snapshot test: `succinctly --version` now reports 0.8.0

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New validator unit tests added (40+ test cases covering accept/reject boundaries, error positions, nesting cap)
- [x] Integration tests for CLI commands (9 tests in `yaml_validate_tests.rs`)
- [x] Conformance test updated to score validator alongside loader
- [x] False-positive guardrail test enforces validator accepts all valid corpus cases

**Manual Testing:**
- [x] Tested validator on both valid and invalid YAML (nested mappings, invalid escapes, tabs, block scalars, flow collections, document markers, directives)
- [x] Tested `succinctly yaml validate` with files and stdin
- [x] Tested `syq --validate` with valid/invalid YAML
- [x] Verified quiet mode suppresses output
- [x] Verified color output on TTY, respects `--color` and `--no-color` flags

### Test Commands
```bash
cargo test --lib yaml::validate
cargo test yaml_validate_tests
cargo test yaml_test_suite
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
echo 'a: b: c' | cargo run --features cli -- yaml validate
echo 'a: 1\nb: 2' | cargo run --features cli -- yq --validate '.'
```

## Performance Impact
- [x] No performance impact on default path
- The validator is opt-in: `YamlIndex::build` path is unchanged and does not link the validator
- The validator is `no_std` and allocation-free on the success path
- Only incurs cost when explicitly called via `validate()`, CLI command, or `--validate` flag
- Recursion depth cap (128) prevents stack-based pathological cases

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings (clippy clean)
- [x] Breaking change documented in CHANGELOG and commit message
- [x] Version bumped per SemVer (0.7.0 → 0.8.0)

## Breaking Changes

The removal of four `YamlError` enum variants is a breaking change:
- `InvalidEscape { offset: usize, sequence: String }` — removed, use `YamlValidationError` instead
- `InvalidIndentation { line: usize, expected: usize, found: usize }` — removed, use `YamlValidationError` instead
- `ExplicitKeyNotSupported { offset: usize }` — removed, use `YamlValidationError` instead
- `ColonWithoutSpace { offset: usize }` — removed, use `YamlValidationError` instead

**Migration**: Code with exhaustive `match`es on `YamlError` must add `_` catch-all or remove the deleted arms. These variants were never constructed in the codebase and only appeared in unit tests. The opt-in validator's `YamlValidationError` is the intended rejection surface for strict validation.

## Additional Notes

**Design Rationale:**
- The validator is intentionally a permissive scalar scanner, not a full grammar checker, matching the philosophy of the non-validating loader
- Validation is a separate pass run before indexing to preserve the speed of the default loader
- The conformance harness treats a must-fail case as handled if either the loader OR the validator rejects it, enabling incremental validator improvements without regressing conformance scores
- The 24 remaining `lax:*` cases require deeper structural analysis (cross-line anchor binding, block-scalar content indentation, flow multi-line implicit keys) and are tracked in #223 for future work

**Measurement:**
The validator correctly handles 59 of 83 previously-accepted-but-invalid YAML Test Suite cases with zero false positives on the ~236 valid corpus cases (enforced by the `validator_accepts_all_valid_cases` guardrail test).

**References:**
- Issue #223: "Add opt-in strict YAML validation"
- `src/yaml/validate.rs` — full validator implementation
- `src/json/validate.rs` — parallel JSON validator (implementation model)
- `docs/compliance/yaml/limitations.md` — detailed conformance data