### PR TITLE
fix(jq): report the container a NaN key cannot index, not a NaN element

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7163,11 +7163,24 @@ fn eval_owned_multi<S: EvalSemantics>(
 /// `[10,20,30] | .[nan] = 5` is an error there too. (jq's `path(.[nan])` instead
 /// yields `[null]`, a path its own `setpath` then rejects; erroring at the
 /// source is the coherent half of that.)
+///
+/// That is only the right complaint where a number addresses an element at all.
+/// The key kind is otherwise dispatched before the container is inspected — which
+/// is what produces jq's `Cannot index <container> with <key>` rather than a
+/// generic type error — but NaN has to consult the container first, or a document
+/// that a number cannot index is reported as an array that has no such element:
+/// `{"a":1} | .[nan] = 5` is `Cannot index object with number` in jq, the same
+/// message `.[0] = 5` gets there, and says nothing about NaN.
 fn key_to_path_component(key: &OwnedValue, container: &OwnedValue) -> Result<Expr, EvalError> {
     match key {
         OwnedValue::String(s) => Ok(Expr::Field(s.clone())),
         // Truncation toward zero, as in the value path.
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+            // Null belongs with array: a write builds the array the index names,
+            // so `null | .[nan] = 5` is the NaN complaint in jq too.
+            if !matches!(container, OwnedValue::Array(_) | OwnedValue::Null) {
+                return Err(EvalError::cannot_index(owned_type_name(container), key));
+            }
             numeric_key_to_index(key)
                 .map(Expr::Index)
                 .ok_or_else(|| EvalError::new("Cannot set array element at NaN index"))

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -137,6 +137,59 @@ fn test_wrong_container_for_key_kind_errors() {
     );
 }
 
+/// #488: NaN is "no array element" only where a number addresses an element.
+///
+/// The key kind is otherwise dispatched before the container (see above), and
+/// NaN is the exception that has to look: on a container a number cannot index
+/// at all, the failure is the ordinary indexing one, and jq's message says
+/// nothing about NaN.
+#[test]
+fn test_nan_key_names_the_container_it_cannot_index() {
+    // An array — and the null a write would build into one — is where NaN's own
+    // complaint belongs.
+    for input in ["[1,2,3]", "null"] {
+        check(
+            input,
+            ".[nan] = 5",
+            Outcome::error("Cannot set array element at NaN index"),
+        );
+    }
+
+    // Anywhere else it is the message `.[0] = 5` gets on the same document.
+    check(
+        r#"{"a":1}"#,
+        ".[nan] = 5",
+        Outcome::error("Cannot index object with number"),
+    );
+    check(
+        r#"{"a":1}"#,
+        ".[0] = 5",
+        Outcome::error("Cannot index object with number"),
+    );
+    check(
+        r#""s""#,
+        ".[nan] = 5",
+        Outcome::error("Cannot index string with number"),
+    );
+    check(
+        "true",
+        ".[nan] = 5",
+        Outcome::error("Cannot index boolean with number"),
+    );
+
+    // Through the other writers that resolve a path, not just `=`.
+    check(
+        r#"{"a":1}"#,
+        ".[nan] |= 5",
+        Outcome::error("Cannot index object with number"),
+    );
+    check(
+        r#"{"a":1}"#,
+        "del(.[nan])",
+        Outcome::error("Cannot index object with number"),
+    );
+}
+
 #[test]
 fn test_key_of_an_unindexable_kind_errors_even_on_a_container() {
     check(


### PR DESCRIPTION
Fixes #488.

`key_to_path_component` dispatched on the key kind before inspecting the container, so a NaN key reported `Cannot set array element at NaN index` no matter what it was indexing:

```
$ echo '{"a":1}' | sjq -c '.[nan] = 5'
jq: error: Cannot set array element at NaN index    # jq: Cannot index object with number
```

jq mentions NaN only where a number addresses an element at all. On an object, string or boolean the failure is the ordinary indexing one — the same message `.[0] = 5` gets on that document, saying nothing about NaN.

The dispatch order is deliberate for every other key kind (it is what produces jq's `Cannot index <container> with <key>` rather than a generic type error), so NaN alone consults the container first, and only an array — or the null a write would build into one — keeps the NaN wording. `index_one` already draws exactly this line in value position via `indexable_by_number`; this is the write side agreeing with it.

### Verified against jq 1.7.1

| input | filter | before | after / jq |
|---|---|---|---|
| `{"a":1}` | `.[nan] = 5` | `Cannot set array element at NaN index` | `Cannot index object with number` |
| `{"a":1}` | `.[nan] \|= 5` | same | `Cannot index object with number` |
| `{"a":1}` | `del(.[nan])` | same | `Cannot index object with number` |
| `"s"` | `.[nan] = 5` | same | `Cannot index string with number` |
| `true` | `.[nan] = 5` | same | `Cannot index boolean with number` |
| `[1,2,3]` | `.[nan] = 5` | `Cannot set array element at NaN index` | unchanged ✓ |
| `null` | `.[nan] = 5` | `Cannot set array element at NaN index` | unchanged ✓ |

Ordinary numeric keys, reads, and the `?` forms are unchanged; the full suite is green and both CI clippy invocations are clean.

Two cases still differ from jq on this branch, both pre-existing and filed: `null | .[0] = 5` (#486, assignment does not create the container) and `[1,2,3] | .[nan]? = 5` (#413, fixed by #482 — not merged yet).

Independent of #482: that PR restructures `resolve_node`, this one touches `key_to_path_component` only. Once both land, #482's container gate in `resolve_index_expr` and this check say the same thing from two directions, and the gate could be simplified to lean on this one.
