### PR TITLE
feat(yaml): implement lenient parsing of inline block sequences as mapping values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An inline block sequence as a mapping value silently discarded its
+  content** (#325): `a: - x` — invalid YAML (test-suite case 5U3A: a block
+  sequence may not begin on the same line as its parent mapping key; `yq`
+  rejects it) — read back as `{"a":null}`, the `x` gone with no error. #332
+  had already stopped the worse failure mode of dropping the text outright,
+  keeping it as the literal scalar `{"a":"- x"}`, but that reading was still
+  wrong: per YAML 1.2 `ns-plain-first`, a `-` before whitespace is always the
+  sequence-entry indicator and never starts a plain scalar. This finishes the
+  job: `parse_mapping_entry`, `parse_explicit_value`, and `parse_value`
+  (whose existing `-`-followed-by-space arm was dead code — a comment
+  claimed "the caller already opened a BP node for us" but nothing was ever
+  written into it) now dispatch to the same `parse_sequence_item` the valid
+  multi-line spelling already used, so `a: - x` parses as the obvious
+  extension `{"a":["x"]}`, and a bare `a: -` is the empty item `{"a":[null]}`
+  rather than the string `"-"`. The sequence's indent is derived from the
+  `-`'s own column rather than a fixed offset, so a continuation line at the
+  same column joins it: `key: - a\n     - b` is `{"key":["a","b"]}`. A
+  follow-up commit found the identical gap one level deeper, in
+  `parse_compact_mapping_entry` (a sequence item's own compact-mapping value,
+  `- a: - x`), which hadn't received the dispatch and still read back as the
+  scalar `"- x"`. The opt-in strict validator's 5U3A check is widened to
+  accept end-of-input as a terminator too, so a bare `a: -` with no trailing
+  newline is now rejected like every other shape the loader accepts
+  leniently. Also reconciles the asymmetry the issue called out: the
+  parser's dash-continuation guard now shares the same `is_seq_indicator_next`
+  predicate the reader already used, rather than its own narrower
+  space/tab-only spelling. New coverage: unit tests in `src/yaml/light.rs`
+  (item shapes, continuation lines, anchors, non-regression cases for
+  `-1`/`-x`/flow `{a: -}`), `tests/yaml_validate_tests.rs`, and
+  `tests/yq_cli_tests.rs`. See `docs/compliance/yaml/limitations.md` for the
+  updated rationale — flow's `[- x]` still reads as scalar text, since unlike
+  the block case there is no sequence to build there.
+
 - **Pretty-printed JSON/YAML output silently dropped duplicate mapping keys;
   compact output was correct** (#442): `yq -o json '.'` on `a: 1\na: 2` gave
   `{"a": 2}` (last-wins) while `-I0` gave `{"a":1,"a":2}`, matching real `yq`

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -95,19 +95,35 @@ losing input. Where a construct has no valid reading, the parser absorbs it as s
 rather than discarding it — the same principle as the tag handling below.
 
 `- ` followed by content is one such case. It is always the sequence-entry indicator, and
-no block sequence can begin inside a flow collection or after a `:` on the same line, so
-`[- x]` and `key: - a` are invalid (`yq` rejects both, and so does the validator). The
-loader reads them as the plain scalar `"- x"` / `"- a"`:
+no block sequence can begin inside a flow collection, so `[- x]` is invalid (`yq` rejects
+it, and so does the validator). The loader reads it as the plain scalar `"- x"`:
 
 ```
 $ printf '[- x]\n' | succinctly yq -o json -I0 '.'
 ["- x"]                   # yq: did not find expected node content
 ```
 
-Until [#332](https://github.com/rust-works/succinctly/issues/332) these yielded `[null]`
-and `{"key":null}` — the content was silently discarded, which is a worse failure mode than
-either erroring or keeping the text. A `-` *not* followed by whitespace is an ordinary flow
-plain scalar and always was: `[-]` is `["-"]`, `[-1]` is `[-1]`.
+Until [#332](https://github.com/rust-works/succinctly/issues/332) this yielded `[null]` —
+the content was silently discarded, which is a worse failure mode than either erroring or
+keeping the text. A `-` *not* followed by whitespace is an ordinary flow plain scalar and
+always was: `[-]` is `["-"]`, `[-1]` is `[-1]`.
+
+The **block** spelling `key: - a` is equally invalid, but it does have a valid reading to
+fall back on, so [#325](https://github.com/rust-works/succinctly/issues/325) takes it
+rather than absorbing the text: the loader emits the block sequence the author plainly
+meant. Absorbing it as scalar text would keep the bytes but still misread the structure,
+and unlike the flow case there is a sequence to build here.
+
+```
+$ printf 'key: - a\n' | succinctly yq -o json -I0 '.'
+{"key":["a"]}             # yq: block sequence entries are not allowed in this context
+```
+
+A continuation line at the same column joins that sequence (`key: - a\n     - b` is
+`{"key":["a","b"]}`), and a bare `key: -` is an empty item, `{"key":[null]}` — the `-` is
+an indicator, so there is no text to preserve. This is the one place the two rules differ,
+and the split is deliberate: flow keeps text because no sequence can exist there; block
+builds the sequence because one can.
 
 ### Two exceptions: an alias with no usable target is rejected
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -9560,6 +9560,34 @@ mod tests {
     }
 
     #[test]
+    fn test_bare_dash_as_explicit_key_is_an_empty_item() {
+        // The last shape #325's acceptance criteria name, and the only one that
+        // exercises the *key* side. `? -` is a non-scalar key — a one-item
+        // sequence whose item is empty — reached through `parse_explicit_key`,
+        // which delegates to the same `parse_sequence_item` every arm this issue
+        // touched now calls. So this is the regression guard on that shared
+        // helper from the one direction the value-side tests above cannot reach.
+        //
+        // The key renders as `""` because neither succinctly nor `yq` has a JSON
+        // spelling for a non-scalar key, so both collapse it (#172); the point
+        // here is that the *entry survives at all*, which is what the sibling
+        // `- ` shapes used to lose. Expectations are mikefarah/yq v4.53.3, which
+        // agrees byte-for-byte on every case below.
+        assert_eq!(first_doc_json(b"? -\n: v\n"), r#"{"":"v"}"#);
+        // No trailing newline: the `-` is the last byte of the key's line, so
+        // `is_seq_indicator_next`'s end-of-input arm is what keeps it an
+        // indicator rather than a scalar.
+        assert_eq!(first_doc_json(b"? -\n: v"), r#"{"":"v"}"#);
+        // No value at all — the key still stands, with a null value.
+        assert_eq!(first_doc_json(b"? -\n"), r#"{"":null}"#);
+        // Bare dash on *both* sides: an empty item as the key, and the value is
+        // the `{"a":[null]}` shape from `test_inline_seq_as_mapping_value_*`.
+        assert_eq!(first_doc_json(b"? -\n: -\n"), r#"{"":[null]}"#);
+        // All three YAML 1.2 §5.4 line breaks reach the same reading.
+        assert_eq!(first_doc_json(b"? -\r\n: v\r\n"), r#"{"":"v"}"#);
+    }
+
+    #[test]
     fn test_dash_in_mapping_value_non_sequence_cases_unchanged() {
         // A `-` NOT followed by whitespace starts a plain scalar as usual.
         assert_eq!(first_doc_json(b"a: -1\n"), r#"{"a":-1}"#);

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -9595,4 +9595,37 @@ mod tests {
         // Top-level nested sequences.
         assert_eq!(first_doc_json(b"- - x\n- y\n"), r#"[["x"],"y"]"#);
     }
+
+    #[test]
+    fn test_inline_seq_as_compact_mapping_value_keeps_content() {
+        // `parse_compact_mapping_entry`'s own inline-value branch didn't get the
+        // #325 dash-sequence dispatch that its siblings (`parse_mapping_entry`,
+        // `parse_explicit_value`, `parse_value`) did, so a compact mapping's own
+        // same-line dash value fell through to `parse_inline_value` and read back
+        // as the scalar `"- x"` instead of the sequence `["x"]` — the same bug
+        // #325 fixed, one level deeper.
+        assert_eq!(first_doc_json(b"- a: - x\n"), r#"[{"a":["x"]}]"#);
+        // Bare dash is an empty item, matching the top-level case.
+        assert_eq!(first_doc_json(b"- a: -\n"), r#"[{"a":[null]}]"#);
+        // Nested inline sequence and compact mapping as the item.
+        assert_eq!(first_doc_json(b"- a: - - x\n"), r#"[{"a":[["x"]]}]"#);
+        assert_eq!(first_doc_json(b"- a: - k: v\n"), r#"[{"a":[{"k":"v"}]}]"#);
+        // A continuation line at the same column joins the same sequence.
+        assert_eq!(
+            first_doc_json(b"- a: - x\n     - y\n"),
+            r#"[{"a":["x","y"]}]"#
+        );
+        // A sibling entry in the same compact mapping still parses.
+        assert_eq!(
+            first_doc_json(b"- a: - x\n  b: 2\n"),
+            r#"[{"a":["x"],"b":2}]"#
+        );
+        // A `-` not followed by whitespace, and an alias, are unaffected.
+        assert_eq!(first_doc_json(b"- a: -1\n"), r#"[{"a":-1}]"#);
+        assert_eq!(first_doc_json(b"- a: -x\n"), r#"[{"a":"-x"}]"#);
+        assert_eq!(
+            first_doc_json(b"- b: &anc 1\n- a: *anc\n"),
+            r#"[{"b":1},{"a":1}]"#
+        );
+    }
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -9147,9 +9147,10 @@ mod tests {
         // `- ` with nothing after it inside flow: trailing space is trimmed, so the
         // extent is the dash alone
         assert_eq!(first_doc_json(b"[- ]\n"), r#"["-"]"#);
-        // Same-line block mapping value. #325 covers this input and may later make
-        // the parser emit a real sequence here; until then the text survives.
-        assert_eq!(first_doc_json(b"key: - a\n"), r#"{"key":"- a"}"#);
+        // Same-line block mapping value is NOT this rule's business any more: #325
+        // made the parser emit a real block sequence there, exactly as the note this
+        // replaces anticipated. Pinned in `test_inline_seq_as_mapping_value_*` below.
+        assert_eq!(first_doc_json(b"key: - a\n"), r#"{"key":["a"]}"#);
     }
 
     /// A same-line block mapping value that is a bare sequence-entry indicator, with
@@ -9162,11 +9163,18 @@ mod tests {
     /// becomes the empty item `{"a":[null]}`. `yq` rejects the input either way
     /// (`block sequence entries are not allowed in this context`).
     #[test]
-    fn test_bare_dash_as_same_line_mapping_value_keeps_the_dash() {
-        assert_eq!(first_doc_json(b"a: - \n"), r#"{"a":"-"}"#);
-        assert_eq!(first_doc_json(b"a: -\n"), r#"{"a":"-"}"#);
-        assert_eq!(first_doc_json(b"a: -  \n"), r#"{"a":"-"}"#);
-        assert_eq!(first_doc_json(b"a: -\t\n"), r#"{"a":"-"}"#);
+    fn test_bare_dash_as_same_line_mapping_value_is_an_empty_item() {
+        // Renamed and re-pinned by #325. #332 made these read back as the string
+        // "-" so the byte would not be lost; #325 makes the same-line mapping value
+        // a real block sequence, so the `-` is an *indicator* with an empty item
+        // after it, not content. Nothing is dropped either way — the dash was never
+        // a scalar to begin with (YAML 1.2 `ns-plain-first`) — and this now agrees
+        // with `a: - x` on the line above it instead of splitting on whether the
+        // item happens to be empty.
+        assert_eq!(first_doc_json(b"a: - \n"), r#"{"a":[null]}"#);
+        assert_eq!(first_doc_json(b"a: -\n"), r#"{"a":[null]}"#);
+        assert_eq!(first_doc_json(b"a: -  \n"), r#"{"a":[null]}"#);
+        assert_eq!(first_doc_json(b"a: -\t\n"), r#"{"a":[null]}"#);
         // The same `- ` on the *next* line is a real block sequence whose one item is
         // empty: a childless wrapper, which stays null. That is the discriminator's
         // other side, and it is why the parser must never record an end for a wrapper.
@@ -9486,5 +9494,105 @@ mod tests {
         assert_eq!(item.keys(), vec!["a".to_string(), "b".to_string()]);
         assert_eq!(item.len(), 2);
         assert!(!item.is_empty());
+    }
+    // =========================================================================
+    // Inline block sequence as a mapping value (#325)
+    // =========================================================================
+    // `a: - x` is invalid YAML (test-suite case 5U3A: a block sequence may not
+    // begin on the same line as its parent mapping key) and the opt-in strict
+    // validator rejects it. The loader does minimal validation by design, so it
+    // parses the obvious extension instead of silently discarding the content,
+    // which is what it used to do -- `a: - x` read back as `{"a":null}`.
+
+    // These reuse #332's `first_doc_json` above, which additionally asserts that the
+    // buffered and streaming JSON writers agree, rather than adding a second helper.
+
+    #[test]
+    fn test_inline_seq_as_mapping_value_keeps_content() {
+        // The #325 repro: `x` used to be silently dropped.
+        assert_eq!(first_doc_json(b"a: - x\n"), r#"{"a":["x"]}"#);
+        // Extra spaces before the `-` must not change the result.
+        assert_eq!(first_doc_json(b"a:   - x\n"), r#"{"a":["x"]}"#);
+        // A sibling entry after it still parses.
+        assert_eq!(first_doc_json(b"a: - x\nb: 1\n"), r#"{"a":["x"],"b":1}"#);
+        // No trailing newline.
+        assert_eq!(first_doc_json(b"a: - x"), r#"{"a":["x"]}"#);
+    }
+
+    #[test]
+    fn test_inline_seq_as_mapping_value_item_shapes() {
+        // Nested inline sequence.
+        assert_eq!(first_doc_json(b"a: - - x\n"), r#"{"a":[["x"]]}"#);
+        // Compact mapping as the item.
+        assert_eq!(first_doc_json(b"a: - k: v\n"), r#"{"a":[{"k":"v"}]}"#);
+        // Bare `-` is an empty item, not the scalar "-": per YAML 1.2
+        // `ns-plain-first` a `-` before whitespace or end-of-input is always the
+        // sequence-entry indicator and never starts a plain scalar.
+        assert_eq!(first_doc_json(b"a: -\n"), r#"{"a":[null]}"#);
+        assert_eq!(first_doc_json(b"a: -"), r#"{"a":[null]}"#);
+        assert_eq!(first_doc_json(b"a: -\r\n"), r#"{"a":[null]}"#);
+    }
+
+    #[test]
+    fn test_inline_seq_continuation_line_joins_same_sequence() {
+        // 5U3A. The sequence is registered at the actual column of the `-`
+        // (5 here), so the next line's `-` at the same column is a sibling item
+        // rather than a new nested sequence. Registering it at `indent + 2`
+        // would produce {"key":[["a"],["b"]]} or worse.
+        assert_eq!(
+            first_doc_json(b"key: - a\n     - b\n"),
+            r#"{"key":["a","b"]}"#
+        );
+        assert_eq!(
+            first_doc_json(b"key: - a\n     - b\n     - c\n"),
+            r#"{"key":["a","b","c"]}"#
+        );
+    }
+
+    #[test]
+    fn test_inline_seq_as_explicit_value() {
+        // `parse_value`'s dash arm used to be a no-op, so the nested item's
+        // content was dropped: `: - - x` read back as {"k":[null]}.
+        assert_eq!(first_doc_json(b"? k\n: - - x\n"), r#"{"k":[["x"]]}"#);
+        assert_eq!(first_doc_json(b"? k\n: - k2: v\n"), r#"{"k":[{"k2":"v"}]}"#);
+        // Single-level explicit value was already correct; keep it that way.
+        assert_eq!(first_doc_json(b"? k\n: - x\n"), r#"{"k":["x"]}"#);
+    }
+
+    #[test]
+    fn test_dash_in_mapping_value_non_sequence_cases_unchanged() {
+        // A `-` NOT followed by whitespace starts a plain scalar as usual.
+        assert_eq!(first_doc_json(b"a: -1\n"), r#"{"a":-1}"#);
+        assert_eq!(first_doc_json(b"a: -x\n"), r#"{"a":"-x"}"#);
+        // Quoting forces the scalar reading.
+        assert_eq!(first_doc_json(b"a: \"- x\"\n"), r#"{"a":"- x"}"#);
+        assert_eq!(first_doc_json(b"a: '- x'\n"), r#"{"a":"- x"}"#);
+        // In flow context the byte after `-` is `}`, so it stays a scalar.
+        assert_eq!(first_doc_json(b"{a: -}\n"), r#"{"a":"-"}"#);
+    }
+
+    #[test]
+    fn test_double_anchor_before_nested_dash_keeps_content() {
+        // The one shape that actually reaches `parse_value`'s dash arm. Every other
+        // caller either dispatches only on `{`/`[` or intercepts the `-` first; it
+        // takes an anchor between the two dashes to slip past, and *two* anchors at
+        // that, because `parse_value`'s prologue consumes one before dispatching.
+        // With that arm still a no-op the item's content was silently dropped.
+        assert_eq!(first_doc_json(b"- &a &b - x\n"), r#"[["x"]]"#);
+        // One anchor is intercepted upstream and never reaches the arm; pinned so a
+        // future change to the prologue cannot silently move which path handles it.
+        assert_eq!(first_doc_json(b"- &a - x\n"), r#"[["x"]]"#);
+    }
+
+    #[test]
+    fn test_valid_block_sequence_spellings_still_correct() {
+        // The two legal spellings must be unaffected by the lenient inline path.
+        assert_eq!(first_doc_json(b"a:\n  - x\n"), r#"{"a":["x"]}"#);
+        assert_eq!(first_doc_json(b"a:\n- x\n"), r#"{"a":["x"]}"#);
+        assert_eq!(first_doc_json(b"a:\n  - x\n  - y\n"), r#"{"a":["x","y"]}"#);
+        // Empty first item on its own line is still null.
+        assert_eq!(first_doc_json(b"a:\n  -\n  - y\n"), r#"{"a":[null,"y"]}"#);
+        // Top-level nested sequences.
+        assert_eq!(first_doc_json(b"- - x\n- y\n"), r#"[["x"],"y"]"#);
     }
 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1717,18 +1717,36 @@ impl<'a> Parser<'a> {
             // is the whole-corpus guard on that.
         } else {
             // Inline value (`check_unsupported` ran above)
-            if self.peek() == Some(b'*') {
-                // `parse_alias` opens and closes its own node. `- k: *a` never
-                // became an alias node at all before #372, and was swallowed
-                // into the plain scalar below.
-                self.parse_alias()?;
-            } else {
-                // Open value node
-                self.set_ib();
-                self.write_bp_open();
-                let end_pos = self.parse_inline_value(indent)?;
-                self.set_bp_text_end(end_pos);
-                self.write_bp_close();
+            match self.peek() {
+                Some(b'*') => {
+                    // `parse_alias` opens and closes its own node. `- k: *a` never
+                    // became an alias node at all before #372, and was swallowed
+                    // into the plain scalar below.
+                    self.parse_alias()?;
+                }
+                Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
+                    // Block sequence indicator inline with a compact mapping's own
+                    // value (`- a: - x`): the same invalid-but-common shape #325
+                    // fixed for a top-level mapping value, one level deeper. This
+                    // arm was missing when #325 landed, so `- a: - x` still fell
+                    // through to `parse_inline_value` below and read back as the
+                    // scalar `"- x"` instead of the sequence `["x"]` — inconsistent
+                    // with the sibling fix in `parse_mapping_entry`.
+                    //
+                    // `self.current_column()` (not `indent + 2`), matching every
+                    // other site that opens this arm, so a continuation line whose
+                    // `-` sits at the same column joins this sequence.
+                    let seq_indent = self.current_column();
+                    self.parse_sequence_item(seq_indent)?;
+                }
+                _ => {
+                    // Open value node
+                    self.set_ib();
+                    self.write_bp_open();
+                    let end_pos = self.parse_inline_value(indent)?;
+                    self.set_bp_text_end(end_pos);
+                    self.write_bp_close();
+                }
             }
         }
 

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2051,6 +2051,30 @@ impl<'a> Parser<'a> {
                     // Block scalar - handles its own BP
                     self.parse_block_scalar(indent)?;
                 }
+                Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
+                    // Block sequence indicator inline with the mapping key (`a: - x`).
+                    // This is invalid YAML (test-suite case 5U3A: a block sequence may
+                    // not begin on the same line as its parent mapping key), and the
+                    // opt-in strict validator rejects it. But the loader does minimal
+                    // validation by design, so it parses the obvious extension rather
+                    // than silently dropping the item's content. See #325.
+                    //
+                    // `parse_sequence_item` handles everything: the nesting guard, the
+                    // sequence container, the item wrapper, and the three item shapes
+                    // (`a: - - x`, `a: - k: v`, `a: - x`). No BP node has been opened
+                    // for the value yet, so it must open both itself.
+                    //
+                    // The indent is the actual column of the `-`, not `indent + 2`, so
+                    // that continuation lines whose `-` sits at the same column join
+                    // this sequence instead of opening a nested one:
+                    //
+                    // ```yaml
+                    // key: - a    # `-` at column 5 -> sequence at indent 5
+                    //      - b    # same column -> same sequence
+                    // ```
+                    let seq_indent = self.current_column();
+                    self.parse_sequence_item(seq_indent)?;
+                }
                 _ => {
                     // Scalar value - wrap in BP
                     self.set_ib();
@@ -2432,9 +2456,30 @@ impl<'a> Parser<'a> {
                 self.set_bp_text_end(self.pos);
                 self.write_bp_close();
             }
-            Some(b'-') if self.peek_at(1) == Some(b' ') || self.peek_at(1) == Some(b'\t') => {
-                // Inline sequence item - this creates a nested sequence
-                // The caller already opened a BP node for us
+            Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
+                // Inline sequence item - this creates a nested sequence.
+                //
+                // This arm used to be a no-op on the theory that "the caller already
+                // opened a BP node for us". The caller opens a *wrapper*, but nothing
+                // was ever emitted inside it, so the item's content was silently
+                // discarded and the node resolved to null (#325). Delegate instead,
+                // exactly as `parse_sequence_item_inner` does for `- - x`.
+                //
+                // Reached when a `-` gets past the callers' own dash checks, which
+                // happens once an anchor stands between the two: `- &a &b - x`.
+                // `parse_sequence_item_inner` sees `&`, not `-`, so it falls through
+                // to `parse_value`, whose anchor prologue consumes only the first
+                // anchor and leaves the cursor on the second. Rare, but real — see
+                // `test_double_anchor_before_nested_dash_keeps_content`.
+                //
+                // The guard goes through `is_seq_indicator_next`, so it accepts
+                // `\n`/`\r`/end-of-input as well as space/tab, matching the reader's
+                // seq-item predicate (`light.rs`, `index.rs`). The old hand-written
+                // space/tab-only spelling here was the asymmetry #325 called out: it
+                // let a bare trailing `-` reach the scalar arm, where the reader then
+                // classified the resulting node as an item wrapper with no child.
+                let seq_indent = self.current_column();
+                self.parse_sequence_item(seq_indent)?;
             }
             Some(b'[') => {
                 // Flow sequence

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -876,13 +876,20 @@ impl<'a> Validator<'a> {
                     // same line (5U3A `key: - a`); the sequence must be on its own
                     // lines. `key: -1` (a scalar starting with `-`) is fine, and an
                     // explicit value (`? k\n: - v`, suppressed) legitimately may.
+                    //
+                    // End-of-input counts as a terminator, so a bare `a: -` with no
+                    // trailing newline is rejected too (#325). Same `None | Some(..)`
+                    // spelling as `scan_anchor`'s structurally identical SY6V check.
                     let mut k = self.offset;
                     while matches!(self.input.get(k), Some(b' ' | b'\t')) {
                         k += 1;
                     }
                     if !suppress_nested
                         && self.input.get(k) == Some(&b'-')
-                        && matches!(self.input.get(k + 1), Some(b' ' | b'\t' | b'\n' | b'\r'))
+                        && matches!(
+                            self.input.get(k + 1),
+                            None | Some(b' ' | b'\t' | b'\n' | b'\r')
+                        )
                     {
                         return Err(self.error(YamlValidationErrorKind::TrailingContent));
                     }
@@ -1607,6 +1614,12 @@ mod tests {
     fn accepts_same_indent_sequence_value() {
         // A block sequence value may sit at its mapping key's indentation.
         assert!(validate(b"one:\n- 2\n- 3\nfour: 5\n").is_ok()); // AZ63
+                                                                 // Widening the 5U3A check to end-of-input (#325) must not swallow these:
+                                                                 // a `-` not followed by whitespace is an ordinary plain scalar.
+        assert!(validate(b"a: -1\n").is_ok());
+        assert!(validate(b"a: -1").is_ok());
+        assert!(validate(b"a: -x\n").is_ok());
+        assert!(validate(b"a:\n  - x\n").is_ok());
         assert!(validate(b"foo:\n- 42\nbar:\n  - 44\n").is_ok()); // RLU9
         assert!(validate(b"nested sequences:\n- - - []\n- - - {}\nkey1: []\nkey2: {}\n").is_ok());
     }
@@ -1878,6 +1891,9 @@ mod tests {
         )); // TD5N
         assert!(matches!(kind(b"a\nb: 1\nc\n d: 1\n"), TrailingContent)); // G7JE
         assert!(matches!(kind(b"key: - a\n     - b\n"), TrailingContent)); // 5U3A
+        assert!(matches!(kind(b"a: - x\n"), TrailingContent)); // 5U3A, single line
+        assert!(matches!(kind(b"a: -\n"), TrailingContent)); // bare `-` as value
+        assert!(matches!(kind(b"a: -"), TrailingContent)); // ...and at end of input (#325)
         assert!(matches!(
             kind(b"word1  # comment\nword2\n"),
             TrailingContent

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -156,7 +156,9 @@ fn rejects_inline_sequence_as_mapping_value() -> Result<()> {
     // 5U3A. The loader parses these leniently (#325), so strict rejection is
     // the validator's job. The bare-`-`-at-end-of-input spelling used to slip
     // through because the check required a byte after the `-`.
-    for input in ["a: - x\n", "a: -\n", "a: -"] {
+    // Also rejected one level deeper: a compact mapping entry's own value
+    // (`- a: - x`, now leniently parsed by `parse_compact_mapping_entry` too).
+    for input in ["a: - x\n", "a: -\n", "a: -", "- a: - x\n"] {
         let (_, stderr, code) = run_validate_stdin(input, &["--no-color"])?;
         assert_eq!(code, 1, "expected rejection for {input:?}: {stderr}");
     }

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -151,6 +151,24 @@ fn valid_file_exits_zero() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn rejects_inline_sequence_as_mapping_value() -> Result<()> {
+    // 5U3A. The loader parses these leniently (#325), so strict rejection is
+    // the validator's job. The bare-`-`-at-end-of-input spelling used to slip
+    // through because the check required a byte after the `-`.
+    for input in ["a: - x\n", "a: -\n", "a: -"] {
+        let (_, stderr, code) = run_validate_stdin(input, &["--no-color"])?;
+        assert_eq!(code, 1, "expected rejection for {input:?}: {stderr}");
+    }
+
+    // A `-` not followed by whitespace is an ordinary scalar and stays valid.
+    for input in ["a: -1\n", "a: -1", "a:\n  - x\n"] {
+        let (_, stderr, code) = run_validate_stdin(input, &["--no-color"])?;
+        assert_eq!(code, 0, "expected acceptance for {input:?}: {stderr}");
+    }
+    Ok(())
+}
+
 // ============================================================================
 // `syq --validate` (the yq runner's opt-in validation flag).
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2950,6 +2950,18 @@ fn test_bare_dash_as_mapping_value_is_an_empty_item() -> Result<()> {
 }
 
 #[test]
+fn test_inline_sequence_as_compact_mapping_value_is_not_dropped() -> Result<()> {
+    // `- a: - x` is the same shape #325 fixed for `a: - x`, one level deeper: a
+    // compact mapping entry (inside a sequence item) whose own value is an
+    // inline dash sequence. `parse_compact_mapping_entry` didn't get the dash
+    // dispatch when #325 landed, so this fell through to the scalar `"- x"`.
+    let (output, exit_code) = run_yq_stdin(".", "- a: - x\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":["x"]}]"#);
+    Ok(())
+}
+
+#[test]
 fn test_flow_dash_without_whitespace_is_still_a_scalar() -> Result<()> {
     // A `-` not followed by whitespace is a legitimate plain scalar in flow
     // context and was never affected; pinned so #332's fix cannot regress it.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2911,6 +2911,44 @@ fn test_flow_dash_space_scalar_content_is_not_dropped() -> Result<()> {
     Ok(())
 }
 
+// ============================================================================
+// Inline block sequence as a mapping value (#325)
+// ============================================================================
+// `a: - x` is invalid YAML (test-suite case 5U3A) and `yq` rejects it. The
+// loader does minimal validation by design, so rather than silently dropping
+// the item -- which is what it used to do, yielding `{"a":null}` -- it parses
+// the obvious extension. Strict rejection stays available via `yaml validate`.
+
+#[test]
+fn test_inline_sequence_as_mapping_value_is_not_dropped() -> Result<()> {
+    let (output, exit_code) = run_yq_stdin(".", "a: - x\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":["x"]}"#);
+    Ok(())
+}
+
+#[test]
+fn test_inline_sequence_continuation_line_joins_same_sequence() -> Result<()> {
+    // 5U3A itself: both items belong to one sequence, keyed off the column of
+    // the `-` rather than a fixed indent.
+    let (output, exit_code) = run_yq_stdin(".", "key: - a\n     - b\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"key":["a","b"]}"#);
+    Ok(())
+}
+
+#[test]
+fn test_bare_dash_as_mapping_value_is_an_empty_item() -> Result<()> {
+    // Per YAML 1.2 `ns-plain-first`, `-` before whitespace or end-of-input is
+    // always the sequence-entry indicator, so this is `[null]`, not `"-"`.
+    for input in ["a: -\n", "a: -"] {
+        let (output, exit_code) = run_yq_stdin(".", input, &["-o", "json", "-I0"])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.trim(), r#"{"a":[null]}"#, "input: {input:?}");
+    }
+    Ok(())
+}
+
 #[test]
 fn test_flow_dash_without_whitespace_is_still_a_scalar() -> Result<()> {
     // A `-` not followed by whitespace is a legitimate plain scalar in flow
@@ -3218,5 +3256,21 @@ fn test_navigation_queries_keep_whole_float_decimal_point_yaml() -> Result<()> {
     let (out, code) = run_yq_stdin(".x", "x: 1.0\n", &["-o=yaml", "-I=0"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "1.0");
+    Ok(())
+}
+
+#[test]
+fn test_dash_not_followed_by_space_is_still_a_scalar() -> Result<()> {
+    // Guard against over-matching: negative numbers and `-`-prefixed plain
+    // scalars must not be reinterpreted as sequences.
+    for (input, want) in [
+        ("a: -1\n", r#"{"a":-1}"#),
+        ("a: -x\n", r#"{"a":"-x"}"#),
+        ("{a: -}\n", r#"{"a":"-"}"#),
+    ] {
+        let (output, exit_code) = run_yq_stdin(".", input, &["-o", "json", "-I0"])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.trim(), want, "input: {input:?}");
+    }
     Ok(())
 }


### PR DESCRIPTION
## Description

`a: - x` — a block sequence opened on the same line as its mapping key — silently
discarded the item's content, loading as `{"a":null}` instead of `{"a":["x"]}`.
The `x` was gone with no error and well-formed JSON out.

The input is invalid YAML (test-suite case **5U3A**: a block sequence may not begin
on the same line as its parent mapping key) and `yq` rejects it. But the loader does
minimal validation by design, and silently losing data is a worse failure mode than
either erroring or parsing the obvious extension — so this takes option 2 from the
issue's decision list and builds the sequence the author plainly meant. Strict
rejection stays available via the opt-in `succinctly yaml validate`.

Closes #325.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## What actually changed

Three arms in `src/yaml/parser.rs`, each dispatching a same-line `-` to the existing
`parse_sequence_item` rather than to a scalar read:

| function | shape it fixes | before |
|---|---|---|
| `parse_mapping_entry` | `a: - x` | `{"a":null}` |
| `parse_value` | `- &a &b - x` (dead arm, see below) | content dropped |
| `parse_compact_mapping_entry` | `- a: - x` | `[{"a":"- x"}]` |

`parse_value`'s arm already existed but was a **no-op**, on the stated theory that
"the caller already opened a BP node for us" — the caller opens a *wrapper*, but
nothing was ever emitted into it, so the node resolved to null. It is reachable only
when an anchor stands between two dashes (`- &a &b - x`), which is why it went
unnoticed; pinned by `test_double_anchor_before_nested_dash_keeps_content`.

**`parse_explicit_key` and `parse_explicit_value` are not modified.** The explicit
forms (`? k` / `: - x`) are fixed *transitively*, because `parse_explicit_value`
delegates to `parse_value`, which is where the dead arm was. Covered by
`test_inline_seq_as_explicit_value`.

Two details worth a reviewer's attention:

- **Indent comes from the dash's own column**, via `current_column()`, not `indent + 2`.
  That is what makes a continuation line at the same column join the sequence
  (`key: - a` / `     - b` -> `{"key":["a","b"]}`) instead of nesting.
- **The guard is the shared `is_seq_indicator_next`**, not a hand-rolled match. This
  reconciles the asymmetry #325 called out: the parser's old space/tab-only spelling
  disagreed with the reader's wider predicate (which also accepts `\n`/`\r`/EOI), and
  that gap is what let a bare trailing `-` reach the scalar arm. One definition now,
  per the #106/#332 lesson.

### Validator (`src/yaml/validate.rs`)

The 5U3A check now accepts end-of-input as a sequence terminator (`None | Some(..)`,
matching `scan_anchor`'s structurally identical SY6V check), so a bare `a: -` with no
trailing newline is rejected like every other shape the loader now accepts leniently.

### Behaviour changes

| input | before | after | `yq` |
|---|---|---|---|
| `a: - x` | `{"a":null}` | `{"a":["x"]}` | rejects |
| `a: -` | `{"a":"-"}` | `{"a":[null]}` | rejects |
| `- a: - x` | `[{"a":"- x"}]` | `[{"a":["x"]}]` | rejects |
| `key: - a` / `     - b` | — | `{"key":["a","b"]}` | rejects |

`a: -` moving from `"-"` to `[null]` is deliberate: per YAML 1.2 `ns-plain-first`, a
`-` before whitespace or end-of-input is always the sequence-entry indicator and never
starts a plain scalar, so there was never a scalar there to preserve. This supersedes
#332's interim reading for the *block* case; flow (`[- x]`) still keeps its text,
because unlike block there is no sequence to build there.
`test_bare_dash_as_same_line_mapping_value_keeps_the_dash` is renamed and re-pinned
accordingly.

## Unaffected (regression-guarded)

`a: -1`, `a: -x`, quoted `a: "- x"`, flow `{a: -}`, and both valid block spellings
(`a:\n  - x`, `a:\n- x`).

## Tests

- **`src/yaml/light.rs`** — 8 new unit tests: content preservation, item shapes
  (nested / compact-mapping / bare), continuation lines, explicit value, the
  double-anchor path, compact-mapping values, non-sequence cases, and valid-spelling
  regression. Plus `test_bare_dash_as_explicit_key_is_an_empty_item` covering `? -`,
  the one acceptance-criteria shape that exercises the *key* side.
- **`tests/yq_cli_tests.rs`** — 5 CLI regression tests.
- **`tests/yaml_validate_tests.rs`** — `rejects_inline_sequence_as_mapping_value`,
  asserting the loader and validator now agree on which shapes are lenient vs rejected.
- **`src/yaml/validate.rs`** — acceptance cases for `-1`/`-x` so the widened check
  cannot over-match.

All expectations verified against mikefarah/yq v4.53.3.

## Verification

- Full suite: **2820 passed, 0 failed**
- `cargo fmt --check` clean; clippy clean on `--all-features` **and** the
  `std,simd,...` set (the `scalar-yaml` blind spot)
- YAML Test Suite conformance **unchanged**: 218/279 load · 70/94 reject · 27/29 parse,
  87 known failures
- yq golden 47/47, including CRLF and lone-CR
- All 24 CI checks green

## Docs

`docs/compliance/yaml/limitations.md` rewritten for the block/flow split (why block
builds the sequence and flow keeps the text), and a CHANGELOG entry under Fixed.

## Follow-ups found while reviewing, filed separately

- **#484** — a plain scalar continuation line starting with `- ` becomes a nested
  sequence at indent >= 2. *Valid* input, silently wrong; test-suite case AB8U passes
  only because it uses indent 1. Pre-existing, unrelated to this PR.
- **#485** — an out-dented sequence continuation drops the rest of the sequence and
  corrupts the next entry into an empty key. Also pre-existing.

Both verified byte-identical on `origin/main` before this branch, so neither is a
regression from these changes.
