### PR TITLE
bench(yaml): add empty-items/half-empty-items generator patterns (#516)

### DIFF
--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -726,6 +726,9 @@ enum YamlPatternArg {
     /// Top-level sequence of childless bare-dash items (`-` alone on its own
     /// line, reads as `null`) — the shape #337 found quadratic
     EmptyItems,
+    /// Childless bare-dash items interleaved with items carrying inline
+    /// scalar content (`- x`)
+    HalfEmptyItems,
 }
 
 impl From<YamlPatternArg> for yaml_generators::YamlPattern {
@@ -748,6 +751,7 @@ impl From<YamlPatternArg> for yaml_generators::YamlPattern {
             YamlPatternArg::ExplicitKeys => Self::ExplicitKeys,
             YamlPatternArg::MultiDoc => Self::MultiDoc,
             YamlPatternArg::EmptyItems => Self::EmptyItems,
+            YamlPatternArg::HalfEmptyItems => Self::HalfEmptyItems,
         }
     }
 }

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -723,6 +723,9 @@ enum YamlPatternArg {
     ExplicitKeys,
     /// Multi-document streams (`---` / `...`)
     MultiDoc,
+    /// Top-level sequence of childless bare-dash items (`-` alone on its own
+    /// line, reads as `null`) — the shape #337 found quadratic
+    EmptyItems,
 }
 
 impl From<YamlPatternArg> for yaml_generators::YamlPattern {
@@ -744,6 +747,7 @@ impl From<YamlPatternArg> for yaml_generators::YamlPattern {
             YamlPatternArg::BlockScalars => Self::BlockScalars,
             YamlPatternArg::ExplicitKeys => Self::ExplicitKeys,
             YamlPatternArg::MultiDoc => Self::MultiDoc,
+            YamlPatternArg::EmptyItems => Self::EmptyItems,
         }
     }
 }

--- a/src/bin/succinctly/yaml_generators.rs
+++ b/src/bin/succinctly/yaml_generators.rs
@@ -29,6 +29,16 @@
 //! - **Tags (`!!str`, `!custom`)** — rejected outright in block context; a
 //!   documented non-support in `src/yaml/mod.rs`.
 //!
+//! # Shape guards, not features (#516)
+//!
+//! `empty-items` does not carry a *construct* absent elsewhere — a childless
+//! bare-dash item parses the same as any other sequence item. It exists
+//! because #337 found that exact shape quadratic while every generator only
+//! ever emitted `- ` items with content nested underneath, so the regression
+//! (and its later, incidental fix) had zero benchmark coverage. Per
+//! `docs/guides/benchmarking.md` rule 7: a benchmark cannot measure a shape it
+//! does not generate.
+//!
 //! # Why this file exists in this shape (#327)
 //!
 //! Until #327 none of the features above were generated at all, so "every
@@ -75,6 +85,9 @@ pub enum YamlPattern {
     ExplicitKeys,
     /// Multi-document streams (`---` / `...`)
     MultiDoc,
+    /// Top-level sequence of childless bare-dash items (`-\n` repeated) — the
+    /// shape #337 found quadratic and no other pattern generates
+    EmptyItems,
 }
 
 /// How the suite generator sizes a pattern.
@@ -135,6 +148,11 @@ pub const ALL_PATTERNS: &[(&str, YamlPattern, PatternScale)] = &[
         PatternScale::Scalable,
     ),
     ("multi-doc", YamlPattern::MultiDoc, PatternScale::Scalable),
+    (
+        "empty-items",
+        YamlPattern::EmptyItems,
+        PatternScale::Scalable,
+    ),
 ];
 
 /// Generate YAML of approximately target_size bytes
@@ -156,6 +174,7 @@ pub fn generate_yaml(target_size: usize, pattern: YamlPattern, seed: Option<u64>
         YamlPattern::BlockScalars => generate_block_scalars(target_size, seed),
         YamlPattern::ExplicitKeys => generate_explicit_keys(target_size, seed),
         YamlPattern::MultiDoc => generate_multidoc(target_size, seed),
+        YamlPattern::EmptyItems => generate_empty_items(target_size),
     }
 }
 
@@ -879,6 +898,35 @@ fn generate_multidoc(target_size: usize, seed: Option<u64>) -> String {
 }
 
 // ============================================================================
+// Shape-focused patterns (#516)
+// ============================================================================
+
+/// Generate a top-level sequence of childless bare-dash items: `-\n` repeated.
+///
+/// A bare `-` alone on its own line, with nothing following it, is valid YAML
+/// that reads as `null`. #337 found this exact shape quadratic (~3.9x per
+/// doubling, 2.5s for 800KB) while the visually similar `- x` was linear — and
+/// no generator produced it, so the regression (and its later, incidental fix)
+/// were both invisible to every end-to-end benchmark.
+///
+/// This is distinct from the `- \n` items `generate_users` and
+/// `generate_navigation` already emit: those always have mapping fields
+/// nested on the following lines, so the item is never actually childless.
+/// Deterministic (no seed): the shape is the entire point, and there is
+/// nothing to randomize.
+fn generate_empty_items(target_size: usize) -> String {
+    let mut yaml = String::with_capacity(target_size);
+    yaml.push_str("# Childless bare-dash items (#337, #516)\n");
+
+    let start_len = yaml.len();
+    while yaml.len().saturating_sub(start_len) < target_size {
+        yaml.push_str("-\n");
+    }
+
+    yaml
+}
+
+// ============================================================================
 // Helper functions
 // ============================================================================
 
@@ -1371,6 +1419,44 @@ mod tests {
             yaml.contains("  - ? valueless item key "),
             "no valueless explicit key at sequence-item position"
         );
+    }
+
+    #[test]
+    fn test_generate_empty_items() {
+        let yaml = generate_yaml(2048, YamlPattern::EmptyItems, Some(42));
+        let body = yaml.lines().skip(1); // drop the leading comment line
+        assert!(
+            body.clone().all(|line| line == "-"),
+            "every line must be a childless bare dash, got:\n{yaml}"
+        );
+
+        let index = succinctly::yaml::YamlIndex::build(yaml.as_bytes())
+            .unwrap_or_else(|e| panic!("generated empty-items does not parse: {e:?}"));
+        // `root()` is a virtual sequence of *documents*; descend into the sole
+        // document to reach our actual top-level sequence of childless items.
+        let doc = match index.root(yaml.as_bytes()).value() {
+            succinctly::yaml::YamlValue::Sequence(docs) => {
+                let (doc, rest) = docs.uncons_cursor().expect("no document");
+                assert!(rest.uncons_cursor().is_none(), "expected a single document");
+                doc
+            }
+            other => panic!("expected the virtual root sequence, got {other:?}"),
+        };
+        match doc.value() {
+            succinctly::yaml::YamlValue::Sequence(mut items) => {
+                let mut count = 0;
+                while let Some((item, rest)) = items.uncons_cursor() {
+                    assert!(
+                        matches!(item.value(), succinctly::yaml::YamlValue::Null),
+                        "item {count} is not null"
+                    );
+                    count += 1;
+                    items = rest;
+                }
+                assert!(count > 1, "must generate more than one childless item");
+            }
+            other => panic!("expected a top-level sequence, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/bin/succinctly/yaml_generators.rs
+++ b/src/bin/succinctly/yaml_generators.rs
@@ -31,13 +31,13 @@
 //!
 //! # Shape guards, not features (#516)
 //!
-//! `empty-items` does not carry a *construct* absent elsewhere — a childless
-//! bare-dash item parses the same as any other sequence item. It exists
-//! because #337 found that exact shape quadratic while every generator only
-//! ever emitted `- ` items with content nested underneath, so the regression
-//! (and its later, incidental fix) had zero benchmark coverage. Per
-//! `docs/guides/benchmarking.md` rule 7: a benchmark cannot measure a shape it
-//! does not generate.
+//! `empty-items` and `half-empty-items` do not carry a *construct* absent
+//! elsewhere — a childless bare-dash item parses the same as any other
+//! sequence item. They exist because #337 found that exact shape quadratic
+//! while every generator only ever emitted `- ` items with content nested
+//! underneath, so the regression (and its later, incidental fix) had zero
+//! benchmark coverage. Per `docs/guides/benchmarking.md` rule 7: a benchmark
+//! cannot measure a shape it does not generate.
 //!
 //! # Why this file exists in this shape (#327)
 //!
@@ -88,6 +88,9 @@ pub enum YamlPattern {
     /// Top-level sequence of childless bare-dash items (`-\n` repeated) — the
     /// shape #337 found quadratic and no other pattern generates
     EmptyItems,
+    /// Childless bare-dash items interleaved with items carrying inline
+    /// scalar content (`- x`)
+    HalfEmptyItems,
 }
 
 /// How the suite generator sizes a pattern.
@@ -153,6 +156,11 @@ pub const ALL_PATTERNS: &[(&str, YamlPattern, PatternScale)] = &[
         YamlPattern::EmptyItems,
         PatternScale::Scalable,
     ),
+    (
+        "half-empty-items",
+        YamlPattern::HalfEmptyItems,
+        PatternScale::Scalable,
+    ),
 ];
 
 /// Generate YAML of approximately target_size bytes
@@ -175,6 +183,7 @@ pub fn generate_yaml(target_size: usize, pattern: YamlPattern, seed: Option<u64>
         YamlPattern::ExplicitKeys => generate_explicit_keys(target_size, seed),
         YamlPattern::MultiDoc => generate_multidoc(target_size, seed),
         YamlPattern::EmptyItems => generate_empty_items(target_size),
+        YamlPattern::HalfEmptyItems => generate_half_empty_items(target_size),
     }
 }
 
@@ -926,6 +935,32 @@ fn generate_empty_items(target_size: usize) -> String {
     yaml
 }
 
+/// Generate a sequence interleaving childless bare-dash items with items
+/// carrying inline scalar content (`- x`).
+///
+/// `empty_items` alone is the uniform, easiest-to-optimize-for shape; #516
+/// asks for a mix as the more realistic case — a document with a run of
+/// populated entries interrupted by empty placeholders, which is what a
+/// quadratic-in-item-count bug would still show up on.
+fn generate_half_empty_items(target_size: usize) -> String {
+    let mut yaml = String::with_capacity(target_size);
+    yaml.push_str("# Half childless, half inline-content bare-dash items (#516)\n");
+
+    let start_len = yaml.len();
+    let mut count = 0;
+
+    while yaml.len().saturating_sub(start_len) < target_size {
+        if count % 2 == 0 {
+            yaml.push_str("-\n");
+        } else {
+            yaml.push_str(&format!("- item_{count}\n"));
+        }
+        count += 1;
+    }
+
+    yaml
+}
+
 // ============================================================================
 // Helper functions
 // ============================================================================
@@ -1457,6 +1492,16 @@ mod tests {
             }
             other => panic!("expected a top-level sequence, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_generate_half_empty_items() {
+        let yaml = generate_yaml(2048, YamlPattern::HalfEmptyItems, Some(42));
+        assert!(yaml.contains("\n-\n"), "no childless bare-dash item");
+        assert!(yaml.contains("- item_"), "no item carrying inline content");
+
+        succinctly::yaml::YamlIndex::build(yaml.as_bytes())
+            .unwrap_or_else(|e| panic!("generated half-empty-items does not parse: {e:?}"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- No YAML generator emitted a **childless bare `-`** on its own line (valid YAML, reads as `null`) — #337 found that exact shape quadratic (~3.9x per doubling, 2.5s for 800KB) while the visually similar `- x` was linear, and the regression (and its later, incidental fix) went unmeasured by every end-to-end benchmark.
- Adds `empty-items` (all-childless) and `half-empty-items` (childless interleaved with `- item_N` content) to `yaml_generators::ALL_PATTERNS`, wired into `yaml generate --pattern` and picked up automatically by `dev bench yq` (which derives its pattern list from `ALL_PATTERNS`) and `yaml generate-suite`, with no further wiring needed.
- Both patterns are appended at the end of `ALL_PATTERNS`, preserving every existing pattern's seed and generated bytes.

## Why

`generate_users`/`generate_navigation`'s `- \n` items always have mapping fields nested on the following lines, so no prior generator ever produced a *childless* wrapper — the item shape #337 found to trigger the quadratic path. Per `docs/guides/benchmarking.md` rule 7: *a benchmark cannot measure a shape it does not generate.*

## Verification

- `cargo build`/`test`/`clippy --all-targets -- -D warnings` clean.
- `tests/yaml_bench_suite_coverage.rs` (pattern-list consistency) passes.
- `succinctly yaml generate -p empty-items` confirmed to emit bare `-` items that round-trip through `yq` as `null`.
- `dev bench yq --patterns empty-items,half-empty-items` runs end-to-end and matches system `yq`'s output.
- Measured the growth curve locally (doubling 1MB→16MB, min-of-3, `succinctly yq -o json -I0 '.'`):

  | Size | Time (min of 3) | Ratio vs. previous |
  |------|------|------|
  | 1 MB | 43 ms | — |
  | 2 MB | 67 ms | 1.56x |
  | 4 MB | 115 ms | 1.72x |
  | 8 MB | 214 ms | 1.86x |
  | 16 MB | 404 ms | 1.89x |

  Ratio converges to ~1.9x per doubling as constant CLI-startup overhead becomes negligible — the linear signature, not the ~3.9x quadratic one #337 found.

Closes #516

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli` (yaml_generators + yaml_bench_suite_coverage)
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] Manual `succinctly yaml generate -p empty-items` / `-p half-empty-items` output inspection
- [x] `dev bench yq --patterns empty-items,half-empty-items` end-to-end run