### PR TITLE
ci: add merge_group trigger to canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,15 +1,19 @@
 name: Canary
 
 # Fires on the exact events issue #531 observed going missing: force-push
-# (synchronize) and reopen. Kept separate from ci.yml so it stays a fast,
-# independent signal of "did GitHub deliver *any* trigger event for this
-# SHA" rather than being entangled with the full matrix's health.
+# (synchronize) and reopen. Also covers merge-queue builds (#552) so the same
+# "did GitHub deliver *any* trigger event for this SHA" signal exists for
+# queued PRs, not just pre-merge review. Kept separate from ci.yml so it
+# stays a fast, independent signal rather than being entangled with the full
+# matrix's health.
 on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- `canary.yml` (added in #531) only fired on `pull_request`/`push`, so merge-queue builds (`gh-readonly-queue/main/*` refs) had no independent signal that GitHub delivered the trigger event
- `ci.yml`/`block-merge.yml` already cover `merge_group: types: [checks_requested]` per #310 — this brings canary in line with the same pattern
- Observability-only change (canary is not a required check), so this is low-risk

Closes #552

## Test plan
- [x] Diffed the new `merge_group` stanza against `ci.yml`'s — structurally identical
- [ ] Confirm the canary job fires and stamps correctly the next time a PR merges via the queue after this lands (can't be exercised pre-merge since this PR itself doesn't go through the queue)