### PR TITLE
fix(yaml): reject tabs indenting sequence-item continuation lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A tab that indented a sequence-item continuation line was folded into a
+  plain scalar instead of rejected** (#432, also fixing #371): three related
+  gaps in `parse_unquoted_value_with_indent_impl` and `parse_mapping_entry`
+  in `src/yaml/parser.rs`, all downstream of the `tab_indents_block_structure`
+  check introduced by #173/#381 not reaching every site that dispatches on a
+  continuation line. `a:\n \t- x\n` loaded as `{"a":"\t- x"}` — a key's
+  "value is on the next line" arm left the tab on the cursor when it indented
+  block structure, so the `Some(b'-')` sequence check silently missed it and
+  fell through to a plain scalar. `- a\n \t- b\n` loaded as `["a - b"]`
+  because the plain-scalar continuation scan only compared indentation by
+  counting *spaces*, so a tab that itself indented a sibling sequence item
+  read as "more indented, keep going" and folded the second item into the
+  first's scalar; the same gap made `a: 1\n \tb: 2\n` silently drop `: 2`
+  (#371) since a mapping value at indent 0 hit the same scan gated on
+  `start_indent == 0` rather than the narrower `is_doc_root` the function
+  already computed. All three now raise `TabIndentation`, matching the
+  opt-in validator, which already rejected all three shapes. New coverage:
+  three rows in the `VERDICTS` table in `tests/yaml_tab_indentation_tests.rs`
+  (plus the pre-existing #371 row moved from the "loader and validator
+  legitimately disagree" section into "both must reject" now that they
+  agree); `yaml_test_suite_conformance` and `yq_golden_conformance` re-run
+  clean.
+
 - **YAML explicit non-scalar keys silently dropped the entry** (#172,
   resolved by drift): `? - a\n  - b\n: value` used to load as `{}`, losing
   both the key and the value, silently — no error, well-formed JSON out. Not

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1242,10 +1242,16 @@ impl<'a> Parser<'a> {
                     }
                     continue;
                 }
-                // Tab followed by content - for document root scalars (start_indent == 0),
-                // this is a continuation per YAML spec example 7.12 "Plain Lines".
-                // The tabs become part of the folded content (converted to space).
-                if start_indent == 0 && next_char == b'\t' {
+                // Tab followed by content - for document root scalars, this is
+                // a continuation per YAML spec example 7.12 "Plain Lines". The
+                // tabs become part of the folded content (converted to space).
+                //
+                // Gated on `is_doc_root`, not `start_indent == 0`: a mapping
+                // value or sequence item at indent 0 also has `start_indent ==
+                // 0` but is not the document root, so a tab there indents
+                // whatever structure follows and must not be folded into
+                // content (#371, #432).
+                if is_doc_root && next_char == b'\t' {
                     // Continue to next line - this is a valid continuation
                     self.skip_line_break();
                     // Skip leading whitespace (tabs are content, but we're at the scalar's level)
@@ -1253,6 +1259,20 @@ impl<'a> Parser<'a> {
                         self.advance();
                     }
                     continue;
+                }
+                // Reaching here means `next_char == b'\t'` and `is_doc_root` is
+                // false (the two branches above already `continue`d for every
+                // other combination). This scan works off local `lookahead`/
+                // `next_indent` variables rather than the cursor, so it can't
+                // reuse `tab_indents_block_structure` directly - `line_is_structural`
+                // is the shared primitive underneath both. Without this check the
+                // generic "more indented, so continue" rule below only compares
+                // space-counts and can't see the tab, so it folds whatever
+                // structure follows (a sequence item, mapping entry, ...) into
+                // the scalar instead of stopping so the per-line dispatcher can
+                // reject the tab as indentation (#371, #432).
+                if super::line_is_structural(self.input, lookahead) {
+                    break;
                 }
             }
 
@@ -1885,6 +1905,18 @@ impl<'a> Parser<'a> {
 
             // Re-advance to content position for the remaining checks
             self.advance_by(next_indent);
+            // A tab here indents whatever block structure follows (most often
+            // a sequence item) - reject it before the dispatch below, which
+            // otherwise misses it: the `Some(b'-')` arm doesn't match while
+            // the tab is still on the cursor, so it fell through to the
+            // plain-scalar arm and folded the dash and all into a string
+            // instead of raising this error (#432).
+            if self.tab_indents_block_structure(saved_pos) {
+                return Err(YamlError::TabIndentation {
+                    line: self.current_line(),
+                    offset: self.pos,
+                });
+            }
             // A tab left over from `advance_by` (which only accounts for
             // spaces) is legal separation here, not content - skip it so the
             // dispatch below, and any node it opens, land on the node's real

--- a/tests/yaml_tab_indentation_tests.rs
+++ b/tests/yaml_tab_indentation_tests.rs
@@ -16,8 +16,8 @@
 //! # Why an agreement *table* and not an invariant
 //!
 //! The obvious assertion — "the loader rejects a tab shape only if the validator
-//! does" — is false, in both directions, for reasons that have nothing to do with
-//! tabs (see the two `Verdict` rows that disagree). Writing it as an invariant would
+//! does" — is false, for reasons that have nothing to do with tabs (see the
+//! `Verdict` row that disagrees). Writing it as an invariant would
 //! mean either a red build or quietly weakening it until it asserted nothing.
 //! Stating both verdicts per row instead makes each divergence a reviewed fact with
 //! a reason attached, which is what CLAUDE.md's #106 lesson asks for: one definition
@@ -108,6 +108,47 @@ const VERDICTS: &[Verdict] = &[
         validator: Validator::RejectsTheTab,
         why: "a tab before a sequence entry is indentation too",
     },
+    Verdict {
+        yaml: b"a: 1\n \tb: 2\n",
+        loader: true,
+        validator: Validator::RejectsTheTab,
+        why: "#371 fixed: the loader used to fold this line into the preceding \
+              plain scalar before the dispatcher saw it (parser.rs, the \
+              `start_indent == 0` continuation arm — a mapping value or sequence \
+              item at indent 0 also has `start_indent == 0` but is not the \
+              document root), yielding {\"a\":\"1 b\"} and silently dropping the \
+              `: 2`. Gating on `is_doc_root` instead makes the loader stop the \
+              scalar and defer to the per-line dispatcher, which already raises \
+              this error (also fixes the sequence-item analogue, #432)",
+    },
+    Verdict {
+        yaml: b"a:\n \t- x\n",
+        loader: true,
+        validator: Validator::RejectsTheTab,
+        why: "#432 repro 1 fixed: a key's \"value is on the next line\" arm left \
+              the tab on the cursor when it indented block structure, so the \
+              `Some(b'-')` sequence-continuation check didn't match it and the \
+              dash fell through to the plain-scalar arm, yielding \
+              {\"a\":\"\\t- x\"} instead of this error",
+    },
+    Verdict {
+        yaml: b"a:\n \t- x\n \t- y\n",
+        loader: true,
+        validator: Validator::RejectsTheTab,
+        why: "#432 repro 2, the same gap as the row above with a second \
+              tab-indented item following - both used to fold into one scalar, \
+              {\"a\":\"\\t- x - y\"}",
+    },
+    Verdict {
+        yaml: b"- a\n \t- b\n",
+        loader: true,
+        validator: Validator::RejectsTheTab,
+        why: "#432 repro 3 fixed: a plain scalar's continuation-line scan only \
+              compared indent by counting spaces, so a tab that itself indented \
+              a sibling sequence item read as \"more indented, so continue\" and \
+              folded the second item into the first's scalar, yielding \
+              [\"a - b\"] instead of this error",
+    },
     // ---- A tab that is separation. Both must accept. ---------------------------
     Verdict {
         yaml: b"foo:\n \tbar\n",
@@ -169,14 +210,6 @@ const VERDICTS: &[Verdict] = &[
               not a value indicator",
     },
     // ---- Rows where the two legitimately disagree. -----------------------------
-    Verdict {
-        yaml: b"a: 1\n \tb: 2\n",
-        loader: false,
-        validator: Validator::RejectsTheTab,
-        why: "the loader folds the line into the preceding plain scalar before the \
-              dispatcher sees it (parser.rs, the `start_indent == 0` continuation \
-              arm), yielding {\"a\":\"1 b\"} — that is #371, which #173 does not reach",
-    },
     Verdict {
         yaml: b"a: |\n    x\n  \tb: c\n",
         loader: true,


### PR DESCRIPTION
## Description

This PR fixes three related bugs in the YAML parser that caused tabs indenting sequence-item continuation lines to be incorrectly folded into plain scalars instead of being rejected with a `TabIndentation` error. All three issues stem from gaps in the `tab_indents_block_structure` validation check introduced in #173/#381 not reaching every code path that dispatches on continuation lines.

**Issue #432 - Primary Fix**: A tab before a sequence entry in a mapping value continuation was silently folded into the preceding scalar instead of rejected. The "value is on the next line" arm in `parse_mapping_entry` left the tab on the cursor when it indented block structure, so the `Some(b'-')` sequence-continuation check failed to match and fell through to the plain-scalar arm.

**Issue #371 - Secondary Fix**: A tab indenting a sibling sequence item folded the second item into the first's scalar. The continuation-line scan in `parse_unquoted_value_with_indent_impl` only counted spaces for indentation comparison, missing tabs that themselves indented subsequent structure. Additionally, the tab-fold exception was gated on `start_indent == 0` rather than the narrower `is_doc_root` condition, causing mapping values at indent 0 to incorrectly absorb continuation lines with leading tabs.

All three patterns now correctly raise `TabIndentation` errors, bringing the loader into alignment with the opt-in strict validator which already reported these shapes as violations.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #432
Fixes #371

## Changes Made

**Core Parser Fixes (`src/yaml/parser.rs`):**
- Modified `parse_unquoted_value_with_indent_impl` to check `is_doc_root` instead of `start_indent == 0` when deciding if a tab-prefixed continuation is valid folding content, correctly distinguishing document-root scalars from mapping values or sequence items at indent 0
- Added explicit `line_is_structural` check in the continuation scan to detect when a tab indents block structure (sequence items, mapping entries, etc.), preventing such lines from being folded into the scalar
- Updated `parse_mapping_entry` to check `tab_indents_block_structure` before dispatching on the next character, preventing tabs that indent block structure from being missed by the `Some(b'-')` sequence-continuation check
- Enhanced comments explaining the rationale for tab-indentation rejection and the narrower `is_doc_root` condition

**Test Coverage (`tests/yaml_tab_indentation_tests.rs`):**
- Added three new `VERDICTS` rows covering the specific repro cases from #432 and #371:
  - `a:\n \t- x\n` (key with tab-indented sequence item)
  - `a:\n \t- x\n \t- y\n` (key with multiple tab-indented sequence items)
  - `- a\n \t- b\n` (sequence item with tab-indented sibling)
- Moved the pre-existing `a: 1\n \tb: 2\n` row from "loader and validator legitimately disagree" section into "both must reject" since the loader now agrees with the validator
- Updated documentation comments to reflect that the agreement gap has been narrowed

**Documentation (`CHANGELOG.md`):**
- Added detailed entry in the "Fixed" section documenting the tab-indentation fix, including:
  - References to issues #432 and #371
  - Explanation of the three distinct code paths that were affected
  - Examples of YAML that was previously mis-parsed
  - Description of how the fixes ensure loader and validator agreement
  - Note that `yaml_test_suite_conformance` and `yq_golden_conformance` continue to pass

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New regression tests added for all three bug scenarios
- [x] `yaml_test_suite_conformance` passes
- [x] `yq_golden_conformance` passes

**Manual Testing:**
- [x] Verified that `a:\n \t- x\n` now raises `TabIndentation` instead of parsing as `{"a":"\t- x"}`
- [x] Verified that `- a\n \t- b\n` now raises `TabIndentation` instead of parsing as `["a - b"]`
- [x] Verified that `a: 1\n \tb: 2\n` now raises `TabIndentation` instead of silently dropping `: 2`

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
cargo test yaml_tab_indentation_tests
```

## Performance Impact
- [x] No performance impact

The fixes add straightforward additional checks in critical paths but do not introduce complexity or overhead.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

These fixes ensure that the YAML loader and validator are in agreement on rejecting tabs that indent block structure, eliminating a significant parsing correctness issue where certain invalid YAML documents were being silently accepted and mis-parsed. The changes are minimal and focused, addressing the root causes in the continuation-line handling logic without requiring broader refactoring.

The fixes properly implement the intent of the `tab_indents_block_structure` check from #173/#381, ensuring it reaches all necessary dispatch points.