### PR TITLE
fix(yaml): strip separation whitespace left after continuation-line tab

### DIFF
--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -26,7 +26,7 @@ path:
 
 | Dimension                              | Result              | Meaning                                        |
 |----------------------------------------|---------------------|------------------------------------------------|
-| **Load** (valid YAML, output compared) | **215/279 = 77.1%** | Parses and produces the JSON the suite expects |
+| **Load** (valid YAML, output compared) | **216/279 = 77.4%** | Parses and produces the JSON the suite expects |
 | **Reject** (invalid YAML, must fail)   | **70/94 = 74.5%**   | Refused by the loader or the opt-in validator  |
 | **Parse** (valid YAML, no JSON form)   | **27/29 = 93.1%**   | Parses without error                           |
 
@@ -35,7 +35,7 @@ validator enabled (loader OR validator, see below). The *default non-validating
 loader alone* still rejects only 12/94 (12.8%) by design — the opt-in validator
 ([#223](https://github.com/rust-works/succinctly/issues/223)) closes 58 more.
 
-The 90 non-passing cases are enumerated individually, with a category and reason, in
+The 89 non-passing cases are enumerated individually, with a category and reason, in
 [`tests/data/yaml-test-suite-known-failures.txt`](../../../tests/data/yaml-test-suite-known-failures.txt).
 That file is the machine-readable source of truth; the test asserts it matches reality
 exactly, so it cannot silently drift from this page.
@@ -313,24 +313,27 @@ floats render as integers on the streaming path, `1.0` → `1` —
 [#168](https://github.com/rust-works/succinctly/issues/168) /
 [#170](https://github.com/rust-works/succinctly/issues/170)).
 
-## Full accounting of the 64 load failures
+## Full accounting of the 63 load failures
 
 | Category     | Cases | Cause                                                             |
 |--------------|-------|-------------------------------------------------------------------|
 | `tags`       | 31    | Tags not supported (above)                                        |
 | `directives` | 16    | `%YAML` / `%TAG` not recognized (above)                           |
 | `structure`  | 9     | Document end markers; anchors with colons in the name             |
-| `scalars`    | 8     | Zero-indented block scalars; tabs; trailing whitespace            |
+| `scalars`    | 7     | Zero-indented block scalars; tabs; trailing whitespace            |
 
 `scalars` was 13 until [#329](https://github.com/rust-works/succinctly/issues/329). Folded
 (`>`) block scalars mis-counted the newlines a blank line is worth — a blank line yielded
 N+1 where YAML 1.2 §8.1.3 and `yq` give N — and folded blocks with keep chomping (`>+`)
 dropped `b-chomped-last` entirely, so `>+` over `a` produced `"a"` rather than `"a\n"`.
 Fixing the folding rule in `decode_block_folded` cleared `4Q9F`, `7T8X`, `93WF`, `K527`
-and `TS54`. What remains under `scalars` is unrelated to folding: zero-indented block
-scalars (`DK3J`, `FP8R`), tab handling (`DK95/00`, `K54U`), trailing whitespace
-(`L24T/00`, `JEF9/02`), explicit indentation indicators (`M5C3`), and the empty stream
-(`AVM7`, filed under `scalars` although it is really a document-level case).
+and `TS54`. `DK95/00` (a tab used as separation before a plain scalar, retained as
+content instead of stripped) was fixed by
+[#381](https://github.com/rust-works/succinctly/issues/381). What remains under
+`scalars` is unrelated to folding: zero-indented block scalars (`DK3J`, `FP8R`), tab
+handling (`K54U`), trailing whitespace (`L24T/00`, `JEF9/02`), explicit indentation
+indicators (`M5C3`), and the empty stream (`AVM7`, filed under `scalars` although it
+is really a document-level case).
 
 ### `JEF9/02`: the one case where we follow `yq` over the suite
 

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -682,6 +682,31 @@ impl<'a> Parser<'a> {
             && super::line_is_structural(self.input, self.pos)
     }
 
+    /// Skip `s-separate-in-line` whitespace still sitting on the cursor after
+    /// the leading indent has already been consumed by `advance_by`.
+    ///
+    /// `count_indent` only counts spaces, so a tab immediately after them is
+    /// left on the cursor. When that tab is legal separation (not indenting
+    /// block structure — see `tab_indents_block_structure`, which this reuses
+    /// so the two never disagree), it is not part of the following node and
+    /// must be skipped before a caller dispatches on `self.peek()` or records
+    /// a node's start position. Otherwise the tab becomes the node's first
+    /// byte: a plain scalar picks up a leading `\t` (`DK95/00`), and a quoted
+    /// node is pushed off its opening quote and misread as a mapping (#381).
+    ///
+    /// A tab that *does* indent block structure is left in place for
+    /// `tab_indents_block_structure`'s caller to reject.
+    #[inline]
+    fn skip_separation_whitespace(&mut self, line_start: usize) {
+        loop {
+            match self.peek() {
+                Some(b' ') => self.advance(),
+                Some(b'\t') if !self.tab_indents_block_structure(line_start) => self.advance(),
+                _ => break,
+            }
+        }
+    }
+
     /// Get the current column position (0-based).
     /// This counts characters from the start of the current line.
     fn current_column(&self) -> usize {
@@ -1254,7 +1279,7 @@ impl<'a> Parser<'a> {
                 && !sequence_indicator_is_block_structure
                 && !(next_char == b':'
                     && lookahead + 1 < self.input.len()
-                    && matches!(self.input[lookahead + 1], b' ' | b'\n' | b'\r'))
+                    && matches!(self.input[lookahead + 1], b' ' | b'\t' | b'\n' | b'\r'))
             {
                 // Continue to next line
                 self.skip_line_break();
@@ -1836,6 +1861,11 @@ impl<'a> Parser<'a> {
 
             // Re-advance to content position for the remaining checks
             self.advance_by(next_indent);
+            // A tab left over from `advance_by` (which only accounts for
+            // spaces) is legal separation here, not content - skip it so the
+            // dispatch below, and any node it opens, land on the node's real
+            // first byte (#381).
+            self.skip_separation_whitespace(saved_pos);
 
             // Check if this is a nested structure or a plain scalar value
             match self.peek() {
@@ -1873,10 +1903,24 @@ impl<'a> Parser<'a> {
                         self.pos = saved_pos;
                         return Ok(());
                     }
-                    // Plain scalar value - parse it here with key's indent as base
+                    // Scalar value - parse it here with key's indent as base.
+                    // Quoted nodes need their own reader: the unquoted scanner
+                    // stops at the first `: ` it sees, including one inside
+                    // the quotes, stranding the cursor mid-string and
+                    // corrupting whatever follows on the document.
                     self.set_ib();
                     self.write_bp_open();
-                    let end_pos = self.parse_unquoted_value_with_indent(indent);
+                    let end_pos = match self.peek() {
+                        Some(b'"') => {
+                            self.parse_double_quoted()?;
+                            self.pos
+                        }
+                        Some(b'\'') => {
+                            self.parse_single_quoted()?;
+                            self.pos
+                        }
+                        _ => self.parse_unquoted_value_with_indent(indent),
+                    };
                     self.set_bp_text_end(end_pos);
                     self.write_bp_close();
                     return Ok(());
@@ -3875,6 +3919,11 @@ impl<'a> Parser<'a> {
                 offset: self.pos,
             });
         }
+
+        // The tab above was ruled out as (illegal) indentation, so it's
+        // separation - skip it, and any more of it, so the dispatch below
+        // lands on the line's real first byte instead of the tab (#381).
+        self.skip_separation_whitespace(line_start);
 
         // close_deeper_indents will handle closing any SequenceItem entries
         // when we return to a lower indent level

--- a/tests/data/yaml-test-suite-known-failures.txt
+++ b/tests/data/yaml-test-suite-known-failures.txt
@@ -68,7 +68,6 @@ CUP7      tags              tags (!) not supported — #224
 CXX2      lax:anchors       anchor/alias rules not validated — #223
 DK3J      scalars           scalar content/folding differs from spec
 DK4H      lax:mapping       mapping/key rules not validated — #223
-DK95/00   scalars           scalar content/folding differs from spec
 DK95/07   directives        %YAML/%TAG directive not recognized — #225
 EHF6      tags              tags (!) not supported — #224
 EW3V      lax:mapping       mapping/key rules not validated — #223

--- a/tests/yaml_tab_indentation_tests.rs
+++ b/tests/yaml_tab_indentation_tests.rs
@@ -252,6 +252,11 @@ fn a_tab_used_as_separation_still_produces_its_value() {
     // opening quote is the node's first byte and it reads as the quoted scalar
     // it is, rather than as a mapping (#381).
     assert_eq!(to_json(b"a:\n \t\"x: y\"\n").unwrap(), r#"{"a":"x: y"}"#);
+
+    // The single-quoted form of the row above — a separate dispatch arm
+    // (`parse_single_quoted`), so it needs its own pinned value rather than
+    // relying on the double-quoted case to stand in for it.
+    assert_eq!(to_json(b"a:\n \t'x: y'\n").unwrap(), r#"{"a":"x: y"}"#);
 }
 
 /// `parse_document_line` is not always entered at a line start — `parse_explicit_key`

--- a/tests/yaml_tab_indentation_tests.rs
+++ b/tests/yaml_tab_indentation_tests.rs
@@ -227,12 +227,10 @@ fn a_tab_used_as_separation_still_produces_its_value() {
     // UV7Q. This is the spec-correct output; the suite agrees.
     assert_eq!(to_json(b"x:\n - x\n  \tx\n").unwrap(), r#"{"x":["x x"]}"#);
 
-    // DK95/00. The suite wants {"foo":"bar"} — the leading tab should be stripped as
-    // separation. Retaining it is a known scalar-folding gap, on record in
-    // tests/data/yaml-test-suite-known-failures.txt as `DK95/00 scalars`. Pinned as
-    // it is so that fixing the folding is a deliberate change to this line, not a
-    // silent one.
-    assert_eq!(to_json(b"foo:\n \tbar\n").unwrap(), r#"{"foo":"\tbar"}"#);
+    // DK95/00. The leading tab is separation and is stripped, matching the suite
+    // (#381). Previously a known scalar-folding gap, on record in
+    // tests/data/yaml-test-suite-known-failures.txt as `DK95/00 scalars`.
+    assert_eq!(to_json(b"foo:\n \tbar\n").unwrap(), r#"{"foo":"bar"}"#);
 
     // Q5MG and 6CA3, both spec-correct.
     assert_eq!(to_json(b"\t{}\n").unwrap(), "{}");
@@ -250,16 +248,10 @@ fn a_tab_used_as_separation_still_produces_its_value() {
         r#"{"a":1,"b":2}"#
     );
 
-    // A quoted scalar after the tab. Spec-correct is {"a":"x: y"}; the loader instead
-    // reads the line as a mapping, the same continuation-line folding gap that leaves
-    // DK95/00 above with its tab — that is #381. #173 is about the tab *verdict* —
-    // this now loads instead of erroring, which is the part that changed — so the
-    // wrong value is pinned rather than hidden, and fixing #381 is a deliberate edit
-    // to this line and to the DK95/00 one above.
-    assert_eq!(
-        to_json(b"a:\n \t\"x: y\"\n").unwrap(),
-        r#"{"a":{"\t\"x":"y\""}}"#
-    );
+    // A quoted scalar after the tab. The tab is stripped as separation, so the
+    // opening quote is the node's first byte and it reads as the quoted scalar
+    // it is, rather than as a mapping (#381).
+    assert_eq!(to_json(b"a:\n \t\"x: y\"\n").unwrap(), r#"{"a":"x: y"}"#);
 }
 
 /// `parse_document_line` is not always entered at a line start — `parse_explicit_key`


### PR DESCRIPTION
## Description

Fix a critical bug in YAML parsing where tab characters used as separation whitespace on continuation lines were incorrectly retained as content instead of being stripped. This caused two distinct failures:

1. **Plain scalars** would incorrectly include a leading tab as part of their value (e.g., `foo:\n \tbar` produced `{"foo":"\tbar"}` instead of `{"foo":"bar"}`)
2. **Quoted scalars** after a tab would be misread as mappings entirely, with the opening quote shifted off-cursor, producing malformed output (e.g., `a:\n \t"x: y"` produced `{"a":{"\t\"x":"y\""}}` instead of `{"a":"x: y"}`)

The root cause was that `count_indent` only counts spaces, leaving tabs on the cursor. When these tabs were legal separation (not block-structure indentation), they were not being skipped before dispatching to value parsers, causing them to become the node's first byte.

The fix introduces proper handling of `s-separate-in-line` whitespace after continuation-line indentation, ensuring tabs are only retained when they legitimately indent block structure, and are otherwise consumed as separation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #381

## Changes Made

**Core Parser Fix (src/yaml/parser.rs):**
- Added `skip_separation_whitespace()` method to properly consume `s-separate-in-line` whitespace (spaces and tabs that don't indent block structure) left on the cursor after `advance_by()`
- Updated `parse_document_line()` to call `skip_separation_whitespace()` after processing continuation-line indentation, ensuring tabs are stripped before dispatching on the node type
- Updated `parse_explicit_key()` to call `skip_separation_whitespace()` to prevent tabs from corrupting subsequent node parsing
- Enhanced scalar value parsing in mapping context to properly dispatch quoted scalars (`"` and `'`) instead of falling into the unquoted scanner, which would incorrectly stop at `: ` sequences inside quotes
- Fixed the `:` lookahead terminator set in `parse_unquoted_value_with_indent_impl` to include tabs, ensuring tab-separated `:` continuation lines are handled consistently with space-separated forms

**Test Updates (tests/yaml_tab_indentation_tests.rs):**
- Updated `a_tab_used_as_separation_still_produces_its_value()` test with corrected expected values:
  - `foo:\n \tbar` now correctly produces `{"foo":"bar"}` (was `{"foo":"\tbar"}`)
  - `a:\n \t"x: y"` now correctly produces `{"a":"x: y"}` (was malformed mapping)
- Updated test comments to reflect that DK95/00 is now spec-compliant

**Known Failures Update (tests/data/yaml-test-suite-known-failures.txt):**
- Removed DK95/00 from the known-failures list, as it now passes the YAML test suite

**Documentation Update (docs/compliance/yaml/limitations.md):**
- Updated YAML Test Suite conformance metrics:
  - Load score: 215/279 → 216/279 (77.1% → 77.4%)
  - Total non-passing cases: 90 → 89
  - Scalars category failures: 8 → 7
- Updated documentation to note that DK95/00 was fixed by #381
- Corrected the full accounting of load failures from 64 to 63

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Tab indentation tests updated with corrected expected output
- [x] YAML Test Suite compliance improved by 1 case (216/279 passing)
- [x] Regression test added to prevent re-introduction of the bug

**Manual Testing:**
- [x] Verified plain scalar values with leading tabs are now parsed correctly
- [x] Verified quoted scalars after tabs are no longer misread as mappings
- [x] Verified tab-separated `:` continuation lines produce correct output
- [x] Verified tabs that do indent block structure are still handled correctly

### Test Commands
```bash
cargo test yaml_tab_indentation_tests -- --nocapture
cargo test --lib yaml -- --nocapture
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The new `skip_separation_whitespace()` method is minimal and only called in specific parsing contexts where tabs may be present. No additional allocations or algorithmic changes impact performance.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Spec Compliance:**
This fix resolves a violation of YAML 1.2 specification regarding `s-separate-in-line` whitespace handling. Tabs used as separation are now properly distinguished from tabs used for indentation, aligning the parser with the YAML Test Suite expectations.

**Related Issues:**
- The same root cause also fixed the inconsistency in tab-separated `:` handling that was reported alongside #381
- This is part of ongoing efforts to improve YAML 1.2 spec compliance (related to #223, #224, #225)