### PR TITLE
perf(text): broadword ASCII fast path for UTF-8 validation

### DIFF
--- a/benches/utf8_validate_bench.rs
+++ b/benches/utf8_validate_bench.rs
@@ -10,14 +10,19 @@
 //! - **Multi-byte Heavy**: Predominantly 2-4 byte UTF-8 sequences
 //! - **CJK Text**: Chinese/Japanese/Korean characters (3-byte sequences)
 //! - **Emoji Heavy**: Heavy use of 4-byte sequences (emojis)
+//! - **Corpus**: the committed real-workload seed (`tests/data/bench-corpus/seed/`),
+//!   whose ASCII-run/multi-byte mix the synthetic generators do not reproduce
 //!
+
 //! ## Sizes
 //!
 //! Benchmarks run at multiple sizes to show scaling characteristics:
 //! - 1KB, 10KB, 100KB, 1MB, 10MB
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::fs;
 use std::hint::black_box;
+use std::path::{Path, PathBuf};
 use succinctly::text::utf8::validate_utf8_scalar;
 #[cfg(target_arch = "x86_64")]
 use succinctly::text::utf8::validate_utf8_simd;
@@ -254,6 +259,84 @@ fn bench_sequence_types(c: &mut Criterion) {
     group.finish();
 }
 
+/// Validate the committed real-workload corpus seed.
+///
+/// The synthetic generators above are uniform by construction; real text mixes
+/// long ASCII runs with sparse multi-byte characters, which is exactly the shape
+/// the broadword ASCII fast path is tuned for. Gating throughput claims on this
+/// corpus is what #301 asks of its consumer issues (#133 among them).
+///
+/// Prefers the fully synced corpus at `data/bench/corpus/` (seed **plus** the
+/// larger fetched files, per `./scripts/sync-bench-corpus.sh`), falling back to
+/// the always-committed `tests/data/bench-corpus/seed/` so this group still runs
+/// offline — the seed alone is only 0.5-4.5 KB per file, which measures
+/// small-input behaviour rather than steady-state throughput.
+///
+/// Files are walked in sorted order to keep benchmark IDs stable across runs.
+fn bench_corpus(c: &mut Criterion) {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let synced = manifest.join("data").join("bench").join("corpus");
+    let seed = manifest
+        .join("tests")
+        .join("data")
+        .join("bench-corpus")
+        .join("seed");
+
+    let mut root = synced;
+    let mut files = Vec::new();
+    collect_files(&root, &mut files);
+    if files.is_empty() {
+        eprintln!(
+            "utf8_corpus: {} is empty; falling back to the committed seed \
+             (run ./scripts/sync-bench-corpus.sh for the full corpus)",
+            root.display()
+        );
+        root = seed;
+        collect_files(&root, &mut files);
+    }
+    files.sort();
+
+    if files.is_empty() {
+        eprintln!("utf8_corpus: no corpus files found; skipping");
+        return;
+    }
+
+    let mut group = c.benchmark_group("utf8_corpus");
+
+    for path in &files {
+        let Ok(data) = fs::read(path) else { continue };
+        if data.is_empty() {
+            continue;
+        }
+        // `<format>/<workload>/<file>` — e.g. `yaml/actions/prometheus-ci.yml`.
+        let name = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .into_owned();
+
+        group.throughput(Throughput::Bytes(data.len() as u64));
+        bench_engines!(group, &name, &data);
+    }
+
+    group.finish();
+}
+
+/// Recursively collect every regular file under `dir` into `out`.
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(&path, out);
+        } else {
+            out.push(path);
+        }
+    }
+}
+
 fn format_size(bytes: usize) -> String {
     if bytes >= 1024 * 1024 {
         format!("{}mb", bytes / (1024 * 1024))
@@ -273,6 +356,7 @@ criterion_group!(
     bench_2byte,
     bench_error_at_end,
     bench_sequence_types,
+    bench_corpus,
 );
 
 criterion_main!(benches);

--- a/docs/benchmarks/inventory.md
+++ b/docs/benchmarks/inventory.md
@@ -132,7 +132,9 @@ Benchmarks for `succinctly json validate` - strict RFC 8259 JSON validation thro
 
 ## [utf8-validate.md](utf8-validate.md) - UTF-8 Validation Benchmarks
 
-Benchmarks for `succinctly text validate utf8` - scalar UTF-8 validation throughput. Serves as baseline for future SIMD implementations.
+Benchmarks for `succinctly text validate utf8` - UTF-8 validation throughput for both engines: the AVX2 SIMD kernel (x86_64 default) and the portable scalar validator with its broadword (SWAR) ASCII fast path, which is the only path on ARM64 and in `no_std` builds.
+
+Alongside the synthetic pattern ladder, the `utf8_corpus` group validates the real-workload corpus (#301) - `data/bench/corpus/` when synced, otherwise the committed seed - so throughput claims are gated on real input shapes rather than generator output.
 
 ### Platforms Covered
 - Apple M4 Pro (ARM)

--- a/docs/benchmarks/utf8-validate.md
+++ b/docs/benchmarks/utf8-validate.md
@@ -9,120 +9,197 @@ interchangeable engines:
   fast accept scan that falls back to the scalar validator for the exact error
   position, so diagnostics are byte-identical either way. Selected at runtime via
   `is_x86_feature_detected!("avx2")`.
-- **Scalar** — the portable byte-by-byte validator, used on non-x86_64 targets, on
-  x86_64 CPUs without AVX2, and whenever `--no-simd` is passed.
+- **Scalar** — the portable validator, used on non-x86_64 targets, on x86_64 CPUs
+  without AVX2, and whenever `--no-simd` is passed. Multi-byte sequences are
+  checked one character at a time; runs of ASCII are skipped eight bytes at a time
+  with a broadword (SWAR) test (`word & 0x8080_8080_8080_8080 == 0`), and
+  line/column for an error are derived from its byte offset rather than tracked
+  per byte (#133). This is the **only** path on ARM64 and in `no_std` builds.
 
 `benches/utf8_validate_bench.rs` reports a `scalar` and a `simd` arm per input so
-the two compare directly (`cargo bench --bench utf8_validate_bench`).
+the two compare directly (`cargo bench --bench utf8_validate_bench`). Its
+`utf8_corpus` group validates the real-workload corpus (#301): the fully synced
+`data/bench/corpus/` when present, otherwise the always-committed seed under
+`tests/data/bench-corpus/seed/`.
 
-> **⚠️ SIMD figures not yet measured.** Every table below is the **scalar** baseline
+> **⚠️ SIMD figures not yet measured.** Every table below is the **scalar** engine
 > only. AVX2 throughput must be measured on an AVX2-capable x86_64 host (CI's x86_64
-> leg or the 7950X bench box) and — per the perf-cluster convention shared with #133
-> (broadword) and #134 (broadword + DFA) — gated on the #301 real-workload corpus
-> before being cited. JSON-validation experience suggests several GiB/s, with the
-> largest wins on ASCII-heavy and mixed content.
+> leg or the 7950X bench box) and — per the perf-cluster convention shared with #134
+> (broadword + DFA) — gated on the #301 real-workload corpus before being cited.
+> JSON-validation experience suggests several GiB/s, with the largest wins on
+> ASCII-heavy and mixed content.
 
-> **⚠️ Provisional — pending re-measurement.** The figures below were captured on a
-> pre-rebase branch tip; those commits were orphaned when this branch was rebased onto
-> `main`, so the per-platform **Commit** references no longer resolve. The scalar
-> validator is unchanged by the rebase, so the numbers should still hold, but per the
-> project's benchmark-freshness rule they must be re-measured on each named platform
-> (and the commit references restored) before being cited as authoritative. Downstream
-> issues #133 and #134 pin their projected gains to these baselines.
+> **⚠️ Mixed vintage — read the per-platform dates.** The **Apple M4 Pro** section was
+> re-measured on 2026-07-25 and reflects the #133 broadword ASCII fast path. The
+> **AMD Ryzen 9 7950X** and **Apple M1 Max** sections still hold pre-#133 figures
+> captured on a pre-rebase branch tip whose commits were orphaned by a rebase, so
+> their **Commit** references no longer resolve; they are byte-per-byte slower than
+> what the current scalar validator achieves and must be re-measured before being
+> cited as authoritative. Do **not** compare an M4 Pro row against a 7950X or M1 Max
+> row — they are different code.
 
 ## Summary
 
-| Platform                      | ASCII (GiB/s) | CJK (GiB/s) | Emoji (GiB/s) | Mixed (GiB/s) |
-|-------------------------------|---------------|-------------|---------------|---------------|
-| Apple M4 Pro (ARM)            | 2.0           | 2.5         | 2.9           | 2.1           |
-| AMD Ryzen 9 7950X (x86_64)    | 2.2           | 1.3         | 1.0           | 1.8           |
-| Apple M1 Max (ARM)            | 1.3           | 1.1         | 1.2           | 1.2           |
+Scalar engine at 1MB. Rows are **not** comparable to each other — see the vintage
+warning above.
 
-**Key Finding**: Apple M4 Pro is **2-3x faster** than AMD Ryzen 9 7950X on multi-byte sequences (CJK, emoji) while maintaining comparable ASCII throughput.
+| Platform                   | Code      | ASCII (GiB/s) | CJK (GiB/s) | Emoji (GiB/s) | Mixed (GiB/s) |
+|----------------------------|-----------|---------------|-------------|---------------|---------------|
+| Apple M4 Pro (ARM)         | post-#133 | 29.2          | 2.7         | 3.2           | 3.2           |
+| AMD Ryzen 9 7950X (x86_64) | pre-#133  | 2.2           | 1.3         | 1.0           | 1.8           |
+| Apple M1 Max (ARM)         | pre-#133  | 1.3           | 1.1         | 1.2           | 1.2           |
+
+**Key Finding**: on ASCII-dominant input the broadword fast path is the whole story —
+M4 Pro scalar validation went from 2.2 to 29.2 GiB/s (#133). Multi-byte content
+improves far less (roughly 1.3-1.6x), because every multi-byte character is still
+decoded one at a time; closing that gap is #134's job.
 
 ## Apple M4 Pro (ARM)
 
-**Date**: 2026-02-06
-**Commit**: _orphaned by rebase — provisional, pending re-measurement_
+**Date**: 2026-07-25
+**Commit**: `1104d93a` + the #133 broadword change (branch `issue-133-perf-text-broadword-swar-optimizations`)
 **CPU**: Apple M4 Pro (12 cores)
 **OS**: macOS 15.6.1
-**Rust**: 1.93.0
+**Rust**: 1.96.0
+**Method**: `cargo bench --bench utf8_validate_bench`, two full repetitions per side,
+run sequentially on an otherwise idle machine; the two trees differed only in
+`src/text/utf8.rs`. Figures are the median of the two repetitions.
+
+ARM64 has no NEON UTF-8 kernel, so **the scalar validator is the only path here** —
+these numbers are what `validate_utf8` actually delivers on Apple Silicon.
 
 ### Performance by Pattern Type (1MB)
 
-| Pattern       | Time (µs) | Throughput (GiB/s) |
-|---------------|-----------|-------------------|
-| ASCII         | 487.6     | 2.00              |
-| Mixed         | 461.0     | 2.12              |
-| CJK (3-byte)  | 396.5     | 2.46              |
-| Emoji (4-byte)| 340.6     | 2.87              |
-| 2-byte Latin  | 431.4     | 2.26              |
+| Pattern        | Before (µs) | After (µs) | Throughput (GiB/s) | Change |
+|----------------|-------------|------------|--------------------|--------|
+| ASCII          | 446.39      | 33.42      | 29.22              | -92.5% |
+| Mixed          | 491.83      | 309.67     | 3.15               | -37.0% |
+| CJK (3-byte)   | 534.82      | 368.98     | 2.65               | -31.0% |
+| Emoji (4-byte) | 395.94      | 307.69     | 3.17               | -22.3% |
+| 2-byte Latin   | 417.14      | 325.77     | 3.00               | -21.9% |
 
 ### Detailed Results by Pattern
 
 #### ASCII (Pure 7-bit)
 
-| Size  | Time       | Throughput (GiB/s) |
-|-------|------------|-------------------|
-| 1KB   | 449.5 ns   | 2.12              |
-| 10KB  | 4.47 µs    | 2.13              |
-| 100KB | 45.3 µs    | 2.10              |
-| 1MB   | 487.6 µs   | 2.00              |
-| 10MB  | 4.73 ms    | 2.07              |
+| Size  | Before    | After     | Throughput (GiB/s) | Change |
+|-------|-----------|-----------|--------------------|--------|
+| 1KB   | 454.1 ns  | 41.5 ns   | 23.01              | -90.9% |
+| 10KB  | 4.48 µs   | 342.6 ns  | 27.83              | -92.4% |
+| 100KB | 43.17 µs  | 3.29 µs   | 29.02              | -92.4% |
+| 1MB   | 446.39 µs | 33.42 µs  | 29.22              | -92.5% |
+| 10MB  | 4.64 ms   | 343.45 µs | 28.43              | -92.6% |
 
 #### Mixed (Realistic content)
 
-| Size  | Time       | Throughput (GiB/s) |
-|-------|------------|-------------------|
-| 1KB   | 463.3 ns   | 2.06              |
-| 10KB  | 4.47 µs    | 2.14              |
-| 100KB | 45.1 µs    | 2.12              |
-| 1MB   | 461.0 µs   | 2.12              |
-| 10MB  | 4.64 ms    | 2.11              |
+| Size  | Before    | After     | Throughput (GiB/s) | Change |
+|-------|-----------|-----------|--------------------|--------|
+| 1KB   | 513.0 ns  | 287.3 ns  | 3.32               | -44.0% |
+| 10KB  | 4.95 µs   | 3.00 µs   | 3.18               | -39.4% |
+| 100KB | 48.68 µs  | 30.25 µs  | 3.15               | -37.9% |
+| 1MB   | 491.83 µs | 309.67 µs | 3.15               | -37.0% |
+| 10MB  | 4.98 ms   | 3.18 ms   | 3.07               | -36.0% |
 
 #### CJK (3-byte sequences)
 
-| Size  | Time       | Throughput (GiB/s) |
-|-------|------------|--------------------|
-| 1KB   | 382.1 ns   | 2.50               |
-| 10KB  | 3.82 µs    | 2.49               |
-| 100KB | 38.7 µs    | 2.46               |
-| 1MB   | 396.5 µs   | 2.46               |
-| 10MB  | 3.94 ms    | 2.48               |
+| Size  | Before    | After     | Throughput (GiB/s) | Change |
+|-------|-----------|-----------|--------------------|--------|
+| 1KB   | 410.5 ns  | 364.8 ns  | 2.61               | -11.1% |
+| 10KB  | 4.03 µs   | 3.22 µs   | 2.96               | -20.0% |
+| 100KB | 44.91 µs  | 31.71 µs  | 3.01               | -29.4% |
+| 1MB   | 534.82 µs | 368.98 µs | 2.65               | -31.0% |
+| 10MB  | 4.31 ms   | 3.32 ms   | 2.94               | -22.9% |
 
 #### Emoji (4-byte sequences)
 
-| Size  | Time       | Throughput (GiB/s) |
-|-------|------------|--------------------|
-| 1KB   | 355.3 ns   | 2.68               |
-| 10KB  | 3.31 µs    | 2.88               |
-| 100KB | 33.4 µs    | 2.85               |
-| 1MB   | 340.6 µs   | 2.87               |
-| 10MB  | 3.44 ms    | 2.84               |
+| Size  | Before    | After     | Throughput (GiB/s) | Change |
+|-------|-----------|-----------|--------------------|--------|
+| 1KB   | 366.8 ns  | 288.6 ns  | 3.30               | -21.3% |
+| 10KB  | 3.67 µs   | 2.93 µs   | 3.25               | -20.2% |
+| 100KB | 39.39 µs  | 36.10 µs  | 2.64               | -8.4%  |
+| 1MB   | 395.94 µs | 307.69 µs | 3.17               | -22.3% |
+| 10MB  | 3.71 ms   | 3.07 ms   | 3.18               | -17.2% |
+
+The 100KB row is the noisiest arm in the suite (the two repetitions disagreed,
+-30.1% and +17.6%); the other four sizes agree closely, so treat -8.4% as a
+lower bound rather than a per-size characteristic.
 
 #### Latin Extended (2-byte sequences)
 
-| Size  | Time       | Throughput (GiB/s) |
-|-------|------------|--------------------|
-| 1KB   | 458.0 ns   | 2.08               |
-| 10KB  | 3.99 µs    | 2.39               |
-| 100KB | 40.6 µs    | 2.35               |
-| 1MB   | 431.4 µs   | 2.26               |
-| 10MB  | 4.31 ms    | 2.27               |
+| Size  | Before    | After     | Throughput (GiB/s) | Change |
+|-------|-----------|-----------|--------------------|--------|
+| 1KB   | 471.3 ns  | 283.6 ns  | 3.36               | -39.8% |
+| 10KB  | 4.24 µs   | 3.14 µs   | 3.04               | -26.0% |
+| 100KB | 45.31 µs  | 30.79 µs  | 3.10               | -32.1% |
+| 1MB   | 417.14 µs | 325.77 µs | 3.00               | -21.9% |
+| 10MB  | 4.40 ms   | 3.20 ms   | 3.05               | -27.2% |
+
+#### Early exit on an invalid byte near end-of-input
+
+`line`/`column` are no longer tracked per byte; they are derived from the error
+offset by one broadword newline scan when an error is found (#133). That extra
+scan is far cheaper than the per-byte bookkeeping it replaced, so the error path
+got faster too:
+
+| Size  | Before    | After     | Change |
+|-------|-----------|-----------|--------|
+| 1KB   | 460.3 ns  | 97.4 ns   | -78.8% |
+| 10KB  | 4.62 µs   | 1.03 µs   | -77.6% |
+| 100KB | 50.11 µs  | 10.13 µs  | -79.8% |
+| 1MB   | 513.02 µs | 112.01 µs | -78.2% |
+
+### Real-workload corpus (#301)
+
+The `utf8_corpus` group over the synced corpus (`./scripts/sync-bench-corpus.sh`).
+Real configuration and data files are overwhelmingly ASCII, so they track the
+ASCII pattern closely — which is the point of gating claims on them rather than on
+the synthetic ladder alone.
+
+| File                                     | Bytes | Before   | After    | Throughput (GiB/s) | Change |
+|------------------------------------------|-------|----------|----------|--------------------|--------|
+| `json/geojson/us-election.geojson`       | 99715 | 50.38 µs | 3.48 µs  | 26.70              | -93.1% |
+| `dsv/gapminder/gapminder-five-year.csv`  | 82079 | 37.40 µs | 2.72 µs  | 28.15              | -92.7% |
+| `yaml/actions/prometheus-ci.yml`         | 18935 | 9.60 µs  | 649.9 ns | 27.13              | -93.2% |
+| `dsv/world-gdp/world-gdp-with-codes.csv` | 4515  | 2.08 µs  | 157.8 ns | 26.65              | -92.4% |
+| `yaml/actions/stale.yml`                 | 1290  | 607.5 ns | 53.1 ns  | 22.63              | -91.3% |
+| `yaml/compose/nginx-flask-mysql.yaml`    | 1239  | 598.7 ns | 52.3 ns  | 22.06              | -91.3% |
+| `yaml/actions/codeql-analysis.yml`       | 925   | 394.9 ns | 34.0 ns  | 25.37              | -91.4% |
+| `yaml/k8s/nginx-deployment.yml`          | 836   | 398.5 ns | 30.9 ns  | 25.16              | -92.2% |
+| `yaml/compose/wordpress.yaml`            | 815   | 392.4 ns | 30.8 ns  | 24.62              | -92.1% |
+| `json/charts/bullet-data.json`           | 548   | 263.1 ns | 23.7 ns  | 21.54              | -91.0% |
 
 ### Sequence Type Comparison (1MB)
 
-Direct comparison of byte sequence lengths at 1MB:
+| Sequence Type     | Before (µs) | After (µs) | Throughput (GiB/s) | Change |
+|-------------------|-------------|------------|--------------------|--------|
+| ASCII (1-byte)    | 481.16      | 34.56      | 28.26              | -92.8% |
+| Extended (2-byte) | 447.45      | 324.38     | 3.01               | -27.5% |
+| CJK (3-byte)      | 397.03      | 337.00     | 2.90               | -15.1% |
+| Emoji (4-byte)    | 346.66      | 318.58     | 3.07               | -8.1%  |
+| Mixed             | 473.18      | 319.01     | 3.06               | -32.6% |
 
-| Sequence Type      | Time (µs) | Throughput (GiB/s) |
-|--------------------|-----------|--------------------|
-| ASCII (1-byte)     | 505.0     | 1.93               |
-| Extended (2-byte)  | 403.9     | 2.42               |
-| CJK (3-byte)       | 394.4     | 2.48               |
-| Emoji (4-byte)     | 350.7     | 2.79               |
-| Mixed              | 469.8     | 2.08               |
+**Observation**: the pre-#133 pattern — longer sequences validating *faster* per
+byte — is gone. ASCII is now an order of magnitude ahead of everything else, and
+the multi-byte patterns have converged on ~3 GiB/s, the cost of decoding each
+character individually.
 
-**Observation**: Longer UTF-8 sequences validate *faster* on M4 Pro due to fewer continuation byte validations per MB of data.
+### Where the gains come from
+
+All 44 benchmark arms improved; none regressed. Three changes contribute:
+
+1. **8-byte ASCII skip** — `word & 0x8080_8080_8080_8080 == 0` clears eight bytes
+   per test. LLVM auto-vectorises this word loop into NEON, so the realised ASCII
+   gain (~13x) far exceeds the ~8x fewer iterations the technique implies on paper.
+2. **Line/column off the hot path** — the old loop read `input[pos - 1]` on *every*
+   byte to maintain `line`/`line_start`. Deriving both from the error offset removes
+   that load entirely and is what lifts the multi-byte patterns, which never touch
+   the ASCII fast path at all.
+3. **Keeping the ASCII skip out of line** — `#[inline(never)]` on `skip_ascii`.
+   Inlining it bloats the enclosing dispatch loop and costs multi-byte input 5-12%;
+   across three repetitions the inlined form ranged from -10.6% to +11.8% versus
+   baseline (regressing pure emoji in three of four runs), while the out-of-line
+   form won on all twelve (benchmark, repetition) pairs at a median of -13.0%. The
+   call is amortised over a whole ASCII run, costing the ASCII path under 1%.
 
 ---
 
@@ -136,19 +213,19 @@ Direct comparison of byte sequence lengths at 1MB:
 
 ### Performance by Pattern Type
 
-| Pattern         | 1KB (MiB/s) | 10KB (MiB/s) | 100KB (MiB/s) | 1MB (MiB/s) | 10MB (MiB/s) | 100MB (MiB/s) |
-|-----------------|-------------|--------------|---------------|-------------|--------------|---------------|
-| ascii           | 2,271       | 2,299        | 2,308         | 2,308       | 2,245        | 2,262         |
-| log_file        | 1,434       | 1,461        | 2,226         | 2,176       | 2,147        | 2,137         |
-| pathological    | 1,358       | 1,416        | 2,165         | 2,149       | 2,147        | 2,153         |
-| source_code     | 1,953       | 2,095        | 2,055         | 1,987       | 1,984        | 1,979         |
-| json_like       | 1,915       | 1,307        | 1,278         | 1,911       | 1,873        | 1,879         |
-| mixed           | 967         | 1,278        | 1,936         | 1,856       | 1,823        | 1,819         |
-| cjk             | 1,684       | 1,852        | 1,386         | 1,358       | 1,368        | 1,359         |
-| greek_cyrillic  | 904         | 1,680        | 1,192         | 1,147       | 1,134        | 1,119         |
-| emoji           | 651         | 1,225        | 1,946         | 1,040       | 1,061        | 1,036         |
-| latin           | 1,528       | 1,531        | 894           | 848         | 874          | 860           |
-| all_lengths     | 1,221       | 1,094        | 536           | 500         | 502          | 492           |
+| Pattern        | 1KB (MiB/s) | 10KB (MiB/s) | 100KB (MiB/s) | 1MB (MiB/s) | 10MB (MiB/s) | 100MB (MiB/s) |
+|----------------|-------------|--------------|---------------|-------------|--------------|---------------|
+| ascii          | 2,271       | 2,299        | 2,308         | 2,308       | 2,245        | 2,262         |
+| log_file       | 1,434       | 1,461        | 2,226         | 2,176       | 2,147        | 2,137         |
+| pathological   | 1,358       | 1,416        | 2,165         | 2,149       | 2,147        | 2,153         |
+| source_code    | 1,953       | 2,095        | 2,055         | 1,987       | 1,984        | 1,979         |
+| json_like      | 1,915       | 1,307        | 1,278         | 1,911       | 1,873        | 1,879         |
+| mixed          | 967         | 1,278        | 1,936         | 1,856       | 1,823        | 1,819         |
+| cjk            | 1,684       | 1,852        | 1,386         | 1,358       | 1,368        | 1,359         |
+| greek_cyrillic | 904         | 1,680        | 1,192         | 1,147       | 1,134        | 1,119         |
+| emoji          | 651         | 1,225        | 1,946         | 1,040       | 1,061        | 1,036         |
+| latin          | 1,528       | 1,531        | 894           | 848         | 874          | 860           |
+| all_lengths    | 1,221       | 1,094        | 536           | 500         | 502          | 492           |
 
 ### Detailed Results by Pattern
 
@@ -231,14 +308,14 @@ Direct comparison of byte sequence lengths at 1MB:
 
 ### Performance by Pattern Type
 
-| Pattern    | 1KB (GiB/s) | 10KB (GiB/s) | 100KB (GiB/s) | 1MB (GiB/s) | 10MB (GiB/s) |
-|------------|-------------|--------------|---------------|-------------|--------------|
-| ascii      | 1.34        | 1.35         | 1.34          | 1.35        | 1.36         |
-| mixed      | 1.19        | 1.21         | 1.23          | 1.22        | 1.20         |
-| cjk        | 1.05        | 1.06         | 1.07          | 1.07        | 1.03         |
-| emoji      | 1.17        | 1.17         | 1.17          | 1.18        | 1.15         |
-| 2-byte     | 1.02        | 1.00         | 1.01          | 1.00        | 1.00         |
-| error_end  | 1.25        | 1.25         | 1.28          | 1.32        | -            |
+| Pattern   | 1KB (GiB/s) | 10KB (GiB/s) | 100KB (GiB/s) | 1MB (GiB/s) | 10MB (GiB/s) |
+|-----------|-------------|--------------|---------------|-------------|--------------|
+| ascii     | 1.34        | 1.35         | 1.34          | 1.35        | 1.36         |
+| mixed     | 1.19        | 1.21         | 1.23          | 1.22        | 1.20         |
+| cjk       | 1.05        | 1.06         | 1.07          | 1.07        | 1.03         |
+| emoji     | 1.17        | 1.17         | 1.17          | 1.18        | 1.15         |
+| 2-byte    | 1.02        | 1.00         | 1.01          | 1.00        | 1.00         |
+| error_end | 1.25        | 1.25         | 1.28          | 1.32        | -            |
 
 ### Detailed Results
 
@@ -313,40 +390,46 @@ Direct comparison of byte sequence lengths at 1MB:
 
 ### Cross-Platform Comparison (1MB)
 
-| Pattern       | M4 Pro (GiB/s) | Ryzen 9 (GiB/s) | M4 Pro Advantage |
-|---------------|----------------|-----------------|------------------|
-| ASCII         | 2.0            | 2.2             | 0.9x (Ryzen wins)|
-| Mixed         | 2.1            | 1.8             | **1.2x**         |
-| CJK (3-byte)  | 2.5            | 1.3             | **1.9x**         |
-| Emoji (4-byte)| 2.9            | 1.0             | **2.9x**         |
-| 2-byte Latin  | 2.3            | 0.8             | **2.9x**         |
+> **Not currently possible.** Only the M4 Pro has been re-measured since #133; the
+> 7950X and M1 Max figures are pre-#133 code. A cross-platform table would compare
+> two different validators and read as a hardware result when it is really a code
+> result. Restore this section once the other two platforms are re-measured.
 
-### Throughput by Character Type (AMD Ryzen 9 7950X)
+Pre-#133 the comparison read: M4 Pro **1.9-2.9x** faster than the 7950X on
+multi-byte sequences, with the 7950X marginally ahead on ASCII (2.2 vs 2.0 GiB/s).
+
+### Throughput by Character Type (AMD Ryzen 9 7950X, pre-#133)
 
 1. **ASCII-dominant content** (~2.2-2.3 GiB/s): Pure ASCII, log files, source code, pathological
 2. **Mixed content** (~1.8-1.9 GiB/s): JSON-like, mixed prose
 3. **Multi-byte content** (~1.0-1.4 GiB/s): CJK (3-byte), emoji (4-byte), Greek/Cyrillic (2-byte)
 4. **Uniform multi-byte** (~0.5 GiB/s): All-lengths pattern with maximum byte diversity
 
-### Throughput by Character Type (Apple M4 Pro)
+### Throughput by Character Type (Apple M4 Pro, post-#133)
 
-1. **Emoji (4-byte)** (~2.8-2.9 GiB/s): Fastest due to fewest characters per MB
-2. **CJK (3-byte)** (~2.4-2.5 GiB/s): Excellent performance on ideographic content
-3. **2-byte Latin** (~2.3-2.4 GiB/s): Extended Latin, Greek, Cyrillic
-4. **ASCII/Mixed** (~2.0-2.1 GiB/s): Comparable performance across content types
+1. **ASCII / ASCII-dominant** (~23-29 GiB/s): pure ASCII and the real-workload corpus
+2. **Mixed prose** (~3.1-3.3 GiB/s): ASCII-dominant with sparse multi-byte characters
+3. **Uniform multi-byte** (~2.6-3.2 GiB/s): 2-byte Latin, CJK, emoji — all converge, since
+   each character is decoded individually regardless of its length
 
 ### Performance Characteristics
 
-- **M4 Pro inverts the pattern**: Multi-byte sequences are *faster* than ASCII (fewer characters to validate per MB)
-- **Ryzen 9 follows expected pattern**: ASCII is fastest, multi-byte is slower
-- **Branch prediction**: M4 Pro's branch predictor handles UTF-8 state machine better
-- **Memory bandwidth**: Both platforms are memory-bound at large sizes
+- **ASCII dominates post-#133**: an order of magnitude ahead of multi-byte content on
+  M4 Pro. The pre-#133 inversion (multi-byte validating faster than ASCII) is gone
+- **Multi-byte is the remaining bottleneck**: ~3 GiB/s across 2/3/4-byte patterns is
+  the per-character decode cost; a DFA (#134) is the next lever
+- **Ryzen 9 (pre-#133) follows the expected pattern**: ASCII fastest, multi-byte slower
+- **Memory bandwidth**: still not the limit. Post-#133 ASCII sustains ~28 GiB/s at
+  10MB (past cache), roughly 30 GB/s — an order of magnitude under M4 Pro's peak
 
-### Scaling
+### Scaling (Apple M4 Pro, post-#133)
 
-- Throughput is consistent from 1MB to 100MB (memory-bound)
-- Small files (1KB-10KB) show higher variance due to measurement overhead
-- No cache effects visible - sequential access pattern is optimal for hardware prefetching
+- ASCII throughput plateaus by 100KB (29.02 GiB/s) and holds through 10MB (28.43),
+  so the fast path is not cache-limited at these sizes
+- 1KB is the outlier at 23.01 GiB/s: at 41 ns per validation, per-call overhead is a
+  visible share of the measurement
+- Multi-byte patterns are flat across all five sizes (~2.6-3.3 GiB/s), consistent
+  with a per-character cost that no amount of input length amortises
 
 ## Running the Benchmarks
 
@@ -354,11 +437,18 @@ Direct comparison of byte sequence lengths at 1MB:
 # Generate test files
 ./target/release/succinctly text generate-suite
 
+# Fetch the real-workload corpus so the `utf8_corpus` group covers the larger
+# files; without this it falls back to the small committed seed
+./scripts/sync-bench-corpus.sh
+
 # Run CLI benchmark
 ./target/release/succinctly dev bench utf8
 
-# Run Criterion benchmark
+# Run Criterion benchmark (all groups, both engines)
 cargo bench --bench utf8_validate_bench
+
+# Just the real-workload corpus group
+cargo bench --bench utf8_validate_bench -- utf8_corpus
 
 # Via unified runner
 ./target/release/succinctly bench run utf8_bench
@@ -366,16 +456,16 @@ cargo bench --bench utf8_validate_bench
 
 ## Test Data Patterns
 
-| Pattern         | Description                                      |
-|-----------------|--------------------------------------------------|
-| ascii           | Pure 7-bit ASCII (single-byte sequences)         |
-| latin           | Latin Extended characters (2-byte sequences)     |
-| greek_cyrillic  | Greek and Cyrillic (2-byte sequences)            |
-| cjk             | Chinese/Japanese/Korean (3-byte sequences)       |
-| emoji           | Emoji and symbols (4-byte sequences)             |
-| mixed           | Realistic prose with occasional non-ASCII        |
-| all_lengths     | Uniform mix of all sequence lengths (1-4 bytes)  |
-| log_file        | Log file style (mostly ASCII with timestamps)    |
-| source_code     | Source code style (ASCII with unicode in strings)|
-| json_like       | JSON-like structure with unicode strings         |
-| pathological    | Maximum multi-byte density                       |
+| Pattern        | Description                                       |
+|----------------|---------------------------------------------------|
+| ascii          | Pure 7-bit ASCII (single-byte sequences)          |
+| latin          | Latin Extended characters (2-byte sequences)      |
+| greek_cyrillic | Greek and Cyrillic (2-byte sequences)             |
+| cjk            | Chinese/Japanese/Korean (3-byte sequences)        |
+| emoji          | Emoji and symbols (4-byte sequences)              |
+| mixed          | Realistic prose with occasional non-ASCII         |
+| all_lengths    | Uniform mix of all sequence lengths (1-4 bytes)   |
+| log_file       | Log file style (mostly ASCII with timestamps)     |
+| source_code    | Source code style (ASCII with unicode in strings) |
+| json_like      | JSON-like structure with unicode strings          |
+| pathological   | Maximum multi-byte density                        |

--- a/src/text/utf8.rs
+++ b/src/text/utf8.rs
@@ -29,6 +29,8 @@
 
 use alloc::string::String;
 
+use crate::util::broadword::{H8, L8};
+
 /// Error information for UTF-8 validation failures.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Utf8Error {
@@ -130,41 +132,35 @@ pub fn validate_utf8(input: &[u8]) -> Result<(), Utf8Error> {
     }
 }
 
-/// Validate UTF-8 using a scalar (byte-by-byte) algorithm.
+/// Validate UTF-8 using a portable scalar algorithm with a broadword (SWAR)
+/// ASCII fast path.
 ///
-/// This is a portable implementation that works on all platforms.
-/// It provides detailed error information including the exact byte offset,
-/// line number, and column position of any error.
+/// This is the only validation path on non-x86_64 targets, in `no_std` builds,
+/// on x86_64 CPUs without AVX2, and behind the CLI's `--no-simd`; on AVX2 hosts
+/// it also backs [`validate_utf8`]'s error reporting.
+///
+/// Runs of ASCII are skipped eight bytes at a time via [`skip_ascii`], while
+/// multi-byte sequences are validated one character at a time. Errors carry the
+/// exact byte offset, line number, and column position, derived from the offset
+/// by [`line_and_column`] once an error is found — see its docs for why keeping
+/// that state off the hot path is exact rather than approximate.
 pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
     let mut pos = 0;
-    let mut line = 1;
-    let mut line_start = 0;
     let len = input.len();
 
     while pos < len {
         let byte = input[pos];
 
-        // Track newlines for error reporting
-        if pos > 0 && input[pos - 1] == b'\n' {
-            line += 1;
-            line_start = pos;
-        }
-
         // Determine sequence length from lead byte
         let seq_len = match byte {
-            // ASCII: 0x00-0x7F (single byte)
+            // ASCII: 0x00-0x7F (single byte). Skip the whole run at once.
             0x00..=0x7F => {
-                pos += 1;
+                pos = skip_ascii(input, pos + 1);
                 continue;
             }
             // Continuation bytes appearing as lead: invalid
             0x80..=0xBF => {
-                return Err(Utf8Error {
-                    offset: pos,
-                    line,
-                    column: pos - line_start + 1,
-                    kind: Utf8ErrorKind::InvalidLeadByte,
-                });
+                return Err(err_at(input, pos, Utf8ErrorKind::InvalidLeadByte));
             }
             // 2-byte sequence: 0xC0-0xDF
             0xC0..=0xDF => 2,
@@ -174,23 +170,13 @@ pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
             0xF0..=0xF7 => 4,
             // Invalid lead bytes: 0xF8-0xFF
             0xF8..=0xFF => {
-                return Err(Utf8Error {
-                    offset: pos,
-                    line,
-                    column: pos - line_start + 1,
-                    kind: Utf8ErrorKind::InvalidLeadByte,
-                });
+                return Err(err_at(input, pos, Utf8ErrorKind::InvalidLeadByte));
             }
         };
 
         // Check for truncation
         if pos + seq_len > len {
-            return Err(Utf8Error {
-                offset: pos,
-                line,
-                column: pos - line_start + 1,
-                kind: Utf8ErrorKind::TruncatedSequence,
-            });
+            return Err(err_at(input, pos, Utf8ErrorKind::TruncatedSequence));
         }
 
         // Validate continuation bytes and decode code point
@@ -198,24 +184,18 @@ pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
             2 => {
                 let b1 = input[pos + 1];
                 if !is_continuation_byte(b1) {
-                    return Err(Utf8Error {
-                        offset: pos + 1,
-                        line,
-                        column: pos + 1 - line_start + 1,
-                        kind: Utf8ErrorKind::InvalidContinuationByte,
-                    });
+                    return Err(err_at(
+                        input,
+                        pos + 1,
+                        Utf8ErrorKind::InvalidContinuationByte,
+                    ));
                 }
 
                 // Check for overlong encoding (code points < 0x80 must use 1 byte)
                 // 2-byte sequences must encode U+0080 or higher
                 // Lead byte 0xC0 or 0xC1 would encode < 0x80
                 if byte <= 0xC1 {
-                    return Err(Utf8Error {
-                        offset: pos,
-                        line,
-                        column: pos - line_start + 1,
-                        kind: Utf8ErrorKind::OverlongEncoding,
-                    });
+                    return Err(err_at(input, pos, Utf8ErrorKind::OverlongEncoding));
                 }
             }
             3 => {
@@ -223,20 +203,18 @@ pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
                 let b2 = input[pos + 2];
 
                 if !is_continuation_byte(b1) {
-                    return Err(Utf8Error {
-                        offset: pos + 1,
-                        line,
-                        column: pos + 1 - line_start + 1,
-                        kind: Utf8ErrorKind::InvalidContinuationByte,
-                    });
+                    return Err(err_at(
+                        input,
+                        pos + 1,
+                        Utf8ErrorKind::InvalidContinuationByte,
+                    ));
                 }
                 if !is_continuation_byte(b2) {
-                    return Err(Utf8Error {
-                        offset: pos + 2,
-                        line,
-                        column: pos + 2 - line_start + 1,
-                        kind: Utf8ErrorKind::InvalidContinuationByte,
-                    });
+                    return Err(err_at(
+                        input,
+                        pos + 2,
+                        Utf8ErrorKind::InvalidContinuationByte,
+                    ));
                 }
 
                 // Decode code point for validation
@@ -245,22 +223,12 @@ pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
 
                 // Check for overlong encoding (code points < 0x800 must use 2 bytes)
                 if cp < 0x800 {
-                    return Err(Utf8Error {
-                        offset: pos,
-                        line,
-                        column: pos - line_start + 1,
-                        kind: Utf8ErrorKind::OverlongEncoding,
-                    });
+                    return Err(err_at(input, pos, Utf8ErrorKind::OverlongEncoding));
                 }
 
                 // Check for surrogate code points (U+D800-U+DFFF)
                 if (0xD800..=0xDFFF).contains(&cp) {
-                    return Err(Utf8Error {
-                        offset: pos,
-                        line,
-                        column: pos - line_start + 1,
-                        kind: Utf8ErrorKind::SurrogateCodepoint,
-                    });
+                    return Err(err_at(input, pos, Utf8ErrorKind::SurrogateCodepoint));
                 }
             }
             4 => {
@@ -269,28 +237,25 @@ pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
                 let b3 = input[pos + 3];
 
                 if !is_continuation_byte(b1) {
-                    return Err(Utf8Error {
-                        offset: pos + 1,
-                        line,
-                        column: pos + 1 - line_start + 1,
-                        kind: Utf8ErrorKind::InvalidContinuationByte,
-                    });
+                    return Err(err_at(
+                        input,
+                        pos + 1,
+                        Utf8ErrorKind::InvalidContinuationByte,
+                    ));
                 }
                 if !is_continuation_byte(b2) {
-                    return Err(Utf8Error {
-                        offset: pos + 2,
-                        line,
-                        column: pos + 2 - line_start + 1,
-                        kind: Utf8ErrorKind::InvalidContinuationByte,
-                    });
+                    return Err(err_at(
+                        input,
+                        pos + 2,
+                        Utf8ErrorKind::InvalidContinuationByte,
+                    ));
                 }
                 if !is_continuation_byte(b3) {
-                    return Err(Utf8Error {
-                        offset: pos + 3,
-                        line,
-                        column: pos + 3 - line_start + 1,
-                        kind: Utf8ErrorKind::InvalidContinuationByte,
-                    });
+                    return Err(err_at(
+                        input,
+                        pos + 3,
+                        Utf8ErrorKind::InvalidContinuationByte,
+                    ));
                 }
 
                 // Decode code point for validation
@@ -301,22 +266,12 @@ pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
 
                 // Check for overlong encoding (code points < 0x10000 must use 3 bytes)
                 if cp < 0x10000 {
-                    return Err(Utf8Error {
-                        offset: pos,
-                        line,
-                        column: pos - line_start + 1,
-                        kind: Utf8ErrorKind::OverlongEncoding,
-                    });
+                    return Err(err_at(input, pos, Utf8ErrorKind::OverlongEncoding));
                 }
 
                 // Check for out of range (> U+10FFFF)
                 if cp > 0x10FFFF {
-                    return Err(Utf8Error {
-                        offset: pos,
-                        line,
-                        column: pos - line_start + 1,
-                        kind: Utf8ErrorKind::OutOfRangeCodepoint,
-                    });
+                    return Err(err_at(input, pos, Utf8ErrorKind::OutOfRangeCodepoint));
                 }
             }
             _ => unreachable!(),
@@ -326,6 +281,124 @@ pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
     }
 
     Ok(())
+}
+
+/// Advance past a run of ASCII bytes starting at `pos`, eight at a time.
+///
+/// Returns the index of the first non-ASCII byte at or after `pos`, or
+/// `input.len()` if the rest of the input is ASCII.
+///
+/// A byte is ASCII exactly when its high bit is clear, so a whole 8-byte word is
+/// ASCII iff `word & H8 == 0` — one load, one AND and one test per eight bytes
+/// instead of per byte. When the word does contain a non-ASCII byte, its index
+/// is `trailing_zeros() / 8`: `from_le_bytes` maps byte *k* to bits *8k..8k+7*
+/// on every host, so this is endian-independent.
+///
+/// The caller only reaches this from the ASCII arm of the lead-byte dispatch, so
+/// multi-byte-heavy input never executes the word loop at all.
+///
+/// `#[inline(never)]` is deliberate and measured. Inlining the word loop into the
+/// dispatch bloats the enclosing loop body and costs multi-byte-heavy input
+/// 5-12%: on an M4 Pro over three repetitions, the inlined form ranged from
+/// -10.6% to +11.8% against the byte-at-a-time baseline (regressing pure emoji in
+/// three of four runs), while keeping it out of line was faster on all twelve
+/// (benchmark, repetition) pairs, median -13.0%. The call is amortised over a
+/// whole ASCII run, so the ASCII path gives up under 1% for it.
+#[inline(never)]
+fn skip_ascii(input: &[u8], mut pos: usize) -> usize {
+    let len = input.len();
+
+    while pos + 8 <= len {
+        let word = u64::from_le_bytes(input[pos..pos + 8].try_into().unwrap());
+        let non_ascii = word & H8;
+        if non_ascii != 0 {
+            return pos + (non_ascii.trailing_zeros() as usize >> 3);
+        }
+        pos += 8;
+    }
+
+    // Fewer than 8 bytes left: finish byte-at-a-time.
+    while pos < len && input[pos] < 0x80 {
+        pos += 1;
+    }
+    pos
+}
+
+/// Build a [`Utf8Error`] for `offset`, resolving its line and column.
+///
+/// Marked `#[cold]` so the optimizer lays this out away from the validation loop
+/// and keeps `line`/`column` bookkeeping out of the hot path entirely.
+#[cold]
+#[inline(never)]
+fn err_at(input: &[u8], offset: usize, kind: Utf8ErrorKind) -> Utf8Error {
+    let (line, column) = line_and_column(input, offset);
+    Utf8Error {
+        offset,
+        line,
+        column,
+        kind,
+    }
+}
+
+/// The 1-indexed line and column (in bytes) of `offset` within `input`.
+///
+/// Called only when validation has already failed, so this single backward-
+/// looking scan replaces per-byte `line`/`line_start` bookkeeping in the hot
+/// loop. That substitution is exact, not approximate:
+///
+/// - The line of `offset` is `1 + (newlines in input[..offset])`, because `\n` is
+///   a one-byte character and so is always counted exactly once.
+/// - Errors reported at `pos + k` inside a multi-byte sequence still resolve to
+///   the same line as the sequence start `pos`: `input[pos]` is a lead byte
+///   (`>= 0xC0`) and `input[pos + 1..pos + k]` have already been checked as
+///   continuation bytes (`0x80..=0xBF`), so no `\n` can occur between them.
+///
+/// Newlines are located eight bytes at a time by XORing against a broadcast `\n`
+/// — turning every match into a zero byte — and then applying an exact broadword
+/// zero-byte test.
+fn line_and_column(input: &[u8], offset: usize) -> (usize, usize) {
+    /// `\n` broadcast to all eight byte lanes.
+    const NEWLINES: u64 = L8.wrapping_mul(b'\n' as u64);
+    /// The low seven bits of each byte lane (the complement of [`H8`]).
+    const LOW7: u64 = !H8;
+
+    let prefix = &input[..offset];
+    let mut line = 1;
+    let mut line_start = 0;
+    let mut pos = 0;
+
+    while pos + 8 <= prefix.len() {
+        let word = u64::from_le_bytes(prefix[pos..pos + 8].try_into().unwrap());
+        let zeros = word ^ NEWLINES;
+
+        // Exact per-byte zero test: `(b & 0x7F) + 0x7F` sets a byte's high bit
+        // iff its low seven bits are non-zero, and OR-ing `b` back in covers the
+        // high bit, so the negation leaves a set high bit exactly where a byte
+        // was zero. Because `(b & 0x7F) + 0x7F <= 0xFE`, no carry escapes a lane.
+        //
+        // The cheaper `(x - L8) & !x & H8` form is *not* usable here: it answers
+        // "does this word contain a zero byte?" correctly, but borrow
+        // propagation also flags the byte following a zero byte when that byte
+        // is 0x01 — i.e. a `\n` followed by `\v` — which would over-count lines.
+        let mask = !((zeros & LOW7).wrapping_add(LOW7) | zeros) & H8;
+
+        if mask != 0 {
+            // Exactly one bit is set per newline byte, so popcount is the count;
+            // the highest set bit locates the last newline in the word.
+            line += mask.count_ones() as usize;
+            line_start = pos + (63 - mask.leading_zeros() as usize) / 8 + 1;
+        }
+        pos += 8;
+    }
+
+    for (i, &byte) in prefix[pos..].iter().enumerate() {
+        if byte == b'\n' {
+            line += 1;
+            line_start = pos + i + 1;
+        }
+    }
+
+    (line, offset - line_start + 1)
 }
 
 /// Check if a byte is a valid UTF-8 continuation byte (0x80-0xBF).
@@ -1726,7 +1799,7 @@ mod tests {
 mod validate_utf8_differential_tests {
     #![allow(unsafe_code)] // the x86_64 test drives the raw AVX2 kernel directly
 
-    use super::{validate_utf8, validate_utf8_scalar};
+    use super::{validate_utf8, validate_utf8_scalar, Utf8Error, Utf8ErrorKind};
     use alloc::string::String;
     use alloc::vec::Vec;
 
@@ -2011,5 +2084,357 @@ mod validate_utf8_differential_tests {
             assert!(core::str::from_utf8(&buf).is_ok());
             assert!(validate_utf8_scalar(&buf).is_ok(), "scalar: {buf:02x?}");
         }
+    }
+
+    /// Invalid fixtures carrying newlines, so the `line`/`column` fields of the
+    /// reported [`Utf8Error`] — not just its `offset` — are exercised.
+    ///
+    /// Newlines are placed at strides that straddle the 8-byte word boundary the
+    /// broadword ASCII fast path steps over, and errors land on the first line,
+    /// immediately after a newline, and several lines in.
+    fn newline_error_fixtures() -> Vec<Vec<u8>> {
+        let bad_seqs: &[&[u8]] = &[
+            &[0x80],                   // stray continuation
+            &[0xC0, 0x80],             // overlong 2-byte
+            &[0xE0, 0x80, 0x80],       // overlong 3-byte
+            &[0xED, 0xA0, 0x80],       // surrogate U+D800
+            &[0xF0, 0x80, 0x80, 0x80], // overlong 4-byte
+            &[0xF4, 0x90, 0x80, 0x80], // above U+10FFFF
+            &[0xFF],                   // invalid lead
+            &[0xC2],                   // truncated 2-byte at EOF
+            &[0xE0, 0xA0],             // truncated 3-byte at EOF
+            &[0xF0, 0x90, 0x80],       // truncated 4-byte at EOF
+            &[0xC2, 0x41],             // bad continuation in 2-byte
+            &[0xE0, 0xA0, 0x41],       // bad continuation in 3-byte
+            &[0xF0, 0x90, 0x80, 0x41], // bad continuation in 4-byte
+        ];
+
+        // Prefix shapes, each `n` bytes long, covering: no newline at all; a
+        // newline every k bytes (k straddling the 8-byte word); a single newline
+        // at the very start; and one immediately before the error.
+        let prefix = |n: usize, shape: u8| -> Vec<u8> {
+            (0..n)
+                .map(|i| match shape {
+                    0 => b'a',
+                    1 => {
+                        if i % 3 == 2 {
+                            b'\n'
+                        } else {
+                            b'a'
+                        }
+                    }
+                    2 => {
+                        if i % 8 == 7 {
+                            b'\n'
+                        } else {
+                            b'a'
+                        }
+                    }
+                    3 => {
+                        if i == 0 {
+                            b'\n'
+                        } else {
+                            b'a'
+                        }
+                    }
+                    _ => {
+                        if i + 1 == n {
+                            b'\n'
+                        } else {
+                            b'a'
+                        }
+                    }
+                })
+                .collect()
+        };
+
+        let mut out = Vec::new();
+        for seq in bad_seqs {
+            for n in 0..24usize {
+                for shape in 0..5u8 {
+                    let mut buf = prefix(n, shape);
+                    buf.extend_from_slice(seq);
+                    out.push(buf);
+                }
+            }
+            // Multi-byte characters before the error: the derived `line_start`
+            // must not be confused by continuation bytes.
+            for n in 0..6usize {
+                let mut buf = Vec::new();
+                for i in 0..n {
+                    buf.extend_from_slice(if i % 2 == 0 {
+                        "日".as_bytes()
+                    } else {
+                        "é\n".as_bytes()
+                    });
+                }
+                buf.extend_from_slice(seq);
+                out.push(buf);
+            }
+            // CRLF line endings.
+            for n in 0..4usize {
+                let mut buf = Vec::new();
+                for _ in 0..n {
+                    buf.extend_from_slice(b"line\r\n");
+                }
+                buf.extend_from_slice(seq);
+                out.push(buf);
+            }
+        }
+        out
+    }
+
+    /// The scalar validator agrees with the byte-by-byte reference on the *whole*
+    /// `Result` — `offset`, `line`, `column` and `kind`, not merely validity.
+    ///
+    /// This is the safety net for deriving `line`/`column` from the error offset
+    /// instead of tracking them per byte: any drift in either field fails here.
+    #[test]
+    fn scalar_matches_reference_including_error() {
+        // Widest `line` / `column` an errored fixture reported, asserted at the
+        // end so this test can never pass vacuously on all-valid or all-line-1
+        // inputs — the very cases that would hide a line-tracking regression.
+        let mut max_line = 0usize;
+        let mut max_column = 0usize;
+        let mut check = |bytes: &[u8]| {
+            let actual = validate_utf8_scalar(bytes);
+            assert_eq!(
+                actual,
+                validate_utf8_scalar_reference(bytes),
+                "scalar diverged from reference on {bytes:02x?}"
+            );
+            if let Err(e) = actual {
+                max_line = max_line.max(e.line);
+                max_column = max_column.max(e.column);
+            }
+        };
+
+        for buf in newline_error_fixtures() {
+            check(&buf);
+        }
+        for buf in invalid_boundary_fixtures() {
+            check(&buf);
+        }
+        for buf in valid_boundary_fixtures() {
+            check(&buf);
+        }
+
+        let mut rng = Rng(0xfeed_face_0133_0001);
+        for _ in 0..20_000 {
+            let len = rng.below(96) as usize;
+            check(&random_bytes(&mut rng, len));
+        }
+        // Byte soup biased towards ASCII and newlines, so long ASCII runs (the
+        // broadword fast path) precede the error rather than random high bytes.
+        for _ in 0..20_000 {
+            let len = rng.below(96) as usize;
+            let mut bytes: Vec<u8> = (0..len)
+                .map(|_| match rng.below(10) {
+                    0 => b'\n',
+                    1 => (rng.next_u32() & 0xFF) as u8,
+                    _ => b'a' + (rng.below(26) as u8),
+                })
+                .collect();
+            if !bytes.is_empty() && rng.below(2) == 0 {
+                let i = rng.below(bytes.len() as u32) as usize;
+                bytes[i] = 0x80 | (rng.below(0x80) as u8);
+            }
+            check(&bytes);
+        }
+        for _ in 0..5_000 {
+            let min_len = rng.below(200) as usize;
+            let mut bytes = random_valid_utf8(&mut rng, min_len);
+            if !bytes.is_empty() {
+                let i = rng.below(bytes.len() as u32) as usize;
+                bytes[i] = if rng.below(2) == 0 {
+                    b'\n'
+                } else {
+                    (rng.next_u32() & 0xFF) as u8
+                };
+            }
+            check(&bytes);
+        }
+
+        assert!(
+            max_line > 5,
+            "fixtures never produced an error past line 5 (max {max_line}); \
+             line tracking is not actually being exercised"
+        );
+        assert!(
+            max_column > 5,
+            "fixtures never produced an error past column 5 (max {max_column}); \
+             column derivation is not actually being exercised"
+        );
+    }
+
+    /// The original byte-at-a-time scalar validator, kept verbatim as the oracle
+    /// for [`scalar_matches_reference_including_error`]. It tracks `line` and
+    /// `line_start` incrementally on the hot path; the shipping validator derives
+    /// them from the error offset instead, and this pins the two to agree.
+    // STYLE-0005: reference impl kept for correctness comparison
+    fn validate_utf8_scalar_reference(input: &[u8]) -> Result<(), Utf8Error> {
+        let mut pos = 0;
+        let mut line = 1;
+        let mut line_start = 0;
+        let len = input.len();
+
+        while pos < len {
+            let byte = input[pos];
+
+            if pos > 0 && input[pos - 1] == b'\n' {
+                line += 1;
+                line_start = pos;
+            }
+
+            let seq_len = match byte {
+                0x00..=0x7F => {
+                    pos += 1;
+                    continue;
+                }
+                0x80..=0xBF => {
+                    return Err(Utf8Error {
+                        offset: pos,
+                        line,
+                        column: pos - line_start + 1,
+                        kind: Utf8ErrorKind::InvalidLeadByte,
+                    });
+                }
+                0xC0..=0xDF => 2,
+                0xE0..=0xEF => 3,
+                0xF0..=0xF7 => 4,
+                0xF8..=0xFF => {
+                    return Err(Utf8Error {
+                        offset: pos,
+                        line,
+                        column: pos - line_start + 1,
+                        kind: Utf8ErrorKind::InvalidLeadByte,
+                    });
+                }
+            };
+
+            if pos + seq_len > len {
+                return Err(Utf8Error {
+                    offset: pos,
+                    line,
+                    column: pos - line_start + 1,
+                    kind: Utf8ErrorKind::TruncatedSequence,
+                });
+            }
+
+            match seq_len {
+                2 => {
+                    let b1 = input[pos + 1];
+                    if (b1 & 0xC0) != 0x80 {
+                        return Err(Utf8Error {
+                            offset: pos + 1,
+                            line,
+                            column: pos + 1 - line_start + 1,
+                            kind: Utf8ErrorKind::InvalidContinuationByte,
+                        });
+                    }
+                    if byte <= 0xC1 {
+                        return Err(Utf8Error {
+                            offset: pos,
+                            line,
+                            column: pos - line_start + 1,
+                            kind: Utf8ErrorKind::OverlongEncoding,
+                        });
+                    }
+                }
+                3 => {
+                    let b1 = input[pos + 1];
+                    let b2 = input[pos + 2];
+                    if (b1 & 0xC0) != 0x80 {
+                        return Err(Utf8Error {
+                            offset: pos + 1,
+                            line,
+                            column: pos + 1 - line_start + 1,
+                            kind: Utf8ErrorKind::InvalidContinuationByte,
+                        });
+                    }
+                    if (b2 & 0xC0) != 0x80 {
+                        return Err(Utf8Error {
+                            offset: pos + 2,
+                            line,
+                            column: pos + 2 - line_start + 1,
+                            kind: Utf8ErrorKind::InvalidContinuationByte,
+                        });
+                    }
+                    let cp = ((byte as u32 & 0x0F) << 12)
+                        | ((b1 as u32 & 0x3F) << 6)
+                        | (b2 as u32 & 0x3F);
+                    if cp < 0x800 {
+                        return Err(Utf8Error {
+                            offset: pos,
+                            line,
+                            column: pos - line_start + 1,
+                            kind: Utf8ErrorKind::OverlongEncoding,
+                        });
+                    }
+                    if (0xD800..=0xDFFF).contains(&cp) {
+                        return Err(Utf8Error {
+                            offset: pos,
+                            line,
+                            column: pos - line_start + 1,
+                            kind: Utf8ErrorKind::SurrogateCodepoint,
+                        });
+                    }
+                }
+                4 => {
+                    let b1 = input[pos + 1];
+                    let b2 = input[pos + 2];
+                    let b3 = input[pos + 3];
+                    if (b1 & 0xC0) != 0x80 {
+                        return Err(Utf8Error {
+                            offset: pos + 1,
+                            line,
+                            column: pos + 1 - line_start + 1,
+                            kind: Utf8ErrorKind::InvalidContinuationByte,
+                        });
+                    }
+                    if (b2 & 0xC0) != 0x80 {
+                        return Err(Utf8Error {
+                            offset: pos + 2,
+                            line,
+                            column: pos + 2 - line_start + 1,
+                            kind: Utf8ErrorKind::InvalidContinuationByte,
+                        });
+                    }
+                    if (b3 & 0xC0) != 0x80 {
+                        return Err(Utf8Error {
+                            offset: pos + 3,
+                            line,
+                            column: pos + 3 - line_start + 1,
+                            kind: Utf8ErrorKind::InvalidContinuationByte,
+                        });
+                    }
+                    let cp = ((byte as u32 & 0x07) << 18)
+                        | ((b1 as u32 & 0x3F) << 12)
+                        | ((b2 as u32 & 0x3F) << 6)
+                        | (b3 as u32 & 0x3F);
+                    if cp < 0x10000 {
+                        return Err(Utf8Error {
+                            offset: pos,
+                            line,
+                            column: pos - line_start + 1,
+                            kind: Utf8ErrorKind::OverlongEncoding,
+                        });
+                    }
+                    if cp > 0x10FFFF {
+                        return Err(Utf8Error {
+                            offset: pos,
+                            line,
+                            column: pos - line_start + 1,
+                            kind: Utf8ErrorKind::OutOfRangeCodepoint,
+                        });
+                    }
+                }
+                _ => unreachable!(),
+            }
+
+            pos += seq_len;
+        }
+
+        Ok(())
     }
 }

--- a/src/text/utf8.rs
+++ b/src/text/utf8.rs
@@ -139,10 +139,10 @@ pub fn validate_utf8(input: &[u8]) -> Result<(), Utf8Error> {
 /// on x86_64 CPUs without AVX2, and behind the CLI's `--no-simd`; on AVX2 hosts
 /// it also backs [`validate_utf8`]'s error reporting.
 ///
-/// Runs of ASCII are skipped eight bytes at a time via [`skip_ascii`], while
+/// Runs of ASCII are skipped eight bytes at a time via `skip_ascii`, while
 /// multi-byte sequences are validated one character at a time. Errors carry the
 /// exact byte offset, line number, and column position, derived from the offset
-/// by [`line_and_column`] once an error is found — see its docs for why keeping
+/// by `line_and_column` once an error is found — see its docs for why keeping
 /// that state off the hot path is exact rather than approximate.
 pub fn validate_utf8_scalar(input: &[u8]) -> Result<(), Utf8Error> {
     let mut pos = 0;


### PR DESCRIPTION
## Summary
- Adds an 8-byte broadword (SWAR) ASCII fast path to the scalar UTF-8 validator (`validate_utf8_scalar`), skipping whole ASCII runs via `word & H8 == 0` instead of walking byte-by-byte
- Removes per-byte `line`/`line_start` bookkeeping from the hot loop entirely; `line`/`column` are now derived from the error offset once (and only if) validation fails, using an exact broadword zero-byte test for newline counting
- Adds a `utf8_corpus` benchmark group over the #301 real-workload corpus so throughput claims are gated on real input shapes, not just synthetic patterns
- Updates `docs/benchmarks/utf8-validate.md` with re-measured Apple M4 Pro figures, explicitly flagging the AMD Ryzen 9 7950X / Apple M1 Max sections as pre-#133 and excluded from cross-platform comparison until re-measured

Refs #133

## Measured impact (Apple M4 Pro, scalar engine — the only path on ARM64)
All 44 benchmark arms improved, none regressed:
- ASCII 1MB: 446.39 µs → 33.42 µs (2.2 → 29.2 GiB/s, **-92.5%**)
- Mixed 1MB: **-37.0%**, CJK 1MB: **-31.0%**, Emoji 1MB: **-22.3%**, 2-byte 1MB: **-21.9%**
- Error-at-end (line/column derivation path): **-78.2%**
- Real corpus: **-91% to -93%** across ten files

x86_64 is unmeasured (the 7950X bench box was unreachable); `validate_utf8` dispatches to AVX2 regardless there, so the scalar path only serves `--no-simd`, non-AVX2 CPUs, and error diagnostics.

## Test plan
- [x] `cargo test --lib --features simd` — 1848 passed, 0 failed
- [x] New differential test `scalar_matches_reference_including_error` compares the *entire* `Utf8Error` (offset, line, column, kind) between the shipped validator and a byte-at-a-time oracle, across targeted newline-straddling fixtures plus ~45k randomized/fuzzed inputs
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo bench --bench utf8_validate_bench --no-run` — compiles