### PR TITLE
feat(bitvec): implement select word-scan vectorization investigation (#40)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,12 @@ broadword-yaml = []
 # Useful for benchmarking baseline scalar performance.
 scalar-yaml = []
 
+# Record how many words each `select` word-scan traverses (#40 measurement).
+# Adds a counter to five hot-ish scan loops, so it must never be on for timing
+# runs -- it exists to decide whether those scans are long enough for a SIMD
+# kernel to pay for itself. See `succinctly dev select-stats`.
+select-stats = ["std"]
+
 # Unified benchmark runner (succinctly bench list/run)
 bench-runner = ["cli", "dep:chrono"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ scalar-yaml = []
 
 # Record how many words each `select` word-scan traverses (#40 measurement).
 # Adds a counter to five hot-ish scan loops, so it must never be on for timing
-# runs -- it exists to decide whether those scans are long enough for a SIMD
+# runs — it exists to decide whether those scans are long enough for a SIMD
 # kernel to pay for itself. See `succinctly dev select-stats`.
 select-stats = ["std"]
 
@@ -188,6 +188,10 @@ harness = false
 
 [[bench]]
 name = "select_scan_micro"
+harness = false
+
+[[bench]]
+name = "yaml_query"
 harness = false
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,10 @@ name = "bp_select_micro"
 harness = false
 
 [[bench]]
+name = "select_scan_micro"
+harness = false
+
+[[bench]]
 name = "elias_fano"
 harness = false
 

--- a/benches/select_scan_micro.rs
+++ b/benches/select_scan_micro.rs
@@ -1,0 +1,161 @@
+//! Crossover micro-benchmark for the `select` word scan (#40).
+//!
+//! Answers one question: from what scan distance does a block kernel beat the
+//! per-word scalar loop? Everything is parameterised by **scan distance in
+//! words**, because that is the quantity `succinctly dev select-stats` measures
+//! on real inputs — so the two measurements compose directly into a decision
+//! instead of needing a judgement call to connect them.
+//!
+//! Three variants are compared at each distance:
+//!
+//! * `scalar`   — the per-word loop every call site used before.
+//! * `dispatch` — `scan_select`, which picks NEON / AVX2 / portable at runtime.
+//! * `portable` — the same block structure with a plain-Rust block popcount,
+//!   which shows how much (if anything) the intrinsics add over what LLVM
+//!   already auto-vectorises. If this matches `dispatch`, the intrinsics are
+//!   not carrying their weight and should go.
+//!
+//! Run with:
+//! ```bash
+//! cargo bench --bench select_scan_micro
+//! ```
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
+use succinctly::bits::{block_popcount_portable, scan_select, scan_select_scalar, BLOCK};
+
+/// Scan distances in words, spanning the range the corpus actually produces:
+/// p50 ≈ 3, p90 ≈ 232, max ≈ 296 at the hot YAML site.
+const DISTANCES: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 256];
+
+/// Bits set per word.
+///
+/// Long scans arise where interest bits are *sparse* — a long YAML scalar puts
+/// many bitmap words between consecutive structural positions — so `1` is the
+/// realistic case for the tail this optimisation targets. `32` is included as
+/// a dense control.
+const DENSITIES: &[u32] = &[1, 32];
+
+/// Build words with exactly `ones_per_word` bits set in each, spread out so no
+/// word is trivially all-ones.
+fn words_with_density(count: usize, ones_per_word: u32) -> Vec<u64> {
+    let stride = 64 / ones_per_word.max(1);
+    let word = (0..ones_per_word).fold(0u64, |acc, i| acc | (1u64 << (i * stride)));
+    vec![word; count]
+}
+
+/// Block-structured scan using the portable block popcount, mirroring
+/// `scan_select`'s shape so the comparison isolates the kernel.
+fn scan_portable(words: &[u64], start_word: usize, remaining: usize) -> Option<(usize, usize)> {
+    if start_word >= words.len() {
+        return None;
+    }
+    let mut rem = remaining;
+    let mut idx = start_word;
+
+    while idx + BLOCK <= words.len() {
+        let total = block_popcount_portable(&words[idx..idx + BLOCK]);
+        if total > rem {
+            break;
+        }
+        rem -= total;
+        idx += BLOCK;
+    }
+
+    for (off, &w) in words[idx..].iter().enumerate() {
+        let pop = w.count_ones() as usize;
+        if pop > rem {
+            return Some((idx + off, rem));
+        }
+        rem -= pop;
+    }
+    None
+}
+
+fn bench_scan(c: &mut Criterion) {
+    for &ones_per_word in DENSITIES {
+        let mut group = c.benchmark_group(format!("select_scan/density_{ones_per_word}"));
+
+        for &distance in DISTANCES {
+            // Enough words to cover the scan plus a block of slack.
+            let words = words_with_density(distance + BLOCK + 2, ones_per_word);
+            // Target the first set bit of the word `distance` words along, so
+            // the scan traverses exactly `distance` words before crossing.
+            let k = distance * ones_per_word as usize;
+
+            // Guard the premise: if these disagree the benchmark is measuring
+            // two different things and any speedup it reports is meaningless.
+            assert_eq!(
+                scan_select(&words, 0, k),
+                scan_select_scalar(&words, 0, k),
+                "dispatch/scalar disagree at distance={distance} density={ones_per_word}"
+            );
+            assert_eq!(
+                scan_portable(&words, 0, k),
+                scan_select_scalar(&words, 0, k),
+                "portable/scalar disagree at distance={distance} density={ones_per_word}"
+            );
+
+            group.bench_with_input(BenchmarkId::new("scalar", distance), &distance, |b, _| {
+                b.iter(|| scan_select_scalar(black_box(&words), 0, black_box(k)));
+            });
+            group.bench_with_input(BenchmarkId::new("dispatch", distance), &distance, |b, _| {
+                b.iter(|| scan_select(black_box(&words), 0, black_box(k)));
+            });
+            group.bench_with_input(BenchmarkId::new("portable", distance), &distance, |b, _| {
+                b.iter(|| scan_portable(black_box(&words), 0, black_box(k)));
+            });
+        }
+
+        group.finish();
+    }
+}
+
+/// The measured corpus distribution, replayed as a mixed workload.
+///
+/// Per-distance numbers can mislead when a distribution is bimodal: a kernel
+/// that wins hugely on long scans and loses slightly on short ones may still be
+/// a net win, or not, depending on the mix. This benchmark applies the real mix
+/// — roughly half trivial scans, the rest spread into a long tail — so the
+/// aggregate is measured rather than inferred.
+fn bench_corpus_mix(c: &mut Criterion) {
+    // Approximates the hot YAML site: p50 ≈ 3, p90 ≈ 232, max ≈ 296,
+    // ~50% of calls below 4 words.
+    let mix: &[usize] = &[
+        1, 1, 2, 2, 3, 3, 3, 1, 2, 3, // the short half
+        8, 14, 20, 45, 96, 160, 232, 246, 288, 296, // the long tail
+    ];
+    let ones_per_word = 1u32;
+    let longest = *mix.iter().max().unwrap();
+    let words = words_with_density(longest + BLOCK + 2, ones_per_word);
+    let targets: Vec<usize> = mix.iter().map(|d| d * ones_per_word as usize).collect();
+
+    let mut group = c.benchmark_group("select_scan/corpus_mix");
+
+    group.bench_function("scalar", |b| {
+        b.iter(|| {
+            for &k in &targets {
+                black_box(scan_select_scalar(black_box(&words), 0, k));
+            }
+        });
+    });
+    group.bench_function("dispatch", |b| {
+        b.iter(|| {
+            for &k in &targets {
+                black_box(scan_select(black_box(&words), 0, k));
+            }
+        });
+    });
+    group.bench_function("portable", |b| {
+        b.iter(|| {
+            for &k in &targets {
+                black_box(scan_portable(black_box(&words), 0, k));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan, bench_corpus_mix);
+criterion_main!(benches);

--- a/benches/yaml_query.rs
+++ b/benches/yaml_query.rs
@@ -1,0 +1,151 @@
+//! YAML **query**-path benchmark (#40).
+//!
+//! `yaml_bench` measures index *building*; every one of its cases calls
+//! `YamlIndex::build` and stops. Nothing in the suite measured the traversal
+//! that follows, so a change to the query path — such as the `select` word scan
+//! this benchmark exists to check — had no end-to-end coverage at all.
+//!
+//! Each case builds the index once, outside the timed region, then walks every
+//! node in document order calling `text_position()`. That call is the sole
+//! entry point to `AdvancePositions::get`, which owns the hottest `select` scan
+//! in the crate, so this measures the affected path with none of the process
+//! startup and 10 MB of output I/O that swamp it when timing the `yq` CLI.
+//!
+//! Scalar length is the axis that matters. Interest bits mark structural
+//! positions, so the byte gap between consecutive scalars *is* the scan length:
+//! short values keep scans to a word or two, long ones push them into the tail
+//! where a block kernel pays off. The cases below span that range deliberately.
+//!
+//! Run with:
+//! ```bash
+//! cargo bench --bench yaml_query
+//! ```
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
+use succinctly::yaml::{YamlCursor, YamlIndex, YamlValue};
+
+/// A mapping of `count` keys whose values are scalars of `value_len` bytes.
+fn mapping_with_scalars(count: usize, value_len: usize) -> Vec<u8> {
+    let mut out = String::new();
+    for i in 0..count {
+        let value = "x".repeat(value_len);
+        out.push_str(&format!("key_{i}: {value}\n"));
+    }
+    out.into_bytes()
+}
+
+/// A sequence of `count` small mappings — the Kubernetes/CI manifest shape,
+/// where structure is dense and scalars are short.
+fn sequence_of_records(count: usize) -> Vec<u8> {
+    let mut out = String::new();
+    out.push_str("items:\n");
+    for i in 0..count {
+        out.push_str(&format!(
+            "  - name: item_{i}\n    id: {i}\n    enabled: true\n"
+        ));
+    }
+    out.into_bytes()
+}
+
+/// Nested mappings `depth` levels deep, `width` keys per level.
+fn nested(depth: usize, width: usize) -> Vec<u8> {
+    fn go(out: &mut String, depth: usize, width: usize, indent: usize) {
+        if depth == 0 {
+            return;
+        }
+        for i in 0..width {
+            let pad = "  ".repeat(indent);
+            if depth == 1 {
+                out.push_str(&format!("{pad}leaf_{i}: value_{i}\n"));
+            } else {
+                out.push_str(&format!("{pad}node_{i}:\n"));
+                go(out, depth - 1, width, indent + 1);
+            }
+        }
+    }
+    let mut out = String::new();
+    go(&mut out, depth, width, 0);
+    out.into_bytes()
+}
+
+/// Walk every node in document order, materialising each text position.
+///
+/// Returns the number of nodes visited so the optimiser cannot discard the
+/// traversal, and so a mismatch between runs would be visible.
+fn walk(cur: YamlCursor<'_, Vec<u64>>) -> usize {
+    let mut visited = 1;
+    black_box(cur.text_position());
+
+    match cur.value() {
+        YamlValue::Mapping(fields) => {
+            for field in fields {
+                visited += walk(field.value_cursor());
+            }
+        }
+        YamlValue::Sequence(mut elements) => {
+            while let Some((child, rest)) = elements.uncons_cursor() {
+                visited += walk(child);
+                elements = rest;
+            }
+        }
+        // Aliases are not followed: the target is visited at its definition.
+        YamlValue::Alias { .. } | YamlValue::String(_) | YamlValue::Null | YamlValue::Error(_) => {}
+    }
+    visited
+}
+
+/// Walk from the document root, which YAML models as a sequence of documents.
+fn walk_root(index: &YamlIndex<Vec<u64>>, text: &[u8]) -> usize {
+    let root = index.root(text);
+    match root.value() {
+        YamlValue::Sequence(mut docs) => {
+            let mut visited = 0;
+            while let Some((doc, rest)) = docs.uncons_cursor() {
+                visited += walk(doc);
+                docs = rest;
+            }
+            visited
+        }
+        _ => walk(root),
+    }
+}
+
+fn bench_case(c: &mut Criterion, group_name: &str, cases: &[(String, Vec<u8>)]) {
+    let mut group = c.benchmark_group(group_name);
+    for (label, yaml) in cases {
+        let index = YamlIndex::build(yaml).expect("benchmark fixture must parse");
+        // Guard the premise: a fixture that produced no nodes would report a
+        // meaningless "speedup".
+        assert!(walk_root(&index, yaml) > 1, "{label} traversed nothing");
+
+        group.throughput(Throughput::Bytes(yaml.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(label), yaml, |b, yaml| {
+            b.iter(|| black_box(walk_root(&index, black_box(yaml))));
+        });
+    }
+    group.finish();
+}
+
+/// Scalar length sweep — the axis that controls scan length.
+fn bench_scalar_length(c: &mut Criterion) {
+    let cases: Vec<(String, Vec<u8>)> = [8usize, 32, 128, 512, 2048]
+        .iter()
+        .map(|&len| (format!("value_{len}b"), mapping_with_scalars(2000, len)))
+        .collect();
+    bench_case(c, "yaml_query/scalar_length", &cases);
+}
+
+/// Realistic document shapes.
+fn bench_shapes(c: &mut Criterion) {
+    let cases = vec![
+        ("records_1k".to_string(), sequence_of_records(1000)),
+        ("records_10k".to_string(), sequence_of_records(10_000)),
+        ("nested_d6_w4".to_string(), nested(6, 4)),
+        ("nested_d4_w8".to_string(), nested(4, 8)),
+    ];
+    bench_case(c, "yaml_query/shapes", &cases);
+}
+
+criterion_group!(benches, bench_scalar_length, bench_shapes);
+criterion_main!(benches);

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -511,6 +511,27 @@ them. #342 acted on that finding by vendoring a Home Assistant config, so the co
 now reports 41 anchors and 86 aliases. That page is date-pinned, not CI-checked:
 upstream branches move.
 
+### Select scan-length lookup
+
+`corpus-stats` answers "does this input shape exist?". `select-stats` answers the
+same question one level down, for the `select` word scans: **how many words does
+each scan actually traverse?** It walks the corpus through the same cursor APIs
+`jq`/`yq` use and reads counters compiled in by the `select-stats` feature.
+
+```bash
+cargo run --release --features cli,select-stats -- \
+  dev select-stats --data-dir data/bench/corpus
+```
+
+The counters live behind a non-default feature, so they are absent from ordinary
+builds and **must never be enabled for a timing run**. The command exits non-zero
+if it recorded nothing, so a binary built without the feature cannot be mistaken
+for a workload that performs no scans.
+
+Read the `work >=4` column, not `calls <4`: the distribution is bimodal, and the
+share of *work* in long scans is what predicts a block kernel's effect. This is
+the measurement that justified [select-scan.md](../optimizations/select-scan.md).
+
 ---
 
 ## Platforms and Hardware

--- a/docs/optimizations/README.md
+++ b/docs/optimizations/README.md
@@ -20,6 +20,7 @@ This directory documents optimization techniques used in the succinctly library,
 | **Parsing**          | [state-machines.md](state-machines.md)                   | PFSM, fast-path bypass, two-stage pipeline       |
 | **Compact encoding** | [end-positions.md](end-positions.md)                     | Bitmap encoding, advance index, sequential cursor|
 | **String search**    | [jq-string-search.md](jq-string-search.md)               | memmem vs std Two-Way for jq substring builtins   |
+| **Select scan**      | [select-scan.md](select-scan.md)                         | #40 scan-length measurement, IB cursor O(n²) fix |
 | **Targets**          | [targets.md](targets.md)                                 | CPU target configurations, architecture flags    |
 | **SIMD Strategy**    | [simd-strategy.md](simd-strategy.md)                     | Per-module SIMD usage, platform support, lessons |
 

--- a/docs/optimizations/select-scan.md
+++ b/docs/optimizations/select-scan.md
@@ -2,7 +2,7 @@
 
 [Home](../../) > [Docs](../) > [Optimizations](./) > Select scan
 
-Investigation of [#40](https://github.com/newhoggy/succinctly/issues/40): should the
+Investigation of [#40](https://github.com/rust-works/succinctly/issues/40): should the
 word scan inside `select` be vectorised?
 
 **Outcome: the SIMD kernel is not justified — but finding that out uncovered an

--- a/docs/optimizations/select-scan.md
+++ b/docs/optimizations/select-scan.md
@@ -1,0 +1,182 @@
+# Select Word Scan (#40)
+
+[Home](../../) > [Docs](../) > [Optimizations](./) > Select scan
+
+Investigation of [#40](https://github.com/newhoggy/succinctly/issues/40): should the
+word scan inside `select` be vectorised?
+
+**Outcome: the SIMD kernel is not justified — but finding that out uncovered an
+O(n²) defect in the YAML query path worth 3.6–23× (see [O5](#o5-ib-cursor-reset--accepted-)).**
+
+## The proposal
+
+A [Reddit commenter](https://www.reddit.com/r/rust/comments/1qleizg/comment/o1e0fyo/)
+suggested SIMD-popcounting several words at once, prefix-summing them, and
+jumping straight to the word holding the k-th set bit, instead of walking words
+one at a time.
+
+The issue framed this as a *batch select* API for multi-index patterns like
+`.users[0, 5, 10]`. That framing was weak on arrival: the real-workload corpus
+puts JSON array size at p50 = 2, p90 = 2 elements
+([corpus-shape.md](../benchmarks/corpus-shape.md)), so there is nothing to batch.
+The issue also stated that tree navigation uses rank rather than select, implying
+no hot call site existed.
+
+Both premises were wrong in an interesting way. Select **is** hot —
+`YamlCursor::text_position()` reaches `AdvancePositions::get_sequential`, which
+contains a literal per-word scan, once per node during `yq` streaming. So the
+optimisation had a real target; it just was not the one the issue named.
+
+## Step 1: measure the scan lengths
+
+A SIMD block only pays off if scans are long. The `select-stats` feature
+(`succinctly dev select-stats`, see [benchmarking.md](../guides/benchmarking.md))
+records how many words each scan traverses. On the real-workload corpus:
+
+| site                                    | calls | mean  | p50 | p90 | max | calls <4 | work >=4 |
+| --------------------------------------- | ----- | ----- | --- | --- | --- | -------- | -------- |
+| `yaml/advance_positions get_sequential` | 744   | 59.97 | 3   | 232 | 296 | 50.7%    | 99.0%    |
+| `json/light ib_select1_from` (probes)   | 17146 | 16.78 | 17  | 19  | 20  | 0.8%     | 99.9%    |
+| the other four scan sites               | 0     | –     | –   | –   | –   | –        | –        |
+
+Sharply bimodal: half the calls are trivial, but **99% of the words popcounted
+happen in scans of 4+ words**. Counting calls alone would have rejected this;
+counting work said proceed. That is why `select-stats` reports both.
+
+Four of the five scan sites recorded nothing at all — `BitVec::select1`,
+`WithSelect::select1` and `EliasFano::select1` are reached only by `locate`
+tooling or have no in-crate consumer.
+
+## Step 2: the kernel, and the crossover
+
+[`bits::scan`](../../src/bits/scan.rs) provides one `scan_select` helper shared
+by all five sites, replacing five copies of the same loop. Rather than the
+issue's per-iteration prefix sum, each iteration computes a single block
+**total** and either skips the block or drops into a short scalar scan to
+pinpoint — a scan needs to locate only once, at the end.
+
+A scalar prologue of `BLOCK` words runs first, so any scan short enough to
+finish inside it executes exactly the old code. That makes "no regression on
+short scans" structural rather than a tuning claim.
+
+Micro-benchmark (`select_scan_micro`, Apple M4 Pro, NEON, sparse words):
+
+| scan distance | scalar   | `scan_select` | speedup |
+| ------------- | -------- | ------------- | ------- |
+| 1 word        | 1.11 ns  | 0.93 ns       | 1.19×   |
+| 4 words       | 1.88 ns  | 1.85 ns       | 1.02×   |
+| 8 words       | 2.89 ns  | 3.43 ns       | 0.84×   |
+| 16 words      | 5.32 ns  | 3.55 ns       | 1.50×   |
+| 64 words      | 18.62 ns | 7.09 ns       | 2.63×   |
+| 256 words     | 89.72 ns | 23.68 ns      | 3.79×   |
+| corpus mix    | 492 ns   | 143 ns        | 3.44×   |
+
+Crossover sits between 8 and 16 words. Explicit NEON beat the portable block
+popcount by ~1.3×, so LLVM's auto-vectorisation was not already sufficient.
+
+At this point the optimisation looked strongly justified, and end-to-end
+`yaml_query` showed 1.8–3.2×.
+
+## Step 3: the number was measuring a bug
+
+The end-to-end win was suspiciously uniform — short-scalar fixtures, where scans
+should be a single word, sped up 1.9×. Measuring the fixtures directly showed
+why: mean scan length was 284 words, not 1. Sweeping file size:
+
+| keys | bytes   | mean scan | total words popcounted |
+| ---- | ------- | --------- | ---------------------- |
+| 250  | 4 390   | 34.1      | 8 564                  |
+| 1000 | 17 890  | 139.4     | 139 489                |
+| 4000 | 74 890  | 578.8     | 2 315 578              |
+| 8000 | 150 890 | 1171.5    | 9 373 251              |
+
+Mean scan length doubles when the file doubles: **total scan work is O(n²)**.
+
+Instrumenting the cursor's path selection found the cause. For a 4000-key
+mapping the traversal took the sequential fast path twice, the forward-gap path
+4000 times, and the random path 4000 times — and `get_random` set
+`ib_word_idx: 0, ib_ones_before: 0` while advancing `next_open_idx`. It computed
+the IB position, then threw it away, so every following scan restarted from word
+0 and walked the whole prefix.
+
+## O5: IB cursor reset — ACCEPTED ✅
+
+Carrying the position `get_random` already computed, instead of zeroing it:
+
+```rust
+let (ib_word_idx, ib_ones_before) = match result {
+    Some(pos) => {
+        let w = pos as usize / 64;
+        (w, self.ib_rank[w] as usize)
+    }
+    None => (0, 0),
+};
+```
+
+Scan length becomes flat in file size — O(n²) → O(n):
+
+| keys | mean scan before | after | total words before | after  |
+| ---- | ---------------- | ----- | ------------------ | ------ |
+| 250  | 34.1             | 1.27  | 8 564              | 318    |
+| 1000 | 139.4            | 1.28  | 139 489            | 1 281  |
+| 4000 | 578.8            | 1.29  | 2 315 578          | 5 161  |
+| 8000 | 1171.5           | 1.29  | 9 373 251          | 10 321 |
+
+At 8000 keys that is a **908× reduction** in scan work.
+
+End-to-end `yaml_query` (Apple M4 Pro, medians):
+
+| case          | baseline | + cursor fix     | + cursor fix + `scan_select` |
+| ------------- | -------- | ---------------- | ---------------------------- |
+| value_8b      | 361 µs   | 99.1 µs (3.6×)   | 99.6 µs (−0.5%)              |
+| value_32b     | 666 µs   | 145 µs (4.6×)    | 140 µs (+3.3%)               |
+| value_128b    | 1.81 ms  | 265 µs (6.8×)    | 258 µs (+2.7%)               |
+| value_512b    | 6.33 ms  | 702 µs (9.0×)    | 677 µs (+3.5%)               |
+| value_2048b   | 24.3 ms  | 2.52 ms (9.6×)   | 2.38 ms (+5.6%)              |
+| records_1k    | 658 µs   | 183 µs (3.6×)    | 185 µs (−1.3%)               |
+| records_10k   | 43.2 ms  | 1.86 ms (23.2×)  | 1.89 ms (−1.5%)              |
+| nested_d6_w4  | 1.77 ms  | 303 µs (5.8×)    | 307 µs (−1.2%)               |
+| nested_d4_w8  | 1.39 ms  | 251 µs (5.5×)    | 256 µs (−2.0%)               |
+
+Output is byte-identical across 127 query/file pairs, and the pinned-`yq` golden
+suite passes unchanged.
+
+## Verdict on #40
+
+**The SIMD batch select is not justified.** Once the cursor is fixed, the mean
+scan is 1.29 words — every scan completes inside the scalar prologue and the
+vector path is never entered. `scan_select` contributes −2% to +5.6% on top of
+the cursor fix, which is noise.
+
+The 1.8–3.2× that `scan_select` appeared to deliver was entirely an artifact of
+the defect: it made a quadratic scan 3× cheaper, where the quadratic scan should
+not have existed. Vectorising it would have locked in the bug behind a
+respectable-looking benchmark.
+
+`scan_select` retains non-performance value — five copies of the same loop
+became one helper with property tests — but its NEON and AVX2 kernels are dead
+weight at the measured scan lengths.
+
+## Lessons
+
+- **A hot loop is not the same as necessary work.** The scan-length distribution
+  said "long scans, lots of work, good SIMD target" and was correct about all
+  three. It could not say the work was avoidable. Asking *why* the tail was long,
+  rather than only how long, is what turned a 3× into a 23×.
+- **Beware a speedup that is too evenly distributed.** Uniform gains across
+  fixtures that should differ is a signal that something other than the intended
+  mechanism is being measured.
+- **Measure the fixture, not just the benchmark.** The synthetic fixtures had a
+  scan distribution far worse than the real corpus. Checking them against the
+  corpus numbers is what exposed the gap.
+- The repo's existing lesson held again: *algorithmic improvements beat
+  micro-optimisations* — here by roughly a factor of 300.
+
+## See also
+
+- [`src/bits/scan.rs`](../../src/bits/scan.rs) — the shared helper
+- [`src/util/select_stats.rs`](../../src/util/select_stats.rs) — instrumentation
+- [`benches/select_scan_micro.rs`](../../benches/select_scan_micro.rs) — crossover
+- [`benches/yaml_query.rs`](../../benches/yaml_query.rs) — query-path coverage
+- [end-positions.md](end-positions.md) — O1/O2, the earlier cursor work
+- [access-patterns.md](access-patterns.md) — sequential vs random access

--- a/src/bin/succinctly/corpus_stats.rs
+++ b/src/bin/succinctly/corpus_stats.rs
@@ -537,7 +537,7 @@ fn density_row(metric: &str, dist: &Dist) -> Vec<String> {
 }
 
 /// Extension → (format tag, optional DSV delimiter).
-fn classify(path: &Path) -> Option<(&'static str, Option<u8>)> {
+pub(crate) fn classify(path: &Path) -> Option<(&'static str, Option<u8>)> {
     match path.extension().and_then(|e| e.to_str()) {
         Some("json" | "geojson" | "ndjson") => Some(("json", None)),
         Some("yaml" | "yml") => Some(("yaml", None)),
@@ -549,7 +549,7 @@ fn classify(path: &Path) -> Option<(&'static str, Option<u8>)> {
 }
 
 /// Recursively collect corpus files under `dir`, sorted for deterministic output.
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+pub(crate) fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
         .with_context(|| format!("reading directory {}", dir.display()))?
         .map(|e| e.map(|e| e.path()))

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -216,6 +216,24 @@ struct DevCommand {
 enum DevSubcommand {
     /// Run benchmarks
     Bench(BenchCommand),
+    /// Report how many words the select word scans traverse (#40)
+    SelectStats(SelectStatsArgs),
+}
+
+/// Arguments for the select scan-length report.
+///
+/// Needs a binary built with the `select-stats` feature; without it the
+/// counters are compiled out and the command exits non-zero rather than
+/// printing zeros that look like a finding.
+#[derive(Debug, Parser)]
+struct SelectStatsArgs {
+    /// Corpus root directory to traverse (recursively, by file extension)
+    #[arg(short, long, default_value = "data/bench/corpus")]
+    data_dir: PathBuf,
+
+    /// Markdown report to write (default: print to stdout)
+    #[arg(short, long)]
+    markdown: Option<PathBuf>,
 }
 
 #[derive(Debug, Parser)]
@@ -1297,6 +1315,10 @@ fn main() -> Result<()> {
                     std::process::exit(exit_code);
                 }
             },
+            DevSubcommand::SelectStats(args) => {
+                let exit_code = select_stats_report::run(&args.data_dir, args.markdown.as_ref())?;
+                std::process::exit(exit_code);
+            }
         },
         Command::InstallAliases(args) => install_aliases(args),
         #[cfg(feature = "bench-runner")]
@@ -2122,6 +2144,7 @@ mod jq_locate;
 mod jq_runner;
 mod json_validate;
 mod output;
+mod select_stats_report;
 mod text_generators;
 mod text_validate;
 mod utf8_bench;

--- a/src/bin/succinctly/select_stats_report.rs
+++ b/src/bin/succinctly/select_stats_report.rs
@@ -1,0 +1,407 @@
+//! Scan-length report for the `select` word-scan loops (#40).
+//!
+//! Issue #40 proposes vectorising the word scan inside `select`: SIMD-popcount
+//! several words at once, prefix-sum, and skip straight to the word holding the
+//! k-th set bit. That can only pay off if the scans are long enough to amortise
+//! the vector setup. This command measures how long they actually are, by
+//! traversing real corpus files through the same cursor APIs `jq`/`yq` use and
+//! reading the counters that [`succinctly::select_stats`] records.
+//!
+//! Requires the `select-stats` feature; without it the counters are never
+//! written and the command says so rather than printing a misleading table of
+//! zeros.
+//!
+//! ```text
+//! cargo run --release --features cli,select-stats -- \
+//!     dev select-stats --data-dir data/bench/corpus
+//! ```
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use succinctly::json::light::{JsonCursor, StandardJson};
+use succinctly::json::JsonIndex;
+use succinctly::select_stats::{self, Histogram, Site};
+use succinctly::yaml::{YamlCursor, YamlIndex, YamlValue};
+
+use crate::corpus_stats::{classify, collect_files};
+
+/// Traverse every JSON node, materialising each one's text position.
+///
+/// This is the access pattern `jq` produces: `text_position()` is called for
+/// every value that gets looked at, and it is the sole entry point to
+/// `ib_select1_from`.
+fn walk_json(cur: JsonCursor<'_, Vec<u64>>) {
+    // The call whose cost we are measuring.
+    let _ = cur.text_position();
+
+    match cur.value() {
+        StandardJson::Object(_) => {
+            let mut child = cur.first_child();
+            while let Some(k) = child {
+                walk_json(k);
+                match k.next_sibling() {
+                    Some(v) => {
+                        walk_json(v);
+                        child = v.next_sibling();
+                    }
+                    None => child = None,
+                }
+            }
+        }
+        StandardJson::Array(_) => {
+            for elem in cur.children() {
+                walk_json(elem);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Traverse every YAML node, materialising each one's text position.
+///
+/// `YamlCursor::text_position()` reaches `AdvancePositions::get_sequential` —
+/// the word scan #40 is really about — so a document-order walk reproduces the
+/// scan-length distribution of `yq` streaming.
+fn walk_yaml(cur: YamlCursor<'_, Vec<u64>>) {
+    let _ = cur.text_position();
+
+    match cur.value() {
+        YamlValue::Mapping(fields) => {
+            for field in fields {
+                walk_yaml(field.value_cursor());
+            }
+        }
+        YamlValue::Sequence(mut elements) => {
+            while let Some((child, rest)) = elements.uncons_cursor() {
+                walk_yaml(child);
+                elements = rest;
+            }
+        }
+        // Aliases are not followed: the target is visited at its definition,
+        // and following them risks a cycle.
+        YamlValue::Alias { .. } | YamlValue::String(_) | YamlValue::Null | YamlValue::Error(_) => {}
+    }
+}
+
+/// Per-file result, kept so the report can attribute scans to inputs.
+struct FileRun {
+    workload: String,
+    file: String,
+    bytes: usize,
+    /// Scans recorded while traversing this file, per site.
+    calls: [u64; Site::COUNT],
+}
+
+/// Traverse one corpus file, returning the per-site call counts it produced.
+fn run_file(root: &Path, path: &Path) -> Result<Option<FileRun>> {
+    let Some((format, _delim)) = classify(path) else {
+        return Ok(None);
+    };
+    // DSV has no select word scan on its read path; skip rather than report zeros.
+    if format == "dsv" {
+        return Ok(None);
+    }
+
+    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+
+    let before: [u64; Site::COUNT] =
+        core::array::from_fn(|i| select_stats::snapshot(Site::all()[i]).calls());
+
+    match format {
+        "json" => {
+            let index = JsonIndex::build(&bytes);
+            walk_json(index.root(&bytes));
+        }
+        "yaml" => {
+            let index = YamlIndex::build(&bytes)
+                .map_err(|e| anyhow::anyhow!("YAML parse failed for {}: {e:?}", path.display()))?;
+            let root = index.root(&bytes);
+            // The YAML root is a virtual sequence of documents.
+            match root.value() {
+                YamlValue::Sequence(mut docs) => {
+                    while let Some((doc, rest)) = docs.uncons_cursor() {
+                        walk_yaml(doc);
+                        docs = rest;
+                    }
+                }
+                _ => walk_yaml(root),
+            }
+        }
+        _ => return Ok(None),
+    }
+
+    let after: [u64; Site::COUNT] =
+        core::array::from_fn(|i| select_stats::snapshot(Site::all()[i]).calls());
+
+    let file = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("?")
+        .to_string();
+    let workload = path
+        .parent()
+        .and_then(|p| p.strip_prefix(root).ok().and_then(|_| p.file_name()))
+        .and_then(|n| n.to_str())
+        .unwrap_or("-")
+        .to_string();
+
+    Ok(Some(FileRun {
+        workload,
+        file,
+        bytes: bytes.len(),
+        calls: core::array::from_fn(|i| after[i] - before[i]),
+    }))
+}
+
+/// Render the fixed-width markdown table used across this repo's reports.
+fn render_table(headers: &[&str], rows: &[Vec<String>]) -> String {
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            if i < widths.len() {
+                widths[i] = widths[i].max(cell.len());
+            }
+        }
+    }
+
+    let mut out = String::new();
+    let header: Vec<String> = headers
+        .iter()
+        .enumerate()
+        .map(|(i, h)| format!("{:width$}", h, width = widths[i]))
+        .collect();
+    out.push_str(&format!("| {} |\n", header.join(" | ")));
+    let sep: Vec<String> = widths.iter().map(|w| "-".repeat(*w)).collect();
+    out.push_str(&format!("| {} |\n", sep.join(" | ")));
+    for row in rows {
+        let cells: Vec<String> = widths
+            .iter()
+            .enumerate()
+            .map(|(i, w)| {
+                format!(
+                    "{:width$}",
+                    row.get(i).map_or("", |c| c.as_str()),
+                    width = w
+                )
+            })
+            .collect();
+        out.push_str(&format!("| {} |\n", cells.join(" | ")));
+    }
+    out
+}
+
+/// One row of the distribution table for `site`.
+fn site_row(site: Site, h: &Histogram) -> Vec<String> {
+    let fmt = |v: Option<u64>| v.map_or_else(|| "-".to_string(), |v| v.to_string());
+    let pct = |v: Option<f64>| v.map_or_else(|| "-".to_string(), |v| format!("{:.1}%", v * 100.0));
+
+    vec![
+        site.name().to_string(),
+        site.unit().to_string(),
+        h.calls().to_string(),
+        h.mean()
+            .map_or_else(|| "-".to_string(), |m| format!("{m:.2}")),
+        fmt(h.percentile(50.0)),
+        fmt(h.percentile(90.0)),
+        fmt(h.percentile(99.0)),
+        h.max().to_string(),
+        pct(h.fraction_below(4)),
+        pct(h.work_fraction_at_or_above(4)),
+    ]
+}
+
+/// Build the markdown report for `data_dir`.
+pub fn generate_report(data_dir: &Path) -> Result<String> {
+    let mut files = Vec::new();
+    collect_files(data_dir, &mut files)?;
+
+    select_stats::reset();
+
+    let mut runs = Vec::new();
+    for path in &files {
+        if let Some(run) = run_file(data_dir, path)? {
+            runs.push(run);
+        }
+    }
+
+    let mut out = String::new();
+    out.push_str("# Select scan-length distribution (#40)\n\n");
+    out.push_str(
+        "How many words each `select` word scan traverses, measured by walking the\n\
+         real-workload corpus through the same cursor APIs `jq`/`yq` use. A SIMD\n\
+         block kernel processes 4 words (AVX2) or 2 (NEON) per iteration, so the\n\
+         `<4 words` column is the decisive one: scans shorter than one block\n\
+         cannot amortise the vector setup.\n\n",
+    );
+
+    if !cfg!(feature = "select-stats") {
+        out.push_str(
+            "> **No data: built without the `select-stats` feature.** The counters are\n\
+             > compiled out, so every row below would read zero. Rebuild with\n\
+             > `--features cli,select-stats` and re-run.\n\n",
+        );
+    }
+
+    out.push_str("## Scan lengths by site\n\n");
+    out.push_str(
+        "`ib_select1_from` rows count `ib_rank` probes rather than words: that path\n\
+         searches a precomputed rank array and never popcounts, so #40's trick does\n\
+         not apply to it. It is listed because it is the *hot* select on the query\n\
+         path, which is what makes the comparison interesting.\n\n",
+    );
+
+    let rows: Vec<Vec<String>> = Site::all()
+        .iter()
+        .map(|&s| site_row(s, &select_stats::snapshot(s)))
+        .collect();
+    out.push_str(&render_table(
+        &[
+            "site", "unit", "calls", "mean", "p50", "p90", "p99", "max", "calls <4", "work >=4",
+        ],
+        &rows,
+    ));
+    out.push_str(
+        "\n`calls <4` is the share of *calls* too short for a 4-word block to help.\n\
+         `work >=4` is the share of *total words scanned* that happens in scans of 4+\n\
+         words. When these disagree the distribution is bimodal, and `work >=4` is the\n\
+         one that predicts a SIMD kernel's effect on runtime: a scalar prologue keeps\n\
+         the short calls free while the vector path absorbs the long tail.\n",
+    );
+
+    out.push_str("\n## Files traversed\n\n");
+    let file_rows: Vec<Vec<String>> = runs
+        .iter()
+        .map(|r| {
+            let total: u64 = r.calls.iter().sum();
+            vec![
+                r.workload.clone(),
+                r.file.clone(),
+                r.bytes.to_string(),
+                total.to_string(),
+            ]
+        })
+        .collect();
+    out.push_str(&render_table(
+        &["workload", "file", "bytes", "select calls"],
+        &file_rows,
+    ));
+
+    Ok(out)
+}
+
+/// Entry point for `succinctly dev select-stats`.
+pub fn run(data_dir: &Path, markdown: Option<&PathBuf>) -> Result<i32> {
+    let report = generate_report(data_dir)?;
+
+    match markdown {
+        Some(path) => {
+            std::fs::write(path, &report)
+                .with_context(|| format!("writing report to {}", path.display()))?;
+            eprintln!("wrote {}", path.display());
+        }
+        None => print!("{report}"),
+    }
+
+    // A run that recorded nothing is a tooling failure, not a finding — most
+    // likely the binary was built without `select-stats`. Surface it as a
+    // non-zero exit so a scripted invocation cannot mistake it for "no scans".
+    let recorded: u64 = Site::all()
+        .iter()
+        .map(|&s| select_stats::snapshot(s).calls())
+        .sum();
+    Ok(i32::from(recorded == 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_file(root: &Path, rel: &str, content: &[u8]) -> PathBuf {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn render_table_pads_columns() {
+        let table = render_table(&["a", "bb"], &[vec!["x".into(), "yy".into()]]);
+        assert!(table.contains("| a | bb |"));
+        assert!(table.contains("| x | yy |"));
+    }
+
+    #[test]
+    fn site_row_renders_placeholders_for_empty_histogram() {
+        let row = site_row(Site::YamlAdvance, &Histogram::default());
+        assert_eq!(row[0], Site::YamlAdvance.name());
+        assert_eq!(row[1], "words");
+        assert_eq!(row[2], "0");
+        // mean / percentiles / fraction have no value to report
+        assert_eq!(row[3], "-");
+        assert_eq!(row[4], "-");
+        assert_eq!(row[8], "-");
+    }
+
+    #[test]
+    fn ib_select_from_sites_are_labelled_in_probes() {
+        let row = site_row(Site::JsonIbSelectFrom, &Histogram::default());
+        assert_eq!(row[1], "probes");
+    }
+
+    #[test]
+    fn report_covers_json_and_yaml_and_skips_dsv() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_file(root, "json/a/one.json", br#"{"a":[1,2,{"b":"c"}]}"#);
+        write_file(root, "yaml/b/two.yaml", b"a:\n  - 1\n  - k: v\n");
+        write_file(root, "dsv/c/three.csv", b"x,y\n1,2\n");
+        write_file(root, "other/skip.txt", b"ignored");
+
+        let report = generate_report(root).unwrap();
+
+        assert!(report.contains("one.json"), "{report}");
+        assert!(report.contains("two.yaml"), "{report}");
+        // DSV has no select word scan on its read path, and non-corpus
+        // extensions are not walked at all.
+        assert!(!report.contains("three.csv"), "{report}");
+        assert!(!report.contains("skip.txt"), "{report}");
+
+        // Every site gets a row, whether or not it recorded anything.
+        for site in Site::all() {
+            assert!(report.contains(site.name()), "missing {}", site.name());
+        }
+    }
+
+    #[test]
+    fn run_writes_markdown_when_asked() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_file(root, "json/a/one.json", br#"{"a":1}"#);
+        let out = root.join("report.md");
+
+        let code = run(root, Some(&out)).unwrap();
+        let written = std::fs::read_to_string(&out).unwrap();
+        assert!(written.contains("Select scan-length distribution"));
+
+        // Exit code reflects whether counters were populated, which depends on
+        // the feature this build was compiled with.
+        assert_eq!(code, i32::from(!cfg!(feature = "select-stats")));
+    }
+
+    #[test]
+    fn run_to_stdout_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "json/a/one.json", br"[1,2,3]");
+        // Exercises the stdout branch; the code again tracks the feature.
+        let code = run(dir.path(), None).unwrap();
+        assert_eq!(code, i32::from(!cfg!(feature = "select-stats")));
+    }
+
+    #[test]
+    fn empty_corpus_reports_no_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = generate_report(dir.path()).unwrap();
+        assert!(report.contains("Files traversed"));
+    }
+}

--- a/src/bits/bitvec.rs
+++ b/src/bits/bitvec.rs
@@ -247,6 +247,13 @@ impl RankSelect for BitVec {
         // ones_count` guarantees the scan finds it, so this `?` is unreachable.
         let (word_idx, rem) = scan_select(&self.words, start_word, remaining)?;
 
+        // #40: words popcounted by this scan, including the crossing word.
+        #[cfg(feature = "select-stats")]
+        crate::util::select_stats::record(
+            crate::util::select_stats::Site::BitVec,
+            word_idx - start_word + 1,
+        );
+
         let bit_pos = select_in_word(self.words[word_idx], rem as u32) as usize;
         let result = word_idx * 64 + bit_pos;
         // Defensive: `with_config` clears every bit at or past `len`, so a set

--- a/src/bits/bitvec.rs
+++ b/src/bits/bitvec.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::bits::popcount::{popcount_word, popcount_words};
 use crate::bits::rank::RankDirectory;
+use crate::bits::scan::scan_select;
 use crate::bits::select::SelectIndex;
 use crate::util::broadword::select_in_word;
 use crate::{Config, RankSelect};
@@ -240,32 +241,22 @@ impl RankSelect for BitVec {
         }
 
         // Use select index to jump to approximate position
-        let (start_word, mut remaining) = self.select_idx.jump_to(k);
+        let (start_word, remaining) = self.select_idx.jump_to(k);
 
-        // Scan words from the starting position
-        for word_idx in start_word..self.words.len() {
-            let word = self.words[word_idx];
-            let pop = popcount_word(word) as usize;
+        // Scan forward for the word holding the target bit. Defensive: `k <
+        // ones_count` guarantees the scan finds it, so this `?` is unreachable.
+        let (word_idx, rem) = scan_select(&self.words, start_word, remaining)?;
 
-            if pop > remaining {
-                // Found the target word
-                let bit_pos = select_in_word(word, remaining as u32) as usize;
-                let result = word_idx * 64 + bit_pos;
-                // Defensive: `with_config` clears every bit at or past `len`, so a
-                // set bit cannot lie outside the vector and this cannot return
-                // None. Kept as a guard, hence unreachable in coverage reports.
-                return if result < self.len {
-                    Some(result)
-                } else {
-                    None
-                };
-            }
-
-            remaining -= pop;
+        let bit_pos = select_in_word(self.words[word_idx], rem as u32) as usize;
+        let result = word_idx * 64 + bit_pos;
+        // Defensive: `with_config` clears every bit at or past `len`, so a set
+        // bit cannot lie outside the vector and this cannot return None. Kept
+        // as a guard, hence unreachable in coverage reports.
+        if result < self.len {
+            Some(result)
+        } else {
+            None
         }
-
-        // Also defensive: `k < ones_count` guarantees the scan finds the bit.
-        None
     }
 }
 

--- a/src/bits/elias_fano.rs
+++ b/src/bits/elias_fano.rs
@@ -348,6 +348,8 @@ impl EliasFano {
             let ones = masked.count_ones() as usize;
             if ones > remaining {
                 // #40: a single-word scan.
+                #[cfg(feature = "select-stats")]
+                crate::util::select_stats::record(crate::util::select_stats::Site::EliasFano, 1);
 
                 return start_word * 64 + select_in_word(masked, remaining as u32) as usize;
             }
@@ -357,6 +359,11 @@ impl EliasFano {
                 .expect("select1: not enough 1-bits");
 
             // #40: words popcounted, counting the masked start word.
+            #[cfg(feature = "select-stats")]
+            crate::util::select_stats::record(
+                crate::util::select_stats::Site::EliasFano,
+                word_idx - start_word + 1,
+            );
 
             let bit_pos = select_in_word(self.high_bits[word_idx], rem as u32) as usize;
             return word_idx * 64 + bit_pos;
@@ -367,6 +374,11 @@ impl EliasFano {
             .expect("select1: not enough 1-bits");
 
         // #40: words popcounted by this scan, including the crossing word.
+        #[cfg(feature = "select-stats")]
+        crate::util::select_stats::record(
+            crate::util::select_stats::Site::EliasFano,
+            word_idx - start_word + 1,
+        );
 
         word_idx * 64 + select_in_word(self.high_bits[word_idx], rem as u32) as usize
     }

--- a/src/bits/elias_fano.rs
+++ b/src/bits/elias_fano.rs
@@ -43,6 +43,7 @@ use alloc::vec;
 #[cfg(not(test))]
 use alloc::vec::Vec;
 
+use crate::bits::scan::scan_select;
 use crate::util::broadword::select_in_word;
 
 /// Select sample rate - one sample per this many elements.
@@ -336,26 +337,38 @@ impl EliasFano {
             (0, k)
         };
 
-        // Scan from sample position
-        for word_idx in start_word..self.high_bits.len() {
-            let word = if word_idx == start_word && sample_idx < self.select_samples.len() {
-                // Mask off bits before sample position
-                let sample_pos = self.select_samples[sample_idx] as usize;
-                let bit_offset = sample_pos % 64;
-                self.high_bits[word_idx] & !((1u64 << bit_offset) - 1)
-            } else {
-                self.high_bits[word_idx]
-            };
+        // The sampled start word must have the bits *before* the sample point
+        // masked off, so it cannot be handed to the shared scan (which reads
+        // whole words). Handle it separately, then scan the rest unmasked.
+        if sample_idx < self.select_samples.len() {
+            let sample_pos = self.select_samples[sample_idx] as usize;
+            let bit_offset = sample_pos % 64;
+            let masked = self.high_bits[start_word] & !((1u64 << bit_offset) - 1);
 
-            let ones = word.count_ones() as usize;
+            let ones = masked.count_ones() as usize;
             if ones > remaining {
-                let bit_pos = select_in_word(word, remaining as u32) as usize;
-                return word_idx * 64 + bit_pos;
+                // #40: a single-word scan.
+
+                return start_word * 64 + select_in_word(masked, remaining as u32) as usize;
             }
             remaining -= ones;
+
+            let (word_idx, rem) = scan_select(&self.high_bits, start_word + 1, remaining)
+                .expect("select1: not enough 1-bits");
+
+            // #40: words popcounted, counting the masked start word.
+
+            let bit_pos = select_in_word(self.high_bits[word_idx], rem as u32) as usize;
+            return word_idx * 64 + bit_pos;
         }
 
-        unreachable!("select1: not enough 1-bits");
+        // No usable sample: scan from the beginning, nothing to mask.
+        let (word_idx, rem) = scan_select(&self.high_bits, start_word, remaining)
+            .expect("select1: not enough 1-bits");
+
+        // #40: words popcounted by this scan, including the crossing word.
+
+        word_idx * 64 + select_in_word(self.high_bits[word_idx], rem as u32) as usize
     }
 
     /// Read low bits for element i.

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -25,10 +25,12 @@ mod bitvec;
 mod elias_fano;
 pub(crate) mod popcount;
 mod rank;
+mod scan;
 mod select;
 
 pub use bitvec::BitVec;
 pub use elias_fano::{EliasFano, EliasFanoCursor, EliasFanoIter};
 pub use popcount::{popcount_word, popcount_word_portable, popcount_words};
 pub use rank::RankDirectory;
+pub use scan::{block_popcount_portable, scan_select, scan_select_scalar, select_from, BLOCK};
 pub use select::SelectIndex;

--- a/src/bits/scan.rs
+++ b/src/bits/scan.rs
@@ -238,7 +238,7 @@ pub unsafe fn block_popcount_avx2(block: &[u64]) -> usize {
             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
         );
         let low_mask = _mm256_set1_epi8(0x0F);
-        let ptr = block.as_ptr() as *const __m256i;
+        let ptr = block.as_ptr().cast::<__m256i>();
 
         let mut acc = _mm256_setzero_si256();
         for i in 0..2 {
@@ -254,7 +254,7 @@ pub unsafe fn block_popcount_avx2(block: &[u64]) -> usize {
         // Sum bytes within each 64-bit lane, then across lanes.
         let sums = _mm256_sad_epu8(acc, _mm256_setzero_si256());
         let mut lanes = [0u64; 4];
-        _mm256_storeu_si256(lanes.as_mut_ptr() as *mut __m256i, sums);
+        _mm256_storeu_si256(lanes.as_mut_ptr().cast::<__m256i>(), sums);
         (lanes[0] + lanes[1] + lanes[2] + lanes[3]) as usize
     }
 }

--- a/src/bits/scan.rs
+++ b/src/bits/scan.rs
@@ -1,0 +1,431 @@
+#![allow(unsafe_code)] // dispatches to NEON / AVX2 block-popcount kernels
+//! Forward word scan for `select` (#40).
+//!
+//! Every `select1` in this crate ends the same way: starting from some word,
+//! walk forward popcounting words until the running total passes the target
+//! rank, then finish inside the crossing word with
+//! [`select_in_word`](crate::util::select_in_word). Five separate copies of
+//! that loop existed before this module; they now share [`scan_select`].
+//!
+//! # Why vectorise it
+//!
+//! Measured on the real-workload corpus (`succinctly dev select-stats`), the
+//! YAML streaming site's scan lengths are sharply **bimodal**: about half the
+//! calls traverse fewer than 4 words, but **99% of all words popcounted happen
+//! in scans of 4 or more**, with p90 ≈ 232 words and a maximum near 300. So the
+//! common call is trivial and the aggregate cost lives entirely in a long tail.
+//!
+//! That shape dictates the design below, and it is why this is not the P2.8 /
+//! P3 / P5 pattern of optimising a shape real inputs do not contain: the long
+//! scans are where the work is, and they are real.
+//!
+//! # Design: skip whole blocks, pinpoint once
+//!
+//! Issue #40 sketched a per-iteration in-vector prefix sum plus a comparison
+//! mask to locate the crossing word. That work is unnecessary. A scan only
+//! needs to *locate* once — at the very end — while every other iteration just
+//! needs to know whether the target lies past the current block. So each
+//! iteration computes one block **total** and either subtracts it and moves on,
+//! or drops into a short scalar scan over that block's ≤ `BLOCK` words to
+//! pinpoint. Block totals are much cheaper than per-lane prefix sums.
+//!
+//! A scalar prologue runs before the block loop, so the ~50% of calls that
+//! finish within a couple of words never touch a vector register and pay no
+//! setup at all. This is a structural guarantee rather than a tuned threshold
+//! constant — the kind of magic number that made P2.8 fragile.
+
+use crate::util::select_in_word;
+
+/// Words consumed per block-loop iteration.
+///
+/// 8 words = 64 bytes = one cache line, and matches the natural width of both
+/// kernels (four NEON `uint64x2_t`, or two AVX2 `__m256i`).
+pub const BLOCK: usize = 8;
+
+/// Words scanned scalar-first, before the block loop starts.
+///
+/// Set to [`BLOCK`] so that any scan short enough to finish inside it runs
+/// *exactly* the code the old per-word loop ran — same instructions, same
+/// cost. That makes "no regression on short scans" a structural property
+/// rather than a tuning claim, which matters here: the measured crossover on
+/// Apple M4 Pro sits between 8 and 16 words, and roughly half of all calls
+/// fall below it.
+///
+/// The price is one block's worth of scalar work on long scans, which the
+/// micro-benchmark prices at a few percent of a win measured in multiples.
+const PROLOGUE: usize = BLOCK;
+
+/// Locate the word holding the `remaining`-th further set bit at or after
+/// `start_word`.
+///
+/// Returns `(word_idx, remaining_in_word)`, where `remaining_in_word` is the
+/// rank of the target bit **within** `words[word_idx]` — ready to hand to
+/// [`select_in_word`](crate::util::select_in_word). Returns `None` if `words`
+/// does not contain enough set bits from `start_word` onward.
+///
+/// # Examples
+///
+/// ```
+/// use succinctly::bits::scan_select;
+///
+/// // Two set bits in word 0, three in word 1.
+/// let words = [0b101u64, 0b111u64];
+///
+/// // The 0th further set bit is in word 0, at in-word rank 0.
+/// assert_eq!(scan_select(&words, 0, 0), Some((0, 0)));
+/// // The 2nd is the first bit of word 1.
+/// assert_eq!(scan_select(&words, 0, 2), Some((1, 0)));
+/// // There is no 5th.
+/// assert_eq!(scan_select(&words, 0, 5), None);
+/// ```
+#[inline]
+pub fn scan_select(words: &[u64], start_word: usize, remaining: usize) -> Option<(usize, usize)> {
+    if start_word >= words.len() {
+        return None;
+    }
+
+    let mut rem = remaining;
+    let mut idx = start_word;
+
+    // Prologue: the common short scan never reaches the vector path.
+    let prologue_end = (start_word + PROLOGUE).min(words.len());
+    while idx < prologue_end {
+        let pop = words[idx].count_ones() as usize;
+        if pop > rem {
+            return Some((idx, rem));
+        }
+        rem -= pop;
+        idx += 1;
+    }
+
+    // Block loop: skip whole blocks whose total does not reach the target.
+    while idx + BLOCK <= words.len() {
+        let block = &words[idx..idx + BLOCK];
+        let total = block_popcount(block);
+        if total > rem {
+            // The target is inside this block; pinpoint scalar.
+            return scan_scalar(block, rem).map(|(off, r)| (idx + off, r));
+        }
+        rem -= total;
+        idx += BLOCK;
+    }
+
+    // Tail: fewer than BLOCK words left.
+    scan_scalar(&words[idx..], rem).map(|(off, r)| (idx + off, r))
+}
+
+/// Plain per-word scan over `words`, returning an offset relative to its start.
+#[inline]
+fn scan_scalar(words: &[u64], remaining: usize) -> Option<(usize, usize)> {
+    let mut rem = remaining;
+    for (off, &w) in words.iter().enumerate() {
+        let pop = w.count_ones() as usize;
+        if pop > rem {
+            return Some((off, rem));
+        }
+        rem -= pop;
+    }
+    None
+}
+
+/// Total popcount of exactly [`BLOCK`] words.
+///
+/// Dispatches to a SIMD kernel where one is available. The scalar body is not
+/// a poor relation: LLVM vectorises it well on several targets, and the
+/// micro-benchmark (`select_scan_micro`) compares all three so the intrinsics
+/// are only kept where they actually win.
+#[inline]
+fn block_popcount(block: &[u64]) -> usize {
+    debug_assert_eq!(block.len(), BLOCK);
+
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
+    {
+        // NEON is baseline on aarch64 — no runtime detection needed.
+        // SAFETY: `block` has exactly BLOCK == 8 words, which is what the
+        // kernel reads.
+        return unsafe { block_popcount_neon(block) };
+    }
+
+    #[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]
+    {
+        if has_avx2() {
+            // SAFETY: AVX2 availability checked above; `block` has exactly
+            // BLOCK == 8 words, which is what the kernel reads.
+            return unsafe { block_popcount_avx2(block) };
+        }
+    }
+
+    #[allow(unreachable_code)]
+    block_popcount_portable(block)
+}
+
+/// Portable block popcount. Also the correctness oracle for the SIMD kernels.
+#[inline]
+pub fn block_popcount_portable(block: &[u64]) -> usize {
+    block.iter().map(|w| w.count_ones() as usize).sum()
+}
+
+/// NEON block popcount over 8 words.
+///
+/// Per-byte `CNT`, summed across all four vectors while still 8-bit (each lane
+/// is at most 8, so four of them cannot exceed 32 and cannot overflow), then a
+/// single widening chain and one horizontal add. Keeping the accumulation
+/// narrow is what makes this cheaper than popcounting each word separately.
+///
+/// # Safety
+///
+/// `block` must contain at least [`BLOCK`] words.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[inline]
+pub unsafe fn block_popcount_neon(block: &[u64]) -> usize {
+    use core::arch::aarch64::*;
+
+    unsafe {
+        let ptr = block.as_ptr().cast::<u8>();
+        let c0 = vcntq_u8(vld1q_u8(ptr));
+        let c1 = vcntq_u8(vld1q_u8(ptr.add(16)));
+        let c2 = vcntq_u8(vld1q_u8(ptr.add(32)));
+        let c3 = vcntq_u8(vld1q_u8(ptr.add(48)));
+
+        // Max 8 per lane, so summing four stays well inside u8.
+        let sum = vaddq_u8(vaddq_u8(c0, c1), vaddq_u8(c2, c3));
+
+        // Widen once, then one horizontal add.
+        vaddvq_u16(vpaddlq_u8(sum)) as usize
+    }
+}
+
+/// Cached AVX2 detection, mirroring the pattern used by `select_in_word`.
+#[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]
+#[inline]
+fn has_avx2() -> bool {
+    use core::sync::atomic::{AtomicU8, Ordering};
+
+    // 0 = unknown, 1 = available, 2 = unavailable
+    static HAS_AVX2: AtomicU8 = AtomicU8::new(0);
+
+    match HAS_AVX2.load(Ordering::Relaxed) {
+        1 => true,
+        2 => false,
+        _ => {
+            let detected = std::arch::is_x86_feature_detected!("avx2");
+            HAS_AVX2.store(u8::from(!detected) + 1, Ordering::Relaxed);
+            detected
+        }
+    }
+}
+
+/// AVX2 block popcount over 8 words.
+///
+/// `vpshufb` as a 16-entry nibble lookup table (the approach #40 sketched),
+/// finished with `vpsadbw` against zero. `vpsadbw` sums bytes within each
+/// 64-bit lane in one instruction, which replaces the issue's scatter-and-
+/// compare step entirely — a block total is all this loop needs.
+///
+/// # Safety
+///
+/// Requires AVX2. `block` must contain at least [`BLOCK`] words.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+#[inline]
+pub unsafe fn block_popcount_avx2(block: &[u64]) -> usize {
+    use core::arch::x86_64::*;
+
+    unsafe {
+        let lut = _mm256_setr_epi8(
+            0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, //
+            0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+        );
+        let low_mask = _mm256_set1_epi8(0x0F);
+        let ptr = block.as_ptr() as *const __m256i;
+
+        let mut acc = _mm256_setzero_si256();
+        for i in 0..2 {
+            let v = _mm256_loadu_si256(ptr.add(i));
+            let lo = _mm256_and_si256(v, low_mask);
+            let hi = _mm256_and_si256(_mm256_srli_epi16(v, 4), low_mask);
+            let counts =
+                _mm256_add_epi8(_mm256_shuffle_epi8(lut, lo), _mm256_shuffle_epi8(lut, hi));
+            // Per-byte counts are at most 8; two vectors keep the u8 lanes safe.
+            acc = _mm256_add_epi8(acc, counts);
+        }
+
+        // Sum bytes within each 64-bit lane, then across lanes.
+        let sums = _mm256_sad_epu8(acc, _mm256_setzero_si256());
+        let mut lanes = [0u64; 4];
+        _mm256_storeu_si256(lanes.as_mut_ptr() as *mut __m256i, sums);
+        (lanes[0] + lanes[1] + lanes[2] + lanes[3]) as usize
+    }
+}
+
+/// Reference implementation: the per-word loop every call site used before.
+///
+/// Retained as the benchmark baseline and as the oracle the property tests
+/// compare [`scan_select`] against.
+#[inline]
+pub fn scan_select_scalar(
+    words: &[u64],
+    start_word: usize,
+    remaining: usize,
+) -> Option<(usize, usize)> {
+    if start_word >= words.len() {
+        return None;
+    }
+    scan_scalar(&words[start_word..], remaining).map(|(off, r)| (start_word + off, r))
+}
+
+/// Complete a scan by locating the target bit position.
+///
+/// Convenience for the call sites: scan to the crossing word, then finish
+/// inside it. Returns the absolute bit position, or `None` if there are not
+/// enough set bits.
+#[inline]
+pub fn select_from(words: &[u64], start_word: usize, remaining: usize) -> Option<usize> {
+    let (word_idx, rem) = scan_select(words, start_word, remaining)?;
+    Some(word_idx * 64 + select_in_word(words[word_idx], rem as u32) as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic pseudo-random words (xorshift64*), so failures reproduce.
+    fn pseudo_random_words(n: usize, seed: u64) -> Vec<u64> {
+        let mut state = seed | 1;
+        (0..n)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                state.wrapping_mul(0x2545_F491_4F6C_DD1D)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn empty_input_has_nothing_to_find() {
+        assert_eq!(scan_select(&[], 0, 0), None);
+        assert_eq!(scan_select(&[1, 2, 3], 3, 0), None);
+        assert_eq!(scan_select(&[1, 2, 3], 99, 0), None);
+    }
+
+    #[test]
+    fn finds_bits_within_the_prologue() {
+        let words = [0b1011u64, 0b110u64];
+        assert_eq!(scan_select(&words, 0, 0), Some((0, 0)));
+        assert_eq!(scan_select(&words, 0, 1), Some((0, 1)));
+        assert_eq!(scan_select(&words, 0, 2), Some((0, 2)));
+        // 4th set bit overall is the first of word 1.
+        assert_eq!(scan_select(&words, 0, 3), Some((1, 0)));
+    }
+
+    #[test]
+    fn all_zero_words_never_satisfy_a_request() {
+        let words = vec![0u64; BLOCK * 4];
+        assert_eq!(scan_select(&words, 0, 0), None);
+    }
+
+    #[test]
+    fn skips_whole_zero_blocks_to_reach_a_distant_bit() {
+        // A single set bit far past several all-zero blocks exercises the
+        // block-skipping path, which is the entire point of the kernel.
+        let mut words = vec![0u64; BLOCK * 5];
+        let last = words.len() - 1;
+        words[last] = 1 << 40;
+        assert_eq!(scan_select(&words, 0, 0), Some((last, 0)));
+        assert_eq!(select_from(&words, 0, 0), Some(last * 64 + 40));
+    }
+
+    #[test]
+    fn matches_scalar_on_dense_words() {
+        // All bits set: word i holds bits [64i, 64i+64).
+        let words = vec![u64::MAX; BLOCK * 3 + 5];
+        let total = words.len() * 64;
+        for k in [0usize, 1, 63, 64, 65, 200, total - 1] {
+            assert_eq!(
+                scan_select(&words, 0, k),
+                scan_select_scalar(&words, 0, k),
+                "k={k}"
+            );
+            assert_eq!(select_from(&words, 0, k), Some(k), "k={k}");
+        }
+        assert_eq!(scan_select(&words, 0, total), None);
+    }
+
+    #[test]
+    fn agrees_with_scalar_across_random_inputs_and_start_words() {
+        for seed in [1u64, 2, 0xDEAD_BEEF] {
+            // Deliberately not a multiple of BLOCK, so the tail path runs.
+            let words = pseudo_random_words(BLOCK * 7 + 3, seed);
+            let total: usize = words.iter().map(|w| w.count_ones() as usize).sum();
+
+            for start in [0usize, 1, 2, 3, BLOCK, BLOCK + 1, words.len() - 1] {
+                let available: usize = words[start..].iter().map(|w| w.count_ones() as usize).sum();
+                for k in [0usize, 1, 5, 40, 100, available.saturating_sub(1)] {
+                    assert_eq!(
+                        scan_select(&words, start, k),
+                        scan_select_scalar(&words, start, k),
+                        "seed={seed} start={start} k={k}"
+                    );
+                }
+                // One past the end must fail from every start word.
+                assert_eq!(scan_select(&words, start, available), None);
+            }
+
+            // select_from must enumerate exactly the set bits, in order.
+            let expected: Vec<usize> = (0..words.len() * 64)
+                .filter(|&b| words[b / 64] >> (b % 64) & 1 == 1)
+                .collect();
+            assert_eq!(expected.len(), total);
+            for (k, &bit) in expected.iter().enumerate() {
+                assert_eq!(select_from(&words, 0, k), Some(bit), "seed={seed} k={k}");
+            }
+        }
+    }
+
+    #[test]
+    fn block_popcount_kernels_agree_with_portable() {
+        for seed in [7u64, 11, 0x5EED] {
+            let words = pseudo_random_words(BLOCK, seed);
+            let expected = block_popcount_portable(&words);
+
+            assert_eq!(block_popcount(&words), expected, "dispatch, seed={seed}");
+
+            #[cfg(target_arch = "aarch64")]
+            {
+                // SAFETY: NEON is baseline on aarch64; `words` has BLOCK words.
+                let neon = unsafe { block_popcount_neon(&words) };
+                assert_eq!(neon, expected, "neon, seed={seed}");
+            }
+
+            #[cfg(target_arch = "x86_64")]
+            {
+                if crate::util::simd::note_simd_skip_unless(has_avx2(), "avx2") {
+                    // SAFETY: AVX2 checked; `words` has BLOCK words.
+                    let avx2 = unsafe { block_popcount_avx2(&words) };
+                    assert_eq!(avx2, expected, "avx2, seed={seed}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn block_popcount_handles_the_extremes() {
+        assert_eq!(block_popcount(&[0u64; BLOCK]), 0);
+        assert_eq!(block_popcount(&[u64::MAX; BLOCK]), BLOCK * 64);
+    }
+
+    #[test]
+    fn scan_select_scalar_rejects_out_of_range_start() {
+        assert_eq!(scan_select_scalar(&[1u64], 1, 0), None);
+        assert_eq!(scan_select_scalar(&[], 0, 0), None);
+    }
+
+    #[test]
+    fn select_from_returns_none_when_bits_run_out() {
+        let words = [0b1u64, 0u64];
+        assert_eq!(select_from(&words, 0, 0), Some(0));
+        assert_eq!(select_from(&words, 0, 1), None);
+    }
+}

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -377,6 +377,11 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
         let k32 = k as u32;
         let n = words.len();
 
+        // #40: count `ib_rank` probes so this path's cost can be compared with
+        // the word-scan sites. Starts at 1 for the `hint_rank` probe below.
+        #[cfg(feature = "select-stats")]
+        let mut probes = 1usize;
+
         // Clamp hint to valid range
         let hint = hint.min(n.saturating_sub(1));
 
@@ -392,6 +397,10 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
 
             // Gallop forward: double the step size until we overshoot
             loop {
+                #[cfg(feature = "select-stats")]
+                {
+                    probes += 1;
+                }
                 let next = (hint + bound).min(n);
                 if next >= n || self.ib_rank[next + 1] > k32 {
                     // Found the range: [prev, next]
@@ -409,6 +418,10 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
 
             // Gallop backward
             loop {
+                #[cfg(feature = "select-stats")]
+                {
+                    probes += 1;
+                }
                 let next = hint.saturating_sub(bound);
                 if next == 0 || self.ib_rank[next + 1] <= k32 {
                     // Found the range: [next, prev]
@@ -425,6 +438,10 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
         let mut lo = lo;
         let mut hi = hi;
         while lo < hi {
+            #[cfg(feature = "select-stats")]
+            {
+                probes += 1;
+            }
             let mid = lo + (hi - lo) / 2;
             if self.ib_rank[mid + 1] <= k32 {
                 lo = mid + 1;
@@ -432,6 +449,12 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
                 hi = mid;
             }
         }
+
+        #[cfg(feature = "select-stats")]
+        crate::util::select_stats::record(
+            crate::util::select_stats::Site::JsonIbSelectFrom,
+            probes,
+        );
 
         if lo >= n {
             return None;

--- a/src/json/simple_light.rs
+++ b/src/json/simple_light.rs
@@ -308,6 +308,11 @@ impl<W: AsRef<[u64]>> SimpleJsonIndex<W> {
         let (word_idx, rem) = crate::bits::scan_select(words, 0, k)?;
 
         // #40: words popcounted by this scan, including the crossing word.
+        #[cfg(feature = "select-stats")]
+        crate::util::select_stats::record(
+            crate::util::select_stats::Site::SimpleJson,
+            word_idx + 1,
+        );
 
         let bit_pos = select_in_word(words[word_idx], rem as u32) as usize;
         let result = word_idx * 64 + bit_pos;

--- a/src/json/simple_light.rs
+++ b/src/json/simple_light.rs
@@ -301,24 +301,21 @@ impl<W: AsRef<[u64]>> SimpleJsonIndex<W> {
     /// Perform select1 on the IB (find position of k-th 1-bit, 0-indexed).
     fn ib_select1(&self, k: usize) -> Option<usize> {
         let words = self.ib.as_ref();
-        let mut remaining = k;
 
-        for (word_idx, &word) in words.iter().enumerate() {
-            let ones = word.count_ones() as usize;
-            if ones > remaining {
-                // Found the target word
-                let bit_pos = select_in_word(word, remaining as u32) as usize;
-                let result = word_idx * 64 + bit_pos;
-                return if result < self.ib_len {
-                    Some(result)
-                } else {
-                    None
-                };
-            }
-            remaining -= ones;
+        // No select index here: this scans from word 0 on every call, so it is
+        // the site that benefits most per call from block skipping — though it
+        // has no in-crate consumer, `SimpleJsonIndex` being a reference API.
+        let (word_idx, rem) = crate::bits::scan_select(words, 0, k)?;
+
+        // #40: words popcounted by this scan, including the crossing word.
+
+        let bit_pos = select_in_word(words[word_idx], rem as u32) as usize;
+        let result = word_idx * 64 + bit_pos;
+        if result < self.ib_len {
+            Some(result)
+        } else {
+            None
         }
-
-        None
     }
 
     /// Perform rank1 on the IB (count 1-bits in [0, pos)).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,14 @@ pub mod trees;
 /// Internal utilities (not part of public API).
 pub(crate) mod util;
 
+/// Scan-length instrumentation for the `select` word-scan loops (#40).
+///
+/// Diagnostic tooling, not a data structure: the counters it collects are only
+/// populated in builds with the non-default `select-stats` feature. See the
+/// module docs for why the measurement exists.
+#[cfg(any(feature = "std", test))]
+pub use util::select_stats;
+
 /// Binary serialization utilities.
 pub mod binary;
 

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -112,6 +112,11 @@ impl SelectSupport for WithSelect {
         let (word_idx, rem) = scan_select(words, start_word, remaining)?;
 
         // #40: words popcounted by this scan, including the crossing word.
+        #[cfg(feature = "select-stats")]
+        crate::util::select_stats::record(
+            crate::util::select_stats::Site::BpWithSelect,
+            word_idx - start_word + 1,
+        );
 
         let bit_pos = select_in_word(words[word_idx], rem as u32) as usize;
         let result = word_idx * 64 + bit_pos;

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -34,8 +34,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::bits::popcount::popcount_word;
-use crate::bits::SelectIndex;
+use crate::bits::{scan_select, SelectIndex};
 use crate::util::broadword::select_in_word;
 
 // ============================================================================
@@ -107,23 +106,20 @@ impl SelectSupport for WithSelect {
         }
 
         // Use select index to jump to approximate position
-        let (start_word, mut remaining) = self.select_idx.jump_to(k);
+        let (start_word, remaining) = self.select_idx.jump_to(k);
 
-        // Scan words from the starting position
-        for (word_idx, &word) in words.iter().enumerate().skip(start_word) {
-            let pop = popcount_word(word) as usize;
+        // Scan forward for the word holding the target bit.
+        let (word_idx, rem) = scan_select(words, start_word, remaining)?;
 
-            if pop > remaining {
-                // Found the target word
-                let bit_pos = select_in_word(word, remaining as u32) as usize;
-                let result = word_idx * 64 + bit_pos;
-                return if result < len { Some(result) } else { None };
-            }
+        // #40: words popcounted by this scan, including the crossing word.
 
-            remaining -= pop;
+        let bit_pos = select_in_word(words[word_idx], rem as u32) as usize;
+        let result = word_idx * 64 + bit_pos;
+        if result < len {
+            Some(result)
+        } else {
+            None
         }
-
-        None
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,6 +6,12 @@
 pub(crate) mod broadword;
 pub(crate) mod table;
 
+// Scan-length instrumentation for the select word-scan loops (#40). Always
+// compiled under `std` so its own logic stays covered by the ordinary test
+// run; only the call sites in the hot loops are gated on `select-stats`.
+#[cfg(any(feature = "std", test))]
+pub mod select_stats;
+
 // Always compiled: `simd::escape` provides the portable scalar escape scanner
 // used under `scalar-yaml` and on non-x86/arm targets. The arch-specific
 // popcount submodules inside stay gated to their target.

--- a/src/util/select_stats.rs
+++ b/src/util/select_stats.rs
@@ -1,0 +1,441 @@
+//! Scan-length instrumentation for the select word-scan loops (#40).
+//!
+//! Issue #40 asks whether the word-scan inside `select` is worth vectorising
+//! (SIMD popcount several words, prefix-sum, skip to the crossing word). That
+//! only pays off if the scans are actually *long*: SIMD setup cost cannot be
+//! recovered when the loop typically exits after one or two words. Four prior
+//! SIMD proposals in this crate (P2.8, P3, P5, P8) were rejected for exactly
+//! that reason — a micro-benchmark win over input shapes real workloads do not
+//! contain.
+//!
+//! So before writing any kernel, we measure: how many words does each scan
+//! site actually traverse on real inputs? This module records that
+//! distribution.
+//!
+//! # Zero cost when disabled
+//!
+//! The five instrumented scan loops call [`record`] only under
+//! `#[cfg(feature = "select-stats")]`, so in normal builds the hot loops carry
+//! no counter at all. This module itself is always compiled (it needs `std`
+//! for its thread-local storage), which keeps its own logic covered by the
+//! ordinary test run rather than only under a feature CI does not enable.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --release --features cli,bench-runner,select-stats -- \
+//!     dev select-stats --data-dir data/bench/corpus
+//! ```
+
+use core::cell::RefCell;
+
+/// The select word-scan sites instrumented for #40.
+///
+/// Each variant is one of the five near-identical scalar scan loops found in
+/// the crate. Recording them separately is the point of the exercise: they
+/// differ enormously in heat, and a distribution pooled across all five would
+/// hide that.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Site {
+    /// `AdvancePositions::get_sequential` — per node on the yq streaming path.
+    /// The only site expected to be hot.
+    YamlAdvance,
+    /// `WithSelect::select1` — YAML `find_bp_at_text_pos`, one call per locate.
+    BpWithSelect,
+    /// `BitVec::select1` — newline / line-start lookup in locate.
+    BitVec,
+    /// `EliasFano::select1` — library-only; no in-crate consumer.
+    EliasFano,
+    /// `SimpleJsonIndex::ib_select1` — unindexed O(n) scan; no in-crate consumer.
+    SimpleJson,
+    /// `JsonIndex::ib_select1_from` — hot (per value materialised), but *not* a
+    /// word scan: gallop + binary search over the precomputed `ib_rank` array.
+    /// Recorded in probes, not words, so the two kinds of cost can be compared.
+    JsonIbSelectFrom,
+    /// `YamlIndex::ib_select1_from` — the YAML twin of [`Site::JsonIbSelectFrom`].
+    YamlIbSelectFrom,
+}
+
+impl Site {
+    /// Total number of instrumented sites.
+    pub const COUNT: usize = 7;
+
+    /// Dense index into the per-site histogram array.
+    #[inline]
+    pub fn index(self) -> usize {
+        match self {
+            Self::YamlAdvance => 0,
+            Self::BpWithSelect => 1,
+            Self::BitVec => 2,
+            Self::EliasFano => 3,
+            Self::SimpleJson => 4,
+            Self::JsonIbSelectFrom => 5,
+            Self::YamlIbSelectFrom => 6,
+        }
+    }
+
+    /// All sites, in histogram order.
+    pub fn all() -> [Self; Self::COUNT] {
+        [
+            Self::YamlAdvance,
+            Self::BpWithSelect,
+            Self::BitVec,
+            Self::EliasFano,
+            Self::SimpleJson,
+            Self::JsonIbSelectFrom,
+            Self::YamlIbSelectFrom,
+        ]
+    }
+
+    /// Human-readable name used in the report.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::YamlAdvance => "yaml/advance_positions get_sequential",
+            Self::BpWithSelect => "trees/bp WithSelect::select1",
+            Self::BitVec => "bits/bitvec BitVec::select1",
+            Self::EliasFano => "bits/elias_fano EliasFano::select1",
+            Self::SimpleJson => "json/simple_light ib_select1",
+            Self::JsonIbSelectFrom => "json/light ib_select1_from",
+            Self::YamlIbSelectFrom => "yaml/index ib_select1_from",
+        }
+    }
+
+    /// Whether this site is a word scan (the shape #40 proposes vectorising)
+    /// or a rank-array search (where the popcount step is already precomputed).
+    #[inline]
+    pub fn is_word_scan(self) -> bool {
+        !matches!(self, Self::JsonIbSelectFrom | Self::YamlIbSelectFrom)
+    }
+
+    /// Unit of the recorded quantity: words popcounted, or `ib_rank` probes.
+    pub fn unit(self) -> &'static str {
+        if self.is_word_scan() {
+            "words"
+        } else {
+            "probes"
+        }
+    }
+}
+
+/// Number of exact histogram buckets: scan lengths `0..EXACT_BUCKETS` are
+/// counted individually. Anything longer lands in the overflow bucket.
+///
+/// Sized well past the decision boundary rather than close to it. An earlier
+/// 64-bucket version saturated: real YAML scans reach 296 words, so p90 pinned
+/// to the ceiling and the distribution's shape was invisible. 512 is cheap
+/// (4 KiB per site) and leaves headroom above the observed maximum.
+pub const EXACT_BUCKETS: usize = 512;
+
+/// Per-site scan-length histogram.
+#[derive(Clone)]
+pub struct Histogram {
+    /// `buckets[n]` counts scans that traversed exactly `n` words.
+    buckets: [u64; EXACT_BUCKETS],
+    /// Scans that traversed `EXACT_BUCKETS` or more words.
+    overflow: u64,
+    /// Longest scan observed (exact, even when it lands in overflow).
+    max: u64,
+    /// Sum of all scan lengths, for the mean.
+    total_words: u64,
+    /// Number of scans recorded.
+    calls: u64,
+}
+
+impl Default for Histogram {
+    fn default() -> Self {
+        Self {
+            buckets: [0; EXACT_BUCKETS],
+            overflow: 0,
+            max: 0,
+            total_words: 0,
+            calls: 0,
+        }
+    }
+}
+
+impl Histogram {
+    /// Record one scan that traversed `words` words.
+    #[inline]
+    fn record(&mut self, words: usize) {
+        let w = words as u64;
+        self.calls += 1;
+        self.total_words += w;
+        if w > self.max {
+            self.max = w;
+        }
+        if words < EXACT_BUCKETS {
+            self.buckets[words] += 1;
+        } else {
+            self.overflow += 1;
+        }
+    }
+
+    /// Number of scans recorded.
+    pub fn calls(&self) -> u64 {
+        self.calls
+    }
+
+    /// Longest scan observed, in words.
+    pub fn max(&self) -> u64 {
+        self.max
+    }
+
+    /// Mean scan length in words, or `None` if nothing was recorded.
+    pub fn mean(&self) -> Option<f64> {
+        (self.calls > 0).then(|| self.total_words as f64 / self.calls as f64)
+    }
+
+    /// Nearest-rank percentile of the scan length, in words.
+    ///
+    /// Returns `None` when nothing was recorded. A result of
+    /// `EXACT_BUCKETS` means "at least `EXACT_BUCKETS`" — the overflow bucket
+    /// does not retain exact lengths, only [`Self::max`] does.
+    pub fn percentile(&self, p: f64) -> Option<u64> {
+        if self.calls == 0 {
+            return None;
+        }
+        // Nearest-rank: smallest value whose cumulative count reaches ceil(p% * n).
+        let rank = ((p / 100.0) * self.calls as f64).ceil().max(1.0) as u64;
+        let mut cumulative = 0u64;
+        for (words, &count) in self.buckets.iter().enumerate() {
+            cumulative += count;
+            if cumulative >= rank {
+                return Some(words as u64);
+            }
+        }
+        Some(EXACT_BUCKETS as u64)
+    }
+
+    /// Fraction of scans that traversed strictly fewer than `words` words.
+    ///
+    /// Counts *calls*, so it answers "how often is a scan too short for a SIMD
+    /// block to help?".
+    pub fn fraction_below(&self, words: usize) -> Option<f64> {
+        if self.calls == 0 {
+            return None;
+        }
+        let below: u64 = self.buckets[..words.min(EXACT_BUCKETS)].iter().sum();
+        Some(below as f64 / self.calls as f64)
+    }
+
+    /// Fraction of *total words scanned* that occurs in scans of at least
+    /// `words` words.
+    ///
+    /// This is the number the #40 decision actually turns on, and it differs
+    /// sharply from [`Self::fraction_below`] when the distribution is bimodal.
+    /// A workload where most *calls* are 1–2 words but most *work* happens in
+    /// rare 300-word scans is a good SIMD target: the vector path handles the
+    /// long tail that dominates runtime, while a scalar prologue keeps the
+    /// short calls free. Counting calls alone would wrongly reject it.
+    ///
+    /// Samples in the overflow bucket contribute their exact length to the
+    /// numerator via `total_words`, so the result stays correct above the
+    /// bucket ceiling.
+    pub fn work_fraction_at_or_above(&self, words: usize) -> Option<f64> {
+        if self.calls == 0 || self.total_words == 0 {
+            return None;
+        }
+        let below_words: u64 = self.buckets[..words.min(EXACT_BUCKETS)]
+            .iter()
+            .enumerate()
+            .map(|(len, &count)| len as u64 * count)
+            .sum();
+        Some((self.total_words - below_words) as f64 / self.total_words as f64)
+    }
+
+    /// Total words popcounted across all recorded scans.
+    pub fn total_words(&self) -> u64 {
+        self.total_words
+    }
+
+    /// Merge another histogram into this one.
+    pub fn merge(&mut self, other: &Self) {
+        for (dst, src) in self.buckets.iter_mut().zip(other.buckets.iter()) {
+            *dst += src;
+        }
+        self.overflow += other.overflow;
+        self.total_words += other.total_words;
+        self.calls += other.calls;
+        if other.max > self.max {
+            self.max = other.max;
+        }
+    }
+}
+
+thread_local! {
+    /// Per-thread, per-site histograms.
+    ///
+    /// Thread-local rather than a global mutex so instrumentation cannot
+    /// perturb the very timings a follow-up benchmark would measure. The
+    /// reporting command is single-threaded, so no cross-thread merge is
+    /// needed.
+    static HISTOGRAMS: RefCell<[Histogram; Site::COUNT]> =
+        RefCell::new(core::array::from_fn(|_| Histogram::default()));
+}
+
+/// Record that a scan at `site` traversed `words` words.
+///
+/// Call sites guard this with `#[cfg(feature = "select-stats")]` so the hot
+/// loops are untouched in normal builds.
+#[inline]
+pub fn record(site: Site, words: usize) {
+    HISTOGRAMS.with(|h| {
+        if let Ok(mut h) = h.try_borrow_mut() {
+            h[site.index()].record(words);
+        }
+    });
+}
+
+/// Take a snapshot of the current thread's histogram for `site`.
+pub fn snapshot(site: Site) -> Histogram {
+    HISTOGRAMS.with(|h| h.borrow()[site.index()].clone())
+}
+
+/// Reset the current thread's histograms.
+pub fn reset() {
+    HISTOGRAMS.with(|h| {
+        *h.borrow_mut() = core::array::from_fn(|_| Histogram::default());
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_histogram_reports_nothing() {
+        let h = Histogram::default();
+        assert_eq!(h.calls(), 0);
+        assert_eq!(h.max(), 0);
+        assert_eq!(h.mean(), None);
+        assert_eq!(h.percentile(50.0), None);
+        assert_eq!(h.fraction_below(4), None);
+    }
+
+    #[test]
+    fn percentile_uses_nearest_rank() {
+        let mut h = Histogram::default();
+        // Ten scans: 1,1,1,1,1,2,2,2,3,9
+        for _ in 0..5 {
+            h.record(1);
+        }
+        for _ in 0..3 {
+            h.record(2);
+        }
+        h.record(3);
+        h.record(9);
+
+        assert_eq!(h.calls(), 10);
+        assert_eq!(h.max(), 9);
+        assert_eq!(h.percentile(50.0), Some(1));
+        assert_eq!(h.percentile(90.0), Some(3));
+        assert_eq!(h.percentile(100.0), Some(9));
+        // mean = (5*1 + 3*2 + 3 + 9) / 10 = 23/10
+        assert!((h.mean().unwrap() - 2.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fraction_below_counts_strictly_shorter_scans() {
+        let mut h = Histogram::default();
+        h.record(0);
+        h.record(1);
+        h.record(4);
+        h.record(10);
+        // 0 and 1 are below 4; 4 itself is not.
+        assert!((h.fraction_below(4).unwrap() - 0.5).abs() < 1e-9);
+        assert!((h.fraction_below(1).unwrap() - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn work_fraction_weights_by_words_not_calls() {
+        let mut h = Histogram::default();
+        // Bimodal: many trivial scans, one long one. By call count the short
+        // scans dominate; by work the long scan does. #40 turns on the latter.
+        for _ in 0..99 {
+            h.record(1);
+        }
+        h.record(901);
+
+        assert_eq!(h.total_words(), 99 + 901);
+        // 99% of calls are below 4 words ...
+        assert!((h.fraction_below(4).unwrap() - 0.99).abs() < 1e-9);
+        // ... but 90.1% of the work is in scans of 4+ words.
+        assert!((h.work_fraction_at_or_above(4).unwrap() - 0.901).abs() < 1e-9);
+    }
+
+    #[test]
+    fn work_fraction_stays_correct_above_the_bucket_ceiling() {
+        let mut h = Histogram::default();
+        h.record(1);
+        // Lands in overflow, but still contributes its exact length to the
+        // total, so the work share must not silently drop it.
+        h.record(EXACT_BUCKETS + 99);
+
+        let total = 1 + (EXACT_BUCKETS as u64 + 99);
+        assert_eq!(h.total_words(), total);
+        let expected = (total - 1) as f64 / total as f64;
+        assert!((h.work_fraction_at_or_above(4).unwrap() - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn work_fraction_is_none_without_samples() {
+        assert_eq!(Histogram::default().work_fraction_at_or_above(4), None);
+        // A histogram of only zero-length scans has no work to attribute.
+        let mut zeros = Histogram::default();
+        zeros.record(0);
+        assert_eq!(zeros.work_fraction_at_or_above(4), None);
+    }
+
+    #[test]
+    fn long_scans_land_in_overflow_but_keep_exact_max() {
+        let mut h = Histogram::default();
+        h.record(1);
+        h.record(EXACT_BUCKETS + 500);
+        assert_eq!(h.calls(), 2);
+        assert_eq!(h.max(), (EXACT_BUCKETS + 500) as u64);
+        // The overflowing sample cannot be resolved beyond the bucket ceiling.
+        assert_eq!(h.percentile(100.0), Some(EXACT_BUCKETS as u64));
+    }
+
+    #[test]
+    fn merge_combines_counts_and_max() {
+        let mut a = Histogram::default();
+        a.record(1);
+        a.record(2);
+        let mut b = Histogram::default();
+        b.record(2);
+        b.record(70);
+
+        a.merge(&b);
+        assert_eq!(a.calls(), 4);
+        assert_eq!(a.max(), 70);
+        assert_eq!(a.percentile(50.0), Some(2));
+    }
+
+    #[test]
+    fn record_and_snapshot_roundtrip() {
+        reset();
+        record(Site::YamlAdvance, 3);
+        record(Site::YamlAdvance, 5);
+        record(Site::BitVec, 1);
+
+        let yaml = snapshot(Site::YamlAdvance);
+        assert_eq!(yaml.calls(), 2);
+        assert_eq!(yaml.max(), 5);
+
+        let bitvec = snapshot(Site::BitVec);
+        assert_eq!(bitvec.calls(), 1);
+
+        reset();
+        assert_eq!(snapshot(Site::YamlAdvance).calls(), 0);
+    }
+
+    #[test]
+    fn sites_have_dense_distinct_indices() {
+        let all = Site::all();
+        assert_eq!(all.len(), Site::COUNT);
+        for (i, site) in all.iter().enumerate() {
+            assert_eq!(site.index(), i, "{}", site.name());
+        }
+    }
+}

--- a/src/yaml/advance_positions.rs
+++ b/src/yaml/advance_positions.rs
@@ -412,6 +412,11 @@ impl AdvancePositions {
             let result = wi * 64 + bit_pos;
 
             // #40: words popcounted by this scan, including the crossing word.
+            #[cfg(feature = "select-stats")]
+            crate::util::select_stats::record(
+                crate::util::select_stats::Site::YamlAdvance,
+                wi - start_wi + 1,
+            );
 
             // `rem` is the target's rank *within* word `wi`, so `k - rem` is
             // the number of ones before that word — the cursor's invariant.

--- a/src/yaml/advance_positions.rs
+++ b/src/yaml/advance_positions.rs
@@ -40,6 +40,7 @@ use alloc::vec::Vec;
 
 use core::cell::Cell;
 
+use crate::bits::scan_select;
 use crate::util::broadword::select_in_word;
 
 /// Select sample rate - one sample per this many 1-bits.
@@ -398,26 +399,28 @@ impl AdvancePositions {
             return Some(cursor.last_ib_result as u32);
         }
 
-        // Forward scan in IB bitmap from cursor position
-        let mut remaining = k - cursor.ib_ones_before;
-        let mut wi = cursor.ib_word_idx;
+        // Forward scan in IB bitmap from cursor position. This is the hottest
+        // select scan in the crate (once per node during yq streaming), and the
+        // one whose measured length distribution justified vectorising the
+        // shared helper — see `bits::scan`.
+        let start_wi = cursor.ib_word_idx;
+        let remaining = k - cursor.ib_ones_before;
 
-        while wi < self.ib_words.len() {
+        if let Some((wi, rem)) = scan_select(&self.ib_words, start_wi, remaining) {
             let word = self.ib_words[wi];
-            let ones = word.count_ones() as usize;
-            if remaining < ones {
-                let bit_pos = select_in_word(word, remaining as u32) as usize;
-                let result = wi * 64 + bit_pos;
+            let bit_pos = select_in_word(word, rem as u32) as usize;
+            let result = wi * 64 + bit_pos;
 
-                cursor.ib_ones_before = k - remaining;
-                cursor.ib_word_idx = wi;
-                cursor.last_ib_arg = k;
-                cursor.last_ib_result = result;
-                self.cursor.set(cursor);
-                return Some(result as u32);
-            }
-            remaining -= ones;
-            wi += 1;
+            // #40: words popcounted by this scan, including the crossing word.
+
+            // `rem` is the target's rank *within* word `wi`, so `k - rem` is
+            // the number of ones before that word — the cursor's invariant.
+            cursor.ib_ones_before = k - rem;
+            cursor.ib_word_idx = wi;
+            cursor.last_ib_arg = k;
+            cursor.last_ib_result = result;
+            self.cursor.set(cursor);
+            return Some(result as u32);
         }
 
         self.cursor.set(cursor);

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -600,6 +600,11 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         let k32 = k as u32;
         let n = words.len();
 
+        // #40: count `ib_rank` probes so this path's cost can be compared with
+        // the word-scan sites. Starts at 1 for the `hint_rank` probe below.
+        #[cfg(feature = "select-stats")]
+        let mut probes = 1usize;
+
         // Clamp hint to valid range
         let hint = hint.min(n.saturating_sub(1));
 
@@ -614,6 +619,10 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             let mut prev = hint;
 
             loop {
+                #[cfg(feature = "select-stats")]
+                {
+                    probes += 1;
+                }
                 let next = (hint + bound).min(n);
                 if next >= n || self.ib_rank[next + 1] > k32 {
                     lo = prev;
@@ -629,6 +638,10 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             let mut prev = hint;
 
             loop {
+                #[cfg(feature = "select-stats")]
+                {
+                    probes += 1;
+                }
                 let next = hint.saturating_sub(bound);
                 if next == 0 || self.ib_rank[next + 1] <= k32 {
                     lo = next;
@@ -644,6 +657,10 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         let mut lo = lo;
         let mut hi = hi;
         while lo < hi {
+            #[cfg(feature = "select-stats")]
+            {
+                probes += 1;
+            }
             let mid = lo + (hi - lo) / 2;
             if self.ib_rank[mid + 1] <= k32 {
                 lo = mid + 1;
@@ -651,6 +668,12 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
                 hi = mid;
             }
         }
+
+        #[cfg(feature = "select-stats")]
+        crate::util::select_stats::record(
+            crate::util::select_stats::Site::YamlIbSelectFrom,
+            probes,
+        );
 
         if lo >= n {
             return None;

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -1108,3 +1108,63 @@ fn test_million_bit_random() {
         );
     }
 }
+
+// ============================================================================
+// scan_select (#40): the vectorised word scan must be indistinguishable from
+// the per-word loop it replaces, for every input and every start word.
+// ============================================================================
+
+proptest! {
+    /// The block-skipping scan agrees with the scalar loop everywhere.
+    ///
+    /// This is the property that lets the five call sites delegate to the
+    /// shared helper: the SIMD path may be faster, but it may never disagree.
+    #[test]
+    fn scan_select_matches_scalar(
+        words in prop::collection::vec(any::<u64>(), 1..80),
+        start_word in 0usize..80,
+        k in 0usize..600,
+    ) {
+        use succinctly::bits::{scan_select, scan_select_scalar};
+        prop_assert_eq!(
+            scan_select(&words, start_word, k),
+            scan_select_scalar(&words, start_word, k)
+        );
+    }
+
+    /// Sparse inputs drive the block-skipping path, where whole all-zero
+    /// blocks are stepped over — the case dense random words rarely reach.
+    #[test]
+    fn scan_select_matches_scalar_when_sparse(
+        seeds in prop::collection::vec(0u32..64, 1..60),
+        k in 0usize..40,
+    ) {
+        use succinctly::bits::{scan_select, scan_select_scalar};
+        // Mostly-empty words with an occasional single set bit.
+        let words: Vec<u64> = seeds
+            .iter()
+            .map(|&s| if s % 5 == 0 { 1u64 << (s % 64) } else { 0 })
+            .collect();
+        prop_assert_eq!(
+            scan_select(&words, 0, k),
+            scan_select_scalar(&words, 0, k)
+        );
+    }
+
+    /// `select_from` enumerates exactly the set bits, in ascending order.
+    #[test]
+    fn select_from_enumerates_set_bits_in_order(
+        words in prop::collection::vec(any::<u64>(), 1..20),
+    ) {
+        use succinctly::bits::select_from;
+        let expected: Vec<usize> = (0..words.len() * 64)
+            .filter(|&b| (words[b / 64] >> (b % 64)) & 1 == 1)
+            .collect();
+
+        for (k, &bit) in expected.iter().enumerate() {
+            prop_assert_eq!(select_from(&words, 0, k), Some(bit));
+        }
+        // One past the last set bit must not resolve.
+        prop_assert_eq!(select_from(&words, 0, expected.len()), None);
+    }
+}


### PR DESCRIPTION
# Investigate SIMD Batch Select Optimization (#40)

This PR comprehensively investigates whether vectorising the word scan inside `select` is justified, resulting in a shared helper implementation, measurement infrastructure, and ultimately rejecting the SIMD kernel in favor of an algorithmic fix that yields far greater gains.

## What This PR Does

Investigates issue #40's proposal to SIMD-popcount several words at once and jump to the crossing word, rather than walking words one at a time. The investigation discovers that the real bottleneck is not the scan algorithm itself, but a cursor reset defect causing O(n²) behavior in YAML queries. Fixing the cursor yields 3.6–23× speedup, while the SIMD kernel contributes only noise on top.

## Type of Change

- [x] New feature (shared `scan_select` helper with NEON/AVX2 kernels)
- [x] Performance improvement (O(n²) → O(n) cursor fix)
- [x] Refactoring (five scan loops consolidated into one helper)
- [x] Test coverage improvement (property tests and benchmarks)
- [x] Documentation update (measurement methodology and findings)

## Related Issue

Fixes #40 (rejects the SIMD kernel proposal, but discovers and accepts O5 cursor fix)

## Changes Made

### Core Infrastructure

**Shared Select Scan Helper:**
- Added `src/bits/scan.rs` with `scan_select()` — a block-skipping word scan that five call sites share
- Implements scalar prologue to guarantee no regression on short scans
- Dispatches to NEON (`block_popcount_neon`) on aarch64 and AVX2 (`block_popcount_avx2`) on x86_64 when available
- Portable fallback using `block_popcount_portable()` for correctness and baseline comparison
- Exported via `src/bits/mod.rs` as public API with `block_popcount_portable`, `scan_select_scalar`, `select_from`, and `BLOCK` constant

**Refactored Call Sites:**
- Routed `BitVec::select1()` through `scan_select()` in `src/bits/bitvec.rs`
- Routed `WithSelect::select1()` through `scan_select()` in `src/trees/bp.rs`
- Refactored `EliasFano::select1()` in `src/bits/elias_fano.rs` with special handling for masked start word
- Routed `SimpleJsonIndex::ib_select1()` through `scan_select()` in `src/json/simple_light.rs`
- Routed `AdvancePositions::get_sequential()` through `scan_select()` in `src/yaml/advance_positions.rs`

### Measurement Infrastructure

**Instrumentation Module:**
- Added `src/util/select_stats.rs` with per-site scan-length histograms behind non-default `select-stats` feature
- `Histogram` type with percentiles, mean, work-fraction analysis (weights by words, not calls)
- `Site` enum identifying seven instrumented locations with dense indexing
- Thread-local storage to avoid perturbing timing runs
- 512-bucket histogram (headroom above observed maximum of 296 words)

**Integration into Scan Sites:**
- Added `record()` calls guarded by `#[cfg(feature = "select-stats")]` in five word-scan sites
- Added `record()` calls for two rank-array search sites (JsonIndex and YamlIndex `ib_select1_from`)
- Cargo.toml feature flag `select-stats` depends on `std`

**Reporting Tool:**
- Added `src/bin/succinctly/select_stats_report.rs` — walks corpus through same cursor APIs as jq/yq
- Renders markdown report with distribution table (calls, mean, p50/p90/p99, max, `calls <4`, `work >=4`)
- Reuses corpus classification and file walking from `corpus_stats`
- Exits non-zero when no data recorded (feature not enabled)
- Accessible via `succinctly dev select-stats --data-dir data/bench/corpus`

### Algorithmic Fix (O5)

**Critical Performance Fix in `src/yaml/advance_positions.rs`:**
- `get_random()` now carries the IB position it computed instead of zeroing it
- Changes from `ib_word_idx: 0, ib_ones_before: 0` to computing them from the result
- Fixes O(n²) scan behavior that dominated real-world YAML queries with random access
- Reduces scan work from 9.4M words to 10K words at 8000-key document (908× improvement)

### Benchmarking

**Crossover Micro-benchmark:**
- Added `benches/select_scan_micro.rs` measuring scalar vs `scan_select` vs portable kernels
- Tests distances 1–256 words with sparsity densities 1 and 32 bits per word
- Corpus-mix workload replaying real YAML site distribution (p50≈3, p90≈232)
- Validates correctness (dispatch/scalar/portable must agree)

**Query-Path Coverage:**
- Added `benches/yaml_query.rs` measuring YAML traversal via `text_position()` calls
- Scalar length sweep (8–2048 bytes) controlling actual scan length
- Realistic shapes: Kubernetes-style records, nested structures
- Isolates query path from startup and I/O noise

### Documentation

**Decision Record:**
- Added `docs/optimizations/select-scan.md` documenting entire investigation arc
- Records measurement showing scans are bimodal (50% trivial, 99% of work in 4+ word scans)
- Shows micro-benchmark crossover between 8–16 words with 3.79× gain on long scans
- Explains discovery of O(n²) cursor defect causing inflated scan lengths
- Documents O5 cursor fix (O(n²) → O(n), 908× reduction at 8K keys)
- Verdict: SIMD kernel not justified (mean scan 1.29 words after fix, below prologue)
- Includes lessons learned about measurement methodology

**Benchmarking Guide:**
- Updated `docs/guides/benchmarking.md` with `select-stats` command documentation
- Explains bimodal distribution and why work-fraction matters more than call-count fraction
- Links to measurement command and optimization record

### Testing

**Property Tests:**
- Added three property tests in `tests/property_tests.rs` under `#[test]`
- `scan_select_matches_scalar`: validates against reference implementation across random inputs
- `scan_select_matches_scalar_when_sparse`: tests bimodal real-world distributions
- `select_from_enumerates_set_bits_in_order`: verifies bit enumeration correctness

**Unit Tests in `src/bits/scan.rs`:**
- `empty_input_has_nothing_to_find`: boundary conditions
- `finds_bits_within_the_prologue`: scalar path correctness
- `all_zero_words_never_satisfy_a_request`: edge case handling
- `skips_whole_zero_blocks_to_reach_a_distant_bit`: block-skipping path
- `matches_scalar_on_dense_words`: dense word correctness
- `agrees_with_scalar_across_random_inputs_and_start_words`: comprehensive randomized testing
- `block_popcount_kernels_agree_with_portable`: validates NEON/AVX2 against portable
- `block_popcount_handles_the_extremes`: zero and all-ones words
- `scan_select_scalar_rejects_out_of_range_start`: boundary validation
- `select_from_returns_none_when_bits_run_out`: fallible case

**Report Tests in `select_stats_report.rs`:**
- `render_table_pads_columns`: table formatting
- `site_row_renders_placeholders_for_empty_histogram`: empty data handling
- `ib_select_from_sites_are_labelled_in_probes`: label correctness
- `report_covers_json_and_yaml_and_skips_dsv`: file classification
- `run_writes_markdown_when_asked`: file output
- `run_to_stdout_succeeds`: stdout path
- `empty_corpus_reports_no_files`: empty input handling

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New unit tests added for `scan_select` covering prologue, block-skipping, dense words, sparse words, and all start-word positions
- [x] Property tests verify dispatch matches scalar across arbitrary inputs
- [x] SIMD kernel tests (NEON/AVX2) validate correctness against portable baseline
- [x] Report generation tests validate file handling and table rendering

**Manual Testing:**
- [x] Tested on aarch64 (Apple M4 Pro) with NEON kernel
- [x] Tested on x86_64 with AVX2 kernel and portable fallback
- [x] Verified output byte-identical across 127 query/file pairs
- [x] Pinned-yq golden suite passes unchanged

### Test Commands
```bash
# Full test suite
cargo test

# Scan-specific tests
cargo test bits::scan

# Property tests
cargo test --test property_tests

# Linting
cargo clippy --all-targets --all-features -- -D warnings

# Code formatting
cargo fmt --check

# Crossover micro-benchmark
cargo bench --bench select_scan_micro

# Query-path benchmark
cargo bench --bench yaml_query

# Measurement on corpus
cargo run --release --features cli,select-stats -- dev select-stats --data-dir data/bench/corpus
```

## Performance Impact

- [x] Performance improvement (algorithmic fix)
- [x] SIMD kernel contributes noise on real workloads

### Scan-Length Measurement Results

Real-workload corpus distribution shows bimodal shape:

| Site | Calls | Mean | p50 | p90 | Max | Work ≥4 words |
|------|-------|------|-----|-----|-----|---------------|
| YAML Advance | 744 | 59.97 | 3 | 232 | 296 | 99.0% |
| JSON IB Select | 17146 | 16.78 | 17 | 19 | 20 | 99.9% |

### Cursor Fix (O5) Results

Carrying IB position across random-access jumps instead of resetting:

| Keys | Before | After | Speedup |
|------|--------|-------|----------|
| 250 | 8,564 | 318 | 26.9× |
| 1000 | 139,489 | 1,281 | 109× |
| 4000 | 2,315,578 | 5,161 | 449× |
| 8000 | 9,373,251 | 10,321 | 908× |

End-to-end `yaml_query` improvements (Apple M4 Pro):
- value_8b: 361µs → 99.1µs (3.6×)
- value_512b: 6.33ms → 702µs (9.0×)
- value_2048b: 24.3ms → 2.52ms (9.6×)
- records_10k: 43.2ms → 1.86ms (23.2×)
- nested_d6_w4: 1.77ms → 303µs (5.8×)

### SIMD Kernel Contribution

Micro-benchmark on long scans (256 words, sparse):
- Scalar: 89.72ns
- NEON `scan_select`: 23.68ns (3.79×)
- Portable block popcount: comparable

But on fixed workload (mean 1.29 words after cursor fix): **No effect** (−2% to +5.6%, noise). The scalar prologue completes every scan, vector path never entered.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed; all placeholder text removed from PR
- [x] Tests added proving feature works and cursor fix is correct
- [x] All new and existing tests pass locally
- [x] Documentation updated (optimization record, benchmarking guide)
- [x] No new clippy warnings
- [x] Property tests validate against reference implementation
- [x] SIMD kernels validated against portable oracle

## Breaking Changes

None. Cursor fix is internal. SIMD kernel is internal dispatch. New helpers are additive.

## Additional Notes

### Design Rationale

**Block-skipping vs prefix-sum:** Issue #40 sketched per-iteration in-vector prefix sum and comparison. Instead, each iteration computes one block total and either skips the block or drops into scalar — a scan only needs to locate *once*, at the end, while every other iteration just needs "is target past this block?". Block totals are much cheaper.

**Scalar prologue:** Running `PROLOGUE` (= `BLOCK` = 8) words first means ~50% of calls that finish within it execute exactly the old code, guaranteeing "no regression on short scans" as a structural property rather than a tuning claim.

**512-bucket histogram:** Earlier 64-bucket version saturated at real scan maximum of 296 words. 512 provides headroom and is cheap (4 KiB per site).

### Why This PR Exists

The investigation journey is the interesting part:
1. Measurement said "scans are long and bimodal, 99% of work in long scans" ✓
2. Micro-benchmark said "3.79× faster on 256-word scans" ✓
3. End-to-end said "1.8–3.2× faster" ✓
4. But the speedup was suspiciously uniform — short-scalar cases sped up 1.9× when they shouldn't have scans at all
5. Measuring the fixtures directly revealed O(n²) cursor behavior inflating scans to 284 words mean (should be ~1)
6. Fixing the cursor: O(n²) → O(n), 908× reduction, mean scan becomes 1.29 words
7. On fixed workload, SIMD kernel is noise

Conclusion: **Algorithmic improvements beat micro-optimizations** (~300× vs 3.79×). The repo's existing wisdom held again.

### Key Files

- `src/bits/scan.rs` — shared helper, SIMD kernels, property tests
- `src/util/select_stats.rs` — instrumentation, histogram analysis
- `src/bin/succinctly/select_stats_report.rs` — measurement reporting
- `src/yaml/advance_positions.rs` — O5 cursor fix
- `docs/optimizations/select-scan.md` — full investigation record
- `benches/select_scan_micro.rs` — crossover measurement
- `benches/yaml_query.rs` — query-path coverage