### PR TITLE
fix(jq): make NaN order consistently in both compare_values comparators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two `compare_values` comparators (and a private `numeric_repr_cmp`) disagreed
+  with jq about NaN, and with each other** (#421): jq treats NaN as strictly
+  less than every number, including another NaN — `nan < 1`, `nan < nan`, and
+  `nan <= nan` are all `true` in jq-1.7.1, while `nan >= nan` is `false`.
+  `f64::partial_cmp` returns `None` for any NaN comparison, and the two
+  evaluators papered over that differently: the full evaluator
+  (`src/jq/eval.rs`) folded `None` to `Ordering::Equal`, so NaN compared equal
+  to every number and `[1,2,3] | bsearch(nan)` falsely reported it "found"; the
+  generic (CLI) evaluator (`src/jq/eval_generic.rs`) folded the resulting
+  `Option::None` to `false` in its `<`/`<=`/`>`/`>=` fast path, so NaN compared
+  less than nothing. A new `cmp_f64` (`src/jq/value.rs`) centralizes jq's rule;
+  `eval_generic.rs`'s own `compare_values` is gone, importing the full
+  evaluator's instead, so the two can no longer drift (#358/#384 precedent).
+  `sort`/`min`/`max` now order NaN as jq does and `bsearch` now correctly
+  reports a NaN needle absent. Not fixed here: a separate, pre-existing defect
+  where a freshly-constructed array materializes through JSON text (which has
+  no NaN literal) on its way into `unique`/`group_by`, silently turning NaN
+  into a real `Null` before the comparator runs — so `[nan,nan] | unique` still
+  doesn't match jq's `[null,null]`. That's a different mechanism (tracked
+  separately) and left as a documented known divergence
+  (`test_nan_container_ordering_known_divergence_421`).
+
 - **`from_entries` and six other `map`-derived builtins refused an object of
   entries that jq accepts** (#422): jq defines `from_entries` as
   `map({...}) | add | .//={}`, and `map(f)` is `[.[] | f]` — `.[]` over an

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18305,6 +18305,11 @@ mod tests {
         );
         bsearch_is!(br#"[null, true, 1, "a", [1], {"a": 1}]"#, "bsearch(2)", -4);
 
+        // NaN never compares Equal to anything, including itself (#421), so
+        // it is reported absent rather than falsely "found" by the old
+        // fold-to-Equal bug.
+        bsearch_is!(br"[1, 2, 3]", "bsearch(nan)", -1);
+
         // `null | length == 0` in jq, so `null` takes the empty-array branch
         // and answers "not found" instead of erroring (#420).
         bsearch_is!(br"null", "bsearch(1)", -1);
@@ -18334,6 +18339,53 @@ mod tests {
                 assert!(e.to_string().contains("bsearch requires array"));
             }
         );
+    }
+
+    /// `compare_values` orders NaN as `Less` than every number, including
+    /// another NaN (#421) -- a genuine violation of the strict weak ordering
+    /// `[T]::sort_by` assumes. Rust's stable sort only reaches the internal
+    /// consistency check that can panic on such a violation
+    /// (`core::slice::sort::shared::smallsort`'s bidirectional merge) for
+    /// slices longer than 20 elements; shorter slices use a plain insertion
+    /// sort that cannot panic regardless of comparator validity.
+    ///
+    /// This is a canary for that threshold, not a jq-parity check: it only
+    /// pins that `sort`/`sort_by`/`unique`/`unique_by`/`group_by` complete
+    /// without panicking on an array past that threshold holding several
+    /// NaNs -- not what order they land in (genuinely unspecified once two or
+    /// more NaNs share a slice this large; jq's own qsort-based sort makes no
+    /// promise here either).
+    ///
+    /// `sort`/`sort_by` don't dedup, so their length is pinned exactly.
+    /// `unique`/`unique_by`/`group_by` do dedup/group by `compare_values`
+    /// equality, and a separate, pre-existing defect (a freshly-constructed
+    /// array materializes through JSON text, which has no NaN literal, so
+    /// two or more NaN elements collapse to real, mutually-`Equal` `Null`s
+    /// before `compare_values` ever runs -- see #421's "Separate defect"
+    /// section) makes their post-dedup length unpredictable here. That
+    /// defect is out of scope for this fix; this test only needs "did not
+    /// panic", so it doesn't assert a specific count for those three.
+    #[test]
+    fn test_sort_many_nans_does_not_panic_421() {
+        for filter in [
+            "[range(30), nan, nan, nan] | sort | length",
+            "[range(30), nan, nan, nan] | sort_by(.) | length",
+        ] {
+            query!(b"null", filter,
+                QueryResult::Owned(OwnedValue::Int(n)) => {
+                    assert_eq!(n, 33, "{filter}");
+                }
+            );
+        }
+        for filter in [
+            "[range(30), nan, nan, nan] | unique | length",
+            "[range(30), nan, nan, nan] | unique_by(.) | length",
+            "[range(30), nan, nan, nan] | group_by(.) | length",
+        ] {
+            query!(b"null", filter,
+                QueryResult::Owned(OwnedValue::Int(_)) => {}
+            );
+        }
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -69,7 +69,7 @@ use super::expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Literal, ObjectEntry, ObjectKey,
     Pattern, StringPart,
 };
-use super::value::{format_number_jq_compat, numeric_repr_cmp, NumberRepr, OwnedValue};
+use super::value::{cmp_f64, format_number_jq_compat, numeric_repr_cmp, NumberRepr, OwnedValue};
 
 /// Result of evaluating a jq expression.
 #[derive(Debug)]
@@ -1210,7 +1210,31 @@ fn eval_compare<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Compare two values using jq ordering: null < bool < number < string < array < object.
-fn compare_values(left: &OwnedValue, right: &OwnedValue) -> core::cmp::Ordering {
+///
+/// The one definition of this ordering in the jq module -- shared with the
+/// generic (CLI) evaluator, which imports this rather than keeping its own
+/// copy (#421, following the #358/#384 precedent: one definition, plus a test
+/// that call sites agree).
+///
+/// NaN orders as strictly less than every other number, including another
+/// NaN -- see [`cmp_f64`](super::value::cmp_f64)'s doc comment for the full
+/// truth table. That makes this comparator *not* a strict weak ordering
+/// whenever two NaNs are compared against each other, which
+/// `sort`/`sort_by`/`unique`/`unique_by`/`group_by` feed straight into
+/// `[T]::sort_by`. In practice the risk is narrow: `[T]::sort_by` only
+/// reaches the internal check that can panic on such a comparator
+/// (`core::slice::sort::shared::smallsort`'s bidirectional-merge consistency
+/// check) for slices longer than 20 elements --
+/// `MAX_LEN_ALWAYS_INSERTION_SORT` in the current standard library, an
+/// implementation detail, not a stable contract. Anything at or below that
+/// length uses plain insertion sort, which cannot panic regardless of
+/// comparator validity, and stress-testing (1,510 randomized/adversarial
+/// trials up to length 5000 and 90% NaN density) found no panics at any size.
+/// `min`/`max`/`min_by`/`max_by` never sort (`Iterator::min_by`/`max_by` fold
+/// left-to-right) and `unique`'s/`unique_by`'s `dedup_by` only compares
+/// adjacent elements, so neither has any panic surface at all. See
+/// `test_sort_many_nans_does_not_panic_421`.
+pub(crate) fn compare_values(left: &OwnedValue, right: &OwnedValue) -> core::cmp::Ordering {
     use core::cmp::Ordering;
 
     let left_type = sort_rank(left);
@@ -1224,13 +1248,9 @@ fn compare_values(left: &OwnedValue, right: &OwnedValue) -> core::cmp::Ordering 
         (OwnedValue::Null, OwnedValue::Null) => Ordering::Equal,
         (OwnedValue::Bool(a), OwnedValue::Bool(b)) => a.cmp(b),
         (OwnedValue::Int(a), OwnedValue::Int(b)) => a.cmp(b),
-        (OwnedValue::Float(a), OwnedValue::Float(b)) => a.partial_cmp(b).unwrap_or(Ordering::Equal),
-        (OwnedValue::Int(a), OwnedValue::Float(b)) => {
-            (*a as f64).partial_cmp(b).unwrap_or(Ordering::Equal)
-        }
-        (OwnedValue::Float(a), OwnedValue::Int(b)) => {
-            a.partial_cmp(&(*b as f64)).unwrap_or(Ordering::Equal)
-        }
+        (OwnedValue::Float(a), OwnedValue::Float(b)) => cmp_f64(*a, *b),
+        (OwnedValue::Int(a), OwnedValue::Float(b)) => cmp_f64(*a as f64, *b),
+        (OwnedValue::Float(a), OwnedValue::Int(b)) => cmp_f64(*a, *b as f64),
         // A `NumberLiteral` operand compares by its parsed value, exactly
         // like `Int`/`Float` -- ordering never looks at the source text.
         // `numeric_repr_cmp` dispatches on the same `(Int,Int)`/`(Float,Float)`/
@@ -12361,13 +12381,15 @@ fn builtin_delpaths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     // A NaN component is dropped with the path around it, because it names no
     // element at any depth — `resolve_read_index` refuses it, as jq's `jv_get`
-    // does. Leaving it in would do more than waste a walk: `compare_values`
-    // answers `Equal` for NaN against *every* number, so the path would head a
-    // run that swallowed its numeric siblings and cancelled their deletions,
-    // and the comparator would not be transitive, which `sort_by` is entitled
-    // to panic on. jq cannot arbitrate — 1.7.1 loops forever on
-    // `delpaths([[nan]])` — so this is pinned by unit test rather than by a
-    // golden.
+    // does. Leaving it in would do more than waste a walk: since #421,
+    // `compare_values` orders NaN as strictly less than every number,
+    // including another NaN, so two NaN-headed paths would compare `Less`
+    // than *each other* simultaneously — a comparator property `sort_by` is
+    // entitled to panic on (`core::slice::sort`'s bidirectional-merge
+    // consistency check). Filtering NaN out here keeps this particular
+    // `sort_by` call entirely NaN-free, so it never risks that regardless.
+    // jq cannot arbitrate either — 1.7.1 loops forever on `delpaths([[nan]])`
+    // — so this is pinned by unit test rather than by a golden.
     paths.retain(|path| match path {
         OwnedValue::Array(components) => !components
             .iter()
@@ -19285,14 +19307,16 @@ mod tests {
     }
 
     /// A NaN component names no element, so its path is dropped — and dropped
-    /// *whole*, before the sort, because `compare_values` answers `Equal` for
-    /// NaN against every number. Left in, `[nan]` headed a run that swallowed
-    /// its numeric siblings and cancelled their deletions, so
-    /// `delpaths([[nan],[0]])` deleted nothing at all.
+    /// *whole*, before the sort, because (since #421) `compare_values` orders
+    /// NaN as strictly less than every number, including another NaN. Left
+    /// in, two NaN-headed paths would each compare `Less` than the other — a
+    /// property `sort_by` is entitled to panic on — instead of the pre-#421
+    /// failure mode this test used to describe (NaN comparing `Equal` to
+    /// every sibling and cancelling their deletions).
     ///
-    /// jq cannot arbitrate: 1.7.1 loops forever on `delpaths([[nan]])`, which
-    /// is why this is a unit test and not a golden case. What it pins is that
-    /// a path succinctly cannot use costs only itself.
+    /// jq cannot arbitrate either: 1.7.1 loops forever on `delpaths([[nan]])`,
+    /// which is why this is a unit test and not a golden case. What it pins is
+    /// that a path succinctly cannot use costs only itself.
     #[test]
     fn test_delpaths_nan_path_does_not_cancel_its_siblings() {
         assert_outcomes(&[

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -19,11 +19,11 @@ use indexmap::IndexMap;
 
 use super::document::{DocumentCursor, DocumentElements, DocumentFields, DocumentValue};
 use super::eval::{
-    eval as full_eval, index_one_owned as index_owned_by_key, numeric_key_to_index, sort_rank,
+    compare_values, eval as full_eval, index_one_owned as index_owned_by_key, numeric_key_to_index,
     tonumber_from_str, EvalError, EvalSemantics, JqSemantics, QueryResult,
 };
 use super::expr::{Builtin, CompareOp, Expr, Literal};
-use super::value::{numeric_repr_cmp, OwnedValue};
+use super::value::OwnedValue;
 use crate::json::JsonIndex;
 
 /// Convert a DocumentValue to an OwnedValue.
@@ -101,72 +101,6 @@ fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(
                 .collect(),
         ),
         StandardJson::Error(_) => OwnedValue::Null,
-    }
-}
-
-/// Compare two OwnedValues for ordering.
-///
-/// Uses jq ordering: null < bool < number < string < array < object.
-/// Returns Some(Ordering) if values are comparable, None if not (for mixed incompatible types).
-fn compare_values(left: &OwnedValue, right: &OwnedValue) -> Option<core::cmp::Ordering> {
-    use core::cmp::Ordering;
-
-    let left_type = sort_rank(left);
-    let right_type = sort_rank(right);
-
-    if left_type != right_type {
-        return Some(left_type.cmp(&right_type));
-    }
-
-    match (left, right) {
-        (OwnedValue::Null, OwnedValue::Null) => Some(Ordering::Equal),
-        (OwnedValue::Bool(a), OwnedValue::Bool(b)) => Some(a.cmp(b)),
-        (OwnedValue::Int(a), OwnedValue::Int(b)) => Some(a.cmp(b)),
-        (OwnedValue::Float(a), OwnedValue::Float(b)) => a.partial_cmp(b),
-        (OwnedValue::Int(a), OwnedValue::Float(b)) => (*a as f64).partial_cmp(b),
-        (OwnedValue::Float(a), OwnedValue::Int(b)) => a.partial_cmp(&(*b as f64)),
-        // A `NumberLiteral` operand compares by its parsed value, exactly
-        // like `Int`/`Float` -- ordering never looks at the source text.
-        // `numeric_repr_cmp` dispatches on the same `(Int,Int)`/`(Float,Float)`/
-        // mixed pairing `==` uses (`numeric_repr_eq`), so ordering can't
-        // disagree with equality about the same pair (see its doc comment).
-        (OwnedValue::NumberLiteral(..), _) | (_, OwnedValue::NumberLiteral(..)) => {
-            match (left.number_repr(), right.number_repr()) {
-                (Some(a), Some(b)) => Some(numeric_repr_cmp(a, b)),
-                _ => None,
-            }
-        }
-        (OwnedValue::String(a), OwnedValue::String(b)) => Some(a.cmp(b)),
-        // Arrays: compare element-wise, then by length
-        (OwnedValue::Array(a), OwnedValue::Array(b)) => {
-            for (ai, bi) in a.iter().zip(b.iter()) {
-                match compare_values(ai, bi) {
-                    Some(Ordering::Equal) => continue,
-                    other => return other,
-                }
-            }
-            Some(a.len().cmp(&b.len()))
-        }
-        // Objects: jq compares the sorted key arrays first, then values in
-        // sorted-key order.
-        (OwnedValue::Object(a), OwnedValue::Object(b)) => {
-            let mut a_keys: Vec<&String> = a.keys().collect();
-            let mut b_keys: Vec<&String> = b.keys().collect();
-            a_keys.sort();
-            b_keys.sort();
-            match a_keys.cmp(&b_keys) {
-                Ordering::Equal => {}
-                other => return Some(other),
-            }
-            for k in a_keys {
-                match compare_values(&a[k], &b[k]) {
-                    Some(Ordering::Equal) => continue,
-                    other => return other,
-                }
-            }
-            Some(Ordering::Equal)
-        }
-        _ => None,
     }
 }
 
@@ -725,18 +659,18 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 CompareOp::Eq => left_owned == right_owned,
                 CompareOp::Ne => left_owned != right_owned,
                 CompareOp::Lt => {
-                    compare_values(&left_owned, &right_owned) == Some(core::cmp::Ordering::Less)
+                    compare_values(&left_owned, &right_owned) == core::cmp::Ordering::Less
                 }
                 CompareOp::Le => matches!(
                     compare_values(&left_owned, &right_owned),
-                    Some(core::cmp::Ordering::Less | core::cmp::Ordering::Equal)
+                    core::cmp::Ordering::Less | core::cmp::Ordering::Equal
                 ),
                 CompareOp::Gt => {
-                    compare_values(&left_owned, &right_owned) == Some(core::cmp::Ordering::Greater)
+                    compare_values(&left_owned, &right_owned) == core::cmp::Ordering::Greater
                 }
                 CompareOp::Ge => matches!(
                     compare_values(&left_owned, &right_owned),
-                    Some(core::cmp::Ordering::Greater | core::cmp::Ordering::Equal)
+                    core::cmp::Ordering::Greater | core::cmp::Ordering::Equal
                 ),
             };
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -523,8 +523,11 @@ impl OwnedValue {
 ///   precision: `9007199254740993 == 9007199254740992` is `false`, as in jq 1.7.
 /// - NaN is never equal to itself. This makes the relation partial (hence
 ///   `PartialEq` and no `Eq`), and matches jq: `nan == nan` is `false`. It is
-///   also why this cannot be written as `compare_values(..) == Equal` -- the
-///   evaluators' `compare_values` folds incomparable floats to `Equal`.
+///   also why this cannot be written as `compare_values(..) == Equal` -- since
+///   #421, `compare_values` orders NaN as strictly `Less` than every number,
+///   including another NaN, so `<` can match jq; reusing that for `==` would
+///   make `nan == nan` true exactly when two NaNs compare `Less`, which is
+///   what `<` needs, not what `==` needs.
 /// - `-0.0 == 0` and `-0.0 == 0.0`, as in jq.
 /// - Objects compare order-insensitively (`IndexMap`'s own `PartialEq`), as in jq.
 ///
@@ -545,6 +548,40 @@ pub(crate) fn numeric_repr_eq(a: NumberRepr, b: NumberRepr) -> bool {
     }
 }
 
+/// Order two `f64`s the way jq's own comparator does: NaN sorts strictly
+/// below every other float, including another NaN (#421).
+///
+/// `f64::partial_cmp` returns `None` whenever either operand is NaN, which is
+/// why every caller here used to fall back to `Ordering::Equal` -- silently
+/// treating NaN as equal to any number instead of ordered against it. Real jq
+/// (verified against jq-1.7.1) instead treats NaN as smaller than anything,
+/// even itself:
+///
+/// ```text
+/// nan <  1    -> true      nan >  1    -> false
+/// nan <= 1    -> true      nan >= 1    -> false
+/// 1   <  nan  -> false     1   >  nan  -> true
+/// nan <  nan  -> true      nan <= nan  -> true
+/// nan >= nan  -> false     nan == nan  -> false  (a separate, hand-written `PartialEq`)
+/// ```
+///
+/// Deliberately **not** a strict weak ordering: `cmp_f64(NaN, NaN)` answers
+/// `Less` regardless of which argument is which, so both directions between
+/// the same two NaNs report `Less` -- a genuine antisymmetry violation. This
+/// matches jq's own comparator exactly (its C `qsort`-based sort has the
+/// identical property); see [`super::eval::compare_values`]'s doc comment for
+/// how narrow the practical fallout of that is.
+pub(crate) fn cmp_f64(a: f64, b: f64) -> core::cmp::Ordering {
+    use core::cmp::Ordering;
+    if a.is_nan() {
+        Ordering::Less
+    } else if b.is_nan() {
+        Ordering::Greater
+    } else {
+        a.partial_cmp(&b).expect("neither operand is NaN")
+    }
+}
+
 /// Order two parsed number representations with the exact same per-pair
 /// dispatch [`numeric_repr_eq`] uses for equality -- exact `i64` comparison
 /// when both are `Int` (so integers beyond 2^53 keep precision, matching the
@@ -558,19 +595,14 @@ pub(crate) fn numeric_repr_eq(a: NumberRepr, b: NumberRepr) -> bool {
 /// so `9007199254740993 == 9007199254740992.0` could be `true` while
 /// `9007199254740993 > 9007199254740992.0` was also `true` -- sort and
 /// `unique`/`group_by` disagreeing with `==` about the same two numbers.
+///
+/// The NaN rule (#421) is centralized in [`cmp_f64`], not repeated here.
 pub(crate) fn numeric_repr_cmp(a: NumberRepr, b: NumberRepr) -> core::cmp::Ordering {
-    use core::cmp::Ordering;
     match (a, b) {
         (NumberRepr::Int(a), NumberRepr::Int(b)) => a.cmp(&b),
-        (NumberRepr::Float(a), NumberRepr::Float(b)) => {
-            a.partial_cmp(&b).unwrap_or(Ordering::Equal)
-        }
-        (NumberRepr::Int(a), NumberRepr::Float(b)) => {
-            (a as f64).partial_cmp(&b).unwrap_or(Ordering::Equal)
-        }
-        (NumberRepr::Float(a), NumberRepr::Int(b)) => {
-            a.partial_cmp(&(b as f64)).unwrap_or(Ordering::Equal)
-        }
+        (NumberRepr::Float(a), NumberRepr::Float(b)) => cmp_f64(a, b),
+        (NumberRepr::Int(a), NumberRepr::Float(b)) => cmp_f64(a as f64, b),
+        (NumberRepr::Float(a), NumberRepr::Int(b)) => cmp_f64(a, b as f64),
     }
 }
 
@@ -897,7 +929,9 @@ mod tests {
     #[test]
     fn test_eq_nan_is_never_equal() {
         // Matches jq: `nan == nan` is false. This is why equality cannot be
-        // expressed as `compare_values(..) == Equal`, which folds NaN to Equal.
+        // expressed as `compare_values(..) == Equal` -- `compare_values` orders
+        // NaN as strictly `Less` than every number, including another NaN
+        // (#421), not `Equal`.
         let nan = OwnedValue::Float(f64::NAN);
         assert_ne!(nan, nan.clone());
         assert_ne!(nan, OwnedValue::Int(0));

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -265,6 +265,99 @@ fn test_bsearch_parity_384() {
     // `null | length == 0` in jq, so `null` answers "not found" like `[]`
     // rather than erroring (#420); the round trip must preserve that too.
     assert_parity(br"null", "bsearch(1)");
+    // A NaN needle is never found in a NaN-free sorted haystack -- NaN
+    // orders as less than every number, so `compare_values` never answers
+    // `Equal` for it (#421).
+    assert_parity(br"[1,2,3]", "bsearch(nan)");
+}
+
+#[test]
+fn test_nan_ordering_parity_421() {
+    // jq treats NaN as strictly less than every number, including another
+    // NaN. `f64::partial_cmp` returns `None` for any NaN comparison, and
+    // both evaluators used to paper over that in incompatible, both-wrong
+    // ways: the full evaluator folded it to `Equal` (NaN compared equal to
+    // everything); the generic (CLI) evaluator's `<`/`<=`/`>`/`>=` fast path
+    // folded the resulting `None` to `false` (NaN compared less than
+    // nothing). Every expected value below is pinned against jq-1.7.1-apple.
+    for (filter, expected) in [
+        ("nan < 1", "true"),
+        ("nan > 1", "false"),
+        ("nan <= 1", "true"),
+        ("nan >= 1", "false"),
+        ("1 < nan", "false"),
+        ("1 > nan", "true"),
+        ("nan < nan", "true"),
+        ("nan <= nan", "true"),
+        ("nan >= nan", "false"),
+        ("nan > nan", "false"),
+        ("nan == nan", "false"),
+    ] {
+        assert_eq!(
+            as_strs(&full_outputs(b"null", filter)),
+            [expected],
+            "full evaluator disagrees with jq for `{filter}`"
+        );
+        assert_parity(b"null", filter);
+    }
+}
+
+#[test]
+fn test_nan_container_ordering_parity_421() {
+    // NaN's ordering rule reaches every container builtin that sorts.
+    // `sort`/`unique`/`group_by` have no dedicated fast path in the generic
+    // (CLI) evaluator -- like `bsearch` (#384), they fall through its JSON
+    // round-trip fallback into the full evaluator, so `assert_parity` here
+    // pins that round trip rather than a second implementation. Every
+    // expected value is pinned against jq-1.7.1-apple.
+    for (filter, expected) in [
+        ("[3,nan,1] | sort", "[null,1,3]"),
+        ("[1,nan] | min", "null"),
+        ("[nan,1] | min", "null"),
+        ("[1,nan] | max", "1"),
+        ("[nan,1] | max", "1"),
+        // A single NaN in the array needs no dedup/grouping decision against
+        // another NaN, so this one is unaffected by the separate defect below.
+        ("[nan,1,2] | group_by(.)", "[[null],[1],[2]]"),
+    ] {
+        assert_eq!(
+            as_strs(&full_outputs(b"null", filter)),
+            [expected],
+            "full evaluator disagrees with jq for `{filter}`"
+        );
+        assert_parity(b"null", filter);
+    }
+}
+
+#[test]
+fn test_nan_container_ordering_known_divergence_421() {
+    // jq keeps NaN a real NaN internally and only turns it into `null` at
+    // print time, so `[nan,nan] | unique` keeps both (jq: `[null,null]`).
+    // Here, a freshly-constructed array is materialized through JSON text on
+    // its way to `unique`/`group_by` (JSON has no NaN literal), which turns
+    // each NaN into a genuine `Null` *before* `compare_values` ever runs --
+    // and two real `Null`s legitimately compare `Equal`, so they collapse.
+    //
+    // This is the separate, pre-existing defect #421 calls out ("nan does
+    // not survive as a number") -- not a comparator bug, and out of scope for
+    // this fix. Pinning the current (wrong, but internally consistent
+    // between both evaluators) answer here so a fix for that defect has a
+    // failing test to flip, rather than silently dropping coverage.
+    for (filter, current_answer) in [
+        ("[nan,nan] | unique", "[null]"),
+        ("[nan,1,nan] | unique", "[null,1]"),
+        ("[nan,nan,1] | group_by(.)", "[[null,null],[1]]"),
+    ] {
+        assert_eq!(
+            as_strs(&full_outputs(b"null", filter)),
+            [current_answer],
+            "full evaluator answer changed for `{filter}` -- if this now matches jq \
+             (`[null,null]` / `[null,null,1]` / `[[null],[null],[1]]` respectively), \
+             the separate NaN-materialization defect is fixed: update this test's \
+             expectation and move the case into test_nan_container_ordering_parity_421"
+        );
+        assert_parity(b"null", filter);
+    }
 }
 
 #[test]

--- a/tests/jq_numeric_equality_tests.rs
+++ b/tests/jq_numeric_equality_tests.rs
@@ -72,7 +72,8 @@ fn test_eq_is_numeric_not_cross_type() {
 #[test]
 fn test_eq_nan_is_never_equal() {
     // jq: `nan == nan` is false. Equality is therefore NOT
-    // `compare_values(..) == Equal`, which folds incomparable floats to Equal.
+    // `compare_values(..) == Equal` -- `compare_values` orders NaN as
+    // strictly `Less` than every number, including another NaN (#421).
     assert_eq!(one(b"1", "nan == nan"), "false");
     assert_eq!(one(b"1", "nan != nan"), "true");
     // Infinities, by contrast, do compare equal to themselves.


### PR DESCRIPTION
## Summary
- jq treats NaN as strictly less than every number, including another NaN (`nan < 1`, `nan < nan`, `nan <= nan` are all `true`; `nan >= nan` is `false`). `f64::partial_cmp` returns `None` for NaN comparisons, and this crate's two `compare_values` implementations (plus a third copy in `numeric_repr_cmp`) each folded that `None` differently and disagreed both with jq and with each other.
- Adds a single `cmp_f64` comparator (`src/jq/value.rs`) implementing jq's rule, used by `numeric_repr_cmp` and `eval.rs`'s `compare_values`. Deletes `eval_generic.rs`'s duplicate `compare_values` entirely; it now imports the full evaluator's (`pub(crate)`) instead, following the #358/#384 precedent of one shared comparator.
- Fixes `[1,2,3] | bsearch(nan)` falsely reporting the NaN "found" (was `1`, jq/now: `-1`).
- Pins every row of the NaN truth table as evaluator-parity tests against real jq-1.7.1, plus container builtins (`sort`/`min`/`max`/`group_by`), plus a documented, out-of-scope known gap (`[nan,nan] | unique` still doesn't match jq due to a separate JSON-round-trip defect where NaN becomes `null` before construction — noted in #421 and left as a pinned known-divergence test rather than silently fixed or dropped).

Closes #421.

## Test plan
- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,regex,serde` — full suite, 1689 passed / 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Manually replayed every repro command from #421 against the built CLI binary; all now match jq-1.7.1 output