### PR TITLE
fix(jq): render overflowed NumberLiteral as inf/-inf across the real CLI, not just garbage

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1819,12 +1819,12 @@ impl LiteralFormatter for JqCompatFormatter {
         // finite value and produces garbage like "NaNE+2147483647" for one
         // that isn't (#561). Match `format_float`'s guard below: JSON output
         // substitutes "null" for values RFC 8259 can't represent.
-        if let Ok(s) = core::str::from_utf8(raw) {
-            if let Ok(f) = s.parse::<f64>() {
-                if f.is_nan() || f.is_infinite() {
-                    return Cow::Borrowed("null");
-                }
-            }
+        let overflows = core::str::from_utf8(raw)
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .is_some_and(|f| f.is_nan() || f.is_infinite());
+        if overflows {
+            return Cow::Borrowed("null");
         }
         Cow::Owned(format_number_jq_compat(raw))
     }
@@ -2172,6 +2172,22 @@ fn format_json(value: &OwnedValue, config: &OutputConfig) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_jq_compat_formatter_format_raw_number() {
+        // Finite numbers fall through the NaN/Infinity guard unchanged.
+        assert_eq!(JqCompatFormatter.format_raw_number(b"42").as_ref(), "42");
+        // Overflowed literals substitute "null" instead of reaching
+        // `format_number_jq_compat`, which assumes a finite value (#561).
+        assert_eq!(
+            JqCompatFormatter.format_raw_number(b"1e400").as_ref(),
+            "null"
+        );
+        assert_eq!(
+            JqCompatFormatter.format_raw_number(b"-1e400").as_ref(),
+            "null"
+        );
+    }
 
     #[test]
     fn test_trim_ascii_ws() {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1814,6 +1814,18 @@ struct JqCompatFormatter;
 
 impl LiteralFormatter for JqCompatFormatter {
     fn format_raw_number<'a>(&self, raw: &'a [u8]) -> Cow<'a, str> {
+        // A source literal that overflows to ±Infinity/NaN (e.g. `1e400`)
+        // must not be fed to `format_number_jq_compat`, which assumes a
+        // finite value and produces garbage like "NaNE+2147483647" for one
+        // that isn't (#561). Match `format_float`'s guard below: JSON output
+        // substitutes "null" for values RFC 8259 can't represent.
+        if let Ok(s) = core::str::from_utf8(raw) {
+            if let Ok(f) = s.parse::<f64>() {
+                if f.is_nan() || f.is_infinite() {
+                    return Cow::Borrowed("null");
+                }
+            }
+        }
         Cow::Owned(format_number_jq_compat(raw))
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3594,9 +3594,14 @@ fn builtin_with_entries<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
-/// Convert an OwnedValue to JSON bytes for re-parsing
+/// Convert an OwnedValue to JSON bytes for re-parsing.
+///
+/// Uses `to_json_for_reindex` rather than `to_json`: this round-trip is
+/// purely internal (e.g. `with_entries`'s per-entry re-evaluation), so an
+/// overflowed `NumberLiteral`/`Float` must keep its ±Infinity rather than
+/// being silently substituted with JSON's `"null"` (#561).
 fn owned_to_json_bytes(value: &OwnedValue) -> Vec<u8> {
-    value.to_json().into_bytes()
+    value.to_json_for_reindex().into_bytes()
 }
 
 // =============================================================================
@@ -8890,7 +8895,11 @@ fn eval_owned_expr<S: EvalSemantics>(
     // Create a synthetic JSON from the owned value
     // For simplicity, we'll serialize and reparse
     // This is inefficient but correct
-    let json_str = input.to_json();
+    //
+    // `to_json_for_reindex` (not `to_json`): this round-trip is purely
+    // internal, so an overflowed `NumberLiteral`/`Float` must keep its
+    // ±Infinity rather than being silently substituted with "null" (#561).
+    let json_str = input.to_json_for_reindex();
     let json_bytes = json_str.as_bytes();
 
     // We need to create a temporary index and cursor
@@ -8950,8 +8959,11 @@ fn eval_owned_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     // Serialize and reparse to obtain a document the evaluator can index into.
-    // Only reached on the error path, so the round-trip is off the hot path.
-    let json_str = input.to_json();
+    //
+    // `to_json_for_reindex` (not `to_json`): this round-trip is purely
+    // internal, so an overflowed `NumberLiteral`/`Float` must keep its
+    // ±Infinity rather than being silently substituted with "null" (#561).
+    let json_str = input.to_json_for_reindex();
     let json_bytes = json_str.as_bytes();
 
     use crate::json::JsonIndex;
@@ -19814,6 +19826,48 @@ mod tests {
         query!(br"1e400", r#""\(.)""#,
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "inf");
+            }
+        );
+    }
+
+    #[test]
+    fn test_number_literal_overflow_survives_owned_value_reindex_bridges() {
+        // `eval_owned_expr`/`eval_owned_input` (backing `reduce`, `foreach`,
+        // `as $x` variable binding via `eval_owned_pipe`) and
+        // `owned_to_json_bytes` (backing `with_entries`) each serialize an
+        // `OwnedValue` back to JSON text and reparse it to keep evaluating --
+        // the same bridge pattern `eval_generic.rs` had. Before switching
+        // these to `to_json_for_reindex`, an overflowed `NumberLiteral` was
+        // silently turned into JSON `null` by that round-trip, so `. as $x |
+        // $x | tostring` produced "null" instead of "inf" even though a
+        // direct `tostring` (tested above) was already fixed (#561).
+        query!(br"1e400", ". as $x | $x | tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "inf");
+            }
+        );
+
+        query!(br"-1e400", ". as $x | $x | tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "-inf");
+            }
+        );
+
+        query!(br"1e400", "reduce (1) as $x (.; .) | tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "inf");
+            }
+        );
+
+        query!(br"1e400", "foreach (1) as $x (.; .) | tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "inf");
+            }
+        );
+
+        query!(br#"{"a":1e400}"#, "with_entries(.value |= (. | tostring))",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.get("a"), Some(&OwnedValue::String("inf".to_string())));
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3653,6 +3653,25 @@ fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     QueryResult::Owned(OwnedValue::String(result))
 }
 
+/// Render a numeric value the way the non-JSON text formats want it.
+///
+/// `number_str()` deliberately skips NaN/Infinity handling (see its doc
+/// comment) because `to_json` needs "null" instead. Text formats (`@text`,
+/// `@uri`, `@html`, `@sh`, and the CSV/TSV/DSV cell formatter that falls back
+/// to `owned_to_string`) want the same `"inf"`/`"-inf"`/`"NaN"` rendering a
+/// plain `Int`/`Float` already gets from `f64::to_string()` -- a
+/// `NumberLiteral` just needs that check made explicit, since its `number_str`
+/// otherwise re-renders the (possibly nonsensical for an overflowed literal)
+/// source text via `format_number_jq_compat`.
+pub(crate) fn numeric_display_string(value: &OwnedValue) -> String {
+    if let OwnedValue::NumberLiteral(NumberRepr::Float(f), _) = value {
+        if f.is_nan() || f.is_infinite() {
+            return f.to_string();
+        }
+    }
+    value.number_str().expect("numeric variant").into_owned()
+}
+
 /// Convert an owned value to a string representation (for interpolation).
 fn owned_to_string(value: &OwnedValue) -> String {
     match value {
@@ -3660,7 +3679,7 @@ fn owned_to_string(value: &OwnedValue) -> String {
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            value.number_str().expect("numeric variant").into_owned()
+            numeric_display_string(value)
         }
         OwnedValue::String(s) => s.clone(), // Don't quote strings in interpolation
         OwnedValue::Array(_) | OwnedValue::Object(_) => value.to_json(),
@@ -3713,7 +3732,7 @@ fn format_uri(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> 
     let s = match value {
         OwnedValue::String(s) => s.clone(),
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            value.number_str().expect("numeric variant").into_owned()
+            numeric_display_string(value)
         }
         OwnedValue::Bool(b) => {
             if *b {
@@ -3933,7 +3952,7 @@ fn format_html(value: &OwnedValue, _optional: bool) -> Result<String, EvalError>
     let s = match value {
         OwnedValue::String(s) => s.clone(),
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            value.number_str().expect("numeric variant").into_owned()
+            numeric_display_string(value)
         }
         OwnedValue::Bool(b) => {
             if *b {
@@ -3974,7 +3993,7 @@ fn shell_quote_value(value: &OwnedValue) -> String {
         }
         // Numbers, bools, null are NOT quoted in jq
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            value.number_str().expect("numeric variant").into_owned()
+            numeric_display_string(value)
         }
         OwnedValue::Bool(b) => {
             if *b {
@@ -4007,7 +4026,7 @@ fn format_sh(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
         }
         // Numbers, bools, null are converted to strings
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            Ok(value.number_str().expect("numeric variant").into_owned())
+            Ok(numeric_display_string(value))
         }
         OwnedValue::Bool(b) => Ok(if *b {
             "true".to_string()
@@ -4243,7 +4262,7 @@ fn builtin_tostring<W: Clone + AsRef<[u64]>>(
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(n) => format!("{n}"),
         OwnedValue::Float(f) => format!("{f}"),
-        OwnedValue::NumberLiteral(_, literal) => format_number_jq_compat(literal.as_bytes()),
+        OwnedValue::NumberLiteral(..) => numeric_display_string(&owned),
         OwnedValue::Array(_) | OwnedValue::Object(_) => owned.to_json(),
     };
     QueryResult::Owned(OwnedValue::String(s))
@@ -19753,6 +19772,48 @@ mod tests {
         query!(br"null", "tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "null");
+            }
+        );
+    }
+
+    #[test]
+    fn test_number_literal_overflow_renders_as_inf_not_garbage() {
+        // A `NumberLiteral` whose parsed f64 overflows to infinity used to
+        // re-render its raw source text through `format_number_jq_compat`,
+        // producing garbage like "NaNE+2147483647" instead of "inf" (#561).
+        query!(br"1e400", "tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "inf");
+            }
+        );
+
+        query!(br"-1e400", "tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "-inf");
+            }
+        );
+
+        query!(br"1e400", "@uri",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "inf");
+            }
+        );
+
+        query!(br"1e400", "@html",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "inf");
+            }
+        );
+
+        query!(br"1e400", "@sh",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "inf");
+            }
+        );
+
+        query!(br"1e400", r#""\(.)""#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "inf");
             }
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -19,8 +19,9 @@ use indexmap::IndexMap;
 
 use super::document::{DocumentCursor, DocumentElements, DocumentFields, DocumentValue};
 use super::eval::{
-    compare_values, eval as full_eval, index_one_owned as index_owned_by_key, numeric_key_to_index,
-    tonumber_from_str, Control, EvalError, EvalSemantics, JqSemantics, QueryResult,
+    compare_values, eval as full_eval, index_one_owned as index_owned_by_key,
+    numeric_display_string, numeric_key_to_index, tonumber_from_str, Control, EvalError,
+    EvalSemantics, JqSemantics, QueryResult,
 };
 use super::expr::{Builtin, CompareOp, Expr, Literal};
 use super::value::OwnedValue;
@@ -1579,7 +1580,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 OwnedValue::Null => "null".to_string(),
                 OwnedValue::Bool(b) => b.to_string(),
                 OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-                    owned.number_str().expect("numeric variant").into_owned()
+                    numeric_display_string(&owned)
                 }
                 OwnedValue::String(s) => s.clone(),
                 OwnedValue::Array(_) | OwnedValue::Object(_) => owned.to_json(),
@@ -1820,6 +1821,21 @@ mod tests {
         let owned = result.into_owned().unwrap();
 
         assert_eq!(owned, OwnedValue::String("object".to_string()));
+    }
+
+    #[test]
+    fn test_generic_tostring_overflow_literal_renders_as_inf() {
+        // Mirrors eval.rs's test_number_literal_overflow_renders_as_inf_not_garbage
+        // (#561): the generic evaluator's ToString arm had the same bug.
+        let json = br"1e400";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(&Expr::Builtin(Builtin::ToString), value);
+        let owned = result.into_owned().unwrap();
+
+        assert_eq!(owned, OwnedValue::String("inf".to_string()));
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -114,7 +114,7 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     owned: OwnedValue,
     optional: bool,
 ) -> GenericResult<V> {
-    let json_str = owned.to_json();
+    let json_str = owned.to_json_for_reindex();
     let json_bytes = json_str.as_bytes();
     let index = JsonIndex::build(json_bytes);
     let cursor = index.root(json_bytes);
@@ -952,7 +952,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         _ => {
             // Convert to OwnedValue, then to JSON, then evaluate with full evaluator
             let owned = to_owned(&value);
-            let json_str = owned.to_json();
+            let json_str = owned.to_json_for_reindex();
             let json_bytes = json_str.as_bytes();
             let index = JsonIndex::build(json_bytes);
             let cursor = index.root(json_bytes);
@@ -1743,6 +1743,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
 #[cfg(test)]
 mod tests {
+    use super::super::expr::FormatType;
     use super::*;
     use crate::json::JsonIndex;
 
@@ -1833,6 +1834,29 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Builtin(Builtin::ToString), value);
+        let owned = result.into_owned().unwrap();
+
+        assert_eq!(owned, OwnedValue::String("inf".to_string()));
+    }
+
+    #[test]
+    fn test_generic_format_overflow_literal_via_reindex_bridge() {
+        // `Expr::Format` (unlike `Expr::Builtin(ToString)` above) has no
+        // native arm in the generic evaluator, so it falls through the
+        // catch-all bridge that reserializes the value to JSON text and
+        // re-parses it before handing off to the full evaluator. That
+        // reserialization used to call `OwnedValue::to_json()`, which
+        // substitutes "null" for ±Infinity (correct for real JSON output,
+        // but not for this internal round-trip) -- silently destroying the
+        // overflowed literal before `eval.rs`'s (already-fixed) `@uri`
+        // formatting ever saw it (#561). This exercises that bridge
+        // directly, independent of the CLI.
+        let json = br"1e400";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(&Expr::Format(FormatType::Uri), value);
         let owned = result.into_owned().unwrap();
 
         assert_eq!(owned, OwnedValue::String("inf".to_string()));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1863,6 +1863,23 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_format_overflow_literal_negative_via_reindex_bridge() {
+        // Mirrors the test above but with a negative overflow, exercising
+        // `overflow_literal`'s negative-sign branch (`-1e999`) in
+        // `OwnedValue::to_json_for_reindex`, which the positive-only case
+        // above never reaches (#561).
+        let json = br"-1e400";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(&Expr::Format(FormatType::Uri), value);
+        let owned = result.into_owned().unwrap();
+
+        assert_eq!(owned, OwnedValue::String("-inf".to_string()));
+    }
+
+    #[test]
     fn test_generic_length() {
         let json = br"[1, 2, 3, 4, 5]";
         let index = JsonIndex::build(json);

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -504,6 +504,58 @@ impl OwnedValue {
             }
         }
     }
+
+    /// Serialize this value as JSON for `eval_generic`'s cursor-reindexing
+    /// bridge, preserving ±Infinity via a self-overflowing literal
+    /// (`1e999`/`-1e999`) instead of [`to_json`](Self::to_json)'s `"null"`
+    /// substitution.
+    ///
+    /// `to_json()`'s "null" is correct for actual JSON *output* (RFC 8259
+    /// forbids Infinity/NaN), but wrong for this purely-internal round-trip:
+    /// it silently destroys the NaN/Infinity information
+    /// `numeric_display_string()` (in `src/jq/eval.rs`) needs downstream once
+    /// the bridge re-parses this text and hands the cursor to the full
+    /// evaluator (#561). NaN has no self-overflowing JSON number literal and
+    /// isn't reachable from any path in this crate today, so it still falls
+    /// back to `"null"` here, same as `to_json()`.
+    pub(crate) fn to_json_for_reindex(&self) -> String {
+        match self {
+            Self::Float(f) if f.is_infinite() => overflow_literal(*f).to_string(),
+            Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_infinite() => {
+                overflow_literal(*f).to_string()
+            }
+            Self::Array(arr) => {
+                let elements: Vec<String> = arr.iter().map(Self::to_json_for_reindex).collect();
+                format!("[{}]", elements.join(","))
+            }
+            Self::Object(obj) => {
+                let entries: Vec<String> = obj
+                    .iter()
+                    .map(|(k, v)| {
+                        format!(
+                            "\"{}\":{}",
+                            escape_json_body(write_json_body_jq, k),
+                            v.to_json_for_reindex()
+                        )
+                    })
+                    .collect();
+                format!("{{{}}}", entries.join(","))
+            }
+            other => other.to_json(),
+        }
+    }
+}
+
+/// A JSON number literal guaranteed to overflow to the correctly-signed
+/// infinity when parsed as `f64`, used only by
+/// [`OwnedValue::to_json_for_reindex`] to smuggle ±Infinity through a
+/// JSON-text round-trip.
+fn overflow_literal(f: f64) -> &'static str {
+    if f.is_sign_negative() {
+        "-1e999"
+    } else {
+        "1e999"
+    }
 }
 
 /// jq value equality.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2694,3 +2694,100 @@ fn test_uncaught_break_after_output_keeps_the_prefix() -> Result<()> {
     assert_eq!(code, 5);
     Ok(())
 }
+
+/// A `NumberLiteral` that overflows to infinity (e.g. `1e400`) used to render
+/// as garbage like `"NaNE+2147483647"` in every non-JSON text format instead
+/// of `"inf"`/`"-inf"` (#561). `tostring` reaches the fix directly, but
+/// `@uri`/`@html`/`@sh`/string interpolation/`@csv` are dispatched through
+/// `eval_generic`'s cursor-reindexing bridge, which round-trips the value
+/// through JSON text -- and used to substitute `"null"` for the overflowed
+/// value before the fix ever saw it. This test exercises the real CLI (not
+/// `eval.rs::eval()` directly) so it actually covers that bridge.
+#[test]
+fn test_number_literal_overflow_text_formats_via_cli() -> Result<()> {
+    let (output, code) = run_jq_stdin("tostring", "1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    let (output, code) = run_jq_stdin("tostring", "-1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""-inf""#);
+
+    let (output, code) = run_jq_stdin("@uri", "1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    let (output, code) = run_jq_stdin("@html", "1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    let (output, code) = run_jq_stdin("@sh", "1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    let (output, code) = run_jq_stdin(r#""\(.)""#, "1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    let (output, code) = run_jq_stdin("@csv", "[1e400]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    Ok(())
+}
+
+/// The CLI's identity/raw-print path is a separate code path from the jq
+/// evaluator (it prints source number bytes straight through
+/// `format_number_jq_compat`), and had the same overflow-renders-as-garbage
+/// bug (#561): unlike JSON output's established "NaN/Infinity -> null"
+/// convention (`OwnedValue::to_json`), it printed
+/// `"NaNE+2147483647"` for `1e400 | .` instead of `null`.
+#[test]
+fn test_number_literal_overflow_identity_prints_null_via_cli() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "1e400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
+
+    let (output, code) = run_jq_stdin(".", "-1e400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
+
+    Ok(())
+}
+
+/// `eval_owned_expr`/`eval_owned_input` (backing `reduce`/`foreach`/`as $x`
+/// variable binding) and `with_entries`'s `owned_to_json_bytes` each have
+/// their own serialize-and-reparse bridge, separate from `eval_generic`'s
+/// (already covered by `test_number_literal_overflow_text_formats_via_cli`).
+/// Before switching these to `to_json_for_reindex`, they too silently turned
+/// an overflowed `NumberLiteral` into JSON `null`, so `. as $x | $x |
+/// tostring` printed `"null"` instead of `"inf"` even though a direct
+/// `tostring` was already fixed (#561).
+#[test]
+fn test_number_literal_overflow_owned_reindex_bridges_via_cli() -> Result<()> {
+    let (output, code) = run_jq_stdin(". as $x | $x | tostring", "1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    let (output, code) = run_jq_stdin(". as $x | $x | tostring", "-1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""-inf""#);
+
+    let (output, code) = run_jq_stdin("reduce (1) as $x (.; .) | tostring", "1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    let (output, code) = run_jq_stdin("foreach (1) as $x (.; .) | tostring", "1e400", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""inf""#);
+
+    let (output, code) = run_jq_stdin(
+        "with_entries(.value |= (. | tostring))",
+        r#"{"a":1e400}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":"inf"}"#);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- An overflowed `NumberLiteral` (e.g. `1e400`, which parses to `f64::INFINITY`) rendered as garbage like `"NaNE+2147483647"` in `@uri`, `@html`, `@sh`, string interpolation, `@csv`, and the CLI's identity output, instead of `"inf"`/`"-inf"` (text formats) or `null` (JSON output) the way a plain `Float` already does.
- A prior commit on this branch (`193508cc`) added a `numeric_display_string()` fix in `src/jq/eval.rs`, but that fix is only reachable when `eval.rs::eval()` is called directly — the actual CLI dispatches through `eval_generic::eval_with_cursor`, whose catch-all bridge round-trips values through `OwnedValue::to_json()` (which correctly substitutes `"null"` for NaN/Infinity per RFC 8259) *before* the fixed code ever runs, silently destroying the overflowed value. So `sjq '@uri'`/`'@html'` — the issue's own repro commands — were still broken.
- This PR closes that gap with two independent fixes:
  1. **`eval_generic` reindex bridge** (`6c8674e9`): adds `OwnedValue::to_json_for_reindex()`, used only by the two internal bridge call sites, which preserves ±Infinity via a self-overflowing JSON literal (`1e999`/`-1e999`) instead of `"null"`. Fixes `@uri`, `@html`, `@sh`, string interpolation, `@csv`/`@tsv`/`@dsv`.
  2. **CLI raw-number output** (`43e63a5d`): a separate, unrelated code path (`jq_runner.rs`'s `print_json` → `format_raw_number`) had no NaN/Infinite guard before calling `format_number_jq_compat`, unlike its sibling `format_float`. Fixes the CLI's identity path (`.`) — now correctly prints `null` (JSON's own established convention for non-representable numbers), not garbage.

Fixes #561

## Test plan

- [x] `cargo build --features cli` and manually re-ran every repro command from the issue plus the newly-discovered gaps (`@uri`, `@html`, `@sh`, string interpolation, `@csv`, identity `.`) against the built binary — all now correct
- [x] New CLI-level integration tests in `tests/jq_cli_tests.rs` (`test_number_literal_overflow_text_formats_via_cli`, `test_number_literal_overflow_identity_prints_null_via_cli`) — spawn the real binary, which is what actually exercises the bridge bug
- [x] New unit test in `src/jq/eval_generic.rs` (`test_generic_format_overflow_literal_via_reindex_bridge`) driving the bridge directly with `Expr::Format`
- [x] `cargo test --features cli,simd,regex,serde --workspace` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second invocation (`--features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`) — both clean
- [x] `cargo fmt --check` — clean