### PR TITLE
fix(jq): del() through an out-of-range index raises on an [] tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`del()` through an out-of-range index silently no-op'd where a `[]` tail
+  should raise** (#529): `[1,2] | del(.[5][])` returned `[1,2]` unchanged
+  where jq raises `Cannot iterate over null (null)` — the last two sites left
+  over from #527's fix, both from #477's original bounds check. The `else`
+  arm of `delete_expr_array_paths`' grouped/comma walker and
+  `delete_at_path`'s `Expr::Pipe` chain-walk `Index` arm skipped the tail
+  outright instead of walking it against a throwaway `null`, the same "reads
+  as `null`, keep walking" rule #527 applied at its own two sites — an
+  out-of-range index is only reachable through `Index`, never through a
+  missing field, so #527 could not have reached it. Both now call
+  `delete_expr_paths_through_absent`/`delete_at_path_through_absent`, #527's
+  own helpers, from their `else` branch instead of returning early. Covers
+  every way in: a positive or negative out-of-range index, and an
+  in-bounds-by-spelling index into an empty array (`[] | del(.[0][])`), with
+  the `[]` any distance past the dead end (`[1,2] | del(.[5].c[])`) and the
+  grouped/comma spelling agreeing with the single-path one
+  (`del(.[5][], .[6][])`). Every other tail keeps the #477 no-op it already
+  had. New coverage:
+  `test_del_through_an_out_of_range_index_still_raises_on_an_iterate_tail` in
+  `src/jq/eval.rs`; the `del_oob_index_iterate_tail`/
+  `del_oob_index_iterate_tail_nested` probes seeded pinning this bug come off
+  `tests/data/jq-error-known-divergences.txt`.
+
 - **jq: a mid-stream error or `break` discarded every output already produced
   by the same evaluation** (#400, #494): `QueryResult` (and its mirror
   `GenericResult`) modeled `Error`/`Break` as a property of the *whole*
@@ -318,10 +341,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `tests/jq_computed_key_tests.rs`, four
   `tests/data/jq-golden/cases/{,comma_}del_missing_*` fixtures captured from
   the pinned jq oracle, and an `iterate_del_through_missing_field` error probe
-  pinning the `[]`-tail sentence. **Not covered**: the two remaining sites
-  with the same shape are #477's out-of-range-index gates, which no missing
-  key can reach — `[1,2] | del(.[5][])` and `{"a":[1,2]} | del(.a[5][])` are
-  still silent no-ops where jq raises. Tracked in #529.
+  pinning the `[]`-tail sentence. The two remaining sites with the same
+  shape — #477's out-of-range-index gates, which no missing key can reach —
+  were fixed separately by #529, above.
 
 - **jq comma/pipe precedence was inverted, silently dropping outputs** (#462).
   `,` was parsed as the loosest operator, wrapping `|`; jq's grammar is the

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -31,9 +31,9 @@ Measured against jq-1.7.1 over the 186 probes in
 
 | Dimension                                    | Result               | Meaning                                            |
 |----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **181/186 = 97.3%**  | Byte-identical to jq                               |
+| **Message text** (both evaluators, verbatim) | **183/186 = 98.4%**  | Byte-identical to jq                               |
 | **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
-| **Behaviour / parser gaps**                  | **5**                | succinctly does not raise the error at all         |
+| **Behaviour / parser gaps**                  | **3**                | succinctly does not raise the error at all         |
 
 These three numbers are asserted, not maintained by hand: `jq_error_message_tests.rs`
 parses them back out of this page and fails if they drift from the corpus (they went stale
@@ -317,17 +317,13 @@ than needing `?` to swallow a failure). No write operator produces `index N out 
 longer a positive case for succinctly's own wording to cover.
 
 `del()` used to sit here too — `del(.[5])` and `del(.[-5])` on `[1,2]`, plus a missing
-intermediate key — but every one of those is a silent no-op now, matching jq, after
-[#477](https://github.com/rust-works/succinctly/issues/477) and
-[#527](https://github.com/rust-works/succinctly/issues/527). A step that reaches nothing
+intermediate key or an out-of-range index — but every one of those is a silent no-op now,
+matching jq, after [#477](https://github.com/rust-works/succinctly/issues/477),
+[#527](https://github.com/rust-works/succinctly/issues/527) and
+[#529](https://github.com/rust-works/succinctly/issues/529). A step that reaches nothing
 reads as `null` and the rest of the path is walked against it, so only an `[]` tail still
-raises (`{"a":{"x":1}} | del(.a.b[])` is `Cannot iterate over null (null)` in both).
-
-What is left of that family diverges in the *opposite* direction, so it does not belong in
-this table at all: after an out-of-range index specifically, succinctly still skips the tail
-instead of walking it, so `[1,2] | del(.[5][])` is a silent no-op where jq raises `Cannot
-iterate over null (null)` — [#529](https://github.com/rust-works/succinctly/issues/529),
-not yet seeded into the probe corpus.
+raises (`{"a":{"x":1}} | del(.a.b[])` and `[1,2] | del(.[5][])` are both `Cannot iterate over
+null (null)`).
 
 The two slice rows were added by [#366](https://github.com/rust-works/succinctly/issues/366)
 deliberately. Writing through a slice could have vivified `null` on its own — `setpath`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11360,9 +11360,15 @@ fn delete_expr_array_paths(
                         let slot = &mut arr[actual as usize];
                         let old = core::mem::replace(slot, OwnedValue::Null);
                         *slot = delete_expr_paths_at(old, group, start + 1)?;
+                    } else {
+                        // An out-of-range index names nothing to delete
+                        // through, so jq's delpaths silently skips the step
+                        // itself, `?` or not (#477) — but the tail still
+                        // decides: `del(.[5].a)` stays a no-op while
+                        // `del(.[5][])` raises `Cannot iterate over null
+                        // (null)` (#527/#529).
+                        delete_expr_paths_through_absent(group, start + 1)?;
                     }
-                    // An out-of-range index names nothing to delete through —
-                    // jq's delpaths silently skips it, `?` or not (#477).
                 }
                 // Deleting *through* a slice deletes inside the sub-array and
                 // splices it back: `[1,[2],[3]] | del(.[1:3][0])` is `[1,[3]]`.
@@ -11655,10 +11661,12 @@ fn delete_at_path(
                             if actual_idx >= 0 && (actual_idx as usize) < arr.len() {
                                 delete_at_path(&mut arr[actual_idx as usize], &rest, optional)
                             } else {
-                                // An out-of-range index resolves to null;
-                                // deleting further into null is always a
-                                // no-op, `?` or not (#477).
-                                Ok(())
+                                // An out-of-range index resolves to null, and
+                                // deleting further into null is a no-op for
+                                // most tails, `?` or not (#477) — but not
+                                // `[]`, which still raises `Cannot iterate
+                                // over null (null)` (#527/#529).
+                                delete_at_path_through_absent(&rest, optional)
                             }
                         }
                         // Same per-step `null` exemption as the `Field` case
@@ -23322,6 +23330,58 @@ mod tests {
         for filter in [r"del(.a.b)", r"del(.[0].a)", r"del(.[0:2].a)"] {
             query!(br"null", filter,
                 QueryResult::Owned(OwnedValue::Null) => {}
+            );
+        }
+    }
+
+    #[test]
+    fn test_del_through_an_out_of_range_index_still_raises_on_an_iterate_tail() {
+        // #529: an out-of-range index (positive, negative, or into an empty
+        // array) reads as `null` just like a missing field does (#527), and
+        // jq keeps walking the rest of the path against that `null` — so a
+        // `[]` tail still raises `Cannot iterate over null (null)` even
+        // though every other tail stays a no-op. Both `[1,2]`'s single-path
+        // walker (`delete_at_path`) and its grouped/comma walker
+        // (`delete_expr_array_paths`) must agree.
+        for (json, filter) in [
+            (&br"[1,2]"[..], r"del(.[5][])"),
+            (&br#"{"a":[1,2]}"#[..], r"del(.a[5][])"),
+            (&br"[1,2]"[..], r"del(.[-5][])"),
+            (&br"[]"[..], r"del(.[0][])"),
+            (&br#"{"a":[]}"#[..], r"del(.a[0][])"),
+            // The `[]` can sit further down than the very next component.
+            (&br"[1,2]"[..], r"del(.[5].c[])"),
+            (&br"[1,2]"[..], r"del(.[5][1:2][])"),
+            // A `?` on the out-of-range step does not suppress what the tail
+            // itself raises.
+            (&br"[1,2]"[..], r"del(.[5]?[])"),
+            // Grouped/comma spelling must land the same as the single path.
+            (&br"[1,2]"[..], r"del(.[5][], .[6][])"),
+        ] {
+            query!(json, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "Cannot iterate over null (null)", "`{filter}`");
+                }
+            );
+        }
+        // `?` on the iterate step itself does suppress it.
+        query!(br"[1,2]", r"del(.[5][]?)",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
+        // Every other tail keeps the #477 no-op it already had, single-path
+        // and grouped alike.
+        for filter in [
+            r"del(.[5])",
+            r"del(.[5].a)",
+            r"del(.[-5])",
+            r"del(.[5], .[6])",
+        ] {
+            query!(br"[1,2]", filter,
+                QueryResult::Owned(OwnedValue::Array(arr)) => {
+                    assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2)], "`{filter}`");
+                }
             );
         }
     }

--- a/tests/data/jq-error-known-divergences.txt
+++ b/tests/data/jq-error-known-divergences.txt
@@ -46,8 +46,6 @@
 # errors raised while *collecting* a path) landed together and took
 # `optional_write_negative_oob` with them: `.[-5]? = 9` now raises, matching jq.
 
-del_oob_index_iterate_tail           del             an out-of-range index resolves to null and the `[]` tail must raise; the #477 bounds check skips the tail entirely — #529
-del_oob_index_iterate_tail_nested    del             same site reached through a field, so the grouped and single-path walkers stay in step — #529
 path_non_path_literal                path            path() answers with no output where jq refuses a non-path filter by name — #530
 path_non_path_builtin                path            same, through a builtin that returns a computed value — #530
 path_non_path_arithmetic             path            same, through an arithmetic expression — #530


### PR DESCRIPTION
## Summary

- `del()` through an out-of-range array index (positive, negative, or into an empty array) silently no-op'd where jq raises `Cannot iterate over null (null)` on an `[]` tail — e.g. `[1,2] | del(.[5][])` returned `[1,2]` unchanged instead of erroring.
- #527 established the rule del() follows: a dead end reads as `null` and the rest of the path is walked against it, so the *tail* decides whether it's a no-op. #527 applied that rule at the two missing-field sites; this closes the two remaining sites from #477's bounds check, which only an out-of-range index (not a missing field) can reach — `delete_expr_array_paths`'s grouped/comma walker and `delete_at_path`'s single-path chain-walk, both now routed through #527's own `*_through_absent` helpers instead of returning early.
- Verified against the pinned jq-1.7.1 oracle for every shape named in the issue and its follow-up comment (positive/negative/empty-array out-of-range, a tail further down the path, comma-grouped spellings, `?` placement).
- `docs/compliance/jq/limitations.md` and `tests/data/jq-error-known-divergences.txt` updated — two probes seeded pinning this bug now pass and come off the manifest — and `CHANGELOG.md` records the fix.

Fixes #529

## Test plan

- [x] `cargo test --lib jq::eval::tests::test_del` — new regression test + existing del() tests pass
- [x] `cargo test --features cli,simd,regex,serde --workspace -- --test-threads=1` — full suite green, including `jq_error_message_tests` (corpus parity)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second feature-combo invocation — clean
- [x] Differential-tested every repro from the issue and its comment against the real `jq-1.7.1` binary