### PR TITLE
docs(test): name the issues the tab tests already describe

### DIFF
--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -138,7 +138,8 @@ pub(crate) fn starts_inline_seq_entry(text: &[u8], pos: usize) -> bool {
 /// past the line break is a node whatever follows it, so the scan stops rather than
 /// chasing the closing quote. That is the deliberate difference from
 /// [`validate::Validator::line_kind`], which asks a related question about a whole
-/// block-context line and does follow a quoted scalar across lines.
+/// block-context line and does follow a quoted scalar across lines. Merging the two
+/// scans has to settle that difference first, and is tracked as #382.
 #[inline]
 pub(crate) fn line_is_structural(text: &[u8], from: usize) -> bool {
     let mut i = from;

--- a/tests/yaml_tab_indentation_tests.rs
+++ b/tests/yaml_tab_indentation_tests.rs
@@ -175,7 +175,7 @@ const VERDICTS: &[Verdict] = &[
         validator: Validator::RejectsTheTab,
         why: "the loader folds the line into the preceding plain scalar before the \
               dispatcher sees it (parser.rs, the `start_indent == 0` continuation \
-              arm), yielding {\"a\":\"1 b\"} — a separate defect #173 does not reach",
+              arm), yielding {\"a\":\"1 b\"} — that is #371, which #173 does not reach",
     },
     Verdict {
         yaml: b"a: |\n    x\n  \tb: c\n",
@@ -252,9 +252,10 @@ fn a_tab_used_as_separation_still_produces_its_value() {
 
     // A quoted scalar after the tab. Spec-correct is {"a":"x: y"}; the loader instead
     // reads the line as a mapping, the same continuation-line folding gap that leaves
-    // DK95/00 above with its tab. #173 is about the tab *verdict* — this now loads
-    // instead of erroring, which is the part that changed — so the wrong value is
-    // pinned rather than hidden, and fixing the folding is a deliberate edit here.
+    // DK95/00 above with its tab — that is #381. #173 is about the tab *verdict* —
+    // this now loads instead of erroring, which is the part that changed — so the
+    // wrong value is pinned rather than hidden, and fixing #381 is a deliberate edit
+    // to this line and to the DK95/00 one above.
     assert_eq!(
         to_json(b"a:\n \t\"x: y\"\n").unwrap(),
         r#"{"a":{"\t\"x":"y\""}}"#


### PR DESCRIPTION
## Description

This PR documents references to three specific issues that were already described in the test code but lacked explicit issue numbers. The changes add cross-references to issues #371, #381, and #382 in the YAML tab indentation tests and related implementation code.

The PR clarifies the relationship between these issues and the existing test cases:
- Issue #371: Plain scalar folding divergence in the continuation line handling
- Issue #381: Pinned wrong value for a quoted node after a separation tab
- Issue #382: Difference in how `line_is_structural` handles quoted scalars compared to `Validator::line_kind`

## Type of Change
- [x] Documentation update

## Related Issue
Relates to #173 (yaml tab after spaces in indentation)

## Changes Made

**Documentation Updates:**
- Updated `src/yaml/mod.rs` to reference issue #382 in the `line_is_structural` function documentation, explaining the deliberate difference between this scan and `Validator::line_kind` regarding quoted scalars across lines
- Updated `tests/yaml_tab_indentation_tests.rs` to add three issue number cross-references:
  - Changed description of DK95/00 verdict to reference #371 (the separate defect regarding plain scalar folding)
  - Added reference to #381 (quoted scalar after tab producing wrong value)
  - Clarified that #382 relates to the deliberately separate implementation of the quoted scalar check

## Testing
- [x] All existing tests pass (no functional changes)
- [x] Documentation-only changes, no test modifications required

## Performance Impact
- [x] No performance impact (documentation only)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Documentation is clear and accurately references related issues
- [x] My changes generate no new warnings

## Additional Notes

These changes improve the maintainability and traceability of the test suite by explicitly linking prose explanations to their corresponding issue numbers. This makes it easier for future developers to understand the context and status of known issues related to YAML tab indentation handling.