### PR TITLE
fix(yaml): trim tab between plain key and colon in both parser and cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `?` now covers the indexing only, matching jq; `try`/`catch` still catches the
   error.
 
+- **A tab between a plain YAML key and its `:` was folded into the key** (#370):
+  `a\t: 1` loaded as `{"a\t":1}`, so a `.a` lookup missed a key the document
+  plainly spells `a`. YAML puts that white space outside the key —
+  `ns-s-implicit-yaml-key ::= ns-yaml-key(c) s-separate-in-line?`, and
+  `s-white` is a space *or a tab* — but the key's trailing trim was the one
+  place in the parser that listed only the space. Every sibling trim (the value
+  path, and all three flow-context sites) already included the tab. A tab
+  *inside* a plain scalar is unaffected and stays content, as
+  `nb-ns-plain-in-line` requires: `a\tb: 1` is still the key `a\tb`.
+
+  The same omission had a second home. A scalar's extent is derived twice by
+  copies that never consult each other: the parser's, stored in the index and
+  reported by `yq`, and `find_scalar_end`'s, re-derived from the text and
+  reported by `yq-locate` and `at_offset`. Fixing only the parser would have
+  left `syq` printing `a` while `syq-locate` still reported the byte range
+  `a\t`. The cursor copy also dropped the tab from its *terminator* set, which
+  broke a document with no trailing tab at all: `a:\t1` is legal YAML whose key
+  located as a range running to end of input. Both are now spelled the way
+  `parse_unquoted_key` spells them. See the #106 lesson in `CLAUDE.md` on
+  predicates that diverge silently — this is the third copy of that story.
+
+  No fixture moved: neither the YAML Test Suite corpus nor
+  `tests/data/yq-golden/` contains a tab adjacent to a colon, which is why the
+  shape survived this long. `tests/yaml_tab_separation_tests.rs` covers it now,
+  pinned by output and by located byte range, and is the separation half of the
+  split `tests/yaml_tab_indentation_tests.rs` (#173) draws — there a tab before
+  block structure is illegal indentation, here a tab before an indicator on the
+  same line is legal separation.
+
 - **YAML flow context silently absorbed tags as scalar text** (#369): block
   context has always rejected `!` via `check_unsupported`, but the flow-context
   scalar readers fell through to the plain-scalar path, so `a: [!!str x]` yielded

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -720,12 +720,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 // Flow context delimiters
                 b',' | b']' | b'}' => break,
                 b':' => {
-                    // Colon followed by space, newline, or EOF ends the scalar
+                    // Colon followed by white space, a line break, or EOF ends
+                    // the scalar. The tab is not optional: this is the same
+                    // terminator set `parse_unquoted_key` uses, and dropping it
+                    // here made `a:\t1` — legal YAML — report a byte range that
+                    // ran to end of input (#370).
                     if end + 1 >= self.text.len() {
                         // Colon at EOF - this is a key separator
                         break;
                     }
-                    if matches!(self.text[end + 1], b' ' | b'\n' | b'\r') {
+                    if matches!(self.text[end + 1], b' ' | b'\t' | b'\n' | b'\r') {
                         break;
                     }
                     end += 1;
@@ -733,8 +737,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 _ => end += 1,
             }
         }
-        // Trim trailing whitespace
-        while end > start && matches!(self.text[end - 1], b' ' | b'\r') {
+        // Trim trailing white space, tab included: this re-derives the extent
+        // the parser already trimmed, so the two must agree on what separation
+        // is, or `yq-locate` reports `a\t` for a key `yq` prints as `a` (#370).
+        while end > start && matches!(self.text[end - 1], b' ' | b'\t' | b'\r') {
             end -= 1;
         }
         end

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1325,9 +1325,13 @@ impl<'a> Parser<'a> {
 
         // Trim trailing whitespace. `\r` goes with it for the same reason as in
         // `parse_unquoted_value_with_indent_impl`: it is a line break, so it is
-        // never part of the key (#324).
+        // never part of the key (#324). A tab goes with it because the white
+        // space between a key and its `:` is `s-separate-in-line`, which
+        // `ns-s-implicit-yaml-key` leaves outside the key — the same reason a
+        // trailing space is trimmed, and this set is why `a\t: 1` used to load
+        // as {"a\t":1} (#370).
         let mut end = self.pos;
-        while end > start && matches!(self.input[end - 1], b' ' | b'\r') {
+        while end > start && matches!(self.input[end - 1], b' ' | b'\t' | b'\r') {
             end -= 1;
         }
 

--- a/tests/yaml_tab_separation_tests.rs
+++ b/tests/yaml_tab_separation_tests.rs
@@ -1,0 +1,228 @@
+//! A tab around a `:` value indicator is separation, never content (#370).
+//!
+//! YAML's [`ns-plain`] excludes trailing white space, and
+//! `ns-s-implicit-yaml-key(c) ::= ns-yaml-key(c) s-separate-in-line?` puts the white
+//! space between a key and its `:` outside the key. `s-white` is a space *or a tab*,
+//! so `a\t: 1` is the mapping `{"a": 1}` — the tab belongs to neither side.
+//!
+//! [`ns-plain`]: https://yaml.org/spec/1.2.2/#733-plain-style
+//!
+//! This is the separation half of the split that `tests/yaml_tab_indentation_tests.rs`
+//! draws: there, a tab before *block structure* is illegal indentation; here, a tab
+//! before an *indicator on the same line* is legal separation and must be discarded.
+//!
+//! # Why the byte ranges are asserted too
+//!
+//! A scalar's extent is derived twice, by two hand-written copies that never consult
+//! each other:
+//!
+//! | derivation | in | reaches the user as |
+//! |---|---|---|
+//! | the parser's, stored in the index | `parse_unquoted_key` (`src/yaml/parser.rs`) | `syq` output, key lookup |
+//! | the cursor's, re-derived from text | `find_scalar_end` (`src/yaml/light.rs`) | `syq-locate`, `at_offset` |
+//!
+//! Before #370 *both* omitted the tab, and fixing only the first would have left
+//! `syq` printing `a` while `syq-locate` reported the byte range `a\t` — a divergence
+//! no output-only test can see. The cursor copy also dropped the tab from its
+//! *terminator* set, so `a:\t1` — which has no trailing tab at all — located as a
+//! range running to end of input. Asserting both halves is what keeps the two copies
+//! honest; see the #106 lesson in `CLAUDE.md` on predicates that diverge silently.
+//!
+//! Inputs are byte literals so that no editor, `.gitattributes` or clippy lint can
+//! quietly launder a tab into spaces.
+//!
+//! Run with: `cargo test --test yaml_tab_separation_tests`
+
+use succinctly::yaml::{locate_offset_detailed, YamlError, YamlIndex, YamlValue};
+
+/// Render as `succinctly yq -o json '.'` does, one JSON value per document.
+/// Mirrors `yaml_to_json_documents` in `tests/yaml_test_suite.rs`.
+fn to_json(yaml: &[u8]) -> Result<String, YamlError> {
+    let index = YamlIndex::build(yaml)?;
+    let root = index.root(yaml);
+    Ok(match root.value() {
+        YamlValue::Sequence(mut elements) => {
+            let mut docs = Vec::new();
+            while let Some((cursor, rest)) = elements.uncons_cursor() {
+                docs.push(cursor.to_json());
+                elements = rest;
+            }
+            docs.join(" ")
+        }
+        _ => root.to_json_document(),
+    })
+}
+
+/// One document whose tabs are all separation, with the value it must produce.
+struct Row {
+    yaml: &'static [u8],
+    json: &'static str,
+    /// Which part of the fix this row is here to hold down.
+    why: &'static str,
+}
+
+/// A plain key long enough to reach the 32-byte SIMD classifier in
+/// `skip_unquoted_simd`, which only the x86_64 leg of CI exercises (the ARM64
+/// broadword path is disabled — see P4 in `docs/parsing/yaml.md`). The trim runs
+/// after the scan loop on absolute positions, so it is not path-dependent; this is
+/// insurance against a future classifier that stops somewhere else.
+const LONG_KEY: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\t: 1\n";
+
+const SEPARATION: &[Row] = &[
+    Row {
+        yaml: b"a\t: 1\n",
+        json: r#"{"a":1}"#,
+        why: "the #370 repro: loaded as {\"a\\t\":1} before the fix, so `.a` missed",
+    },
+    Row {
+        yaml: b"a \t : 1\n",
+        json: r#"{"a":1}"#,
+        why: "a mixed run of separation, not one byte of it",
+    },
+    Row {
+        yaml: b"a\t\t: 1\n",
+        json: r#"{"a":1}"#,
+        why: "the trim loop runs to exhaustion, not once",
+    },
+    Row {
+        yaml: b"a\t:\t1\n",
+        json: r#"{"a":1}"#,
+        why: "a tab on both sides: the value indicator may be followed by s-white too",
+    },
+    Row {
+        yaml: b"- a\t: 1\n",
+        json: r#"[{"a":1}]"#,
+        why: "parse_compact_mapping_entry, the other caller of parse_unquoted_key",
+    },
+    Row {
+        yaml: b"a\t: 1\r\n",
+        json: r#"{"a":1}"#,
+        why: "tab and CR are trimmed by the same loop — the #324 fix pairs with this one",
+    },
+    Row {
+        yaml: LONG_KEY,
+        json: r#"{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":1}"#,
+        why: "a key past the SIMD classifier threshold",
+    },
+    Row {
+        yaml: b"a: 1\t\n",
+        json: r#"{"a":1}"#,
+        why: "the value side, already correct — pins that the cursor-side edits do not \
+               regress it into the string \"1\\t\"",
+    },
+];
+
+#[track_caller]
+fn assert_json(yaml: &[u8], expected: &str, why: &str) {
+    let actual =
+        to_json(yaml).unwrap_or_else(|e| panic!("{:?} failed to parse: {e} — {why}", Text(yaml)));
+    assert_eq!(actual, expected, "input {:?} — {why}", Text(yaml));
+}
+
+/// Renders a byte string with its tabs visible in assertion output.
+struct Text<'a>(&'a [u8]);
+
+impl core::fmt::Debug for Text<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", String::from_utf8_lossy(self.0))
+    }
+}
+
+#[test]
+fn a_tab_around_the_value_indicator_is_not_part_of_the_key() {
+    for row in SEPARATION {
+        assert_json(row.yaml, row.json, row.why);
+    }
+}
+
+/// The property behind the table: separation is separation whichever `s-white` byte
+/// spells it. Stated as an invariance so a future change has to break the *rule* to
+/// break the test, not just one of eight pinned strings — and the space form is
+/// anchored to the same expectation, so "both spellings are equally wrong" cannot
+/// pass for agreement.
+#[test]
+fn spelling_the_separation_with_a_space_gives_the_same_document() {
+    for row in SEPARATION {
+        let spaces: Vec<u8> = row
+            .yaml
+            .iter()
+            .map(|&b| if b == b'\t' { b' ' } else { b })
+            .collect();
+        assert_json(&spaces, row.json, row.why);
+
+        let tabbed = to_json(row.yaml).expect("the tab form parses");
+        let spaced = to_json(&spaces).expect("the space form parses");
+        assert_eq!(
+            tabbed,
+            spaced,
+            "{:?} and {:?} are the same document — {}",
+            Text(row.yaml),
+            Text(&spaces),
+            row.why
+        );
+    }
+}
+
+/// The other side of the rule, and the one a too-eager trim would break: a tab
+/// *inside* a plain scalar is ordinary content. `nb-ns-plain-in-line` admits
+/// `s-white*` between plain characters, so these tabs are part of the scalar and must
+/// survive verbatim.
+#[test]
+fn a_tab_inside_a_plain_scalar_is_content() {
+    assert_json(b"a\tb: 1\n", r#"{"a\tb":1}"#, "internal tab in a key");
+    assert_json(b"k: a\tb\n", r#"{"k":"a\tb"}"#, "internal tab in a value");
+    assert_json(
+        b"a\tb\t: 1\n",
+        r#"{"a\tb":1}"#,
+        "internal kept, trailing trimmed",
+    );
+}
+
+/// The `syq-locate` half. `YamlCursor::raw_bytes` re-derives the extent rather than
+/// reusing the index, so these would still have been wrong had #370 changed only the
+/// parser — and the `a:\t1` row was wrong regardless of #370's shape.
+#[test]
+fn the_located_byte_range_excludes_the_separating_tab() {
+    // (document, offset to locate, the bytes the reported range must cover)
+    for (yaml, offset, expected) in [
+        (&b"a\t: 1\n"[..], 0, &b"a"[..]), // key: range was `a\t`
+        (b"a\t: 1\n", 4, b"1"),           // its value
+        (b"a:\t1\n", 0, b"a"),            // key: range ran to end of input
+        (b"a:\t1\n", 3, b"1"),            // its value
+        (b"a\t:\t1\n", 0, b"a"),          // both sides tabbed
+        (b"a\t:\t1\n", 4, b"1"),
+        (b"a\tb: 1\n", 0, b"a\tb"), // content, so the range keeps the tab
+    ] {
+        let index = YamlIndex::build(yaml).expect("parses");
+        let found = locate_offset_detailed(&index, yaml, offset)
+            .unwrap_or_else(|| panic!("offset {offset} of {:?} located nothing", Text(yaml)));
+        let (start, end) = found.byte_range;
+        assert_eq!(
+            &yaml[start..end],
+            expected,
+            "offset {offset} of {:?}: range {:?} covers {:?}",
+            Text(yaml),
+            found.byte_range,
+            Text(&yaml[start..end])
+        );
+    }
+}
+
+/// The opt-in strict validator must agree that these are valid documents. A tab here
+/// is separation, so the tab-in-indentation rule (#173) must not fire on it — the two
+/// rules meet on the same byte and only the position tells them apart.
+#[test]
+fn the_strict_validator_accepts_every_separation_form() {
+    let mut rejected = Vec::new();
+    for row in SEPARATION {
+        if let Err(e) = succinctly::yaml::validate::validate(row.yaml) {
+            rejected.push(format!("  {:?}: {e} — {}", Text(row.yaml), row.why));
+        }
+    }
+    assert!(
+        rejected.is_empty(),
+        "the validator rejected {} valid document(s):\n{}",
+        rejected.len(),
+        rejected.join("\n")
+    );
+}


### PR DESCRIPTION
## Description

This PR fixes a critical YAML parsing bug where tabs adjacent to value indicators (`:`) were incorrectly included in scalar content instead of being treated as separation characters.

According to the YAML specification, `ns-s-implicit-yaml-key ::= ns-yaml-key(c) s-separate-in-line?` places whitespace between a key and its `:` outside the key boundary. Since `s-white` includes both spaces and tabs, the input `a\t: 1` should parse as `{"a": 1}`, not `{"a\t": 1}`. However, the key trimming logic in the parser omitted tabs while all sibling trim operations (value path and flow-context sites) correctly included them.

A second instance of this bug existed in `find_scalar_end()`, which re-derives scalar extents independently from the parser's stored index. This divergence meant that `syq` would print one representation while `yq-locate` reported a different byte range—a silent divergence that output-only tests could not catch. Additionally, `find_scalar_end()` dropped the tab from its terminator set, causing documents like `a:\t1` (legal YAML with no trailing tab) to incorrectly locate as a byte range extending to end of input.

Both issues are now fixed to match the behavior established in `parse_unquoted_key`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #370

## Changes Made

**Core Parser Fixes:**
- Modified `parse_unquoted_key` in `src/yaml/parser.rs` to include tabs in the trailing whitespace trim pattern (changed from `b' ' | b'\r'` to `b' ' | b'\t' | b'\r'`)
- Updated comments to document that separation whitespace (`s-separate-in-line`) must be discarded from key content

**Cursor Scalar Boundary Detection:**
- Fixed `find_scalar_end()` in `src/yaml/light.rs` to include tabs in both the terminator check and the trailing whitespace trim
- Updated terminator condition from `b' ' | b'\n' | b'\r'` to `b' ' | b'\t' | b'\n' | b'\r'`
- Updated trailing trim loop from `b' ' | b'\r'` to `b' ' | b'\t' | b'\r'` to match parser behavior
- Added detailed comments explaining that this re-derivation of scalar extent must agree with the parser's stored index

**Testing:**
- Added comprehensive test suite `tests/yaml_tab_separation_tests.rs` with 228 lines of tests covering:
  - Basic tab-as-separator cases (e.g., `a\t: 1`)
  - Mixed separation characters (spaces and tabs)
  - Multiple consecutive tabs
  - Tabs on both sides of the value indicator
  - Tab separation in compact mapping entries
  - Tabs with CRLF line endings
  - Keys exceeding the 32-byte SIMD classifier threshold
  - Value-side tabs to ensure cursor edits don't regress existing behavior
  - Internal tabs within scalar content (which must be preserved as content)
  - Byte range assertions for `yq-locate` output
  - Strict validator acceptance of all separation forms

**Documentation:**
- Updated `CHANGELOG.md` with detailed explanation of the bug, its symptoms, root cause, and fix
- Documented the dual-derivation issue where parser and cursor independently compute scalar extents
- Noted this as the third instance of the #106 lesson on silent predicate divergence
- Clarified distinction between tabs as separation (removed) and tabs as content (preserved)

## Testing

**Automated Testing:**
- [x] All 2522 existing tests pass
- [x] New test suite `yaml_tab_separation_tests.rs` added with 5 test functions
  - `a_tab_around_the_value_indicator_is_not_part_of_the_key()`: Core functionality with 8 input variants
  - `spelling_the_separation_with_a_space_gives_the_same_document()`: Invariance that space and tab separation produce identical results
  - `a_tab_inside_a_plain_scalar_is_content()`: Ensures internal tabs are preserved
  - `the_located_byte_range_excludes_the_separating_tab()`: Validates `yq-locate` output correctness
  - `the_strict_validator_accepts_every_separation_form()`: Ensures validator accepts valid documents

**Manual Testing:**
- [x] Verified with `--features cli,simd,regex,serde --workspace`

### Test Commands
```bash
cargo test --features cli,simd,regex,serde --workspace
cargo test --test yaml_tab_separation_tests
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The changes involve only whitespace classification in existing trim loops, with no algorithmic changes or new operations.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

No fixture changes were required—neither the YAML Test Suite corpus (402 cases) nor the golden test data contains tabs adjacent to colons, which is why this bug survived so long.

Two related divergences were discovered during investigation but filed separately to keep this PR focused:
- #410: A tab before `#` does not start a comment in a key context
- #411: `find_scalar_end()` breaks at any `#`, causing `a#b` to locate short

This fix illustrates an important lesson (#106 in `CLAUDE.md`): when multiple hand-written copies of a predicate exist without cross-consultation, they inevitably diverge. The parser's `parse_unquoted_key`, cursor's `find_scalar_end()`, and value-path trim now all use identical whitespace classification.