### PR TITLE
feat(bitvec, core, cli): Elias-Fano line index replacing dense bitmap (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pays nothing. It rejects 58 of the 82 previously-accepted-but-invalid YAML
   Test Suite cases (reject conformance 12/94 → 70/94) with no false positives on
   the valid corpus; the remaining structurally-deep cases stay on record.
+- **`succinctly::text::LineIndex`** (#228): a shared, Elias-Fano-backed line-start
+  index replacing three separate copies of the same `BitVec` newline scanner
+  (`JsonIndex`, `YamlIndex`, and `json::locate::NewlineIndex`). It costs
+  ~`2 + log2(average line length)` bits per *line* instead of ~1.27 bits per
+  *input byte*: 3.6-145x smaller on the real-workload corpus, and near-zero on
+  minified single-line input where the bitmap still cost 15.6% of the file.
+  See [ADR-0012](docs/adrs/adr-0012.md).
+- `EliasFano::predecessor` — the largest element `<= value`, with its index
+  (O(log n); intended for cold paths).
+- `heap_size()` on `BitVec`, `RankDirectory` and `SelectIndex`, matching
+  `EliasFano` and `CompactRank`.
+- The corpus shape report gains a `## Line index` section recording retained
+  index bytes per file, so the existing `corpus-shape-drift` CI job now guards
+  index space against regression.
 
 ### Changed
 
@@ -1653,6 +1667,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `AliasCycle` error on a valid document.
   - A **block sequence at a lower indent than a mapping key** was treated as
     that key's value, leaving the key's anchor dangling.
+- `YamlIndex::to_offset` no longer returns byte offsets past the end of the text
+  for an out-of-range column; it returns `None`, matching `JsonIndex::to_offset` (#228)
 - `jq -R -s` now yields the entire input as a single string instead of an array of per-line strings, matching jq (#176)
 - `yq -R -s` now yields the entire input as a single string instead of an array of per-line strings, matching jq and `jq -R -s` (#271)
 - YAML alias cycles (`a: &anchor {self: *anchor}`) are rejected at index build with the
@@ -1739,6 +1755,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the existing `AliasCycle` check, where it previously produced garbage. `yq`
   instead emits a depth-limited expansion; rejecting cycles is the documented
   policy (see `docs/compliance/yaml/limitations.md`).
+- **BREAKING — `JsonIndex` line/column lookup takes the text** (#228):
+  `to_line_column(offset, text)` and `to_offset(line, column, text)` now match
+  the existing `YamlIndex` signatures. The line index is built lazily on first
+  use instead of eagerly in `JsonIndex::build`, which removes an O(n) scan and a
+  full bitmap allocation from every JSON index build (−25.8% of build allocation
+  on a 100 KB GeoJSON file). `JsonCursor::cursor_at_position` and the
+  `at_position(line; col)` builtin are unaffected. As a consequence `JsonIndex`
+  is no longer `Sync` (`YamlIndex` already was not).
+- **BREAKING — zero-caller `BitVec` constructors removed** (#228):
+  `JsonIndex::from_parts_with_newlines`, `YamlIndex::from_parts_with_newlines`
+  and `YamlIndex::newlines` are gone. They were the last public signatures
+  exposing `BitVec` outside `succinctly::bits`; line indices are now derived from
+  the text on demand. `JsonIndex::from_parts` gains working line/column lookup as
+  a side effect — it used to install an empty newline index that silently
+  reported every position as line 1.
+- `succinctly::json::locate::NewlineIndex` is now an alias for
+  `succinctly::text::LineIndex`; `build`, `to_offset` and `to_line_column` are
+  unchanged. The alias will be removed in 0.9.0. (#228)
 - **4 GiB input ceilings enforced** (#188): instead of silently truncating
   `u32` counters, builds now fail loudly for inputs over `u32::MAX` bytes —
   `YamlIndex::build` returns the new `YamlError::InputTooLarge` variant

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,7 +521,11 @@ For detailed documentation on optimization techniques used in this project, see 
   - **Additional context-sensitivity**: YAML has two quote types (`"` vs `'`), block scalars (`|` `>`), and context-dependent quote meaning
   - See [docs/parsing/yaml.md#p6-bmi2-operations-pdeppext---rejected-](docs/parsing/yaml.md#p6-bmi2-operations-pdeppext---rejected-) for full analysis
 - ❌ P7 (Newline Index): **REJECTED** - use case mismatch (CLI feature, not parsing optimization)
-  - **Discovery**: JSON's `NewlineIndex` is NOT built during parsing
+  - ⚠️ **Premise corrected by #228**: JSON had *two* newline structures and P7 found only one.
+    `JsonIndex::newlines` **was** built eagerly in every `JsonIndex::build` — an O(n) scan and ~15.9%
+    of the input on every jq query. P7's conclusion held; JSON was violating it. Both are now
+    `text::LineIndex`, built lazily (ADR-0012).
+  - **Discovery** (as believed at the time): JSON's `NewlineIndex` is NOT built during parsing
     - Only used in `jq-locate` CLI tool for `--line X --column Y` → byte offset conversion
     - Never built during JSON parsing, jq queries, or benchmarks
     - Zero performance impact on actual JSON processing

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -38,6 +38,7 @@ by Michael Nygard.
 | [ADR-0009](adr-0009.md) | ✅ Accepted | 2026-07-12 | Reject a Parse-Time Newline Index (P7)                 |
 | [ADR-0010](adr-0010.md) | ✅ Accepted | 2026-07-12 | Reject AVX-512 SIMD Variants (P8)                      |
 | [ADR-0011](adr-0011.md) | ✅ Accepted | 2026-07-15 | Custom Succinct Structures over Existing Rust Crates   |
+| [ADR-0012](adr-0012.md) | ✅ Accepted | 2026-07-25 | Elias-Fano Line Index over a Dense Bitmap              |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0009.md
+++ b/docs/adrs/adr-0009.md
@@ -17,6 +17,14 @@ benchmarks. YAML, meanwhile, already computes line numbers lazily via an O(n) `c
 that is called only on error paths (4 call sites, all in error reporting), so valid documents
 never pay for it.
 
+> **Correction (#228).** That paragraph is right about `json::locate::NewlineIndex` and wrong about
+> JSON overall: there were *two* newline structures, and the other one — `JsonIndex::newlines` —
+> was built **eagerly in every `JsonIndex::build`**, costing an O(n) scan and ~15.9% of the input
+> size on every jq query, for a structure only `at_position` and the locate CLIs read. The
+> investigation found the CLI-only one and stopped. The conclusion below still holds (and is now
+> applied to JSON too, which was violating it); the premise "JSON does not pay for this" did not.
+> See [ADR-0012](adr-0012.md).
+
 ## Decision
 
 We will **not** build a newline index during YAML parsing.

--- a/docs/adrs/adr-0011.md
+++ b/docs/adrs/adr-0011.md
@@ -77,10 +77,14 @@ Measured comparisons: [benchmarks/rust-succinct-libs.md](../benchmarks/rust-succ
   untested, as is vers-vecs' AVX-512 select. The space figures are exact and platform-independent; the
   `select1` ratios are noisy — see the benchmark page.) Requirements
   2 and 3 are about `BalancedParens` and `JsonIndex`, neither of which uses `BitVec` — both bypass it
-  for a plain `Vec<u64>` plus cumulative-rank `Vec<u32>`. `BitVec` survives only in auxiliary newline
-  indices and at the DSV API boundary. Its use there is a candidate for replacement, tracked in
-  [issue #228](https://github.com/rust-works/succinctly/issues/228); only requirement 1 currently keeps
-  it in-crate.
+  for a plain `Vec<u64>` plus cumulative-rank `Vec<u32>`. `BitVec` survived only in auxiliary newline
+  indices. (An earlier revision of this ADR also claimed it survived "at the DSV API boundary"; that
+  was wrong — [src/dsv/](../../src/dsv/) contains no `BitVec`, only `DsvIndexLightweight`, and
+  mentions the type solely in a comment comparing against it.) Those newline indices have since been
+  replaced by an Elias-Fano `text::LineIndex` under
+  [issue #228](https://github.com/rust-works/succinctly/issues/228) — see [ADR-0012](adr-0012.md) —
+  so `BitVec` now has **no production callers at all** and survives as public API only. Whether to
+  shrink, deprecate or keep it is still open; only requirement 1 keeps it `no_std`-viable in-crate.
 - **The space cost is real and was previously misdocumented.** The rank directory spends 128 bits per
   512 bits of data (~25%) and the sampled select index grows with density, so a full `BitVec` measures
   27.5-47.5% resident overhead. Four documents claimed ~3%, which is the Poppy *paper's* figure, not

--- a/docs/adrs/adr-0012.md
+++ b/docs/adrs/adr-0012.md
@@ -1,0 +1,135 @@
+# ADR-0012: Elias-Fano Line Index over a Dense Bitmap
+
+## Status
+
+✅ Accepted
+
+## Context
+
+[ADR-0011](adr-0011.md) concluded that succinctly's succinct *structures* stay in-crate — `no_std`
+rules out every candidate crate, and none provide balanced-parentheses navigation or hinted select —
+but explicitly excluded the general-purpose `BitVec` from that argument, and recorded its remaining
+use as a candidate for replacement in
+[issue #228](https://github.com/rust-works/succinctly/issues/228).
+
+Auditing those remaining uses turned up three, all of them the same thing: a line-start index, one
+bit per text byte, set at the byte immediately after each line terminator.
+
+| Site                                                                 | Built                                    | Read by                                                 |
+|----------------------------------------------------------------------|------------------------------------------|---------------------------------------------------------|
+| `JsonIndex::newlines` ([src/json/light.rs](../../src/json/light.rs)) | **eagerly, in every `JsonIndex::build`** | `to_line_column`/`to_offset` → `at_position(line; col)` |
+| `NewlineIndex` ([src/json/locate.rs](../../src/json/locate.rs))      | on demand                                | `jq-locate`/`yq-locate --line --column`                 |
+| `YamlIndex::newlines` ([src/yaml/index.rs](../../src/yaml/index.rs)) | lazily (`OnceCell`)                      | `to_line_column`/`to_offset`                            |
+
+Each carried its own copy of the same LF/CRLF/CR scanner. Two facts reframed the question:
+
+1. **`BitVec` does not survive "at the DSV API boundary."** Both #228 and ADR-0011 say it does; the
+   DSV module contains no `BitVec` at all ([src/dsv/](../../src/dsv/) uses `DsvIndexLightweight`,
+   a plain `Vec<u64>` plus a cumulative-rank `Vec<u32>`). That claim was stale and is corrected in
+   ADR-0011.
+2. **The defect is not which rank/select structure is used — it is the representation.** Line starts
+   are a *sparse monotone set*. Storing them as a dense bitmap over the whole text costs ~1.27 bits
+   per **input byte** (bitmap + 25% rank directory + select samples) no matter how few lines there
+   are. That is worst exactly where it should be cheapest: a 100 KB single-line file paid 15.6% of
+   its size to record one line.
+
+## Decision
+
+Replace all three with one shared [`succinctly::text::LineIndex`](../../src/text/lines.rs), storing
+the line-start offsets themselves Elias-Fano encoded (~`2 + log2(average line length)` bits per
+**line**), and make JSON's index lazy like YAML's.
+
+Elias-Fano was already in-crate ([src/bits/elias_fano.rs](../../src/bits/elias_fano.rs)), is
+`alloc`-only, and does not depend on `BitVec`. It gained one method, `predecessor`, an O(log n)
+binary search over `get` — every consumer is a cold path (error reporting, `at_position`, the locate
+CLIs), so a proper `select0`-based predecessor was not worth ~80 lines and a second sample array.
+
+Line 1 is stored explicitly as element 0, which removes the `line == 1` special case all three
+copies carried.
+
+### The issue's other options, and why they were rejected
+
+- **Option 1 — the DSV-style cumulative-rank index.** *Rejected: it is a space regression.* One
+  `u32` per 64-bit word is 50% of the bitmap against the rank directory's 25%, so the total goes
+  from ~15.9% of input to ~18.75%. It is a 5-9x *iteration* win in DSV, which is not what a line
+  index does — and it leaves cost scaling with file size rather than line count.
+- **Option 2 — shrink `SelectIndex`.** *Rejected: subsumed.* At one 16-byte sample per 256 ones, the
+  select index is a rounding error on a sparse newline bitmap; the cost is the bitmap and its rank
+  directory. The new design has no select index at all.
+- **Option 3 — adopt a crate.** *Still blocked on `no_std`*, unchanged from ADR-0011.
+
+## Consequences
+
+**Measured.** Retained bytes per corpus file, from the structures' own `heap_size()`, now recorded in
+[benchmarks/corpus-shape.md](../benchmarks/corpus-shape.md) and guarded by the `corpus-shape-drift`
+CI job:
+
+| file                     | bytes  | lines | dense bitmap | `LineIndex` | factor   |
+|--------------------------|--------|-------|--------------|-------------|----------|
+| us-election.geojson      | 99,715 | 60    | 15,608       | 108         | **145x** |
+| gapminder-five-year.csv  | 82,079 | 1,705 | 12,952       | 1,636       | **7.9x** |
+| prometheus-ci.yml        | 18,935 | 453   | 2,992        | 432         | **6.9x** |
+| world-gdp-with-codes.csv | 4,515  | 223   | 728          | 180         | **4.0x** |
+| nginx-deployment.yml     | 836    | 43    | 160          | 44          | **3.6x** |
+
+The dense index cost 15.6-21.8% of every file; the line index costs 0.1-5.3%. A tracking-allocator
+A/B over the same corpus confirms `JsonIndex::build` now allocates 25.8% less on the geojson file
+(60,514 → 44,906 bytes) and 29.3% less on the small JSON file (409 → 289) — deltas that equal the
+dense index's `heap_size()` exactly, because that allocation is simply gone.
+
+**Positive:**
+
+- The eager build disappears from the jq hot path. Every `JsonIndex::build` used to scan the whole
+  text and allocate a bitmap for a structure that only `at_position` and the locate CLIs read.
+- One implementation instead of three, with a property test against a naive scanner over
+  terminator-dense inputs, and the first integration coverage of `jq-locate`/`yq-locate
+  --line --column` (there was none).
+- `BitVec` no longer appears in any public signature outside `succinctly::bits`.
+- `YamlIndex::to_offset` stops returning offsets past the end of the text, which `JsonIndex` already
+  rejected.
+
+**Negative / trade-offs:**
+
+- **Breaking API change.** `JsonIndex::to_line_column`/`to_offset` take the source text, matching
+  `YamlIndex`'s existing signatures, and `JsonIndex` is no longer `Sync` (`YamlIndex` already was
+  not). Three zero-caller items were removed outright. `json::locate::NewlineIndex` survives as an
+  alias until 0.9.0.
+- **Query cost rises from O(1) to O(log lines)**, plus a sampled select per binary-search step. This
+  is deliberate: the paths that read it are cold. It has not been benchmarked, because every
+  available machine was running other benchmarks concurrently; see below.
+- **A transient `Vec<u32>` during build.** Exactly capacity-sized from a counting pass, so no `Vec`
+  doubling — the O4 trap. It makes momentary peak higher than the old *retained* size on small
+  short-lined files (e.g. 204 vs 168 bytes on a 925-byte manifest) and lower on larger ones (2,248 vs
+  2,992 on 19 KB). Crossover is ~26 bytes per line. Since the peak is momentary and the old cost was
+  permanent, an `EliasFanoBuilder` to remove the transient was judged gold-plating and left
+  unimplemented.
+- **Elias-Fano loses below ~2.6 bytes per line**, where `2 + log2(A)` bits per line exceeds `1.27 * A`.
+  A file that is almost entirely newlines would cost ~26% of its size against the bitmap's ~16%. The
+  corpus runs 19-78 bytes per line, so this is theoretical, but it is a real edge and worth stating.
+- **`LineIndex::build` panics above `u32::MAX` bytes** where the `BitVec` path accepted `usize`
+  lengths. Consistent with the #188 ceiling `JsonIndex`, `YamlIndex` and `BalancedParens` already
+  enforce; recorded in [reference/limits.md](../reference/limits.md).
+
+**Not measured:** the build-time effect. Removing an O(n) scan should show up in
+`pipeline_indexing/build_index`, but every host available at the time was running other benchmarks
+(load 9-12), and this repository's rule is that benchmarks get exclusive CPU. Timing claims were
+therefore not made rather than made badly. To close it on an idle host:
+
+```bash
+cargo bench --bench json_pipeline -- pipeline_indexing --save-baseline before   # at 1104d93a
+cargo bench --bench json_pipeline -- pipeline_indexing --baseline before        # at this branch
+```
+
+## Follow-ups
+
+After this change `BitVec`, `RankDirectory` and `SelectIndex` have **zero production callers** — they
+survive as public API, doctests and serde tests only. So does `CompactRank`, which never had any.
+Whether to shrink, deprecate or keep them is a public-API policy question that #228 did not ask; it
+is deliberately left open.
+
+## See Also
+
+- [ADR-0011](adr-0011.md) — why the succinct structures are in-crate at all
+- [optimizations/line-index.md](../optimizations/line-index.md) — the space arithmetic and crossover
+- [benchmarks/rust-succinct-libs.md](../benchmarks/rust-succinct-libs.md) — the `BitVec` measurements
+  that prompted #228

--- a/docs/adrs/adr-0012.md
+++ b/docs/adrs/adr-0012.md
@@ -116,18 +116,40 @@ dense index's `heap_size()` exactly, because that allocation is simply gone.
   lengths. Consistent with the #188 ceiling `JsonIndex`, `YamlIndex` and `BalancedParens` already
   enforce; recorded in [reference/limits.md](../reference/limits.md).
 
-**Not measured:** anything with a clock on it. Two gaps, both open for the same reason — every host
-available at the time was running other benchmarks (load 9-12), and this repository's rule is that
-benchmarks get exclusive CPU. Timing claims were therefore not made rather than made badly.
+**Not measured, at the time this ADR was written:** anything with a clock on it. Two gaps, both
+open for the same reason — every host available at the time was running other benchmarks (load
+9-12), and this repository's rule is that benchmarks get exclusive CPU. Timing claims were
+therefore not made rather than made badly. Build time has since been closed (below); query time
+remains open.
 
-1. *Build time.* Removing an O(n) scan should show up in `pipeline_indexing/build_index`.
+1. *Build time* — measured 2026-08-01 on idle hosts: `pipeline_indexing/build_index` over the
+   10 MB `comprehensive` corpus file, before (`fb82b0ce`, this PR's merge-base) vs after
+   (`0a828f14`, this branch's final commit):
+
+   | Platform                  | Before               | After                | Change                      | Verdict                            |
+   |---------------------------|----------------------|----------------------|-----------------------------|-------------------------------------|
+   | AMD Ryzen 9 7950X (Zen 4) | 21.53 ms (372 MiB/s) | 21.26 ms (377 MiB/s) | -2.9% to +3.5% CI, p=0.92   | No significant change              |
+   | Apple M4 Pro              | 11.25 ms (712 MiB/s) | 9.57 ms (837 MiB/s)  | -15.3% to -14.4% CI, p=0.00 | **-14.8% time, +17.4% throughput** |
+
+   Removing the O(n) newline scan is a real, statistically significant win on the M4 Pro and
+   statistically invisible on Zen 4 at this file shape — another instance of this project's
+   established pattern that memory-bound effects do not port across architectures (see
+   [benchmarking.md](../guides/benchmarking.md#ab-benchmarking-method) rule 5). Likely explanation:
+   Zen 4's BMI2 PDEP-backed build path was already fast enough that the removed scan was a smaller
+   fraction of total build time there than on the M4 Pro's broadword path. This was a single
+   before→after run per host (build, bench, checkout, rebuild, bench), not the fully interleaved
+   method [benchmarking.md](../guides/benchmarking.md#ab-benchmarking-method) rule 1 calls for —
+   criterion has no built-in way to alternate between two already-built binaries mid-run. One point
+   against this being a sequential-thermal artifact: that bias makes the *second*-run binary look
+   slower, and "after" (run second on both hosts) came out faster or neutral, not slower.
 2. *Query time.* `to_line_column` went from O(1) rank + sampled select to an O(log n) binary search
-   of sampled selects. No benchmark drives it, so nothing would catch a regression.
+   of sampled selects. No benchmark drives it, so nothing would catch a regression. Still open —
+   closing it means writing a new benchmark; none currently exercises this path.
 
-To close both on an idle host:
+To reproduce the build-time comparison on an idle host:
 
 ```bash
-cargo bench --bench json_pipeline -- pipeline_indexing --save-baseline before   # at 1104d93a
+cargo bench --bench json_pipeline -- pipeline_indexing --save-baseline before   # at fb82b0ce
 cargo bench --bench json_pipeline -- pipeline_indexing --baseline before        # at this branch
 ```
 

--- a/docs/adrs/adr-0012.md
+++ b/docs/adrs/adr-0012.md
@@ -41,8 +41,12 @@ the line-start offsets themselves Elias-Fano encoded (~`2 + log2(average line le
 
 Elias-Fano was already in-crate ([src/bits/elias_fano.rs](../../src/bits/elias_fano.rs)), is
 `alloc`-only, and does not depend on `BitVec`. It gained one method, `predecessor`, an O(log n)
-binary search over `get` — every consumer is a cold path (error reporting, `at_position`, the locate
-CLIs), so a proper `select0`-based predecessor was not worth ~80 lines and a second sample array.
+binary search over `get`, rather than a proper `select0`-based predecessor costing ~80 lines and a
+second sample array. The `to_offset` direction — which is what `at_position` and both locate CLIs
+use — does not touch it at all and stays O(1). The `to_line_column` direction has one caller that is
+*not* a cold path: `YamlCursor::line()`/`column()`, behind the yq `line`/`column` builtins, which
+run once per node visited. See [optimizations/line-index.md](../optimizations/line-index.md#query-cost-and-why-olog-n-is-acceptable-here)
+for why that is tolerable today and what the accelerators are.
 
 Line 1 is stored explicitly as element 0, which removes the `line == 1` special case all three
 copies carried.
@@ -94,11 +98,13 @@ dense index's `heap_size()` exactly, because that allocation is simply gone.
   `YamlIndex`'s existing signatures, and `JsonIndex` is no longer `Sync` (`YamlIndex` already was
   not). Three zero-caller items were removed outright. `json::locate::NewlineIndex` survives as an
   alias until 0.9.0.
-- **Query cost rises from O(1) to O(log lines)**, plus a sampled select per binary-search step. This
-  is deliberate: the paths that read it are cold. It has not been benchmarked, because every
-  available machine was running other benchmarks concurrently; see below.
-- **A transient `Vec<u32>` during build.** Exactly capacity-sized from a counting pass, so no `Vec`
-  doubling — the O4 trap. It makes momentary peak higher than the old *retained* size on small
+- **`to_line_column` rises from O(1) to O(log lines)**, plus a sampled select per binary-search step
+  (`to_offset` stays O(1)). Accepted because the `line`/`column` builtins that call it per node are
+  stubbed to `0` on the CLI's evaluator path today, and because the `BitVec` select it replaces was
+  itself sampled every 256 ones. Neither claim is measured; see *Not measured* below.
+- **A transient `Vec<u32>` during build.** Capacity reserved from a counting pass, so it never
+  reallocates — the O4 trap. (The count is terminator bytes, so all-CRLF text over-reserves 2x;
+  exact on the LF/CR-only text the corpus contains.) It makes momentary peak higher than the old *retained* size on small
   short-lined files (e.g. 204 vs 168 bytes on a 925-byte manifest) and lower on larger ones (2,248 vs
   2,992 on 19 KB). Crossover is ~26 bytes per line. Since the peak is momentary and the old cost was
   permanent, an `EliasFanoBuilder` to remove the transient was judged gold-plating and left
@@ -110,10 +116,15 @@ dense index's `heap_size()` exactly, because that allocation is simply gone.
   lengths. Consistent with the #188 ceiling `JsonIndex`, `YamlIndex` and `BalancedParens` already
   enforce; recorded in [reference/limits.md](../reference/limits.md).
 
-**Not measured:** the build-time effect. Removing an O(n) scan should show up in
-`pipeline_indexing/build_index`, but every host available at the time was running other benchmarks
-(load 9-12), and this repository's rule is that benchmarks get exclusive CPU. Timing claims were
-therefore not made rather than made badly. To close it on an idle host:
+**Not measured:** anything with a clock on it. Two gaps, both open for the same reason — every host
+available at the time was running other benchmarks (load 9-12), and this repository's rule is that
+benchmarks get exclusive CPU. Timing claims were therefore not made rather than made badly.
+
+1. *Build time.* Removing an O(n) scan should show up in `pipeline_indexing/build_index`.
+2. *Query time.* `to_line_column` went from O(1) rank + sampled select to an O(log n) binary search
+   of sampled selects. No benchmark drives it, so nothing would catch a regression.
+
+To close both on an idle host:
 
 ```bash
 cargo bench --bench json_pipeline -- pipeline_indexing --save-baseline before   # at 1104d93a
@@ -123,9 +134,16 @@ cargo bench --bench json_pipeline -- pipeline_indexing --baseline before        
 ## Follow-ups
 
 After this change `BitVec`, `RankDirectory` and `SelectIndex` have **zero production callers** — they
-survive as public API, doctests and serde tests only. So does `CompactRank`, which never had any.
-Whether to shrink, deprecate or keep them is a public-API policy question that #228 did not ask; it
-is deliberately left open.
+survive as public API, doctests, the corpus-shape report's comparison column, and serde tests only.
+So does `CompactRank`, which never had any. Whether to shrink, deprecate or keep them is a
+public-API policy question that #228 did not ask; it is deliberately left open.
+
+The `line`/`column` builtins are stubbed to `0` on the `OwnedValue` evaluator path
+([src/jq/eval.rs](../../src/jq/eval.rs), `builtin_line`/`builtin_column`), which is what the `syq`
+CLI takes — so the one per-node consumer of `to_line_column` is currently unreachable from the
+command line. Wiring them up is a correctness fix in its own right, and is the point at which the
+`Cell`-cached predecessor in [optimizations/line-index.md](../optimizations/line-index.md#query-cost-and-why-olog-n-is-acceptable-here)
+stops being speculative. The two should land together.
 
 ## See Also
 

--- a/docs/architecture/balanced-parens.md
+++ b/docs/architecture/balanced-parens.md
@@ -31,12 +31,27 @@ A B   C E     D
 ## Data Structure
 
 ```rust
-pub struct BalancedParens {
-    bp: BitVec,              // Parentheses as bits
-    excess_min: Vec<i32>,    // RangeMin index for find_close
-    excess_min_pos: Vec<u32>,// Position of minimum
+pub struct BalancedParens<W = Vec<u64>, S: SelectSupport = NoSelect> {
+    words: W,                  // Parentheses as bits (1=open, 0=close)
+    len: usize,                // Number of valid bits
+    total_ones: usize,         // Cached count of open parens
+
+    // Three-level min-excess index for find_close
+    l0_min_excess: Vec<i8>,    l0_word_excess: Vec<i16>,   // per word
+    l1_min_excess: Vec<i16>,   l1_block_excess: Vec<i16>,  // per 32 words
+    l2_min_excess: Vec<i32>,   l2_block_excess: Vec<i32>,  // per 1024 words
+
+    // Cumulative rank directory for O(1) rank1()
+    rank_l1: Vec<u32>,         // absolute count per 512-bit block
+    rank_l2: Vec<u64>,         // 7 x 9-bit within-block offsets
+
+    select: S,                 // ZST for NoSelect; SelectIndex for WithSelect (P11)
 }
 ```
+
+Note it is **not** built on [`BitVec`](bitvec.md): it holds plain words plus its own rank arrays, so
+that `W` can be a borrowed slice (mmap) and so that select support is a compile-time choice. See
+[ADR-0011](../adrs/adr-0011.md#consequences).
 
 ## Core Operations
 
@@ -126,7 +141,9 @@ See [SIMD Optimizations](../optimizations/simd.md#x86-sse41-horizontal-minimum-p
 
 ## Depends On
 
-- [BitVec](bitvec.md) — the parenthesis sequence and RangeMin index are stored as bitvectors
+Nothing in [`bits/`](../../src/bits/) — the parenthesis sequence is a plain `Vec<u64>` (or borrowed
+slice) and the RangeMin and rank indices are its own arrays. See
+[BitVec](bitvec.md#used-by) for why it does not use that type.
 
 ## Academic Papers
 

--- a/docs/architecture/bitvec.md
+++ b/docs/architecture/bitvec.md
@@ -102,9 +102,12 @@ Popcount uses platform-specific SIMD:
 
 ## Used By
 
-**Nothing in the crate, as of [#228](https://github.com/rust-works/succinctly/issues/228).** `BitVec`
-is public API — exported from the crate root, exercised by doctests and the serde round-trip tests —
-but it has no production callers. This section previously listed four, none of which were accurate:
+**No data path in the crate, as of [#228](https://github.com/rust-works/succinctly/issues/228).**
+`BitVec` is public API — exported from the crate root, exercised by doctests and the serde
+round-trip tests — but nothing parses, indexes or queries through it. Its one remaining caller is
+measurement scaffolding: the corpus-shape report reconstructs a dense bitmap per file purely to
+print what `LineIndex` saves against it ([src/bin/succinctly/corpus_stats.rs](../../src/bin/succinctly/corpus_stats.rs)).
+This section previously listed four callers, none of which were accurate:
 
 | Structure                             | What it actually stores                                                                                                                        |
 |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/architecture/bitvec.md
+++ b/docs/architecture/bitvec.md
@@ -9,18 +9,22 @@ Design and implementation of the bit vector with rank/select support.
 `BitVec` is a bit vector that supports:
 - O(1) rank operations
 - O(log n) select operations
-- ~3-4% space overhead
+- **27.5-47.5% space overhead**, rising with bit density (see [Space Analysis](#space-analysis)) —
+  *not* the ~3% of a compact Poppy index, a figure this page previously quoted from the paper
 
 ## Data Layout
 
 ```rust
 pub struct BitVec {
-    bits: Vec<u64>,           // Raw bit storage
-    len: usize,               // Number of bits
-    superblock_rank: Vec<u64>, // Cumulative counts per 512 bits
-    block_rank: Vec<u16>,     // Counts per 64 bits within superblock
+    words: Vec<u64>,          // Raw bit storage
+    len: usize,               // Number of valid bits
+    ones_count: usize,        // Cached popcount
+    rank_dir: RankDirectory,  // 3-level Poppy directory (l0 + cache-aligned l1/l2)
+    select_idx: SelectIndex,  // One 16-byte sample per `select_sample_rate` ones
 }
 ```
+
+`heap_size()` reports the total of all three parts.
 
 ## Index Structure
 
@@ -98,10 +102,21 @@ Popcount uses platform-specific SIMD:
 
 ## Used By
 
-- [BalancedParens](balanced-parens.md) — stores its parenthesis sequence as a `BitVec`, uses rank1/select1 for tree navigation
-- [JsonIndex](../parsing/json-index.md) — interest bits and BP encoding are both bitvectors
-- [YamlIndex](../parsing/yaml-index.md) — same pattern, plus type bits
-- [DsvIndex](../parsing/dsv-index.md) — marker and newline bitvectors
+**Nothing in the crate, as of [#228](https://github.com/rust-works/succinctly/issues/228).** `BitVec`
+is public API — exported from the crate root, exercised by doctests and the serde round-trip tests —
+but it has no production callers. This section previously listed four, none of which were accurate:
+
+| Structure                             | What it actually stores                                                                                                                        |
+|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| [BalancedParens](balanced-parens.md)  | `words: W` (a plain `Vec<u64>` or borrowed slice) plus its own `rank_l1`/`rank_l2` arrays — never a `BitVec`                                   |
+| [JsonIndex](../parsing/json-index.md) | interest bits as `W` plus a cumulative-rank `Vec<u32>`; the newline index moved to [`text::LineIndex`](../../src/text/lines.rs)                |
+| [YamlIndex](../parsing/yaml-index.md) | same pattern, plus type bits; newline index likewise now `LineIndex`                                                                           |
+| [DsvIndex](../parsing/dsv-index.md)   | `DsvIndexLightweight` — plain `Vec<u64>` markers and newlines with cumulative-rank `Vec<u32>`, measured 5-9x faster to iterate than a `BitVec` |
+
+The parsers bypass `BitVec` because they need storage genericity (`W: AsRef<[u64]>` for mmap),
+hinted select, or cheap sequential iteration, none of which it offers. See
+[ADR-0011](../adrs/adr-0011.md) for why the structures are in-crate at all, and
+[ADR-0012](../adrs/adr-0012.md) for why the last auxiliary uses moved to Elias-Fano.
 
 ## Academic Papers
 

--- a/docs/benchmarks/corpus-shape.md
+++ b/docs/benchmarks/corpus-shape.md
@@ -25,6 +25,25 @@ Distributions are derived from the crate's own semi-index (`JsonIndex` / `YamlIn
 | yaml   | k8s            | nginx-deployment.yml        | 836   |
 | yaml   | lint           | sass-lint.yml               | 2055  |
 
+## Line index
+
+Bytes retained by `text::LineIndex` per corpus file, against what the dense-bitmap newline index it replaced would have cost for the same text (#228). Both columns are the structures' own `heap_size()`, not a formula, so this section is a space-regression guard as well as a record: the dense representation cost ~1.27 bits per *input byte* whatever the line count, while the Elias-Fano one costs ~2 + log2(average line length) bits per *line*. `permille` is parts-per-thousand of the file.
+
+| format | file                                       | bytes | lines | bitvec bytes | line index bytes | bitvec permille | line index permille |
+| ------ | ------------------------------------------ | ----- | ----- | ------------ | ---------------- | --------------- | ------------------- |
+| dsv    | gapminder/gapminder-five-year.csv          | 82079 | 1705  | 12952        | 1636             | 157             | 19                  |
+| dsv    | world-gdp/world-gdp-with-codes.csv         | 4515  | 223   | 728          | 180              | 161             | 39                  |
+| json   | charts/bullet-data.json                    | 548   | 7     | 120          | 20               | 218             | 36                  |
+| json   | geojson/us-election.geojson                | 99715 | 60    | 15608        | 108              | 156             | 1                   |
+| yaml   | actions/codeql-analysis.yml                | 925   | 39    | 168          | 44               | 181             | 47                  |
+| yaml   | actions/prometheus-ci.yml                  | 18935 | 453   | 2992         | 432              | 158             | 22                  |
+| yaml   | actions/stale.yml                          | 1290  | 34    | 232          | 44               | 179             | 34                  |
+| yaml   | compose/nginx-flask-mysql.yaml             | 1239  | 62    | 224          | 60               | 180             | 48                  |
+| yaml   | compose/wordpress.yaml                     | 815   | 33    | 152          | 44               | 186             | 53                  |
+| yaml   | home-assistant/air-quality-conditions.yaml | 9990  | 466   | 1608         | 384              | 160             | 38                  |
+| yaml   | k8s/nginx-deployment.yml                   | 836   | 43    | 160          | 44               | 191             | 52                  |
+| yaml   | lint/sass-lint.yml                         | 2055  | 98    | 360          | 92               | 175             | 44                  |
+
 ## YAML
 
 files: 8, total bytes: 36085, anchors: 41, aliases: 86, bare-dash items: 5

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ graph TD
 | DSV/CSV structural index   | [DsvIndex](parsing/dsv-index.md)                      | [src/dsv/](../src/dsv/)               | [parsing/dsv.md](parsing/dsv.md)                                   |
 | Query language             | [jq Evaluator](reference/jq-evaluator.md)             | [src/jq/](../src/jq/)                 | [CLAUDE.md](../CLAUDE.md#jq-format-functions)                      |
 | SIMD acceleration          | [SIMD Strategy](optimizations/simd-strategy.md)       | per-module `simd/` dirs               | [optimizations/simd.md](optimizations/simd.md)                     |
+| Line/column lookup         | [Line Index](optimizations/line-index.md)             | [src/text/lines.rs](../src/text/lines.rs) | [adrs/adr-0012.md](adrs/adr-0012.md)                           |
 
 ## How Semi-Indexing Works
 
@@ -79,7 +80,8 @@ Full data: [benchmarks/](benchmarks/)
 
 ## Key Cross-References
 
-- **BitVec → BalancedParens**: BP stores its parenthesis sequence as a `BitVec`, using rank1/select1 for O(1) tree navigation. See [architecture/core-concepts.md](architecture/core-concepts.md).
+- **BalancedParens rank/select**: BP stores its parenthesis sequence as plain `Vec<u64>` words with its own cumulative-rank arrays — *not* a `BitVec`, which it bypasses for storage genericity and hinted select. See [architecture/core-concepts.md](architecture/core-concepts.md) and [ADR-0011](adrs/adr-0011.md).
+- **LineIndex → JsonIndex/YamlIndex/locate CLIs**: line/column lookup is served by one shared Elias-Fano index over line starts, built lazily on first use. It replaced three dense-bitmap copies that cost ~16% of the input regardless of line count. See [ADR-0012](adrs/adr-0012.md).
 - **BalancedParens → JsonIndex/YamlIndex**: Each semi-index builds a BP encoding of the document's nesting structure. The BP's `find_close()` operation enables skipping entire subtrees.
 - **Interest Bits → Cursor API**: Additional bitvectors (string positions, array elements, object keys) enable the cursor to distinguish node types without re-parsing.
 - **jq Evaluator → Document trait**: The evaluator is generic over `Document`, allowing it to work with both `JsonIndex` and `YamlIndex` through a shared cursor interface. See [jq Evaluator](reference/jq-evaluator.md).

--- a/docs/optimizations/README.md
+++ b/docs/optimizations/README.md
@@ -19,6 +19,7 @@ This directory documents optimization techniques used in the succinctly library,
 | **Parallelism**      | [parallel-prefix.md](parallel-prefix.md)                 | Prefix XOR, cumulative index, carry propagation  |
 | **Parsing**          | [state-machines.md](state-machines.md)                   | PFSM, fast-path bypass, two-stage pipeline       |
 | **Compact encoding** | [end-positions.md](end-positions.md)                     | Bitmap encoding, advance index, sequential cursor|
+| **Sparse sets**      | [line-index.md](line-index.md)                           | Elias-Fano line starts, lazy build, crossover    |
 | **String search**    | [jq-string-search.md](jq-string-search.md)               | memmem vs std Two-Way for jq substring builtins   |
 | **Select scan**      | [select-scan.md](select-scan.md)                         | #40 scan-length measurement, IB cursor O(n²) fix |
 | **Targets**          | [targets.md](targets.md)                                 | CPU target configurations, architecture flags    |

--- a/docs/optimizations/line-index.md
+++ b/docs/optimizations/line-index.md
@@ -94,26 +94,52 @@ Cost of the lazy path is paid only by callers who need it:
 
 The deltas equal the dense index's `heap_size()` exactly — the allocation is simply gone.
 
-## Query cost, and why O(log n) is fine here
+## Query cost, and why O(log n) is acceptable here
 
 `to_line_column` needs "how many line starts precede this offset", which is a predecessor query.
 Elias-Fano has no rank, so `EliasFano::predecessor` is a binary search over `get` — O(log n) with a
 sampled select per step, against the bitmap's O(1) rank.
 
-That trade is deliberate. Every consumer is cold: error reporting, `$__loc__`'s document sibling
-`at_position`, and the two locate CLIs. Nothing in the parse or query hot path touches it.
-`to_offset` does not even need the predecessor — a line number is a direct index, so it stays O(1).
+`to_offset` does not need the predecessor at all — a line number is a direct index — so it stays
+O(1), and it is the direction both locate CLIs and `at_position(line; col)` use.
 
-If a hot consumer ever appears, the accelerator is already designed: `select_samples[j] -
-j * SAMPLE_RATE` is the high part of element `j*256` and is monotone in `j`, so binary-searching that
-plain `Vec<u32>` narrows to a 256-element block with zero select calls.
+### Who calls `to_line_column`
+
+| Caller                                                          | Frequency                  |
+|-----------------------------------------------------------------|----------------------------|
+| `jq-locate` / `yq-locate` (`--offset` → reported position)      | once per invocation        |
+| `YamlCursor::line()` / `column()` → the yq `line`/`column` builtins | **once per node visited**  |
+
+The second row is not a cold path, and an earlier draft of this page claimed it did not exist. It is
+reached only through the cursor evaluator ([src/jq/eval_generic.rs](../../src/jq/eval_generic.rs));
+the `OwnedValue` path that the `syq` CLI takes today stubs both builtins to `0`
+([src/jq/eval.rs](../../src/jq/eval.rs), `builtin_line`), so no shipped command currently drives it
+per node. That is a gap in the builtins, not a licence to call the path cold — if the stubs are ever
+wired up, `.[] | line` becomes one binary search per node, and `{l: line, c: column}` two, because
+`column()` recomputes the search rather than sharing it.
+
+Neither direction has been benchmarked. The comparison is not obviously a regression even at the
+per-node rate: `BitVec::select1` was itself sampled every 256 ones, which at the corpus's ~20
+bytes/line meant scanning up to ~80 words, against ~`log2(lines)` Elias-Fano `get`s here.
+
+If a hot consumer does appear, two accelerators are available. The cheap one is a one-entry
+`Cell` cache of the last `(offset, line, line_start)`, which makes the monotone walk `line()`
+performs amortised O(1) — the same trick `AdvancePositions` uses for O1/O2. The structural one:
+`select_samples[j] - j * SAMPLE_RATE` is the high part of element `j*256` and is monotone in `j`, so
+binary-searching that plain `Vec<u32>` narrows to a 256-element block with zero select calls.
 
 ## Transient build memory
 
 Building Elias-Fano needs the values up front (`universe` sizes `low_width`), so `LineIndex::build`
-collects a `Vec<u32>` of line starts first. A counting pass sizes it exactly, which matters more than
-it looks: without it, `Vec` doubling makes the transient 1.5-2x the vector — the failure mode O4
+collects a `Vec<u32>` of line starts first. A counting pass reserves it up front, which matters more
+than it looks: without it, `Vec` doubling makes the transient 1.5-2x the vector — the failure mode O4
 documented, where transient scratch dwarfed the retained structure.
+
+The count is *terminator bytes*, not line starts: it tallies `\n` and `\r` independently, so CRLF
+contributes two. On LF- or CR-only text — the whole corpus — that is exact. On an all-CRLF file it
+over-reserves by 2x, which is the same magnitude as the doubling it exists to prevent, so the
+guarantee is "never reallocates", not "never overshoots". Making it exact costs a second branch in
+the counting loop and buys nothing on any input the corpus contains.
 
 Measured momentary peak against the old *retained* cost:
 
@@ -138,8 +164,13 @@ momentary, where the old cost was permanent. Removing the transient entirely wou
   same discipline that rejected P5.
 - **Not building it beats making it smaller.** A 4-12x smaller structure is worth less than not
   constructing the structure at all on the hot path.
-- **Exact-size the scratch vector.** `Vec::with_capacity` from a counting pass costs one cheap
+- **Reserve the scratch vector.** `Vec::with_capacity` from a counting pass costs one cheap
   auto-vectorised scan and removes a 1.5-2x transient spike.
+- **Collapsing three copies of a scanner is worth nothing if it leaves a fourth.** The first cut of
+  this work open-coded the LF/CR/CRLF rule in `text::lines` on the grounds that JSON and DSV are not
+  YAML — but the rule is byte-identical for all three, so that was #341's duplication reintroduced
+  one module over. The definition lives in [text::line_break](../../src/text/line_break.rs) and
+  `yaml::line_break` re-exports it.
 
 ## See Also
 

--- a/docs/optimizations/line-index.md
+++ b/docs/optimizations/line-index.md
@@ -1,0 +1,151 @@
+# Line Index: Sparse Monotone Sets Beat Dense Bitmaps
+
+[Home](../../) > [Docs](../) > [Optimizations](./) > Line index
+
+How succinctly stores line-start offsets, why a dense bitmap was the wrong shape for them, and the
+arithmetic that decides between the two. Implemented in
+[src/text/lines.rs](../../src/text/lines.rs) for [issue #228](https://github.com/rust-works/succinctly/issues/228);
+the decision record is [ADR-0012](../adrs/adr-0012.md).
+
+## The problem
+
+Three modules each kept a line-start index as a `BitVec`: one bit per text byte, set at the byte
+after every LF/CRLF/CR. Rank gave the line number, select gave the line start.
+
+That is a correct use of rank/select and the wrong representation, because **line starts are sparse
+and monotone**. A dense bitmap's cost is fixed by the size of the *universe* (the text), not by the
+size of the *set* (the lines):
+
+```
+bitmap        1/8 byte per input byte                = 0.1250 B/byte
+rank directory  128 bits metadata per 512 bits data  = 0.0313 B/byte
+select samples  16 bytes per 256 ones                ≈ 0.0031 B/byte at 20 B/line
+                                                       ---------
+                                                       ~0.159 B/byte = 15.9% of input
+```
+
+Every file paid ~16% of its size, whether it had 2 lines or 20,000. The worst case in the corpus is
+a 100 KB GeoJSON file with 60 long lines: 15,608 bytes of index for 60 numbers.
+
+## The fix
+
+Store the line starts themselves, Elias-Fano encoded
+([src/bits/elias_fano.rs](../../src/bits/elias_fano.rs)). For `n` values over universe `u`, Elias-Fano
+splits each value into `low_width = floor(log2(u/n))` low bits stored densely and a unary-coded high
+part, costing about `2 + log2(u/n)` bits per element. With `A` = average bytes per line, that is
+`2 + log2(A)` bits **per line** rather than `1.27 * A` bits per line.
+
+| Average line length | Dense bitmap | `LineIndex` | Factor |
+|---------------------|--------------|-------------|--------|
+| 20 B (YAML/CSV)     | 15.9%        | ~3.9%       | ~4x    |
+| 78 B (pretty JSON)  | 15.7%        | ~1.3%       | ~12x   |
+| minified (one line) | 15.6%        | ~0          | huge   |
+
+Measured over the real-workload corpus (both columns are the structures' own `heap_size()`, recorded
+per file in [benchmarks/corpus-shape.md](../benchmarks/corpus-shape.md)):
+
+| file                     | bytes  | lines | dense bitmap | `LineIndex` | factor   |
+|--------------------------|--------|-------|--------------|-------------|----------|
+| us-election.geojson      | 99,715 | 60    | 15,608       | 108         | **145x** |
+| gapminder-five-year.csv  | 82,079 | 1,705 | 12,952       | 1,636       | **7.9x** |
+| prometheus-ci.yml        | 18,935 | 453   | 2,992        | 432         | **6.9x** |
+| world-gdp-with-codes.csv | 4,515  | 223   | 728          | 180         | **4.0x** |
+| nginx-deployment.yml     | 836    | 43    | 160          | 44          | **3.6x** |
+
+## Where the crossover is
+
+Elias-Fano is not unconditionally smaller. Setting the two costs equal:
+
+```
+2 + log2(A) bits/line  vs  1.27 * A bits/line     →  equal at A ≈ 2.6
+```
+
+Below ~2.6 bytes per line — a file that is almost entirely newlines — the dense bitmap wins. The
+corpus runs 19-78 bytes per line, so this does not arise in practice, but the honest statement is
+"sparser than ~1 line per 3 bytes", not "always smaller".
+
+The same arithmetic rules out two representations that look plausible:
+
+| Representation                             | Cost at A=20    | Verdict                                                                       |
+|--------------------------------------------|-----------------|-------------------------------------------------------------------------------|
+| Dense bitmap + rank + select               | 15.9% of input  | The status quo                                                                |
+| Cumulative-rank `Vec<u32>` (the DSV index) | 18.75% of input | **Worse** — 4 B per 8 B of bitmap is 50% overhead vs the rank directory's 25% |
+| `Vec<u32>` of line starts                  | 20% of input    | **Worse below 26 B/line**; better above                                       |
+| Elias-Fano line starts                     | ~3.9% of input  | Adopted                                                                       |
+
+The `Vec<u32>` row is the trap: it looks like the obvious sparse encoding, and it loses on the
+corpus's dominant shape (short YAML and CSV lines) while winning on pretty-printed JSON. Checking the
+corpus before choosing is what separates it from Elias-Fano, which wins on both.
+
+## Don't build what nobody reads
+
+The bigger win was not the encoding. `JsonIndex::build` built its newline index **eagerly**, so every
+jq query paid an O(n) scan and a full bitmap allocation for a structure only `at_position(line; col)`
+and `jq-locate --line --column` ever read. YAML had already made its equivalent lazy (`OnceCell`) in
+P12-A/A4; JSON now matches.
+
+Cost of the lazy path is paid only by callers who need it:
+
+| Structure                                    | Before                   | After                 |
+|----------------------------------------------|--------------------------|-----------------------|
+| `JsonIndex::build` allocation, 99 KB GeoJSON | 60,514 B                 | 44,906 B (**−25.8%**) |
+| `JsonIndex::build` allocation, 548 B JSON    | 409 B                    | 289 B (**−29.3%**)    |
+| `YamlIndex::build`                           | unchanged (already lazy) | unchanged             |
+
+The deltas equal the dense index's `heap_size()` exactly — the allocation is simply gone.
+
+## Query cost, and why O(log n) is fine here
+
+`to_line_column` needs "how many line starts precede this offset", which is a predecessor query.
+Elias-Fano has no rank, so `EliasFano::predecessor` is a binary search over `get` — O(log n) with a
+sampled select per step, against the bitmap's O(1) rank.
+
+That trade is deliberate. Every consumer is cold: error reporting, `$__loc__`'s document sibling
+`at_position`, and the two locate CLIs. Nothing in the parse or query hot path touches it.
+`to_offset` does not even need the predecessor — a line number is a direct index, so it stays O(1).
+
+If a hot consumer ever appears, the accelerator is already designed: `select_samples[j] -
+j * SAMPLE_RATE` is the high part of element `j*256` and is monotone in `j`, so binary-searching that
+plain `Vec<u32>` narrows to a 256-element block with zero select calls.
+
+## Transient build memory
+
+Building Elias-Fano needs the values up front (`universe` sizes `low_width`), so `LineIndex::build`
+collects a `Vec<u32>` of line starts first. A counting pass sizes it exactly, which matters more than
+it looks: without it, `Vec` doubling makes the transient 1.5-2x the vector — the failure mode O4
+documented, where transient scratch dwarfed the retained structure.
+
+Measured momentary peak against the old *retained* cost:
+
+| file                                   | old retained | new peak | new retained |
+|----------------------------------------|--------------|----------|--------------|
+| codeql-analysis.yml (925 B, 39 lines)  | 168          | 204      | 44           |
+| nginx-deployment.yml (836 B, 43 lines) | 160          | 220      | 44           |
+| prometheus-ci.yml (18.9 KB, 453 lines) | 2,992        | 2,248    | 432          |
+
+Peak is higher on small short-lined files (crossover ~26 B/line) and lower on larger ones — and it is
+momentary, where the old cost was permanent. Removing the transient entirely would need a streaming
+`EliasFanoBuilder`; at this scale that is gold-plating.
+
+## Lessons
+
+- **A rank/select structure can be correct and still be the wrong shape.** The question is not "is
+  the bitmap's rank fast" but "should cost scale with the universe or with the set".
+- **Cost that scales with the wrong quantity hides in small files.** 15.9% of a 900-byte manifest is
+  143 bytes and invisible; the same rule costs 15,608 bytes on a 100 KB file with 60 lines.
+- **The obvious sparse encoding was the wrong one.** `Vec<u32>` of offsets loses on the corpus's
+  dominant shape. Checking [corpus-shape.md](../benchmarks/corpus-shape.md) before choosing is the
+  same discipline that rejected P5.
+- **Not building it beats making it smaller.** A 4-12x smaller structure is worth less than not
+  constructing the structure at all on the hot path.
+- **Exact-size the scratch vector.** `Vec::with_capacity` from a counting pass costs one cheap
+  auto-vectorised scan and removes a 1.5-2x transient spike.
+
+## See Also
+
+- [ADR-0012](../adrs/adr-0012.md) — the decision and the rejected options
+- [end-positions.md](end-positions.md) — the other compact-encoding work (P12, O1, O2)
+- [cache-memory.md](cache-memory.md) — the DSV lightweight index, whose 5-9x iteration win does not
+  transfer to this use
+- [hierarchical-structures.md](hierarchical-structures.md) — the rank directory and select index this
+  avoids

--- a/docs/parsing/dsv-index.md
+++ b/docs/parsing/dsv-index.md
@@ -53,7 +53,9 @@ DSV indexing throughput (API-level, not end-to-end CLI):
 
 ## Depends On
 
-- [BitVec](../architecture/bitvec.md) — marker and newline bitvectors with rank/select
+- `DsvIndexLightweight` ([src/dsv/index_lightweight.rs](../../src/dsv/index_lightweight.rs)) — marker
+  and newline words as plain `Vec<u64>` plus cumulative-rank `Vec<u32>`, measured 5-9x faster to
+  iterate than [BitVec](../architecture/bitvec.md), which this module does not use
 
 ## Used By
 

--- a/docs/parsing/json-index.md
+++ b/docs/parsing/json-index.md
@@ -81,8 +81,11 @@ let name: &str = cursor.as_str();
 
 ## Depends On
 
-- [BitVec](../architecture/bitvec.md) — IB and BP are stored as bitvectors with rank/select indices
 - [BalancedParens](../architecture/balanced-parens.md) — BP encoding with `find_close` for subtree skipping
+- [LineIndex](../optimizations/line-index.md) — line/column lookup, built lazily on first use
+
+IB is a plain `W: AsRef<[u64]>` plus a cumulative-rank `Vec<u32>`, not a
+[BitVec](../architecture/bitvec.md) — see that page's *Used By* section.
 
 ## Used By
 

--- a/docs/parsing/json.md
+++ b/docs/parsing/json.md
@@ -286,15 +286,16 @@ The `locate` module enables reverse lookup: given a byte offset or line/column p
 2. **Node lookup**: Use `ib_rank1(offset)` to find the containing structural element
 3. **Path construction**: Walk up using `bp.parent()`, collecting path components
 
-### NewlineIndex
+### LineIndex
 
-Fast line/column to offset conversion using rank/select on newline positions:
+Line/column to offset conversion, backed by Elias-Fano-encoded line starts so the index scales with
+the number of lines rather than the size of the text:
 
 ```rust
-use succinctly::json::locate::NewlineIndex;
+use succinctly::text::LineIndex;
 
 let text = b"line1\nline2\nline3";
-let index = NewlineIndex::build(text);
+let index = LineIndex::build(text);
 
 // Line/column are 1-indexed
 assert_eq!(index.to_offset(2, 1), Some(6));  // Start of line 2
@@ -302,6 +303,13 @@ assert_eq!(index.to_line_column(6), (2, 1)); // Reverse lookup
 ```
 
 Handles all line ending conventions: Unix (LF), Windows (CRLF), and classic Mac (CR).
+
+`JsonIndex` and `YamlIndex` build one lazily on the first `to_line_column`/`to_offset` call, so a jq
+query that never asks for a position never pays for it. See
+[optimizations/line-index.md](../optimizations/line-index.md) and [ADR-0012](../adrs/adr-0012.md).
+
+> `succinctly::json::locate::NewlineIndex` is a deprecated alias for this type, kept for source
+> compatibility until 0.9.0 (#228). New code should use `succinctly::text::LineIndex`.
 
 ### CLI Usage
 

--- a/docs/parsing/yaml-index.md
+++ b/docs/parsing/yaml-index.md
@@ -99,8 +99,11 @@ list of unsupported features (tags, `%YAML`/`%TAG` directives).
 
 ## Depends On
 
-- [BitVec](../architecture/bitvec.md) — all bit vectors use rank/select
 - [BalancedParens](../architecture/balanced-parens.md) — with `WithSelect` generic parameter
+- [LineIndex](../optimizations/line-index.md) — line/column lookup, built lazily on first use
+
+IB, TY and the container bits are plain `W: AsRef<[u64]>` with cumulative-rank `Vec<u32>`, not
+[BitVec](../architecture/bitvec.md) — see that page's *Used By* section.
 - [YAML Conformance](../compliance/yaml/limitations.md) — measured behavior and limitations
 
 ## Used By

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -2022,11 +2022,19 @@ YAML cannot use BMI2 like DSV does because:
 
 **Status:** Analyzed and rejected 2026-01-17 (not implemented)
 
+> **Correction (#228).** The premise below is half wrong. JSON had *two* newline structures, and the
+> analysis found only the CLI-only one. The other, `JsonIndex::newlines`, was built **eagerly in
+> every `JsonIndex::build`**, costing an O(n) scan and ~15.9% of the input on every jq query. The
+> conclusion — don't build it during parsing — was right, and JSON was violating it. Both are now
+> [`text::LineIndex`](../optimizations/line-index.md), built lazily; see
+> [ADR-0012](../adrs/adr-0012.md). The same stale claim appears in [ADR-0009](../adrs/adr-0009.md),
+> corrected there too.
+
 **Goal:** Build a newline index (bitvector + rank structure) for fast line number lookups, similar to JSON's `NewlineIndex`.
 
 **Analysis Findings:**
 
-**JSON's `NewlineIndex` usage:**
+**JSON's `NewlineIndex` usage** (as believed at the time — see the correction above):
 - **NOT built during parsing** - only in `jq-locate` CLI tool
 - **Purpose:** Convert `--line X --column Y` to byte offset for user convenience
 - **Never used in:** JSON parsing, jq queries, or benchmarks

--- a/docs/reference/limits.md
+++ b/docs/reference/limits.md
@@ -15,6 +15,7 @@ silently truncating.
 | `YamlIndex::build`               | `u32::MAX` bytes (< 4 GiB)     | `Err(YamlError::InputTooLarge)`           | Text positions stored as u32 throughout the semi-index  |
 | `DsvIndexLightweight::new`       | `u32::MAX` bytes (< 4 GiB)     | Panic (documented)                        | Two rank arrays are ~12.5% of input combined            |
 | `BalancedParens` constructors    | `u32::MAX` bits                | Panic (documented)                        | `rank_l1` stores absolute cumulative rank as u32        |
+| `LineIndex::build`               | `u32::MAX` bytes (< 4 GiB)     | Panic (documented)                        | Line starts are Elias-Fano encoded from u32 offsets     |
 
 The `BalancedParens` ceiling acts as a backstop for pathological JSON/YAML
 that emits more BP bits than input bytes: such inputs can exceed the BP

--- a/src/bin/succinctly/corpus_stats.rs
+++ b/src/bin/succinctly/corpus_stats.rs
@@ -21,9 +21,11 @@ use serde::Serialize;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
+use succinctly::bits::BitVec;
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
 use succinctly::json::light::{JsonCursor, StandardJson};
 use succinctly::json::JsonIndex;
+use succinctly::text::LineIndex;
 use succinctly::yaml::{YamlCursor, YamlIndex, YamlValue};
 
 /// A distribution of integer samples, summarised as min/median/p90/p99/max.
@@ -171,6 +173,65 @@ pub struct FileRecord {
     pub workload: String,
     pub file: String,
     pub bytes: u64,
+}
+
+/// Space taken by the line index for one corpus file, against what the
+/// pre-#228 dense-bitmap representation would have cost for the same text.
+///
+/// Both figures come from the structures' own `heap_size()`, not from a
+/// formula, so the row cannot drift away from what the code actually
+/// allocates. All-integer, so it is arch-stable and safe to hold as a golden.
+struct LineSpaceRecord {
+    format: String,
+    file: String,
+    bytes: usize,
+    lines: usize,
+    bitvec_bytes: usize,
+    line_index_bytes: usize,
+}
+
+impl LineSpaceRecord {
+    fn measure(format: &str, file: &str, text: &[u8]) -> Self {
+        let index = LineIndex::build(text);
+
+        // Reconstruct the representation this replaced: one bit per input
+        // byte, set at each line start after line 1, plus a rank directory
+        // and select samples.
+        let mut bits = vec![0u64; text.len().div_ceil(64)];
+        for line in 2..=index.line_count() {
+            let pos = index.line_start(line).expect("line within count");
+            bits[pos / 64] |= 1 << (pos % 64);
+        }
+        let dense = BitVec::from_words(bits, text.len());
+
+        Self {
+            format: format.to_string(),
+            file: file.to_string(),
+            bytes: text.len(),
+            lines: index.line_count(),
+            bitvec_bytes: dense.heap_size(),
+            line_index_bytes: index.heap_size(),
+        }
+    }
+
+    /// Index size as parts-per-thousand of the input, rounded down.
+    /// An empty file reports 0 rather than dividing by zero.
+    fn permille(&self, index_bytes: usize) -> usize {
+        (index_bytes * 1000).checked_div(self.bytes).unwrap_or(0)
+    }
+
+    fn row(&self) -> Vec<String> {
+        vec![
+            self.format.clone(),
+            self.file.clone(),
+            self.bytes.to_string(),
+            self.lines.to_string(),
+            self.bitvec_bytes.to_string(),
+            self.line_index_bytes.to_string(),
+            self.permille(self.bitvec_bytes).to_string(),
+            self.permille(self.line_index_bytes).to_string(),
+        ]
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -624,6 +685,7 @@ pub fn generate_report(data_dir: &Path) -> Result<(String, Vec<FileRecord>)> {
         .with_context(|| format!("scanning corpus at {}", data_dir.display()))?;
 
     let mut corpus = Corpus::default();
+    let mut line_space = Vec::new();
     for path in &files {
         let (fmt, delim) = classify(path).expect("filtered by classify");
         let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
@@ -634,6 +696,11 @@ pub fn generate_report(data_dir: &Path) -> Result<(String, Vec<FileRecord>)> {
             file: file.clone(),
             bytes: bytes.len() as u64,
         });
+        line_space.push(LineSpaceRecord::measure(
+            fmt,
+            &format!("{workload}/{file}"),
+            &bytes,
+        ));
         match fmt {
             "json" => ingest_json(&bytes, &mut corpus.json),
             "yaml" => ingest_yaml(&bytes, &mut corpus.yaml)
@@ -680,6 +747,38 @@ percentiles use nearest-rank.\n\n",
         md.push_str(&render_table(
             &["format", "workload", "file", "bytes"],
             &inv_rows,
+        ));
+        md.push('\n');
+    }
+
+    // Line index space (#228)
+    md.push_str("## Line index\n\n");
+    md.push_str(
+        "Bytes retained by `text::LineIndex` per corpus file, against what the \
+dense-bitmap newline index it replaced would have cost for the same text \
+(#228). Both columns are the structures' own `heap_size()`, not a formula, so \
+this section is a space-regression guard as well as a record: the dense \
+representation cost ~1.27 bits per *input byte* whatever the line count, \
+while the Elias-Fano one costs ~2 + log2(average line length) bits per \
+*line*. `permille` is parts-per-thousand of the file.\n\n",
+    );
+    let mut space_rows: Vec<Vec<String>> = line_space.iter().map(LineSpaceRecord::row).collect();
+    space_rows.sort();
+    if space_rows.is_empty() {
+        md.push_str("_No corpus files found. Run `./scripts/sync-bench-corpus.sh` first._\n\n");
+    } else {
+        md.push_str(&render_table(
+            &[
+                "format",
+                "file",
+                "bytes",
+                "lines",
+                "bitvec bytes",
+                "line index bytes",
+                "bitvec permille",
+                "line index permille",
+            ],
+            &space_rows,
         ));
         md.push('\n');
     }
@@ -1032,6 +1131,44 @@ mod tests {
         assert!(records
             .iter()
             .any(|r| r.format == "dsv" && r.workload == "tab"));
+    }
+
+    #[test]
+    fn line_space_section_shows_the_line_index_beating_the_dense_bitmap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // 20 bytes per line, the corpus median shape.
+        let mut yaml = Vec::new();
+        for _ in 0..200 {
+            yaml.extend_from_slice(b"key: value-abcdefg\n");
+        }
+        write_file(root, "yaml/svc/app.yaml", &yaml);
+
+        let (md, _) = generate_report(root).unwrap();
+
+        assert!(md.contains("## Line index"));
+        assert!(md.contains("line index permille"));
+
+        let record = LineSpaceRecord::measure("yaml", "svc/app.yaml", &yaml);
+        assert!(
+            record.line_index_bytes * 3 < record.bitvec_bytes,
+            "line index {} should be several times smaller than bitvec {}",
+            record.line_index_bytes,
+            record.bitvec_bytes
+        );
+        assert_eq!(record.lines, 200);
+        assert_eq!(record.permille(0), 0, "zero bytes is zero permille");
+    }
+
+    #[test]
+    fn line_space_record_handles_empty_input() {
+        let record = LineSpaceRecord::measure("json", "empty/x.json", b"");
+
+        assert_eq!(record.bytes, 0);
+        assert_eq!(record.lines, 1, "empty text still has one line");
+        // No division by zero when the file is empty.
+        assert_eq!(record.permille(record.line_index_bytes), 0);
+        assert_eq!(record.row().len(), 8);
     }
 
     #[test]

--- a/src/bin/succinctly/jq_locate.rs
+++ b/src/bin/succinctly/jq_locate.rs
@@ -7,7 +7,8 @@ use clap::ValueEnum;
 use std::path::PathBuf;
 
 use succinctly::json::light::JsonIndex;
-use succinctly::json::locate::{locate_offset_detailed, NewlineIndex};
+use succinctly::json::locate::locate_offset_detailed;
+use succinctly::text::LineIndex;
 
 /// Arguments for jq-locate command
 #[derive(Debug, clap::Parser)]
@@ -52,9 +53,9 @@ pub fn run_jq_locate(args: JqLocateArgs) -> Result<i32> {
     let offset = match (args.offset, args.line, args.column) {
         (Some(off), None, None) => off,
         (None, Some(line), Some(column)) => {
-            // Build newline index to convert line/column to offset
-            let newline_index = NewlineIndex::build(&text);
-            newline_index
+            // Build the line index to convert line/column to offset
+            let line_index = LineIndex::build(&text);
+            line_index
                 .to_offset(line, column)
                 .with_context(|| format!("Invalid position: line {line} column {column}"))?
         }

--- a/src/bin/succinctly/yq_locate.rs
+++ b/src/bin/succinctly/yq_locate.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use clap::ValueEnum;
 use std::path::PathBuf;
 
-use succinctly::json::locate::NewlineIndex;
+use succinctly::text::LineIndex;
 use succinctly::yaml::{locate_offset_detailed, YamlIndex};
 
 /// Arguments for yq-locate command
@@ -52,9 +52,9 @@ pub fn run_yq_locate(args: YqLocateArgs) -> Result<i32> {
     let offset = match (args.offset, args.line, args.column) {
         (Some(off), None, None) => off,
         (None, Some(line), Some(column)) => {
-            // Build newline index to convert line/column to offset
-            let newline_index = NewlineIndex::build(&text);
-            newline_index
+            // Build the line index to convert line/column to offset
+            let line_index = LineIndex::build(&text);
+            line_index
                 .to_offset(line, column)
                 .with_context(|| format!("Invalid position: line {line} column {column}"))?
         }

--- a/src/bits/bitvec.rs
+++ b/src/bits/bitvec.rs
@@ -188,6 +188,18 @@ impl BitVec {
     pub fn words(&self) -> &[u64] {
         &self.words
     }
+
+    /// Returns the heap memory usage in bytes: raw words plus both indices.
+    ///
+    /// The indices are not free — the rank directory costs ~25% of the raw
+    /// words and the select index one 16-byte sample per
+    /// [`Config::select_sample_rate`](crate::Config) set bits. See
+    /// `docs/benchmarks/rust-succinct-libs.md` for measured totals.
+    pub fn heap_size(&self) -> usize {
+        self.words.len() * core::mem::size_of::<u64>()
+            + self.rank_dir.heap_size()
+            + self.select_idx.heap_size()
+    }
 }
 
 impl Default for BitVec {
@@ -893,5 +905,49 @@ mod tests {
             assert_eq!(bv.select1(k), Some(k), "select1({k})");
         }
         assert_eq!(bv.select1(bv.count_ones()), None);
+    }
+
+    // ========================================================================
+    // Space accounting
+    // ========================================================================
+
+    #[test]
+    fn test_heap_size_empty() {
+        assert_eq!(BitVec::new().heap_size(), 0);
+    }
+
+    #[test]
+    fn test_heap_size_accounts_for_both_indices() {
+        // 64 words = 4096 bits = 8 rank blocks; dense enough for select samples.
+        let words = vec![u64::MAX; 64];
+        let bv = BitVec::from_words(words, 4096);
+
+        let raw = 64 * 8;
+        // 8 blocks x 16 bytes of L1/L2 metadata (~25% of the raw words).
+        let rank = 8 * 16;
+        // 4096 ones at the default sample rate of 256 = 16 samples x 16 bytes.
+        let select = 16 * 16;
+
+        assert_eq!(bv.heap_size(), raw + rank + select);
+        assert!(
+            bv.heap_size() > raw,
+            "heap_size must include the indices, not just the words"
+        );
+    }
+
+    #[test]
+    fn test_heap_size_grows_with_density() {
+        // The select index samples set bits, so a denser vector costs more
+        // even at identical length. This is the effect measured in
+        // docs/benchmarks/rust-succinct-libs.md (27.5% -> 47.5%).
+        let sparse = BitVec::from_words(vec![1u64; 64], 4096);
+        let dense = BitVec::from_words(vec![u64::MAX; 64], 4096);
+
+        assert!(
+            dense.heap_size() > sparse.heap_size(),
+            "dense {} should exceed sparse {}",
+            dense.heap_size(),
+            sparse.heap_size()
+        );
     }
 }

--- a/src/bits/elias_fano.rs
+++ b/src/bits/elias_fano.rs
@@ -15,6 +15,7 @@
 //! | Operation | Complexity | Notes |
 //! |-----------|------------|-------|
 //! | `get(i)` | O(1) | Uses select samples |
+//! | `predecessor(v)` | O(log n) | Binary search over `get`; cold paths only |
 //! | `advance_one()` | O(1) amortized | Scans for next 1-bit |
 //! | `advance_by(k)` | O(k/64) | Word-by-word scanning |
 //! | `seek(i)` | O(1) | Uses select samples |
@@ -245,6 +246,47 @@ impl EliasFano {
 
         let value = ((high_value as u64) << self.low_width) | low_value;
         Some(value as u32)
+    }
+
+    /// Find the largest element `<= value`, returning its index and value.
+    ///
+    /// Returns `None` if the sequence is empty or every element exceeds `value`.
+    /// When the sequence contains duplicates of the answer, the **last** such
+    /// index is returned.
+    ///
+    /// # Performance
+    ///
+    /// O(log n) binary search over [`get`](Self::get), so O(log n) sampled
+    /// selects. Intended for cold paths (line/column lookup); use
+    /// [`EliasFanoCursor`] for sequential access.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use succinctly::bits::EliasFano;
+    ///
+    /// let ef = EliasFano::build(&[0, 15, 23, 45]);
+    /// assert_eq!(ef.predecessor(23), Some((2, 23))); // exact hit
+    /// assert_eq!(ef.predecessor(30), Some((2, 23))); // largest <= 30
+    /// assert_eq!(ef.predecessor(99), Some((3, 45))); // past the end
+    /// ```
+    pub fn predecessor(&self, value: u32) -> Option<(usize, u32)> {
+        let mut lo = 0usize;
+        let mut hi = self.len;
+        let mut best = None;
+
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            let v = self.get(mid).expect("mid < len");
+            if v <= value {
+                best = Some((mid, v));
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+
+        best
     }
 
     /// Create a cursor starting at element 0.
@@ -844,6 +886,85 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_predecessor_empty() {
+        let ef = EliasFano::build(&[]);
+        assert_eq!(ef.predecessor(0), None);
+        assert_eq!(ef.predecessor(u32::MAX), None);
+    }
+
+    #[test]
+    fn test_predecessor_single_element() {
+        let ef = EliasFano::build(&[42]);
+        assert_eq!(ef.predecessor(41), None, "below the only element");
+        assert_eq!(ef.predecessor(42), Some((0, 42)), "exact hit");
+        assert_eq!(ef.predecessor(43), Some((0, 42)), "above the only element");
+    }
+
+    #[test]
+    fn test_predecessor_exact_and_between() {
+        let values = [0u32, 15, 23, 45, 52, 78, 120, 256];
+        let ef = EliasFano::build(&values);
+
+        for (i, &v) in values.iter().enumerate() {
+            assert_eq!(ef.predecessor(v), Some((i, v)), "exact hit on {v}");
+        }
+
+        assert_eq!(ef.predecessor(1), Some((0, 0)));
+        assert_eq!(ef.predecessor(14), Some((0, 0)));
+        assert_eq!(ef.predecessor(22), Some((1, 15)));
+        assert_eq!(ef.predecessor(255), Some((6, 120)));
+        assert_eq!(ef.predecessor(u32::MAX), Some((7, 256)), "past the end");
+    }
+
+    #[test]
+    fn test_predecessor_below_first() {
+        // The first element is non-zero, so small queries have no predecessor.
+        let ef = EliasFano::build(&[10, 20, 30]);
+        assert_eq!(ef.predecessor(0), None);
+        assert_eq!(ef.predecessor(9), None);
+        assert_eq!(ef.predecessor(10), Some((0, 10)));
+    }
+
+    #[test]
+    fn test_predecessor_duplicates_returns_last() {
+        // Elias-Fano permits non-decreasing input; the contract is that
+        // `predecessor` returns the LAST index holding the answer.
+        let ef = EliasFano::build(&[5, 7, 7, 7, 9]);
+        assert_eq!(ef.predecessor(7), Some((3, 7)));
+        assert_eq!(ef.predecessor(8), Some((3, 7)));
+        assert_eq!(ef.predecessor(9), Some((4, 9)));
+    }
+
+    #[test]
+    fn test_predecessor_across_sample_boundaries() {
+        // Crosses SELECT_SAMPLE_RATE (256) and 2x it.
+        let values: Vec<u32> = (0..1000).map(|i| i * 5).collect();
+        let ef = EliasFano::build(&values);
+
+        for idx in [0usize, 255, 256, 257, 511, 512, 513, 999] {
+            let v = values[idx];
+            assert_eq!(ef.predecessor(v), Some((idx, v)), "exact hit at {idx}");
+            // v + 1..v + 5 all resolve back to the same element.
+            assert_eq!(ef.predecessor(v + 3), Some((idx, v)), "gap after {idx}");
+        }
+    }
+
+    #[test]
+    fn test_predecessor_matches_partition_point() {
+        // Exhaustive cross-check against the obvious slice implementation.
+        let values: Vec<u32> = (0..300).map(|i| i * 3 + 7).collect();
+        let ef = EliasFano::build(&values);
+
+        for query in 0..(values[values.len() - 1] + 5) {
+            let expected = match values.partition_point(|&x| x <= query) {
+                0 => None,
+                n => Some((n - 1, values[n - 1])),
+            };
+            assert_eq!(ef.predecessor(query), expected, "query {query}");
         }
     }
 

--- a/src/bits/elias_fano.rs
+++ b/src/bits/elias_fano.rs
@@ -15,7 +15,7 @@
 //! | Operation | Complexity | Notes |
 //! |-----------|------------|-------|
 //! | `get(i)` | O(1) | Uses select samples |
-//! | `predecessor(v)` | O(log n) | Binary search over `get`; cold paths only |
+//! | `predecessor(v)` | O(log n) | Binary search over `get`; no sequential fast path |
 //! | `advance_one()` | O(1) amortized | Scans for next 1-bit |
 //! | `advance_by(k)` | O(k/64) | Word-by-word scanning |
 //! | `seek(i)` | O(1) | Uses select samples |
@@ -257,8 +257,10 @@ impl EliasFano {
     /// # Performance
     ///
     /// O(log n) binary search over [`get`](Self::get), so O(log n) sampled
-    /// selects. Intended for cold paths (line/column lookup); use
-    /// [`EliasFanoCursor`] for sequential access.
+    /// selects, with no reuse between calls. A monotone sequence of queries —
+    /// which is what walking a document's nodes produces — pays the full
+    /// search every time; use [`EliasFanoCursor`] for sequential access, or
+    /// cache the last answer at the call site.
     ///
     /// # Example
     ///

--- a/src/bits/rank.rs
+++ b/src/bits/rank.rs
@@ -95,7 +95,6 @@ impl CacheAlignedL1L2 {
 
     /// Get the number of entries.
     #[inline]
-    #[allow(dead_code)] // STYLE-0005: utility accessor kept for symmetry
     fn len(&self) -> usize {
         self.len
     }
@@ -461,6 +460,15 @@ impl RankDirectory {
         };
 
         (l0_rank + l1_rank + l2_rank) as usize
+    }
+
+    /// Returns the heap memory usage in bytes.
+    ///
+    /// One `u128` of L1+L2 metadata per 512-bit block (~25% of the indexed
+    /// bits, see the module docs) plus one `u64` per 2^32-bit superblock.
+    pub fn heap_size(&self) -> usize {
+        self.l0.len() * core::mem::size_of::<u64>()
+            + self.l1_l2.len() * core::mem::size_of::<u128>()
     }
 }
 

--- a/src/bits/select.rs
+++ b/src/bits/select.rs
@@ -138,6 +138,14 @@ impl SelectIndex {
     pub fn sample_rate(&self) -> u32 {
         self.sample_rate
     }
+
+    /// Returns the heap memory usage in bytes.
+    ///
+    /// One `SampleEntry` (16 bytes) per [`sample_rate`](Self::sample_rate)
+    /// set bits.
+    pub fn heap_size(&self) -> usize {
+        self.samples.len() * core::mem::size_of::<SampleEntry>()
+    }
 }
 
 #[cfg(test)]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -229,10 +229,25 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
     }
 
     /// Get the line index, building it lazily on first use.
+    ///
+    /// The first caller's `text` wins for the lifetime of the index, so a
+    /// later call with different text silently reads the first one's line
+    /// map. The debug assertion catches the cheap half of that mistake.
     #[inline]
     fn ensure_lines(&self, text: &[u8]) -> &crate::text::LineIndex {
-        self.lines
-            .get_or_init(|| crate::text::LineIndex::build(text))
+        let lines = self
+            .lines
+            .get_or_init(|| crate::text::LineIndex::build(text));
+
+        debug_assert_eq!(
+            lines.text_len(),
+            text.len(),
+            "line index was built from different text ({} bytes) than this call passed ({} bytes)",
+            lines.text_len(),
+            text.len()
+        );
+
+        lines
     }
 
     /// Create a cursor at the root of the JSON document.

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -40,12 +40,12 @@
 //! ```
 
 #[cfg(not(test))]
-use alloc::vec;
-#[cfg(not(test))]
 use alloc::{borrow::Cow, string::String, vec::Vec};
 
 #[cfg(test)]
 use std::borrow::Cow;
+
+use core::cell::OnceCell;
 
 use crate::trees::BalancedParens;
 use crate::util::broadword::select_in_word;
@@ -72,9 +72,13 @@ pub struct JsonIndex<W = Vec<u64>> {
     ib_rank: Vec<u32>,
     /// Balanced parentheses - encodes the JSON structure as a tree
     bp: BalancedParens<W>,
-    /// Newline positions for fast line/column lookup.
-    /// Bit i is set if position i is the start of a new line (immediately after a line terminator).
-    newlines: crate::bits::BitVec,
+    /// Line starts for line/column lookup, built lazily on first use.
+    ///
+    /// Only [`to_line_column`](JsonIndex::to_line_column) and
+    /// [`to_offset`](JsonIndex::to_offset) need it — the `at_position` jq
+    /// builtin and the locate CLIs — so building it during `build()` would
+    /// charge every jq query for something almost no query reads (#228).
+    lines: OnceCell<crate::text::LineIndex>,
 }
 
 /// Build cumulative popcount index for IB.
@@ -93,48 +97,6 @@ fn build_ib_rank(words: &[u64]) -> Vec<u32> {
         rank.push(cumulative);
     }
     rank
-}
-
-/// Build newline index from text.
-/// Sets bit i if position i is the start of a new line (immediately after a line terminator).
-/// Handles Unix (LF), Windows (CRLF), and classic Mac (CR) line endings.
-fn build_newline_index(text: &[u8]) -> crate::bits::BitVec {
-    if text.is_empty() {
-        return crate::bits::BitVec::new();
-    }
-
-    let mut bits = vec![0u64; text.len().div_ceil(64)];
-    let mut i = 0;
-
-    while i < text.len() {
-        match text[i] {
-            b'\n' => {
-                // LF: next byte starts a new line
-                let next = i + 1;
-                if next < text.len() {
-                    bits[next / 64] |= 1 << (next % 64);
-                }
-                i += 1;
-            }
-            b'\r' => {
-                // CR: check for CRLF
-                let next = if i + 1 < text.len() && text[i + 1] == b'\n' {
-                    // CRLF: skip both, new line starts after \n
-                    i + 2
-                } else {
-                    // Standalone CR (classic Mac): new line starts after \r
-                    i + 1
-                };
-                if next < text.len() {
-                    bits[next / 64] |= 1 << (next % 64);
-                }
-                i = next;
-            }
-            _ => i += 1,
-        }
-    }
-
-    crate::bits::BitVec::from_words(bits, text.len())
 }
 
 impl JsonIndex<Vec<u64>> {
@@ -172,15 +134,12 @@ impl JsonIndex<Vec<u64>> {
         // Build cumulative popcount index for IB
         let ib_rank = build_ib_rank(&semi.ib);
 
-        // Build newline index for fast line/column lookup
-        let newlines = build_newline_index(json);
-
         Self {
             ib: semi.ib,
             ib_len,
             ib_rank,
             bp: BalancedParens::new(semi.bp, bp_bit_count),
-            newlines,
+            lines: OnceCell::new(),
         }
     }
 }
@@ -189,8 +148,8 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
     /// Create a JSON index from pre-existing IB and BP data.
     ///
     /// This is useful for loading serialized index data, e.g., from mmap.
-    /// Note: This creates an empty newline index. For line/column lookup,
-    /// use `from_parts_with_newlines` or rebuild with `build`.
+    /// Line/column lookup works as usual: the line index is derived from the
+    /// text on first use, not from the serialized parts.
     ///
     /// # Arguments
     ///
@@ -218,43 +177,7 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
             ib_len,
             ib_rank,
             bp: BalancedParens::from_words(bp, bp_len),
-            newlines: crate::bits::BitVec::new(),
-        }
-    }
-
-    /// Create a JSON index from pre-existing IB, BP, and newline data.
-    ///
-    /// # Arguments
-    ///
-    /// * `ib` - Interest bits data
-    /// * `ib_len` - Number of valid bits in IB (typically == JSON text length)
-    /// * `bp` - Balanced parentheses data
-    /// * `bp_len` - Number of valid bits in BP
-    /// * `newlines` - Newline position bitvector
-    ///
-    /// # Panics
-    ///
-    /// Panics if `ib_len` exceeds `u32::MAX` bits (#188): the IB rank
-    /// directory stores cumulative counts as `u32`.
-    pub fn from_parts_with_newlines(
-        ib: W,
-        ib_len: usize,
-        bp: W,
-        bp_len: usize,
-        newlines: crate::bits::BitVec,
-    ) -> Self {
-        assert!(
-            u32::try_from(ib_len).is_ok(),
-            "JsonIndex supports inputs up to u32::MAX (4294967295) bytes; got {ib_len} bits (#188)"
-        );
-        let ib_rank = build_ib_rank(ib.as_ref());
-
-        Self {
-            ib,
-            ib_len,
-            ib_rank,
-            bp: BalancedParens::from_words(bp, bp_len),
-            newlines,
+            lines: OnceCell::new(),
         }
     }
 
@@ -279,65 +202,37 @@ impl<W: AsRef<[u64]>> JsonIndex<W> {
     /// Convert byte offset to 1-indexed line and column.
     ///
     /// Returns (line, column) where both are 1-indexed.
-    /// Useful for error reporting and `$__loc__` implementation.
+    /// Useful for error reporting and position-based navigation.
+    ///
+    /// `text` must be the JSON text the index was built from; the line index
+    /// is derived from it on first use and cached (#228).
     ///
     /// # Performance
     ///
-    /// O(1) using rank on the newline bitvector.
+    /// O(log lines) via [`LineIndex`](crate::text::LineIndex), plus a one-off
+    /// O(n) scan the first time either this or [`Self::to_offset`] is called.
     #[inline]
-    pub fn to_line_column(&self, offset: usize) -> (usize, usize) {
-        use crate::RankSelect;
-
-        if self.newlines.is_empty() {
-            return (1, offset + 1);
-        }
-
-        // Line-start markers are at positions immediately after line terminators.
-        // rank1(offset + 1) gives the count of line-start markers in [0, offset],
-        // which equals the number of lines before the current line.
-        // So line number = 1 + rank1(offset + 1).
-        let markers_before_or_at = self.newlines.rank1(offset + 1);
-        let line = 1 + markers_before_or_at;
-
-        // Column = offset - start of this line + 1
-        let line_start = if line == 1 {
-            0
-        } else {
-            // The start of line N is at the (N-2)th marker (0-indexed select)
-            // because line 1 has no marker, line 2 has marker 0, line 3 has marker 1, etc.
-            self.newlines.select1(line - 2).unwrap_or(0)
-        };
-
-        let column = offset - line_start + 1;
-        (line, column)
+    pub fn to_line_column(&self, offset: usize, text: &[u8]) -> (usize, usize) {
+        self.ensure_lines(text).to_line_column(offset)
     }
 
     /// Convert 1-indexed line and column to byte offset.
     ///
     /// Column is 1-indexed byte offset within the line.
     /// Returns `None` if line/column is 0 or if the position is out of bounds.
+    ///
+    /// `text` must be the JSON text the index was built from; the line index
+    /// is derived from it on first use and cached (#228).
     #[inline]
-    pub fn to_offset(&self, line: usize, column: usize) -> Option<usize> {
-        use crate::RankSelect;
+    pub fn to_offset(&self, line: usize, column: usize, text: &[u8]) -> Option<usize> {
+        self.ensure_lines(text).to_offset(line, column)
+    }
 
-        if line == 0 || column == 0 {
-            return None;
-        }
-
-        let line_start = if line == 1 {
-            // First line starts at offset 0
-            0
-        } else {
-            // Line N starts at the (N-1)th line-start marker (0-indexed select)
-            self.newlines.select1(line - 2)?
-        };
-
-        let offset = line_start + column - 1;
-        if offset < self.ib_len {
-            Some(offset)
-        } else {
-            None
-        }
+    /// Get the line index, building it lazily on first use.
+    #[inline]
+    fn ensure_lines(&self, text: &[u8]) -> &crate::text::LineIndex {
+        self.lines
+            .get_or_init(|| crate::text::LineIndex::build(text))
     }
 
     /// Create a cursor at the root of the JSON document.
@@ -937,7 +832,7 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
     /// This enables position-based navigation in jq queries via `at_position(line; col)`.
     pub fn cursor_at_position(&self, line: usize, col: usize) -> Option<Self> {
         // Convert line/column to byte offset
-        let offset = self.index.to_offset(line, col)?;
+        let offset = self.index.to_offset(line, col, self.text)?;
 
         // Use cursor_at_offset to find the node
         self.cursor_at_offset(offset)
@@ -3049,14 +2944,14 @@ mod tests {
         let index = JsonIndex::build(json);
 
         // All positions on line 1
-        assert_eq!(index.to_line_column(0), (1, 1)); // '{'
-        assert_eq!(index.to_line_column(8), (1, 9)); // ' '
-        assert_eq!(index.to_line_column(16), (1, 17)); // '}'
+        assert_eq!(index.to_line_column(0, json), (1, 1)); // '{'
+        assert_eq!(index.to_line_column(8, json), (1, 9)); // ' '
+        assert_eq!(index.to_line_column(16, json), (1, 17)); // '}'
 
         // Reverse lookup
-        assert_eq!(index.to_offset(1, 1), Some(0));
-        assert_eq!(index.to_offset(1, 9), Some(8));
-        assert_eq!(index.to_offset(2, 1), None); // No line 2
+        assert_eq!(index.to_offset(1, 1, json), Some(0));
+        assert_eq!(index.to_offset(1, 9, json), Some(8));
+        assert_eq!(index.to_offset(2, 1, json), None); // No line 2
     }
 
     #[test]
@@ -3065,20 +2960,20 @@ mod tests {
         let index = JsonIndex::build(json);
 
         // Line 1: position 0 ('{')
-        assert_eq!(index.to_line_column(0), (1, 1));
-        assert_eq!(index.to_line_column(1), (1, 2)); // '\n'
+        assert_eq!(index.to_line_column(0, json), (1, 1));
+        assert_eq!(index.to_line_column(1, json), (1, 2)); // '\n'
 
         // Line 2: positions 2-18 ('  "name": "Alice"')
-        assert_eq!(index.to_line_column(2), (2, 1)); // first space
-        assert_eq!(index.to_line_column(4), (2, 3)); // '"'
+        assert_eq!(index.to_line_column(2, json), (2, 1)); // first space
+        assert_eq!(index.to_line_column(4, json), (2, 3)); // '"'
 
         // Line 3: position 20 ('}')
-        assert_eq!(index.to_line_column(20), (3, 1));
+        assert_eq!(index.to_line_column(20, json), (3, 1));
 
         // Reverse lookup
-        assert_eq!(index.to_offset(1, 1), Some(0));
-        assert_eq!(index.to_offset(2, 1), Some(2));
-        assert_eq!(index.to_offset(3, 1), Some(20));
+        assert_eq!(index.to_offset(1, 1, json), Some(0));
+        assert_eq!(index.to_offset(2, 1, json), Some(2));
+        assert_eq!(index.to_offset(3, 1, json), Some(20));
     }
 
     #[test]
@@ -3097,26 +2992,26 @@ mod tests {
         let index = JsonIndex::build(json);
 
         // Line 1: '['
-        assert_eq!(index.to_line_column(0), (1, 1));
+        assert_eq!(index.to_line_column(0, json), (1, 1));
 
         // Line 2: '  1,' starts at position 2
-        assert_eq!(index.to_line_column(2), (2, 1));
-        assert_eq!(index.to_line_column(5), (2, 4)); // the comma
+        assert_eq!(index.to_line_column(2, json), (2, 1));
+        assert_eq!(index.to_line_column(5, json), (2, 4)); // the comma
 
         // Line 3: '  2,' starts at position 7
-        assert_eq!(index.to_line_column(7), (3, 1));
+        assert_eq!(index.to_line_column(7, json), (3, 1));
 
         // Line 4: '  3' starts at position 12
-        assert_eq!(index.to_line_column(12), (4, 1));
+        assert_eq!(index.to_line_column(12, json), (4, 1));
 
         // Line 5: ']' starts at position 16
-        assert_eq!(index.to_line_column(16), (5, 1));
+        assert_eq!(index.to_line_column(16, json), (5, 1));
 
         // Reverse lookup
-        assert_eq!(index.to_offset(1, 1), Some(0));
-        assert_eq!(index.to_offset(2, 1), Some(2));
-        assert_eq!(index.to_offset(3, 1), Some(7));
-        assert_eq!(index.to_offset(5, 1), Some(16));
+        assert_eq!(index.to_offset(1, 1, json), Some(0));
+        assert_eq!(index.to_offset(2, 1, json), Some(2));
+        assert_eq!(index.to_offset(3, 1, json), Some(7));
+        assert_eq!(index.to_offset(5, 1, json), Some(16));
     }
 
     #[test]
@@ -3125,15 +3020,15 @@ mod tests {
         let index = JsonIndex::build(json);
 
         // Line 1: '{'
-        assert_eq!(index.to_line_column(0), (1, 1));
+        assert_eq!(index.to_line_column(0, json), (1, 1));
 
         // Line 2: '"a": 1' (starts at position 3, after \r\n)
-        assert_eq!(index.to_line_column(3), (2, 1));
-        assert_eq!(index.to_offset(2, 1), Some(3));
+        assert_eq!(index.to_line_column(3, json), (2, 1));
+        assert_eq!(index.to_offset(2, 1, json), Some(3));
 
         // Line 3: '}' (starts at position 11, after \r\n)
-        assert_eq!(index.to_line_column(11), (3, 1));
-        assert_eq!(index.to_offset(3, 1), Some(11));
+        assert_eq!(index.to_line_column(11, json), (3, 1));
+        assert_eq!(index.to_offset(3, 1, json), Some(11));
     }
 
     #[test]
@@ -3141,8 +3036,8 @@ mod tests {
         let json = b"{\n\"a\": 1\n}";
         let index = JsonIndex::build(json);
 
-        assert_eq!(index.to_offset(0, 1), None); // line 0 invalid
-        assert_eq!(index.to_offset(1, 0), None); // column 0 invalid
+        assert_eq!(index.to_offset(0, 1, json), None); // line 0 invalid
+        assert_eq!(index.to_offset(1, 0, json), None); // column 0 invalid
     }
 
     #[test]
@@ -3153,8 +3048,8 @@ mod tests {
 
         // Test round-trip: offset -> line/column -> offset
         for offset in 0..json.len() {
-            let (line, col) = index.to_line_column(offset);
-            let result = index.to_offset(line, col);
+            let (line, col) = index.to_line_column(offset, json);
+            let result = index.to_offset(line, col, json);
             assert_eq!(
                 result,
                 Some(offset),

--- a/src/json/locate.rs
+++ b/src/json/locate.rs
@@ -7,16 +7,10 @@
 use alloc::{
     format,
     string::{String, ToString},
-    vec,
     vec::Vec,
 };
 
-#[cfg(test)]
-use std::vec;
-
-use crate::bits::BitVec;
 use crate::json::light::{JsonCursor, JsonIndex, StandardJson};
-use crate::RankSelect;
 
 // ============================================================================
 // NewlineIndex: Fast line/column to byte offset conversion
@@ -24,119 +18,10 @@ use crate::RankSelect;
 
 /// Index for fast line/column to byte offset conversion.
 ///
-/// Handles Unix (LF), Windows (CRLF), and classic Mac (CR) line endings.
-#[derive(Debug)]
-pub struct NewlineIndex {
-    /// Bitvector with 1s at positions immediately after line terminators
-    /// (i.e., the first byte of each line after line 1).
-    line_starts: BitVec,
-    /// Total length of the text
-    text_len: usize,
-}
-
-impl NewlineIndex {
-    /// Build a newline index from text.
-    ///
-    /// Scans the text once to find all line terminators and marks
-    /// the start position of each subsequent line.
-    pub fn build(text: &[u8]) -> Self {
-        if text.is_empty() {
-            return Self {
-                line_starts: BitVec::new(),
-                text_len: 0,
-            };
-        }
-
-        let mut bits = vec![0u64; text.len().div_ceil(64)];
-        let mut i = 0;
-
-        while i < text.len() {
-            match text[i] {
-                b'\n' => {
-                    // LF: next byte starts a new line
-                    let next = i + 1;
-                    if next < text.len() {
-                        bits[next / 64] |= 1 << (next % 64);
-                    }
-                    i += 1;
-                }
-                b'\r' => {
-                    // CR: check for CRLF
-                    let next = if i + 1 < text.len() && text[i + 1] == b'\n' {
-                        // CRLF: skip both, new line starts after \n
-                        i + 2
-                    } else {
-                        // Standalone CR (classic Mac): new line starts after \r
-                        i + 1
-                    };
-                    if next < text.len() {
-                        bits[next / 64] |= 1 << (next % 64);
-                    }
-                    i = next;
-                }
-                _ => i += 1,
-            }
-        }
-
-        Self {
-            line_starts: BitVec::from_words(bits, text.len()),
-            text_len: text.len(),
-        }
-    }
-
-    /// Convert 1-indexed line and column to byte offset.
-    ///
-    /// Column is 1-indexed byte offset within the line.
-    /// Returns `None` if line/column is 0 or if the position is out of bounds.
-    pub fn to_offset(&self, line: usize, column: usize) -> Option<usize> {
-        if line == 0 || column == 0 {
-            return None;
-        }
-
-        let line_start = if line == 1 {
-            // First line starts at offset 0
-            0
-        } else {
-            // Line N starts at the (N-1)th line-start marker (0-indexed select)
-            self.line_starts.select1(line - 2)?
-        };
-
-        let offset = line_start + column - 1;
-        if offset < self.text_len {
-            Some(offset)
-        } else {
-            None
-        }
-    }
-
-    /// Convert byte offset to 1-indexed line and column.
-    ///
-    /// Useful for error reporting and display.
-    pub fn to_line_column(&self, offset: usize) -> (usize, usize) {
-        if self.text_len == 0 {
-            return (1, 1);
-        }
-
-        // Line-start markers are at positions immediately after line terminators.
-        // rank1(offset + 1) gives the count of line-start markers in [0, offset],
-        // which equals the number of lines before the current line.
-        // So line number = 1 + rank1(offset + 1).
-        let markers_before_or_at = self.line_starts.rank1(offset + 1);
-        let line = 1 + markers_before_or_at;
-
-        // Column = offset - start of this line + 1
-        let line_start = if line == 1 {
-            0
-        } else {
-            // The start of line N is at the (N-2)th marker (0-indexed select)
-            // because line 1 has no marker, line 2 has marker 0, line 3 has marker 1, etc.
-            self.line_starts.select1(line - 2).unwrap_or(0)
-        };
-
-        let column = offset - line_start + 1;
-        (line, column)
-    }
-}
+/// Retained for compatibility; the implementation moved to
+/// [`crate::text::LineIndex`], which is shared with `JsonIndex`, `YamlIndex`
+/// and the locate CLIs (#228). This alias will be removed in 0.9.0.
+pub use crate::text::LineIndex as NewlineIndex;
 
 // ============================================================================
 // Path building utilities
@@ -494,102 +379,17 @@ mod tests {
     use super::*;
 
     // ------------------------------------------------------------------------
-    // NewlineIndex tests
+    // NewlineIndex alias
     // ------------------------------------------------------------------------
 
+    /// The behaviour itself is covered by `crate::text::lines`; this only
+    /// guards the compatibility re-export (#228).
     #[test]
-    fn test_newline_index_empty() {
-        let index = NewlineIndex::build(b"");
-        // Empty string has no valid positions
-        assert_eq!(index.to_offset(1, 1), None);
-        // But if we ask for line/column of offset 0, it's (1, 1)
-        assert_eq!(index.to_line_column(0), (1, 1));
-    }
+    fn test_newline_index_alias_resolves_to_line_index() {
+        let index = NewlineIndex::build(b"line1\nline2");
 
-    #[test]
-    fn test_newline_index_no_newlines() {
-        let text = b"hello world";
-        let index = NewlineIndex::build(text);
-
-        assert_eq!(index.to_offset(1, 1), Some(0));
-        assert_eq!(index.to_offset(1, 6), Some(5)); // space
-        assert_eq!(index.to_offset(1, 12), None); // past end
-        assert_eq!(index.to_offset(2, 1), None); // no line 2
-
-        assert_eq!(index.to_line_column(0), (1, 1));
-        assert_eq!(index.to_line_column(5), (1, 6));
-    }
-
-    #[test]
-    fn test_newline_index_unix_lf() {
-        let text = b"line1\nline2\nline3";
-        let index = NewlineIndex::build(text);
-
-        // Line 1: positions 0-4 (line1)
-        assert_eq!(index.to_offset(1, 1), Some(0));
-        assert_eq!(index.to_offset(1, 5), Some(4));
-
-        // Line 2: positions 6-10 (line2)
         assert_eq!(index.to_offset(2, 1), Some(6));
-        assert_eq!(index.to_offset(2, 5), Some(10));
-
-        // Line 3: positions 12-16 (line3)
-        assert_eq!(index.to_offset(3, 1), Some(12));
-        assert_eq!(index.to_offset(3, 5), Some(16));
-
-        // Reverse lookup
-        assert_eq!(index.to_line_column(0), (1, 1));
-        assert_eq!(index.to_line_column(5), (1, 6)); // the \n
         assert_eq!(index.to_line_column(6), (2, 1));
-        assert_eq!(index.to_line_column(12), (3, 1));
-    }
-
-    #[test]
-    fn test_newline_index_windows_crlf() {
-        let text = b"line1\r\nline2\r\nline3";
-        let index = NewlineIndex::build(text);
-
-        // Line 1: positions 0-4 (line1)
-        assert_eq!(index.to_offset(1, 1), Some(0));
-        assert_eq!(index.to_offset(1, 5), Some(4));
-
-        // Line 2: positions 7-11 (line2) - after \r\n
-        assert_eq!(index.to_offset(2, 1), Some(7));
-        assert_eq!(index.to_offset(2, 5), Some(11));
-
-        // Line 3: positions 14-18 (line3)
-        assert_eq!(index.to_offset(3, 1), Some(14));
-
-        // Reverse lookup
-        assert_eq!(index.to_line_column(0), (1, 1));
-        assert_eq!(index.to_line_column(7), (2, 1));
-        assert_eq!(index.to_line_column(14), (3, 1));
-    }
-
-    #[test]
-    fn test_newline_index_classic_mac_cr() {
-        let text = b"line1\rline2\rline3";
-        let index = NewlineIndex::build(text);
-
-        // Line 1: positions 0-4 (line1)
-        assert_eq!(index.to_offset(1, 1), Some(0));
-
-        // Line 2: positions 6-10 (line2) - after \r
-        assert_eq!(index.to_offset(2, 1), Some(6));
-
-        // Line 3: positions 12-16 (line3)
-        assert_eq!(index.to_offset(3, 1), Some(12));
-
-        // Reverse lookup
-        assert_eq!(index.to_line_column(6), (2, 1));
-    }
-
-    #[test]
-    fn test_newline_index_invalid_inputs() {
-        let index = NewlineIndex::build(b"hello\nworld");
-
-        assert_eq!(index.to_offset(0, 1), None); // line 0
-        assert_eq!(index.to_offset(1, 0), None); // column 0
     }
 
     // ------------------------------------------------------------------------

--- a/src/text/line_break.rs
+++ b/src/text/line_break.rs
@@ -1,0 +1,178 @@
+//! The line-break rule, in one place.
+//!
+//! A line break is spelled three ways: `\n`, a lone `\r`, and `\r\n` as the
+//! two-byte spelling of a *single* break. That is YAML 1.2 §5.4's definition,
+//! but it is not YAML-specific — [`crate::text::LineIndex`] applies the same
+//! rule to JSON and DSV text, and every consumer needs the same two answers:
+//! *is this byte a break*, and *how wide is the break here*.
+//!
+//! Before #341 the YAML module carried roughly twenty open-coded
+//! `if b == b'\r' { … if next == b'\n' { … } } else if b == b'\n' { … }` chains,
+//! grown while fixing CRLF handling (#324) and folded-scalar folding (#329).
+//! They all agreed, but that is exactly the shape #106 warns about — duplicated
+//! predicates diverge silently, and the next edge case would have landed in one
+//! copy and not the others. #341 collapsed them onto `yaml::line_break`; #228
+//! added a fourth consumer outside `yaml`, so the definition moved here and
+//! [`crate::yaml::line_break`] re-exports it. Callers that need a different
+//! *shape* adapt around these three functions rather than restating the rule.
+//!
+//! Two exceptions survive, both in YAML and both documented at their sites:
+//! `yaml::parser::Parser::skip_line_break` keeps a hand-rolled dispatch for a
+//! measured reason and is pinned to [`line_break_len`] by a test, and the SIMD
+//! kernels under `yaml::simd` keep their own representation — a
+//! `carriage_returns` mask cannot be phrased as a byte predicate — covered by
+//! the per-kernel differential tests.
+
+/// Is `b` a line break? That is `\n` or `\r`; `\r\n` is the two-byte spelling
+/// of a single break.
+///
+/// Scans that look only for `\n` run straight past a lone `\r`, which is how a
+/// classic-Mac document turned every block scalar into the empty string (#324).
+#[inline]
+pub(crate) fn is_line_break(b: u8) -> bool {
+    matches!(b, b'\n' | b'\r')
+}
+
+/// Width in bytes of the line break at `pos`: 2 for `\r\n`, 1 for a lone `\r`
+/// or `\n`, 0 if `pos` is not at a break.
+///
+/// Zero doubles as "not at a break", so `pos += line_break_len(text, pos)` is a
+/// safe unconditional advance only when the caller has already established that
+/// it is at one; otherwise test the width before stepping.
+#[inline]
+pub(crate) fn line_break_len(text: &[u8], pos: usize) -> usize {
+    match text.get(pos) {
+        Some(b'\r') if text.get(pos + 1) == Some(&b'\n') => 2,
+        Some(b'\r' | b'\n') => 1,
+        _ => 0,
+    }
+}
+
+/// Width in bytes of the line break ending immediately *before* `pos`: 2 for
+/// `\r\n`, 1 for a lone `\r` or `\n`, 0 if `pos` is not preceded by one.
+///
+/// The mirror of [`line_break_len`], for backwards scans. Stepping back a fixed
+/// one byte lands in the middle of a CRLF, which leaves the `\r` attached to the
+/// previous line's text (#324).
+///
+/// Note this answers "is there break *text* behind me", not "does a break *end*
+/// here": standing on the `\n` of a CRLF it reports 1, for the `\r` behind it.
+/// Callers asking the latter want `line_break_len(text, pos - 1) == 1`, which is
+/// true only when the break starting one byte back also finishes there.
+#[inline]
+pub(crate) fn line_break_len_before(text: &[u8], pos: usize) -> usize {
+    match pos.checked_sub(1).and_then(|i| text.get(i)) {
+        Some(b'\n') if pos >= 2 && text[pos - 2] == b'\r' => 2,
+        Some(b'\n' | b'\r') => 1,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_line_break_accepts_both_break_bytes() {
+        assert!(is_line_break(b'\n'));
+        assert!(is_line_break(b'\r'));
+        for b in [b' ', b'\t', b'a', 0x0b, 0x0c] {
+            assert!(!is_line_break(b), "{b:#04x} is not a line break");
+        }
+    }
+
+    #[test]
+    fn line_break_len_measures_each_break_form() {
+        assert_eq!(
+            line_break_len(b"a\r\nb", 1),
+            2,
+            "CRLF is one two-byte break"
+        );
+        assert_eq!(line_break_len(b"a\rb", 1), 1, "lone CR");
+        assert_eq!(line_break_len(b"a\nb", 1), 1, "LF");
+        // A CR at end of input has no LF to pair with.
+        assert_eq!(line_break_len(b"a\r", 1), 1);
+        // Not at a break, and past the end, both measure zero.
+        assert_eq!(line_break_len(b"ab", 0), 0);
+        assert_eq!(line_break_len(b"a\n", 9), 0);
+        assert_eq!(line_break_len(b"", 0), 0);
+    }
+
+    /// Standing on the LF of a CRLF, the break does not *end* there — it ends
+    /// one byte later. Callers distinguishing the two (`find_block_content_range`,
+    /// `Parser::current_line`) rely on the width being 2, not on a separate
+    /// lookahead.
+    #[test]
+    fn line_break_len_distinguishes_a_break_that_ends_here() {
+        // b"a\r\nb\rc\nd"
+        //   0 1 2 3 4 5 6 7
+        let text = b"a\r\nb\rc\nd";
+        assert_eq!(line_break_len(text, 1), 2, "CR of a CRLF: ends at 3, not 2");
+        assert_eq!(line_break_len(text, 4), 1, "lone CR ends at 5");
+        assert_eq!(line_break_len(text, 6), 1, "LF ends at 7");
+    }
+
+    #[test]
+    fn line_break_len_before_measures_backwards() {
+        // b"a\r\nb\rc\nd"
+        //   0 1 2 3 4 5 6 7
+        let text = b"a\r\nb\rc\nd";
+        assert_eq!(line_break_len_before(text, 3), 2, "CRLF ends before `b`");
+        assert_eq!(line_break_len_before(text, 2), 1, "just the CR of a CRLF");
+        assert_eq!(line_break_len_before(text, 5), 1, "lone CR ends before `c`");
+        assert_eq!(line_break_len_before(text, 7), 1, "LF ends before `d`");
+        assert_eq!(line_break_len_before(text, 1), 0, "`a` is not a break");
+        assert_eq!(
+            line_break_len_before(text, 0),
+            0,
+            "nothing before the start"
+        );
+        assert_eq!(line_break_len_before(b"", 0), 0);
+        // A bare LF at index 0 is a one-byte break with no CR in front of it.
+        assert_eq!(line_break_len_before(b"\nx", 1), 1);
+    }
+
+    /// The three helpers are one rule seen from three angles, and must not
+    /// drift apart: a byte is a break iff a break has non-zero width there, and
+    /// a break of width `n` *starting* at `i` is the break of width `n` ending
+    /// at `i + n`.
+    ///
+    /// The round trip is asserted only where `pos` really starts a break. On
+    /// the LF of a CRLF the forward width is 1 (that LF) while the backward
+    /// width is 2 (the whole CRLF) — the two helpers answer different
+    /// questions there, by design, and `find_block_content_range` depends on
+    /// exactly that difference.
+    #[test]
+    fn the_three_helpers_agree_over_every_break_form() {
+        for text in [
+            b"a\r\nb\rc\nd".as_slice(),
+            b"\r\n",
+            b"\n\r",
+            b"\r\r\n",
+            b"\n\n",
+            b"x",
+            b"",
+        ] {
+            for pos in 0..=text.len() {
+                let here = line_break_len(text, pos);
+
+                assert_eq!(
+                    here > 0,
+                    text.get(pos).copied().is_some_and(is_line_break),
+                    "{text:?} @ {pos}: width disagrees with the byte predicate"
+                );
+
+                let inside_a_crlf = pos > 0 && line_break_len(text, pos - 1) == 2;
+                if here > 0 && !inside_a_crlf {
+                    let ends_at = pos + here;
+                    assert_eq!(
+                        line_break_len_before(text, ends_at),
+                        here,
+                        "{text:?} @ {pos}: a break of width {here} starting here \
+                         must be the break of width {here} ending at {ends_at}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/text/lines.rs
+++ b/src/text/lines.rs
@@ -18,8 +18,10 @@
 //!
 //! # Line terminators
 //!
-//! Unix (LF), Windows (CRLF) and classic Mac (CR) are all recognised. A
-//! terminator at the very end of the text does *not* start a new line, so
+//! Unix (LF), Windows (CRLF) and classic Mac (CR) are all recognised, via the
+//! shared rule in [`crate::text::line_break`] that the YAML scanners also use —
+//! one definition, not a per-module copy (#341).
+//! A terminator at the very end of the text does *not* start a new line, so
 //! `"a\n"` has one line, not two.
 //!
 //! # Example
@@ -38,10 +40,21 @@
 use alloc::vec::Vec;
 
 use crate::bits::EliasFano;
+use crate::text::line_break::{is_line_break, line_break_len};
 
 /// Index over the byte offsets at which each line starts.
 ///
 /// Line and column numbers are 1-indexed; byte offsets are 0-indexed.
+///
+/// # Out-of-range positions
+///
+/// The two directions disagree on purpose, each preserving the behaviour of
+/// the `BitVec` implementation it replaced.
+/// [`to_line_column`](Self::to_line_column) extrapolates past the end of the
+/// text — offset 99 of a 5-byte text reports as a column on the last line —
+/// while [`to_offset`](Self::to_offset) rejects anything that would land past
+/// the end. So the round trip is total for in-bounds offsets only; feed it an
+/// out-of-range offset and `to_offset` returns `None` on the way back.
 ///
 /// See the [module docs](self) for the space rationale and terminator handling.
 #[derive(Clone, Debug)]
@@ -67,41 +80,32 @@ impl LineIndex {
             text.len()
         );
 
-        // Pass 1: size the scratch vector exactly. Counting LF and CR
-        // separately over-counts CRLF by one per line, which only
-        // over-reserves; an inexact capacity would let Vec doubling make the
+        // Pass 1: reserve the scratch vector up front. This counts break
+        // *bytes*, so CRLF contributes two where it needs one — an over-reserve
+        // on Windows text, exact on LF/CR-only text. Either way the vector
+        // never reallocates, which is the point: doubling would make the
         // transient allocation 1.5-2x the vector it is building.
-        let terminators = text.iter().filter(|&&b| b == b'\n' || b == b'\r').count();
+        let terminators = text.iter().copied().filter(|&b| is_line_break(b)).count();
         let mut starts = Vec::with_capacity(terminators + 1);
 
         // Line 1 starts at offset 0 even when the text is empty. Storing it
         // removes the `line == 1` special case from every query.
         starts.push(0u32);
 
-        // Pass 2: one line start per terminator that has text after it.
+        // Pass 2: one line start per break that has text after it. `\r\n` is a
+        // single break two bytes wide, so the rule lives in `text::line_break`
+        // rather than being spelled out again here (#341).
         let mut i = 0;
         while i < text.len() {
-            match text[i] {
-                b'\n' => {
-                    let next = i + 1;
-                    if next < text.len() {
-                        starts.push(next as u32);
-                    }
-                    i = next;
-                }
-                b'\r' => {
-                    // CRLF is one terminator, not two.
-                    let next = if i + 1 < text.len() && text[i + 1] == b'\n' {
-                        i + 2
-                    } else {
-                        i + 1
-                    };
-                    if next < text.len() {
-                        starts.push(next as u32);
-                    }
-                    i = next;
-                }
-                _ => i += 1,
+            let width = line_break_len(text, i);
+            if width == 0 {
+                i += 1;
+                continue;
+            }
+
+            i += width;
+            if i < text.len() {
+                starts.push(i as u32);
             }
         }
 

--- a/src/text/lines.rs
+++ b/src/text/lines.rs
@@ -1,0 +1,447 @@
+//! Line-start index for byte-offset <-> line/column conversion.
+//!
+//! Line starts are a *sparse monotone* set: real workloads run 19-78 bytes per
+//! line (see `docs/benchmarks/corpus-shape.md`), so one line start every few
+//! dozen bytes. Storing them as a dense bitmap over the whole text — which is
+//! what the three separate `BitVec` newline indices did before #228 — costs
+//! ~1.27 bits per *input byte* regardless of how few lines there are, and pays
+//! the full rank-directory and select-sample overhead on top.
+//!
+//! [`LineIndex`] stores the line starts themselves, Elias-Fano encoded, at
+//! roughly `2 + log2(average line length)` bits per *line*:
+//!
+//! | Average line length | Dense bitmap | `LineIndex` |
+//! |---------------------|--------------|-------------|
+//! | 20 bytes (YAML/CSV) | 15.9% of input | ~3.9% |
+//! | 78 bytes (pretty JSON) | 15.7% of input | ~1.3% |
+//! | minified (one line) | 15.6% of input | ~0 |
+//!
+//! # Line terminators
+//!
+//! Unix (LF), Windows (CRLF) and classic Mac (CR) are all recognised. A
+//! terminator at the very end of the text does *not* start a new line, so
+//! `"a\n"` has one line, not two.
+//!
+//! # Example
+//!
+//! ```
+//! use succinctly::text::LineIndex;
+//!
+//! let index = LineIndex::build(b"line1\nline2\nline3");
+//!
+//! assert_eq!(index.line_count(), 3);
+//! assert_eq!(index.to_line_column(6), (2, 1));
+//! assert_eq!(index.to_offset(2, 1), Some(6));
+//! ```
+
+#[cfg(not(test))]
+use alloc::vec::Vec;
+
+use crate::bits::EliasFano;
+
+/// Index over the byte offsets at which each line starts.
+///
+/// Line and column numbers are 1-indexed; byte offsets are 0-indexed.
+///
+/// See the [module docs](self) for the space rationale and terminator handling.
+#[derive(Clone, Debug)]
+pub struct LineIndex {
+    /// Byte offset of every line start, including line 1 at offset 0.
+    /// Always non-empty: text with no terminators still has one line.
+    starts: EliasFano,
+    /// Total length of the indexed text.
+    text_len: usize,
+}
+
+impl LineIndex {
+    /// Build a line index by scanning the text once for line terminators.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `text.len() > u32::MAX`, the crate-wide 4 GiB input ceiling
+    /// (#188). See `docs/reference/limits.md`.
+    pub fn build(text: &[u8]) -> Self {
+        assert!(
+            u32::try_from(text.len()).is_ok(),
+            "LineIndex supports inputs up to u32::MAX bytes, got {} (#188)",
+            text.len()
+        );
+
+        // Pass 1: size the scratch vector exactly. Counting LF and CR
+        // separately over-counts CRLF by one per line, which only
+        // over-reserves; an inexact capacity would let Vec doubling make the
+        // transient allocation 1.5-2x the vector it is building.
+        let terminators = text.iter().filter(|&&b| b == b'\n' || b == b'\r').count();
+        let mut starts = Vec::with_capacity(terminators + 1);
+
+        // Line 1 starts at offset 0 even when the text is empty. Storing it
+        // removes the `line == 1` special case from every query.
+        starts.push(0u32);
+
+        // Pass 2: one line start per terminator that has text after it.
+        let mut i = 0;
+        while i < text.len() {
+            match text[i] {
+                b'\n' => {
+                    let next = i + 1;
+                    if next < text.len() {
+                        starts.push(next as u32);
+                    }
+                    i = next;
+                }
+                b'\r' => {
+                    // CRLF is one terminator, not two.
+                    let next = if i + 1 < text.len() && text[i + 1] == b'\n' {
+                        i + 2
+                    } else {
+                        i + 1
+                    };
+                    if next < text.len() {
+                        starts.push(next as u32);
+                    }
+                    i = next;
+                }
+                _ => i += 1,
+            }
+        }
+
+        Self {
+            starts: EliasFano::build(&starts),
+            text_len: text.len(),
+        }
+    }
+
+    /// Number of lines in the indexed text. Always at least 1.
+    #[inline]
+    pub fn line_count(&self) -> usize {
+        self.starts.len()
+    }
+
+    /// Length in bytes of the indexed text.
+    #[inline]
+    pub fn text_len(&self) -> usize {
+        self.text_len
+    }
+
+    /// Byte offset at which the given 1-indexed line starts.
+    ///
+    /// Returns `None` if `line` is 0 or past the last line.
+    #[inline]
+    pub fn line_start(&self, line: usize) -> Option<usize> {
+        let idx = line.checked_sub(1)?;
+        self.starts.get(idx).map(|start| start as usize)
+    }
+
+    /// Convert a 0-indexed byte offset to a 1-indexed `(line, column)`.
+    ///
+    /// Offsets past the end of the text are reported against the last line
+    /// rather than rejected, matching the previous `BitVec`-backed behaviour.
+    ///
+    /// # Performance
+    ///
+    /// O(log lines). A cold path: error reporting, `at_position`, and the
+    /// locate CLIs.
+    pub fn to_line_column(&self, offset: usize) -> (usize, usize) {
+        // text_len <= u32::MAX, so clamping only affects offsets that are
+        // already past the end.
+        let query = offset.min(u32::MAX as usize) as u32;
+
+        // Always `Some`: element 0 is offset 0.
+        let (idx, start) = self
+            .starts
+            .predecessor(query)
+            .expect("LineIndex always holds line 1");
+
+        (idx + 1, offset - start as usize + 1)
+    }
+
+    /// Convert a 1-indexed line and column to a 0-indexed byte offset.
+    ///
+    /// Returns `None` if `line` or `column` is 0, if the line does not exist,
+    /// or if the resulting offset is past the end of the text.
+    #[inline]
+    pub fn to_offset(&self, line: usize, column: usize) -> Option<usize> {
+        if column == 0 {
+            return None;
+        }
+
+        let offset = self.line_start(line)? + column - 1;
+        if offset < self.text_len {
+            Some(offset)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the heap memory usage in bytes.
+    #[inline]
+    pub fn heap_size(&self) -> usize {
+        self.starts.heap_size()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reference implementation: the obvious forward scan.
+    fn naive_line_starts(text: &[u8]) -> Vec<usize> {
+        let mut starts = vec![0usize];
+        let mut i = 0;
+        while i < text.len() {
+            match text[i] {
+                b'\n' => {
+                    if i + 1 < text.len() {
+                        starts.push(i + 1);
+                    }
+                    i += 1;
+                }
+                b'\r' => {
+                    let next = if i + 1 < text.len() && text[i + 1] == b'\n' {
+                        i + 2
+                    } else {
+                        i + 1
+                    };
+                    if next < text.len() {
+                        starts.push(next);
+                    }
+                    i = next;
+                }
+                _ => i += 1,
+            }
+        }
+        starts
+    }
+
+    #[test]
+    fn empty_text_has_one_line() {
+        let index = LineIndex::build(b"");
+
+        assert_eq!(index.line_count(), 1);
+        assert_eq!(index.text_len(), 0);
+        assert_eq!(index.line_start(1), Some(0));
+        assert_eq!(index.to_line_column(0), (1, 1));
+        // No offset is in bounds, so no position resolves.
+        assert_eq!(index.to_offset(1, 1), None);
+    }
+
+    #[test]
+    fn single_line_without_terminator() {
+        let text = b"hello world";
+        let index = LineIndex::build(text);
+
+        assert_eq!(index.line_count(), 1);
+        assert_eq!(index.to_offset(1, 1), Some(0));
+        assert_eq!(index.to_offset(1, 6), Some(5));
+        assert_eq!(index.to_offset(1, 12), None, "past end");
+        assert_eq!(index.to_offset(2, 1), None, "no line 2");
+        assert_eq!(index.to_line_column(0), (1, 1));
+        assert_eq!(index.to_line_column(5), (1, 6));
+    }
+
+    #[test]
+    fn unix_lf() {
+        let text = b"line1\nline2\nline3";
+        let index = LineIndex::build(text);
+
+        assert_eq!(index.line_count(), 3);
+        assert_eq!(index.to_offset(1, 1), Some(0));
+        assert_eq!(index.to_offset(1, 5), Some(4));
+        assert_eq!(index.to_offset(2, 1), Some(6));
+        assert_eq!(index.to_offset(2, 5), Some(10));
+        assert_eq!(index.to_offset(3, 1), Some(12));
+        assert_eq!(index.to_offset(3, 5), Some(16));
+
+        assert_eq!(index.to_line_column(0), (1, 1));
+        assert_eq!(index.to_line_column(5), (1, 6), "the \\n itself");
+        assert_eq!(index.to_line_column(6), (2, 1));
+        assert_eq!(index.to_line_column(12), (3, 1));
+    }
+
+    #[test]
+    fn windows_crlf() {
+        let text = b"line1\r\nline2\r\nline3";
+        let index = LineIndex::build(text);
+
+        assert_eq!(index.line_count(), 3);
+        assert_eq!(index.to_offset(1, 1), Some(0));
+        assert_eq!(index.to_offset(1, 5), Some(4));
+        assert_eq!(index.to_offset(2, 1), Some(7));
+        assert_eq!(index.to_offset(2, 5), Some(11));
+        assert_eq!(index.to_offset(3, 1), Some(14));
+
+        assert_eq!(index.to_line_column(0), (1, 1));
+        assert_eq!(index.to_line_column(7), (2, 1));
+        assert_eq!(index.to_line_column(14), (3, 1));
+    }
+
+    #[test]
+    fn classic_mac_cr() {
+        let text = b"line1\rline2\rline3";
+        let index = LineIndex::build(text);
+
+        assert_eq!(index.line_count(), 3);
+        assert_eq!(index.to_offset(1, 1), Some(0));
+        assert_eq!(index.to_offset(2, 1), Some(6));
+        assert_eq!(index.to_offset(3, 1), Some(12));
+        assert_eq!(index.to_line_column(6), (2, 1));
+    }
+
+    #[test]
+    fn mixed_terminators() {
+        // LF, CRLF, CR in one document.
+        let text = b"a\nb\r\nc\rd";
+        let index = LineIndex::build(text);
+
+        assert_eq!(index.line_count(), 4);
+        assert_eq!(index.line_start(1), Some(0)); // a
+        assert_eq!(index.line_start(2), Some(2)); // b
+        assert_eq!(index.line_start(3), Some(5)); // c
+        assert_eq!(index.line_start(4), Some(7)); // d
+        assert_eq!(index.to_line_column(7), (4, 1));
+    }
+
+    #[test]
+    fn trailing_terminator_adds_no_phantom_line() {
+        for text in [&b"a\n"[..], &b"a\r\n"[..], &b"a\r"[..]] {
+            let index = LineIndex::build(text);
+            assert_eq!(index.line_count(), 1, "text {text:?}");
+            assert_eq!(index.line_start(2), None, "text {text:?}");
+        }
+    }
+
+    #[test]
+    fn leading_and_consecutive_terminators() {
+        // Leading newline, then an empty line in the middle.
+        let text = b"\na\n\nb";
+        let index = LineIndex::build(text);
+
+        assert_eq!(index.line_count(), 4);
+        assert_eq!(index.line_start(1), Some(0)); // the leading \n
+        assert_eq!(index.line_start(2), Some(1)); // a
+        assert_eq!(index.line_start(3), Some(3)); // the empty line
+        assert_eq!(index.line_start(4), Some(4)); // b
+        assert_eq!(index.to_line_column(3), (3, 1), "empty line");
+    }
+
+    #[test]
+    fn offset_past_end_reports_against_last_line() {
+        // Matches the clamping the BitVec rank1 path had before #228.
+        let index = LineIndex::build(b"ab\ncd");
+        assert_eq!(index.to_line_column(4), (2, 2));
+        assert_eq!(index.to_line_column(5), (2, 3), "one past the end");
+        assert_eq!(index.to_line_column(99), (2, 97));
+    }
+
+    #[test]
+    fn zero_line_or_column_is_rejected() {
+        let index = LineIndex::build(b"hello\nworld");
+        assert_eq!(index.to_offset(0, 1), None);
+        assert_eq!(index.to_offset(1, 0), None);
+        assert_eq!(index.line_start(0), None);
+    }
+
+    #[test]
+    fn one_huge_line() {
+        // The case a dense bitmap handled worst: 1 MiB, a single line.
+        let text = vec![b'x'; 1024 * 1024];
+        let index = LineIndex::build(&text);
+
+        assert_eq!(index.line_count(), 1);
+        assert_eq!(index.to_line_column(1_000_000), (1, 1_000_001));
+        assert_eq!(index.to_offset(1, 1_000_001), Some(1_000_000));
+        // One line costs a handful of bytes, not 1/8th of the text.
+        assert!(
+            index.heap_size() < 1024,
+            "heap_size {} should be trivial for one line",
+            index.heap_size()
+        );
+    }
+
+    #[test]
+    fn crosses_elias_fano_select_sample_boundaries() {
+        // EliasFano samples every 256 elements; exercise several boundaries.
+        for line_count in [255usize, 256, 257, 512, 8193] {
+            let mut text = Vec::new();
+            for i in 0..line_count {
+                if i > 0 {
+                    text.push(b'\n');
+                }
+                text.extend_from_slice(b"abcdefgh");
+            }
+            let index = LineIndex::build(&text);
+
+            assert_eq!(index.line_count(), line_count, "{line_count} lines");
+            for line in [1usize, 2, 256, 257, line_count] {
+                if line <= line_count {
+                    let expected = (line - 1) * 9;
+                    assert_eq!(index.line_start(line), Some(expected), "line {line}");
+                    assert_eq!(index.to_line_column(expected), (line, 1), "line {line}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn matches_naive_scanner_at_every_offset() {
+        let texts: [&[u8]; 6] = [
+            b"",
+            b"no terminators here",
+            b"a\nb\nc",
+            b"a\r\nb\r\nc",
+            b"\r\r\n\n\ra",
+            b"{\n  \"key\": \"value\",\n  \"n\": 42\n}\n",
+        ];
+
+        for text in texts {
+            let index = LineIndex::build(text);
+            let starts = naive_line_starts(text);
+
+            assert_eq!(index.line_count(), starts.len(), "text {text:?}");
+
+            for offset in 0..text.len() {
+                // Expected line = index of the last start <= offset.
+                let line = starts.partition_point(|&s| s <= offset);
+                let expected = (line, offset - starts[line - 1] + 1);
+                assert_eq!(
+                    index.to_line_column(offset),
+                    expected,
+                    "text {text:?} offset {offset}"
+                );
+
+                // Round-trip.
+                let (l, c) = expected;
+                assert_eq!(
+                    index.to_offset(l, c),
+                    Some(offset),
+                    "round-trip text {text:?} offset {offset}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn heap_size_beats_a_dense_bitmap_on_realistic_lines() {
+        // 20 bytes per line, the corpus median shape.
+        let mut text = Vec::new();
+        for _ in 0..1000 {
+            text.extend_from_slice(b"key: value-abcdefg\n");
+        }
+        let index = LineIndex::build(&text);
+
+        // What the pre-#228 representation would have cost for the same text.
+        let mut bits = vec![0u64; text.len().div_ceil(64)];
+        for line in 2..=index.line_count() {
+            let pos = index.line_start(line).unwrap();
+            bits[pos / 64] |= 1 << (pos % 64);
+        }
+        let dense = crate::bits::BitVec::from_words(bits, text.len());
+
+        assert!(
+            index.heap_size() * 3 < dense.heap_size(),
+            "LineIndex {} should be several times smaller than BitVec {}",
+            index.heap_size(),
+            dense.heap_size()
+        );
+    }
+}

--- a/src/text/lines.rs
+++ b/src/text/lines.rs
@@ -19,8 +19,8 @@
 //! # Line terminators
 //!
 //! Unix (LF), Windows (CRLF) and classic Mac (CR) are all recognised, via the
-//! shared rule in [`crate::text::line_break`] that the YAML scanners also use —
-//! one definition, not a per-module copy (#341).
+//! shared rule in `crate::text::line_break` (private) that the YAML scanners
+//! also use — one definition, not a per-module copy (#341).
 //! A terminator at the very end of the text does *not* start a new line, so
 //! `"a\n"` has one line, not two.
 //!

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,6 +1,22 @@
 //! Text processing utilities.
 //!
-//! This module provides utilities for text processing, including UTF-8 validation.
+//! This module provides utilities for text processing, including UTF-8
+//! validation and line/column lookup.
+//!
+//! ## Line/column lookup
+//!
+//! [`LineIndex`](crate::text::LineIndex) maps byte offsets to 1-indexed
+//! line/column positions and back,
+//! storing line starts Elias-Fano encoded so the index scales with the number
+//! of lines rather than the size of the text.
+//!
+//! ```
+//! use succinctly::text::LineIndex;
+//!
+//! let index = LineIndex::build(b"line1\nline2");
+//! assert_eq!(index.to_line_column(6), (2, 1));
+//! assert_eq!(index.to_offset(2, 1), Some(6));
+//! ```
 //!
 //! ## UTF-8 Validation
 //!
@@ -22,9 +38,11 @@
 //! assert_eq!(err.offset, 0);
 //! ```
 
+pub mod lines;
 pub mod utf8;
 
 // Re-export commonly used types
+pub use lines::LineIndex;
 pub use utf8::{validate_utf8, validate_utf8_scalar, Utf8Error, Utf8ErrorKind};
 
 // The AVX2 fast path is only present on x86_64 when runtime feature detection

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -38,6 +38,7 @@
 //! assert_eq!(err.offset, 0);
 //! ```
 
+pub(crate) mod line_break;
 pub mod lines;
 pub mod utf8;
 

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -727,10 +727,25 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     }
 
     /// Lazily build and cache the line index from the source text.
+    ///
+    /// The first caller's `text` wins for the lifetime of the index, so a
+    /// later call with different text silently reads the first one's line
+    /// map. The debug assertion catches the cheap half of that mistake.
     #[inline]
     fn ensure_lines(&self, text: &[u8]) -> &crate::text::LineIndex {
-        self.lines
-            .get_or_init(|| crate::text::LineIndex::build(text))
+        let lines = self
+            .lines
+            .get_or_init(|| crate::text::LineIndex::build(text));
+
+        debug_assert_eq!(
+            lines.text_len(),
+            text.len(),
+            "line index was built from different text ({} bytes) than this call passed ({} bytes)",
+            lines.text_len(),
+            text.len()
+        );
+
+        lines
     }
 }
 

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -3,8 +3,6 @@
 //! Holds the semi-index (IB, BP, TY) and provides rank/select operations.
 
 #[cfg(not(test))]
-use alloc::vec;
-#[cfg(not(test))]
 use alloc::{string::String, vec::Vec};
 
 #[cfg(not(test))]
@@ -22,7 +20,6 @@ use super::advance_positions::{build_cumulative_rank, OpenPositions};
 use super::end_positions::EndPositions;
 use super::error::YamlError;
 use super::light::YamlCursor;
-use super::line_break::line_break_len;
 use super::parser::build_semi_index;
 use super::starts_seq_entry;
 
@@ -69,10 +66,10 @@ pub struct YamlIndex<W = Vec<u64>> {
     bp_to_anchor: BTreeMap<usize, String>,
     /// Alias references: BP position of alias → target BP position (resolved at parse time)
     aliases: BTreeMap<usize, usize>,
-    /// Newline positions for fast line/column lookup (built lazily on first use).
-    /// Bit i is set if position i is the start of a new line (immediately after a line terminator).
-    /// Only needed by `to_line_column()` and `to_offset()` (used by `yq-locate` CLI).
-    newlines: OnceCell<crate::bits::BitVec>,
+    /// Line starts for line/column lookup (built lazily on first use).
+    /// Only needed by `to_line_column()` and `to_offset()` (used by the
+    /// `yq-locate` CLI and the `at_position` jq builtin).
+    lines: OnceCell<crate::text::LineIndex>,
 }
 
 /// Build cumulative popcount index for IB.
@@ -85,34 +82,6 @@ fn build_ib_rank(words: &[u64]) -> Vec<u32> {
 #[inline]
 fn build_containers_rank(words: &[u64]) -> Vec<u32> {
     build_cumulative_rank(words)
-}
-
-/// Build newline index from text.
-/// Sets bit i if position i is the start of a new line (immediately after a line terminator).
-/// Handles Unix (LF), Windows (CRLF), and classic Mac (CR) line endings.
-fn build_newline_index(text: &[u8]) -> crate::bits::BitVec {
-    if text.is_empty() {
-        return crate::bits::BitVec::new();
-    }
-
-    let mut bits = vec![0u64; text.len().div_ceil(64)];
-    let mut i = 0;
-
-    while i < text.len() {
-        // A new line starts at the byte after the break — one past a lone `\r`
-        // or `\n`, two past a `\r\n`, which is a single break.
-        let break_len = line_break_len(text, i);
-        if break_len == 0 {
-            i += 1;
-            continue;
-        }
-        i += break_len;
-        if i < text.len() {
-            bits[i / 64] |= 1 << (i % 64);
-        }
-    }
-
-    crate::bits::BitVec::from_words(bits, text.len())
 }
 
 impl YamlIndex<Vec<u64>> {
@@ -160,7 +129,7 @@ impl YamlIndex<Vec<u64>> {
             anchors: semi.anchors,
             bp_to_anchor,
             aliases: semi.aliases,
-            newlines: OnceCell::new(),
+            lines: OnceCell::new(),
         };
         index.validate_alias_acyclicity()?;
         Ok(index)
@@ -211,55 +180,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             anchors,
             bp_to_anchor,
             aliases,
-            newlines: OnceCell::new(),
-        }
-    }
-
-    /// Create a YAML index from pre-existing data including newlines.
-    ///
-    /// This is useful for loading serialized index data with full line/column support.
-    #[allow(clippy::too_many_arguments)] // STYLE-0004: constructor threads each index array; a builder would hide the 1:1 field mapping
-    pub fn from_parts_with_newlines(
-        ib: W,
-        ib_len: usize,
-        bp: W,
-        bp_len: usize,
-        ty: W,
-        ty_len: usize,
-        bp_to_text: Vec<u32>,
-        bp_to_text_end: Vec<u32>,
-        containers: W,
-        anchors: BTreeMap<String, usize>,
-        aliases: BTreeMap<usize, usize>,
-        newlines: crate::bits::BitVec,
-    ) -> Self {
-        let ib_rank = build_ib_rank(ib.as_ref());
-        let containers_rank = build_containers_rank(containers.as_ref());
-
-        // Build reverse anchor mapping
-        let bp_to_anchor: BTreeMap<usize, String> = anchors
-            .iter()
-            .map(|(name, &bp_pos)| (bp_pos, name.clone()))
-            .collect();
-
-        // Convert bp_to_text to compact storage when positions are monotonic
-        let open_positions = OpenPositions::build(&bp_to_text, ib_len);
-
-        Self {
-            ib,
-            ib_len,
-            ib_rank,
-            bp: BalancedParens::from_words_with_select(bp, bp_len),
-            ty,
-            ty_len,
-            open_positions,
-            bp_to_text_end: EndPositions::build(&bp_to_text_end, ib_len),
-            containers,
-            containers_rank,
-            anchors,
-            bp_to_anchor,
-            aliases,
-            newlines: OnceCell::from(newlines),
+            lines: OnceCell::new(),
         }
     }
 
@@ -753,12 +674,12 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         count
     }
 
-    /// Convert a byte offset to (line, column) using the newline index.
+    /// Convert a byte offset to (line, column) using the line index.
     ///
     /// Lines and columns are 1-based to match common editor conventions.
-    /// Returns (1, offset+1) if the text has no newlines.
+    /// Returns (1, offset+1) if the text has no line terminators.
     ///
-    /// The newline index is built lazily on first call from `text`.
+    /// The line index is built lazily on first call from `text`.
     ///
     /// # Example
     ///
@@ -776,40 +697,15 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// ```
     #[inline]
     pub fn to_line_column(&self, offset: usize, text: &[u8]) -> (usize, usize) {
-        use crate::RankSelect;
-
-        let newlines = self.ensure_newlines(text);
-
-        if newlines.is_empty() {
-            return (1, offset + 1);
-        }
-
-        // Line-start markers are at positions immediately after line terminators.
-        // rank1(offset + 1) gives the count of line-start markers in [0, offset],
-        // which equals the number of lines before the current line.
-        // So line number = 1 + rank1(offset + 1).
-        let markers_before_or_at = newlines.rank1(offset + 1);
-        let line = 1 + markers_before_or_at;
-
-        // Column = offset - start of this line + 1
-        let line_start = if line == 1 {
-            0
-        } else {
-            // The start of line N is at the (N-2)th marker (0-indexed select)
-            // because line 1 has no marker, line 2 has marker 0, line 3 has marker 1, etc.
-            newlines.select1(line - 2).unwrap_or(0)
-        };
-
-        let column = offset - line_start + 1;
-        (line, column)
+        self.ensure_lines(text).to_line_column(offset)
     }
 
-    /// Convert (line, column) to a byte offset using the newline index.
+    /// Convert (line, column) to a byte offset using the line index.
     ///
     /// Lines and columns are 1-based to match common editor conventions.
     /// Returns None if the line/column is out of bounds.
     ///
-    /// The newline index is built lazily on first call from `text`.
+    /// The line index is built lazily on first call from `text`.
     ///
     /// # Example
     ///
@@ -827,43 +723,14 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// ```
     #[inline]
     pub fn to_offset(&self, line: usize, column: usize, text: &[u8]) -> Option<usize> {
-        use crate::RankSelect;
-
-        if line == 0 || column == 0 {
-            return None;
-        }
-
-        let newlines = self.ensure_newlines(text);
-
-        if newlines.is_empty() {
-            // No newline markers means single-line document
-            if line == 1 {
-                return Some(column - 1);
-            }
-            return None;
-        }
-
-        // Line 1 starts at offset 0
-        // Line N starts at the (N-2)th line-start marker (0-indexed select)
-        let line_start = if line == 1 {
-            0
-        } else {
-            newlines.select1(line - 2)?
-        };
-
-        Some(line_start + column - 1)
+        self.ensure_lines(text).to_offset(line, column)
     }
 
-    /// Get a reference to the newline bitvector, building it lazily if needed.
+    /// Lazily build and cache the line index from the source text.
     #[inline]
-    pub fn newlines(&self, text: &[u8]) -> &crate::bits::BitVec {
-        self.ensure_newlines(text)
-    }
-
-    /// Lazily build and cache the newline index from the source text.
-    #[inline]
-    fn ensure_newlines(&self, text: &[u8]) -> &crate::bits::BitVec {
-        self.newlines.get_or_init(|| build_newline_index(text))
+    fn ensure_lines(&self, text: &[u8]) -> &crate::text::LineIndex {
+        self.lines
+            .get_or_init(|| crate::text::LineIndex::build(text))
     }
 }
 
@@ -1411,6 +1278,19 @@ mod tests {
 
         assert_eq!(index.to_offset(0, 1, yaml), None); // line 0 invalid
         assert_eq!(index.to_offset(1, 0, yaml), None); // column 0 invalid
+    }
+
+    #[test]
+    fn test_to_offset_rejects_positions_past_the_end() {
+        // Before #228 this returned Some(offset) for offsets past the text,
+        // unlike JsonIndex::to_offset. The shared LineIndex bounds-checks both.
+        let yaml = b"name: Alice\nage: 30";
+        let index = YamlIndex::build(yaml).unwrap();
+
+        assert_eq!(index.to_offset(2, 7, yaml), Some(18), "last byte");
+        assert_eq!(index.to_offset(2, 8, yaml), None, "one past the end");
+        assert_eq!(index.to_offset(2, 999, yaml), None, "far past the end");
+        assert_eq!(index.to_offset(3, 1, yaml), None, "no line 3");
     }
 
     #[test]

--- a/src/yaml/line_break.rs
+++ b/src/yaml/line_break.rs
@@ -1,4 +1,4 @@
-//! The YAML line-break rule, in one place.
+//! The YAML line-break rule — re-exported from [`crate::text::line_break`].
 //!
 //! YAML 1.2 §5.4 spells a line break three ways: `\n`, a lone `\r`, and `\r\n`
 //! as the two-byte spelling of a *single* break. Every scalar consumer of YAML
@@ -7,17 +7,13 @@
 //! the same two answers: *is this byte a break*, and *how wide is the break
 //! here*.
 //!
-//! Line/column lookup was a fourth caller until #228 moved it to
-//! [`crate::text::LineIndex`], which carries its own copy of the rule because
-//! it indexes JSON and DSV text too, where the YAML spelling does not apply.
-//!
-//! Before #341 each of them carried its own copy: roughly twenty open-coded
-//! `if b == b'\r' { … if next == b'\n' { … } } else if b == b'\n' { … }` chains,
-//! grown while fixing CRLF handling (#324) and folded-scalar folding (#329).
-//! They all agreed, but that is exactly the shape #106 warns about — duplicated
-//! predicates diverge silently, and the next edge case would have landed in one
-//! copy and not the others. This module is the single definition; callers that
-//! need a different *shape* adapt around it rather than restating the rule.
+//! #341 collapsed roughly twenty open-coded copies of that rule onto this
+//! module. #228 then added a consumer outside `yaml` —
+//! [`crate::text::LineIndex`], which indexes JSON and DSV text as well — and
+//! the rule is byte-identical for all three formats, so the definition moved up
+//! to [`crate::text::line_break`] rather than being copied a second time. This
+//! module stays as the YAML-facing name and the place the YAML rationale is
+//! recorded; there is still exactly one definition.
 //!
 //! One deliberate exception survives: [`super::parser::Parser::skip_line_break`]
 //! keeps a hand-rolled dispatch for a measured reason documented there. It is
@@ -27,156 +23,4 @@
 //! `carriage_returns` mask cannot be phrased as a byte predicate — and stay
 //! covered by the per-kernel differential tests.
 
-/// Is `b` a YAML line break? Per YAML 1.2 §5.4 that is `\n` or `\r`; `\r\n` is
-/// the two-byte spelling of a single break.
-///
-/// Scans that look only for `\n` run straight past a lone `\r`, which is how a
-/// classic-Mac document turned every block scalar into the empty string (#324).
-#[inline]
-pub(super) fn is_line_break(b: u8) -> bool {
-    matches!(b, b'\n' | b'\r')
-}
-
-/// Width in bytes of the line break at `pos`: 2 for `\r\n`, 1 for a lone `\r`
-/// or `\n`, 0 if `pos` is not at a break.
-///
-/// Zero doubles as "not at a break", so `pos += line_break_len(text, pos)` is a
-/// safe unconditional advance only when the caller has already established that
-/// it is at one; otherwise test the width before stepping.
-#[inline]
-pub(super) fn line_break_len(text: &[u8], pos: usize) -> usize {
-    match text.get(pos) {
-        Some(b'\r') if text.get(pos + 1) == Some(&b'\n') => 2,
-        Some(b'\r' | b'\n') => 1,
-        _ => 0,
-    }
-}
-
-/// Width in bytes of the line break ending immediately *before* `pos`: 2 for
-/// `\r\n`, 1 for a lone `\r` or `\n`, 0 if `pos` is not preceded by one.
-///
-/// The mirror of [`line_break_len`], for backwards scans. Stepping back a fixed
-/// one byte lands in the middle of a CRLF, which leaves the `\r` attached to the
-/// previous line's text (#324).
-///
-/// Note this answers "is there break *text* behind me", not "does a break *end*
-/// here": standing on the `\n` of a CRLF it reports 1, for the `\r` behind it.
-/// Callers asking the latter want `line_break_len(text, pos - 1) == 1`, which is
-/// true only when the break starting one byte back also finishes there.
-#[inline]
-pub(super) fn line_break_len_before(text: &[u8], pos: usize) -> usize {
-    match pos.checked_sub(1).and_then(|i| text.get(i)) {
-        Some(b'\n') if pos >= 2 && text[pos - 2] == b'\r' => 2,
-        Some(b'\n' | b'\r') => 1,
-        _ => 0,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn is_line_break_accepts_both_break_bytes() {
-        assert!(is_line_break(b'\n'));
-        assert!(is_line_break(b'\r'));
-        for b in [b' ', b'\t', b'a', 0x0b, 0x0c] {
-            assert!(!is_line_break(b), "{b:#04x} is not a YAML line break");
-        }
-    }
-
-    #[test]
-    fn line_break_len_measures_each_break_form() {
-        assert_eq!(
-            line_break_len(b"a\r\nb", 1),
-            2,
-            "CRLF is one two-byte break"
-        );
-        assert_eq!(line_break_len(b"a\rb", 1), 1, "lone CR");
-        assert_eq!(line_break_len(b"a\nb", 1), 1, "LF");
-        // A CR at end of input has no LF to pair with.
-        assert_eq!(line_break_len(b"a\r", 1), 1);
-        // Not at a break, and past the end, both measure zero.
-        assert_eq!(line_break_len(b"ab", 0), 0);
-        assert_eq!(line_break_len(b"a\n", 9), 0);
-        assert_eq!(line_break_len(b"", 0), 0);
-    }
-
-    /// Standing on the LF of a CRLF, the break does not *end* there — it ends
-    /// one byte later. Callers distinguishing the two (`find_block_content_range`,
-    /// `Parser::current_line`) rely on the width being 2, not on a separate
-    /// lookahead.
-    #[test]
-    fn line_break_len_distinguishes_a_break_that_ends_here() {
-        // b"a\r\nb\rc\nd"
-        //   0 1 2 3 4 5 6 7
-        let text = b"a\r\nb\rc\nd";
-        assert_eq!(line_break_len(text, 1), 2, "CR of a CRLF: ends at 3, not 2");
-        assert_eq!(line_break_len(text, 4), 1, "lone CR ends at 5");
-        assert_eq!(line_break_len(text, 6), 1, "LF ends at 7");
-    }
-
-    #[test]
-    fn line_break_len_before_measures_backwards() {
-        // b"a\r\nb\rc\nd"
-        //   0 1 2 3 4 5 6 7
-        let text = b"a\r\nb\rc\nd";
-        assert_eq!(line_break_len_before(text, 3), 2, "CRLF ends before `b`");
-        assert_eq!(line_break_len_before(text, 2), 1, "just the CR of a CRLF");
-        assert_eq!(line_break_len_before(text, 5), 1, "lone CR ends before `c`");
-        assert_eq!(line_break_len_before(text, 7), 1, "LF ends before `d`");
-        assert_eq!(line_break_len_before(text, 1), 0, "`a` is not a break");
-        assert_eq!(
-            line_break_len_before(text, 0),
-            0,
-            "nothing before the start"
-        );
-        assert_eq!(line_break_len_before(b"", 0), 0);
-        // A bare LF at index 0 is a one-byte break with no CR in front of it.
-        assert_eq!(line_break_len_before(b"\nx", 1), 1);
-    }
-
-    /// The three helpers are one rule seen from three angles, and must not
-    /// drift apart: a byte is a break iff a break has non-zero width there, and
-    /// a break of width `n` *starting* at `i` is the break of width `n` ending
-    /// at `i + n`.
-    ///
-    /// The round trip is asserted only where `pos` really starts a break. On
-    /// the LF of a CRLF the forward width is 1 (that LF) while the backward
-    /// width is 2 (the whole CRLF) — the two helpers answer different
-    /// questions there, by design, and `find_block_content_range` depends on
-    /// exactly that difference.
-    #[test]
-    fn the_three_helpers_agree_over_every_break_form() {
-        for text in [
-            b"a\r\nb\rc\nd".as_slice(),
-            b"\r\n",
-            b"\n\r",
-            b"\r\r\n",
-            b"\n\n",
-            b"x",
-            b"",
-        ] {
-            for pos in 0..=text.len() {
-                let here = line_break_len(text, pos);
-
-                assert_eq!(
-                    here > 0,
-                    text.get(pos).copied().is_some_and(is_line_break),
-                    "{text:?} @ {pos}: width disagrees with the byte predicate"
-                );
-
-                let inside_a_crlf = pos > 0 && line_break_len(text, pos - 1) == 2;
-                if here > 0 && !inside_a_crlf {
-                    let ends_at = pos + here;
-                    assert_eq!(
-                        line_break_len_before(text, ends_at),
-                        here,
-                        "{text:?} @ {pos}: a break of width {here} starting here \
-                         must be the break of width {here} ending at {ends_at}"
-                    );
-                }
-            }
-        }
-    }
-}
+pub(super) use crate::text::line_break::{is_line_break, line_break_len, line_break_len_before};

--- a/src/yaml/line_break.rs
+++ b/src/yaml/line_break.rs
@@ -3,9 +3,13 @@
 //! YAML 1.2 §5.4 spells a line break three ways: `\n`, a lone `\r`, and `\r\n`
 //! as the two-byte spelling of a *single* break. Every scalar consumer of YAML
 //! text in this module — the oracle ([`super::parser`]), the cursor
-//! ([`super::light`]), the strict validator ([`super::validate`]), and the
-//! newline index ([`super::index`]) — needs the same two answers: *is this byte
-//! a break*, and *how wide is the break here*.
+//! ([`super::light`]), and the strict validator ([`super::validate`]) — needs
+//! the same two answers: *is this byte a break*, and *how wide is the break
+//! here*.
+//!
+//! Line/column lookup was a fourth caller until #228 moved it to
+//! [`crate::text::LineIndex`], which carries its own copy of the rule because
+//! it indexes JSON and DSV text too, where the YAML spelling does not apply.
 //!
 //! Before #341 each of them carried its own copy: roughly twenty open-coded
 //! `if b == b'\r' { … if next == b'\n' { … } } else if b == b'\n' { … }` chains,

--- a/tests/data/bench-corpus/expected-shape.md
+++ b/tests/data/bench-corpus/expected-shape.md
@@ -22,6 +22,24 @@ Distributions are derived from the crate's own semi-index (`JsonIndex` / `YamlIn
 | yaml   | k8s            | nginx-deployment.yml        | 836   |
 | yaml   | lint           | sass-lint.yml               | 2055  |
 
+## Line index
+
+Bytes retained by `text::LineIndex` per corpus file, against what the dense-bitmap newline index it replaced would have cost for the same text (#228). Both columns are the structures' own `heap_size()`, not a formula, so this section is a space-regression guard as well as a record: the dense representation cost ~1.27 bits per *input byte* whatever the line count, while the Elias-Fano one costs ~2 + log2(average line length) bits per *line*. `permille` is parts-per-thousand of the file.
+
+| format | file                                       | bytes | lines | bitvec bytes | line index bytes | bitvec permille | line index permille |
+| ------ | ------------------------------------------ | ----- | ----- | ------------ | ---------------- | --------------- | ------------------- |
+| dsv    | world-gdp/world-gdp-with-codes.csv         | 4515  | 223   | 728          | 180              | 161             | 39                  |
+| json   | charts/bullet-data.json                    | 548   | 7     | 120          | 20               | 218             | 36                  |
+| json   | npm/express-package.json                   | 2731  | 99    | 456          | 100              | 166             | 36                  |
+| json   | openapi/swagger-v2-schema.json             | 40247 | 1607  | 6408         | 1356             | 159             | 33                  |
+| yaml   | actions/codeql-analysis.yml                | 925   | 39    | 168          | 44               | 181             | 47                  |
+| yaml   | actions/stale.yml                          | 1290  | 34    | 232          | 44               | 179             | 34                  |
+| yaml   | compose/nginx-flask-mysql.yaml             | 1239  | 62    | 224          | 60               | 180             | 48                  |
+| yaml   | compose/wordpress.yaml                     | 815   | 33    | 152          | 44               | 186             | 53                  |
+| yaml   | home-assistant/air-quality-conditions.yaml | 9990  | 466   | 1608         | 384              | 160             | 38                  |
+| yaml   | k8s/nginx-deployment.yml                   | 836   | 43    | 160          | 44               | 191             | 52                  |
+| yaml   | lint/sass-lint.yml                         | 2055  | 98    | 360          | 92               | 175             | 44                  |
+
 ## YAML
 
 files: 7, total bytes: 17150, anchors: 41, aliases: 86, bare-dash items: 5

--- a/tests/locate_cli_tests.rs
+++ b/tests/locate_cli_tests.rs
@@ -1,0 +1,94 @@
+//! End-to-end CLI coverage for `jq-locate` / `yq-locate` `--line/--column`.
+//!
+//! The line/column -> byte offset path had no integration coverage at all
+//! before #228 — only help-text snapshots mentioned these commands — so the
+//! `LineIndex` migration would have been invisible to the test suite at the
+//! CLI boundary. These spawn the built binary directly (the
+//! `corpus_stats_cli_tests.rs` pattern) rather than going through `cargo run`.
+//!
+//! The working directory for integration tests is the crate root, so the seed
+//! corpus paths resolve as-is.
+#![cfg(feature = "cli")]
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_succinctly")
+}
+
+fn run(args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn succinctly");
+    (
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+const JSON_FIXTURE: &str = "tests/data/bench-corpus/seed/json/charts/bullet-data.json";
+const YAML_FIXTURE: &str = "tests/data/bench-corpus/seed/yaml/k8s/nginx-deployment.yml";
+
+#[test]
+fn jq_locate_resolves_line_and_column() {
+    let (stdout, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "3", "--column", "5"]);
+
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, ".[1].title");
+}
+
+#[test]
+fn jq_locate_line_column_agrees_with_offset() {
+    // Line 3 column 5 of the fixture is byte 122. The two paths share nothing:
+    // --offset skips the line index entirely, so agreement is a real check
+    // that the line index maps positions the way the file is actually laid out.
+    let (by_position, _, _) = run(&["jq-locate", JSON_FIXTURE, "--line", "3", "--column", "5"]);
+    let (by_offset, _, _) = run(&["jq-locate", JSON_FIXTURE, "--offset", "122"]);
+
+    assert_eq!(by_position, by_offset);
+    assert!(!by_position.is_empty());
+}
+
+#[test]
+fn jq_locate_rejects_out_of_range_position() {
+    let (_, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "9999", "--column", "1"]);
+
+    assert_ne!(code, 0, "out-of-range position must fail");
+    assert!(
+        stderr.contains("Invalid position"),
+        "expected an invalid-position error, got: {stderr}"
+    );
+}
+
+#[test]
+fn jq_locate_rejects_zero_column() {
+    let (_, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "1", "--column", "0"]);
+
+    assert_ne!(code, 0, "column 0 must fail");
+    assert!(
+        stderr.contains("Invalid position"),
+        "expected an invalid-position error, got: {stderr}"
+    );
+}
+
+#[test]
+fn yq_locate_resolves_line_and_column() {
+    // Line 5 of the manifest is "  labels:", so column 3 is the key itself.
+    let (stdout, stderr, code) = run(&["yq-locate", YAML_FIXTURE, "--line", "5", "--column", "3"]);
+
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, ".[0].metadata.labels");
+}
+
+#[test]
+fn yq_locate_rejects_out_of_range_position() {
+    let (_, stderr, code) = run(&["yq-locate", YAML_FIXTURE, "--line", "9999", "--column", "1"]);
+
+    assert_ne!(code, 0, "out-of-range position must fail");
+    assert!(
+        stderr.contains("Invalid position"),
+        "expected an invalid-position error, got: {stderr}"
+    );
+}

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -1,6 +1,7 @@
 //! Property-based tests for rank/select operations.
 
 use proptest::prelude::*;
+use succinctly::text::LineIndex;
 use succinctly::{BitVec, RankSelect};
 
 proptest! {
@@ -224,6 +225,113 @@ proptest! {
             let expected = reference_select1(&words, len, k);
             let actual = bv.select1(k);
             prop_assert_eq!(actual, expected, "select1({}) mismatch", k);
+        }
+    }
+}
+
+// ============================================================================
+// LineIndex (#228)
+// ============================================================================
+
+/// Reference implementation of the line-start scan.
+///
+/// A terminator at the very end of the text starts no new line, and CRLF is
+/// one terminator rather than two.
+fn reference_line_starts(text: &[u8]) -> Vec<usize> {
+    let mut starts = vec![0usize];
+    let mut i = 0;
+    while i < text.len() {
+        match text[i] {
+            b'\n' => {
+                if i + 1 < text.len() {
+                    starts.push(i + 1);
+                }
+                i += 1;
+            }
+            b'\r' => {
+                let next = if i + 1 < text.len() && text[i + 1] == b'\n' {
+                    i + 2
+                } else {
+                    i + 1
+                };
+                if next < text.len() {
+                    starts.push(next);
+                }
+                i = next;
+            }
+            _ => i += 1,
+        }
+    }
+    starts
+}
+
+/// Bytes drawn from `{a, b, \n, \r}` so CRLF / CR / LF / empty-line
+/// interleavings are dense — that is where hand-written cases are thinnest.
+fn terminator_heavy_text() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(
+        prop::sample::select(vec![b'a', b'b', b'\n', b'\r']),
+        0..400usize,
+    )
+}
+
+proptest! {
+    /// `to_line_column` agrees with a naive forward scan at every offset.
+    #[test]
+    fn prop_line_index_matches_naive_scanner(text in terminator_heavy_text()) {
+        let index = LineIndex::build(&text);
+        let starts = reference_line_starts(&text);
+
+        prop_assert_eq!(index.line_count(), starts.len());
+
+        for offset in 0..text.len() {
+            let line = starts.partition_point(|&s| s <= offset);
+            let expected = (line, offset - starts[line - 1] + 1);
+            prop_assert_eq!(index.to_line_column(offset), expected, "offset {}", offset);
+        }
+    }
+
+    /// Every in-bounds offset survives offset -> line/column -> offset.
+    #[test]
+    fn prop_line_index_round_trip(text in terminator_heavy_text()) {
+        let index = LineIndex::build(&text);
+
+        for offset in 0..text.len() {
+            let (line, column) = index.to_line_column(offset);
+            prop_assert_eq!(index.to_offset(line, column), Some(offset), "offset {}", offset);
+        }
+    }
+
+    /// Line starts are strictly increasing, in bounds, and start at 0.
+    #[test]
+    fn prop_line_starts_are_monotone_and_in_bounds(text in terminator_heavy_text()) {
+        let index = LineIndex::build(&text);
+
+        prop_assert_eq!(index.line_start(1), Some(0));
+
+        let mut previous = None;
+        for line in 1..=index.line_count() {
+            let start = index.line_start(line).expect("line within count");
+            if let Some(previous) = previous {
+                prop_assert!(start > previous, "line {} start {} <= previous", line, start);
+            }
+            prop_assert!(start <= text.len());
+            previous = Some(start);
+        }
+
+        prop_assert_eq!(index.line_start(index.line_count() + 1), None);
+    }
+
+    /// Positions past the end are rejected, never turned into a bogus offset.
+    #[test]
+    fn prop_to_offset_stays_in_bounds(
+        text in terminator_heavy_text(),
+        line in 1usize..50,
+        column in 1usize..500,
+    ) {
+        let index = LineIndex::build(&text);
+
+        if let Some(offset) = index.to_offset(line, column) {
+            prop_assert!(offset < text.len(), "offset {} outside {} bytes", offset, text.len());
         }
     }
 }


### PR DESCRIPTION
# Elias-Fano Line Index Migration (#228)

This PR replaces three separate dense-bitmap copies of the line-start scanner with one shared `text::LineIndex` backed by Elias-Fano encoding. Line starts are a sparse monotone set; storing them as a dense bitmap costs ~1.27 bits per *input byte* regardless of line count, while Elias-Fano costs ~`2 + log2(average line length)` bits per *line* — achieving 3.6x to 145x space reduction on the real-workload corpus.

## Problem Solved

Three modules carried byte-identical copies of the same line-start scanner (`JsonIndex::newlines`, `YamlIndex::newlines`, and `json::locate::NewlineIndex`), each storing the result as a dense `BitVec` over the whole text. This cost:

- ~15.9% of the input file size in retained memory, regardless of how few lines the file has
- An O(n) scan and full bitmap allocation on every `JsonIndex::build`, though the structure was only read by `at_position(line; col)` and the locate CLIs
- A layering bug where `yq-locate` reached into `json::locate` for a YAML file's line index

## Solution

Introduce `succinctly::text::LineIndex`, storing line-start offsets themselves Elias-Fano encoded:

**Core changes:**
- Added `LineIndex::build(text)` — one implementation instead of three, with comprehensive test coverage including property-based tests over terminator-dense inputs
- Added `EliasFano::predecessor(value) -> Option<(usize, u32)>` — O(log n) binary search for cold paths (error reporting, locate CLIs, `at_position`)
- Made JSON's line index lazy like YAML's — the index is now built on first use via `OnceCell`, removing an O(n) scan from the hot path
- Hoisted the line-break rule to `text::line_break` and removed duplication with YAML's copy (#341)

**Space results** (per-file heap usage from `heap_size()`, not formulas):

| File | Bytes | Lines | Dense Bitmap | LineIndex | Factor |
|------|-------|-------|--------------|-----------|--------|
| us-election.geojson | 99,715 | 60 | 15,608 B | 108 B | **145x** |
| gapminder-five-year.csv | 82,079 | 1,705 | 12,952 B | 1,636 B | **7.9x** |
| prometheus-ci.yml | 18,935 | 453 | 2,992 B | 432 B | **6.9x** |
| nginx-deployment.yml | 836 | 43 | 160 B | 44 B | **3.6x** |

**Build-time impact** (from tracking allocator on geojson file): `JsonIndex::build` allocation reduced 25.8% (60,514 → 44,906 bytes) because the eager bitmap construction is gone.

## Changes Made

### New Types and Methods
- `src/text/lines.rs`: `LineIndex` type with `build()`, `line_count()`, `to_line_column()`, `to_offset()`, `heap_size()`
- `src/text/line_break.rs`: Shared LF/CR/CRLF recognition (`is_line_break`, `line_break_len`, `line_break_len_before`) — moved from YAML module and made crate-public
- `EliasFano::predecessor()` — O(log n) method for largest element `<= value`
- `BitVec::heap_size()`, `RankDirectory::heap_size()`, `SelectIndex::heap_size()` — enables accurate space measurement

### Modified Signatures (Breaking)
- **`JsonIndex::to_line_column(offset, text)`** and **`to_offset(line, column, text)`** now take the source text as a final argument, matching `YamlIndex`'s existing signatures. The line index is built lazily on first use and cached.
- **`JsonIndex` is no longer `Sync`** (it holds a `OnceCell` of non-`Sync` `LineIndex`); `YamlIndex` already was not
- Removed zero-caller constructors: `JsonIndex::from_parts_with_newlines`, `YamlIndex::from_parts_with_newlines`, `YamlIndex::newlines()`
- `json::locate::NewlineIndex` is now an alias for `text::LineIndex` (deprecated, will be removed in 0.9.0)

### Refactoring
- `JsonIndex::build` no longer calls `build_newline_index()` — the index is built on demand
- `YamlIndex` line index representation swapped from `BitVec` to `LineIndex` (lazy build already existed)
- `yaml::line_break` is now a re-export of `text::line_break`
- Both locate CLIs updated to use `text::LineIndex` directly, removing `json::locate` layering oddity

### Testing and Documentation
- New `tests/locate_cli_tests.rs` with end-to-end coverage of `jq-locate` and `yq-locate --line --column` (previously uncovered)
- Property-based tests in `tests/properties.rs` with terminator-heavy input generation
- Corpus shape report now includes `## Line index` section recording retained bytes per file, guarded by `corpus-shape-drift` CI job
- ADR-0012 documents the decision and rejected alternatives
- `docs/optimizations/line-index.md` covers space arithmetic, crossover point (~2.6 bytes/line), transient build memory, and query cost
- Corrected three stale claims in ADR-0009, ADR-0011, and docs/architecture/bitvec.md about where `BitVec` is actually used
- Debug assertion in `ensure_lines()` catches mismatched text between index build and query time

## Performance Impact

**Build time:** Removes O(n) scan and bitmap allocation from every `JsonIndex::build`. Measured ~25.8% allocation reduction on 100 KB GeoJSON; unmeasured on clock time due to concurrent CI load (see ADR-0012's "Not measured" section).

**Query time:** `to_line_column()` rises from O(1) to O(log lines) with sampled selects per binary-search step; `to_offset()` stays O(1). Accepted because:
  - `to_offset` is what `at_position` and both locate CLIs use (all cold paths)
  - `to_line_column` via the `line`/`column` builtins is currently stubbed to `0` on the CLI path and unreachable
  - The `BitVec` select it replaces was itself sampled every 256 ones
  - Two accelerators exist if needed: a one-entry cache for monotone walks, or a second binary search over select sample indices

**Space:** 3.6-145x reduction on corpus files; the dense representation cost 15.6-21.8% of input size, the new one costs 0.1-5.3%.

## Checklist
- [x] All existing tests pass (no changes to test expectations needed; semantics preserved exactly)
- [x] New tests added for `LineIndex`, `EliasFano::predecessor`, corpus-shape reporting, and locate CLI coverage
- [x] Code follows project style guidelines
- [x] Self-review complete; no new warnings
- [x] Documentation updated with ADRs, module docs, and corrections to stale architecture claims
- [x] `BitVec`, `RankDirectory`, `SelectIndex` now have `heap_size()` for accurate measurement

## Additional Notes

This change leaves `BitVec`, `RankDirectory`, `SelectIndex`, and `CompactRank` with zero production callers — they survive as public API and measurement scaffolding only. Whether to shrink, deprecate, or keep them is a public-API policy question deliberately left open.

The `line`/`column` builtins stubs on the `OwnedValue` path are a gap in the builtins, not a licence to call this path cold. Wiring them up and adding the `Cell` cache should land together when measured.

See [ADR-0012](docs/adrs/adr-0012.md) for the full decision record, rejected alternatives, and measured space results.