### PR TITLE
ci: extend security audits to isolated fuzz and bench-compare workspaces

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,6 +30,16 @@ jobs:
       - name: Run cargo-audit
         run: cargo audit
 
+      # fuzz/ and bench-compare/ are separate cargo workspaces (own
+      # Cargo.lock), deliberately isolated from the root dependency graph --
+      # see fuzz/Cargo.toml's header comment. CI compiles them but the
+      # default `cargo audit` above only ever looks at the root Cargo.lock.
+      - name: Run cargo-audit (fuzz workspace)
+        run: cargo audit -f fuzz/Cargo.lock
+
+      - name: Run cargo-audit (bench-compare workspace)
+        run: cargo audit -f bench-compare/Cargo.lock
+
   deny:
     name: Dependency Policy
     runs-on: ubuntu-latest
@@ -39,6 +49,20 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2.1.1
         with:
           command: check all
+
+      # Same isolation gap as cargo-audit above. cargo-deny-action has no
+      # input for a custom config path, so invoke cargo-deny directly with
+      # each workspace's own deny.toml (root deny.toml is intentionally
+      # tuned to the shipped crate's dependency tree only).
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      - name: Dependency Policy (fuzz workspace)
+        run: cargo deny --manifest-path fuzz/Cargo.toml --config fuzz/deny.toml check all
+
+      - name: Dependency Policy (bench-compare workspace)
+        run: cargo deny --manifest-path bench-compare/Cargo.toml --config bench-compare/deny.toml check all
 
   secrets:
     name: Secret Scanning

--- a/bench-compare/Cargo.toml
+++ b/bench-compare/Cargo.toml
@@ -3,6 +3,7 @@ name = "json-parser-bench"
 version = "0.1.0"
 edition = "2024"
 publish = false
+license = "MIT"
 
 [dependencies]
 criterion = "0.5"

--- a/bench-compare/deny.toml
+++ b/bench-compare/deny.toml
@@ -1,0 +1,52 @@
+# deny.toml -- cargo-deny configuration for the bench-compare/ workspace
+# Reference: https://embarkstudios.github.io/cargo-deny/
+#
+# bench-compare/ is a deliberately separate workspace with its own lockfile,
+# isolated from the root dependency graph so third-party comparison crates
+# (sux, sucds, vers-vecs, etc.) don't affect the main crate's MSRV promise or
+# `cargo deny check all`. It gets its own policy file rather than sharing the
+# root deny.toml for the same reason -- the root file is tuned to the licenses
+# actually encountered in succinctly's shipped dependency tree.
+#
+# Run locally with:  cargo deny --manifest-path bench-compare/Cargo.toml --config bench-compare/deny.toml check all
+
+[graph]
+targets = []
+all-features = true
+
+# ── Advisories ────────────────────────────────────────────────────────
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+unmaintained = "workspace"
+yanked = "warn"
+ignore = []
+
+# ── Licenses ──────────────────────────────────────────────────────────
+# Same as root, plus MPL-2.0 (tracking-allocator) and BSL-1.0 (xxhash-rust,
+# via sux) -- both legitimate OSI-approved licenses pulled in only by
+# comparison-benchmark dependencies, not the shipped crate.
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+    "MPL-2.0",
+    "BSL-1.0",
+]
+
+# ── Bans ──────────────────────────────────────────────────────────────
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+# ── Sources ───────────────────────────────────────────────────────────
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ name = "succinctly-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
+license = "MIT"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/deny.toml
+++ b/fuzz/deny.toml
@@ -1,0 +1,48 @@
+# deny.toml -- cargo-deny configuration for the fuzz/ workspace
+# Reference: https://embarkstudios.github.io/cargo-deny/
+#
+# fuzz/ is a deliberately separate workspace (see fuzz/Cargo.toml's header),
+# so it gets its own policy file rather than sharing the root deny.toml --
+# the root file is tuned to the licenses actually encountered in succinctly's
+# shipped dependency tree, and fuzz-only deps like libfuzzer-sys shouldn't
+# loosen that for the crate that actually ships.
+#
+# Run locally with:  cargo deny --manifest-path fuzz/Cargo.toml --config fuzz/deny.toml check all
+
+[graph]
+targets = []
+all-features = true
+
+# ── Advisories ────────────────────────────────────────────────────────
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+unmaintained = "workspace"
+yanked = "warn"
+ignore = []
+
+# ── Licenses ──────────────────────────────────────────────────────────
+# Same as root, plus NCSA (libfuzzer-sys is `(MIT OR Apache-2.0) AND NCSA`).
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+    "NCSA",
+]
+
+# ── Bans ──────────────────────────────────────────────────────────────
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+# ── Sources ───────────────────────────────────────────────────────────
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Description

This PR fixes issue #545 by implementing comprehensive cargo-deny security audit policies for the isolated `fuzz/` and `bench-compare/` workspaces. These workspaces have separate Cargo.lock files and dependency graphs that were not covered by the root deny.toml, creating a gap in dependency security and license compliance checks.

The implementation adds workspace-specific deny.toml configurations that account for unique licensing requirements of workspace-only dependencies (NCSA for libfuzzer-sys in fuzz/, and MPL-2.0/BSL-1.0 for comparison benchmarks like sux and tracking-allocator in bench-compare/), while maintaining the same security advisory standards as the root configuration.

## Type of Change

- [x] Test coverage improvement
- [x] CI/CD changes
- [x] Documentation update

## Related Issue

Fixes #545

## Changes Made

**Fuzz Workspace Configuration:**
- Added `license = "MIT"` field to `fuzz/Cargo.toml` as required by cargo-deny
- Created `fuzz/deny.toml` with advisory, license, bans, and sources policies
- License whitelist includes NCSA for libfuzzer-sys and all root policy licenses

**Bench-Compare Workspace Configuration:**
- Added `license = "MIT"` field to `bench-compare/Cargo.toml` as required by cargo-deny
- Created `bench-compare/deny.toml` with advisory, license, bans, and sources policies
- License whitelist includes MPL-2.0 (tracking-allocator) and BSL-1.0 (xxhash-rust via sux)

**CI/CD Security Workflow Updates:**
- Added explicit `cargo audit -f fuzz/Cargo.lock` and `cargo audit -f bench-compare/Cargo.lock` steps to security.yml
- Installed cargo-deny tool via taiki-e/install-action for direct invocation
- Added workspace-specific deny checks: `cargo deny --manifest-path fuzz/Cargo.toml --config fuzz/deny.toml check all` and corresponding bench-compare command
- All new steps properly documented with inline comments explaining the workspace isolation rationale

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New CI security checks validate fuzz workspace advisories and licenses
- [x] New CI security checks validate bench-compare workspace advisories and licenses

**Manual Testing:**
- [x] Verified `cargo audit -f fuzz/Cargo.lock` passes
- [x] Verified `cargo deny --manifest-path fuzz/Cargo.toml --config fuzz/deny.toml check all` passes
- [x] Verified `cargo audit -f bench-compare/Cargo.lock` passes
- [x] Verified `cargo deny --manifest-path bench-compare/Cargo.toml --config bench-compare/deny.toml check all` passes

### Test Commands
```bash
# Verify fuzz workspace
cargo audit -f fuzz/Cargo.lock
cargo deny --manifest-path fuzz/Cargo.toml --config fuzz/deny.toml check all

# Verify bench-compare workspace
cargo audit -f bench-compare/Cargo.lock
cargo deny --manifest-path bench-compare/Cargo.toml --config bench-compare/deny.toml check all

# Run full security checks as CI would
cargo audit
cargo deny check all
```

## Performance Impact
- [x] No performance impact

These are configuration and CI changes only with no impact on runtime performance.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings
- [x] Updated CI security workflow to audit isolated workspaces

## Additional Notes

**Design Rationale:**
The fuzz/ and bench-compare/ workspaces are deliberately isolated from the root dependency graph to:
- Keep fuzz-only dependencies (libfuzzer-sys) and benchmark-only dependencies separate from the shipped crate
- Prevent test/development dependencies from affecting the main crate's MSRV promise
- Allow comparison benchmarks to use alternative libraries without constraining the production library choice

Workspace-specific deny.toml files are essential because cargo-deny-action defaults to root Cargo.toml and cannot be configured for custom paths. Workspace policies inherit root policies while adding legitimate OSI-approved licenses used only in their isolated dependency trees.

**Documentation:**
Each deny.toml includes inline comments explaining the workspace's purpose and providing the exact cargo commands for local validation.