### PR TITLE
docs(docs): clarify CompactRank documentation as historical record and index archived plan

### DIFF
--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -21,6 +21,12 @@ These plans are kept for:
 | [m2-benchmark-improvements.md](m2-benchmark-improvements.md)     | Proposed    | `yq_bench.rs`                     | Benchmark M2 streaming path    |
 | [simd-features.md](simd-features.md)                             | Current     | `src/yaml/simd/`                  | YAML SIMD feature flag matrix  |
 
+## Archived Plans
+
+| Plan                                                             | Status   | Module              | Description                             |
+|------------------------------------------------------------------|----------|---------------------|-----------------------------------------|
+| [yaml-index-post-compactrank.md](yaml-index-post-compactrank.md) | Archived | `src/yaml/index.rs` | Index analysis from the CompactRank era |
+
 ## Plan Status Legend
 
 - **Implemented**: Feature exists in codebase, plan reflects final design

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -38,6 +38,6 @@ These plans are kept for:
 When implementing similar features:
 1. Review relevant plan for design patterns
 2. Note any lessons learned sections
-3. Check archive for rejected approaches
+3. Check Archived Plans for superseded analyses and rejected approaches
 
 If the codebase diverges from a plan, the plan should be updated or archived.

--- a/docs/plan/yaml-index-post-compactrank.md
+++ b/docs/plan/yaml-index-post-compactrank.md
@@ -72,8 +72,8 @@ For typical YAML with N ≈ L/7.5:
 | **`bp_to_text_end`**     | **4N ≈ 0.53L**   | **~53%**  |
 | Total                    |                  | ~125%     |
 
-**`bp_to_text_end` is now the single largest structure** — roughly 40% of the
-entire index.
+**`bp_to_text_end` was, in 2026-01, the single largest structure** — roughly
+40% of the entire index.
 
 ---
 
@@ -91,7 +91,7 @@ meaningful end positions.
 In typical YAML, containers + sequence items make up 30-50% of BP opens,
 meaning 30-50% of entries are wasted zeros.
 
-### Current usage
+### Usage (2026-01-27)
 
 ```
 index.rs:294    bp_to_text_end_pos(bp_pos)  →  self.bp_to_text_end.get(open_idx)
@@ -237,10 +237,10 @@ now costs 2 lookups + up to 7 popcounts (vs the old single array lookup with
 
 For a 1MB file with ~16K IB words:
 
-| Method              | Binary search steps | Cost per step                | Total cost              |
-|---------------------|---------------------|------------------------------|-------------------------|
-| Old (`Vec<u32>`)    | ~14                 | 1 array read                 | 14 reads                |
-| Current (CompactRank) | ~14               | 2 reads + up to 7 popcounts  | 28 reads + 98 popcounts |
+| Method                  | Binary search steps | Cost per step               | Total cost              |
+|-------------------------|---------------------|-----------------------------|-------------------------|
+| Old (`Vec<u32>`)        | ~14                 | 1 array read                | 14 reads                |
+| 2026-01 (CompactRank)   | ~14                 | 2 reads + up to 7 popcounts | 28 reads + 98 popcounts |
 
 `AdvancePositions` already solves this with `ib_select_samples` (one sample
 per 256 ones), reducing select to a linear scan over ~256 ones instead of
@@ -459,12 +459,12 @@ The two optimizations are complementary:
 - **yq-memory-optimization** reduces runtime memory (DOM → streaming)
 - **This plan** reduces index memory (bp_to_text_end compression)
 
-Together, the goal is total memory ≈ 1.1-1.5× input size (currently ~1.25×
-for index alone, plus runtime overhead).
+Together, the goal is total memory ≈ 1.1-1.5× input size (~1.25× for index
+alone as of 2026-01, plus runtime overhead).
 
 ## Changelog
 
-| Date       | Change                                                    |
-|------------|-----------------------------------------------------------|
-| 2026-01-27 | Initial analysis post-CompactRank migration               |
-| 2026-07-27 | Retired as historical record; dated layout heading (#368) |
+| Date       | Change                                                            |
+|------------|-------------------------------------------------------------------|
+| 2026-01-27 | Initial analysis post-CompactRank migration                       |
+| 2026-07-27 | Retired; dated currency claims, marked CompactRank tables (#368)  |

--- a/docs/plan/yaml-index-post-compactrank.md
+++ b/docs/plan/yaml-index-post-compactrank.md
@@ -30,6 +30,11 @@ remaining optimization opportunities.
 
 ## YamlIndex Memory Layout (2026-01-27)
 
+> **Superseded**: the `CompactRank` rows below hold only for the
+> `bc169609..0156707a` window. Both rank indices are cumulative `Vec<u32>` at
+> ~50% of the bitmap they index, not ~3.5% — see
+> [yaml-succinct.md § Current derived index structures](../parsing/yaml-succinct.md#current-derived-index-structures).
+
 | Structure             | Type                     | Size                | Notes                                |
 |-----------------------|--------------------------|---------------------|--------------------------------------|
 | `ib`                  | bitmap                   | L/8 bytes           | 1 bit/text byte                      |
@@ -53,6 +58,10 @@ Where L = text length, B = BP length (~2N), N = BP opens, T = container count.
 > [parsing/yaml.md O4](../parsing/yaml.md#o4-seq_items-bitvector-elimination--accepted-).
 
 For typical YAML with N ≈ L/7.5:
+
+> **Superseded**: at ~50% of each indexed bitmap rather than ~3.5%, the rank
+> row below is more than an order of magnitude larger than shown, and the
+> ~125% total is understated to match.
 
 | Component                | Cost             | % of text |
 |--------------------------|------------------|-----------|

--- a/docs/plan/yaml-index-post-compactrank.md
+++ b/docs/plan/yaml-index-post-compactrank.md
@@ -18,11 +18,15 @@ with `CompactRank` (~3.5% overhead).
 
 The CompactRank migration replaced four `Vec<u32>` cumulative rank indices (50%
 overhead each) with two-level `CompactRank` structures (~3.5% overhead). This
-reduced memory usage by 20-52% in CLI benchmarks — uncited, and from the same
-era as `0156707a`'s memory claim, which
-[../parsing/yaml-succinct.md](../parsing/yaml-succinct.md) shows to be wrong in
-the direction of the trade it made. Do not quote it forward. This document
-identifies the remaining optimization opportunities.
+reduced memory usage by 20-52% in CLI benchmarks. This document identifies the
+remaining optimization opportunities.
+
+> **Note (2026-07)**: the 20-52% figure is uncited — it appears nowhere else in
+> the repo, and `bc169609` (the migration commit) does not claim it. It also
+> dates from the same week as `0156707a`, whose own "~3.5% to ~3.1%" memory
+> claim is wrong in the direction of the trade it made; see
+> [yaml-succinct.md § Design constraint](../parsing/yaml-succinct.md#design-constraint-bitmaps-not-position-vectors).
+> Do not quote the 20-52% forward without re-measuring.
 
 ## YamlIndex Memory Layout (2026-01-27)
 

--- a/docs/plan/yaml-index-post-compactrank.md
+++ b/docs/plan/yaml-index-post-compactrank.md
@@ -18,10 +18,13 @@ with `CompactRank` (~3.5% overhead).
 
 The CompactRank migration replaced four `Vec<u32>` cumulative rank indices (50%
 overhead each) with two-level `CompactRank` structures (~3.5% overhead). This
-reduced memory usage by 20-52% in CLI benchmarks. This document identifies the
-remaining optimization opportunities.
+reduced memory usage by 20-52% in CLI benchmarks — uncited, and from the same
+era as `0156707a`'s memory claim, which
+[../parsing/yaml-succinct.md](../parsing/yaml-succinct.md) shows to be wrong in
+the direction of the trade it made. Do not quote it forward. This document
+identifies the remaining optimization opportunities.
 
-## Current YamlIndex Memory Layout
+## YamlIndex Memory Layout (2026-01-27)
 
 | Structure             | Type                     | Size                | Notes                                |
 |-----------------------|--------------------------|---------------------|--------------------------------------|
@@ -451,3 +454,4 @@ for index alone, plus runtime overhead).
 | Date       | Change                                                    |
 |------------|-----------------------------------------------------------|
 | 2026-01-27 | Initial analysis post-CompactRank migration               |
+| 2026-07-27 | Retired as historical record; dated layout heading (#368) |


### PR DESCRIPTION
## Description

This PR fixes issue #368 by correcting two documentation files that incorrectly present the retired CompactRank memory layout as current information. The CompactRank structure was only used in a specific commit window and is not part of the current codebase, but two docs still referenced it as if it were the current design.

The changes involve:
1. Updating the title of the main memory layout section to clarify it reflects a historical snapshot (2026-01-27) rather than current architecture
2. Flagging an uncited performance claim from the CompactRank era with context about its reliability
3. Adding the previously orphaned plan document to the documentation index under a new "Archived Plans" section

This ensures readers who encounter these documents through search or direct links understand they are historical records, not current design documentation.

## Type of Change
- [x] Documentation update

## Related Issue
Fixeshtml #368

## Changes Made

**docs/plan/yaml-index-post-compactrank.md:**
- Changed heading from "## Current YamlIndex Memory Layout" to "## YamlIndex Memory Layout (2026-01-27)" to clarify this reflects a historical snapshot
- Added inline context flag to the "reduced memory usage by 20-52%" claim, noting it is uncited and from the CompactRank era, with a reference to yaml-succinct.md showing this claim requires verification
- Added changelog entry documenting retirement as historical record due to #368

**docs/plan/README.md:**
- Added new "Archived Plans" section to the documentation index
- Listed yaml-index-post-compactrank.md as an Archived plan with its module and description
- This makes the document discoverable through the documentation structure rather than only through search

## Testing

**Documentation Validation:**
- [x] All links in updated documentation are valid
- [x] Documentation structure is consistent with existing format
- [x] No broken internal references

## Checklist
- [x] My changes follow the project's documentation style guidelines
- [x] I have performed a self-review of my documentation changes
- [x] Documentation changes are accurate and reflect the actual codebase state
- [x] I have updated documentation as needed (these changes ARE documentation updates)
- [x] My changes generate no new warnings

## Additional Notes

These changes are minimal and surgical, preserving the CompactRank-era documentation as a historical record (since the opportunity analysis it contains was valid for that period) while clearly marking it as such. This prevents readers from mistakenly treating retired architectural decisions as current design patterns.

The CompactRank structure was replaced with a different approach in commits after 0156707a, and yaml-succinct.md already documents the supersession with a banner. These changes ensure readers who bypass that banner understand the context of what they're reading.