### PR TITLE
fix(yaml): reject tabs in leading indentation of structural lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the `yaml` module root and has both consult it, rather than adding a second
   spelling of the rule. Loader-only reject conformance goes 11/94 → 12/94 (case
   DK95/06, which the validator already caught); the combined figure stays 70/94.
-  A tab before a *flow* node is now correctly treated as separation by the
-  validator too, so it accepts `\t{a: 1}` as it already accepted `\t{}`.
+  Sharing the predicate also fixed two false positives on the validator side,
+  where the `:` scan read a `:` that was not a value indicator: a tab before a
+  *flow* node is now separation, so `\t{a: 1}` is accepted as `\t{}` already
+  was; and the scan now skips quoted scalars and comments, so `a:\n \t"x: y"`
+  and `a: 1\n \t# c: d` are accepted while `a:\n \t"b": 1` — a quoted *key*, so
+  really indentation — is still refused.
 - **jq `try/catch` discarded the raised error** (#158): the catch handler ran
   against the *original input* rather than the error value, so a handler could
   never see what went wrong — `try error("boom") catch .` gave `null` where jq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pass, exposed as `succinctly yaml validate [FILES]...` and `syq --validate`,
   that rejects invalid YAML. It mirrors `json validate` — a separate pass run
   before indexing, so the default non-validating loader path is unchanged and
-  pays nothing. It rejects 59 of the 83 previously-accepted-but-invalid YAML
-  Test Suite cases (reject conformance 11/94 → 70/94) with no false positives on
+  pays nothing. It rejects 58 of the 82 previously-accepted-but-invalid YAML
+  Test Suite cases (reject conformance 12/94 → 70/94) with no false positives on
   the valid corpus; the remaining structurally-deep cases stay on record.
 
 ### Removed
@@ -27,6 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **YAML: a tab after spaces in indentation was folded into the key** (#173):
+  the loader rejected a tab only at column 0 and treated a tab following one or
+  more spaces as start-of-content, so `a:\n \tb: 1` loaded as
+  `{"a":{"\tb":1}}` rather than being refused. YAML forbids a tab in
+  indentation, but a tab is only *indentation* when block structure follows it —
+  before a plain scalar it is separation and legal (`foo:\n \tbar`, and Test
+  Suite case UV7Q, "Legal tab after indentation"). The strict validator already
+  drew that distinction, so the fix promotes its `line_is_structural` predicate
+  to the `yaml` module root and has both consult it, rather than adding a second
+  spelling of the rule. Loader-only reject conformance goes 11/94 → 12/94 (case
+  DK95/06, which the validator already caught); the combined figure stays 70/94.
+  A tab before a *flow* node is now correctly treated as separation by the
+  validator too, so it accepts `\t{a: 1}` as it already accepted `\t{}`.
 - **jq `try/catch` discarded the raised error** (#158): the catch handler ran
   against the *original input* rather than the error value, so a handler could
   never see what went wrong — `try error("boom") catch .` gave `null` where jq

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -32,8 +32,8 @@ path:
 
 The **Reject** figure is what the conformance harness rejects with the opt-in
 validator enabled (loader OR validator, see below). The *default non-validating
-loader alone* still rejects only 11/94 (11.7%) by design — the opt-in validator
-([#223](https://github.com/rust-works/succinctly/issues/223)) closes 59 more.
+loader alone* still rejects only 12/94 (12.8%) by design — the opt-in validator
+([#223](https://github.com/rust-works/succinctly/issues/223)) closes 58 more.
 
 The 90 non-passing cases are enumerated individually, with a category and reason, in
 [`tests/data/yaml-test-suite-known-failures.txt`](../../../tests/data/yaml-test-suite-known-failures.txt).
@@ -42,8 +42,8 @@ exactly, so it cannot silently drift from this page.
 
 ## Validation: default loader vs. the opt-in validator
 
-**The default loader is non-validating by design.** `YamlIndex::build` rejects 11 of the
-suite's 94 invalid documents; the other 83 are accepted and produce a value.
+**The default loader is non-validating by design.** `YamlIndex::build` rejects 12 of the
+suite's 94 invalid documents; the other 82 are accepted and produce a value.
 
 This follows from semi-indexing. The index records *structure* — where values start and
 end, and how they nest — not grammar conformance. The parser is a structure recognizer:
@@ -55,25 +55,25 @@ it is 5-10x faster than `yq`.
 **When you need malformed YAML rejected, use the opt-in validator.**
 [`succinctly yaml validate`](../../guides/cli.md) / `syq --validate` runs a separate strict
 pass ([`src/yaml/validate.rs`](../../../src/yaml/validate.rs)) before indexing — mirroring
-`json validate` / `sjq --validate`, so the default path pays nothing. It rejects **59 of
-the 83** documents below with zero false positives on the valid corpus (a guardrail test,
+`json validate` / `sjq --validate`, so the default path pays nothing. It rejects **58 of
+the 82** documents below with zero false positives on the valid corpus (a guardrail test,
 `validator_accepts_all_valid_cases`, enforces that). The conformance harness treats a
 must-fail case as handled if the loader *or* the validator rejects it, which is why the
-Reject figure above is 70/94 rather than 11/94.
+Reject figure above is 70/94 rather than 12/94.
 
 The 24 documents the validator does not yet reject (marked `lax:*` in the manifest) need
 deeper structural analysis — cross-line anchor binding, block-scalar content indentation,
 flow multi-line implicit keys — and are tracked in
 [#223](https://github.com/rust-works/succinctly/issues/223).
 
-The 83 accepted-but-invalid documents (of which the validator now rejects 59) break down as:
+The 82 accepted-but-invalid documents (of which the validator now rejects 58) break down as:
 
 | Category           | Cases | What is not checked                          |
 |--------------------|-------|----------------------------------------------|
 | `lax:mapping`      | 14    | Mapping and implicit-key rules               |
 | `lax:documents`    | 12    | Directive and document-marker placement      |
 | `lax:flow`         | 11    | Flow collection syntax                       |
-| `lax:tabs`         | 9     | Tabs where indentation is expected           |
+| `lax:tabs`         | 8     | Tabs where indentation is expected           |
 | `lax:indentation`  | 7     | Indentation consistency                      |
 | `lax:other`        | 7     | Assorted                                     |
 | `lax:quoting`      | 6     | Quoting and escape sequences                 |
@@ -84,8 +84,8 @@ The 83 accepted-but-invalid documents (of which the validator now rejects 59) br
 The opt-in validation mode now exists ([#223](https://github.com/rust-works/succinctly/issues/223)),
 mirroring the JSON side's `succinctly json validate` / `sjq --validate`. Validation is a
 separate pass run before indexing, so the default path pays nothing for it — see
-[`src/yaml/validate.rs`](../../../src/yaml/validate.rs). The 83 cases above were its
-acceptance criteria; it rejects 59 of them today (each `lax:*` line removed from the
+[`src/yaml/validate.rs`](../../../src/yaml/validate.rs). The 82 cases above were its
+acceptance criteria; it rejects 58 of them today (each `lax:*` line removed from the
 manifest is a case now rejected), with the 24 harder cases still tracked in #223.
 
 ### What "accepted" means: the text is kept, not dropped

--- a/docs/parsing/yaml-index.md
+++ b/docs/parsing/yaml-index.md
@@ -89,7 +89,7 @@ Key lesson: micro-benchmark wins frequently don't translate to end-to-end gains.
 ## Validation
 
 `YamlIndex` performs minimal validation during indexing (structural recognition only) and
-accepts many malformed documents — `YamlIndex::build` rejects 11 of the YAML Test Suite's
+accepts many malformed documents — `YamlIndex::build` rejects 12 of the YAML Test Suite's
 94 invalid inputs. When strict validation is needed, an opt-in pass
 ([`src/yaml/validate.rs`](../../src/yaml/validate.rs), `succinctly yaml validate` /
 `syq --validate`) mirrors `json validate`: a separate pass before indexing that rejects

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -660,8 +660,8 @@ This separation keeps the index small and fast. A higher-level `YamlValue` type 
 ### 8. Error Handling
 
 > **Superseded.** This section recorded an intent that was never implemented as described.
-> succinctly's default loader is **non-validating**: `YamlIndex::build` rejects only 11 of
-> the YAML Test Suite's 94 invalid documents (11.7%). The four `YamlError` variants that
+> succinctly's default loader is **non-validating**: `YamlIndex::build` rejects only 12 of
+> the YAML Test Suite's 94 invalid documents (12.8%). The four `YamlError` variants that
 > were never constructed — including `InvalidIndentation` — have since been removed (#223).
 > Strict rejection is instead provided by an **opt-in** validator
 > ([`src/yaml/validate.rs`](../../src/yaml/validate.rs), `succinctly yaml validate` /

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -27,7 +27,7 @@
 //!
 //! `YamlIndex::build` performs minimal validation during indexing (structural recognition
 //! only) and accepts many malformed documents. It is a non-validating loader: of the YAML
-//! Test Suite's 94 invalid documents it rejects 11. Do not rely on a parse error to
+//! Test Suite's 94 invalid documents it rejects 12. Do not rely on a parse error to
 //! detect malformed input. See `docs/compliance/yaml/limitations.md`.
 //!
 //! # Example
@@ -113,24 +113,33 @@ pub(crate) fn starts_inline_seq_entry(text: &[u8], pos: usize) -> bool {
 
 /// Is the line at `from` *structural* — a block sequence entry (`- ` …) or a block
 /// mapping entry (a `: ` value indicator before end of line) — rather than a plain
-/// scalar?
+/// scalar or a flow node?
 ///
 /// The one definition of "a leading tab here is illegal indentation". YAML forbids a
 /// tab in indentation, but a tab is only *indentation* when block structure follows:
 /// before a plain scalar it is separation and legal (`DK95/00` `foo:\n \tbar`, `UV7Q`
-/// `x:\n - x\n  \tx`), while before a key or a `-` it is not (`DK95/06`).
-///
-/// It lives at the module root because the strict validator
-/// ([`validate::Validator::scan_line`]) and the loader must classify a line
-/// identically, and #106 and #332 were both a predicate copied to several sites and
-/// then diverging.
+/// `x:\n - x\n  \tx`), while before a key or a `-` it is not (`DK95/06`). The loader
+/// ([`parser::Parser::parse_document_line`]) and the strict validator
+/// ([`validate::Validator::scan_line`]) must classify a line identically, so they share
+/// this one spelling — #106 and #332 were both a predicate copied to several sites and
+/// then diverging. `tests/yaml_tab_indentation_tests.rs` pins the two call sites
+/// against each other (#173).
 ///
 /// Leading spaces and tabs are skipped first, so `from` may point at either.
+///
+/// A flow node is deliberately *not* structural: a root flow node's leading separation
+/// may contain tabs (`Q5MG` `\t{}`, `6CA3` `\t[…]`), and a `:` inside the collection is
+/// flow syntax rather than a block value indicator, so scanning on would misread
+/// `\t{a: 1}` as block structure while `\t{}` reads as a node.
 #[inline]
 pub(crate) fn line_is_structural(text: &[u8], from: usize) -> bool {
     let mut i = from;
     while matches!(text.get(i), Some(b' ' | b'\t')) {
         i += 1;
+    }
+    // A flow node, not block structure — see the doc comment.
+    if matches!(text.get(i), Some(b'{' | b'[')) {
+        return false;
     }
     if starts_seq_entry(text, i) {
         return true;
@@ -178,7 +187,12 @@ mod tests {
             (&b"\ta:b\n"[..], false), // `:` not followed by whitespace is content
             (&b"\t-1\n"[..], false),  // Y79Y/010: `-1` is a scalar, not an entry
             (&b"\tbar"[..], false),   // end of input, no line break
-            (&b"\t{}\n"[..], false),  // Q5MG: a flow node, and no `:` at all
+            // Flow nodes: a root flow node's separation may contain tabs, and a `:`
+            // inside the collection is flow syntax, not a block value indicator.
+            (&b"\t{}\n"[..], false),     // Q5MG
+            (&b"\t{a: 1}\n"[..], false), // same node, now with a `:` inside
+            (&b"\t[\n"[..], false),      // 6CA3
+            (&b"\t[a: 1]\n"[..], false),
             // Nothing at all.
             (&b"\t\n"[..], false),
             (&b"\t"[..], false),

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -111,6 +111,43 @@ pub(crate) fn starts_inline_seq_entry(text: &[u8], pos: usize) -> bool {
     text.get(pos) == Some(&b'-') && matches!(text.get(pos + 1), Some(b' ' | b'\t'))
 }
 
+/// Is the line at `from` *structural* — a block sequence entry (`- ` …) or a block
+/// mapping entry (a `: ` value indicator before end of line) — rather than a plain
+/// scalar?
+///
+/// The one definition of "a leading tab here is illegal indentation". YAML forbids a
+/// tab in indentation, but a tab is only *indentation* when block structure follows:
+/// before a plain scalar it is separation and legal (`DK95/00` `foo:\n \tbar`, `UV7Q`
+/// `x:\n - x\n  \tx`), while before a key or a `-` it is not (`DK95/06`).
+///
+/// It lives at the module root because the strict validator
+/// ([`validate::Validator::scan_line`]) and the loader must classify a line
+/// identically, and #106 and #332 were both a predicate copied to several sites and
+/// then diverging.
+///
+/// Leading spaces and tabs are skipped first, so `from` may point at either.
+#[inline]
+pub(crate) fn line_is_structural(text: &[u8], from: usize) -> bool {
+    let mut i = from;
+    while matches!(text.get(i), Some(b' ' | b'\t')) {
+        i += 1;
+    }
+    if starts_seq_entry(text, i) {
+        return true;
+    }
+    // A block mapping entry: a `:` value indicator somewhere on this line.
+    while let Some(&b) = text.get(i) {
+        match b {
+            b'\n' | b'\r' => return false,
+            b':' if matches!(text.get(i + 1), None | Some(b' ' | b'\t' | b'\n' | b'\r')) => {
+                return true
+            }
+            _ => i += 1,
+        }
+    }
+    false
+}
+
 pub use error::YamlError;
 pub use index::YamlIndex;
 pub use light::{
@@ -119,3 +156,52 @@ pub use light::{
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
 pub use scalar::{resolve_plain, ResolvedScalar};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the classification that decides whether a leading tab is illegal
+    /// indentation. Each row names the YAML Test Suite case it stands for, so the
+    /// rule cannot be widened without someone re-deciding a named case (#173).
+    #[test]
+    fn line_is_structural_classifies_block_structure_only() {
+        for (text, want) in [
+            // Block structure: the tab before it is indentation, and illegal.
+            (&b"\tb: 2\n"[..], true),
+            (&b"\t- a\n"[..], true),
+            (&b"\tkey:\n"[..], true), // `:` at end of line is still an indicator
+            (&b"  \tb: 2\n"[..], true), // leading spaces are skipped
+            // Plain scalars: the tab is separation, and legal.
+            (&b"\tbar\n"[..], false), // DK95/00 `foo:\n \tbar`
+            (&b"\tx\n"[..], false),   // UV7Q `x:\n - x\n  \tx`
+            (&b"\ta:b\n"[..], false), // `:` not followed by whitespace is content
+            (&b"\t-1\n"[..], false),  // Y79Y/010: `-1` is a scalar, not an entry
+            (&b"\tbar"[..], false),   // end of input, no line break
+            (&b"\t{}\n"[..], false),  // Q5MG: a flow node, and no `:` at all
+            // Nothing at all.
+            (&b"\t\n"[..], false),
+            (&b"\t"[..], false),
+        ] {
+            assert_eq!(
+                line_is_structural(text, 0),
+                want,
+                "line_is_structural({text:?})"
+            );
+        }
+    }
+
+    /// `from` may point at either a space or a tab, and the scan starts there —
+    /// the loader passes the position of the tab, the validator the position of
+    /// the first non-space.
+    #[test]
+    fn line_is_structural_starts_scanning_at_the_given_offset() {
+        let text = b"a: 1\n  \tb foo\n";
+        assert!(line_is_structural(text, 0)); // line 1: `a: 1`
+                                              // Line 2 is a plain scalar, so every offset within it agrees — and the scan
+                                              // must stop at the line break rather than running on into line 1's `:`.
+        assert!(!line_is_structural(text, 5)); // start of line 2's indentation
+        assert!(!line_is_structural(text, 7)); // the tab itself
+        assert!(!line_is_structural(text, 8)); // the content
+    }
+}

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -131,6 +131,14 @@ pub(crate) fn starts_inline_seq_entry(text: &[u8], pos: usize) -> bool {
 /// may contain tabs (`Q5MG` `\t{}`, `6CA3` `\t[…]`), and a `:` inside the collection is
 /// flow syntax rather than a block value indicator, so scanning on would misread
 /// `\t{a: 1}` as block structure while `\t{}` reads as a node.
+///
+/// The `:` must be a *value indicator*, so the scan skips what cannot hold one: a
+/// quoted scalar (`\t"x: y"` is a node, `\t"b": 1` is a key) and a comment
+/// (`\t# c: d`). Both quoted-scalar forms are single-line here — a scalar that runs
+/// past the line break is a node whatever follows it, so the scan stops rather than
+/// chasing the closing quote. That is the deliberate difference from
+/// [`validate::Validator::line_kind`], which asks a related question about a whole
+/// block-context line and does follow a quoted scalar across lines.
 #[inline]
 pub(crate) fn line_is_structural(text: &[u8], from: usize) -> bool {
     let mut i = from;
@@ -144,10 +152,23 @@ pub(crate) fn line_is_structural(text: &[u8], from: usize) -> bool {
     if starts_seq_entry(text, i) {
         return true;
     }
+    // A `"`, `'` or `#` is only itself at a node position — at the start of the
+    // content or after separation. Mid-scalar they are ordinary content, and the
+    // `:` after them is a real indicator (`foo#bar: baz`, `foo"bar: baz`).
+    let content_start = i;
+    let after_separation =
+        |i: usize| i == content_start || matches!(text.get(i - 1), Some(b' ' | b'\t'));
     // A block mapping entry: a `:` value indicator somewhere on this line.
     while let Some(&b) = text.get(i) {
         match b {
             b'\n' | b'\r' => return false,
+            // Everything past a comment is comment text, so no indicator follows.
+            b'#' if after_separation(i) => return false,
+            b'"' | b'\'' if after_separation(i) => match quoted_scalar_end(text, i) {
+                Some(end) => i = end,
+                // Runs past the line break: a multi-line scalar, hence a node.
+                None => return false,
+            },
             b':' if matches!(text.get(i + 1), None | Some(b' ' | b'\t' | b'\n' | b'\r')) => {
                 return true
             }
@@ -155,6 +176,37 @@ pub(crate) fn line_is_structural(text: &[u8], from: usize) -> bool {
         }
     }
     false
+}
+
+/// The offset just past the closing quote of the quoted scalar opening at `pos`, or
+/// `None` if it does not close before the end of the line (or of the input).
+///
+/// Single-line by construction — see [`line_is_structural`], its only caller, for why
+/// a scalar that spans lines is answered with `None` rather than followed.
+fn quoted_scalar_end(text: &[u8], pos: usize) -> Option<usize> {
+    let quote = text[pos];
+    let mut i = pos + 1;
+    while let Some(&c) = text.get(i) {
+        match c {
+            b'\n' | b'\r' => return None,
+            // Inside `"…"`, `\` escapes the next byte — and a `\` before the line
+            // break continues the scalar onto the next line, which is also a `None`.
+            b'\\' if quote == b'"' => match text.get(i + 1) {
+                None | Some(b'\n' | b'\r') => return None,
+                Some(_) => i += 2,
+            },
+            // Inside `'…'`, `''` is an escaped quote rather than the close.
+            _ if c == quote => {
+                if quote == b'\'' && text.get(i + 1) == Some(&b'\'') {
+                    i += 2;
+                } else {
+                    return Some(i + 1);
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    None
 }
 
 pub use error::YamlError;
@@ -193,6 +245,22 @@ mod tests {
             (&b"\t{a: 1}\n"[..], false), // same node, now with a `:` inside
             (&b"\t[\n"[..], false),      // 6CA3
             (&b"\t[a: 1]\n"[..], false),
+            // Quoted scalars: the `:` inside one is content, so the line is a node —
+            // but a quoted *key* is still a mapping entry.
+            (&b"\t\"x: y\"\n"[..], false),
+            (&b"\t'x: y'\n"[..], false),
+            (&b"\t\"b\": 1\n"[..], true),
+            (&b"\t'b': 1\n"[..], true),
+            (&b"\t\"a\\\": b\"\n"[..], false), // `\"` is an escaped quote, not the close
+            (&b"\t'a'': b'\n"[..], false),     // `''` likewise
+            (&b"\t&an \"x: y\"\n"[..], false), // a quote after separation still opens
+            (&b"\t\"x: y\n"[..], false),       // unterminated: a multi-line scalar
+            (&b"\t\"x\\\n"[..], false),        // `\` continues it onto the next line
+            (&b"\tfoo\"bar: baz\n"[..], true), // mid-scalar `\"` is content, `: ` is real
+            // Comments: everything past one is comment text.
+            (&b"\t# c: d\n"[..], false),
+            (&b"\tfoo # c: d\n"[..], false),
+            (&b"\tfoo#bar: baz\n"[..], true), // `#` glued to a scalar is content
             // Nothing at all.
             (&b"\t\n"[..], false),
             (&b"\t"[..], false),
@@ -217,5 +285,22 @@ mod tests {
         assert!(!line_is_structural(text, 5)); // start of line 2's indentation
         assert!(!line_is_structural(text, 7)); // the tab itself
         assert!(!line_is_structural(text, 8)); // the content
+    }
+
+    /// `quoted_scalar_end` stops at the line break rather than chasing the closing
+    /// quote onto the next line. `line_is_structural` reads that `None` as "a node",
+    /// which is the answer it wants for a multi-line scalar however the scalar ends.
+    #[test]
+    fn quoted_scalar_end_is_single_line() {
+        assert_eq!(quoted_scalar_end(b"\"ab\" rest", 0), Some(4));
+        assert_eq!(quoted_scalar_end(b"'ab' rest", 0), Some(4));
+        assert_eq!(quoted_scalar_end(b"\"a\\\"b\" rest", 0), Some(6)); // `\"` inside
+        assert_eq!(quoted_scalar_end(b"'a''b' rest", 0), Some(6)); // `''` inside
+        assert_eq!(quoted_scalar_end(b"\"ab\nc\"", 0), None); // crosses a break
+        assert_eq!(quoted_scalar_end(b"'ab\nc'", 0), None);
+        assert_eq!(quoted_scalar_end(b"\"ab\r\nc\"", 0), None); // CRLF too
+        assert_eq!(quoted_scalar_end(b"\"ab\\\nc\"", 0), None); // escaped break
+        assert_eq!(quoted_scalar_end(b"\"ab", 0), None); // end of input
+        assert_eq!(quoted_scalar_end(b"\"ab\\", 0), None); // trailing `\`
     }
 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -638,6 +638,30 @@ impl<'a> Parser<'a> {
         Ok(count)
     }
 
+    /// Is the cursor sitting on a tab that is *indentation* rather than separation?
+    ///
+    /// `count_indent` counts spaces only, so after `advance_by(indent)` the cursor
+    /// lands on a tab whenever one follows the leading spaces. YAML forbids a tab in
+    /// indentation, but a tab is only indentation when block structure follows —
+    /// hence [`super::line_is_structural`], shared with the strict validator, rather
+    /// than a bare "is there a tab" (#173).
+    ///
+    /// `line_start` is where this line's leading spaces began. The check matters
+    /// because `parse_document_line` is not always entered at a line start:
+    /// `parse_explicit_key` returns mid-line for `? k: v` (see
+    /// docs/compliance/yaml/limitations.md), and the flow and quoted scanners stop
+    /// just past their closing delimiter, so the main loop can re-derive an "indent"
+    /// from a mid-line cursor. A tab in the middle of a line is never indentation.
+    ///
+    /// Only reachable with `indent >= 1`: `count_indent` already returns
+    /// `Err(TabIndentation)` for a tab at column 0, so `Ok(0)` implies no tab here.
+    #[inline]
+    fn tab_indents_block_structure(&self, line_start: usize) -> bool {
+        self.peek() == Some(b'\t')
+            && (line_start == 0 || is_line_break(self.input[line_start - 1]))
+            && super::line_is_structural(self.input, self.pos)
+    }
+
     /// Get the current column position (0-based).
     /// This counts characters from the start of the current line.
     fn current_column(&self) -> usize {
@@ -3638,7 +3662,19 @@ impl<'a> Parser<'a> {
         };
 
         // Skip to content
+        let line_start = self.pos;
         self.advance_by(indent);
+
+        // A tab *after* the leading spaces is indentation — and so illegal — only when
+        // block structure follows. Before a plain scalar it is separation and legal
+        // (DK95/00 `foo:\n \tbar`, UV7Q `x:\n - x\n  \tx`), which is why the test is
+        // `line_is_structural` and not "is there a tab" (#173).
+        if self.tab_indents_block_structure(line_start) {
+            return Err(YamlError::TabIndentation {
+                line: self.current_line(),
+                offset: self.pos,
+            });
+        }
 
         // close_deeper_indents will handle closing any SequenceItem entries
         // when we return to a lower indent level
@@ -3874,6 +3910,68 @@ mod tests {
         let yaml = b"name:\n\tvalue";
         let result = build_semi_index(yaml);
         assert!(matches!(result, Err(YamlError::TabIndentation { .. })));
+    }
+
+    /// #173: a tab following the leading spaces was treated as start-of-content, so
+    /// this loaded as `{"a":{"\tb":1}}` — the tab folded into the key — instead of
+    /// being rejected as indentation.
+    #[test]
+    fn regression_issue_173_tab_after_spaces_before_a_mapping_key_is_rejected() {
+        let err = build_semi_index(b"a:\n \tb: 1\n").unwrap_err();
+        assert!(
+            matches!(err, YamlError::TabIndentation { line: 2, offset: 4 }),
+            "expected the tab at line 2 offset 4, got {err:?}"
+        );
+    }
+
+    /// DK95/06. The conformance harness already counted this as rejected because the
+    /// opt-in validator caught it; after #173 the default loader catches it too.
+    #[test]
+    fn regression_issue_173_dk95_06_is_rejected_by_the_loader_not_only_the_validator() {
+        let err = build_semi_index(b"foo:\n  a: 1\n  \tb: 2\n").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                YamlError::TabIndentation {
+                    line: 3,
+                    offset: 14
+                }
+            ),
+            "expected the tab at line 3 offset 14, got {err:?}"
+        );
+    }
+
+    /// A tab before a sequence entry is indentation just as much as one before a
+    /// key. Starting at offset 0 also exercises the `line_start == 0` arm of
+    /// `tab_indents_block_structure`.
+    #[test]
+    fn tab_after_spaces_before_a_sequence_entry_is_rejected() {
+        assert!(matches!(
+            build_semi_index(b"  \t- a\n"),
+            Err(YamlError::TabIndentation { .. })
+        ));
+    }
+
+    /// Q5MG and 6CA3: a root flow node's leading separation may contain tabs. These
+    /// go through `count_indent`'s column-0 arm and its flow recovery, both of which
+    /// #173 left untouched — this pins that.
+    #[test]
+    fn a_flow_node_after_a_leading_tab_is_still_accepted() {
+        assert!(build_semi_index(b"\t{}\n").is_ok());
+        assert!(build_semi_index(b"\t[\n\t]\n").is_ok());
+    }
+
+    /// `parse_document_line` is not always entered at a line start — the flow scanner
+    /// stops just past `]`, leaving the cursor mid-line, and the main loop then
+    /// re-derives an "indent" from there. The tab below is separation in the middle
+    /// of a line, never indentation, so it must not be reported as such.
+    #[test]
+    fn a_mid_line_tab_is_not_reported_as_indentation() {
+        // Two root nodes: malformed either way. What matters is *which* complaint.
+        assert!(!matches!(
+            build_semi_index(b"[1] \tfoo: bar\n"),
+            Err(YamlError::TabIndentation { .. })
+        ));
     }
 
     #[test]

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3961,6 +3961,21 @@ mod tests {
         assert!(build_semi_index(b"\t[\n\t]\n").is_ok());
     }
 
+    /// A quoted scalar after the tab is a *node*, so the tab is separation — the `:`
+    /// inside the quotes is content, not a value indicator. Rejecting these would be
+    /// a false positive on valid YAML (same production as DK95/00), which is why
+    /// `line_is_structural` skips quoted spans.
+    #[test]
+    fn a_quoted_scalar_after_the_tab_is_not_indentation() {
+        assert!(build_semi_index(b"a:\n \t\"x: y\"\n").is_ok());
+        assert!(build_semi_index(b"a:\n \t'x: y'\n").is_ok());
+        // A quoted *key*, though, is a mapping entry and the tab really is indentation.
+        assert!(matches!(
+            build_semi_index(b"a:\n \t\"b\": 1\n"),
+            Err(YamlError::TabIndentation { .. })
+        ));
+    }
+
     /// `parse_document_line` is not always entered at a line start — the flow scanner
     /// stops just past `]`, leaving the cursor mid-line, and the main loop then
     /// re-derives an "indent" from there. The tab below is separation in the middle

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -574,35 +574,11 @@ impl<'a> Validator<'a> {
     /// is a structural node — a sequence item (`-` + whitespace) or a block
     /// mapping entry (a `: ` value indicator before end of line) — rather than a
     /// plain scalar. Used to decide whether a leading tab is illegal indentation.
+    ///
+    /// Delegates to the module-level definition the loader also consults, so the
+    /// two agree by construction rather than by review (#173).
     fn line_is_structural(&self) -> bool {
-        let mut i = self.offset;
-        while matches!(self.input.get(i), Some(b' ' | b'\t')) {
-            i += 1;
-        }
-        // Sequence item: `-` followed by whitespace or end of line.
-        if self.input.get(i) == Some(&b'-')
-            && matches!(
-                self.input.get(i + 1),
-                None | Some(b' ' | b'\t' | b'\n' | b'\r')
-            )
-        {
-            return true;
-        }
-        // Mapping entry: a `:` value indicator somewhere on the line.
-        while let Some(&b) = self.input.get(i) {
-            match b {
-                b'\n' | b'\r' => return false,
-                b':' if matches!(
-                    self.input.get(i + 1),
-                    None | Some(b' ' | b'\t' | b'\n' | b'\r')
-                ) =>
-                {
-                    return true
-                }
-                _ => i += 1,
-            }
-        }
-        false
+        super::line_is_structural(self.input, self.offset)
     }
 
     /// True if the line begins with a block indicator (`-`/`?`/`:`) whose

--- a/tests/yaml_tab_indentation_tests.rs
+++ b/tests/yaml_tab_indentation_tests.rs
@@ -1,0 +1,258 @@
+//! Tabs in YAML indentation: the loader and the validator must agree (#173).
+//!
+//! YAML forbids a tab in indentation, but a tab is only *indentation* when block
+//! structure follows it. Before a plain scalar the same byte is separation and
+//! perfectly legal — `foo:\n \tbar` (DK95/00) and `x:\n - x\n  \tx` (UV7Q, "Legal
+//! tab after indentation") are both valid documents. That distinction is what
+//! `succinctly::yaml::line_is_structural` encodes.
+//!
+//! Before #173 only the strict validator applied the rule; the default loader
+//! rejected a tab at column 0 and treated a tab after one or more spaces as
+//! start-of-content, so `a:\n \tb: 1` loaded as `{"a":{"\tb":1}}` — the tab folded
+//! into the key. Both now consult one definition.
+//!
+//! # Why an agreement *table* and not an invariant
+//!
+//! The obvious assertion — "the loader rejects a tab shape only if the validator
+//! does" — is false, in both directions, for reasons that have nothing to do with
+//! tabs (see the two `Verdict` rows that disagree). Writing it as an invariant would
+//! mean either a red build or quietly weakening it until it asserted nothing.
+//! Stating both verdicts per row instead makes each divergence a reviewed fact with
+//! a reason attached, which is what CLAUDE.md's #106 lesson asks for: one definition
+//! of the predicate, plus a test that the call sites agree.
+//!
+//! Run with: `cargo test --test yaml_tab_indentation_tests`
+
+use succinctly::yaml::{YamlError, YamlIndex, YamlValue};
+
+const CORPUS: &str = include_str!("data/yaml-test-suite-2022-01-17.json");
+
+/// Render as `succinctly yq -o json '.'` does, one JSON value per document.
+/// Mirrors `yaml_to_json_documents` in `tests/yaml_test_suite.rs`.
+fn to_json(yaml: &[u8]) -> Result<String, YamlError> {
+    let index = YamlIndex::build(yaml)?;
+    let root = index.root(yaml);
+    Ok(match root.value() {
+        YamlValue::Sequence(mut elements) => {
+            let mut docs = Vec::new();
+            while let Some((cursor, rest)) = elements.uncons_cursor() {
+                docs.push(cursor.to_json());
+                elements = rest;
+            }
+            docs.join(" ")
+        }
+        _ => root.to_json_document(),
+    })
+}
+
+fn loader_reports_tab_indentation(yaml: &[u8]) -> bool {
+    matches!(
+        YamlIndex::build(yaml),
+        Err(YamlError::TabIndentation { .. })
+    )
+}
+
+fn validator_rejects(yaml: &[u8]) -> bool {
+    succinctly::yaml::validate::validate(yaml).is_err()
+}
+
+/// One row of the agreement table.
+struct Verdict {
+    yaml: &'static [u8],
+    /// Does `YamlIndex::build` reject it as `TabIndentation`?
+    loader: bool,
+    /// Does the opt-in strict validator reject it (for any reason)?
+    validator: bool,
+    /// Why — and, where the two disagree, why that is not a tab bug.
+    why: &'static str,
+}
+
+const VERDICTS: &[Verdict] = &[
+    // ---- A tab that is indentation. Both must reject. --------------------------
+    Verdict {
+        yaml: b"a:\n \tb: 1\n",
+        loader: true,
+        validator: true,
+        why: "#173 repro: loaded as {\"a\":{\"\\tb\":1}} before the fix",
+    },
+    Verdict {
+        yaml: b"foo:\n  a: 1\n  \tb: 2\n",
+        loader: true,
+        validator: true,
+        why: "DK95/06, the suite's must-fail case for this shape",
+    },
+    Verdict {
+        yaml: b"  \t- a\n",
+        loader: true,
+        validator: true,
+        why: "a tab before a sequence entry is indentation too",
+    },
+    // ---- A tab that is separation. Both must accept. ---------------------------
+    Verdict {
+        yaml: b"foo:\n \tbar\n",
+        loader: false,
+        validator: false,
+        why: "DK95/00: a tab before a plain scalar is separation, not indentation",
+    },
+    Verdict {
+        yaml: b"x:\n - x\n  \tx\n",
+        loader: false,
+        validator: false,
+        why: "UV7Q, named upstream 'Legal tab after indentation'",
+    },
+    Verdict {
+        yaml: b"\t{}\n",
+        loader: false,
+        validator: false,
+        why: "Q5MG: a root flow node's leading separation may contain tabs",
+    },
+    Verdict {
+        yaml: b"\t[\n\t]\n",
+        loader: false,
+        validator: false,
+        why: "6CA3, the sequence form of Q5MG",
+    },
+    Verdict {
+        yaml: b"a: |\n  x\n  \tb: c\n",
+        loader: false,
+        validator: false,
+        why: "inside a block scalar the tab is content; the body never reaches \
+              either line dispatcher",
+    },
+    // ---- Rows where the two legitimately disagree. -----------------------------
+    Verdict {
+        yaml: b"a: 1\n \tb: 2\n",
+        loader: false,
+        validator: true,
+        why: "the loader folds the line into the preceding plain scalar before the \
+              dispatcher sees it (parser.rs, the `start_indent == 0` continuation \
+              arm), yielding {\"a\":\"1 b\"} — a separate defect #173 does not reach",
+    },
+    Verdict {
+        yaml: b"a: |\n    x\n  \tb: c\n",
+        loader: true,
+        validator: false,
+        why: "indent 2 < the block's content indent 4, so the scalar ends and the \
+              tab really is indentation; the validator's block-scalar body check \
+              measures against the parent indent and skips the line",
+    },
+];
+
+/// The #106 artefact: one definition of `line_is_structural`, and a test that its
+/// two call sites — the loader and the validator — classify the same bytes the same
+/// way, with every deliberate divergence named.
+#[test]
+fn loader_and_validator_agree_on_tab_indentation() {
+    let mut wrong = Vec::new();
+    for v in VERDICTS {
+        let text = String::from_utf8_lossy(v.yaml);
+        let loader = loader_reports_tab_indentation(v.yaml);
+        let validator = validator_rejects(v.yaml);
+        if loader != v.loader {
+            wrong.push(format!(
+                "  {text:?}: loader should {} — {}",
+                if v.loader {
+                    "report TabIndentation but accepted it"
+                } else {
+                    "accept but reported TabIndentation"
+                },
+                v.why
+            ));
+        }
+        if validator != v.validator {
+            wrong.push(format!(
+                "  {text:?}: validator should {} — {}",
+                if v.validator { "reject" } else { "accept" },
+                v.why
+            ));
+        }
+    }
+    assert!(wrong.is_empty(), "verdicts changed:\n{}", wrong.join("\n"));
+}
+
+/// The acceptance side, pinned by **output** rather than by `is_ok()`: a document
+/// where the tab is separation must keep producing the same value, so "tab is
+/// separation" cannot regress into "tab is an error" — nor into silently different
+/// scalar content.
+#[test]
+fn a_tab_used_as_separation_still_produces_its_value() {
+    // UV7Q. This is the spec-correct output; the suite agrees.
+    assert_eq!(to_json(b"x:\n - x\n  \tx\n").unwrap(), r#"{"x":["x x"]}"#);
+
+    // DK95/00. The suite wants {"foo":"bar"} — the leading tab should be stripped as
+    // separation. Retaining it is a known scalar-folding gap, on record in
+    // tests/data/yaml-test-suite-known-failures.txt as `DK95/00 scalars`. Pinned as
+    // it is so that fixing the folding is a deliberate change to this line, not a
+    // silent one.
+    assert_eq!(to_json(b"foo:\n \tbar\n").unwrap(), r#"{"foo":"\tbar"}"#);
+
+    // Q5MG and 6CA3, both spec-correct.
+    assert_eq!(to_json(b"\t{}\n").unwrap(), "{}");
+    assert_eq!(to_json(b"\t[\n\t]\n").unwrap(), "[]");
+
+    // A tab inside a block scalar body is content, and survives verbatim.
+    assert_eq!(
+        to_json(b"a: |\n  x\n  \tb: c\n").unwrap(),
+        r#"{"a":"x\n\tb: c\n"}"#
+    );
+}
+
+/// `parse_document_line` is not always entered at a line start — `parse_explicit_key`
+/// returns mid-line, and the flow and quoted scanners stop just past their closing
+/// delimiter, after which the main loop re-derives an "indent" from a mid-line
+/// cursor. A tab reached that way is separation, never indentation, so it must not
+/// be blamed on indentation. These inputs are malformed for other reasons; what is
+/// asserted is *which* complaint they draw.
+#[test]
+fn a_mid_line_tab_is_never_blamed_on_indentation() {
+    for yaml in [
+        &b"[1] \tfoo: bar\n"[..],
+        b"\"a\" \tb: c\n",
+        b"? k: v\n \tx\n",
+    ] {
+        assert!(
+            !loader_reports_tab_indentation(yaml),
+            "{:?} was reported as tab indentation",
+            String::from_utf8_lossy(yaml)
+        );
+    }
+}
+
+/// Corpus guardrail, the loader-side counterpart to `validator_accepts_all_valid_cases`
+/// in `tests/yaml_test_suite.rs`: tightening the tab rule must never make the loader
+/// reject a **valid** suite case as tab indentation.
+///
+/// The conformance harness would catch a valid case that stops loading, but only as
+/// "newly failing" among 402 cases. This says what went wrong and why.
+#[test]
+fn the_loader_never_reports_tab_indentation_for_a_valid_corpus_case() {
+    let cases: Vec<serde_json::Value> = serde_json::from_str(CORPUS).expect("corpus is valid JSON");
+    let mut rejected = Vec::new();
+    let mut checked = 0usize;
+
+    for case in &cases {
+        if case["fail"].as_bool().unwrap_or(false) {
+            continue;
+        }
+        let yaml = case["yaml"].as_str().expect("case has yaml");
+        checked += 1;
+        if loader_reports_tab_indentation(yaml.as_bytes()) {
+            rejected.push(format!(
+                "  {}: {}",
+                case["id"].as_str().unwrap_or("?"),
+                case["name"].as_str().unwrap_or_default()
+            ));
+        }
+    }
+
+    assert!(
+        checked > 250,
+        "corpus looks truncated ({checked} valid cases)"
+    );
+    assert!(
+        rejected.is_empty(),
+        "the loader reported tab indentation for {} valid case(s):\n{}",
+        rejected.len(),
+        rejected.join("\n")
+    );
+}

--- a/tests/yaml_tab_indentation_tests.rs
+++ b/tests/yaml_tab_indentation_tests.rs
@@ -4,7 +4,9 @@
 //! structure follows it. Before a plain scalar the same byte is separation and
 //! perfectly legal — `foo:\n \tbar` (DK95/00) and `x:\n - x\n  \tx` (UV7Q, "Legal
 //! tab after indentation") are both valid documents. That distinction is what
-//! `succinctly::yaml::line_is_structural` encodes.
+//! the crate-private `yaml::line_is_structural` encodes (`src/yaml/mod.rs`); from
+//! out here it is reachable only through its two call sites, which is what this
+//! file exercises.
 //!
 //! Before #173 only the strict validator applied the rule; the default loader
 //! rejected a tab at column 0 and treated a tab after one or more spaces as
@@ -23,6 +25,7 @@
 //!
 //! Run with: `cargo test --test yaml_tab_indentation_tests`
 
+use succinctly::yaml::validate::YamlValidationErrorKind;
 use succinctly::yaml::{YamlError, YamlIndex, YamlValue};
 
 const CORPUS: &str = include_str!("data/yaml-test-suite-2022-01-17.json");
@@ -52,8 +55,26 @@ fn loader_reports_tab_indentation(yaml: &[u8]) -> bool {
     )
 }
 
-fn validator_rejects(yaml: &[u8]) -> bool {
-    succinctly::yaml::validate::validate(yaml).is_err()
+/// What the opt-in strict validator makes of a document.
+///
+/// Deliberately finer than `is_err()`: a row that rejects for an unrelated reason
+/// would otherwise read as agreement with the loader's tab verdict, and would keep
+/// passing if the tab rule stopped firing entirely.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Validator {
+    Accepts,
+    /// Rejected as `TabInIndentation` — the same judgement the loader makes.
+    RejectsTheTab,
+    /// Rejected, but for something else; the tab verdict is not what is under test.
+    RejectsOtherwise,
+}
+
+fn validator_verdict(yaml: &[u8]) -> Validator {
+    match succinctly::yaml::validate::validate(yaml) {
+        Ok(()) => Validator::Accepts,
+        Err(e) if e.kind == YamlValidationErrorKind::TabInIndentation => Validator::RejectsTheTab,
+        Err(_) => Validator::RejectsOtherwise,
+    }
 }
 
 /// One row of the agreement table.
@@ -61,8 +82,8 @@ struct Verdict {
     yaml: &'static [u8],
     /// Does `YamlIndex::build` reject it as `TabIndentation`?
     loader: bool,
-    /// Does the opt-in strict validator reject it (for any reason)?
-    validator: bool,
+    /// What the opt-in strict validator makes of it.
+    validator: Validator,
     /// Why — and, where the two disagree, why that is not a tab bug.
     why: &'static str,
 }
@@ -72,58 +93,86 @@ const VERDICTS: &[Verdict] = &[
     Verdict {
         yaml: b"a:\n \tb: 1\n",
         loader: true,
-        validator: true,
+        validator: Validator::RejectsTheTab,
         why: "#173 repro: loaded as {\"a\":{\"\\tb\":1}} before the fix",
     },
     Verdict {
         yaml: b"foo:\n  a: 1\n  \tb: 2\n",
         loader: true,
-        validator: true,
+        validator: Validator::RejectsTheTab,
         why: "DK95/06, the suite's must-fail case for this shape",
     },
     Verdict {
         yaml: b"  \t- a\n",
         loader: true,
-        validator: true,
+        validator: Validator::RejectsTheTab,
         why: "a tab before a sequence entry is indentation too",
     },
     // ---- A tab that is separation. Both must accept. ---------------------------
     Verdict {
         yaml: b"foo:\n \tbar\n",
         loader: false,
-        validator: false,
+        validator: Validator::Accepts,
         why: "DK95/00: a tab before a plain scalar is separation, not indentation",
     },
     Verdict {
         yaml: b"x:\n - x\n  \tx\n",
         loader: false,
-        validator: false,
+        validator: Validator::Accepts,
         why: "UV7Q, named upstream 'Legal tab after indentation'",
     },
     Verdict {
         yaml: b"\t{}\n",
         loader: false,
-        validator: false,
+        validator: Validator::Accepts,
         why: "Q5MG: a root flow node's leading separation may contain tabs",
     },
     Verdict {
         yaml: b"\t[\n\t]\n",
         loader: false,
-        validator: false,
+        validator: Validator::Accepts,
         why: "6CA3, the sequence form of Q5MG",
     },
     Verdict {
         yaml: b"a: |\n  x\n  \tb: c\n",
         loader: false,
-        validator: false,
+        validator: Validator::Accepts,
         why: "inside a block scalar the tab is content; the body never reaches \
               either line dispatcher",
+    },
+    Verdict {
+        yaml: b"a:\n \t\"x: y\"\n",
+        loader: false,
+        validator: Validator::Accepts,
+        why: "the `:` is inside a quoted scalar, so the line is a node and the tab \
+              is separation — same production as DK95/00",
+    },
+    Verdict {
+        yaml: b"a:\n \t'x: y'\n",
+        loader: false,
+        validator: Validator::Accepts,
+        why: "the single-quoted form of the row above",
+    },
+    Verdict {
+        yaml: b"a:\n \t\"b\": 1\n",
+        loader: true,
+        validator: Validator::RejectsTheTab,
+        why: "a quoted *key* is still a mapping entry, so the tab is indentation — \
+              the pair to the two rows above, and why the scan skips the quoted \
+              span rather than bailing out at the quote",
+    },
+    Verdict {
+        yaml: b"a: 1\n \t# c: d\nb: 2\n",
+        loader: false,
+        validator: Validator::Accepts,
+        why: "a tab before a comment is separation; the `: ` in the comment text is \
+              not a value indicator",
     },
     // ---- Rows where the two legitimately disagree. -----------------------------
     Verdict {
         yaml: b"a: 1\n \tb: 2\n",
         loader: false,
-        validator: true,
+        validator: Validator::RejectsTheTab,
         why: "the loader folds the line into the preceding plain scalar before the \
               dispatcher sees it (parser.rs, the `start_indent == 0` continuation \
               arm), yielding {\"a\":\"1 b\"} — a separate defect #173 does not reach",
@@ -131,7 +180,7 @@ const VERDICTS: &[Verdict] = &[
     Verdict {
         yaml: b"a: |\n    x\n  \tb: c\n",
         loader: true,
-        validator: false,
+        validator: Validator::Accepts,
         why: "indent 2 < the block's content indent 4, so the scalar ends and the \
               tab really is indentation; the validator's block-scalar body check \
               measures against the parent indent and skips the line",
@@ -147,7 +196,7 @@ fn loader_and_validator_agree_on_tab_indentation() {
     for v in VERDICTS {
         let text = String::from_utf8_lossy(v.yaml);
         let loader = loader_reports_tab_indentation(v.yaml);
-        let validator = validator_rejects(v.yaml);
+        let validator = validator_verdict(v.yaml);
         if loader != v.loader {
             wrong.push(format!(
                 "  {text:?}: loader should {} — {}",
@@ -161,9 +210,8 @@ fn loader_and_validator_agree_on_tab_indentation() {
         }
         if validator != v.validator {
             wrong.push(format!(
-                "  {text:?}: validator should {} — {}",
-                if v.validator { "reject" } else { "accept" },
-                v.why
+                "  {text:?}: validator {validator:?}, expected {:?} — {}",
+                v.validator, v.why
             ));
         }
     }
@@ -194,6 +242,22 @@ fn a_tab_used_as_separation_still_produces_its_value() {
     assert_eq!(
         to_json(b"a: |\n  x\n  \tb: c\n").unwrap(),
         r#"{"a":"x\n\tb: c\n"}"#
+    );
+
+    // A tab before a comment is separation, and the comment is dropped.
+    assert_eq!(
+        to_json(b"a: 1\n \t# c: d\nb: 2\n").unwrap(),
+        r#"{"a":1,"b":2}"#
+    );
+
+    // A quoted scalar after the tab. Spec-correct is {"a":"x: y"}; the loader instead
+    // reads the line as a mapping, the same continuation-line folding gap that leaves
+    // DK95/00 above with its tab. #173 is about the tab *verdict* — this now loads
+    // instead of erroring, which is the part that changed — so the wrong value is
+    // pinned rather than hidden, and fixing the folding is a deliberate edit here.
+    assert_eq!(
+        to_json(b"a:\n \t\"x: y\"\n").unwrap(),
+        r#"{"a":{"\t\"x":"y\""}}"#
     );
 }
 


### PR DESCRIPTION
## Description

Fixes #173: the loader caught a tab in indentation only at column 0, and treated a tab *following* spaces as start-of-content, so `a:\n \tb: 1` loaded as `{"a":{"\tb":1}}` — the tab folded into the key — instead of being refused.

The issue asks to "reject a tab anywhere in leading indentation". This PR deliberately does something narrower, because the literal rule is wrong: YAML forbids a tab in indentation, but a tab is only *indentation* when block structure follows it. Before a node the same byte is `s-separate-in-line` and legal — Test Suite cases `DK95/00` (`foo:\n \tbar`) and `UV7Q` ("Legal tab after indentation") are both valid documents that "reject anywhere" would break.

The validator already drew that distinction. The fix promotes its `line_is_structural` predicate to the `yaml` module root and has the loader consult it too, rather than adding a second spelling of the rule — CLAUDE.md's #106/#332 lesson.

**A "structural line" is decided by finding a `:` value indicator, and the predicate had to get stricter about which `:` bytes count.** As inherited from the validator it took the first `:` followed by whitespace, which is as true of a `:` in running text as of one in a key. A quoted scalar carrying a colon therefore read as block structure:

```
a:
 <TAB>"x: y"        # a node — same production as DK95/00 — but read as a mapping
```

That was a valid document the loader started refusing the moment it began consulting the predicate. The scan now steps over quoted scalars as a unit and stops at a comment, so `"x: y"` is content while `"b": 1` is still a key. Both only where a `"`/`'`/`#` can *begin* something (after separation), because `foo#bar: baz` and `foo"bar: baz` really are mapping entries.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue

Fixes #173.

Two follow-ups filed from this work, both deliberately **not** fixed here:

- **#381** — a tab used as separation is kept as scalar content, so `a:\n \t"x: y"` loads as `{"a":{"\t\"x":"y\""}}` rather than `{"a":"x: y"}`. Same root cause as the known failure `DK95/00 scalars`. #173's scope is the tab *verdict*; this is the value produced once accepted. Both wrong values are pinned verbatim in the tests so a fix is a deliberate edit.
- **#382** — `Validator::line_kind` is a second implementation of the value-indicator scan. It is not merged here because the two want different answers for a quoted scalar that does not close on its line (`line_is_structural` stops; `line_kind`'s `"` arm continues past the break, and its `'` arm does not even match its own `"` arm). Settling that needs #324's intent, so a merge under a bug fix would be a behaviour change dressed as a refactor.

## Changes Made

**`src/yaml/mod.rs`**
- `line_is_structural` moved here from the validator, so loader and validator share one definition
- Skips quoted spans and comments when looking for a `:` value indicator, and only where a `"`/`'`/`#` is at a node position
- New `quoted_scalar_end` helper: single-line by construction, handling `\"` and `''` escapes; `None` ("does not close on this line") answers "node, not block structure"
- Flow nodes are explicitly not structural — a root flow node's separation may contain tabs (`Q5MG`, `6CA3`), and a `:` inside the collection is flow syntax

**`src/yaml/parser.rs`**
- `tab_indents_block_structure`, guarded by a line-start check: `parse_document_line` is not always entered at a line start (`parse_explicit_key` returns mid-line, flow/quoted scanners stop just past their delimiter), and a mid-line tab is never indentation
- The check runs in `parse_document_line` after `count_indent`, which counts spaces only

**`src/yaml/validate.rs`**
- `line_is_structural` delegates to the module-level definition

**Tests** — `tests/yaml_tab_indentation_tests.rs` (new, 322 lines, 4 test functions) plus unit tests in both modules
- A 15-row **agreement table**, not an invariant: the loader and validator legitimately disagree in both directions for reasons unrelated to tabs, so each divergence is a named, reasoned row (#371; block-scalar body indent) rather than an assertion weakened until it says nothing
- Each row records *why* the validator rejected — `RejectsTheTab` vs `RejectsOtherwise` — so a row cannot pass by rejecting for an unrelated reason while the tab rule silently stops firing
- Acceptance pinned by **output**, not `is_ok()`, so "tab is separation" cannot regress into different scalar content
- Corpus guardrail: no valid Test Suite case may be rejected as tab indentation — the loader-side counterpart to `validator_accepts_all_valid_cases`
- `quoted_scalar_end` unit tests cover both quote types, both escape forms, CRLF, escaped breaks and end-of-input

**Documentation**
- `CHANGELOG.md`, `docs/compliance/yaml/limitations.md`, `docs/parsing/yaml-index.md`, `docs/parsing/yaml.md` and the `yaml` module docs updated for 11/94 → 12/94

## Testing

- [x] Full suite green (`--features cli,simd,regex,serde --workspace`)
- [x] Clippy `--all-targets --all-features`, `cargo fmt --check`, `cargo doc` all clean
- [x] Conformance re-measured directly against all 402 suite cases, not just via the harness

Re-measured on the built CLI:

| Measure | Before | After |
|---|---|---|
| Loader-only reject | 11/94 | **12/94** (adds `DK95/06`) |
| Validator-only reject | 59 | 58 |
| Combined reject | 70/94 | 70/94 |
| Load / Parse | 215/279, 27/29 | 215/279, 27/29 |
| Validator false positives on the valid corpus | 0 | 0 |
| Valid corpus cases the loader errors on | 29 | **29 — no case changed, either way** |

## Performance Impact
- [x] No performance impact

`tab_indents_block_structure` is called once per document line but short-circuits on `self.peek() == Some(b'\t')`, so the common path is a single byte comparison. The scan itself runs only when a tab actually follows the leading spaces at a line start. `count_indent` is unchanged, so no existing path pays anything new.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Design decisions**

1. **Refactor first, fix second.** The first commit moves `line_is_structural` to the module root with byte-identical conformance, so the functional change is reviewable on its own.
2. **`count_indent` left alone.** Five of its six call sites use `.unwrap_or(0)` for dedent lookaheads; stricter error handling there would emit null nodes.
3. **Quoted spans are skipped, not bailed out on.** Returning "not structural" at the first quote would have been simpler but wrong: `\t"b": 1` is a quoted *key*, and the tab before it really is indentation.
4. **`quoted_scalar_end` stops at the line break** rather than chasing the closing quote. A scalar spanning lines is a node whatever follows it, so the `None` is the answer this predicate wants — and it is exactly where the two scans in #382 part company.

**Known limitations left unchanged**

- `count_indent` still counts spaces only, and raises `TabIndentation` at column 0 only
- Separation tabs are not stripped from scalar content (#381, and the `DK95/00 scalars` known failure)
- Block-scalar body indentation is validated against the parent indent, not the detected content indent

No valid document changes behaviour: the corpus measurement above compares every valid Test Suite case before and after and finds no movement in either direction.
