### PR TITLE
refactor(yaml): consolidate duplicated SIMD scalar handlers and unify terminator set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,14 @@ jobs:
         if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features portable-popcount
 
+      # scalar-yaml switches x86_64 off the `x86` module entirely, so it is a
+      # distinct dispatch set that no other step here builds (#185). Its ARM
+      # counterpart, plus broadword-yaml, run on the test-arm leg —
+      # broadword-yaml is a no-op on x86_64.
+      - name: Run tests (scalar-yaml — no SIMD or broadword)
+        if: needs.gate.outputs.code == 'true'
+        run: cargo test --verbose --features simd,scalar-yaml
+
       - name: Check no_std compatibility
         if: needs.gate.outputs.code == 'true'
         run: cargo check --no-default-features
@@ -256,6 +264,21 @@ jobs:
       - name: Run tests (portable-popcount feature)
         if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features portable-popcount
+
+      # The YAML backend selectors are mutually exclusive by cfg, so a build
+      # compiles at most one of neon/broadword/x86 and the compiler never
+      # compares them. Nothing built these two flags until #185, which is how
+      # `neon.rs` came to carry a drifted duplicate of the whole broadword layer
+      # for however long: both copies were syntactically fine, and no leg ever
+      # instantiated the one that had gone stale. These runs exist to make the
+      # unselected backends fail loudly rather than rot quietly.
+      - name: Run tests (broadword-yaml — ARM64 SWAR instead of NEON)
+        if: needs.gate.outputs.code == 'true'
+        run: cargo test --verbose --features simd,broadword-yaml
+
+      - name: Run tests (scalar-yaml — no SIMD or broadword)
+        if: needs.gate.outputs.code == 'true'
+        run: cargo test --verbose --features simd,scalar-yaml
 
   test-macos-arm:
     name: Test (macOS ARM64)
@@ -458,6 +481,21 @@ jobs:
       - name: Run Clippy
         if: needs.gate.outputs.code == 'true'
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      # `--all-features` turns on `scalar-yaml`, whose cfgs compile out *every*
+      # YAML SIMD backend — so the step above has never linted `yaml/simd/x86.rs`,
+      # `neon.rs` or `broadword.rs` (verified: a lint planted in x86.rs does not
+      # fire under `--all-features`, and does with the set below). That is the same
+      # blind spot that let the duplicated broadword layer drift, one level up
+      # (#185). This runner is x86_64, so it covers the x86 backend; the ARM
+      # backends are compiled — though not linted — by the test-arm leg.
+      #
+      # `portable-popcount` is kept deliberately: dropping it also un-gates the
+      # AVX-512 popcount path, which carries pre-existing lints that are not this
+      # job's to fix. Linting that path is tracked separately.
+      - name: Run Clippy (YAML SIMD backend selected)
+        if: needs.gate.outputs.code == 'true'
+        run: cargo clippy --all-targets --features std,simd,portable-popcount,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
 
   fmt:
     name: Format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Test Suite cases (reject conformance 12/94 → 70/94) with no false positives on
   the valid corpus; the remaining structurally-deep cases stay on record.
 
+### Changed
+
+- **`yaml::simd` terminator accessors renamed and narrowed** (#185):
+  `YamlCharClass16::value_terminators` and
+  `YamlCharClassBroadword::value_terminators` are now
+  `plain_scalar_terminators`, and no longer include the `spaces` channel.
+  **Breaking** for anything naming them through the public `yaml::simd` module.
+  A plain scalar may contain spaces, so a space was never a terminator for the
+  parser's byte loop; the live x86 mask has never included it, and the two
+  disagreed only because they were separate copies. `YamlCharClass` (x86) gains
+  a `plain_scalar_terminators` accessor holding the same set it already used
+  inline.
+
 ### Removed
 
 - Removed four never-constructed `YamlError` variants — `InvalidEscape`,

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -2540,26 +2540,39 @@ Following the P3 NEON rejection, we implemented a pure broadword (SWAR) approach
 - Classification functions: [`src/yaml/simd/broadword.rs:111-230`](../../src/yaml/simd/broadword.rs#L111-L230)
 - Parser integration (disabled): [`src/yaml/parser.rs:585-622`](../../src/yaml/parser.rs#L585-L622)
 
-**Caveat on these numbers — the measured variant stopped at spaces (#185)**
+**Caveat on these numbers — the workload never exercised the skip path (#185)**
 
 The disabled ARM integration asked its classifier for `value_terminators()`,
 which was `newlines | carriage_returns | colons | spaces | hash`. The live x86
-path has never included `spaces`. The parser's byte loop does not treat a space
-as a terminator either — a plain scalar may contain them (`key: hello world`) —
-so on the ARM path every space aborted a 16-byte skip that had no reason to stop,
-and the fast path degenerated toward byte-at-a-time on exactly the prose-like
-values it was meant to accelerate.
+path has never included `spaces`, and the parser's byte loop does not treat a
+space as a terminator either — a plain scalar may contain them (`key: hello
+world`). So on the ARM path a space would abort a 16-byte skip that had no reason
+to stop. #185 unified both paths on `plain_scalar_terminators()` (line break,
+colon, hash; no spaces).
 
-That confounds the table above. Note its shape: the only workloads that showed
-any gain were `long_strings/*`, which are *quoted* and so never reach this skip
-path at all, while `simple_kv/*` — space-bearing plain scalars — regressed 6-14%.
-"Break-even point >64 bytes" may be measuring the space-stop rather than
-broadword overhead.
+That divergence is **not** what the table above measures, and the reason is worth
+recording, because it is the more useful finding: `yaml_bench` contains no plain
+scalar with an interior space. Every unquoted value it generates is a single
+token — `value{i}`, `leaf`, `item{i}`, `myapp`, `production`, `val{i}` — and the
+only spaces in the corpus sit inside quoted strings or block-scalar content,
+neither of which reaches `skip_unquoted_simd`. On `key0: value0\n` the `\n` at
+offset 6 precedes the next line's space at offset 12, so `trailing_zeros()`
+returns 6 under either mask: on this input the two terminator sets are
+behaviourally identical.
 
-#185 unified both paths on `plain_scalar_terminators()` (line break, colon, hash;
-no spaces) but did **not** re-measure — the ARM integration remains disabled.
-Re-running this benchmark against the corrected set is open follow-up, and is the
-cheapest way to find out whether broadword on ARM64 was ever really neutral.
+Note the table's shape from the same angle. The only workloads that gained were
+`long_strings/*`, which are *quoted* and never reach the skip path at all, while
+`simple_kv/*` — 6-byte plain values — regressed 6-14%, which the analysis above
+already attributes to 16-byte classification overhead on short values. Nothing in
+the suite is prose-like enough to tell the two terminator sets apart.
+
+So "break-even point >64 bytes" stands as a statement about broadword overhead,
+not about the space-stop. The open follow-up is therefore *not* a re-run: re-running
+`yaml_bench` unchanged would reproduce these numbers, because the generators emit
+no shape that distinguishes the masks. Deciding whether the corrected set makes
+broadword on ARM64 worth re-enabling needs a space-bearing plain-scalar pattern
+added to the suite first — a benchmark cannot measure a shape it does not
+generate.
 
 ---
 

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -1731,6 +1731,7 @@ This is the **first optimization since P2.7 (Block Scalar SIMD)** to show end-to
 **Files Modified:**
 - [`src/yaml/simd/x86.rs`](../../src/yaml/simd/x86.rs) - Added `parse_anchor_name_avx2()`, `parse_anchor_name_scalar()`, `parse_anchor_name()`
 - [`src/yaml/simd/neon.rs`](../../src/yaml/simd/neon.rs) - Added `parse_anchor_name_neon()` for ARM64
+- (Since #185 the shared remainder handler `parse_anchor_name_scalar()` lives once in [`src/yaml/simd/scalar.rs`](../../src/yaml/simd/scalar.rs), not per backend.)
 - [`src/yaml/simd/mod.rs`](../../src/yaml/simd/mod.rs) - Exported `parse_anchor_name()` public API
 - [`src/yaml/parser.rs:3061`](../../src/yaml/parser.rs#L3061) - Replaced scalar loop with SIMD call
 
@@ -2484,7 +2485,7 @@ Following the P3 NEON rejection, we implemented a pure broadword (SWAR) approach
 
 **Key Insight:** The multiplication trick magic constant must be `0x0102040810204080`, not `0x0002040810204081`. The former correctly maps bit positions 0,8,16,24,32,40,48,56 to result bits 0-7.
 
-**Code Location:** [`src/yaml/simd/neon.rs:171-367`](../../src/yaml/simd/neon.rs#L171-L367)
+**Code Location:** [`src/yaml/simd/broadword.rs`](../../src/yaml/simd/broadword.rs) (was `neon.rs:171-367` until #185 merged the two copies)
 
 **Micro-Benchmark Results (Apple M1 Max):**
 
@@ -2535,9 +2536,30 @@ Following the P3 NEON rejection, we implemented a pure broadword (SWAR) approach
 - Reference implementation for other projects
 
 **Code kept at:**
-- Broadword primitives: [`src/yaml/simd/neon.rs:171-220`](../../src/yaml/simd/neon.rs#L171-L220)
-- Classification functions: [`src/yaml/simd/neon.rs:253-367`](../../src/yaml/simd/neon.rs#L253-L367)
-- Parser integration (disabled): [`src/yaml/parser.rs:438-471`](../../src/yaml/parser.rs#L438-L471)
+- Broadword primitives: [`src/yaml/simd/broadword.rs:23-65`](../../src/yaml/simd/broadword.rs#L23-L65)
+- Classification functions: [`src/yaml/simd/broadword.rs:111-230`](../../src/yaml/simd/broadword.rs#L111-L230)
+- Parser integration (disabled): [`src/yaml/parser.rs:585-622`](../../src/yaml/parser.rs#L585-L622)
+
+**Caveat on these numbers — the measured variant stopped at spaces (#185)**
+
+The disabled ARM integration asked its classifier for `value_terminators()`,
+which was `newlines | carriage_returns | colons | spaces | hash`. The live x86
+path has never included `spaces`. The parser's byte loop does not treat a space
+as a terminator either — a plain scalar may contain them (`key: hello world`) —
+so on the ARM path every space aborted a 16-byte skip that had no reason to stop,
+and the fast path degenerated toward byte-at-a-time on exactly the prose-like
+values it was meant to accelerate.
+
+That confounds the table above. Note its shape: the only workloads that showed
+any gain were `long_strings/*`, which are *quoted* and so never reach this skip
+path at all, while `simple_kv/*` — space-bearing plain scalars — regressed 6-14%.
+"Break-even point >64 bytes" may be measuring the space-stop rather than
+broadword overhead.
+
+#185 unified both paths on `plain_scalar_terminators()` (line break, colon, hash;
+no spaces) but did **not** re-measure — the ARM integration remains disabled.
+Re-running this benchmark against the corrected set is open follow-up, and is the
+cheapest way to find out whether broadword on ARM64 was ever really neutral.
 
 ---
 

--- a/docs/plan/simd-features.md
+++ b/docs/plan/simd-features.md
@@ -11,6 +11,10 @@ This document describes the build configurations for YAML SIMD optimizations acr
 
 ## Build Matrix
 
+`scalar` is compiled unconditionally on every target and flag combination below: the
+vector kernels call it to finish the remainder their vector loop cannot cover, so it is
+never merely a fallback. The "Module Used" column names what is compiled *in addition*.
+
 ### Target: x86_64
 
 | Feature Flags    | Module Used | Functions Used       | Notes                                              |
@@ -21,11 +25,11 @@ This document describes the build configurations for YAML SIMD optimizations acr
 
 ### Target: aarch64 (ARM64)
 
-| Feature Flags    | Module Used | Functions Used       | Notes                                        |
-|------------------|-------------|----------------------|----------------------------------------------|
-| (none)           | `neon`      | NEON intrinsics      | Default. Uses ARM NEON SIMD                  |
-| `broadword-yaml` | `broadword` | Broadword (SWAR)     | Portable u64 arithmetic, no intrinsics       |
-| `scalar-yaml`    | (none)      | `*_scalar` functions | Pure byte-by-byte, for benchmarking baseline |
+| Feature Flags    | Module Used          | Functions Used                           | Notes                                                       |
+|------------------|----------------------|------------------------------------------|-------------------------------------------------------------|
+| (none)           | `neon` + `broadword` | NEON intrinsics; SWAR for `find_newline` | Default. `broadword` also owns the classifier (#185)        |
+| `broadword-yaml` | `broadword`          | Broadword (SWAR)                         | Portable u64 arithmetic, no intrinsics; `neon` not compiled |
+| `scalar-yaml`    | (none)               | `*_scalar` functions                     | Pure byte-by-byte, for benchmarking baseline                |
 
 ### Target: Other (WebAssembly, RISC-V, etc.)
 
@@ -39,9 +43,14 @@ This document describes the build configurations for YAML SIMD optimizations acr
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
+│  scalar module: always compiled (vector kernels call it for the remainder)   │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
 │                           scalar-yaml enabled?                               │
 │                                                                              │
-│  YES → No SIMD modules compiled. All functions use *_scalar implementations  │
+│  YES → No vector modules compiled. All functions use *_scalar implementations│
 │                                                                              │
 │  NO  → Continue to architecture check                                        │
 └─────────────────────────────────────────────────────────────────────────────┘
@@ -51,49 +60,55 @@ This document describes the build configurations for YAML SIMD optimizations acr
 │                            Target Architecture                               │
 │                                                                              │
 │  x86_64:                                                                     │
-│    └─ x86 module compiled (SSE2/AVX2)                                        │
+│    └─ x86 module compiled (SSE2/AVX2). broadword NOT compiled                │
 │                                                                              │
-│  aarch64:                                                                    │
-│    └─ broadword-yaml enabled?                                                │
-│        YES → broadword module compiled and used                              │
-│        NO  → neon module compiled and used                                   │
-│                                                                              │
-│  Other:                                                                      │
-│    └─ broadword module compiled and used (automatic fallback)                │
+│  Everything else:                                                            │
+│    └─ broadword module compiled (owns the classifier and find_newline)       │
+│        └─ aarch64 without broadword-yaml?                                    │
+│            YES → neon module compiled too; dispatch prefers NEON where it    │
+│                  has a kernel, broadword elsewhere                           │
+│            NO  → broadword is the whole implementation                       │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Module Compilation Details
 
-The broadword module is only compiled when actually needed, eliminating dead code warnings:
+The broadword module is compiled on every non-x86_64 target, because it owns the only
+copy of the SWAR classifier and of `find_newline_broadword`:
 
 ```rust
-#[cfg(all(
-    not(feature = "scalar-yaml"),
-    any(
-        all(target_arch = "aarch64", feature = "broadword-yaml"),
-        not(any(target_arch = "aarch64", target_arch = "x86_64"))
-    )
-))]
+#[cfg(all(not(feature = "scalar-yaml"), not(target_arch = "x86_64")))]
 mod broadword;
 ```
 
 This means:
-- **x86_64**: Only the `x86` module is compiled (broadword not needed)
-- **aarch64**: Only `neon` is compiled by default; `broadword` requires explicit opt-in via `broadword-yaml`
+- **x86_64**: Only the `x86` module is compiled (native SIMD covers all of it)
+- **aarch64**: Both `neon` and `broadword` are compiled. NEON supplies quote scanning,
+  indentation counting, anchors and block scalars; broadword supplies the classifier
+  and `find_newline`, which have no NEON kernel. `broadword-yaml` switches the
+  *dispatch* of the NEON-backed operations over to broadword for comparison — it no
+  longer controls whether the module is compiled.
 - **Other platforms**: Only `broadword` is compiled (automatic fallback)
 
 ### Historical Context: Why This Changed
 
-Previous versions compiled the broadword module on ARM64 even when not used, which caused dead code warnings:
+Until #185 the gate above was `aarch64 + broadword-yaml`, or a non-SIMD arch. That kept
+the module out of the default ARM64 build — but only because `neon.rs` carried its own
+copy of the whole broadword layer to serve that build. The two copies were gated to
+complementary cfgs, so no build ever compiled both and the compiler never compared them;
+they drifted until #185 deleted the `neon.rs` copy and widened the gate. The
+`#[allow(dead_code)]` markers that gate was avoiding are cheaper than the drift, and are
+now attached per function with a STYLE-0005 justification.
 
-| Build Target | Feature Flags | Warning Source                     | Reason                                           |
-|--------------|---------------|------------------------------------|--------------------------------------------------|
-| aarch64      | (none)        | `broadword.rs` functions           | NEON is used; broadword compiled but not called  |
-| aarch64      | (none)        | `neon.rs::classify_yaml_chars_16`  | Infrastructure function not yet integrated       |
-| aarch64      | (none)        | `neon.rs::find_newline_broadword`  | Infrastructure function not yet integrated       |
+Before that, an earlier revision compiled broadword on ARM64 unconditionally and hit
+these dead-code warnings, which is what motivated the narrow gate in the first place:
 
-The old approach allowed easy testing/comparison via feature flag, but at the cost of dead code warnings. The current approach requires explicitly enabling `broadword-yaml` for comparison testing on ARM64.
+| Build Target | Feature Flags | Warning Source              | Reason                                          |
+|--------------|---------------|-----------------------------|-------------------------------------------------|
+| aarch64      | (none)        | `broadword.rs` scan kernels | NEON is dispatched to instead                   |
+| aarch64      | (none)        | `classify_yaml_chars_16`    | Only the disabled `skip_unquoted_simd` calls it |
+
+Use `--features broadword-yaml` for comparison testing on ARM64.
 
 ## Performance Characteristics
 

--- a/docs/plan/sve2-optimizations.md
+++ b/docs/plan/sve2-optimizations.md
@@ -136,7 +136,8 @@ The only beneficial SVE2 feature is **SVEBITPERM** (BDEP/BEXT instructions), whi
 | File | Operations | Key Techniques |
 |------|------------|----------------|
 | [src/json/simd/neon.rs](../../src/json/simd/neon.rs) | JSON character classification | Nibble lookup tables (`vqtbl1q_u8`), custom `neon_movemask` |
-| [src/yaml/simd/neon.rs](../../src/yaml/simd/neon.rs) | String scanning, indentation counting | Direct comparison, broadword fallbacks |
+| [src/yaml/simd/neon.rs](../../src/yaml/simd/neon.rs) | String scanning, indentation counting, anchors, block scalars | Direct comparison; remainders handled by `simd/scalar.rs` |
+| [src/yaml/simd/broadword.rs](../../src/yaml/simd/broadword.rs) | YAML char classification, newline scanning | SWAR on `u64`; compiled on ARM64 too, since neither has a NEON kernel (#185) |
 | [src/dsv/simd/neon.rs](../../src/dsv/simd/neon.rs) | DSV field detection | Character matching, **PMULL prefix XOR** for quotes |
 | [src/bits/popcount.rs](../../src/bits/popcount.rs) | Population count | `vcntq_u8`, `vaddvq_u16` |
 

--- a/docs/plan/sve2-optimizations.md
+++ b/docs/plan/sve2-optimizations.md
@@ -631,7 +631,7 @@ combined with SIMD prefix sums for dramatic speedup.
 
 ### Low Confidence: Anchor Terminator Nibble Tables
 
-**Current State** ([src/yaml/simd/neon.rs](../../src/yaml/simd/neon.rs#L422-L498)):
+**Current State** (`parse_anchor_name_neon`, [src/yaml/simd/neon.rs](../../src/yaml/simd/neon.rs#L225-L248)):
 ```rust
 // 10 separate CMEQ comparisons + 9 ORR operations
 let is_space = vceqq_u8(chunk, space);

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -549,11 +549,13 @@ impl<'a> Parser<'a> {
     fn skip_unquoted_simd(&self, _value_start: usize) -> Option<usize> {
         // Use classify_yaml_chars to scan 32 bytes at once
         if let Some(class) = super::simd::classify_yaml_chars(self.input, self.pos) {
-            // Check for any potential terminators: line break, colon, or hash.
-            // `\r` counts: it is a YAML 1.2 §5.4 line break, and without it the
-            // classifier skips straight over a lone CR and swallows the rest of
-            // the document into one scalar (#324).
-            let terminators = class.newlines | class.carriage_returns | class.colons | class.hash;
+            // Line break, colon, or hash — see `plain_scalar_terminators`, which
+            // both this and the ARM variant below share so the two cannot drift
+            // on what ends a scalar (#185). `\r` counts: it is a YAML 1.2 §5.4
+            // line break, and without it the classifier skips straight over a
+            // lone CR and swallows the rest of the document into one scalar
+            // (#324).
+            let terminators = class.plain_scalar_terminators();
 
             if terminators == 0 {
                 // No structural characters in the classified chunk — skip
@@ -593,8 +595,11 @@ impl<'a> Parser<'a> {
     fn skip_unquoted_simd(&self, _value_start: usize) -> Option<usize> {
         // Use broadword classify to scan 16 bytes at once (two 8-byte chunks)
         if let Some(class) = super::simd::classify_yaml_chars_16(self.input, self.pos) {
-            // Check for any potential terminators: newline, colon, or hash
-            let terminators = class.value_terminators();
+            // The same set the live x86 path uses: line break (LF or CR), colon,
+            // hash. This called a `value_terminators()` that also included
+            // spaces until #185, so re-enabling this path would have stopped the
+            // skip at every space for no reason.
+            let terminators = class.plain_scalar_terminators();
 
             if terminators == 0 {
                 // No structural characters in this 16-byte chunk - safe to skip all

--- a/src/yaml/simd/broadword.rs
+++ b/src/yaml/simd/broadword.rs
@@ -483,6 +483,11 @@ mod tests {
         assert_eq!(find_newline_broadword(&input, 0), Some(9));
     }
 
+    /// Twin of `plain_scalar_terminators_is_exactly_line_break_colon_hash` in
+    /// `yaml::simd::x86`, which pins the same set for the 32-byte classifier the
+    /// live parser path uses. Neither type is compiled on the other's target, so
+    /// the agreement can only be asserted once per arch — but it must be
+    /// asserted on both, or the set drifts exactly as it did before #185.
     #[test]
     fn plain_scalar_terminators_stop_at_structure_but_not_at_spaces() {
         let input = b"value: x";

--- a/src/yaml/simd/broadword.rs
+++ b/src/yaml/simd/broadword.rs
@@ -99,11 +99,12 @@ impl YamlCharClassBroadword {
             != 0
     }
 
-    /// Get mask of all value terminators (for unquoted values).
-    /// Terminators: newline, colon, space, hash
+    /// Bytes at which a plain (unquoted) scalar scan must stop and re-examine.
+    ///
+    /// See [`YamlCharClass16::plain_scalar_terminators`].
     #[inline(always)]
-    pub fn value_terminators(&self) -> u8 {
-        self.newlines | self.carriage_returns | self.colons | self.spaces | self.hash
+    pub fn plain_scalar_terminators(&self) -> u8 {
+        self.newlines | self.carriage_returns | self.colons | self.hash
     }
 }
 
@@ -149,10 +150,8 @@ pub fn classify_yaml_chars_broadword(
     })
 }
 
-/// Classify 16 bytes using two broadword operations.
-///
-/// Returns combined u16 masks (low 8 bits from first chunk, high 8 from second).
-/// Returns `None` if fewer than 16 bytes remain.
+/// Classification of a 16-byte chunk: one `u16` mask per character type, with
+/// bit `i` set iff byte `i` of the chunk is that character.
 #[derive(Debug, Clone, Copy, Default)]
 #[allow(dead_code)] // STYLE-0005: broadword fallback classifier; unused when SIMD is active
 pub struct YamlCharClass16 {
@@ -169,14 +168,30 @@ pub struct YamlCharClass16 {
 }
 
 impl YamlCharClass16 {
-    /// Get mask of value terminators.
+    /// Bytes at which a plain (unquoted) scalar scan must stop and re-examine.
+    ///
+    /// The scan may stop early and lose nothing but speed, so this only has to
+    /// be a *superset* of what the parser's byte loop breaks on: `\n`, `\r`
+    /// (YAML 1.2 §5.4 makes a lone CR a line break too — #324), `#`, and `:`.
+    /// The loop re-checks the context-sensitive pair itself — `#` opens a
+    /// comment only after whitespace, `:` ends a key only before whitespace —
+    /// so the mask does not model that.
+    ///
+    /// Notably **not** `spaces`: a plain scalar may contain them (`key: hello
+    /// world`), so stopping at each one only costs a re-entry into the byte
+    /// loop. Until #185 this mask included them and the x86 classifier's did
+    /// not, which meant re-enabling the ARM fast path would have silently
+    /// surrendered most of its skipping to prose-like values.
     #[inline(always)]
-    pub fn value_terminators(&self) -> u16 {
-        self.newlines | self.carriage_returns | self.colons | self.spaces | self.hash
+    pub fn plain_scalar_terminators(&self) -> u16 {
+        self.newlines | self.carriage_returns | self.colons | self.hash
     }
 }
 
 /// Classify 16 bytes at once using two broadword operations.
+///
+/// Returns combined u16 masks (low 8 bits from the first chunk, high 8 from the
+/// second), or `None` if fewer than 16 bytes remain.
 #[inline]
 pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharClass16> {
     if offset + 16 > input.len() {
@@ -212,6 +227,7 @@ pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharCla
 ///
 /// Returns offset from `start` to the found character, or `None` if not found.
 #[inline]
+#[allow(dead_code)] // STYLE-0005: broadword scan kernel; ARM64 dispatches to the NEON one instead
 pub fn find_quote_or_escape_broadword(input: &[u8], start: usize, end: usize) -> Option<usize> {
     if start >= end || start >= input.len() {
         return None;
@@ -247,6 +263,7 @@ pub fn find_quote_or_escape_broadword(input: &[u8], start: usize, end: usize) ->
 ///
 /// Returns offset from `start` to the found character, or `None` if not found.
 #[inline]
+#[allow(dead_code)] // STYLE-0005: broadword scan kernel; ARM64 dispatches to the NEON one instead
 pub fn find_single_quote_broadword(input: &[u8], start: usize, end: usize) -> Option<usize> {
     if start >= end || start >= input.len() {
         return None;
@@ -279,6 +296,7 @@ pub fn find_single_quote_broadword(input: &[u8], start: usize, end: usize) -> Op
 ///
 /// Returns the number of consecutive space characters starting at `start`.
 #[inline]
+#[allow(dead_code)] // STYLE-0005: broadword scan kernel; ARM64 dispatches to the NEON one instead
 pub fn count_leading_spaces_broadword(input: &[u8], start: usize) -> usize {
     if start >= input.len() {
         return 0;
@@ -291,11 +309,9 @@ pub fn count_leading_spaces_broadword(input: &[u8], start: usize) -> usize {
     // Process 8 bytes at a time
     while offset + 8 <= len {
         let chunk = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
-        let _non_spaces = has_zero_byte(chunk ^ broadcast_byte(b' '));
 
-        // If non_spaces is 0, all bytes are spaces - invert to check
-        // Actually, has_zero_byte returns high bits set where bytes ARE equal to space
-        // So we need to check if ALL bytes are spaces (all high bits set = 0x8080808080808080)
+        // `find_byte` sets the high bit of every byte that IS a space, so all
+        // eight being spaces means exactly `HI_BYTES`.
         let space_matches = find_byte(chunk, b' ');
         if space_matches != HI_BYTES {
             // Found a non-space - count spaces up to it
@@ -460,12 +476,78 @@ mod tests {
     }
 
     #[test]
-    fn test_broadword_value_terminators() {
+    fn test_broadword_find_newline_in_remainder() {
+        // Newline in bytes after last 8-byte chunk
+        let mut input = vec![b'a'; 10];
+        input[9] = b'\n';
+        assert_eq!(find_newline_broadword(&input, 0), Some(9));
+    }
+
+    #[test]
+    fn plain_scalar_terminators_stop_at_structure_but_not_at_spaces() {
         let input = b"value: x";
         let class = classify_yaml_chars_broadword(input, 0).unwrap();
 
-        let terminators = class.value_terminators();
-        assert!(terminators & (1 << 5) != 0); // colon at 5
-        assert!(terminators & (1 << 6) != 0); // space at 6
+        let terminators = class.plain_scalar_terminators();
+        assert!(terminators & (1 << 5) != 0, "colon at 5 must terminate");
+        assert_eq!(
+            terminators & (1 << 6),
+            0,
+            "space at 6 must NOT terminate: a plain scalar may contain spaces, \
+             and stopping there only costs skip distance (#185)"
+        );
+        // The space is still classified — it is the terminator set that excludes it.
+        assert!(class.spaces & (1 << 6) != 0);
+    }
+
+    /// The broadword classifiers are the ARM64 fast path's eyes, but that path
+    /// is disabled, so nothing on a live route exercises their accessors. They
+    /// still have to agree that a CR terminates a value — a classifier that
+    /// quietly omits it is what let a lone CR swallow a whole document (#324).
+    #[test]
+    fn broadword_classifiers_treat_cr_as_a_value_terminator() {
+        let input = b"abcdefg\rhijklmno";
+        let class = classify_yaml_chars_broadword(input, 0).expect("8 bytes available");
+        assert_eq!(class.carriage_returns, 1 << 7, "CR is at offset 7");
+        assert!(class.has_any());
+        assert!(
+            class.plain_scalar_terminators() & (1 << 7) != 0,
+            "CR must terminate an unquoted value"
+        );
+
+        let class16 = classify_yaml_chars_16(input, 0).expect("16 bytes available");
+        assert_eq!(class16.carriage_returns, 1 << 7);
+        assert!(class16.plain_scalar_terminators() & (1 << 7) != 0);
+
+        // A chunk with no CR reports none, so the mask is not just always set.
+        let plain = b"abcdefghijklmnop";
+        let none = classify_yaml_chars_broadword(plain, 0).expect("8 bytes available");
+        assert_eq!(none.carriage_returns, 0);
+        assert!(!none.has_any(), "no structural bytes in {plain:?}");
+        assert_eq!(none.plain_scalar_terminators(), 0);
+    }
+
+    /// Both widths must agree on the set, or the 8- and 16-byte paths would
+    /// disagree about where a scalar ends. Asserted as an exact channel list so
+    /// adding a channel to one and not the other fails here (#185).
+    #[test]
+    fn both_classifier_widths_agree_on_the_terminator_set() {
+        let input = b"a:b\nc\rd#e f:g\nhi";
+        let c8 = classify_yaml_chars_broadword(input, 0).expect("8 bytes available");
+        let c16 = classify_yaml_chars_16(input, 0).expect("16 bytes available");
+
+        assert_eq!(
+            c8.plain_scalar_terminators(),
+            c8.newlines | c8.carriage_returns | c8.colons | c8.hash
+        );
+        assert_eq!(
+            c16.plain_scalar_terminators(),
+            c16.newlines | c16.carriage_returns | c16.colons | c16.hash
+        );
+        // The 16-byte mask's low half is the 8-byte mask.
+        assert_eq!(
+            c16.plain_scalar_terminators() as u8,
+            c8.plain_scalar_terminators()
+        );
     }
 }

--- a/src/yaml/simd/mod.rs
+++ b/src/yaml/simd/mod.rs
@@ -26,6 +26,10 @@
 //! Use `--features scalar-yaml` to force pure scalar (byte-by-byte) implementations.
 //! This is useful for benchmarking baseline performance without any SIMD or broadword.
 
+// Scalar kernels shared by every backend: each vector loop calls them for its
+// remainder, so they compile everywhere (#185).
+mod scalar;
+
 // NEON module only when not using broadword or scalar fallback
 #[cfg(all(
     target_arch = "aarch64",
@@ -38,17 +42,13 @@ mod neon;
 #[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
 mod x86;
 
-// Portable broadword module - compiled when:
-// 1. broadword-yaml feature is enabled on ARM64 (explicit opt-in), OR
-// 2. On non-SIMD platforms (automatic fallback)
-// NOT compiled on x86_64 (uses native SIMD) or ARM64 without broadword-yaml (uses NEON)
-#[cfg(all(
-    not(feature = "scalar-yaml"),
-    any(
-        all(target_arch = "aarch64", feature = "broadword-yaml"),
-        not(any(target_arch = "aarch64", target_arch = "x86_64"))
-    )
-))]
+// Portable broadword module - compiled on every non-x86 target, because it owns
+// the only copy of the SWAR classifier and of `find_newline_broadword`, which
+// ARM64 dispatches to even when NEON supplies the rest. It used to be gated to
+// `broadword-yaml`-on-ARM64 plus exotic arches, with `neon.rs` carrying a second
+// copy for the default ARM64 build; no build compiled both, so the two drifted
+// unchecked until #185 merged them. x86_64 has native SIMD for all of it.
+#[cfg(all(not(feature = "scalar-yaml"), not(target_arch = "x86_64")))]
 mod broadword;
 
 // Re-export platform-specific types for P0 optimizations
@@ -56,23 +56,8 @@ mod broadword;
 pub use x86::YamlCharClass;
 
 // Re-export broadword types when broadword module is compiled
-#[cfg(all(
-    not(feature = "scalar-yaml"),
-    any(
-        all(target_arch = "aarch64", feature = "broadword-yaml"),
-        not(any(target_arch = "aarch64", target_arch = "x86_64"))
-    )
-))]
+#[cfg(all(not(feature = "scalar-yaml"), not(target_arch = "x86_64")))]
 pub use broadword::{YamlCharClass16, YamlCharClassBroadword};
-
-// Re-export NEON types on ARM64 when using NEON (not broadword)
-// Only YamlCharClass16 is used; YamlCharClassBroadword is broadword-specific
-#[cfg(all(
-    target_arch = "aarch64",
-    not(feature = "broadword-yaml"),
-    not(feature = "scalar-yaml")
-))]
-pub use neon::YamlCharClass16;
 
 // ============================================================================
 // Public API - platform-dispatched functions
@@ -237,49 +222,27 @@ pub fn classify_yaml_chars(input: &[u8], offset: usize) -> Option<YamlCharClass>
     x86::classify_yaml_chars(input, offset)
 }
 
-/// Classify 16 bytes of YAML structural characters.
+/// Classify 16 bytes of YAML structural characters using broadword (SWAR).
 ///
-/// On ARM64: Uses NEON or broadword depending on feature flags.
-/// On other platforms: Uses broadword (SWAR).
-/// Returns classification bitmasks for 8 character types at once.
+/// Returns classification bitmasks for nine character types at once.
 ///
-/// Available on ARM64 and non-SIMD platforms.
+/// Available on every non-x86_64 target; x86_64 uses `classify_yaml_chars`
+/// instead, which classifies 32 bytes under AVX2. (Not an intra-doc link: that
+/// function is not compiled on the targets this one exists on.)
 #[inline]
-#[cfg(all(
-    not(feature = "scalar-yaml"),
-    any(target_arch = "aarch64", not(target_arch = "x86_64"))
-))]
+#[cfg(all(not(feature = "scalar-yaml"), not(target_arch = "x86_64")))]
 #[allow(dead_code)] // STYLE-0005: alternate classifier; unused in current path
 pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharClass16> {
-    // ARM64 with NEON (default)
-    #[cfg(all(target_arch = "aarch64", not(feature = "broadword-yaml")))]
-    {
-        neon::classify_yaml_chars_16(input, offset)
-    }
-
-    // Broadword: when feature enabled on ARM64, or on non-SIMD platforms
-    #[cfg(any(
-        all(target_arch = "aarch64", feature = "broadword-yaml"),
-        not(any(target_arch = "aarch64", target_arch = "x86_64"))
-    ))]
-    {
-        broadword::classify_yaml_chars_16(input, offset)
-    }
+    broadword::classify_yaml_chars_16(input, offset)
 }
 
 /// Classify 8 bytes of YAML structural characters using broadword operations.
 ///
 /// Uses pure u64 arithmetic instead of SIMD intrinsics.
 ///
-/// Available on ARM64 (with broadword-yaml feature) and non-SIMD platforms.
+/// Available on every non-x86_64 target.
 #[inline]
-#[cfg(all(
-    not(feature = "scalar-yaml"),
-    any(
-        all(target_arch = "aarch64", feature = "broadword-yaml"),
-        not(any(target_arch = "aarch64", target_arch = "x86_64"))
-    )
-))]
+#[cfg(all(not(feature = "scalar-yaml"), not(target_arch = "x86_64")))]
 #[allow(dead_code)] // STYLE-0005: alternate classifier; unused in current path
 pub fn classify_yaml_chars_8(input: &[u8], offset: usize) -> Option<YamlCharClassBroadword> {
     broadword::classify_yaml_chars_broadword(input, offset)
@@ -308,24 +271,9 @@ pub fn find_newline(input: &[u8], start: usize) -> Option<usize> {
         x86::find_newline_x86(input, start)
     }
 
-    // ARM64 with NEON (default, when not scalar or broadword)
-    #[cfg(all(
-        target_arch = "aarch64",
-        not(feature = "broadword-yaml"),
-        not(feature = "scalar-yaml")
-    ))]
-    {
-        neon::find_newline_broadword(input, start)
-    }
-
-    // Broadword: when feature enabled on ARM64, or on non-SIMD platforms (when not scalar)
-    #[cfg(all(
-        not(feature = "scalar-yaml"),
-        any(
-            all(target_arch = "aarch64", feature = "broadword-yaml"),
-            not(any(target_arch = "aarch64", target_arch = "x86_64"))
-        )
-    ))]
+    // Broadword everywhere else (including ARM64 with NEON: newline scanning has
+    // no NEON kernel, so SWAR is the fast path there too).
+    #[cfg(all(not(feature = "scalar-yaml"), not(target_arch = "x86_64")))]
     {
         broadword::find_newline_broadword(input, start)
     }
@@ -363,7 +311,9 @@ pub fn find_block_scalar_end(input: &[u8], start: usize, min_indent: usize) -> O
         )
     )))]
     {
-        find_block_scalar_end_scalar(input, start, min_indent)
+        Some(scalar::find_block_scalar_end_scalar(
+            input, start, min_indent,
+        ))
     }
 }
 
@@ -406,7 +356,7 @@ pub fn parse_anchor_name(input: &[u8], start: usize) -> usize {
         )
     )))]
     {
-        parse_anchor_name_scalar(input, start)
+        scalar::parse_anchor_name_scalar(input, start)
     }
 }
 
@@ -422,64 +372,6 @@ pub fn parse_anchor_name(input: &[u8], start: usize) -> usize {
 /// `succinctly::yaml::simd::find_json_escape` path keep resolving for existing
 /// consumers (`yaml/light.rs`, the escape benches).
 pub use crate::util::simd::escape::find_json_escape;
-
-/// Scalar fallback for parse_anchor_name
-#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
-fn parse_anchor_name_scalar(input: &[u8], start: usize) -> usize {
-    let mut pos = start;
-    while pos < input.len() {
-        let b = input[pos];
-        match b {
-            // Stop at flow indicators, whitespace, and newlines
-            b' ' | b'\t' | b'\n' | b'\r' | b'[' | b']' | b'{' | b'}' | b',' => break,
-            // Colon is allowed in anchor names if not followed by whitespace
-            b':' => {
-                if pos + 1 < input.len() {
-                    let next = input[pos + 1];
-                    if next == b' ' || next == b'\t' || next == b'\n' || next == b'\r' {
-                        break;
-                    }
-                }
-                pos += 1;
-            }
-            _ => pos += 1,
-        }
-    }
-    pos
-}
-
-/// Scalar fallback for find_block_scalar_end
-#[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
-fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -> Option<usize> {
-    let mut pos = start;
-
-    while pos < input.len() {
-        if matches!(input[pos], b'\n' | b'\r') {
-            let line_start = pos + 1;
-
-            if line_start >= input.len() {
-                return Some(input.len());
-            }
-
-            // Count leading spaces
-            let mut indent = 0;
-            while line_start + indent < input.len() && input[line_start + indent] == b' ' {
-                indent += 1;
-            }
-
-            // Check if this line has content at insufficient indent
-            if line_start + indent < input.len() {
-                let next_char = input[line_start + indent];
-                if next_char != b'\n' && next_char != b'\r' && indent < min_indent {
-                    return Some(line_start);
-                }
-            }
-        }
-        pos += 1;
-    }
-
-    Some(input.len())
-}
 
 /// Scalar implementation of find_newline.
 #[allow(dead_code)] // STYLE-0005: scalar fallback (SIMD path used when detected)
@@ -720,7 +612,7 @@ mod tests {
         ];
         for (input, min_indent) in cases {
             assert_eq!(
-                find_block_scalar_end_scalar(input, 0, *min_indent),
+                Some(scalar::find_block_scalar_end_scalar(input, 0, *min_indent)),
                 find_block_scalar_end(input, 0, *min_indent),
                 "scalar fallback disagrees with SIMD on {:?}",
                 String::from_utf8_lossy(input)

--- a/src/yaml/simd/neon.rs
+++ b/src/yaml/simd/neon.rs
@@ -3,20 +3,22 @@
 //!
 //! Uses 128-bit NEON vectors to process 16 bytes at a time.
 //!
-//! ## Broadword (SWAR) Operations
+//! ## What is *not* here
 //!
-//! For bulk character classification, we use pure broadword arithmetic instead of
-//! NEON intrinsics. This avoids the expensive `neon_movemask` emulation which requires
-//! SIMD→scalar lane extractions and multiplication tricks (~10 instructions per call).
+//! Bulk character classification uses pure broadword (SWAR) arithmetic rather
+//! than NEON, because `neon_movemask` emulation costs a SIMD→scalar lane
+//! extraction plus a multiply per channel (~10 instructions), and a classifier
+//! needs nine of them. Newline scanning is broadword for the same reason. Both
+//! live in [`super::broadword`], which ARM64 compiles and dispatches to
+//! alongside this module — see the `mod broadword` gate in [`super`].
 //!
-//! Broadword operations process 8 bytes at a time using u64 arithmetic:
-//! - XOR with broadcast byte to find matches (matching bytes become 0x00)
-//! - Use `(x - 0x0101...) & ~x & 0x8080...` trick to detect zero bytes
-//! - Extract high bits via shift and mask
-//!
-//! This approach is ~5x faster than calling `neon_movemask` 8 times for classification.
+//! Until #185 this file carried its own copy of that broadword layer. The two
+//! copies could never be compiled together, so they drifted: the copy here
+//! still documented terminators (`,`, `[`, `]`) it never classified.
 
 use core::arch::aarch64::*;
+
+use super::scalar::{find_block_scalar_end_scalar, parse_anchor_name_scalar};
 
 /// Extract a bitmask from the high bit of each byte in a NEON vector.
 /// Returns a u16 where bit i is set if byte i has its high bit set.
@@ -170,239 +172,6 @@ unsafe fn count_leading_spaces_neon_impl(input: &[u8], start: usize) -> usize {
 }
 
 // ============================================================================
-// Broadword (SWAR) Character Classification
-// ============================================================================
-//
-// These functions use pure u64 arithmetic to classify characters without
-// the expensive NEON movemask emulation. Process 8 bytes at a time.
-
-/// Broadcast a byte to all 8 positions in a u64.
-#[inline(always)]
-const fn broadcast_byte(b: u8) -> u64 {
-    0x0101010101010101u64 * (b as u64)
-}
-
-/// Constants for broadword zero-byte detection.
-const LO_BYTES: u64 = 0x0101010101010101u64;
-const HI_BYTES: u64 = 0x8080808080808080u64;
-
-/// Detect which bytes in `x` are zero using the classic broadword trick.
-/// Returns a u64 where the high bit of each byte is set if that byte was zero.
-///
-/// Algorithm: `(x - 0x0101...) & ~x & 0x8080...`
-/// - For zero bytes: subtraction causes borrow, setting high bit
-/// - For non-zero bytes: either no borrow, or high bit was already set
-#[inline(always)]
-const fn has_zero_byte(x: u64) -> u64 {
-    x.wrapping_sub(LO_BYTES) & !x & HI_BYTES
-}
-
-/// Find bytes equal to `target` in `x`.
-/// Returns a u64 where the high bit of each byte is set if that byte equals target.
-#[inline(always)]
-const fn find_byte(x: u64, target: u8) -> u64 {
-    has_zero_byte(x ^ broadcast_byte(target))
-}
-
-/// Extract a bitmask from the high bits of each byte in a u64.
-/// Returns a u8 where bit i is set if byte i has its high bit set.
-///
-/// Uses multiplication trick: multiply by magic constant to gather bits.
-/// After `has_zero_byte`, matching bytes have high bit set at positions 7, 15, 23, ...
-/// We shift right by 7 to get bits at positions 0, 8, 16, ...
-/// Then multiply by magic to gather them into bits 56-63.
-#[inline(always)]
-const fn extract_mask_u64(x: u64) -> u8 {
-    // Shift high bits to bit 0 of each byte, then pack via multiplication
-    // Magic constant: each byte position contributes to a different result bit
-    // Bit at pos 0 -> bit 56, pos 8 -> bit 57, ..., pos 56 -> bit 63
-    const MAGIC: u64 = 0x0102040810204080u64;
-    ((x >> 7).wrapping_mul(MAGIC) >> 56) as u8
-}
-
-/// YAML character classification result using broadword operations.
-/// Each field is a u8 bitmask for 8 bytes (one bit per byte position).
-///
-/// NOTE: Currently unused - broadword integration is disabled. See P4 analysis.
-#[derive(Debug, Clone, Copy, Default)]
-#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
-pub struct YamlCharClassBroadword {
-    pub newlines: u8,
-    /// Mask of bytes that are '\r' — a YAML 1.2 §5.4 line break in its own
-    /// right, so a value terminator just like '\n' (#324).
-    pub carriage_returns: u8,
-    pub colons: u8,
-    pub hyphens: u8,
-    pub spaces: u8,
-    pub quotes_double: u8,
-    pub quotes_single: u8,
-    pub backslashes: u8,
-    pub hash: u8,
-}
-
-#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
-impl YamlCharClassBroadword {
-    /// Check if any structural character was found.
-    #[inline(always)]
-    pub fn has_any(&self) -> bool {
-        (self.newlines
-            | self.carriage_returns
-            | self.colons
-            | self.hyphens
-            | self.spaces
-            | self.quotes_double
-            | self.quotes_single
-            | self.backslashes
-            | self.hash)
-            != 0
-    }
-
-    /// Get mask of all value terminators (for unquoted values).
-    /// Terminators: newline, colon, space, hash, comma (flow), brackets (flow)
-    #[inline(always)]
-    pub fn value_terminators(&self) -> u8 {
-        self.newlines | self.carriage_returns | self.colons | self.spaces | self.hash
-    }
-}
-
-/// Classify 8 bytes at once using pure broadword arithmetic.
-///
-/// This is the core optimization: instead of 8 NEON movemask calls (~80 instructions),
-/// we use ~24 arithmetic operations to classify all 8 character types.
-///
-/// Returns `None` if fewer than 8 bytes remain.
-///
-/// NOTE: Currently unused - broadword integration is disabled. See P4 analysis.
-#[inline]
-#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
-pub fn classify_yaml_chars_broadword(
-    input: &[u8],
-    offset: usize,
-) -> Option<YamlCharClassBroadword> {
-    if offset + 8 > input.len() {
-        return None;
-    }
-
-    // Load 8 bytes as a u64 (unaligned load is fine on ARM64)
-    let chunk = u64::from_le_bytes(input[offset..offset + 8].try_into().unwrap());
-
-    // Find each character type using broadword operations
-    let newlines = find_byte(chunk, b'\n');
-    let carriage_returns = find_byte(chunk, b'\r');
-    let colons = find_byte(chunk, b':');
-    let hyphens = find_byte(chunk, b'-');
-    let spaces = find_byte(chunk, b' ');
-    let quotes_double = find_byte(chunk, b'"');
-    let quotes_single = find_byte(chunk, b'\'');
-    let backslashes = find_byte(chunk, b'\\');
-    let hash = find_byte(chunk, b'#');
-
-    Some(YamlCharClassBroadword {
-        newlines: extract_mask_u64(newlines),
-        carriage_returns: extract_mask_u64(carriage_returns),
-        colons: extract_mask_u64(colons),
-        hyphens: extract_mask_u64(hyphens),
-        spaces: extract_mask_u64(spaces),
-        quotes_double: extract_mask_u64(quotes_double),
-        quotes_single: extract_mask_u64(quotes_single),
-        backslashes: extract_mask_u64(backslashes),
-        hash: extract_mask_u64(hash),
-    })
-}
-
-/// Classify 16 bytes using two broadword operations.
-///
-/// Returns combined u16 masks (low 8 bits from first chunk, high 8 from second).
-/// Returns `None` if fewer than 16 bytes remain.
-///
-/// NOTE: Currently unused - broadword integration is disabled. See P4 analysis.
-#[derive(Debug, Clone, Copy, Default)]
-#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
-pub struct YamlCharClass16 {
-    pub newlines: u16,
-    /// Mask of bytes that are '\r' — see [`YamlCharClassBroadword`] (#324).
-    pub carriage_returns: u16,
-    pub colons: u16,
-    pub hyphens: u16,
-    pub spaces: u16,
-    pub quotes_double: u16,
-    pub quotes_single: u16,
-    pub backslashes: u16,
-    pub hash: u16,
-}
-
-#[allow(dead_code)] // STYLE-0005: broadword classifier kept as reference/fallback
-impl YamlCharClass16 {
-    /// Get mask of value terminators.
-    #[inline(always)]
-    pub fn value_terminators(&self) -> u16 {
-        self.newlines | self.carriage_returns | self.colons | self.spaces | self.hash
-    }
-}
-
-/// Classify 16 bytes at once using two broadword operations.
-#[inline]
-pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharClass16> {
-    if offset + 16 > input.len() {
-        return None;
-    }
-
-    // Load two 8-byte chunks
-    let chunk0 = u64::from_le_bytes(input[offset..offset + 8].try_into().unwrap());
-    let chunk1 = u64::from_le_bytes(input[offset + 8..offset + 16].try_into().unwrap());
-
-    // Process both chunks for each character type
-    #[inline(always)]
-    fn classify_both(c0: u64, c1: u64, target: u8) -> u16 {
-        let m0 = extract_mask_u64(find_byte(c0, target)) as u16;
-        let m1 = extract_mask_u64(find_byte(c1, target)) as u16;
-        m0 | (m1 << 8)
-    }
-
-    Some(YamlCharClass16 {
-        newlines: classify_both(chunk0, chunk1, b'\n'),
-        carriage_returns: classify_both(chunk0, chunk1, b'\r'),
-        colons: classify_both(chunk0, chunk1, b':'),
-        hyphens: classify_both(chunk0, chunk1, b'-'),
-        spaces: classify_both(chunk0, chunk1, b' '),
-        quotes_double: classify_both(chunk0, chunk1, b'"'),
-        quotes_single: classify_both(chunk0, chunk1, b'\''),
-        backslashes: classify_both(chunk0, chunk1, b'\\'),
-        hash: classify_both(chunk0, chunk1, b'#'),
-    })
-}
-
-/// Find the next newline using broadword operations.
-///
-/// Returns offset from `start` to the newline, or `None` if not found.
-#[inline]
-pub fn find_newline_broadword(input: &[u8], start: usize) -> Option<usize> {
-    let data = &input[start..];
-    let len = data.len();
-    let mut offset = 0;
-
-    // Process 8 bytes at a time
-    while offset + 8 <= len {
-        let chunk = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
-        let matches = find_byte(chunk, b'\n');
-
-        if matches != 0 {
-            // Found a newline - return position of first match
-            // Each matching byte has its high bit set, so count trailing zeros / 8
-            return Some(offset + (matches.trailing_zeros() / 8) as usize);
-        }
-
-        offset += 8;
-    }
-
-    // Handle remaining bytes
-    data[offset..]
-        .iter()
-        .position(|&b| b == b'\n')
-        .map(|pos| offset + pos)
-}
-
-// ============================================================================
 // P4 Optimization: Anchor/Alias SIMD Parsing
 // ============================================================================
 
@@ -511,30 +280,6 @@ unsafe fn parse_anchor_name_neon_impl(input: &[u8], start: usize) -> usize {
     parse_anchor_name_scalar(input, pos)
 }
 
-/// Scalar fallback for parsing anchor names.
-fn parse_anchor_name_scalar(input: &[u8], start: usize) -> usize {
-    let mut pos = start;
-    while pos < input.len() {
-        let b = input[pos];
-        match b {
-            // Stop at flow indicators, whitespace, and newlines
-            b' ' | b'\t' | b'\n' | b'\r' | b'[' | b']' | b'{' | b'}' | b',' => break,
-            // Colon is allowed in anchor names if not followed by whitespace
-            b':' => {
-                if pos + 1 < input.len() {
-                    let next = input[pos + 1];
-                    if next == b' ' || next == b'\t' || next == b'\n' || next == b'\r' {
-                        break;
-                    }
-                }
-                pos += 1;
-            }
-            _ => pos += 1,
-        }
-    }
-    pos
-}
-
 // ============================================================================
 // P2.7 Optimization: Block Scalar SIMD Parsing
 // ============================================================================
@@ -632,38 +377,6 @@ unsafe fn find_block_scalar_end_neon_impl(input: &[u8], start: usize, min_indent
     find_block_scalar_end_scalar(input, pos, min_indent)
 }
 
-/// Scalar fallback for find_block_scalar_end.
-fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -> usize {
-    let mut pos = start;
-
-    while pos < input.len() {
-        if matches!(input[pos], b'\n' | b'\r') {
-            let line_start = pos + 1;
-
-            if line_start >= input.len() {
-                return input.len();
-            }
-
-            // Count leading spaces
-            let mut indent = 0;
-            while line_start + indent < input.len() && input[line_start + indent] == b' ' {
-                indent += 1;
-            }
-
-            // Check if this line has content at insufficient indent
-            if line_start + indent < input.len() {
-                let next_char = input[line_start + indent];
-                if next_char != b'\n' && next_char != b'\r' && indent < min_indent {
-                    return line_start;
-                }
-            }
-        }
-        pos += 1;
-    }
-
-    input.len()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -746,98 +459,7 @@ mod tests {
         assert_eq!(count_leading_spaces_neon(&input, 0), 20);
     }
 
-    // ========================================================================
-    // Broadword tests
-    // ========================================================================
-
-    #[test]
-    fn test_broadword_find_byte_basic() {
-        // Test the core find_byte function
-        let data = b"hello:world";
-        let chunk = u64::from_le_bytes(data[0..8].try_into().unwrap());
-        let colon_mask = find_byte(chunk, b':');
-        // Colon is at position 5, so bit 5*8+7 = 47 should be set
-        assert_ne!(colon_mask, 0);
-        assert_eq!(colon_mask.trailing_zeros() / 8, 5);
-    }
-
-    #[test]
-    fn test_broadword_classify_basic() {
-        let input = b"key: value\n";
-        let class = classify_yaml_chars_broadword(input, 0).unwrap();
-
-        // Check specific character positions
-        assert_eq!(class.colons, 0b00001000); // colon at position 3
-        assert_eq!(class.spaces, 0b00010000); // space at position 4
-    }
-
-    #[test]
-    fn test_broadword_classify_multiple() {
-        let input = b": - # \"\n\\";
-        let class = classify_yaml_chars_broadword(input, 0).unwrap();
-
-        assert_ne!(class.colons, 0);
-        assert_ne!(class.hyphens, 0);
-        assert_ne!(class.hash, 0);
-        assert_ne!(class.quotes_double, 0);
-        assert_ne!(class.newlines, 0);
-    }
-
-    #[test]
-    fn test_broadword_classify_16_basic() {
-        let input = b"0123456789abcdef";
-        let class = classify_yaml_chars_16(input, 0).unwrap();
-
-        // No special characters
-        assert_eq!(class.colons, 0);
-        assert_eq!(class.newlines, 0);
-    }
-
-    #[test]
-    fn test_broadword_classify_16_with_matches() {
-        let input = b"key: val\nmore: x\n";
-        let class = classify_yaml_chars_16(input, 0).unwrap();
-
-        // Colon at position 3 and 13
-        assert!(class.colons & (1 << 3) != 0);
-        assert!(class.colons & (1 << 13) != 0);
-
-        // Newline at position 8
-        assert!(class.newlines & (1 << 8) != 0);
-    }
-
-    #[test]
-    fn test_broadword_find_newline() {
-        let input = b"hello\nworld";
-        assert_eq!(find_newline_broadword(input, 0), Some(5));
-
-        let input2 = b"no newline here";
-        assert_eq!(find_newline_broadword(input2, 0), None);
-
-        // Long input
-        let mut long = vec![b'a'; 100];
-        long[50] = b'\n';
-        assert_eq!(find_newline_broadword(&long, 0), Some(50));
-    }
-
-    #[test]
-    fn test_broadword_find_newline_in_remainder() {
-        // Newline in bytes after last 8-byte chunk
-        let mut input = vec![b'a'; 10];
-        input[9] = b'\n';
-        assert_eq!(find_newline_broadword(&input, 0), Some(9));
-    }
-
-    #[test]
-    fn test_broadword_value_terminators() {
-        let input = b"value: x";
-        let class = classify_yaml_chars_broadword(input, 0).unwrap();
-
-        let terminators = class.value_terminators();
-        // Should have colon at 5 and space at 6
-        assert!(terminators & (1 << 5) != 0);
-        assert!(terminators & (1 << 6) != 0);
-    }
+    // Broadword tests live with the broadword code in `super::broadword` (#185).
 
     // ========================================================================
     // P4: Anchor/Alias NEON tests
@@ -960,31 +582,5 @@ mod tests {
                 min_indent
             );
         }
-    }
-    /// The broadword classifiers are kept as a reference/fallback and are not
-    /// on the dispatched path, so nothing else exercises their accessors. They
-    /// still have to agree that a CR terminates a value — a classifier that
-    /// quietly omits it is what let a lone CR swallow a whole document (#324).
-    #[test]
-    fn broadword_classifiers_treat_cr_as_a_value_terminator() {
-        let input = b"abcdefg\rhijklmno";
-        let class = classify_yaml_chars_broadword(input, 0).expect("8 bytes available");
-        assert_eq!(class.carriage_returns, 1 << 7, "CR is at offset 7");
-        assert!(class.has_any());
-        assert!(
-            class.value_terminators() & (1 << 7) != 0,
-            "CR must terminate an unquoted value"
-        );
-
-        let class16 = classify_yaml_chars_16(input, 0).expect("16 bytes available");
-        assert_eq!(class16.carriage_returns, 1 << 7);
-        assert!(class16.value_terminators() & (1 << 7) != 0);
-
-        // A chunk with no CR reports none, so the mask is not just always set.
-        let plain = b"abcdefghijklmnop";
-        let none = classify_yaml_chars_broadword(plain, 0).expect("8 bytes available");
-        assert_eq!(none.carriage_returns, 0);
-        assert!(!none.has_any(), "no structural bytes in {plain:?}");
-        assert_eq!(none.value_terminators(), 0);
     }
 }

--- a/src/yaml/simd/scalar.rs
+++ b/src/yaml/simd/scalar.rs
@@ -1,5 +1,11 @@
 //! Scalar kernels shared by every YAML SIMD backend.
 //!
+//! "Scalar" here means *non-vector*, as it does in the `scalar-yaml` feature and
+//! in `mod.rs`'s `find_newline_scalar` / `count_leading_spaces_scalar` — not a
+//! YAML scalar node. For the latter see `crate::yaml::scalar` (not an intra-doc
+//! link: it is a private module), which resolves a plain scalar's type against
+//! the 1.2 core schema and is unrelated to this one despite the shared word.
+//!
 //! These are not "the no-SIMD fallback" — each vector kernel calls them to
 //! finish the sub-chunk remainder its vector loop cannot cover, so they run on
 //! every target. They also stand in as the whole implementation on platforms

--- a/src/yaml/simd/scalar.rs
+++ b/src/yaml/simd/scalar.rs
@@ -1,0 +1,161 @@
+//! Scalar kernels shared by every YAML SIMD backend.
+//!
+//! These are not "the no-SIMD fallback" — each vector kernel calls them to
+//! finish the sub-chunk remainder its vector loop cannot cover, so they run on
+//! every target. They also stand in as the whole implementation on platforms
+//! with no backend at all, and under `--features scalar-yaml`.
+//!
+//! They lived once per backend file (`mod.rs`, `x86.rs`, `neon.rs`) until #185.
+//! The copies were byte-identical apart from `find_block_scalar_end_scalar`'s
+//! return type, which `mod.rs` wrapped in an `Option` that was always `Some`.
+//! Nothing forced them to stay in step: a build compiles at most one backend, so
+//! a fix applied to one copy left the others untouched and the compiler silent.
+
+/// Scan forward to the end of a YAML anchor or alias name.
+///
+/// Returns the position of the first terminator, or `input.len()` if the name
+/// runs to end of input. Terminators are whitespace (space, tab, LF, CR), the
+/// flow indicators `[ ] { } ,`, and a `:` that is followed by whitespace — a
+/// bare `:` is legal inside an anchor name.
+pub(super) fn parse_anchor_name_scalar(input: &[u8], start: usize) -> usize {
+    let mut pos = start;
+    while pos < input.len() {
+        let b = input[pos];
+        match b {
+            // Stop at flow indicators, whitespace, and newlines
+            b' ' | b'\t' | b'\n' | b'\r' | b'[' | b']' | b'{' | b'}' | b',' => break,
+            // Colon is allowed in anchor names if not followed by whitespace
+            b':' => {
+                if pos + 1 < input.len() {
+                    let next = input[pos + 1];
+                    if next == b' ' || next == b'\t' || next == b'\n' || next == b'\r' {
+                        break;
+                    }
+                }
+                pos += 1;
+            }
+            _ => pos += 1,
+        }
+    }
+    pos
+}
+
+/// Scan forward to the end of a `|` or `>` block scalar.
+///
+/// Returns the start of the first line whose content sits at less than
+/// `min_indent` spaces, or `input.len()` if no such line exists. Blank lines
+/// belong to the block however they are indented, so only a line with real
+/// content can end it.
+///
+/// Both `\n` and `\r` open a new line: YAML 1.2 §5.4 makes a lone CR a line
+/// break in its own right, and scanning for LF alone ran a classic-Mac document
+/// to EOF as a single block (#324).
+pub(super) fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -> usize {
+    let mut pos = start;
+
+    while pos < input.len() {
+        if matches!(input[pos], b'\n' | b'\r') {
+            let line_start = pos + 1;
+
+            if line_start >= input.len() {
+                return input.len();
+            }
+
+            // Count leading spaces
+            let mut indent = 0;
+            while line_start + indent < input.len() && input[line_start + indent] == b' ' {
+                indent += 1;
+            }
+
+            // Check if this line has content at insufficient indent
+            if line_start + indent < input.len() {
+                let next_char = input[line_start + indent];
+                if next_char != b'\n' && next_char != b'\r' && indent < min_indent {
+                    return line_start;
+                }
+            }
+        }
+        pos += 1;
+    }
+
+    input.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_anchor_name_stops_at_each_terminator_class() {
+        // Whitespace, flow indicators, and `: ` all end a name; a bare `:` does not.
+        for (input, expected, what) in [
+            (b"anchor rest".as_slice(), 6, "space"),
+            (b"anchor\trest".as_slice(), 6, "tab"),
+            (b"anchor\nrest".as_slice(), 6, "LF"),
+            (b"anchor\rrest".as_slice(), 6, "CR"),
+            (b"anchor]rest".as_slice(), 6, "close bracket"),
+            (b"anchor}rest".as_slice(), 6, "close brace"),
+            (b"anchor,rest".as_slice(), 6, "comma"),
+            (b"anchor: rest".as_slice(), 6, "colon then space"),
+            (
+                b"anchor:rest".as_slice(),
+                11,
+                "bare colon is part of the name",
+            ),
+            (b"anchor".as_slice(), 6, "end of input"),
+        ] {
+            assert_eq!(
+                parse_anchor_name_scalar(input, 0),
+                expected,
+                "{what}: {:?}",
+                core::str::from_utf8(input).unwrap_or("<non-utf8>")
+            );
+        }
+    }
+
+    #[test]
+    fn parse_anchor_name_honours_the_start_offset() {
+        // A trailing colon with nothing after it is still part of the name.
+        assert_eq!(parse_anchor_name_scalar(b"*alias more", 1), 6);
+        assert_eq!(parse_anchor_name_scalar(b"name:", 0), 5);
+    }
+
+    #[test]
+    fn find_block_scalar_end_stops_at_the_first_dedented_content_line() {
+        // Same document under each break form: the block ends at `c` every time.
+        // Offsets differ because CRLF is two bytes, so assert on the byte landed
+        // on rather than the number (#324).
+        for (input, form) in [
+            (b"  a\n  b\nc\n".as_slice(), "LF"),
+            (b"  a\r\n  b\r\nc\r\n".as_slice(), "CRLF"),
+            (b"  a\r  b\rc\r".as_slice(), "lone CR"),
+        ] {
+            let end = find_block_scalar_end_scalar(input, 0, 2);
+            assert_eq!(
+                input.get(end).copied(),
+                Some(b'c'),
+                "{form}: ended at {end}, which is {:?}",
+                input.get(end).map(|&b| b as char)
+            );
+        }
+    }
+
+    #[test]
+    fn find_block_scalar_end_keeps_blank_lines_and_runs_to_eof_without_a_dedent() {
+        // A blank line is not content, so it cannot end the block...
+        let input = b"  a\n\n  b\nc\n";
+        assert_eq!(
+            input.get(find_block_scalar_end_scalar(input, 0, 2)),
+            Some(&b'c')
+        );
+
+        // ...and with nothing dedented, the block owns the rest of the input.
+        for input in [
+            b"  a\n  b\n".as_slice(),
+            b"  a\r  b\r".as_slice(),
+            b"".as_slice(),
+        ] {
+            assert_eq!(find_block_scalar_end_scalar(input, 0, 2), input.len());
+        }
+    }
+}

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -6,6 +6,8 @@
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+use super::scalar::{find_block_scalar_end_scalar, parse_anchor_name_scalar};
+
 // ============================================================================
 // Dispatch clamp (SUCCINCTLY_SIMD)
 // ============================================================================
@@ -88,6 +90,31 @@ pub struct YamlCharClass {
     /// 32 bytes were scanned — deriving the width from input length alone
     /// skipped structural bytes 16..31 on non-AVX2 CPUs (#193).
     pub width: usize,
+}
+
+impl YamlCharClass {
+    /// Bytes at which a plain (unquoted) scalar scan must stop and re-examine.
+    ///
+    /// The scan may stop early and lose nothing but speed, so this only has to
+    /// be a *superset* of what the parser's byte loop breaks on: `\n`, `\r`
+    /// (YAML 1.2 §5.4 makes a lone CR a line break too — #324), `#`, and `:`.
+    /// The loop re-checks the context-sensitive pair itself — `#` opens a
+    /// comment only after whitespace, `:` ends a key only before whitespace —
+    /// so the mask does not model that.
+    ///
+    /// Notably **not** `spaces`: a plain scalar may contain them (`key: hello
+    /// world`), so stopping at each one only costs a re-entry into the byte
+    /// loop.
+    ///
+    /// Kept verbatim in sync with `YamlCharClass16::plain_scalar_terminators`
+    /// in `yaml::simd::broadword`, which is the same set for the ARM64 variant
+    /// of `skip_unquoted_simd`. (Not an intra-doc link: that module is not
+    /// compiled on x86_64.) The two disagreed until #185 — this one omitted
+    /// `\r` before #324, and the broadword one added `spaces`.
+    #[inline(always)]
+    pub fn plain_scalar_terminators(&self) -> u32 {
+        self.newlines | self.carriage_returns | self.colons | self.hash
+    }
 }
 
 /// Classify YAML structural characters in a 32-byte chunk using AVX2.
@@ -753,37 +780,6 @@ unsafe fn find_block_scalar_end_sse2(input: &[u8], start: usize, min_indent: usi
     find_block_scalar_end_scalar(input, pos, min_indent)
 }
 
-fn find_block_scalar_end_scalar(input: &[u8], start: usize, min_indent: usize) -> usize {
-    let mut pos = start;
-
-    while pos < input.len() {
-        if matches!(input[pos], b'\n' | b'\r') {
-            let line_start = pos + 1;
-
-            if line_start >= input.len() {
-                return input.len();
-            }
-
-            // Count leading spaces
-            let mut indent = 0;
-            while line_start + indent < input.len() && input[line_start + indent] == b' ' {
-                indent += 1;
-            }
-
-            // Check if this line has content at insufficient indent
-            if line_start + indent < input.len() {
-                let next_char = input[line_start + indent];
-                if next_char != b'\n' && next_char != b'\r' && indent < min_indent {
-                    return line_start;
-                }
-            }
-        }
-        pos += 1;
-    }
-
-    input.len()
-}
-
 // ============================================================================
 // Anchor/Alias Name Parsing (P4 Optimization)
 // ============================================================================
@@ -860,30 +856,6 @@ unsafe fn parse_anchor_name_avx2(input: &[u8], start: usize) -> usize {
 
     // Handle remaining bytes with scalar fallback
     parse_anchor_name_scalar(input, pos)
-}
-
-/// Scalar fallback for parsing anchor names.
-fn parse_anchor_name_scalar(input: &[u8], start: usize) -> usize {
-    let mut pos = start;
-    while pos < input.len() {
-        let b = input[pos];
-        match b {
-            // Stop at flow indicators, whitespace, and newlines
-            b' ' | b'\t' | b'\n' | b'\r' | b'[' | b']' | b'{' | b'}' | b',' => break,
-            // Colon is allowed in anchor names if not followed by whitespace
-            b':' => {
-                if pos + 1 < input.len() {
-                    let next = input[pos + 1];
-                    if next == b' ' || next == b'\t' || next == b'\n' || next == b'\r' {
-                        break;
-                    }
-                }
-                pos += 1;
-            }
-            _ => pos += 1,
-        }
-    }
-    pos
 }
 
 /// Public API: Parse anchor/alias name with runtime SIMD dispatch.

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -1189,11 +1189,16 @@ mod tests {
         }
     }
 
-    /// All eight mask channels of a `YamlCharClass`, paired with names for
+    /// All nine mask channels of a `YamlCharClass`, paired with names for
     /// assertion messages.
-    fn classify_channels(class: &YamlCharClass) -> [(u32, &'static str); 8] {
+    ///
+    /// `carriage_returns` was missing here until #185, so the channel #324 added
+    /// to the live terminator mask was the one channel the sweep below never
+    /// checked.
+    fn classify_channels(class: &YamlCharClass) -> [(u32, &'static str); 9] {
         [
             (class.newlines, "newlines"),
+            (class.carriage_returns, "carriage_returns"),
             (class.colons, "colons"),
             (class.hyphens, "hyphens"),
             (class.spaces, "spaces"),
@@ -1211,15 +1216,17 @@ mod tests {
     /// terminators after a 16-byte SSE2 classify (#231).
     #[test]
     fn test_classify_kernels_differential_terminator_sweep() {
-        let structural: [(u8, usize); 8] = [
+        // Second field indexes into `classify_channels`; keep the two in step.
+        let structural: [(u8, usize); 9] = [
             (b'\n', 0),
-            (b':', 1),
-            (b'-', 2),
-            (b' ', 3),
-            (b'"', 4),
-            (b'\'', 5),
-            (b'\\', 6),
-            (b'#', 7),
+            (b'\r', 1),
+            (b':', 2),
+            (b'-', 3),
+            (b' ', 4),
+            (b'"', 5),
+            (b'\'', 6),
+            (b'\\', 7),
+            (b'#', 8),
         ];
         let run_avx2 = has_avx2();
 
@@ -1280,5 +1287,49 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// `plain_scalar_terminators` is the mask the *live* `skip_unquoted_simd`
+    /// runs on ([`crate::yaml::parser`]), so it is the copy that matters and the
+    /// one nothing tested before #185. Asserted per byte rather than as an OR of
+    /// the channel fields, which would restate the implementation: a channel
+    /// added to or dropped from the set changes which bytes stop the skip, and
+    /// that is what this pins.
+    ///
+    /// The twin of this test for the broadword widths is
+    /// `plain_scalar_terminators_stop_at_structure_but_not_at_spaces` in
+    /// `yaml::simd::broadword`; the two sets must stay identical because the
+    /// parser's byte loop is shared.
+    #[test]
+    fn plain_scalar_terminators_is_exactly_line_break_colon_hash() {
+        // A terminator must be a superset of what the byte loop breaks on, and
+        // must exclude space — a plain scalar may contain one (`key: hello
+        // world`), so stopping there only shortens the skip.
+        let terminating = *b"\n\r:#";
+        let passing = *b" \t-\"'\\a0";
+
+        for byte in terminating.into_iter().chain(passing) {
+            let mut buf = [b'a'; 48];
+            buf[3] = byte;
+            let class = classify_yaml_chars(&buf, 0).expect("48 bytes available");
+            let stops = class.plain_scalar_terminators() & (1 << 3) != 0;
+
+            assert_eq!(
+                stops,
+                terminating.contains(&byte),
+                "0x{byte:02x} ({:?}) must {} a plain scalar",
+                byte as char,
+                if terminating.contains(&byte) {
+                    "terminate"
+                } else {
+                    "not terminate"
+                }
+            );
+        }
+
+        // An inert chunk sets nothing, so the mask is not simply always hot.
+        let inert = [b'a'; 48];
+        let class = classify_yaml_chars(&inert, 0).expect("48 bytes available");
+        assert_eq!(class.plain_scalar_terminators(), 0);
     }
 }


### PR DESCRIPTION
## Description

This PR eliminates code duplication in the YAML SIMD module by consolidating four copies of scalar remainder handlers and two copies of the broadword classifier layer into shared, unified implementations — then closes the gaps a review of that consolidation turned up.

**Problem:** The `src/yaml/simd/` directory contained byte-identical code across `mod.rs`, `x86.rs`, and `neon.rs` that was never compiled together. This meant:
- Scalar remainder handlers (`parse_anchor_name_scalar` and `find_block_scalar_end_scalar`) existed in three places with no mechanism to keep them synchronized
- A complete copy of the broadword (SWAR) classifier lived in both `neon.rs` (for the disabled ARM64 path) and `broadword.rs` (for every non-x86_64 target), diverging undetected until #185
- The broadword classifier's `value_terminators()` included spaces, while the x86 path's terminator set did not — a latent divergence that would have silently degraded performance on ARM64 if that path were enabled

**Solution:** Consolidate duplicated code into a new shared `scalar.rs` module and unify the classifier interface.

### Changes Made

**Consolidated Scalar Kernels:**
- Created `src/yaml/simd/scalar.rs` containing `parse_anchor_name_scalar()` and `find_block_scalar_end_scalar()`
- These functions run on every target (each vector loop calls them to finish sub-chunk remainders) and must not diverge
- Removed duplicate implementations from `mod.rs`, `x86.rs`, and `neon.rs`
- Preserved exact semantics: `find_block_scalar_end_scalar()` returns `usize` (the canonical signature); callers handle the Option wrapping
- Added unit tests to `scalar.rs` covering all terminator classes and edge cases

**Unified Broadword Classifiers:**
- `broadword.rs` now compiles on every non-x86_64 target (previously gated to `broadword-yaml` on ARM64 plus exotic architectures)
- `neon.rs` no longer carries a duplicate copy of the broadword layer; ARM64 dispatches to `broadword.rs` for classification and newline scanning
- Removed ~240 lines of duplicated broadword logic from `neon.rs`

**Fixed Terminator Set Inconsistency:**
- Renamed both `value_terminators()` methods to `plain_scalar_terminators()`
- Unified the terminator set across x86 and ARM64: newlines, carriage returns, colons, and hash (NO spaces)
- Spaces were incorrectly included in the broadword variant, which would abort the skip at every space in prose-like values
- Documented why spaces are excluded, and the context from #324 (CR handling)
- Updated `src/yaml/parser.rs` to use the unified method

**Module Restructuring:**
- `src/yaml/simd/mod.rs`: simplified platform-conditional compilation by removing nested feature gates; `broadword` now always compiles on non-x86_64 targets; removed the NEON-specific `YamlCharClass16` re-export
- `classify_yaml_chars_16()` always calls `broadword::classify_yaml_chars_16()` on non-x86_64; `find_newline()` dispatches to broadword on ARM64 (no NEON kernel exists)
- Moved doc comments describing `classify_yaml_chars_16` off the struct onto the function for correct rustdoc scoping
- Added `#[allow(dead_code)]` annotations with STYLE-0005 justifications

**Test Coverage (consolidation):**
- Migrated two tests from `neon.rs` to `broadword.rs`: the #324 CR regression test and `find_newline_broadword`'s remainder case
- New in `broadword.rs`: `plain_scalar_terminators_stop_at_structure_but_not_at_spaces()`, `broadword_classifiers_treat_cr_as_a_value_terminator()`, `both_classifier_widths_agree_on_the_terminator_set()`

---

## Review follow-ups (later commits on this branch)

A review of the consolidation found five things; all are addressed here.

**1. The one *live* copy of the terminator set was the untested one** (`test(yaml)`)

The consolidation gave the two broadword widths a test pinning their channel list, and left `YamlCharClass::plain_scalar_terminators` — the copy `skip_unquoted_simd` actually dispatches to on x86_64 — with no test at all. Its only guarantee was a doc comment saying it stayed in step, which is exactly the guarantee the duplicated broadword layer had.

`plain_scalar_terminators_is_exactly_line_break_colon_hash` asserts per byte rather than as an OR of the channel fields (which would restate the implementation): four bytes that must terminate, eight that must not, `' '` among them. Mutation-checked both ways — re-adding `spaces` and dropping `carriage_returns` each fail with a specific message.

Also widens the differential terminator sweep, whose `classify_channels` omitted `carriage_returns` — so the one channel #324 added to the live mask was the one channel the sweep never checked. Now nine channels with `\r` in the swept byte set.

**2. The P4 benchmark caveat was wrong and is corrected** (`docs(docs)`)

The consolidation added a caveat claiming the P4 broadword table was confounded by the ARM path stopping at spaces. It is not. `yaml_bench` generates **no plain scalar with an interior space** — every unquoted value is a single token (`value{i}`, `leaf`, `item{i}`, `myapp`, `production`, `val{i}`), and every space in the corpus sits inside a quoted string or block-scalar content, neither of which reaches `skip_unquoted_simd`.

Stronger than "rare": the two masks are *behaviourally identical* on this input. On `key0: value0\n` the `\n` at offset 6 precedes the next line's space at offset 12, so `trailing_zeros()` returns 6 either way.

That changes the follow-up too. It is not a re-run — re-running `yaml_bench` unchanged reproduces the same numbers by construction. A space-bearing plain-scalar generator has to exist first. Tracked in #383.

**3. Two doc pages still described the pre-#185 layout** (`docs(docs)`)

`docs/plan/simd-features.md` said aarch64 compiles only `neon` by default and listed dead-code warnings from `neon.rs::find_newline_broadword`, a symbol that no longer exists. `docs/plan/sve2-optimizations.md` credited `neon.rs` with "broadword fallbacks". Both corrected, with the history recording why the narrow gate existed and what it cost.

**4. The public API rename was unrecorded** (`docs(docs)`)

`yaml::simd` is a `pub mod`, so renaming `value_terminators` → `plain_scalar_terminators` and dropping the `spaces` channel is breaking. Added to the CHANGELOG's Unreleased/Changed section, matching how the `YamlError` variant removal is marked.

**5. `simd/scalar.rs` collides with `yaml::scalar` — resolved by *not* renaming** (`docs(yaml)`)

Two unrelated modules, one word: `yaml::scalar` resolves a plain scalar's type against the 1.2 core schema, `yaml::simd::scalar` holds non-vector kernels. Renaming looked obvious and is wrong — "scalar" already means non-vector throughout this subtree (`scalar-yaml`, `find_newline_scalar`, `count_leading_spaces_scalar`, every `*_scalar` suffix). A `bytewise.rs` trades one collision for inconsistency with all of that. The module doc now states which sense is meant.

---

## CI: the backends no leg was selecting (`ci(ci)`)

The YAML backend selectors are mutually exclusive by cfg, so a build compiles at most one of `neon` / `broadword` / `x86` and the compiler never compares them. **Nothing in CI built `broadword-yaml` or `scalar-yaml`** — which is how `neon.rs` came to carry a drifted duplicate of the whole broadword layer: both copies were syntactically fine, and no leg ever instantiated the stale one.

- `test-arm` gains `simd,broadword-yaml` and `simd,scalar-yaml`
- `test-x86` gains `simd,scalar-yaml` (`broadword-yaml` is a no-op there)

Clippy had the same hole from the opposite direction: `--all-features` turns *on* `scalar-yaml`, whose cfgs compile out every YAML SIMD backend, so `--all-targets --all-features` has never linted `x86.rs`, `neon.rs` or `broadword.rs`. Verified, not assumed — a lint planted in `x86.rs` produces no diagnostic under `--all-features` and does fire without `scalar-yaml`. A second Clippy step names its features explicitly.

That step deliberately keeps `portable-popcount`: dropping it also un-gates the AVX-512 popcount path, which carries five pre-existing lints and needs an MSRV decision that is not this PR's to make. That, and Clippy coverage for the ARM backends, are tracked in #388.

## Verification

Beyond CI: clippy `-D warnings` clean on aarch64 × {default, `broadword-yaml`, `scalar-yaml`}; the new clippy step green on x86_64 and both aarch64 configs; full test suite green on aarch64 default, aarch64 `broadword-yaml`, aarch64 `scalar-yaml`, and x86_64 (Rosetta) under `simd` and `simd,scalar-yaml`; rustdoc `-D warnings` clean on all five configurations; `yq` output byte-identical to the parent of the first commit across 183 (file, query) pairs.

No live path changes behaviour. The x86 mask is the same four channels behind an accessor; ARM64's `find_newline` and `classify_yaml_chars_16` now reach `broadword.rs`, whose implementations are identical to the deleted `neon.rs` copies. The only semantic change — dropping `spaces` — is in the `#[allow(dead_code)]` ARM `skip_unquoted_simd` whose call site is commented out.

## Type of Change
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement
- [x] Documentation update
- [x] CI configuration

## Related Issues
Fixes #185. Opens #383 (benchmark generator needed before P4 can be re-measured) and #388 (Clippy feature-selector coverage).
