### PR TITLE
fix(jq): propagate errors raised inside nth(n; expr)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13099,7 +13099,12 @@ fn builtin_nth_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 QueryResult::None
             }
         }
-        _ => QueryResult::None,
+        QueryResult::One(_)
+        | QueryResult::OneCursor(_)
+        | QueryResult::Owned(_)
+        | QueryResult::None => QueryResult::None,
+        QueryResult::Error(e) => QueryResult::Error(e),
+        QueryResult::Break(label) => QueryResult::Break(label),
     }
 }
 
@@ -21852,6 +21857,25 @@ mod tests {
         query!(b"[10, 20, 30]", "nth(1; .[])",
             QueryResult::Owned(v) => {
                 assert_eq!(v, OwnedValue::Int(20));
+            }
+        );
+    }
+
+    #[test]
+    fn regression_issue_464_nth_stream_propagates_expr_error() {
+        // builtin_nth_stream's final match on expr's result had no explicit
+        // Error arm, so it fell through to the catch-all `_ => None` and
+        // silently discarded the error instead of propagating it.
+        query!(b"null", r#"nth(0; error("boom"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boom");
+            }
+        );
+        // Also reachable via a comma-generator argument (the path that
+        // originally surfaced this while verifying #155's fix).
+        query!(b"null", r#"nth(0; 1, error("boom"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boom");
             }
         );
     }


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the `nth(n; expr)` jq builtin where errors raised inside the expression argument were silently discarded instead of being propagated to the caller. The `builtin_nth_stream` function had a catch-all pattern match that fell through to `_ => QueryResult::None`, which incorrectly suppressed any `Error` or `Break` results from the expression.

This fix ensures `nth(n; expr)` behaves consistently with sibling stream builtins like `limit`, `first`, and `last`, which all properly propagate errors and break signals.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #464

## Changes Made

**Core Fix:**
- Modified `builtin_nth_stream` in `src/jq/eval.rs` to explicitly handle `Error` and `Break` result types
- Replaced the catch-all `_ => QueryResult::None` pattern with explicit arms that handle `One`, `OneCursor`, `Owned`, and `None` variants separately
- Added dedicated match arms for `QueryResult::Error(e) => QueryResult::Error(e)` and `QueryResult::Break(label) => QueryResult::Break(label)` to propagate these conditions

**Test Coverage:**
- Added comprehensive regression test `regression_issue_464_nth_stream_propagates_expr_error` that verifies error propagation through `nth(0; error("boom"))`
- Added test case covering comma-generator argument path: `nth(0; 1, error("boom"))` (the original issue discovery path)
- Both test cases assert that errors are properly propagated with correct error messages

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New regression tests added specifically for issue #464
- [x] Tests cover both direct error expressions and comma-generator paths

**Manual Testing:**
- [x] Verified error propagation with direct error expressions
- [x] Verified error propagation with generator expressions containing errors

### Test Commands
```bash
cargo test regression_issue_464_nth_stream_propagates_expr_error
cargo test --lib jq::eval
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

This is a correctness fix that adds explicit pattern matching arms. The performance characteristics remain unchanged as the fix simply prevents silent error suppression without introducing new computational overhead.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

The root cause was a pattern matching shortcut that used a catch-all `_` pattern without explicit `Error` and `Break` arms. This caused error propagation to be lost, making debugging jq expressions with `nth` difficult when errors occurred in the stream expression. The fix aligns `nth(n; expr)` behavior with other stream builtins that correctly propagate error conditions.