### PR TITLE
fix(jq): accept postfix ? after any expression, not just path expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1372,6 +1372,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SelectIndex sample overflow** (#188): `SampleEntry` counters were `u32`
   and wrapped past 2^32 set bits (~512 MB of ones); widened to `u64`.
 
+- **jq postfix `?` was only accepted after a path expression** (#367): jq's
+  grammar allows `?` (shorthand for `try f`) after any Term — `length?`,
+  `keys?`, `(1)?`, `(.a)?`, `first(.[])?`, `getpath(["a"])?`,
+  `setpath(["a"];1)?`, `$x?`, `.?` — but succinctly's parser only checked for
+  a trailing `?` in two spots: the dot-field branch of `parse_primary`
+  (`.foo?`) and `parse_index_bracket_with_optional` (`.[0]?`). Everywhere
+  else a trailing `?` was left unconsumed, tripping the top-level "unexpected
+  character '?'" check. Rather than patch each of the ~13 branches that
+  didn't check for it individually, `parse_primary`'s whole dispatch is now
+  wrapped once (renamed to `parse_primary_inner`, with a thin outer
+  `parse_primary` checking for a trailing `?` after any Term); `?` was also
+  added to `is_expr_terminator` so bare `.?` is recognized as identity rather
+  than an attempted (invalid) field name. `Expr::Optional`'s evaluation was
+  already fully generic (`src/jq/eval.rs`/`eval_generic.rs`), so the parsing
+  gap itself needed no evaluator changes — but unlocking `?` after arbitrary
+  builtins surfaced latent divergences that were previously unreachable with
+  `optional` set through real syntax: `tonumber?`, `length?`, `keys?`,
+  `keys_unsorted?`, `first?`, `last?`, and `reverse?` raised a hard error
+  instead of suppressing it on a value they can't operate on, because their
+  `eval_generic.rs` arms (and, for `first`/`last`/`reverse`, their `eval.rs`
+  counterparts too) never checked the `optional` flag they were already
+  passed. All seven are now threaded through, verified row-by-row against jq
+  1.7.1. Not fixed here: `null | reverse` (no `?` involved) still errors
+  instead of yielding `[]` in the generic evaluator — a pre-existing,
+  unrelated gap (missing `is_null()` arm) that this change didn't expose or
+  touch.
+
 ### Changed
 
 - **A tag on an anchored sequence item is now rejected** (#328): `- &a !!str x`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1384,9 +1384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrapped once (renamed to `parse_primary_inner`, with a thin outer
   `parse_primary` checking for a trailing `?` after any Term); `?` was also
   added to `is_expr_terminator` so bare `.?` is recognized as identity rather
-  than an attempted (invalid) field name. `Expr::Optional`'s evaluation was
-  already fully generic (`src/jq/eval.rs`/`eval_generic.rs`), so the parsing
-  gap itself needed no evaluator changes — but unlocking `?` after arbitrary
+  than an attempted (invalid) field name. Unlocking `?` after arbitrary
   builtins surfaced latent divergences that were previously unreachable with
   `optional` set through real syntax: `tonumber?`, `length?`, `keys?`,
   `keys_unsorted?`, `first?`, `last?`, and `reverse?` raised a hard error
@@ -1398,6 +1396,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of yielding `[]` in the generic evaluator — a pre-existing,
   unrelated gap (missing `is_null()` arm) that this change didn't expose or
   touch.
+
+  A second, broader divergence surfaced once `?` could wrap compound
+  expressions rather than just bare builtins: `(.a)?`, `("a"+1)?`,
+  `first(error("x"))?`, and `setpath(["a"]; error)?` all leaked their error to
+  stderr instead of suppressing it, even though the CLI ran under the exact
+  `?` syntax the issue asked for. Root cause: the CLI's generic evaluator
+  (`eval_generic.rs`) only checks `optional` natively for a handful of `Expr`
+  shapes (`Field`, `Index`, `Iterate`, a few builtins); anything else (`Paren`,
+  `Arithmetic`, `Error`, `first(...)`, `reduce`, ...) falls through a bridge
+  that re-evaluates via the full evaluator's `eval()` — which always starts
+  with `optional = false`, silently dropping the flag. The bridge now
+  re-wraps the expression in `Expr::Optional` before re-entering the full
+  evaluator when the ambient `optional` is true, mirroring the
+  `eval_on_owned`/`eval_on_many_owned` builtin-fallback bridge already fixed
+  for #386. `eval_arithmetic` and `eval_error` (in `eval.rs`) also never
+  checked `optional` on their own final result, and `builtin_setpath` treated
+  a suppressed sub-result the same as a real `null` value instead of
+  propagating the suppression — all three are fixed the same way. Deliberately
+  preserved: `.[.k]?` and `.[error("boom")]?` still propagate an error raised
+  while evaluating the *key* expression, uncaught — jq's `?` only guards the
+  indexing operation itself, not the key computation (verified against jq
+  1.7.1; a regression here would have broken the existing
+  `test_optional_does_not_suppress_key_errors` coverage). Not fixed: `reduce`
+  built from a bare erroring generator (e.g. `(reduce error as $x (0; $x))?`)
+  still returns `0` instead of suppressing, and `(reduce .[] as $x (0;
+  $x+.))?` over a type-erroring element returns `null` instead of suppressing
+  — both go through `eval_owned_expr`, a helper shared by `reduce`/`foreach`/
+  `while`/`until`/`repeat` (20+ call sites) that collapses any suppressed
+  sub-result to `Ok(null)` before its caller can tell the difference. That is
+  the same class of problem as the already-tracked stream-builtin
+  error-swallowing issues and needs its own fix, not a tail-end change here.
 
 ### Changed
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8300,6 +8300,7 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Owned(v) => vec![v],
         QueryResult::ManyOwned(vs) => vs,
         QueryResult::None => Vec::new(),
+        QueryResult::Error(_) if optional => return QueryResult::None,
         QueryResult::Error(e) => return QueryResult::Error(e),
         QueryResult::Break(label) => return QueryResult::Break(label),
     };
@@ -8308,6 +8309,7 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let init_result = eval_single::<W, S>(init, value.clone(), optional);
     let mut acc = match result_to_owned(init_result) {
         Ok(v) => v,
+        Err(_) if optional => return QueryResult::None,
         Err(e) => return QueryResult::Error(e),
     };
 
@@ -8319,6 +8321,7 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         let acc_result = eval_owned_expr::<S>(&substituted, &acc, optional);
         match acc_result {
             Ok(new_acc) => acc = new_acc,
+            Err(_) if optional => return QueryResult::None,
             Err(e) => return QueryResult::Error(e),
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2802,7 +2802,7 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Builtin: first - first element (.[0])
 fn builtin_first<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
-    _optional: bool,
+    optional: bool,
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => match elements.get(0) {
@@ -2812,6 +2812,7 @@ fn builtin_first<W: Clone + AsRef<[u64]>>(
         },
         // jq: null | first => null
         StandardJson::Null => QueryResult::Owned(OwnedValue::Null),
+        _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index_with_type(
             type_name(&value),
             "number",
@@ -2822,7 +2823,7 @@ fn builtin_first<W: Clone + AsRef<[u64]>>(
 /// Builtin: last - last element (.[-1])
 fn builtin_last<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
-    _optional: bool,
+    optional: bool,
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
@@ -2836,6 +2837,7 @@ fn builtin_last<W: Clone + AsRef<[u64]>>(
         }
         // jq: null | last => null
         StandardJson::Null => QueryResult::Owned(OwnedValue::Null),
+        _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index_with_type(
             type_name(&value),
             "number",
@@ -2876,7 +2878,7 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Builtin: reverse - reverse array
 fn builtin_reverse<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
-    _optional: bool,
+    optional: bool,
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
@@ -2895,6 +2897,7 @@ fn builtin_reverse<W: Clone + AsRef<[u64]>>(
         }
         // jq: null | reverse => []
         StandardJson::Null => QueryResult::Owned(OwnedValue::Array(Vec::new())),
+        _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index_with_type(
             type_name(&value),
             "number",

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -879,6 +879,7 @@ fn eval_arithmetic<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     match result {
         Ok(v) => QueryResult::Owned(v),
+        Err(_) if optional => QueryResult::None,
         Err(e) => QueryResult::Error(e),
     }
 }
@@ -1460,13 +1461,18 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let msg_result = eval_single::<W, S>(msg_expr, value, optional);
             match result_to_owned(msg_result) {
                 Ok(v) => v,
+                Err(_) if optional => return QueryResult::None,
                 Err(e) => return QueryResult::Error(e),
             }
         }
         None => to_owned(&value),
     };
 
-    QueryResult::Error(EvalError::from_value(payload))
+    if optional {
+        QueryResult::None
+    } else {
+        QueryResult::Error(EvalError::from_value(payload))
+    }
 }
 
 /// Evaluate a builtin function.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10227,11 +10227,16 @@ fn builtin_setpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::One(v) => to_owned(&v),
         QueryResult::Owned(v) => v,
         QueryResult::Error(e) => return QueryResult::Error(e),
+        // A suppressed sub-result (e.g. `setpath((.a)?; 1)` on a value `.a`
+        // can't index) propagates as a suppressed whole, not `null`/an error.
+        QueryResult::None => return QueryResult::None,
+        _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::path_must_be_array()),
     };
 
     let path = match path_owned {
         OwnedValue::Array(p) => p,
+        _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::path_must_be_array()),
     };
 
@@ -10240,6 +10245,9 @@ fn builtin_setpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::One(v) => to_owned(&v),
         QueryResult::Owned(v) => v,
         QueryResult::Error(e) => return QueryResult::Error(e),
+        // Same reasoning as the path result above: `setpath(["a"]; error)?`
+        // suppresses the whole call rather than setting `"a"` to `null` (#367).
+        QueryResult::None => return QueryResult::None,
         _ => OwnedValue::Null,
     };
 
@@ -10247,8 +10255,7 @@ fn builtin_setpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     match set_value_at_path(owned, &path, new_val) {
         Ok(result) => QueryResult::Owned(result),
         // An optional context swallows the refusal, as it does for every other
-        // builtin here. Not reachable through `setpath(…)?` yet — the parser
-        // does not take `?` after a call — but the flag is threaded in anyway.
+        // builtin here.
         Err(_) if optional => QueryResult::None,
         Err(e) => QueryResult::Error(e),
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1077,6 +1077,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 })
             } else if let Some(f) = value.as_f64() {
                 GenericResult::Owned(OwnedValue::Float(f.abs()))
+            } else if optional {
+                GenericResult::None
             } else {
                 GenericResult::Error(EvalError::has_no_length(&to_owned(&value)))
             }
@@ -1094,6 +1096,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 let indices: Vec<OwnedValue> =
                     (0..len).map(|i| OwnedValue::Int(i as i64)).collect();
                 GenericResult::Owned(OwnedValue::Array(indices))
+            } else if optional {
+                GenericResult::None
             } else {
                 GenericResult::Error(EvalError::has_no_keys(&to_owned(&value)))
             }
@@ -1110,6 +1114,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 let indices: Vec<OwnedValue> =
                     (0..len).map(|i| OwnedValue::Int(i as i64)).collect();
                 GenericResult::Owned(OwnedValue::Array(indices))
+            } else if optional {
+                GenericResult::None
             } else {
                 GenericResult::Error(EvalError::has_no_keys(&to_owned(&value)))
             }
@@ -1204,6 +1210,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 }
             } else if value.is_null() {
                 GenericResult::Owned(OwnedValue::Null)
+            } else if optional {
+                GenericResult::None
             } else {
                 GenericResult::Error(EvalError::cannot_index_with_type(
                     value.type_name(),
@@ -1222,6 +1230,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 }
             } else if value.is_null() {
                 GenericResult::Owned(OwnedValue::Null)
+            } else if optional {
+                GenericResult::None
             } else {
                 GenericResult::Error(EvalError::cannot_index_with_type(
                     value.type_name(),
@@ -1239,6 +1249,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     .map(to_owned)
                     .collect();
                 GenericResult::Owned(OwnedValue::Array(values))
+            } else if optional {
+                GenericResult::None
             } else {
                 GenericResult::Error(EvalError::cannot_index_with_type(
                     value.type_name(),
@@ -1275,8 +1287,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if let Some(s) = value.as_str() {
                 match tonumber_from_str(s.as_ref()) {
                     Ok(n) => GenericResult::Owned(n),
+                    Err(_) if optional => GenericResult::None,
                     Err(e) => GenericResult::Error(e),
                 }
+            } else if optional {
+                GenericResult::None
             } else {
                 GenericResult::Error(EvalError::cannot_parse_as_number(&to_owned(&value)))
             }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -688,6 +688,22 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             let index = JsonIndex::build(json_bytes);
             let cursor = index.root(json_bytes);
 
+            // The full evaluator always starts a fresh `eval()` with
+            // `optional = false`, so an ambient `optional = true` here (e.g.
+            // `(.a + .b)?`, `first(.[])?`) would otherwise be silently
+            // dropped at this bridge instead of suppressing the error, as it
+            // does for the natively-handled arms above. Re-wrap in
+            // `Expr::Optional` so the full evaluator's own (nuanced) handling
+            // of `?` sees it, same as the `eval_on_owned` builtin-fallback
+            // bridge below (#367, #386).
+            let wrapped;
+            let expr = if optional {
+                wrapped = Expr::Optional(Box::new(expr.clone()));
+                &wrapped
+            } else {
+                expr
+            };
+
             // Evaluate using the full evaluator
             match full_eval::<Vec<u64>, S>(expr, cursor) {
                 QueryResult::One(v) => {

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -853,8 +853,25 @@ impl<'a> Parser<'a> {
         Ok(Expr::Object(entries))
     }
 
-    /// Parse a primary expression (atoms and parenthesized expressions).
+    /// Parse a primary expression (atoms and parenthesized expressions), then
+    /// check for a trailing `?` (jq's postfix `try` shorthand), which applies
+    /// to any Term - not just path expressions. Field/bracket access already
+    /// consume their own narrower `?` inline (see
+    /// `parse_index_bracket_with_optional` and the dot-field branch below),
+    /// so by the time control reaches here any such `?` is already gone;
+    /// this only wraps a `?` still left over the whole term.
     fn parse_primary(&mut self) -> Result<Expr, ParseError> {
+        let expr = self.parse_primary_inner()?;
+        self.skip_ws();
+        if self.peek() == Some('?') {
+            self.next();
+            Ok(Expr::Optional(Box::new(expr)))
+        } else {
+            Ok(expr)
+        }
+    }
+
+    fn parse_primary_inner(&mut self) -> Result<Expr, ParseError> {
         self.skip_ws();
 
         match self.peek() {
@@ -3181,7 +3198,7 @@ impl<'a> Parser<'a> {
     fn is_expr_terminator(&self) -> bool {
         match self.peek() {
             // Structural terminators
-            Some(',' | ')' | ']' | '}' | '|' | ':' | ';') => true,
+            Some(',' | ')' | ']' | '}' | '|' | ':' | ';' | '?') => true,
             // Arithmetic operators
             Some('+' | '-' | '*' | '/' | '%') => true,
             // Comparison operators

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -4180,6 +4180,72 @@ mod tests {
         );
     }
 
+    /// jq accepts postfix `?` after any Term, not just a path expression
+    /// (#367). These cover the forms that used to fail with "unexpected
+    /// character '?'" because only the dot-field and index-bracket
+    /// productions checked for a trailing `?`.
+    #[test]
+    fn test_optional_after_builtin() {
+        assert_eq!(
+            parse("length?").unwrap(),
+            Expr::Optional(Box::new(Expr::Builtin(Builtin::Length)))
+        );
+        assert_eq!(
+            parse("keys?").unwrap(),
+            Expr::Optional(Box::new(Expr::Builtin(Builtin::Keys)))
+        );
+        assert_eq!(
+            parse("tonumber?").unwrap(),
+            Expr::Optional(Box::new(Expr::Builtin(Builtin::ToNumber)))
+        );
+    }
+
+    #[test]
+    fn test_optional_after_parenthesized_expr() {
+        assert_eq!(
+            parse("(.a)?").unwrap(),
+            Expr::Optional(Box::new(Expr::Paren(Box::new(Expr::Field("a".into())))))
+        );
+        assert_eq!(
+            parse("(1)?").unwrap(),
+            Expr::Optional(Box::new(Expr::Paren(Box::new(Expr::Literal(
+                Literal::Int(1)
+            )))))
+        );
+    }
+
+    #[test]
+    fn test_optional_after_function_call() {
+        match parse("first(.[])?").unwrap() {
+            Expr::Optional(inner) => assert!(matches!(*inner, Expr::FirstExpr(_))),
+            other => panic!("expected Expr::Optional, got {other:?}"),
+        }
+        match parse(r#"getpath(["a"])?"#).unwrap() {
+            Expr::Optional(inner) => {
+                assert!(matches!(*inner, Expr::Builtin(Builtin::GetPath(_))));
+            }
+            other => panic!("expected Expr::Optional, got {other:?}"),
+        }
+        match parse(r#"setpath(["a"];1)?"#).unwrap() {
+            Expr::Optional(inner) => {
+                assert!(matches!(*inner, Expr::Builtin(Builtin::SetPath(_, _))));
+            }
+            other => panic!("expected Expr::Optional, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_optional_after_variable_and_identity() {
+        assert_eq!(
+            parse("$x?").unwrap(),
+            Expr::Optional(Box::new(Expr::Var("x".into())))
+        );
+        assert_eq!(
+            parse(".?").unwrap(),
+            Expr::Optional(Box::new(Expr::Identity))
+        );
+    }
+
     #[test]
     fn test_chained() {
         assert_eq!(

--- a/tests/jq_containment_tests.rs
+++ b/tests/jq_containment_tests.rs
@@ -258,23 +258,19 @@ fn containment_matches_jq_in_the_generic_evaluator() {
 /// An optional expression swallows the error and yields nothing, as `?` does for
 /// every other error — jq prints nothing for `1 | contains("a")?`.
 ///
-/// The expression is built with [`Expr::optional`] rather than parsed, because
-/// succinctly's parser rejects a postfix `?` after *any* function call
-/// (`contains("a")?`, `has("a")?`, even `(contains("a"))?` — "unexpected
-/// character '?'"), where jq accepts all three. That is a parser gap unrelated to
-/// containment; going through the builder still exercises the evaluators' real
-/// `Expr::Optional` path, so this starts covering the surface syntax the moment
-/// the parser catches up (#367).
+/// Parses the real `?` syntax directly (`contains("a")?`, `inside([1])?`);
+/// the parser used to reject a postfix `?` after any function call, only
+/// accepting it after a path expression like `.a?` (#367, fixed).
 ///
 /// Both evaluators agree here: the generic evaluator's fallback to the full
-/// evaluator for builtins it doesn't implement itself now threads `optional`
+/// evaluator for builtins it doesn't implement itself threads `optional`
 /// through (`src/jq/eval_generic.rs`, `eval_on_owned`/`eval_on_many_owned`), so
 /// an optional-wrapped builtin it delegates is suppressed the same way as the
 /// full evaluator (#386, previously pinned as open drift here).
 #[test]
 fn optional_suppresses_the_error() {
-    for filter in [r#"contains("a")"#, r"inside([1])"] {
-        let expr = parse(filter).expect("parse failed").optional();
+    for filter in [r#"contains("a")?"#, r"inside([1])?"] {
+        let expr = parse(filter).expect("parse failed");
         let json: &[u8] = br"1";
         let index = JsonIndex::build(json);
 

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -423,11 +423,11 @@ fn test_optional_builtin_fallback_parity_386() {
     // `contains` both live only in the full evaluator, so both reach this
     // fallback (`src/jq/eval_generic.rs`, `eval_builtin`'s `_ =>` arm).
     //
-    // `?` can't be parsed after a call (#367), so the expression is built
-    // with `Expr::optional` rather than parsed -- same as
-    // `jq_containment_tests.rs::optional_suppresses_the_error`.
-    for (json, filter) in [(b"1".as_slice(), r#"contains("a")"#), (b"1", "bsearch(9)")] {
-        let expr = parse(filter).expect("parse failed").optional();
+    for (json, filter) in [
+        (b"1".as_slice(), r#"contains("a")?"#),
+        (b"1", "bsearch(9)?"),
+    ] {
+        let expr = parse(filter).expect("parse failed");
         assert_optional_parity_suppressed(json, &expr);
     }
 }

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -477,6 +477,42 @@ fn test_optional_iterate_on_scalar() {
     );
 }
 
+/// jq accepts `?` after any Term, not just a path expression (#367): builtins,
+/// parenthesized expressions, and bare `.` should all parse and behave the
+/// same as the already-working `.foo?` form.
+#[test]
+fn test_optional_after_builtin_call_suppresses_error() {
+    // jq: 42 | keys? => (empty), since `keys` on a number is an error
+    query!(b"42", "keys?",
+        QueryResult::None => {}
+    );
+}
+
+#[test]
+fn test_optional_after_builtin_call_success() {
+    query!(br#"{"a": 1}"#, "length?",
+        QueryResult::Owned(OwnedValue::Int(n)) => {
+            assert_eq!(n, 1);
+        }
+    );
+}
+
+#[test]
+fn test_optional_after_parenthesized_expr() {
+    query!(b"null", "(1)?",
+        QueryResult::Owned(OwnedValue::Int(n)) => {
+            assert_eq!(n, 1);
+        }
+    );
+}
+
+#[test]
+fn test_optional_after_bare_dot() {
+    query!(br#"{"a": 1}"#, ".?",
+        QueryResult::One(StandardJson::Object(_)) => {}
+    );
+}
+
 // =============================================================================
 // Chained expression tests
 // =============================================================================


### PR DESCRIPTION
## Description

This PR fixes issue #367 where jq's postfix `?` operator (shorthand for `try`) was only accepted after path expressions like `.foo?` and `.[0]?`, but not after literals, parenthesized expressions, builtins, function calls, variables, or bare `.`. The fix involves both parser changes to accept `?` after any Term, and evaluator changes to properly thread the optional flag through all code paths that were previously unreachable.

### Root Cause

jq's grammar allows `?` after any Term, but succinctly's parser only checked for trailing `?` in two specific locations:
- The dot-field branch of `parse_primary` (`.foo?`)
- `parse_index_bracket_with_optional` (`.[0]?`)

Everywhere else — `length?`, `keys?`, `tonumber?`, `(1)?`, `(.a)?`, `first(.[])?`, `getpath(["a"])?`, `$x?`, `.?` — the trailing `?` was left unconsumed, causing the top-level parser to raise "unexpected character '?'" error.

Additionally, several evaluation paths never checked the `optional` flag they received, causing suppressed expressions to leak errors instead of silently failing.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #367

## Changes Made

**Parser Changes (src/jq/parser.rs):**
- Refactored `parse_primary` by extracting the main dispatch logic into `parse_primary_inner`
- Wrapped the entire dispatch in an outer `parse_primary` that checks for trailing `?` after any Term
- Added `?` to `is_expr_terminator` so bare `.?` is recognized as identity rather than an attempted field name
- This single wrapping eliminates the need to patch ~13 individual branches

**Evaluator Changes (src/jq/eval.rs):**
- Updated `builtin_first`, `builtin_last`, and `builtin_reverse` to check `optional` flag before erroring
- Updated `builtin_tonumber` to check `optional` flag before erroring
- Modified `eval_arithmetic` to suppress errors when optional is true
- Modified `eval_error` to return `QueryResult::None` instead of error when optional is true
- Modified `eval_reduce` to propagate suppressed input and init sub-results instead of converting to errors
- Updated `builtin_setpath` to propagate suppressed sub-results and check optional on path validation

**Generic Evaluator Changes (src/jq/eval_generic.rs):**
- Updated `builtin_keys`, `builtin_keys_unsorted`, `builtin_length`, `builtin_first`, `builtin_last`, and `builtin_reverse` to check `optional` flag
- Updated `builtin_tonumber` to check `optional` flag with proper error handling
- Added optional-aware re-wrapping in the fallback bridge that delegates to the full evaluator, ensuring compound expressions properly suppress errors

**Test Coverage (tests/jq_tests.rs, tests/jq_containment_tests.rs, tests/jq_evaluator_parity_tests.rs):**
- Added `test_optional_after_builtin` covering `length?`, `keys?`, `tonumber?`
- Added `test_optional_after_parenthesized_expr` covering `(.a)?`, `(1)?`
- Added `test_optional_after_function_call` covering `first(.[])?`, `getpath(["a"])?`, `setpath(["a"];1)?`
- Added `test_optional_after_variable_and_identity` covering `$x?`, `.?`
- Added integration tests for actual query evaluation: `keys?` suppressing errors, `length?` on objects, `(1)?`, `.?`
- Simplified existing workaround tests to use direct parsing of `?` syntax instead of builder methods

**Documentation (CHANGELOG.md):**
- Documented the parser fix explaining the old limitation and the wrapping solution
- Documented which builtins were fixed to respect the optional flag
- Noted pre-existing gaps deliberately left unfixed (e.g., `null | reverse` without `?`)
- Documented evaluator fixes for arithmetic, error, reduce, and setpath suppression
- Documented the generic evaluator's fallback bridge fix
- Noted intentionally preserved behavior: key expression errors in `.[.k]?` still propagate
- Documented known limitations with `reduce` and `eval_owned_expr` shared across multiple flow control constructs

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New parser unit tests verify `?` parses correctly after builtins, parens, calls, variables, and bare `.`
- [x] New integration tests exercise the full evaluation pipeline for previously-failing syntax
- [x] Simplified existing workaround tests now use real syntax instead of builder methods
- [x] Verified row-by-row against jq 1.7.1 for builtin behavior

**Manual Testing:**
The following expressions now parse and evaluate correctly (previously failed with "unexpected character '?'"):
```bash
# Builtins
cargo test -- --nocapture | grep -E 'length\?|keys\?|tonumber\?'

# Parenthesized expressions
cargo test -- --nocapture | grep -E '\(\.a\)\?|\(1\)\?'

# Function calls
cargo test -- --nocapture | grep -E 'first\(.*\)\?|getpath|setpath'

# Variables and identity
cargo test -- --nocapture | grep -E '\$x\?|\.\?'
```

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The parser change wraps the dispatch once rather than patching multiple branches, slightly improving code locality. Evaluator changes only add conditional checks that were missing, with no additional overhead for the non-optional path.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Deliberate Non-Fixes:**
- `.[.k]?` and `.[error("boom")]?` still propagate errors raised while evaluating the key expression — this is correct behavior matching jq, where `?` only guards the indexing operation itself, not key computation
- `null | reverse` (without `?`) still errors in the generic evaluator instead of yielding `[]` — this is a pre-existing gap (missing `is_null()` arm) unrelated to this fix
- `reduce` built from a bare erroring generator or with type-erroring elements has suppression gaps that go through the shared `eval_owned_expr` helper and need a separate, broader fix alongside other stream-builtin error-swallowing issues

**Future Enhancements:**
The `eval_owned_expr` helper (used by `reduce`, `foreach`, `while`, `until`, `repeat`) collapses suppressed sub-results to `Ok(null)` before callers can distinguish them from real nulls. This should be addressed in a follow-up PR alongside other tracked stream-builtin error-swallowing issues (#386 class of problems).