### PR TITLE
fix(cli): correct off-by-one line number in error diagnostics without trailing newline

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2198,6 +2198,34 @@ mod tests {
     }
 
     #[test]
+    fn test_line_at() {
+        // Single value, no trailing newline: jq's counter never advances (#524).
+        let bytes = br#"{"a":1}"#;
+        assert_eq!(line_at(bytes, bytes.len()), 0);
+
+        // Multi-value, no trailing newline after the last value: both values
+        // report the same line jq does, not "line of value + 1" (#524).
+        let bytes = b"1\n2";
+        let ends = find_json_values(bytes);
+        assert_eq!(ends, vec![(0, 1), (2, 3)]);
+        assert_eq!(line_at(bytes, 1), 1); // "1" ends before the '\n' lookahead
+        assert_eq!(line_at(bytes, 3), 1); // "2" ends at EOF, no lookahead byte
+
+        // Container value spanning multiple lines, no trailing newline: jq
+        // names the line the value's closing brace is on, not one past it
+        // (#524 -- the naive "1 + newlines-before-end" formula overcounts).
+        let bytes = b"{\n\"a\":1\n}";
+        assert_eq!(line_at(bytes, bytes.len()), 2);
+
+        // With a trailing newline after every value, the lookahead-aware
+        // formula agrees with plain "count of newlines up to and including
+        // the delimiter" -- unaffected by this fix.
+        let bytes = b"1\n2\n";
+        assert_eq!(line_at(bytes, 1), 1);
+        assert_eq!(line_at(bytes, 3), 2);
+    }
+
+    #[test]
     fn test_trim_ascii_ws() {
         assert_eq!(trim_ascii_ws(b"  x  "), b"x");
         assert_eq!(trim_ascii_ws(b"abc"), b"abc");

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1266,16 +1266,24 @@ fn read_file_bytes(path: &Path) -> Result<Vec<u8>> {
     std::fs::read(path).with_context(|| format!("Failed to read file: {}", path.display()))
 }
 
-/// 1-based line number of the byte at `end` within `bytes`.
+/// jq's line number for the value whose exclusive end offset is `end` within
+/// `bytes`.
 ///
 /// jq's `(at <file>:<line>)` marker names the line on which the input value
 /// *ends*, so callers pass the exclusive end offset from [`find_json_values`].
-/// Only reached on the error path, so a plain scan is cheap enough.
+/// jq's counter is the number of `\n` bytes its lexer has consumed by the
+/// time the value's boundary is confirmed: every newline strictly before
+/// `end`, plus exactly one byte of trailing lookahead if it exists and is a
+/// newline. It is zero-based, not one-based — a value ending before any `\n`
+/// reports line 0. Only reached on the error path, so a plain scan is cheap
+/// enough.
 fn line_at(bytes: &[u8], end: usize) -> usize {
-    1 + bytes[..end.min(bytes.len())]
-        .iter()
-        .filter(|&&b| b == b'\n')
-        .count()
+    let end = end.min(bytes.len());
+    let mut count = bytes[..end].iter().filter(|&&b| b == b'\n').count();
+    if bytes.get(end) == Some(&b'\n') {
+        count += 1;
+    }
+    count
 }
 
 /// Find the byte ranges of JSON values in a byte slice.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2487,11 +2487,12 @@ fn temp_json(contents: &str) -> Result<(NamedTempFile, String)> {
 
 #[test]
 fn test_uncaught_error_exits_5() -> Result<()> {
-    // jq: `jq: error (at <stdin>:1): boom`, exit 5.
+    // jq: `jq: error (at <stdin>:0): boom`, exit 5. Line 0: the input has no
+    // trailing newline, so jq's zero-based counter never advances (#524).
     let (stdout, stderr, code) = run_jq_full(&["-c", r#"error("boom")"#], Some(r#"{"x":1}"#))?;
     assert_eq!(code, 5, "uncaught error must exit 5: {stderr}");
     assert_eq!(stdout, "", "a failed filter produces no output");
-    assert_eq!(stderr.trim_end(), "jq: error (at <stdin>:1): boom");
+    assert_eq!(stderr.trim_end(), "jq: error (at <stdin>:0): boom");
     Ok(())
 }
 
@@ -2503,7 +2504,8 @@ fn test_uncaught_type_error_exits_5() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-c", "1|.foo"], Some(r#"{"x":1}"#))?;
     assert_eq!(code, 5, "uncaught type error must exit 5: {stderr}");
     assert_eq!(stdout, "");
-    assert!(stderr.starts_with("jq: error (at <stdin>:1): "), "{stderr}");
+    // Line 0: the input has no trailing newline (#524).
+    assert!(stderr.starts_with("jq: error (at <stdin>:0): "), "{stderr}");
     assert!(!stderr.contains("(not a string)"), "{stderr}");
     Ok(())
 }
@@ -2512,18 +2514,19 @@ fn test_uncaught_type_error_exits_5() -> Result<()> {
 fn test_uncaught_error_marks_non_string_payload() -> Result<()> {
     // jq flags a raised payload that is not a string. Needs the raw value at
     // the print site -- the rendered message alone cannot tell the two apart.
+    // Line 0 throughout: the input has no trailing newline (#524).
     for (filter, want) in [
         (
             r#"error({"a":1})"#,
-            r#"jq: error (at <stdin>:1) (not a string): {"a":1}"#,
+            r#"jq: error (at <stdin>:0) (not a string): {"a":1}"#,
         ),
         (
             "error(null)",
-            "jq: error (at <stdin>:1) (not a string): null",
+            "jq: error (at <stdin>:0) (not a string): null",
         ),
-        ("error(42)", "jq: error (at <stdin>:1) (not a string): 42"),
+        ("error(42)", "jq: error (at <stdin>:0) (not a string): 42"),
         // A string payload is *not* flagged.
-        (r#"error("boom")"#, "jq: error (at <stdin>:1): boom"),
+        (r#"error("boom")"#, "jq: error (at <stdin>:0): boom"),
     ] {
         let (_, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"x":1}"#))?;
         assert_eq!(code, 5, "{filter}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2559,6 +2559,31 @@ fn test_uncaught_error_names_the_file_and_line() -> Result<()> {
 }
 
 #[test]
+fn test_uncaught_error_line_number_without_trailing_newline() -> Result<()> {
+    // #524: `line_at` reported one line too many whenever the erroring value
+    // is the last one and the input lacks a trailing newline. Every
+    // expectation here was captured against pinned jq 1.7.1-apple.
+
+    // Multi-value input with no trailing newline after the last value: real
+    // jq reports line 1 for *both* values, not line 2 for the second.
+    let (_keep, path) = temp_json("1\n2")?;
+    let (_, stderr, code) = run_jq_full(&["-c", r#"error("boom")"#, &path], None)?;
+    assert_eq!(code, 5);
+    assert_eq!(
+        stderr.trim_end(),
+        format!("jq: error (at {path}:1): boom\njq: error (at {path}:1): boom")
+    );
+
+    // A container value spanning multiple lines with no trailing newline:
+    // real jq names its closing brace's line, not one past it.
+    let (_keep, path) = temp_json("{\n\"a\":1\n}")?;
+    let (_, stderr, code) = run_jq_full(&["-c", r#"error("boom")"#, &path], None)?;
+    assert_eq!(code, 5);
+    assert_eq!(stderr.trim_end(), format!("jq: error (at {path}:2): boom"));
+    Ok(())
+}
+
+#[test]
 fn test_uncaught_error_on_any_input_fails_the_run() -> Result<()> {
     // DELIBERATE DIVERGENCE FROM jq. jq's exit code reflects only the *last*
     // input, so an error on any earlier one exits 0 -- the exact


### PR DESCRIPTION
## Summary
- `line_at()` unconditionally returned `1 + newlines-strictly-before-end`, overcounting by one whenever the erroring value is the last one and the input has no trailing newline (scalars *and* multi-line containers).
- Replaced with jq's actual zero-based counter: newlines strictly before `end`, plus one byte of trailing lookahead only if it exists and is `\n` — matches pinned jq 1.7.1 across all three repro cases in the issue.
- Corrected three existing tests that were unknowingly asserting the buggy `:1` output for a no-trailing-newline input.
- Added a direct unit test for `line_at()` and a CLI-level integration test covering the multi-value and multi-line-container cases.

Fixes #524

## Test plan
- [x] `cargo test --features cli --bin succinctly jq_runner::tests::test_line_at`
- [x] `cargo test --features cli --test jq_cli_tests` (144 passed)
- [x] `cargo clippy --features cli,simd,regex,serde --all-targets -- -D warnings`
- [x] Manually verified all three issue repros match pinned jq output