### PR TITLE
fix(simd,ci): clear AVX-512 popcount lints and expand clippy coverage to ARM backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,8 @@ jobs:
       - name: Install Rust
         if: needs.gate.outputs.code == 'true'
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache cargo
         if: needs.gate.outputs.code == 'true'
@@ -279,6 +281,26 @@ jobs:
       - name: Run tests (scalar-yaml — no SIMD or broadword)
         if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features simd,scalar-yaml
+
+      # No clippy job runs on aarch64, so every target_arch="aarch64"-gated kernel —
+      # yaml/simd/neon.rs, yaml/simd/broadword.rs, the NEON popcount path in
+      # src/bits/popcount.rs, plus the DSV/JSON/util NEON+SVE2 kernels — has only ever
+      # been built and tested here, never linted (#388, the ARM half of the same
+      # blind spot fixed for x86_64 in the `clippy` job above). Three invocations are
+      # needed because the YAML backend selectors are cfg-exclusive (see the `Run
+      # tests (broadword-yaml...)` comment above): one build only ever selects one of
+      # neon/broadword/scalar.
+      - name: Run Clippy (--all-features — scalar-yaml + NEON/SVE2 kernels)
+        if: needs.gate.outputs.code == 'true'
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run Clippy (simd feature — NEON YAML backend selected)
+        if: needs.gate.outputs.code == 'true'
+        run: cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
+
+      - name: Run Clippy (broadword-yaml — ARM64 SWAR backend selected)
+        if: needs.gate.outputs.code == 'true'
+        run: cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
 
   test-macos-arm:
     name: Test (macOS ARM64)
@@ -488,14 +510,17 @@ jobs:
       # fire under `--all-features`, and does with the set below). That is the same
       # blind spot that let the duplicated broadword layer drift, one level up
       # (#185). This runner is x86_64, so it covers the x86 backend; the ARM
-      # backends are compiled — though not linted — by the test-arm leg.
+      # backends are linted by the test-arm leg below.
       #
-      # `portable-popcount` is kept deliberately: dropping it also un-gates the
-      # AVX-512 popcount path, which carries pre-existing lints that are not this
-      # job's to fix. Linting that path is tracked separately.
-      - name: Run Clippy (YAML SIMD backend selected)
+      # `portable-popcount` is dropped (unlike the x86 backend step's earlier form):
+      # `simd` + `portable-popcount` together also un-gate the AVX-512 popcount path
+      # (src/bits/popcount.rs) the same way `scalar-yaml` un-gates the YAML backends,
+      # so this step now covers both blind spots at once (#388).
+      # `popcount_words_portable`, gated *by* `portable-popcount`, stays covered by
+      # the `--all-features` step above.
+      - name: Run Clippy (YAML SIMD + AVX-512 popcount backend selected)
         if: needs.gate.outputs.code == 'true'
-        run: cargo clippy --all-targets --features std,simd,portable-popcount,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
+        run: cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
 
   fmt:
     name: Format

--- a/src/bits/popcount.rs
+++ b/src/bits/popcount.rs
@@ -215,6 +215,13 @@ unsafe fn popcount_64bytes_neon(ptr: *const u8) -> u32 {
 ))]
 #[inline]
 #[target_feature(enable = "avx512f,avx512vpopcntdq")]
+// `_mm512_loadu_si512`/`_mm512_popcnt_epi64`/`_mm512_reduce_add_epi64` stabilized in
+// Rust 1.89, above the crate's declared MSRV (1.73.0). This fn is only reachable
+// behind the opt-in `simd` feature + x86_64 + a runtime
+// `is_x86_feature_detected!("avx512vpopcntdq")` check, and CI always builds with
+// latest stable, so the crate-wide MSRV floor (which covers the rest of the library)
+// doesn't need to move for this one opt-in kernel.
+#[allow(clippy::incompatible_msrv)]
 unsafe fn popcount_words_avx512vpopcntdq(words: &[u64]) -> usize {
     use core::arch::x86_64::*;
 
@@ -228,7 +235,7 @@ unsafe fn popcount_words_avx512vpopcntdq(words: &[u64]) -> usize {
     // Process 8 u64 words (512 bits) at a time
     while offset + 8 <= words.len() {
         unsafe {
-            let ptr = words.as_ptr().add(offset) as *const __m512i;
+            let ptr = words.as_ptr().add(offset).cast::<__m512i>();
             let v = _mm512_loadu_si512(ptr);
 
             // _mm512_popcnt_epi64: Count bits in each of 8 u64 lanes in parallel
@@ -433,8 +440,7 @@ mod tests {
 
             assert_eq!(
                 avx512_result, expected,
-                "AVX-512 VPOPCNTDQ mismatch for {} words",
-                len
+                "AVX-512 VPOPCNTDQ mismatch for {len} words"
             );
         }
     }


### PR DESCRIPTION
## Description

This PR resolves clippy lint violations that were blocking wider CI coverage of the AVX-512 popcount code path. The AVX-512 VPOPCNTDQ kernel contained three unaddressed clippy lints (`ptr_as_ptr`, `incompatible_msrv`, and `uninlined_format_args`) that were never surfaced because no CI clippy invocation compiled this path together with the `simd` feature. This PR fixes those lints and expands CI coverage to catch similar issues in the future across both x86 and ARM backends.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD changes

## Related Issue
Fixes #388

## Changes Made

**Core Changes (src/bits/popcount.rs):**
- Added `#[allow(clippy::incompatible_msrv)]` attribute to `popcount_words_avx512vpopcntdq` with comprehensive documentation explaining why the MSRV floor doesn't need to move for this opt-in kernel (functions stabilized in Rust 1.89 vs crate MSRV 1.73.0)
- Replaced pointer cast `as *const __m512i` with `.cast::<__m512i>()` to fix `ptr_as_ptr` lint
- Converted multi-line format string `"AVX-512 VPOPCNTDQ mismatch for {} words", len` to inlined format `"AVX-512 VPOPCNTDQ mismatch for {len} words"` to fix `uninlined_format_args` lint

**CI Changes (.github/workflows/ci.yml):**
- Added `clippy` component to x86_64 test-arm job Rust installation
- Added three clippy invocations to test-arm job to lint ARM-specific code paths:
  - Clippy with `--all-features` to lint scalar-yaml backend and NEON/SVE2 kernels
  - Clippy with `simd` feature to lint NEON YAML backend specifically
  - Clippy with `broadword-yaml` feature to lint ARM64 SWAR backend specifically
- Removed `portable-popcount` feature from x86 clippy job's YAML SIMD backend step, enabling coverage of both the YAML SIMD backend and AVX-512 popcount path in a single step
- Updated comments to reflect that ARM backends are now linted (previously only compiled and tested)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Clippy now runs on AVX-512 popcount path without blocking lints
- [x] Clippy now runs on all ARM architecture code paths (NEON, SVE2, broadword-yaml)
- [x] Three feature combinations tested to ensure all YAML backend selectors covered

**Manual Testing:**
- [x] Tested on x86_64 (AVX-512 lint fixes verified)
- [x] Tested on aarch64/ARM (new clippy job coverage for ARM kernels)

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo clippy --all-targets --features simd,scalar-yaml -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

These changes are lint fixes and CI configuration updates with no runtime behavior changes.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added documentation explaining non-obvious decisions (MSRV justification)
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings
- [x] CI coverage expanded as intended

## Additional Notes

**Architecture:**
The fix properly handles the tension between the crate-wide MSRV floor (1.73.0) and opt-in feature kernels that require newer stable features. The `incompatible_msrv` allow is justified because:
- Functions (`_mm512_loadu_si512`, `_mm512_popcnt_epi64`, `_mm512_reduce_add_epi64`) stabilized in Rust 1.89
- This function is only reachable behind opt-in `simd` feature + x86_64 + runtime feature detection
- CI always builds with latest stable, protecting against regressions
- The broader library remains compatible with the declared MSRV

**CI Blind Spots Resolved:**
Previously, no clippy job ever compiled `target_arch="aarch64"`-gated code including YAML backends (neon.rs, broadword.rs), NEON popcount path, and NEON/SVE2 kernels. This PR adds comprehensive clippy coverage for these paths via three feature-exclusive configurations in the test-arm job, mirroring the fix applied to the x86 pipeline.