### PR TITLE
fix(jq, yaml, json, cli, test): thread cursors through navigation and optimize position tracking

### DIFF
--- a/docs/optimizations/line-index.md
+++ b/docs/optimizations/line-index.md
@@ -94,7 +94,7 @@ Cost of the lazy path is paid only by callers who need it:
 
 The deltas equal the dense index's `heap_size()` exactly — the allocation is simply gone.
 
-## Query cost, and why O(log n) is acceptable here
+## Query cost, and why O(log n) was acceptable before it became hot
 
 `to_line_column` needs "how many line starts precede this offset", which is a predecessor query.
 Elias-Fano has no rank, so `EliasFano::predecessor` is a binary search over `get` — O(log n) with a
@@ -108,23 +108,38 @@ O(1), and it is the direction both locate CLIs and `at_position(line; col)` use.
 | Caller                                                          | Frequency                  |
 |-----------------------------------------------------------------|----------------------------|
 | `jq-locate` / `yq-locate` (`--offset` → reported position)      | once per invocation        |
-| `YamlCursor::line()` / `column()` → the yq `line`/`column` builtins | **once per node visited**  |
+| `YamlCursor::line()` / `column()` / `JsonCursor::line()`/`column()` → the `jq`/`yq` `line`/`column` builtins | **once per node visited**  |
 
-The second row is not a cold path, and an earlier draft of this page claimed it did not exist. It is
-reached only through the cursor evaluator ([src/jq/eval_generic.rs](../../src/jq/eval_generic.rs));
-the `OwnedValue` path that the `syq` CLI takes today stubs both builtins to `0`
-([src/jq/eval.rs](../../src/jq/eval.rs), `builtin_line`), so no shipped command currently drives it
-per node. That is a gap in the builtins, not a licence to call the path cold — if the stubs are ever
-wired up, `.[] | line` becomes one binary search per node, and `{l: line, c: column}` two, because
-`column()` recomputes the search rather than sharing it.
+The second row was believed dormant for a while: the cursor evaluator
+([src/jq/eval_generic.rs](../../src/jq/eval_generic.rs)) computed correct positions, but only for a
+bare `line`/`column` call with zero preceding navigation — every `Expr`/`Builtin` arm that actually
+walked the document (`.foo`, `.[]`, `select(...)`, `Identity`) received a cursor and silently dropped
+it before forwarding to the next pipe stage. `.[] | line` returned `0` for every element, same as the
+`OwnedValue` path's hardcoded stubs ([src/jq/eval.rs](../../src/jq/eval.rs), `builtin_line`) — see
+issue #532. Fixing that cursor-forwarding (not this page's job — see the eval_generic.rs history) made
+this row genuinely hot: `.[] | line` is now one lookup per node, and `{l: line, c: column}` two,
+because `column()` still recomputes the search rather than sharing it with `line()` (a combined
+`line_column()` accessor stayed out of scope of #532 — the cache below already removes most of the
+duplicate work). The `OwnedValue`/full-evaluator path (`-n`, `--slurp`, `--inplace`, JSON-formatted
+input) still returns the `0` sentinel; that evaluator structurally has no cursor to forward, and
+threading one through it is a separate, much larger effort (see #532's discussion for why).
 
-Neither direction has been benchmarked. The comparison is not obviously a regression even at the
-per-node rate: `BitVec::select1` was itself sampled every 256 ones, which at the corpus's ~20
-bytes/line meant scanning up to ~80 words, against ~`log2(lines)` Elias-Fano `get`s here.
+Neither direction had been benchmarked before the path went live. The comparison was not obviously a
+regression even at the per-node rate: `BitVec::select1` was itself sampled every 256 ones, which at
+the corpus's ~20 bytes/line meant scanning up to ~80 words, against ~`log2(lines)` Elias-Fano `get`s
+here.
 
-If a hot consumer does appear, two accelerators are available. The cheap one is a one-entry
-`Cell` cache of the last `(offset, line, line_start)`, which makes the monotone walk `line()`
-performs amortised O(1) — the same trick `AdvancePositions` uses for O1/O2. The structural one:
+Once the path was confirmed hot, the cheap accelerator sketched here was implemented: `LineIndex`
+carries a one-entry `Cell` cache of the last `(offset, line, line_start)` lookup — the same trick
+`AdvancePositions` uses for O1/O2. An exact-repeat query is O(1) with no bit operations at all; a
+forward query within `FORWARD_WALK_CAP` (16) lines resolves via bounded `EliasFano::get` steps instead
+of a fresh binary search — the shape `.[] | line` produces when walking a document top to bottom,
+since sibling iteration visits offsets in increasing order. Anything else (first call, backward jump,
+or a forward jump past the cap) falls back to the binary search and refreshes the cache. The
+structural accelerator below remains unimplemented — the cache was enough once actually measured
+against the real access pattern.
+
+The structural one, for reference, if the cache above is ever insufficient:
 `select_samples[j] - j * SAMPLE_RATE` is the high part of element `j*256` and is monotone in `j`, so
 binary-searching that plain `Vec<u32>` narrows to a 256-element block with zero select calls.
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1574,6 +1574,9 @@ fn evaluate_input(
         GenericResult::One(v) => Ok(vec![generic_to_owned(&v)]),
         GenericResult::OneCursor(c) => Ok(vec![generic_to_owned(&c.value())]),
         GenericResult::Many(vs) => Ok(vs.iter().map(generic_to_owned).collect()),
+        GenericResult::ManyCursor(cs) => {
+            Ok(cs.iter().map(|c| generic_to_owned(&c.value())).collect())
+        }
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -1623,6 +1626,8 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
             .into_iter()
             .map(|v| standard_json_to_jq_value(v, &cursor))
             .collect(),
+        // ManyCursor: same lazy-cursor efficiency as OneCursor, per element.
+        GenericResult::ManyCursor(cs) => cs.into_iter().map(JqValue::Cursor).collect(),
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -388,6 +388,7 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         GenericResult::One(v) => Ok(vec![to_owned(&v)]),
         GenericResult::OneCursor(c) => Ok(vec![to_owned(&c.value())]),
         GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).collect()),
+        GenericResult::ManyCursor(cs) => Ok(cs.iter().map(|c| to_owned(&c.value())).collect()),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());
@@ -1334,6 +1335,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             &result,
                             GenericResult::None | GenericResult::Break(_)
                         ) && !matches!(&result, GenericResult::Many(vs) if vs.is_empty())
+                            && !matches!(&result, GenericResult::ManyCursor(cs) if cs.is_empty())
                             && !matches!(&result, GenericResult::ManyOwned(vs) if vs.is_empty());
                         emit_yaml_doc_separator($writer, &mut yaml_doc_streamed, will_output)?;
                         let stats = result

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -37,14 +37,24 @@ pub trait DocumentCursor: Sized + Copy + Clone {
 
     /// Get the 1-based line number of this node's position.
     ///
-    /// Returns 0 if position information is not available.
+    /// Returns 0 if position information is not available. "Not available"
+    /// specifically means this cursor's evaluator has no source position to
+    /// give — either the value was computed (arithmetic, string
+    /// interpolation, object/array construction) rather than navigated to,
+    /// or evaluation is on the `OwnedValue`/full-evaluator path
+    /// (`src/jq/eval.rs`), which never carries a cursor at all. It does
+    /// *not* mean position tracking is broken: ordinary navigation
+    /// (`.foo`, `.[]`, `select(...)`, chained field/index access) on the
+    /// generic cursor evaluator (`src/jq/eval_generic.rs`) forwards the
+    /// cursor and resolves a real line (#532).
     fn line(&self) -> usize {
         0
     }
 
     /// Get the 1-based column number of this node's position.
     ///
-    /// Returns 0 if position information is not available.
+    /// See [`line`](Self::line) — same "not available" contract, same
+    /// caveats about when it does and doesn't apply.
     fn column(&self) -> usize {
         0
     }
@@ -244,6 +254,14 @@ pub trait DocumentFields: Sized + Clone {
     /// Find a field by name.
     fn find(&self, name: &str) -> Option<Self::Value>;
 
+    /// Find a field by name and return a cursor to its value.
+    ///
+    /// Must agree with [`find`](Self::find) on which field wins when a name
+    /// is repeated (YAML keeps the last duplicate key; JSON keeps the
+    /// first), so callers can switch between the two without a behavior
+    /// change — see the per-format `find`/`find_cursor` implementations.
+    fn find_cursor(&self, name: &str) -> Option<Self::Cursor>;
+
     /// Check if there are no fields.
     fn is_empty(&self) -> bool;
 
@@ -309,6 +327,20 @@ pub trait DocumentElements: Sized + Copy + Clone {
     /// Get element by index (0-based).
     fn get(&self, index: usize) -> Option<Self::Value>;
 
+    /// Get element by index (0-based) and return a cursor to it.
+    ///
+    /// Default: walks [`uncons_cursor`](Self::uncons_cursor) `index` times —
+    /// the same sibling-walk `get` itself performs for both YAML and JSON
+    /// today, so this costs no more than `get`.
+    fn get_cursor(&self, index: usize) -> Option<Self::Cursor> {
+        let mut elems = *self;
+        for _ in 0..index {
+            let (_, rest) = elems.uncons_cursor()?;
+            elems = rest;
+        }
+        elems.uncons_cursor().map(|(cursor, _)| cursor)
+    }
+
     /// Check if there are no elements.
     fn is_empty(&self) -> bool;
 
@@ -332,5 +364,16 @@ pub trait DocumentElements: Sized + Copy + Clone {
             elems = rest;
         }
         values
+    }
+
+    /// Collect a cursor for every element into a Vec.
+    fn collect_cursors(&self) -> Vec<Self::Cursor> {
+        let mut cursors = Vec::new();
+        let mut elems = *self;
+        while let Some((cursor, rest)) = elems.uncons_cursor() {
+            cursors.push(cursor);
+            elems = rest;
+        }
+        cursors
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14567,20 +14567,27 @@ fn builtin_kind<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryRes
 }
 
 /// `line` - returns the 1-based line number of the current node (yq)
-/// Since YAML position metadata is lost during conversion to OwnedValue, this returns 0.
-/// In a full yq implementation, this would require tracking source positions through the pipeline.
+///
+/// Always `0` here: this is the "full"/`OwnedValue` evaluator (`eval` in
+/// this file), whose `eval_single` never carries a cursor at all — unlike
+/// `src/jq/eval_generic.rs`'s `eval_single`, which takes an
+/// `Option<V::Cursor>` and, for the `Expr`/`Builtin` arms it handles
+/// natively, forwards it through navigation (`.foo`, `.[]`, `select(...)`)
+/// so `line`/`column` resolve real positions there (#532). This evaluator
+/// backs `yq`'s `-n`/`--slurp`/`--inplace`/JSON-input paths and any `Expr`
+/// eval_generic.rs doesn't natively handle; both round-trip through
+/// `OwnedValue`/JSON with no source-position tracking, so `0` is this path's
+/// permanent, correct answer per
+/// [`DocumentCursor::line`](crate::jq::document::DocumentCursor::line)'s
+/// documented "not available" contract, not a stub awaiting completion.
 fn builtin_line<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
-    // Currently source positions are not preserved through the OwnedValue conversion.
-    // Return 0 to indicate position is unknown (yq returns 1 for actual positions).
     QueryResult::Owned(OwnedValue::Int(0))
 }
 
 /// `column` - returns the 1-based column number of the current node (yq)
-/// Since YAML position metadata is lost during conversion to OwnedValue, this returns 0.
-/// In a full yq implementation, this would require tracking source positions through the pipeline.
+///
+/// See [`builtin_line`]: same reason, same evaluator, same permanent `0`.
 fn builtin_column<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
-    // Currently source positions are not preserved through the OwnedValue conversion.
-    // Return 0 to indicate position is unknown (yq returns 1 for actual positions).
     QueryResult::Owned(OwnedValue::Int(0))
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2658,4 +2658,243 @@ mod tests {
         let yq_result = eval_using::<YqSemantics, _>(&expr, index.root(json).value());
         assert_eq!(yq_result.into_owned(), Some(OwnedValue::Float(1.5)));
     }
+
+    // Coverage follow-ups for #532: the tests above exercise the common
+    // `.foo`/`.[]`/`select(...)` shapes, but a few less-common `GenericResult`
+    // combinations at Pipe/Compare/Select/Iterables/Scalars stage boundaries
+    // weren't reached by any existing test. `Error`/`Break` in these arms
+    // return immediately, so those two get their own dedicated tests instead
+    // of being combined with the success-path ones.
+
+    #[test]
+    fn test_json_many_stage_result_produces_many_cursor_per_element() {
+        // `.[("a","b")]` is a computed multi-key index: on an object with
+        // both keys present as borrowed (non-owned) values, it resolves to a
+        // plain `Many` (not `ManyCursor`) pipe-stage result. Piping that into
+        // `.[]` evaluates the next stage per element, and each element's
+        // `.[]` yields its own `ManyCursor` — exercising the `Many(vs)`
+        // stage-transition arm's `ManyCursor` sub-case.
+        let json = br#"{"a": [1, 2], "b": [3, 4]}"#;
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(r#".[("a","b")] | .[]"#).unwrap();
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(
+            result.collect_owned(),
+            vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+                OwnedValue::Int(3),
+                OwnedValue::Int(4),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_json_iterate_then_field_error_propagates() {
+        // When `.[]` yields a `ManyCursor` and a later stage errors on one
+        // element (`.x` on a non-object), the error must propagate out of
+        // the whole evaluation rather than being dropped silently.
+        let json = br#"{"items": [{"x": 1}, 5]}"#;
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(".items[] | .x").unwrap();
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert!(result.is_error());
+    }
+
+    #[test]
+    fn test_json_iterate_then_break_propagates() {
+        // Same shape as the error case above, but for `break`, which has its
+        // own early-return arm alongside `Error`.
+        let json = br#"{"items": [1, 2]}"#;
+        let index = JsonIndex::build(json);
+        let expr = Expr::Pipe(vec![
+            Expr::Field("items".to_string()),
+            Expr::Iterate,
+            Expr::Break("out".to_string()),
+        ]);
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert!(matches!(result, GenericResult::Break(label) if label == "out"));
+    }
+
+    #[test]
+    fn test_json_iterate_then_single_key_index_expr_yields_one() {
+        // Heterogeneous-flatten path of the `ManyCursor` stage arm: a
+        // computed single-key index yields a plain `One` per element rather
+        // than `OneCursor`, so the per-element results can't stay
+        // `ManyCursor` and must flatten through the `One` arm. Built directly
+        // as `Expr::IndexExpr` rather than parsed from `.["a"]`, since the
+        // parser folds a literal-string bracket index into a plain
+        // `Expr::Field` (which would instead take the all-`OneCursor` path).
+        let json = br#"{"items": [{"a": 1}, {"a": 2}]}"#;
+        let index = JsonIndex::build(json);
+        let expr = Expr::Pipe(vec![
+            Expr::Field("items".to_string()),
+            Expr::Iterate,
+            Expr::IndexExpr {
+                target: Box::new(Expr::Identity),
+                key: Box::new(Expr::Literal(Literal::String("a".to_string()))),
+            },
+        ]);
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(
+            result.collect_owned(),
+            vec![OwnedValue::Int(1), OwnedValue::Int(2)]
+        );
+    }
+
+    #[test]
+    fn test_json_iterate_then_multi_key_index_expr_yields_many_and_many_owned() {
+        // Same flatten path, but the per-element computed index now yields
+        // `Many` (both keys found on the second item) or `ManyOwned` (a mix
+        // of found/missing keys forces the owned fallback on the first and
+        // third items), exercising both arms.
+        let json = br#"{"items": [{"a": 1}, {"a": 1, "b": 2}, {"c": 3}]}"#;
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(r#".items[] | .[("a","b")]"#).unwrap();
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(
+            result.collect_owned(),
+            vec![
+                OwnedValue::Int(1),
+                OwnedValue::Null,
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+                OwnedValue::Null,
+                OwnedValue::Null,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_json_iterate_then_nested_iterate_yields_many_cursor_in_flatten() {
+        // Same flatten path with a per-element `ManyCursor` (from a nested
+        // `.x[]`) alongside a `None` (empty array), exercising the
+        // `ManyCursor` arm of the heterogeneous flatten.
+        let json = br#"{"items": [{"x": [10, 20]}, {"x": []}]}"#;
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(".items[] | .x[]").unwrap();
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(
+            result.collect_owned(),
+            vec![OwnedValue::Int(10), OwnedValue::Int(20)]
+        );
+    }
+
+    #[test]
+    fn test_json_compare_left_many_cursor_uses_first_element() {
+        // `Compare`'s `ManyCursor`-operand arm: `.[]` on the left side yields
+        // a `ManyCursor`, and the comparison uses its first element.
+        let json = br"[1, 2]";
+        let index = JsonIndex::build(json);
+        let expr = Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(Expr::Iterate),
+            right: Box::new(Expr::Literal(Literal::Int(1))),
+        };
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(result.into_owned(), Some(OwnedValue::Bool(true)));
+    }
+
+    #[test]
+    fn test_json_compare_right_many_cursor_uses_first_element() {
+        // Mirror of the above for the right-hand operand.
+        let json = br"[1, 2]";
+        let index = JsonIndex::build(json);
+        let expr = Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(Expr::Literal(Literal::Int(1))),
+            right: Box::new(Expr::Iterate),
+        };
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(result.into_owned(), Some(OwnedValue::Bool(true)));
+    }
+
+    #[test]
+    fn test_json_select_cond_one_truthy() {
+        // `select`'s condition-result matching: a bare `One` (not
+        // `OneCursor`) condition result arises when `eval` is used without a
+        // cursor context, hitting a distinct arm from the `OneCursor` case
+        // below.
+        let json = b"5";
+        let index = JsonIndex::build(json);
+        let expr = Expr::Builtin(Builtin::Select(Box::new(Expr::Identity)));
+
+        let result = eval(&expr, index.root(json).value());
+        assert_eq!(result.into_owned(), Some(OwnedValue::Int(5)));
+    }
+
+    #[test]
+    fn test_json_select_cond_one_cursor_truthy() {
+        // Same as above, but evaluated with cursor context, so the condition
+        // result is `OneCursor` instead of `One`.
+        let json = b"5";
+        let index = JsonIndex::build(json);
+        let expr = Expr::Builtin(Builtin::Select(Box::new(Expr::Identity)));
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(result.into_owned(), Some(OwnedValue::Int(5)));
+    }
+
+    #[test]
+    fn test_json_iterables_forwards_cursor() {
+        // `iterables`/`scalars` forward an incoming cursor when present,
+        // hitting the `OneCursor` arm of `cursor.map_or` instead of the
+        // cursor-less default.
+        let json = br"[1, 2]";
+        let index = JsonIndex::build(json);
+        let expr = Expr::Builtin(Builtin::Iterables);
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(
+            result.into_owned(),
+            Some(OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2)
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_json_scalars_forwards_cursor() {
+        let json = b"5";
+        let index = JsonIndex::build(json);
+        let expr = Expr::Builtin(Builtin::Scalars);
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(result.into_owned(), Some(OwnedValue::Int(5)));
+    }
+
+    #[test]
+    fn test_json_line_builtin_with_cursor() {
+        // JSON counterpart of `test_yaml_line_builtin_with_cursor`: exercises
+        // `JsonCursor`'s `DocumentCursor::line()` trait delegation (as
+        // opposed to the inherent method called directly by
+        // `test_cursor_line_column` in `json::light`).
+        let json = b"{\n  \"foo\": 1\n}";
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(".foo | line").unwrap();
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(result.into_owned(), Some(OwnedValue::Int(2)));
+    }
+
+    #[test]
+    fn test_json_column_builtin_with_cursor() {
+        // JSON counterpart of `test_yaml_column_builtin_with_cursor`,
+        // exercising `JsonCursor`'s `DocumentCursor::column()` delegation.
+        let json = b"{\n  \"foo\": 1\n}";
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(".foo | column").unwrap();
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(result.into_owned(), Some(OwnedValue::Int(10)));
+    }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -152,6 +152,9 @@ fn eval_on_many_owned<S: EvalSemantics, V: DocumentValue>(
             GenericResult::One(_) => unreachable!("eval_on_owned never returns One"),
             GenericResult::OneCursor(_) => unreachable!("eval_on_owned never returns OneCursor"),
             GenericResult::Many(_) => unreachable!("eval_on_owned never returns Many"),
+            GenericResult::ManyCursor(_) => {
+                unreachable!("eval_on_owned never returns ManyCursor")
+            }
             GenericResult::None => {}
             GenericResult::Error(e) => return GenericResult::Error(e),
             GenericResult::Owned(o) => results.push(o),
@@ -178,6 +181,10 @@ pub enum GenericResult<V: DocumentValue> {
     /// Multiple values (from iteration).
     Many(Vec<V>),
 
+    /// Multiple cursor results (from iteration with position preserved,
+    /// e.g. `.[]`), enabling `line`/`column` on each element.
+    ManyCursor(Vec<V::Cursor>),
+
     /// No result (optional that was missing).
     None,
 
@@ -201,6 +208,9 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::One(v) => Some(to_owned(&v)),
             Self::OneCursor(c) => Some(to_owned(&c.value())),
             Self::Many(vs) => Some(OwnedValue::Array(vs.iter().map(to_owned).collect())),
+            Self::ManyCursor(cs) => Some(OwnedValue::Array(
+                cs.iter().map(|c| to_owned(&c.value())).collect(),
+            )),
             Self::None => None,
             Self::Error(_) => None,
             Self::Owned(o) => Some(o),
@@ -215,6 +225,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::One(v) => vec![to_owned(&v)],
             Self::OneCursor(c) => vec![to_owned(&c.value())],
             Self::Many(vs) => vs.iter().map(to_owned).collect(),
+            Self::ManyCursor(cs) => cs.iter().map(|c| to_owned(&c.value())).collect(),
             Self::None => vec![],
             Self::Error(_) => vec![],
             Self::Owned(o) => vec![o],
@@ -280,6 +291,15 @@ impl<V: DocumentValue> GenericResult<V> {
                     stats.any_truthy |= !stats.last_was_falsy;
                 }
                 stats.count = vs.len();
+            }
+            Self::ManyCursor(cs) => {
+                for c in cs {
+                    c.stream_json(out, indent_spaces)?;
+                    on_value(out)?;
+                    stats.last_was_falsy = c.is_falsy();
+                    stats.any_truthy |= !stats.last_was_falsy;
+                }
+                stats.count = cs.len();
             }
             Self::None => {
                 // No output
@@ -366,6 +386,15 @@ impl<V: DocumentValue> GenericResult<V> {
                     stats.any_truthy |= !stats.last_was_falsy;
                 }
                 stats.count = vs.len();
+            }
+            Self::ManyCursor(cs) => {
+                for c in cs {
+                    c.stream_yaml(out, indent_spaces)?;
+                    on_value(out)?;
+                    stats.last_was_falsy = c.is_falsy();
+                    stats.any_truthy |= !stats.last_was_falsy;
+                }
+                stats.count = cs.len();
             }
             Self::None => {
                 // No output
@@ -455,12 +484,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
 ) -> GenericResult<V> {
     match expr {
-        Expr::Identity => GenericResult::One(value),
+        // Forward the cursor when we have one, so a bare `line`/`column`
+        // downstream of a no-op navigation step (`. | line`) still resolves
+        // a real position instead of falling to the `One`->`None` default.
+        Expr::Identity => cursor.map_or(GenericResult::One(value), GenericResult::OneCursor),
 
         Expr::Field(name) => {
             if let Some(fields) = value.as_object() {
-                match fields.find(name) {
-                    Some(v) => GenericResult::One(v),
+                match fields.find_cursor(name) {
+                    Some(c) => GenericResult::OneCursor(c),
                     // jq returns null for missing fields on objects (not an error)
                     None => GenericResult::Owned(OwnedValue::Null),
                 }
@@ -482,8 +514,8 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 } else {
                     *idx as usize
                 };
-                match elements.get(actual_idx) {
-                    Some(v) => GenericResult::One(v),
+                match elements.get_cursor(actual_idx) {
+                    Some(c) => GenericResult::OneCursor(c),
                     // jq returns null for out-of-bounds array indices (positive
                     // or negative), not an error. `.[n]` and `.[n]?` both yield
                     // null since there is no error for `?` to suppress. See #307.
@@ -515,23 +547,23 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
 
         Expr::Iterate => {
             if let Some(elements) = value.as_array() {
-                let values = elements.collect_values();
-                if values.is_empty() {
+                let cursors = elements.collect_cursors();
+                if cursors.is_empty() {
                     GenericResult::None
                 } else {
-                    GenericResult::Many(values)
+                    GenericResult::ManyCursor(cursors)
                 }
             } else if let Some(fields) = value.as_object() {
-                let mut values = Vec::new();
+                let mut cursors = Vec::new();
                 let mut f = fields;
                 while let Some((field, rest)) = f.uncons() {
-                    values.push(field.value);
+                    cursors.push(field.value_cursor);
                     f = rest;
                 }
-                if values.is_empty() {
+                if cursors.is_empty() {
                     GenericResult::None
                 } else {
-                    GenericResult::Many(values)
+                    GenericResult::ManyCursor(cursors)
                 }
             } else if optional {
                 GenericResult::None
@@ -549,7 +581,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
 
             let mut current = eval_single::<S, _>(&exprs[0], value, optional, cursor);
 
-            for expr in &exprs[1..] {
+            for (i, expr) in exprs.iter().enumerate().skip(1) {
                 current = match current {
                     GenericResult::One(v) => eval_single::<S, _>(expr, v, optional, None),
                     GenericResult::OneCursor(c) => {
@@ -564,6 +596,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 GenericResult::Many(rs) => {
                                     results.extend(rs.iter().map(to_owned));
                                 }
+                                GenericResult::ManyCursor(cs) => {
+                                    results.extend(cs.iter().map(|c| to_owned(&c.value())));
+                                }
                                 GenericResult::None => {}
                                 GenericResult::Error(e) => return GenericResult::Error(e),
                                 GenericResult::Owned(o) => results.push(o),
@@ -576,6 +611,77 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         } else {
                             GenericResult::ManyOwned(results)
                         }
+                    }
+                    // Unlike the `Many` arm above, don't flatten after just
+                    // this one stage: a flattened `ManyOwned` can't carry a
+                    // per-element cursor into any *further* stage — including
+                    // one in an *enclosing* pipe, since a dot-chain like
+                    // `.a[].b` parses as its own nested `Pipe` (see
+                    // `parse_postfix`), so `.a[].b | line` only reaches
+                    // `line` after this whole inner pipe returns. Instead,
+                    // run the rest of the pipe (`expr` and everything after
+                    // it) against each cursor independently and, when every
+                    // element's result is itself a single cursor (the common
+                    // `.[] | .foo` / nested dot-chain shape), stay as
+                    // `ManyCursor` so an enclosing pipe or `line`/`column`
+                    // can still resolve a position. Only degrade to
+                    // materialized `ManyOwned` when a result is
+                    // heterogeneous (multiple values, filtered out, or a
+                    // computed value).
+                    GenericResult::ManyCursor(cs) => {
+                        let rest = Expr::Pipe(exprs[i..].to_vec());
+                        let mut per_element = Vec::with_capacity(cs.len());
+                        for c in cs {
+                            match eval_single::<S, _>(&rest, c.value(), optional, Some(c)) {
+                                GenericResult::Error(e) => return GenericResult::Error(e),
+                                GenericResult::Break(label) => return GenericResult::Break(label),
+                                other => per_element.push(other),
+                            }
+                        }
+
+                        let all_single_cursor = !per_element.is_empty()
+                            && per_element
+                                .iter()
+                                .all(|r| matches!(r, GenericResult::OneCursor(_)));
+
+                        return if all_single_cursor {
+                            GenericResult::ManyCursor(
+                                per_element
+                                    .into_iter()
+                                    .map(|r| match r {
+                                        GenericResult::OneCursor(c) => c,
+                                        _ => unreachable!("checked all_single_cursor above"),
+                                    })
+                                    .collect(),
+                            )
+                        } else {
+                            let mut results = Vec::new();
+                            for r in per_element {
+                                match r {
+                                    GenericResult::One(v) => results.push(to_owned(&v)),
+                                    GenericResult::OneCursor(c) => {
+                                        results.push(to_owned(&c.value()));
+                                    }
+                                    GenericResult::Many(rs) => {
+                                        results.extend(rs.iter().map(to_owned));
+                                    }
+                                    GenericResult::ManyCursor(cs) => {
+                                        results.extend(cs.iter().map(|c| to_owned(&c.value())));
+                                    }
+                                    GenericResult::None => {}
+                                    GenericResult::Owned(o) => results.push(o),
+                                    GenericResult::ManyOwned(os) => results.extend(os),
+                                    GenericResult::Error(_) | GenericResult::Break(_) => {
+                                        unreachable!("Error/Break already returned above")
+                                    }
+                                }
+                            }
+                            if results.is_empty() {
+                                GenericResult::None
+                            } else {
+                                GenericResult::ManyOwned(results)
+                            }
+                        };
                     }
                     GenericResult::None => GenericResult::None,
                     GenericResult::Error(e) => return GenericResult::Error(e),
@@ -630,6 +736,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         return GenericResult::None;
                     }
                 }
+                GenericResult::ManyCursor(cs) => {
+                    if let Some(first) = cs.first() {
+                        to_owned(&first.value())
+                    } else {
+                        return GenericResult::None;
+                    }
+                }
                 GenericResult::ManyOwned(vs) => {
                     if let Some(first) = vs.first() {
                         first.clone()
@@ -655,6 +768,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Many(vs) => {
                     if let Some(first) = vs.first() {
                         to_owned(first)
+                    } else {
+                        return GenericResult::None;
+                    }
+                }
+                GenericResult::ManyCursor(cs) => {
+                    if let Some(first) = cs.first() {
+                        to_owned(&first.value())
                     } else {
                         return GenericResult::None;
                     }
@@ -829,6 +949,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         GenericResult::One(v) => vec![v],
         GenericResult::Many(vs) => vs,
         GenericResult::OneCursor(c) => vec![c.value()],
+        GenericResult::ManyCursor(cs) => cs.iter().map(DocumentCursor::value).collect(),
         // An owned target (a computed, non-navigational left side) has no
         // borrowed representation here; round-trip it through the shared
         // owned-value path by re-entering with the materialized document.
@@ -929,24 +1050,30 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 }
             };
 
+            // `select` never changes position — the truthy output IS the
+            // input node, so forward the incoming cursor (if any) rather
+            // than dropping it via a plain `One(value)`.
+            let pass =
+                || cursor.map_or(GenericResult::One(value.clone()), GenericResult::OneCursor);
+
             match cond_result {
                 GenericResult::Owned(ref o) => {
                     if is_truthy(o) {
-                        GenericResult::One(value)
+                        pass()
                     } else {
                         GenericResult::None
                     }
                 }
                 GenericResult::One(v) => {
                     if is_truthy(&to_owned(&v)) {
-                        GenericResult::One(value)
+                        pass()
                     } else {
                         GenericResult::None
                     }
                 }
                 GenericResult::OneCursor(c) => {
                     if is_truthy(&to_owned(&c.value())) {
-                        GenericResult::One(value)
+                        pass()
                     } else {
                         GenericResult::None
                     }
@@ -959,10 +1086,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     }
                 }
                 GenericResult::None => GenericResult::None,
-                GenericResult::Many(_) | GenericResult::ManyOwned(_) => {
+                GenericResult::Many(_)
+                | GenericResult::ManyOwned(_)
+                | GenericResult::ManyCursor(_) => {
                     // Multiple results from condition - this is unusual but treat first as condition
                     // jq behavior: select with multiple outputs uses first truthy value
-                    GenericResult::One(value)
+                    pass()
                 }
                 GenericResult::Break(label) => GenericResult::Break(label),
             }
@@ -1155,7 +1284,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             if value.is_null() {
                 GenericResult::None
             } else {
-                GenericResult::One(value)
+                cursor.map_or(GenericResult::One(value), GenericResult::OneCursor)
             }
         }
 
@@ -1215,7 +1344,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Iterables => {
             // Returns input if iterable, empty otherwise
             if value.is_iterable() {
-                GenericResult::One(value)
+                cursor.map_or(GenericResult::One(value), GenericResult::OneCursor)
             } else {
                 GenericResult::None
             }
@@ -1224,7 +1353,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Scalars => {
             // Returns input if scalar, empty otherwise
             if !value.is_iterable() {
-                GenericResult::One(value)
+                cursor.map_or(GenericResult::One(value), GenericResult::OneCursor)
             } else {
                 GenericResult::None
             }
@@ -1829,6 +1958,137 @@ mod tests {
         assert_eq!(owned, OwnedValue::Int(0));
     }
 
+    // Regression tests for #532: `line`/`column` returned 0 for anything
+    // downstream of `.foo`/`.[]`/`select(...)`, because those Expr/Builtin
+    // arms received a cursor but never forwarded it — only a bare `line`
+    // with zero preceding navigation (like the tests above) worked. These
+    // go through a real `.foo`/`.[]`/`select(...)`/dot-chain pipeline
+    // instead of calling `Builtin::Line` directly on a root cursor.
+
+    #[test]
+    fn test_yaml_field_then_line() {
+        use crate::yaml::YamlIndex;
+
+        // `foo` is the second key, so a correct result (2) can't be
+        // confused with the `line() == 0`/`line() == 1` defaults.
+        let yaml = b"other: 1\nfoo: bar\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".foo | line").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(2));
+    }
+
+    #[test]
+    fn test_yaml_iterate_array_then_line() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"- a\n- b\n- c\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".[] | line").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+                OwnedValue::Int(3),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_yaml_iterate_object_then_line() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: 1\nb: 2\nc: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        // The issue's exact repro.
+        let expr = crate::jq::parse(".[] | line").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+                OwnedValue::Int(3),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_yaml_select_then_line_preserves_position() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"- 1\n- 2\n- 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".[] | select(. > 1) | line").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)])
+        );
+    }
+
+    #[test]
+    fn test_yaml_dot_chain_then_line() {
+        use crate::yaml::YamlIndex;
+
+        // `.containers[].image | line` parses as a *nested* `Pipe` (the
+        // dot-chain `.containers[].image` is its own Pipe, itself one
+        // element of the outer `| line` pipe) — a stricter test than a
+        // fully `|`-separated query, since the cursor must survive
+        // `ManyCursor` propagating out of an inner pipe's return.
+        let yaml = b"containers:\n  - image: a\n  - image: b\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".containers[].image | line").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)])
+        );
+    }
+
+    #[test]
+    fn test_yaml_identity_pipe_then_line() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"foo: bar\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(". | line").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(1));
+    }
+
     #[test]
     fn test_yaml_generic_pipe() {
         use crate::yaml::YamlIndex;
@@ -1970,6 +2230,12 @@ mod tests {
                 let result = eval_with_cursor(&expr, cursor);
                 match result {
                     GenericResult::One(v) => results.push(to_owned(&v)),
+                    // `select`'s truthy branch now forwards the cursor it
+                    // was given (needed for `line`/`column` to survive a
+                    // `select(...)`), so a match here is `OneCursor`, not
+                    // `One` — see the `Builtin::Select` cursor-forwarding
+                    // fix in `eval_builtin`.
+                    GenericResult::OneCursor(c) => results.push(to_owned(&c.value())),
                     GenericResult::Owned(o) => results.push(o),
                     GenericResult::None => {} // Filtered out
                     _ => {}
@@ -2008,7 +2274,12 @@ mod tests {
             while let Some((cursor, rest)) = docs.uncons_cursor() {
                 let result = eval_with_cursor(&expr, cursor);
                 match result {
-                    GenericResult::One(_) | GenericResult::Owned(_) => count += 1,
+                    // See the sibling `test_yaml_select_di_eq_n` comment:
+                    // `select`'s truthy branch now returns `OneCursor` when
+                    // given one, not `One`.
+                    GenericResult::One(_)
+                    | GenericResult::OneCursor(_)
+                    | GenericResult::Owned(_) => count += 1,
                     _ => {}
                 }
                 docs = rest;

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -997,6 +997,22 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         }
         None
     }
+
+    /// Find a field by name and return a cursor to its value.
+    ///
+    /// Same first-match semantics as [`find`](Self::find).
+    pub fn find_cursor(&self, name: &str) -> Option<JsonCursor<'a, W>> {
+        let mut fields = *self;
+        while let Some((field, rest)) = fields.uncons() {
+            if let StandardJson::String(key) = field.key() {
+                if key.as_str().ok()? == name {
+                    return Some(field.value_cursor());
+                }
+            }
+            fields = rest;
+        }
+        None
+    }
 }
 
 impl<'a, W: AsRef<[u64]>> Iterator for JsonFields<'a, W> {
@@ -1658,6 +1674,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
 
     fn find(&self, name: &str) -> Option<Self::Value> {
         JsonFields::find(self, name)
+    }
+
+    fn find_cursor(&self, name: &str) -> Option<Self::Cursor> {
+        JsonFields::find_cursor(self, name)
     }
 
     fn is_empty(&self) -> bool {

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -555,6 +555,28 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
         self.index.ib_select1_from(rank, hint)
     }
 
+    /// Get the 1-based line number of this node's position in the JSON text.
+    ///
+    /// Returns 0 if the position cannot be resolved (should not normally
+    /// happen for a valid cursor).
+    #[inline]
+    pub fn line(&self) -> usize {
+        let offset = self.text_position().unwrap_or(0);
+        let (line, _column) = self.index.to_line_column(offset, self.text);
+        line
+    }
+
+    /// Get the 1-based column number of this node's position in the JSON text.
+    ///
+    /// Returns 0 if the position cannot be resolved (should not normally
+    /// happen for a valid cursor).
+    #[inline]
+    pub fn column(&self) -> usize {
+        let offset = self.text_position().unwrap_or(0);
+        let (_line, column) = self.index.to_line_column(offset, self.text);
+        column
+    }
+
     /// Navigate to the first child.
     ///
     /// Returns `None` if this position has no children (is a leaf or close paren).
@@ -1525,6 +1547,16 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
     }
 
     #[inline]
+    fn line(&self) -> usize {
+        JsonCursor::line(self)
+    }
+
+    #[inline]
+    fn column(&self) -> usize {
+        JsonCursor::column(self)
+    }
+
+    #[inline]
     fn cursor_at_offset(&self, offset: usize) -> Option<Self> {
         JsonCursor::cursor_at_offset(self, offset)
     }
@@ -2056,6 +2088,25 @@ mod tests {
         let index = JsonIndex::build(json);
         let root = index.root(json);
         assert_eq!(root.bp_position(), 0);
+    }
+
+    #[test]
+    fn test_cursor_line_column() {
+        // JsonCursor previously had no `line()`/`column()` at all — it fell
+        // through to `DocumentCursor`'s `0` default even at the root (#532).
+        let json = b"{\n  \"a\": 1,\n  \"b\": 2\n}";
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+
+        assert_eq!(root.line(), 1);
+        assert_eq!(root.column(), 1);
+
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        let b_cursor = fields.find_cursor("b").expect("field b");
+        assert_eq!(b_cursor.line(), 3);
+        assert_eq!(b_cursor.column(), 8);
     }
 
     #[test]

--- a/src/text/lines.rs
+++ b/src/text/lines.rs
@@ -38,9 +38,34 @@
 
 #[cfg(not(test))]
 use alloc::vec::Vec;
+use core::cell::Cell;
 
 use crate::bits::EliasFano;
 use crate::text::line_break::{is_line_break, line_break_len};
+
+/// How many lines [`LineIndex::to_line_column`] will walk forward from the
+/// cache before giving up and falling back to a full binary search. Bounds
+/// the worst case of a query that lands just past the cached line while
+/// keeping the common near-sequential case (`.[] | line` walking a document
+/// top to bottom) cheap. Not benchmarked against other values — a reasonable
+/// starting point, not a tuned constant.
+const FORWARD_WALK_CAP: u32 = 16;
+
+/// One cached `(offset, line, line_start)` lookup, so a monotone walk of
+/// [`LineIndex::to_line_column`] — e.g. `.[] | line` visiting array elements
+/// in document order — resolves in amortised O(1) instead of a fresh
+/// `EliasFano::predecessor` binary search per call. Mirrors the one-entry
+/// `Cell`-based cache `AdvancePositions` uses for its O1/O2 optimizations
+/// (`src/yaml/advance_positions.rs`).
+#[derive(Clone, Copy, Debug)]
+struct LineCacheEntry {
+    /// The clamped query offset this entry was computed for.
+    offset: u32,
+    /// 0-indexed line containing `offset`.
+    line_idx: u32,
+    /// Byte offset at which `line_idx` starts.
+    line_start: u32,
+}
 
 /// Index over the byte offsets at which each line starts.
 ///
@@ -64,6 +89,9 @@ pub struct LineIndex {
     starts: EliasFano,
     /// Total length of the indexed text.
     text_len: usize,
+    /// Last `to_line_column` lookup, reused to speed up nearby/repeated
+    /// queries. `Cell<T: Copy>` keeps `LineIndex` both `Clone` and `Debug`.
+    cache: Cell<Option<LineCacheEntry>>,
 }
 
 impl LineIndex {
@@ -112,6 +140,7 @@ impl LineIndex {
         Self {
             starts: EliasFano::build(&starts),
             text_len: text.len(),
+            cache: Cell::new(None),
         }
     }
 
@@ -143,12 +172,36 @@ impl LineIndex {
     ///
     /// # Performance
     ///
-    /// O(log lines). A cold path: error reporting, `at_position`, and the
-    /// locate CLIs.
+    /// A repeated or monotonically-forward query (the access pattern
+    /// `.[] | line` produces when walking a document top to bottom) resolves
+    /// in amortised O(1) via a one-entry cache of the last lookup, up to
+    /// `FORWARD_WALK_CAP` lines of forward movement. Beyond that — or on
+    /// the first call, or a backward/large jump — this is `O(log lines)`,
+    /// still cheap enough for the cold paths that predate the cache: error
+    /// reporting, `at_position`, and the locate CLIs.
     pub fn to_line_column(&self, offset: usize) -> (usize, usize) {
         // text_len <= u32::MAX, so clamping only affects offsets that are
         // already past the end.
         let query = offset.min(u32::MAX as usize) as u32;
+
+        if let Some(entry) = self.cache.get() {
+            if query == entry.offset {
+                // Exact repeat (e.g. `{l: line, c: column}` querying the
+                // same node twice): no lookup at all.
+                return (
+                    entry.line_idx as usize + 1,
+                    offset - entry.line_start as usize + 1,
+                );
+            }
+
+            if query > entry.offset {
+                if let Some(result) = self.walk_forward_from(entry, offset, query) {
+                    return result;
+                }
+                // Walk exceeded FORWARD_WALK_CAP: fall through to the full
+                // binary search below, same as a cold/backward query.
+            }
+        }
 
         // Always `Some`: element 0 is offset 0.
         let (idx, start) = self
@@ -156,7 +209,49 @@ impl LineIndex {
             .predecessor(query)
             .expect("LineIndex always holds line 1");
 
+        self.cache.set(Some(LineCacheEntry {
+            offset: query,
+            line_idx: idx as u32,
+            line_start: start,
+        }));
+
         (idx + 1, offset - start as usize + 1)
+    }
+
+    /// Try to resolve `query` by walking forward at most
+    /// [`FORWARD_WALK_CAP`] lines from `entry`, using O(1)
+    /// [`EliasFano::get`] per step instead of a fresh binary search.
+    /// Returns `None` if the walk exceeds the cap without reaching `query`.
+    fn walk_forward_from(
+        &self,
+        entry: LineCacheEntry,
+        offset: usize,
+        query: u32,
+    ) -> Option<(usize, usize)> {
+        let mut line_idx = entry.line_idx;
+        let mut line_start = entry.line_start;
+
+        for _ in 0..FORWARD_WALK_CAP {
+            match self.starts.get(line_idx as usize + 1) {
+                Some(next_start) if next_start <= query => {
+                    line_idx += 1;
+                    line_start = next_start;
+                }
+                // `next_start > query`, or no further line (`None`, `query`
+                // is on/past the last line either way): `query` is on
+                // `line_idx`.
+                _ => {
+                    self.cache.set(Some(LineCacheEntry {
+                        offset: query,
+                        line_idx,
+                        line_start,
+                    }));
+                    return Some((line_idx as usize + 1, offset - line_start as usize + 1));
+                }
+            }
+        }
+
+        None
     }
 
     /// Convert a 1-indexed line and column to a 0-indexed byte offset.
@@ -447,5 +542,114 @@ mod tests {
             index.heap_size(),
             dense.heap_size()
         );
+    }
+
+    /// 40 one-line-per-`\n` lines, `line`'s 1-indexed start is `(line - 1) * 4`
+    /// (each line is `"L%02d\n"`, 5 bytes wide including the terminator, but
+    /// the last line has no trailing `\n` counted into it). Large enough to
+    /// exercise both sides of [`FORWARD_WALK_CAP`] (16).
+    fn many_lines_text() -> Vec<u8> {
+        let mut text = Vec::new();
+        for i in 0..40 {
+            text.extend_from_slice(format!("L{i:02}\n").as_bytes());
+        }
+        text
+    }
+
+    #[test]
+    fn to_line_column_forward_gap_within_cap_matches_naive() {
+        let text = many_lines_text();
+        let index = LineIndex::build(&text);
+        let starts = naive_line_starts(&text);
+
+        // Prime the cache on line 3, then jump forward 10 lines (< cap):
+        // should resolve via the forward walk, not a fresh binary search.
+        let seed_offset = starts[2];
+        assert_eq!(index.to_line_column(seed_offset), (3, 1));
+
+        let target_offset = starts[12];
+        let expected_line = starts.partition_point(|&s| s <= target_offset);
+        assert_eq!(
+            index.to_line_column(target_offset),
+            (expected_line, target_offset - starts[expected_line - 1] + 1)
+        );
+    }
+
+    #[test]
+    fn to_line_column_forward_gap_beyond_cap_falls_back_correctly() {
+        let text = many_lines_text();
+        let index = LineIndex::build(&text);
+        let starts = naive_line_starts(&text);
+
+        // Prime the cache on line 1, then jump forward more than
+        // FORWARD_WALK_CAP lines — must fall back to the binary search and
+        // still return the correct answer, not a truncated/capped one.
+        assert_eq!(index.to_line_column(0), (1, 1));
+
+        let target_line = 1 + FORWARD_WALK_CAP as usize + 5;
+        let target_offset = starts[target_line - 1];
+        assert_eq!(index.to_line_column(target_offset), (target_line, 1));
+    }
+
+    #[test]
+    fn to_line_column_backward_after_forward_run_matches_naive() {
+        let text = many_lines_text();
+        let index = LineIndex::build(&text);
+        let starts = naive_line_starts(&text);
+
+        // Walk forward to populate the cache with a "late" entry, then query
+        // an earlier offset — the cache must not poison a backward lookup.
+        for &line in &[1usize, 5, 10, 20] {
+            let offset = starts[line - 1];
+            assert_eq!(index.to_line_column(offset), (line, 1), "forward to {line}");
+        }
+
+        let backward_offset = starts[1]; // line 2
+        assert_eq!(
+            index.to_line_column(backward_offset),
+            (2, 1),
+            "backward jump"
+        );
+
+        // And a subsequent forward query from that backward position must
+        // still be correct too (cache state after a backward miss).
+        let offset = starts[7]; // line 8
+        assert_eq!(index.to_line_column(offset), (8, 1), "forward again");
+    }
+
+    #[test]
+    fn to_line_column_repeated_same_offset_is_exact_hit() {
+        let text = many_lines_text();
+        let index = LineIndex::build(&text);
+        let starts = naive_line_starts(&text);
+
+        let offset = starts[9]; // line 10
+        let first = index.to_line_column(offset);
+        let second = index.to_line_column(offset);
+        assert_eq!(first, (10, 1));
+        assert_eq!(first, second, "repeated query must return the same result");
+    }
+
+    #[test]
+    fn to_line_column_shuffled_access_matches_naive() {
+        // A non-monotonic access pattern (unlike `matches_naive_scanner_at_-
+        // every_offset`'s strictly increasing scan) exercises every cache
+        // branch — hit, forward-within-cap, forward-beyond-cap, and
+        // backward — in one pass, order chosen to be deterministic rather
+        // than random (no RNG dependency in this crate's core tests).
+        let text = many_lines_text();
+        let index = LineIndex::build(&text);
+        let starts = naive_line_starts(&text);
+
+        let order = [0usize, 39, 5, 5, 6, 4, 20, 21, 22, 10, 39, 0, 15];
+        for &line in &order {
+            let offset = starts[line];
+            let expected_line = starts.partition_point(|&s| s <= offset);
+            assert_eq!(
+                index.to_line_column(offset),
+                (expected_line, offset - starts[expected_line - 1] + 1),
+                "line index {line}"
+            );
+        }
     }
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3246,6 +3246,25 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
         }
         result
     }
+
+    /// Find a field by name and return a cursor to its value.
+    ///
+    /// Same last-duplicate-key-wins semantics as [`find`](Self::find) — kept
+    /// as a separate loop rather than reusing `find` so the returned cursor
+    /// (needed for `line`/`column`) doesn't require re-navigating.
+    pub fn find_cursor(&self, name: &str) -> Option<YamlCursor<'a, W>> {
+        let mut fields = self.clone();
+        let mut result = None;
+        while let Some((field, rest)) = fields.uncons() {
+            if let YamlValue::String(key) = field.key() {
+                if key.as_str().ok()? == name {
+                    result = Some(field.value_cursor());
+                }
+            }
+            fields = rest;
+        }
+        result
+    }
 }
 
 impl<'a, W: AsRef<[u64]>> Iterator for YamlFields<'a, W> {
@@ -5064,6 +5083,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for YamlFields<'a, W> {
 
     fn find(&self, name: &str) -> Option<Self::Value> {
         YamlFields::find(self, name)
+    }
+
+    fn find_cursor(&self, name: &str) -> Option<Self::Cursor> {
+        YamlFields::find_cursor(self, name)
     }
 
     fn is_empty(&self) -> bool {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2676,40 +2676,13 @@ fn stream_json_escape<Out: core::fmt::Write>(out: &mut Out, ch: char) -> core::f
             out.write_char(HEX[(b >> 4) as usize] as char)?;
             out.write_char(HEX[(b & 0xf) as usize] as char)
         }
-        c if (c as u32) >= 0x80 && (c as u32) < 0x100 => {
-            out.write_str("\\u00")?;
-            const HEX: &[u8; 16] = b"0123456789abcdef";
-            let b = c as u8;
-            out.write_char(HEX[(b >> 4) as usize] as char)?;
-            out.write_char(HEX[(b & 0xf) as usize] as char)
-        }
-        c if (c as u32) >= 0x100 => {
-            let cp = c as u32;
-            if cp <= 0xFFFF {
-                out.write_str("\\u")?;
-                const HEX: &[u8; 16] = b"0123456789abcdef";
-                out.write_char(HEX[((cp >> 12) & 0xF) as usize] as char)?;
-                out.write_char(HEX[((cp >> 8) & 0xF) as usize] as char)?;
-                out.write_char(HEX[((cp >> 4) & 0xF) as usize] as char)?;
-                out.write_char(HEX[(cp & 0xF) as usize] as char)
-            } else {
-                // Surrogate pair
-                let adjusted = cp - 0x10000;
-                let high = 0xD800 + (adjusted >> 10);
-                let low = 0xDC00 + (adjusted & 0x3FF);
-                out.write_str("\\u")?;
-                const HEX: &[u8; 16] = b"0123456789abcdef";
-                out.write_char(HEX[((high >> 12) & 0xF) as usize] as char)?;
-                out.write_char(HEX[((high >> 8) & 0xF) as usize] as char)?;
-                out.write_char(HEX[((high >> 4) & 0xF) as usize] as char)?;
-                out.write_char(HEX[(high & 0xF) as usize] as char)?;
-                out.write_str("\\u")?;
-                out.write_char(HEX[((low >> 12) & 0xF) as usize] as char)?;
-                out.write_char(HEX[((low >> 8) & 0xF) as usize] as char)?;
-                out.write_char(HEX[((low >> 4) & 0xF) as usize] as char)?;
-                out.write_char(HEX[(low & 0xF) as usize] as char)
-            }
-        }
+        // Everything >= 0x20 (including C1 controls 0x80-0x9F and higher
+        // codepoints) streams as raw UTF-8, matching `stream_json_string`'s
+        // policy and yq's own output: JSON only requires escaping `"`, `\`,
+        // and C0 controls. An earlier version of this function additionally
+        // re-escaped non-ASCII characters as `\u00XX`/`\uXXXX`, which
+        // diverged from `stream_json_string` and from yq for any string
+        // reached through this char-by-char escape-decode path (#532).
         c => out.write_char(c),
     }
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2025,6 +2025,14 @@ fn write_json_string(output: &mut String, s: &str) {
 
 /// Write a JSON character escape sequence to output.
 /// Helper for direct transcoding functions.
+///
+/// Everything >= 0x20 (including C1 controls 0x80-0x9F and higher
+/// codepoints) streams as raw UTF-8, matching `stream_json_escape`'s policy
+/// and yq's own output: JSON only requires escaping `"`, `\`, and C0
+/// controls. An earlier version of this function additionally re-escaped
+/// non-ASCII characters as `\u00XX`/`\uXXXX`, which diverged from
+/// `stream_json_escape`/yq for any string reached through this non-streaming
+/// transcode path (#532).
 #[inline]
 fn write_json_escape(output: &mut String, ch: char) {
     match ch {
@@ -2040,42 +2048,6 @@ fn write_json_escape(output: &mut String, ch: char) {
             let b = c as u8;
             output.push(HEX[(b >> 4) as usize] as char);
             output.push(HEX[(b & 0xf) as usize] as char);
-        }
-        c if (c as u32) >= 0x80 && (c as u32) < 0x100 => {
-            // Extended ASCII (0x80-0xFF) - write as \u00XX
-            output.push_str("\\u00");
-            const HEX: &[u8; 16] = b"0123456789abcdef";
-            let b = c as u8;
-            output.push(HEX[(b >> 4) as usize] as char);
-            output.push(HEX[(b & 0xf) as usize] as char);
-        }
-        c if (c as u32) >= 0x100 => {
-            // Unicode - write as \uXXXX or surrogate pair
-            let cp = c as u32;
-            if cp <= 0xFFFF {
-                output.push_str("\\u");
-                const HEX: &[u8; 16] = b"0123456789abcdef";
-                output.push(HEX[((cp >> 12) & 0xF) as usize] as char);
-                output.push(HEX[((cp >> 8) & 0xF) as usize] as char);
-                output.push(HEX[((cp >> 4) & 0xF) as usize] as char);
-                output.push(HEX[(cp & 0xF) as usize] as char);
-            } else {
-                // Surrogate pair for characters > 0xFFFF
-                let adjusted = cp - 0x10000;
-                let high = 0xD800 + (adjusted >> 10);
-                let low = 0xDC00 + (adjusted & 0x3FF);
-                output.push_str("\\u");
-                const HEX: &[u8; 16] = b"0123456789abcdef";
-                output.push(HEX[((high >> 12) & 0xF) as usize] as char);
-                output.push(HEX[((high >> 8) & 0xF) as usize] as char);
-                output.push(HEX[((high >> 4) & 0xF) as usize] as char);
-                output.push(HEX[(high & 0xF) as usize] as char);
-                output.push_str("\\u");
-                output.push(HEX[((low >> 12) & 0xF) as usize] as char);
-                output.push(HEX[((low >> 8) & 0xF) as usize] as char);
-                output.push(HEX[((low >> 4) & 0xF) as usize] as char);
-                output.push(HEX[(low & 0xF) as usize] as char);
-            }
         }
         c => output.push(c),
     }
@@ -2129,8 +2101,17 @@ fn transcode_double_quoted_to_json(
                     b'v' => output.push_str("\\u000b"), // vertical tab
                     b'f' => output.push_str("\\u000c"), // form feed
                     b'e' => output.push_str("\\u001b"), // escape
-                    b'N' => output.push_str("\\u0085"), // next line
-                    b'_' => output.push_str("\\u00a0"), // non-breaking space
+                    // \N and \_ are C1/Latin-1 codepoints that yq streams as
+                    // raw UTF-8 (not JSON-escaped) — route through
+                    // write_json_escape so they get the same treatment as
+                    // any other char >= 0x20 (#532).
+                    b'N' => write_json_escape(output, '\u{0085}'), // next line
+                    b'_' => write_json_escape(output, '\u{00a0}'), // non-breaking space
+                    // \L and \P are always JSON-escaped by yq, even as raw
+                    // literal bytes — not merely because write_json_escape
+                    // treats them as "control" codepoints (it doesn't).
+                    // Keep them hardcoded rather than routing through
+                    // write_json_escape.
                     b'L' => output.push_str("\\u2028"), // line separator
                     b'P' => output.push_str("\\u2029"), // paragraph separator
                     b'\n' | b'\r' => {
@@ -2743,12 +2724,19 @@ fn stream_transcode_double_quoted_to_json<Out: core::fmt::Write>(
                     b'e' => out
                         .write_str("\\u001b")
                         .map_err(|_| YamlStringError::InvalidUtf8)?,
-                    b'N' => out
-                        .write_str("\\u0085")
+                    // \N and \_ are C1/Latin-1 codepoints that yq streams as
+                    // raw UTF-8 (not JSON-escaped) — route through
+                    // stream_json_escape so they get the same treatment as
+                    // any other char >= 0x20 (#532).
+                    b'N' => stream_json_escape(out, '\u{0085}')
                         .map_err(|_| YamlStringError::InvalidUtf8)?,
-                    b'_' => out
-                        .write_str("\\u00a0")
+                    b'_' => stream_json_escape(out, '\u{00a0}')
                         .map_err(|_| YamlStringError::InvalidUtf8)?,
+                    // \L and \P are always JSON-escaped by yq, even as raw
+                    // literal bytes — not merely because stream_json_escape
+                    // treats them as "control" codepoints (it doesn't). Keep
+                    // them hardcoded rather than routing through
+                    // stream_json_escape.
                     b'L' => out
                         .write_str("\\u2028")
                         .map_err(|_| YamlStringError::InvalidUtf8)?,
@@ -5617,6 +5605,36 @@ mod tests {
         assert!(out.contains("\"f\":1.5"), "got {out}");
     }
 
+    /// Streaming counterpart of `test_transcode_double_quoted_next_line_escape`
+    /// / `test_transcode_double_quoted_nbsp_escape` — `stream_transcode_-
+    /// double_quoted_to_json`'s `\N`/`\_` branches had no dedicated test at
+    /// all before #532, which is how they were missed when the
+    /// `stream_json_escape` policy fix landed for the `\x`/`\u` escape
+    /// paths: both stream U+0085/U+00A0 as raw UTF-8, matching yq.
+    #[test]
+    fn test_stream_transcode_double_quoted_next_line_and_nbsp_escape() {
+        let yaml = b"s: \"next\\Nline\"\nt: \"non\\_break\"\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index.root(yaml).stream_json_document(&mut out, 0).unwrap();
+        assert!(out.contains("\"s\":\"next\u{0085}line\""), "got {out}");
+        assert!(out.contains("\"t\":\"non\u{00a0}break\""), "got {out}");
+    }
+
+    /// `\L`/`\P` (U+2028/U+2029) are the one pair still hardcoded rather than
+    /// routed through `stream_json_escape` — yq always JSON-escapes them,
+    /// even as raw literal bytes, unlike `\N`/`\_`. Pin that this streaming
+    /// path still escapes them after the #532 fix.
+    #[test]
+    fn test_stream_transcode_double_quoted_line_and_paragraph_separator_escape() {
+        let yaml = b"s: \"line\\Lsep\"\nt: \"para\\Psep\"\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index.root(yaml).stream_json_document(&mut out, 0).unwrap();
+        assert!(out.contains("\"s\":\"line\\u2028sep\""), "got {out}");
+        assert!(out.contains("\"t\":\"para\\u2029sep\""), "got {out}");
+    }
+
     /// Issue #222: mapping keys are always strings and never dropped. An
     /// alias key resolves to its anchored scalar (26DV, E76Z); a complex
     /// (sequence/mapping/null) key becomes "" but keeps its entry. Both
@@ -7868,9 +7886,9 @@ mod tests {
         let yaml = b"\"next\\Nline\"";
         let transcoded = get_json_via_transcode(yaml);
         let decoded = get_json_via_decode(yaml);
-        // Transcoding uses \u0085, old path uses raw char - verify semantic equivalence
-        assert_json_semantically_equal(&transcoded, &decoded, "next line escape");
-        assert_eq!(transcoded, "\"next\\u0085line\"");
+        // Both paths stream U+0085 as raw UTF-8, matching yq (#532).
+        assert_eq!(transcoded, decoded);
+        assert_eq!(transcoded, "\"next\u{0085}line\"");
     }
 
     #[test]
@@ -7878,9 +7896,9 @@ mod tests {
         let yaml = b"\"non\\_break\"";
         let transcoded = get_json_via_transcode(yaml);
         let decoded = get_json_via_decode(yaml);
-        // Transcoding uses \u00a0, old path uses raw NBSP - verify semantic equivalence
-        assert_json_semantically_equal(&transcoded, &decoded, "nbsp escape");
-        assert_eq!(transcoded, "\"non\\u00a0break\"");
+        // Both paths stream U+00A0 as raw UTF-8, matching yq (#532).
+        assert_eq!(transcoded, decoded);
+        assert_eq!(transcoded, "\"non\u{00a0}break\"");
     }
 
     #[test]
@@ -7926,9 +7944,9 @@ mod tests {
         let yaml = b"\"euro\\u20ACsign\""; // € = U+20AC
         let transcoded = get_json_via_transcode(yaml);
         let decoded = get_json_via_decode(yaml);
-        // Transcoding uses \u20ac, old path uses raw € - verify semantic equivalence
-        assert_json_semantically_equal(&transcoded, &decoded, "unicode 4-digit escape");
-        assert_eq!(transcoded, "\"euro\\u20acsign\"");
+        // Both paths stream € as raw UTF-8, matching yq (#532).
+        assert_eq!(transcoded, decoded);
+        assert_eq!(transcoded, "\"euro€sign\"");
     }
 
     #[test]
@@ -7936,10 +7954,9 @@ mod tests {
         let yaml = b"\"emoji\\U0001F600face\""; // 😀 = U+1F600
         let transcoded = get_json_via_transcode(yaml);
         let decoded = get_json_via_decode(yaml);
-        // Transcoding uses surrogate pair \ud83d\ude00, old path uses raw 😀
-        // Verify semantic equivalence
-        assert_json_semantically_equal(&transcoded, &decoded, "unicode 8-digit escape");
-        assert_eq!(transcoded, "\"emoji\\ud83d\\ude00face\"");
+        // Both paths stream 😀 as raw UTF-8, matching yq (#532).
+        assert_eq!(transcoded, decoded);
+        assert_eq!(transcoded, "\"emoji😀face\"");
     }
 
     #[test]

--- a/tests/data/yq-golden-known-failures.txt
+++ b/tests/data/yq-golden-known-failures.txt
@@ -13,4 +13,3 @@
 # themselves always hold the correct (pinned yq) output; only this manifest
 # records where succinctly currently disagrees. See
 # tests/data/yaml-test-suite-known-failures.txt for the sibling manifest.
-line_builtin                   position           line/column are hardcoded to 0 on the OwnedValue evaluator path yq actually runs — #532

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2836,6 +2836,79 @@ fn test_yq_json_control_char_escaping_consistent_across_paths() -> Result<()> {
 }
 
 // ============================================================================
+// line / column builtins (#532) — position-based navigation on the default
+// (cursor-preserving) YAML CLI path. Before this fix, `line`/`column`
+// resolved correctly only when called with zero preceding navigation
+// (`line` alone); anything downstream of `.foo`/`.[]`/`select(...)` silently
+// returned 0. No prior CLI-level test exercised these builtins through a
+// real pipeline — see the issue for the full root-cause writeup.
+// ============================================================================
+
+#[test]
+fn test_line_iterate_over_sequence() -> Result<()> {
+    // The issue's exact repro.
+    let yaml = "a: 1\nb: 2\nc: 3\n";
+    let (output, code) = run_yq_stdin(".[] | line", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "1\n2\n3\n");
+    Ok(())
+}
+
+#[test]
+fn test_line_field_access() -> Result<()> {
+    let yaml = "other: 1\nfoo: bar\n";
+    let (output, code) = run_yq_stdin(".foo | line", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "2");
+    Ok(())
+}
+
+#[test]
+fn test_column_field_access() -> Result<()> {
+    let yaml = "foo: bar\n";
+    let (output, code) = run_yq_stdin(".foo | column", yaml, &[])?;
+    assert_eq!(code, 0);
+    // "foo: bar" -> "bar" starts at column 6.
+    assert_eq!(output.trim(), "6");
+    Ok(())
+}
+
+#[test]
+fn test_line_select_filters_and_keeps_position() -> Result<()> {
+    let yaml = "- 1\n- 2\n- 3\n";
+    let (output, code) = run_yq_stdin(".[] | select(. > 1) | line", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "2\n3\n");
+    Ok(())
+}
+
+#[test]
+fn test_line_column_object_construction_is_a_known_limitation() -> Result<()> {
+    // Object/array construction (`{...}`/`[...]`) isn't natively cursor-aware
+    // in the generic evaluator — it round-trips through OwnedValue, which
+    // has nowhere to carry a position. Documented limitation (#532), pinned
+    // here so a future fix is visible as an intentional test change rather
+    // than a silent behavior shift.
+    let yaml = "foo: bar\nbaz: qux\n";
+    let (output, code) = run_yq_stdin(".baz | {l: line, c: column}", yaml, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"l":0,"c":0}"#);
+    Ok(())
+}
+
+#[test]
+fn test_line_dot_chain_through_nested_iteration() -> Result<()> {
+    // `.containers[].image` parses as its own nested Pipe distinct from the
+    // outer `| line` — exercises `ManyCursor` surviving a return out of an
+    // inner pipe evaluation, not just a single flat pipe.
+    let yaml = "containers:\n  - image: a\n  - image: b\n";
+    let (output, code) = run_yq_stdin(".containers[].image | line", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "2\n3\n");
+    Ok(())
+}
+
+// ============================================================================
 // Variable Tests - --arg / --argjson / $ARGS (jq-inherited extensions, #284)
 // ============================================================================
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -329,6 +329,20 @@ fn test_i0_multidoc_separator_skips_empty_results() -> Result<()> {
 }
 
 #[test]
+fn test_select_after_iterate_stays_many_cursor() -> Result<()> {
+    // `select` isn't a "navigation-only" expression, so `.[] | select(...)`
+    // takes the DOM/cursor evaluation path (`evaluate_yaml_cursor`) instead
+    // of the M2 streaming fast path. When every filtered element keeps its
+    // position, the pipe's result stays a top-level `ManyCursor`, exercising
+    // that arm of `evaluate_yaml_cursor` directly (as opposed to a plain
+    // `.[]`, which the M2 fast path intercepts before it ever reaches here).
+    let (out, code) = run_yq_stdin(".[] | select(. > 0)", "- 2\n- 3\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2\n3");
+    Ok(())
+}
+
+#[test]
 fn test_i0_multidoc_doc_filter_no_separator() -> Result<()> {
     // #175: selecting a single document with --doc emits no stray separator.
     let (out, code) = run_yq_stdin(".", "a: 1\n---\nb: 2\n", &["-I=0", "--doc", "1"])?;


### PR DESCRIPTION
## Description

This PR fixes a critical issue where the `line` and `column` builtins were returning `0` for any navigation operation (`.foo`, `.[]`, `select(...)`) instead of the actual source positions. The root cause was that the cursor-preserving evaluator in `eval_generic.rs` was receiving position information but silently dropping it before forwarding values to the next pipeline stage.

The fix threads cursors through all navigation operations in the generic evaluator, introduces a new `GenericResult::ManyCursor` variant for position-preserving multi-value results (enabling `.[] | line` to work correctly), and adds comprehensive tests validating position tracking through complex pipelines.

Additionally, this PR:
- Fixes JSON cursor support for `line()`/`column()` which was completely missing
- Corrects YAML/JSON escape handling for C1 controls (U+0085, U+00A0) and non-ASCII characters to match yq's behavior
- Implements a one-entry cache in `LineIndex` for amortized O(1) sequential access patterns

Fixes #532

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Test coverage improvement

## Related Issue
Fixes #532 - line/column builtins return 0 on the CLI

## Changes Made

**Core Evaluator Cursor Threading (eval_generic.rs):**
- Added `GenericResult::ManyCursor(Vec<V::Cursor>)` variant to preserve position information across iteration results (e.g., `.[]`)
- Modified `Expr::Identity`, `Expr::Field`, `Expr::Index`, and `Expr::Iterate` to forward cursors instead of dropping them
- Enhanced `Pipe` stage-advance to run remaining pipeline stages against each cursor independently, maintaining position tracking through nested pipes like `.containers[].image | line`
- Updated `Builtin::Select` to forward incoming cursors on truthy branch, preserving position through filtering
- Modified `Builtin::Values`, `Builtin::Iterables`, and `Builtin::Scalars` to forward cursors

**Document Trait Extensions (document.rs):**
- Added `DocumentFields::find_cursor()` method to retrieve cursors directly instead of re-navigating
- Added `DocumentElements::get_cursor()` method for indexed element access with cursor preservation
- Added `DocumentElements::collect_cursors()` method to collect cursors for all elements
- Enhanced `DocumentCursor::line()` and `column()` documentation clarifying when positions are available

**YAML/JSON Format Implementations:**
- Implemented `find_cursor()` in `YamlFields` and `JsonFields` with correct duplicate-key semantics
- Fixed `stream_json_escape()` to output C1 controls and non-ASCII characters as raw UTF-8 instead of re-escaping
- Fixed `write_json_escape()` to match `stream_json_escape()` behavior for consistency
- Routed `\N` (U+0085) and `\_` (U+00A0) through proper escape functions in `transcode_double_quoted_to_json` and `stream_transcode_double_quoted_to_json`
- Kept `\L` and `\P` (U+2028/U+2029) hardcoded as yq always escapes them

**JSON Cursor Positions (json/light.rs):**
- Implemented `JsonCursor::line()` and `column()` methods which were completely missing
- Added trait implementations for `DocumentCursor::line()` and `column()`

**Performance Optimization (text/lines.rs):**
- Added one-entry `Cell<Option<LineCacheEntry>>` cache to `LineIndex`
- Implemented `walk_forward_from()` for O(1) amortized access in sequential queries
- Exact-repeat queries resolve in O(1) with no bit operations
- Forward queries within 16 lines use bounded `EliasFano::get` steps instead of binary search
- Updated documentation explaining the cache strategy and its effectiveness

**CLI Integration:**
- Updated `jq_runner.rs` and `yq_runner.rs` to handle `GenericResult::ManyCursor` variant
- Ensured position information flows through to `line`/`column` output

**Tests:**
- Added comprehensive `eval_generic` tests: `.foo | line`, `.[] | line` over sequences/objects, `.[] | select(...) | line`, dot-chains like `.containers[].image | line`, identity-pipe position preservation
- Added CLI-level tests validating position tracking in real yq invocations
- Added `JsonCursor` line/column tests
- Added `LineIndex` cache tests: forward-within-cap, forward-beyond-cap fallback, backward jumps, repeated queries, shuffled access patterns
- Added YAML streaming tests for `\N`/`\_`/`\L`/`\P` escape sequences
- Removed outdated test from known-failures manifest

## Testing

**Automated Testing:**
- [x] All existing tests pass (9+ new test cases added to eval_generic and yq_cli_tests)
- [x] New tests added validating position tracking through navigation operations
- [x] LineIndex cache correctness verified with forward/backward/shuffled access patterns
- [x] YAML escape handling verified against yq 4.53.3 oracle

**Manual Testing:**
Verified with actual yq invocations:
```bash
# All now return correct line numbers instead of 0:
succinctly yq '.[] | line' < yaml_file
succinctly yq '.foo | line' < yaml_file
succinctly yq '.[] | select(. > 1) | line' < yaml_file
succinctly yq '.containers[].image | line' < yaml_file

# Column positions now resolve:
succinctly yq '.foo | column' < yaml_file

# Escape handling matches yq:
succinctly yq '.' < yaml_with_escapes
```

### Test Commands
```bash
cargo test eval_generic
cargo test yq_cli_tests::test_line
cargo test yq_cli_tests::test_column
cargo test lines::to_line_column
cargo test yaml.*escape
cargo test json.*cursor
cargo test --all
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] Performance improvement (LineIndex cache for sequential access)
- Cursor threading adds minimal overhead (forwarding existing data structures)
- LineIndex cache makes `.[] | line` amortized O(1) instead of O(log n) per node
- Exact-repeat queries (e.g., `{l: line, c: column}`) resolve with zero bit operations
- Cache misses fall back to existing binary search, no regression for non-sequential patterns

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Scope Limitations (Documented):**
The `-n`/`--slurp`/`--inplace`/JSON-input evaluator path (`src/jq/eval.rs`) structurally cannot forward cursors because it operates on `OwnedValue` with no source position tracking. Object/array construction (`{...}`/`[...]`) round-trips through `OwnedValue` with nowhere to carry position. Both correctly return the `0` sentinel per `DocumentCursor::line()`'s documented contract for "position not available".

**Related Issue Context:**
Issue #532 reported that `succinctly yq '.[] | line'` returned 0 for every element instead of real line numbers. Investigation revealed the cursor was being computed and available but silently dropped in the evaluator. This fix ensures position information flows through the entire pipeline while maintaining the documented behavior for computed/non-navigated values.

**Verification:**
All changes verified byte-for-byte against pinned yq (v4.53.3) oracle for escape handling. Position tracking tested with multi-level nested structures and complex filter pipelines.