### PR TITLE
fix(test): locate CLI binary by target-dir depth, not fixed deps/ pop

### DIFF
--- a/tests/dsv_cli_tests.rs
+++ b/tests/dsv_cli_tests.rs
@@ -36,11 +36,7 @@ fn succinctly_bin() -> &'static Path {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        let mut path = std::env::current_exe().expect("resolve current_exe");
-        path.pop(); // drop the test executable's file name -> `.../deps`
-        if path.file_name().and_then(|s| s.to_str()) == Some("deps") {
-            path.pop(); // drop `deps` -> `.../<profile>`
-        }
+        let mut path = target_profile_dir_from_test_exe();
         path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
         assert!(
             path.is_file(),
@@ -49,6 +45,24 @@ fn succinctly_bin() -> &'static Path {
         );
         path
     })
+}
+
+/// Derive `<target>/<profile>/` from this test executable's own path.
+///
+/// The classic flat layout places the test exe at
+/// `<target>/<profile>/deps/<test>-<hash>`, but nightly's build-dir-layout-v2
+/// (rust-lang/cargo#17258, defaulted on nightly toolchains from ~2026-07)
+/// instead nests it at `<target>/<profile>/build/<pkg>/<hash>/out/<test>-<hash>`.
+/// Both layouts keep `<profile>` as the path component immediately after
+/// `target`, so locate it that way instead of assuming a fixed depth.
+fn target_profile_dir_from_test_exe() -> PathBuf {
+    let current_exe = std::env::current_exe().expect("resolve current_exe");
+    let components: Vec<_> = current_exe.components().collect();
+    let target_idx = components
+        .iter()
+        .rposition(|c| c.as_os_str() == "target")
+        .expect("test executable path has no `target` component");
+    components[..=target_idx + 1].iter().collect()
 }
 
 /// Run `dsv generate` and capture stdout, stderr, and exit code.

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -38,13 +38,9 @@ fn succinctly_bin() -> &'static Path {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        // The test executable lives at `<target>/<profile>/deps/<test>-<hash>`;
-        // the CLI binary is its sibling at `<target>/<profile>/succinctly`.
-        let mut path = std::env::current_exe().expect("resolve current_exe");
-        path.pop(); // drop the test executable's file name -> `.../deps`
-        if path.file_name().and_then(|s| s.to_str()) == Some("deps") {
-            path.pop(); // drop `deps` -> `.../<profile>`
-        }
+        // The CLI binary is `<target>/<profile>/succinctly`, a sibling of the
+        // test executable's own `<target>/<profile>/` ancestor.
+        let mut path = target_profile_dir_from_test_exe();
         path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
         assert!(
             path.is_file(),
@@ -53,6 +49,24 @@ fn succinctly_bin() -> &'static Path {
         );
         path
     })
+}
+
+/// Derive `<target>/<profile>/` from this test executable's own path.
+///
+/// The classic flat layout places the test exe at
+/// `<target>/<profile>/deps/<test>-<hash>`, but nightly's build-dir-layout-v2
+/// (rust-lang/cargo#17258, defaulted on nightly toolchains from ~2026-07)
+/// instead nests it at `<target>/<profile>/build/<pkg>/<hash>/out/<test>-<hash>`.
+/// Both layouts keep `<profile>` as the path component immediately after
+/// `target`, so locate it that way instead of assuming a fixed depth.
+fn target_profile_dir_from_test_exe() -> PathBuf {
+    let current_exe = std::env::current_exe().expect("resolve current_exe");
+    let components: Vec<_> = current_exe.components().collect();
+    let target_idx = components
+        .iter()
+        .rposition(|c| c.as_os_str() == "target")
+        .expect("test executable path has no `target` component");
+    components[..=target_idx + 1].iter().collect()
 }
 
 /// Helper to run `json validate` with input from stdin.

--- a/tests/text_cli_tests.rs
+++ b/tests/text_cli_tests.rs
@@ -38,11 +38,7 @@ fn succinctly_bin() -> &'static Path {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        let mut path = std::env::current_exe().expect("resolve current_exe");
-        path.pop(); // drop the test executable's file name -> `.../deps`
-        if path.file_name().and_then(|s| s.to_str()) == Some("deps") {
-            path.pop(); // drop `deps` -> `.../<profile>`
-        }
+        let mut path = target_profile_dir_from_test_exe();
         path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
         assert!(
             path.is_file(),
@@ -51,6 +47,24 @@ fn succinctly_bin() -> &'static Path {
         );
         path
     })
+}
+
+/// Derive `<target>/<profile>/` from this test executable's own path.
+///
+/// The classic flat layout places the test exe at
+/// `<target>/<profile>/deps/<test>-<hash>`, but nightly's build-dir-layout-v2
+/// (rust-lang/cargo#17258, defaulted on nightly toolchains from ~2026-07)
+/// instead nests it at `<target>/<profile>/build/<pkg>/<hash>/out/<test>-<hash>`.
+/// Both layouts keep `<profile>` as the path component immediately after
+/// `target`, so locate it that way instead of assuming a fixed depth.
+fn target_profile_dir_from_test_exe() -> PathBuf {
+    let current_exe = std::env::current_exe().expect("resolve current_exe");
+    let components: Vec<_> = current_exe.components().collect();
+    let target_idx = components
+        .iter()
+        .rposition(|c| c.as_os_str() == "target")
+        .expect("test executable path has no `target` component");
+    components[..=target_idx + 1].iter().collect()
 }
 
 /// Run `text validate utf8` with raw bytes piped on stdin.

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -28,11 +28,7 @@ fn succinctly_bin() -> &'static Path {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        let mut path = std::env::current_exe().expect("resolve current_exe");
-        path.pop();
-        if path.file_name().and_then(|s| s.to_str()) == Some("deps") {
-            path.pop();
-        }
+        let mut path = target_profile_dir_from_test_exe();
         path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
         assert!(
             path.is_file(),
@@ -41,6 +37,24 @@ fn succinctly_bin() -> &'static Path {
         );
         path
     })
+}
+
+/// Derive `<target>/<profile>/` from this test executable's own path.
+///
+/// The classic flat layout places the test exe at
+/// `<target>/<profile>/deps/<test>-<hash>`, but nightly's build-dir-layout-v2
+/// (rust-lang/cargo#17258, defaulted on nightly toolchains from ~2026-07)
+/// instead nests it at `<target>/<profile>/build/<pkg>/<hash>/out/<test>-<hash>`.
+/// Both layouts keep `<profile>` as the path component immediately after
+/// `target`, so locate it that way instead of assuming a fixed depth.
+fn target_profile_dir_from_test_exe() -> PathBuf {
+    let current_exe = std::env::current_exe().expect("resolve current_exe");
+    let components: Vec<_> = current_exe.components().collect();
+    let target_idx = components
+        .iter()
+        .rposition(|c| c.as_os_str() == "target")
+        .expect("test executable path has no `target` component");
+    components[..=target_idx + 1].iter().collect()
 }
 
 fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {


### PR DESCRIPTION
## Description

This PR fixes test suite failures on nightly Cargo builds caused by Cargo's new `build-dir-layout-v2` directory structure. Nightly Cargo (from ~2026-07 onwards) changed the default build directory layout, nesting test binaries under `target/<profile>/build/<pkg>/<hash>/out/` instead of the flat `target/<profile>/deps/` structure. The CLI binary locator helper in four test suites was hardcoded to pop the `deps/` directory component, resulting in incorrect paths and test failures.

The fix introduces a layout-agnostic path resolution strategy that locates the `target` directory component and derives `<target>/<profile>/` from there, working correctly with both the legacy flat layout and the new nested build-dir-layout-v2.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] CI/CD changes

## Related Issue
Fixes #507 - CI nightly Cargo build-dir-layout-v2 breaks CLI binary tests

## Changes Made

**Test Binary Path Resolution:**
- Replaced hardcoded `deps/` path popping logic with a new `target_profile_dir_from_test_exe()` helper function in all four test suites
- The new helper searches for the `target` path component and derives `<target>/<profile>/` by collecting path components up to and including the profile directory
- This approach works with both Cargo's classic flat layout (`target/<profile>/deps/`) and the new build-dir-layout-v2 nested layout (`target/<profile>/build/<pkg>/<hash>/out/`)

**Files Modified:**
- `tests/dsv_cli_tests.rs` - Added `target_profile_dir_from_test_exe()` helper, refactored `succinctly_bin()` to use it
- `tests/json_validate_tests.rs` - Added `target_profile_dir_from_test_exe()` helper, refactored `succinctly_bin()` to use it
- `tests/text_cli_tests.rs` - Added `target_profile_dir_from_test_exe()` helper, refactored `succinctly_bin()` to use it
- `tests/yaml_validate_tests.rs` - Added `target_profile_dir_from_test_exe()` helper, refactored `succinctly_bin()` to use it

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Tests verified to work with Cargo's classic flat layout
- [x] Tests verified to work with Cargo's new build-dir-layout-v2 nested layout
- [x] Changes are backward compatible with stable Rust toolchains

**Manual Testing:**
- [x] Tested on x86_64
- [x] Test suites verified on nightly toolchain with build-dir-layout-v2

### Test Commands
```bash
cargo test
cargo +nightly test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact - only affects test execution, not production code

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Changes address the root cause of the nightly CI failures
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

**Root Cause Analysis:**
Cargo's new build-dir-layout-v2 (rust-lang/cargo#17258) changes directory nesting but preserves the property that the profile directory immediately follows the `target` component in all paths. The original code assumed a fixed depth (always popping two levels to reach the profile directory), which broke under the new layout. By searching for the `target` component dynamically, we make the code resilient to both current and future Cargo layout changes.

**Why This Solution:**
This approach is layout-agnostic and doesn't rely on assumptions about directory depth. It will continue working if Cargo changes the layout again, as long as the `target/<profile>/` ancestor relationship is maintained.

**CI Impact:**
This fix enables the full test suite to pass on nightly CI runs without requiring layout-specific workarounds or conditional compilation.