### PR TITLE
fix(yaml): resolve anchor/alias on a flow-sequence implicit-entry key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An anchor or alias on the key of a flow-sequence's implicit single-pair
+  mapping was a parse error or bound to the wrong node** (#409, found while
+  fixing #405 — that issue was the same key position in a flow *mapping*,
+  `{*a: v}`): `[&x k: 1, *x: 2]` errored `unexpected character ':': expected
+  ',' or ']' in flow sequence` instead of `yq`'s `[{"k":1},{"k":2}]`, and
+  `[&x k: 1, *x]` — an anchor on such a key, aliased from a later plain item —
+  resolved the alias to the mapping `{"k":1}` instead of the key text `"k"`.
+  Two independent bugs in `parse_flow_sequence_inner`'s per-item dispatch,
+  neither in the key handling #405 consolidated:
+
+  The dispatch consumed a leading `&`/`*` *before* asking whether the item was
+  a `key: value` pair, so an alias key's `*` was read as a standalone aliased
+  *value* by `parse_alias`, which `continue`d with the cursor left on `:` —
+  reordering alone would not have fixed it, since `looks_like_flow_mapping_entry`
+  skipped a leading quote or container when scanning ahead for the `:` but not
+  a leading `&name`/`*name`, so it answered `false` for both shapes. And an
+  anchor's bare `parse_anchor()` call records the anchor against whatever BP
+  node opens *next* — here the implicit mapping *wrapper*
+  `parse_implicit_flow_mapping_entry` was about to open, not the key inside
+  it. This is exactly the shape `record_key_anchor`/`record_key_alias` exist
+  for (corpus case CN3R: `&flowseq [a: b, &c c: d, ...]` exercises the anchor
+  half already, but never aliases `&c`, so the wrong binding was invisible on
+  JSON-output-only assertion — corpus-latent, and confirmed unaffected by this
+  fix); `parse_implicit_flow_mapping_entry` was the one key site that read
+  straight from `parse_flow_key_scalar` instead.
+
+  `looks_like_flow_mapping_entry` now skips a leading `&name`/`*name` (reusing
+  `simd::parse_anchor_name`, the same scanner the real anchor/alias parse
+  uses, rather than a second hand-rolled terminator set — see the #106 lesson
+  in `CLAUDE.md`) before scanning for the `:`, so the pair check runs before
+  the sequence loop's anchor/alias consumption rather than after. And
+  `parse_implicit_flow_mapping_entry`'s key now shares `parse_flow_key` with
+  the flow-mapping key site wholesale, rather than adding a fourth direct
+  call to `record_key_anchor`/`record_key_alias` alongside it — one definition
+  for both implicit-key sites, gaining the anchor/alias handling for free.
+  `parse_flow_key_scalar`, now unreachable, is removed. Unaffected: `[a: 1, b:
+  2]` and `[&x a, *x]`, the two shapes the issue calls out as already correct.
+
 - **A comma-generator was rejected inside call arguments** (#155, closing the
   call-argument half — #360 already closed the index-bracket half): builtin
   calls like `sort_by(.a,.b)`, `first(1,2,3)`, `[limit(2;1,2,3,4)]`, and

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1215,6 +1215,12 @@ mod tests {
             // like the other three, so the offset it reports is the helper's
             // rather than `parse_alias`'s. Both are the `*`, and this pins that.
             ("{*nope: v}", "nope", "*nope"),
+            // The flow-*sequence* implicit single-pair-mapping key didn't
+            // reach this rejection at all before #409: the sequence loop
+            // consumed a leading `*` as a standalone item before the pair
+            // check ever ran, so `[*nope: v]` errored `expected ',' or ']'`
+            // rather than naming the unknown anchor.
+            ("[*nope: v]", "nope", "*nope"),
             // A forward reference is a miss like any other: YAML 1.2 §7.1
             // requires an alias to name a *previous* anchor, so the anchor
             // below is not in scope at the alias.

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -7260,6 +7260,18 @@ mod tests {
             // Two aliases to one anchor: resolution is per-node, so the second
             // must not depend on the first having consumed the edge.
             (b"{&x k: 1, *x: 2, *x: 3}", r#"{"k":1,"k":2,"k":3}"#),
+            // Flow-*sequence* implicit-mapping-entry keys (#409), a separate
+            // bug from #405 above: the sequence loop consumed a leading `&`
+            // or `*` before ever checking whether the item was a pair, so a
+            // miss errored `expected ',' or ']'` instead of naming the
+            // unknown anchor, and a hit either failed the same way (alias) or
+            // bound to the mapping wrapper instead of the key (anchor).
+            (b"[&x k: 1, *x: 2]", r#"[{"k":1},{"k":2}]"#),
+            // Anchor on the key, aliased by a later plain (non-pair) item.
+            (b"[&x k: 1, *x]", r#"[{"k":1},"k"]"#),
+            // Anchored value in a block mapping, aliased as a flow-sequence
+            // implicit-entry key nested in that mapping's value.
+            (b"{a: &x 1, b: [*x: 2]}", r#"{"a":1,"b":[{"1":2}]}"#),
         ];
         for (yaml, expected) in cases {
             assert_eq!(

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2485,6 +2485,34 @@ impl<'a> Parser<'a> {
     fn looks_like_flow_mapping_entry(&self) -> bool {
         let mut i = self.pos;
 
+        // Skip a leading anchor or alias: an aliased key IS the key (`*x: v`,
+        // #409) and an anchored key just prefixes it (`&x k: v`, corpus case
+        // CN3R) - what determines whether this item is a pair is what
+        // follows the name, not the indicator. Uses the same scanner the
+        // real anchor/alias parse uses, so this can't drift from what will
+        // actually be consumed (#106).
+        if i < self.input.len() && (self.input[i] == b'&' || self.input[i] == b'*') {
+            let is_alias = self.input[i] == b'*';
+            let name_start = i + 1;
+            let name_end = simd::parse_anchor_name(self.input, name_start);
+            if name_end == name_start {
+                // Empty name - not a valid anchor/alias; let the real parse
+                // report it.
+                return false;
+            }
+            i = name_end;
+            while i < self.input.len() && matches!(self.input[i], b' ' | b'\t') {
+                i += 1;
+            }
+            if is_alias {
+                // The alias name is the whole key; nothing else to scan.
+                return i < self.input.len() && self.input[i] == b':';
+            }
+            // An anchor prefixes the actual key, which still needs to be
+            // scanned below - it may be quoted, a container, or a plain
+            // scalar.
+        }
+
         // Skip quoted string if present
         if i < self.input.len() && (self.input[i] == b'"' || self.input[i] == b'\'') {
             let quote = self.input[i];
@@ -2695,21 +2723,18 @@ impl<'a> Parser<'a> {
         self.write_bp_open();
         self.write_ty(false); // 0 = mapping
 
-        // Parse key - can be scalar, quoted, flow mapping, or flow sequence
+        // Parse key - shares `parse_flow_key` with the flow-mapping key site,
+        // so an anchor or alias prefixing this key (`[&x k: 1, *x: 2]`,
+        // #409) binds via `record_key_anchor` / `record_key_alias` to this
+        // already-open key node, rather than `parse_anchor`/`parse_alias`'s
+        // "next node opened" semantics binding to the wrong node.
         self.set_ib();
         self.write_bp_open();
-        match self.peek() {
-            // Nested flow containers need no end of their own (#332)
-            Some(b'{') => {
-                self.parse_flow_mapping()?;
-            }
-            Some(b'[') => {
-                self.parse_flow_sequence()?;
-            }
-            _ => {
-                let key_end = self.parse_flow_key_scalar()?;
-                self.set_bp_text_end(key_end);
-            }
+        if !self.parse_flow_key()? {
+            // A complex key (a nested flow container) opened its own BP nodes
+            // and carries its own end; recording one here would clobber the
+            // innermost of them (#332).
+            self.set_bp_text_end(self.pos);
         }
         self.write_bp_close();
 
@@ -2807,41 +2832,40 @@ impl<'a> Parser<'a> {
             }
             first = false;
 
-            // Check for anchor first - it prefixes the actual value
-            if self.peek() == Some(b'&') {
-                self.parse_anchor()?;
-            }
-
-            // Check for alias - this IS the value
-            if self.peek() == Some(b'*') {
-                self.parse_alias()?;
-                self.skip_flow_whitespace();
-                continue;
-            }
-
             // Check for explicit key `? key : value` in flow context
             if self.looks_like_explicit_flow_key() {
                 self.parse_explicit_flow_mapping_entry()?;
             } else if self.looks_like_flow_mapping_entry() {
-                // Check for implicit mapping entry (handles all key types including { and [)
-                // This is an implicit single-pair mapping: [ key : value ]
+                // Handles all key forms, including a leading anchor or alias
+                // (`[&x k: 1, *x: 2]`, #409), { and [, quoted, and plain scalar
+                // keys. This is an implicit single-pair mapping: [ key : value ]
                 self.parse_implicit_flow_mapping_entry()?;
             } else {
-                // Parse flow value (item) - containers handle their own BP
-                match self.peek() {
-                    Some(b'[') => {
-                        self.parse_flow_sequence()?;
-                    }
-                    Some(b'{') => {
-                        self.parse_flow_mapping()?;
-                    }
-                    _ => {
-                        // Plain scalar value - wrap in BP
-                        self.set_ib();
-                        self.write_bp_open();
-                        let end = self.parse_flow_scalar()?;
-                        self.set_bp_text_end(end);
-                        self.write_bp_close();
+                // Not a key:value pair - an anchor or alias here prefixes a
+                // standalone value instead (`[&x a, *x]`), so it's consumed
+                // only now that the pair check has ruled that out.
+                if self.peek() == Some(b'&') {
+                    self.parse_anchor()?;
+                }
+                if self.peek() == Some(b'*') {
+                    self.parse_alias()?;
+                } else {
+                    // Parse flow value (item) - containers handle their own BP
+                    match self.peek() {
+                        Some(b'[') => {
+                            self.parse_flow_sequence()?;
+                        }
+                        Some(b'{') => {
+                            self.parse_flow_mapping()?;
+                        }
+                        _ => {
+                            // Plain scalar value - wrap in BP
+                            self.set_ib();
+                            self.write_bp_open();
+                            let end = self.parse_flow_scalar()?;
+                            self.set_bp_text_end(end);
+                            self.write_bp_close();
+                        }
                     }
                 }
             }
@@ -3000,6 +3024,11 @@ impl<'a> Parser<'a> {
     /// Parse an *implicit* key in flow context.
     /// Keys can be scalars, flow sequences, or flow mappings (complex keys).
     ///
+    /// Shared by both implicit-key sites: a flow mapping's own entries
+    /// (`{k: v}`) and a flow sequence's implicit single-pair-mapping entry
+    /// (`[k: v]`, since #409 — it used to hand-roll a narrower version of
+    /// this match with no anchor/alias arms).
+    ///
     /// The explicit `? key` form is not handled here: its indicator has to be consumed
     /// before the caller plants the key's interest bit, so the caller dispatches it to
     /// [`Self::parse_explicit_flow_key_node`] instead (#402).
@@ -3034,9 +3063,10 @@ impl<'a> Parser<'a> {
                 self.parse_flow_mapping()?;
                 return Ok(true);
             }
-            // Alias as key (`{*a: v}`), sharing the block and compact mappings'
-            // site. The caller already opened the key's BP node, so the edge
-            // binds to that node; `parse_alias` here opened a *second* one, which
+            // Alias as key (`{*a: v}`, and via this same function `[*a: v]`
+            // since #409), sharing the block and compact mappings' site. The
+            // caller already opened the key's BP node, so the edge binds to
+            // that node; `parse_alias` here opened a *second* one, which
             // took the edge and left the key with no extent, so a resolving alias
             // still rendered as `""` while a miss went through `parse_alias`'s
             // lookup and errored — the one key position that stayed inconsistent
@@ -3056,11 +3086,12 @@ impl<'a> Parser<'a> {
     /// Stops at `:`, `,`, `}`, `]`, or whitespace before those.
     /// Handles multiline keys (continues across newlines with proper indentation).
     fn parse_flow_unquoted_key(&mut self) -> Result<usize, YamlError> {
-        // #369: reject a tag at the start of a flow key. Both callers land here
-        // with `pos` at the key's first byte — `parse_flow_key` dispatches
-        // anchors, aliases and nested containers first, and
-        // `parse_flow_key_scalar` only peels off the quoted forms — so this one
-        // gate covers the whole plain-key path.
+        // #369: reject a tag at the start of a flow key. `parse_flow_key` is
+        // the only caller, from two call sites (the flow-mapping key and,
+        // since #409, the flow-sequence implicit-entry key); it dispatches
+        // anchors, aliases and nested containers first and lands here with
+        // `pos` at the key's first byte, so this one gate covers the whole
+        // plain-key path from both sites.
         self.check_unsupported()?;
 
         let start = self.pos;
@@ -3176,31 +3207,6 @@ impl<'a> Parser<'a> {
                 self.pos
             }
             _ => self.parse_flow_unquoted_value(),
-        };
-        Ok(end)
-    }
-
-    /// Parse a flow key (for implicit mapping entries).
-    /// Like parse_flow_scalar but also stops at `: ` (colon followed by space/flow indicator).
-    fn parse_flow_key_scalar(&mut self) -> Result<usize, YamlError> {
-        // No #369 tag gate here, unlike `parse_flow_scalar`: the two quoted arms
-        // below cannot begin with `!`, and the plain arm is
-        // `parse_flow_unquoted_key`, which gates at this same position. A check
-        // here would reject nothing extra. The path is pinned by a test instead,
-        // so a future change to the plain arm cannot lose the gate silently.
-        let end = match self.peek() {
-            Some(b'"') => {
-                self.parse_double_quoted()?;
-                self.pos
-            }
-            Some(b'\'') => {
-                self.parse_single_quoted()?;
-                self.pos
-            }
-            _ => {
-                // Use existing parse_flow_unquoted_key which stops at `:`
-                self.parse_flow_unquoted_key()?
-            }
         };
         Ok(end)
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1028,9 +1028,10 @@ fn test_yaml_flow_context_rejects_tags_like_block_context() -> Result<()> {
     //
     // Every flow position that reaches a plain-scalar reader. The last two are
     // the ones no other case covers: an implicit `k: v` entry inside a flow
-    // *sequence* enters through `parse_flow_key_scalar`, and the explicit
-    // `? k : v` form through `parse_explicit_flow_unquoted_key`. Without them,
-    // deleting either gate leaves this test green.
+    // *sequence* enters through `parse_flow_key` (shared with the flow-mapping
+    // key site since #409), and the explicit `? k : v` form through
+    // `parse_explicit_flow_unquoted_key`. Without them, deleting either gate
+    // leaves this test green.
     for (name, input) in [
         ("seq item", "a: [!!str x]\n"),
         ("mapping value", "a: {k: !custom v}\n"),
@@ -1291,6 +1292,21 @@ fn test_yaml_anchor_on_flow_mapping_key_binds_to_key() -> Result<()> {
     let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
     assert_eq!(exit_code, 0);
     assert_eq!(output.trim(), r#"{"a":{"e":"f"},"b":"e"}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_anchor_on_flow_sequence_key_binds_to_key() -> Result<()> {
+    // The flow-*sequence* counterpart of the test above (#409): an implicit
+    // single-pair-mapping entry inside `[...]` also opens the key's BP node
+    // before the anchor is read, so a bare `parse_anchor` here bound the
+    // anchor to the mapping *wrapper* `parse_implicit_flow_mapping_entry` was
+    // about to open, not the key `k` inside it — invisible on `&flowseq [...,
+    // &c c: d, ...]` (corpus case CN3R) since that case never aliases `&c`.
+    let input = "[&x k: 1, *x: 2]\n";
+    let (output, exit_code) = run_yq_stdin("at_offset(11)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#""k""#);
     Ok(())
 }
 
@@ -2962,6 +2978,48 @@ fn test_alias_as_a_flow_mapping_key_resolves() -> Result<()> {
     // `validate_alias_acyclicity` rather than by its ancestor arm. It must stay an
     // error — resolving it would be unbounded materialization.
     let (stdout, stderr, code) = run_yq_stdin_with_stderr(".", "{&x *x: 1}\n", &["-o=json"])?;
+    assert_eq!(code, 1, "expected clean error exit, stderr: {stderr}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("cyclic alias 'x'"),
+        "stderr should name the cycle: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_alias_as_a_flow_sequence_key_resolves() -> Result<()> {
+    // #409, the flow-*sequence* counterpart of #405 above. An implicit
+    // single-pair-mapping entry inside `[...]` never reached the pair check
+    // at all for an alias key: the sequence loop consumed a leading `*` as a
+    // *standalone* item and `continue`d, so `*x: 2` left the cursor on `:`
+    // and errored `expected ',' or ']'`. An anchor on such a key parsed
+    // without erroring but bound to the mapping wrapper instead of the key,
+    // the same wrong-node shape #405 fixed for the flow-mapping key.
+    //
+    // Every expectation is `yq` v4.53.3's output for the same input, on the
+    // streaming path (`-I 0`), taken directly from the issue's repro table.
+    for (yaml, expected) in [
+        // Alias to an anchored key.
+        ("[&x k: 1, *x: 2]\n", r#"[{"k":1},{"k":2}]"#),
+        // Alias to an anchored value, nested inside a block mapping.
+        ("{a: &x 1, b: [*x: 2]}\n", r#"{"a":1,"b":[{"1":2}]}"#),
+        // Anchor on the key, aliased by a later *plain* (non-pair) item.
+        ("[&x k: 1, *x]\n", r#"[{"k":1},"k"]"#),
+        // Unaffected baselines the issue calls out: no anchor/alias at all,
+        // and a plain aliased scalar item (not a key) - both must still work.
+        ("[a: 1, b: 2]\n", r#"[{"a":1},{"b":2}]"#),
+        ("[&x a, *x]\n", r#"["a","a"]"#),
+    ] {
+        let (output, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(output.trim(), expected, "for {yaml:?}");
+    }
+
+    // An anchor and an alias to it on the same key: must still be rejected as
+    // a cycle, the same as the flow-mapping key position above - this call
+    // path must not have quietly dropped `record_key_alias`'s cycle check.
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".", "[&x *x: 1]\n", &["-o=json"])?;
     assert_eq!(code, 1, "expected clean error exit, stderr: {stderr}");
     assert_eq!(stdout, "");
     assert!(


### PR DESCRIPTION
## Description

This PR fixes two independent bugs in YAML flow-sequence anchor/alias handling for implicit single-pair mapping keys. Previously, anchors and aliases on flow-sequence implicit-entry keys were either parse errors or bound to the wrong node, causing incorrect parsing and resolution behavior.

**Before:**
- `[&x k: 1, *x: 2]` → parse error: "expected ',' or ']'"
- `[&x k: 1, *x]` → anchor bound to mapping wrapper instead of key, resolving incorrectly

**After:**
- `[&x k: 1, *x: 2]` → `[{"k":1},{"k":2}]` (matches yq output)
- `[&x k: 1, *x]` → `[{"k":1},"k"]` (anchor correctly binds to key)

The root cause involved two separate issues in `parse_flow_sequence_inner`:

1. **Dispatch ordering bug**: The sequence loop consumed leading `&`/`*` indicators before checking if the item was a `key: value` pair, causing aliases to be parsed as standalone values instead of keys.

2. **Anchor binding bug**: A bare `parse_anchor()` call recorded anchors against the implicit mapping wrapper node instead of the key node inside it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #409
Refs #405, #372, #402

## Changes Made

**Parser Implementation (`src/yaml/parser.rs`):**
- Modified `looks_like_flow_mapping_entry()` to skip leading `&name`/`*name` before scanning for `:`, reusing `simd::parse_anchor_name` for consistency (#106)
- Refactored `parse_implicit_flow_mapping_entry()` to use `parse_flow_key()` wholesale instead of `parse_flow_key_scalar()`, gaining proper anchor/alias binding semantics via `record_key_anchor`/`record_key_alias`
- Reordered dispatch in `parse_flow_sequence_inner()` to check for `key: value` pairs before consuming standalone anchors/aliases
- Removed now-unreachable `parse_flow_key_scalar()` function
- Updated comments to document the anchor/alias handling for both implicit-key sites (flow-mapping and flow-sequence)

**Test Coverage (`tests/yq_cli_tests.rs`):**
- Added `test_yaml_anchor_on_flow_sequence_key_binds_to_key()` verifying anchor binds to the key
- Added `test_alias_as_a_flow_sequence_key_resolves()` with comprehensive test cases including:
  - Alias to anchored key in flow sequence
  - Alias to anchored value from block mapping nested in flow sequence
  - Anchor on key aliased by plain item
  - Cycle detection for `&x *x: 1`
  - Unaffected baseline cases
- Updated documentation in `test_yaml_flow_context_rejects_tags_like_block_context()` to reflect new code path

**Index & Resolution (`src/yaml/index.rs`, `src/yaml/light.rs`):**
- Added unknown-anchor test case for `[*nope: v]` that previously errored
- Added anchor/alias resolution test cases for flow-sequence implicit-entry keys
- Verified new test cases match yq v4.53.3 output

**Documentation (`CHANGELOG.md`):**
- Added detailed changelog entry documenting the bug, root causes, and solution approach
- Included examples of broken behavior and fix
- Cross-referenced related issues (#405, #409)

## Testing

**Automated Testing:**
- [x] All existing tests pass (yaml_test_suite_conformance numbers unchanged)
- [x] New tests added for anchor binding on flow-sequence keys
- [x] New tests added for alias resolution to flow-sequence keys
- [x] Verified baseline cases unaffected: `[a: 1, b: 2]` and `[&x a, *x]`
- [x] Cycle detection verified for `[&x *x: 1]`

**Manual Testing:**
- [x] Verified flow-sequence implicit-entry keys now parse correctly
- [x] Verified anchor binding points to key node, not wrapper
- [x] Verified alias resolution uses correct node
- [x] Tested error case with proper error message for unknown anchor

### Test Commands
```bash
cargo test yaml
cargo test test_yaml_anchor_on_flow_sequence_key_binds_to_key
cargo test test_alias_as_a_flow_sequence_key_resolves
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- Parser now skips anchor names once (in lookahead) instead of having potential to re-parse them
- No additional allocations or expensive operations introduced

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Design Decisions:**
- `parse_flow_key()` is now the single definition for implicit-key parsing at both sites (flow-mapping and flow-sequence), eliminating code duplication and inconsistency
- Reused `simd::parse_anchor_name` in `looks_like_flow_mapping_entry()` rather than hand-rolling anchor name scanning, preventing drift as addressed in #106
- The fix is fully backward compatible; no breaking changes to public API or YAML semantics

**Unaffected Cases:**
- Plain flow-sequence items: `[a, b, c]`
- Flow-sequence with implicit mappings: `[a: 1, b: 2]`
- Aliased plain items in flow-sequence: `[&x a, *x]`
- Flow-mapping entries (already fixed by #405)

**Related Work:**
- Similar anchor/alias issue for flow-mapping keys fixed in #405
- Part of broader anchor/alias handling improvements (#372, #402)
- Follows YAML 1.2 specification §7.1 for anchor/alias semantics