### PR TITLE
feat(cli): establish bare-dash YAML shape existence and frequency baselines for #326

### DIFF
--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -28,6 +28,7 @@ The benchmarks below compare succinctly against DOM-based tools (jq, yq, serde_j
 | [Cross-Language](cross-language.md)              | Multi-language parser comparison     | Best-in-class for semi-indexing                |
 | [DSV](dsv.md)                                    | CSV/TSV parsing performance          | 85-1676 MiB/s (API)                            |
 | [Corpus Shape](corpus-shape.md)                  | Real-workload input shape statistics | Representativeness lookup for perf proposals   |
+| [YAML Shape Survey](yaml-shape-survey.md)        | Upstream shape frequency (26 repos)  | Bare dashes 0.042% of files; anchors 100x more |
 
 ## Methodology
 

--- a/docs/benchmarks/corpus-shape.md
+++ b/docs/benchmarks/corpus-shape.md
@@ -23,13 +23,14 @@ Distributions are derived from the crate's own semi-index (`JsonIndex` / `YamlIn
 
 ## YAML
 
-files: 6, total bytes: 24040, anchors: 0, aliases: 0
+files: 6, total bytes: 24040, anchors: 0, aliases: 0, bare-dash items: 0
 
 | metric               | unit         | n   | min  | p50  | p90  | p99  | max  |
 | -------------------- | ------------ | --- | ---- | ---- | ---- | ---- | ---- |
 | scalar length        | bytes/scalar | 896 | 0    | 7    | 43   | 146  | 374  |
 | mapping keys         | keys/mapping | 225 | 0    | 2    | 4    | 9    | 20   |
 | sequence items       | items/seq    | 52  | 1    | 2    | 8    | 12   | 12   |
+| bare-dash seq items  | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |
 | flow-collection size | bytes/flow   | 14  | 2    | 11   | 91   | 100  | 100  |
 | nesting depth        | levels/node  | 669 | 2    | 7    | 9    | 11   | 12   |
 | anchors              | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |

--- a/docs/benchmarks/corpus-shape.md
+++ b/docs/benchmarks/corpus-shape.md
@@ -20,22 +20,23 @@ Distributions are derived from the crate's own semi-index (`JsonIndex` / `YamlIn
 | yaml   | compose   | nginx-flask-mysql.yaml   | 1239  |
 | yaml   | compose   | wordpress.yaml           | 815   |
 | yaml   | k8s       | nginx-deployment.yml     | 836   |
+| yaml   | lint      | sass-lint.yml            | 2055  |
 
 ## YAML
 
-files: 6, total bytes: 24040, anchors: 0, aliases: 0, bare-dash items: 0
+files: 7, total bytes: 26095, anchors: 0, aliases: 0, bare-dash items: 5
 
-| metric               | unit         | n   | min  | p50  | p90  | p99  | max  |
-| -------------------- | ------------ | --- | ---- | ---- | ---- | ---- | ---- |
-| scalar length        | bytes/scalar | 896 | 0    | 7    | 43   | 146  | 374  |
-| mapping keys         | keys/mapping | 225 | 0    | 2    | 4    | 9    | 20   |
-| sequence items       | items/seq    | 52  | 1    | 2    | 8    | 12   | 12   |
-| bare-dash seq items  | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |
-| flow-collection size | bytes/flow   | 14  | 2    | 11   | 91   | 100  | 100  |
-| nesting depth        | levels/node  | 669 | 2    | 7    | 9    | 11   | 12   |
-| anchors              | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |
-| aliases              | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |
-| escape density       | per KiB/file | 6   | 0.00 | 0.00 | 0.05 | 0.05 | 0.05 |
+| metric               | unit         | n    | min  | p50  | p90  | p99  | max  |
+| -------------------- | ------------ | ---- | ---- | ---- | ---- | ---- | ---- |
+| scalar length        | bytes/scalar | 1052 | 0    | 7    | 38   | 109  | 374  |
+| mapping keys         | keys/mapping | 233  | 0    | 2    | 4    | 9    | 69   |
+| sequence items       | items/seq    | 58   | 1    | 2    | 8    | 12   | 12   |
+| bare-dash seq items  | count/file   | 7    | 0    | 0    | 5    | 5    | 5    |
+| flow-collection size | bytes/flow   | 14   | 2    | 11   | 91   | 100  | 100  |
+| nesting depth        | levels/node  | 761  | 2    | 7    | 9    | 11   | 12   |
+| anchors              | count/file   | 7    | 0    | 0    | 0    | 0    | 0    |
+| aliases              | count/file   | 7    | 0    | 0    | 0    | 0    | 0    |
+| escape density       | per KiB/file | 7    | 0.00 | 0.00 | 0.05 | 0.05 | 0.05 |
 
 ## JSON
 

--- a/docs/benchmarks/inventory.md
+++ b/docs/benchmarks/inventory.md
@@ -16,6 +16,7 @@ The project contains **10 main benchmark documentation files** with approximatel
 | [utf8-validate.md](utf8-validate.md)           | UTF-8 validation throughput (scalar)        | ~15      |
 | [dsv.md](dsv.md)                               | CSV/TSV parsing performance                 | ~8       |
 | [corpus-shape.md](corpus-shape.md)             | Real-workload input shape statistics (#301) | ~4       |
+| [yaml-shape-survey.md](yaml-shape-survey.md)   | Upstream YAML shape frequency (#326)        | ~9       |
 | [cross-language.md](cross-language.md)         | Multi-parser JSON comparison                | ~15      |
 | [rust-parsers.md](rust-parsers.md)             | Rust JSON parser comparison (x86_64 + ARM)  | ~20      |
 | [rust-yaml-parsers.md](rust-yaml-parsers.md)   | Rust YAML parser comparison (x86_64 + ARM)  | ~16      |

--- a/docs/benchmarks/yaml-shape-survey.md
+++ b/docs/benchmarks/yaml-shape-survey.md
@@ -1,0 +1,156 @@
+# YAML Input Shape Survey — Upstream Frequency
+
+> Produced by `./scripts/survey-yaml-shapes.sh --defaults`, run 2026-07-25 against
+> branch tips. Deliberately **not** CI-checked: upstream branches move, so re-running
+> will not reproduce these numbers byte-for-byte. The date above is the pin.
+
+## Why this exists
+
+[`corpus-shape.md`](corpus-shape.md) is the representativeness lookup that gates perf
+claims (#235 Phase 6): before optimising for an input shape, confirm the shape appears
+there. It answers **existence** — this shape occurs in real files, at this size. It
+cannot answer **frequency**: seven files cannot measure a shape that occurs in a
+fraction of a percent of real input, and reading a shape's presence in a seven-file
+corpus as "one real file in seven looks like this" inverts the very error the corpus
+exists to prevent.
+
+This survey answers the frequency half, by scanning whole upstream repositories.
+It was built for #326, which asked what fraction of real YAML uses bare-dash block
+sequence items — the shape whose detection cost #106 measured at up to 16.37x.
+
+## Method
+
+- 26 public repositories, branch tips as of 2026-07-25, weighted towards the
+  Kubernetes and Ansible workloads #326 predicted would carry the bare-dash shape,
+  so that a null result there means something.
+- Every `.yml`/`.yaml` file between 200 B and 300 KB. The bounds exclude trivia and
+  generated giants (CRDs, vendored lock-alikes) that would swamp the denominator.
+- **Bare-dash item**: a `-` alone on its line whose next non-blank, non-comment line
+  is more indented — i.e. `-\n  key: value`, an item with content of its own. A `-`
+  with nothing under it is a null item, a different shape, and is excluded.
+- **Anchors / aliases**: `&name` / `*name` in node position (directly after a `:` or
+  a `-` indicator), comments stripped.
+
+Both classifiers are regexes, not the parser, so they are approximations: an anchor
+inside a block scalar still counts, and a bare dash inside a block scalar could too.
+They are calibrated for the one question asked of them — order of magnitude — and the
+node-position constraint on anchors matters, since without it prose emphasis
+(`*every*`), Helm comment delimiters, and globs in quoted strings dominate the count.
+
+## Headline
+
+| Shape                     | Files    | % of 33,575 | Occurrences         |
+|---------------------------|----------|-------------|---------------------|
+| bare-dash sequence items  | 14       | **0.042%**  | 65 items            |
+| anchors                   | 166      | **0.494%**  | 777 anchors         |
+| aliases                   | —        | —           | 2,543 aliases       |
+
+## Bare-dash items: the #326 hypothesis is false
+
+#326 expected the shape to be "common in Ansible task lists and hand-written
+Kubernetes manifests, particularly where the first key would make the line long".
+It is neither:
+
+| Workload family      | Repos | YAML files | Files with bare-dash | Rate       |
+|----------------------|-------|------------|----------------------|------------|
+| Kubernetes/manifests | 9     | 18,362     | 5                    | **0.027%** |
+| Ansible              | 9     | 3,785      | 2                    | **0.053%** |
+| Other config/CI      | 8     | 11,428     | 7                    | 0.061%     |
+
+`kubernetes/kubernetes` has **0 of 6,154**. Both Ansible hits are
+`test/integration/` fixtures in `ansible/ansible`; across every production playbook
+scanned — `ansible-examples`, `awx`, `molecule`, `kubespray`, `openstack-ansible`,
+`community.docker`, and two `geerlingguy` repos — the count is **zero**.
+
+Every file where the shape does occur, in full — 14 files, and the list is this short
+because the shape really is this rare:
+
+| File                                                              | Items | Bytes   | Kind             |
+|-------------------------------------------------------------------|-------|---------|------------------|
+| `opentelemetry-collector` `confmap/testdata/merge-append-…yaml`   | 22    | 12,673  | test fixture     |
+| `opentelemetry-collector` `…-featuregate-disabled.yaml`           | 6     | 3,839   | test fixture     |
+| `gitlabhq` `spec/fixtures/config/redis_sentinel_password.yml`     | 6     | 1,075   | test fixture     |
+| `gitlabhq` `spec/fixtures/config/redis_new_format_host.yml`       | 6     | 949     | test fixture     |
+| `gitlabhq` `spec/fixtures/config/redis_cluster_format_host.yml`   | 6     | 600     | test fixture     |
+| **`istio` `common/config/sass-lint.yml`**                         | **5** | 2,055   | **real config**  |
+| `gitlabhq` `config/mail_room.yml`                                 | 3     | 3,518   | ERB template     |
+| `beats` `filebeat/tests/files/config.yml`                         | 3     | 849     | test fixture     |
+| `istio` `manifests/charts/gateways/istio-ingress/…/service.yaml`  | 2     | 1,674   | Helm template    |
+| `istio` `manifests/charts/gateways/istio-egress/…/service.yaml`   | 2     | 1,670   | Helm template    |
+| `ansible` `test/integration/targets/filter_core/vars/main.yml`    | 1     | 4,920   | test fixture     |
+| `ansible` `test/integration/targets/vars_files/runme.yml`         | 1     | 439     | test fixture     |
+| `kube-prometheus` `manifests/prometheus-prometheusRule.yaml`      | 1     | 17,233  | generated        |
+| `bitnami/charts` `bitnami/seaweedfs/values.yaml`                  | 1     | 184,155 | Helm values      |
+
+Only one is an ordinary hand-written config file that parses standalone. That file is
+now vendored into the corpus as `yaml/lint/sass-lint.yml`, which is why the corpus can
+report `bare-dash items: 5` at all. Its selection was a search over 46 repositories,
+not a preference.
+
+Two denser candidates were rejected, recorded so the search is not repeated: an AWS
+CloudFormation template (4 items in 6,194 B) is unusable because its `!Ref`/`!GetAtt`
+shorthand tags hit `YamlError::TagNotSupported`, and the 22-item
+`opentelemetry-collector` file is a test fixture, which cannot carry a "real workload"
+claim.
+
+## Anchors are the opposite case — a genuine sampling gap
+
+[`NOTICES.md`](../../tests/data/bench-corpus/NOTICES.md) has long flagged that the
+corpus reads `anchors: 0`. The natural reading — that P4's anchor-heavy
+micro-benchmarks simply over-assumed, and real input has no anchors — is wrong.
+Anchors are an order of magnitude more common than bare dashes, and heavily
+concentrated by ecosystem:
+
+| Repo                          | YAML files | Files with anchors | Rate       |
+|-------------------------------|------------|--------------------|------------|
+| `home-assistant/core`         | 747        | 82                 | **10.98%** |
+| `saltstack/salt`              | 67         | 6                  | **8.96%**  |
+| `concourse/concourse`         | 166        | 7                  | 4.22%      |
+| `elastic/beats`               | 1,667      | 23                 | 1.38%      |
+| `gitlabhq/gitlabhq`           | 8,354      | 27                 | 0.32%      |
+| Kubernetes/manifests (9 repos)| 18,362     | 5                  | 0.027%     |
+
+So `anchors: 0` in the corpus is a **sampling artefact**, not upstream reality: the
+corpus over-samples Kubernetes and Docker Compose, the two families that genuinely do
+not use anchors. In workloads that do — Home Assistant configuration, Salt states,
+Concourse pipelines, GitLab CI — anchors appear in 4–11% of files, which makes them
+roughly 100x more prevalent than the bare-dash shape. Of the two gaps #326 raised,
+this is the one worth closing with a corpus file.
+
+## What this means for #106
+
+The bare-dash finding was a real quadratic term, and removing it was worth doing on
+its own merits. What the survey changes is the claim attached to it. Before:
+
+> large where the shape occurs, and the shape is idiomatic but unsampled
+
+After:
+
+> large where the shape occurs, but the shape occurs in 0.042% of real YAML files —
+> absent from `kubernetes/kubernetes` entirely and from every production Ansible
+> playbook scanned — and where it does occur it is overwhelmingly in test fixtures,
+> generated manifests, and templates rather than hand-written config.
+
+The 16.37x @ 4 MB figure is not wrong; it is just not a claim about the input this
+parser will typically see. The `seqwrap` generator remains the right tool for
+*benchmarking* the shape — it simply is not evidence of representativeness, which is
+the distinction that got P5 rejected.
+
+## Reproducing
+
+```bash
+# The 26-repo set behind this page (streams tarballs; nothing written to disk).
+./scripts/survey-yaml-shapes.sh --defaults
+
+# Or an ad-hoc set.
+./scripts/survey-yaml-shapes.sh kubernetes/kubernetes@master istio/istio@master
+```
+
+## Related
+
+| Document                                                          | Purpose                                      |
+|-------------------------------------------------------------------|----------------------------------------------|
+| [corpus-shape.md](corpus-shape.md)                                | Shape distributions of the corpus (existence)|
+| [../../tests/data/bench-corpus/NOTICES.md](../../tests/data/bench-corpus/NOTICES.md) | Corpus provenance and licenses |
+| [../guides/benchmarking.md](../guides/benchmarking.md)            | How the corpus and its reports are used      |
+| [../parsing/yaml.md](../parsing/yaml.md)                          | YAML optimization phases (P4 anchors, P5)    |

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -422,6 +422,26 @@ This gates the open perf issues #40 #56 #58 #64 #91 #106 #122 #123 #124 #126 #13
 ([`tests/data/bench-corpus/expected-shape.md`](../../tests/data/bench-corpus/expected-shape.md))
 is drift-checked in CI so the tooling and report cannot silently rot.
 
+### Frequency lookup
+
+The corpus establishes that a shape **exists** at a given size. It cannot establish
+**how often** it occurs — a handful of files cannot measure a shape present in a
+fraction of a percent of real input, and reading a shape's presence in a seven-file
+corpus as "one file in seven looks like this" inverts the error the corpus exists to
+prevent. For frequency, scan whole upstream repositories:
+
+```bash
+# The 26-repo set behind the recorded results (streams tarballs; nothing hits disk).
+./scripts/survey-yaml-shapes.sh --defaults
+```
+
+Results are recorded in
+[docs/benchmarks/yaml-shape-survey.md](../benchmarks/yaml-shape-survey.md), which is
+where #326 established that bare-dash sequence items occur in 0.042% of real YAML
+files — and, conversely, that the corpus's `anchors: 0` is a sampling artefact rather
+than upstream reality, since anchors reach 4–11% of files in the ecosystems that use
+them. That page is date-pinned, not CI-checked: upstream branches move.
+
 ---
 
 ## Platforms and Hardware

--- a/scripts/survey-yaml-shapes.sh
+++ b/scripts/survey-yaml-shapes.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Survey YAML input shapes across upstream repositories (#326).
+#
+# The benchmark corpus (#301) answers "does this shape exist in real workloads?"
+# for the handful of files it contains. It cannot answer "how often?" — seven
+# files cannot measure a shape that occurs in a fraction of a percent of real
+# input. This script answers the frequency half, by streaming public repository
+# tarballs and classifying every YAML file inside them.
+#
+# It reports two shapes the corpus has been unable to speak to:
+#   * bare-dash sequence items — `-` alone on its line, the shape whose
+#     detection cost #106 measured at 16.37x @ 4 MB (Ryzen 9 7950X)
+#   * anchors / aliases        — the corpus reads `anchors: 0`, and P4's
+#     micro-benchmarks assumed anchor-heavy input
+#
+# Nothing is written to disk: each tarball is decompressed in memory and
+# discarded. Only files between 200 B and 300 KB are counted, which excludes
+# both trivia and generated giants (e.g. CRDs) that would swamp the denominator.
+#
+# Usage:
+#   ./scripts/survey-yaml-shapes.sh <owner>/<repo>@<branch> ...
+#   ./scripts/survey-yaml-shapes.sh --defaults     # the #326 repository set
+#
+# Example:
+#   ./scripts/survey-yaml-shapes.sh kubernetes/kubernetes@master istio/istio@master
+#
+# Results are recorded in docs/benchmarks/yaml-shape-survey.md. Re-running will
+# not reproduce those numbers byte-for-byte — upstream branches move — so the
+# doc pins the date it was run. This is deliberately not a CI drift check.
+
+set -euo pipefail
+
+command -v python3 >/dev/null 2>&1 || { echo "error: python3 is required" >&2; exit 1; }
+
+# The repository set behind docs/benchmarks/yaml-shape-survey.md. Chosen to
+# over-sample the workloads #326 predicted would carry the bare-dash shape
+# (Ansible, Kubernetes) so a null result there is meaningful rather than absent.
+DEFAULT_REPOS=(
+  # Kubernetes / manifests
+  kubernetes/kubernetes@master
+  kubernetes/examples@master
+  kubernetes-sigs/kustomize@master
+  kubernetes/ingress-nginx@main
+  argoproj/argo-cd@master
+  prometheus-operator/kube-prometheus@main
+  helm/charts@master
+  bitnami/charts@main
+  istio/istio@master
+  # Ansible
+  ansible/ansible@devel
+  ansible/ansible-examples@master
+  ansible/awx@devel
+  ansible/molecule@main
+  ansible-collections/community.docker@main
+  kubernetes-sigs/kubespray@master
+  openstack/openstack-ansible@master
+  geerlingguy/ansible-for-devops@master
+  geerlingguy/ansible-role-docker@master
+  # Compose / CI / other hand-written config
+  docker/awesome-compose@master
+  prometheus/prometheus@main
+  open-telemetry/opentelemetry-collector@main
+  elastic/beats@main
+  gitlabhq/gitlabhq@master
+  saltstack/salt@master
+  home-assistant/core@dev
+  concourse/concourse@master
+)
+
+if [[ "${1:-}" == "--defaults" ]]; then
+  set -- "${DEFAULT_REPOS[@]}"
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <owner>/<repo>@<branch> ... | --defaults" >&2
+  exit 1
+fi
+
+python3 - "$@" <<'PY'
+import re
+import sys
+import tarfile
+import urllib.request
+
+# A `-` alone on its line. Whether it is a sequence indicator (rather than, say,
+# a line inside a block scalar) is not decidable without parsing; the follow-on
+# indentation check below is what makes this a usable approximation.
+BARE = re.compile(r'^([ \t]*)-[ \t]*$')
+
+# An anchor or alias only ever occupies a node position: directly after a `:` or
+# after a `-` item indicator. Requiring that is what separates the real thing from
+# the three things that otherwise dominate the count — prose emphasis (`*every*`),
+# Helm comment delimiters (`{{/*...*/}}`), and glob/regex wildcards inside quoted
+# strings (`["*bar/ns/foo"]`). It also catches merge keys (`<<: *defaults`).
+ANCHOR = re.compile(r'(?:^[ \t]*-|:)[ \t]+&[A-Za-z0-9_][\w.-]*')
+ALIAS = re.compile(r'(?:^[ \t]*-|:)[ \t]+\*[A-Za-z0-9_][\w.-]*')
+COMMENT = re.compile(r'(?:^|[ \t])#.*$')
+
+MIN_BYTES, MAX_BYTES = 200, 300_000
+
+
+def count_anchors(text):
+    """Anchors and aliases in node position, per line, comments stripped.
+
+    Approximate by construction: it is a regex, not the parser, so an anchor
+    inside a block scalar still counts. Good enough to answer "is the corpus's
+    `anchors: 0` a sampling artefact or upstream reality?", which is all it is for.
+    """
+    anchors = aliases = 0
+    for line in text.split('\n'):
+        line = COMMENT.sub('', line)
+        anchors += len(ANCHOR.findall(line))
+        aliases += len(ALIAS.findall(line))
+    return anchors, aliases
+
+
+def classify(text):
+    """Count bare-dash items, split by whether the item has indented content.
+
+    `structured` is the #326 shape (`-\\n  key: value`) — an item whose content
+    begins on a later line. `empty` is a `-` with nothing under it, i.e. a null
+    item, which is a different shape that happens to share the indicator form.
+    """
+    lines = text.split('\n')
+    structured = empty = 0
+    for i, line in enumerate(lines):
+        m = BARE.match(line)
+        if not m:
+            continue
+        indent = len(m.group(1))
+        nxt = None
+        for cand in lines[i + 1:]:
+            if cand.strip() == '' or cand.lstrip().startswith('#'):
+                continue
+            nxt = cand
+            break
+        if nxt is not None and (len(nxt) - len(nxt.lstrip())) > indent:
+            structured += 1
+        else:
+            empty += 1
+    return structured, empty
+
+
+def survey(spec):
+    owner_repo, branch = spec.rsplit('@', 1)
+    url = f"https://codeload.github.com/{owner_repo}/tar.gz/refs/heads/{branch}"
+    try:
+        stream = urllib.request.urlopen(url, timeout=300)
+        tf = tarfile.open(fileobj=stream, mode='r|gz')
+    except Exception as e:  # network, 404, bad branch — report and continue
+        print(f"!! {spec}: {e}", flush=True)
+        return None
+
+    files = bare_files = anchor_files = 0
+    bare_items = anchors = aliases = 0
+    worst = []
+    try:
+        for m in tf:
+            if not m.isfile() or not m.name.endswith(('.yml', '.yaml')):
+                continue
+            if not (MIN_BYTES <= m.size <= MAX_BYTES):
+                continue
+            try:
+                text = tf.extractfile(m).read().decode('utf-8')
+            except Exception:
+                continue  # binary or non-UTF-8; not YAML we can classify
+            files += 1
+            structured, _empty = classify(text)
+            if structured:
+                bare_files += 1
+                bare_items += structured
+                worst.append((structured, m.size, m.name))
+            a, al = count_anchors(text)
+            if a:
+                anchor_files += 1
+            anchors += a
+            aliases += al
+    except Exception as e:
+        print(f"!! {spec} mid-scan: {e}", flush=True)
+
+    worst.sort(reverse=True)
+    print(
+        f"== {spec}\n"
+        f"   yaml files scanned:   {files}\n"
+        f"   with bare-dash items: {bare_files} ({bare_items} items)\n"
+        f"   with anchors:         {anchor_files} ({anchors} anchors, {aliases} aliases)",
+        flush=True,
+    )
+    for n, size, name in worst[:5]:
+        print(f"     {n:4d} items  {size:7d} B  {name}", flush=True)
+    return files, bare_files, bare_items, anchor_files, anchors, aliases
+
+
+totals = [0] * 6
+scanned = 0
+for spec in sys.argv[1:]:
+    r = survey(spec)
+    if r is None:
+        continue
+    scanned += 1
+    totals = [t + v for t, v in zip(totals, r)]
+
+files, bare_files, bare_items, anchor_files, anchors, aliases = totals
+pct = (100.0 * bare_files / files) if files else 0.0
+apct = (100.0 * anchor_files / files) if files else 0.0
+print(
+    f"\nTOTAL over {scanned} repo(s): {files} yaml files\n"
+    f"  bare-dash sequence items: {bare_files} files ({pct:.3f}%), {bare_items} items\n"
+    f"  anchors:                  {anchor_files} files ({apct:.3f}%), {anchors} anchors, {aliases} aliases",
+    flush=True,
+)
+PY

--- a/src/bin/succinctly/corpus_stats.rs
+++ b/src/bin/succinctly/corpus_stats.rs
@@ -127,6 +127,19 @@ struct YamlStats {
     escape_density: Dist, // per file
     anchors_per_file: Dist,
     aliases_per_file: Dist,
+    bare_dash_items_per_file: Dist,
+}
+
+/// Counters that are accumulated over a whole file rather than per node, so the
+/// distribution gets one sample per file (like `anchors_per_file`) instead of one
+/// per occurrence. Threaded through `visit_yaml` as a single `&mut` to keep the
+/// recursion's parameter count down as counters are added.
+#[derive(Default)]
+struct YamlFileCounters {
+    /// `\` bytes across every scalar and key, for the escape-density metric.
+    escapes: u64,
+    /// Block-sequence items whose `-` indicator sits alone on its own line.
+    bare_dash_items: u64,
 }
 
 #[derive(Default)]
@@ -258,7 +271,7 @@ fn visit_yaml(
     bytes: &[u8],
     cur: YamlCursor<'_, Vec<u64>>,
     st: &mut YamlStats,
-    escapes: &mut u64,
+    counters: &mut YamlFileCounters,
 ) {
     st.depth
         .push(index.bp().depth(cur.bp_position()).unwrap_or(0) as u64);
@@ -267,7 +280,7 @@ fn visit_yaml(
         YamlValue::String(ys) => {
             let raw = ys.raw_bytes();
             st.scalar_len.push(raw.len() as u64);
-            *escapes += raw.iter().filter(|&&b| b == b'\\').count() as u64;
+            counters.escapes += raw.iter().filter(|&&b| b == b'\\').count() as u64;
         }
         YamlValue::Mapping(fields) => {
             record_flow(bytes, &cur, st);
@@ -277,19 +290,25 @@ fn visit_yaml(
                 if let YamlValue::String(ks) = field.key() {
                     let raw = ks.raw_bytes();
                     st.scalar_len.push(raw.len() as u64);
-                    *escapes += raw.iter().filter(|&&b| b == b'\\').count() as u64;
+                    counters.escapes += raw.iter().filter(|&&b| b == b'\\').count() as u64;
                 }
-                visit_yaml(index, bytes, field.value_cursor(), st, escapes);
+                visit_yaml(index, bytes, field.value_cursor(), st, counters);
             }
             st.keys_per_mapping.push(keys);
         }
         YamlValue::Sequence(elements) => {
             record_flow(bytes, &cur, st);
+            // Only block sequences carry a `-` indicator to classify; flow
+            // sequences (`[a, b]`) have none.
+            let block = cur.style() != "flow";
             let mut es = elements;
             let mut n = 0u64;
             while let Some((child, rest)) = es.uncons_cursor() {
                 n += 1;
-                visit_yaml(index, bytes, child, st, escapes);
+                if block && has_bare_dash_indicator(bytes, &child) {
+                    counters.bare_dash_items += 1;
+                }
+                visit_yaml(index, bytes, child, st, counters);
                 es = rest;
             }
             st.items_per_sequence.push(n);
@@ -297,6 +316,40 @@ fn visit_yaml(
         // Aliases are counted via the BP scan below; do not recurse (cycle-safe).
         YamlValue::Alias { .. } | YamlValue::Null | YamlValue::Error(_) => {}
     }
+}
+
+/// Whether a block-sequence item's `-` indicator sits alone on its own line
+/// (`-\n  key: value`) rather than inline with the content (`- key: value`).
+///
+/// Derived from the item's own text position rather than a bespoke re-scan of the
+/// document, on the same principle as O4's seq-item wrappers: the text already
+/// encodes it. The index distinguishes the two forms by where it anchors the item
+/// — an inline item's position is its *content* (the `b` of `- b: 2`), while a
+/// bare-dash item has no content on that line so the position is the `-` itself.
+/// So the test is: the position is a `-`, and the rest of that line is blank.
+///
+/// Both halves are load-bearing. Requiring a `-` rejects inline items; requiring
+/// the rest of the line to be blank rejects the two shapes whose *content* also
+/// starts with a dash — a negative number (`- -5`) and a nested inline sequence
+/// (`- - deep`) — which the first check alone would miscount.
+///
+/// One deliberate undercount: a comment between the indicator and the content
+/// (`-  # note\n  key: v`) anchors the item at the content, so it reads as inline.
+/// The metric is therefore a lower bound on bare-dash usage.
+fn has_bare_dash_indicator(bytes: &[u8], child: &YamlCursor<'_, Vec<u64>>) -> bool {
+    child.text_position().is_some_and(|start| {
+        bytes.get(start) == Some(&b'-')
+            // The indicator is bare only if nothing but horizontal whitespace
+            // follows it on that line. Running out of input counts: a trailing
+            // `-` with no newline after it is still alone on its line.
+            && match bytes[start + 1..]
+                .iter()
+                .find(|&&b| !matches!(b, b' ' | b'\t' | b'\r'))
+            {
+                Some(&b) => b == b'\n',
+                None => true,
+            }
+    })
 }
 
 /// Record a flow collection's byte extent (the P5 metric) when `cur` is a flow
@@ -382,18 +435,22 @@ fn ingest_yaml(bytes: &[u8], st: &mut YamlStats) -> Result<()> {
 
     // The YAML root is a virtual sequence of documents; visit each document so
     // the doc-list does not pollute the sequence-item distribution.
-    let mut escapes = 0u64;
+    let mut counters = YamlFileCounters::default();
     let root = index.root(bytes);
     match root.value() {
         YamlValue::Sequence(mut docs) => {
             while let Some((doc, rest)) = docs.uncons_cursor() {
-                visit_yaml(&index, bytes, doc, st, &mut escapes);
+                visit_yaml(&index, bytes, doc, st, &mut counters);
                 docs = rest;
             }
         }
-        _ => visit_yaml(&index, bytes, root, st, &mut escapes),
+        // Defensive, and not reachable for any input observed: `index.root()`
+        // returns the virtual document sequence for empty, comment-only, scalar,
+        // flow, block-scalar and multi-document input alike.
+        _ => visit_yaml(&index, bytes, root, st, &mut counters),
     }
-    push_escape_density(&mut st.escape_density, escapes, bytes.len());
+    st.bare_dash_items_per_file.push(counters.bare_dash_items);
+    push_escape_density(&mut st.escape_density, counters.escapes, bytes.len());
     st.files += 1;
     st.total_bytes += bytes.len() as u64;
     Ok(())
@@ -630,11 +687,17 @@ percentiles use nearest-rank.\n\n",
     // YAML
     md.push_str("## YAML\n\n");
     md.push_str(&format!(
-        "files: {}, total bytes: {}, anchors: {}, aliases: {}\n\n",
+        "files: {}, total bytes: {}, anchors: {}, aliases: {}, bare-dash items: {}\n\n",
         corpus.yaml.files,
         corpus.yaml.total_bytes,
         corpus.yaml.anchors_per_file.values.iter().sum::<u64>(),
         corpus.yaml.aliases_per_file.values.iter().sum::<u64>(),
+        corpus
+            .yaml
+            .bare_dash_items_per_file
+            .values
+            .iter()
+            .sum::<u64>(),
     ));
     md.push_str(&render_table(
         DIST_HEADERS,
@@ -649,6 +712,11 @@ percentiles use nearest-rank.\n\n",
                 "sequence items",
                 "items/seq",
                 &corpus.yaml.items_per_sequence,
+            ),
+            dist_row(
+                "bare-dash seq items",
+                "count/file",
+                &corpus.yaml.bare_dash_items_per_file,
             ),
             dist_row(
                 "flow-collection size",
@@ -822,6 +890,68 @@ mod tests {
         // exactly one flow collection recorded, of length == "[1, 2, 3]"
         assert_eq!(st.flow_collection_bytes.values.len(), 1);
         assert_eq!(st.flow_collection_bytes.values[0], "[1, 2, 3]".len() as u64);
+    }
+
+    #[test]
+    fn yaml_bare_dash_items_counted() {
+        // Two bare-dash items (the `-` alone on its line) and one inline `- `.
+        let doc = b"rules:\n  -\n    a: 1\n  - b: 2\n  -\n    c: 3\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        assert_eq!(st.bare_dash_items_per_file.values, vec![2]);
+        // The sequence itself still reports all three items.
+        assert_eq!(st.items_per_sequence.values, vec![3]);
+    }
+
+    #[test]
+    fn yaml_inline_and_flow_items_are_not_bare_dash() {
+        // Inline block items and flow sequences carry no bare-dash indicator.
+        let doc = b"block:\n  - one\n  - two\nflow: [1, 2, 3]\nnested:\n  - - deep\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        assert_eq!(st.bare_dash_items_per_file.values, vec![0]);
+    }
+
+    #[test]
+    fn yaml_bare_dash_nests_and_counts_empty_items() {
+        // A bare dash whose content is itself a bare-dash sequence, plus a trailing
+        // empty item (`-` with no content) — which is also a dash alone on its own
+        // line, so it counts too.
+        let doc = b"outer:\n  -\n    inner:\n      -\n        x: 1\n  -\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        assert_eq!(st.bare_dash_items_per_file.values, vec![3]);
+    }
+
+    #[test]
+    fn bare_dash_counts_a_trailing_indicator_at_end_of_input() {
+        // A `-` that is the last byte of the file, with no newline after it, is
+        // still alone on its line — the "ran out of input" arm of the scan.
+        let doc = b"k:\n  -";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        assert_eq!(st.bare_dash_items_per_file.values, vec![1]);
+    }
+
+    #[test]
+    fn bare_dash_ignores_content_that_starts_with_a_dash() {
+        // `- -5` anchors the item at the `-` of the negative number, so the
+        // "rest of the line is blank" half of the check is what keeps it out.
+        let doc = b"neg:\n  - -5\n  -\n    z: 1\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        assert_eq!(st.bare_dash_items_per_file.values, vec![1]);
+    }
+
+    #[test]
+    fn bare_dash_undercounts_when_a_comment_follows_the_indicator() {
+        // A comment sits between the indicator and the content, so the index
+        // anchors the item at the content and it reads as inline. This is the
+        // documented undercount, pinned so it stays a deliberate choice.
+        let doc = b"k:\n  -  # note\n    a: 1\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        assert_eq!(st.bare_dash_items_per_file.values, vec![0]);
     }
 
     #[test]

--- a/tests/data/bench-corpus/NOTICES.md
+++ b/tests/data/bench-corpus/NOTICES.md
@@ -20,6 +20,7 @@ retains its upstream license below.
 | `yaml/actions/codeql-analysis.yml`    | [prometheus/prometheus](https://github.com/prometheus/prometheus) `.github/workflows/codeql-analysis.yml` | Apache-2.0 |
 | `yaml/actions/stale.yml`              | [prometheus/prometheus](https://github.com/prometheus/prometheus) `.github/workflows/stale.yml`        | Apache-2.0 |
 | `yaml/k8s/nginx-deployment.yml`       | [kubernetes/examples](https://github.com/kubernetes/examples) `nginx-platform-app/deployment.yml`      | Apache-2.0 |
+| `yaml/lint/sass-lint.yml`             | [istio/istio](https://github.com/istio/istio) `common/config/sass-lint.yml` (bare-dash sequence items: `-` alone on its line) | Apache-2.0 |
 | `json/charts/bullet-data.json`        | [plotly/datasets](https://github.com/plotly/datasets) `BulletData.json`                                | MIT        |
 | `dsv/world-gdp/world-gdp-with-codes.csv` | [plotly/datasets](https://github.com/plotly/datasets) `2014_world_gdp_with_codes.csv` (genuine quoting: `"Bahamas, The"`) | MIT |
 
@@ -31,11 +32,30 @@ retains its upstream license below.
 | `json/geojson/us-election.geojson`   | 100kb | [plotly/datasets](https://github.com/plotly/datasets) `election.geojson`                      | MIT        |
 | `dsv/gapminder/gapminder-five-year.csv` | 100kb | [plotly/datasets](https://github.com/plotly/datasets) `gapminderDataFiveYear.csv`         | MIT        |
 
+## What the corpus can and cannot tell you
+
+The corpus establishes **existence** — that a shape occurs in real files, and what
+it looks like at what size. It cannot establish **frequency**: seven files can never
+proportionally represent a shape that appears in a fraction of a percent of real
+input. `yaml/lint/sass-lint.yml` is the worked example. It was added for #326 so the
+bare-dash sequence item (`-` alone on its line) is sampled at all, but a survey of
+46 upstream repositories found that shape in under 0.1% of real YAML files. Reading
+its presence here as "roughly one YAML file in six uses bare dashes" inverts the
+error the corpus exists to prevent. Frequency questions belong to
+[`docs/benchmarks/yaml-shape-survey.md`](../../../docs/benchmarks/yaml-shape-survey.md).
+
 ## Extending the corpus
 
 The 1MB/10MB ladder tiers and anchor/alias-heavy YAML (real workloads use anchors
-far less than the P4 micro-benchmarks assumed — the seed shows `anchors: 0`) are
-follow-up curation: add a `manifest.json` entry (`vendored: false`) with a
+far less than the P4 micro-benchmarks assumed — the corpus still shows `anchors: 0`,
+and the survey above confirms that is upstream reality rather than a sampling gap)
+are follow-up curation: add a `manifest.json` entry (`vendored: false`) with a
 commit-pinned `source_url`, `license`, `bytes`, and `sha256`, then run
 `./scripts/sync-bench-corpus.sh` to fetch and verify it. Prefer public-domain or
 permissive (CC0 / MIT / Apache-2.0 / BSD) sources and always record provenance.
+
+Test-parse any candidate before committing it (`succinctly yq -o json '.' <file>`).
+`ingest_yaml` turns a parse failure into an error that aborts the whole report, and
+plausible-looking sources do fail: the densest bare-dash file found during the #326
+search was an AWS CloudFormation template, which is unusable here because its
+`!Ref`/`!GetAtt` shorthand tags hit `YamlError::TagNotSupported`.

--- a/tests/data/bench-corpus/NOTICES.md
+++ b/tests/data/bench-corpus/NOTICES.md
@@ -39,17 +39,20 @@ it looks like at what size. It cannot establish **frequency**: seven files can n
 proportionally represent a shape that appears in a fraction of a percent of real
 input. `yaml/lint/sass-lint.yml` is the worked example. It was added for #326 so the
 bare-dash sequence item (`-` alone on its line) is sampled at all, but a survey of
-46 upstream repositories found that shape in under 0.1% of real YAML files. Reading
-its presence here as "roughly one YAML file in six uses bare dashes" inverts the
-error the corpus exists to prevent. Frequency questions belong to
+26 upstream repositories (33,575 YAML files) found that shape in 0.042% of them.
+Reading its presence here as "roughly one YAML file in six uses bare dashes" inverts
+the error the corpus exists to prevent. Frequency questions belong to
 [`docs/benchmarks/yaml-shape-survey.md`](../../../docs/benchmarks/yaml-shape-survey.md).
 
 ## Extending the corpus
 
-The 1MB/10MB ladder tiers and anchor/alias-heavy YAML (real workloads use anchors
-far less than the P4 micro-benchmarks assumed — the corpus still shows `anchors: 0`,
-and the survey above confirms that is upstream reality rather than a sampling gap)
-are follow-up curation: add a `manifest.json` entry (`vendored: false`) with a
+The 1MB/10MB ladder tiers and anchor/alias-heavy YAML are follow-up curation. The
+anchor gap is the more urgent of the two: the corpus still shows `anchors: 0`, and the
+survey establishes that this is a **sampling artefact**, not upstream reality — the
+corpus over-samples Kubernetes and Compose, the two families that genuinely avoid
+anchors, while ecosystems that use them (Home Assistant, Salt, Concourse, GitLab CI)
+carry anchors in 4–11% of files, roughly 100x the bare-dash rate. To add one: add a
+`manifest.json` entry (`vendored: false`) with a
 commit-pinned `source_url`, `license`, `bytes`, and `sha256`, then run
 `./scripts/sync-bench-corpus.sh` to fetch and verify it. Prefer public-domain or
 permissive (CC0 / MIT / Apache-2.0 / BSD) sources and always record provenance.

--- a/tests/data/bench-corpus/expected-shape.md
+++ b/tests/data/bench-corpus/expected-shape.md
@@ -20,13 +20,14 @@ Distributions are derived from the crate's own semi-index (`JsonIndex` / `YamlIn
 
 ## YAML
 
-files: 5, total bytes: 5105, anchors: 0, aliases: 0
+files: 5, total bytes: 5105, anchors: 0, aliases: 0, bare-dash items: 0
 
 | metric               | unit         | n   | min  | p50  | p90  | p99  | max  |
 | -------------------- | ------------ | --- | ---- | ---- | ---- | ---- | ---- |
 | scalar length        | bytes/scalar | 254 | 0    | 7    | 20   | 71   | 92   |
 | mapping keys         | keys/mapping | 61  | 0    | 2    | 5    | 9    | 9    |
 | sequence items       | items/seq    | 24  | 1    | 1    | 4    | 4    | 4    |
+| bare-dash seq items  | count/file   | 5   | 0    | 0    | 0    | 0    | 0    |
 | flow-collection size | bytes/flow   | 4   | 2    | 2    | 100  | 100  | 100  |
 | nesting depth        | levels/node  | 192 | 2    | 6    | 9    | 11   | 12   |
 | anchors              | count/file   | 5   | 0    | 0    | 0    | 0    | 0    |

--- a/tests/data/bench-corpus/expected-shape.md
+++ b/tests/data/bench-corpus/expected-shape.md
@@ -17,22 +17,23 @@ Distributions are derived from the crate's own semi-index (`JsonIndex` / `YamlIn
 | yaml   | compose   | nginx-flask-mysql.yaml   | 1239  |
 | yaml   | compose   | wordpress.yaml           | 815   |
 | yaml   | k8s       | nginx-deployment.yml     | 836   |
+| yaml   | lint      | sass-lint.yml            | 2055  |
 
 ## YAML
 
-files: 5, total bytes: 5105, anchors: 0, aliases: 0, bare-dash items: 0
+files: 6, total bytes: 7160, anchors: 0, aliases: 0, bare-dash items: 5
 
 | metric               | unit         | n   | min  | p50  | p90  | p99  | max  |
 | -------------------- | ------------ | --- | ---- | ---- | ---- | ---- | ---- |
-| scalar length        | bytes/scalar | 254 | 0    | 7    | 20   | 71   | 92   |
-| mapping keys         | keys/mapping | 61  | 0    | 2    | 5    | 9    | 9    |
-| sequence items       | items/seq    | 24  | 1    | 1    | 4    | 4    | 4    |
-| bare-dash seq items  | count/file   | 5   | 0    | 0    | 0    | 0    | 0    |
+| scalar length        | bytes/scalar | 410 | 0    | 7    | 21   | 66   | 92   |
+| mapping keys         | keys/mapping | 69  | 0    | 2    | 5    | 69   | 69   |
+| sequence items       | items/seq    | 30  | 1    | 1    | 3    | 4    | 4    |
+| bare-dash seq items  | count/file   | 6   | 0    | 0    | 5    | 5    | 5    |
 | flow-collection size | bytes/flow   | 4   | 2    | 2    | 100  | 100  | 100  |
-| nesting depth        | levels/node  | 192 | 2    | 6    | 9    | 11   | 12   |
-| anchors              | count/file   | 5   | 0    | 0    | 0    | 0    | 0    |
-| aliases              | count/file   | 5   | 0    | 0    | 0    | 0    | 0    |
-| escape density       | per KiB/file | 5   | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| nesting depth        | levels/node  | 284 | 2    | 5    | 9    | 11   | 12   |
+| anchors              | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |
+| aliases              | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |
+| escape density       | per KiB/file | 6   | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 
 ## JSON
 

--- a/tests/data/bench-corpus/manifest.json
+++ b/tests/data/bench-corpus/manifest.json
@@ -57,6 +57,17 @@
       "vendored": true
     },
     {
+      "format": "yaml",
+      "workload": "lint",
+      "tier": "1kb",
+      "file": "yaml/lint/sass-lint.yml",
+      "bytes": 2055,
+      "sha256": "9fa69044cf3acfebc48245f6d174d9e458f5f6c553f310899f7a6dc4290471fb",
+      "source_url": "https://raw.githubusercontent.com/istio/istio/03387cfe484b4c285c460f499035cb722fceff72/common/config/sass-lint.yml",
+      "license": "Apache-2.0",
+      "vendored": true
+    },
+    {
       "format": "json",
       "workload": "charts",
       "tier": "1kb",

--- a/tests/data/bench-corpus/seed/yaml/lint/sass-lint.yml
+++ b/tests/data/bench-corpus/seed/yaml/lint/sass-lint.yml
@@ -1,0 +1,98 @@
+#########################
+## Config for sass-lint
+#########################
+# Linter Options
+options:
+  # Don't merge default rules
+  merge-default-rules: false
+  # Raise an error if more than 50 warnings are generated
+  max-warnings: 500
+# Rule Configuration
+rules:
+  attribute-quotes:
+    - 2
+    -
+      include: false
+  bem-depth: 2
+  border-zero: 2
+  brace-style: 2
+  class-name-format: 2
+  clean-import-paths: 2
+  declarations-before-nesting: 2
+  empty-args: 2
+  empty-line-between-blocks: 2
+  extends-before-declarations: 2
+  extends-before-mixins: 2
+  final-newline: 2
+  force-attribute-nesting: 0
+  force-element-nesting: 0
+  force-pseudo-nesting: 0
+  function-name-format: 2
+  hex-length: 0
+  hex-notation: 2
+  id-name-format: 2
+  indentation:
+    - 2
+    -
+      size: 4
+  leading-zero:
+    - 2
+    -
+      include: false
+  max-file-line-count: 0
+  max-file-length: 0
+  mixins-before-declarations: 2
+  no-attribute-selectors: 0
+  no-color-hex: 0
+  no-color-keywords: 0
+  no-color-literals: 0
+  no-combinators: 0
+  no-css-comments: 2
+  no-debug: 2
+  no-disallowed-properties: 2
+  no-duplicate-properties: 2
+  no-empty-rulesets: 2
+  no-extends: 2
+  no-ids: 0
+  no-invalid-hex: 2
+  no-important: 0
+  no-mergeable-selectors: 2
+  no-misspelled-properties: 2
+  no-qualifying-elements: 0
+  no-trailing-whitespace: 2
+  no-trailing-zero: 2
+  no-transition-all: 0
+  no-url-domains: 2
+  no-url-protocols: 2
+  no-warn: 2
+  one-declaration-per-line: 2
+  placeholder-in-extend: 2
+  placeholder-name-format: 2
+  property-sort-order: 0
+  property-units: 2
+  pseudo-element: 2
+  quotes:
+    - 2
+    -
+      style: double
+  shorthand-values: 2
+  single-line-per-selector: 0
+  space-after-bang: 2
+  space-after-colon: 2
+  space-after-comma: 2
+  space-around-operator: 2
+  space-before-bang: 2
+  space-before-brace: 2
+  space-before-colon: 2
+  space-between-parens: 2
+  trailing-semicolon: 2
+  url-quotes: 2
+  variable-for-property:
+    - 0
+    -
+      properties:
+        - color
+        - background-color
+        - fill
+  variable-name-format: 0
+  zero-unit: 2


### PR DESCRIPTION
## Description

This PR implements comprehensive bare-dash sequence item detection and reporting for YAML shape analysis, addresses the representativeness gap in the benchmark corpus, and establishes frequency baselines through upstream repository surveying.

The work directly addresses #326, which identified that the corpus could not detect or report block-sequence items written as bare `-` indicators on their own lines (`-\n  key: value`). This shape was particularly relevant because #106 measured its detection cost at up to 16.37x performance impact @ 4 MB on the Ryzen 9 7950X. The changes establish both existence (via corpus addition) and frequency (via upstream survey) of this and related YAML shapes across real workloads.

## Type of Change
- [x] New feature (adds bare-dash detection and shape surveying)
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue
Fixes #326

Relates to #106 (bare-dash performance optimization)

## Changes Made

**Core Bare-Dash Detection:**
- Added `bare_dash_items_per_file` distribution metric to `YamlStats` struct in `src/bin/succinctly/corpus_stats.rs`
- Introduced `YamlFileCounters` struct to thread file-level counters through recursive YAML traversal, consolidating escape counting and bare-dash tracking
- Implemented `has_bare_dash_indicator()` function using position-based detection: a block-sequence item anchors at its `-` indicator if the item is bare, or at its content if inline. The test is "position is `-` and rest of line is blank", which correctly rejects inline items and negative numbers (`- -5`)
- Added comprehensive tests: `yaml_bare_dash_items_counted()`, `yaml_inline_and_flow_items_are_not_bare_dash()`, `yaml_bare_dash_nests_and_counts_empty_items()`, `bare_dash_ignores_content_that_starts_with_a_dash()`, and `bare_dash_undercounts_when_a_comment_follows_the_indicator()`

**Corpus Shape Reporting:**
- Updated `ingest_yaml()` to accumulate bare-dash counts via the new `YamlFileCounters` struct
- Modified corpus summary header to include `bare-dash items:` alongside anchors and aliases counts
- Added `bare-dash seq items` distribution row (count/file) to markdown output, showing min/p50/p90/p99/max statistics alongside other metrics
- Regenerated both `docs/benchmarks/corpus-shape.md` and `tests/data/bench-corpus/expected-shape.md` golden files

**Corpus Extension:**
- Vendored `istio/istio` `common/config/sass-lint.yml` (2,055 B, Apache-2.0) as `tests/data/bench-corpus/seed/yaml/lint/sass-lint.yml` — the only hand-written standalone config file identified that uses bare-dash items (5 instances)
- Updated `tests/data/bench-corpus/manifest.json` with the new corpus entry
- Updated `tests/data/bench-corpus/NOTICES.md` to document the vendored file and establish distinction between corpus existence (what this shape looks like) vs. frequency (how often it occurs)

**Upstream Shape Survey Tool:**
- Created `scripts/survey-yaml-shapes.sh` — a comprehensive Python/Bash tool that streams public repository tarballs (nothing written to disk) and classifies every YAML file by shape occurrence
- Scans 26 repositories (weighted toward Kubernetes and Ansible workloads that #326 predicted would use bare-dash items)
- Reports bare-dash structured items (items with indented content), empty items, and anchors/aliases in node position
- Includes safeguards: 200 B – 300 KB file size bounds to exclude trivia and generated giants, comment stripping for anchor/alias detection, node-position constraints to exclude prose emphasis and glob patterns

**Frequency Documentation:**
- Added `docs/benchmarks/yaml-shape-survey.md` documenting findings from 26 repositories (33,575 YAML files) as of 2026-07-25
- Key findings: bare-dash items occur in 0.042% of files (14 files, 65 items total); anchors occur in 0.494% (166 files, 777 anchors + 2,543 aliases)
- Detailed breakdown by workload family: Kubernetes manifests 0.027%, Ansible 0.053%, other config 0.061%
- Complete enumeration of all 14 files using the shape, with file sizes and provenance
- Corrects #326's initial hypothesis: the shape is not "idiomatic but unsampled"; it is genuinely rare and occurs primarily in test fixtures, generated content, and templates
- Establishes anchors as the actual sampling gap: roughly 100x more common than bare-dash, reaching 4–11% in ecosystems that use them (Home Assistant, Salt, Concourse, GitLab CI)

**Documentation Updates:**
- Updated `docs/benchmarks/README.md` to link to the new shape survey
- Updated `docs/benchmarks/inventory.md` with YAML Shape Survey entry
- Updated `docs/guides/benchmarking.md` with frequency lookup section explaining the distinction between existence (corpus) and frequency (survey) and providing reproduction instructions
- Updated corpus `NOTICES.md` with corrected premise: sampling artefact clarification and guidance that anchor-heavy YAML curation is more urgent than bare-dash

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Five new unit tests added for bare-dash detection logic, covering: basic structured items, inline vs. flow rejection, nested bare-dash sequences, content starting with dash rejection, and comment-handling undercount
- [x] Test coverage for edge cases: empty items (`-` with no content), negative numbers, nested sequences, block vs. flow distinction

**Manual Testing:**
- [x] Verified corpus statistics regenerate correctly with new metric
- [x] Tested shape survey tool against default 26-repo set
- [x] Verified survey correctly identifies bare-dash items and distinguishes empty items from structured items
- [x] Validated anchor/alias detection filters out prose emphasis, Helm delimiters, and quoted globs via node-position constraint
- [x] Confirmed expected-shape.md outputs match corpus-shape.md after golden regeneration

### Test Commands
```bash
# Run full test suite including new bare-dash tests
cargo test

# Run corpus-specific tests
cargo test --test '*' corpus

# Verify corpus shape statistics
cargo run --release --bin succinctly -- bench-corpus

# Reproduce upstream shape survey (26 repos, streams tarballs)
./scripts/survey-yaml-shapes.sh --defaults

# Survey a specific repository
./scripts/survey-yaml-shapes.sh kubernetes/kubernetes@master istio/istio@master
```

## Performance Impact
- [x] No performance impact on parsing
- Bare-dash detection is derived from existing index position data, not a re-scan
- Additional distribution metric requires one `push()` per file, negligible overhead
- Survey tool is CPU-bound on regex classification; network is the bottleneck, mitigated by streaming decompression

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed; code organization is clear with new counters struct separating concerns
- [x] Tests added and all existing tests pass
- [x] Documentation updated: corpus docs, guides, survey results
- [x] No new clippy warnings introduced
- [x] Golden files (expected-shape.md) regenerated and committed

## Additional Notes

**Architectural Decisions:**
- Position-based detection (checking `text_position()` against `-` byte) avoids a second traversal of the document
- `YamlFileCounters` struct consolidates file-scoped metrics to avoid parameter explosion in the recursive `visit_yaml()` function as more counters are added in the future
- Survey uses regexes intentionally for scalability; not 100% precise (e.g., bare dash inside block scalar still counts) but sufficient for order-of-magnitude frequency questions
- Node-position anchor/alias detection is critical: without it, prose emphasis dominates; tested during istio scan where unfiltered approach produced impossible "0 anchors, 53 aliases"

**Future Work:**
- #326 follow-up: add anchor/alias-heavy corpus file (indicated as higher priority than bare-dash now that frequency is established)
- Benchmark optimization of actual shapes identified by survey (bare-dash remains valid for benchmarking despite low real-world frequency; this changes the *claim*, not the *optimization*)
- Extended survey across more ecosystems if new performance optimizations are proposed

**Correctness Notes:**
- Bare-dash metric is a lower bound: a comment between indicator and content (`-  # note\n  key: v`) anchors at content, reads as inline. Documented in both code and docs.
- Survey file size bounds (200 B – 300 KB) chosen to balance representativeness vs. noise; excludes CRD-like generated files that would swamp statistics

**Testing Insight:**
- The added test `bare_dash_undercounts_when_a_comment_follows_the_indicator()` pins the deliberate undercount behavior so future changes don't silently alter semantics