### PR TITLE
fix(simd): wrap __cpuid calls in unsafe blocks for pre-1.96 toolchains

### DIFF
--- a/src/util/simd/x86.rs
+++ b/src/util/simd/x86.rs
@@ -229,7 +229,11 @@ fn detect_fast_bmi2() -> bool {
     // - AMD: Check family >= 0x19 (Zen 3+)
 
     // Check vendor string via CPUID leaf 0
-    let cpuid0 = core::arch::x86_64::__cpuid(0);
+    // SAFETY: CPUID leaf 0 has no target-feature precondition on x86_64.
+    // `__cpuid` became a safe fn in Rust 1.96; `allow` keeps this building
+    // on older toolchains where it is still `unsafe fn` (#474).
+    #[allow(unused_unsafe)]
+    let cpuid0 = unsafe { core::arch::x86_64::__cpuid(0) };
     let is_amd = cpuid0.ebx == 0x6874_7541  // "Auth"
         && cpuid0.edx == 0x6974_6E65        // "enti"
         && cpuid0.ecx == 0x444D_4163; // "cAMD"
@@ -240,7 +244,9 @@ fn detect_fast_bmi2() -> bool {
     }
 
     // AMD: Check family from CPUID leaf 1
-    let cpuid1 = core::arch::x86_64::__cpuid(1);
+    // SAFETY: CPUID leaf 1 has no target-feature precondition on x86_64.
+    #[allow(unused_unsafe)]
+    let cpuid1 = unsafe { core::arch::x86_64::__cpuid(1) };
     let family = ((cpuid1.eax >> 8) & 0xF) + ((cpuid1.eax >> 20) & 0xFF);
 
     // Family 0x17 = Zen 1/2 (slow BMI2)


### PR DESCRIPTION
## Description

This PR fixes a critical build failure in the `detect_fast_bmi2()` function in `src/util/simd/x86.rs` caused by Rust 1.96's change to the `__cpuid` intrinsic from `unsafe fn` to `safe fn`. Prior to Rust 1.96, calling `__cpuid` without an `unsafe` block resulted in a hard E0133 error on older toolchains. This issue went unnoticed because the x86_64-specific module is only compiled on x86_64 targets, and ARM CI lanes never encountered it (issue #474).

The fix wraps both `__cpuid` call sites in `unsafe` blocks and adds `#[allow(unused_unsafe)]` attributes to suppress warnings on Rust 1.96+, ensuring the code compiles warning-free across both toolchain versions without trading one broken range for another under `-D warnings`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD changes (fixes cross-toolchain compilation)

## Related Issue
Fixes #474

## Changes Made

**SIMD Module:**
- Wrapped first `__cpuid(0)` call in `unsafe { }` block at leaf 0 (vendor string detection) with `#[allow(unused_unsafe)]` attribute
- Added SAFETY comment explaining that CPUID leaf 0 has no target-feature precondition on x86_64
- Wrapped second `__cpuid(1)` call in `unsafe { }` block at leaf 1 (family detection) with `#[allow(unused_unsafe)]` attribute
- Added SAFETY comment explaining that CPUID leaf 1 has no target-feature precondition on x86_64
- Both changes accommodate the difference between pre-1.96 toolchains (where `__cpuid` is `unsafe fn`) and Rust 1.96+ (where it became `safe fn`)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Code compiles without warnings on both pre-1.96 and 1.96+ toolchains

**Manual Testing:**
- [x] Tested on x86_64
- [x] Verified compilation on multiple Rust toolchain versions

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The `unsafe` blocks are purely for compiler compatibility and have no runtime performance implications. CPUID instructions execute at the same cost regardless of whether they are wrapped in `unsafe` blocks.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings
- [x] SAFETY comments explain the unsafe block rationale

## Additional Notes

**Rationale for `#[allow(unused_unsafe)]`:**
On Rust 1.96+, `__cpuid` is a safe function, making the `unsafe` block technically unnecessary and triggering an `unused_unsafe` warning. However, this wrapper is required for compatibility with pre-1.96 toolchains. The `#[allow(unused_unsafe)]` directive silences this warning on newer versions while maintaining build compatibility across the toolchain boundary.

**Why This Matters:**
This fix enables the project to maintain a single codebase that compiles cleanly across multiple Rust versions without requiring version-specific conditional compilation or separate code paths, which improves maintainability and reduces technical debt.