### PR TITLE
ci: exclude vigna.di.unimi.it from link checker

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -62,6 +62,7 @@ jobs:
             --exclude '^https://doi\.org/'
             --exclude '^https://no-color\.org/'
             --exclude '^https://www\.reddit\.com/'
+            --exclude '^https://vigna\.di\.unimi\.it/'
             '**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,6 +97,7 @@ jobs:
             --exclude '^https://doi\.org/'
             --exclude '^https://no-color\.org/'
             --exclude '^https://www\.reddit\.com/'
+            --exclude '^https://vigna\.di\.unimi\.it/'
             '**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR fixes flaky CI link validation failures by excluding the `vigna.di.unimi.it` domain from the GitHub link checker. The Broadword.pdf paper link hosted on this domain times out during CI workflows, causing intermittent test failures. The fix adds exclusion rules to the link validation workflow to prevent these timeout-related failures.

## Type of Change
- [x] CI/CD changes

## Changes Made

**Workflow Configuration:**
- Added `--exclude '^https://vigna\.di\.unimi\.it/'` pattern to the link checker in `.github/workflows/links.yml`
- Applied the exclusion in both the pull request and push workflow jobs to ensure consistent behavior across CI runs
- The Broadword.pdf paper references in README.md, docs/index.md, docs/architecture/prior-art.md, and docs/architecture/bitvec.md will no longer trigger link validation timeouts

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Link checker workflow will no longer timeout on vigna.di.unimi.it domain

**Manual Testing:**
- [x] Verified exclusion pattern syntax is correct for lychee link checker
- [x] Confirmed pattern matches the target domain in all documentation files

## Performance Impact
- [x] No performance impact
- Removes intermittent CI delays caused by domain timeouts

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Changes generate no new warnings
- [x] CI workflow modification is minimal and focused

## Additional Notes

The vigna.di.unimi.it domain appears to have intermittent connectivity issues or aggressive rate limiting that causes timeouts during automated link validation. This is a common issue with external academic institution servers. The exclusion is conservative and only targets this specific domain, preserving link validation for all other references.