### PR TITLE
scripts: add the interleaved A/B harness the benchmarking guide describes

### DIFF
--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -640,6 +640,22 @@ benchmark suite. Every rule below cost a wrong conclusion at least once, during 
 detection work in #106; that investigation's write-up in `docs/parsing/yaml.md` (optimisations
 O5 and O6) carries the full numbers.
 
+`scripts/ab-cli.py` implements rules 1, 2, 4 and 6 for CLI-level A/B work:
+
+```bash
+# what the harness reports for a change that does not exist — run this first, once per machine
+scripts/ab-cli.py --before ./succ-base --control --corpus ~/wrk/bench-scratch/mycorpus
+
+# the real comparison
+scripts/ab-cli.py --before ./succ-base --after ./succ-head --corpus ~/wrk/bench-scratch/mycorpus
+```
+
+Run `--control` before trusting any result. It times the baseline binary against a copy of
+itself, so whatever it reports is noise by construction, and that is the bar a real delta has
+to clear — an idle M4 Pro reads +0.09% median with a per-row range of -1.8%..+1.5%. Without
+that number, #332's +1.1% median across 22 workloads was arguable; with it, the consistent
+sign was decisive, and the fix was restructured before merge.
+
 ### 1. Interleave the two binaries; never run all of A then all of B
 
 Alternate them **within** each repetition, then compare min-of-N and median:

--- a/scripts/ab-cli.py
+++ b/scripts/ab-cli.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Interleaved A/B timing for two `succinctly` binaries.
+
+Implements the method in docs/guides/benchmarking.md § A/B Benchmarking Method:
+the two binaries alternate *within* each repetition (rule 1), output identity is
+gated before any timing is believed (rule 4), inputs below 1 MB are called out
+(rule 2), and the machine is checked for idleness and mains power (rule 6).
+
+    scripts/ab-cli.py --before /path/succ-base --after /path/succ-head \\
+        --corpus ~/wrk/bench-scratch/mycorpus
+
+`--control` replaces the "after" side with a copy of the "before" binary. Run it
+once per machine before trusting any result: it measures what this harness
+reports for a change that does not exist, which is the bar a real delta has to
+clear. On an idle M4 Pro it reads +0.09% median with a per-row range of
+-1.8%..+1.5%, so a single row at +1% means nothing and twenty rows at +1% mean a
+regression.
+
+Standard library only; no third-party dependencies.
+"""
+
+import argparse
+import glob
+import hashlib
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+SPAWN_FLOOR_BYTES = 1_000_000  # rule 2: startup is ~4-6 ms, the whole runtime below this
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Interleaved A/B timing for two succinctly binaries.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("\n\n", 1)[1],
+    )
+    p.add_argument("--before", required=True, help="baseline binary")
+    p.add_argument("--after", help="binary under test (omit with --control)")
+    p.add_argument("--corpus", help="directory searched recursively for inputs")
+    p.add_argument("--files", nargs="*", default=[], help="explicit input files or globs")
+    p.add_argument("--tool", default="yq", help="succinctly subcommand (default: yq)")
+    p.add_argument("--queries", nargs="*", default=[".", ".[]"], help="queries to time")
+    p.add_argument("--output", default="json", help="-o format passed to the tool")
+    p.add_argument("--reps", type=int, default=7, help="repetitions per configuration")
+    p.add_argument("--control", action="store_true",
+                   help="time --before against a copy of itself (noise floor)")
+    p.add_argument("--no-identity", action="store_true",
+                   help="skip the output identity gate (rule 4) — for control runs")
+    p.add_argument("--force", action="store_true",
+                   help="run even if the machine looks busy or is on battery")
+    return p.parse_args(argv)
+
+
+def collect_inputs(args):
+    paths = []
+    for pattern in args.files:
+        paths.extend(sorted(glob.glob(pattern)))
+    if args.corpus:
+        for root, _dirs, names in os.walk(args.corpus):
+            paths.extend(sorted(os.path.join(root, n) for n in names
+                                if n.endswith((".yaml", ".yml", ".json"))))
+    seen, unique = set(), []
+    for p in paths:
+        if p not in seen and os.path.isfile(p):
+            seen.add(p)
+            unique.append(p)
+    return unique
+
+
+def machine_warnings():
+    """Rule 6: read the signals that actually mean 'busy', not the load average."""
+    warnings = []
+    if sys.platform == "darwin":
+        batt = run_text(["pmset", "-g", "batt"])
+        if "Battery Power" in batt:
+            warnings.append("running on battery — never benchmark a laptop unplugged")
+        # macOS load average counts uninterruptible-wait threads; sum actual CPU instead.
+        ps = run_text(["ps", "-Ao", "pcpu"])
+        total = sum(float(x) for x in ps.split()[1:] if x.replace(".", "", 1).isdigit())
+        if total > 25.0:
+            warnings.append(f"{total:.0f}% CPU busy across all processes")
+    else:
+        load1 = os.getloadavg()[0]
+        if load1 > 1.0:
+            warnings.append(f"1-minute load average is {load1:.2f}")
+    busy = run_text(["pgrep", "-fl", "cargo|rustc|criterion|claude"])
+    if busy.strip():
+        warnings.append("build or agent processes are running:\n    "
+                        + "\n    ".join(busy.strip().splitlines()[:5]))
+    return warnings
+
+
+def run_text(cmd):
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, check=False).stdout
+    except (OSError, ValueError):
+        return ""
+
+
+def command(binary, args, query, path):
+    return [binary, args.tool, "-o", args.output, "-I0", query, path]
+
+
+def digest(binary, args, query, path):
+    """Hash stdout+stderr in a pipe; capturing 10 MB into memory costs more than the run."""
+    h = hashlib.blake2b(digest_size=16)
+    proc = subprocess.Popen(command(binary, args, query, path),
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    for chunk in iter(lambda: proc.stdout.read(1 << 16), b""):
+        h.update(chunk)
+    proc.stdout.close()
+    proc.wait()
+    return h.hexdigest()
+
+
+def gate_identity(args, inputs):
+    """Rule 4: a faster binary that changed behaviour is not a win."""
+    checked = differences = 0
+    for path in inputs:
+        for query in args.queries:
+            checked += 1
+            if digest(args.before, args, query, path) != digest(args.after, args, query, path):
+                differences += 1
+                print(f"  DIFF  {path}  query={query!r}")
+    print(f"  identity: {checked} configurations, {differences} differences")
+    return differences == 0
+
+
+def time_once(binary, args, query, path):
+    t0 = time.perf_counter()
+    subprocess.run(command(binary, args, query, path),
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    return (time.perf_counter() - t0) * 1000.0
+
+
+def measure(args, query, path):
+    """Rule 1: alternate the binaries within each repetition, never in halves."""
+    time_once(args.before, args, query, path)  # warm the page cache, discarded
+    time_once(args.after, args, query, path)
+    before, after = [], []
+    for i in range(args.reps):
+        if i % 2 == 0:
+            before.append(time_once(args.before, args, query, path))
+            after.append(time_once(args.after, args, query, path))
+        else:
+            after.append(time_once(args.after, args, query, path))
+            before.append(time_once(args.before, args, query, path))
+    return before, after
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    control_copy = None
+    if args.control:
+        if args.after:
+            sys.exit("--control replaces --after with a copy of --before; pass only one")
+        fd, control_copy = tempfile.mkstemp(prefix="ab-control-")
+        os.close(fd)
+        shutil.copy2(args.before, control_copy)
+        os.chmod(control_copy, 0o755)
+        args.after = control_copy
+        args.no_identity = True
+    elif not args.after:
+        sys.exit("--after is required (or use --control)")
+
+    inputs = collect_inputs(args)
+    if not inputs:
+        sys.exit("no inputs: pass --corpus and/or --files")
+
+    warnings = machine_warnings()
+    for w in warnings:
+        print(f"WARNING: {w}")
+    if warnings and not args.force:
+        sys.exit("machine does not look idle; fix the above or pass --force")
+
+    small = [p for p in inputs if os.path.getsize(p) < SPAWN_FLOOR_BYTES]
+    if small:
+        print(f"WARNING: {len(small)} input(s) below 1 MB — process spawn is ~4-6 ms, "
+              f"which is most of the runtime at that size (rule 2)")
+
+    print(f"before={args.before}")
+    print(f"after ={args.after}" + ("  (copy of --before: noise floor)" if args.control else ""))
+    print(f"inputs={len(inputs)} queries={args.queries} reps={args.reps}")
+    print()
+
+    if not args.no_identity:
+        print("output identity gate:")
+        if not gate_identity(args, inputs):
+            sys.exit("outputs differ — fix that before believing any timing (rule 4)")
+        print()
+
+    header = (f"{'workload':<44} {'before min':>11} {'after min':>11} {'min d':>7} "
+              f"{'before med':>11} {'after med':>11} {'med d':>7}")
+    print(header)
+    print("-" * len(header))
+    deltas = []
+    try:
+        for path in inputs:
+            for query in args.queries:
+                before, after = measure(args, query, path)
+                bmin, amin = min(before), min(after)
+                bmed, amed = statistics.median(before), statistics.median(after)
+                dmin = (amin / bmin - 1) * 100
+                dmed = (amed / bmed - 1) * 100
+                deltas.append(dmed)
+                label = f"{os.path.basename(path)} {query}"
+                print(f"{label:<44} {bmin:>10.1f}m {amin:>10.1f}m {dmin:>+6.1f}% "
+                      f"{bmed:>10.1f}m {amed:>10.1f}m {dmed:>+6.1f}%")
+                sys.stdout.flush()
+    finally:
+        if control_copy:
+            os.unlink(control_copy)
+
+    print()
+    print(f"median of medians: {statistics.median(deltas):+.2f}%   "
+          f"mean: {statistics.mean(deltas):+.2f}%   "
+          f"range: {min(deltas):+.1f}%..{max(deltas):+.1f}%   "
+          f"({sum(1 for d in deltas if d > 0)}/{len(deltas)} rows slower)")
+    print("A single row inside the control's range is noise; a consistent sign across "
+          "every row is not.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

`docs/guides/benchmarking.md` § A/B Benchmarking Method has described how to run a before/after comparison since #106, but nothing in the repo implemented it. Each investigation rebuilt the harness from the prose — twice during #332 alone, once per session.

This adds `scripts/ab-cli.py`, which implements the mechanical rules, and a short section in the guide pointing at it.

## What it implements

| rule | in the script |
|------|---------------|
| 1 — interleave within each repetition | alternates before/after per rep; reports min *and* median |
| 2 — process-spawn A/B needs ≥ 1 MB | warns per input below the floor |
| 4 — gate on output identity first | hashes both binaries' output for every input × query, exits non-zero on any difference |
| 6 — verify the machine is idle | sums actual CPU rather than trusting macOS's load average, checks `pmset` for battery, looks for cargo/rustc/criterion/agent processes; `--force` to override |

Rules 3 (scaling curve), 5 (both architectures) and 7 (the suite must contain the shape) are judgement calls about *what* to measure, so they stay in the guide.

## `--control` is the point

It times `--before` against a copy of itself, so whatever it prints is noise by construction — the per-machine bar a real delta has to clear.

That is not academic. In #332 the reader-side fix measured **+1.1% median across 22 workloads**. Any single row at +1% is unremarkable; what made it a regression rather than noise was the control's **+0.09% median with a −1.8%..+1.5% per-row range**, against which 22 same-signed rows are not an accident. The fix was restructured (discriminator moved to a `#[cold]` helper) and re-measured to +0.4% before merge. Without the control run that regression ships.

## Testing

- [x] `--control` on a deliberately busy machine: warns about CPU, agent processes and sub-1 MB inputs, then reports the inflated numbers those warnings predict
- [x] identity gate passes for two copies of the same binary (2 configurations, 0 differences)
- [x] identity gate catches a stub binary that prints something else, and exits 1
- [x] the numbers in the #332 PR were produced by this harness

Standard library only; no new dependencies. Not wired into CI — this is a developer tool for A/B investigations, which need a quiet machine and human interpretation.
