### PR TITLE
Remove deprecated json::locate::NewlineIndex alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the deprecated `succinctly::json::locate::NewlineIndex` alias
+  (#542), a compatibility re-export of `succinctly::text::LineIndex` kept
+  since #228. **Breaking**: code still importing `NewlineIndex` must switch
+  to `text::LineIndex` directly — `build`, `to_offset` and `to_line_column`
+  are unchanged.
+
 - Removed `succinctly::jq::EvalError::field_not_found` (#527), whose last two
   callers were the `del()` path walkers fixed below. **Breaking**: the
   constructor is gone from the public API. `field '<name>' not found` was

--- a/docs/parsing/json.md
+++ b/docs/parsing/json.md
@@ -308,9 +308,6 @@ Handles all line ending conventions: Unix (LF), Windows (CRLF), and classic Mac 
 query that never asks for a position never pays for it. See
 [optimizations/line-index.md](../optimizations/line-index.md) and [ADR-0012](../adrs/adr-0012.md).
 
-> `succinctly::json::locate::NewlineIndex` is a deprecated alias for this type, kept for source
-> compatibility until 0.9.0 (#228). New code should use `succinctly::text::LineIndex`.
-
 ### CLI Usage
 
 ```bash

--- a/src/json/locate.rs
+++ b/src/json/locate.rs
@@ -13,17 +13,6 @@ use alloc::{
 use crate::json::light::{JsonCursor, JsonIndex, StandardJson};
 
 // ============================================================================
-// NewlineIndex: Fast line/column to byte offset conversion
-// ============================================================================
-
-/// Index for fast line/column to byte offset conversion.
-///
-/// Retained for compatibility; the implementation moved to
-/// [`crate::text::LineIndex`], which is shared with `JsonIndex`, `YamlIndex`
-/// and the locate CLIs (#228). This alias will be removed in 0.9.0.
-pub use crate::text::LineIndex as NewlineIndex;
-
-// ============================================================================
 // Path building utilities
 // ============================================================================
 
@@ -377,20 +366,6 @@ pub fn locate_offset_detailed<W: AsRef<[u64]>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ------------------------------------------------------------------------
-    // NewlineIndex alias
-    // ------------------------------------------------------------------------
-
-    /// The behaviour itself is covered by `crate::text::lines`; this only
-    /// guards the compatibility re-export (#228).
-    #[test]
-    fn test_newline_index_alias_resolves_to_line_index() {
-        let index = NewlineIndex::build(b"line1\nline2");
-
-        assert_eq!(index.to_offset(2, 1), Some(6));
-        assert_eq!(index.to_line_column(6), (2, 1));
-    }
 
     // ------------------------------------------------------------------------
     // Path notation tests


### PR DESCRIPTION
## Summary
- Removes `json::locate::NewlineIndex`, a compatibility re-export of `text::LineIndex` kept since #228 with a doc comment promising removal in 0.9.0
- Drops the guard test (behavior is already covered by `text::lines`) and the stale deprecation blockquote in `docs/parsing/json.md`
- Records the removal in the changelog

**Breaking**: `succinctly::json::locate::NewlineIndex` no longer exists; callers must use `succinctly::text::LineIndex` directly (`build`, `to_offset`, `to_line_column` are unchanged).

Fixes #542

## Test plan
- [x] `cargo build --features cli,simd,regex,serde`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, no failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's second, non-scalar-yaml invocation)
- [x] `grep -rn "NewlineIndex" src/ docs/parsing/json.md` — no live references remain (only the intentionally-untouched historical ADR-0012 mentions)