### PR TITLE
fix(yaml): treat `#` as a comment start in flow-mapping keys

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3038,6 +3038,22 @@ impl<'a> Parser<'a> {
         while let Some(b) = self.peek() {
             match b {
                 b':' | b',' | b'}' | b']' => break,
+                b'#' => {
+                    // # starts a comment only after s-separate-in-line (space or
+                    // tab), same rule as the block-key and flow-value arms
+                    // (#410, `parse_flow_unquoted_value`). A comment here means
+                    // the key never reached its `:`, so this errors the same way
+                    // the block-key path does rather than folding the comment
+                    // text into the key (#437). Otherwise `#` is ordinary key
+                    // content (e.g. `a#b: value`).
+                    if self.pos > start && matches!(self.input[self.pos - 1], b' ' | b'\t') {
+                        return Err(YamlError::KeyWithoutValue {
+                            offset: start,
+                            line: self.current_line(),
+                        });
+                    }
+                    self.advance();
+                }
                 b'\n' | b'\r' => {
                     // Multiline key - check if next line continues the key
                     // Skip the line break (CRLF counts as the one break it is)
@@ -4220,6 +4236,42 @@ mod tests {
         assert!(
             matches!(err, YamlError::KeyWithoutValue { line: 1, offset: 0 }),
             "expected key-without-value at line 1 offset 0, got {err:?}"
+        );
+    }
+
+    /// #437: `parse_flow_unquoted_key` had no `#` arm at all, so a comment inside
+    /// a flow-mapping key folded into the key text instead of erroring, unlike
+    /// its block-key (#410) and flow-value siblings which both treat a
+    /// whitespace-preceded `#` as a comment.
+    #[test]
+    fn regression_issue_437_space_before_hash_starts_a_comment_in_a_flow_key() {
+        let err = build_semi_index(b"{a # b: c}\n").unwrap_err();
+        assert!(
+            matches!(err, YamlError::KeyWithoutValue { line: 1, offset: 1 }),
+            "expected key-without-value at line 1 offset 1, got {err:?}"
+        );
+    }
+
+    /// #437: same gap, tab variant.
+    #[test]
+    fn regression_issue_437_tab_before_hash_starts_a_comment_in_a_flow_key() {
+        let err = build_semi_index(b"{a\t# b: c}\n").unwrap_err();
+        assert!(
+            matches!(err, YamlError::KeyWithoutValue { line: 1, offset: 1 }),
+            "expected key-without-value at line 1 offset 1, got {err:?}"
+        );
+    }
+
+    /// #437: a `#` not preceded by whitespace stays ordinary key content, in flow
+    /// context exactly as it already does in block context (`a#b: value`).
+    /// Content is pinned via the CLI in
+    /// `hash_without_preceding_space_is_flow_key_content` (tests/yq_cli_tests.rs).
+    #[test]
+    fn hash_without_preceding_space_in_a_flow_key_still_parses() {
+        let result = build_semi_index(b"{a#b: c}\n");
+        assert!(
+            result.is_ok(),
+            "expected a#b to parse as key content: {result:?}"
         );
     }
 

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3270,6 +3270,20 @@ impl<'a> Parser<'a> {
         while let Some(b) = self.peek() {
             match b {
                 b',' | b'}' | b']' => break,
+                b'#' => {
+                    // Same rule as `parse_flow_unquoted_key` (#437): a `#`
+                    // preceded by a space or tab starts a comment, so the key
+                    // never reached its value and this errors instead of
+                    // folding the comment text into the key. Otherwise `#` is
+                    // ordinary key content.
+                    if self.pos > start && matches!(self.input[self.pos - 1], b' ' | b'\t') {
+                        return Err(YamlError::KeyWithoutValue {
+                            offset: start,
+                            line: self.current_line(),
+                        });
+                    }
+                    self.advance();
+                }
                 b':' => {
                     // Only stop at `: ` or `:\n` or `:` at end. A flow indicator after
                     // the colon does *not* stop the key (#402) — `,`/`}`/`]` end it on
@@ -4272,6 +4286,17 @@ mod tests {
         assert!(
             result.is_ok(),
             "expected a#b to parse as key content: {result:?}"
+        );
+    }
+
+    /// #437: the explicit `? key : value` flow form (`parse_explicit_flow_unquoted_key`)
+    /// has the same shape as the implicit key parser and was missing the same `#` arm.
+    #[test]
+    fn regression_issue_437_space_before_hash_starts_a_comment_in_an_explicit_flow_key() {
+        let err = build_semi_index(b"{? a # b : c}\n").unwrap_err();
+        assert!(
+            matches!(err, YamlError::KeyWithoutValue { line: 1, offset: 3 }),
+            "expected key-without-value at line 1 offset 3, got {err:?}"
         );
     }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1611,6 +1611,41 @@ fn test_yaml_flow_question_mark_without_a_space_is_content() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// `#` as a comment start in flow-mapping keys (#437). `parse_flow_unquoted_key`
+// had no `#` arm at all, so a comment folded into the key text instead of
+// erroring — unlike the block-key path (#410) and the flow-*value* path, both
+// of which already treat a whitespace-preceded `#` as a comment.
+// =============================================================================
+
+#[test]
+fn test_yaml_flow_key_comment_requires_preceding_whitespace() -> Result<()> {
+    for (name, input) in [
+        ("space before hash, implicit key", "{a # b: c}\n"),
+        ("tab before hash, implicit key", "{a\t# b: c}\n"),
+    ] {
+        let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".", input, &[])?;
+        assert_eq!(exit_code, 1, "{name}: expected clean error exit: {stderr}");
+        assert_eq!(stdout, "", "{name}: nothing should reach stdout");
+        assert!(
+            stderr.contains("key without value"),
+            "{name}: stderr should name the missing value: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn hash_without_preceding_space_is_flow_key_content() -> Result<()> {
+    // The boundary the #437 fix must not cross: `#` not preceded by a space or
+    // tab is ordinary key content, exactly as it already is in block context
+    // (`a#b: value`).
+    let (stdout, exit_code) = run_yq_stdin(".", "{a#b: c}\n", &["-o", "json", "-I", "0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(stdout.trim(), r#"{"a#b":"c"}"#);
+    Ok(())
+}
+
 #[test]
 fn test_yaml_flow_explicit_key_colon_before_a_flow_indicator_is_content() -> Result<()> {
     // A deliberate divergence from YAML 1.2, pinned here because nothing else

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1671,6 +1671,22 @@ fn test_yaml_flow_explicit_key_colon_before_a_flow_indicator_is_content() -> Res
     Ok(())
 }
 
+#[test]
+fn test_yaml_explicit_flow_key_comment_requires_preceding_whitespace() -> Result<()> {
+    // #437: `parse_explicit_flow_unquoted_key` has the same shape as
+    // `parse_flow_unquoted_key` and was missing the same `#` arm — a comment
+    // inside a `? key : value` flow key folded into the key text instead of
+    // erroring.
+    let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".", "{? a # b : c}\n", &[])?;
+    assert_eq!(exit_code, 1, "expected clean error exit: {stderr}");
+    assert_eq!(stdout, "", "nothing should reach stdout");
+    assert!(
+        stderr.contains("key without value"),
+        "stderr should name the missing value: {stderr}"
+    );
+    Ok(())
+}
+
 // =============================================================================
 // Explicit keys as sequence items (#339) - `- ? k` / `  : v` is a mapping, not
 // a plain scalar. Expectations are mikefarah/yq v4.53.3 output.


### PR DESCRIPTION
## Description

This PR fixes YAML comment handling in flow-mapping keys by treating `#` as a comment start when it is preceded by whitespace (space or tab), consistent with existing behavior in block-key and flow-value contexts. Previously, `#` characters in flow-mapping keys were always treated as ordinary key content, even when preceded by whitespace, causing comments to be incorrectly folded into the key text.

The fixes address issue #437 in two parts: implicit flow-mapping keys (`{a # b: c}`) and explicit flow-mapping keys (`{? a # b : c}`). Both now properly error with `KeyWithoutValue` when a whitespace-preceded `#` indicates the key never reached its required `:` or value, matching the behavior already implemented in block-key parsing.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #437

## Changes Made

**Parser Implementation (`src/yaml/parser.rs`):**
- Added `#` character handling in `parse_flow_unquoted_key()` to detect comment start after whitespace
  - When `#` is preceded by space or tab: errors as `KeyWithoutValue` (key missing its required value)
  - When `#` has no preceding whitespace: remains ordinary key content (e.g., `a#b: value`)
- Added matching `#` character handling in `parse_explicit_flow_unquoted_key()` for the `{? key : value}` form
  - Implements identical whitespace-detection logic as implicit-key variant
  - Prevents comment text from being folded into explicit flow-mapping keys

**Unit Tests (`src/yaml/parser.rs`):**
- `regression_issue_437_space_before_hash_starts_a_comment_in_a_flow_key()`: validates space-before-hash errors correctly
- `regression_issue_437_tab_before_hash_starts_a_comment_in_a_flow_key()`: validates tab-before-hash errors correctly
- `hash_without_preceding_space_in_a_flow_key_still_parses()`: confirms `#` without preceding whitespace still works as key content
- `regression_issue_437_space_before_hash_starts_a_comment_in_an_explicit_flow_key()`: validates explicit key form error handling

**CLI Integration Tests (`tests/yq_cli_tests.rs`):**
- `test_yaml_flow_key_comment_requires_preceding_whitespace()`: end-to-end test of implicit flow-key comment detection
- `hash_without_preceding_space_is_flow_key_content()`: confirms boundary condition that `a#b: c` correctly parses as JSON `{"a#b":"c"}`
- `test_yaml_explicit_flow_key_comment_requires_preceding_whitespace()`: end-to-end test of explicit flow-key comment detection

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New regression tests added for both implicit and explicit flow-mapping key forms
- [x] Boundary condition tests ensure `#` without preceding whitespace remains ordinary content
- [x] CLI integration tests verify correct error reporting and JSON output

**Test Coverage:**
- Space-before-hash in implicit keys: `{a # b: c}` → `KeyWithoutValue` error
- Tab-before-hash in implicit keys: `{a\t# b: c}` → `KeyWithoutValue` error  
- Space-before-hash in explicit keys: `{? a # b : c}` → `KeyWithoutValue` error
- Hash without preceding whitespace: `{a#b: c}` → parses successfully as `{"a#b":"c"}`

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The changes add a single character-dispatch branch in the parser's hot loop, with negligible performance consequences. No new allocations or algorithmic changes introduced.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

**Consistency with Existing Behavior:**
These fixes align the flow-mapping key paths with the block-key implementation (addressed in #410) and the flow-value path, which already correctly treat whitespace-preceded `#` as comment starts. The fix ensures YAML comment handling is consistent across all key parsing contexts.

**Boundary Preservation:**
The implementation carefully preserves the important boundary that `#` without preceding whitespace remains ordinary key content in flow contexts, exactly as it already does in block contexts (`a#b: value`). This is validated through explicit test cases and CLI integration tests.