### PR TITLE
fix(jq): make del() no-op on out-of-range array index

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10728,9 +10728,9 @@ fn delete_expr_array_paths(
                         let slot = &mut arr[actual as usize];
                         let old = core::mem::replace(slot, OwnedValue::Null);
                         *slot = delete_expr_paths_at(old, group, start + 1)?;
-                    } else if !group.iter().any(|p| p[start].optional) {
-                        return Err(out_of_range_index(*idx, arr.len()));
                     }
+                    // An out-of-range index names nothing to delete through —
+                    // jq's delpaths silently skips it, `?` or not (#477).
                 }
                 // Deleting *through* a slice deletes inside the sub-array and
                 // splices it back: `[1,[2],[3]] | del(.[1:3][0])` is `[1,[3]]`.
@@ -10745,24 +10745,11 @@ fn delete_expr_array_paths(
                 }
             }
         }
-
-        // `delete_keys` silently drops an index that names nothing
-        // (`delpaths` has always done that, #415); a bare `del` never has, so
-        // an out-of-range terminal index still errors unless `?` covers it,
-        // exactly as the single-path case in `delete_at_path` does. A slice
-        // is exempt: jq clamps an out-of-range range rather than refusing it.
-        let len = arr.len() as i64;
-        for (step, opt) in &terminal {
-            let ArrayStep::Index(idx) = step else {
-                continue;
-            };
-            let actual = if *idx < 0 { len + idx } else { *idx };
-            if !opt && (actual < 0 || actual as usize >= arr.len()) {
-                return Err(out_of_range_index(*idx, arr.len()));
-            }
-        }
     }
 
+    // Terminal indices are deleted below via `delete_keys`, which already
+    // silently drops an index that names nothing (`delpaths` has always done
+    // that, #415) — including an out-of-range one, `?` or not (#477).
     if !terminal.is_empty() {
         let owned_keys: Vec<OwnedValue> = terminal
             .iter()
@@ -10917,12 +10904,10 @@ fn delete_at_path(
                 let actual_idx = if *idx < 0 { len + idx } else { *idx };
                 if actual_idx >= 0 && (actual_idx as usize) < arr.len() {
                     arr.remove(actual_idx as usize);
-                    Ok(())
-                } else if optional {
-                    Ok(())
-                } else {
-                    Err(out_of_range_index(*idx, arr.len()))
                 }
+                // An out-of-range index names nothing to delete — jq's
+                // delpaths silently skips it, `?` or not (#477).
+                Ok(())
             } else if optional {
                 Ok(())
             } else {
@@ -11006,10 +10991,11 @@ fn delete_at_path(
                             let actual_idx = if *idx < 0 { len + idx } else { *idx };
                             if actual_idx >= 0 && (actual_idx as usize) < arr.len() {
                                 delete_at_path(&mut arr[actual_idx as usize], &rest, optional)
-                            } else if here {
-                                Ok(())
                             } else {
-                                Err(out_of_range_index(*idx, arr.len()))
+                                // An out-of-range index resolves to null;
+                                // deleting further into null is always a
+                                // no-op, `?` or not (#477).
+                                Ok(())
                             }
                         } else if here {
                             Ok(())

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -940,6 +940,48 @@ fn test_del_with_negative_computed_indexes_resolves_against_original_length() {
     );
 }
 
+/// #477: an out-of-range array index used to raise in `del()`, where jq's
+/// `delpaths` — which `del` is defined in terms of, `def del(f):
+/// delpaths([path(f)]);` — silently skips a path that names nothing, `?` or
+/// not. `delete_keys` already matched that (its doc comment: "silently drops
+/// an index that names nothing"); `del`'s own path-walking code, which can't
+/// just call `delete_keys` directly since it works on path *expressions*
+/// rather than resolved paths, raised instead.
+#[test]
+fn test_del_on_out_of_range_index_is_a_silent_noop() {
+    // Positive index past the end.
+    check("[1,2]", "del(.[5])", Outcome::values(&["[1,2]"]));
+    // Negative index still negative after counting back from the end.
+    check("[1,2]", "del(.[-5])", Outcome::values(&["[1,2]"]));
+    // `?` makes no difference — jq never errors on this in the first place.
+    check("[1,2]", "del(.[5]?)", Outcome::values(&["[1,2]"]));
+    check("[1,2]", "del(.[-5]?)", Outcome::values(&["[1,2]"]));
+    // The rest of the path is skipped along with it, rather than walked
+    // against the `null` an in-range read would have produced.
+    check("[1,2]", "del(.[5].a)", Outcome::values(&["[1,2]"]));
+    check(
+        "[[1,2],[3,4]]",
+        "del(.[5][0])",
+        Outcome::values(&["[[1,2],[3,4]]"]),
+    );
+}
+
+/// Same no-op behavior through the grouped/computed-key deletion path added
+/// for #424 — both when the out-of-range index shares a sibling group with an
+/// in-range one (`delete_expr_array_paths`'s per-key check), and when every
+/// sibling is out of range and the index only ever reaches the terminal
+/// `delete_keys` call.
+#[test]
+fn test_del_on_out_of_range_computed_index_is_a_silent_noop() {
+    check("[1,2]", "del(.[(0,5)])", Outcome::values(&["[2]"]));
+    check("[1,2]", "del(.[(5,6)])", Outcome::values(&["[1,2]"]));
+    check(
+        "[[1,2],[3,4]]",
+        "del(.[(0,5)][0])",
+        Outcome::values(&["[[2],[3,4]]"]),
+    );
+}
+
 /// Grouped deletion (added above for #424) assumed every sibling path
 /// reaching the same depth shared the exact same shape — all `Field`, all
 /// `Index`, or all `Iterate` — and dispatched once on the first path's shape


### PR DESCRIPTION
## Description

Fixes issue #477 where `del()` was incorrectly raising an error when attempting to delete at an out-of-range array index. According to jq semantics, `del()` is defined as `delpaths([path(f)])`, and jq's `delpaths` silently skips paths that resolve to nothing rather than raising an error. This PR aligns the implementation with jq's behavior by making `del()` a no-op for out-of-range indices, matching the behavior of `delete_keys` which already implemented this correctly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement

## Related Issue
Fixes #477

## Changes Made

**Core Implementation Changes (src/jq/eval.rs):**
- Removed error-raising logic in `delete_expr_array_paths()` when an out-of-range index is encountered; now silently skips such indices consistent with `delpaths` semantics
- Simplified `delete_at_path()` to return `Ok(())` for out-of-range terminal indices instead of raising `out_of_range_index` error
- Updated path-walking logic in nested deletion to treat out-of-range indices as silent no-ops, understanding that deletion into null is always a no-op regardless of the `?` operator
- Removed the post-processing validation loop that was checking terminal indices for out-of-range errors; this responsibility now falls entirely to `delete_keys` which already handles it correctly
- Added inline comments explaining that out-of-range indices name nothing to delete and jq's `delpaths` silently skips them

**Test Coverage (tests/jq_computed_key_tests.rs):**
- Added `test_del_on_out_of_range_index_is_a_silent_noop()`: Comprehensive test covering bare `del()` with out-of-range indices (positive past-the-end, negative past-the-start), with and without the `?` operator, including nested paths
- Added `test_del_on_out_of_range_computed_index_is_a_silent_noop()`: Test coverage for the grouped/computed-key deletion path added in #424, verifying both sibling-group cases and terminal `delete_keys` cases

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for out-of-range index deletion (6 test cases for basic behavior, 3 test cases for computed key paths)

**Manual Testing:**
- [x] Tested on x86_64

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The changes simplify the deletion logic by removing redundant validation and consolidating error handling through `delete_keys`, which may provide a minor performance improvement in some edge cases.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

The fix ensures consistency between different code paths in jq evaluation:
- `delete_keys` already correctly implemented silent skipping of out-of-range indices
- `del()`'s own path-walking code (`delete_at_path` and `delete_expr_array_paths`) now match this behavior
- The implementation properly handles the distinction between path expressions (which `del()` uses) and resolved paths (which `delpaths` uses), while ensuring both produce identical results
- The `?` operator correctly has no effect on out-of-range indices since jq never raises an error for them in the first place