### PR TITLE
fix(yaml): preserve plain scalars beginning `- ` in flow context and fix flow container end positions (#332)

### DIFF
--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -88,6 +88,27 @@ separate pass run before indexing, so the default path pays nothing for it — s
 acceptance criteria; it rejects 59 of them today (each `lax:*` line removed from the
 manifest is a case now rejected), with the 24 harder cases still tracked in #223.
 
+### What "accepted" means: the text is kept, not dropped
+
+For an accepted-but-invalid document the loader's job is to produce *some* value without
+losing input. Where a construct has no valid reading, the parser absorbs it as scalar text
+rather than discarding it — the same principle as the tag handling below.
+
+`- ` followed by content is one such case. It is always the sequence-entry indicator, and
+no block sequence can begin inside a flow collection or after a `:` on the same line, so
+`[- x]` and `key: - a` are invalid (`yq` rejects both, and so does the validator). The
+loader reads them as the plain scalar `"- x"` / `"- a"`:
+
+```
+$ printf '[- x]\n' | succinctly yq -o json -I0 '.'
+["- x"]                   # yq: did not find expected node content
+```
+
+Until [#332](https://github.com/rust-works/succinctly/issues/332) these yielded `[null]`
+and `{"key":null}` — the content was silently discarded, which is a worse failure mode than
+either erroring or keeping the text. A `-` *not* followed by whitespace is an ordinary flow
+plain scalar and always was: `[-]` is `["-"]`, `[-1]` is `[-1]`.
+
 ### One exception: cyclic aliases are rejected
 
 An alias that would make an anchored value contain itself (`a: &x {self: *x}`) is

--- a/src/yaml/end_positions.rs
+++ b/src/yaml/end_positions.rs
@@ -26,12 +26,20 @@
 //!
 //! # API Note
 //!
-//! The Compact variant may return `Some(value)` for container entries (which
-//! get the previous scalar's end position due to zero-filling). The Dense
-//! variant returns `None` for zero entries. This inconsistency is acceptable
-//! because the only production caller (`value()` in `light.rs`) only calls
-//! `get()` for scalar nodes — containers exit before reaching the end position
-//! lookup.
+//! The two variants disagree on entries the parser never recorded: Compact returns
+//! `Some(previous non-zero end)` (an artefact of the zero-filling above), Dense returns
+//! `None`. What both guarantee, and what callers may rely on, is:
+//!
+//! > `get(i)` returns either node `i`'s own end, or a non-decreasing end recorded for an
+//! > *earlier* node. Since the parser writes a node's open position while positioned at
+//! > it, and every end it records is at or before the current position, an inherited value
+//! > is always at or before the node's own text position. So `end > text_pos` means "this
+//! > node has an extent of its own".
+//!
+//! `value()` in `light.rs` depends on exactly that: it distinguishes an empty block
+//! sequence-item wrapper (no extent, reads as null) from a plain scalar that merely begins
+//! `- ` (#332). The parser upholds the invariant with a debug assertion in
+//! `set_bp_text_end`.
 
 #[cfg(not(test))]
 use alloc::boxed::Box;
@@ -156,14 +164,15 @@ impl EndPositions {
 
     /// Get the end position for the `open_idx`-th BP open.
     ///
-    /// For the Dense variant, returns `None` if the entry is 0 (container).
-    /// For the Compact variant, may return `Some(value)` for containers
-    /// (they inherit the previous scalar's end position due to zero-filling).
-    /// Returns `None` only for leading containers (before any scalar) or
-    /// out of bounds.
+    /// For the Dense variant, returns `None` if the entry is 0 (no end recorded).
+    /// For the Compact variant, an unrecorded entry instead yields `Some(previous
+    /// non-zero end)` because of zero-filling; `None` comes back only for leading
+    /// entries (before any end was recorded) or out of bounds.
     ///
-    /// In production, this is only called for scalar nodes from `value()`,
-    /// so the container behavior is irrelevant.
+    /// Either way the result is node `open_idx`'s own end or an earlier node's, never a
+    /// later one — so a caller holding the node's text position can test `end > text_pos`
+    /// to ask "does this node have an extent of its own?". See the module-level API note;
+    /// `value()` in `light.rs` relies on this for #332.
     #[inline]
     pub fn get(&self, open_idx: usize) -> Option<usize> {
         match self {

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -284,7 +284,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// — containers, nulls, sequence-item wrappers — the result depends on the storage
     /// variant: `None`, or an *earlier* node's end. Never a later node's, so
     /// `end > bp_to_text_pos(bp_pos)` is a sound test for "this node has an extent of its
-    /// own" (see [`EndPositions::get`](super::end_positions) and #332).
+    /// own" (see the `EndPositions::get` contract in `yaml::end_positions`, and #332).
     #[inline]
     pub fn bp_to_text_end_pos(&self, bp_pos: usize) -> Option<usize> {
         let open_idx = self.bp.rank1(bp_pos);
@@ -436,13 +436,12 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// They are wrapper nodes around the item's content.
     /// Derives this from text (starts with `- `) rather than storing a bitvector.
     ///
-    /// Unlike [`YamlCursor::value`](super::light::YamlCursor::value) this does *not*
-    /// discriminate a childless wrapper from a plain scalar that merely begins `- `
-    /// (see #332). It does not need to: the only caller,
-    /// [`locate::path_to_bp`](super::locate), asks about a node's *ancestors*, and such a
-    /// scalar is always a BP leaf — a flow scalar is opened and closed with nothing pushed
-    /// in between. Adding the end-position lookup here would be unreachable code paid for
-    /// on every ancestor of every backwards walk.
+    /// Unlike [`YamlCursor::value`] this does *not* discriminate a childless wrapper from
+    /// a plain scalar that merely begins `- ` (see #332). It does not need to: the only
+    /// caller, `locate::path_to_bp`, asks about a node's *ancestors*, and such a scalar is
+    /// always a BP leaf — a flow scalar is opened and closed with nothing pushed in
+    /// between. Adding the end-position lookup here would be unreachable code paid for on
+    /// every ancestor of every backwards walk.
     #[inline]
     pub fn is_seq_item(&self, text: &[u8], bp_pos: usize) -> bool {
         // Fast path: containers (mappings/sequences) are never seq_items

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -24,6 +24,7 @@ use super::error::YamlError;
 use super::light::YamlCursor;
 use super::line_break::line_break_len;
 use super::parser::build_semi_index;
+use super::starts_seq_entry;
 
 /// Index structures for navigating YAML.
 ///
@@ -279,7 +280,11 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
 
     /// Get the text end byte offset for a BP position.
     ///
-    /// For scalars, returns the end position. For containers and null values, returns `None`.
+    /// For scalars, returns the end position. For nodes the parser recorded no end for
+    /// — containers, nulls, sequence-item wrappers — the result depends on the storage
+    /// variant: `None`, or an *earlier* node's end. Never a later node's, so
+    /// `end > bp_to_text_pos(bp_pos)` is a sound test for "this node has an extent of its
+    /// own" (see [`EndPositions::get`](super::end_positions) and #332).
     #[inline]
     pub fn bp_to_text_end_pos(&self, bp_pos: usize) -> Option<usize> {
         let open_idx = self.bp.rank1(bp_pos);
@@ -430,6 +435,14 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// Sequence items have BP open/close but no TY entry.
     /// They are wrapper nodes around the item's content.
     /// Derives this from text (starts with `- `) rather than storing a bitvector.
+    ///
+    /// Unlike [`YamlCursor::value`](super::light::YamlCursor::value) this does *not*
+    /// discriminate a childless wrapper from a plain scalar that merely begins `- `
+    /// (see #332). It does not need to: the only caller,
+    /// [`locate::path_to_bp`](super::locate), asks about a node's *ancestors*, and such a
+    /// scalar is always a BP leaf — a flow scalar is opened and closed with nothing pushed
+    /// in between. Adding the end-position lookup here would be unreachable code paid for
+    /// on every ancestor of every backwards walk.
     #[inline]
     pub fn is_seq_item(&self, text: &[u8], bp_pos: usize) -> bool {
         // Fast path: containers (mappings/sequences) are never seq_items
@@ -442,16 +455,9 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             return false;
         };
 
-        // Check for block sequence indicator `-` followed by whitespace.
-        // Branchless form (see #106): a `-` at end of input is a seq_item, so a
-        // missing next byte is treated as whitespace via `unwrap_or(b' ')`.
-        text_pos < text.len()
-            && text[text_pos] == b'-'
-            && matches!(
-                text.get(text_pos + 1).copied().unwrap_or(b' '),
-                b' ' | b'\t' | b'\n' | b'\r'
-            )
+        starts_seq_entry(text, text_pos)
     }
+
     /// Debug helper to get open position for a given open index.
     #[cfg(test)]
     pub fn debug_open_position_at(&self, open_idx: usize) -> Option<u32> {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -17,6 +17,7 @@ use std::string::ToString;
 use super::index::YamlIndex;
 use super::line_break::{is_line_break, line_break_len, line_break_len_before};
 use super::scalar::{could_be_null_or_bool, resolve_plain, ResolvedScalar};
+use super::{starts_inline_seq_entry, starts_seq_entry};
 use crate::util::simd::escape::find_json_escape;
 
 // ============================================================================
@@ -161,20 +162,35 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
 
         // Check for sequence item wrapper (non-container node starting with "- ").
         // Sequence items delegate to their first child's value. Uses the
-        // already-computed text_pos to avoid redundant lookups. Branchless seq-item
-        // test (see #106): a `-` at end of input is a seq_item, so a missing next
-        // byte is treated as whitespace via `unwrap_or(b' ')`.
-        if self.text[text_pos] == b'-'
-            && matches!(
-                self.text.get(text_pos + 1).copied().unwrap_or(b' '),
-                b' ' | b'\t' | b'\n' | b'\r'
-            )
-        {
+        // already-computed text_pos to avoid redundant lookups.
+        if starts_seq_entry(self.text, text_pos) {
             if let Some(child) = self.first_child() {
                 return child.value();
             }
-            // Empty sequence item (null)
-            return YamlValue::Null;
+
+            // Childless. Two different shapes reach here (#332):
+            //
+            //   * a genuine empty block sequence item (`-`, `- `, `- # comment`). The
+            //     parser opens the wrapper while positioned *at* the `-` and never records
+            //     an end for it, so the lookup below yields `None` (dense storage) or a
+            //     stale earlier scalar's end at or before the dash (compact storage).
+            //
+            //   * a plain scalar that merely *begins* `- `, which is what `[- x]` and
+            //     `a: - x` produce. Invalid YAML — the strict validator rejects both — but
+            //     the parser records a real trimmed end past the content, and dropping that
+            //     content silently is a worse failure mode than preserving the text.
+            //
+            // So `end > text_pos` means "this node has an extent of its own". Cold path:
+            // only reached when a `- `-prefixed node has no BP child, i.e. for empty
+            // sequence items. Every `- x` short-circuits above with zero extra work.
+            if self
+                .index
+                .text_end_pos_by_open_idx(open_idx)
+                .map_or(true, |end| end <= text_pos)
+            {
+                return YamlValue::Null;
+            }
+            // Otherwise fall through and decode `- …` as the plain scalar it is.
         }
 
         // Check for alias (only for non-container nodes)
@@ -3130,26 +3146,25 @@ impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
             element_cursor: element_cursor.next_sibling(),
         };
 
-        // For block sequences, navigate to the actual value cursor
+        // For a block sequence, element_cursor points at the item wrapper node (at the
+        // `-`) and the value lives in its first child; unwrap so callers that use the
+        // cursor *positionally* — `is_yaml_cursor_container`, which decides block-vs-inline
+        // YAML layout — see the content rather than the wrapper. For flow sequences,
+        // virtual root sequences, and document containers the element IS the value.
+        //
+        // Deliberately `starts_inline_seq_entry`, not the wider `starts_seq_entry` that
+        // `value()` uses: a bare `-` stays pointed at the wrapper, which is what
+        // `corpus_stats`'s bare-dash counting reads. Value decoding is the same either way.
+        //
+        // A childless wrapper is returned as-is: `value()` decides whether it is an empty
+        // sequence item (null) or a plain scalar that merely begins `- ` (#332).
         if element_cursor.is_container() {
             Some((element_cursor, rest))
-        } else if let Some(text_pos) = element_cursor.text_position() {
-            if text_pos < element_cursor.text.len()
-                && element_cursor.text[text_pos] == b'-'
-                && text_pos + 1 < element_cursor.text.len()
-                && (element_cursor.text[text_pos + 1] == b' '
-                    || element_cursor.text[text_pos + 1] == b'\t')
-            {
-                // Block sequence item - return child cursor if exists
-                if let Some(child) = element_cursor.first_child() {
-                    Some((child, rest))
-                } else {
-                    // Empty item - return element cursor (will produce null)
-                    Some((element_cursor, rest))
-                }
-            } else {
-                Some((element_cursor, rest))
-            }
+        } else if element_cursor
+            .text_position()
+            .is_some_and(|text_pos| starts_inline_seq_entry(element_cursor.text, text_pos))
+        {
+            Some((element_cursor.first_child().unwrap_or(element_cursor), rest))
         } else {
             Some((element_cursor, rest))
         }
@@ -3157,50 +3172,10 @@ impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
 
     /// Get the first element and the remaining elements.
     pub fn uncons(&self) -> Option<(YamlValue<'a, W>, Self)> {
-        let element_cursor = self.element_cursor?;
-
-        let rest = YamlElements {
-            element_cursor: element_cursor.next_sibling(),
-        };
-
-        // For block sequences, element_cursor points to the item wrapper node (at `-`).
-        // We need to navigate to the item's first child to get the actual value.
-        // However, for flow sequences, virtual root sequences, and document containers,
-        // the element IS the value directly.
-        //
-        // Block sequence items are detected by:
-        // 1. Text starts with `-`
-        // 2. The element is NOT itself a container (containers starting with `-` are sequences)
-        //
-        // If the element is a container (like a nested sequence or mapping), use it directly.
-        let value = if element_cursor.is_container() {
-            // This is a container (mapping or sequence) - use it directly
-            element_cursor.value()
-        } else if let Some(text_pos) = element_cursor.text_position() {
-            // Not a container - check if it's a block sequence item wrapper
-            if text_pos < element_cursor.text.len()
-                && element_cursor.text[text_pos] == b'-'
-                && text_pos + 1 < element_cursor.text.len()
-                && (element_cursor.text[text_pos + 1] == b' '
-                    || element_cursor.text[text_pos + 1] == b'\t')
-            {
-                // This is a block sequence item marker `- `
-                if let Some(child) = element_cursor.first_child() {
-                    // Block sequence item with content - unwrap to get the actual value
-                    child.value()
-                } else {
-                    // Empty sequence item (like `- # comment` or `- ` with nothing)
-                    // This should be null
-                    YamlValue::Null
-                }
-            } else {
-                // Scalar value
-                element_cursor.value()
-            }
-        } else {
-            element_cursor.value()
-        };
-        Some((value, rest))
+        // Delegate rather than re-deriving the sequence-item unwrap: this used to be a
+        // third open-coded copy of the `- ` test with its own acceptance set (#332).
+        let (cursor, rest) = self.uncons_cursor()?;
+        Some((cursor.value(), rest))
     }
 
     /// Get element by index.
@@ -3209,22 +3184,9 @@ impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
         for _ in 0..index {
             cursor = cursor.next_sibling()?;
         }
-        // Same logic as uncons - containers are used directly, block sequence items are unwrapped
-        let value_cursor = if cursor.is_container() {
-            cursor
-        } else if let Some(text_pos) = cursor.text_position() {
-            if text_pos < cursor.text.len()
-                && cursor.text[text_pos] == b'-'
-                && cursor.first_child().is_some()
-            {
-                cursor.first_child().unwrap()
-            } else {
-                cursor
-            }
-        } else {
-            cursor
-        };
-        Some(value_cursor.value())
+        // `value()` performs the sequence-item unwrap itself, so no `- ` test is needed
+        // here — this site used to carry one that omitted the whitespace check entirely.
+        Some(cursor.value())
     }
 }
 
@@ -4790,9 +4752,14 @@ fn stream_yaml_string_value<Out: core::fmt::Write>(
             // Source plain scalar: re-emit verbatim so both the scalar type and
             // its representation survive (`1`, `true`, `1.0`, `.5`, `yes`),
             // matching yq. Quote only when the decoded value cannot round-trip
-            // as a plain scalar (empty, or control chars / newlines from folded
-            // multiline plains with blank lines).
-            if str_val.is_empty() || str_val.bytes().any(|b| b < 0x20) {
+            // as a plain scalar (empty, control chars / newlines from folded
+            // multiline plains with blank lines, or a leading sequence-entry
+            // indicator — `- x` emitted bare under a `- ` would read back as a
+            // nested sequence, #332).
+            if str_val.is_empty()
+                || str_val.bytes().any(|b| b < 0x20)
+                || starts_seq_entry(str_val.as_bytes(), 0)
+            {
                 stream_yaml_double_quoted(out, &str_val)
             } else {
                 out.write_str(&str_val)
@@ -8340,5 +8307,197 @@ mod tests {
             );
             assert!(!root.is_in_flow_context(0), "column 0 is outside any flow");
         }
+    }
+
+    // ========================================================================
+    // Sequence-entry indicator (`- `) classification — #332
+    // ========================================================================
+
+    /// JSON for the first document, asserting the buffered (`to_json`) and streaming
+    /// (`stream_json`, what `yq -o json -I0` takes) emitters agree.
+    #[track_caller]
+    fn first_doc_json(yaml: &[u8]) -> String {
+        let index = YamlIndex::build(yaml).expect("builds");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(elements) = root.value() else {
+            panic!("expected root document sequence");
+        };
+        let (cursor, _rest) = elements.uncons_cursor().expect("one document");
+
+        let buffered = cursor.to_json();
+        let mut streamed = String::new();
+        cursor.stream_json(&mut streamed).expect("streams");
+        assert_eq!(
+            buffered,
+            streamed,
+            "buffered and streaming JSON differ for {}",
+            String::from_utf8_lossy(yaml)
+        );
+        buffered
+    }
+
+    /// A plain scalar beginning `- ` is only reachable where no block sequence can
+    /// start: inside a flow collection, and as a same-line block mapping value. The
+    /// input is invalid YAML (the strict validator rejects it) but the loader is
+    /// lenient, and preserving the text beats silently dropping it (#332).
+    #[test]
+    fn test_dash_space_plain_scalar_content_is_preserved() {
+        // Flow sequence — the shapes from the issue report
+        assert_eq!(first_doc_json(b"[- x]\n"), r#"["- x"]"#);
+        assert_eq!(first_doc_json(b"[- x, 1]\n"), r#"["- x",1]"#);
+        assert_eq!(first_doc_json(b"[a, - b]\n"), r#"["a","- b"]"#);
+        // Flow mapping value, and a flow sequence nested in a flow mapping
+        assert_eq!(first_doc_json(b"{a: - x}\n"), r#"{"a":"- x"}"#);
+        assert_eq!(first_doc_json(b"{a: [- x]}\n"), r#"{"a":["- x"]}"#);
+        // Multi-line flow collection: the `-` is followed by a newline, so a
+        // line-local text scan would misread this as a block sequence item
+        assert_eq!(first_doc_json(b"[\n  - x\n]\n"), r#"["- x"]"#);
+        // `- ` with nothing after it inside flow: trailing space is trimmed, so the
+        // extent is the dash alone
+        assert_eq!(first_doc_json(b"[- ]\n"), r#"["-"]"#);
+        // Same-line block mapping value. #325 covers this input and may later make
+        // the parser emit a real sequence here; until then the text survives.
+        assert_eq!(first_doc_json(b"key: - a\n"), r#"{"key":"- a"}"#);
+    }
+
+    /// A `-` *not* followed by whitespace is an ordinary plain scalar in flow
+    /// context and must keep decoding as one.
+    #[test]
+    fn test_dash_without_whitespace_stays_a_plain_scalar() {
+        assert_eq!(first_doc_json(b"[-]\n"), r#"["-"]"#);
+        assert_eq!(first_doc_json(b"{a: -}\n"), r#"{"a":"-"}"#);
+        assert_eq!(first_doc_json(b"[-1, -2]\n"), "[-1,-2]");
+        assert_eq!(first_doc_json(b"[-a]\n"), r#"["-a"]"#);
+    }
+
+    /// The other shape that reaches the childless `- ` branch: a genuine empty
+    /// block sequence item, for which the parser records no end position. These
+    /// must stay null — this is what the end-position discriminator protects.
+    #[test]
+    fn test_empty_block_sequence_items_are_null() {
+        assert_eq!(first_doc_json(b"-\n"), "[null]");
+        assert_eq!(first_doc_json(b"- \n"), "[null]");
+        assert_eq!(first_doc_json(b"- # comment\n"), "[null]");
+        assert_eq!(first_doc_json(b"a:\n  -\n  - y\n"), r#"{"a":[null,"y"]}"#);
+        // An anchor before an inline `- ` used to leave the wrapper with neither a
+        // child nor an end, so it reached this branch and read as null. #328 made
+        // it a real nested sequence, so it now short-circuits at `is_container()`
+        // long before the discriminator — kept as a pin that the two fixes compose.
+        assert_eq!(first_doc_json(b"- &a - x\n"), r#"[["x"]]"#);
+    }
+
+    /// Ordinary block sequence items still unwrap to their content — the hot path
+    /// the discriminator must not disturb.
+    #[test]
+    fn test_block_sequence_items_still_unwrap_to_their_content() {
+        assert_eq!(first_doc_json(b"- x\n"), r#"["x"]"#);
+        assert_eq!(first_doc_json(b"- x\n- y\n"), r#"["x","y"]"#);
+        assert_eq!(first_doc_json(b"- - x\n"), r#"[["x"]]"#);
+        assert_eq!(first_doc_json(b"- k: v\n"), r#"[{"k":"v"}]"#);
+        assert_eq!(first_doc_json(b"-\n  a: b\n"), r#"[{"a":"b"}]"#);
+        assert_eq!(first_doc_json(b"-\tx\n"), r#"["x"]"#);
+    }
+
+    /// `YamlElements` has three accessors and they used to open-code the `- ` test
+    /// three different ways, with three different acceptance sets. They now all
+    /// route through `value()`; this asserts they *agree*, so re-divergence fails a
+    /// test instead of shipping (#332, and the same class of bug as #106).
+    #[test]
+    fn test_sequence_element_accessors_agree() {
+        let inputs: &[&[u8]] = &[
+            b"[- x, 1, - y]\n",
+            b"[-, -1, - ]\n",
+            b"- x\n- y\n- - z\n",
+            b"-\n- y\n",
+            b"- # c\n- y\n",
+            b"a:\n  -\n  - y\n  - k: v\n",
+            b"[\n  - x,\n  y\n]\n",
+            b"- &a x\n- *a\n",
+        ];
+        for yaml in inputs {
+            let index = YamlIndex::build(yaml).expect("builds");
+            let root = index.root(yaml);
+            let YamlValue::Sequence(docs) = root.value() else {
+                panic!("expected document sequence");
+            };
+            let (doc, _) = docs.uncons_cursor().expect("one document");
+            // Only sequence documents have elements to compare.
+            let YamlValue::Sequence(elements) = doc.value() else {
+                continue;
+            };
+
+            let mut via_uncons = Vec::new();
+            let mut rest = elements;
+            while let Some((value, next)) = rest.uncons() {
+                via_uncons.push(write_yaml_value_as_json_string(value));
+                rest = next;
+            }
+
+            let mut via_uncons_cursor = Vec::new();
+            let mut rest = elements;
+            while let Some((cursor, next)) = rest.uncons_cursor() {
+                via_uncons_cursor.push(cursor.to_json());
+                rest = next;
+            }
+
+            let via_get: Vec<String> = (0..via_uncons.len())
+                .map(|i| {
+                    write_yaml_value_as_json_string(
+                        elements.get(i).expect("element index in range"),
+                    )
+                })
+                .collect();
+
+            assert_eq!(
+                via_uncons,
+                via_uncons_cursor,
+                "uncons and uncons_cursor disagree on {}",
+                String::from_utf8_lossy(yaml)
+            );
+            assert_eq!(
+                via_uncons,
+                via_get,
+                "uncons and get disagree on {}",
+                String::from_utf8_lossy(yaml)
+            );
+            assert!(
+                elements.get(via_uncons.len()).is_none(),
+                "get past the end returned a value for {}",
+                String::from_utf8_lossy(yaml)
+            );
+        }
+    }
+
+    /// A plain scalar that begins `- ` cannot be re-emitted bare: written under a
+    /// `- ` item marker it would read back as a nested sequence. Before #332 no
+    /// unquoted scalar could start that way, so this is a new obligation.
+    #[test]
+    fn test_dash_space_plain_scalar_is_quoted_in_yaml_output() {
+        for (yaml, expected) in [
+            (&b"[- x]\n"[..], "- \"- x\""),
+            (&b"{a: - x}\n"[..], "a: \"- x\""),
+            (&b"[- x, 1]\n"[..], "- \"- x\"\n- 1"),
+        ] {
+            let index = YamlIndex::build(yaml).expect("builds");
+            let root = index.root(yaml);
+            let mut out = String::new();
+            root.stream_yaml_document(&mut out, 2).expect("streams");
+            assert_eq!(out, expected, "for {}", String::from_utf8_lossy(yaml));
+
+            // And the emitted YAML must read back as the same value.
+            assert_eq!(
+                first_doc_json(out.as_bytes()),
+                first_doc_json(yaml),
+                "round-trip changed the value of {}",
+                String::from_utf8_lossy(yaml)
+            );
+        }
+    }
+
+    /// Helper: render a `YamlValue` as JSON, matching `to_json`'s output.
+    fn write_yaml_value_as_json_string<W: AsRef<[u64]>>(value: YamlValue<'_, W>) -> String {
+        let mut out = String::new();
+        write_yaml_value_as_json(&mut out, value);
+        out
     }
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -183,11 +183,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             // So `end > text_pos` means "this node has an extent of its own". Cold path:
             // only reached when a `- `-prefixed node has no BP child, i.e. for empty
             // sequence items. Every `- x` short-circuits above with zero extra work.
-            if self
-                .index
-                .text_end_pos_by_open_idx(open_idx)
-                .map_or(true, |end| end <= text_pos)
-            {
+            if !self.childless_seq_entry_has_own_extent(open_idx, text_pos) {
                 return YamlValue::Null;
             }
             // Otherwise fall through and decode `- …` as the plain scalar it is.
@@ -313,6 +309,20 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 })
             }
         }
+    }
+
+    /// Does a childless `- `-prefixed node cover text of its own past the indicator?
+    ///
+    /// Split out of [`Self::value`] and marked cold so the discrimination it performs
+    /// (#332) stays off the path every sequence item walks: `value` is recursive and
+    /// sits under `yq`'s whole read path, and inlining this made it 1-2% slower on
+    /// sequence-heavy documents even though the branch itself is never taken there.
+    #[cold]
+    #[inline(never)]
+    fn childless_seq_entry_has_own_extent(&self, open_idx: usize, text_pos: usize) -> bool {
+        self.index
+            .text_end_pos_by_open_idx(open_idx)
+            .is_some_and(|end| end > text_pos)
     }
 
     /// Parse an alias value from text position.

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -8369,6 +8369,27 @@ mod tests {
         assert_eq!(first_doc_json(b"key: - a\n"), r#"{"key":"- a"}"#);
     }
 
+    /// A same-line block mapping value that is a bare sequence-entry indicator, with
+    /// no content after it. The parser records an extent covering the `-` alone
+    /// (trailing spaces are trimmed), so this decodes as the string `"-"` — where
+    /// before #332 it was `null`, the same silent loss as `a: - x`.
+    ///
+    /// Pinned apart from the `- x` shapes because it is the one #325 is expected to
+    /// flip: once the parser emits a real sequence for a same-line `- ` value, this
+    /// becomes the empty item `{"a":[null]}`. `yq` rejects the input either way
+    /// (`block sequence entries are not allowed in this context`).
+    #[test]
+    fn test_bare_dash_as_same_line_mapping_value_keeps_the_dash() {
+        assert_eq!(first_doc_json(b"a: - \n"), r#"{"a":"-"}"#);
+        assert_eq!(first_doc_json(b"a: -\n"), r#"{"a":"-"}"#);
+        assert_eq!(first_doc_json(b"a: -  \n"), r#"{"a":"-"}"#);
+        assert_eq!(first_doc_json(b"a: -\t\n"), r#"{"a":"-"}"#);
+        // The same `- ` on the *next* line is a real block sequence whose one item is
+        // empty: a childless wrapper, which stays null. That is the discriminator's
+        // other side, and it is why the parser must never record an end for a wrapper.
+        assert_eq!(first_doc_json(b"a:\n  - \n"), r#"{"a":[null]}"#);
+    }
+
     /// A `-` *not* followed by whitespace is an ordinary plain scalar in flow
     /// context and must keep decoding as one.
     #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -8313,25 +8313,34 @@ mod tests {
     // Sequence-entry indicator (`- `) classification — #332
     // ========================================================================
 
+    /// Cursor at the first document. The root is always the implicit document
+    /// sequence, so this is the node a `yq` filter of `.` actually sees.
+    #[track_caller]
+    fn first_doc_cursor<'a, W: AsRef<[u64]>>(
+        index: &'a YamlIndex<W>,
+        yaml: &'a [u8],
+    ) -> YamlCursor<'a, W> {
+        let YamlValue::Sequence(docs) = index.root(yaml).value() else {
+            panic!("root is always the document sequence");
+        };
+        let (cursor, _rest) = docs.uncons_cursor().expect("one document");
+        cursor
+    }
+
     /// JSON for the first document, asserting the buffered (`to_json`) and streaming
     /// (`stream_json`, what `yq -o json -I0` takes) emitters agree.
     #[track_caller]
     fn first_doc_json(yaml: &[u8]) -> String {
         let index = YamlIndex::build(yaml).expect("builds");
-        let root = index.root(yaml);
-        let YamlValue::Sequence(elements) = root.value() else {
-            panic!("expected root document sequence");
-        };
-        let (cursor, _rest) = elements.uncons_cursor().expect("one document");
+        let cursor = first_doc_cursor(&index, yaml);
 
         let buffered = cursor.to_json();
         let mut streamed = String::new();
         cursor.stream_json(&mut streamed).expect("streams");
+        let what = String::from_utf8_lossy(yaml);
         assert_eq!(
-            buffered,
-            streamed,
-            "buffered and streaming JSON differ for {}",
-            String::from_utf8_lossy(yaml)
+            buffered, streamed,
+            "buffered and streaming JSON differ for {what}"
         );
         buffered
     }
@@ -8386,6 +8395,19 @@ mod tests {
         assert_eq!(first_doc_json(b"- &a - x\n"), r#"[["x"]]"#);
     }
 
+    /// The empty-key arms of `parse_explicit_flow_mapping_entry`. #332 split what was
+    /// one shared `set_bp_text_end(key_end)` into a call per arm so the nested-container
+    /// arms could opt out; these two keep recording an end equal to the key's own start,
+    /// which decodes as the empty key `""`.
+    #[test]
+    fn test_explicit_flow_key_with_no_key_is_empty() {
+        // `?` then the value indicator — the `Some(b':')` arm
+        assert_eq!(first_doc_json(b"[? : v]\n"), r#"[{"":"v"}]"#);
+        // `?` then a terminator — the `Some(b',' | b']' | b'}')` arm
+        assert_eq!(first_doc_json(b"[? , a]\n"), r#"[{"":null},"a"]"#);
+        assert_eq!(first_doc_json(b"[? ]\n"), r#"[{"":null}]"#);
+    }
+
     /// Ordinary block sequence items still unwrap to their content — the hot path
     /// the discriminator must not disturb.
     #[test]
@@ -8416,11 +8438,7 @@ mod tests {
         ];
         for yaml in inputs {
             let index = YamlIndex::build(yaml).expect("builds");
-            let root = index.root(yaml);
-            let YamlValue::Sequence(docs) = root.value() else {
-                panic!("expected document sequence");
-            };
-            let (doc, _) = docs.uncons_cursor().expect("one document");
+            let doc = first_doc_cursor(&index, yaml);
             // Only sequence documents have elements to compare.
             let YamlValue::Sequence(elements) = doc.value() else {
                 continue;
@@ -8448,22 +8466,15 @@ mod tests {
                 })
                 .collect();
 
+            let what = String::from_utf8_lossy(yaml);
             assert_eq!(
-                via_uncons,
-                via_uncons_cursor,
-                "uncons and uncons_cursor disagree on {}",
-                String::from_utf8_lossy(yaml)
+                via_uncons, via_uncons_cursor,
+                "uncons vs uncons_cursor: {what}"
             );
-            assert_eq!(
-                via_uncons,
-                via_get,
-                "uncons and get disagree on {}",
-                String::from_utf8_lossy(yaml)
-            );
+            assert_eq!(via_uncons, via_get, "uncons vs get: {what}");
             assert!(
                 elements.get(via_uncons.len()).is_none(),
-                "get past the end returned a value for {}",
-                String::from_utf8_lossy(yaml)
+                "get past the end returned a value for {what}"
             );
         }
     }
@@ -8482,14 +8493,15 @@ mod tests {
             let root = index.root(yaml);
             let mut out = String::new();
             root.stream_yaml_document(&mut out, 2).expect("streams");
-            assert_eq!(out, expected, "for {}", String::from_utf8_lossy(yaml));
+            let what = String::from_utf8_lossy(yaml);
+            assert_eq!(out, expected, "for {what}");
 
             // And the emitted YAML must read back as the same value.
+            let round_tripped = first_doc_json(out.as_bytes());
             assert_eq!(
-                first_doc_json(out.as_bytes()),
+                round_tripped,
                 first_doc_json(yaml),
-                "round-trip changed the value of {}",
-                String::from_utf8_lossy(yaml)
+                "round-trip changed {what}"
             );
         }
     }

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -74,6 +74,43 @@ mod scalar;
 pub mod simd;
 pub mod validate;
 
+/// Does `next` terminate a `-` sequence-entry indicator? That is whitespace, a line
+/// break, or end of input.
+///
+/// The one definition of the terminator set. It lives at the module root because the
+/// parser (which sees the next byte as it scans) and the reader (which indexes into the
+/// text) both need it, and #332 was caused by each site spelling it out separately —
+/// five copies with three different acceptance sets.
+#[inline]
+pub(crate) fn is_seq_indicator_next(next: Option<u8>) -> bool {
+    matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None)
+}
+
+/// Does `text` at `pos` begin with the block sequence-entry indicator?
+///
+/// A `-` followed by anything outside [`is_seq_indicator_next`] (`-1`, `-`, `[-]`) starts
+/// a plain scalar instead. A trailing `-` *is* an indicator (see #106).
+#[inline]
+pub(crate) fn starts_seq_entry(text: &[u8], pos: usize) -> bool {
+    text.get(pos) == Some(&b'-') && is_seq_indicator_next(text.get(pos + 1).copied())
+}
+
+/// Is the sequence-entry indicator at `pos` followed by content on the *same* line?
+///
+/// Deliberately narrower than [`starts_seq_entry`]: a bare `-` — line break or end of
+/// input after it — is excluded. `YamlElements::uncons_cursor` uses this so that a bare
+/// `-` keeps yielding the wrapper node rather than its child, because callers that use the
+/// returned cursor *positionally* depend on it: `corpus_stats` counts bare-dash items by
+/// the cursor's text position, and `is_yaml_cursor_container` decides block-vs-inline YAML
+/// layout from it.
+///
+/// Value decoding is unaffected either way — `value()` applies the wider
+/// [`starts_seq_entry`] and unwraps a bare-`-` wrapper itself.
+#[inline]
+pub(crate) fn starts_inline_seq_entry(text: &[u8], pos: usize) -> bool {
+    text.get(pos) == Some(&b'-') && matches!(text.get(pos + 1), Some(b' ' | b'\t'))
+}
+
 pub use error::YamlError;
 pub use index::YamlIndex;
 pub use light::{

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -178,6 +178,15 @@ struct Parser<'a> {
     /// [`Self::set_bp_text_end`]; release builds carry nothing.
     #[cfg(debug_assertions)]
     wrapper_slots: Vec<bool>,
+
+    /// The end position most recently recorded by [`Self::set_bp_text_end`].
+    ///
+    /// The other half of the same invariant: a wrapper stores no end of its own, so
+    /// under the compact `EndPositions` variant it *inherits* this value, and that is
+    /// what `YamlCursor::value` measures against the wrapper's own text position.
+    /// Asserted in [`Self::write_bp_open_seq_item`].
+    #[cfg(debug_assertions)]
+    last_recorded_end: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -215,6 +224,8 @@ impl<'a> Parser<'a> {
             nesting_depth: 0,
             #[cfg(debug_assertions)]
             wrapper_slots: Vec::with_capacity(estimated_opens),
+            #[cfg(debug_assertions)]
+            last_recorded_end: 0,
         }
     }
 
@@ -298,13 +309,32 @@ impl<'a> Parser<'a> {
     /// Distinct from [`Self::write_bp_open`] only in debug builds, where it records the
     /// slot so [`Self::set_bp_text_end`] can assert no end is ever stored for it — the
     /// invariant `YamlCursor::value` relies on to tell an empty item from a plain scalar
-    /// beginning `- ` (#332).
+    /// beginning `- ` (#332) — and asserts the other half of that invariant here.
     #[inline]
     fn write_bp_open_seq_item(&mut self) {
         self.write_bp_open();
         #[cfg(debug_assertions)]
-        if let Some(last) = self.wrapper_slots.last_mut() {
-            *last = true;
+        {
+            // Storing no end is only half of what the reader needs. Under the compact
+            // `EndPositions` variant the wrapper's slot is zero-filled from the last end
+            // recorded *before* it, and `value()` reads `end <= text_pos` as "no extent
+            // of its own — empty item, null". So that inherited end must never sit past
+            // the `-`. It cannot today: every end is recorded at or before `self.pos`,
+            // and `self.pos` only advances. Assert it because the failure is silent —
+            // an empty `- ` would start reading as the string `"-"` — and because the
+            // wrapper's text position is a parameter of `write_bp_open_at`, not a
+            // constant.
+            let text_pos = self.bp_to_text.last().copied().unwrap_or_default() as usize;
+            debug_assert!(
+                self.last_recorded_end <= text_pos,
+                "sequence-item wrapper at text {text_pos} inherits the end position {} \
+                 of an earlier node; YamlCursor::value reads an end past the wrapper as \
+                 the plain scalar `- …` rather than an empty item (#332)",
+                self.last_recorded_end
+            );
+            if let Some(last) = self.wrapper_slots.last_mut() {
+                *last = true;
+            }
         }
     }
 
@@ -328,6 +358,10 @@ impl<'a> Parser<'a> {
         );
         if let Some(last) = self.bp_to_text_end.last_mut() {
             *last = end_pos as u32;
+        }
+        #[cfg(debug_assertions)]
+        {
+            self.last_recorded_end = end_pos;
         }
     }
 

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -432,9 +432,13 @@ impl<'a> Parser<'a> {
 
     /// Does `next` terminate a `-` sequence indicator? That is whitespace, a
     /// line break, or end of input.
+    ///
+    /// Delegates to the module-level definition the reader also uses, so the terminator
+    /// set has one spelling (#332). Kept as an associated fn because the guard it appears
+    /// in must stay on one line for `llvm-cov` to see it (#324).
     #[inline]
     fn is_seq_indicator_next(next: Option<u8>) -> bool {
-        matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None)
+        super::is_seq_indicator_next(next)
     }
 
     /// Consume the line break at the current position, if any.

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -167,6 +167,17 @@ struct Parser<'a> {
     /// Current depth of recursively-parsed constructs, capped at
     /// [`MAX_NESTING_DEPTH`] to bound call-stack growth
     nesting_depth: usize,
+
+    /// One flag per `bp_to_text_end` slot, set for block sequence-item wrapper nodes.
+    ///
+    /// `YamlCursor::value` tells a childless wrapper from a plain scalar that merely
+    /// begins `- ` by whether an end position was recorded (#332). That rests on the
+    /// parser *never* recording one for a wrapper — an invariant the code held only by
+    /// accident of left-to-right parsing, whose failure mode is silent: `- a` would
+    /// start decoding as the string `"- a"`. Debug builds assert it in
+    /// [`Self::set_bp_text_end`]; release builds carry nothing.
+    #[cfg(debug_assertions)]
+    wrapper_slots: Vec<bool>,
 }
 
 impl<'a> Parser<'a> {
@@ -202,6 +213,8 @@ impl<'a> Parser<'a> {
             in_document: false,
             pending_explicit_key: false,
             nesting_depth: 0,
+            #[cfg(debug_assertions)]
+            wrapper_slots: Vec::with_capacity(estimated_opens),
         }
     }
 
@@ -275,13 +288,44 @@ impl<'a> Parser<'a> {
         self.bp_to_text.push(text_pos as u32);
         // Placeholder for end position (will be set by set_bp_text_end for scalars)
         self.bp_to_text_end.push(0);
+        #[cfg(debug_assertions)]
+        self.wrapper_slots.push(false);
         self.bp_pos += 1;
+    }
+
+    /// Open a block sequence-item wrapper node.
+    ///
+    /// Distinct from [`Self::write_bp_open`] only in debug builds, where it records the
+    /// slot so [`Self::set_bp_text_end`] can assert no end is ever stored for it — the
+    /// invariant `YamlCursor::value` relies on to tell an empty item from a plain scalar
+    /// beginning `- ` (#332).
+    #[inline]
+    fn write_bp_open_seq_item(&mut self) {
+        self.write_bp_open();
+        #[cfg(debug_assertions)]
+        if let Some(last) = self.wrapper_slots.last_mut() {
+            *last = true;
+        }
     }
 
     /// Set the end text position for the most recently opened BP node.
     /// Call this before write_bp_close for scalar nodes.
+    ///
+    /// "Most recently opened" means the last slot *pushed*, not the node the caller is
+    /// about to close. If the content just parsed opened BP nodes of its own — a nested
+    /// flow container, an alias — this writes the innermost of those instead, corrupting
+    /// its extent (#332). Such nodes need no end anyway: `value()` recognises them from
+    /// their leading `[`, `{` or `*`. So don't call this after them.
     #[inline]
     fn set_bp_text_end(&mut self, end_pos: usize) {
+        #[cfg(debug_assertions)]
+        debug_assert!(
+            self.wrapper_slots.last() != Some(&true),
+            "recorded an end position for a block sequence-item wrapper at text {}; \
+             YamlCursor::value would decode it as the plain scalar `- …` instead of \
+             unwrapping to its content (#332)",
+            self.bp_to_text.last().copied().unwrap_or_default()
+        );
         if let Some(last) = self.bp_to_text_end.last_mut() {
             *last = end_pos as u32;
         }
@@ -1297,7 +1341,7 @@ impl<'a> Parser<'a> {
         }
 
         // Open the sequence item node
-        self.write_bp_open();
+        self.write_bp_open_seq_item();
 
         // Skip `- `
         self.advance(); // -
@@ -1940,7 +1984,7 @@ impl<'a> Parser<'a> {
                 self.push_type(NodeType::Sequence);
 
                 // Parse first sequence item inline
-                self.write_bp_open(); // item node
+                self.write_bp_open_seq_item(); // item node
                 self.advance(); // skip `-`
                 self.skip_inline_whitespace();
 
@@ -2045,7 +2089,9 @@ impl<'a> Parser<'a> {
                 // Sequence as value. Routed through the shared sequence-item
                 // parser rather than an inlined copy of its dispatch, so anchor
                 // handling (#328) and every future fix land here too — this was
-                // the third divergent copy of this decision (#106).
+                // the third divergent copy of this decision (#106). That shared
+                // parser opens the item wrapper via `write_bp_open_seq_item`, so
+                // the #332 wrapper-end invariant is enforced here too.
                 self.parse_sequence_item(self.current_column())?;
             }
             Some(b'[') => {
@@ -2305,27 +2351,29 @@ impl<'a> Parser<'a> {
         // Parse key - can be scalar, quoted, flow mapping, or flow sequence
         self.set_ib();
         self.write_bp_open();
-        let key_end = match self.peek() {
+        match self.peek() {
+            // Nested flow containers open their own BP nodes and need no end of their
+            // own; recording one here would clobber the innermost of them (#332).
             Some(b'{') => {
                 self.parse_flow_mapping()?;
-                self.pos
             }
             Some(b'[') => {
                 self.parse_flow_sequence()?;
-                self.pos
             }
             Some(b':') => {
                 // Empty key (null) - ?: means null key
                 // Don't consume anything, write empty node
-                self.pos
+                self.set_bp_text_end(self.pos);
             }
             Some(b',' | b']' | b'}') => {
                 // Empty key (null) - ? followed by terminator
-                self.pos
+                self.set_bp_text_end(self.pos);
             }
-            _ => self.parse_explicit_flow_key_scalar()?,
-        };
-        self.set_bp_text_end(key_end);
+            _ => {
+                let key_end = self.parse_explicit_flow_key_scalar()?;
+                self.set_bp_text_end(key_end);
+            }
+        }
         self.write_bp_close();
 
         // Skip whitespace before possible colon
@@ -2341,13 +2389,12 @@ impl<'a> Parser<'a> {
                 self.set_ib();
                 self.write_bp_open();
                 match self.peek() {
+                    // Nested flow containers need no end of their own (#332)
                     Some(b'[') => {
                         self.parse_flow_sequence()?;
-                        self.set_bp_text_end(self.pos);
                     }
                     Some(b'{') => {
                         self.parse_flow_mapping()?;
-                        self.set_bp_text_end(self.pos);
                     }
                     _ => {
                         let end = self.parse_flow_scalar()?;
@@ -2386,18 +2433,19 @@ impl<'a> Parser<'a> {
         // Parse key - can be scalar, quoted, flow mapping, or flow sequence
         self.set_ib();
         self.write_bp_open();
-        let key_end = match self.peek() {
+        match self.peek() {
+            // Nested flow containers need no end of their own (#332)
             Some(b'{') => {
                 self.parse_flow_mapping()?;
-                self.pos
             }
             Some(b'[') => {
                 self.parse_flow_sequence()?;
-                self.pos
             }
-            _ => self.parse_flow_key_scalar()?,
-        };
-        self.set_bp_text_end(key_end);
+            _ => {
+                let key_end = self.parse_flow_key_scalar()?;
+                self.set_bp_text_end(key_end);
+            }
+        }
         self.write_bp_close();
 
         // Skip whitespace before colon
@@ -2418,18 +2466,19 @@ impl<'a> Parser<'a> {
         if !matches!(self.peek(), Some(b',' | b']' | b'}') | None) {
             self.set_ib();
             self.write_bp_open();
-            let val_end = match self.peek() {
+            match self.peek() {
+                // Nested flow containers need no end of their own (#332)
                 Some(b'[') => {
                     self.parse_flow_sequence()?;
-                    self.pos
                 }
                 Some(b'{') => {
                     self.parse_flow_mapping()?;
-                    self.pos
                 }
-                _ => self.parse_flow_scalar()?,
-            };
-            self.set_bp_text_end(val_end);
+                _ => {
+                    let val_end = self.parse_flow_scalar()?;
+                    self.set_bp_text_end(val_end);
+                }
+            }
             self.write_bp_close();
         } else {
             // Empty value (null)
@@ -2597,8 +2646,12 @@ impl<'a> Parser<'a> {
             // Parse key
             self.set_ib();
             self.write_bp_open();
-            self.parse_flow_key()?;
-            self.set_bp_text_end(self.pos);
+            // A complex key (nested flow container) or an alias opened its own BP nodes
+            // and carries its own end; recording one here would clobber the innermost of
+            // them (#332).
+            if !self.parse_flow_key()? {
+                self.set_bp_text_end(self.pos);
+            }
             self.write_bp_close();
 
             self.skip_flow_whitespace();
@@ -2669,7 +2722,11 @@ impl<'a> Parser<'a> {
 
     /// Parse a key in flow context.
     /// Keys can be scalars, flow sequences, or flow mappings (complex keys).
-    fn parse_flow_key(&mut self) -> Result<(), YamlError> {
+    ///
+    /// Returns `true` when the key opened BP nodes of its own — a nested flow container,
+    /// or an alias. The caller must **not** record an end position in that case — see
+    /// [`Self::set_bp_text_end`].
+    fn parse_flow_key(&mut self) -> Result<bool, YamlError> {
         // Check for anchor on key. The caller already opened the key's BP node,
         // so this records `bp_pos - 1`; using `parse_anchor` here bound the
         // anchor to the key's close bit, and aliases to it resolved to the
@@ -2694,9 +2751,11 @@ impl<'a> Parser<'a> {
                 }
                 Some(b'[') => {
                     self.parse_flow_sequence()?;
+                    return Ok(true);
                 }
                 Some(b'{') => {
                     self.parse_flow_mapping()?;
+                    return Ok(true);
                 }
                 Some(b':' | b',' | b'}') => {
                     // Empty key (null) - don't consume anything
@@ -2705,7 +2764,7 @@ impl<'a> Parser<'a> {
                     self.parse_explicit_flow_unquoted_key()?;
                 }
             }
-            return Ok(());
+            return Ok(false);
         }
 
         match self.peek() {
@@ -2718,20 +2777,24 @@ impl<'a> Parser<'a> {
             Some(b'[') => {
                 // Flow sequence as key (complex key)
                 self.parse_flow_sequence()?;
+                return Ok(true);
             }
             Some(b'{') => {
                 // Flow mapping as key (complex key)
                 self.parse_flow_mapping()?;
+                return Ok(true);
             }
             Some(b'*') => {
-                // Alias as key
+                // Alias as key — `parse_alias` opens and closes its own node, and
+                // records its own end
                 self.parse_alias()?;
+                return Ok(true);
             }
             _ => {
                 self.parse_flow_unquoted_key()?;
             }
         }
-        Ok(())
+        Ok(false)
     }
 
     /// Parse an unquoted key in flow context.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2033,12 +2033,52 @@ fn test_flow_dash_space_scalar_round_trips_through_yaml_output() -> Result<()> {
 
 #[test]
 fn test_flow_container_key_does_not_leak_its_closing_bracket() -> Result<()> {
-    // The end position of a flow key/value that is itself a nested container
-    // used to be written onto the innermost node inside it, stretching that
-    // node's extent past the closing bracket (#332). Observable via at_offset:
-    // offset 5 is the `e` of `[d, e]`, which decoded as "e]".
-    let (output, code) = run_yq_stdin("at_offset(5)", "{[d, e]: f}\n", &["-o=json", "-I=0"])?;
+    // `set_bp_text_end` writes the last slot *pushed*, so recording an end after
+    // parsing a nested `[`/`{` landed it on the innermost node inside that
+    // container and stretched its extent past the closing bracket (#332). One
+    // case per site that used to do it; `at_offset` names the inner node, whose
+    // decoded value carried the stray delimiter before the fix.
+    //
+    // Each `offset` below points at the last element inside the nested container:
+    // the assertion fails with a trailing `]` or `}` if the clobber returns.
+    for (yaml, offset, expected) in [
+        // flow-mapping key via parse_flow_key, sequence — `e` of `[d, e]`, was "e]"
+        ("{[d, e]: f}\n", 5, r#""e""#),
+        // flow-mapping key via parse_flow_key, mapping — the `1` of `{a: 1}`
+        ("{{a: 1}: 2}\n", 5, "1"),
+        // explicit flow key, sequence — `b` of `[a, b]`
+        ("{? [a, b]: 1}\n", 7, r#""b""#),
+        // explicit flow key, mapping — the `1` of `{a: 1}`
+        ("{? {a: 1}: 2}\n", 7, "1"),
+        // explicit flow entry inside a sequence — `b` of `[a, b]`
+        ("[? [a, b] : 1]\n", 7, r#""b""#),
+        // implicit flow-mapping-entry key — `b` of `[a, b]`
+        ("[[a, b]: 1]\n", 5, r#""b""#),
+        // implicit flow-mapping-entry value — `c` of `[b, c]`
+        ("[a: [b, c]]\n", 8, r#""c""#),
+    ] {
+        let (output, code) =
+            run_yq_stdin(&format!("at_offset({offset})"), yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(output.trim(), expected, "for {yaml:?} at offset {offset}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_alias_as_a_flow_mapping_key_keeps_its_own_extent() -> Result<()> {
+    // `parse_alias` opens and closes its own node and records its own end, so the
+    // flow-mapping key site must not record one over the top of it (#332). The
+    // alias resolves to the anchored value, which only works if its extent covers
+    // exactly `*x`.
+    let yaml = "x: &x 1\ny: {*x: 2}\n";
+    let (output, code) = run_yq_stdin("at_offset(13)", yaml, &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""e""#);
+    assert_eq!(output.trim(), "1");
+
+    // And the document as a whole still reads back correctly.
+    let (whole, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(whole.trim(), r#"{"x":1,"y":{"":2}}"#);
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1956,3 +1956,89 @@ fn test_argjson_invalid_value_errors() -> Result<()> {
     );
     Ok(())
 }
+
+// ============================================================================
+// Sequence-entry indicator in flow context (#332)
+//
+// These inputs are invalid YAML — `-` followed by whitespace is always the
+// sequence-entry indicator, and no block sequence can start inside a flow
+// collection — and real `yq` rejects every one of them. So they cannot be yq
+// goldens: `scripts/sync-yq-golden.sh` has no `expected.out` to capture. The
+// loader is deliberately lenient here (`succinctly yaml validate` is the layer
+// that rejects them); what it must not do is silently discard the content,
+// which is what it did before #332.
+// ============================================================================
+
+#[test]
+fn test_flow_dash_space_scalar_content_is_not_dropped() -> Result<()> {
+    for (yaml, expected) in [
+        ("[- x]\n", r#"["- x"]"#),
+        ("{a: - x}\n", r#"{"a":"- x"}"#),
+        ("[- x, 1]\n", r#"["- x",1]"#),
+        ("[a, - b]\n", r#"["a","- b"]"#),
+        ("{a: [- x]}\n", r#"{"a":["- x"]}"#),
+    ] {
+        let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(output.trim(), expected, "for {yaml:?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_flow_dash_without_whitespace_is_still_a_scalar() -> Result<()> {
+    // A `-` not followed by whitespace is a legitimate plain scalar in flow
+    // context and was never affected; pinned so #332's fix cannot regress it.
+    for (yaml, expected) in [
+        ("[-]\n", r#"["-"]"#),
+        ("{a: -}\n", r#"{"a":"-"}"#),
+        ("[-1, -2]\n", "[-1,-2]"),
+    ] {
+        let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(output.trim(), expected, "for {yaml:?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_empty_block_sequence_items_remain_null() -> Result<()> {
+    // The other shape that reaches the same branch. These are valid YAML and
+    // must keep reading as null — `yq` agrees.
+    for (yaml, expected) in [
+        ("-\n", "[null]"),
+        ("- # comment\n", "[null]"),
+        ("a:\n  -\n  - y\n", r#"{"a":[null,"y"]}"#),
+    ] {
+        let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(output.trim(), expected, "for {yaml:?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_flow_dash_space_scalar_round_trips_through_yaml_output() -> Result<()> {
+    // Default `-o yaml` must quote the scalar: emitted bare under a `- ` marker
+    // it would read back as a nested sequence.
+    let (yaml_out, code) = run_yq_stdin(".", "[- x]\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(yaml_out, "- \"- x\"\n");
+
+    let (json_out, code) = run_yq_stdin(".", &yaml_out, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(json_out.trim(), r#"["- x"]"#);
+    Ok(())
+}
+
+#[test]
+fn test_flow_container_key_does_not_leak_its_closing_bracket() -> Result<()> {
+    // The end position of a flow key/value that is itself a nested container
+    // used to be written onto the innermost node inside it, stretching that
+    // node's extent past the closing bracket (#332). Observable via at_offset:
+    // offset 5 is the `e` of `[d, e]`, which decoded as "e]".
+    let (output, code) = run_yq_stdin("at_offset(5)", "{[d, e]: f}\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""e""#);
+    Ok(())
+}

--- a/tests/yq_path_consistency_tests.rs
+++ b/tests/yq_path_consistency_tests.rs
@@ -253,6 +253,14 @@ fn paths_agree_on_key_and_scalar_constructs() {
         // quoted-string folding: literal trailing whitespace dropped, escaped kept
         "\"folded \nto a space,\t\n \nto a line feed, or \t\\\n \\ \tnon-content\"\n",
         "\"1 trailing\\t\n    tab\"\n",
+        // #332: a plain scalar beginning `- ` in flow context is preserved, not
+        // dropped — and both emitters must preserve the same thing
+        "[- x]\n",
+        "[- x, 1]\n",
+        "{a: - x}\n",
+        "{a: [- x]}\n",
+        // and an empty block sequence item stays null on both paths
+        "a:\n  -\n  - y\n",
     ];
     for yaml in inputs {
         compare(yaml).unwrap_or_else(|e| panic!("paths diverge on {yaml:?}:\n{e}"));


### PR DESCRIPTION
## Description

A plain scalar that begins `- ` inside a flow collection was read back as `null` — `[- x]` gave `[null]`, `{a: - x}` gave `{"a":null}` — silently losing the text the parser had recorded correctly. The input is invalid YAML (`yq` rejects it, and so does this repo's opt-in strict validator), but the lenient loader dropping content is a worse failure mode than either erroring or preserving it.

### Problem Summary

- Flow sequences like `[- x]` read back as `[null]` instead of `["- x"]`
- Flow mapping values like `{a: - x}` read back as `{"a":null}` instead of `{"a":"- x"}`
- The same-line block spelling `a: - x` lost its text too
- Independently: a flow key or value that was itself a nested container (`{[d, e]: f}`) had the closing bracket pulled into the innermost node's extent

### Root Cause

Two parser bugs behind one reader symptom:

1. **Flow container end positions.** `set_bp_text_end` writes to the last BP slot *pushed*, not to the node the caller is closing. Called after parsing a nested flow container or an alias, it overwrote the innermost node's end, stretching that node past the closing bracket.
2. **The wrapper invariant was undeclared.** `YamlCursor::value` classifies a `- `-prefixed non-container node as a sequence-item wrapper and delegates to its first child, returning `Null` when there is none. That is only correct because the parser never records an end position for a wrapper — an invariant nothing stated and nothing checked.

The reader could not tell an empty block sequence item from a flow plain scalar beginning `- ` because the distinction had nowhere to be recorded. It does now: the node's own extent.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #332

## Changes Made

**Parser (`src/yaml/parser.rs`)**
- `parse_explicit_flow_key`, `parse_flow_key` and `parse_flow_value` now call `set_bp_text_end` only for scalar content, never after a nested flow container or an alias (which open and close BP nodes of their own, and carry their own ends)
- `parse_flow_key` returns whether it delegated to such a node, so its caller can skip the end recording too
- `write_bp_open_seq_item()` marks block sequence-item wrapper opens; debug builds assert both halves of the invariant `value()` depends on — that no end is ever *recorded* on a wrapper slot, and that a wrapper never *inherits* (via compact `EndPositions` zero-filling) an end past its own `-`
- The sequence-indicator terminator set is delegated to the module-level definition

**Reader (`src/yaml/light.rs`, `src/yaml/index.rs`, `src/yaml/end_positions.rs`)**
- `YamlCursor::value()` discriminates a childless `- ` node by its extent: `end > text_pos` means the node covers text of its own, so it decodes as the plain scalar it is; otherwise it is an empty item and stays `null`. The lookup lives in a `#[cold] #[inline(never)]` helper — see Performance Impact
- `EndPositions::get()`'s contract is now stated: the result is the node's own end or an *earlier* node's, never a later one. That is what makes `end > text_pos` a sound test
- `YamlElements::uncons()` and `::get()` delegate to `value()` instead of re-deriving the unwrap; the three accessors now agree by construction
- YAML output quotes a plain scalar beginning `- `, which would otherwise read back as a nested sequence

**Centralised definitions (`src/yaml/mod.rs`)**
- `is_seq_indicator_next()`, `starts_seq_entry()`, `starts_inline_seq_entry()` — one definition each. #332 was caused by five copies of this predicate with three different acceptance sets

**Documentation (`docs/compliance/yaml/limitations.md`)**
- Records the lenient-loader behaviour: constructs with no valid reading keep their text rather than being dropped, and the contrast between `- x` (sequence entry, invalid in flow) and `-1` / `-` (valid plain scalars)

## Testing

**Automated:**
- [x] `cargo test --features cli,simd,regex,serde` green; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean
- [x] 8 new unit tests in `light.rs`, 6 new CLI tests in `yq_cli_tests.rs`, 5 more inputs in the `yq_path_consistency_tests.rs` corpus
- [x] Buffered (`to_json`) and streaming (`stream_json`) emitters asserted to agree on every case
- [x] The three `YamlElements` accessors (`uncons`, `uncons_cursor`, `get`) asserted to agree, so re-divergence fails a test
- [x] Emitted YAML asserted to read back to the same JSON value

**Behaviour pinned:**

| input | before | after | `yq` |
|-------|--------|-------|------|
| `[- x]` | `[null]` | `["- x"]` | rejects |
| `{a: - x}` | `{"a":null}` | `{"a":"- x"}` | rejects |
| `[- x, 1]` | `[null,1]` | `["- x",1]` | rejects |
| `a: - x` | `{"a":null}` | `{"a":"- x"}` | rejects |
| `a: - ` | `{"a":null}` | `{"a":"-"}` | rejects |
| `[-]` / `{a: -}` / `[-1]` | `["-"]` / `{"a":"-"}` / `[-1]` | unchanged | same |
| `-` / `- ` / `- # c` (block) | `[null]` | unchanged | `[null]` |
| `a:` / `  -` / `  - y` | `{"a":[null,"y"]}` | unchanged | same |

`a: - ` is the one case #325 is expected to flip (to `{"a":[null]}`, once a same-line `- ` value emits a real sequence); it is pinned in its own test so that moves deliberately.

## Performance Impact

The issue makes this an acceptance criterion, because the reader-side branch is on the path *every* sequence item takes — the reason the fix was scoped out of #325.

**Method** (docs/guides/benchmarking.md § A/B): the two release binaries (`--features cli,simd`, base `598b0b75` vs branch head) alternate **within** each repetition, 7 reps, `succinctly yq -o json -I0 <query> <file>`; both min and median reported. Corpus is `succinctly yaml generate` at 1 MB and 10 MB, plus two shapes no generator emits — `empty_items` (500k bare `-`, i.e. every item takes the new branch) and `half_empty` (alternating) — because an empty item is the *only* shape that reaches the new lookup. Idle machines, mains power.

**Output identity gated first** (rule 4): 160 configurations on the M4 Pro and 88 on the 7950X — every corpus file × {`.`, `.[0]`, `.[]`, `length`} × {json, yaml} — **0 differences**.

**Noise floor**: the same harness run with *the same binary on both sides* (M4 Pro) gives a median-of-medians of **+0.09%** (mean −0.07%, per-row range −1.8%..+1.5%). That is the bar any per-row number has to clear.

**Summary**: M4 Pro median-of-medians **+0.3%** (mean +0.05%, range −1.9%..+2.1%); 7950X **−4.2%** (mean −3.3%, range −8.6%..+0.9%). The x86 result says the branch measured *faster*, which no mechanism in this diff explains — it adds work and removes none. Treat it as code layout, not a win: the same effect shows in the scaling curves below, where the `- x` shape (which never reaches the new code) is uniformly 0.94-0.96× on the 7950X. What both machines agree on is that the fix costs nothing measurable.

### Apple M4 Pro (arm64)

```
workload                    before min   after min   min d  before med   after med   med d
------------------------------------------------------------------------------------------
users/1mb identity               11.2m       11.1m   -0.8%       11.5m       11.3m   -1.9%
users/1mb iterate                17.7m       18.0m   +1.8%       18.1m       18.3m   +1.4%
users/10mb identity              89.1m       88.8m   -0.4%       89.6m       89.1m   -0.6%
users/10mb iterate              152.3m      154.4m   +1.4%      155.0m      156.5m   +1.0%
sequences/1mb identity           11.2m       11.4m   +1.4%       11.6m       11.6m   +0.1%
sequences/1mb iterate            14.3m       14.4m   +0.7%       14.6m       14.7m   +0.4%
sequences/10mb identity          87.4m       88.2m   +0.9%       88.6m       89.0m   +0.5%
sequences/10mb iterate          118.5m      115.5m   -2.5%      119.2m      117.3m   -1.6%
nested/1mb identity               8.3m        8.4m   +1.1%        8.6m        8.4m   -1.8%
nested/1mb iterate               11.4m       11.5m   +0.3%       11.6m       11.8m   +2.1%
nested/10mb identity             57.2m       56.4m   -1.5%       57.9m       57.2m   -1.2%
nested/10mb iterate              83.8m       86.2m   +2.8%       84.9m       86.5m   +1.9%
mixed/1mb identity               10.7m       10.6m   -1.2%       10.8m       10.7m   -0.7%
mixed/1mb iterate                14.2m       14.0m   -0.8%       14.2m       14.2m   +0.1%
mixed/10mb identity              80.7m       79.6m   -1.4%       81.4m       80.5m   -1.1%
mixed/10mb iterate              113.2m      112.6m   -0.6%      113.5m      114.1m   +0.5%
flow/1mb identity               169.3m      169.7m   +0.2%      169.5m      170.1m   +0.4%
flow/1mb iterate                181.5m      181.7m   +0.1%      181.6m      182.1m   +0.3%
empty_items/1mb identity       1206.5m     1210.7m   +0.3%     1207.9m     1212.7m   +0.4%
empty_items/1mb iterate        1212.7m     1216.5m   +0.3%     1213.8m     1218.0m   +0.3%
half_empty/1mb identity         177.0m      177.6m   +0.4%      177.1m      177.8m   +0.4%
half_empty/1mb iterate          182.0m      182.5m   +0.3%      182.3m      182.6m   +0.2%
```

### AMD Ryzen 9 7950X (x86_64)

```
workload                    before min   after min   min d  before med   after med   med d
------------------------------------------------------------------------------------------
users/1mb identity               11.4m       10.8m   -4.7%       11.5m       11.0m   -4.2%
users/1mb iterate                22.1m       20.5m   -7.1%       22.3m       20.9m   -6.6%
users/10mb identity             103.9m       98.5m   -5.1%      104.6m       99.2m   -5.1%
users/10mb iterate              219.8m      205.0m   -6.8%      220.3m      205.5m   -6.7%
sequences/1mb identity           10.9m       10.5m   -3.8%       11.2m       10.6m   -5.1%
sequences/1mb iterate            16.2m       16.4m   +1.4%       16.5m       16.6m   +0.9%
sequences/10mb identity          96.6m       92.5m   -4.3%       97.2m       93.2m   -4.1%
sequences/10mb iterate          146.6m      148.2m   +1.0%      149.3m      150.4m   +0.8%
nested/1mb identity               8.2m        7.8m   -4.6%        8.4m        8.2m   -2.7%
nested/1mb iterate               13.9m       12.9m   -7.7%       14.2m       13.0m   -8.6%
nested/10mb identity             70.0m       67.1m   -4.1%       70.2m       67.5m   -3.9%
nested/10mb iterate             127.1m      118.8m   -6.5%      128.8m      119.5m   -7.2%
mixed/1mb identity               10.4m        9.9m   -4.9%       10.7m       10.3m   -4.2%
mixed/1mb iterate                15.7m       15.0m   -4.4%       15.9m       15.2m   -4.7%
mixed/10mb identity              89.5m       86.2m   -3.7%       90.4m       86.6m   -4.2%
mixed/10mb iterate              146.9m      140.9m   -4.1%      149.4m      141.5m   -5.3%
flow/1mb identity               503.8m      502.8m   -0.2%      504.4m      503.7m   -0.1%
flow/1mb iterate                526.9m      526.9m   +0.0%      528.4m      528.9m   +0.1%
empty_items/1mb identity       3755.5m     3767.1m   +0.3%     3777.4m     3773.3m   -0.1%
empty_items/1mb iterate        3794.5m     3785.0m   -0.3%     3818.1m     3809.4m   -0.2%
half_empty/1mb identity         532.7m      530.9m   -0.3%      537.7m      533.6m   -0.8%
half_empty/1mb iterate          538.1m      538.6m   +0.1%      540.0m      540.3m   +0.1%
```

### Scaling — the shape that actually takes the new branch

`-` repeated (every item empty, so every item hits the lookup) against `- x` repeated (every item short-circuits), query `.`.

Apple M4 Pro:

```
=== shape: `-` repeated   (query '.', -o json -I0) ===
    bytes   before ms     x2    after ms     x2  after/before
   100000       18.4      -       18.6      -        1.013x
   200000       56.7   3.09       58.5   3.15        1.031x
   400000      204.8   3.61      207.3   3.55        1.012x
   800000      780.8   3.81      783.7   3.78        1.004x

=== shape: `- x` repeated   (query '.', -o json -I0) ===
    bytes   before ms     x2    after ms     x2  after/before
   100000        5.2      -        5.0      -        0.976x
   200000        7.2   1.39        7.2   1.44        1.009x
   400000       11.6   1.61       11.6   1.61        1.006x
   800000       20.5   1.77       20.5   1.76        1.000x
```

AMD Ryzen 9 7950X:

```
=== shape: `-` repeated   (query '.', -o json -I0) ===
    bytes   before ms     x2    after ms     x2  after/before
   100000       42.3      -       42.2      -        0.997x
   200000      159.0   3.75      156.9   3.71        0.986x
   400000      612.2   3.85      609.2   3.88        0.995x
   800000     2417.4   3.95     2415.2   3.96        0.999x

=== shape: `- x` repeated   (query '.', -o json -I0) ===
    bytes   before ms     x2    after ms     x2  after/before
   100000        3.8      -        3.6      -        0.955x
   200000        6.4   1.70        6.2   1.71        0.962x
   400000       11.7   1.82       11.0   1.78        0.940x
   800000       22.1   1.89       21.1   1.92        0.953x
```

Growth per doubling is unchanged on both shapes and both machines, so nothing algorithmic moved. (The `-`-only shape grows ~3.8-4.0× per doubling on both sides — that is the pre-existing quadratic read of bare-dash documents, #337, not this branch.)

### What the measurement changed

The first version of the fix wrote the discriminator inline in `value()`. It measured **+1.1%** median-of-medians over all 22 workloads, with **every one of the 22 medians positive** — a real regression rather than noise, even though none of those documents ever takes the branch. `value()` is recursive and every node in a document passes through it, so the extra basic blocks moved the whole read path.

On the 16-workload generator subset used for the variant comparison (M4 Pro, same harness, medians of per-workload medians):

| variant | median | mean |
|---------|--------|------|
| same binary vs itself (noise floor) | +0.09% | −0.07% |
| discriminator inline in `value()` | +1.3% | +1.5% |
| `- ` predicates respelled as byte tests | +1.8% | +1.8% |
| **discriminator in a `#[cold]` helper (this PR)** | **+0.4%** | **+0.3%** |

The predicate respelling was tried first and did nothing, which is what pointed at code size in `value()` rather than at the predicate. The confirmation run of the shipped code — the M4 Pro table above — gives +0.1% on that same 16-workload subset.

Release builds carry no wrapper tracking and no assertions; both are `#[cfg(debug_assertions)]`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Composition with other fixes.** #328 made an anchored inline `- ` a real nested sequence, so `- &a - x` now short-circuits at `is_container()` long before this discriminator; a test pins that the two compose. #325 will make the same-line `a: - x` a real sequence too, at which point the `a: - x` rows above move from "preserved as text" to "parsed as a sequence" — the tests are written so that shows up as a deliberate edit.

**Invariant.** `EndPositions::get()` returning the node's own end or an earlier node's — never a later one — is now stated in the module docs and enforced from the parser side by two debug assertions. It is what lets a reader holding a node's text position ask "does this node have an extent of its own?" without storing another bit.
