### PR TITLE
fix(ci): sync commit-guidelines with enforced lint config, raise subject limit to 100

### DIFF
--- a/.omni-dev/commit-guidelines.md
+++ b/.omni-dev/commit-guidelines.md
@@ -39,28 +39,16 @@ Required. Must be one of:
 
 ## Scopes
 
-Required. `.omni-dev/scopes.yaml` is authoritative; this list mirrors it and must
-be updated alongside it:
-
-- `bitvec` - Bitvector data structure and rank/select operations
-- `bp` - Balanced parentheses tree navigation
-- `json` - JSON semi-indexing and parsing
-- `yaml` - YAML semi-indexing and parsing
-- `jq` - jq query language parser and evaluator
-- `dsv` - DSV/CSV semi-indexing and parsing
-- `simd` - SIMD optimizations (x86, AVX2, NEON)
-- `core` - Core utilities (broadword, tables, binary ops, text/UTF-8 helpers)
-- `cli` - Command-line interface tool
-- `bench` - Benchmarks and performance testing
-- `test` - Test suite and property tests
-- `docs` - Documentation and optimization notes
-- `ci` - CI/CD pipelines, GitHub Actions, and commit-lint configuration
-- `build` - Build configuration and feature flags
-- `scripts` - Developer and repository maintenance shell scripts
+Required. See [`.omni-dev/scopes.yaml`](scopes.yaml) for the canonical, enforced
+list — do not duplicate it here. `omni-dev` also silently accepts a handful of
+ecosystem-default scopes not listed there (for this repo: `cargo`, `lib`); run
+`omni-dev git commit message lint --verbose` to see the full resolved set.
 
 ## Subject Line
 
-- Keep under 72 characters total
+- Keep under 100 characters total (enforced by `.omni-dev/commit-rules.yaml`'s
+  `subject_max_len`; `omni-dev git commit message lint` is the source of truth if
+  this drifts)
 - Use imperative mood: "add feature" not "added feature" or "adds feature"
 - Be specific: avoid vague terms like "update", "fix stuff", "changes"
 

--- a/.omni-dev/commit-rules.yaml
+++ b/.omni-dev/commit-rules.yaml
@@ -1,0 +1,15 @@
+# Deterministic commit-lint rules for `omni-dev git commit message lint`
+# (the local CLI and the "Commit Lint" CI job both read this, via
+# action-works/omni-dev-commit-check@v1.4, command: lint).
+#
+# Fields omitted here fall back to CommitRules::default() in omni-dev
+# (rust-works/omni-dev, src/data/context.rs) — types matching the `## Types`
+# table in commit-guidelines.md, require_scope: false, forbidden_footers:
+# ["Co-Authored-By"]. Before this file existed, `lint` silently used its
+# built-in subject_max_len (80), which didn't match what
+# commit-guidelines.md documented (72) — see #588.
+#
+# subject_max_len raised to 100: this project routinely stacks 2-3 scopes in
+# one subject (e.g. `test(bench, cli, docs): ...`), which the 80-char
+# built-in default regularly rejected.
+subject_max_len: 100

--- a/tests/scopes_yaml_tests.rs
+++ b/tests/scopes_yaml_tests.rs
@@ -316,48 +316,6 @@ fn every_src_subdirectory_has_a_scope() {
 }
 
 #[test]
-fn scope_list_matches_scopes_yaml() {
-    let yaml_scopes = parse_scopes_yaml(&scopes_yaml_text());
-    let yaml: BTreeMap<String, String> = yaml_scopes
-        .into_iter()
-        .map(|s| (s.name, s.description))
-        .collect();
-    let guidelines = commit_guidelines_text();
-    let markdown = markdown_scopes(section(&guidelines, "Scopes"));
-
-    let mut problems = Vec::new();
-    for (name, description) in &yaml {
-        match markdown.get(name) {
-            None => problems.push(format!(
-                "missing from commit-guidelines.md: `{name}` - {description}"
-            )),
-            Some(listed) if listed != description => problems.push(format!(
-                "description differs for `{name}`:\n\
-                 \x20   scopes.yaml:          {description}\n\
-                 \x20   commit-guidelines.md: {listed}"
-            )),
-            Some(_) => {}
-        }
-    }
-    for name in markdown.keys() {
-        if !yaml.contains_key(name) {
-            problems.push(format!(
-                "listed in commit-guidelines.md but not defined in scopes.yaml: `{name}`"
-            ));
-        }
-    }
-    problems.sort();
-
-    assert!(
-        problems.is_empty(),
-        "the `## Scopes` list in .omni-dev/commit-guidelines.md has drifted from \
-         .omni-dev/scopes.yaml (#568):\n  {}\n\n\
-         scopes.yaml is the single source of truth — update the markdown list to match it.",
-        problems.join("\n  ")
-    );
-}
-
-#[test]
 fn example_scopes_are_defined_in_scopes_yaml() {
     let yaml_scopes = parse_scopes_yaml(&scopes_yaml_text());
     let known: Vec<String> = yaml_scopes.into_iter().map(|s| s.name).collect();
@@ -381,14 +339,18 @@ fn example_scopes_are_defined_in_scopes_yaml() {
 
 #[test]
 fn skill_and_style_guide_point_at_scopes_yaml_instead_of_hardcoding_it() {
-    for path in [".claude/skills/commit-msg/SKILL.md", "docs/STYLE_GUIDE.md"] {
+    for path in [
+        ".claude/skills/commit-msg/SKILL.md",
+        "docs/STYLE_GUIDE.md",
+        ".omni-dev/commit-guidelines.md",
+    ] {
         let full_path = PathBuf::from(REPO_ROOT).join(path);
         let text = fs::read_to_string(&full_path)
             .unwrap_or_else(|e| panic!("read {}: {e}", full_path.display()));
         assert!(
             text.contains(".omni-dev/scopes.yaml"),
             "{path} should point at .omni-dev/scopes.yaml as the source of truth for commit \
-             scopes, not restate them (#568)"
+             scopes, not restate them (#568, #588)"
         );
     }
 
@@ -399,6 +361,15 @@ fn skill_and_style_guide_point_at_scopes_yaml_instead_of_hardcoding_it() {
         !skill_md.contains("## Scopes for This Project"),
         "SKILL.md has reintroduced a hardcoded scope table (#568) — point at \
          .omni-dev/scopes.yaml instead of a competing list"
+    );
+
+    let guidelines = commit_guidelines_text();
+    let markdown = markdown_scopes(section(&guidelines, "Scopes"));
+    assert!(
+        markdown.is_empty(),
+        "commit-guidelines.md's `## Scopes` section has reintroduced a hardcoded scope list \
+         (#588) — point at .omni-dev/scopes.yaml instead of a competing, drift-prone copy:\n  {}",
+        markdown.keys().cloned().collect::<Vec<_>>().join(", ")
     );
 }
 


### PR DESCRIPTION
## Summary
- `commit-guidelines.md` documented a 72-char subject limit while `omni-dev git commit message lint` silently enforced its built-in default of 80 (no `.omni-dev/commit-rules.yaml` existed to pin the documented number).
- The Scopes section hand-duplicated `.omni-dev/scopes.yaml`'s list — the same drift-prone pattern #568 already replaced with a pointer in `SKILL.md`/`STYLE_GUIDE.md` — and was incomplete regardless, since `omni-dev` also merges in ecosystem-default scopes (`cargo`, `lib` for this repo) not listed anywhere.

## Changes
- Add `.omni-dev/commit-rules.yaml` pinning `subject_max_len: 100` (this project routinely stacks 2-3 scopes in one subject, which the 80-char default regularly rejected).
- Update `commit-guidelines.md`'s Subject Line bullet to match (100).
- Replace the Scopes section's hand-kept list with a pointer to `.omni-dev/scopes.yaml`, noting the `cargo`/`lib` ecosystem-default scopes.

Closes #588

## Test plan
- [x] `omni-dev git commit message lint --verbose main..HEAD` shows `📏 Commit rules: ✅ Project: .../.omni-dev/commit-rules.yaml` with `subject_max_len=100` (previously `⚪ Using built-in defaults`)
- [x] The branch's own commit lints clean under the new config