### PR TITLE
docs(test): improve documentation of error and break handling in jq evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,12 +118,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   values borrowed, so the zero-copy path survives. `succinctly yq` gets the fix
   too, since its evaluator delegates all three operators to this one. Ten new
   pinned-`jq` golden cases cover the family, and the known-failures manifest
-  drops to two entries. **Not fixed**: `QueryResult` still models an error as a
-  property of the whole stream rather than of one output, so `(1,error("x")) // 2`
-  yields `2` where jq yields `1`, and a mid-stream error in `and`/`or` discards
-  the outputs already computed; `//` still suppresses left-hand errors, which
-  jq 1.7.1 propagates; and `if`/`select` still collapse a multi-output condition
-  to its first output (sibling of #354).
+  drops to two entries. **Not fixed**: `QueryResult` still models an error or a
+  `break` as a property of the whole stream rather than of one output, so
+  `(1,error("x")) // 2` yields `2` where jq yields `1`, and a mid-stream error
+  or `break` in `and`/`or` discards the outputs already computed —
+  `label $out | ((true,true) and (1, break $out))` yields nothing where jq
+  yields `true` (#400); `//` still suppresses left-hand errors, which jq 1.7.1
+  propagates (#377); and `if`/`select` still collapse a multi-output condition
+  to its first output (#378, sibling of #354).
 - **YAML: a tab after spaces in indentation was folded into the key** (#173):
   the loader rejected a tab only at column 0 and treated a tab following one or
   more spaces as start-of-content, so `a:\n \tb: 1` loaded as

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1898,9 +1898,19 @@ fn test_boolean_with_empty_operand_is_silent() -> Result<()> {
     // An empty operand used to reach `result_to_owned`, which reported it as
     // `Error("no value")` and printed a diagnostic. jq emits nothing at all,
     // quietly. The goldens compare stdout only, so stderr is asserted here.
+    //
+    // Matching on the absence of a diagnostic rather than on a byte-empty
+    // stderr keeps the test independent of whatever else may reach that stream:
+    // `--quiet` silences cargo's own progress lines, but not a rustc warning
+    // from the build it triggers. Requiring stderr to be empty would couple this
+    // assertion to the whole workspace compiling warning-free, which is not what
+    // it is testing.
     let (stdout, stderr, code) = run_jq_stdin_streams("empty and true", "null", &["-c"])?;
     assert_eq!(stdout, "", "expected no output");
-    assert_eq!(stderr, "", "expected no diagnostic on stderr");
+    assert!(
+        !stderr.contains("jq: error"),
+        "expected no diagnostic on stderr, got: {stderr}"
+    );
     assert_eq!(code, 0, "expected success");
     Ok(())
 }


### PR DESCRIPTION
## Description

This PR improves documentation and test robustness related to jq error and break handling in the evaluator. It clarifies known limitations in how `QueryResult` models errors and `break` statements at the stream level rather than per-output, and enhances test comments to explain the testing strategy for silent operations.

The changes make the test suite more resilient by using diagnostic marker detection instead of requiring exact stderr emptiness, reducing coupling to workspace compilation state while maintaining the actual behavioral assertions.

## Type of Change
- [x] Documentation update
- [x] Test coverage improvement

## Related Issue
Relates to #400, #377, #378, #354 - known limitations in jq error and break handling

## Changes Made

**Documentation (CHANGELOG.md):**
- Clarified that `QueryResult` models errors and `break` as properties of the whole stream rather than individual outputs
- Added specific issue references (#400, #377, #378, #354) for known limitations
- Documented the incorrect behavior where `(1,error("x")) // 2` yields `2` instead of `1`
- Added example of mid-stream `break` in `and`/`or` producing incorrect results
- Noted that `//` operator still suppresses left-hand errors (issue #377)
- Clarified that `if`/`select` still collapse multi-output conditions to first output (issue #378, sibling of #354)

**Tests (tests/jq_cli_tests.rs):**
- Enhanced comments in `test_boolean_with_empty_operand_is_silent()` to explain testing strategy
- Documented why substring detection for diagnostic markers is used instead of exact empty stderr assertion
- Improved test clarity regarding the independence from workspace compilation state
- Updated test assertion from exact empty stderr check to diagnostic marker detection using `stderr.contains("jq: error")`
- This makes tests more robust and focused on actual behavior rather than side effects

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Enhanced test comments improve clarity without breaking functionality
- [x] Test assertion refactored to be more robust (diagnostic marker detection)

**Manual Testing:**
- [x] Verified test behavior with diagnostic output verification
- [x] Confirmed test independence from workspace compilation state

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact - documentation and test changes only

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Documentation has been updated appropriately
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

This documentation update provides clarity on known limitations in the jq evaluator's error and break handling. The test improvement makes the test suite more maintainable by reducing environmental coupling while preserving the actual behavioral verification. These changes support better understanding of the known issues and improve test robustness for CI/CD environments.