### PR TITLE
feat(cli): add CR/CRLF line-break frequency counter to corpus-stats

### DIFF
--- a/docs/benchmarks/corpus-shape.md
+++ b/docs/benchmarks/corpus-shape.md
@@ -54,7 +54,7 @@ Bytes retained by `text::LineIndex` per corpus file, against what the dense-bitm
 
 ## YAML
 
-files: 8, total bytes: 36085, anchors: 41, aliases: 86, bare-dash items: 5
+files: 8, total bytes: 36085, anchors: 41, aliases: 86, bare-dash items: 5, CRLF/CR files: 0.00% (0/8)
 
 | metric               | unit         | n    | min  | p50  | p90  | p99  | max  |
 | -------------------- | ------------ | ---- | ---- | ---- | ---- | ---- | ---- |
@@ -62,6 +62,7 @@ files: 8, total bytes: 36085, anchors: 41, aliases: 86, bare-dash items: 5
 | mapping keys         | keys/mapping | 398  | 0    | 2    | 4    | 9    | 69   |
 | sequence items       | items/seq    | 94   | 1    | 2    | 4    | 12   | 12   |
 | bare-dash seq items  | count/file   | 8    | 0    | 0    | 5    | 5    | 5    |
+| CR line breaks       | count/file   | 8    | 0    | 0    | 0    | 0    | 0    |
 | flow-collection size | bytes/flow   | 14   | 2    | 11   | 91   | 100  | 100  |
 | nesting depth        | levels/node  | 1218 | 2    | 6    | 8    | 10   | 12   |
 | anchors              | count/file   | 8    | 0    | 0    | 41   | 41   | 41   |

--- a/src/bin/succinctly/corpus_stats.rs
+++ b/src/bin/succinctly/corpus_stats.rs
@@ -130,6 +130,10 @@ struct YamlStats {
     anchors_per_file: Dist,
     aliases_per_file: Dist,
     bare_dash_items_per_file: Dist,
+    /// Files containing at least one `\r`-based line break (CRLF or lone CR) —
+    /// what #340's `has_cr` fast path actually gates on, per `docs/parsing/yaml.md`.
+    cr_line_breaks_files: u64,
+    cr_line_breaks_per_file: Dist,
 }
 
 /// Counters that are accumulated over a whole file rather than per node, so the
@@ -478,6 +482,27 @@ fn flow_extent(bytes: &[u8], start: usize) -> Option<usize> {
 fn ingest_yaml(bytes: &[u8], st: &mut YamlStats) -> Result<()> {
     let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse failed: {e:?}"))?;
 
+    // \r-based line breaks (CRLF or lone CR) — a raw-byte property of the whole
+    // file, independent of the parsed structure, so it needs no visit_yaml pass.
+    let mut cr_line_breaks = 0u64;
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\r' {
+            cr_line_breaks += 1;
+            i += if bytes.get(i + 1) == Some(&b'\n') {
+                2
+            } else {
+                1
+            };
+        } else {
+            i += 1;
+        }
+    }
+    st.cr_line_breaks_per_file.push(cr_line_breaks);
+    if cr_line_breaks > 0 {
+        st.cr_line_breaks_files += 1;
+    }
+
     // Anchor/alias totals from the BP structure (no bulk accessor exists).
     let bp = index.bp();
     let (mut anchors, mut aliases) = (0u64, 0u64);
@@ -785,8 +810,14 @@ while the Elias-Fano one costs ~2 + log2(average line length) bits per \
 
     // YAML
     md.push_str("## YAML\n\n");
+    let cr_pct = if corpus.yaml.files > 0 {
+        100.0 * corpus.yaml.cr_line_breaks_files as f64 / corpus.yaml.files as f64
+    } else {
+        0.0
+    };
     md.push_str(&format!(
-        "files: {}, total bytes: {}, anchors: {}, aliases: {}, bare-dash items: {}\n\n",
+        "files: {}, total bytes: {}, anchors: {}, aliases: {}, bare-dash items: {}, \
+CRLF/CR files: {:.2}% ({}/{})\n\n",
         corpus.yaml.files,
         corpus.yaml.total_bytes,
         corpus.yaml.anchors_per_file.values.iter().sum::<u64>(),
@@ -797,6 +828,9 @@ while the Elias-Fano one costs ~2 + log2(average line length) bits per \
             .values
             .iter()
             .sum::<u64>(),
+        cr_pct,
+        corpus.yaml.cr_line_breaks_files,
+        corpus.yaml.files,
     ));
     md.push_str(&render_table(
         DIST_HEADERS,
@@ -816,6 +850,11 @@ while the Elias-Fano one costs ~2 + log2(average line length) bits per \
                 "bare-dash seq items",
                 "count/file",
                 &corpus.yaml.bare_dash_items_per_file,
+            ),
+            dist_row(
+                "CR line breaks",
+                "count/file",
+                &corpus.yaml.cr_line_breaks_per_file,
             ),
             dist_row(
                 "flow-collection size",
@@ -989,6 +1028,35 @@ mod tests {
         // exactly one flow collection recorded, of length == "[1, 2, 3]"
         assert_eq!(st.flow_collection_bytes.values.len(), 1);
         assert_eq!(st.flow_collection_bytes.values[0], "[1, 2, 3]".len() as u64);
+    }
+
+    #[test]
+    fn yaml_lf_only_has_no_cr_line_breaks() {
+        let doc = b"a: 1\nb: 2\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        assert_eq!(st.cr_line_breaks_per_file.values, vec![0]);
+        assert_eq!(st.cr_line_breaks_files, 0);
+    }
+
+    #[test]
+    fn yaml_crlf_counts_one_break_per_crlf_pair() {
+        let doc = b"a: 1\r\nb: 2\r\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        // Two CRLF pairs, not four bytes counted individually.
+        assert_eq!(st.cr_line_breaks_per_file.values, vec![2]);
+        assert_eq!(st.cr_line_breaks_files, 1);
+    }
+
+    #[test]
+    fn yaml_lone_cr_counts_as_a_line_break() {
+        // A lone `\r` with no trailing `\n` still counts as one break.
+        let doc = b"a: 1\rb: 2\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+        assert_eq!(st.cr_line_breaks_per_file.values, vec![1]);
+        assert_eq!(st.cr_line_breaks_files, 1);
     }
 
     #[test]

--- a/tests/data/bench-corpus/expected-shape.md
+++ b/tests/data/bench-corpus/expected-shape.md
@@ -42,7 +42,7 @@ Bytes retained by `text::LineIndex` per corpus file, against what the dense-bitm
 
 ## YAML
 
-files: 7, total bytes: 17150, anchors: 41, aliases: 86, bare-dash items: 5
+files: 7, total bytes: 17150, anchors: 41, aliases: 86, bare-dash items: 5, CRLF/CR files: 0.00% (0/7)
 
 | metric               | unit         | n   | min  | p50  | p90  | p99  | max  |
 | -------------------- | ------------ | --- | ---- | ---- | ---- | ---- | ---- |
@@ -50,6 +50,7 @@ files: 7, total bytes: 17150, anchors: 41, aliases: 86, bare-dash items: 5
 | mapping keys         | keys/mapping | 234 | 0    | 2    | 3    | 9    | 69   |
 | sequence items       | items/seq    | 66  | 1    | 2    | 3    | 4    | 4    |
 | bare-dash seq items  | count/file   | 7   | 0    | 0    | 5    | 5    | 5    |
+| CR line breaks       | count/file   | 7   | 0    | 0    | 0    | 0    | 0    |
 | flow-collection size | bytes/flow   | 4   | 2    | 2    | 100  | 100  | 100  |
 | nesting depth        | levels/node  | 741 | 2    | 5    | 8    | 11   | 12   |
 | anchors              | count/file   | 7   | 0    | 0    | 41   | 41   | 41   |


### PR DESCRIPTION
## Summary

- Adds a `cr_line_breaks_files` / `cr_line_breaks_per_file` counter to `YamlStats` in `corpus_stats.rs`, following the exact pattern already established by `anchors_per_file`/`bare_dash_items_per_file`.
- Counts any `\r`-based line break (CRLF **or** lone CR) — that's what #340's `has_cr` fast path actually gates on per `docs/parsing/yaml.md:260-263`, not strictly CRLF as the issue's suggested field names imply.
- Reports a `CRLF/CR files: {:.2}% (n/total)` clause in the YAML summary line (DSV's `quoted_fields` style) plus a `CR line breaks` distribution row in the table.
- Regenerates both drift-checked goldens: `tests/data/bench-corpus/expected-shape.md` (7-file seed) and `docs/benchmarks/corpus-shape.md` (8-file full corpus).

**Measured result**: 0.00% (0/8) of files in the real-workload corpus contain any CR-based line break — a real (if small-sample) data point supporting #340's "most real YAML is LF-only" premise, so #340 has a number to cite before implementation starts.

Closes #571. Gates #340.

## Test plan

- [x] `cargo test --bin succinctly` — 25 corpus_stats tests pass, including 3 new ones (LF-only, CRLF pairs, lone CR)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean (second CI feature-set invocation)
- [x] `succinctly dev bench corpus-stats --data-dir tests/data/bench-corpus/seed --markdown tests/data/bench-corpus/expected-shape.md --check` — passes
- [x] `cargo test --features cli --test corpus_stats_cli_tests` — both integration tests pass