### PR TITLE
bench(bench, docs): benchmark LineIndex query time vs pre-#228 dense BitVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,10 @@ name = "elias_fano"
 harness = false
 
 [[bench]]
+name = "line_index"
+harness = false
+
+[[bench]]
 name = "json_escape_micro"
 harness = false
 

--- a/benches/elias_fano.rs
+++ b/benches/elias_fano.rs
@@ -337,6 +337,111 @@ fn bench_cursor_from(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark `EliasFano::predecessor` (issue #543 — the ADR-0012 query-time gap).
+///
+/// `predecessor` is an O(log n) binary search over `get`, with "no sequential
+/// fast path" per the type's own doc comment. Two query patterns exercise
+/// that claim directly:
+/// - `random`: no locality, the worst case.
+/// - `monotonic`: increasing queries — the shape `LineIndex::to_line_column`
+///   produces walking a document top to bottom, before any caller-side cache
+///   (see `benches/line_index.rs` for the cached, end-to-end version).
+///
+/// Baseline is `Vec<u32>::partition_point`, the same oracle
+/// `src/text/lines.rs`'s own tests use to check `LineIndex`.
+fn bench_predecessor(c: &mut Criterion) {
+    let mut group = c.benchmark_group("elias_fano/predecessor");
+
+    for n in [1_000, 10_000, 100_000] {
+        // Gaps shaped like real line lengths (corpus-shape.md: ~20-78 B/line).
+        let values = generate_bp_to_text(n, 42);
+        let ef = EliasFano::build(&values);
+        let universe = *values.last().unwrap();
+
+        let random_queries = generate_queries(10_000, universe as usize, 7);
+        let monotonic_queries: Vec<u32> = {
+            let mut rng = ChaCha8Rng::seed_from_u64(99);
+            let mut pos = 0u32;
+            (0..10_000)
+                .map(|_| {
+                    pos = pos.saturating_add(rng.random_range(1..50));
+                    pos.min(universe)
+                })
+                .collect()
+        };
+
+        group.throughput(Throughput::Elements(10_000));
+
+        group.bench_with_input(
+            BenchmarkId::new("ef_random", format!("{}K", n / 1000)),
+            &(&ef, &random_queries),
+            |b, (ef, queries)| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &q in *queries {
+                        if let Some((idx, _)) = ef.predecessor(black_box(q as u32)) {
+                            sum += idx as u64;
+                        }
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("vec_random", format!("{}K", n / 1000)),
+            &(&values, &random_queries),
+            |b, (values, queries)| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &q in *queries {
+                        match values.partition_point(|&x| x <= black_box(q as u32)) {
+                            0 => {}
+                            i => sum += (i - 1) as u64,
+                        }
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("ef_monotonic", format!("{}K", n / 1000)),
+            &(&ef, &monotonic_queries),
+            |b, (ef, queries)| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &q in *queries {
+                        if let Some((idx, _)) = ef.predecessor(black_box(q)) {
+                            sum += idx as u64;
+                        }
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("vec_monotonic", format!("{}K", n / 1000)),
+            &(&values, &monotonic_queries),
+            |b, (values, queries)| {
+                b.iter(|| {
+                    let mut sum = 0u64;
+                    for &q in *queries {
+                        match values.partition_point(|&x| x <= black_box(q)) {
+                            0 => {}
+                            i => sum += (i - 1) as u64,
+                        }
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn bench_memory(c: &mut Criterion) {
     let mut group = c.benchmark_group("elias_fano/memory");
 
@@ -376,6 +481,7 @@ criterion_group!(
     bench_skip_by_small,
     bench_seek,
     bench_cursor_from,
+    bench_predecessor,
     bench_memory,
 );
 criterion_main!(benches);

--- a/benches/line_index.rs
+++ b/benches/line_index.rs
@@ -1,0 +1,255 @@
+//! Benchmark `LineIndex::to_line_column` against the pre-#228 dense-`BitVec`
+//! implementation it replaced (issue #543, closing ADR-0012's query-time gap).
+//!
+//! `to_line_column` moved from O(1) rank + a sampled select to an O(log lines)
+//! binary search of sampled selects (`EliasFano::predecessor`), with a
+//! one-entry `Cell` cache added later (`bc877b54`) so a monotone walk — the
+//! access pattern the `line`/`column` jq/yq builtins produce — resolves in
+//! amortised O(1) instead. Two benchmarks cover both paths as they exist
+//! today:
+//!
+//! - `sequential_forward`: offsets in increasing order, exercising the cache.
+//! - `random`: shuffled offsets, defeating the cache and forcing the full
+//!   binary search every call.
+//!
+//! `DenseLineIndexV1` reconstructs the removed `BitVec`-backed
+//! `to_line_column` verbatim from commit `48dcdb59` (`rank1(offset+1)` +
+//! `select1(line-2)`), so "before" and "after" run in the same binary and
+//! process rather than needing a cross-commit rebuild against a since-removed
+//! API — the same in-file A/B style `benches/json_pipeline.rs` already uses
+//! for `JsonIndexV2`/`bench_v1_vs_v2_text_position`.
+//!
+//! Run with: cargo bench --bench line_index
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+use succinctly::text::LineIndex;
+use succinctly::{BitVec, RankSelect};
+
+/// Pre-#228 dense `to_line_column`: one bit per input byte, set immediately
+/// after every LF/CRLF/CR, read via O(1) `rank1` + a `select1` sampled every
+/// 256 ones. Reconstructed from the code removed in commit `48dcdb59`
+/// (`src/json/light.rs`) — not part of the public API, benchmark-only.
+struct DenseLineIndexV1 {
+    newlines: BitVec,
+}
+
+impl DenseLineIndexV1 {
+    fn build(text: &[u8]) -> Self {
+        if text.is_empty() {
+            return Self {
+                newlines: BitVec::new(),
+            };
+        }
+
+        let mut bits = vec![0u64; text.len().div_ceil(64)];
+        let mut i = 0;
+        while i < text.len() {
+            match text[i] {
+                b'\n' => {
+                    let next = i + 1;
+                    if next < text.len() {
+                        bits[next / 64] |= 1 << (next % 64);
+                    }
+                    i += 1;
+                }
+                b'\r' => {
+                    let next = if i + 1 < text.len() && text[i + 1] == b'\n' {
+                        i + 2
+                    } else {
+                        i + 1
+                    };
+                    if next < text.len() {
+                        bits[next / 64] |= 1 << (next % 64);
+                    }
+                    i = next;
+                }
+                _ => i += 1,
+            }
+        }
+
+        Self {
+            newlines: BitVec::from_words(bits, text.len()),
+        }
+    }
+
+    fn to_line_column(&self, offset: usize) -> (usize, usize) {
+        if self.newlines.is_empty() {
+            return (1, offset + 1);
+        }
+
+        let markers_before_or_at = self.newlines.rank1(offset + 1);
+        let line = 1 + markers_before_or_at;
+        let line_start = if line == 1 {
+            0
+        } else {
+            self.newlines.select1(line - 2).unwrap_or(0)
+        };
+
+        (line, offset - line_start + 1)
+    }
+}
+
+/// Synthetic text with `n` lines at realistic lengths
+/// (corpus-shape.md: ~20-78 bytes/line; 20 here matches the corpus median).
+fn generate_text(n: usize, avg_line_len: usize, seed: u64) -> Vec<u8> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut text = Vec::new();
+    for i in 0..n {
+        if i > 0 {
+            text.push(b'\n');
+        }
+        let len = avg_line_len.saturating_sub(4) + rng.random_range(0..8);
+        for _ in 0..len {
+            text.push(b'a' + rng.random_range(0..26));
+        }
+    }
+    text
+}
+
+/// Offset of every line start, in increasing order — the `.[] | line` access
+/// pattern that visits one node per line walking a document top to bottom.
+/// Crucially the gap between consecutive queries is always ~1 line
+/// regardless of `text`'s total size, so this stays within
+/// `LineIndex::FORWARD_WALK_CAP` at every scale; an earlier version of this
+/// benchmark instead spread a fixed query count across the whole text, which
+/// made the per-query line-gap (and so the number of cache-miss binary
+/// searches) grow with file size — an artifact of the query set, not of
+/// `LineIndex` itself.
+fn generate_offsets_sequential(text: &[u8]) -> Vec<usize> {
+    let mut starts = vec![0usize];
+    for (i, &b) in text.iter().enumerate() {
+        if b == b'\n' && i + 1 < text.len() {
+            starts.push(i + 1);
+        }
+    }
+    starts
+}
+
+/// Offsets in random order, defeating `LineIndex`'s forward-walk cache.
+fn generate_offsets_random(text: &[u8], count: usize, seed: u64) -> Vec<usize> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    if text.is_empty() {
+        return vec![0; count];
+    }
+    (0..count)
+        .map(|_| rng.random_range(0..text.len()))
+        .collect()
+}
+
+/// Cross-check `DenseLineIndexV1` against `LineIndex` before trusting either
+/// side's numbers — bench files aren't covered by `cargo test`.
+fn assert_v1_matches_line_index(text: &[u8]) {
+    let v1 = DenseLineIndexV1::build(text);
+    let index = LineIndex::build(text);
+    let step = (text.len() / 200).max(1);
+    for offset in (0..text.len()).step_by(step) {
+        assert_eq!(
+            v1.to_line_column(offset),
+            index.to_line_column(offset),
+            "DenseLineIndexV1/LineIndex disagree at offset {offset}"
+        );
+    }
+}
+
+/// Line counts spanning the real corpus (corpus-shape.md), up to its largest
+/// file (34,169 lines, `pretty/3d-ribbon.json`).
+const LINE_COUNTS: [usize; 4] = [1_000, 10_000, 34_169, 100_000];
+
+fn bench_sequential_forward(c: &mut Criterion) {
+    let mut group = c.benchmark_group("line_index/sequential_forward");
+
+    for n in LINE_COUNTS {
+        let text = generate_text(n, 20, 42);
+        assert_v1_matches_line_index(&text);
+        let offsets = generate_offsets_sequential(&text);
+
+        let index = LineIndex::build(&text);
+        let v1 = DenseLineIndexV1::build(&text);
+
+        group.throughput(Throughput::Elements(offsets.len() as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("line_index", format!("{n}_lines")),
+            &(&index, &offsets),
+            |b, (index, offsets)| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &off in *offsets {
+                        let (l, c) = index.to_line_column(black_box(off));
+                        sum += l + c;
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("v1_dense_bitvec", format!("{n}_lines")),
+            &(&v1, &offsets),
+            |b, (v1, offsets)| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &off in *offsets {
+                        let (l, c) = v1.to_line_column(black_box(off));
+                        sum += l + c;
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_random(c: &mut Criterion) {
+    let mut group = c.benchmark_group("line_index/random");
+
+    for n in LINE_COUNTS {
+        let text = generate_text(n, 20, 42);
+        let offsets = generate_offsets_random(&text, 10_000, 123);
+
+        let index = LineIndex::build(&text);
+        let v1 = DenseLineIndexV1::build(&text);
+
+        group.throughput(Throughput::Elements(offsets.len() as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("line_index", format!("{n}_lines")),
+            &(&index, &offsets),
+            |b, (index, offsets)| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &off in *offsets {
+                        let (l, c) = index.to_line_column(black_box(off));
+                        sum += l + c;
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("v1_dense_bitvec", format!("{n}_lines")),
+            &(&v1, &offsets),
+            |b, (v1, offsets)| {
+                b.iter(|| {
+                    let mut sum = 0usize;
+                    for &off in *offsets {
+                        let (l, c) = v1.to_line_column(black_box(off));
+                        sum += l + c;
+                    }
+                    black_box(sum)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_sequential_forward, bench_random);
+criterion_main!(benches);

--- a/docs/adrs/adr-0012.md
+++ b/docs/adrs/adr-0012.md
@@ -99,9 +99,9 @@ dense index's `heap_size()` exactly, because that allocation is simply gone.
   not). Three zero-caller items were removed outright. `json::locate::NewlineIndex` survives as an
   alias until 0.9.0.
 - **`to_line_column` rises from O(1) to O(log lines)**, plus a sampled select per binary-search step
-  (`to_offset` stays O(1)). Accepted because the `line`/`column` builtins that call it per node are
-  stubbed to `0` on the CLI's evaluator path today, and because the `BitVec` select it replaces was
-  itself sampled every 256 ones. Neither claim is measured; see *Not measured* below.
+  (`to_offset` stays O(1)). Accepted because the `line`/`column` builtins that call it per node were
+  stubbed to `0` on the CLI's evaluator path at the time, and because the `BitVec` select it replaces
+  was itself sampled every 256 ones. Now measured; see *Not measured* below.
 - **A transient `Vec<u32>` during build.** Capacity reserved from a counting pass, so it never
   reallocates — the O4 trap. (The count is terminator bytes, so all-CRLF text over-reserves 2x;
   exact on the LF/CR-only text the corpus contains.) It makes momentary peak higher than the old *retained* size on small
@@ -119,8 +119,7 @@ dense index's `heap_size()` exactly, because that allocation is simply gone.
 **Not measured, at the time this ADR was written:** anything with a clock on it. Two gaps, both
 open for the same reason — every host available at the time was running other benchmarks (load
 9-12), and this repository's rule is that benchmarks get exclusive CPU. Timing claims were
-therefore not made rather than made badly. Build time has since been closed (below); query time
-remains open.
+therefore not made rather than made badly. Both gaps have since been closed (below).
 
 1. *Build time* — measured 2026-08-01 on idle hosts: `pipeline_indexing/build_index` over the
    10 MB `comprehensive` corpus file, before (`fb82b0ce`, this PR's merge-base) vs after
@@ -142,15 +141,54 @@ remains open.
    criterion has no built-in way to alternate between two already-built binaries mid-run. One point
    against this being a sequential-thermal artifact: that bias makes the *second*-run binary look
    slower, and "after" (run second on both hosts) came out faster or neutral, not slower.
-2. *Query time.* `to_line_column` went from O(1) rank + sampled select to an O(log n) binary search
-   of sampled selects. No benchmark drives it, so nothing would catch a regression. Still open —
-   closing it means writing a new benchmark; none currently exercises this path.
+2. *Query time* — measured 2026-08-03 on the same idle hosts (issue #543), via two new benchmarks:
+   `benches/elias_fano.rs`'s `predecessor` group, and a new `benches/line_index.rs`. Neither existed
+   before; `to_line_column` went from O(1) rank + sampled select to an O(log lines) binary search of
+   sampled selects (`EliasFano::predecessor`) with no benchmark to catch a regression.
+
+   `benches/line_index.rs` reconstructs the removed dense-`BitVec` `to_line_column`
+   (`rank1(offset+1)` + `select1(line-2)`, from the code commit `48dcdb59` deleted) as a same-binary
+   baseline, run side by side with today's `LineIndex` across four line counts — 1K, 10K, 34,169
+   (the corpus's largest real file, `pretty/3d-ribbon.json`) and 100K — and two access patterns:
+
+   **Sequential** (`.[] | line` walking a document top to bottom — exercises the `bc877b54` cache):
+   flat from 1K to 100K lines on both platforms, confirming the cache delivers true O(1) amortized.
+   The two platforms disagree on which side of 1.0x it lands:
+
+   | Platform                  | `LineIndex` (cached) | Old dense `BitVec` | Ratio                        |
+   |---------------------------|----------------------|--------------------|------------------------------|
+   | AMD Ryzen 9 7950X (Zen 4) | 23.0 ns/query        | 28.1-28.5 ns/query | **0.81x — 19-24% faster**    |
+   | Apple M4 Pro              | 16.8-17.3 ns/query   | 10.4-10.8 ns/query | **1.57-1.61x — ~60% slower** |
+
+   **Random** (shuffled offsets, defeating the cache — the full binary search every call):
+
+   | Platform                 | 1K lines | 10K lines | 34,169 lines | 100K lines |
+   |--------------------------|----------|-----------|--------------|------------|
+   | Zen 4 (`LineIndex`/old)  | 5.6x     | 7.0x      | 7.3x         | 7.7x       |
+   | M4 Pro (`LineIndex`/old) | 12.2x    | 16.7x     | 17.7x        | 16.0x      |
+
+   Verdict: the O(log n) trade-off this ADR accepted is real and larger than "the old select was
+   sampled every 256 ones too" implied — 5.6-18x slower on the cache-miss path, growing with line
+   count as expected for a logarithmic term (rule 3,
+   [benchmarking.md](../guides/benchmarking.md#ab-benchmarking-method)). The cache recovers O(1) for
+   the access pattern that actually matters (#532's `.[] | line`), but at a real, platform-dependent
+   constant-factor cost on top of that O(1) — a ~20% win on Zen 4, a ~60% loss on M4 Pro, not further
+   investigated here (cache/memory-bound effects do not port between these two boxes; rule 5 of the
+   same guide). Whether the random-path cost is worth addressing is a question for a follow-up issue;
+   per #543's own non-goals, this only measures.
 
 To reproduce the build-time comparison on an idle host:
 
 ```bash
 cargo bench --bench json_pipeline -- pipeline_indexing --save-baseline before   # at fb82b0ce
 cargo bench --bench json_pipeline -- pipeline_indexing --baseline before        # at this branch
+```
+
+To reproduce the query-time comparison on an idle host:
+
+```bash
+cargo bench --bench elias_fano -- predecessor
+cargo bench --bench line_index
 ```
 
 ## Follow-ups
@@ -160,12 +198,15 @@ survive as public API, doctests, the corpus-shape report's comparison column, an
 So does `CompactRank`, which never had any. Whether to shrink, deprecate or keep them is a
 public-API policy question that #228 did not ask; it is deliberately left open.
 
-The `line`/`column` builtins are stubbed to `0` on the `OwnedValue` evaluator path
+The `line`/`column` builtins are still stubbed to `0` on the `OwnedValue` evaluator path
 ([src/jq/eval.rs](../../src/jq/eval.rs), `builtin_line`/`builtin_column`), which is what the `syq`
-CLI takes — so the one per-node consumer of `to_line_column` is currently unreachable from the
-command line. Wiring them up is a correctness fix in its own right, and is the point at which the
-`Cell`-cached predecessor in [optimizations/line-index.md](../optimizations/line-index.md#query-cost-and-why-olog-n-is-acceptable-here)
-stops being speculative. The two should land together.
+CLI takes with `-n`/`--slurp`/`--inplace`/JSON-formatted input — that evaluator has no cursor to
+forward, and wiring one through it remains a separate, larger effort (#532's discussion covers why).
+The *cursor* evaluator path #532 did wire up made `to_line_column` hot for `.[] | line`, and in
+response — before a benchmark existed — commit `bc877b54` added the `Cell`-cached predecessor
+sketched in [optimizations/line-index.md](../optimizations/line-index.md#query-cost-and-why-olog-n-was-acceptable-before-it-became-hot).
+It is no longer speculative: the *Query time* measurement above is that benchmark, written after
+the fact rather than before (#543).
 
 ## See Also
 

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -55,12 +55,13 @@ For a complete index of all benchmark reports by file and section, see:
 
 Located in `benches/`:
 
-| Benchmark               | Purpose                                    | Data Source      |
-|-------------------------|--------------------------------------------|------------------|
-| `rank_select`           | BitVec rank/select operations              | Generated inline |
-| `balanced_parens`       | Tree navigation operations                 | Generated inline |
-| `elias_fano`            | Elias-Fano encoding for monotone sequences | Generated inline |
-| `popcount_strategies`   | Popcount implementations                   | Generated inline |
+| Benchmark             | Purpose                                     | Data Source      |
+|-----------------------|---------------------------------------------|------------------|
+| `rank_select`         | BitVec rank/select operations               | Generated inline |
+| `balanced_parens`     | Tree navigation operations                  | Generated inline |
+| `elias_fano`          | Elias-Fano encoding for monotone sequences  | Generated inline |
+| `line_index`          | `to_line_column` vs pre-#228 dense `BitVec` | Generated inline |
+| `popcount_strategies` | Popcount implementations                    | Generated inline |
 
 ### 2. JSON Benchmarks
 

--- a/docs/optimizations/line-index.md
+++ b/docs/optimizations/line-index.md
@@ -136,12 +136,30 @@ forward query within `FORWARD_WALK_CAP` (16) lines resolves via bounded `EliasFa
 of a fresh binary search — the shape `.[] | line` produces when walking a document top to bottom,
 since sibling iteration visits offsets in increasing order. Anything else (first call, backward jump,
 or a forward jump past the cap) falls back to the binary search and refreshes the cache. The
-structural accelerator below remains unimplemented — the cache was enough once actually measured
-against the real access pattern.
+structural accelerator below remains unimplemented — the cache was judged enough at the time, ahead
+of any benchmark; see *Measured* below for the benchmark that eventually checked that judgement.
 
 The structural one, for reference, if the cache above is ever insufficient:
 `select_samples[j] - j * SAMPLE_RATE` is the high part of element `j*256` and is monotone in `j`, so
 binary-searching that plain `Vec<u32>` narrows to a 256-element block with zero select calls.
+
+### Measured (issue #543)
+
+`benches/line_index.rs` runs today's `LineIndex` against a same-binary reconstruction of the removed
+dense-`BitVec` `to_line_column` (`rank1(offset+1)` + `select1(line-2)`), across 1K-100K lines and two
+access patterns. Full numbers and interpretation are in
+[ADR-0012's *Not measured* section](../adrs/adr-0012.md#consequences); the summary:
+
+- **Sequential** (the cached path, `.[] | line`'s shape): flat 1K→100K lines on both platforms —
+  confirms the cache is genuinely O(1) amortized, not just usually fast. But the constant factor
+  against the old dense `BitVec` disagrees by platform: **~20% faster on Zen 4, ~60% slower on M4
+  Pro.** Cache/memory-bound effects do not port between these boxes; see
+  [benchmarking.md](../guides/benchmarking.md#ab-benchmarking-method) rule 5.
+- **Random** (the cache-miss path, the full `EliasFano::predecessor` binary search): **5.6-18x
+  slower** than the old dense `BitVec`, growing with line count on both platforms — the O(log n) term
+  this page predicted, now with a number attached instead of "not obviously a regression."
+
+Reproduce: `cargo bench --bench elias_fano -- predecessor` and `cargo bench --bench line_index`.
 
 ## Transient build memory
 
@@ -186,6 +204,11 @@ momentary, where the old cost was permanent. Removing the transient entirely wou
   YAML — but the rule is byte-identical for all three, so that was #341's duplication reintroduced
   one module over. The definition lives in [text::line_break](../../src/text/line_break.rs) and
   `yaml::line_break` re-exports it.
+- **A reactive fix can be right in shape and still unmeasured in size.** The `Cell` cache landed
+  before any benchmark existed and did deliver true O(1) amortized (#543 confirms it), but its
+  constant-factor cost against the structure it replaced was unknown until measured — and turned out
+  to flip sign by platform (faster on Zen 4, slower on M4 Pro). "It's O(1) now" and "it's fast now"
+  are different claims.
 
 ## See Also
 

--- a/src/bin/succinctly/bench_runner/registry.rs
+++ b/src/bin/succinctly/bench_runner/registry.rs
@@ -325,6 +325,15 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
     },
     // ========== TEXT ==========
     BenchmarkInfo {
+        name: "line_index",
+        description: "LineIndex::to_line_column vs the pre-#228 dense BitVec (#543)",
+        category: BenchmarkCategory::Text,
+        bench_type: BenchmarkType::Criterion,
+        criterion_name: Some("line_index"),
+        cli_subcommand: None,
+        working_dir: ".",
+    },
+    BenchmarkInfo {
         name: "utf8_validate_bench",
         description: "UTF-8 validation throughput (Criterion)",
         category: BenchmarkCategory::Text,


### PR DESCRIPTION
## Summary

Closes the query-time half of ADR-0012's "Not measured" gap (issue #543). Build time was already
closed in an earlier change; this adds the missing query-time benchmarks and records results.

- `benches/elias_fano.rs`: new `predecessor` group, comparing `EliasFano::predecessor` against a
  `Vec<u32>::partition_point` oracle under random and monotonic query patterns.
- `benches/line_index.rs` (new): `LineIndex::to_line_column` benchmarked against a same-binary
  reconstruction of the removed dense-`BitVec` implementation (from commit `48dcdb59`), across
  1K-100K lines, split into `sequential_forward` (the `.[] | line` cache-hit path added in
  `bc877b54`) and `random` (cache-miss, full binary search) access patterns.
- Registered the new bench in `Cargo.toml`, the bench-runner CLI registry, and the benchmarking
  guide's inventory table.
- `docs/adrs/adr-0012.md` and `docs/optimizations/line-index.md`: recorded the measured numbers
  from idle Zen 4 and M4 Pro hosts.

**Headline result:** the `Cell` cache does deliver true O(1) amortized on the sequential path, but
its constant factor against the old dense `BitVec` disagrees by platform — ~20% faster on Zen 4,
~60% slower on M4 Pro. The cache-miss/random path is 5.6-18x slower, growing with line count as
expected for the O(log n) term the ADR accepted without a measured number. No production code
changed — this is benchmarks and documentation only, per the issue's own non-goals.

Closes #543.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second
      (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`) invocation, both clean
- [x] `cargo test --lib` (1847 passed) and `cargo test --features bench-runner --bin succinctly`
      (138 passed), including the bench-runner registry tests covering the new entry
- [x] `cargo bench --bench elias_fano -- predecessor --test` and
      `cargo bench --bench line_index -- --test` (correctness smoke tests, incl. the in-benchmark
      `DenseLineIndexV1`-vs-`LineIndex` cross-check)
- [x] Full benchmark runs completed on idle `johns-mac-mini` (M4 Pro, ARM) and `terminus` (7950X,
      x86_64) hosts over Tailscale SSH, per this repo's A/B benchmarking discipline