### PR TITLE
fix(yaml): fold plain scalar `- ` continuation line at any indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A plain scalar's `- `-led continuation line was misread as a nested
+  sequence at indent 2 and deeper** (#484): `- x\n  - y\n` produced
+  `["x",["y"]]`, inventing a nested sequence, where `yq` folds the
+  continuation line into the scalar and gives `["x - y"]`. Both are valid
+  YAML per the strict validator. `parse_unquoted_value_with_indent_impl`'s
+  `sequence_indicator_is_block_structure` (`src/yaml/parser.rs`) treated a
+  continuation line's leading `-` as block structure whenever
+  `next_indent >= start_indent + 2`, folding only at `next_indent ==
+  start_indent + 1`. Per YAML 1.2 `nb-ns-plain-in-line`, once a plain
+  scalar's first line has begun, a `-` on a later line is never re-tested as
+  a sequence indicator, at any indent — the disjunct is removed outright,
+  leaving `next_indent <= start_indent` (reachable only at document root, for
+  a `- ` reappearing at column 0 as a genuine new top-level item). The YAML
+  Test Suite's only relevant case, AB8U, uses continuation indent exactly 1 —
+  the one value that happened to work — so it gave no signal on indent 2+;
+  corpus-latent the same way #382 and #409 were. Unaffected: a genuinely
+  nested sequence (`- - y`, `- x\n- - y`), recognized immediately after an
+  item's own `-` rather than via this continuation-fold path, and the locate
+  path (`at_offset`/`yq-locate`), which reads multi-line scalar extents from
+  the same index this fixes rather than re-deriving them independently.
+
 - **`del()` errored when a deleted key's container was `null`, where jq
   silently no-ops** (#476): jq indexes `null` with any key and gets `null`
   back — `null | .a`, `null | .[0]` and `null | delpaths([["a"]])` are all

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -9153,6 +9153,38 @@ mod tests {
         assert_eq!(first_doc_json(b"key: - a\n"), r#"{"key":["a"]}"#);
     }
 
+    /// A `- ` on a plain scalar's *continuation* line (as opposed to its first
+    /// line, covered above) is ordinary content at any indent greater than the
+    /// enclosing block's own indent, matching `yq`. The corpus's only case for
+    /// this shape, AB8U, uses continuation indent exactly 1 - the parser used to
+    /// treat that as the *only* valid indent and wrongly cut the scalar short
+    /// (reparsing the `- ` line as a nested sequence) at indent 2 and deeper,
+    /// which AB8U can never catch (#484, corpus-latent like #382 and #409).
+    #[test]
+    fn test_dash_continuation_at_any_indent_folds_into_plain_scalar() {
+        // AB8U itself (continuation indent 1) must stay passing.
+        assert_eq!(
+            first_doc_json(b"- single multiline\n - sequence entry\n"),
+            r#"["single multiline - sequence entry"]"#
+        );
+        // The bug's exact repro (indent 2), and deeper indents - none of these
+        // should stop the fold.
+        assert_eq!(first_doc_json(b"- x\n  - y\n"), r#"["x - y"]"#);
+        assert_eq!(first_doc_json(b"- x\n   - y\n"), r#"["x - y"]"#);
+        assert_eq!(first_doc_json(b"- x\n    - y\n"), r#"["x - y"]"#);
+        assert_eq!(first_doc_json(b"- x\n     - y\n"), r#"["x - y"]"#);
+        // Same shape as a mapping value.
+        assert_eq!(
+            first_doc_json(b"b:\n  - x\n    - y\n"),
+            r#"{"b":["x - y"]}"#
+        );
+        // Regression guard: a genuinely nested sequence is unaffected, since it's
+        // recognized immediately after an item's own `-`, not via continuation
+        // folding.
+        assert_eq!(first_doc_json(b"- - y\n"), r#"[["y"]]"#);
+        assert_eq!(first_doc_json(b"- x\n- - y\n"), r#"["x",["y"]]"#);
+    }
+
     /// A same-line block mapping value that is a bare sequence-entry indicator, with
     /// no content after it. The parser records an extent covering the `-` alone
     /// (trailing spaces are trimmed), so this decodes as the string `"-"` — where

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1253,15 +1253,23 @@ impl<'a> Parser<'a> {
             // EXCEPT at document root (start_indent == 0) where same-indent is allowed.
             // Next line shouldn't start block structure or be a comment.
             //
-            // For sequence indicators `- `, they're only block structure if at a
-            // "proper" indent level. A `- ` at indent just 1 greater than start_indent
-            // (like ` - ` when start_indent is 0) is scalar content, not a sequence.
-            // This handles cases like AB8U where the `- ` is at an invalid indent.
+            // A `- ` on a continuation line is ordinary scalar content at ANY indent
+            // greater than start_indent - per YAML 1.2 `nb-ns-plain-in-line`, once a
+            // plain scalar's first line has begun, a leading `-` on a later line is
+            // never re-tested as a sequence indicator. It's only block structure when
+            // it's at or before start_indent, which (since indent_allows_continuation
+            // already requires next_indent > start_indent outside doc-root) can only
+            // happen at document root, where it means a `- ` reappearing at column 0
+            // is a genuine new top-level sequence item, not scalar content.
+            //
+            // AB8U (`next_indent == start_indent + 1`) is just the narrowest case of
+            // "greater than start_indent" - it was once mishandled as the only correct
+            // one, wrongly stopping continuation for any deeper indent too (#484).
             let is_sequence_indicator = next_char == b'-'
                 && lookahead + 1 < self.input.len()
                 && matches!(self.input[lookahead + 1], b' ' | b'\t');
-            let sequence_indicator_is_block_structure = is_sequence_indicator
-                && (next_indent <= start_indent || next_indent >= start_indent + 2);
+            let sequence_indicator_is_block_structure =
+                is_sequence_indicator && next_indent <= start_indent;
 
             // At document root, same-indent continues the scalar (YAML spec 7.4).
             // Inside containers, must be more indented than start.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1380,6 +1380,21 @@ fn test_yaml_anchor_on_flow_sequence_key_binds_to_key() -> Result<()> {
 }
 
 #[test]
+fn test_yaml_plain_scalar_dash_continuation_at_indent_two_folds() -> Result<()> {
+    // #484, corpus-latent the same way #409 was: the YAML Test Suite's only
+    // relevant case, AB8U, uses a `- `-led continuation line at indent 1 - the
+    // one indent the parser happened to get right - so it gave no signal that
+    // indent 2 and deeper wrongly cut the scalar short and reparsed the `- `
+    // line as a nested sequence instead of folding it into the scalar, as `yq`
+    // does.
+    let input = "- x\n  - y\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"["x - y"]"#);
+    Ok(())
+}
+
+#[test]
 fn test_yaml_anchor_on_null_explicit_value_resolves_to_null() -> Result<()> {
     // Also found by the invariant (corpus case PW8X): an anchor on an explicit
     // value that turns out to be null had no node to point at, so the alias


### PR DESCRIPTION
## Description

This PR fixes a critical bug in YAML plain scalar parsing where continuation lines beginning with `- ` (dash-space) were incorrectly interpreted as nested sequence indicators at indentation levels of 2 or deeper, rather than being folded as part of the scalar's text content.

### The Problem

A multi-line plain scalar whose continuation line begins with `- ` was only folded correctly when that line was indented exactly one column past the enclosing block's own indent. At deeper indentations (2+ columns), the parser would incorrectly cut the scalar short and reparse the `- ` line as a brand-new nested sequence:

```yaml
- x
  - y
```

This produced `["x",["y"]]` in this crate (incorrectly creating a nested array) but `yq` correctly produces `["x - y"]` (folding the continuation into the scalar). Both are valid YAML per the strict validator, making this a silently incorrect structure on legal input.

### Root Cause

The `parse_unquoted_value_with_indent_impl` function in `src/yaml/parser.rs` had a `sequence_indicator_is_block_structure` condition that treated a continuation line's leading `-` as block structure whenever `next_indent >= start_indent + 2`. Per YAML 1.2 spec (`nb-ns-plain-in-line`), once a plain scalar's first line has begun, a `-` on a later line should never be re-tested as a sequence indicator at any indent. The spec removes this disjunct entirely, leaving only `next_indent <= start_indent` as the condition for block structure—reachable only at document root, where it correctly ends a document-root scalar when a `- ` reappears at column 0 as a genuine new top-level item.

### Why This Wasn't Caught

The YAML Test Suite's only relevant case, AB8U, uses continuation indent exactly 1—the one value that happened to work—so it provided no signal on indent 2 and deeper. This is corpus-latent, similar to issues #382 and #409.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue

Fixes #484

## Changes Made

**Parser Fix (`src/yaml/parser.rs`):**
- Modified `sequence_indicator_is_block_structure` condition from `is_sequence_indicator && (next_indent <= start_indent || next_indent >= start_indent + 2)` to `is_sequence_indicator && next_indent <= start_indent`
- Updated logic comments to clarify that per YAML 1.2, a `-` on a continuation line is never re-tested as a sequence indicator, regardless of indent depth
- The narrower condition ensures `- ` is only treated as block structure at document root (indent 0), while deeper indents fold the `- ` into the plain scalar as ordinary content

**Test Coverage (`src/yaml/light.rs`):**
- Added `test_dash_continuation_at_any_indent_folds_into_plain_scalar` comprehensive test covering:
  - AB8U case (continuation indent 1) to verify existing behavior remains correct
  - Bug reproduction at indent 2: `- x\n  - y\n` must produce `["x - y"]`
  - Additional verification at indents 3, 4, and 5 to ensure the fix is indent-agnostic
  - Mapping value variant to verify the fix works in both sequence and mapping contexts
  - Regression guard confirming genuinely nested sequences (`- - y`, `- x\n- - y`) remain unaffected, since they're recognized immediately after an item's own `-` rather than through the continuation-fold path

**CLI Test (`tests/yq_cli_tests.rs`):**
- Added `test_yaml_plain_scalar_dash_continuation_at_indent_two_folds` to pin the exact reproduction case at the CLI level
- Verifies that `- x\n  - y\n` with JSON output produces `["x - y"]` matching `yq` behavior

**Documentation (`CHANGELOG.md`):**
- Added comprehensive entry in the Unreleased section documenting the bug, its impact, root cause, and fix
- Formatted consistently with sibling corpus-latent entries (#382, #409)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added covering the bug fix and regressions
- [x] Tests added for multiple indentation levels (1-5 columns)
- [x] Tests added for both sequence and mapping value contexts
- [x] Regression tests verify genuinely nested sequences remain unaffected

**Manual Testing:**
- [x] Verified with CLI test case at the exact reported repro
- [x] Tested continuation fold across indent range 1-5
- [x] Verified mapping value variant works correctly
- [x] Confirmed nested sequence discrimination still functions properly

### Test Commands
```bash
cargo test test_dash_continuation_at_any_indent_folds_into_plain_scalar
cargo test test_yaml_plain_scalar_dash_continuation_at_indent_two_folds
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The fix simplifies the condition check (one fewer boolean clause) rather than adding new work, so there is no performance regression.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Unaffected Components:**
- The locate path (`at_offset`/`yq-locate`) is unaffected, as it reads multi-line scalar extents from the same index that this fix addresses rather than re-deriving them independently
- Genuinely nested sequences are unaffected, as they're recognized immediately after an item's own `-` rather than through the continuation-fold path

**Technical Details:**
This fix aligns the parser's behavior with YAML 1.2 specification section 7.3.1 (`nb-ns-plain-in-line`), which explicitly states that once a plain scalar's first line has begun, subsequent lines are no longer subject to the sequence indicator test. The original code's restriction to `next_indent == start_indent + 1` was an overly conservative interpretation that didn't account for the spec's intent.