### PR TITLE
fix(yaml): treat all YAML 1.2 line breaks identically — LF, CRLF, and lone CR

### DIFF
--- a/.claude/skills/yaml-semi-indexing/SKILL.md
+++ b/.claude/skills/yaml-semi-indexing/SKILL.md
@@ -119,6 +119,44 @@ close_deeper_indents(indent);  // Close first
 let need_new = type_stack.last() != expected;  // Then check
 ```
 
+### Never Test for `b'\n'` by Hand
+
+YAML 1.2 §5.4 has three line breaks — `\n`, `\r\n`, and a lone `\r` — and §5.7
+requires normalizing all of them to `\n`. A raw `\r` is never scalar content, so
+a scan that stops only at `\n` is a bug in two distinct ways (#324):
+
+- **CRLF**: the scan still stops on the right *line*, so nothing looks broken — it
+  just leaves the `\r` inside the preceding token's extent. The plain-scalar
+  folding decoder then turns that trailing break into a space, and `a: 1` resolves
+  as the string `"1 "` instead of the number `1`. Silent and well-formed.
+- **Lone CR**: there is no `\n` to stop on, so the scan runs to EOF and swallows
+  the rest of the document.
+
+Use the helpers instead of hand-rolling the test:
+
+```rust
+// src/yaml/parser.rs — the oracle
+Self::is_break(b)          // \n or \r
+self.break_len_at(pos)     // 2 for \r\n, 1 for a lone \r or \n, 0 otherwise
+self.at_break()
+self.skip_line_break()     // consumes exactly one break, whatever its width
+
+// src/yaml/light.rs — the query side
+is_line_break(b)
+line_break_len(text, pos)
+```
+
+Two extra traps:
+
+- **Trailing-whitespace trims** must include `\r`, not just `' '` and `'\t'` — the
+  SIMD classifier can skip a CR to land on the LF after it.
+- **SIMD scans** need `\r` in their terminator set (`YamlCharClass::carriage_returns`,
+  `find_block_scalar_end`), or a 32-byte chunk steps straight over a lone CR.
+
+`tests/yaml_crlf_tests.rs` is the guard: it parses the whole YAML Test Suite
+corpus under all three break forms and demands identical output. Run it after any
+change to a line-scanning loop.
+
 ## Test Suite Notes
 
 The YAML test suite (`tests/yaml_test_suite.rs`) is generated from the official YAML test suite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CRLF and lone-CR line breaks in YAML** (#324): a `\r` was folded into every
+  *plain* scalar as a trailing space, which also destroyed type resolution — a
+  Windows-authored `a: 1` loaded as the string `"1 "` rather than the number `1`,
+  and `a: true` as `"true "`. There was no error and no warning, and the output
+  was well-formed JSON, so nothing downstream could detect it. Quoted scalars and
+  LF input were unaffected, which is why the whole suite missed it: every fixture
+  and benchmark input in the repo uses LF. The fix treats `\r\n` and a lone `\r`
+  as line breaks throughout — plain scalar and key extents, document markers,
+  blank lines, comment termination, block-scalar content and chomping, `raw_bytes`,
+  and the strict validator — per YAML 1.2 §5.4. `succinctly yq` now produces
+  byte-identical output for a document whichever of the three break forms it uses.
+  Correctness here has a measured price on LF input: `yaml_bench` index build is
+  +14.9% median on x86 (7950X) and +6.9% on ARM (M4 Pro) excluding block scalars,
+  which are 8–18% *faster* on x86; end-to-end `yq` on a 1 MB document moves
+  +1.8% (`.`) to +6.4% (`.[].name`). See `docs/parsing/yaml.md` for the
+  per-change attribution and the const-generic option that would buy it back.
 - `jq -R -s` now yields the entire input as a single string instead of an array of per-line strings, matching jq (#176)
 - `yq -R -s` now yields the entire input as a single string instead of an array of per-line strings, matching jq and `jq -R -s` (#271)
 - YAML alias cycles (`a: &anchor {self: *anchor}`) are rejected at index build with the

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -129,6 +129,25 @@ $ printf '%%YAML 1.2\n--- text\n' | succinctly yq '.'
 
 Tracked in [#225](https://github.com/rust-works/succinctly/issues/225).
 
+## Line breaks — resolved
+
+All three YAML 1.2 §5.4 line-break forms — LF (`\n`), CRLF (`\r\n`) and a lone CR
+(`\r`) — are normalized to `\n` on input, so the same document loads identically
+whichever one it uses.
+
+This was not always so. Until [#324](https://github.com/rust-works/succinctly/issues/324)
+the `\r` was folded into every *plain* scalar as a trailing space, which also
+destroyed type resolution: a Windows-authored `a: 1` loaded as the string `"1 "`
+rather than the number `1`, and `a: true` as `"true "`. It was silent — no error,
+no diagnostic, and well-formed JSON out — and it went unnoticed because every
+fixture and benchmark input in this repo uses LF.
+
+`tests/yaml_crlf_tests.rs` now holds the line against it: every case in the YAML
+Test Suite corpus is parsed under all three break forms and the outputs must be
+identical, and `tests/yq_golden_tests.rs` runs the pinned-`yq` goldens the same
+way. Both assertions are on invariance, so a document's line-break form can never
+again change what it loads as.
+
 ## Two output paths that used to disagree — resolved
 
 `succinctly yq` has two YAML-to-JSON implementations and picks between them based on

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -185,6 +185,83 @@ Unlike JSON where each structural character has unambiguous meaning, YAML charac
 
 **Resolution**: Oracle tracks block scalar state and flow depth.
 
+### 9. Line Breaks `\n` `\r\n` `\r`
+
+YAML 1.2 §5.4 makes all three a line break, and §5.7 requires a processor to
+normalize them to `\n` on input. There is *no* context in which a raw `\r` is
+scalar content, so every scan that stops at `\n` must stop at `\r` too.
+
+| Form   | Width   | Note                                                      |
+|--------|---------|-----------------------------------------------------------|
+| `\n`   | 1 byte  | Unix                                                       |
+| `\r\n` | 2 bytes | Windows — **one** break, so a scan must consume both       |
+| `\r`   | 1 byte  | Classic Mac — a break with no LF to backstop a `\n`-only scan |
+
+**Resolution**: `Parser::{is_break, break_len_at, at_break, skip_line_break}` are
+the single source of truth in the oracle; `light.rs` has the free-function pair
+`is_line_break` / `line_break_len` for the query side. Use them rather than
+testing `b'\n'` by hand.
+
+Two failure modes are worth naming, because [#324](https://github.com/rust-works/succinctly/issues/324)
+hit both:
+
+- **A CRLF costs one byte of token extent.** A `\n`-only scan still stops on the
+  right *line*, so nothing looks broken — it just leaves the `\r` inside the
+  preceding token. In a plain scalar the folding decoder then turns that trailing
+  break into a space, and `a: 1` resolves as the string `"1 "` instead of the
+  number `1`. Silent, well-formed, wrong.
+- **A lone CR costs the rest of the document.** With no `\n` to stop on, a
+  `\n`-only scan runs to EOF. This is why `\r` belongs in the SIMD classifier's
+  terminator set (`YamlCharClass::carriage_returns`, consumed by
+  `skip_unquoted_simd`) and in `find_block_scalar_end`'s line-start scan: without
+  it the 32-byte classifier skips straight over the break.
+
+`tests/yaml_crlf_tests.rs` parses the whole YAML Test Suite corpus under all
+three forms and demands identical output, which is what makes this property
+test-enforced rather than aspirational.
+
+#### What correctness here costs
+
+Making every line scan CR-aware is not free, and the cost was measured rather
+than assumed. Interleaved A/B (3 reps, arms alternating per rep), `yaml_bench`,
+`c5dab403` vs. the #324 fix:
+
+| Machine                | median | excl. block scalars | block scalars      |
+|------------------------|--------|---------------------|--------------------|
+| AMD Ryzen 9 7950X      | +10.3% | +14.9%              | **−8% to −18%**    |
+| Apple M4 Pro           |  +5.0% |  +6.9%              | −7% to +2%         |
+
+End-to-end `succinctly yq` on a generated 1 MB document (7950X) moves far less,
+because index build is only part of the pipeline: `.` +1.8%, `.[0]` +5.2%,
+`.[].name` +6.4%.
+
+Block scalars got materially *faster* on x86 — `consume_block_scalar_content`
+and `parse_block_scalar` lost their hand-rolled `\r`/`\n` ladders in favour of
+`skip_to_eol` + `skip_line_break`.
+
+Per-change attribution on x86 (revert one change, re-measure):
+
+| Change                                   | Cost   | Needed for |
+|------------------------------------------|--------|------------|
+| SIMD classifier CR mask                  | ~2 pp  | lone CR only |
+| `looks_like_mapping_entry` CR arm        | ~3 pp  | lone CR only |
+| `parse_unquoted_value_…` CR arm          | ~2 pp  | **CRLF**   |
+| `skip_to_eol` → `is_break`               | ~1 pp  | **CRLF**   |
+| remainder (~7 pp)                        | diffuse | codegen in the large, heavily-inlined scalar path |
+
+The individual reverts do not sum to the total, which is the signal that most of
+it is codegen perturbation rather than any single added compare. Note the second
+row in particular: dropping lone-CR support would recover only ~5 pp of ~15 pp,
+because the per-byte CR arms in the value scanner are load-bearing for **CRLF**
+too — a blank line between mapping entries makes `a: 1\r\n\r\nb: 2\r\n` resolve
+as `{"a": "1\n", …}` without them. "CRLF is nearly free, only lone CR costs" is
+an appealing theory that the differential harness disproves in 8 corpus cases.
+
+Recovering the rest would mean gating the parser on a `has_cr` flag via a const
+generic, so LF documents keep the original codegen exactly. That buys back the
+diffuse cost at the price of one input scan (~2%), a doubled parser
+monomorphization, and CR-conditioning roughly 25 call sites.
+
 ---
 
 ## Additional Index Storage Required

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -7722,4 +7722,263 @@ mod tests {
             }
         }
     }
+
+    // ========================================================================
+    // Line-break helpers and the alternate-parse-path scanners (#324)
+    //
+    // The `#[allow(dead_code)]` STYLE-0005 helpers below are not on the current
+    // parse path, so no integration test can reach them. They were still made
+    // CR-aware, because a helper that silently keeps LF-only semantics is a
+    // trap for whoever re-enables it. These tests pin that behaviour directly
+    // so it cannot rot unnoticed.
+    // ========================================================================
+
+    #[test]
+    fn line_break_len_measures_each_break_form() {
+        assert_eq!(
+            line_break_len(b"a\r\nb", 1),
+            2,
+            "CRLF is one two-byte break"
+        );
+        assert_eq!(line_break_len(b"a\rb", 1), 1, "lone CR");
+        assert_eq!(line_break_len(b"a\nb", 1), 1, "LF");
+        // A CR at end of input has no LF to pair with.
+        assert_eq!(line_break_len(b"a\r", 1), 1);
+        // Not at a break, and past the end, both measure zero.
+        assert_eq!(line_break_len(b"ab", 0), 0);
+        assert_eq!(line_break_len(b"a\n", 9), 0);
+        assert_eq!(line_break_len(b"", 0), 0);
+    }
+
+    #[test]
+    fn line_break_len_before_measures_backwards() {
+        // b"a\r\nb\rc\nd"
+        //   0 1 2 3 4 5 6 7
+        let text = b"a\r\nb\rc\nd";
+        assert_eq!(line_break_len_before(text, 3), 2, "CRLF ends before `b`");
+        assert_eq!(line_break_len_before(text, 2), 1, "just the CR of a CRLF");
+        assert_eq!(line_break_len_before(text, 5), 1, "lone CR ends before `c`");
+        assert_eq!(line_break_len_before(text, 7), 1, "LF ends before `d`");
+        assert_eq!(line_break_len_before(text, 1), 0, "`a` is not a break");
+        assert_eq!(
+            line_break_len_before(text, 0),
+            0,
+            "nothing before the start"
+        );
+        assert_eq!(line_break_len_before(b"", 0), 0);
+        // A bare LF at index 0 is a one-byte break with no CR in front of it.
+        assert_eq!(line_break_len_before(b"\nx", 1), 1);
+    }
+
+    #[test]
+    fn is_line_break_accepts_both_break_bytes() {
+        assert!(is_line_break(b'\n'));
+        assert!(is_line_break(b'\r'));
+        for b in [b' ', b'\t', b'a', 0x0b, 0x0c] {
+            assert!(!is_line_break(b), "{b:#04x} is not a YAML line break");
+        }
+    }
+
+    /// Build an index and hand back the root cursor, for the private scanners
+    /// below that need a `YamlCursor` but not a particular node.
+    fn cursor_over(yaml: &[u8]) -> (YamlIndex<Vec<u64>>, &[u8]) {
+        (YamlIndex::build(yaml).expect("parses"), yaml)
+    }
+
+    #[test]
+    fn find_plain_scalar_end_stops_at_every_break_form() {
+        // `value` starts at offset 3 in each spelling; the scan must end at 8,
+        // never carrying the break into the scalar.
+        for yaml in [
+            b"a: value\nb: 2\n".as_slice(),
+            b"a: value\r\nb: 2\r\n".as_slice(),
+            b"a: value\rb: 2\r".as_slice(),
+        ] {
+            let (index, text) = cursor_over(yaml);
+            let root = index.root(text);
+            assert_eq!(
+                root.find_plain_scalar_end(3, 0, false),
+                8,
+                "input {:?}",
+                String::from_utf8_lossy(yaml)
+            );
+        }
+    }
+
+    #[test]
+    fn find_plain_scalar_end_folds_continuation_lines() {
+        // A more-indented next line continues the scalar under every spelling.
+        for yaml in [
+            b"a: one\n  two\n".as_slice(),
+            b"a: one\r\n  two\r\n".as_slice(),
+            b"a: one\r  two\r".as_slice(),
+        ] {
+            let (index, text) = cursor_over(yaml);
+            let root = index.root(text);
+            let end = root.find_plain_scalar_end(3, 0, false);
+            let scanned = &text[3..end];
+            assert!(
+                scanned.ends_with(b"two"),
+                "input {:?} scanned {:?}",
+                String::from_utf8_lossy(yaml),
+                String::from_utf8_lossy(scanned)
+            );
+        }
+    }
+
+    #[test]
+    fn find_plain_scalar_end_keeps_a_colon_that_is_not_a_separator() {
+        // `12:30` and `http://` hold colons the scan must walk past — only a
+        // colon followed by whitespace or a break ends the scalar.
+        for yaml in [
+            b"a: at 12:30 sharp\nb: 2\n".as_slice(),
+            b"a: at 12:30 sharp\r\nb: 2\r\n".as_slice(),
+            b"a: at 12:30 sharp\rb: 2\r".as_slice(),
+        ] {
+            let (index, text) = cursor_over(yaml);
+            let root = index.root(text);
+            let end = root.find_plain_scalar_end(3, 0, false);
+            assert_eq!(
+                &text[3..end],
+                b"at 12:30 sharp",
+                "input {:?}",
+                String::from_utf8_lossy(yaml)
+            );
+        }
+    }
+
+    #[test]
+    fn compute_base_indent_and_root_flag_finds_the_line_start() {
+        // Second line's value sits at indent 2 and is not document root. The
+        // walk back to the line start has to recognise the preceding break.
+        for yaml in [
+            b"top:\n  key: value\n".as_slice(),
+            b"top:\r\n  key: value\r\n".as_slice(),
+            b"top:\r  key: value\r".as_slice(),
+        ] {
+            let (index, text) = cursor_over(yaml);
+            let root = index.root(text);
+            let value_pos = text
+                .windows(5)
+                .position(|w| w == b"value")
+                .expect("input holds `value`");
+            let (indent, is_root) = root.compute_base_indent_and_root_flag(value_pos);
+            assert_eq!(
+                (indent, is_root),
+                (2, false),
+                "input {:?}",
+                String::from_utf8_lossy(yaml)
+            );
+        }
+    }
+
+    /// The line scan also recognises an explicit-key indicator (`? `), whose
+    /// terminator set includes both break bytes.
+    #[test]
+    fn compute_base_indent_and_root_flag_sees_an_explicit_key_indicator() {
+        for yaml in [
+            b"? key\n: value\n".as_slice(),
+            b"? key\r\n: value\r\n".as_slice(),
+            b"? key\r: value\r".as_slice(),
+        ] {
+            let (index, text) = cursor_over(yaml);
+            let root = index.root(text);
+            let key_pos = text
+                .windows(3)
+                .position(|w| w == b"key")
+                .expect("input holds `key`");
+            // Reached at all is the point: the `?` branch is on this path only
+            // when the indicator is followed by whitespace or a break.
+            let (indent, _) = root.compute_base_indent_and_root_flag(key_pos);
+            assert_eq!(indent, 0, "input {:?}", String::from_utf8_lossy(yaml));
+        }
+    }
+
+    #[test]
+    fn compute_base_indent_and_root_flag_looks_back_for_a_document_marker() {
+        // A value alone on its line sends the scan back over the *previous*
+        // line to look for `---`. That walk-back is a second line-start scan,
+        // and a lone CR hides the boundary from an LF-only one.
+        for (yaml, expect_root) in [
+            (b"---\nplain\n".as_slice(), true),
+            (b"---\r\nplain\r\n".as_slice(), true),
+            (b"---\rplain\r".as_slice(), true),
+            // No marker on the previous line: not document root.
+            (b"key:\nplain\n".as_slice(), false),
+            (b"key:\r\nplain\r\n".as_slice(), false),
+            (b"key:\rplain\r".as_slice(), false),
+        ] {
+            let (index, text) = cursor_over(yaml);
+            let root = index.root(text);
+            let value_pos = text
+                .windows(5)
+                .position(|w| w == b"plain")
+                .expect("input holds `plain`");
+            let (_, is_root) = root.compute_base_indent_and_root_flag(value_pos);
+            assert_eq!(
+                is_root,
+                expect_root,
+                "input {:?}",
+                String::from_utf8_lossy(yaml)
+            );
+        }
+    }
+
+    #[test]
+    fn is_in_flow_context_rewinds_to_a_line_start_past_4kb() {
+        // Past 4 KB into the document the scan no longer starts at byte 0: it
+        // rewinds ~4 KB and then back to the enclosing line start, so it never
+        // begins mid-line. That rewind is its own line-start walk, and a lone
+        // CR hides the boundary from an LF-only one.
+        //
+        // The scan window is deliberately bounded, so the opener has to sit
+        // *inside* the last 4 KB for the answer to be `true` — this pads before
+        // the opener, not after it.
+        for (nl, form) in [("\n", "LF"), ("\r\n", "CRLF"), ("\r", "CR")] {
+            let mut yaml = String::new();
+            for i in 0..400 {
+                yaml.push_str(&alloc::format!("pad{i}: value{nl}"));
+            }
+            let opener = yaml.len();
+            yaml.push_str(&alloc::format!("opener: [1,{nl}  last]{nl}"));
+            let bytes = yaml.as_bytes();
+            assert!(
+                opener > 4096,
+                "{form}: opener must sit past the 4 KB rewind"
+            );
+
+            let index = YamlIndex::build(bytes).expect("parses");
+            let root = index.root(bytes);
+            let inside = yaml.rfind("last").expect("holds `last`");
+            assert!(
+                root.is_in_flow_context(inside),
+                "{form}: `last` is inside the flow sequence opened on the line before"
+            );
+            assert!(
+                !root.is_in_flow_context(opener),
+                "{form}: the opener line's own start is not yet inside the flow"
+            );
+        }
+    }
+
+    #[test]
+    fn is_in_flow_context_sees_an_opener_on_an_earlier_line() {
+        // The scan walks back over line starts; with an LF-only walk a lone CR
+        // hides the line boundary and the answer flips.
+        for yaml in [
+            b"a: [1,\n  2]\n".as_slice(),
+            b"a: [1,\r\n  2]\r\n".as_slice(),
+            b"a: [1,\r  2]\r",
+        ] {
+            let (index, text) = cursor_over(yaml);
+            let root = index.root(text);
+            let inside = text.iter().position(|&b| b == b'2').expect("holds `2`");
+            assert!(
+                root.is_in_flow_context(inside),
+                "input {:?}",
+                String::from_utf8_lossy(yaml)
+            );
+            assert!(!root.is_in_flow_context(0), "column 0 is outside any flow");
+        }
+    }
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -65,6 +65,21 @@ fn line_break_len(text: &[u8], pos: usize) -> usize {
     }
 }
 
+/// Width in bytes of the line break ending immediately *before* `pos`: 2 for
+/// `\r\n`, 1 for a lone `\r` or `\n`, 0 if `pos` is not preceded by one.
+///
+/// The mirror of [`line_break_len`], for backwards scans. Stepping back a fixed
+/// one byte lands in the middle of a CRLF, which leaves the `\r` attached to the
+/// previous line's text (#324).
+#[inline]
+fn line_break_len_before(text: &[u8], pos: usize) -> usize {
+    match pos.checked_sub(1).and_then(|i| text.get(i)) {
+        Some(b'\n') if pos >= 2 && text[pos - 2] == b'\r' => 2,
+        Some(b'\n' | b'\r') => 1,
+        _ => 0,
+    }
+}
+
 impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// Create a new cursor at the given BP position.
     #[inline]
@@ -570,14 +585,21 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 return (0, true);
             }
 
-            // Go to previous line
-            let mut prev_line_start = line_start - 1;
+            // Step back over the break that ended the previous line — the whole
+            // break, not one byte. Stepping back a fixed 1 landed on the `\n`
+            // of a CRLF, so the walk below stopped dead on its `\r` and the
+            // previous line came out as `---\r`, which never matched the
+            // document marker (#324).
+            let prev_line_end = line_start - line_break_len_before(self.text, line_start).max(1);
+
+            // Go to the start of that line
+            let mut prev_line_start = prev_line_end;
             while prev_line_start > 0 && !is_line_break(self.text[prev_line_start - 1]) {
                 prev_line_start -= 1;
             }
 
             // Check if previous line is "---" (document start marker)
-            let prev_line = &self.text[prev_line_start..line_start.saturating_sub(1)];
+            let prev_line = &self.text[prev_line_start..prev_line_end];
             let trimmed = prev_line
                 .iter()
                 .copied()
@@ -736,7 +758,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             // Find end of current line content
             while end < self.text.len() {
                 match self.text[end] {
-                    b'\n' => break,
+                    b'\n' | b'\r' => break,
                     b'#' => {
                         // # preceded by whitespace (space or tab) is a comment
                         if end > start && matches!(self.text[end - 1], b' ' | b'\t') {
@@ -760,21 +782,22 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 }
             }
 
-            // Trim trailing whitespace (spaces and tabs) from current line
+            // Trim trailing whitespace (spaces, tabs, and a CR that a SIMD skip
+            // may have carried past) from current line
             let mut line_end = end;
-            while line_end > start && matches!(self.text[line_end - 1], b' ' | b'\t') {
+            while line_end > start && matches!(self.text[line_end - 1], b' ' | b'\t' | b'\r') {
                 line_end -= 1;
             }
 
             // Check if there's a continuation line
-            if end >= self.text.len() || self.text[end] != b'\n' {
-                // No newline, end of text or hit delimiter
+            if end >= self.text.len() || !is_line_break(self.text[end]) {
+                // No line break, end of text or hit delimiter
                 return line_end;
             }
 
             // Look ahead to see if next line is a continuation
             let newline_pos = end;
-            end += 1; // Skip newline
+            end += line_break_len(self.text, end); // Skip the line break
 
             // Skip empty lines (they can be part of multiline scalar)
             let mut empty_lines_end = end;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -44,6 +44,27 @@ impl<W> Clone for YamlCursor<'_, W> {
 
 impl<W> Copy for YamlCursor<'_, W> {}
 
+/// Is `b` a YAML line break? Per YAML 1.2 §5.4 that is `\n` or `\r`; `\r\n` is
+/// the two-byte spelling of a single break.
+///
+/// Scans that look only for `\n` run straight past a lone `\r`, which is how a
+/// classic-Mac document turned every block scalar into the empty string (#324).
+#[inline]
+fn is_line_break(b: u8) -> bool {
+    matches!(b, b'\n' | b'\r')
+}
+
+/// Width in bytes of the line break at `pos`: 2 for `\r\n`, 1 for a lone `\r`
+/// or `\n`, 0 if `pos` is not at a break.
+#[inline]
+fn line_break_len(text: &[u8], pos: usize) -> usize {
+    match text.get(pos) {
+        Some(b'\r') if text.get(pos + 1) == Some(&b'\n') => 2,
+        Some(b'\r' | b'\n') => 1,
+        _ => 0,
+    }
+}
+
 impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// Create a new cursor at the given BP position.
     #[inline]
@@ -386,7 +407,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     fn compute_line_indent_static(text: &[u8], pos: usize) -> usize {
         // Find start of line
         let mut line_start = pos;
-        while line_start > 0 && text[line_start - 1] != b'\n' {
+        while line_start > 0 && !is_line_break(text[line_start - 1]) {
             line_start -= 1;
         }
 
@@ -404,7 +425,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     fn compute_scalar_base_indent(&self, value_pos: usize) -> usize {
         // Find start of current line
         let mut line_start = value_pos;
-        while line_start > 0 && self.text[line_start - 1] != b'\n' {
+        while line_start > 0 && !is_line_break(self.text[line_start - 1]) {
             line_start -= 1;
         }
 
@@ -422,7 +443,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     fn compute_base_indent_and_root_flag(&self, value_pos: usize) -> (usize, bool) {
         // Find start of current line
         let mut line_start = value_pos;
-        while line_start > 0 && self.text[line_start - 1] != b'\n' {
+        while line_start > 0 && !is_line_break(self.text[line_start - 1]) {
             line_start -= 1;
         }
 
@@ -447,7 +468,8 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             }
             if self.text[scan] == b':' {
                 // Check if this colon is a key separator (followed by space/tab/newline)
-                if scan + 1 < self.text.len() && matches!(self.text[scan + 1], b' ' | b'\t' | b'\n')
+                if scan + 1 < self.text.len()
+                    && matches!(self.text[scan + 1], b' ' | b'\t' | b'\n' | b'\r')
                 {
                     // Check if this is an explicit value indicator at start of content
                     if scan == line_start + line_indent {
@@ -502,7 +524,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 // Check if this colon is a key separator (followed by space/tab/newline)
                 if scan + 1 < self.text.len() {
                     let next = self.text[scan + 1];
-                    if next == b' ' || next == b'\t' || next == b'\n' {
+                    if matches!(next, b' ' | b'\t' | b'\n' | b'\r') {
                         has_colon_before = true;
                         colon_pos = scan;
                     }
@@ -550,7 +572,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
 
             // Go to previous line
             let mut prev_line_start = line_start - 1;
-            while prev_line_start > 0 && self.text[prev_line_start - 1] != b'\n' {
+            while prev_line_start > 0 && !is_line_break(self.text[prev_line_start - 1]) {
                 prev_line_start -= 1;
             }
 
@@ -584,7 +606,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     fn is_in_flow_context(&self, pos: usize) -> bool {
         // Find start of line containing pos
         let mut line_start = pos;
-        while line_start > 0 && self.text[line_start - 1] != b'\n' {
+        while line_start > 0 && !is_line_break(self.text[line_start - 1]) {
             line_start -= 1;
         }
 
@@ -624,7 +646,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // Scan back up to 4KB or start of text
         let scan_start = if line_start > 4096 {
             let mut start = line_start.saturating_sub(4096);
-            while start > 0 && self.text[start - 1] != b'\n' {
+            while start > 0 && !is_line_break(self.text[start - 1]) {
                 start -= 1;
             }
             start
@@ -671,13 +693,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         depth > 0
     }
 
-    /// Find the end of a single-line unquoted scalar (stops at newline).
+    /// Find the end of a single-line unquoted scalar (stops at a line break).
     fn find_scalar_end(&self, start: usize) -> usize {
         let mut end = start;
         while end < self.text.len() {
             match self.text[end] {
                 // Block context delimiters
-                b'\n' | b'#' => break,
+                b'\n' | b'\r' | b'#' => break,
                 // Flow context delimiters
                 b',' | b']' | b'}' => break,
                 b':' => {
@@ -686,7 +708,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         // Colon at EOF - this is a key separator
                         break;
                     }
-                    if self.text[end + 1] == b' ' || self.text[end + 1] == b'\n' {
+                    if matches!(self.text[end + 1], b' ' | b'\n' | b'\r') {
                         break;
                     }
                     end += 1;
@@ -695,7 +717,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             }
         }
         // Trim trailing whitespace
-        while end > start && self.text[end - 1] == b' ' {
+        while end > start && matches!(self.text[end - 1], b' ' | b'\r') {
             end -= 1;
         }
         end
@@ -729,10 +751,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         if end + 1 >= self.text.len() {
                             break;
                         }
-                        if self.text[end + 1] == b' '
-                            || self.text[end + 1] == b'\n'
-                            || self.text[end + 1] == b'\t'
-                        {
+                        if matches!(self.text[end + 1], b' ' | b'\t' | b'\n' | b'\r') {
                             break;
                         }
                         end += 1;
@@ -3491,15 +3510,15 @@ impl<'a> YamlString<'a> {
         // In this case, content can be at indent 0 (zero-indented block scalar)
         let on_document_start_line = Self::is_document_start_line(text, indicator_pos);
 
-        // Skip indicator and modifiers to find newline
+        // Skip indicator and modifiers to find the end of the indicator line
         let mut pos = indicator_pos + 1;
-        while pos < text.len() && text[pos] != b'\n' {
+        while pos < text.len() && !is_line_break(text[pos]) {
             pos += 1;
         }
         if pos >= text.len() {
             return (pos, pos); // Empty block scalar
         }
-        pos += 1; // Skip newline
+        pos += line_break_len(text, pos); // Skip the line break
 
         let content_start = pos;
 
@@ -3671,7 +3690,7 @@ impl<'a> YamlString<'a> {
     fn compute_key_indent(text: &[u8], indicator_pos: usize) -> usize {
         // Find start of line
         let mut line_start = indicator_pos;
-        while line_start > 0 && text[line_start - 1] != b'\n' {
+        while line_start > 0 && !is_line_break(text[line_start - 1]) {
             line_start -= 1;
         }
 
@@ -3712,7 +3731,7 @@ impl<'a> YamlString<'a> {
     fn is_document_start_line(text: &[u8], pos: usize) -> bool {
         // Find start of line
         let mut line_start = pos;
-        while line_start > 0 && text[line_start - 1] != b'\n' {
+        while line_start > 0 && !is_line_break(text[line_start - 1]) {
             line_start -= 1;
         }
 
@@ -4225,8 +4244,11 @@ fn decode_block_literal(
     } else {
         YamlString::detect_block_indent(text, content_start).unwrap_or(0)
     };
-    if indent == 0 {
-        // No indentation to strip - just convert to string
+    if indent == 0 && !content.contains(&b'\r') {
+        // No indentation to strip and no line breaks to normalize - borrow as is.
+        // Content holding a `\r` must go through the loop below, which rewrites
+        // every break form to `\n` as YAML 1.2 §5.4 requires; borrowing it would
+        // emit the raw CRs instead (#324).
         let s = core::str::from_utf8(content).map_err(|_| YamlStringError::InvalidUtf8)?;
         return Ok(Cow::Borrowed(s));
     }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -4257,4 +4257,77 @@ mod tests {
             "nesting depth exceeds limit of 128 at offset 131"
         );
     }
+    /// The oracle's line-break primitives (#324). `break_len_at` is what tells
+    /// every caller that a CRLF is *one* break two bytes wide; getting it wrong
+    /// leaves a stray `\r` inside the preceding token, which is the whole bug.
+    #[test]
+    fn line_break_primitives_measure_each_form() {
+        let parser = Parser::new(b"a\r\nb\rc\nd");
+        //                        0 1 2 3 4 5 6 7
+        assert_eq!(parser.break_len_at(1), 2, "CRLF at 1");
+        assert_eq!(
+            parser.break_len_at(2),
+            1,
+            "the LF of a CRLF, measured alone"
+        );
+        assert_eq!(parser.break_len_at(4), 1, "lone CR at 4");
+        assert_eq!(parser.break_len_at(6), 1, "LF at 6");
+        assert_eq!(parser.break_len_at(0), 0, "`a` is not a break");
+        assert_eq!(parser.break_len_at(99), 0, "past end of input");
+
+        // A CR at end of input has no LF to pair with.
+        assert_eq!(Parser::new(b"a\r").break_len_at(1), 1);
+        assert_eq!(Parser::new(b"").break_len_at(0), 0);
+
+        assert!(Parser::is_break(b'\n'));
+        assert!(Parser::is_break(b'\r'));
+        assert!(!Parser::is_break(b'\t'));
+        assert!(!Parser::is_break(b' '));
+    }
+
+    /// `skip_line_break` consumes exactly one break, never half of a CRLF and
+    /// never a byte when the cursor is not on one.
+    #[test]
+    fn skip_line_break_consumes_exactly_one_break() {
+        let mut parser = Parser::new(b"\r\n\r\nx");
+        parser.skip_line_break();
+        assert_eq!(parser.pos, 2, "first CRLF consumed whole");
+        parser.skip_line_break();
+        assert_eq!(parser.pos, 4, "second CRLF consumed whole");
+        parser.skip_line_break();
+        assert_eq!(parser.pos, 4, "`x` is not a break, so nothing moves");
+
+        let mut lone = Parser::new(b"\r\rx");
+        lone.skip_line_break();
+        assert_eq!(lone.pos, 1, "a lone CR is a complete break");
+        assert!(lone.at_break());
+        lone.skip_line_break();
+        assert_eq!(lone.pos, 2);
+        assert!(!lone.at_break());
+    }
+
+    /// `current_line` counts breaks, and a CRLF is one of them — not two.
+    #[test]
+    fn current_line_counts_a_crlf_once() {
+        // b"a\r\nb\r\nc"
+        //   0 1 2 3 4 5 6
+        let mut parser = Parser::new(b"a\r\nb\r\nc");
+        assert_eq!(parser.current_line(), 1);
+        parser.pos = 3;
+        assert_eq!(parser.current_line(), 2, "`b` is on line 2");
+        // Sitting on the LF of the second CRLF is still line 2: that CR's
+        // partner lies past the counted prefix and must not read as a lone CR.
+        parser.pos = 5;
+        assert_eq!(
+            parser.current_line(),
+            2,
+            "the LF of a CRLF is not a new line"
+        );
+        parser.pos = 6;
+        assert_eq!(parser.current_line(), 3, "`c` is on line 3");
+
+        let mut lone = Parser::new(b"a\rb\rc");
+        lone.pos = 4;
+        assert_eq!(lone.current_line(), 3, "lone CRs each start a line");
+    }
 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -410,6 +410,13 @@ impl<'a> Parser<'a> {
         self.peek().is_some_and(Self::is_break)
     }
 
+    /// Does `next` terminate a `-` sequence indicator? That is whitespace, a
+    /// line break, or end of input.
+    #[inline]
+    fn is_seq_indicator_next(next: Option<u8>) -> bool {
+        matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None)
+    }
+
     /// Consume the line break at the current position, if any.
     ///
     /// Dispatches on the byte rather than going through `break_len_at`, so the
@@ -3473,6 +3480,11 @@ impl<'a> Parser<'a> {
                 // Explicit value indicator (value for previous explicit key)
                 self.parse_explicit_value(indent)?;
             }
+            // These two arms are defensive and carry no coverage: `parse_documents`
+            // calls `skip_newlines` before each line, and that consumes comment
+            // lines and blank lines (including whitespace-only ones) itself, so a
+            // `#` or a line break is never the first byte here. Kept as a backstop
+            // for any future caller that dispatches a line without pre-skipping.
             Some(b'#') => {
                 // Comment line - skip
                 self.skip_to_eol();
@@ -3541,12 +3553,11 @@ impl<'a> Parser<'a> {
                         Some(b'\n' | b'\r') | None => {
                             // Anchor with value on next line - will be parsed in next iteration
                         }
-                        Some(b'-')
-                            if matches!(
-                                self.peek_at(1),
-                                Some(b' ' | b'\t' | b'\n' | b'\r') | None
-                            ) =>
-                        {
+                        // Keep this guard on one line: rustfmt splitting the
+                        // `matches!` across lines gives the opening line its own
+                        // coverage region that never reports as executed, even
+                        // though the arm body does.
+                        Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
                             // Anchor before block sequence on same line
                             self.parse_sequence_item(indent)?;
                         }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -367,11 +367,15 @@ impl<'a> Parser<'a> {
     fn current_line(&self) -> usize {
         // Count line breaks from start to current position. A CRLF is one
         // break, so a `\r` only counts when it is not part of one (#324).
-        let text = &self.input[..self.pos];
-        let breaks = text
+        //
+        // The lookahead reads `self.input`, not the truncated prefix: when the
+        // cursor sits on the LF of a CRLF, that CR's partner is one byte past
+        // the prefix, and checking the prefix would read it as a lone CR and
+        // report a line too many.
+        let breaks = self.input[..self.pos]
             .iter()
             .enumerate()
-            .filter(|&(i, &b)| b == b'\n' || (b == b'\r' && text.get(i + 1) != Some(&b'\n')))
+            .filter(|&(i, &b)| b == b'\n' || (b == b'\r' && self.input.get(i + 1) != Some(&b'\n')))
             .count();
         breaks + 1
     }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -365,12 +365,66 @@ impl<'a> Parser<'a> {
     /// Only called on error paths, so we pay the cost only when needed.
     #[inline]
     fn current_line(&self) -> usize {
-        // Count newlines from start to current position
-        self.input[..self.pos]
+        // Count line breaks from start to current position. A CRLF is one
+        // break, so a `\r` only counts when it is not part of one (#324).
+        let text = &self.input[..self.pos];
+        let breaks = text
             .iter()
-            .filter(|&&b| b == b'\n')
-            .count()
-            + 1
+            .enumerate()
+            .filter(|&(i, &b)| b == b'\n' || (b == b'\r' && text.get(i + 1) != Some(&b'\n')))
+            .count();
+        breaks + 1
+    }
+
+    /// Is `b` a YAML line break? Per YAML 1.2 §5.4 that is `\n` or `\r`;
+    /// `\r\n` is the two-byte spelling of a single break (#324).
+    #[inline]
+    fn is_break(b: u8) -> bool {
+        matches!(b, b'\n' | b'\r')
+    }
+
+    /// Width in bytes of the line break at `pos`: 2 for `\r\n`, 1 for a lone
+    /// `\r` or `\n`, 0 if `pos` is not at a break.
+    #[inline]
+    fn break_len_at(&self, pos: usize) -> usize {
+        match self.input.get(pos) {
+            Some(b'\r') => {
+                if self.input.get(pos + 1) == Some(&b'\n') {
+                    2
+                } else {
+                    1
+                }
+            }
+            Some(b'\n') => 1,
+            _ => 0,
+        }
+    }
+
+    /// Is the current position at a line break?
+    #[inline]
+    fn at_break(&self) -> bool {
+        self.peek().is_some_and(Self::is_break)
+    }
+
+    /// Consume the line break at the current position, if any.
+    ///
+    /// Dispatches on the byte rather than going through `break_len_at`, so the
+    /// overwhelmingly common LF case costs one bounds-checked load and an
+    /// increment — exactly what the `if peek() == Some(b'\n') { advance() }` it
+    /// replaced cost. Routing it through `advance_by(break_len_at(..))` instead
+    /// doubled the bounds checks on a per-line path.
+    #[inline]
+    fn skip_line_break(&mut self) {
+        match self.input.get(self.pos) {
+            Some(b'\n') => self.pos += 1,
+            Some(b'\r') => {
+                self.pos += 1;
+                if self.input.get(self.pos) == Some(&b'\n') {
+                    self.pos += 1;
+                }
+            }
+            _ => {}
+        }
     }
 
     /// Skip whitespace on the current line (spaces and tabs, not newlines).
@@ -422,8 +476,11 @@ impl<'a> Parser<'a> {
     fn skip_unquoted_simd(&self, _value_start: usize) -> Option<usize> {
         // Use classify_yaml_chars to scan 32 bytes at once
         if let Some(class) = super::simd::classify_yaml_chars(self.input, self.pos) {
-            // Check for any potential terminators: newline, colon, or hash
-            let terminators = class.newlines | class.colons | class.hash;
+            // Check for any potential terminators: line break, colon, or hash.
+            // `\r` counts: it is a YAML 1.2 §5.4 line break, and without it the
+            // classifier skips straight over a lone CR and swallows the rest of
+            // the document into one scalar (#324).
+            let terminators = class.newlines | class.carriage_returns | class.colons | class.hash;
 
             if terminators == 0 {
                 // No structural characters in the classified chunk — skip
@@ -513,7 +570,7 @@ impl<'a> Parser<'a> {
     fn current_column(&self) -> usize {
         // Find the start of the current line
         let mut line_start = self.pos;
-        while line_start > 0 && self.input[line_start - 1] != b'\n' {
+        while line_start > 0 && !Self::is_break(self.input[line_start - 1]) {
             line_start -= 1;
         }
         self.pos - line_start
@@ -524,7 +581,7 @@ impl<'a> Parser<'a> {
         let mut i = self.pos;
         while i < self.input.len() {
             match self.input[i] {
-                b'\n' => return true,
+                b'\n' | b'\r' => return true,
                 b'#' => return true, // Comment starts
                 b' ' => i += 1,
                 _ => return false,
@@ -543,7 +600,7 @@ impl<'a> Parser<'a> {
             // Empty key: `:` at start followed by whitespace/newline/EOF
             Some(b':') => {
                 let next = self.peek_at(1);
-                if matches!(next, Some(b' ' | b'\t' | b'\n') | None) {
+                if matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
                     return true;
                 }
                 // Colon not followed by whitespace - continue checking
@@ -568,7 +625,7 @@ impl<'a> Parser<'a> {
                     break;
                 } else if self.input[i] == b'\\' && quote == b'"' {
                     i += 2; // Skip escape sequence in double-quoted
-                } else if self.input[i] == b'\n' {
+                } else if Self::is_break(self.input[i]) {
                     return false; // Unclosed quote
                 } else {
                     i += 1;
@@ -585,7 +642,7 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                return matches!(next, Some(b' ' | b'\t' | b'\n') | None);
+                return matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None);
             }
             return false;
         }
@@ -593,7 +650,7 @@ impl<'a> Parser<'a> {
         // Scan for `: ` pattern in unquoted key
         while i < self.input.len() {
             match self.input[i] {
-                b'\n' => return false, // Line ended without finding `: `
+                b'\n' | b'\r' => return false, // Line ended without finding `: `
                 b':' => {
                     // Check what follows the colon
                     let next = if i + 1 < self.input.len() {
@@ -602,7 +659,7 @@ impl<'a> Parser<'a> {
                         None
                     };
                     match next {
-                        Some(b' ' | b'\t' | b'\n') | None => return true,
+                        Some(b' ' | b'\t' | b'\n' | b'\r') | None => return true,
                         _ => i += 1, // Colon not followed by whitespace, continue
                     }
                 }
@@ -615,9 +672,12 @@ impl<'a> Parser<'a> {
     }
 
     /// Skip to end of line (handles comments).
+    ///
+    /// Stops *before* the line break, whichever of the three forms it is, so
+    /// callers can consume it with `skip_line_break` (#324).
     #[inline]
     fn skip_to_eol(&mut self) {
-        while self.pos < self.input.len() && self.input[self.pos] != b'\n' {
+        while self.pos < self.input.len() && !Self::is_break(self.input[self.pos]) {
             self.pos += 1;
         }
     }
@@ -625,8 +685,8 @@ impl<'a> Parser<'a> {
     /// Skip newline and empty/comment lines.
     fn skip_newlines(&mut self) {
         while let Some(b) = self.peek() {
-            if b == b'\n' {
-                self.advance();
+            if Self::is_break(b) {
+                self.skip_line_break();
             } else if b == b'#' {
                 // Comment line
                 self.skip_to_eol();
@@ -634,8 +694,7 @@ impl<'a> Parser<'a> {
                 // Check if rest of line is whitespace or comment
                 let start = self.pos;
                 self.skip_inline_whitespace();
-                if self.peek() == Some(b'\n') || self.peek() == Some(b'#') || self.peek().is_none()
-                {
+                if self.at_break() || self.peek() == Some(b'#') || self.peek().is_none() {
                     if self.peek() == Some(b'#') {
                         self.skip_to_eol();
                     }
@@ -686,8 +745,8 @@ impl<'a> Parser<'a> {
         if slice != b"---" {
             return false;
         }
-        // Must be followed by space, newline, or EOF
-        self.peek_at(3) == Some(b' ') || self.peek_at(3) == Some(b'\n') || self.peek_at(3).is_none()
+        // Must be followed by space, line break, or EOF
+        matches!(self.peek_at(3), Some(b' ' | b'\n' | b'\r') | None)
     }
 
     /// Check if we're at a document end marker (`...`).
@@ -699,8 +758,8 @@ impl<'a> Parser<'a> {
         if slice != b"..." {
             return false;
         }
-        // Must be followed by space, newline, or EOF
-        self.peek_at(3) == Some(b' ') || self.peek_at(3) == Some(b'\n') || self.peek_at(3).is_none()
+        // Must be followed by space, line break, or EOF
+        matches!(self.peek_at(3), Some(b' ' | b'\n' | b'\r') | None)
     }
 
     /// Skip past a document marker (`---` or `...`).
@@ -760,12 +819,7 @@ impl<'a> Parser<'a> {
                 // Flow collection
                 self.parse_value(0)?;
             }
-            Some(b'-')
-                if self.peek_at(1) == Some(b' ')
-                    || self.peek_at(1) == Some(b'\t')
-                    || self.peek_at(1) == Some(b'\n')
-                    || self.peek_at(1).is_none() =>
-            {
+            Some(b'-') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) => {
                 // Block sequence item
                 self.parse_sequence_item(0)?;
             }
@@ -918,7 +972,7 @@ impl<'a> Parser<'a> {
             // Use inline scalar loop for common case, SIMD for long runs
             while let Some(b) = self.peek() {
                 match b {
-                    b'\n' => break,
+                    b'\n' | b'\r' => break,
                     b'#' => {
                         // # is only a comment if preceded by whitespace (space or tab)
                         if self.pos > start && matches!(self.input[self.pos - 1], b' ' | b'\t') {
@@ -929,10 +983,7 @@ impl<'a> Parser<'a> {
                     b':' => {
                         // Colon followed by whitespace ends the value (could be a key)
                         // But in value context, colons in URLs etc. are allowed
-                        if self.peek_at(1) == Some(b' ')
-                            || self.peek_at(1) == Some(b'\t')
-                            || self.peek_at(1) == Some(b'\n')
-                        {
+                        if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r')) {
                             break;
                         }
                         self.advance();
@@ -967,12 +1018,12 @@ impl<'a> Parser<'a> {
             }
 
             // Check if we can continue to next line
-            if self.peek() != Some(b'\n') {
+            if !self.at_break() {
                 break;
             }
 
             // Look ahead to see if next line is a continuation
-            let mut lookahead = self.pos + 1; // Skip \n
+            let mut lookahead = self.pos + self.break_len_at(self.pos); // Skip the line break
             let mut next_indent = 0;
 
             // Count indentation on next line (only spaces count as indent in YAML)
@@ -991,20 +1042,17 @@ impl<'a> Parser<'a> {
 
             // If empty line (just whitespace then newline), skip it and continue
             // This includes lines with only spaces, tabs, or a mix
-            if next_char == b'\n' || next_char == b'\t' {
+            if matches!(next_char, b'\n' | b'\r' | b'\t') {
                 // Check if rest of line is whitespace
                 let mut check_pos = lookahead;
                 while check_pos < self.input.len() && matches!(self.input[check_pos], b' ' | b'\t')
                 {
                     check_pos += 1;
                 }
-                if check_pos >= self.input.len()
-                    || self.input[check_pos] == b'\n'
-                    || self.input[check_pos] == b'\r'
-                {
+                if check_pos >= self.input.len() || Self::is_break(self.input[check_pos]) {
                     // Empty line - skip it and continue
-                    self.advance(); // Skip current \n
-                                    // Skip to end of empty line
+                    self.skip_line_break(); // Skip the current line break
+                                            // Skip to end of empty line
                     while matches!(self.peek(), Some(b' ' | b'\t')) {
                         self.advance();
                     }
@@ -1015,8 +1063,8 @@ impl<'a> Parser<'a> {
                 // The tabs become part of the folded content (converted to space).
                 if start_indent == 0 && next_char == b'\t' {
                     // Continue to next line - this is a valid continuation
-                    self.advance(); // Skip \n
-                                    // Skip leading whitespace (tabs are content, but we're at the scalar's level)
+                    self.skip_line_break();
+                    // Skip leading whitespace (tabs are content, but we're at the scalar's level)
                     while matches!(self.peek(), Some(b' ' | b'\t')) {
                         self.advance();
                     }
@@ -1047,11 +1095,11 @@ impl<'a> Parser<'a> {
                 && !sequence_indicator_is_block_structure
                 && !(next_char == b':'
                     && lookahead + 1 < self.input.len()
-                    && matches!(self.input[lookahead + 1], b' ' | b'\n'))
+                    && matches!(self.input[lookahead + 1], b' ' | b'\n' | b'\r'))
             {
                 // Continue to next line
-                self.advance(); // Skip \n
-                                // Skip leading whitespace
+                self.skip_line_break();
+                // Skip leading whitespace
                 while matches!(self.peek(), Some(b' ' | b'\t')) {
                     self.advance();
                 }
@@ -1061,9 +1109,13 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // Trim trailing whitespace from content_end
+        // Trim trailing whitespace from content_end. `\r` is a line break, never
+        // scalar content, so it is trimmed too: the SIMD classifier can skip a
+        // CR to land on the LF that follows it, leaving the CR inside the
+        // extent, which is what made `a: 1\r\n` resolve as the string `"1 "`
+        // rather than the number 1 (#324).
         let mut end = content_end;
-        while end > start && matches!(self.input[end - 1], b' ' | b'\t') {
+        while end > start && matches!(self.input[end - 1], b' ' | b'\t' | b'\r') {
             end -= 1;
         }
 
@@ -1078,19 +1130,15 @@ impl<'a> Parser<'a> {
         while let Some(b) = self.peek() {
             match b {
                 b':' => {
-                    // Check for colon + whitespace or colon + newline
-                    if self.peek_at(1) == Some(b' ')
-                        || self.peek_at(1) == Some(b'\t')
-                        || self.peek_at(1) == Some(b'\n')
-                        || self.peek_at(1).is_none()
-                    {
+                    // Check for colon + whitespace or colon + line break
+                    if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
                         break;
                     }
                     // Colon not followed by whitespace is part of the key
                     // (e.g., "key::" or URLs like "http://example.com")
                     self.advance();
                 }
-                b'\n' => {
+                b'\n' | b'\r' => {
                     // Key without colon
                     return Err(YamlError::KeyWithoutValue {
                         offset: start,
@@ -1130,9 +1178,11 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // Trim trailing whitespace
+        // Trim trailing whitespace. `\r` goes with it for the same reason as in
+        // `parse_unquoted_value_with_indent_impl`: it is a line break, so it is
+        // never part of the key (#324).
         let mut end = self.pos;
-        while end > start && self.input[end - 1] == b' ' {
+        while end > start && matches!(self.input[end - 1], b' ' | b'\r') {
             end -= 1;
         }
 
@@ -1360,7 +1410,7 @@ impl<'a> Parser<'a> {
                 let saved_pos = self.pos;
                 self.advance_by(next_indent);
                 let is_sequence_indicator = matches!(self.peek(), Some(b'-'))
-                    && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n') | None);
+                    && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None);
                 self.pos = saved_pos;
 
                 if next_indent < indent || (next_indent == indent && !is_sequence_indicator) {
@@ -1445,7 +1495,7 @@ impl<'a> Parser<'a> {
         let key_end = if self.peek() == Some(b':') {
             // Empty key - check that it's followed by proper terminator
             let next = self.peek_at(1);
-            if matches!(next, Some(b' ' | b'\t' | b'\n') | None) {
+            if matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
                 // Empty key case - key length is 0, don't advance yet
                 self.pos
             } else {
@@ -1531,7 +1581,7 @@ impl<'a> Parser<'a> {
             self.advance_by(next_indent);
             let next_char = self.peek();
             let is_sequence_indicator = matches!(next_char, Some(b'-'))
-                && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n') | None);
+                && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None);
             self.pos = saved_pos;
 
             if next_indent < indent {
@@ -1556,12 +1606,14 @@ impl<'a> Parser<'a> {
 
             // Check if this is a nested structure or a plain scalar value
             match self.peek() {
-                Some(b'-') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n') | None) => {
+                Some(b'-')
+                    if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) =>
+                {
                     // Sequence - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
                 }
-                Some(b'?') if matches!(self.peek_at(1), Some(b' ' | b'\n') | None) => {
+                Some(b'?') if matches!(self.peek_at(1), Some(b' ' | b'\n' | b'\r') | None) => {
                     // Explicit key - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
@@ -1638,7 +1690,7 @@ impl<'a> Parser<'a> {
                     // Skip past indent spaces to check what follows (SIMD accelerated)
                     self.skip_spaces_simd();
                     matches!(self.peek(), Some(b'-'))
-                        && matches!(self.peek_at(1), Some(b' ' | b'\n') | None)
+                        && matches!(self.peek_at(1), Some(b' ' | b'\n' | b'\r') | None)
                 };
                 // Restore position after checking
                 self.pos = pos_before_check;
@@ -1761,7 +1813,7 @@ impl<'a> Parser<'a> {
                     && (next_indent == indent)
                     && matches!(
                         self.input.get(saved_pos + next_indent + 1).copied(),
-                        Some(b' ' | b'\t' | b'\n') | None
+                        Some(b' ' | b'\t' | b'\n' | b'\r') | None
                     )
                 {
                     // `: value` at same indent - empty key (null), value follows
@@ -2135,7 +2187,7 @@ impl<'a> Parser<'a> {
         // Scan unquoted content for `: ` pattern
         while i < self.input.len() {
             match self.input[i] {
-                b',' | b']' | b'}' | b'\n' => return false,
+                b',' | b']' | b'}' | b'\n' | b'\r' => return false,
                 b':' => {
                     let next = if i + 1 < self.input.len() {
                         Some(self.input[i + 1])
@@ -2995,23 +3047,14 @@ impl<'a> Parser<'a> {
 
             // Check what's on this line
             match self.peek() {
-                Some(b'\n') => {
+                Some(b'\n' | b'\r') => {
                     // Empty line - skip and continue
-                    self.advance();
+                    self.skip_line_break();
                 }
                 Some(b'#') => {
                     // Comment line - skip to end
                     self.skip_to_eol();
-                    if self.peek() == Some(b'\n') {
-                        self.advance();
-                    }
-                }
-                Some(b'\r') => {
-                    // Handle \r\n
-                    self.advance();
-                    if self.peek() == Some(b'\n') {
-                        self.advance();
-                    }
+                    self.skip_line_break();
                 }
                 None => {
                     // EOF
@@ -3057,18 +3100,10 @@ impl<'a> Parser<'a> {
 
             // Check what's on this line
             match self.peek() {
-                Some(b'\n') => {
+                Some(b'\n' | b'\r') => {
                     // Empty line - part of trailing newlines
                     trailing_newline_start = line_start;
-                    self.advance();
-                }
-                Some(b'\r') => {
-                    // Handle \r\n
-                    trailing_newline_start = line_start;
-                    self.advance();
-                    if self.peek() == Some(b'\n') {
-                        self.advance();
-                    }
+                    self.skip_line_break();
                 }
                 None => {
                     break; // EOF
@@ -3078,15 +3113,7 @@ impl<'a> Parser<'a> {
                     self.skip_to_eol();
                     last_content_end = self.pos;
                     trailing_newline_start = self.pos;
-
-                    if self.peek() == Some(b'\n') {
-                        self.advance();
-                    } else if self.peek() == Some(b'\r') {
-                        self.advance();
-                        if self.peek() == Some(b'\n') {
-                            self.advance();
-                        }
-                    }
+                    self.skip_line_break();
                 }
             }
         }
@@ -3098,9 +3125,10 @@ impl<'a> Parser<'a> {
         match chomping {
             ChompingIndicator::Strip => last_content_end,
             ChompingIndicator::Clip => {
-                // Include one trailing newline if there was content
+                // Include one trailing line break if there was content — two
+                // bytes wide when that break is a CRLF (#324)
                 if last_content_end > 0 && trailing_newline_start > last_content_end {
-                    last_content_end + 1 // Include one newline
+                    last_content_end + self.break_len_at(last_content_end)
                 } else {
                     last_content_end
                 }
@@ -3120,14 +3148,7 @@ impl<'a> Parser<'a> {
 
         // Skip to end of indicator line (may have trailing comment)
         self.skip_to_eol();
-        if self.peek() == Some(b'\n') {
-            self.advance();
-        } else if self.peek() == Some(b'\r') {
-            self.advance();
-            if self.peek() == Some(b'\n') {
-                self.advance();
-            }
-        }
+        self.skip_line_break();
 
         // Determine content indentation
         let content_indent = if header.explicit_indent > 0 {
@@ -3414,9 +3435,7 @@ impl<'a> Parser<'a> {
                         self.close_deeper_indents(0);
                         self.parse_value(0)?;
                         // Move to next line if we haven't already
-                        if self.peek() == Some(b'\n') {
-                            self.advance();
-                        }
+                        self.skip_line_break();
                         return Ok(());
                     }
                     _ => {
@@ -3454,9 +3473,9 @@ impl<'a> Parser<'a> {
                 // Comment line - skip
                 self.skip_to_eol();
             }
-            Some(b'\n') => {
+            Some(b'\n' | b'\r') => {
                 // Empty line
-                self.advance();
+                self.skip_line_break();
             }
             Some(b'{' | b'[') => {
                 // Flow mapping or sequence at document root
@@ -3515,11 +3534,14 @@ impl<'a> Parser<'a> {
                     self.skip_inline_whitespace();
                     // Check what follows
                     match self.peek() {
-                        Some(b'\n') | None => {
+                        Some(b'\n' | b'\r') | None => {
                             // Anchor with value on next line - will be parsed in next iteration
                         }
                         Some(b'-')
-                            if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n') | None) =>
+                            if matches!(
+                                self.peek_at(1),
+                                Some(b' ' | b'\t' | b'\n' | b'\r') | None
+                            ) =>
                         {
                             // Anchor before block sequence on same line
                             self.parse_sequence_item(indent)?;
@@ -3607,9 +3629,7 @@ impl<'a> Parser<'a> {
         }
 
         // Move to next line if we haven't already
-        if self.peek() == Some(b'\n') {
-            self.advance();
-        }
+        self.skip_line_break();
 
         Ok(())
     }

--- a/src/yaml/simd/broadword.rs
+++ b/src/yaml/simd/broadword.rs
@@ -70,6 +70,9 @@ const fn extract_mask_u64(x: u64) -> u8 {
 #[allow(dead_code)] // STYLE-0005: broadword fallback classifier; unused when SIMD is active
 pub struct YamlCharClassBroadword {
     pub newlines: u8,
+    /// Mask of bytes that are '\r' — a YAML 1.2 §5.4 line break in its own
+    /// right, so a value terminator just like '\n' (#324).
+    pub carriage_returns: u8,
     pub colons: u8,
     pub hyphens: u8,
     pub spaces: u8,
@@ -85,6 +88,7 @@ impl YamlCharClassBroadword {
     #[inline(always)]
     pub fn has_any(&self) -> bool {
         (self.newlines
+            | self.carriage_returns
             | self.colons
             | self.hyphens
             | self.spaces
@@ -99,7 +103,7 @@ impl YamlCharClassBroadword {
     /// Terminators: newline, colon, space, hash
     #[inline(always)]
     pub fn value_terminators(&self) -> u8 {
-        self.newlines | self.colons | self.spaces | self.hash
+        self.newlines | self.carriage_returns | self.colons | self.spaces | self.hash
     }
 }
 
@@ -123,6 +127,7 @@ pub fn classify_yaml_chars_broadword(
 
     // Find each character type using broadword operations
     let newlines = find_byte(chunk, b'\n');
+    let carriage_returns = find_byte(chunk, b'\r');
     let colons = find_byte(chunk, b':');
     let hyphens = find_byte(chunk, b'-');
     let spaces = find_byte(chunk, b' ');
@@ -133,6 +138,7 @@ pub fn classify_yaml_chars_broadword(
 
     Some(YamlCharClassBroadword {
         newlines: extract_mask_u64(newlines),
+        carriage_returns: extract_mask_u64(carriage_returns),
         colons: extract_mask_u64(colons),
         hyphens: extract_mask_u64(hyphens),
         spaces: extract_mask_u64(spaces),
@@ -151,6 +157,8 @@ pub fn classify_yaml_chars_broadword(
 #[allow(dead_code)] // STYLE-0005: broadword fallback classifier; unused when SIMD is active
 pub struct YamlCharClass16 {
     pub newlines: u16,
+    /// Mask of bytes that are '\r' — see [`YamlCharClassBroadword`] (#324).
+    pub carriage_returns: u16,
     pub colons: u16,
     pub hyphens: u16,
     pub spaces: u16,
@@ -164,7 +172,7 @@ impl YamlCharClass16 {
     /// Get mask of value terminators.
     #[inline(always)]
     pub fn value_terminators(&self) -> u16 {
-        self.newlines | self.colons | self.spaces | self.hash
+        self.newlines | self.carriage_returns | self.colons | self.spaces | self.hash
     }
 }
 
@@ -189,6 +197,7 @@ pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharCla
 
     Some(YamlCharClass16 {
         newlines: classify_both(chunk0, chunk1, b'\n'),
+        carriage_returns: classify_both(chunk0, chunk1, b'\r'),
         colons: classify_both(chunk0, chunk1, b':'),
         hyphens: classify_both(chunk0, chunk1, b'-'),
         spaces: classify_both(chunk0, chunk1, b' '),

--- a/src/yaml/simd/mod.rs
+++ b/src/yaml/simd/mod.rs
@@ -454,7 +454,7 @@ fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -
     let mut pos = start;
 
     while pos < input.len() {
-        if input[pos] == b'\n' {
+        if matches!(input[pos], b'\n' | b'\r') {
             let line_start = pos + 1;
 
             if line_start >= input.len() {

--- a/src/yaml/simd/mod.rs
+++ b/src/yaml/simd/mod.rs
@@ -703,4 +703,48 @@ mod tests {
             );
         }
     }
+    /// The scalar fallback must agree with the dispatched SIMD kernel on every
+    /// line-break form, including a lone CR — a `\n`-only scan finds no line
+    /// starts at all in a classic-Mac document and runs to EOF (#324).
+    #[test]
+    fn find_block_scalar_end_scalar_matches_the_dispatched_kernel() {
+        let cases: &[(&[u8], usize)] = &[
+            (b"  a\n  b\nc\n", 2),
+            (b"  a\r\n  b\r\nc\r\n", 2),
+            (b"  a\r  b\rc\r", 2),
+            // Blank lines stay inside the block; only real content can end it.
+            (b"  a\r\n\r\n  b\r\nc\r\n", 2),
+            (b"  a\r\r  b\rc\r", 2),
+            // No dedent at all: the block runs to end of input.
+            (b"  a\r  b\r", 2),
+        ];
+        for (input, min_indent) in cases {
+            assert_eq!(
+                find_block_scalar_end_scalar(input, 0, *min_indent),
+                find_block_scalar_end(input, 0, *min_indent),
+                "scalar fallback disagrees with SIMD on {:?}",
+                String::from_utf8_lossy(input)
+            );
+        }
+    }
+
+    /// Every break form ends the block at the same *place* — the dedented `c`.
+    /// The byte offsets differ because CRLF is two bytes wide, so the invariant
+    /// is what the returned position points at, not the number itself.
+    #[test]
+    fn find_block_scalar_end_lands_on_the_dedent_under_every_break_form() {
+        for (input, form) in [
+            (b"  a\n  b\nc\n".as_slice(), "LF"),
+            (b"  a\r\n  b\r\nc\r\n".as_slice(), "CRLF"),
+            (b"  a\r  b\rc\r".as_slice(), "lone CR"),
+        ] {
+            let end = find_block_scalar_end(input, 0, 2).expect("kernel returns a position");
+            assert_eq!(
+                input.get(end).copied(),
+                Some(b'c'),
+                "{form}: block ended at {end}, which is {:?} not the dedented line",
+                input.get(end).map(|&b| b as char)
+            );
+        }
+    }
 }

--- a/src/yaml/simd/neon.rs
+++ b/src/yaml/simd/neon.rs
@@ -228,6 +228,9 @@ const fn extract_mask_u64(x: u64) -> u8 {
 #[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
 pub struct YamlCharClassBroadword {
     pub newlines: u8,
+    /// Mask of bytes that are '\r' — a YAML 1.2 §5.4 line break in its own
+    /// right, so a value terminator just like '\n' (#324).
+    pub carriage_returns: u8,
     pub colons: u8,
     pub hyphens: u8,
     pub spaces: u8,
@@ -243,6 +246,7 @@ impl YamlCharClassBroadword {
     #[inline(always)]
     pub fn has_any(&self) -> bool {
         (self.newlines
+            | self.carriage_returns
             | self.colons
             | self.hyphens
             | self.spaces
@@ -257,7 +261,7 @@ impl YamlCharClassBroadword {
     /// Terminators: newline, colon, space, hash, comma (flow), brackets (flow)
     #[inline(always)]
     pub fn value_terminators(&self) -> u8 {
-        self.newlines | self.colons | self.spaces | self.hash
+        self.newlines | self.carriage_returns | self.colons | self.spaces | self.hash
     }
 }
 
@@ -284,6 +288,7 @@ pub fn classify_yaml_chars_broadword(
 
     // Find each character type using broadword operations
     let newlines = find_byte(chunk, b'\n');
+    let carriage_returns = find_byte(chunk, b'\r');
     let colons = find_byte(chunk, b':');
     let hyphens = find_byte(chunk, b'-');
     let spaces = find_byte(chunk, b' ');
@@ -294,6 +299,7 @@ pub fn classify_yaml_chars_broadword(
 
     Some(YamlCharClassBroadword {
         newlines: extract_mask_u64(newlines),
+        carriage_returns: extract_mask_u64(carriage_returns),
         colons: extract_mask_u64(colons),
         hyphens: extract_mask_u64(hyphens),
         spaces: extract_mask_u64(spaces),
@@ -314,6 +320,8 @@ pub fn classify_yaml_chars_broadword(
 #[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
 pub struct YamlCharClass16 {
     pub newlines: u16,
+    /// Mask of bytes that are '\r' — see [`YamlCharClassBroadword`] (#324).
+    pub carriage_returns: u16,
     pub colons: u16,
     pub hyphens: u16,
     pub spaces: u16,
@@ -328,7 +336,7 @@ impl YamlCharClass16 {
     /// Get mask of value terminators.
     #[inline(always)]
     pub fn value_terminators(&self) -> u16 {
-        self.newlines | self.colons | self.spaces | self.hash
+        self.newlines | self.carriage_returns | self.colons | self.spaces | self.hash
     }
 }
 
@@ -353,6 +361,7 @@ pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharCla
 
     Some(YamlCharClass16 {
         newlines: classify_both(chunk0, chunk1, b'\n'),
+        carriage_returns: classify_both(chunk0, chunk1, b'\r'),
         colons: classify_both(chunk0, chunk1, b':'),
         hyphens: classify_both(chunk0, chunk1, b'-'),
         spaces: classify_both(chunk0, chunk1, b' '),
@@ -548,6 +557,7 @@ pub fn find_block_scalar_end_neon(input: &[u8], start: usize, min_indent: usize)
 #[target_feature(enable = "neon")]
 unsafe fn find_block_scalar_end_neon_impl(input: &[u8], start: usize, min_indent: usize) -> usize {
     let newline_vec = vdupq_n_u8(b'\n');
+    let carriage_return_vec = vdupq_n_u8(b'\r');
     let space_vec = vdupq_n_u8(b' ');
 
     let mut pos = start;
@@ -555,7 +565,12 @@ unsafe fn find_block_scalar_end_neon_impl(input: &[u8], start: usize, min_indent
     // Process in 16-byte chunks, looking for newlines
     while pos + 16 < input.len() {
         let chunk = vld1q_u8(input.as_ptr().add(pos));
-        let nl_matches = vceqq_u8(chunk, newline_vec);
+        // Match either line-break byte (#324). A CRLF sets both bits; the CR's
+        // "next line" is the LF itself, which the empty-line guard below skips.
+        let nl_matches = vorrq_u8(
+            vceqq_u8(chunk, newline_vec),
+            vceqq_u8(chunk, carriage_return_vec),
+        );
         let mut nl_mask = neon_movemask(nl_matches);
 
         if nl_mask != 0 {
@@ -622,7 +637,7 @@ fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -
     let mut pos = start;
 
     while pos < input.len() {
-        if input[pos] == b'\n' {
+        if matches!(input[pos], b'\n' | b'\r') {
             let line_start = pos + 1;
 
             if line_start >= input.len() {

--- a/src/yaml/simd/neon.rs
+++ b/src/yaml/simd/neon.rs
@@ -961,4 +961,30 @@ mod tests {
             );
         }
     }
+    /// The broadword classifiers are kept as a reference/fallback and are not
+    /// on the dispatched path, so nothing else exercises their accessors. They
+    /// still have to agree that a CR terminates a value — a classifier that
+    /// quietly omits it is what let a lone CR swallow a whole document (#324).
+    #[test]
+    fn broadword_classifiers_treat_cr_as_a_value_terminator() {
+        let input = b"abcdefg\rhijklmno";
+        let class = classify_yaml_chars_broadword(input, 0).expect("8 bytes available");
+        assert_eq!(class.carriage_returns, 1 << 7, "CR is at offset 7");
+        assert!(class.has_any());
+        assert!(
+            class.value_terminators() & (1 << 7) != 0,
+            "CR must terminate an unquoted value"
+        );
+
+        let class16 = classify_yaml_chars_16(input, 0).expect("16 bytes available");
+        assert_eq!(class16.carriage_returns, 1 << 7);
+        assert!(class16.value_terminators() & (1 << 7) != 0);
+
+        // A chunk with no CR reports none, so the mask is not just always set.
+        let plain = b"abcdefghijklmnop";
+        let none = classify_yaml_chars_broadword(plain, 0).expect("8 bytes available");
+        assert_eq!(none.carriage_returns, 0);
+        assert!(!none.has_any(), "no structural bytes in {plain:?}");
+        assert_eq!(none.value_terminators(), 0);
+    }
 }

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -63,6 +63,12 @@ fn avx2_enabled() -> bool {
 pub struct YamlCharClass {
     /// Mask of bytes that are '\n'
     pub newlines: u32,
+    /// Mask of bytes that are '\r'.
+    ///
+    /// YAML 1.2 §5.4 makes `\r` a line break in its own right, so scalar scans
+    /// must stop at one exactly as they stop at `\n`. Kept separate from
+    /// `newlines` so callers that genuinely mean LF still get LF (#324).
+    pub carriage_returns: u32,
     /// Mask of bytes that are ':'
     pub colons: u32,
     /// Mask of bytes that are '-'
@@ -118,6 +124,7 @@ unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass
 
     // Create comparison vectors for each character
     let v_newline = _mm256_set1_epi8(b'\n' as i8);
+    let v_carriage_return = _mm256_set1_epi8(b'\r' as i8);
     let v_colon = _mm256_set1_epi8(b':' as i8);
     let v_hyphen = _mm256_set1_epi8(b'-' as i8);
     let v_space = _mm256_set1_epi8(b' ' as i8);
@@ -128,6 +135,7 @@ unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass
 
     // Compare and extract masks
     let eq_newline = _mm256_cmpeq_epi8(chunk, v_newline);
+    let eq_carriage_return = _mm256_cmpeq_epi8(chunk, v_carriage_return);
     let eq_colon = _mm256_cmpeq_epi8(chunk, v_colon);
     let eq_hyphen = _mm256_cmpeq_epi8(chunk, v_hyphen);
     let eq_space = _mm256_cmpeq_epi8(chunk, v_space);
@@ -138,6 +146,7 @@ unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass
 
     YamlCharClass {
         newlines: _mm256_movemask_epi8(eq_newline) as u32,
+        carriage_returns: _mm256_movemask_epi8(eq_carriage_return) as u32,
         colons: _mm256_movemask_epi8(eq_colon) as u32,
         hyphens: _mm256_movemask_epi8(eq_hyphen) as u32,
         spaces: _mm256_movemask_epi8(eq_space) as u32,
@@ -156,6 +165,7 @@ unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass
 
     // Create comparison vectors for each character
     let v_newline = _mm_set1_epi8(b'\n' as i8);
+    let v_carriage_return = _mm_set1_epi8(b'\r' as i8);
     let v_colon = _mm_set1_epi8(b':' as i8);
     let v_hyphen = _mm_set1_epi8(b'-' as i8);
     let v_space = _mm_set1_epi8(b' ' as i8);
@@ -166,6 +176,7 @@ unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass
 
     // Compare and extract masks
     let eq_newline = _mm_cmpeq_epi8(chunk, v_newline);
+    let eq_carriage_return = _mm_cmpeq_epi8(chunk, v_carriage_return);
     let eq_colon = _mm_cmpeq_epi8(chunk, v_colon);
     let eq_hyphen = _mm_cmpeq_epi8(chunk, v_hyphen);
     let eq_space = _mm_cmpeq_epi8(chunk, v_space);
@@ -176,6 +187,7 @@ unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass
 
     YamlCharClass {
         newlines: _mm_movemask_epi8(eq_newline) as u32,
+        carriage_returns: _mm_movemask_epi8(eq_carriage_return) as u32,
         colons: _mm_movemask_epi8(eq_colon) as u32,
         hyphens: _mm_movemask_epi8(eq_hyphen) as u32,
         spaces: _mm_movemask_epi8(eq_space) as u32,
@@ -595,6 +607,7 @@ pub fn find_block_scalar_end(input: &[u8], start: usize, min_indent: usize) -> O
 #[target_feature(enable = "avx2")]
 unsafe fn find_block_scalar_end_avx2(input: &[u8], start: usize, min_indent: usize) -> usize {
     let newline_vec = _mm256_set1_epi8(b'\n' as i8);
+    let carriage_return_vec = _mm256_set1_epi8(b'\r' as i8);
     let space_vec = _mm256_set1_epi8(b' ' as i8);
 
     let mut pos = start;
@@ -602,7 +615,12 @@ unsafe fn find_block_scalar_end_avx2(input: &[u8], start: usize, min_indent: usi
     // Process in 32-byte chunks, looking for newlines
     while pos + 32 < input.len() {
         let chunk = _mm256_loadu_si256(input.as_ptr().add(pos).cast::<__m256i>());
-        let nl_matches = _mm256_cmpeq_epi8(chunk, newline_vec);
+        // Match either line-break byte (#324). A CRLF sets both bits; the CR's
+        // "next line" is the LF itself, which the empty-line guard below skips.
+        let nl_matches = _mm256_or_si256(
+            _mm256_cmpeq_epi8(chunk, newline_vec),
+            _mm256_cmpeq_epi8(chunk, carriage_return_vec),
+        );
         let mut nl_mask = _mm256_movemask_epi8(nl_matches) as u32;
 
         if nl_mask != 0 {
@@ -668,6 +686,7 @@ unsafe fn find_block_scalar_end_avx2(input: &[u8], start: usize, min_indent: usi
 #[target_feature(enable = "sse2")]
 unsafe fn find_block_scalar_end_sse2(input: &[u8], start: usize, min_indent: usize) -> usize {
     let newline_vec = _mm_set1_epi8(b'\n' as i8);
+    let carriage_return_vec = _mm_set1_epi8(b'\r' as i8);
     let space_vec = _mm_set1_epi8(b' ' as i8);
 
     let mut pos = start;
@@ -675,7 +694,11 @@ unsafe fn find_block_scalar_end_sse2(input: &[u8], start: usize, min_indent: usi
     // Process in 16-byte chunks
     while pos + 16 < input.len() {
         let chunk = _mm_loadu_si128(input.as_ptr().add(pos).cast::<__m128i>());
-        let nl_matches = _mm_cmpeq_epi8(chunk, newline_vec);
+        // Match either line-break byte — see the AVX2 path (#324).
+        let nl_matches = _mm_or_si128(
+            _mm_cmpeq_epi8(chunk, newline_vec),
+            _mm_cmpeq_epi8(chunk, carriage_return_vec),
+        );
         let mut nl_mask = _mm_movemask_epi8(nl_matches) as u32;
 
         if nl_mask != 0 {
@@ -734,7 +757,7 @@ fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -
     let mut pos = start;
 
     while pos < input.len() {
-        if input[pos] == b'\n' {
+        if matches!(input[pos], b'\n' | b'\r') {
             let line_start = pos + 1;
 
             if line_start >= input.len() {

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -523,7 +523,15 @@ impl<'a> Validator<'a> {
                         i += 1;
                         if c == b'\\' {
                             i += 1;
-                        } else if c == b'"' || c == b'\n' || c == b'\r' {
+                        } else if c == b'"' || c == b'\n' {
+                            break;
+                        } else if c == b'\r' {
+                            // A CRLF is a single line break: consume the LF too,
+                            // so an unterminated quote resumes this scan exactly
+                            // where the LF-only spelling would (#324).
+                            if self.input.get(i) == Some(&b'\n') {
+                                i += 1;
+                            }
                             break;
                         }
                     }

--- a/tests/data/yaml-crlf-known-failures.txt
+++ b/tests/data/yaml-crlf-known-failures.txt
@@ -1,0 +1,21 @@
+# YAML Test Suite cases whose parse is NOT invariant under line-break form (#324).
+#
+# Format:  <case-id>/<variant>  <category>  <reason>
+#
+# `<variant>` is `crlf` (\r\n) or `cr` (a lone \r). The baseline is the same case
+# with LF breaks, so an entry here means rewriting the document's line breaks
+# changed what the parser produced — which YAML 1.2 §5.4/§5.7 forbid, since a
+# processor must normalize all three forms to \n on input.
+#
+# Consumed by tests/yaml_crlf_tests.rs, which asserts this list matches the actual
+# divergence set exactly: a newly divergent case and a newly invariant case both
+# break the build. Do not add entries to silence a failure without understanding
+# it.
+#
+# Note this is an *invariance* manifest, not a correctness one: a case that is
+# wrong under LF is expected to be wrong the same way under CRLF, and so does not
+# belong here. Correctness under LF is pinned by tests/yaml_test_suite.rs.
+#
+# Categories
+# ----------
+#   (none yet — the list is empty, and should stay that way)

--- a/tests/yaml_crlf_tests.rs
+++ b/tests/yaml_crlf_tests.rs
@@ -37,7 +37,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value;
-use succinctly::yaml::{YamlIndex, YamlValue};
+use succinctly::yaml::{locate_offset_detailed, YamlIndex, YamlValue};
 
 const CORPUS: &str = include_str!("data/yaml-test-suite-2022-01-17.json");
 const KNOWN_FAILURES: &str = include_str!("data/yaml-crlf-known-failures.txt");
@@ -411,6 +411,16 @@ mod issue_324 {
         assert_json(b"a: [1, 2]\rb: {c: 3}\r", r#"{"a":[1,2],"b":{"c":3}}"#);
     }
 
+    /// `--- - a` puts a sequence item on the document-marker line, which is its
+    /// own dispatch arm in `parse_inline_document_value` and reaches none of
+    /// the tests above.
+    #[test]
+    fn sequence_item_on_the_document_marker_line() {
+        assert_json(b"--- - a\n- b\n", r#"["a","b"]"#);
+        assert_json(b"--- - a\r\n- b\r\n", r#"["a","b"]"#);
+        assert_json(b"--- - a\r- b\r", r#"["a","b"]"#);
+    }
+
     #[test]
     fn literal_block_scalars_drop_the_cr() {
         assert_json(b"a: |\r\n  one\r\n  two\r\n", r#"{"a":"one\ntwo\n"}"#);
@@ -508,6 +518,53 @@ mod line_column {
                     String::from_utf8_lossy(&yaml)
                 );
             }
+        }
+    }
+
+    /// The byte range `yq-locate` reports comes from `YamlCursor::raw_bytes`,
+    /// which re-derives a plain scalar's end from the text rather than reusing
+    /// the index. That scan is a second place a `\r` can leak in: the range
+    /// would be one byte too long and point at `hello\r` instead of `hello`.
+    #[test]
+    fn locate_byte_range_excludes_the_line_break() {
+        for (yaml, break_form) in [
+            (b"a: hello\nb: 2\n".as_slice(), "LF"),
+            (b"a: hello\r\nb: 2\r\n".as_slice(), "CRLF"),
+            (b"a: hello\rb: 2\r".as_slice(), "CR"),
+        ] {
+            let index = YamlIndex::build(yaml).expect("parses");
+            let found =
+                locate_offset_detailed(&index, yaml, 4).expect("offset 4 is inside `hello`");
+            let (start, end) = found.byte_range;
+            assert_eq!(
+                &yaml[start..end],
+                b"hello",
+                "{break_form}: byte range {:?} covers {:?}",
+                found.byte_range,
+                String::from_utf8_lossy(&yaml[start..end])
+            );
+        }
+    }
+
+    /// The same scan stops at a comment, so a trailing comment must not extend
+    /// the range either — under any break form.
+    #[test]
+    fn locate_byte_range_stops_before_a_trailing_comment() {
+        for yaml in [
+            b"a: hi # note\n".as_slice(),
+            b"a: hi # note\r\n".as_slice(),
+            b"a: hi # note\r".as_slice(),
+        ] {
+            let index = YamlIndex::build(yaml).expect("parses");
+            let found = locate_offset_detailed(&index, yaml, 3).expect("offset 3 is inside `hi`");
+            let (start, end) = found.byte_range;
+            assert_eq!(
+                &yaml[start..end],
+                b"hi",
+                "byte range {:?} in {:?}",
+                found.byte_range,
+                String::from_utf8_lossy(yaml)
+            );
         }
     }
 }

--- a/tests/yaml_crlf_tests.rs
+++ b/tests/yaml_crlf_tests.rs
@@ -1,0 +1,513 @@
+//! Line-break differential harness: LF vs CRLF vs lone CR (#324).
+//!
+//! YAML 1.2 [§5.4] lists `\n`, `\r\n` and `\r` as line breaks, and [§5.7] requires
+//! a processor to normalize all of them to `\n` on input. So for any document,
+//! rewriting its line breaks from one form to another must not change what the
+//! parser produces — that invariance is the property this file tests.
+//!
+//! [§5.4]: https://yaml.org/spec/1.2.2/#54-line-break-characters
+//! [§5.7]: https://yaml.org/spec/1.2.2/#57-escaped-characters
+//!
+//! # Why a differential rather than fixtures
+//!
+//! #324 was a *silent* corruption: `a: 1\r\n` parsed as the string `"1 "` instead
+//! of the number `1`, because the plain-scalar extent swallowed the `\r`, which
+//! the folding decoder then turned into a trailing space. Nothing errored. The
+//! whole suite missed it because every fixture and benchmark input in the repo
+//! uses LF.
+//!
+//! Hand-written CRLF fixtures would only ever cover the cases someone thought to
+//! write. Driving the entire YAML Test Suite corpus through all three line-break
+//! forms and demanding identical output instead *measures* the surface, and keeps
+//! measuring it as the parser changes.
+//!
+//! The property is invariance, not correctness: a case that is wrong under LF is
+//! expected to be wrong in exactly the same way under CRLF. Correctness under LF
+//! is what `tests/yaml_test_suite.rs` pins, and the two suites compose.
+//!
+//! # Manifest
+//!
+//! Cases that are not yet invariant are listed in
+//! `tests/data/yaml-crlf-known-failures.txt`, keyed `<case-id>/<variant>`. As in
+//! the conformance harness, the assertion is two-sided: a new divergence fails
+//! the build, and so does a manifest entry for a case that now passes.
+//!
+//! Run with: `cargo test --test yaml_crlf_tests -- --nocapture`
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+use succinctly::yaml::{YamlIndex, YamlValue};
+
+const CORPUS: &str = include_str!("data/yaml-test-suite-2022-01-17.json");
+const KNOWN_FAILURES: &str = include_str!("data/yaml-crlf-known-failures.txt");
+
+/// The line-break form a document's `\n`s are rewritten to.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Breaks {
+    /// Windows: `\r\n`.
+    Crlf,
+    /// Classic Mac: a lone `\r`.
+    Cr,
+}
+
+impl Breaks {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Crlf => "crlf",
+            Self::Cr => "cr",
+        }
+    }
+
+    /// Rewrite every LF in `yaml` to this form.
+    ///
+    /// Sound because a raw LF in YAML is *always* a line break — there is no
+    /// context in which one is content. (The `\n` inside a double-quoted scalar
+    /// is the two characters `\` and `n`, which this leaves alone.)
+    fn apply(self, yaml: &str) -> String {
+        match self {
+            Self::Crlf => yaml.replace('\n', "\r\n"),
+            Self::Cr => yaml.replace('\n', "\r"),
+        }
+    }
+}
+
+// ============================================================================
+// Parse path — identical to tests/yaml_test_suite.rs, for the same reason:
+// this is the path `succinctly yq -o json '.'` actually takes.
+// ============================================================================
+
+fn yaml_to_json_documents(yaml: &[u8]) -> Result<Vec<String>, String> {
+    let index = YamlIndex::build(yaml).map_err(|e| e.to_string())?;
+    let root = index.root(yaml);
+
+    let mut docs = Vec::new();
+    match root.value() {
+        YamlValue::Sequence(mut elements) => {
+            while let Some((cursor, rest)) = elements.uncons_cursor() {
+                docs.push(cursor.to_json());
+                elements = rest;
+            }
+        }
+        _ => docs.push(root.to_json_document()),
+    }
+    Ok(docs)
+}
+
+/// The observable outcome of parsing, reduced to what must be invariant.
+///
+/// Error *messages* carry byte offsets and line numbers that legitimately shift
+/// when line breaks change width, so a rejection compares only as "rejected".
+/// Accepted documents compare by their full JSON output.
+#[derive(PartialEq, Eq)]
+enum Outcome {
+    Rejected,
+    Accepted(Vec<String>),
+}
+
+impl Outcome {
+    fn of(yaml: &[u8]) -> Self {
+        match yaml_to_json_documents(yaml) {
+            Ok(docs) => Self::Accepted(docs),
+            Err(_) => Self::Rejected,
+        }
+    }
+
+    fn render(&self) -> String {
+        match self {
+            Self::Rejected => "<rejected>".to_string(),
+            Self::Accepted(docs) => docs.join(" "),
+        }
+    }
+}
+
+// ============================================================================
+// Corpus and manifest
+// ============================================================================
+
+struct Case {
+    id: String,
+    name: String,
+    yaml: String,
+}
+
+/// Every corpus case whose input can be rewritten.
+///
+/// Cases that already contain a `\r` are skipped: rewriting their `\n`s would
+/// produce `\r\r\n` and test a document the corpus never described. Those cases
+/// exercise CR handling directly under `tests/yaml_test_suite.rs` instead.
+fn corpus() -> Vec<Case> {
+    let raw: Vec<Value> = serde_json::from_str(CORPUS).expect("corpus is valid JSON");
+    raw.into_iter()
+        .map(|c| Case {
+            id: c["id"].as_str().expect("case has id").to_string(),
+            name: c["name"].as_str().unwrap_or_default().to_string(),
+            yaml: c["yaml"].as_str().expect("case has yaml").to_string(),
+        })
+        .filter(|c| !c.yaml.contains('\r'))
+        .collect()
+}
+
+/// Parse the known-failures manifest: `<case-id>/<variant>  <category>  <reason>`,
+/// with `#` comments and blank lines ignored. Returns key -> category.
+fn known_failures() -> BTreeMap<String, String> {
+    KNOWN_FAILURES
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            // Columns are padded for readability, so split on whitespace runs.
+            let mut parts = line.split_whitespace();
+            let key = parts.next().unwrap_or_default();
+            let category = parts.next().unwrap_or_default();
+            assert!(
+                !key.is_empty() && !category.is_empty(),
+                "malformed manifest line (want `<case-id>/<variant>  <category>  <reason>`): {line}"
+            );
+            (key.to_string(), category.to_string())
+        })
+        .collect()
+}
+
+// ============================================================================
+// The differential
+// ============================================================================
+
+#[test]
+fn line_break_form_does_not_change_the_parse() {
+    let cases = corpus();
+    assert!(
+        cases.len() > 300,
+        "corpus looks truncated ({} cases) — rerun ./scripts/sync-yaml-test-suite.sh",
+        cases.len()
+    );
+
+    let mut failures: BTreeMap<String, String> = BTreeMap::new();
+    let mut totals: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
+
+    for case in &cases {
+        let baseline = Outcome::of(case.yaml.as_bytes());
+
+        for variant in [Breaks::Crlf, Breaks::Cr] {
+            let entry = totals.entry(variant.name()).or_insert((0, 0));
+            entry.0 += 1;
+
+            let rewritten = variant.apply(&case.yaml);
+            let actual = Outcome::of(rewritten.as_bytes());
+
+            if actual == baseline {
+                entry.1 += 1;
+            } else {
+                failures.insert(
+                    format!("{}/{}", case.id, variant.name()),
+                    format!(
+                        "{} — LF gives {}, {} gives {}",
+                        case.name,
+                        baseline.render(),
+                        variant.name().to_uppercase(),
+                        actual.render()
+                    ),
+                );
+            }
+        }
+    }
+
+    println!("\nLine-break invariance ({} cases)\n", cases.len());
+    for (variant, (total, pass)) in &totals {
+        let pct = if *total == 0 {
+            100.0
+        } else {
+            100.0 * *pass as f64 / *total as f64
+        };
+        println!("  {variant:<5} matches LF : {pass}/{total} = {pct:.1}%");
+    }
+    println!("\n  known failures on record: {}\n", known_failures().len());
+
+    let expected: BTreeSet<String> = known_failures().keys().cloned().collect();
+    let actual: BTreeSet<String> = failures.keys().cloned().collect();
+
+    let unexpected: Vec<_> = actual.difference(&expected).collect();
+    let stale: Vec<_> = expected.difference(&actual).collect();
+
+    let mut report = String::new();
+    if !unexpected.is_empty() {
+        report.push_str(&format!(
+            "\n{} case(s) newly divergent, absent from \
+             tests/data/yaml-crlf-known-failures.txt:\n",
+            unexpected.len()
+        ));
+        for key in &unexpected {
+            report.push_str(&format!("  {key}: {}\n", failures[key.as_str()]));
+        }
+        report.push_str(
+            "\nIf this is a known gap, add it to the manifest with a reason and issue link.\n",
+        );
+    }
+    if !stale.is_empty() {
+        report.push_str(&format!(
+            "\n{} case(s) now invariant but still listed as known failures:\n",
+            stale.len()
+        ));
+        for key in &stale {
+            report.push_str(&format!("  {key}\n"));
+        }
+        report.push_str("\nNice — remove these lines from the manifest.\n");
+    }
+    assert!(report.is_empty(), "{report}");
+}
+
+/// The manifest is hand-maintained; keep it honest about the corpus it describes.
+#[test]
+fn known_failures_manifest_is_wellformed() {
+    let ids: BTreeSet<String> = corpus().into_iter().map(|c| c.id).collect();
+    let unknown: Vec<_> = known_failures()
+        .into_keys()
+        .filter(|key| match key.rsplit_once('/') {
+            Some((id, variant)) => !ids.contains(id) || !matches!(variant, "crlf" | "cr"),
+            None => true,
+        })
+        .collect();
+    assert!(
+        unknown.is_empty(),
+        "manifest lists keys that are not `<corpus case id>/<crlf|cr>`: {unknown:?}"
+    );
+}
+
+/// The opt-in strict validator must reach the same verdict under every
+/// line-break form. Without this the validator could drift from the loader —
+/// #324 showed the two files handle line breaks in independent code.
+#[test]
+fn validator_verdict_does_not_change_with_line_breaks() {
+    let mut divergent = Vec::new();
+    for case in corpus() {
+        let baseline = succinctly::yaml::validate::validate(case.yaml.as_bytes()).is_ok();
+        for variant in [Breaks::Crlf, Breaks::Cr] {
+            let rewritten = variant.apply(&case.yaml);
+            let actual = succinctly::yaml::validate::validate(rewritten.as_bytes()).is_ok();
+            if actual != baseline {
+                let verdict = |ok: bool| if ok { "accepted" } else { "rejected" };
+                divergent.push(format!(
+                    "  {}/{}: {} — LF {}, {} {}",
+                    case.id,
+                    variant.name(),
+                    case.name,
+                    verdict(baseline),
+                    variant.name().to_uppercase(),
+                    verdict(actual)
+                ));
+            }
+        }
+    }
+    assert!(
+        divergent.is_empty(),
+        "the validator changed its verdict on {} case(s) purely from line-break form:\n{}",
+        divergent.len(),
+        divergent.join("\n")
+    );
+}
+
+// ============================================================================
+// Targeted cases from the issue
+// ============================================================================
+
+/// The reproductions in #324, plus the boundaries the issue asked to check.
+///
+/// Written as byte literals so no git line-ending setting can ever launder the
+/// `\r` out of the fixture.
+mod issue_324 {
+    use super::*;
+
+    #[track_caller]
+    fn assert_json(yaml: &[u8], expected: &str) {
+        let docs = yaml_to_json_documents(yaml)
+            .unwrap_or_else(|e| panic!("parse failed on {:?}: {e}", String::from_utf8_lossy(yaml)));
+        assert_eq!(
+            docs.join(" "),
+            expected,
+            "input: {:?}",
+            String::from_utf8_lossy(yaml)
+        );
+    }
+
+    #[test]
+    fn mapping_values_keep_their_type() {
+        assert_json(b"a: 1\r\nb: 2\r\n", r#"{"a":1,"b":2}"#);
+        assert_json(b"a: 1\rb: 2\r", r#"{"a":1,"b":2}"#);
+    }
+
+    #[test]
+    fn booleans_and_nulls_keep_their_type() {
+        assert_json(b"a: true\r\n", r#"{"a":true}"#);
+        assert_json(b"a: false\r\n", r#"{"a":false}"#);
+        assert_json(b"a: null\r\n", r#"{"a":null}"#);
+        assert_json(b"a: ~\r\n", r#"{"a":null}"#);
+        assert_json(b"a: 1.5\r\n", r#"{"a":1.5}"#);
+        assert_json(b"a: true\r", r#"{"a":true}"#);
+    }
+
+    #[test]
+    fn sequence_items_have_no_trailing_space() {
+        assert_json(b"- a\r\n- b\r\n", r#"["a","b"]"#);
+        assert_json(b"- 1\r\n- 2\r\n", "[1,2]");
+        assert_json(b"- a\r- b\r", r#"["a","b"]"#);
+    }
+
+    #[test]
+    fn quoted_scalars_stay_correct() {
+        assert_json(b"a: \"x\"\r\n", r#"{"a":"x"}"#);
+        assert_json(b"a: 'x'\r\n", r#"{"a":"x"}"#);
+        // A quoted number stays a string, as under LF (P10 type preservation).
+        assert_json(b"a: \"1.0\"\r\n", r#"{"a":"1.0"}"#);
+    }
+
+    #[test]
+    fn empty_values_resolve_to_null() {
+        assert_json(b"a:\r\nb: 1\r\n", r#"{"a":null,"b":1}"#);
+        assert_json(b"a:\rb: 1\r", r#"{"a":null,"b":1}"#);
+    }
+
+    #[test]
+    fn blank_lines_do_not_become_nodes() {
+        assert_json(b"a: 1\r\n\r\nb: 2\r\n", r#"{"a":1,"b":2}"#);
+        assert_json(b"a: 1\r\rb: 2\r", r#"{"a":1,"b":2}"#);
+    }
+
+    #[test]
+    fn comments_terminate_at_the_line_break() {
+        assert_json(b"a: 1 # note\r\nb: 2\r\n", r#"{"a":1,"b":2}"#);
+        assert_json(b"# lead\r\na: 1\r\n", r#"{"a":1}"#);
+        assert_json(b"a: 1 # note\rb: 2\r", r#"{"a":1,"b":2}"#);
+    }
+
+    #[test]
+    fn document_markers_are_recognised() {
+        assert_json(b"---\r\na: 1\r\n", r#"{"a":1}"#);
+        assert_json(b"---\r\na: 1\r\n...\r\n", r#"{"a":1}"#);
+        assert_json(b"---\r\na: 1\r\n---\r\nb: 2\r\n", r#"{"a":1} {"b":2}"#);
+        assert_json(b"---\ra: 1\r", r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn nested_block_structure_survives() {
+        assert_json(
+            b"root:\r\n  child:\r\n    - 1\r\n    - two\r\n",
+            r#"{"root":{"child":[1,"two"]}}"#,
+        );
+        assert_json(
+            b"root:\r  child:\r    - 1\r    - two\r",
+            r#"{"root":{"child":[1,"two"]}}"#,
+        );
+    }
+
+    #[test]
+    fn multiline_plain_scalars_fold_to_a_single_space() {
+        assert_json(b"a: one\r\n  two\r\n", r#"{"a":"one two"}"#);
+        assert_json(b"a: one\r  two\r", r#"{"a":"one two"}"#);
+    }
+
+    #[test]
+    fn flow_collections_survive() {
+        assert_json(b"a: [1, 2]\r\nb: {c: 3}\r\n", r#"{"a":[1,2],"b":{"c":3}}"#);
+        assert_json(b"a: [1, 2]\rb: {c: 3}\r", r#"{"a":[1,2],"b":{"c":3}}"#);
+    }
+
+    #[test]
+    fn literal_block_scalars_drop_the_cr() {
+        assert_json(b"a: |\r\n  one\r\n  two\r\n", r#"{"a":"one\ntwo\n"}"#);
+        assert_json(b"a: |-\r\n  one\r\n  two\r\n", r#"{"a":"one\ntwo"}"#);
+        assert_json(b"a: |+\r\n  one\r\n\r\n", r#"{"a":"one\n\n"}"#);
+        assert_json(b"a: |\r  one\r  two\r", r#"{"a":"one\ntwo\n"}"#);
+    }
+
+    #[test]
+    fn folded_block_scalars_drop_the_cr() {
+        assert_json(b"a: >\r\n  one\r\n  two\r\n", r#"{"a":"one two\n"}"#);
+        assert_json(b"a: >-\r\n  one\r\n  two\r\n", r#"{"a":"one two"}"#);
+        assert_json(b"a: >\r  one\r  two\r", r#"{"a":"one two\n"}"#);
+    }
+
+    #[test]
+    fn anchors_and_aliases_survive() {
+        assert_json(b"a: &x 1\r\nb: *x\r\n", r#"{"a":1,"b":1}"#);
+        assert_json(b"a: &x 1\rb: *x\r", r#"{"a":1,"b":1}"#);
+    }
+
+    /// A plain scalar long enough to reach the 32-byte SIMD classifier in
+    /// `skip_unquoted_simd`. Under a lone CR the classifier must stop at the
+    /// break; if it does not, it skips straight past and swallows the rest of
+    /// the document into one scalar.
+    #[test]
+    fn long_scalars_stop_at_the_break() {
+        assert_json(
+            b"a: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\nb: 2\r\n",
+            r#"{"a":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","b":2}"#,
+        );
+        assert_json(
+            b"a: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\rb: 2\r",
+            r#"{"a":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","b":2}"#,
+        );
+        // Same for keys, which use the classifier via `parse_unquoted_key`.
+        assert_json(
+            b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: 1\r\nb: 2\r\n",
+            r#"{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":1,"b":2}"#,
+        );
+    }
+}
+
+/// Line/column reporting drives `yq-locate` and `at_position`. The newline index
+/// already handles all three break forms; assert it, so it stays true.
+mod line_column {
+    use super::*;
+
+    #[track_caller]
+    fn assert_line_column(yaml: &[u8], offset: usize, expected: (usize, usize)) {
+        let index = YamlIndex::build(yaml).expect("parses");
+        assert_eq!(
+            index.to_line_column(offset, yaml),
+            expected,
+            "offset {offset} in {:?}",
+            String::from_utf8_lossy(yaml)
+        );
+    }
+
+    #[test]
+    fn crlf_line_column() {
+        // "a: 1\r\nbb: 2\r\n"
+        //  0123 4 5 678
+        let yaml = b"a: 1\r\nbb: 2\r\n";
+        assert_line_column(yaml, 0, (1, 1)); // `a`
+        assert_line_column(yaml, 3, (1, 4)); // `1`
+        assert_line_column(yaml, 6, (2, 1)); // `b`
+        assert_line_column(yaml, 10, (2, 5)); // `2`
+    }
+
+    #[test]
+    fn lone_cr_line_column() {
+        let yaml = b"a: 1\rbb: 2\r";
+        assert_line_column(yaml, 0, (1, 1));
+        assert_line_column(yaml, 3, (1, 4));
+        assert_line_column(yaml, 5, (2, 1));
+        assert_line_column(yaml, 9, (2, 5));
+    }
+
+    /// Round-trip through `to_offset`, which `yq-locate --line --column` uses.
+    #[test]
+    fn offset_round_trips_under_every_break_form() {
+        for yaml in [
+            b"a: 1\nbb: 2\n".to_vec(),
+            b"a: 1\r\nbb: 2\r\n".to_vec(),
+            b"a: 1\rbb: 2\r".to_vec(),
+        ] {
+            let index = YamlIndex::build(&yaml).expect("parses");
+            for offset in 0..yaml.len() {
+                let (line, column) = index.to_line_column(offset, &yaml);
+                assert_eq!(
+                    index.to_offset(line, column, &yaml),
+                    Some(offset),
+                    "offset {offset} in {:?}",
+                    String::from_utf8_lossy(&yaml)
+                );
+            }
+        }
+    }
+}

--- a/tests/yq_golden_tests.rs
+++ b/tests/yq_golden_tests.rs
@@ -103,6 +103,11 @@ fn known_failures() -> BTreeMap<String, String> {
 /// Run `succinctly yq <args> <filter>` with the case input on stdin and demand
 /// exit code 0 plus stdout byte-equal to the golden.
 fn run_case(case: &Case) -> Result<(), String> {
+    run_case_with_input(case, &case.input)
+}
+
+/// As [`run_case`], but with the document's line breaks possibly rewritten.
+fn run_case_with_input(case: &Case, input: &str) -> Result<(), String> {
     let mut child = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .arg("yq")
         .args(&case.args)
@@ -116,7 +121,7 @@ fn run_case(case: &Case) -> Result<(), String> {
         .stdin
         .take()
         .expect("stdin piped")
-        .write_all(case.input.as_bytes())
+        .write_all(input.as_bytes())
         .map_err(|e| format!("write stdin: {e}"))?;
     let output = child.wait_with_output().map_err(|e| format!("wait: {e}"))?;
 
@@ -186,6 +191,70 @@ fn yq_golden_conformance() {
         report.push_str("\nNice — remove these lines from the manifest.\n");
     }
     assert!(report.is_empty(), "{report}");
+}
+
+/// The same goldens, with the input's line breaks rewritten to CRLF and to a
+/// lone CR (#324).
+///
+/// No new fixtures are needed: YAML 1.2 §5.4/§5.7 make a processor normalize all
+/// three break forms to `\n` on input, so `yq`'s output is identical for all
+/// three spellings of the same document — the existing `expected.out` is the
+/// oracle for every variant. Rewriting `\n` is sound because a raw LF in YAML is
+/// always a line break; the `\n` inside a double-quoted scalar is the two
+/// characters `\` and `n`, which `str::replace` leaves alone.
+///
+/// The assertion is invariance: each variant must fail on exactly the cases the
+/// LF run fails on, so this stays honest without a second manifest.
+#[test]
+fn yq_golden_conformance_under_crlf_and_lone_cr() {
+    let cases = cases();
+    let baseline: BTreeSet<String> = cases
+        .iter()
+        .filter(|c| run_case(c).is_err())
+        .map(|c| c.name.clone())
+        .collect();
+
+    for (variant, rewrite) in [("CRLF", "\r\n"), ("CR", "\r")] {
+        let mut failures: BTreeMap<String, String> = BTreeMap::new();
+        for case in &cases {
+            let input = case.input.replace('\n', rewrite);
+            if let Err(reason) = run_case_with_input(case, &input) {
+                failures.insert(case.name.clone(), reason);
+            }
+        }
+
+        let actual: BTreeSet<String> = failures.keys().cloned().collect();
+        let regressed: Vec<_> = actual.difference(&baseline).collect();
+        let inverted: Vec<_> = baseline.difference(&actual).collect();
+
+        let mut report = String::new();
+        if !regressed.is_empty() {
+            report.push_str(&format!(
+                "\n{} case(s) match pinned yq under LF but not under {variant}:\n",
+                regressed.len()
+            ));
+            for name in &regressed {
+                report.push_str(&format!("  {name}: {}\n", failures[name.as_str()]));
+            }
+        }
+        if !inverted.is_empty() {
+            report.push_str(&format!(
+                "\n{} case(s) diverge from pinned yq under LF but match under {variant} — \
+                 line-break form must not change the output at all:\n",
+                inverted.len()
+            ));
+            for name in &inverted {
+                report.push_str(&format!("  {name}\n"));
+            }
+        }
+        assert!(report.is_empty(), "{report}");
+
+        println!(
+            "yq golden conformance under {variant}: {}/{} cases, same failure set as LF",
+            cases.len() - failures.len(),
+            cases.len()
+        );
+    }
 }
 
 /// The manifest is hand-maintained; keep it honest about the corpus it describes.


### PR DESCRIPTION
## Description

Fixes a silent corruption bug where YAML files with Windows (CRLF) or classic Mac (lone CR) line endings were mis-parsed. The `\r` character was folded into every plain scalar as a trailing space, destroying type resolution: `a: 1\r\n` loaded as the string `"1 "` instead of the number `1`, and `a: true` as `"true "`. There was no error message, no diagnostic, and the JSON output was well-formed, so nothing downstream could detect it. The entire test suite missed this because every fixture and benchmark input uses LF.

YAML 1.2 §5.4 specifies three line breaks — `\n`, `\r\n`, and a lone `\r` — and §5.7 requires normalization of all three to `\n` on input. This fix ensures the parser treats all three forms identically throughout the codebase, making `succinctly yq` produce byte-identical output regardless of which line-break form a document uses.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #324

## Changes Made

**SIMD Character Classification**
- Added `carriage_returns` mask to `YamlCharClass` in all SIMD variants (x86, NEON, broadword)
- Updated `classify_yaml_chars_avx2`, `classify_yaml_chars_sse2`, and broadword classifiers to detect `\r` bytes
- Modified `value_terminators()` to include carriage returns alongside newlines, colons, spaces, and hashes
- Updated block-scalar scans (`find_block_scalar_end`) to match either `\n` or `\r` when locating line starts

**Core Parser Logic (`src/yaml/parser.rs`)**
- Added `is_break()` helper to test for `\n` or `\r`
- Added `break_len_at()` to compute line-break width: 2 for `\r\n`, 1 for lone `\r` or `\n`, 0 otherwise
- Added `at_break()` and `skip_line_break()` methods as single source of truth for line-break handling
- Updated `current_line()` to count `\r` only when not part of a CRLF pair
- Modified all line-scanning predicates (`at_line_end`, `is_empty_key`, `looks_like_mapping_entry`, etc.) to recognize `\r` as a line terminator
- Updated `skip_unquoted_simd` to include `carriage_returns` in terminator set
- Fixed document markers (`---` and `...`) to work with all line-break forms
- Updated scalar extent trimming to remove `\r` alongside spaces and tabs
- Fixed block-scalar chomping to account for CRLF width when including trailing line breaks

**Query-Side Cursor and Light Scanning (`src/yaml/light.rs`)**
- Added free-function pair `is_line_break()` and `line_break_len()` for consistent line-break detection
- Updated all line-start walk-backs in indent computation to use the new helpers
- Fixed `find_scalar_end()` to stop at either break byte and trim trailing `\r`
- Updated `decode_block_literal` to skip the fast path when content contains `\r`, ensuring proper normalization through the main loop
- Modified indicator-line scan to recognize all break forms

**Validator (`src/yaml/validate.rs`)**
- Fixed unterminated quote scan to consume the entire CRLF when encountering `\r`, ensuring consistent scan resumption point across line-break forms
- This prevents LF and CRLF documents from disagreeing about line type classification

**Comprehensive Testing**
- Added `tests/yaml_crlf_tests.rs` — differential harness that parses the entire YAML Test Suite corpus under all three line-break forms and asserts identical output
- Added `tests/data/yaml-crlf-known-failures.txt` — manifest for cases not yet invariant (currently empty as all 402+ cases now pass)
- Extended `tests/yq_golden_tests.rs` with line-break variant testing to ensure `yq` output is identical across all three forms
- Created targeted test cases from issue #324 covering mappings, sequences, booleans, nulls, quoted scalars, empty values, blank lines, comments, document markers, nested structures, multiline scalars, flow collections, and block scalars
- Added invariance assertions for validator verdicts and line/column reporting

**Documentation**
- Updated `.claude/skills/yaml-semi-indexing/SKILL.md` with detailed guidance on line-break handling, naming the two failure modes, and pointing developers to the helper functions
- Added comprehensive section to `docs/parsing/yaml.md` documenting all three YAML 1.2 §5.4 line breaks, the resolution approach, and measured performance impact
- Updated `docs/compliance/yaml/limitations.md` with resolution note and history of the bug
- Added CHANGELOG entry explaining the silent corruption, the fix scope, and measured performance trade-offs

## Testing

**Automated Testing**
- [x] All existing tests pass
- [x] New differential harness added that parses 400+ YAML Test Suite cases under LF, CRLF, and lone CR forms
- [x] Validator invariance test ensures same verdict across all line-break forms
- [x] Line/column reporting invariance test confirms offset round-tripping
- [x] Extended `yq` golden tests to verify byte-identical output across all three forms
- [x] Targeted issue reproduction cases for #324

**Manual Testing**
- [x] Tested on x86_64 (7950X)
- [x] Tested on aarch64/ARM (M4 Pro) via benchmarking

### Test Commands
```bash
cargo test --test yaml_crlf_tests -- --nocapture
cargo test --test yaml_test_suite
cargo test --test yq_golden_tests -- --nocapture
cargo test --lib yaml
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] Potential performance regression on LF input (measured and justified)

**Benchmark Results** (interleaved A/B, 3 reps, `yaml_bench`):

| Metric                          | x86 (7950X)  | ARM (M4 Pro) |
|---------------------------------|--------------|---------------|
| Median index build              | +10.3%       | +5.0%         |
| Excluding block scalars         | +14.9%       | +6.9%         |
| Block scalars (FASTER!)         | −8% to −18%  | −7% to +2%    |
| End-to-end `yq .`              | +1.8%        | —             |
| End-to-end `yq .[].name`       | +6.4%        | —             |

**Performance Attribution** (per-change revert analysis on x86):
- SIMD classifier CR mask: ~2 pp (lone CR only)
- `looks_like_mapping_entry` CR arm: ~3 pp (lone CR only)
- `parse_unquoted_value_…` CR arm: ~2 pp (CRLF required)
- `skip_to_eol` → `is_break`: ~1 pp (CRLF required)
- Remaining (~7 pp): diffuse codegen perturbation in heavily-inlined scalar path

Note: The per-byte CR arms in the value scanner are load-bearing for CRLF too — blank lines between mapping entries require them. Dropping lone-CR support would recover only ~5 pp of the ~15 pp total cost. A const-generic `has_cr` gate would buy back the rest but at the cost of doubled parser monomorphization and ~25 conditional sites.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works (differential harness on 400+ cases)
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings
- [x] Performance regression is measured and documented

## Additional Notes

**Why This Matters**

This was a silent corruption bug affecting real-world Windows and Mac users. The fact that the entire test suite missed it — with 306 of 402 YAML Test Suite cases diverging under CRLF and 348 under lone CR — demonstrates why differential testing is essential for character-handling code. The invariance harness in `tests/yaml_crlf_tests.rs` ensures this class of bug cannot regress undetected.

**Design Decisions**

1. **Kept `newlines` and `carriage_returns` separate** in the character classifier because callers that genuinely mean LF (and tests that pin them) still mean LF. This is slightly more explicit than bitwise operations.

2. **Helper functions as single source of truth**: Rather than scattering `\r` tests throughout, `is_break()`, `break_len_at()`, `skip_line_break()` in the parser and `is_line_break()`, `line_break_len()` in the light module create a clear dependency on the specification.

3. **Trailing-whitespace trim includes `\r`**: The SIMD classifier can skip a CR to land on the LF after it, leaving the CR inside the token extent. Trimming must clean this up.

4. **No const-generic gate**: The option was considered but rejected — the ~5 pp savings do not justify the doubled monomorphization and conditioning ~25 call sites.

**Testing Strategy**

The differential harness is the guard: every YAML Test Suite case runs under all three break forms, and the outputs must be identical. No case is exempt (though cases already containing `\r` are skipped to avoid `\r\r\n`). The manifest (`yaml-crlf-known-failures.txt`) starts empty and stays empty — new divergences break the build, as do stale entries.

**Future Work**

If performance becomes critical, the const-generic `has_cr` gate is fully designed and documented in `docs/parsing/yaml.md`.