### PR TITLE
fix(yaml): resolve phantom-key corruption from out-dented sequence continuations (#485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path (`at_offset`/`yq-locate`), which reads multi-line scalar extents from
   the same index this fixes rather than re-deriving them independently.
 
+- **An out-dented block sequence continuation silently dropped the item and
+  corrupted the next mapping entry** (#485): a `-` continuation line indented
+  strictly between its sequence's own indent and whatever encloses it —
+  `b:\n    - x\n   - y\nc: 2` — read back as `{"b":["x"],"":"c"}`: `y` vanished
+  with no error, and the well-formed `c: 2` that followed became a phantom
+  `"":"c"` pair with the `2` also gone. `close_deeper_indents` popped the
+  sequence for any indent shallower than its own, including one that still sat
+  inside the mapping enclosing it; `parse_sequence_item_inner` then reopened a
+  *second*, untagged sequence as a sibling child of the mapping rather than a
+  value under a key, throwing off the mapping's key/value pairing for
+  everything after it. A new `sequence_frame_reaches` predicate — shared by a
+  sequence-item-specific close variant and the reuse check, so the two
+  definitions of "does this indent still belong to the sequence" cannot drift
+  apart — now recognizes an out-of-range indent that doesn't reach down to the
+  enclosing frame and keeps the sequence open instead, joining the item to it:
+  `{"b":["x","y"],"c":2}`. This is the same "parse the obvious extension"
+  policy #325 used for `a: - x`. The input is still invalid YAML and the
+  opt-in strict validator continues to reject it.
+
 - **`del()` errored when a deleted key's container was `null`, where jq
   silently no-ops** (#476): jq indexes `null` with any key and gets `null`
   back — `null | .a`, `null | .[0]` and `null | delpaths([["a"]])` are all

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -125,6 +125,22 @@ an indicator, so there is no text to preserve. This is the one place the two rul
 and the split is deliberate: flow keeps text because no sequence can exist there; block
 builds the sequence because one can.
 
+A continuation line can also be invalid the other way: out-dented, sitting strictly between
+the sequence's own indent and whatever encloses it, rather than on the mapping key's line.
+[#485](https://github.com/rust-works/succinctly/issues/485) takes the same stance as #325 —
+the item joins the sequence rather than being dropped:
+
+```
+$ printf 'b:\n    - x\n   - y\nc: 2\n' | succinctly yq -o json -I0 '.'
+{"b":["x","y"],"c":2}     # yq: did not find expected key
+```
+
+Before #485 this lost more than the misaligned item: closing the sequence for the
+out-of-range indent reopened a second, untagged sequence as a sibling *child* of the
+mapping instead of a value under a key, which corrupted the next entry — here `c: 2` — into
+a phantom `"":"c"` pair, with the `2` dropped as well. Content after the misaligned item is
+kept too: a further out-dented or realigned line still joins the same sequence.
+
 ### Two exceptions: an alias with no usable target is rejected
 
 Two alias forms are refused at index build. They are the same failure underneath — an

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1404,6 +1404,63 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Whether a sequence frame at `indent_stack[frame_idx]` should still hold
+    /// an item at `indent`: either an exact indent match (the ordinary case)
+    /// or, leniently, an out-of-range indent strictly between the sequence
+    /// and whatever encloses it.
+    ///
+    /// A block sequence continuation at such an indent is invalid YAML (`yq`
+    /// and the strict validator both reject it), but closing the sequence
+    /// here — the plain `close_deeper_indents` behaviour — pops it back to
+    /// its enclosing mapping and then reopens a second, untagged sequence as
+    /// a sibling *child* of that mapping instead of a value under any key.
+    /// That extra child throws off the mapping's key/value pairing for
+    /// everything after it, silently dropping the item and corrupting the
+    /// next entry into a phantom empty key (#485). Treating the out-of-range
+    /// indent as still belonging to the open sequence avoids that, the same
+    /// "parse the obvious extension" policy #325 used for `a: - x`.
+    ///
+    /// Shared by `close_deeper_indents_for_sequence_item` (decides whether to
+    /// stop closing) and `parse_sequence_item_inner` (decides whether to
+    /// reuse the sequence rather than opening a new one) so the two
+    /// can't drift out of sync (the #106 lesson: duplicated predicates
+    /// diverge silently).
+    fn sequence_frame_reaches(&self, frame_idx: usize, indent: usize) -> bool {
+        let frame_indent = self.indent_stack[frame_idx];
+        indent == frame_indent
+            || (frame_idx > 0 && indent > self.indent_stack[frame_idx - 1] && indent < frame_indent)
+    }
+
+    /// Close deeper containers before parsing a `-` sequence item at
+    /// `new_indent`, tolerating an out-dented continuation via
+    /// [`Self::sequence_frame_reaches`] instead of popping the sequence
+    /// (#485).
+    ///
+    /// Only `parse_sequence_item_inner` uses this variant of
+    /// `close_deeper_indents`: the tolerance is specific to the sequence
+    /// getting a new *item*, and does not generalize to other callers (a
+    /// mapping key at the same out-of-range indent has no sequence-item
+    /// wrapper to land in, and would produce a different, wrong shape).
+    fn close_deeper_indents_for_sequence_item(&mut self, new_indent: usize) {
+        while self.indent_stack.len() > 1 {
+            let top_idx = self.indent_stack.len() - 1;
+            let current_indent = self.indent_stack[top_idx];
+            if current_indent <= new_indent {
+                break;
+            }
+            if self.type_stack[top_idx] == NodeType::Sequence
+                && self.sequence_frame_reaches(top_idx, new_indent)
+            {
+                // Out-dented continuation - keep this sequence open.
+                break;
+            }
+            self.close_pending_explicit_key();
+            self.indent_stack.pop();
+            self.pop_type();
+            self.write_bp_close();
+        }
+    }
+
     /// Close a sequence that was the value of a previous mapping entry.
     ///
     /// When we're about to add a new entry to a mapping at indent N, and the top
@@ -1454,19 +1511,23 @@ impl<'a> Parser<'a> {
         self.set_ib();
 
         // First close any deeper containers. This might reveal an existing sequence
-        // at this indent level that we can reuse.
-        self.close_deeper_indents(indent);
+        // at this indent level that we can reuse. Uses the sequence-item-aware
+        // variant so an out-dented continuation reuses the open sequence instead
+        // of being closed out from under it (#485).
+        self.close_deeper_indents_for_sequence_item(indent);
 
         // Now check if we need to open a new sequence (check AFTER closing)
         // Normally, sequence items must be at the exact same indent as the sequence.
         // However, for nested sequences created by `- - item` pattern, items can be
-        // at greater indent because the nested sequence's indent is virtual.
+        // at greater indent because the nested sequence's indent is virtual. And an
+        // out-dented continuation (#485) can be at *lesser* indent, as long as it's
+        // still within the range `close_deeper_indents_for_sequence_item` tolerated.
         //
-        // We need a new sequence if:
-        // 1. There's no sequence on the stack, OR
-        // 2. The item indent doesn't match the sequence indent
+        // We need a new sequence if there's no sequence on the stack, or the item
+        // indent doesn't fall within the current sequence's range (exact match, or
+        // the same out-of-range gap `sequence_frame_reaches` already tolerated).
         let need_new_sequence = self.current_type != Some(NodeType::Sequence)
-            || self.indent_stack.last().copied() != Some(indent);
+            || !self.sequence_frame_reaches(self.indent_stack.len() - 1, indent);
 
         if need_new_sequence {
             // Open new sequence
@@ -1475,6 +1536,18 @@ impl<'a> Parser<'a> {
             self.indent_stack.push(indent);
             self.push_type(NodeType::Sequence);
         }
+
+        // Normalize to the sequence's own recorded indent for everything below:
+        // the item's virtual child indent, a compact mapping's indent, and the
+        // structure indent passed to `parse_value`. A no-op for the ordinary
+        // exact-match case and for a sequence just opened above (both already
+        // equal `indent`), but load-bearing for an out-dented continuation that
+        // reused the sequence (#485) - without it, a later sibling line whose
+        // indent falls between this out-dented `indent` and the sequence's real
+        // indent would look like "more indented than this item's own value" and
+        // fold into it as scalar continuation text instead of being recognized
+        // as the next sequence item.
+        let indent = *self.indent_stack.last().unwrap();
 
         // Open the sequence item node
         self.write_bp_open_seq_item();

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -145,6 +145,30 @@ fn rejects_inline_sequence_as_mapping_value() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn rejects_out_dented_sequence_continuation() -> Result<()> {
+    // #485. The loader parses these leniently (attaching the out-dented item
+    // to the enclosing sequence), but strict rejection stays the validator's
+    // job: a dedent that stops strictly between two open levels is invalid
+    // (`check_block_indent`'s `popped && matches!(kind, Seq | Map)` case).
+    for input in [
+        "b:\n    - x\n   - y\nc: 2\n",
+        "b:\n    - x\n   - y\n    - z\n",
+        "b:\n  - x\n - y\n",
+        "a:\n  b:\n    - x\n   - y\n  c: 2\n",
+    ] {
+        let (_, stderr, code) = run_validate_stdin(input, &["--no-color"])?;
+        assert_eq!(code, 1, "expected rejection for {input:?}: {stderr}");
+    }
+
+    // Correctly-aligned sequences stay valid.
+    for input in ["b:\n  - x\n  - y\n", "b:\n    - x\n    - y\nc: 2\n"] {
+        let (_, stderr, code) = run_validate_stdin(input, &["--no-color"])?;
+        assert_eq!(code, 0, "expected acceptance for {input:?}: {stderr}");
+    }
+    Ok(())
+}
+
 // ============================================================================
 // `syq --validate` (the yq runner's opt-in validation flag).
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2976,6 +2976,76 @@ fn test_inline_sequence_as_compact_mapping_value_is_not_dropped() -> Result<()> 
     Ok(())
 }
 
+// ============================================================================
+// Out-dented block sequence continuation (#485)
+// ============================================================================
+// A continuation `-` indented strictly between a sequence's own indent and
+// whatever encloses it is invalid YAML (`yq` rejects it, and so does the
+// strict validator), but the loader parses the obvious extension rather than
+// silently dropping the item, the same policy #325 chose for `a: - x`.
+// Before this fix, closing the sequence for the out-of-range indent reopened
+// a second, untagged sequence as a sibling child of the mapping instead of a
+// value under a key, which not only dropped the misaligned item but corrupted
+// the *next* mapping entry into a phantom `"":<value>` pair.
+
+#[test]
+fn test_out_dented_sequence_continuation_joins_the_sequence() -> Result<()> {
+    // The #485 repro: `y` used to vanish and `c: 2` corrupted into `"":"c"`.
+    let (output, exit_code) =
+        run_yq_stdin(".", "b:\n    - x\n   - y\nc: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"b":["x","y"],"c":2}"#);
+    Ok(())
+}
+
+#[test]
+fn test_out_dented_sequence_continuation_does_not_lose_later_items() -> Result<()> {
+    // Everything after the misaligned item must survive too, not just resume
+    // being lost one item later.
+    let (output, exit_code) = run_yq_stdin(
+        ".",
+        "b:\n    - x\n   - y\n    - z\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"b":["x","y","z"]}"#);
+    Ok(())
+}
+
+#[test]
+fn test_out_dented_sequence_continuation_minimal_form() -> Result<()> {
+    // No trailing entry, no outer nesting.
+    let (output, exit_code) = run_yq_stdin(".", "b:\n  - x\n - y\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"b":["x","y"]}"#);
+    Ok(())
+}
+
+#[test]
+fn test_out_dented_sequence_continuation_nested_in_a_mapping() -> Result<()> {
+    // The same shape one level deeper: `b`'s sequence sits inside `a`, and the
+    // enclosing frame the out-dented `- y` must reach past is `b`, not the
+    // document root.
+    let (output, exit_code) = run_yq_stdin(
+        ".",
+        "a:\n  b:\n    - x\n   - y\n  c: 2\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":{"b":["x","y"],"c":2}}"#);
+    Ok(())
+}
+
+#[test]
+fn test_correctly_aligned_sequence_is_unaffected_by_out_dent_handling() -> Result<()> {
+    // Regression guard: an ordinary, correctly-indented sequence must parse
+    // exactly as before.
+    let (output, exit_code) = run_yq_stdin(".", "b:\n  - x\n  - y\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"b":["x","y"]}"#);
+    Ok(())
+}
+
 #[test]
 fn test_flow_dash_without_whitespace_is_still_a_scalar() -> Result<()> {
     // A `-` not followed by whitespace is a legitimate plain scalar in flow


### PR DESCRIPTION
## Description

This PR fixes issue #485, where an out-dented block sequence continuation item was silently dropped and corrupted the next mapping entry into a phantom empty-key pair. The root cause was in the sequence item parsing logic: when a `-` continuation line appeared at an indent strictly between a sequence's own indent and its enclosing container, `close_deeper_indents` would pop the sequence entirely. The parser would then reopen a second, untagged sequence as a sibling *child* of the mapping rather than a value under a key, destroying the mapping's key/value pairing for all subsequent entries.

The fix introduces lenient parsing that recognizes out-of-range indents still logically belonging to the sequence and reuses it instead of closing it. This follows the same "parse the obvious extension" policy as #325 (for `a: - x`). The input remains invalid YAML (both `yq` and the strict validator reject it), but we now handle the corruption gracefully by joining the misaligned item to its sequence and preserving subsequent entries intact.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #485

## Changes Made

**Core Parser Changes (src/yaml/parser.rs):**
- Added `sequence_frame_reaches()` predicate to determine whether an indent still belongs to a sequence frame (exact match, or an out-of-range gap that doesn't reach the enclosing frame)
- Added `close_deeper_indents_for_sequence_item()` method, a sequence-item-specific variant of `close_deeper_indents` that stops instead of popping once it encounters a valid out-of-range gap
- Updated `parse_sequence_item_inner()` to use the new sequence-item-aware close logic
- Modified sequence reuse check to use `sequence_frame_reaches()` so the decision to reuse vs. open a new sequence is consistent with the close logic
- Added indent normalization in `parse_sequence_item_inner()` so that out-dented continuations don't confuse later sibling items as scalar folding continuation text

**Test Coverage (tests/yq_cli_tests.rs):**
- Added `test_out_dented_sequence_continuation_joins_the_sequence()`: validates the main repro case where `y` now correctly joins the sequence and `c: 2` is no longer corrupted
- Added `test_out_dented_sequence_continuation_does_not_lose_later_items()`: ensures all items after the misaligned item survive
- Added `test_out_dented_sequence_continuation_minimal_form()`: covers the two-line minimal case
- Added `test_out_dented_sequence_continuation_nested_in_a_mapping()`: verifies the same pattern works nested inside another mapping
- Added `test_correctly_aligned_sequence_is_unaffected_by_out_dent_handling()`: regression test ensuring normal sequences are unaffected

**Validator Tests (tests/yaml_validate_tests.rs):**
- Added `rejects_out_dented_sequence_continuation()`: confirms the strict validator still rejects these invalid YAML inputs, while verifying the loader parses them leniently

**Documentation (CHANGELOG.md and docs/compliance/yaml/limitations.md):**
- Added CHANGELOG entry documenting the phantom-key corruption bug and the fix
- Added section in limitations documentation explaining the out-dented continuation behavior alongside the #325 entry

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added covering main repro, multi-item case, minimal form, nested mapping case, and regression guard
- [x] Validator tests confirm strict mode still rejects these invalid YAML inputs

**Manual Testing:**
- [x] Verified main repro case: `b:\n    - x\n   - y\nc: 2` now correctly parses to `{"b":["x","y"],"c":2}` instead of corrupting to `{"b":["x"],"":"c"}`
- [x] Verified multi-item case preserves all items
- [x] Verified nested mapping case works correctly
- [x] Verified correctly-aligned sequences remain unaffected

### Test Commands
```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
cargo test out_dented_sequence
cargo test rejects_out_dented_sequence
```

## Performance Impact
- [x] No performance impact: the new predicates are simple comparisons, and the logic only affects the specific case of out-dented continuations which are invalid YAML anyway

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works (5 new integration tests + validator tests)
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed (CHANGELOG and limitations guide)
- [x] My changes generate no new warnings

## Additional Notes

**Design Decisions:**
- The fix is scoped specifically to `parse_sequence_item_inner()` rather than changing `close_deeper_indents` globally, because mapping keys at the same out-of-range indent have no sequence-item wrapper to land in and would produce incorrect results
- The `sequence_frame_reaches()` predicate is shared between the close logic and the reuse check to prevent them from drifting out of sync (following the lesson from #106 about duplicated predicates diverging silently)
- Indent normalization happens immediately after deciding to reuse a sequence, so later correctly-aligned siblings aren't mistaken for scalar-folding continuation text

**Backwards Compatibility:**
- This is a pure bug fix with no breaking changes
- Correctly-aligned sequences continue to work exactly as before
- The input `b:\n    - x\n   - y\nc: 2` was producing corrupt output; now it produces sensible output
- The strict validator continues to reject this input as invalid YAML, maintaining strict compliance standards