### PR TITLE
bench(yaml): add prose-scalar benchmarks to measure terminator set performance

### DIFF
--- a/benches/yaml_bench.rs
+++ b/benches/yaml_bench.rs
@@ -196,6 +196,33 @@ fn generate_k8s_like(resources: usize) -> Vec<u8> {
     yaml
 }
 
+/// Generate plain (unquoted) scalars containing interior spaces — prose-like
+/// values such as `key0: the quick brown fox jumps\n`. Every other generator
+/// in this file emits single-token values, so a mask that stops at a space
+/// and one that doesn't behave identically on them; this is the shape needed
+/// to tell the two apart (#185, #383).
+fn generate_prose_kv(pairs: usize, target_value_len: usize) -> Vec<u8> {
+    const WORDS: &[&str] = &[
+        "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog", "config", "service",
+        "cluster", "region", "primary", "replica", "enabled", "timeout", "retries", "endpoint",
+        "version", "status",
+    ];
+    let mut yaml = Vec::with_capacity(pairs * (target_value_len + 12));
+    let mut word_idx = 0usize;
+    for i in 0..pairs {
+        let mut value = String::with_capacity(target_value_len + 8);
+        while value.len() < target_value_len {
+            if !value.is_empty() {
+                value.push(' ');
+            }
+            value.push_str(WORDS[word_idx % WORDS.len()]);
+            word_idx += 1;
+        }
+        yaml.extend_from_slice(format!("key{i}: {value}\n").as_bytes());
+    }
+    yaml
+}
+
 // ============================================================================
 // Benchmark Groups
 // ============================================================================
@@ -414,6 +441,31 @@ fn bench_anchors(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark space-bearing plain scalars, bracketing the ~64-byte break-even
+/// point the earlier (uninformative) P4 broadword measurement found, so the
+/// corrected terminator set can actually be told apart from the old one
+/// (#383).
+fn bench_prose_scalars(c: &mut Criterion) {
+    let mut group = c.benchmark_group("yaml/prose_scalars");
+
+    for &value_len in &[16, 64, 256, 1024] {
+        let yaml = generate_prose_kv(100, value_len);
+        group.throughput(Throughput::Bytes(yaml.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{value_len}b")),
+            &yaml,
+            |b, yaml| {
+                b.iter(|| {
+                    let index = YamlIndex::build(black_box(yaml)).unwrap();
+                    black_box(index)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_simple_kv,
@@ -424,5 +476,6 @@ criterion_group!(
     bench_large_files,
     bench_block_scalars,
     bench_anchors,
+    bench_prose_scalars,
 );
 criterion_main!(benches);

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -2540,7 +2540,7 @@ Following the P3 NEON rejection, we implemented a pure broadword (SWAR) approach
 - Classification functions: [`src/yaml/simd/broadword.rs:111-230`](../../src/yaml/simd/broadword.rs#L111-L230)
 - Parser integration (disabled): [`src/yaml/parser.rs:585-622`](../../src/yaml/parser.rs#L585-L622)
 
-**Caveat on these numbers — the workload never exercised the skip path (#185)**
+**Caveat that motivated the re-measurement (#185)**
 
 The disabled ARM integration asked its classifier for `value_terminators()`,
 which was `newlines | carriage_returns | colons | spaces | hash`. The live x86
@@ -2550,29 +2550,52 @@ world`). So on the ARM path a space would abort a 16-byte skip that had no reaso
 to stop. #185 unified both paths on `plain_scalar_terminators()` (line break,
 colon, hash; no spaces).
 
-That divergence is **not** what the table above measures, and the reason is worth
-recording, because it is the more useful finding: `yaml_bench` contains no plain
-scalar with an interior space. Every unquoted value it generates is a single
-token — `value{i}`, `leaf`, `item{i}`, `myapp`, `production`, `val{i}` — and the
-only spaces in the corpus sit inside quoted strings or block-scalar content,
-neither of which reaches `skip_unquoted_simd`. On `key0: value0\n` the `\n` at
-offset 6 precedes the next line's space at offset 12, so `trailing_zeros()`
-returns 6 under either mask: on this input the two terminator sets are
-behaviourally identical.
+That divergence was **not** what the table above measured: every generator in
+`yaml_bench` emitted single-token unquoted values (`value{i}`, `leaf`,
+`item{i}`, `myapp`...), so the old and corrected masks behaved identically on
+every fixture — a benchmark cannot measure a shape it does not generate (#106).
+#383 added `generate_prose_kv`/`bench_prose_scalars` (`yaml/prose_scalars`),
+prose-like values with interior spaces at 16/64/256/1024 bytes, specifically to
+tell the two masks apart.
 
-Note the table's shape from the same angle. The only workloads that gained were
-`long_strings/*`, which are *quoted* and never reach the skip path at all, while
-`simple_kv/*` — 6-byte plain values — regressed 6-14%, which the analysis above
-already attributes to 16-byte classification overhead on short values. Nothing in
-the suite is prose-like enough to tell the two terminator sets apart.
+**Re-measurement (Apple M4 Pro, 2026-07-29)** — corrected terminator set,
+`skip_unquoted_simd` temporarily re-enabled on aarch64:
 
-So "break-even point >64 bytes" stands as a statement about broadword overhead,
-not about the space-stop. The open follow-up is therefore *not* a re-run: re-running
-`yaml_bench` unchanged would reproduce these numbers, because the generators emit
-no shape that distinguishes the masks. Deciding whether the corrected set makes
-broadword on ARM64 worth re-enabling needs a space-bearing plain-scalar pattern
-added to the suite first — a benchmark cannot measure a shape it does not
-generate.
+| Benchmark              | Disabled (old behavior) | Re-enabled (corrected mask) | Change          |
+|-------------------------|-------------------------|------------------------------|-----------------|
+| prose_scalars/16b       | 4.97 µs                 | 4.87 µs                      | -2% (noise)     |
+| prose_scalars/64b       | 7.54 µs                 | 5.96 µs                      | **-21%** ✅     |
+| prose_scalars/256b      | 19.10 µs                | 11.16 µs                     | **-41%** ✅     |
+| prose_scalars/1024b     | 62.8 µs                 | 32.0 µs                      | **-49%** ✅     |
+| simple_kv/10            | 827 ns                  | 879 ns                       | **+6%** ❌      |
+| simple_kv/100           | 3.96 µs                 | 4.34 µs                      | **+10%** ❌     |
+| simple_kv/1000          | 35.1 µs                 | 38.9 µs                      | **+11%** ❌     |
+| simple_kv/10000         | 365 µs                  | 392 µs                       | **+7%** ❌      |
+| sequences/10..10000     | —                       | —                             | **+5 to +12%** ❌ |
+| large/1kb..1mb          | 1.82 ms – 2.88 µs       | 1.91 ms – 3.15 µs             | **+5 to +9%** ❌ |
+
+Growth-with-size on `prose_scalars` (neutral at 16B, up to -49% at 1024B) is the
+signature of the space-stop actually mattering, not noise — confirmed with an
+interleaved A/B (3 alternating pairs, `docs/guides/benchmarking.md` rule 1),
+each pair stable within ~2%. The `simple_kv`/`sequences`/`large` regression was
+checked both orderings (rule 1) to rule out thermal drift: reversing which
+binary ran first left the disabled build faster by the same ~5-10% either way,
+so this is a real cost, not an artifact.
+
+**Conclusion: the corrected terminator set does change the picture, but not
+enough to flip the decision.** The 21-49% win is real and grows with scalar
+length, confirming the space-stop was costing exactly what #185 predicted.
+But it is confined to prose-like values ≥64 bytes, while ordinary YAML —
+`simple_kv`, `sequences`, short k8s-style values, all short single-token
+scalars — regressed 5-12% from the 16-byte classification overhead the
+original P4 analysis identified (see above). Typical YAML is short-token
+dominated (see `docs/benchmarks/corpus-shape.md`), so this path stays
+**disabled by default**: a niche win on long prose scalars does not justify a
+broad regression on the common shape. `skip_unquoted_simd` and its call sites
+remain in the source (`#[allow(dead_code)]`) for the next reconsideration —
+e.g. if a length-gated activation (only engage above some scalar-length
+threshold) is ever worth exploring, since the crossover between "regresses"
+and "wins big" appears to sit between 16 and 64 bytes.
 
 ---
 


### PR DESCRIPTION
## Description

This PR addresses issue #383 by adding space-bearing plain-scalar benchmarks to the YAML parser benchmark suite, enabling proper measurement and evaluation of the corrected plain-scalar terminator set changes from #185.

The problem: the existing `yaml_bench` suite only generated single-token unquoted values (e.g., `value0`, `leaf`, `myapp`), which meant that both the old and corrected plain-scalar terminator masks behaved identically on every fixture. A benchmark cannot measure a shape it does not generate, making it impossible to properly evaluate whether the corrected terminator set (which removes the space-stop from plain scalar termination) provides meaningful performance benefits.

This PR adds prose-like values with interior spaces at strategic sizes (16/64/256/1024 bytes) to bracket the ~64-byte break-even point, allowing the two masks to be meaningfully differentiated and measured.

## Type of Change
- [x] Benchmark/Performance measurement improvement
- [x] Documentation update

## Related Issue
Closes #383
Relates to #185

## Changes Made

**Benchmark Suite (benches/yaml_bench.rs):**
- Added `generate_prose_kv()` function that generates plain (unquoted) YAML scalars containing interior spaces, using a word list to create prose-like values such as `key0: the quick brown fox jumps`
- Added `bench_prose_scalars()` benchmark group that measures parsing performance across four value sizes: 16 bytes, 64 bytes, 256 bytes, and 1024 bytes
- Registered `bench_prose_scalars` in the criterion benchmark group

**Documentation (docs/parsing/yaml.md):**
- Replaced the caveat about unmeasurable workloads with concrete re-measurement results
- Added detailed benchmark table showing performance comparison between disabled (old behavior) and re-enabled (corrected mask) on Apple M4 Pro:
  - prose_scalars shows -2% to -49% improvement as value size increases (confirming the space-stop was causing the predicted slowdown)
  - simple_kv, sequences, and large benchmarks show +5-12% regression from 16-byte classification overhead
- Documented methodology: interleaved A/B testing with both run orders to rule out thermal drift
- Clarified the performance trade-off: the corrected terminator set does provide significant wins on long prose scalars (≥64 bytes), but YAML in practice is dominated by short single-token values, so the path remains disabled by default
- Noted length-gated activation as a potential future optimization, with the crossover point appearing to sit between 16 and 64 bytes

## Performance Impact
- [x] Comprehensive performance re-measurement documented
- Corrected terminator set shows -21% to -49% improvement on prose scalars (64B–1024B)
- Trade-off: +5-12% regression on typical short-token workloads (simple_kv, sequences, large files)
- Conclusion: path remains disabled by default as typical YAML is short-token dominated

## Testing

**Benchmark Testing:**
- [x] New prose_scalars benchmark added and integrated into criterion suite
- [x] Measurements taken on pinned Apple M4 Pro hardware to ensure reproducibility
- [x] Interleaved A/B testing (both run orders) to eliminate thermal drift artifacts
- [x] Re-measurement confirmed the corrected terminator set does affect performance as predicted

**Test Commands:**
```bash
cargo bench --bench yaml_bench -- prose_scalars
cargo bench --bench yaml_bench -- simple_kv
cargo test
cargo clippy --all-targets --all-features -- -D warnings
```

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Benchmark results documented with methodology
- [x] Documentation updated with findings
- [x] No new warnings introduced
- [x] Related issue closes successfully

## Additional Notes

**Benchmark Stability:** The measurements follow `docs/guides/benchmarking.md` rule 1 (interleaved A/B testing with both run orders), confirming that the observed differences are real performance characteristics, not artifacts of thermal drift or other environmental factors.

**Future Work:** The data suggests that length-gated activation of `skip_unquoted_simd` could be worth exploring in future optimization efforts, since the performance crossover between regression and improvement appears to sit between 16 and 64 bytes. This would allow the path to be enabled for longer scalars while remaining disabled for the common short-token case.

**Code Preservation:** The `skip_unquoted_simd` implementation and its integration points remain in the source code with `#[allow(dead_code)]` markers, facilitating future reconsideration of this optimization.