### PR TITLE
fix(jq, yaml, json, cli): stream duplicate mapping keys through pretty-printed output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pretty-printed JSON/YAML output silently dropped duplicate mapping keys;
+  compact output was correct** (#442): `yq -o json '.'` on `a: 1\na: 2` gave
+  `{"a": 2}` (last-wins) while `-I0` gave `{"a":1,"a":2}`, matching real `yq`
+  v4.53.3 only in compact mode. Cause: the pretty path evaluated through
+  `GenericResult`/`to_owned()` into `OwnedValue::Object`, backed by an
+  `IndexMap` that structurally cannot hold duplicate keys, while `-I0` streamed
+  straight from the document cursor. Fix: `JsonCursor`/`YamlCursor`'s
+  `stream_json`/`stream_json_document` (and the YAML-side JSON value
+  streamers) are now indentation-aware, and the M2 fast path's gate
+  (`can_json_fast_path`/`can_yaml_fast_path` in `yq_runner.rs`) no longer
+  requires `output_config.compact` — pretty output now takes the same
+  cursor-streaming path as compact for identity and simple navigation
+  (`.`, `.field`, `.[n]`, `.[]`, and pipes/parens/`?` of those), skipping
+  `OwnedValue` construction entirely rather than just formatting it
+  differently. Excluded from the widened fast path (falls back to the DOM
+  path, unchanged): `sort_keys`, `--ascii-output` (JSON target only — YAML
+  output has no such escaping), color, and `--tab` (its indent unit isn't
+  plumbed through yet). `explicit_key_non_scalar_pretty` moves off the
+  known-failures manifest. Also fixed as a side effect of routing more cases
+  through cursor streaming: multi-file pretty output no longer emits a
+  spurious leading `---` before the first document.
+
+  Not fixed by this change, since the M2 fast path only gives `Expr::Identity`
+  a true cursor result — `Field`/`Index`/`Iterate` still evaluate to an owned
+  `GenericResult::One`/`Many` and go through `to_owned()` when streamed, so a
+  duplicate key *nested inside* a navigated field (`.a` where `a`'s value has
+  a repeated key) still collapses, in both compact and pretty output, exactly
+  as before this fix (tracked as a comment on #443, which already covers the
+  same `to_owned()`/`IndexMap` mechanism for `to_entries`); `--slurp`,
+  `--inplace` (`yaml_to_owned_value`), and `jq --preserve-input` pretty output
+  (`standard_json_to_jq_value`, gated by `jq_runner.rs`'s
+  `can_use_raw_identity`) go through their own separate, still-`IndexMap`-backed
+  conversions and are tracked in #478.
+
 - **The strict YAML validator accepted a flow-collection anchor immediately
   followed by an alias** (#452): `[&a *a]` and `{k: &a *a}` passed
   `succinctly yaml validate`, which `yq` rejects — an anchor property cannot

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1230,7 +1230,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // Check if expression contains split_doc - if so, each result is a separate document
     let has_split_doc = contains_split_doc(&program.expr);
 
-    // M2 streaming fast path: navigation queries with compact output
+    // M2/M2.5 streaming fast path: navigation queries stream results
+    // directly from the document cursor, skipping the OwnedValue DOM (and
+    // its IndexMap, which cannot represent duplicate mapping keys — #442).
+    // Compact output always qualified; indented (pretty) output now does
+    // too, since both the YAML- and JSON-target streamers are indent-aware.
     // This avoids building OwnedValue DOM for:
     // - Identity: `.`
     // - Field access: `.field`
@@ -1241,8 +1245,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // Supports both JSON and YAML output formats.
     let is_identity = matches!(program.expr, Expr::Identity);
     let is_m2_streamable = can_use_m2_streaming(&program.expr);
+    // sort_keys and color aren't implemented by the cursor streamers, and
+    // tab indentation needs a string-based indent unit they don't accept
+    // yet — all three fall back to the DOM path, unchanged, rather than
+    // silently ignoring the flag the way compact mode already does today.
+    let can_stream_pretty = !args.sort_keys && !output_config.use_color && !args.tab;
     let can_json_fast_path = is_m2_streamable
-        && output_config.compact
+        && (output_config.compact || (can_stream_pretty && !args.ascii_output))
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
         && !args.raw_input
@@ -1250,7 +1259,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && !args.inplace
         && context.named.is_empty();
     let can_yaml_fast_path = is_m2_streamable
-        && output_config.compact
+        && (output_config.compact || can_stream_pretty)
         && output_config.output_format == OutputFormat::Yaml
         && !args.null_input
         && !args.raw_input
@@ -1258,6 +1267,21 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && !args.inplace
         && context.named.is_empty();
     let can_fast_path = can_json_fast_path || can_yaml_fast_path;
+
+    // Indent width for the fast path's streamers. YAML's `-I0` is a special
+    // case: real `yq` treats it as "use the library default" (4 spaces),
+    // and succinctly's existing (pre-#442) compact-YAML fast path hardcodes
+    // 2 regardless of `-I` — preserved as-is here since reconciling that
+    // mismatch is a separate, out-of-scope issue. Every other value threads
+    // through directly, matching what the DOM path already produces
+    // (verified against `-I1` through `-I6`). JSON has no such quirk: `-I0`
+    // means compact/flow for both real yq and succinctly today.
+    let yaml_indent_spaces: usize = if args.indent == 0 {
+        2
+    } else {
+        args.indent as usize
+    };
+    let json_indent_spaces: usize = args.indent as usize;
 
     if can_fast_path {
         // M2 streaming fast path: evaluate expression and stream results directly
@@ -1276,7 +1300,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // P9 path: stream directly without evaluation
                         emit_yaml_doc_separator($writer, &mut yaml_doc_streamed, true)?;
                         $cursor
-                            .stream_yaml(&mut FmtWriter($writer), 2)
+                            .stream_yaml(&mut FmtWriter($writer), yaml_indent_spaces)
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
                         writeln!($writer)?;
                         // Streaming skips evaluation, so inspect the document
@@ -1294,7 +1318,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             && !matches!(&result, GenericResult::ManyOwned(vs) if vs.is_empty());
                         emit_yaml_doc_separator($writer, &mut yaml_doc_streamed, will_output)?;
                         let stats = result
-                            .stream_yaml(&mut FmtWriter($writer), 2, |w| w.write_str("\n"))
+                            .stream_yaml(&mut FmtWriter($writer), yaml_indent_spaces, |w| {
+                                w.write_str("\n")
+                            })
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
                         any_truthy |= stats.any_truthy;
                     }
@@ -1303,7 +1329,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     if is_identity {
                         // P9 path: stream directly without evaluation
                         $cursor
-                            .stream_json(&mut FmtWriter($writer))
+                            .stream_json(&mut FmtWriter($writer), json_indent_spaces)
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
                         writeln!($writer)?;
                         // Streaming skips evaluation, so inspect the document
@@ -1315,7 +1341,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // M2 path: evaluate and stream results
                         let result = eval_with_cursor_using::<YqSemantics, _>(&program.expr, $cursor);
                         let stats = result
-                            .stream_json(&mut FmtWriter($writer), |w| w.write_str("\n"))
+                            .stream_json(&mut FmtWriter($writer), json_indent_spaces, |w| {
+                                w.write_str("\n")
+                            })
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
                         any_truthy |= stats.any_truthy;
                     }
@@ -1357,11 +1385,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         if is_identity {
                             // P9 path for identity on single doc
                             if can_yaml_fast_path {
-                                root.stream_yaml_document(&mut FmtWriter(&mut writer), 2)
-                                    .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                root.stream_yaml_document(
+                                    &mut FmtWriter(&mut writer),
+                                    yaml_indent_spaces,
+                                )
+                                .map_err(|_| anyhow::anyhow!("Write error"))?;
                             } else {
-                                root.stream_json_document(&mut FmtWriter(&mut writer))
-                                    .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                root.stream_json_document(
+                                    &mut FmtWriter(&mut writer),
+                                    json_indent_spaces,
+                                )
+                                .map_err(|_| anyhow::anyhow!("Write error"))?;
                             }
                             writeln!(writer)?;
                             // `root` is the virtual document sequence; falsiness
@@ -1419,11 +1453,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             if is_identity {
                                 // P9 path for identity on single doc
                                 if can_yaml_fast_path {
-                                    root.stream_yaml_document(&mut FmtWriter(&mut writer), 2)
-                                        .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                    root.stream_yaml_document(
+                                        &mut FmtWriter(&mut writer),
+                                        yaml_indent_spaces,
+                                    )
+                                    .map_err(|_| anyhow::anyhow!("Write error"))?;
                                 } else {
-                                    root.stream_json_document(&mut FmtWriter(&mut writer))
-                                        .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                    root.stream_json_document(
+                                        &mut FmtWriter(&mut writer),
+                                        json_indent_spaces,
+                                    )
+                                    .map_err(|_| anyhow::anyhow!("Write error"))?;
                                 }
                                 writeln!(writer)?;
                                 // `root` is the virtual document sequence; falsiness

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -77,13 +77,18 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         None
     }
 
-    /// Stream this cursor's value as compact JSON to the output.
+    /// Stream this cursor's value as JSON to the output.
     ///
     /// This enables M2 streaming optimization where navigation query results
     /// can be written directly to output without materializing OwnedValue.
+    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
     ///
     /// Default implementation returns an error indicating streaming is not supported.
-    fn stream_json<W: core::fmt::Write>(&self, _out: &mut W) -> core::fmt::Result {
+    fn stream_json<W: core::fmt::Write>(
+        &self,
+        _out: &mut W,
+        _indent_spaces: usize,
+    ) -> core::fmt::Result {
         Err(core::fmt::Error)
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -240,11 +240,13 @@ impl<V: DocumentValue> GenericResult<V> {
     ///
     /// This is the M2 streaming fast path that avoids OwnedValue materialization
     /// for cursor-based results. For owned results, uses the StreamableValue impl.
+    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
     ///
     /// Returns the number of values streamed and whether the last was falsy.
     pub fn stream_json<W: core::fmt::Write>(
         &self,
         out: &mut W,
+        indent_spaces: usize,
         mut on_value: impl FnMut(&mut W) -> core::fmt::Result,
     ) -> Result<crate::jq::stream::StreamStats, core::fmt::Error> {
         use crate::jq::stream::{StreamStats, StreamableValue};
@@ -255,7 +257,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::One(v) => {
                 // Convert to owned for streaming
                 let owned = to_owned(v);
-                owned.stream_json(out)?;
+                owned.stream_json(out, indent_spaces)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = owned.is_falsy();
@@ -263,7 +265,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::OneCursor(c) => {
                 // Stream directly from cursor using DocumentCursor trait
-                c.stream_json(out)?;
+                c.stream_json(out, indent_spaces)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = c.is_falsy();
@@ -272,7 +274,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::Many(vs) => {
                 for v in vs {
                     let owned = to_owned(v);
-                    owned.stream_json(out)?;
+                    owned.stream_json(out, indent_spaces)?;
                     on_value(out)?;
                     stats.last_was_falsy = owned.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -288,7 +290,7 @@ impl<V: DocumentValue> GenericResult<V> {
                 on_value(out)?;
             }
             Self::Owned(o) => {
-                o.stream_json(out)?;
+                o.stream_json(out, indent_spaces)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = o.is_falsy();
@@ -296,7 +298,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::ManyOwned(os) => {
                 for o in os {
-                    o.stream_json(out)?;
+                    o.stream_json(out, indent_spaces)?;
                     on_value(out)?;
                     stats.last_was_falsy = o.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -2034,16 +2036,20 @@ mod tests {
         // stream_json / stream_yaml exercise every variant's match arm.
         for r in &results {
             let mut j = String::new();
-            r.stream_json(&mut j, |_| Ok(())).unwrap();
+            r.stream_json(&mut j, 0, |_| Ok(())).unwrap();
             let mut y = String::new();
             r.stream_yaml(&mut y, 2, |_| Ok(())).unwrap();
         }
         // Spot-check the owned and error stream output.
         let mut owned_json = String::new();
-        results[2].stream_json(&mut owned_json, |_| Ok(())).unwrap();
+        results[2]
+            .stream_json(&mut owned_json, 0, |_| Ok(()))
+            .unwrap();
         assert_eq!(owned_json, "5");
         let mut err_json = String::new();
-        results[5].stream_json(&mut err_json, |_| Ok(())).unwrap();
+        results[5]
+            .stream_json(&mut err_json, 0, |_| Ok(()))
+            .unwrap();
         assert!(err_json.contains("boom"));
 
         // into_owned consumes; check the owned-family variants.
@@ -2101,13 +2107,52 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_single_cursor());
         let mut j = String::new();
-        result.stream_json(&mut j, |_| Ok(())).unwrap();
+        result.stream_json(&mut j, 0, |_| Ok(())).unwrap();
         assert_eq!(j, "1");
         let mut y = String::new();
         result.stream_yaml(&mut y, 2, |_| Ok(())).unwrap();
 
         let result2 = eval_with_cursor(&expr, index.root(json));
         assert_eq!(result2.collect_owned(), vec![OwnedValue::Int(1)]);
+    }
+
+    #[test]
+    fn test_json_cursor_stream_json_rejects_pretty_indent() {
+        // JsonCursor::stream_json only supports compact (indent_spaces == 0)
+        // output; indented JSON->JSON cursor streaming isn't implemented, so
+        // callers must fall back to the DOM path (#442). Exercised through
+        // the generic OneCursor arm, same as the compact case above.
+        let json = br#"{"a": 1}"#;
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse("at_offset(6)").unwrap();
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert!(result.is_single_cursor());
+        let mut j = String::new();
+        assert!(result.stream_json(&mut j, 2, |_| Ok(())).is_err());
+    }
+
+    #[test]
+    fn test_yaml_generic_result_one_cursor_streaming() {
+        // YAML counterpart of `test_generic_result_one_cursor_streaming`:
+        // at_offset lands on a YamlCursor node and yields a OneCursor result,
+        // exercising the YamlCursor `DocumentCursor::stream_json`/`stream_yaml`
+        // trait delegation (as opposed to the inherent `YamlCursor` methods
+        // called directly elsewhere).
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: 1\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let expr = crate::jq::parse("at_offset(3)").unwrap(); // offset 3 == the `1`
+
+        let result = eval_with_cursor(&expr, index.root(yaml));
+        assert!(result.is_single_cursor());
+        let mut j = String::new();
+        result.stream_json(&mut j, 0, |_| Ok(())).unwrap();
+        assert_eq!(j, "1");
+        let mut y = String::new();
+        result.stream_yaml(&mut y, 2, |_| Ok(())).unwrap();
+        assert_eq!(y, "1");
     }
 
     #[test]

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -766,6 +766,35 @@ mod tests {
         );
     }
 
+    /// A `core::fmt::Write` that fails as soon as it sees a specific marker
+    /// string, simulating a downstream write failure (e.g. a broken pipe)
+    /// partway through streaming.
+    struct FailOnMarker {
+        marker: &'static str,
+    }
+
+    impl core::fmt::Write for FailOnMarker {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            if s.contains(self.marker) {
+                Err(core::fmt::Error)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn test_stream_json_pretty_object_propagates_write_error() {
+        // A write failure while streaming an object field's value (not the
+        // key or punctuation around it) must propagate out of the recursive
+        // call rather than being silently swallowed.
+        let mut map = IndexMap::new();
+        map.insert("a".to_string(), OwnedValue::String("boom".to_string()));
+        let mut out = FailOnMarker { marker: "boom" };
+        let result = OwnedValue::Object(map).stream_json(&mut out, 2);
+        assert!(result.is_err());
+    }
+
     #[test]
     fn test_is_falsy() {
         assert!(OwnedValue::Null.is_falsy());

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -32,10 +32,16 @@ use crate::yaml::format_float_with_fraction;
 /// and owned values (OwnedValue), enabling unified streaming output regardless of
 /// how the value was obtained.
 pub trait StreamableValue {
-    /// Stream this value as compact JSON to the output.
+    /// Stream this value as JSON to the output.
     ///
     /// The output should be valid JSON without trailing newlines or separators.
-    fn stream_json<W: core::fmt::Write>(&self, out: &mut W) -> core::fmt::Result;
+    /// For pretty-printed output, pass indent_spaces > 0. For compact output,
+    /// pass indent_spaces = 0.
+    fn stream_json<W: core::fmt::Write>(
+        &self,
+        out: &mut W,
+        indent_spaces: usize,
+    ) -> core::fmt::Result;
 
     /// Stream this value as YAML to the output.
     ///
@@ -71,8 +77,12 @@ pub struct StreamStats {
 }
 
 impl StreamableValue for OwnedValue {
-    fn stream_json<W: core::fmt::Write>(&self, out: &mut W) -> core::fmt::Result {
-        stream_owned_value_json(self, out)
+    fn stream_json<W: core::fmt::Write>(
+        &self,
+        out: &mut W,
+        indent_spaces: usize,
+    ) -> core::fmt::Result {
+        stream_owned_value_json(self, out, 0, indent_spaces)
     }
 
     fn stream_yaml<W: core::fmt::Write>(
@@ -102,8 +112,17 @@ impl StreamableValue for OwnedValue {
 fn stream_owned_value_json<W: core::fmt::Write>(
     value: &OwnedValue,
     out: &mut W,
+    current_indent: usize,
+    indent_spaces: usize,
 ) -> core::fmt::Result {
-    stream_owned_value_json_with(value, out, write_json_body_yq, format_float_with_fraction)
+    stream_owned_value_json_with(
+        value,
+        out,
+        current_indent,
+        indent_spaces,
+        write_json_body_yq,
+        format_float_with_fraction,
+    )
 }
 
 /// Stream an OwnedValue as JSON, escaping strings the way `jq` does.
@@ -123,15 +142,22 @@ pub fn stream_owned_value_json_jq<W: core::fmt::Write>(
     value: &OwnedValue,
     out: &mut W,
 ) -> core::fmt::Result {
-    stream_owned_value_json_with(value, out, write_json_body_jq, |f| f.to_string())
+    // Always compact: this is the jq-error-message convention, which never
+    // pretty-prints.
+    stream_owned_value_json_with(value, out, 0, 0, write_json_body_jq, |f| f.to_string())
 }
 
 /// Stream an OwnedValue as JSON without intermediate string allocation, using
 /// `escape` for every string body and `float_fmt` for every float — the two
 /// places the `yq`/jq-error conventions differ.
+///
+/// - `current_indent`: Current indentation level (number of spaces)
+/// - `indent_spaces`: Spaces per indentation level (0 for compact)
 fn stream_owned_value_json_with<W: core::fmt::Write>(
     value: &OwnedValue,
     out: &mut W,
+    current_indent: usize,
+    indent_spaces: usize,
     escape: fn(&mut W, &str) -> core::fmt::Result,
     float_fmt: fn(f64) -> String,
 ) -> core::fmt::Result {
@@ -157,24 +183,62 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
         }
         OwnedValue::String(s) => stream_json_string(out, s, escape),
         OwnedValue::Array(arr) => {
+            if arr.is_empty() {
+                return out.write_str("[]");
+            }
             out.write_char('[')?;
+            let next_indent = current_indent + indent_spaces;
             for (i, elem) in arr.iter().enumerate() {
                 if i > 0 {
                     out.write_char(',')?;
                 }
-                stream_owned_value_json_with(elem, out, escape, float_fmt)?;
+                if indent_spaces > 0 {
+                    out.write_char('\n')?;
+                    write_indent(out, next_indent)?;
+                }
+                stream_owned_value_json_with(
+                    elem,
+                    out,
+                    next_indent,
+                    indent_spaces,
+                    escape,
+                    float_fmt,
+                )?;
+            }
+            if indent_spaces > 0 {
+                out.write_char('\n')?;
+                write_indent(out, current_indent)?;
             }
             out.write_char(']')
         }
         OwnedValue::Object(obj) => {
+            if obj.is_empty() {
+                return out.write_str("{}");
+            }
             out.write_char('{')?;
+            let next_indent = current_indent + indent_spaces;
             for (i, (key, value)) in obj.iter().enumerate() {
                 if i > 0 {
                     out.write_char(',')?;
                 }
+                if indent_spaces > 0 {
+                    out.write_char('\n')?;
+                    write_indent(out, next_indent)?;
+                }
                 stream_json_string(out, key, escape)?;
-                out.write_char(':')?;
-                stream_owned_value_json_with(value, out, escape, float_fmt)?;
+                out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
+                stream_owned_value_json_with(
+                    value,
+                    out,
+                    next_indent,
+                    indent_spaces,
+                    escape,
+                    float_fmt,
+                )?;
+            }
+            if indent_spaces > 0 {
+                out.write_char('\n')?;
+                write_indent(out, current_indent)?;
             }
             out.write_char('}')
         }
@@ -507,36 +571,36 @@ mod tests {
     #[test]
     fn test_stream_null() {
         let mut buf = String::new();
-        OwnedValue::Null.stream_json(&mut buf).unwrap();
+        OwnedValue::Null.stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "null");
     }
 
     #[test]
     fn test_stream_bool() {
         let mut buf = String::new();
-        OwnedValue::Bool(true).stream_json(&mut buf).unwrap();
+        OwnedValue::Bool(true).stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "true");
 
         buf.clear();
-        OwnedValue::Bool(false).stream_json(&mut buf).unwrap();
+        OwnedValue::Bool(false).stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "false");
     }
 
     #[test]
     fn test_stream_int() {
         let mut buf = String::new();
-        OwnedValue::Int(42).stream_json(&mut buf).unwrap();
+        OwnedValue::Int(42).stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "42");
 
         buf.clear();
-        OwnedValue::Int(-123).stream_json(&mut buf).unwrap();
+        OwnedValue::Int(-123).stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "-123");
     }
 
     #[test]
     fn test_stream_float() {
         let mut buf = String::new();
-        OwnedValue::Float(3.125).stream_json(&mut buf).unwrap();
+        OwnedValue::Float(3.125).stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "3.125");
     }
 
@@ -546,16 +610,16 @@ mod tests {
     #[test]
     fn test_stream_json_whole_float_keeps_decimal_point() {
         let mut buf = String::new();
-        OwnedValue::Float(1.0).stream_json(&mut buf).unwrap();
+        OwnedValue::Float(1.0).stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "1.0");
 
         buf.clear();
-        OwnedValue::Float(-0.0).stream_json(&mut buf).unwrap();
+        OwnedValue::Float(-0.0).stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "-0.0");
 
         buf.clear();
         OwnedValue::Array(vec![OwnedValue::Float(1.0), OwnedValue::Float(2.5)])
-            .stream_json(&mut buf)
+            .stream_json(&mut buf, 0)
             .unwrap();
         assert_eq!(buf, "[1.0,2.5]");
     }
@@ -584,7 +648,7 @@ mod tests {
     fn test_stream_json_number_literal() {
         let mut buf = String::new();
         OwnedValue::NumberLiteral(NumberRepr::Float(1.2e3), "1.2e3".into())
-            .stream_json(&mut buf)
+            .stream_json(&mut buf, 0)
             .unwrap();
         assert_eq!(buf, "1.2E+3");
     }
@@ -596,13 +660,13 @@ mod tests {
         // non-finite Float does, not fall through to `format_number_jq_compat`.
         let mut buf = String::new();
         OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into())
-            .stream_json(&mut buf)
+            .stream_json(&mut buf, 0)
             .unwrap();
         assert_eq!(buf, "null");
 
         buf.clear();
         OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1e400".into())
-            .stream_json(&mut buf)
+            .stream_json(&mut buf, 0)
             .unwrap();
         assert_eq!(buf, "null");
     }
@@ -632,7 +696,7 @@ mod tests {
     fn test_stream_string() {
         let mut buf = String::new();
         OwnedValue::String("hello".to_string())
-            .stream_json(&mut buf)
+            .stream_json(&mut buf, 0)
             .unwrap();
         assert_eq!(buf, "\"hello\"");
     }
@@ -641,19 +705,19 @@ mod tests {
     fn test_stream_string_escaping() {
         let mut buf = String::new();
         OwnedValue::String("hello\nworld".to_string())
-            .stream_json(&mut buf)
+            .stream_json(&mut buf, 0)
             .unwrap();
         assert_eq!(buf, "\"hello\\nworld\"");
 
         buf.clear();
         OwnedValue::String("tab\there".to_string())
-            .stream_json(&mut buf)
+            .stream_json(&mut buf, 0)
             .unwrap();
         assert_eq!(buf, "\"tab\\there\"");
 
         buf.clear();
         OwnedValue::String("quote\"here".to_string())
-            .stream_json(&mut buf)
+            .stream_json(&mut buf, 0)
             .unwrap();
         assert_eq!(buf, "\"quote\\\"here\"");
     }
@@ -666,7 +730,7 @@ mod tests {
             OwnedValue::Int(2),
             OwnedValue::Int(3),
         ])
-        .stream_json(&mut buf)
+        .stream_json(&mut buf, 0)
         .unwrap();
         assert_eq!(buf, "[1,2,3]");
     }
@@ -677,8 +741,29 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert("name".to_string(), OwnedValue::String("Alice".to_string()));
         map.insert("age".to_string(), OwnedValue::Int(30));
-        OwnedValue::Object(map).stream_json(&mut buf).unwrap();
+        OwnedValue::Object(map).stream_json(&mut buf, 0).unwrap();
         assert_eq!(buf, "{\"name\":\"Alice\",\"age\":30}");
+    }
+
+    #[test]
+    fn test_stream_json_pretty_nested_containers() {
+        // All the pretty-print (indent_spaces > 0) tests above use indent 0;
+        // this covers the indented recursion path for a container nested
+        // inside another container (object-in-object, array-in-object).
+        let mut buf = String::new();
+        let mut inner = IndexMap::new();
+        inner.insert("name".to_string(), OwnedValue::String("Alice".to_string()));
+        let mut outer = IndexMap::new();
+        outer.insert("user".to_string(), OwnedValue::Object(inner));
+        outer.insert(
+            "tags".to_string(),
+            OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
+        );
+        OwnedValue::Object(outer).stream_json(&mut buf, 2).unwrap();
+        assert_eq!(
+            buf,
+            "{\n  \"user\": {\n    \"name\": \"Alice\"\n  },\n  \"tags\": [\n    1,\n    2\n  ]\n}"
+        );
     }
 
     #[test]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1609,8 +1609,18 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
     }
 
     #[inline]
-    fn stream_json<Out: core::fmt::Write>(&self, out: &mut Out) -> core::fmt::Result {
-        // For JSON, we can directly output the raw bytes - they're already valid JSON
+    fn stream_json<Out: core::fmt::Write>(
+        &self,
+        out: &mut Out,
+        indent_spaces: usize,
+    ) -> core::fmt::Result {
+        // Compact only: echo the raw bytes verbatim, since they're already
+        // valid JSON. Indented (pretty) JSON->JSON streaming isn't
+        // implemented here — callers fall back to the DOM path (#442 only
+        // extended the YAML-target and YAML-cursor-to-JSON pretty paths).
+        if indent_spaces != 0 {
+            return Err(core::fmt::Error);
+        }
         if let Some(bytes) = self.raw_bytes() {
             // SAFETY: JSON input is valid UTF-8 (checked during indexing)
             let s = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1127,17 +1127,29 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     ///         self.0.write_all(s.as_bytes()).map_err(|_| core::fmt::Error)
     ///     }
     /// }
-    /// cursor.stream_json(&mut FmtWriter(&mut output)).unwrap();
+    /// cursor.stream_json(&mut FmtWriter(&mut output), 0).unwrap();
     /// ```
-    pub fn stream_json<Out: core::fmt::Write>(&self, out: &mut Out) -> core::fmt::Result {
-        self.stream_json_value(out)
+    ///
+    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
+    pub fn stream_json<Out: core::fmt::Write>(
+        &self,
+        out: &mut Out,
+        indent_spaces: usize,
+    ) -> core::fmt::Result {
+        self.stream_json_value(out, 0, indent_spaces)
     }
 
     /// Stream YAML as JSON, unwrapping single documents (matches yq behavior).
     ///
     /// If the root is a single-document array `[doc]`, outputs just `doc` as JSON.
     /// If there are multiple documents, outputs the array `[doc1, doc2, ...]`.
-    pub fn stream_json_document<Out: core::fmt::Write>(&self, out: &mut Out) -> core::fmt::Result {
+    ///
+    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
+    pub fn stream_json_document<Out: core::fmt::Write>(
+        &self,
+        out: &mut Out,
+        indent_spaces: usize,
+    ) -> core::fmt::Result {
         // Check if this is the root document array with a single document
         if self.bp_pos == 0 {
             if let YamlValue::Sequence(elements) = self.value() {
@@ -1145,14 +1157,14 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if let Some(first) = iter.next() {
                     if iter.next().is_none() {
                         // Single document - output it directly without array wrapper
-                        return stream_yaml_value_as_json(out, first);
+                        return stream_yaml_value_as_json(out, first, 0, indent_spaces);
                     }
                 }
             }
         }
 
         // Multiple documents or not at root - output as-is
-        self.stream_json_value(out)
+        self.stream_json_value(out, 0, indent_spaces)
     }
 
     /// Stream this cursor's value as YAML.
@@ -1293,9 +1305,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             write_yaml_indent(out, current_indent)?;
                         }
                         first = false;
-                        out.write_str("- ")?;
-                        // Check if value needs newline
+                        // Check if value needs newline. A container value
+                        // gets a bare `-` (no trailing space) followed by its
+                        // own indented line — matching real yq and the
+                        // DOM/pretty-printer, and avoiding a stray trailing
+                        // space before the newline.
                         if is_yaml_cursor_container(&cursor) {
+                            out.write_char('-')?;
                             out.write_char('\n')?;
                             write_yaml_indent(out, current_indent + indent_spaces)?;
                             cursor.stream_yaml_value(
@@ -1304,6 +1320,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 indent_spaces,
                             )?;
                         } else {
+                            out.write_str("- ")?;
                             cursor.stream_yaml_value(
                                 out,
                                 current_indent + indent_spaces,
@@ -1327,7 +1344,14 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     }
 
     /// Internal: stream this cursor's value as JSON.
-    fn stream_json_value<Out: core::fmt::Write>(&self, out: &mut Out) -> core::fmt::Result {
+    ///
+    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
+    fn stream_json_value<Out: core::fmt::Write>(
+        &self,
+        out: &mut Out,
+        current_indent: usize,
+        indent_spaces: usize,
+    ) -> core::fmt::Result {
         match self.value() {
             YamlValue::Null => out.write_str("null"),
             YamlValue::String(s) => {
@@ -1351,13 +1375,21 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 }
             }
             YamlValue::Mapping(fields) => {
+                if fields.is_empty() {
+                    return out.write_str("{}");
+                }
                 out.write_char('{')?;
+                let next_indent = current_indent + indent_spaces;
                 let mut first = true;
                 for field in fields {
                     if !first {
                         out.write_char(',')?;
                     }
                     first = false;
+                    if indent_spaces > 0 {
+                        out.write_char('\n')?;
+                        write_yaml_indent(out, next_indent)?;
+                    }
 
                     // Write key
                     if let YamlValue::String(s) = field.key() {
@@ -1377,26 +1409,44 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         stream_json_string(out, &field.key().key_string())?;
                     }
 
-                    out.write_char(':')?;
-                    field.value_cursor().stream_json_value(out)?;
+                    out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
+                    field
+                        .value_cursor()
+                        .stream_json_value(out, next_indent, indent_spaces)?;
+                }
+                if indent_spaces > 0 {
+                    out.write_char('\n')?;
+                    write_yaml_indent(out, current_indent)?;
                 }
                 out.write_char('}')
             }
             YamlValue::Sequence(elements) => {
+                if elements.is_empty() {
+                    return out.write_str("[]");
+                }
                 out.write_char('[')?;
+                let next_indent = current_indent + indent_spaces;
                 let mut first = true;
                 for elem in elements {
                     if !first {
                         out.write_char(',')?;
                     }
                     first = false;
-                    stream_yaml_value_as_json(out, elem)?;
+                    if indent_spaces > 0 {
+                        out.write_char('\n')?;
+                        write_yaml_indent(out, next_indent)?;
+                    }
+                    stream_yaml_value_as_json(out, elem, next_indent, indent_spaces)?;
+                }
+                if indent_spaces > 0 {
+                    out.write_char('\n')?;
+                    write_yaml_indent(out, current_indent)?;
                 }
                 out.write_char(']')
             }
             YamlValue::Alias { target, .. } => {
                 if let Some(target_cursor) = target {
-                    target_cursor.stream_json_value(out)
+                    target_cursor.stream_json_value(out, current_indent, indent_spaces)
                 } else {
                     out.write_str("null")
                 }
@@ -2464,6 +2514,8 @@ fn write_yaml_scalar_as_json(output: &mut String, str_val: &str) {
 fn stream_yaml_value_as_json<W: AsRef<[u64]>, Out: core::fmt::Write>(
     out: &mut Out,
     value: YamlValue<'_, W>,
+    current_indent: usize,
+    indent_spaces: usize,
 ) -> core::fmt::Result {
     match value {
         YamlValue::Null => out.write_str("null"),
@@ -2485,13 +2537,21 @@ fn stream_yaml_value_as_json<W: AsRef<[u64]>, Out: core::fmt::Write>(
             Err(_) => out.write_str("null"),
         },
         YamlValue::Mapping(fields) => {
+            if fields.is_empty() {
+                return out.write_str("{}");
+            }
             out.write_char('{')?;
+            let next_indent = current_indent + indent_spaces;
             let mut first = true;
             for field in fields {
                 if !first {
                     out.write_char(',')?;
                 }
                 first = false;
+                if indent_spaces > 0 {
+                    out.write_char('\n')?;
+                    write_yaml_indent(out, next_indent)?;
+                }
 
                 if let YamlValue::String(s) = field.key() {
                     match stream_yaml_string_to_json(out, &s) {
@@ -2510,26 +2570,44 @@ fn stream_yaml_value_as_json<W: AsRef<[u64]>, Out: core::fmt::Write>(
                     stream_json_string(out, &field.key().key_string())?;
                 }
 
-                out.write_char(':')?;
-                field.value_cursor().stream_json_value(out)?;
+                out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
+                field
+                    .value_cursor()
+                    .stream_json_value(out, next_indent, indent_spaces)?;
+            }
+            if indent_spaces > 0 {
+                out.write_char('\n')?;
+                write_yaml_indent(out, current_indent)?;
             }
             out.write_char('}')
         }
         YamlValue::Sequence(elements) => {
+            if elements.is_empty() {
+                return out.write_str("[]");
+            }
             out.write_char('[')?;
+            let next_indent = current_indent + indent_spaces;
             let mut first = true;
             for elem in elements {
                 if !first {
                     out.write_char(',')?;
                 }
                 first = false;
-                stream_yaml_value_as_json(out, elem)?;
+                if indent_spaces > 0 {
+                    out.write_char('\n')?;
+                    write_yaml_indent(out, next_indent)?;
+                }
+                stream_yaml_value_as_json(out, elem, next_indent, indent_spaces)?;
+            }
+            if indent_spaces > 0 {
+                out.write_char('\n')?;
+                write_yaml_indent(out, current_indent)?;
             }
             out.write_char(']')
         }
         YamlValue::Alias { target, .. } => {
             if let Some(target_cursor) = target {
-                target_cursor.stream_json_value(out)
+                target_cursor.stream_json_value(out, current_indent, indent_spaces)
             } else {
                 out.write_str("null")
             }
@@ -4782,8 +4860,12 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
-    fn stream_json<Out: core::fmt::Write>(&self, out: &mut Out) -> core::fmt::Result {
-        YamlCursor::stream_json(self, out)
+    fn stream_json<Out: core::fmt::Write>(
+        &self,
+        out: &mut Out,
+        indent_spaces: usize,
+    ) -> core::fmt::Result {
+        YamlCursor::stream_json(self, out, indent_spaces)
     }
 
     #[inline]
@@ -5534,7 +5616,7 @@ mod tests {
         let yaml = b"s: \"caf\\xe9\"\ni: +123\nf: +1.5\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_json_document(&mut out).unwrap();
+        index.root(yaml).stream_json_document(&mut out, 0).unwrap();
         assert!(out.contains("\"i\":123"), "got {out}");
         assert!(out.contains("\"f\":1.5"), "got {out}");
     }
@@ -5568,12 +5650,30 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed)
+                .stream_json_document(&mut streamed, 0)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
             assert_eq!(streamed, *expected, "stream_json mismatch for {input:?}");
         }
+    }
+
+    /// `stream_json_document`/`to_json_document` unwrap a single-document
+    /// root (`bp_pos == 0` with exactly one element) but must pass multi-
+    /// document roots through as a JSON array, matching yq. Covers the
+    /// non-single-document fallback branch in `stream_json_document`.
+    #[test]
+    fn test_json_document_multi_doc_wraps_in_array() {
+        let yaml = b"a: 1\n---\nb: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let root = index.root(yaml);
+
+        let json = root.to_json_document();
+        let mut streamed = String::new();
+        root.stream_json_document(&mut streamed, 0).unwrap();
+
+        assert_eq!(json, r#"[{"a":1},{"b":2}]"#);
+        assert_eq!(streamed, json);
     }
 
     /// Issue #222: block scalars are always strings — never type-inferred
@@ -5598,7 +5698,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed)
+                .stream_json_document(&mut streamed, 0)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -5659,7 +5759,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed)
+                .stream_json_document(&mut streamed, 0)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -5733,7 +5833,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed)
+                .stream_json_document(&mut streamed, 0)
                 .unwrap();
             let mut expected_json = String::new();
             write_json_string(&mut expected_json, expected);
@@ -5801,7 +5901,7 @@ mod tests {
         let yaml = multibyte_yaml();
         let index = YamlIndex::build(&yaml).unwrap();
         let mut out = String::new();
-        index.root(&yaml).stream_json_document(&mut out).unwrap();
+        index.root(&yaml).stream_json_document(&mut out, 0).unwrap();
         for expect in MULTIBYTE_JSON_VALUES {
             assert!(
                 out.contains(expect),
@@ -6387,7 +6487,7 @@ mod tests {
             );
 
             let mut streamed = String::new();
-            root.stream_json_document(&mut streamed).unwrap();
+            root.stream_json_document(&mut streamed, 0).unwrap();
             assert_eq!(
                 streamed,
                 *expected,
@@ -6754,7 +6854,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed)
+                .stream_json_document(&mut streamed, 0)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -6869,7 +6969,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed)
+                .stream_json_document(&mut streamed, 0)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -6973,7 +7073,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed)
+                .stream_json_document(&mut streamed, 0)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -7022,7 +7122,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed)
+                .stream_json_document(&mut streamed, 0)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -9019,7 +9119,7 @@ mod tests {
 
         let buffered = cursor.to_json();
         let mut streamed = String::new();
-        cursor.stream_json(&mut streamed).expect("streams");
+        cursor.stream_json(&mut streamed, 0).expect("streams");
         let what = String::from_utf8_lossy(yaml);
         assert_eq!(
             buffered, streamed,

--- a/tests/data/yq-golden-known-failures.txt
+++ b/tests/data/yq-golden-known-failures.txt
@@ -13,5 +13,3 @@
 # themselves always hold the correct (pinned yq) output; only this manifest
 # records where succinctly currently disagrees. See
 # tests/data/yaml-test-suite-known-failures.txt for the sibling manifest.
-
-explicit_key_non_scalar_pretty  dedup-keys  pretty-print silently drops a duplicate mapping key (last wins); compact (-I0) is correct — #442

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -539,6 +539,48 @@ fn test_duplicate_mapping_key_is_last_wins() -> Result<()> {
     Ok(())
 }
 
+/// Field-lookup semantics (`.a` above, last-wins) are distinct from
+/// output/serialization semantics: on identity pass-through, real yq keeps
+/// *both* duplicate keys, in every output mode. Before #442, succinctly's
+/// pretty (indented) output silently dropped the earlier occurrence via an
+/// `IndexMap`-backed DOM, while compact (`-I0`) streamed straight from the
+/// cursor and kept both. The M2 fast path now covers pretty output too, so
+/// all four combinations agree with real yq.
+#[test]
+fn test_duplicate_mapping_key_survives_json_output() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (pretty, code) = run_yq_stdin(".", yaml, &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty, "{\n  \"a\": 1,\n  \"a\": 2\n}\n");
+
+    let (compact, code) = run_yq_stdin(".", yaml, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "{\"a\":1,\"a\":2}\n");
+
+    Ok(())
+}
+
+/// Same as [`test_duplicate_mapping_key_survives_json_output`], but for the
+/// default YAML output format — plain `yq '.'` with no flags shares the
+/// same materialize-into-`OwnedValue::Object` code path as `-o json`, so it
+/// had the identical pre-#442 bug (undocumented by the issue's own repro,
+/// which only showed `-o json`).
+#[test]
+fn test_duplicate_mapping_key_survives_yaml_output() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (pretty, code) = run_yq_stdin(".", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty, "a: 1\na: 2\n");
+
+    let (compact, code) = run_yq_stdin(".", yaml, &["-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "a: 1\na: 2\n");
+
+    Ok(())
+}
+
 #[test]
 fn test_compact_json_output() -> Result<()> {
     let yaml = r"
@@ -2445,7 +2487,12 @@ fn test_from_file_with_multiple_input_files() -> Result<()> {
     )?;
 
     assert_eq!(code, 0);
-    assert_eq!(output, "---\n1\n---\n2\n");
+    // No leading `---` before the first file's result, matching real yq —
+    // the separator only appears *between* documents (#442 routed this
+    // non-compact multi-file case through the M2 fast path's
+    // `emit_yaml_doc_separator`, which corrects a pre-existing divergence
+    // from the DOM/slow path that had emitted a spurious leading `---`).
+    assert_eq!(output, "1\n---\n2\n");
     Ok(())
 }
 
@@ -2947,9 +2994,11 @@ fn test_alias_as_a_flow_mapping_key_resolves() -> Result<()> {
     // does too.
     //
     // Every expectation is `yq` v4.53.3's output for the same input, on the
-    // streaming path (`-I 0`). The pretty path is deliberately not asserted here:
-    // its DOM collapses duplicate mapping keys (#174), which resolution makes
-    // reachable from more inputs but does not cause.
+    // streaming path (`-I 0`). Before #442, the pretty path wasn't asserted
+    // here: its DOM collapsed duplicate mapping keys, which resolution makes
+    // reachable from more inputs but does not cause. #442 fixed pretty output
+    // for identity/navigation queries, so a couple of representative cases
+    // are now spot-checked in pretty mode too, below.
     for (yaml, expected) in [
         // Alias to an anchored key, and to an anchored value — different targets.
         ("{&x k: 1, *x: 2}\n", r#"{"k":1,"k":2}"#),
@@ -2972,6 +3021,16 @@ fn test_alias_as_a_flow_mapping_key_resolves() -> Result<()> {
         assert_eq!(code, 0, "for {yaml:?}");
         assert_eq!(output.trim(), expected, "for {yaml:?}");
     }
+
+    // Pretty-mode spot check (#442): a duplicate-`k`-key case and a
+    // duplicate-empty-string-key case, matching real yq's pretty output.
+    let (output, code) = run_yq_stdin(".", "{&x k: 1, *x: 2}\n", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "{\n  \"k\": 1,\n  \"k\": 2\n}\n");
+
+    let (output, code) = run_yq_stdin(".", "{&x [1,2]: 3, *x: 4}\n", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "{\n  \"\": 3,\n  \"\": 4\n}\n");
 
     // An anchor and an alias to it on the *same* node: the alias edge now lands on
     // the node the anchor names, so this is a cycle by the `target == alias` arm of

--- a/tests/yq_path_consistency_tests.rs
+++ b/tests/yq_path_consistency_tests.rs
@@ -1,18 +1,25 @@
 //! Cross-path consistency: `yq -o=json` must equal `yq -o=json -I=0` in value.
 //!
-//! `succinctly yq` has two YAML→JSON conversions. Compact output (`-I 0`) takes
-//! the streaming fast path (`YamlCursor::stream_json`); any other indent
-//! materializes an `OwnedValue` and pretty-prints. An indent flag must not
-//! change data, so for every input the two paths must agree on the JSON
-//! *values* they produce (issue #222).
+//! `succinctly yq` has two YAML→JSON conversions, both taking the streaming
+//! M2 fast path (`YamlCursor::stream_json`) directly from the cursor for the
+//! identity query this harness runs — compact (`-I 0`) and pretty differ only
+//! in whitespace, not in whether duplicate keys survive (issue #442). Older
+//! query shapes that fall back to materializing an `OwnedValue` still collapse
+//! duplicate keys via its `IndexMap`, but identity does not. An indent flag
+//! must not change data, so for every input the two paths must agree on the
+//! JSON *values* they produce (issue #222).
 //!
 //! This harness runs every case in the vendored YAML Test Suite corpus through
 //! both paths and compares. Comparison is on parsed, key-sorted JSON values,
-//! not bytes: the paths legitimately differ in whitespace, and objects with
-//! duplicate `""` keys (multiple complex keys in one mapping) collapse
-//! last-wins identically on both sides once parsed. If either path errors, they
-//! must both error; if either emits output that is not valid JSON, that counts
-//! as a divergence.
+//! not bytes: the paths legitimately differ in whitespace. Objects with
+//! duplicate `""` keys (multiple complex keys in one mapping) would collapse
+//! last-wins identically on both sides once parsed even if the comparator
+//! were byte-exact, since the comparator's own JSON parser dedupes on parse —
+//! this harness's parsed-value comparison can't distinguish "both paths kept
+//! both keys" from "both paths dropped one," so it isn't a substitute for the
+//! byte-level assertions in `tests/yq_cli_tests.rs` and
+//! `tests/yq_golden_tests.rs`. If either path errors, they must both error; if
+//! either emits output that is not valid JSON, that counts as a divergence.
 //!
 //! Cases that still diverge — for reasons tracked by *other* issues, not the
 //! key/fold/block-scalar drift #222 fixed — are listed in


### PR DESCRIPTION
## Summary

- Pretty-printed JSON/YAML output silently dropped duplicate mapping keys (last-wins) while compact (`-I0`) was correct, because the pretty path materialized `OwnedValue::Object` (backed by `IndexMap`, which can't hold duplicate keys) instead of streaming from the cursor.
- Makes `JsonCursor`/`YamlCursor`'s JSON streamers indentation-aware, and drops the `output_config.compact` requirement from the M2 fast path's gate in `yq_runner.rs`, so pretty output takes the same cursor-streaming path as compact for identity and simple navigation (`.`, `.field`, `.[n]`, `.[]`, and pipes/parens/`?` of those) — skipping `OwnedValue` construction rather than just reformatting it. `sort_keys`, `--ascii-output`, color, and `--tab` still fall back to the DOM path unchanged.
- `explicit_key_non_scalar_pretty` moves off the known-failures manifest. Multi-file pretty output also no longer emits a spurious leading `---` before the first document, a side effect of routing more cases through cursor streaming.

**Not fixed here** (both filed/updated during review, so the remaining scope stays tracked once this closes #442):
- `Field`/`Index`/`Iterate` still evaluate to an owned `GenericResult` and go through `to_owned()`/`IndexMap` when streamed, so a duplicate key *nested inside* a navigated field (`.a` where `a`'s value has a repeated key) still collapses, in both compact and pretty — noted on #443, which already tracks the same `to_owned()`/`IndexMap` mechanism.
- `--slurp`, `--inplace`, and `jq --preserve-input` pretty output use separate, still-`IndexMap`-backed conversions — filed as #478.

Closes #442

## Test plan

- [x] `cargo test --features cli,simd,regex` — full suite green (unit + integration + doc-tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Manually diffed every case in #442's repro/acceptance criteria against real `yq` v4.53.3 (pretty/compact JSON, default YAML output, explicit-non-scalar-key case, nested containers, empty `{}`/`[]`) — byte-for-byte match
- [x] `explicit_key_non_scalar_pretty` golden fixture passes; removed from known-failures manifest
- [x] New regression tests in `tests/yq_cli_tests.rs` covering pretty JSON output, default YAML output, and multi-file document-separator placement