### PR TITLE
fix(yaml): reject flow-collection anchor immediately followed by alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The strict YAML validator accepted a flow-collection anchor immediately
+  followed by an alias** (#452): `[&a *a]` and `{k: &a *a}` passed
+  `succinctly yaml validate`, which `yq` rejects — an anchor property cannot
+  decorate an alias node. Block context already rejected the same shape on
+  one line (`&a *b`, `AnchorOnAlias`, SR86/SU74) via `scan_anchor`, but
+  `scan_flow`'s `&` arm (shared by `[...]` and `{...}`) had no equivalent
+  check: it recorded the anchor and read a following `*alias` as an ordinary
+  reference, which also passed the unrelated #404 unknown-anchor check since
+  the anchor had just been registered into scope. The placement check is now
+  `check_after_anchor`, shared by both call sites — block's `scan_anchor`
+  (after its same-line `skip_spaces_and_tabs`) and flow's `&` arm (after
+  `skip_flow_ws`, which — unlike block — also crosses line breaks and
+  comments, so `[&a\n*a]` is rejected too).
+
 - **Two `compare_values` comparators (and a private `numeric_repr_cmp`) disagreed
   with jq about NaN, and with each other** (#421): jq treats NaN as strictly
   less than every number, including another NaN — `nan < 1`, `nan < nan`, and

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -1927,6 +1927,38 @@ mod tests {
             kind(b"&anchor - sequence entry\n"),
             MisplacedAnchor
         )); // SY6V
+
+        // #452: `scan_flow`'s `&` arm (shared by `[...]` and `{...}`) had no
+        // placement check — it recorded the anchor and read a following
+        // `*alias` as an ordinary reference, which also passed the unrelated
+        // #404 unknown-anchor check since the anchor was just registered into
+        // scope.
+        assert!(matches!(kind(b"[&a *a]\n"), AnchorOnAlias));
+        assert!(matches!(kind(b"{k: &a *a}\n"), AnchorOnAlias));
+    }
+
+    /// #452: unlike block's `scan_anchor`, which skips only same-line
+    /// spaces/tabs before this check, flow's equivalent runs after
+    /// `skip_flow_ws`, which also crosses line breaks and comments — so an
+    /// anchor and alias split across either still decorate the same node and
+    /// must still be rejected, with the error still pointing at the `*`.
+    #[test]
+    fn rejects_anchor_on_alias_across_flow_separation() {
+        for input in [&b"[&a\n*a]\n"[..], b"[&a # note\n*a]\n"] {
+            let err = validate(input).unwrap_err();
+            let shown = String::from_utf8_lossy(input);
+            assert!(
+                matches!(err.kind, AnchorOnAlias),
+                "{shown:?}: {:?}",
+                err.kind
+            );
+            assert_eq!(
+                input.get(err.position.offset),
+                Some(&b'*'),
+                "{shown:?}: error should point at the alias sigil, not {:?}",
+                err.position
+            );
+        }
     }
 
     /// Issue #404: an alias naming an anchor that is not in scope. `yq` v4.53.3

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -1116,10 +1116,16 @@ impl<'a> Validator<'a> {
                 // Every arm here is reached at a node start — after `[`, `{`,
                 // `,` or `:` — so a `*` is an alias, not scalar content (#404).
                 // An anchor is a property: its node still follows, so
-                // `expect_item` is left alone.
+                // `expect_item` is left alone. #452: that node must not itself
+                // be an alias (`[&a *a]`) — `check_after_anchor` (shared with
+                // block's `scan_anchor`) rejects that, after skipping the same
+                // separation `skip_flow_ws` already provides between any two
+                // flow tokens.
                 Some(b'&') => {
                     let name = self.scan_anchor_name();
                     self.record_anchor(name);
+                    self.skip_flow_ws()?;
+                    self.check_after_anchor()?;
                 }
                 Some(b'*') => {
                     self.scan_alias(true)?;
@@ -1254,11 +1260,24 @@ impl<'a> Validator<'a> {
         let name = self.scan_anchor_name(); // consumes `&` and the name
         self.record_anchor(name);
         self.skip_spaces_and_tabs();
+        self.check_after_anchor()?;
         match self.peek() {
-            Some(b'*') => Err(self.error(YamlValidationErrorKind::AnchorOnAlias)),
             Some(b'-') if matches!(self.peek_at(1), None | Some(b' ' | b'\t' | b'\n' | b'\r')) => {
                 Err(self.error(YamlValidationErrorKind::MisplacedAnchor))
             }
+            _ => Ok(()),
+        }
+    }
+
+    /// After an anchor property, reject an immediately following alias (`&a
+    /// *b`, SR86/SU74): an anchor decorates the node that follows it, and an
+    /// alias is a reference, not a node an anchor can decorate. Shared by
+    /// [`Self::scan_anchor`] (block context) and `scan_flow`'s `&` arm (flow
+    /// context, #452) — each skips its own context's whitespace/separation
+    /// before calling this, so the cursor sits on the byte right after that.
+    fn check_after_anchor(&self) -> Result<(), YamlValidationError> {
+        match self.peek() {
+            Some(b'*') => Err(self.error(YamlValidationErrorKind::AnchorOnAlias)),
             _ => Ok(()),
         }
     }


### PR DESCRIPTION
## Description

This PR fixes issue #452 where the strict YAML validator incorrectly accepted flow-collection anchors immediately followed by aliases. Patterns like `[&a *a]` and `{k: &a *a}` should be rejected because an anchor property cannot decorate an alias node — the alias is a reference, not a node that can be decorated.

The root cause was that `scan_flow`'s `&` arm (shared by `[...]` and `{...}`) recorded an anchor and moved on without checking what followed. Block context already had this validation in `scan_anchor`, but the flow scanner lacked the equivalent check. The fix factors the validation logic into a shared `check_after_anchor` method called by both scan paths.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #452

## Changes Made

**Core Validation Logic:**
- Refactored anchor placement validation from `scan_anchor` into a new `check_after_anchor` method in `src/yaml/validate.rs`
- Updated `scan_anchor` to call `check_after_anchor` after skipping same-line spaces/tabs
- Added `check_after_anchor` call to `scan_flow`'s `&` arm after `skip_flow_ws` to catch flow-context anchor-on-alias patterns
- The shared method rejects the `&a *b` pattern (and its flow equivalents) consistently across both contexts

**Test Coverage:**
- Extended `rejects_anchor_placement` test to cover flow-collection cases: `[&a *a]` and `{k: &a *a}`
- Added new test `rejects_anchor_on_alias_across_flow_separation` to verify that anchors and aliases split across line breaks or comments in flow context are still rejected (e.g., `[&a\n*a]`, `[&a # note\n*a]`)
- Confirmed error messages point at the alias sigil (`*`) rather than the anchor

**Documentation:**
- Updated CHANGELOG.md with detailed description of the fix
- Documented the distinction between block and flow context handling: flow's `skip_flow_ws` crosses line breaks and comments, unlike block's `skip_spaces_and_tabs`
- Referenced YAML spec sections SR86/SU74 for anchor placement rules

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for flow-collection anchor-on-alias rejection
- [x] Tests verify error positioning and rejection across line breaks/comments

**Test Commands:**
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact
- The `check_after_anchor` method is a simple single-byte lookahead with no computational overhead

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

This fix ensures parity between block and flow context validation for anchor placement rules. The key insight is that `skip_flow_ws` (used in flow context) is more permissive than `skip_spaces_and_tabs` (used in block context) — it crosses line breaks and comments — so the validation must account for this difference to correctly reject patterns like `[&a\n*a]` where the anchor and alias are separated by a newline or comment.