### PR TITLE
fix(yaml): reject aliases to unknown anchors in the strict validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to a single entry via the owned-value conversion in `to_owned` — a
   separate, still-open gap, not fixed here.)
 
+- **The strict YAML validator accepted an alias to an unknown anchor** (#404):
+  `succinctly yaml validate` passed `a: *nope`, which `yq` rejects with
+  `unknown anchor 'nope' referenced`. Since #372 taught the default loader the
+  same rule, the *opt-in strict* mode had become the laxer of the two — `syq`
+  refused the document while `yaml validate`, documented as the yq-conformance
+  gate, gave it a clean exit 0, so a CI check built on the validator stayed
+  green on input `yq` refuses. The validator now tracks the anchor names a
+  document defines and rejects an alias naming one that is not in scope, in
+  every position an alias can occupy (value, sequence item, implicit key,
+  explicit key, and both flow collections — the flow ones had no anchor/alias
+  handling at all), with a new `YamlValidationErrorKind::UnknownAnchor`.
+
+  Rejecting a `*` first requires knowing it *starts a node* rather than sitting
+  inside a scalar: `a: rm *.tmp` and `a: text` continued by `  *notanalias` are
+  strings, and `yq` loads both. The scanner now tracks where a node can begin —
+  after a `:`/`-`/`?` indicator, after `[`/`{`/`,`/`:` in flow, and at the start
+  of a line that is not the continuation of an open plain scalar — and checks
+  only there. Anchor *registration* stays deliberately permissive, because an
+  extra name can only make the check accept more, never reject valid input: a
+  `&foo` that is really scalar content still satisfies a later `*foo`, as does
+  an anchor the loader declines to record (`&x` alone on a `---` line, #372).
+  Anchor scope is not reset at a document boundary, since `yq` and the loader
+  both resolve an alias against an earlier document's anchor.
+
+  Names now take their extent from `simd::parse_anchor_name`, the definition the
+  loader scans with, rather than the validator's own — which stopped only at
+  whitespace, read `*nope: v`'s name as `nope:`, and so would have rejected the
+  valid `&a: 1` / `b: *a`. See the #106 note in `CLAUDE.md` on predicates that
+  diverge silently.
+
+  The validator remains `no_std`, but now allocates on the success path for a
+  document that defines anchors, whose names it must remember.
+
+  No YAML Test Suite manifest movement, for the reason #372 gives: no case in
+  the suite contains an alias to an anchor that is not in scope.
+
 - **jq's regex builtins and `endswith` kept the pre-#356 wording after #356
   fixed their siblings** (#393): `test("a")` and `startswith("a")` were
   probed and now report jq's sentences, but `match`, `capture`, `scan`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   No YAML Test Suite manifest movement, for the reason #372 gives: no case in
   the suite contains an alias to an anchor that is not in scope.
 
+- **The AVX2 anchor-name scanner treated every `:` as a terminator, truncating
+  names on x86_64** (#453, found while fixing #404's CI): `parse_anchor_name_avx2`
+  (`src/yaml/simd/x86.rs`) is the AVX2 kernel behind `simd::parse_anchor_name`,
+  the function both the loader and, since #404, the strict validator use to
+  compute anchor/alias name extents. It stopped at *every* `:`, unlike the
+  scalar reference and the NEON kernel, which correctly stop only at a `:`
+  followed by whitespace (a bare `:` is a legal anchor-name character). On
+  x86_64 with AVX2, this silently truncated a name of at least ~32 bytes
+  remaining in the buffer that contains such a colon — e.g. the YAML Test
+  Suite's `W5VH` case (`&:@*!$"<foo>: scalar a` / `*:@*!$"<foo>:`) computed an
+  *empty* anchor name instead of its real 11 bytes. This is a pre-existing bug
+  in the already-shipped "P4 Anchor/Alias SIMD" optimization, not something
+  #404 introduced; it went unnoticed because nothing previously compared a
+  registered anchor name against later text by content, which is exactly what
+  #404's new `anchor_in_scope` check does, surfacing the truncation as a false
+  `unknown anchor` rejection on x86_64 only. `parse_anchor_name_avx2` now
+  mirrors the NEON kernel: SIMD flags only whitespace/flow-indicators as
+  definite terminators, and a candidate colon is resolved by checking the
+  actual next byte, falling back to the scalar scanner for the remainder when
+  the colon turns out to be a name character. New differential test
+  `test_parse_anchor_name_avx2_matches_scalar_around_colons` in
+  `src/yaml/simd/x86.rs` pins colon-then-whitespace, colon-then-name-char, a
+  colon run, colon-before-flow-indicator, and a colon crossing a 32-byte chunk
+  boundary against the scalar reference.
+
 - **jq's regex builtins and `endswith` kept the pre-#356 wording after #356
   fixed their siblings** (#393): `test("a")` and `startswith("a")` were
   probed and now report jq's sentences, but `match`, `capture`, `scan`,

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -125,7 +125,10 @@ alias with nothing to resolve to:
   *later* — fails with `YamlError::UnknownAnchor` since
   [#372](https://github.com/rust-works/succinctly/issues/372). YAML 1.2 §7.1 requires an
   alias to name a *previous* anchor, so a miss is invalid input rather than a value, and
-  `yq` reports `unknown anchor 'x' referenced` for the same input.
+  `yq` reports `unknown anchor 'x' referenced` for the same input. The strict validator
+  enforces this too ([#404](https://github.com/rust-works/succinctly/issues/404)); it did
+  not at first, which briefly made the opt-in strict mode *laxer* than the default one for
+  this input.
 
 ```
 $ printf 'a: &x {self: *x}\n' | succinctly yq '.'

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -251,7 +251,9 @@ invalid, it accepts.
   (`|0`, `|10`, `> text`).
 - **Flow collections** — leading/doubled commas, unbalanced or unclosed brackets, bare `-`
   items, document markers inside a flow collection.
-- **Anchors** — an anchor immediately followed by an alias (`&a *b`) or a block indicator.
+- **Anchors & aliases** — an anchor immediately followed by an alias (`&a *b`) or a block
+  indicator; an alias naming an anchor that is not in scope (`a: *nope`), including a forward
+  reference. A `*` that is scalar content rather than a node (`a: rm *.tmp`) is untouched.
 - **Comments** — a `#` not separated from the preceding token by whitespace; a comment
   interrupting a multi-line plain scalar.
 - **Documents & directives** — content after a `...` marker; a `%YAML` directive with no

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -1431,7 +1431,7 @@ mod tests {
         // A colon followed by a flow indicator: the colon rule only checks for
         // whitespace, so the colon is content and the flow indicator (not the
         // colon) is the terminator.
-        for term in [b',', b']', b'}'] {
+        for term in *b",]}" {
             let mut buf = vec![b'a', b':'];
             buf.push(term);
             buf.extend(std::iter::repeat_n(b'a', 61));

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -789,7 +789,12 @@ unsafe fn find_block_scalar_end_sse2(input: &[u8], start: usize, min_indent: usi
 /// Searches for YAML anchor name terminators:
 /// - Whitespace: space, tab, newline, CR
 /// - Flow indicators: [ ] { } ,
-/// - Colons followed by whitespace
+/// - Colons followed by whitespace (a bare `:` is a legal name character,
+///   mirroring [`super::neon::parse_anchor_name_neon`] and
+///   [`parse_anchor_name_scalar`] — see #404's follow-up fix: this function
+///   used to treat every `:` as an unconditional terminator, which shrank an
+///   anchor name like `:@*!$"<foo>` to empty and made an alias to it read as
+///   unresolved).
 ///
 /// Returns the position of the first terminator, or end of input.
 #[target_feature(enable = "avx2")]
@@ -830,7 +835,9 @@ unsafe fn parse_anchor_name_avx2(input: &[u8], start: usize) -> usize {
         let is_comma = _mm256_cmpeq_epi8(chunk, comma);
         let is_colon = _mm256_cmpeq_epi8(chunk, colon);
 
-        // Combine all terminator checks
+        // Whitespace and flow indicators are unconditional terminators. A
+        // colon is only a terminator when the byte after it is whitespace, so
+        // it cannot be decided from this chunk alone — resolve it below.
         let ws = _mm256_or_si256(is_space, is_tab);
         let ws = _mm256_or_si256(ws, is_newline);
         let ws = _mm256_or_si256(ws, is_cr);
@@ -840,15 +847,34 @@ unsafe fn parse_anchor_name_avx2(input: &[u8], start: usize) -> usize {
         let flow = _mm256_or_si256(flow, is_rbrace);
         let flow = _mm256_or_si256(flow, is_comma);
 
-        let terminators = _mm256_or_si256(ws, flow);
-        let terminators = _mm256_or_si256(terminators, is_colon);
+        let definite = _mm256_or_si256(ws, flow);
 
-        let mask = _mm256_movemask_epi8(terminators);
+        let definite_mask = _mm256_movemask_epi8(definite) as u32;
+        let colon_mask = _mm256_movemask_epi8(is_colon) as u32;
+        let combined_mask = definite_mask | colon_mask;
 
-        if mask != 0 {
-            // Found terminator - find first position
-            let offset = mask.trailing_zeros() as usize;
-            return pos + offset;
+        if combined_mask != 0 {
+            let first_pos = combined_mask.trailing_zeros() as usize;
+
+            // A definite terminator at or before the first colon candidate
+            // wins outright — it needs no lookahead.
+            if (definite_mask >> first_pos) & 1 != 0 {
+                return pos + first_pos;
+            }
+
+            // The first candidate is a colon: it terminates only if the very
+            // next byte is whitespace.
+            let colon_pos = pos + first_pos;
+            if colon_pos + 1 < end {
+                if let b' ' | b'\t' | b'\n' | b'\r' = input[colon_pos + 1] {
+                    return colon_pos;
+                }
+            }
+
+            // Not a terminator — the colon is a name character. Hand the rest
+            // of the scan to the scalar version rather than re-deriving the
+            // same colon-lookahead rule in SIMD for every subsequent byte.
+            return parse_anchor_name_scalar(input, colon_pos + 1);
         }
 
         pos += 32;
@@ -1331,5 +1357,109 @@ mod tests {
         let inert = [b'a'; 48];
         let class = classify_yaml_chars(&inert, 0).expect("48 bytes available");
         assert_eq!(class.plain_scalar_terminators(), 0);
+    }
+
+    // ========================================================================
+    // parse_anchor_name AVX2/scalar differential tests (#404 follow-up)
+    // ========================================================================
+
+    /// The AVX2 kernel used to treat every `:` as an unconditional terminator
+    /// (missing the "only when followed by whitespace" rule the doc comment
+    /// itself described), shrinking a name like `:@*!$"<foo>` to empty. Confirmed
+    /// against the YAML Test Suite's W5VH case ("Allowed characters in alias"),
+    /// which the strict validator's alias-scope check (#404) turned into a
+    /// spurious `unknown anchor` rejection on x86_64 only — `parse_anchor_name`
+    /// is shared with the loader (`src/yaml/parser.rs`), so this also risked
+    /// silently breaking real anchor resolution on x86_64 hardware, just never
+    /// observed because typical anchor names don't contain a bare `:`.
+    ///
+    /// Differential against [`parse_anchor_name_scalar`] — the reference both
+    /// this kernel and [`super::neon::parse_anchor_name_neon`] are meant to
+    /// match — over every placement class the colon rule must distinguish:
+    /// colon-then-whitespace (terminates before the colon), colon-then-name-char
+    /// (colon is content, scan continues), a colon run before whitespace, and
+    /// colon-then-flow-indicator (the colon rule only checks for whitespace, so
+    /// the flow indicator terminates and the colon stays in the name). Buffers
+    /// are 64 bytes so every case is reached through the 32-byte AVX2 loop
+    /// rather than its scalar tail, including a colon placed as the last byte of
+    /// the first chunk so the next-byte lookahead crosses the chunk boundary.
+    #[test]
+    fn test_parse_anchor_name_avx2_matches_scalar_around_colons() {
+        if !has_avx2() {
+            return;
+        }
+
+        let case = |input: &[u8], start: usize| {
+            let scalar = parse_anchor_name_scalar(input, start);
+            let avx2 = unsafe { parse_anchor_name_avx2(input, start) };
+            assert_eq!(
+                avx2,
+                scalar,
+                "AVX2/scalar mismatch for {:?} from {start}",
+                String::from_utf8_lossy(input)
+            );
+            avx2
+        };
+
+        // The exact W5VH name, embedded so the colon lands inside the first
+        // 32-byte AVX2 chunk: `:@*!$"<foo>` followed by `: ` (colon-space,
+        // terminates before the colon) then filler.
+        let mut buf = b":@*!$\"<foo>: ".to_vec();
+        buf.extend(std::iter::repeat_n(b'a', 64 - buf.len()));
+        assert_eq!(case(&buf, 0), 11, "name must stop before the `: ` pair");
+
+        // A colon immediately followed by whitespace at the very start.
+        let mut buf = b": ".to_vec();
+        buf.extend(std::iter::repeat_n(b'a', 62));
+        assert_eq!(
+            case(&buf, 0),
+            0,
+            "empty name: `:` is followed by whitespace"
+        );
+
+        // A colon followed by a non-whitespace name character: content, not a
+        // terminator; the scan continues to the real terminator (a space).
+        let mut buf = b"a:b c".to_vec();
+        buf.extend(std::iter::repeat_n(b'a', 59));
+        assert_eq!(case(&buf, 0), 3, "`a:b` is all name; stops at the space");
+
+        // A run of colons before the whitespace that actually terminates.
+        let mut buf = b"foo::: bar".to_vec();
+        buf.extend(std::iter::repeat_n(b'a', 54));
+        assert_eq!(case(&buf, 0), 5, "stops at the colon adjacent to the space");
+
+        // A colon followed by a flow indicator: the colon rule only checks for
+        // whitespace, so the colon is content and the flow indicator (not the
+        // colon) is the terminator.
+        for term in [b',', b']', b'}'] {
+            let mut buf = vec![b'a', b':'];
+            buf.push(term);
+            buf.extend(std::iter::repeat_n(b'a', 61));
+            assert_eq!(
+                case(&buf, 0),
+                2,
+                "colon before {:?} is content; {:?} terminates",
+                term as char,
+                term as char
+            );
+        }
+
+        // A colon as the last byte of the first 32-byte chunk, with the
+        // terminating whitespace as the first byte of the next chunk — the
+        // next-byte check must read across the chunk boundary correctly.
+        let mut buf = vec![b'a'; 31];
+        buf.push(b':');
+        buf.push(b' ');
+        buf.extend(std::iter::repeat_n(b'a', 32));
+        assert_eq!(case(&buf, 0), 31, "boundary-crossing colon-space");
+
+        // The same shape, but the colon is not followed by whitespace across
+        // the boundary: it stays content and scanning continues past it.
+        let mut buf = vec![b'a'; 31];
+        buf.push(b':');
+        buf.push(b'b');
+        buf.push(b' ');
+        buf.extend(std::iter::repeat_n(b'a', 31));
+        assert_eq!(case(&buf, 0), 33, "boundary-crossing colon-then-name-char");
     }
 }

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -1623,6 +1623,36 @@ mod tests {
         assert!(validate(b"---\nseq:\n &anchor\n- a\n- b\n").is_ok()); // SKE5
     }
 
+    /// Issue #404: the unknown-anchor rejection must not take valid input with
+    /// it. Two ways it could: a `*` that is plain-scalar content rather than an
+    /// alias, and an anchor whose definition the scanner fails to register.
+    /// Every case here loads under `yq` v4.53.3 (the goldens' pinned version).
+    #[test]
+    fn accepts_resolvable_aliases_and_stars_in_scalars() {
+        // A `*` inside a scalar is content: `{"a":"text *star"}`.
+        assert!(validate(b"a: text *star\n").is_ok());
+        assert!(validate(b"a: rm *.tmp\n").is_ok());
+        assert!(validate(b"a: what? *star\n").is_ok());
+        // ... including on the continuation line of a multi-line plain scalar,
+        // where the `*` opens the line: `{"a":"text *notanalias"}`.
+        assert!(validate(b"a: text\n  *notanalias\n").is_ok());
+        assert!(validate(b"a:\n  text\n  *notanalias\n").is_ok());
+        assert!(validate(b"root\n*notanalias\n").is_ok()); // "root *notanalias"
+        assert!(validate(b"a: text &amp more\n").is_ok());
+        // An anchor defined before the alias, in each position defining one.
+        assert!(validate(b"a: &x 1\nb: *x\n").is_ok());
+        assert!(validate(b"- &x 1\n- *x\n").is_ok());
+        assert!(validate(b"a: [&x 1, *x]\n").is_ok());
+        assert!(validate(b"a: {k: &x 1, j: *x}\n").is_ok());
+        assert!(validate(b"? &x k\n: *x\n").is_ok());
+        // The name ends at a `: ` value indicator, as the loader's scan does —
+        // registering `a:` here would reject the alias below.
+        assert!(validate(b"&a: 1\nb: *a\n").is_ok());
+        // Anchors carry across documents for `yq` and for the loader, so an
+        // alias to an earlier document's anchor is not an unresolved one.
+        assert!(validate(b"a: &x 1\n---\nb: *x\n").is_ok());
+    }
+
     /// Issue #328: every shape the loader now handles must also pass the
     /// validator, or `syq --validate` would reject documents `syq` reads fine.
     ///
@@ -1879,6 +1909,51 @@ mod tests {
         )); // SY6V
     }
 
+    /// Issue #404: an alias naming an anchor that is not in scope. `yq` v4.53.3
+    /// rejects every case below with `unknown anchor 'nope' referenced`, and
+    /// `yaml validate` is documented as the yq-conformance gate, so accepting
+    /// them left a CI check green on input `yq` refuses.
+    ///
+    /// Table-driven over the positions an alias can occupy — a value, a
+    /// sequence item, an explicit key, an implicit key, and both flow
+    /// collections — because they reach the check through different scanners
+    /// (`scan_content_tokens` and `scan_flow`), and a position added later that
+    /// forgets to check fails here. The position is asserted too: reporting
+    /// some other plausible offset would still pass a kind-only assertion.
+    #[test]
+    fn rejects_alias_to_unknown_anchor() {
+        for input in [
+            &b"a: *nope\n"[..],
+            b"- *nope\n",
+            b"? *nope\n: v\n",
+            b"*nope: v\n",
+            b"a: [*nope]\n",
+            b"a: {k: *nope}\n",
+            b"[*nope]\n",
+            b"a: &x 1\nb: [1, *nope]\n",
+        ] {
+            let err = validate(input).unwrap_err();
+            let shown = String::from_utf8_lossy(input);
+            assert!(
+                matches!(&err.kind, UnknownAnchor { name } if name == "nope"),
+                "{shown:?}: {:?}",
+                err.kind
+            );
+            assert_eq!(
+                input.get(err.position.offset),
+                Some(&b'*'),
+                "{shown:?}: error should point at the alias sigil, not {:?}",
+                err.position
+            );
+        }
+        // A forward reference: the anchor exists, but not yet. YAML 1.2 §7.1
+        // requires an alias to name a *previous* anchor.
+        assert!(matches!(
+            kind(b"a: *x\nb: &x 5\n"),
+            UnknownAnchor { name } if name == "x"
+        ));
+    }
+
     #[test]
     fn rejects_document_and_directive_errors() {
         assert!(matches!(
@@ -1954,6 +2029,9 @@ mod tests {
             TabInIndentation,
             AnchorOnAlias,
             MisplacedAnchor,
+            UnknownAnchor {
+                name: "nope".into(),
+            },
             ContentAfterDocumentEnd,
             MisplacedDirective,
             InvalidDirective,

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -7,8 +7,10 @@
 //! *before* indexing, that rejects invalid YAML. The default indexing path does
 //! not link it and is structurally incapable of regressing because of it.
 //!
-//! Like the JSON validator this is a plain scalar scanner — `no_std`, with no
-//! allocation on the success path. It is **not** a full YAML grammar checker:
+//! Like the JSON validator this is a plain scalar scanner — `no_std`, and it
+//! allocates on the success path only for a document that defines anchors,
+//! whose names it must remember to resolve later aliases (#404). It is **not**
+//! a full YAML grammar checker:
 //! it walks the document permissively and rejects only the specific classes of
 //! malformed input enumerated in issue #223 (the YAML Test Suite's `lax:*`
 //! cases). Everything it does not recognize as invalid, it accepts — the same
@@ -25,6 +27,8 @@
 //! assert!(validate(b"a: b: c\n").is_err()); // nested mapping key
 //! ```
 
+use alloc::string::String;
+use alloc::vec::Vec;
 use core::fmt;
 
 use super::line_break::{is_line_break, line_break_len};
@@ -105,6 +109,19 @@ pub enum YamlValidationErrorKind {
     AnchorOnAlias,
     /// An anchor was placed where it cannot bind to a following node.
     MisplacedAnchor,
+    /// An alias named an anchor that is not in scope (`a: *nope`), including a
+    /// forward reference — YAML 1.2 §7.1 requires an alias to name a *previous*
+    /// anchor, and `yq` rejects every such alias with
+    /// `unknown anchor 'nope' referenced`.
+    ///
+    /// The lenient loader rejects this too ([`YamlError::UnknownAnchor`], #372);
+    /// without this kind the *strict* validator was the laxer of the two (#404).
+    ///
+    /// [`YamlError::UnknownAnchor`]: super::YamlError::UnknownAnchor
+    UnknownAnchor {
+        /// The referenced anchor name.
+        name: String,
+    },
 
     // --- Documents / directives ---
     /// Non-comment content followed a `...` document-end marker on its line.
@@ -178,6 +195,7 @@ impl fmt::Display for YamlValidationErrorKind {
             }
             Self::AnchorOnAlias => write!(f, "anchor immediately followed by an alias"),
             Self::MisplacedAnchor => write!(f, "misplaced anchor"),
+            Self::UnknownAnchor { name } => write!(f, "unknown anchor '{name}' referenced"),
             Self::ContentAfterDocumentEnd => {
                 write!(f, "content after document-end marker '...'")
             }
@@ -283,6 +301,25 @@ pub struct Validator<'a> {
     /// A root plain scalar was closed by a trailing comment; any further content
     /// in the same document is a second root node (BS4K, EB22).
     root_scalar_done: bool,
+    /// Byte spans of the anchor names defined so far, so an alias can be checked
+    /// against them (#404). Empty — and unallocated — until the first anchor.
+    ///
+    /// Deliberately *not* cleared at a document boundary: `yq` resolves an alias
+    /// against an anchor defined in an earlier document of the same stream
+    /// (`a: &x 1\n---\nb: *x` loads), and the loader's anchor table is not
+    /// cleared either, so clearing here would reject input both accept.
+    anchors: Vec<(usize, usize)>,
+    /// True while the cursor sits where a node may begin, so a `*` there is an
+    /// alias rather than plain-scalar content (`a: text *star` is the string
+    /// `text *star`). Only meaningful during [`Self::scan_content_tokens`].
+    at_node_start: bool,
+    /// The previous content line ended inside plain-scalar content, so a
+    /// following scalar line at or past its indentation continues that scalar
+    /// rather than starting a node.
+    prev_line_open_plain: bool,
+    /// Indentation of the previous content line, paired with
+    /// [`Self::prev_line_open_plain`].
+    prev_line_indent: usize,
 }
 
 impl<'a> Validator<'a> {
@@ -304,6 +341,10 @@ impl<'a> Validator<'a> {
             frame_len: 0,
             line_had_comment: false,
             root_scalar_done: false,
+            anchors: Vec::new(),
+            at_node_start: true,
+            prev_line_open_plain: false,
+            prev_line_indent: 0,
         }
     }
 
@@ -732,6 +773,8 @@ impl<'a> Validator<'a> {
             self.root_kind = None;
             self.root_scalar_done = false;
             self.frame_len = 0;
+            // A marker closes any open plain scalar; the next line starts a node.
+            self.prev_line_open_plain = false;
             Ok(())
         } else {
             // `---` document start; a document root node may follow on this line.
@@ -744,13 +787,43 @@ impl<'a> Validator<'a> {
             self.root_kind = None;
             self.root_scalar_done = false;
             self.frame_len = 0;
+            self.prev_line_open_plain = false;
             self.scan_content_line()
         }
     }
 
     /// Scan the significant content of a line (after leading indent), consuming
     /// scalars, flow collections, and comments to the line break.
+    ///
+    /// Wraps [`Self::scan_content_tokens`] with the cross-line bookkeeping that
+    /// tells a node from the continuation of the previous line's plain scalar
+    /// (#404), so both call sites — a plain line and `--- x` — get it.
     fn scan_content_line(&mut self) -> Result<(), YamlValidationError> {
+        self.at_node_start = !self.continues_plain_scalar();
+        let result = self.scan_content_tokens();
+        // A line that ended inside plain content may be continued by the next;
+        // a trailing comment closes the scalar, so it cannot be.
+        self.prev_line_open_plain = !self.at_node_start && !self.line_had_comment;
+        self.prev_line_indent = self.line_indent;
+        result
+    }
+
+    /// True if this line continues the previous line's plain scalar rather than
+    /// starting a node, so a leading `*` is scalar content — `a: text\n  *x` is
+    /// the string `text *x`, and `root\n*x` is `root *x`.
+    ///
+    /// A continuation is a scalar line at or past the open scalar's
+    /// indentation. A `-`/`?`/`:` indicator or a `: ` value indicator makes the
+    /// line a node instead ([`Self::line_kind`] reports those as `Seq`/`Map`),
+    /// which is what keeps an alias key (`*nope: v`) checked.
+    fn continues_plain_scalar(&self) -> bool {
+        self.prev_line_open_plain
+            && self.line_indent >= self.prev_line_indent
+            && self.line_kind() == LineKind::Scalar
+    }
+
+    /// Walk one content line's tokens. See [`Self::scan_content_line`].
+    fn scan_content_tokens(&mut self) -> Result<(), YamlValidationError> {
         // A tab used as indentation between block indicators (Y79Y/004-009).
         if self.tab_between_indicators() {
             return Err(self.error(YamlValidationErrorKind::TabInIndentation));
@@ -773,16 +846,24 @@ impl<'a> Validator<'a> {
                     self.consume_line_break();
                     return Ok(());
                 }
+                // An anchor is a property, not a node: whatever follows it still
+                // begins one, so `at_node_start` carries through.
                 Some(b'&') if self.at_quote_start() => {
                     suppress_nested = true;
                     self.scan_anchor()?;
                 }
                 Some(b'*') if self.at_quote_start() => {
                     suppress_nested = true;
-                    self.scan_anchor_name();
+                    self.scan_alias(self.at_node_start)?;
+                    self.at_node_start = false;
                 }
                 Some(b'?') => {
                     suppress_nested = true;
+                    // An explicit key indicator opens a node. A `?` inside a
+                    // scalar does not, even when a space follows it — the
+                    // `*star` in `a: what? *star` is content.
+                    self.at_node_start = self.at_node_start
+                        && matches!(self.peek_at(1), None | Some(b' ' | b'\t' | b'\n' | b'\r'));
                     self.advance();
                 }
                 Some(b'"') if self.at_quote_start() => {
@@ -795,6 +876,7 @@ impl<'a> Validator<'a> {
                     };
                     let multiline = self.scan_double_quoted(min)?;
                     self.check_after_block_quoted(multiline)?;
+                    self.at_node_start = false;
                 }
                 Some(b'\'') if self.at_quote_start() => {
                     let min = if seen_value_indicator {
@@ -804,6 +886,7 @@ impl<'a> Validator<'a> {
                     };
                     let multiline = self.scan_single_quoted(min)?;
                     self.check_after_block_quoted(multiline)?;
+                    self.at_node_start = false;
                 }
                 Some(b':') if self.is_value_indicator() => {
                     if seen_value_indicator && !suppress_nested {
@@ -825,10 +908,13 @@ impl<'a> Validator<'a> {
                     {
                         return Err(self.error(YamlValidationErrorKind::TrailingContent));
                     }
+                    // The entry's value node follows the indicator.
+                    self.at_node_start = true;
                 }
                 Some(b'[' | b'{') if self.at_quote_start() => {
                     self.scan_flow()?;
                     self.check_after_top_level_flow()?;
+                    self.at_node_start = false;
                 }
                 Some(b'|' | b'>') if self.at_block_scalar_header() => {
                     self.scan_block_scalar_header()?;
@@ -840,8 +926,22 @@ impl<'a> Validator<'a> {
                     self.skip_to_line_end();
                     return Ok(());
                 }
+                // Separation between tokens: whatever the cursor was expecting,
+                // it still is.
+                Some(b' ' | b'\t') => {
+                    self.advance();
+                }
+                // A block sequence indicator; the item's node follows it.
+                Some(b'-')
+                    if self.at_node_start
+                        && matches!(self.peek_at(1), None | Some(b' ' | b'\t' | b'\n' | b'\r')) =>
+                {
+                    self.advance();
+                }
+                // Plain scalar content, so no node begins at the next byte.
                 Some(_) => {
                     self.advance();
+                    self.at_node_start = false;
                 }
             }
         }
@@ -1035,6 +1135,18 @@ impl<'a> Validator<'a> {
                     self.scan_flow()?;
                     expect_item = false;
                 }
+                // Every arm here is reached at a node start — after `[`, `{`,
+                // `,` or `:` — so a `*` is an alias, not scalar content (#404).
+                // An anchor is a property: its node still follows, so
+                // `expect_item` is left alone.
+                Some(b'&') => {
+                    let name = self.scan_anchor_name();
+                    self.record_anchor(name);
+                }
+                Some(b'*') => {
+                    self.scan_alias(true)?;
+                    expect_item = false;
+                }
                 Some(b'"') => {
                     self.scan_double_quoted(0)?;
                     expect_item = false;
@@ -1161,7 +1273,8 @@ impl<'a> Validator<'a> {
     /// not be immediately followed by an alias (`&a *b`, SR86/SU74) nor by a
     /// block sequence indicator on the same line (`&a - x`, SY6V).
     fn scan_anchor(&mut self) -> Result<(), YamlValidationError> {
-        self.scan_anchor_name(); // consumes `&`/`*` and the name
+        let name = self.scan_anchor_name(); // consumes `&` and the name
+        self.record_anchor(name);
         self.skip_spaces_and_tabs();
         match self.peek() {
             Some(b'*') => Err(self.error(YamlValidationErrorKind::AnchorOnAlias)),
@@ -1172,16 +1285,60 @@ impl<'a> Validator<'a> {
         }
     }
 
-    /// Consume an anchor or alias token: the `&`/`*` sigil and its name (any
-    /// non-whitespace, non-flow-indicator bytes; `:` is a legal name character).
-    fn scan_anchor_name(&mut self) {
+    /// Consume an anchor or alias token — the `&`/`*` sigil and its name — and
+    /// return the name's byte span, excluding the sigil.
+    ///
+    /// The extent is [`super::simd::parse_anchor_name`], the definition the
+    /// loader scans names with, rather than a second copy here: an alias is
+    /// resolved against the names the loader recorded, so a name it reads as
+    /// `a` must not be read as `a:` here (`&a: 1\nb: *a` loads under `yq`).
+    /// See the #106 note in `CLAUDE.md` on predicates that diverge silently.
+    ///
+    /// A name holds no line break, so the column advances by its length.
+    fn scan_anchor_name(&mut self) -> (usize, usize) {
         self.advance(); // `&` or `*`
-        while !matches!(
-            self.peek(),
-            None | Some(b' ' | b'\t' | b'\n' | b'\r' | b',' | b'[' | b']' | b'{' | b'}')
-        ) {
-            self.advance();
+        let start = self.offset;
+        let end = super::simd::parse_anchor_name(self.input, start);
+        self.column += end - start;
+        self.offset = end;
+        (start, end)
+    }
+
+    /// Record an anchor name as in scope for later aliases (#404).
+    ///
+    /// Registration is deliberately permissive — every `&name` the scanner
+    /// reaches is recorded, whether or not it truly binds a node. An extra name
+    /// can only make [`Self::scan_alias`] accept more, never reject valid input.
+    fn record_anchor(&mut self, (start, end): (usize, usize)) {
+        if end > start {
+            self.anchors.push((start, end));
         }
+    }
+
+    /// True if `input[start..end]` names an anchor already defined.
+    fn anchor_in_scope(&self, start: usize, end: usize) -> bool {
+        let name = &self.input[start..end];
+        self.anchors.iter().any(|&(s, e)| &self.input[s..e] == name)
+    }
+
+    /// Consume an alias token (`*name`), positioned on the `*`, and — when
+    /// `checked` — reject a name no anchor has defined (#404).
+    ///
+    /// The lookup happens *before* consuming so the error points at the `*`, as
+    /// the loader's `UnknownAnchor` offset does. `checked` is false where the
+    /// `*` may be plain-scalar content instead of a node (see
+    /// [`Self::at_node_start`]); an empty name is left to the loader.
+    fn scan_alias(&mut self, checked: bool) -> Result<(), YamlValidationError> {
+        if checked {
+            let start = self.offset + 1;
+            let end = super::simd::parse_anchor_name(self.input, start);
+            if end > start && !self.anchor_in_scope(start, end) {
+                let name = String::from_utf8_lossy(&self.input[start..end]).into_owned();
+                return Err(self.error(YamlValidationErrorKind::UnknownAnchor { name }));
+            }
+        }
+        self.scan_anchor_name();
+        Ok(())
     }
 
     /// Scan a double-quoted scalar, validating escape sequences. May span lines.


### PR DESCRIPTION
## Description

This PR fixes a critical bug where the strict YAML validator was incorrectly accepting aliases to unknown anchors, making it more permissive than the default loader. The validator now properly rejects aliases that reference anchors not in scope, matching `yq` behavior and ensuring consistent validation across the codebase.

Previously, `succinctly yaml validate` would pass documents like `a: *nope` with exit code 0, while `yq` rejects them with `unknown anchor 'nope' referenced`. Since the loader was fixed in #372 to reject this same case, the opt-in strict validator had become the laxer of the two modes, defeating its purpose as the yq-conformance gate.

The fix introduces anchor tracking to the validator and implements precise detection of where a `*` begins a node versus appearing as plain-scalar content, since `a: rm *.tmp` and `a: text\n  *notanalias` are both valid strings that `yq` loads correctly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #404
Refs #372

## Changes Made

**Core Validation Logic (`src/yaml/validate.rs`):**
- Added `UnknownAnchor` variant to `YamlValidationErrorKind` with the anchor name for clear error messages
- Introduced anchor tracking via `anchors: Vec<(usize, usize)>` field to store byte spans of defined anchor names
- Added `at_node_start` boolean field to track whether the cursor is positioned where a node can begin (after `:`, `-`, `?`, or flow collection indicators)
- Added `prev_line_open_plain` and `prev_line_indent` fields to track multi-line plain scalar continuations across lines
- Refactored `scan_content_line()` to manage cross-line bookkeeping, distinguishing between node starts and plain scalar continuations
- Implemented `continues_plain_scalar()` to prevent false positives where a `*` on a continuation line is scalar content
- Added `scan_alias()` method that validates alias references against recorded anchors only when positioned at true node starts
- Added `record_anchor()` method to register anchor definitions (deliberately permissive to avoid over-rejection)
- Added `anchor_in_scope()` method to check if an alias references a previously defined anchor
- Updated `scan_anchor_name()` to use `simd::parse_anchor_name` (matching the loader's definition) instead of whitespace-only boundary detection, fixing edge cases like `&a: 1` / `b: *a`
- Added anchor handling in flow collections (`scan_flow()`) where it was previously missing entirely
- Anchor scope is deliberately *not* reset at document boundaries, matching `yq` and loader behavior

**Test Coverage (`src/yaml/validate.rs` tests):**
- Added `accepts_resolvable_aliases_and_stars_in_scalars()` test covering:
  - `*` characters that are plain-scalar content (`a: text *star`, `a: rm *.tmp`, `a: what? *star`)
  - Multi-line plain scalars with `*` on continuation lines (`a: text\n  *notanalias`)
  - Anchor definitions and valid alias references in all positions (value, sequence item, explicit key, implicit key, flow collections)
  - Proper anchor name boundary detection (`&a: 1` / `b: *a`)
  - Anchors carrying across document boundaries
- Added `rejects_alias_to_unknown_anchor()` test table-driven over all positions an alias can occupy:
  - Value position (`a: *nope`)
  - Sequence item (`- *nope`)
  - Explicit key (`? *nope\n: v`)
  - Implicit key (`*nope: v`)
  - Flow collections (`a: [*nope]`, `a: {k: *nope}`, `[*nope]`)
  - Verifies error kind and offset both point to the `*` sigil
  - Tests forward reference rejection (alias before anchor definition)
- Updated error kind coverage test to include `UnknownAnchor` variant

**Documentation (`docs/guides/cli.md` and `docs/compliance/yaml/limitations.md`):**
- Updated CLI validation rules list to document the unresolved-alias rejection with clarification that `a: rm *.tmp` (scalar content) is untouched
- Updated limitations page to describe both alias cycle and unknown anchor checks together as related failures
- Documented that the strict validator briefly lacked this check, explaining how the opt-in mode became laxer than default

**Changelog (`CHANGELOG.md`):**
- Added detailed entry documenting the fix with technical context about anchor scope tracking, `*` node detection, and anchor name boundary definition

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added covering unknown anchor rejection in all alias positions
- [x] Tests for valid `*` characters in plain scalars to prevent over-rejection
- [x] Tests for anchor definitions and references across document boundaries

**Test Commands**
```bash
cargo test --lib yaml::validate
cargo test yaml::validate::tests
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact on validation path
- Allocation occurs only on the success path for documents that define anchors, which is a rare case
- The validator remains `no_std` compatible with zero-copy anchor tracking via byte span storage

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Key Design Decisions:**
- Anchor scope is not reset at document boundaries to match `yq` and loader behavior where `a: &x 1\n---\nb: *x` is valid
- Anchor registration is deliberately permissive (accepts every `&name` encountered) because extra names can only increase acceptance, never reject valid input
- The `*` node detection logic tracks positions where nodes can begin (after indicators, in flow context, and at line starts) rather than attempting to parse plain scalars from the `*` position, which would be fragile
- Uses `simd::parse_anchor_name` for boundary detection to ensure validator and loader agree on anchor name extent, preventing silent divergence

**Edge Cases Handled:**
- `&a: 1` followed by `b: *a` (anchor name boundary at `:` separator)
- Multi-line plain scalars where `*` appears on a continuation line
- Flow collections that previously had no anchor/alias validation
- `*` in various scalar contexts (`a: rm *.tmp`, `a: what? *star`)
- Forward references to not-yet-defined anchors
- Anchors defined across multiple documents in a stream