### PR TITLE
ci(ci, docs): silence the CPU-conditional popcount coverage flap (#302)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,7 +539,12 @@ jobs:
 
       - uses: action-works/omni-dev-coverage-check@v1
         with:
-          version: 0.34.0                               # pin; we're a consumer
+          # Pin; we're a consumer. Must stay >= 0.38.0: that release added the
+          # declarative `.omni-dev/coverage.yaml` ignore-list (omni-dev#1398),
+          # which is how the CPU-conditional `src/bits/popcount.rs` flap (#302)
+          # is silenced. The action does not thread `--ignore-filename-regex`,
+          # so config-file discovery from the checkout is the only route.
+          version: 0.38.0
           use-prebuilt-binary: ${{ matrix.use-prebuilt }}
           test-args: --features cli,simd,regex,serde --workspace
           fail-under-lines: 55   # floor a few pts below local llvm-cov (ARM: 59.58% lines)

--- a/.omni-dev/coverage.yaml
+++ b/.omni-dev/coverage.yaml
@@ -1,0 +1,45 @@
+# Coverage config for `omni-dev coverage diff` (the sticky PR comment posted by
+# the `Coverage (x86_64)` / `Coverage (ARM64)` jobs in .github/workflows/ci.yml).
+#
+# Requires omni-dev >= 0.38.0 (rust-works/omni-dev#1398). On older versions this
+# file is simply not read, so the pin in ci.yml must stay at or above 0.38.0 for
+# the exclusions below to take effect.
+diff:
+  # Repo-relative path regexes, unanchored (partial match), applied after
+  # --strip-prefix normalisation — same semantics as the
+  # `--ignore-filename-regex` flag, with which this list is set-unioned.
+  #
+  # Only files whose coverage is *inherently non-deterministic across runs*
+  # belong here: a region gated on a runtime CPU-feature check (not a `#[cfg]`)
+  # is compiled into the denominator on every run but executed only on a host
+  # whose CPU has the instruction. When the `main` baseline run and the PR-head
+  # run draw different runner CPUs, the file moves with no source change.
+  # Matching files are dropped from *both* reports before the diff, so they can
+  # no longer produce a phantom entry in the "unchanged file(s) also moved"
+  # note. See CONTRIBUTING.md "SIMD CI coverage" and succinctly#302.
+  ignore-filename-regex:
+    # ~30 lines behind `is_x86_feature_detected!("avx512vpopcntdq")`. The x86
+    # runners are usually Zen 3 (EPYC 7763, no AVX-512) but the fleet is not
+    # CPU-homogeneous, so this file reports ~93% on a capable host and ~66%
+    # otherwise — a ±26pp swing observed on unrelated PRs (#287, #357).
+    # `SUCCINCTLY_EXPECT_SIMD` intentionally omits `avx512vpopcntdq`, so this
+    # cannot be made deterministic by pinning the runner's feature set.
+    - 'src/bits/popcount\.rs'
+
+  # Deliberately NOT excluded, contrary to the illustrative list in
+  # rust-works/omni-dev#1398:
+  #
+  #   src/dsv/simd/**, src/yaml/simd/**, src/json/simd/**
+  #     Their runtime dispatch gates on avx2 / bmi2 / sve2 / sve2-bitperm only —
+  #     every one of which the test legs pin via `SUCCINCTLY_EXPECT_SIMD`, so
+  #     they are deterministic on the runner fleet, not CPU-conditional noise.
+  #
+  #   src/util/simd/x86.rs
+  #     Has an `avx512f` arm (the `has_fast_bmi2` early return), so it flaps by
+  #     the same mechanism — but only by ~1-2 lines in a large file, below the
+  #     threshold that surfaces the "also moved" note. Excluding the whole file
+  #     would hide far more real coverage than noise.
+  #
+  # Keep this list to files with *observed* flap: an entry here removes the file
+  # from the reported total as well, so over-excluding quietly shrinks what the
+  # comment measures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,15 +265,24 @@ VPOPCNTDQ (`SUCCINCTLY_EXPECT_SIMD` intentionally omits it — see the note in
 so **`src/bits/popcount.rs` reports a non-deterministic x86 coverage number**:
 ~93% when the run happens to draw a VPOPCNTDQ-capable host, ~66% when it
 doesn't — a ±~26pp swing driven purely by which CPU the run landed on, not by
-any code change. This is expected, not a regression. The coverage bot
-quarantines it into the "N unchanged file(s) also moved (not attributed to this
-PR)" section, it doesn't count against patch coverage on PRs that leave the
-file untouched, and the
-`fail-under-lines` gate has ~19pp of headroom over the ~74.5% total, so the
-wobble can't trip the build. If you see `popcount.rs` move by ±26pp on an
-otherwise-unrelated PR (e.g. a dependabot bump), that's this — no need to
-re-triage it. Tracked in #302; the kernel's correctness is still validated on
-capable hardware by the two host-gated tests in `popcount.rs`.
+any code change. This is expected, not a regression — and it is now **filtered
+out of the PR comment** rather than merely tolerated: `src/bits/popcount.rs` is
+listed in [`.omni-dev/coverage.yaml`](.omni-dev/coverage.yaml), which
+`omni-dev coverage diff` (>= 0.38.0, pinned in `ci.yml`) reads straight from the
+checkout and applies to *both* the baseline and head reports before diffing, so
+the file can no longer generate a phantom entry. Note the exclusion is symmetric
+and therefore also removes the file from the **`Total:`** the comment reports —
+that number is a couple of points off the raw `cargo llvm-cov` total for this
+reason. It does not weaken any gate: `fail-under-lines` is computed by
+`cargo llvm-cov` itself, independently of `omni-dev`, over the unfiltered set
+(and has ~19pp of headroom over the ~74.5% total regardless).
+
+If you are reading a *pre-filter* PR comment, or `popcount.rs` moves by ±26pp on
+an otherwise-unrelated PR (e.g. a dependabot bump), that's this — no need to
+re-triage it. Tracked in #302 (and omni-dev#1398 for the mechanism); the
+kernel's correctness is still validated on capable hardware by the two
+host-gated tests in `popcount.rs`, which the exclusion does not affect — it
+suppresses *reporting*, not measurement or testing.
 
 ### Unsafe Code
 


### PR DESCRIPTION
## Description

This PR resolves the non-deterministic x86_64 coverage reporting for `src/bits/popcount.rs` by leveraging omni-dev's new declarative ignore-list feature. The file contains ~30 lines gated behind a runtime `is_x86_feature_detected!("avx512vpopcntdq")` check that causes coverage to swing ±26pp depending on whether the runner's CPU supports AVX-512 VPOPCNTDQ. By pinning omni-dev to 0.38.0 and adding a `.omni-dev/coverage.yaml` configuration file, the problematic file is now filtered from both baseline and PR-head reports before diffing, eliminating phantom coverage changes on unrelated PRs.

## Type of Change
- [x] CI/CD changes
- [x] Documentation update

## Related Issue
Fixes #302
Relates to rust-works/omni-dev#1398

## Changes Made

**CI Configuration:**
- Bumped `action-works/omni-dev-coverage-check` version from 0.34.0 to 0.38.0 in `.github/workflows/ci.yml`
- Added comprehensive inline comments documenting the version pin requirement and the config-file discovery mechanism

**Coverage Configuration:**
- Created new `.omni-dev/coverage.yaml` file with declarative ignore-list for CPU-conditional coverage flaps
- Configured `ignore-filename-regex` to exclude `src/bits/popcount.rs` from coverage diff reporting
- Documented rationale for exclusion and explicitly listed files that were *not* excluded (DSV/YAML/JSON SIMD dispatchers and `src/util/simd/x86.rs`) with reasoning for each decision

**Documentation:**
- Updated `CONTRIBUTING.md` to explain the coverage filtering mechanism
- Clarified that the exclusion applies symmetrically to both baseline and head reports
- Added note that `fail-under-lines` gate is unaffected and still calculated by `cargo llvm-cov` independently
- Documented that host-gated tests in `popcount.rs` still validate the kernel on capable hardware

## Testing

**Validation:**
- [x] Configuration follows omni-dev 0.38.0+ specification for `.omni-dev/coverage.yaml`
- [x] Regex pattern matches the problematic file path correctly
- [x] Version pin ensures feature availability (declarative ignore-list requires 0.38.0+)
- [x] Existing tests remain unaffected by coverage filtering changes

## Performance Impact
- [x] No performance impact
- Coverage reporting will be more stable, eliminating false positives from CPU-conditional code paths

## Checklist
- [x] Changes follow project conventions
- [x] Documentation has been updated to explain the mechanism
- [x] No code functionality is altered—only CI/coverage reporting
- [x] Filtering is applied symmetrically to prevent measurement distortion
- [x] Rationale is documented in both config file and CONTRIBUTING.md

## Additional Notes

**Scope of Filtering:**
The ignore-list is deliberately narrow, excluding only `src/bits/popcount.rs`, which has an observed ±26pp coverage swing. Files like the DSV/YAML/JSON SIMD dispatchers were intentionally not excluded because their runtime dispatchers are pinned by `SUCCINCTLY_EXPECT_SIMD` on their respective test legs, making them deterministic. Similarly, `src/util/simd/x86.rs` flaps by only ~1-2 lines, below the noise threshold.

**Impact on Metrics:**
The symmetric filtering removes `popcount.rs` from both the baseline and head coverage reports, which also shifts the `Total:` metric by a couple of percentage points compared to raw `cargo llvm-cov` output. This is acceptable because the `fail-under-lines` gate remains independent and is still calculated over the unfiltered set with sufficient headroom.

**Future Stability:**
With this change, unrelated PRs (like dependabot bumps or documentation-only changes) will no longer show false coverage movements in the PR comment, significantly improving signal-to-noise ratio in code review.