### PR TITLE
fix(yaml): correct explicit flow key parsing and consolidate duplicate code

### DIFF
--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -362,6 +362,42 @@ its `explicit_indent` case last.
 
 The two `parse` failures (`FH7J`, `UKK6/02`) are also tags.
 
+### `FRK4`: a divergence the ledger cannot see
+
+`JEF9/02` above is the one case where following `yq` moves a case *across* the ledger.
+[#402](https://github.com/rust-works/succinctly/issues/402) added a second place where we
+follow `yq` over the spec, and this one does not move the ledger at all — which is why it is
+recorded here.
+
+In an explicit **flow** key, a `:` ends the key only when a blank, a line break or end of
+input follows it. Before a flow indicator it is ordinary key content, and the scan stops at
+the indicator instead:
+
+```
+$ printf 'a: [? k :, x]\n' | succinctly yq -o=json -I=0 '.'
+{"a":[{"k :":null},"x"]}             # agrees with yq
+```
+
+YAML 1.2 §7.3.3 says the opposite — `ns-plain-char` excludes a `:` followed by a
+`c-flow-indicator`, so the colon is the value indicator and the key is just `k`. The visible
+cost is spec example 7.3, corpus case `FRK4`:
+
+```
+$ printf '{\n  ? foo :,\n  : bar,\n}\n' | succinctly yq -o=json -I=0 '.'
+{"foo :":null,"":"bar"}              # spec: key is `foo`; yq: rejects the document
+```
+
+`yq` rejects `FRK4` outright, so there is no `yq` answer to agree with there — only the rule
+it applies everywhere else. `FRK4` is a *parses-only* corpus case (`json: null`), so it still
+passes and the known-failures manifest cannot notice the change:
+`test_yaml_flow_explicit_key_colon_before_a_flow_indicator_is_content` in
+`tests/yq_cli_tests.rs` is the only guard.
+
+The same change made `? ` a node marker in flow mappings rather than key text — `{? k : v}`
+used to key on `? k` — and stopped a space before a line break from aborting the key scan, so
+`[? k \n  x : v]` now reads the same as `[? k\n  x : v]`. Both of those are plain bug fixes
+that move toward `yq` *and* the spec together.
+
 ## Why not wrap an existing parser?
 
 Issue [#49](https://github.com/rust-works/succinctly/issues/49) raised the option of using

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3222,6 +3222,15 @@ impl<'a> Parser<'a> {
 
     /// Parse an explicit unquoted key in flow context.
     /// Stops at `: ` (colon followed by whitespace) or flow delimiters, but NOT at bare `:`.
+    ///
+    /// A `:` ends the key only when a blank, a line break or end-of-input follows it.
+    /// `:` before a flow indicator (`,`, `}`, `]`) is ordinary key content and the scan
+    /// stops at the indicator instead, so `[? k :, x]` keys on `k :`. That is `yq`'s
+    /// rule, and it is a **deliberate divergence from YAML 1.2 §7.3.3**, under which the
+    /// colon would be the value indicator and the key just `k` — see spec example 7.3
+    /// (corpus case FRK4), which `yq` rejects outright. Chosen for `yq` agreement in
+    /// #402; `test_yaml_flow_explicit_key_colon_before_a_flow_indicator_is_content` is
+    /// the only guard, since FRK4 is a parses-only corpus case.
     fn parse_explicit_flow_unquoted_key(&mut self) -> Result<usize, YamlError> {
         // #369: the `? key : value` form in flow context is a fourth way to
         // reach a plain scalar at node start.
@@ -3233,12 +3242,11 @@ impl<'a> Parser<'a> {
             match b {
                 b',' | b'}' | b']' => break,
                 b':' => {
-                    // Only stop at `: ` or `:\n` or `:` at end
+                    // Only stop at `: ` or `:\n` or `:` at end. A flow indicator after
+                    // the colon does *not* stop the key (#402) — `,`/`}`/`]` end it on
+                    // their own arm, one byte later, with the colon kept.
                     let next = self.peek_at(1);
-                    if matches!(
-                        next,
-                        Some(b' ' | b'\t' | b'\n' | b'\r' | b',' | b'}' | b']') | None
-                    ) {
+                    if matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
                         break;
                     }
                     // Colon not followed by space - include it in the key
@@ -3269,14 +3277,9 @@ impl<'a> Parser<'a> {
                         // Explicit value indicator - stop key here
                         break;
                     }
-                    // Check for single `:` followed by flow delimiter
-                    if lookahead < self.input.len()
-                        && self.input[lookahead] == b':'
-                        && (lookahead + 1 >= self.input.len()
-                            || matches!(self.input[lookahead + 1], b',' | b'}' | b']'))
-                    {
-                        break;
-                    }
+                    // A `:` before a flow indicator on the next line is *not* a value
+                    // indicator — the key continues onto that line and keeps the colon,
+                    // so `[? k\n  :, x]` keys on `k :` (#402).
                     // Continue parsing on next line
                     self.advance(); // Skip newline char(s)
                     if self.peek() == Some(b'\n') {
@@ -3298,16 +3301,15 @@ impl<'a> Parser<'a> {
                     if lookahead < self.input.len() {
                         match self.input[lookahead] {
                             b':' => {
-                                // Check if colon is followed by space/end
+                                // Check if colon is followed by space/end. A flow
+                                // indicator after it keeps the key going (#402).
                                 let after_colon = if lookahead + 1 < self.input.len() {
                                     Some(self.input[lookahead + 1])
                                 } else {
                                     None
                                 };
-                                if matches!(
-                                    after_colon,
-                                    Some(b' ' | b'\t' | b'\n' | b'\r' | b',' | b'}' | b']') | None
-                                ) {
+                                if matches!(after_colon, Some(b' ' | b'\t' | b'\n' | b'\r') | None)
+                                {
                                     // Whitespace before `: ` - stop here
                                     break;
                                 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2545,24 +2545,18 @@ impl<'a> Parser<'a> {
             && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None)
     }
 
-    /// Parse an explicit mapping entry in flow context: `? key : value`
-    /// Creates a single-pair mapping as the sequence element.
-    fn parse_explicit_flow_mapping_entry(&mut self) -> Result<(), YamlError> {
-        // Open implicit mapping
-        self.set_ib();
-        self.write_bp_open();
-        self.write_ty(false); // 0 = mapping
-
-        // Skip `?`
-        self.advance();
-        self.skip_flow_whitespace();
-
-        // Parse key - can be scalar, quoted, flow mapping, or flow sequence
-        self.set_ib();
-        self.write_bp_open();
+    /// Parse the key node of an explicit flow entry, with the `? ` indicator already
+    /// consumed and the key's BP node already open.
+    ///
+    /// Records the key's own text end. Nested flow containers open and end BP nodes of
+    /// their own, so none is recorded for them — doing so would clobber the innermost
+    /// of them (#332).
+    ///
+    /// One definition for the flow-sequence and flow-mapping sites. They were separate
+    /// and diverged: the mapping one planted the interest bit on the `?` *before*
+    /// consuming it, folding the indicator and its space into the key text (#402).
+    fn parse_explicit_flow_key_node(&mut self) -> Result<(), YamlError> {
         match self.peek() {
-            // Nested flow containers open their own BP nodes and need no end of their
-            // own; recording one here would clobber the innermost of them (#332).
             Some(b'{') => {
                 self.parse_flow_mapping()?;
             }
@@ -2583,6 +2577,25 @@ impl<'a> Parser<'a> {
                 self.set_bp_text_end(key_end);
             }
         }
+        Ok(())
+    }
+
+    /// Parse an explicit mapping entry in flow context: `? key : value`
+    /// Creates a single-pair mapping as the sequence element.
+    fn parse_explicit_flow_mapping_entry(&mut self) -> Result<(), YamlError> {
+        // Open implicit mapping
+        self.set_ib();
+        self.write_bp_open();
+        self.write_ty(false); // 0 = mapping
+
+        // Skip `?`
+        self.advance();
+        self.skip_flow_whitespace();
+
+        // Parse key - can be scalar, quoted, flow mapping, or flow sequence
+        self.set_ib();
+        self.write_bp_open();
+        self.parse_explicit_flow_key_node()?;
         self.write_bp_close();
 
         // Skip whitespace before possible colon
@@ -2852,12 +2865,25 @@ impl<'a> Parser<'a> {
             }
             first = false;
 
+            // `? ` is a node marker, not key text: consume it *before* the interest bit
+            // is planted, or the indicator and the space after it land inside the key's
+            // span. The flow-sequence path has always done it in this order (#402).
+            let explicit = self.looks_like_explicit_flow_key();
+            if explicit {
+                self.advance();
+                self.skip_flow_whitespace();
+            }
+
             // Parse key
             self.set_ib();
             self.write_bp_open();
-            // A complex key (a nested flow container) opened its own BP nodes and carries
-            // its own end; recording one here would clobber the innermost of them (#332).
-            if !self.parse_flow_key()? {
+            if explicit {
+                // Records its own end, or none at all for a nested flow container.
+                self.parse_explicit_flow_key_node()?;
+            } else if !self.parse_flow_key()? {
+                // A complex key (a nested flow container) opened its own BP nodes and
+                // carries its own end; recording one here would clobber the innermost of
+                // them (#332).
                 self.set_bp_text_end(self.pos);
             }
             self.write_bp_close();
@@ -2928,8 +2954,12 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    /// Parse a key in flow context.
+    /// Parse an *implicit* key in flow context.
     /// Keys can be scalars, flow sequences, or flow mappings (complex keys).
+    ///
+    /// The explicit `? key` form is not handled here: its indicator has to be consumed
+    /// before the caller plants the key's interest bit, so the caller dispatches it to
+    /// [`Self::parse_explicit_flow_key_node`] instead (#402).
     ///
     /// Returns `true` when the key opened BP nodes of its own — a nested flow container.
     /// The caller must **not** record an end position in that case — see
@@ -2942,37 +2972,6 @@ impl<'a> Parser<'a> {
         if self.peek() == Some(b'&') {
             self.record_key_anchor()?;
             self.skip_flow_whitespace();
-        }
-
-        // Check for explicit key indicator
-        if self.looks_like_explicit_flow_key() {
-            // Skip `?`
-            self.advance();
-            self.skip_flow_whitespace();
-            // Parse the actual key
-            match self.peek() {
-                Some(b'"') => {
-                    self.parse_double_quoted()?;
-                }
-                Some(b'\'') => {
-                    self.parse_single_quoted()?;
-                }
-                Some(b'[') => {
-                    self.parse_flow_sequence()?;
-                    return Ok(true);
-                }
-                Some(b'{') => {
-                    self.parse_flow_mapping()?;
-                    return Ok(true);
-                }
-                Some(b':' | b',' | b'}') => {
-                    // Empty key (null) - don't consume anything
-                }
-                _ => {
-                    self.parse_explicit_flow_unquoted_key()?;
-                }
-            }
-            return Ok(false);
         }
 
         match self.peek() {

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3318,12 +3318,13 @@ impl<'a> Parser<'a> {
                                 // Whitespace before delimiter - stop here
                                 break;
                             }
-                            b'\n' | b'\r' => {
-                                // Newline - check next line
-                                break;
-                            }
                             _ => {
-                                // Continue with the key
+                                // Continue with the key. A line break lands here too:
+                                // walking the blanks hands the decision to the `\n`/`\r`
+                                // arm, which is the one that knows whether the next line
+                                // continues the key. Stopping here instead made a space
+                                // before the break abort the parse — `[? k \n  x : v]`
+                                // errored while `[? k\n  x : v]` was fine (#402).
                                 self.advance();
                             }
                         }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1180,6 +1180,29 @@ fn test_yaml_explicit_flow_key_scalar_shapes() -> Result<()> {
             "a: [? k\n  , x]\n",
             r#"{"a":[{"k":null},"x"]}"#,
         ),
+        // #402. A space before the break used to abort the parse outright
+        // ("unexpected character 'x'") while the same input without it parsed.
+        // Folding drops the trailing space, so both give the one key.
+        (
+            "space before a continued line",
+            "a: [? k \n  x : v]\n",
+            r#"{"a":[{"k x":"v"}]}"#,
+        ),
+        (
+            "tab before a continued line",
+            "a: [? k\t\n  x : v]\n",
+            r#"{"a":[{"k x":"v"}]}"#,
+        ),
+        (
+            "space before a continued line, no value",
+            "a: [? k \n  x]\n",
+            r#"{"a":[{"k x":null}]}"#,
+        ),
+        (
+            "space before a continued line, in a mapping",
+            "a: {? k \n  x : v}\n",
+            r#"{"a":{"k x":"v"}}"#,
+        ),
     ] {
         let (stdout, exit_code) = run_yq_stdin(".", input, &["-o", "json", "-I", "0"])?;
         assert_eq!(exit_code, 0, "{name}: should parse cleanly");
@@ -1329,6 +1352,7 @@ fn test_yaml_explicit_flow_key_agrees_across_positions() -> Result<()> {
         ("double-quoted", "\"k\" : v", r#"{"k":"v"}"#),
         ("single-quoted", "'k' : v", r#"{"k":"v"}"#),
         ("embedded colon", "a:b : v", r#"{"a:b":"v"}"#),
+        ("continued line", "k \n  x : v", r#"{"k x":"v"}"#),
     ] {
         let (in_mapping, code) = run_yq_stdin(
             ".a",

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1040,6 +1040,9 @@ fn test_yaml_flow_context_rejects_tags_like_block_context() -> Result<()> {
         ("seq item with a plain sibling", "a: [!custom x, plain]\n"),
         ("implicit entry key in a seq", "a: [!!str k: v]\n"),
         ("explicit key", "a: [? !!str k : v]\n"),
+        // #402 routed the flow *mapping*'s explicit key through the same reader.
+        // Without this the gate could be dropped from that path unnoticed.
+        ("explicit key in a mapping", "a: {? !!str k : v}\n"),
     ] {
         let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".", input, &[])?;
         assert_eq!(exit_code, 1, "{name}: expected clean error exit: {stderr}");
@@ -1251,6 +1254,130 @@ fn test_yaml_anchor_on_null_explicit_value_resolves_to_null() -> Result<()> {
     let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
     assert_eq!(exit_code, 0);
     assert_eq!(output.trim(), r#"{"e":null,"z":null}"#);
+    Ok(())
+}
+
+// =============================================================================
+// Explicit keys in flow mappings (#402) - `{? k : v}` keys on `k`, not on `? k`.
+// Expectations are mikefarah/yq v4.53.3 output.
+// =============================================================================
+
+#[test]
+fn test_yaml_explicit_flow_mapping_key_drops_the_indicator() -> Result<()> {
+    // `? ` is a node marker, not key text. The flow *sequence* path consumed it
+    // before marking the key's start; the flow *mapping* path planted the
+    // interest bit on the `?` first, so the indicator and the space after it
+    // ended up inside the key string — `{"? k":"v"}`. Silently wrong data, the
+    // same failure mode as #339 (block context) and #369 (flow tags).
+    for (name, input, expected) in [
+        ("plain key", "a: {? k : v}\n", r#"{"a":{"k":"v"}}"#),
+        ("no value", "a: {? k}\n", r#"{"a":{"k":null}}"#),
+        // The quoted arms: every input that reached them exhibited the bug, so
+        // they were the last uncovered lines of the explicit branch.
+        (
+            "double-quoted key",
+            "a: {? \"k\" : v}\n",
+            r#"{"a":{"k":"v"}}"#,
+        ),
+        (
+            "single-quoted key",
+            "a: {? 'k' : v}\n",
+            r#"{"a":{"k":"v"}}"#,
+        ),
+        ("embedded colon", "a: {? a:b : v}\n", r#"{"a":{"a:b":"v"}}"#),
+        ("empty key", "a: {? : v}\n", r#"{"a":{"":"v"}}"#),
+        (
+            "empty key, no value",
+            "a: {? , b: 1}\n",
+            r#"{"a":{"":null,"b":1}}"#,
+        ),
+        ("empty key at the brace", "a: {? }\n", r#"{"a":{"":null}}"#),
+        (
+            "two explicit entries",
+            "a: {? k : v, ? j : w}\n",
+            r#"{"a":{"k":"v","j":"w"}}"#,
+        ),
+        (
+            "after an implicit entry",
+            "a: {x: 1, ? k : v}\n",
+            r#"{"a":{"x":1,"k":"v"}}"#,
+        ),
+        // The anchor is stripped when the key is read, as in the sequence form.
+        ("anchored key", "a: {? &n k : v}\n", r#"{"a":{"k":"v"}}"#),
+        // Complex keys open their own BP nodes; yq renders them as "" in JSON.
+        ("sequence key", "a: {? [1,2] : v}\n", r#"{"a":{"":"v"}}"#),
+        ("mapping key", "a: {? {x: 1} : v}\n", r#"{"a":{"":"v"}}"#),
+    ] {
+        let (stdout, exit_code) = run_yq_stdin(".", input, &["-o", "json", "-I", "0"])?;
+        assert_eq!(exit_code, 0, "{name}: should parse cleanly");
+        assert_eq!(stdout.trim(), expected, "{name}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_yaml_explicit_flow_key_agrees_across_positions() -> Result<()> {
+    // The fix is "one definition of `? key`, shared by both flow containers",
+    // so the two call sites must agree. They diverged before precisely because
+    // there were two copies of the dispatch — only the sequence one was right.
+    //
+    // Comparing the entries themselves rather than whole documents: `.a` in a
+    // mapping and `.a[0]` in a sequence are the same single-pair mapping.
+    for (name, shape, expected) in [
+        ("plain", "k : v", r#"{"k":"v"}"#),
+        ("no value", "k", r#"{"k":null}"#),
+        ("double-quoted", "\"k\" : v", r#"{"k":"v"}"#),
+        ("single-quoted", "'k' : v", r#"{"k":"v"}"#),
+        ("embedded colon", "a:b : v", r#"{"a:b":"v"}"#),
+    ] {
+        let (in_mapping, code) = run_yq_stdin(
+            ".a",
+            &format!("a: {{? {shape}}}\n"),
+            &["-o", "json", "-I", "0"],
+        )?;
+        assert_eq!(code, 0, "{name}: mapping form should parse");
+        let (in_sequence, code) = run_yq_stdin(
+            ".a[0]",
+            &format!("a: [? {shape}]\n"),
+            &["-o", "json", "-I", "0"],
+        )?;
+        assert_eq!(code, 0, "{name}: sequence form should parse");
+
+        assert_eq!(
+            in_mapping.trim(),
+            in_sequence.trim(),
+            "{name}: the two call sites disagree"
+        );
+        assert_eq!(in_mapping.trim(), expected, "{name}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_yaml_flow_question_mark_without_a_space_is_content() -> Result<()> {
+    // The boundary the fix must not cross. `?` is an indicator only when
+    // whitespace or end-of-input follows it; otherwise it starts no node and is
+    // ordinary scalar text. If one of these starts losing the `?`, the check
+    // moved from "node begins with an explicit-key indicator" to "node contains
+    // a `?`".
+    //
+    // The first two are yq v4.53.3 output. The third is not: yq rejects a `?`
+    // inside a flow plain scalar, while the YAML Test Suite says it is content
+    // (JR7V, "Question marks in scalars"), and that corpus case passes. It is
+    // pinned here against the suite, not against yq.
+    for (name, input, expected) in [
+        ("unspaced key", "a: {?k : v}\n", r#"{"a":{"?k":"v"}}"#),
+        ("bare question mark", "a: {?}\n", r#"{"a":{"?":null}}"#),
+        (
+            "inside a plain scalar",
+            "a: [b ? c]\n",
+            r#"{"a":["b ? c"]}"#,
+        ),
+    ] {
+        let (stdout, exit_code) = run_yq_stdin(".", input, &["-o", "json", "-I", "0"])?;
+        assert_eq!(exit_code, 0, "{name}: should parse cleanly");
+        assert_eq!(stdout.trim(), expected, "{name}");
+    }
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1180,6 +1180,34 @@ fn test_yaml_explicit_flow_key_scalar_shapes() -> Result<()> {
             "a: [? k\n  , x]\n",
             r#"{"a":[{"k":null},"x"]}"#,
         ),
+        // #402. A `:` ends the key only before a blank, a break or end of input.
+        // Before a flow indicator it is content, and the scan stops at the
+        // indicator one byte later — so the colon stays in the key.
+        (
+            "colon then comma",
+            "a: [? k :, x]\n",
+            r#"{"a":[{"k :":null},"x"]}"#,
+        ),
+        (
+            "colon then bracket",
+            "a: [? k :]\n",
+            r#"{"a":[{"k :":null}]}"#,
+        ),
+        (
+            "unspaced colon then bracket",
+            "a: [? k:]\n",
+            r#"{"a":[{"k:":null}]}"#,
+        ),
+        (
+            "colon then comma on the next line",
+            "a: [? k\n  :, x]\n",
+            r#"{"a":[{"k :":null},"x"]}"#,
+        ),
+        (
+            "colon then bracket on the next line",
+            "a: [? k\n  :]\n",
+            r#"{"a":[{"k :":null}]}"#,
+        ),
         // #402. A space before the break used to abort the parse outright
         // ("unexpected character 'x'") while the same input without it parsed.
         // Folding drops the trailing space, so both give the one key.
@@ -1352,6 +1380,7 @@ fn test_yaml_explicit_flow_key_agrees_across_positions() -> Result<()> {
         ("double-quoted", "\"k\" : v", r#"{"k":"v"}"#),
         ("single-quoted", "'k' : v", r#"{"k":"v"}"#),
         ("embedded colon", "a:b : v", r#"{"a:b":"v"}"#),
+        ("trailing colon", "k :", r#"{"k :":null}"#),
         ("continued line", "k \n  x : v", r#"{"k x":"v"}"#),
     ] {
         let (in_mapping, code) = run_yq_stdin(
@@ -1402,6 +1431,31 @@ fn test_yaml_flow_question_mark_without_a_space_is_content() -> Result<()> {
         assert_eq!(exit_code, 0, "{name}: should parse cleanly");
         assert_eq!(stdout.trim(), expected, "{name}");
     }
+    Ok(())
+}
+
+#[test]
+fn test_yaml_flow_explicit_key_colon_before_a_flow_indicator_is_content() -> Result<()> {
+    // A deliberate divergence from YAML 1.2, pinned here because nothing else
+    // can catch it moving.
+    //
+    // In an explicit flow key, `:` ends the key only before a blank, a break or
+    // end of input; before a flow indicator it is content. That is yq's rule
+    // (see `test_yaml_explicit_flow_key_scalar_shapes`), and it contradicts
+    // §7.3.3, under which `:` before `,`/`}`/`]` is the value indicator.
+    //
+    // The visible cost is spec example 7.3, YAML Test Suite case FRK4, whose
+    // first key the spec reads as `foo` and we now read as `foo :`. yq rejects
+    // that document outright, so there is no yq answer to agree with. FRK4 is a
+    // parses-only corpus case (`json: null`), so `yaml_test_suite`'s manifest
+    // will not notice the change — this assertion is the only guard. #402.
+    let (stdout, exit_code) = run_yq_stdin(
+        ".",
+        "{\n  ? foo :,\n  : bar,\n}\n",
+        &["-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(exit_code, 0, "FRK4 must still parse");
+    assert_eq!(stdout.trim(), r#"{"foo :":null,"":"bar"}"#);
     Ok(())
 }
 


### PR DESCRIPTION
## Description

This PR fixes multiple issues with explicit flow key parsing in YAML, specifically addressing the incorrect handling of the `? ` indicator in flow mappings and flow sequences, as well as related edge cases with whitespace and colons.

The root cause was that explicit flow key parsing existed in two separate code paths (one for sequences, one for mappings) that had diverged. The mapping path was planting the interest bit before consuming the `? ` indicator, causing the indicator and following space to be included in the key text. For example, `{? k : v}` was incorrectly keyed on `"? k"` instead of `"k"`.

These fixes consolidate the parsing logic and bring the implementation into alignment with `yq` v4.53.3 behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #402 - YAML flow mapping folds the explicit key indicator into the key text

## Changes Made

**Core Fixes:**
- Added `parse_explicit_flow_key_node()` method to consolidate explicit flow key parsing logic shared by both flow sequences and flow mappings, eliminating code duplication
- Modified `parse_explicit_flow_mapping_entry()` to consume the `? ` indicator **before** planting the interest bit, ensuring the indicator is not included in the key's text span
- Updated `parse_flow_mapping_inner()` to check for explicit keys and consume the `? ` indicator before key parsing begins
- Removed the unreachable explicit key handling from `parse_flow_key()` since explicit keys are now dispatched to `parse_explicit_flow_key_node()`
- Fixed `parse_explicit_flow_unquoted_key()` to allow spaces before line breaks to continue the key (folding behavior)
- Modified colon handling in explicit flow keys so that `:` only ends the key when followed by whitespace, line break, or end-of-input; before flow indicators (`,`, `}`, `]`) the colon is treated as key content

**Test Coverage:**
- Added `test_yaml_explicit_flow_mapping_key_drops_the_indicator()` covering plain keys, quoted keys, empty keys, anchored keys, and complex keys in flow mappings
- Added `test_yaml_explicit_flow_key_agrees_across_positions()` to verify that explicit key parsing produces identical results in both flow sequence and flow mapping contexts
- Added `test_yaml_flow_question_mark_without_a_space_is_content()` to validate that `?` without following whitespace is treated as ordinary scalar content
- Added whitespace continuation tests in `test_yaml_explicit_flow_key_scalar_shapes()` covering spaces and tabs before line breaks
- Added colon handling tests covering colons before flow indicators in both sequence and mapping contexts
- Added `test_yaml_flow_explicit_key_colon_before_a_flow_indicator_is_content()` as a guard against the intentional YAML 1.2 divergence in FRK4 handling

**Documentation:**
- Updated `docs/compliance/yaml/limitations.md` with a new section documenting the FRK4 divergence and explaining why explicit flow keys treat `:` before flow indicators as content rather than value indicators, matching `yq` behavior over YAML 1.2 §7.3.3

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality covering:
  - Plain and quoted explicit flow keys
  - Empty keys and missing values
  - Anchored and complex keys
  - Whitespace and line break handling in keys
  - Colon behavior before flow indicators
  - Agreement between sequence and mapping forms

**Manual Testing:**
- [x] Tested on x86_64
- [x] Verified flow mapping explicit keys: `{? k : v}` correctly keys on `k`
- [x] Verified flow sequence explicit keys: `[? k : v]` correctly keys on `k`
- [x] Verified whitespace before breaks: `[? k \n  x : v]` parses as `{"k x":"v"}`
- [x] Verified colon handling: `[? k :, x]` keys on `k :`
- [x] Verified edge cases: empty keys, quoted keys, nested containers, anchored keys

### Test Commands
```bash
cargo test yaml
cargo test explicit_flow
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

These changes consolidate parsing logic (removing duplication) and slightly reduce branching complexity.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Implementation Details:**
- The fix required three commits to address the issue comprehensively:
  1. Consolidate explicit flow key parsing and fix the `? ` indicator issue in mappings
  2. Fix whitespace before line breaks in explicit keys
  3. Fix colon handling before flow indicators and document the YAML 1.2 divergence

**Design Decision:**
The PR intentionally diverges from YAML 1.2 §7.3.3 in one case (FRK4) to maintain agreement with `yq`'s interpretation of colons before flow indicators in explicit flow keys. This is documented in `limitations.md` with a reference to the test case that guards against regression.

**Related Issues:**
This PR also relates to previous fixes in #339 (block context) and #369 (flow context tags), which had similar issues with incorrectly including markers in key text. All three issues stem from the same root cause: processing node markers before planting the interest bit.