### PR TITLE
fix(test): resolve CLI binary via CARGO_BIN_EXE instead of path heuristic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,9 @@ jobs:
         if: needs.gate.outputs.code == 'true'
         run: cargo build --features cli --bin succinctly
 
-      - name: Run cli-gated yq/jq tests
+      - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
 
       - name: Run tests
         if: needs.gate.outputs.code == 'true'
@@ -242,9 +242,9 @@ jobs:
         if: needs.gate.outputs.code == 'true'
         run: cargo build --features cli --bin succinctly
 
-      - name: Run cli-gated yq/jq tests
+      - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
 
       - name: Run tests
         if: needs.gate.outputs.code == 'true'
@@ -340,9 +340,9 @@ jobs:
         if: needs.gate.outputs.code == 'true'
         run: cargo build --features cli --bin succinctly
 
-      - name: Run cli-gated yq/jq tests
+      - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
 
       - name: Run tests
         if: needs.gate.outputs.code == 'true'
@@ -403,8 +403,8 @@ jobs:
       - name: Build CLI (for integration tests)
         run: cargo build --features cli --bin succinctly
 
-      - name: Run cli-gated yq tests
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test yaml_bench_suite_coverage
+      - name: Run cli-gated tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
 
       - name: Run tests
         run: cargo test --verbose

--- a/tests/dsv_cli_tests.rs
+++ b/tests/dsv_cli_tests.rs
@@ -6,63 +6,19 @@
 //! declaration (`--header` / `--no-header` override pair) and the `main`
 //! dispatch into `dsv_generators` are exercised end-to-end.
 //!
-//! Run with: cargo test --test dsv_cli_tests
+//! Run with: cargo test --test dsv_cli_tests --features cli
+#![cfg(feature = "cli")]
 
-use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 
 use anyhow::Result;
 
-/// Resolve the path to the pre-built `succinctly` CLI binary, building it once.
-///
-/// Mirrors the helper in `text_cli_tests.rs`: the integration-test harness
-/// is compiled without the `cli` feature, and the `succinctly` binary is gated by
-/// `required-features = ["cli"]`, so `CARGO_BIN_EXE_succinctly` is unavailable
-/// here. We build the binary once with the `cli` feature and derive its path from
-/// this test executable's own location. Invoking the built binary directly (not
-/// `cargo run`) keeps cargo's output out of each child's captured stderr.
-fn succinctly_bin() -> &'static Path {
-    static BIN: OnceLock<PathBuf> = OnceLock::new();
-    BIN.get_or_init(|| {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let output = Command::new(cargo)
-            .args(["build", "--features", "cli", "--bin", "succinctly"])
-            .output()
-            .expect("failed to spawn `cargo build`");
-        assert!(
-            output.status.success(),
-            "`cargo build --features cli --bin succinctly` failed:\n{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-
-        let mut path = target_profile_dir_from_test_exe();
-        path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
-        assert!(
-            path.is_file(),
-            "built `succinctly` binary not found at {}",
-            path.display()
-        );
-        path
-    })
-}
-
-/// Derive `<target>/<profile>/` from this test executable's own path.
-///
-/// The classic flat layout places the test exe at
-/// `<target>/<profile>/deps/<test>-<hash>`, but nightly's build-dir-layout-v2
-/// (rust-lang/cargo#17258, defaulted on nightly toolchains from ~2026-07)
-/// instead nests it at `<target>/<profile>/build/<pkg>/<hash>/out/<test>-<hash>`.
-/// Both layouts keep `<profile>` as the path component immediately after
-/// `target`, so locate it that way instead of assuming a fixed depth.
-fn target_profile_dir_from_test_exe() -> PathBuf {
-    let current_exe = std::env::current_exe().expect("resolve current_exe");
-    let components: Vec<_> = current_exe.components().collect();
-    let target_idx = components
-        .iter()
-        .rposition(|c| c.as_os_str() == "target")
-        .expect("test executable path has no `target` component");
-    components[..=target_idx + 1].iter().collect()
+/// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
+/// bin target (gated `required-features = ["cli"]`) before this test binary
+/// runs, since this file is itself gated on `cli`, and bakes the resulting
+/// path in at compile time — correct under any target-dir layout.
+fn succinctly_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_succinctly")
 }
 
 /// Run `dsv generate` and capture stdout, stderr, and exit code.

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -2,71 +2,20 @@
 //!
 //! These tests verify RFC 8259 compliance and CLI behavior.
 //! Run with: cargo test --features cli --test json_validate_tests
+#![cfg(feature = "cli")]
 
 use std::io::Write;
-use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 
 use anyhow::Result;
 use tempfile::NamedTempFile;
 
-/// Resolve the path to the pre-built `succinctly` CLI binary, building it once.
-///
-/// The integration-test harness is compiled without the `cli` feature (CI runs
-/// plain `cargo test`), and the `succinctly` binary is gated by
-/// `required-features = ["cli"]`, so `CARGO_BIN_EXE_succinctly` is not available
-/// here. We therefore build the binary once with the `cli` feature and derive its
-/// path from this test executable's own location.
-///
-/// Invoking the built binary directly (rather than `cargo run`) keeps cargo's own
-/// output — compile progress and, on nightly, the future-incompatibility `note:` —
-/// out of each child's captured stderr, so stderr assertions observe only the
-/// application's output. The one-time `cargo build` blocking-waits on the build
-/// lock, so no retry loop for lock contention is needed.
-fn succinctly_bin() -> &'static Path {
-    static BIN: OnceLock<PathBuf> = OnceLock::new();
-    BIN.get_or_init(|| {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let output = Command::new(cargo)
-            .args(["build", "--features", "cli", "--bin", "succinctly"])
-            .output()
-            .expect("failed to spawn `cargo build`");
-        assert!(
-            output.status.success(),
-            "`cargo build --features cli --bin succinctly` failed:\n{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-
-        // The CLI binary is `<target>/<profile>/succinctly`, a sibling of the
-        // test executable's own `<target>/<profile>/` ancestor.
-        let mut path = target_profile_dir_from_test_exe();
-        path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
-        assert!(
-            path.is_file(),
-            "built `succinctly` binary not found at {}",
-            path.display()
-        );
-        path
-    })
-}
-
-/// Derive `<target>/<profile>/` from this test executable's own path.
-///
-/// The classic flat layout places the test exe at
-/// `<target>/<profile>/deps/<test>-<hash>`, but nightly's build-dir-layout-v2
-/// (rust-lang/cargo#17258, defaulted on nightly toolchains from ~2026-07)
-/// instead nests it at `<target>/<profile>/build/<pkg>/<hash>/out/<test>-<hash>`.
-/// Both layouts keep `<profile>` as the path component immediately after
-/// `target`, so locate it that way instead of assuming a fixed depth.
-fn target_profile_dir_from_test_exe() -> PathBuf {
-    let current_exe = std::env::current_exe().expect("resolve current_exe");
-    let components: Vec<_> = current_exe.components().collect();
-    let target_idx = components
-        .iter()
-        .rposition(|c| c.as_os_str() == "target")
-        .expect("test executable path has no `target` component");
-    components[..=target_idx + 1].iter().collect()
+/// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
+/// bin target (gated `required-features = ["cli"]`) before this test binary
+/// runs, since this file is itself gated on `cli`, and bakes the resulting
+/// path in at compile time — correct under any target-dir layout.
+fn succinctly_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_succinctly")
 }
 
 /// Helper to run `json validate` with input from stdin.

--- a/tests/text_cli_tests.rs
+++ b/tests/text_cli_tests.rs
@@ -7,64 +7,20 @@
 //! exercised end-to-end.
 //!
 //! Run with: cargo test --features cli --test text_cli_tests
+#![cfg(feature = "cli")]
 
 use std::io::Write;
-use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 
 use anyhow::Result;
 use tempfile::{NamedTempFile, TempDir};
 
-/// Resolve the path to the pre-built `succinctly` CLI binary, building it once.
-///
-/// Mirrors the helper in `json_validate_tests.rs`: the integration-test harness
-/// is compiled without the `cli` feature, and the `succinctly` binary is gated by
-/// `required-features = ["cli"]`, so `CARGO_BIN_EXE_succinctly` is unavailable
-/// here. We build the binary once with the `cli` feature and derive its path from
-/// this test executable's own location. Invoking the built binary directly (not
-/// `cargo run`) keeps cargo's output out of each child's captured stderr.
-fn succinctly_bin() -> &'static Path {
-    static BIN: OnceLock<PathBuf> = OnceLock::new();
-    BIN.get_or_init(|| {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let output = Command::new(cargo)
-            .args(["build", "--features", "cli", "--bin", "succinctly"])
-            .output()
-            .expect("failed to spawn `cargo build`");
-        assert!(
-            output.status.success(),
-            "`cargo build --features cli --bin succinctly` failed:\n{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-
-        let mut path = target_profile_dir_from_test_exe();
-        path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
-        assert!(
-            path.is_file(),
-            "built `succinctly` binary not found at {}",
-            path.display()
-        );
-        path
-    })
-}
-
-/// Derive `<target>/<profile>/` from this test executable's own path.
-///
-/// The classic flat layout places the test exe at
-/// `<target>/<profile>/deps/<test>-<hash>`, but nightly's build-dir-layout-v2
-/// (rust-lang/cargo#17258, defaulted on nightly toolchains from ~2026-07)
-/// instead nests it at `<target>/<profile>/build/<pkg>/<hash>/out/<test>-<hash>`.
-/// Both layouts keep `<profile>` as the path component immediately after
-/// `target`, so locate it that way instead of assuming a fixed depth.
-fn target_profile_dir_from_test_exe() -> PathBuf {
-    let current_exe = std::env::current_exe().expect("resolve current_exe");
-    let components: Vec<_> = current_exe.components().collect();
-    let target_idx = components
-        .iter()
-        .rposition(|c| c.as_os_str() == "target")
-        .expect("test executable path has no `target` component");
-    components[..=target_idx + 1].iter().collect()
+/// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
+/// bin target (gated `required-features = ["cli"]`) before this test binary
+/// runs, since this file is itself gated on `cli`, and bakes the resulting
+/// path in at compile time — correct under any target-dir layout.
+fn succinctly_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_succinctly")
 }
 
 /// Run `text validate utf8` with raw bytes piped on stdin.

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -1,60 +1,20 @@
 //! Integration tests for the `succinctly yaml validate` CLI command.
 //!
 //! Run with: cargo test --features cli --test yaml_validate_tests
+#![cfg(feature = "cli")]
 
 use std::io::Write;
-use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 
 use anyhow::Result;
 use tempfile::NamedTempFile;
 
-/// Resolve the path to the pre-built `succinctly` CLI binary, building it once.
-/// Mirrors `tests/json_validate_tests.rs` — the integration harness is compiled
-/// without `cli`, so we build the binary and derive its path from this test
-/// executable's own location.
-fn succinctly_bin() -> &'static Path {
-    static BIN: OnceLock<PathBuf> = OnceLock::new();
-    BIN.get_or_init(|| {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let output = Command::new(cargo)
-            .args(["build", "--features", "cli", "--bin", "succinctly"])
-            .output()
-            .expect("failed to spawn `cargo build`");
-        assert!(
-            output.status.success(),
-            "`cargo build --features cli --bin succinctly` failed:\n{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-
-        let mut path = target_profile_dir_from_test_exe();
-        path.push(format!("succinctly{}", std::env::consts::EXE_SUFFIX));
-        assert!(
-            path.is_file(),
-            "built `succinctly` binary not found at {}",
-            path.display()
-        );
-        path
-    })
-}
-
-/// Derive `<target>/<profile>/` from this test executable's own path.
-///
-/// The classic flat layout places the test exe at
-/// `<target>/<profile>/deps/<test>-<hash>`, but nightly's build-dir-layout-v2
-/// (rust-lang/cargo#17258, defaulted on nightly toolchains from ~2026-07)
-/// instead nests it at `<target>/<profile>/build/<pkg>/<hash>/out/<test>-<hash>`.
-/// Both layouts keep `<profile>` as the path component immediately after
-/// `target`, so locate it that way instead of assuming a fixed depth.
-fn target_profile_dir_from_test_exe() -> PathBuf {
-    let current_exe = std::env::current_exe().expect("resolve current_exe");
-    let components: Vec<_> = current_exe.components().collect();
-    let target_idx = components
-        .iter()
-        .rposition(|c| c.as_os_str() == "target")
-        .expect("test executable path has no `target` component");
-    components[..=target_idx + 1].iter().collect()
+/// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
+/// bin target (gated `required-features = ["cli"]`) before this test binary
+/// runs, since this file is itself gated on `cli`, and bakes the resulting
+/// path in at compile time — correct under any target-dir layout.
+fn succinctly_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_succinctly")
 }
 
 fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {


### PR DESCRIPTION
## Description

This PR resolves CLI binary resolution failures in integration tests by replacing a fragile path-based heuristic with Cargo's compile-time `CARGO_BIN_EXE_*` environment variables. The fix ensures tests work correctly under all target directory layouts, including cargo-llvm-cov's coverage-diff nested structure (`target/llvm-cov-target/`).

The original `target_profile_dir_from_test_exe()` function attempted to derive the target profile directory by walking the test executable's path and locating the last `target` component. This approach broke under cargo-llvm-cov's coverage-diff workflow (issue #511), which nests test binaries deeper than expected, causing all 4 affected CLI test suites to fail during coverage jobs.

The solution gates these 4 test files on the `cli` feature flag and adopts the pattern already used by 6 other CLI test files in the repository: using `env!("CARGO_BIN_EXE_succinctly")` to let Cargo inject the binary's exact path at compile time. This is infallible under any target layout.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] CI/CD changes

## Related Issue
Fixes #511 - Coverage diff with llvm-cov target layer

## Changes Made

**Test Files Modified (4 files):**
- `tests/dsv_cli_tests.rs`: Replaced `target_profile_dir_from_test_exe()` heuristic with `env!("CARGO_BIN_EXE_succinctly")`, added `#![cfg(feature = "cli")]` gate, updated run instructions
- `tests/json_validate_tests.rs`: Same refactoring as above
- `tests/text_cli_tests.rs`: Same refactoring as above
- `tests/yaml_validate_tests.rs`: Same refactoring as above

**Removed Code:**
- Deleted `target_profile_dir_from_test_exe()` function (no longer needed)
- Removed manual `cargo build --features cli --bin succinctly` logic (Cargo handles this automatically now)
- Removed `OnceLock` and path manipulation boilerplate

**CI Configuration:**
- `.github/workflows/ci.yml`: Updated "Run cli-gated yq/jq tests" step name to "Run cli-gated tests" across all job matrices
- Added `--test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests` to the `cargo test --features cli` command in 4 job definitions (x86_64-linux, x86_64-macos, aarch64-macos, coverage)

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] dsv_cli_tests, json_validate_tests, text_cli_tests, yaml_validate_tests now run under cli-gated step in CI
- [x] Verified against nightly's build-dir-layout-v2 and cargo-llvm-cov coverage-diff structure

**Manual Testing:**
- [x] Tested on x86_64 with `cargo test --features cli --test dsv_cli_tests`
- [x] Verified feature gate works: tests skip without `--features cli`
- [x] Confirmed binary resolution is correct under various target layouts

### Test Commands
```bash
# Run individual test suites with CLI feature
cargo test --features cli --test dsv_cli_tests
cargo test --features cli --test json_validate_tests
cargo test --features cli --test text_cli_tests
cargo test --features cli --test yaml_validate_tests

# Run all cli-gated tests as in CI
cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests

# Verify tests are properly gated
cargo test --test dsv_cli_tests  # Should compile but run 0 tests
```

## Performance Impact
- [x] No performance impact
- Compile-time environment variable substitution has zero runtime cost
- Eliminates unnecessary `cargo build` invocations that were happening at test runtime

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (test run instructions in file comments)
- [x] My changes generate no new warnings
- [x] All existing tests pass with the changes

## Additional Notes

**Why This Fix is Robust:**
Using `env!("CARGO_BIN_EXE_succinctly")` is the canonical approach because:
1. Cargo bakes the path in at compile time, making it correct by definition
2. The `cli` feature gate ensures this file only compiles when the binary is available
3. No path walking, assumptions, or heuristics—eliminating future layout issues
4. Already proven in 6 other CLI test files in the same repository

**Consistency:**
This PR brings all CLI test files into alignment using the same pattern, making the test harness more maintainable and less fragile to changes in Cargo's internal directory layouts.