### PR TITLE
fix(jq): make ltrimstr/rtrimstr total, matching jq's pass-through behavior

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2464,7 +2464,8 @@ fn builtin_ltrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let prefix_result = eval_single::<W, S>(prefix_expr, value.clone(), optional);
     let prefix = match result_to_owned(prefix_result) {
         Ok(OwnedValue::String(s)) => s,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "non-string")),
+        // jq's ltrimstr is total: a non-string argument leaves input unchanged.
+        Ok(_) => return QueryResult::Owned(to_owned(&value)),
         Err(e) => return QueryResult::Error(e),
     };
 
@@ -2481,8 +2482,8 @@ fn builtin_ltrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 QueryResult::Owned(OwnedValue::String(String::new()))
             }
         }
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::type_error("string", type_name(&value))),
+        // jq's ltrimstr is total: a non-string input passes through unchanged.
+        _ => QueryResult::Owned(to_owned(&value)),
     }
 }
 
@@ -2496,7 +2497,8 @@ fn builtin_rtrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let suffix_result = eval_single::<W, S>(suffix_expr, value.clone(), optional);
     let suffix = match result_to_owned(suffix_result) {
         Ok(OwnedValue::String(s)) => s,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "non-string")),
+        // jq's rtrimstr is total: a non-string argument leaves input unchanged.
+        Ok(_) => return QueryResult::Owned(to_owned(&value)),
         Err(e) => return QueryResult::Error(e),
     };
 
@@ -2513,8 +2515,8 @@ fn builtin_rtrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 QueryResult::Owned(OwnedValue::String(String::new()))
             }
         }
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::type_error("string", type_name(&value))),
+        // jq's rtrimstr is total: a non-string input passes through unchanged.
+        _ => QueryResult::Owned(to_owned(&value)),
     }
 }
 
@@ -16268,6 +16270,20 @@ mod tests {
                 assert_eq!(s, "hello world");
             }
         );
+
+        // jq's ltrimstr is total: non-string argument leaves input unchanged (#394)
+        query!(br#""abc""#, "ltrimstr(1)",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "abc");
+            }
+        );
+
+        // jq's ltrimstr is total: non-string input passes through unchanged (#394)
+        query!(b"1", r#"ltrimstr("a")"#,
+            QueryResult::Owned(OwnedValue::Int(n)) => {
+                assert_eq!(n, 1);
+            }
+        );
     }
 
     #[test]
@@ -16282,6 +16298,20 @@ mod tests {
         query!(br#""hello world""#, r#"rtrimstr("goodbye")"#,
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "hello world");
+            }
+        );
+
+        // jq's rtrimstr is total: non-string argument leaves input unchanged (#394)
+        query!(br#""abc""#, "rtrimstr(null)",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "abc");
+            }
+        );
+
+        // jq's rtrimstr is total: non-string input passes through unchanged (#394)
+        query!(b"1", r#"rtrimstr("a")"#,
+            QueryResult::Owned(OwnedValue::Int(n)) => {
+                assert_eq!(n, 1);
             }
         );
     }


### PR DESCRIPTION
## Description

This PR fixes the `ltrimstr` and `rtrimstr` functions in the jq evaluator to match jq's actual behavior. jq's trim functions are total functions that never error: when given a non-string argument or operating on non-string input, they pass the value through unchanged rather than raising a type error.

Previously, Succinctly would raise a type error in both cases, causing operations like `map(ltrimstr("/"))` over mixed-type data to fail entirely instead of gracefully handling non-string values.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #394

## Changes Made

**Core Implementation:**
- Modified `builtin_ltrimstr` in `src/jq/eval.rs` to return the input value unchanged when the argument is non-string, instead of raising a type error
- Modified `builtin_ltrimstr` to return the input value unchanged when the input itself is non-string, instead of raising a type error or returning None
- Modified `builtin_rtrimstr` in `src/jq/eval.rs` to return the input value unchanged when the argument is non-string, instead of raising a type error
- Modified `builtin_rtrimstr` to return the input value unchanged when the input itself is non-string, instead of raising a type error or returning None

**Testing:**
- Added test case for `ltrimstr` with non-string argument: `"abc" | ltrimstr(1)` returns `"abc"` unchanged
- Added test case for `ltrimstr` with non-string input: `1 | ltrimstr("a")` returns `1` unchanged
- Added test case for `rtrimstr` with non-string argument: `"abc" | rtrimstr(null)` returns `"abc"` unchanged
- Added test case for `rtrimstr` with non-string input: `1 | rtrimstr("a")` returns `1` unchanged

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested `ltrimstr` and `rtrimstr` with non-string arguments
- [x] Tested `ltrimstr` and `rtrimstr` with non-string input values
- [x] Verified that string inputs with string arguments still work correctly

### Test Commands
```bash
cargo test builtin_ltrimstr
cargo test builtin_rtrimstr
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The changes are straightforward control flow modifications that do not affect performance characteristics.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

This fix ensures that Succinctly's jq implementation correctly matches jq's behavior for trim functions, which is critical for data transformation pipelines that operate over heterogeneous data structures. The functions now gracefully handle mixed-type inputs, a common pattern when processing real-world JSON data.