### PR TITLE
chore(build): sync bench-compare/Cargo.lock and patch security advisories

### DIFF
--- a/bench-compare/Cargo.lock
+++ b/bench-compare/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -823,7 +823,7 @@ dependencies = [
  "serde_yaml",
  "simd-json",
  "sonic-rs",
- "succinctly 0.7.0",
+ "succinctly 0.8.0",
  "sucds",
  "sux",
  "tracking-allocator",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "succinctly"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytemuck",
  "indexmap",


### PR DESCRIPTION
## Description

This PR resolves #548 by performing a targeted, intentional update to the `bench-compare/Cargo.lock` file separate from the unrelated license-field changes in #545. The update addresses two security vulnerabilities (RUSTSEC-2026-0007 and RUSTSEC-2026-0204) and synchronizes the local path-dependency version to match the root crate.

### Problem
The `bench-compare/Cargo.lock` file contained outdated and vulnerable dependencies that `cargo audit` was flagging as real security issues. Additionally, the local `succinctly` path-dependency was pinned to an older version (0.7.0) that didn't match the root crate's current version (0.8.0).

### Solution
Updated three key dependencies in `bench-compare/Cargo.lock`:
- `bytes`: 1.11.0 → 1.12.1 (resolves RUSTSEC-2026-0007)
- `crossbeam-epoch`: 0.9.18 → 0.9.20 (resolves RUSTSEC-2026-0204)
- `succinctly`: 0.7.0 → 0.8.0 (synchronizes with root crate)

This is a focused maintenance update that addresses security advisories while keeping the benchmark comparison tool aligned with the main project version.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] CI/CD changes

## Related Issue
Fixes #548

## Changes Made

**Dependency Updates:**
- Updated `bytes` from 1.11.0 to 1.12.1 in bench-compare/Cargo.lock, updating checksum from `b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3` to `fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04`
- Updated `crossbeam-epoch` from 0.9.18 to 0.9.20 in bench-compare/Cargo.lock, updating checksum from `5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e` to `2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f`
- Updated `succinctly` path-dependency from 0.7.0 to 0.8.0 in bench-compare/Cargo.lock to match root crate version

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Verified with `cargo audit -f bench-compare/Cargo.lock` that security advisories are resolved

**Manual Testing:**
- [x] Tested on x86_64

### Test Commands
```bash
cd bench-compare
cargo update
cargo audit -f Cargo.lock
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact

The dependency updates target security fixes only; the byte version bump (1.12.1) and crossbeam-epoch update (0.9.20) are maintenance releases with no breaking changes or performance implications.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] All existing tests pass locally
- [x] My changes generate no new warnings
- [x] This PR addresses the specific scope of #548, separate from #545's unrelated changes

## Additional Notes

This update is intentionally focused on resolving the security advisories identified by `cargo audit` without including unrelated changes. The separation from #545 ensures a clean, reviewable history of maintenance work.

**Security Impact:**
- RUSTSEC-2026-0007 (bytes vulnerability): Resolved
- RUSTSEC-2026-0204 (crossbeam-epoch vulnerability): Resolved

**Dependency Alignment:**
The `succinctly` version is now synchronized with the root crate's Cargo.toml (0.8.0), ensuring consistency across the project's build artifacts.