### PR TITLE
fix(jq): stop repeat() from discarding an error mid-loop

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -31,9 +31,9 @@ Measured against jq-1.7.1 over the 186 probes in
 
 | Dimension                                    | Result               | Meaning                                            |
 |----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **180/186 = 96.8%**  | Byte-identical to jq                               |
+| **Message text** (both evaluators, verbatim) | **181/186 = 97.3%**  | Byte-identical to jq                               |
 | **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
-| **Behaviour / parser gaps**                  | **6**                | succinctly does not raise the error at all         |
+| **Behaviour / parser gaps**                  | **5**                | succinctly does not raise the error at all         |
 
 These three numbers are asserted, not maintained by hand: `jq_error_message_tests.rs`
 parses them back out of this page and fails if they drift from the corpus (they went stale
@@ -246,20 +246,23 @@ shortest rendering differs from their source spelling.
 
 ## Behaviour and parser gaps
 
-One remains open, recorded in
+None remain open in this section's own narrative, tracked in
 [`tests/data/jq-error-known-divergences.txt`](../../../tests/data/jq-error-known-divergences.txt).
 That file's check is two-sided — a probe that starts diverging without a line there fails
 the build, and so does a line for a probe that starts matching — so this section cannot
 silently drift from the corpus.
 
-- **`repeat_error_swallowed`** (`repeat(if . > 3 then error("boom") else .+1 end)` on
-  `5`): jq propagates the generator's error the first time it is raised — here, on the
-  very first iteration, since `5 > 3` immediately. `eval_repeat` in
-  [`src/jq/eval.rs`](../../../src/jq/eval.rs) discards the error (`Err(_) => break`)
-  instead of propagating it, so both evaluators produce no output at all rather than
-  erroring. [#495](https://github.com/rust-works/succinctly/issues/495).
-
 What used to be listed here, and what closed it:
+
+`repeat_error_swallowed` (`repeat(if . > 3 then error("boom") else .+1 end)` on `5`) was
+here: jq propagates the generator's error the first time it is raised — here, on the very
+first iteration, since `5 > 3` immediately. `eval_repeat` in
+[`src/jq/eval.rs`](../../../src/jq/eval.rs) discarded the error (`Err(_) => break`) instead
+of propagating it, so both evaluators produced no output at all rather than erroring.
+[#495](https://github.com/rust-works/succinctly/issues/495) closed it: an error with no
+prior output now surfaces as `QueryResult::Error` (via the same `partial()` helper #494 used
+for `while`/`foreach`/`limit`), and output already produced before the error is no longer
+discarded either.
 
 `optional_write_negative_oob` (`.[-5]? = 9` on `[1,2]`) was here: `?` only suppresses
 errors raised while *collecting* a path, not the write-time bounds check on a

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9348,17 +9348,15 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Evaluate expr with the original input each time
         match eval_owned_expr::<S>(expr, &owned, optional) {
             Ok(new_val) => outputs.push(new_val),
-            Err(_) => break, // Stop on error
+            // The values already output no longer vanish, and an error with
+            // no prior output surfaces as an error rather than empty output
+            // (#495): `repeat(if . > 3 then error("boom") else .+1 end)` on
+            // `5` raises immediately with no output, matching jq exactly.
+            Err(e) => return partial(outputs, Control::Error(e)),
         }
     }
 
-    if outputs.is_empty() {
-        QueryResult::None
-    } else if outputs.len() == 1 {
-        QueryResult::Owned(outputs.pop().unwrap())
-    } else {
-        QueryResult::ManyOwned(outputs)
-    }
+    owned_vec_to_result(outputs)
 }
 
 /// A numeric argument to `range()`: kept as `i64` when exact so all-integer

--- a/tests/data/jq-error-known-divergences.txt
+++ b/tests/data/jq-error-known-divergences.txt
@@ -46,7 +46,6 @@
 # errors raised while *collecting* a path) landed together and took
 # `optional_write_negative_oob` with them: `.[-5]? = 9` now raises, matching jq.
 
-repeat_error_swallowed       repeat      eval_repeat (src/jq/eval.rs) discards the generator's first error instead of propagating it — #495
 del_oob_index_iterate_tail           del             an out-of-range index resolves to null and the `[]` tail must raise; the #477 bounds check skips the tail entirely — #529
 del_oob_index_iterate_tail_nested    del             same site reached through a field, so the grouped and single-path walkers stay in step — #529
 path_non_path_literal                path            path() answers with no output where jq refuses a non-path filter by name — #530


### PR DESCRIPTION
## Summary
- `eval_repeat` used `Err(_) => break`, silently discarding any error raised inside its argument — `repeat(if . > 3 then error("boom") else .+1 end)` on `5` produced empty stdout and exit 0, indistinguishable from legitimately-empty output
- Routes the error through the same `partial(outputs, Control::Error(e))` helper #494 already uses for `while`/`foreach`/`limit`: an error with no prior output now surfaces as `QueryResult::Error` (matching jq's immediate-error, exit-5 behavior), and output already produced before a later error is kept rather than dropped
- `repeat(exp)`'s existing "apply exp to the original input each time" semantics were verified against real jq and left unchanged — only the error handling was broken
- Retires the now-resolved `repeat_error_swallowed` entry from the known-divergences manifest and refreshes the compliance page's asserted parity numbers (181/186 = 97.3%, 5 behaviour/parser gaps)

Fixes #495

## Test plan
- [x] `cargo build --release --features cli` — issue repro now matches jq byte-for-byte (message + exit code 5)
- [x] `cargo test --features cli,simd,regex,serde --tests` — full suite green, no failures
- [x] `cargo test --features cli,simd,regex,serde --test jq_error_message_tests` — all 3 parity/manifest/docs-consistency tests pass
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings` — clean