### PR TITLE
fix(jq): propagate left-hand errors through the alternative operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`//` discarded a left-hand error instead of propagating it** (#377):
+  `eval_alternative` treated a left-hand `Error` the same as `None` and fell
+  through to the right side, so `error("x") // 3` and `.a // 3` (on a
+  non-object) silently produced `3` instead of raising, where jq 1.7.1
+  raises. Split out of #160, which deliberately left this arm unchanged to
+  keep that fix scoped to the multi-output bug. `//` now propagates a
+  left-hand error; `.a? // 3` is unaffected since `?` already resolves to
+  `None` before reaching the operator. **Not fixed**: the whole-stream error
+  model means `(1, error("x")) // 2` still yields `2` where jq yields `1` —
+  `QueryResult::Error` is a property of the stream, not of one output, so
+  partial-then-error is unrepresentable; a faithful fix is the same larger
+  change `eval_comma` needs for #400.
+
 - **YAML alias used as a flow-mapping key rendered as the empty string** (#405):
   `{&x k: 1, *x: 2}` loaded as `{"k":1,"":2}` where `yq` gives `{"k":1,"k":2}`,
   and likewise for a flow mapping nested in a block one or in a sequence. The
@@ -334,9 +347,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `(1,error("x")) // 2` yields `2` where jq yields `1`, and a mid-stream error
   or `break` in `and`/`or` discards the outputs already computed —
   `label $out | ((true,true) and (1, break $out))` yields nothing where jq
-  yields `true` (#400); `//` still suppresses left-hand errors, which jq 1.7.1
-  propagates (#377); and `if`/`select` still collapse a multi-output condition
-  to its first output (#378, sibling of #354).
+  yields `true` (#400); and `if`/`select` still collapse a multi-output condition
+  to its first output (#378, sibling of #354). `//` also suppressed left-hand
+  errors rather than propagating them; fixed separately below (#377).
 - **YAML: a tab after spaces in indentation was folded into the key** (#173):
   the loader rejected a tab only at column 0 and treated a tab following one or
   more spaces as start-of-content, so `a:\n \tb: 1` loaded as

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1353,11 +1353,12 @@ fn eval_alternative<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     match retain_truthy(eval_single::<W, S>(left, value.clone(), optional)) {
         // A `break` escapes the operator rather than selecting a branch.
         QueryResult::Break(label) => QueryResult::Break(label),
-        // No truthy output on the left, so the right side answers. An error on
-        // the left also falls through here, discarding it; jq 1.7.1 instead
-        // propagates left-hand errors, which is a separate divergence from the
-        // multi-output bug this function fixes.
-        QueryResult::None | QueryResult::Error(_) => eval_single::<W, S>(right, value, optional),
+        // No truthy output on the left, so the right side answers.
+        QueryResult::None => eval_single::<W, S>(right, value, optional),
+        // An error on the left propagates, matching jq 1.7.1: `//` only
+        // substitutes for falsy/absent output, not for a raised error. Use
+        // `?` on the left (e.g. `.a? // 3`) to suppress the error instead.
+        error @ QueryResult::Error(_) => error,
         kept => kept,
     }
 }
@@ -15178,6 +15179,29 @@ mod tests {
         // Chain alternatives
         query!(br#"{"a": null, "b": null}"#, ".a // .b // 42",
             QueryResult::Owned(OwnedValue::Int(42)) => {}
+        );
+    }
+
+    #[test]
+    fn regression_issue_377_alternative_propagates_left_hand_errors() {
+        // jq 1.7.1 raises a left-hand error rather than treating it as falsy;
+        // `//` only substitutes for false/null/absent output.
+        query!(br"null", r#"error("x") // 3"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+        query!(br"1", ".a // 3",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with string \"a\"");
+            }
+        );
+
+        // A `?` on the erroring operand still suppresses the error and falls
+        // through to the right side, since `.a?` never produces `Error` in
+        // the first place.
+        query!(br"1", ".a? // 3",
+            QueryResult::Owned(OwnedValue::Int(3)) => {}
         );
     }
 


### PR DESCRIPTION
## Description

This PR fixes the jq alternative operator (`//`) to properly propagate left-hand errors, matching jq 1.7.1 behavior. Previously, the operator treated left-hand `Error` results the same as falsy values (`None`), causing expressions like `error("x") // 3` to silently return the right-hand fallback instead of raising an error.

The fix ensures that `//` only substitutes for false/null/absent output, not for raised errors. If an error should be suppressed, users can explicitly use the `?` operator on the left side (e.g., `.a? // 3`).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Fixes #377

## Changes Made

**Error Handling in Alternative Operator:**
- Modified `eval_alternative()` function in `src/jq/eval.rs` to distinguish between `None` (falsy/absent) and `Error` results
- Left-hand `Error` values now propagate directly instead of triggering right-hand evaluation
- `None` results continue to evaluate the right side as the fallback
- Behavior now matches jq 1.7.1: the `//` operator substitutes for falsy/absent output only, not for raised errors

**Test Coverage:**
- Added `regression_issue_377_alternative_propagates_left_hand_errors()` test to verify correct error propagation
- Test cases cover:
  - `error("x") // 3` correctly raises the error instead of returning 3
  - `.a // 3` on a non-object raises a type error instead of returning 3
  - `.a? // 3` still works correctly by suppressing the error with `?`, allowing the fallback

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New regression test added for issue #377 with three specific test cases
- [x] Verified error propagation behavior matches jq 1.7.1

**Manual Testing:**
```bash
cargo test regression_issue_377_alternative_propagates_left_hand_errors
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The change is a simple control flow modification that maintains the same operational complexity.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

This fix addresses a divergence from jq 1.7.1 behavior. The alternative operator now correctly distinguishes between:
- **Falsy/absent values** (false, null, or missing fields) → use right-hand fallback
- **Errors** → propagate the error up the evaluation chain
- **Explicit error suppression** → use `?` operator on left side to convert errors to `None` before the alternative operator

The implementation is minimal and focused, changing only the error handling logic without affecting other operator behavior.