### PR TITLE
test(bench): add anchor-heavy Home Assistant YAML to corpus and close sampling gap

### DIFF
--- a/docs/benchmarks/corpus-shape.md
+++ b/docs/benchmarks/corpus-shape.md
@@ -8,35 +8,36 @@ Distributions are derived from the crate's own semi-index (`JsonIndex` / `YamlIn
 
 ## Corpus inventory
 
-| format | workload  | file                     | bytes |
-| ------ | --------- | ------------------------ | ----- |
-| dsv    | gapminder | gapminder-five-year.csv  | 82079 |
-| dsv    | world-gdp | world-gdp-with-codes.csv | 4515  |
-| json   | charts    | bullet-data.json         | 548   |
-| json   | geojson   | us-election.geojson      | 99715 |
-| yaml   | actions   | codeql-analysis.yml      | 925   |
-| yaml   | actions   | prometheus-ci.yml        | 18935 |
-| yaml   | actions   | stale.yml                | 1290  |
-| yaml   | compose   | nginx-flask-mysql.yaml   | 1239  |
-| yaml   | compose   | wordpress.yaml           | 815   |
-| yaml   | k8s       | nginx-deployment.yml     | 836   |
-| yaml   | lint      | sass-lint.yml            | 2055  |
+| format | workload       | file                        | bytes |
+| ------ | -------------- | --------------------------- | ----- |
+| dsv    | gapminder      | gapminder-five-year.csv     | 82079 |
+| dsv    | world-gdp      | world-gdp-with-codes.csv    | 4515  |
+| json   | charts         | bullet-data.json            | 548   |
+| json   | geojson        | us-election.geojson         | 99715 |
+| yaml   | actions        | codeql-analysis.yml         | 925   |
+| yaml   | actions        | prometheus-ci.yml           | 18935 |
+| yaml   | actions        | stale.yml                   | 1290  |
+| yaml   | compose        | nginx-flask-mysql.yaml      | 1239  |
+| yaml   | compose        | wordpress.yaml              | 815   |
+| yaml   | home-assistant | air-quality-conditions.yaml | 9990  |
+| yaml   | k8s            | nginx-deployment.yml        | 836   |
+| yaml   | lint           | sass-lint.yml               | 2055  |
 
 ## YAML
 
-files: 7, total bytes: 26095, anchors: 0, aliases: 0, bare-dash items: 5
+files: 8, total bytes: 36085, anchors: 41, aliases: 86, bare-dash items: 5
 
 | metric               | unit         | n    | min  | p50  | p90  | p99  | max  |
 | -------------------- | ------------ | ---- | ---- | ---- | ---- | ---- | ---- |
-| scalar length        | bytes/scalar | 1052 | 0    | 7    | 38   | 109  | 374  |
-| mapping keys         | keys/mapping | 233  | 0    | 2    | 4    | 9    | 69   |
-| sequence items       | items/seq    | 58   | 1    | 2    | 8    | 12   | 12   |
-| bare-dash seq items  | count/file   | 7    | 0    | 0    | 5    | 5    | 5    |
+| scalar length        | bytes/scalar | 1587 | 0    | 7    | 25   | 89   | 374  |
+| mapping keys         | keys/mapping | 392  | 0    | 2    | 4    | 9    | 69   |
+| sequence items       | items/seq    | 94   | 1    | 2    | 4    | 12   | 12   |
+| bare-dash seq items  | count/file   | 8    | 0    | 0    | 5    | 5    | 5    |
 | flow-collection size | bytes/flow   | 14   | 2    | 11   | 91   | 100  | 100  |
-| nesting depth        | levels/node  | 761  | 2    | 7    | 9    | 11   | 12   |
-| anchors              | count/file   | 7    | 0    | 0    | 0    | 0    | 0    |
-| aliases              | count/file   | 7    | 0    | 0    | 0    | 0    | 0    |
-| escape density       | per KiB/file | 7    | 0.00 | 0.00 | 0.05 | 0.05 | 0.05 |
+| nesting depth        | levels/node  | 1206 | 2    | 6    | 8    | 10   | 12   |
+| anchors              | count/file   | 8    | 0    | 0    | 41   | 41   | 41   |
+| aliases              | count/file   | 8    | 0    | 0    | 86   | 86   | 86   |
+| escape density       | per KiB/file | 8    | 0.00 | 0.00 | 0.05 | 0.05 | 0.05 |
 
 ## JSON
 

--- a/docs/benchmarks/yaml-shape-survey.md
+++ b/docs/benchmarks/yaml-shape-survey.md
@@ -95,8 +95,8 @@ claim.
 
 ## Anchors are the opposite case — a genuine sampling gap
 
-[`NOTICES.md`](../../tests/data/bench-corpus/NOTICES.md) has long flagged that the
-corpus reads `anchors: 0`. The natural reading — that P4's anchor-heavy
+[`NOTICES.md`](../../tests/data/bench-corpus/NOTICES.md) long flagged that the
+corpus read `anchors: 0`. The natural reading — that P4's anchor-heavy
 micro-benchmarks simply over-assumed, and real input has no anchors — is wrong.
 Anchors are an order of magnitude more common than bare dashes, and heavily
 concentrated by ecosystem:
@@ -110,12 +110,23 @@ concentrated by ecosystem:
 | `gitlabhq/gitlabhq`           | 8,354      | 27                 | 0.32%      |
 | Kubernetes/manifests (9 repos)| 18,362     | 5                  | 0.027%     |
 
-So `anchors: 0` in the corpus is a **sampling artefact**, not upstream reality: the
-corpus over-samples Kubernetes and Docker Compose, the two families that genuinely do
+So `anchors: 0` in the corpus was a **sampling artefact**, not upstream reality: the
+corpus over-sampled Kubernetes and Docker Compose, the two families that genuinely do
 not use anchors. In workloads that do — Home Assistant configuration, Salt states,
 Concourse pipelines, GitLab CI — anchors appear in 4–11% of files, which makes them
 roughly 100x more prevalent than the bare-dash shape. Of the two gaps #326 raised,
-this is the one worth closing with a corpus file.
+this was the one worth closing with a corpus file.
+
+#342 closed it, from the densest ecosystem in the table above:
+`yaml/home-assistant/air-quality-conditions.yaml` is `home-assistant/core`'s
+`homeassistant/components/air_quality/conditions.yaml`, a shipped hand-written config
+carrying 41 anchors, 86 aliases, and 6 merge keys (`<<: *name`) in 9,990 B — so the
+corpus now reports `anchors: 41, aliases: 86` rather than zero. As with the bare-dash
+search, the alternates are recorded so the search is not repeated: `saltstack/salt`
+`pkg/common/env-cleanup-rules.yml` (12 anchors, 18 aliases, 12,796 B) parses cleanly and
+would serve as a second ecosystem, but adds no idiom the Home Assistant file lacks;
+every anchor-carrying file in `concourse/concourse` is a `testflight/` or `topgun/`
+fixture, which cannot carry a "real workload" claim.
 
 ## What this means for #106
 

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -493,8 +493,8 @@ is drift-checked in CI so the tooling and report cannot silently rot.
 
 The corpus establishes that a shape **exists** at a given size. It cannot establish
 **how often** it occurs — a handful of files cannot measure a shape present in a
-fraction of a percent of real input, and reading a shape's presence in a seven-file
-corpus as "one file in seven looks like this" inverts the error the corpus exists to
+fraction of a percent of real input, and reading a shape's presence in a corpus this
+small as "one file in eight looks like this" inverts the error the corpus exists to
 prevent. For frequency, scan whole upstream repositories:
 
 ```bash
@@ -505,9 +505,11 @@ prevent. For frequency, scan whole upstream repositories:
 Results are recorded in
 [docs/benchmarks/yaml-shape-survey.md](../benchmarks/yaml-shape-survey.md), which is
 where #326 established that bare-dash sequence items occur in 0.042% of real YAML
-files — and, conversely, that the corpus's `anchors: 0` is a sampling artefact rather
+files — and, conversely, that the corpus's `anchors: 0` was a sampling artefact rather
 than upstream reality, since anchors reach 4–11% of files in the ecosystems that use
-them. That page is date-pinned, not CI-checked: upstream branches move.
+them. #342 acted on that finding by vendoring a Home Assistant config, so the corpus
+now reports 41 anchors and 86 aliases. That page is date-pinned, not CI-checked:
+upstream branches move.
 
 ---
 

--- a/tests/data/bench-corpus/NOTICES.md
+++ b/tests/data/bench-corpus/NOTICES.md
@@ -21,6 +21,7 @@ retains its upstream license below.
 | `yaml/actions/stale.yml`              | [prometheus/prometheus](https://github.com/prometheus/prometheus) `.github/workflows/stale.yml`        | Apache-2.0 |
 | `yaml/k8s/nginx-deployment.yml`       | [kubernetes/examples](https://github.com/kubernetes/examples) `nginx-platform-app/deployment.yml`      | Apache-2.0 |
 | `yaml/lint/sass-lint.yml`             | [istio/istio](https://github.com/istio/istio) `common/config/sass-lint.yml` (bare-dash sequence items: `-` alone on its line) | Apache-2.0 |
+| `yaml/home-assistant/air-quality-conditions.yaml` | [home-assistant/core](https://github.com/home-assistant/core) `homeassistant/components/air_quality/conditions.yaml` (anchors, aliases, and merge keys: `&name`, `*name`, `<<: *name`) | Apache-2.0 |
 | `json/charts/bullet-data.json`        | [plotly/datasets](https://github.com/plotly/datasets) `BulletData.json`                                | MIT        |
 | `dsv/world-gdp/world-gdp-with-codes.csv` | [plotly/datasets](https://github.com/plotly/datasets) `2014_world_gdp_with_codes.csv` (genuine quoting: `"Bahamas, The"`) | MIT |
 
@@ -35,27 +36,44 @@ retains its upstream license below.
 ## What the corpus can and cannot tell you
 
 The corpus establishes **existence** — that a shape occurs in real files, and what
-it looks like at what size. It cannot establish **frequency**: seven files can never
-proportionally represent a shape that appears in a fraction of a percent of real
+it looks like at what size. It cannot establish **frequency**: a corpus this small can
+never proportionally represent a shape that appears in a fraction of a percent of real
 input. `yaml/lint/sass-lint.yml` is the worked example. It was added for #326 so the
 bare-dash sequence item (`-` alone on its line) is sampled at all, but a survey of
 26 upstream repositories (33,575 YAML files) found that shape in 0.042% of them.
-Reading its presence here as "roughly one YAML file in six uses bare dashes" inverts
-the error the corpus exists to prevent. Frequency questions belong to
+Reading its presence here as "roughly one YAML file in seven uses bare dashes" inverts
+the error the corpus exists to prevent.
+
+`yaml/home-assistant/air-quality-conditions.yaml` (#342) is the same story one order of
+magnitude up. It carries 41 anchors and 86 aliases, which is what a genuinely
+anchor-dense file looks like — but anchors appear in only 0.494% of real YAML files,
+and even in Home Assistant, the densest ecosystem surveyed, in 10.98%. The corpus now
+answers "what does anchor-heavy YAML look like, and at what size"; it still does not say
+how often you will meet one. Frequency questions belong to
 [`docs/benchmarks/yaml-shape-survey.md`](../../../docs/benchmarks/yaml-shape-survey.md).
 
 ## Extending the corpus
 
-The 1MB/10MB ladder tiers and anchor/alias-heavy YAML are follow-up curation. The
-anchor gap is the more urgent of the two: the corpus still shows `anchors: 0`, and the
-survey establishes that this is a **sampling artefact**, not upstream reality — the
-corpus over-samples Kubernetes and Compose, the two families that genuinely avoid
-anchors, while ecosystems that use them (Home Assistant, Salt, Concourse, GitLab CI)
-carry anchors in 4–11% of files, roughly 100x the bare-dash rate. To add one: add a
-`manifest.json` entry (`vendored: false`) with a
-commit-pinned `source_url`, `license`, `bytes`, and `sha256`, then run
-`./scripts/sync-bench-corpus.sh` to fetch and verify it. Prefer public-domain or
-permissive (CC0 / MIT / Apache-2.0 / BSD) sources and always record provenance.
+The anchor gap the survey identified is closed (#342): the corpus over-sampled
+Kubernetes and Compose, the two families that genuinely avoid anchors, so its
+`anchors: 0` was a **sampling artefact** rather than upstream reality. Vendoring one
+Home Assistant file — the ecosystem the survey measured at 10.98% — moves the reading to
+41 anchors and 86 aliases. The 1MB/10MB ladder tiers remain outstanding.
+
+To add a file: add a `manifest.json` entry with a commit-pinned `source_url`, `license`,
+`bytes`, and `sha256`, add a row here, then run `./scripts/sync-bench-corpus.sh --check`
+(vendored) or `./scripts/sync-bench-corpus.sh` (fetched) to verify it. Prefer
+public-domain or permissive (CC0 / MIT / Apache-2.0 / BSD) sources and always record
+provenance.
+
+Choose `vendored` by what the file is *for*. A file added to put an input shape on the
+record must be `vendored: true`: only `seed/` reaches
+[`expected-shape.md`](expected-shape.md), the golden CI checks, so a `vendored: false`
+file lands in [`corpus-shape.md`](../../../docs/benchmarks/corpus-shape.md) alone and
+nothing guards it against drifting back out. Reserve `vendored: false` for files that
+exist to fill a large ladder tier, where committing megabytes would be the greater cost.
+Either way, regenerate both reports afterwards — the commands are in
+[`docs/guides/benchmarking.md`](../../../docs/guides/benchmarking.md).
 
 Test-parse any candidate before committing it (`succinctly yq -o json '.' <file>`).
 `ingest_yaml` turns a parse failure into an error that aborts the whole report, and

--- a/tests/data/bench-corpus/expected-shape.md
+++ b/tests/data/bench-corpus/expected-shape.md
@@ -8,32 +8,33 @@ Distributions are derived from the crate's own semi-index (`JsonIndex` / `YamlIn
 
 ## Corpus inventory
 
-| format | workload  | file                     | bytes |
-| ------ | --------- | ------------------------ | ----- |
-| dsv    | world-gdp | world-gdp-with-codes.csv | 4515  |
-| json   | charts    | bullet-data.json         | 548   |
-| yaml   | actions   | codeql-analysis.yml      | 925   |
-| yaml   | actions   | stale.yml                | 1290  |
-| yaml   | compose   | nginx-flask-mysql.yaml   | 1239  |
-| yaml   | compose   | wordpress.yaml           | 815   |
-| yaml   | k8s       | nginx-deployment.yml     | 836   |
-| yaml   | lint      | sass-lint.yml            | 2055  |
+| format | workload       | file                        | bytes |
+| ------ | -------------- | --------------------------- | ----- |
+| dsv    | world-gdp      | world-gdp-with-codes.csv    | 4515  |
+| json   | charts         | bullet-data.json            | 548   |
+| yaml   | actions        | codeql-analysis.yml         | 925   |
+| yaml   | actions        | stale.yml                   | 1290  |
+| yaml   | compose        | nginx-flask-mysql.yaml      | 1239  |
+| yaml   | compose        | wordpress.yaml              | 815   |
+| yaml   | home-assistant | air-quality-conditions.yaml | 9990  |
+| yaml   | k8s            | nginx-deployment.yml        | 836   |
+| yaml   | lint           | sass-lint.yml               | 2055  |
 
 ## YAML
 
-files: 6, total bytes: 7160, anchors: 0, aliases: 0, bare-dash items: 5
+files: 7, total bytes: 17150, anchors: 41, aliases: 86, bare-dash items: 5
 
 | metric               | unit         | n   | min  | p50  | p90  | p99  | max  |
 | -------------------- | ------------ | --- | ---- | ---- | ---- | ---- | ---- |
-| scalar length        | bytes/scalar | 410 | 0    | 7    | 21   | 66   | 92   |
-| mapping keys         | keys/mapping | 69  | 0    | 2    | 5    | 69   | 69   |
-| sequence items       | items/seq    | 30  | 1    | 1    | 3    | 4    | 4    |
-| bare-dash seq items  | count/file   | 6   | 0    | 0    | 5    | 5    | 5    |
+| scalar length        | bytes/scalar | 945 | 0    | 7    | 19   | 49   | 92   |
+| mapping keys         | keys/mapping | 228 | 0    | 2    | 3    | 9    | 69   |
+| sequence items       | items/seq    | 66  | 1    | 2    | 3    | 4    | 4    |
+| bare-dash seq items  | count/file   | 7   | 0    | 0    | 5    | 5    | 5    |
 | flow-collection size | bytes/flow   | 4   | 2    | 2    | 100  | 100  | 100  |
-| nesting depth        | levels/node  | 284 | 2    | 5    | 9    | 11   | 12   |
-| anchors              | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |
-| aliases              | count/file   | 6   | 0    | 0    | 0    | 0    | 0    |
-| escape density       | per KiB/file | 6   | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| nesting depth        | levels/node  | 729 | 2    | 5    | 8    | 11   | 12   |
+| anchors              | count/file   | 7   | 0    | 0    | 41   | 41   | 41   |
+| aliases              | count/file   | 7   | 0    | 0    | 86   | 86   | 86   |
+| escape density       | per KiB/file | 7   | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 
 ## JSON
 

--- a/tests/data/bench-corpus/manifest.json
+++ b/tests/data/bench-corpus/manifest.json
@@ -91,6 +91,17 @@
     },
     {
       "format": "yaml",
+      "workload": "home-assistant",
+      "tier": "10kb",
+      "file": "yaml/home-assistant/air-quality-conditions.yaml",
+      "bytes": 9990,
+      "sha256": "98d0e726ebf70e1537fce12ddd403b9629868a4559b27d979252adf92ee70662",
+      "source_url": "https://raw.githubusercontent.com/home-assistant/core/05eeb6a1bcc18ff18d8edb8da376b9d648f89ce0/homeassistant/components/air_quality/conditions.yaml",
+      "license": "Apache-2.0",
+      "vendored": true
+    },
+    {
+      "format": "yaml",
       "workload": "actions",
       "tier": "10kb",
       "file": "yaml/actions/prometheus-ci.yml",

--- a/tests/data/bench-corpus/seed/yaml/home-assistant/air-quality-conditions.yaml
+++ b/tests/data/bench-corpus/seed/yaml/home-assistant/air-quality-conditions.yaml
@@ -1,0 +1,466 @@
+# --- Common condition fields ---
+
+.condition_behavior: &condition_behavior
+  required: true
+  default: any
+  selector:
+    automation_behavior:
+      mode: condition
+
+.condition_for: &condition_for
+  required: true
+  default: 00:00:00
+  selector:
+    duration:
+
+# --- Unit lists for multi-unit pollutants ---
+
+.co_units: &co_units
+  - "ppb"
+  - "ppm"
+  - "mg/m³"
+  - "μg/m³"
+
+.ozone_units: &ozone_units
+  - "ppb"
+  - "ppm"
+  - "μg/m³"
+
+.voc_units: &voc_units
+  - "μg/m³"
+  - "mg/m³"
+
+.voc_ratio_units: &voc_ratio_units
+  - "ppb"
+  - "ppm"
+
+.no_units: &no_units
+  - "ppb"
+  - "μg/m³"
+
+.no2_units: &no2_units
+  - "ppb"
+  - "ppm"
+  - "μg/m³"
+
+.so2_units: &so2_units
+  - "ppb"
+  - "μg/m³"
+
+# --- Entity filter anchors ---
+
+.co_threshold_entity: &co_threshold_entity
+  - domain: input_number
+    unit_of_measurement: *co_units
+  - domain: sensor
+    device_class: carbon_monoxide
+  - domain: number
+    device_class: carbon_monoxide
+
+.co2_threshold_entity: &co2_threshold_entity
+  - domain: input_number
+    unit_of_measurement: "ppm"
+  - domain: sensor
+    device_class: carbon_dioxide
+  - domain: number
+    device_class: carbon_dioxide
+
+.pm1_threshold_entity: &pm1_threshold_entity
+  - domain: input_number
+    unit_of_measurement: "μg/m³"
+  - domain: sensor
+    device_class: pm1
+  - domain: number
+    device_class: pm1
+
+.pm25_threshold_entity: &pm25_threshold_entity
+  - domain: input_number
+    unit_of_measurement: "μg/m³"
+  - domain: sensor
+    device_class: pm25
+  - domain: number
+    device_class: pm25
+
+.pm4_threshold_entity: &pm4_threshold_entity
+  - domain: input_number
+    unit_of_measurement: "μg/m³"
+  - domain: sensor
+    device_class: pm4
+  - domain: number
+    device_class: pm4
+
+.pm10_threshold_entity: &pm10_threshold_entity
+  - domain: input_number
+    unit_of_measurement: "μg/m³"
+  - domain: sensor
+    device_class: pm10
+  - domain: number
+    device_class: pm10
+
+.ozone_threshold_entity: &ozone_threshold_entity
+  - domain: input_number
+    unit_of_measurement: *ozone_units
+  - domain: sensor
+    device_class: ozone
+  - domain: number
+    device_class: ozone
+
+.voc_threshold_entity: &voc_threshold_entity
+  - domain: input_number
+    unit_of_measurement: *voc_units
+  - domain: sensor
+    device_class: volatile_organic_compounds
+  - domain: number
+    device_class: volatile_organic_compounds
+
+.voc_ratio_threshold_entity: &voc_ratio_threshold_entity
+  - domain: input_number
+    unit_of_measurement: *voc_ratio_units
+  - domain: sensor
+    device_class: volatile_organic_compounds_parts
+  - domain: number
+    device_class: volatile_organic_compounds_parts
+
+.no_threshold_entity: &no_threshold_entity
+  - domain: input_number
+    unit_of_measurement: *no_units
+  - domain: sensor
+    device_class: nitrogen_monoxide
+  - domain: number
+    device_class: nitrogen_monoxide
+
+.no2_threshold_entity: &no2_threshold_entity
+  - domain: input_number
+    unit_of_measurement: *no2_units
+  - domain: sensor
+    device_class: nitrogen_dioxide
+  - domain: number
+    device_class: nitrogen_dioxide
+
+.n2o_threshold_entity: &n2o_threshold_entity
+  - domain: input_number
+    unit_of_measurement: "μg/m³"
+  - domain: sensor
+    device_class: nitrous_oxide
+  - domain: number
+    device_class: nitrous_oxide
+
+.so2_threshold_entity: &so2_threshold_entity
+  - domain: input_number
+    unit_of_measurement: *so2_units
+  - domain: sensor
+    device_class: sulphur_dioxide
+  - domain: number
+    device_class: sulphur_dioxide
+
+# --- Number anchors for single-unit pollutants ---
+
+.co2_threshold_number: &co2_threshold_number
+  mode: box
+  unit_of_measurement: "ppm"
+
+.ugm3_threshold_number: &ugm3_threshold_number
+  mode: box
+  unit_of_measurement: "μg/m³"
+
+# --- Binary sensor targets ---
+
+.target_gas: &target_gas
+  entity:
+    - domain: binary_sensor
+      device_class: gas
+
+.target_co_binary: &target_co_binary
+  entity:
+    - domain: binary_sensor
+      device_class: carbon_monoxide
+
+.target_smoke: &target_smoke
+  entity:
+    - domain: binary_sensor
+      device_class: smoke
+
+# --- Sensor targets ---
+
+.target_co_sensor: &target_co_sensor
+  entity:
+    - domain: sensor
+      device_class: carbon_monoxide
+
+.target_co2: &target_co2
+  entity:
+    - domain: sensor
+      device_class: carbon_dioxide
+
+.target_pm1: &target_pm1
+  entity:
+    - domain: sensor
+      device_class: pm1
+
+.target_pm25: &target_pm25
+  entity:
+    - domain: sensor
+      device_class: pm25
+
+.target_pm4: &target_pm4
+  entity:
+    - domain: sensor
+      device_class: pm4
+
+.target_pm10: &target_pm10
+  entity:
+    - domain: sensor
+      device_class: pm10
+
+.target_ozone: &target_ozone
+  entity:
+    - domain: sensor
+      device_class: ozone
+
+.target_voc: &target_voc
+  entity:
+    - domain: sensor
+      device_class: volatile_organic_compounds
+
+.target_voc_ratio: &target_voc_ratio
+  entity:
+    - domain: sensor
+      device_class: volatile_organic_compounds_parts
+
+.target_no: &target_no
+  entity:
+    - domain: sensor
+      device_class: nitrogen_monoxide
+
+.target_no2: &target_no2
+  entity:
+    - domain: sensor
+      device_class: nitrogen_dioxide
+
+.target_n2o: &target_n2o
+  entity:
+    - domain: sensor
+      device_class: nitrous_oxide
+
+.target_so2: &target_so2
+  entity:
+    - domain: sensor
+      device_class: sulphur_dioxide
+
+# --- Binary sensor conditions ---
+
+.condition_binary_common: &condition_binary_common
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+
+is_gas_detected:
+  <<: *condition_binary_common
+  target: *target_gas
+
+is_gas_cleared:
+  <<: *condition_binary_common
+  target: *target_gas
+
+is_co_detected:
+  <<: *condition_binary_common
+  target: *target_co_binary
+
+is_co_cleared:
+  <<: *condition_binary_common
+  target: *target_co_binary
+
+is_smoke_detected:
+  <<: *condition_binary_common
+  target: *target_smoke
+
+is_smoke_cleared:
+  <<: *condition_binary_common
+  target: *target_smoke
+
+# --- Numerical sensor conditions with unit conversion ---
+
+is_co_value:
+  target: *target_co_sensor
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *co_threshold_entity
+          mode: is
+          number:
+            mode: box
+          unit_of_measurement: *co_units
+
+is_ozone_value:
+  target: *target_ozone
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *ozone_threshold_entity
+          mode: is
+          number:
+            mode: box
+          unit_of_measurement: *ozone_units
+
+is_voc_value:
+  target: *target_voc
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *voc_threshold_entity
+          mode: is
+          number:
+            mode: box
+          unit_of_measurement: *voc_units
+
+is_voc_ratio_value:
+  target: *target_voc_ratio
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *voc_ratio_threshold_entity
+          mode: is
+          number:
+            mode: box
+          unit_of_measurement: *voc_ratio_units
+
+is_no_value:
+  target: *target_no
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *no_threshold_entity
+          mode: is
+          number:
+            mode: box
+          unit_of_measurement: *no_units
+
+is_no2_value:
+  target: *target_no2
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *no2_threshold_entity
+          mode: is
+          number:
+            mode: box
+          unit_of_measurement: *no2_units
+
+is_so2_value:
+  target: *target_so2
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *so2_threshold_entity
+          mode: is
+          number:
+            mode: box
+          unit_of_measurement: *so2_units
+
+# --- Numerical sensor conditions without unit conversion ---
+
+is_co2_value:
+  target: *target_co2
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *co2_threshold_entity
+          mode: is
+          number: *co2_threshold_number
+
+is_pm1_value:
+  target: *target_pm1
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *pm1_threshold_entity
+          mode: is
+          number: *ugm3_threshold_number
+
+is_pm25_value:
+  target: *target_pm25
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *pm25_threshold_entity
+          mode: is
+          number: *ugm3_threshold_number
+
+is_pm4_value:
+  target: *target_pm4
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *pm4_threshold_entity
+          mode: is
+          number: *ugm3_threshold_number
+
+is_pm10_value:
+  target: *target_pm10
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *pm10_threshold_entity
+          mode: is
+          number: *ugm3_threshold_number
+
+is_n2o_value:
+  target: *target_n2o
+  fields:
+    behavior: *condition_behavior
+    for: *condition_for
+    threshold:
+      required: true
+      selector:
+        numeric_threshold:
+          entity: *n2o_threshold_entity
+          mode: is
+          number: *ugm3_threshold_number


### PR DESCRIPTION
## Description

This PR closes issue #342 by adding anchor-heavy YAML content to the benchmark corpus, addressing a sampling artifact in the test data. The corpus previously reported `anchors: 0`, which was identified in issue #326 as incorrect—the survey established that anchors appear in 0.494% of real YAML files overall and in 10.98% of Home Assistant configurations. This PR vendors a Home Assistant configuration file containing 41 anchors and 86 aliases, providing real-world representation of anchor-dense YAML patterns.

## Type of Change
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #342

## Changes Made

**Benchmark Corpus Data:**
- Added `tests/data/bench-corpus/seed/yaml/home-assistant/air-quality-conditions.yaml` (9,990 B, Apache-2.0 licensed) from `home-assistant/core` repository pinned at commit `05eeb6a1`
- File contains 41 anchors, 86 aliases, and 6 merge keys (`<<: *name`) demonstrating all three anchor idioms
- Includes non-ASCII scalars (`μg/m³` unit strings) as a side effect, providing additional character encoding representation

**Corpus Metadata and Documentation:**
- Updated `tests/data/bench-corpus/manifest.json` to register the new Home Assistant file with source URL, license, SHA256 hash, and vendored flag
- Updated `tests/data/bench-corpus/expected-shape.md` golden benchmark with corrected statistics:
  - YAML file count: 6 → 7 files
  - Total bytes: 7,160 → 17,150 B
  - Anchors: 0 → 41 (count/file metrics updated accordingly)
  - Aliases: 0 → 86 (count/file metrics updated accordingly)
  - Updated distribution metrics for scalar length, mapping keys, sequence items, nesting depth
- Updated `tests/data/bench-corpus/NOTICES.md` with comprehensive documentation:
  - Added vendor attribution row for the new Home Assistant file
  - Clarified corpus limitations regarding frequency vs. existence
  - Documented the actual rule for choosing vendored vs. fetched files based on their purpose
  - Explained that shape-closing files must be vendored to reach CI drift checks
  - Recorded alternate candidates considered but not selected (Salt Stack and Concourse)

**Documentation Updates:**
- Updated `docs/benchmarks/corpus-shape.md` with regenerated full-corpus statistics (8 YAML files, 36,085 B total, 41 anchors, 86 aliases)
- Updated `docs/benchmarks/yaml-shape-survey.md` to reflect the closed anchor gap:
  - Changed past tense ("reads" → "read", "is" → "was") to indicate the artefact is now resolved
  - Added reference to #342 and the specific file that closed the gap
  - Documented why this file was chosen over rejected alternates
- Updated `docs/guides/benchmarking.md` to:
  - Change the artefact claim to past tense
  - Update hardcoded "seven-file corpus" reference to reflect the new eight-file corpus
  - Explain that the #326 survey findings were acted upon in #342

## Testing

**Validation Performed:**
- [x] New YAML file test-parsed before committing using `succinctly yq` to verify it parses correctly
- [x] Verified that `ingest_yaml` successfully processes the file (parse failures abort the entire report)
- [x] Confirmed the file generates expected anchor and alias statistics (41 anchors, 86 aliases)
- [x] Validated all metadata in manifest.json (source URL pinned to specific commit, license, file size, SHA256 hash)
- [x] All existing tests pass with updated golden files

**Benchmark Output Validation:**
- YAML files: 7 (seed) and 8 (full corpus including fetched files)
- Anchor statistics now correctly reflect real-world density rather than artifact
- All statistical distributions updated correctly in expected-shape.md

## Performance Impact
- [x] No performance impact
- Corpus size increased by ~10 KB in seed directory; this is intentional to capture anchor-heavy patterns
- Benchmark metrics are now more representative of real-world YAML characteristics

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] New YAML corpus file added and validated
- [x] All documentation updates are accurate and complete
- [x] Golden benchmark files (expected-shape.md) regenerated with correct statistics
- [x] New file test-parsed to prevent parse failures during corpus ingestion
- [x] My changes generate no new warnings

## Additional Notes

**Rationale for File Selection:**
The Home Assistant configuration file was chosen because:
- It is a shipped hand-written config (not a test fixture), meeting the quality standard
- It is from the ecosystem with the highest measured anchor density (10.98% of files)
- It comprehensively demonstrates all three anchor idioms: anchors (`&name`), aliases (`*name`), and merge keys (`<<: *name`)
- It provides non-ASCII character sampling as a beneficial side effect

**Why Vendored:**
This file is marked as `vendored: true` because it serves the critical purpose of closing a sampling gap and putting anchor-heavy patterns on the record. Only vendored files in the `seed/` directory reach the golden CI drift checks in `expected-shape.md`, ensuring this important shape cannot regress.

**Rejected Alternatives:**
- Salt Stack `pkg/common/env-cleanup-rules.yml`: Parses cleanly with 12 anchors and 18 aliases, but adds no new idioms not already present in the Home Assistant file
- Concourse `concourse/concourse`: All anchor-carrying files are test fixtures (in `testflight/` or `topgun/` directories), disqualifying them as real workloads

**Documentation Note:**
The NOTICES.md section on "Extending the corpus" was updated to correctly state the rule for choosing vendored vs. fetched files. Previously it stated vendored should always be `false`, which was incorrect for files added to close a sampling gap.