### PR TITLE
perf(yaml): recover the CRLF-support regression with a has_cr const-generic fast path (#324 follow-up)

### DIFF
--- a/.claude/skills/yaml-semi-indexing/SKILL.md
+++ b/.claude/skills/yaml-semi-indexing/SKILL.md
@@ -136,15 +136,24 @@ Use the helpers instead of hand-rolling the test:
 
 ```rust
 // src/yaml/parser.rs — the oracle
-Self::is_break(b)          // \n or \r
-self.break_len_at(pos)     // 2 for \r\n, 1 for a lone \r or \n, 0 otherwise
+Self::is_break(b)               // \n or \r
+Self::is_ws_or_break(b)         // ' ' | '\t' | break
+Self::is_space_or_break(b)      // ' ' | break  (no tab)
+Self::is_ws_break_or_eoi(next)  // the indicator lookahead: Option<u8>, EOI counts
+Self::is_space_break_or_eoi(next)
+Self::is_flow_key_terminator(next) // the above plus , } ]
+self.break_len_at(pos)          // 2 for \r\n, 1 for a lone \r or \n, 0 otherwise
 self.at_break()
-self.skip_line_break()     // consumes exactly one break, whatever its width
+self.skip_line_break()          // consumes exactly one break, whatever its width
 
 // src/yaml/light.rs — the query side
 is_line_break(b)
 line_break_len(text, pos)
 ```
+
+Going through a helper is not just tidiness — it is what makes the `HAS_CR`
+specialization possible (see below). A hand-rolled `matches!(b, b'\n' | b'\r')`
+is a site the const generic cannot reach.
 
 Two extra traps:
 
@@ -156,6 +165,32 @@ Two extra traps:
 `tests/yaml_crlf_tests.rs` is the guard: it parses the whole YAML Test Suite
 corpus under all three break forms and demands identical output. Run it after any
 change to a line-scanning loop.
+
+### The `HAS_CR` Specialization
+
+`Parser<'a, const HAS_CR: bool>` (#340). `build_semi_index` runs `contains_cr`
+over the input once — a SIMD byte scan — and picks `Parser::<false>` for the
+LF-only documents that are nearly all of them, which compiles every `\r` arm out
+and restores the pre-#324 codegen. `Parser::<true>` is the #324 parser verbatim.
+
+The rule to internalize when editing a line scan:
+
+- **`HAS_CR == true` is always correct.** Only `false` carries an obligation, and
+  the whole-input precheck discharges it: no `\r` in the input means no `\r` arm
+  is reachable, in any context. There is no quoted-string or block-scalar
+  subtlety, because one `\r` anywhere forces the `true` path.
+- **So gating is a performance knob, not a correctness one.** Leaving a new site
+  un-gated is a missed optimization, never a bug. Gate the hot ones; don't
+  contort cold code to reach them.
+- **Match arms cannot be gated.** `b'\n' | b'\r' =>` is a pattern, and a const
+  cannot reach into it. The hot loops use `b if Self::is_break(b) =>` guards
+  instead. Cold sites keep the literal pattern deliberately.
+
+`both_monomorphizations_agree_on_cr_free_input` in `src/yaml/parser.rs` is the
+guard, and it is the only one: `yaml_crlf_tests` and the CRLF reruns in
+`yq_golden_tests` all feed inputs containing a `\r`, which is exactly the set
+that takes the `true` path. If you gate a site whose `\r` arm was doing something
+other than handling a carriage return, that test is what catches it.
 
 ## Test Suite Notes
 

--- a/.claude/skills/yaml-semi-indexing/SKILL.md
+++ b/.claude/skills/yaml-semi-indexing/SKILL.md
@@ -144,7 +144,6 @@ Self::is_break(b)               // is_line_break, or `== b'\n'` under !HAS_CR
 self.break_len_at(pos)          // line_break_len, or the LF answer under !HAS_CR
 Self::is_ws_or_break(b)         // ' ' | '\t' | break
 Self::is_ws_break_or_eoi(next)  // the indicator lookahead: Option<u8>, EOI counts
-Self::is_flow_key_terminator(next) // the above plus , } ]
 self.at_break()
 self.skip_line_break()          // consumes exactly one break, whatever its width
 ```

--- a/.claude/skills/yaml-semi-indexing/SKILL.md
+++ b/.claude/skills/yaml-semi-indexing/SKILL.md
@@ -143,9 +143,7 @@ line_break_len(text, pos)       // 2 for \r\n, 1 for a lone \r or \n, 0 otherwis
 Self::is_break(b)               // is_line_break, or `== b'\n'` under !HAS_CR
 self.break_len_at(pos)          // line_break_len, or the LF answer under !HAS_CR
 Self::is_ws_or_break(b)         // ' ' | '\t' | break
-Self::is_space_or_break(b)      // ' ' | break  (no tab)
 Self::is_ws_break_or_eoi(next)  // the indicator lookahead: Option<u8>, EOI counts
-Self::is_space_break_or_eoi(next)
 Self::is_flow_key_terminator(next) // the above plus , } ]
 self.at_break()
 self.skip_line_break()          // consumes exactly one break, whatever its width

--- a/.claude/skills/yaml-semi-indexing/SKILL.md
+++ b/.claude/skills/yaml-semi-indexing/SKILL.md
@@ -135,25 +135,30 @@ a scan that stops only at `\n` is a bug in two distinct ways (#324):
 Use the helpers instead of hand-rolling the test:
 
 ```rust
-// src/yaml/parser.rs — the oracle
-Self::is_break(b)               // \n or \r
+// src/yaml/line_break.rs — the rule, defined once, for every consumer (#341)
+is_line_break(b)                // \n or \r
+line_break_len(text, pos)       // 2 for \r\n, 1 for a lone \r or \n, 0 otherwise
+
+// src/yaml/parser.rs — the oracle, where the HAS_CR gate lives (#340)
+Self::is_break(b)               // is_line_break, or `== b'\n'` under !HAS_CR
+self.break_len_at(pos)          // line_break_len, or the LF answer under !HAS_CR
 Self::is_ws_or_break(b)         // ' ' | '\t' | break
 Self::is_space_or_break(b)      // ' ' | break  (no tab)
 Self::is_ws_break_or_eoi(next)  // the indicator lookahead: Option<u8>, EOI counts
 Self::is_space_break_or_eoi(next)
 Self::is_flow_key_terminator(next) // the above plus , } ]
-self.break_len_at(pos)          // 2 for \r\n, 1 for a lone \r or \n, 0 otherwise
 self.at_break()
 self.skip_line_break()          // consumes exactly one break, whatever its width
-
-// src/yaml/light.rs — the query side
-is_line_break(b)
-line_break_len(text, pos)
 ```
 
-Going through a helper is not just tidiness — it is what makes the `HAS_CR`
-specialization possible (see below). A hand-rolled `matches!(b, b'\n' | b'\r')`
-is a site the const generic cannot reach.
+Inside the oracle prefer the `Self::`/`self.` forms over the free functions: they
+are the same rule, but they are also where `HAS_CR` switches. Calling
+`is_line_break` directly from a parser hot path silently opts that site out of the
+specialization — correct, just slower. `current_line` does exactly that on
+purpose, being an error path.
+
+Going through a helper at all is not just tidiness. A hand-rolled
+`matches!(b, b'\n' | b'\r')` is a site the const generic cannot reach.
 
 Two extra traps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   codegen. Interleaved `yaml_bench` versus `c5dab403`, excluding block scalars:
   ARM (M4 Pro) +4.0% → **+0.7%**, x86 (7950X) +11.0% → **+4.7%**, with x86 block
   scalars 31–34% *faster* than the pre-#324 baseline. End-to-end `yq` over 32
-  configurations: +5.0% → **+0.8%** median. CRLF documents are unchanged (+1.1%
-  median, the precheck early-exiting). Output is byte-identical to #324 across
-  244 file × query configurations on both architectures.
+  configurations recovers completely: x86 +5.0% → **+0.8%** median, ARM +2.3% →
+  **−0.2%**. CRLF documents are unchanged (+1.1% x86 / +0.5% ARM, the precheck
+  early-exiting). Output is byte-identical to #324 across 244 file × query
+  configurations on both architectures.
 
   The one shape that regresses is long quoted scalars, +7% to +12%: the parser
   bulk-skips those at ~15 GB/s, so the precheck's second pass over the input is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **YAML parsing specializes on whether the document contains a carriage return**
+  (#340), recovering most of the cost #324 paid for CRLF and lone-CR
+  correctness. `build_semi_index` runs one SIMD pass over the input and parses
+  with `Parser::<false>` or `Parser::<true>`; the LF-only monomorphization —
+  nearly every document — compiles out every `\r` arm and keeps the pre-#324
+  codegen. Interleaved `yaml_bench` versus `c5dab403`, excluding block scalars:
+  ARM (M4 Pro) +4.0% → **+0.7%**, x86 (7950X) +11.0% → **+4.7%**, with x86 block
+  scalars 31–34% *faster* than the pre-#324 baseline. End-to-end `yq` over 32
+  configurations: +5.0% → **+0.8%** median. CRLF documents are unchanged (+1.1%
+  median, the precheck early-exiting). Output is byte-identical to #324 across
+  244 file × query configurations on both architectures.
+
+  The one shape that regresses is long quoted scalars, +7% to +12%: the parser
+  bulk-skips those at ~15 GB/s, so the precheck's second pass over the input is
+  large next to the parse it precedes. That is the standing cost of the gate.
+
+  **Breaking** (low-level): `succinctly::yaml::simd::classify_yaml_chars` takes a
+  `const HAS_CR: bool` parameter — call it as `classify_yaml_chars::<true>(..)`
+  for the previous behaviour.
+
 ### Added
 
 - **jq streaming builtins `tostream`, `fromstream(f)`, `truncate_stream(f)`**
@@ -1775,8 +1797,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Correctness here has a measured price on LF input: `yaml_bench` index build is
   +14.9% median on x86 (7950X) and +6.9% on ARM (M4 Pro) excluding block scalars,
   which are 8–18% *faster* on x86; end-to-end `yq` on a 1 MB document moves
-  +1.8% (`.`) to +6.4% (`.[].name`). See `docs/parsing/yaml.md` for the
-  per-change attribution and the const-generic option that would buy it back.
+  +1.8% (`.`) to +6.4% (`.[].name`). Most of that is bought back in #340 (below);
+  see `docs/parsing/yaml.md` for the per-change attribution.
 - **YAML anchors on sequence items whose value is a collection** (#328): `- &m`
   followed by an indented mapping was read as a multi-line plain scalar, so
   `list:\n  - &m\n    k: v\n  - *m` came out as `{"list":["k"],"v":["k"]}` — a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -640,7 +640,7 @@ For detailed documentation on optimization techniques used in this project, see 
 - ✅ O5 (`HAS_CR` Const-Generic Specialization): **recovers most of the #324 CRLF-correctness cost**, issue #340
   - `build_semi_index` SIMD-scans once for `\r`, then parses with `Parser::<false>` (LF-only) or `Parser::<true>` (#324 parser verbatim)
   - Interleaved `yaml_bench` vs `c5dab403`, excl. block scalars: **M4 Pro +4.0% → +0.7%**, **7950X +11.0% → +4.7%**; x86 block scalars 31-34% *faster* than pre-#324
-  - End-to-end `dev bench yq` (32 configs, 7950X): **+5.0% → +0.8%** median; CRLF documents +1.1% (unchanged); binary +52 KB (+0.9%)
+  - End-to-end `dev bench yq` (32 configs) recovers fully: **7950X +5.0% → +0.8%**, **M4 Pro +2.3% → −0.2%** median; CRLF documents +1.1%/+0.5% (unchanged); binary +52 KB (+0.9%)
   - **The gate is one-directional**: `true` is always correct, and the whole-input precheck proves no `\r` arm is reachable under `false`. An un-gated site is a missed optimization, never a bug — so gating can be applied incrementally and measured
   - **Cost the estimate missed**: long quoted scalars regress +7-12%. The parser bulk-skips them at ~15 GB/s, so a second pass over the input is large next to the parse. Reusing the position-finding `define_escape_scanner!` first made it **+42%**; an existence-only scan (OR the chunk compares, reduce once) was needed
   - Key insight: a precheck that enables a fast path is charged to *every* input, including the ones it cannot help — measure it against the workload where the parser is already fastest, not the one it is slowest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -637,6 +637,14 @@ For detailed documentation on optimization techniques used in this project, see 
   - **16-byte threshold + `#[inline(always)]`**: Both required to prevent regression (threshold alone still caused 3-5% regression)
   - Best for: YAML with long string values (logs, templates, embedded content)
   - See [docs/parsing/yaml.md#o3-simd-escape-scanning-for-json-output--accepted-](docs/parsing/yaml.md#o3-simd-escape-scanning-for-json-output--accepted-) for full analysis
+- ✅ O5 (`HAS_CR` Const-Generic Specialization): **recovers most of the #324 CRLF-correctness cost**, issue #340
+  - `build_semi_index` SIMD-scans once for `\r`, then parses with `Parser::<false>` (LF-only) or `Parser::<true>` (#324 parser verbatim)
+  - Interleaved `yaml_bench` vs `c5dab403`, excl. block scalars: **M4 Pro +4.0% → +0.7%**, **7950X +11.0% → +4.7%**; x86 block scalars 31-34% *faster* than pre-#324
+  - End-to-end `dev bench yq` (32 configs, 7950X): **+5.0% → +0.8%** median; CRLF documents +1.1% (unchanged); binary +52 KB (+0.9%)
+  - **The gate is one-directional**: `true` is always correct, and the whole-input precheck proves no `\r` arm is reachable under `false`. An un-gated site is a missed optimization, never a bug — so gating can be applied incrementally and measured
+  - **Cost the estimate missed**: long quoted scalars regress +7-12%. The parser bulk-skips them at ~15 GB/s, so a second pass over the input is large next to the parse. Reusing the position-finding `define_escape_scanner!` first made it **+42%**; an existence-only scan (OR the chunk compares, reduce once) was needed
+  - Key insight: a precheck that enables a fast path is charged to *every* input, including the ones it cannot help — measure it against the workload where the parser is already fastest, not the one it is slowest
+  - See [docs/parsing/yaml.md#buying-it-back-the-has_cr-specialization](docs/parsing/yaml.md#buying-it-back-the-has_cr-specialization) for full analysis
 - ✅ O4 (seq_items Bitvector Elimination): **−12.5% build peak memory, 2-6% faster builds**, issues #75/#104/#106
   - Removed the stored `seq_items` bitvector; seq-item wrappers are derived from text (`-` + whitespace/EOI)
   - Branchless `matches!` derivation at both detection sites recovers the 7-15% query regression #106 found in the naive form

--- a/benches/yaml_bench.rs
+++ b/benches/yaml_bench.rs
@@ -466,6 +466,54 @@ fn bench_prose_scalars(c: &mut Criterion) {
     group.finish();
 }
 
+/// Rewrite every LF as a CRLF, as `tests/yaml_crlf_tests.rs` does.
+fn to_crlf(yaml: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(yaml.len() + yaml.len() / 16);
+    for &b in yaml {
+        if b == b'\n' {
+            out.push(b'\r');
+        }
+        out.push(b);
+    }
+    out
+}
+
+/// The CRLF arm of the `HAS_CR` specialization (#340).
+///
+/// Every other generator in this file emits LF only, so without this group the
+/// `HAS_CR == true` path is not measured at all — and "all benchmarks neutral"
+/// is not evidence about a shape the suite does not generate (see
+/// `docs/guides/benchmarking.md` § A/B, rule 7). These cases exist to show that
+/// CRLF documents did not *lose* anything to the specialization; the LF-only
+/// gain is what the other groups measure.
+///
+/// Deliberately not a full mirror of the suite: the CR path is the #324 parser
+/// unchanged, so a representative slice of the shapes whose LF counterparts moved
+/// most is what is worth the bench time.
+fn bench_crlf(c: &mut Criterion) {
+    let mut group = c.benchmark_group("yaml/crlf");
+
+    let cases: [(&str, Vec<u8>); 4] = [
+        ("simple_kv/1000", generate_simple_kv(1000)),
+        ("sequences/1000", generate_sequence(1000)),
+        ("large/100kb", generate_mixed_yaml(100_000)),
+        ("large/1mb", generate_mixed_yaml(1_000_000)),
+    ];
+
+    for (label, lf) in &cases {
+        let yaml = to_crlf(lf);
+        group.throughput(Throughput::Bytes(yaml.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(label), &yaml, |b, yaml| {
+            b.iter(|| {
+                let index = YamlIndex::build(black_box(yaml)).unwrap();
+                black_box(index)
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_simple_kv,
@@ -477,5 +525,6 @@ criterion_group!(
     bench_block_scalars,
     bench_anchors,
     bench_prose_scalars,
+    bench_crlf,
 );
 criterion_main!(benches);

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -290,18 +290,20 @@ which is a different measurement session and shorter criterion sampling, not a
 change in the code — the point of re-measuring all three arms in one interleaved
 sweep is that only within-sweep comparisons are load-bearing.
 
-CRLF documents are unaffected: the `yaml/crlf` group moves +1.1% median (−0.9% to
-+1.9%) on the 7950X against the #324 parser, which is the precheck early-exiting
-on the first line.
+CRLF documents are unaffected: against the #324 parser the `yaml/crlf` group moves
++1.1% median on the 7950X and +0.5% on the M4 Pro, which is the precheck
+early-exiting on the first line and then doing exactly what #324 did.
 
-End-to-end recovers further, because index build is only part of the pipeline and
-the query side was never regressed. `dev bench yq`, 4 patterns x {1mb, 10mb} x 4
-queries = 32 configurations, same interleaving, 7950X:
+End-to-end recovers completely, because index build is only part of the pipeline
+and the query side was never regressed. `dev bench yq`, 4 patterns x {1mb, 10mb}
+x 4 queries = 32 configurations, same interleaving:
 
-| arm      | median | worst |
-|----------|--------|-------|
-| #324     | +5.0%  | +12.3% (`nested/10mb length`) |
-| **#340** | **+0.8%** | +4.5% (`comprehensive/10mb .[0]`) |
+| Machine           | arm      | median    | worst                             |
+|-------------------|----------|-----------|-----------------------------------|
+| AMD Ryzen 9 7950X | #324     | +5.0%     | +12.3% (`nested/10mb length`)     |
+| AMD Ryzen 9 7950X | **#340** | **+0.8%** | +4.5% (`comprehensive/10mb .[0]`) |
+| Apple M4 Pro      | #324     | +2.3%     | +8.0%                             |
+| Apple M4 Pro      | **#340** | **−0.2%** | +3.0% (`users/10mb .[0]`)         |
 
 Output identity was gated before any of these timings were believed: 244
 (file x query) configurations on both architectures, byte-identical between the

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -197,10 +197,17 @@ scalar content, so every scan that stops at `\n` must stop at `\r` too.
 | `\r\n` | 2 bytes | Windows — **one** break, so a scan must consume both       |
 | `\r`   | 1 byte  | Classic Mac — a break with no LF to backstop a `\n`-only scan |
 
-**Resolution**: `Parser::{is_break, break_len_at, at_break, skip_line_break}` are
-the single source of truth in the oracle; `light.rs` has the free-function pair
-`is_line_break` / `line_break_len` for the query side. Use them rather than
-testing `b'\n'` by hand.
+**Resolution**: `yaml/line_break.rs` holds the rule in one place —
+`is_line_break` and `line_break_len` — for every consumer of YAML text: the
+oracle, the cursor, the validator and the newline index (#341). Use them rather
+than testing `b'\n'` by hand.
+
+Two wrappers in the oracle look like exceptions and are not.
+`Parser::{is_break, break_len_at}` exist so the `HAS_CR` const generic has
+somewhere to switch (see below); their CR-aware arms call straight through to the
+shared pair, so the rule is still defined once. `Parser::skip_line_break` is the
+one genuine restatement, kept for the measured reason on its doc comment and
+pinned to `line_break_len` by `skip_line_break_agrees_with_line_break_len`.
 
 Two failure modes are worth naming, because [#324](https://github.com/rust-works/succinctly/issues/324)
 hit both:

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -257,10 +257,79 @@ too — a blank line between mapping entries makes `a: 1\r\n\r\nb: 2\r\n` resolv
 as `{"a": "1\n", …}` without them. "CRLF is nearly free, only lone CR costs" is
 an appealing theory that the differential harness disproves in 8 corpus cases.
 
-Recovering the rest would mean gating the parser on a `has_cr` flag via a const
-generic, so LF documents keep the original codegen exactly. That buys back the
-diffuse cost at the price of one input scan (~2%), a doubled parser
-monomorphization, and CR-conditioning roughly 25 call sites.
+#### Buying it back: the `HAS_CR` specialization
+
+[#340](https://github.com/rust-works/succinctly/issues/340) took the const-generic
+option this section used to describe as hypothetical. `build_semi_index` runs one
+SIMD pass to answer "is there a `\r` anywhere in this input", then parses with
+`Parser::<false>` or `Parser::<true>`. The LF-only monomorphization compiles every
+`\r` arm out; the CR one is the #324 parser verbatim.
+
+The gate is one-directional, which is what makes it safe to apply incrementally:
+`HAS_CR == true` is always correct, and the whole-input precheck discharges the
+obligation on `false` outright — no `\r` in the input means no `\r` arm is
+reachable, in any context. A site left un-gated is a missed optimization, never a
+bug. Match arms are the one place the const cannot reach (`b'\n' | b'\r' =>` is a
+pattern), so the hot loops use `b if Self::is_break(b) =>` guards and cold sites
+keep the literal.
+
+Interleaved A/B, 3 arms x 3 reps rotated so no arm keeps the thermally-loaded
+slot, `yaml_bench`, all three versus `c5dab403`:
+
+| Machine           | arm      | median | excl. block scalars | block scalars    |
+|-------------------|----------|--------|---------------------|------------------|
+| AMD Ryzen 9 7950X | #324     | +9.1%  | +11.0%              | −11% to −19%     |
+| AMD Ryzen 9 7950X | **#340** | +4.2%  | **+4.7%**           | **−31% to −34%** |
+| Apple M4 Pro      | #324     | +3.6%  | +4.0%               | −6% to +3%       |
+| Apple M4 Pro      | **#340** | +0.8%  | **+0.7%**           | −6% to +3%       |
+
+ARM recovers essentially completely; x86 gets about half back, and its block
+scalars end up well ahead of both baselines. The #324 arms here re-measure a
+little lower than the numbers recorded above (+10.3%/+14.9% and +5.0%/+6.9%),
+which is a different measurement session and shorter criterion sampling, not a
+change in the code — the point of re-measuring all three arms in one interleaved
+sweep is that only within-sweep comparisons are load-bearing.
+
+CRLF documents are unaffected: the `yaml/crlf` group moves +1.1% median (−0.9% to
++1.9%) on the 7950X against the #324 parser, which is the precheck early-exiting
+on the first line.
+
+End-to-end recovers further, because index build is only part of the pipeline and
+the query side was never regressed. `dev bench yq`, 4 patterns x {1mb, 10mb} x 4
+queries = 32 configurations, same interleaving, 7950X:
+
+| arm      | median | worst |
+|----------|--------|-------|
+| #324     | +5.0%  | +12.3% (`nested/10mb length`) |
+| **#340** | **+0.8%** | +4.5% (`comprehensive/10mb .[0]`) |
+
+Output identity was gated before any of these timings were believed: 244
+(file x query) configurations on both architectures, byte-identical between the
+#324 parser and #340, and the eight `.[0]` cases where succinctly diverges from
+real `yq` are the same eight in all three arms.
+
+Two things this cost that the estimate above got wrong:
+
+- **"One input scan (~2%)" holds only for documents the parser walks.** It does
+  not hold for ones it *skips*. `long_strings/4096b` is 410 KB of quoted content
+  bulk-skipped at ~15 GB/s, so index build is ~28 µs and a second pass over the
+  input is enormous next to it. The first implementation reused
+  `define_escape_scanner!`, which finds the *position* of a match and pays a
+  movemask extraction per chunk; it put that benchmark **+42%**. Rewriting the
+  precheck as an existence scan — OR the chunk compares, reduce once, 64 bytes
+  per reduction on NEON/SSE2 and 128 on AVX2 — brought it to +7% to +12% on both
+  machines. That residual is the honest floor for any approach that reads the
+  input twice, and `long_strings` is the one group where #340 is *worse* than
+  #324 rather than better. It is the price of the gate, paid by every document
+  including the ones the gate cannot help.
+- **The monomorphization is cheaper than feared.** The release binary grows
+  52 KB (+0.9%), not the doubling the word "doubled" suggests: only the code
+  reachable from both instantiations is duplicated.
+
+Analysed and *not* done: gating `parse_anchor_name`'s CR terminator. Real anchor
+names are 5-20 bytes, below the 32-byte AVX2 threshold, so the vector loop
+carrying the CR compare rarely runs at all — the P5 lesson about SIMD wins that
+do not exist at real input sizes.
 
 ---
 

--- a/src/util/simd/escape.rs
+++ b/src/util/simd/escape.rs
@@ -1,24 +1,29 @@
 #![allow(unsafe_code)] // runtime SIMD feature dispatch for escape scanning
-//! Shared SIMD escape scanning.
+//! Shared SIMD byte scanning.
 //!
-//! Finds the next byte in a string that a text format would need to *escape* —
-//! the hot inner loop of streaming-output transcoders. Historically this lived in
-//! `yaml/simd/` while `jq/stream.rs` consumed it, making jq depend on yaml
-//! internals (#125). It now lives here as a neutral, shared utility that any
-//! consumer (jq streaming, jq/yq output escaping in #91, jq format functions in
-//! #124) can use without a cross-module dependency.
+//! Finds the next byte in a buffer matching a predicate. The original consumer —
+//! and the reason for the module's name — is "the next byte a text format would
+//! need to *escape*", the hot inner loop of streaming-output transcoders.
+//! Historically this lived in `yaml/simd/` while `jq/stream.rs` consumed it,
+//! making jq depend on yaml internals (#125). It now lives here as a neutral,
+//! shared utility that any consumer (jq streaming, jq/yq output escaping in #91,
+//! jq format functions in #124) can use without a cross-module dependency.
 //!
 //! ## The predicate seam
 //!
 //! The scanning machinery — the 16/32-byte SIMD chunk loop, the movemask +
 //! `trailing_zeros` position extraction, and the scalar remainder — is identical
-//! across escape predicates; only the *set of bytes considered special* differs
+//! across predicates; only the *set of bytes considered special* differs
 //! (JSON escapes `"` / `\` / `< 0x20`; a future `@html` scanner would want
 //! `<` / `>` / `&` / `'` / `"`, etc.). [`define_escape_scanner!`] captures the
 //! machinery once and takes the predicate as a parameter: a scalar `|b| ...`
 //! expression plus three per-backend mask helpers (NEON / AVX2 / SSE2). Adding a
 //! new scanner (#124) is a new macro invocation, not another refactor of this
-//! file. Only [`find_json_escape`] is instantiated today.
+//! file.
+//!
+//! Two are instantiated: [`find_json_escape`] and [`contains_cr`]. The second is
+//! not an escape predicate at all — it is the #340 `has_cr` precheck — which is
+//! the point of the seam: the predicate is the parameter, the machinery is not.
 //!
 //! ## Dispatch
 //!
@@ -403,6 +408,69 @@ pub fn find_json_escape(bytes: &[u8], start: usize) -> usize {
     json_escape::find(bytes, start)
 }
 
+// ---- Carriage-return predicate ---------------------------------------------
+//
+// Not an escape predicate: this is the `has_cr` precheck the YAML oracle uses to
+// pick its `HAS_CR` monomorphization (#340). A single byte compare, so the mask
+// helpers below are one intrinsic each.
+
+/// NEON match mask for `\r`.
+#[cfg(all(
+    target_arch = "aarch64",
+    not(feature = "broadword-yaml"),
+    not(feature = "scalar-yaml")
+))]
+#[inline]
+#[target_feature(enable = "neon")]
+unsafe fn cr_neon_mask(chunk: uint8x16_t) -> uint8x16_t {
+    vceqq_u8(chunk, vdupq_n_u8(b'\r'))
+}
+
+/// AVX2 match mask for `\r`.
+#[cfg(all(
+    target_arch = "x86_64",
+    not(feature = "scalar-yaml"),
+    any(test, feature = "std")
+))]
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn cr_avx2_mask(chunk: __m256i) -> __m256i {
+    _mm256_cmpeq_epi8(chunk, _mm256_set1_epi8(b'\r' as i8))
+}
+
+/// SSE2 match mask for `\r`.
+#[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
+#[inline]
+#[target_feature(enable = "sse2")]
+unsafe fn cr_sse2_mask(chunk: __m128i) -> __m128i {
+    _mm_cmpeq_epi8(chunk, _mm_set1_epi8(b'\r' as i8))
+}
+
+define_escape_scanner! {
+    /// Carriage-return scanner (the #340 `has_cr` precheck).
+    mod cr_scan;
+    scalar: |b| b == b'\r';
+    neon_mask: cr_neon_mask;
+    avx2_mask: cr_avx2_mask;
+    sse2_mask: cr_sse2_mask;
+}
+
+/// Does `input` contain a carriage return anywhere?
+///
+/// The YAML oracle calls this once per document to choose between its two
+/// `HAS_CR` monomorphizations (#340). A `false` answer means every `\r` arm in
+/// the parser is provably dead for this input, so the LF-only specialization can
+/// drop them and keep the pre-#324 codegen.
+///
+/// SIMD is load-bearing here rather than decorative: `YamlIndex::build` runs at
+/// ~250-400 MiB/s, so a byte-at-a-time precheck would cost several percent of the
+/// build it is meant to speed up, while a 16-32 byte/iteration scan costs a
+/// fraction of one.
+#[inline]
+pub fn contains_cr(input: &[u8]) -> bool {
+    cr_scan::find(input, 0) < input.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -752,6 +820,128 @@ mod tests {
         fn neon_returns_len_when_start_past_end() {
             // The kernel's own `start >= len` guard, not reached through find().
             assert_eq!(super::super::json_escape::neon(b"abc", 9), 3);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // The `has_cr` precheck (#340).
+    //
+    // Both directions of a wrong answer matter, and only one of them is loud.
+    // Under-reporting (`false` when a `\r` is present) sends a CRLF document down
+    // the LF-only parser and silently corrupts it — `tests/yaml_crlf_tests.rs` and
+    // the CRLF/CR reruns in `tests/yq_golden_tests.rs` catch that. Over-reporting
+    // (`true` for a CR-free document) is *correct* and merely gives up the whole
+    // optimization, so nothing else in the suite would notice; that is what these
+    // exact-agreement tests are for.
+    // ------------------------------------------------------------------------
+    mod cr_precheck {
+        use super::super::contains_cr;
+
+        /// Independent reference, deliberately not `cr_scan::scalar`.
+        fn reference(bytes: &[u8]) -> bool {
+            bytes.contains(&b'\r')
+        }
+
+        #[test]
+        fn agrees_with_reference_on_shapes() {
+            let cases: Vec<Vec<u8>> = vec![
+                b"".to_vec(),
+                b"\r".to_vec(),
+                b"\n".to_vec(),
+                b"a: 1\n".to_vec(),
+                b"a: 1\r\n".to_vec(),
+                b"a: 1\rb: 2".to_vec(),
+                b"no breaks at all".to_vec(),
+                vec![b'a'; 1000],
+                // 0x0A and 0x0D differ in one bit; a mask built for the wrong
+                // constant would still "find line breaks" and read as working.
+                b"lots\nof\nline\nfeeds\nbut\nno\ncarriage\nreturns\n".to_vec(),
+            ];
+            for input in &cases {
+                assert_eq!(
+                    reference(input),
+                    contains_cr(input),
+                    "mismatch for {input:?}"
+                );
+            }
+        }
+
+        /// A `\r` anywhere must be seen, whichever kernel path covers that offset.
+        ///
+        /// Lengths straddle the 16-byte (NEON/SSE2), 32-byte (AVX2) and 48-byte
+        /// (AVX2 + SSE2 tail) boundaries, so each length exercises a different mix
+        /// of vector loop and scalar remainder — a `\r` living only in the tail is
+        /// exactly what a chunk-loop-only scan would miss.
+        #[test]
+        fn finds_a_cr_at_every_offset_and_length() {
+            for len in [0usize, 1, 15, 16, 17, 31, 32, 33, 47, 48, 63, 64, 65, 129] {
+                let clean = vec![b'a'; len];
+                assert!(!contains_cr(&clean), "false positive at len {len}");
+                for pos in 0..len {
+                    let mut input = clean.clone();
+                    input[pos] = b'\r';
+                    assert!(contains_cr(&input), "missed CR at {pos} of {len}");
+                }
+            }
+        }
+
+        /// No other byte may be mistaken for `\r` — in particular not `\n`.
+        #[test]
+        fn no_other_byte_reports_as_cr() {
+            for byte in 0u8..=255 {
+                for pos in [0usize, 15, 16, 31, 32, 40] {
+                    let mut input = vec![b'a'; 48];
+                    input[pos] = byte;
+                    assert_eq!(
+                        byte == b'\r',
+                        contains_cr(&input),
+                        "byte {byte:#04x} at {pos}"
+                    );
+                }
+            }
+        }
+
+        /// The scalar fallback is the only path in a `scalar-yaml` build and the
+        /// short-input path everywhere else; check it directly on every target.
+        #[test]
+        fn scalar_fallback_matches_reference() {
+            for len in [0usize, 1, 5, 16, 33] {
+                let clean = vec![b'z'; len];
+                assert_eq!(super::super::cr_scan::scalar(&clean, 0), len);
+                for pos in 0..len {
+                    let mut input = clean.clone();
+                    input[pos] = b'\r';
+                    assert_eq!(super::super::cr_scan::scalar(&input, 0), pos);
+                }
+            }
+        }
+
+        /// Both x86 tiers, since `find` only ever picks one of them on a given
+        /// runner and the SSE2 baseline would otherwise go untested on AVX2
+        /// hardware (#193).
+        #[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
+        #[test]
+        fn both_x86_tiers_agree() {
+            let has_avx2 =
+                crate::util::simd::note_simd_skip_unless(is_x86_feature_detected!("avx2"), "avx2");
+            for len in [16usize, 32, 48, 64] {
+                for pos in 0..len {
+                    let mut input = vec![b'a'; len];
+                    input[pos] = b'\r';
+                    assert_eq!(
+                        super::super::cr_scan::dispatch(&input, 0, false),
+                        pos,
+                        "SSE2 missed CR at {pos} of {len}"
+                    );
+                    if has_avx2 {
+                        assert_eq!(
+                            super::super::cr_scan::dispatch(&input, 0, true),
+                            pos,
+                            "AVX2 missed CR at {pos} of {len}"
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/src/util/simd/escape.rs
+++ b/src/util/simd/escape.rs
@@ -567,7 +567,7 @@ pub fn contains_cr(input: &[u8]) -> bool {
     ))]
     {
         // SAFETY: NEON is mandatory on aarch64.
-        return unsafe { contains_cr_neon(input) };
+        unsafe { contains_cr_neon(input) }
     }
 
     #[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
@@ -578,7 +578,7 @@ pub fn contains_cr(input: &[u8]) -> bool {
             return unsafe { contains_cr_avx2(input) };
         }
         // SAFETY: SSE2 is the x86_64 baseline.
-        return unsafe { contains_cr_sse2(input) };
+        unsafe { contains_cr_sse2(input) }
     }
 
     // Scalar: under `scalar-yaml`, on aarch64 under `broadword-yaml` (no

--- a/src/util/simd/escape.rs
+++ b/src/util/simd/escape.rs
@@ -19,11 +19,12 @@
 //! machinery once and takes the predicate as a parameter: a scalar `|b| ...`
 //! expression plus three per-backend mask helpers (NEON / AVX2 / SSE2). Adding a
 //! new scanner (#124) is a new macro invocation, not another refactor of this
-//! file.
+//! file. [`find_json_escape`] is its only instantiation.
 //!
-//! Two are instantiated: [`find_json_escape`] and [`contains_cr`]. The second is
-//! not an escape predicate at all — it is the #340 `has_cr` precheck — which is
-//! the point of the seam: the predicate is the parameter, the machinery is not.
+//! [`contains_cr`] also lives here, but is hand-written rather than generated:
+//! it answers "is there a match anywhere" rather than "where is the first one",
+//! and skipping the per-chunk position extraction is worth several times the
+//! throughput. See the comment above its kernels (#340).
 //!
 //! ## Dispatch
 //!
@@ -408,51 +409,143 @@ pub fn find_json_escape(bytes: &[u8], start: usize) -> usize {
     json_escape::find(bytes, start)
 }
 
-// ---- Carriage-return predicate ---------------------------------------------
+// ---- Carriage-return existence scan -----------------------------------------
 //
-// Not an escape predicate: this is the `has_cr` precheck the YAML oracle uses to
-// pick its `HAS_CR` monomorphization (#340). A single byte compare, so the mask
-// helpers below are one intrinsic each.
+// The `has_cr` precheck the YAML oracle uses to pick its `HAS_CR`
+// monomorphization (#340). Deliberately NOT a `define_escape_scanner!`
+// instantiation, even though the predicate would fit in one line there.
+//
+// That machinery answers "where is the first match", and paying for the position
+// is what made the first attempt at this too slow to ship. Its per-chunk cost is
+// dominated by extracting a bitmask — on NEON that is the shift/multiply
+// movemask emulation, roughly eleven operations per sixteen bytes. The precheck
+// does not want a position; it wants one bit for the whole buffer. So it ORs the
+// per-chunk compares together and reduces once, which lets it run four chunks
+// per iteration and touch the reduction once per 64 (NEON/SSE2) or 128 (AVX2)
+// bytes.
+//
+// The difference is not academic. `yaml_bench`'s `long_strings/4096b` is 410 KB
+// that the parser bulk-skips at ~15 GB/s, so index build is ~28 µs; a
+// position-finding precheck added ~12 µs to that — a 42% regression on the very
+// benchmark the specialization was supposed to leave alone.
+//
+// The loop still early-exits, which costs nothing in the common case (a CR-free
+// document is scanned to the end either way) and helps CRLF documents, which
+// usually hit a `\r` in the first line.
 
-/// NEON match mask for `\r`.
+/// NEON: 64 bytes per iteration, one horizontal reduce.
 #[cfg(all(
     target_arch = "aarch64",
     not(feature = "broadword-yaml"),
     not(feature = "scalar-yaml")
 ))]
-#[inline]
 #[target_feature(enable = "neon")]
-unsafe fn cr_neon_mask(chunk: uint8x16_t) -> uint8x16_t {
-    vceqq_u8(chunk, vdupq_n_u8(b'\r'))
+unsafe fn contains_cr_neon(bytes: &[u8]) -> bool {
+    let needle = vdupq_n_u8(b'\r');
+    let p = bytes.as_ptr();
+    let n = bytes.len();
+    let mut i = 0;
+
+    while i + 64 <= n {
+        let m = vorrq_u8(
+            vorrq_u8(
+                vceqq_u8(vld1q_u8(p.add(i)), needle),
+                vceqq_u8(vld1q_u8(p.add(i + 16)), needle),
+            ),
+            vorrq_u8(
+                vceqq_u8(vld1q_u8(p.add(i + 32)), needle),
+                vceqq_u8(vld1q_u8(p.add(i + 48)), needle),
+            ),
+        );
+        if vmaxvq_u8(m) != 0 {
+            return true;
+        }
+        i += 64;
+    }
+    while i + 16 <= n {
+        if vmaxvq_u8(vceqq_u8(vld1q_u8(p.add(i)), needle)) != 0 {
+            return true;
+        }
+        i += 16;
+    }
+    bytes[i..].contains(&b'\r')
 }
 
-/// AVX2 match mask for `\r`.
+/// AVX2: 128 bytes per iteration, one `vptest`.
 #[cfg(all(
     target_arch = "x86_64",
     not(feature = "scalar-yaml"),
     any(test, feature = "std")
 ))]
-#[inline]
 #[target_feature(enable = "avx2")]
-unsafe fn cr_avx2_mask(chunk: __m256i) -> __m256i {
-    _mm256_cmpeq_epi8(chunk, _mm256_set1_epi8(b'\r' as i8))
+unsafe fn contains_cr_avx2(bytes: &[u8]) -> bool {
+    let needle = _mm256_set1_epi8(b'\r' as i8);
+    let p = bytes.as_ptr();
+    let n = bytes.len();
+    let mut i = 0;
+
+    while i + 128 <= n {
+        let load = |off: usize| _mm256_loadu_si256(p.add(i + off).cast::<__m256i>());
+        let m = _mm256_or_si256(
+            _mm256_or_si256(
+                _mm256_cmpeq_epi8(load(0), needle),
+                _mm256_cmpeq_epi8(load(32), needle),
+            ),
+            _mm256_or_si256(
+                _mm256_cmpeq_epi8(load(64), needle),
+                _mm256_cmpeq_epi8(load(96), needle),
+            ),
+        );
+        // testz sets ZF when the AND is all-zero; m & m == m, so ZF == "no match".
+        if _mm256_testz_si256(m, m) == 0 {
+            return true;
+        }
+        i += 128;
+    }
+    while i + 32 <= n {
+        let m = _mm256_cmpeq_epi8(_mm256_loadu_si256(p.add(i).cast::<__m256i>()), needle);
+        if _mm256_testz_si256(m, m) == 0 {
+            return true;
+        }
+        i += 32;
+    }
+    bytes[i..].contains(&b'\r')
 }
 
-/// SSE2 match mask for `\r`.
+/// SSE2 baseline: 64 bytes per iteration, one movemask.
 #[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
-#[inline]
 #[target_feature(enable = "sse2")]
-unsafe fn cr_sse2_mask(chunk: __m128i) -> __m128i {
-    _mm_cmpeq_epi8(chunk, _mm_set1_epi8(b'\r' as i8))
-}
+unsafe fn contains_cr_sse2(bytes: &[u8]) -> bool {
+    let needle = _mm_set1_epi8(b'\r' as i8);
+    let p = bytes.as_ptr();
+    let n = bytes.len();
+    let mut i = 0;
 
-define_escape_scanner! {
-    /// Carriage-return scanner (the #340 `has_cr` precheck).
-    mod cr_scan;
-    scalar: |b| b == b'\r';
-    neon_mask: cr_neon_mask;
-    avx2_mask: cr_avx2_mask;
-    sse2_mask: cr_sse2_mask;
+    while i + 64 <= n {
+        let load = |off: usize| _mm_loadu_si128(p.add(i + off).cast::<__m128i>());
+        let m = _mm_or_si128(
+            _mm_or_si128(
+                _mm_cmpeq_epi8(load(0), needle),
+                _mm_cmpeq_epi8(load(16), needle),
+            ),
+            _mm_or_si128(
+                _mm_cmpeq_epi8(load(32), needle),
+                _mm_cmpeq_epi8(load(48), needle),
+            ),
+        );
+        if _mm_movemask_epi8(m) != 0 {
+            return true;
+        }
+        i += 64;
+    }
+    while i + 16 <= n {
+        let m = _mm_cmpeq_epi8(_mm_loadu_si128(p.add(i).cast::<__m128i>()), needle);
+        if _mm_movemask_epi8(m) != 0 {
+            return true;
+        }
+        i += 16;
+    }
+    bytes[i..].contains(&b'\r')
 }
 
 /// Does `input` contain a carriage return anywhere?
@@ -462,13 +555,42 @@ define_escape_scanner! {
 /// the parser is provably dead for this input, so the LF-only specialization can
 /// drop them and keep the pre-#324 codegen.
 ///
-/// SIMD is load-bearing here rather than decorative: `YamlIndex::build` runs at
-/// ~250-400 MiB/s, so a byte-at-a-time precheck would cost several percent of the
-/// build it is meant to speed up, while a 16-32 byte/iteration scan costs a
-/// fraction of one.
+/// This runs on every `YamlIndex::build`, including the ones it cannot help, so
+/// its cost is charged against documents that never see a `\r`. See the note
+/// above the kernels for why it is hand-written rather than macro-generated.
 #[inline]
 pub fn contains_cr(input: &[u8]) -> bool {
-    cr_scan::find(input, 0) < input.len()
+    #[cfg(all(
+        target_arch = "aarch64",
+        not(feature = "broadword-yaml"),
+        not(feature = "scalar-yaml")
+    ))]
+    {
+        // SAFETY: NEON is mandatory on aarch64.
+        return unsafe { contains_cr_neon(input) };
+    }
+
+    #[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
+    {
+        #[cfg(any(test, feature = "std"))]
+        if avx2_enabled() {
+            // SAFETY: guarded by runtime detection.
+            return unsafe { contains_cr_avx2(input) };
+        }
+        // SAFETY: SSE2 is the x86_64 baseline.
+        return unsafe { contains_cr_sse2(input) };
+    }
+
+    // Scalar: under `scalar-yaml`, on aarch64 under `broadword-yaml` (no
+    // broadword kernel here), and on every other target.
+    #[cfg(any(
+        feature = "scalar-yaml",
+        all(target_arch = "aarch64", feature = "broadword-yaml"),
+        not(any(target_arch = "aarch64", target_arch = "x86_64"))
+    ))]
+    {
+        input.contains(&b'\r')
+    }
 }
 
 #[cfg(test)]
@@ -868,13 +990,17 @@ mod tests {
 
         /// A `\r` anywhere must be seen, whichever kernel path covers that offset.
         ///
-        /// Lengths straddle the 16-byte (NEON/SSE2), 32-byte (AVX2) and 48-byte
-        /// (AVX2 + SSE2 tail) boundaries, so each length exercises a different mix
-        /// of vector loop and scalar remainder — a `\r` living only in the tail is
-        /// exactly what a chunk-loop-only scan would miss.
+        /// The lengths straddle every boundary in the three kernels: the 64-byte
+        /// NEON/SSE2 main loop, the 128-byte AVX2 one, their 16- and 32-byte
+        /// secondary loops, and the scalar remainder past both. A `\r` living only
+        /// in a tail the main loop does not reach is exactly the miss that would
+        /// send a CRLF document down the LF-only parser.
         #[test]
         fn finds_a_cr_at_every_offset_and_length() {
-            for len in [0usize, 1, 15, 16, 17, 31, 32, 33, 47, 48, 63, 64, 65, 129] {
+            for len in [
+                0usize, 1, 15, 16, 17, 31, 32, 33, 47, 48, 63, 64, 65, 95, 96, 127, 128, 129, 191,
+                256, 257,
+            ] {
                 let clean = vec![b'a'; len];
                 assert!(!contains_cr(&clean), "false positive at len {len}");
                 for pos in 0..len {
@@ -901,45 +1027,60 @@ mod tests {
             }
         }
 
-        /// The scalar fallback is the only path in a `scalar-yaml` build and the
-        /// short-input path everywhere else; check it directly on every target.
+        /// Every kernel directly, not just the one this CPU dispatches to.
+        ///
+        /// `contains_cr` picks a single backend per machine, so on an AVX2 runner
+        /// the SSE2 kernel is never exercised by the tests above and on any x86
+        /// box the NEON one is not compiled at all (#193). Sweep each available
+        /// kernel over the same offsets the dispatcher test uses.
         #[test]
-        fn scalar_fallback_matches_reference() {
-            for len in [0usize, 1, 5, 16, 33] {
-                let clean = vec![b'z'; len];
-                assert_eq!(super::super::cr_scan::scalar(&clean, 0), len);
-                for pos in 0..len {
-                    let mut input = clean.clone();
-                    input[pos] = b'\r';
-                    assert_eq!(super::super::cr_scan::scalar(&input, 0), pos);
-                }
-            }
-        }
+        fn every_available_kernel_agrees() {
+            let lengths = [0usize, 15, 16, 31, 33, 63, 64, 65, 127, 128, 130];
 
-        /// Both x86 tiers, since `find` only ever picks one of them on a given
-        /// runner and the SSE2 baseline would otherwise go untested on AVX2
-        /// hardware (#193).
-        #[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
-        #[test]
-        fn both_x86_tiers_agree() {
-            let has_avx2 =
-                crate::util::simd::note_simd_skip_unless(is_x86_feature_detected!("avx2"), "avx2");
-            for len in [16usize, 32, 48, 64] {
+            for len in lengths {
+                let clean = vec![b'a'; len];
+                let mut inputs = vec![(clean.clone(), false)];
                 for pos in 0..len {
-                    let mut input = vec![b'a'; len];
-                    input[pos] = b'\r';
-                    assert_eq!(
-                        super::super::cr_scan::dispatch(&input, 0, false),
-                        pos,
-                        "SSE2 missed CR at {pos} of {len}"
-                    );
-                    if has_avx2 {
+                    let mut dirty = clean.clone();
+                    dirty[pos] = b'\r';
+                    inputs.push((dirty, true));
+                }
+
+                for (input, want) in &inputs {
+                    #[cfg(all(
+                        target_arch = "aarch64",
+                        not(feature = "broadword-yaml"),
+                        not(feature = "scalar-yaml")
+                    ))]
+                    {
+                        // SAFETY: NEON is mandatory on aarch64.
                         assert_eq!(
-                            super::super::cr_scan::dispatch(&input, 0, true),
-                            pos,
-                            "AVX2 missed CR at {pos} of {len}"
+                            unsafe { super::super::contains_cr_neon(input) },
+                            *want,
+                            "NEON, len {len}"
                         );
                     }
+                    #[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
+                    {
+                        // SAFETY: SSE2 is the x86_64 baseline.
+                        assert_eq!(
+                            unsafe { super::super::contains_cr_sse2(input) },
+                            *want,
+                            "SSE2, len {len}"
+                        );
+                        if crate::util::simd::note_simd_skip_unless(
+                            is_x86_feature_detected!("avx2"),
+                            "avx2",
+                        ) {
+                            // SAFETY: guarded by runtime detection.
+                            assert_eq!(
+                                unsafe { super::super::contains_cr_avx2(input) },
+                                *want,
+                                "AVX2, len {len}"
+                            );
+                        }
+                    }
+                    assert_eq!(input.contains(&b'\r'), *want, "scalar, len {len}");
                 }
             }
         }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -124,7 +124,20 @@ pub struct SemiIndex {
 const MAX_NESTING_DEPTH: usize = 128;
 
 /// Parser state for the YAML-lite oracle.
-struct Parser<'a> {
+///
+/// `HAS_CR` says whether the input contains a carriage return anywhere.
+/// [`build_semi_index`] answers that with one SIMD pass before parsing and picks
+/// the matching monomorphization, so the LF-only specialization can drop every
+/// `\r` arm the CRLF correctness fix added and keep the pre-#324 codegen (#340).
+///
+/// The gate is a *performance* knob, not a correctness one, in one direction
+/// only. `HAS_CR == true` is always correct — it is exactly the #324 parser. It
+/// is `HAS_CR == false` that carries the obligation, and the precheck discharges
+/// it: no `\r` in the input means no CR arm can ever be reached, whatever the
+/// context. So a site left un-gated is merely a missed optimization, while a
+/// wrongly-`false` gate would corrupt the parse — which is why the flag is
+/// derived from the bytes rather than from any parser-state heuristic.
+struct Parser<'a, const HAS_CR: bool> {
     input: &'a [u8],
     pos: usize,
 
@@ -201,8 +214,13 @@ struct Parser<'a> {
     last_recorded_end: usize,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     fn new(input: &'a [u8]) -> Self {
+        debug_assert!(
+            HAS_CR || !crate::util::simd::escape::contains_cr(input),
+            "Parser::<false> built for input containing a carriage return: the \
+             LF-only specialization would silently mis-parse it (#340)"
+        );
         let ib_words = vec![0u64; input.len().div_ceil(64).max(1)];
         let bp_words = vec![0u64; input.len().div_ceil(32).max(1)]; // ~2x IB for BP
         let ty_words = vec![0u64; input.len().div_ceil(64).max(1)];
@@ -480,6 +498,35 @@ impl<'a> Parser<'a> {
         breaks + 1
     }
 
+    /// Is `b` a YAML line break, under this parser's `HAS_CR` specialization?
+    ///
+    /// Not a second spelling of [`is_line_break`] — #341 deleted that and was
+    /// right to. The `HAS_CR` arm *delegates* to it, so the rule still has one
+    /// definition; what this adds is the compile-time switch #340 needs. On a
+    /// document with no `\r` anywhere the `\r` compare is not merely never taken,
+    /// it is not emitted, and this is the per-byte test in the inlined scalar
+    /// loop where that matters.
+    #[inline]
+    fn is_break(b: u8) -> bool {
+        if HAS_CR {
+            is_line_break(b)
+        } else {
+            b == b'\n'
+        }
+    }
+
+    /// Width in bytes of the line break at `pos`, under this parser's `HAS_CR`
+    /// specialization: [`line_break_len`] when a `\r` may be present, and
+    /// otherwise the one-byte LF answer it collapses to.
+    #[inline]
+    fn break_len_at(&self, pos: usize) -> usize {
+        if HAS_CR {
+            line_break_len(self.input, pos)
+        } else {
+            usize::from(self.input.get(pos) == Some(&b'\n'))
+        }
+    }
+
     /// Is the current position at a line break?
     #[inline]
     fn at_break(&self) -> bool {
@@ -489,7 +536,7 @@ impl<'a> Parser<'a> {
     /// Is `b` whitespace or a line break?
     #[inline]
     fn is_ws_or_break(b: u8) -> bool {
-        matches!(b, b' ' | b'\t') || is_line_break(b)
+        matches!(b, b' ' | b'\t') || Self::is_break(b)
     }
 
     /// Does `next` terminate an indicator character — whitespace, a line break,
@@ -529,6 +576,13 @@ impl<'a> Parser<'a> {
     /// (#341). Change one and that test fails.
     #[inline]
     fn skip_line_break(&mut self) {
+        if !HAS_CR {
+            // Exactly the `if peek() == Some(b'\n') { advance() }` this replaced.
+            if self.input.get(self.pos) == Some(&b'\n') {
+                self.pos += 1;
+            }
+            return;
+        }
         match self.input.get(self.pos) {
             Some(b'\n') => self.pos += 1,
             Some(b'\r') => {
@@ -589,14 +643,21 @@ impl<'a> Parser<'a> {
     #[inline]
     fn skip_unquoted_simd(&self, _value_start: usize) -> Option<usize> {
         // Use classify_yaml_chars to scan 32 bytes at once
-        if let Some(class) = super::simd::classify_yaml_chars(self.input, self.pos) {
+        if let Some(class) = super::simd::classify_yaml_chars::<HAS_CR>(self.input, self.pos) {
             // Line break, colon, or hash — see `plain_scalar_terminators`, which
             // both this and the ARM variant below share so the two cannot drift
             // on what ends a scalar (#185). `\r` counts: it is a YAML 1.2 §5.4
             // line break, and without it the classifier skips straight over a
             // lone CR and swallows the rest of the document into one scalar
             // (#324).
-            let terminators = class.plain_scalar_terminators();
+            //
+            // The accessor takes the same `HAS_CR` the classifier did. Under
+            // `false` the classifier leaves `carriage_returns` zero, so the OR
+            // would be a no-op — but that promise is one the optimizer cannot
+            // verify across the `#[target_feature]` call, so the const gates
+            // both ends and the compare never reaches the instruction stream
+            // (#340).
+            let terminators = class.plain_scalar_terminators::<HAS_CR>();
 
             if terminators == 0 {
                 // No structural characters in the classified chunk — skip
@@ -738,7 +799,7 @@ impl<'a> Parser<'a> {
     fn current_column(&self) -> usize {
         // Find the start of the current line
         let mut line_start = self.pos;
-        while line_start > 0 && !is_line_break(self.input[line_start - 1]) {
+        while line_start > 0 && !Self::is_break(self.input[line_start - 1]) {
             line_start -= 1;
         }
         self.pos - line_start
@@ -751,7 +812,7 @@ impl<'a> Parser<'a> {
             match self.input[i] {
                 b'#' => return true, // Comment starts
                 b' ' => i += 1,
-                b if is_line_break(b) => return true,
+                b if Self::is_break(b) => return true,
                 _ => return false,
             }
         }
@@ -793,7 +854,7 @@ impl<'a> Parser<'a> {
                     break;
                 } else if self.input[i] == b'\\' && quote == b'"' {
                     i += 2; // Skip escape sequence in double-quoted
-                } else if is_line_break(self.input[i]) {
+                } else if Self::is_break(self.input[i]) {
                     return false; // Unclosed quote
                 } else {
                     i += 1;
@@ -831,7 +892,7 @@ impl<'a> Parser<'a> {
                     i += 1; // Colon not followed by whitespace, continue
                 }
                 // Line ended without finding `: `
-                b if is_line_break(b) => return false,
+                b if Self::is_break(b) => return false,
                 // Note: " and ' in the middle of a key are allowed (e.g., bla"keks: foo)
                 // Continue scanning past them.
                 _ => i += 1,
@@ -867,7 +928,7 @@ impl<'a> Parser<'a> {
     /// callers can consume it with `skip_line_break` (#324).
     #[inline]
     fn skip_to_eol(&mut self) {
-        while self.pos < self.input.len() && !is_line_break(self.input[self.pos]) {
+        while self.pos < self.input.len() && !Self::is_break(self.input[self.pos]) {
             self.pos += 1;
         }
     }
@@ -875,7 +936,7 @@ impl<'a> Parser<'a> {
     /// Skip newline and empty/comment lines.
     fn skip_newlines(&mut self) {
         while let Some(b) = self.peek() {
-            if is_line_break(b) {
+            if Self::is_break(b) {
                 self.skip_line_break();
             } else if b == b'#' {
                 // Comment line
@@ -1241,7 +1302,7 @@ impl<'a> Parser<'a> {
                         }
                         self.advance();
                     }
-                    b if is_line_break(b) => break,
+                    b if Self::is_break(b) => break,
                     _ => {
                         // SIMD/broadword fast-path: skip long runs of regular characters
                         // Only use SIMD if we have enough remaining bytes to justify overhead
@@ -1277,7 +1338,7 @@ impl<'a> Parser<'a> {
             }
 
             // Look ahead to see if next line is a continuation
-            let mut lookahead = self.pos + line_break_len(self.input, self.pos); // Skip the line break
+            let mut lookahead = self.pos + self.break_len_at(self.pos); // Skip the line break
             let mut next_indent = 0;
 
             // Count indentation on next line (only spaces count as indent in YAML)
@@ -1296,14 +1357,14 @@ impl<'a> Parser<'a> {
 
             // If empty line (just whitespace then newline), skip it and continue
             // This includes lines with only spaces, tabs, or a mix
-            if is_line_break(next_char) || next_char == b'\t' {
+            if Self::is_break(next_char) || next_char == b'\t' {
                 // Check if rest of line is whitespace
                 let mut check_pos = lookahead;
                 while check_pos < self.input.len() && matches!(self.input[check_pos], b' ' | b'\t')
                 {
                     check_pos += 1;
                 }
-                if check_pos >= self.input.len() || is_line_break(self.input[check_pos]) {
+                if check_pos >= self.input.len() || Self::is_break(self.input[check_pos]) {
                     // Empty line - skip it and continue
                     self.skip_line_break(); // Skip the current line break
                                             // Skip to end of empty line
@@ -1450,7 +1511,7 @@ impl<'a> Parser<'a> {
                     }
                     self.advance();
                 }
-                b if is_line_break(b) => {
+                b if Self::is_break(b) => {
                     // Key without colon
                     return Err(YamlError::KeyWithoutValue {
                         offset: start,
@@ -3368,7 +3429,7 @@ impl<'a> Parser<'a> {
                 b'\n' | b'\r' => {
                     // Multiline key - check if next line continues the key
                     // Skip the line break (CRLF counts as the one break it is)
-                    let mut lookahead = self.pos + line_break_len(self.input, self.pos);
+                    let mut lookahead = self.pos + self.break_len_at(self.pos);
                     // Skip leading whitespace on next line
                     while lookahead < self.input.len()
                         && matches!(self.input[lookahead], b' ' | b'\t')
@@ -3480,7 +3541,7 @@ impl<'a> Parser<'a> {
                 b'\n' | b'\r' => {
                     // Multiline value - check if next line continues the value
                     // Skip the line break (CRLF counts as the one break it is)
-                    let mut lookahead = self.pos + line_break_len(self.input, self.pos);
+                    let mut lookahead = self.pos + self.break_len_at(self.pos);
                     // Skip leading whitespace on next line
                     while lookahead < self.input.len()
                         && matches!(self.input[lookahead], b' ' | b'\t')
@@ -3583,7 +3644,7 @@ impl<'a> Parser<'a> {
                 b'\n' | b'\r' => {
                     // Multiline key - check if next line continues the key
                     // Skip the line break (CRLF counts as the one break it is)
-                    let mut lookahead = self.pos + line_break_len(self.input, self.pos);
+                    let mut lookahead = self.pos + self.break_len_at(self.pos);
                     // Skip leading whitespace on next line
                     while lookahead < self.input.len()
                         && matches!(self.input[lookahead], b' ' | b'\t')
@@ -3823,7 +3884,7 @@ impl<'a> Parser<'a> {
                 // Include one trailing line break if there was content — two
                 // bytes wide when that break is a CRLF (#324)
                 if last_content_end > 0 && trailing_newline_start > last_content_end {
-                    last_content_end + line_break_len(self.input, last_content_end)
+                    last_content_end + self.break_len_at(last_content_end)
                 } else {
                     last_content_end
                 }
@@ -4453,8 +4514,16 @@ pub fn build_semi_index(input: &[u8]) -> Result<SemiIndex, YamlError> {
     if u32::try_from(input.len()).is_err() {
         return Err(YamlError::InputTooLarge { len: input.len() });
     }
-    let mut parser = Parser::new(input);
-    parser.parse()
+    // One SIMD pass to pick the parser's `HAS_CR` monomorphization (#340). LF-only
+    // documents — the overwhelming majority — then parse with every `\r` arm the
+    // #324 correctness fix added compiled out. The scan reads the input straight
+    // through at 16-32 bytes per iteration and leaves it warm in cache for the
+    // parse that follows.
+    if crate::util::simd::escape::contains_cr(input) {
+        Parser::<true>::new(input).parse()
+    } else {
+        Parser::<false>::new(input).parse()
+    }
 }
 
 #[cfg(test)]
@@ -5272,13 +5341,26 @@ mod tests {
     /// by the compiler — see the doc comment for why the parser cannot just call
     /// it. Exhaustive over every byte plus end of input, so a divergence in the
     /// acceptance set cannot hide in an untested byte.
+    ///
+    /// `Parser::<true>` is the unconditional rule and must match the reader
+    /// outright. `Parser::<false>` is the #340 specialization, and the only
+    /// licence it has is to drop `\r` — a document the precheck routed there
+    /// contains none, so the answer is unobservable. Pinning both directions
+    /// keeps the gate from quietly widening into some other byte.
     #[test]
     fn is_ws_break_or_eoi_agrees_with_is_seq_indicator_next() {
         for next in (0..=u8::MAX).map(Some).chain(core::iter::once(None)) {
+            let reader = crate::yaml::is_seq_indicator_next(next);
+
             assert_eq!(
-                Parser::is_ws_break_or_eoi(next),
-                crate::yaml::is_seq_indicator_next(next),
+                Parser::<true>::is_ws_break_or_eoi(next),
+                reader,
                 "{next:?}: parser and reader disagree on the indicator terminator set"
+            );
+            assert_eq!(
+                Parser::<false>::is_ws_break_or_eoi(next),
+                reader && next != Some(b'\r'),
+                "{next:?}: the HAS_CR gate changed something other than the `\\r` arm"
             );
         }
     }
@@ -5290,8 +5372,10 @@ mod tests {
     /// widths must agree byte for byte.
     #[test]
     fn skip_line_break_agrees_with_line_break_len() {
-        for input in [
-            b"a\r\nb\rc\nd".as_slice(),
+        // CR-bearing inputs only reach the `HAS_CR == true` parser, which is what
+        // `build_semi_index`'s precheck guarantees.
+        skip_line_break_agrees::<true>(&[
+            b"a\r\nb\rc\nd",
             b"\r\n",
             b"\n\r",
             b"\r\r\n",
@@ -5300,15 +5384,37 @@ mod tests {
             b"a\n",
             b"x",
             b"",
-        ] {
+        ]);
+        // The #340 specialization has to hold the same property against its own
+        // narrowed `break_len_at`, or its `skip_line_break` fast path would be a
+        // third spelling rather than a second one.
+        skip_line_break_agrees::<false>(&[b"a\nb\nc", b"\n\n", b"a\n", b"\n", b"x", b""]);
+    }
+
+    /// Shared body of the #106 guard, over both `HAS_CR` monomorphizations.
+    ///
+    /// Under `HAS_CR` the expected width is tied to [`line_break_len`] itself, so
+    /// the hand-rolled `skip_line_break`, the `break_len_at` dispatcher, and the
+    /// shared definition are all pinned to each other.
+    fn skip_line_break_agrees<const HAS_CR: bool>(inputs: &[&[u8]]) {
+        for input in inputs {
             for pos in 0..=input.len() {
-                let mut parser = Parser::new(input);
+                let want = Parser::<HAS_CR>::new(input).break_len_at(pos);
+                if HAS_CR {
+                    assert_eq!(
+                        want,
+                        line_break_len(input, pos),
+                        "{input:?} @ {pos}: break_len_at and line_break_len disagree"
+                    );
+                }
+                let mut parser = Parser::<HAS_CR>::new(input);
                 parser.pos = pos;
                 parser.skip_line_break();
                 assert_eq!(
                     parser.pos - pos,
-                    line_break_len(input, pos),
-                    "{input:?} @ {pos}: skip_line_break and line_break_len disagree"
+                    want,
+                    "{input:?} @ {pos} (HAS_CR={HAS_CR}): \
+                     skip_line_break and break_len_at disagree"
                 );
             }
         }
@@ -5318,7 +5424,7 @@ mod tests {
     /// never a byte when the cursor is not on one.
     #[test]
     fn skip_line_break_consumes_exactly_one_break() {
-        let mut parser = Parser::new(b"\r\n\r\nx");
+        let mut parser = Parser::<true>::new(b"\r\n\r\nx");
         parser.skip_line_break();
         assert_eq!(parser.pos, 2, "first CRLF consumed whole");
         parser.skip_line_break();
@@ -5326,7 +5432,7 @@ mod tests {
         parser.skip_line_break();
         assert_eq!(parser.pos, 4, "`x` is not a break, so nothing moves");
 
-        let mut lone = Parser::new(b"\r\rx");
+        let mut lone = Parser::<true>::new(b"\r\rx");
         lone.skip_line_break();
         assert_eq!(lone.pos, 1, "a lone CR is a complete break");
         assert!(lone.at_break());
@@ -5340,7 +5446,7 @@ mod tests {
     fn current_line_counts_a_crlf_once() {
         // b"a\r\nb\r\nc"
         //   0 1 2 3 4 5 6
-        let mut parser = Parser::new(b"a\r\nb\r\nc");
+        let mut parser = Parser::<true>::new(b"a\r\nb\r\nc");
         assert_eq!(parser.current_line(), 1);
         parser.pos = 3;
         assert_eq!(parser.current_line(), 2, "`b` is on line 2");
@@ -5355,8 +5461,83 @@ mod tests {
         parser.pos = 6;
         assert_eq!(parser.current_line(), 3, "`c` is on line 3");
 
-        let mut lone = Parser::new(b"a\rb\rc");
+        let mut lone = Parser::<true>::new(b"a\rb\rc");
         lone.pos = 4;
         assert_eq!(lone.current_line(), 3, "lone CRs each start a line");
+    }
+
+    /// The two `HAS_CR` monomorphizations must agree on every CR-free document.
+    ///
+    /// This is the test that pins the #340 gating. `HAS_CR == true` is the #324
+    /// parser verbatim, so it is the oracle here; `HAS_CR == false` is the
+    /// specialization, and the only way it can be wrong is by gating a site whose
+    /// `\r` arm was doing something *other* than handling a carriage return.
+    /// Nothing else in the suite would catch that: `tests/yaml_crlf_tests.rs` and
+    /// the CRLF reruns in `tests/yq_golden_tests.rs` exercise inputs that all
+    /// contain a `\r`, which is precisely the set that takes the `true` path.
+    #[test]
+    fn both_monomorphizations_agree_on_cr_free_input() {
+        // 4096 `a`s, so the plain-scalar case clears the 32-byte SIMD classifier
+        // threshold by a wide margin rather than only just.
+        let long_scalar = format!("long: {}\n", "a".repeat(4096));
+        let cases: &[&str] = &[
+            "",
+            "\n",
+            "name: Alice\nage: 30\n",
+            "person:\n  name: Alice\n  address:\n    city: Sydney\n",
+            "- one\n- two\n- three\n",
+            "- - nested\n  - items\n",
+            "quoted: \"has: colon\"\nsingle: 'and ''escaped'' quotes'\n",
+            "flow_map: {a: 1, b: 2}\nflow_seq: [1, 2, [3, 4]]\n",
+            "literal: |\n  line one\n  line two\nfolded: >\n  folded one\n\n  folded two\n",
+            "? explicit key\n: explicit value\n",
+            "base: &anchor\n  a: 1\nderived: *anchor\n",
+            "---\ndoc: one\n---\ndoc: two\n...\n",
+            "# leading comment\nkey: value # trailing comment\n\n\nafter: blanks\n",
+            "empty:\nnull_value: ~\nbool: true\nnum: 1.5\n",
+            "url: http://example.com/path\ntime: 12:30:00\n",
+            "  indented_root: value\n",
+            "no trailing newline: here",
+            "plain\nmultiline\nscalar\n",
+            "outer:\n- a\n- b\n",
+            &long_scalar,
+        ];
+
+        for case in cases {
+            let input = case.as_bytes();
+            assert!(!input.contains(&b'\r'), "fixture must be CR-free: {case:?}");
+
+            let with = Parser::<true>::new(input).parse();
+            let without = Parser::<false>::new(input).parse();
+
+            match (with, without) {
+                (Ok(a), Ok(b)) => {
+                    assert_eq!(a.ib, b.ib, "ib differs for {case:?}");
+                    assert_eq!(a.bp, b.bp, "bp differs for {case:?}");
+                    assert_eq!(a.ty, b.ty, "ty differs for {case:?}");
+                    assert_eq!(
+                        a.bp_to_text, b.bp_to_text,
+                        "bp_to_text differs for {case:?}"
+                    );
+                    assert_eq!(
+                        a.bp_to_text_end, b.bp_to_text_end,
+                        "bp_to_text_end differs for {case:?}"
+                    );
+                    assert_eq!(
+                        a.containers, b.containers,
+                        "containers differs for {case:?}"
+                    );
+                    assert_eq!(a.ib_len, b.ib_len, "ib_len differs for {case:?}");
+                    assert_eq!(a.bp_len, b.bp_len, "bp_len differs for {case:?}");
+                    assert_eq!(a.ty_len, b.ty_len, "ty_len differs for {case:?}");
+                    assert_eq!(a.anchors, b.anchors, "anchors differ for {case:?}");
+                    assert_eq!(a.aliases, b.aliases, "aliases differ for {case:?}");
+                }
+                (Err(a), Err(b)) => {
+                    assert_eq!(a.to_string(), b.to_string(), "errors differ for {case:?}");
+                }
+                (a, b) => panic!("acceptance differs for {case:?}: {a:?} vs {b:?}"),
+            }
+        }
     }
 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1978,7 +1978,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     // into the plain scalar below.
                     self.parse_alias()?;
                 }
-                Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
+                Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                     // Block sequence indicator inline with a compact mapping's own
                     // value (`- a: - x`): the same invalid-but-common shape #325
                     // fixed for a top-level mapping value, one level deeper. This
@@ -2318,7 +2318,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     // Block scalar - handles its own BP
                     self.parse_block_scalar(indent)?;
                 }
-                Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
+                Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                     // Block sequence indicator inline with the mapping key (`a: - x`).
                     // This is invalid YAML (test-suite case 5U3A: a block sequence may
                     // not begin on the same line as its parent mapping key), and the
@@ -2723,7 +2723,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.set_bp_text_end(self.pos);
                 self.write_bp_close();
             }
-            Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
+            Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                 // Inline sequence item - this creates a nested sequence.
                 //
                 // This arm used to be a no-op on the theory that "the caller already

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -486,15 +486,34 @@ impl<'a> Parser<'a> {
         self.peek().is_some_and(is_line_break)
     }
 
-    /// Does `next` terminate a `-` sequence indicator? That is whitespace, a
-    /// line break, or end of input.
-    ///
-    /// Delegates to the module-level definition the reader also uses, so the terminator
-    /// set has one spelling (#332). Kept as an associated fn because the guard it appears
-    /// in must stay on one line for `llvm-cov` to see it (#324).
+    /// Is `b` whitespace or a line break?
     #[inline]
-    fn is_seq_indicator_next(next: Option<u8>) -> bool {
-        super::is_seq_indicator_next(next)
+    fn is_ws_or_break(b: u8) -> bool {
+        matches!(b, b' ' | b'\t') || is_line_break(b)
+    }
+
+    /// Does `next` terminate an indicator character — whitespace, a line break,
+    /// or end of input?
+    ///
+    /// This is the lookahead that separates a *structural* `-`/`?`/`:` from the
+    /// first byte of a plain scalar. It had seventeen inline `matches!` copies
+    /// before #340; one definition means the `HAS_CR` gate has a single place to
+    /// live and the copies cannot drift apart (#106). It also keeps the test off
+    /// its own source line, which a multi-line `matches!` in a match guard turns
+    /// into a coverage region that never reports as executed.
+    ///
+    /// This is the parser's spelling of the terminator set [`super::is_seq_indicator_next`]
+    /// gives the *reader* (#332). It cannot simply call it: the whole point of #340 is that
+    /// the `\r` arm here becomes compile-time gated, and the reader — which indexes into
+    /// text rather than scanning it under a `HAS_CR` specialization — has no such gate. The
+    /// two are therefore pinned by `is_ws_break_or_eoi_agrees_with_is_seq_indicator_next`
+    /// rather than by the compiler; change one acceptance set and that test fails.
+    #[inline]
+    fn is_ws_break_or_eoi(next: Option<u8>) -> bool {
+        match next {
+            Some(b) => Self::is_ws_or_break(b),
+            None => true,
+        }
     }
 
     /// Consume the line break at the current position, if any.
@@ -730,9 +749,9 @@ impl<'a> Parser<'a> {
         let mut i = self.pos;
         while i < self.input.len() {
             match self.input[i] {
-                b'\n' | b'\r' => return true,
                 b'#' => return true, // Comment starts
                 b' ' => i += 1,
+                b if is_line_break(b) => return true,
                 _ => return false,
             }
         }
@@ -749,7 +768,7 @@ impl<'a> Parser<'a> {
             // Empty key: `:` at start followed by whitespace/newline/EOF
             Some(b':') => {
                 let next = self.peek_at(1);
-                if matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
+                if Self::is_ws_break_or_eoi(next) {
                     return true;
                 }
                 // Colon not followed by whitespace - continue checking
@@ -791,7 +810,7 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                return matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None);
+                return Self::is_ws_break_or_eoi(next);
             }
             return false;
         }
@@ -799,7 +818,6 @@ impl<'a> Parser<'a> {
         // Scan for `: ` pattern in unquoted key
         while i < self.input.len() {
             match self.input[i] {
-                b'\n' | b'\r' => return false, // Line ended without finding `: `
                 b':' => {
                     // Check what follows the colon
                     let next = if i + 1 < self.input.len() {
@@ -807,11 +825,13 @@ impl<'a> Parser<'a> {
                     } else {
                         None
                     };
-                    match next {
-                        Some(b' ' | b'\t' | b'\n' | b'\r') | None => return true,
-                        _ => i += 1, // Colon not followed by whitespace, continue
+                    if Self::is_ws_break_or_eoi(next) {
+                        return true;
                     }
+                    i += 1; // Colon not followed by whitespace, continue
                 }
+                // Line ended without finding `: `
+                b if is_line_break(b) => return false,
                 // Note: " and ' in the middle of a key are allowed (e.g., bla"keks: foo)
                 // Continue scanning past them.
                 _ => i += 1,
@@ -920,7 +940,7 @@ impl<'a> Parser<'a> {
         // validator's copy of this same check, already includes it, and
         // dropping it here meant `---\tfoo` was silently parsed as content
         // instead of a document boundary (#434).
-        matches!(self.peek_at(3), Some(b' ' | b'\t' | b'\n' | b'\r') | None)
+        Self::is_ws_break_or_eoi(self.peek_at(3))
     }
 
     /// Check if we're at a document end marker (`...`).
@@ -934,7 +954,7 @@ impl<'a> Parser<'a> {
         }
         // Must be followed by white space (space or tab), a line break, or EOF.
         // See `is_document_start` for why the tab isn't optional (#434).
-        matches!(self.peek_at(3), Some(b' ' | b'\t' | b'\n' | b'\r') | None)
+        Self::is_ws_break_or_eoi(self.peek_at(3))
     }
 
     /// Skip past a document marker (`---` or `...`).
@@ -1199,7 +1219,6 @@ impl<'a> Parser<'a> {
             // Use inline scalar loop for common case, SIMD for long runs
             while let Some(b) = self.peek() {
                 match b {
-                    b'\n' | b'\r' => break,
                     b'#' => {
                         // # is only a comment if preceded by whitespace (space or tab)
                         if self.pos > start && matches!(self.input[self.pos - 1], b' ' | b'\t') {
@@ -1210,18 +1229,19 @@ impl<'a> Parser<'a> {
                     b':' => {
                         // Colon followed by whitespace, a line break, or EOF ends
                         // the value (could be a key). In value context, colons in
-                        // URLs etc. are allowed. The `| None` arm matters: without
+                        // URLs etc. are allowed. The EOF case matters: without
                         // it, a colon as the last byte of the document (no trailing
                         // newline) was absorbed as content instead of terminating
                         // the value, while `find_scalar_end` (the locate-path copy
                         // of this same boundary) already stopped there - eval and
                         // locate disagreed on the same node (#434, same shape as
                         // #370).
-                        if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
+                        if Self::is_ws_break_or_eoi(self.peek_at(1)) {
                             break;
                         }
                         self.advance();
                     }
+                    b if is_line_break(b) => break,
                     _ => {
                         // SIMD/broadword fast-path: skip long runs of regular characters
                         // Only use SIMD if we have enough remaining bytes to justify overhead
@@ -1276,7 +1296,7 @@ impl<'a> Parser<'a> {
 
             // If empty line (just whitespace then newline), skip it and continue
             // This includes lines with only spaces, tabs, or a mix
-            if matches!(next_char, b'\n' | b'\r' | b'\t') {
+            if is_line_break(next_char) || next_char == b'\t' {
                 // Check if rest of line is whitespace
                 let mut check_pos = lookahead;
                 while check_pos < self.input.len() && matches!(self.input[check_pos], b' ' | b'\t')
@@ -1374,8 +1394,7 @@ impl<'a> Parser<'a> {
                 && !sequence_indicator_is_block_structure
                 && !is_document_marker
                 && !(next_char == b':'
-                    && (lookahead + 1 >= self.input.len()
-                        || matches!(self.input[lookahead + 1], b' ' | b'\t' | b'\n' | b'\r')))
+                    && Self::is_ws_break_or_eoi(self.input.get(lookahead + 1).copied()))
             {
                 // Continue to next line
                 self.skip_line_break();
@@ -1411,19 +1430,12 @@ impl<'a> Parser<'a> {
             match b {
                 b':' => {
                     // Check for colon + whitespace or colon + line break
-                    if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
+                    if Self::is_ws_break_or_eoi(self.peek_at(1)) {
                         break;
                     }
                     // Colon not followed by whitespace is part of the key
                     // (e.g., "key::" or URLs like "http://example.com")
                     self.advance();
-                }
-                b'\n' | b'\r' => {
-                    // Key without colon
-                    return Err(YamlError::KeyWithoutValue {
-                        offset: start,
-                        line: self.current_line(),
-                    });
                 }
                 b'#' => {
                     // # starts a comment only after s-separate-in-line, and
@@ -1437,6 +1449,13 @@ impl<'a> Parser<'a> {
                         });
                     }
                     self.advance();
+                }
+                b if is_line_break(b) => {
+                    // Key without colon
+                    return Err(YamlError::KeyWithoutValue {
+                        offset: start,
+                        line: self.current_line(),
+                    });
                 }
                 _ => {
                     // SIMD/broadword fast-path: skip long runs of regular characters
@@ -1695,9 +1714,7 @@ impl<'a> Parser<'a> {
         }
 
         // Check for nested sequence: `- - item` (sequence item containing a sequence)
-        if self.peek() == Some(b'-')
-            && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None)
-        {
+        if self.peek() == Some(b'-') && Self::is_ws_break_or_eoi(self.peek_at(1)) {
             // Nested sequence - the item value is another sequence.
             // Use the actual column position of the nested `-` as the indent.
             // This ensures that subsequent items at the same column (like `- d` after `- c`)
@@ -1869,8 +1886,8 @@ impl<'a> Parser<'a> {
                 // Check if next content is a sequence indicator
                 let saved_pos = self.pos;
                 self.advance_by(next_indent);
-                let is_sequence_indicator = matches!(self.peek(), Some(b'-'))
-                    && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None);
+                let is_sequence_indicator =
+                    matches!(self.peek(), Some(b'-')) && Self::is_ws_break_or_eoi(self.peek_at(1));
                 self.pos = saved_pos;
 
                 if next_indent < indent || (next_indent == indent && !is_sequence_indicator) {
@@ -1979,7 +1996,7 @@ impl<'a> Parser<'a> {
         let key_end = if self.peek() == Some(b':') {
             // Empty key - check that it's followed by proper terminator
             let next = self.peek_at(1);
-            if matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
+            if Self::is_ws_break_or_eoi(next) {
                 // Empty key case - key length is 0, don't advance yet
                 self.pos
             } else {
@@ -2053,8 +2070,8 @@ impl<'a> Parser<'a> {
             let saved_pos = self.pos;
             self.advance_by(next_indent);
             let next_char = self.peek();
-            let is_sequence_indicator = matches!(next_char, Some(b'-'))
-                && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None);
+            let is_sequence_indicator =
+                matches!(next_char, Some(b'-')) && Self::is_ws_break_or_eoi(self.peek_at(1));
             self.pos = saved_pos;
 
             if next_indent < indent {
@@ -2096,18 +2113,14 @@ impl<'a> Parser<'a> {
 
             // Check if this is a nested structure or a plain scalar value
             match self.peek() {
-                Some(b'-')
-                    if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) =>
-                {
+                Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                     // Sequence - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
                 }
                 // Tab included: the sibling `-` check just above uses the
                 // same 4-way terminator set (#434).
-                Some(b'?')
-                    if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) =>
-                {
+                Some(b'?') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                     // Explicit key - will be handled by main loop
                     self.pos = saved_pos;
                     return Ok(());
@@ -2197,8 +2210,7 @@ impl<'a> Parser<'a> {
                 let is_sequence_at_same_indent = {
                     // Skip past indent spaces to check what follows (SIMD accelerated)
                     self.skip_spaces_simd();
-                    matches!(self.peek(), Some(b'-'))
-                        && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None)
+                    matches!(self.peek(), Some(b'-')) && Self::is_ws_break_or_eoi(self.peek_at(1))
                 };
                 // Restore position after checking
                 self.pos = pos_before_check;
@@ -2358,9 +2370,8 @@ impl<'a> Parser<'a> {
                 // Next content is at same or lower indent
                 if next_char == Some(b':')
                     && (next_indent == indent)
-                    && matches!(
+                    && Self::is_ws_break_or_eoi(
                         self.input.get(saved_pos + next_indent + 1).copied(),
-                        Some(b' ' | b'\t' | b'\n' | b'\r') | None
                     )
                 {
                     // `: value` at same indent - empty key (null), value follows
@@ -2396,12 +2407,13 @@ impl<'a> Parser<'a> {
 
         // Parse the key value inline
         match self.peek() {
-            // Tab included: this is the same terminator set `is_seq_indicator_next`
-            // canonicalizes (#332) and every sibling `-` check in this file already
-            // uses it, but this site still hand-rolled a 3-way match missing the
-            // tab, so `? -\ta\n  -\tb\n: value` fell through to being parsed as a
-            // plain scalar key `-\ta` instead of a sequence key (#434).
-            Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
+            // Tab included: every sibling `-` check in this file uses the same
+            // 4-way terminator set (kept in sync with `super::is_seq_indicator_next`
+            // by `is_ws_break_or_eoi_agrees_with_is_seq_indicator_next`), but this
+            // site still hand-rolled a 3-way match missing the tab, so
+            // `? -\ta\n  -\tb\n: value` fell through to being parsed as a plain
+            // scalar key `-\ta` instead of a sequence key (#434).
+            Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                 // Sequence as key - open key node and let sequence parsing continue
                 // The key will be a sequence
                 self.write_bp_open();
@@ -2547,7 +2559,7 @@ impl<'a> Parser<'a> {
 
         // Parse the value
         match self.peek() {
-            Some(b'-') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) => {
+            Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                 // Sequence as value. Routed through the shared sequence-item
                 // parser rather than an inlined copy of its dispatch, so anchor
                 // handling (#328) and every future fix land here too — this was
@@ -2851,8 +2863,7 @@ impl<'a> Parser<'a> {
 
     /// Check if we're looking at an explicit key indicator `?` in flow context
     fn looks_like_explicit_flow_key(&self) -> bool {
-        self.peek() == Some(b'?')
-            && matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None)
+        self.peek() == Some(b'?') && Self::is_ws_break_or_eoi(self.peek_at(1))
     }
 
     /// Parse the key node of an explicit flow entry, with the `? ` indicator already
@@ -3563,8 +3574,7 @@ impl<'a> Parser<'a> {
                     // Only stop at `: ` or `:\n` or `:` at end. A flow indicator after
                     // the colon does *not* stop the key (#402) — `,`/`}`/`]` end it on
                     // their own arm, one byte later, with the colon kept.
-                    let next = self.peek_at(1);
-                    if matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r') | None) {
+                    if Self::is_ws_break_or_eoi(self.peek_at(1)) {
                         break;
                     }
                     // Colon not followed by space - include it in the key
@@ -3590,7 +3600,7 @@ impl<'a> Parser<'a> {
                     // Check for `: ` on next line (explicit value indicator)
                     if lookahead + 1 < self.input.len()
                         && self.input[lookahead] == b':'
-                        && matches!(self.input[lookahead + 1], b' ' | b'\t' | b'\n' | b'\r')
+                        && Self::is_ws_or_break(self.input[lookahead + 1])
                     {
                         // Explicit value indicator - stop key here
                         break;
@@ -3626,8 +3636,7 @@ impl<'a> Parser<'a> {
                                 } else {
                                     None
                                 };
-                                if matches!(after_colon, Some(b' ' | b'\t' | b'\n' | b'\r') | None)
-                                {
+                                if Self::is_ws_break_or_eoi(after_colon) {
                                     // Whitespace before `: ` - stop here
                                     break;
                                 }
@@ -4277,7 +4286,7 @@ impl<'a> Parser<'a> {
 
         // Check what kind of content this is
         match self.peek() {
-            Some(b'-') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) => {
+            Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                 self.parse_sequence_item(indent)?;
             }
             // Tab included in both arms below: the sibling `-` arm just above
@@ -4285,11 +4294,11 @@ impl<'a> Parser<'a> {
             // tab meant `?\tkey` / `:\tvalue` fell through to
             // `looks_like_mapping_entry()` instead of being recognized here
             // (#434).
-            Some(b'?') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) => {
+            Some(b'?') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                 // Explicit key indicator
                 self.parse_explicit_key(indent)?;
             }
-            Some(b':') if matches!(self.peek_at(1), Some(b' ' | b'\t' | b'\n' | b'\r') | None) => {
+            Some(b':') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                 // Explicit value indicator (value for previous explicit key)
                 self.parse_explicit_value(indent)?;
             }
@@ -4335,7 +4344,7 @@ impl<'a> Parser<'a> {
                         // `matches!` across lines gives the opening line its own
                         // coverage region that never reports as executed, even
                         // though the arm body does.
-                        Some(b'-') if Self::is_seq_indicator_next(self.peek_at(1)) => {
+                        Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                             // Anchor before block sequence on same line
                             self.parse_sequence_item(indent)?;
                         }
@@ -5257,6 +5266,23 @@ mod tests {
             "nesting depth exceeds limit of 128 at offset 131"
         );
     }
+    /// The other #106 guard: [`Parser::is_ws_break_or_eoi`] is the parser's
+    /// spelling of the terminator set [`super::super::is_seq_indicator_next`]
+    /// gives the reader (#332), and the two are pinned by this test rather than
+    /// by the compiler — see the doc comment for why the parser cannot just call
+    /// it. Exhaustive over every byte plus end of input, so a divergence in the
+    /// acceptance set cannot hide in an untested byte.
+    #[test]
+    fn is_ws_break_or_eoi_agrees_with_is_seq_indicator_next() {
+        for next in (0..=u8::MAX).map(Some).chain(core::iter::once(None)) {
+            assert_eq!(
+                Parser::is_ws_break_or_eoi(next),
+                crate::yaml::is_seq_indicator_next(next),
+                "{next:?}: parser and reader disagree on the indicator terminator set"
+            );
+        }
+    }
+
     /// The #106 guard: `skip_line_break` is the one place in the crate that
     /// restates [`line_break_len`] instead of calling it, for the measured
     /// reason on its doc comment. A restated predicate diverges silently, so

--- a/src/yaml/simd/mod.rs
+++ b/src/yaml/simd/mod.rs
@@ -216,10 +216,16 @@ pub fn count_leading_spaces(input: &[u8], start: usize) -> usize {
 /// This is the main P0 optimization for bulk character detection.
 ///
 /// Currently only available on x86_64. Returns None on other platforms.
+///
+/// `HAS_CR` gates the `\r` mask; see [`x86::classify_yaml_chars`] for why the
+/// const has to reach this far down (#340).
 #[inline]
 #[cfg(all(target_arch = "x86_64", not(feature = "scalar-yaml")))]
-pub fn classify_yaml_chars(input: &[u8], offset: usize) -> Option<YamlCharClass> {
-    x86::classify_yaml_chars(input, offset)
+pub fn classify_yaml_chars<const HAS_CR: bool>(
+    input: &[u8],
+    offset: usize,
+) -> Option<YamlCharClass> {
+    x86::classify_yaml_chars::<HAS_CR>(input, offset)
 }
 
 /// Classify 16 bytes of YAML structural characters using broadword (SWAR).

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -1278,9 +1278,11 @@ mod tests {
     /// over colons or hashes and the parse would silently change shape.
     #[test]
     fn test_classify_has_cr_gate_only_affects_the_cr_channel() {
-        // Every structural byte present at once, plus a `\r`, in both a 16-byte
-        // SSE2 chunk and a 32-byte AVX2 one.
-        let input = b"a\rb\nc:d-e f\"g'h\\i#jklmnopqrstuvwxyz0123456789";
+        // Every structural byte present at once, plus a `\r` at 1, 10, and 24 so
+        // every tested offset's minimum (16-byte SSE2) window contains one: [0,
+        // 16), [4, 20), and [16, 32) respectively. A single `\r` cannot satisfy
+        // all three — those windows don't share a common byte.
+        let input = b"a\rb\nc:d-e \r\"g'h\\i#jklmno\rqrstuvwxyz0123456789";
         for &offset in &[0usize, 4, 16] {
             let with = classify_yaml_chars::<true>(input, offset).unwrap();
             let without = classify_yaml_chars::<false>(input, offset).unwrap();

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -70,6 +70,10 @@ pub struct YamlCharClass {
     /// YAML 1.2 §5.4 makes `\r` a line break in its own right, so scalar scans
     /// must stop at one exactly as they stop at `\n`. Kept separate from
     /// `newlines` so callers that genuinely mean LF still get LF (#324).
+    ///
+    /// Always `0` when the classifier was called with `HAS_CR == false`, which is
+    /// how a document with no carriage return in it avoids paying for the compare
+    /// (#340). Read it only under the same const the call site passed.
     pub carriage_returns: u32,
     /// Mask of bytes that are ':'
     pub colons: u32,
@@ -111,9 +115,20 @@ impl YamlCharClass {
     /// of `skip_unquoted_simd`. (Not an intra-doc link: that module is not
     /// compiled on x86_64.) The two disagreed until #185 — this one omitted
     /// `\r` before #324, and the broadword one added `spaces`.
+    ///
+    /// `HAS_CR` must be the one [`classify_yaml_chars`] was called with. Passing
+    /// `false` drops the `\r` arm at compile time, which is sound precisely
+    /// because that classifier left `carriage_returns` zero; the const is what
+    /// lets the optimizer *know* it, across a `#[target_feature]` call it cannot
+    /// see through (#340). The broadword twin takes no such parameter — the ARM
+    /// classifier is ungated, and the path that reads it is disabled anyway.
     #[inline(always)]
-    pub fn plain_scalar_terminators(&self) -> u32 {
-        self.newlines | self.carriage_returns | self.colons | self.hash
+    pub fn plain_scalar_terminators<const HAS_CR: bool>(&self) -> u32 {
+        let mut terminators = self.newlines | self.colons | self.hash;
+        if HAS_CR {
+            terminators |= self.carriage_returns;
+        }
+        terminators
     }
 }
 
@@ -121,8 +136,18 @@ impl YamlCharClass {
 ///
 /// This is the main P0 optimization - bulk classification of YAML characters.
 /// Falls back to SSE2 (16 bytes) for inputs smaller than 32 bytes.
+///
+/// `HAS_CR` selects whether the `\r` mask is computed at all. The kernels carry
+/// `#[target_feature]`, so they are never inlined into their caller and the
+/// optimizer cannot see that a caller ignores `carriage_returns` — the compare
+/// and its movemask survive to the instruction stream unless the const removes
+/// them here. That is the ~2pp the #324 attribution charges to this function
+/// (#340).
 #[inline]
-pub fn classify_yaml_chars(input: &[u8], offset: usize) -> Option<YamlCharClass> {
+pub fn classify_yaml_chars<const HAS_CR: bool>(
+    input: &[u8],
+    offset: usize,
+) -> Option<YamlCharClass> {
     // Require at least 16 bytes for SSE2
     if offset + 16 > input.len() {
         return None;
@@ -131,13 +156,13 @@ pub fn classify_yaml_chars(input: &[u8], offset: usize) -> Option<YamlCharClass>
     #[cfg(any(test, feature = "std"))]
     {
         if offset + 32 <= input.len() && avx2_enabled() {
-            return Some(unsafe { classify_yaml_chars_avx2(input, offset) });
+            return Some(unsafe { classify_yaml_chars_avx2::<HAS_CR>(input, offset) });
         }
     }
 
     // Fallback to SSE2 (requires 16 bytes minimum)
     if offset + 16 <= input.len() {
-        return Some(unsafe { classify_yaml_chars_sse2(input, offset) });
+        return Some(unsafe { classify_yaml_chars_sse2::<HAS_CR>(input, offset) });
     }
 
     None
@@ -146,12 +171,14 @@ pub fn classify_yaml_chars(input: &[u8], offset: usize) -> Option<YamlCharClass>
 /// AVX2 implementation of character classification (32 bytes at a time).
 #[cfg(any(test, feature = "std"))]
 #[target_feature(enable = "avx2")]
-unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass {
+unsafe fn classify_yaml_chars_avx2<const HAS_CR: bool>(
+    input: &[u8],
+    offset: usize,
+) -> YamlCharClass {
     let chunk = _mm256_loadu_si256(input.as_ptr().add(offset).cast::<__m256i>());
 
     // Create comparison vectors for each character
     let v_newline = _mm256_set1_epi8(b'\n' as i8);
-    let v_carriage_return = _mm256_set1_epi8(b'\r' as i8);
     let v_colon = _mm256_set1_epi8(b':' as i8);
     let v_hyphen = _mm256_set1_epi8(b'-' as i8);
     let v_space = _mm256_set1_epi8(b' ' as i8);
@@ -162,7 +189,6 @@ unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass
 
     // Compare and extract masks
     let eq_newline = _mm256_cmpeq_epi8(chunk, v_newline);
-    let eq_carriage_return = _mm256_cmpeq_epi8(chunk, v_carriage_return);
     let eq_colon = _mm256_cmpeq_epi8(chunk, v_colon);
     let eq_hyphen = _mm256_cmpeq_epi8(chunk, v_hyphen);
     let eq_space = _mm256_cmpeq_epi8(chunk, v_space);
@@ -173,7 +199,11 @@ unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass
 
     YamlCharClass {
         newlines: _mm256_movemask_epi8(eq_newline) as u32,
-        carriage_returns: _mm256_movemask_epi8(eq_carriage_return) as u32,
+        carriage_returns: if HAS_CR {
+            _mm256_movemask_epi8(_mm256_cmpeq_epi8(chunk, _mm256_set1_epi8(b'\r' as i8))) as u32
+        } else {
+            0
+        },
         colons: _mm256_movemask_epi8(eq_colon) as u32,
         hyphens: _mm256_movemask_epi8(eq_hyphen) as u32,
         spaces: _mm256_movemask_epi8(eq_space) as u32,
@@ -187,12 +217,14 @@ unsafe fn classify_yaml_chars_avx2(input: &[u8], offset: usize) -> YamlCharClass
 
 /// SSE2 implementation of character classification (16 bytes at a time).
 #[target_feature(enable = "sse2")]
-unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass {
+unsafe fn classify_yaml_chars_sse2<const HAS_CR: bool>(
+    input: &[u8],
+    offset: usize,
+) -> YamlCharClass {
     let chunk = _mm_loadu_si128(input.as_ptr().add(offset).cast::<__m128i>());
 
     // Create comparison vectors for each character
     let v_newline = _mm_set1_epi8(b'\n' as i8);
-    let v_carriage_return = _mm_set1_epi8(b'\r' as i8);
     let v_colon = _mm_set1_epi8(b':' as i8);
     let v_hyphen = _mm_set1_epi8(b'-' as i8);
     let v_space = _mm_set1_epi8(b' ' as i8);
@@ -203,7 +235,6 @@ unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass
 
     // Compare and extract masks
     let eq_newline = _mm_cmpeq_epi8(chunk, v_newline);
-    let eq_carriage_return = _mm_cmpeq_epi8(chunk, v_carriage_return);
     let eq_colon = _mm_cmpeq_epi8(chunk, v_colon);
     let eq_hyphen = _mm_cmpeq_epi8(chunk, v_hyphen);
     let eq_space = _mm_cmpeq_epi8(chunk, v_space);
@@ -214,7 +245,11 @@ unsafe fn classify_yaml_chars_sse2(input: &[u8], offset: usize) -> YamlCharClass
 
     YamlCharClass {
         newlines: _mm_movemask_epi8(eq_newline) as u32,
-        carriage_returns: _mm_movemask_epi8(eq_carriage_return) as u32,
+        carriage_returns: if HAS_CR {
+            _mm_movemask_epi8(_mm_cmpeq_epi8(chunk, _mm_set1_epi8(b'\r' as i8))) as u32
+        } else {
+            0
+        },
         colons: _mm_movemask_epi8(eq_colon) as u32,
         hyphens: _mm_movemask_epi8(eq_hyphen) as u32,
         spaces: _mm_movemask_epi8(eq_space) as u32,
@@ -996,7 +1031,7 @@ mod tests {
     fn test_classify_yaml_chars_basic() {
         // Keep input under 16 bytes for SSE2 test
         let input = b"key: #val-item\nmore";
-        let class = classify_yaml_chars(input, 0).unwrap();
+        let class = classify_yaml_chars::<true>(input, 0).unwrap();
 
         // Check colon at position 3
         assert_ne!(class.colons & (1 << 3), 0, "Colon not found at position 3");
@@ -1025,7 +1060,7 @@ mod tests {
     #[test]
     fn test_classify_yaml_chars_quotes() {
         let input = b"a: \"val\" 'x'end."; // 16 bytes
-        let class = classify_yaml_chars(input, 0).unwrap();
+        let class = classify_yaml_chars::<true>(input, 0).unwrap();
 
         // Check double quote at position 3
         assert_ne!(
@@ -1059,7 +1094,7 @@ mod tests {
     #[test]
     fn test_classify_yaml_chars_backslash() {
         let input = b"text: \"esc\\n\"ok."; // 16 bytes
-        let class = classify_yaml_chars(input, 0).unwrap();
+        let class = classify_yaml_chars::<true>(input, 0).unwrap();
 
         // Check backslash at position 10
         assert_ne!(
@@ -1093,7 +1128,7 @@ mod tests {
     fn test_classify_context_sensitive() {
         // Test ": " pattern (colon followed by space)
         let input = b"key: val t:1:2x."; // 16 bytes
-        let class = classify_yaml_chars(input, 0).unwrap();
+        let class = classify_yaml_chars::<true>(input, 0).unwrap();
 
         // Colon at position N followed by space at N+1 means:
         // - Colon bit is set at position N
@@ -1126,7 +1161,7 @@ mod tests {
     fn test_classify_hyphen_space_pattern() {
         // Test "- " pattern (hyphen followed by space)
         let input = b"- item\nval-nosp."; // 16 bytes
-        let class = classify_yaml_chars(input, 0).unwrap();
+        let class = classify_yaml_chars::<true>(input, 0).unwrap();
 
         // Hyphen at position N followed by space at N+1
         let hyphen_space_pattern = class.hyphens & (class.spaces >> 1);
@@ -1181,7 +1216,7 @@ mod tests {
     #[test]
     fn test_succinctly_simd_env_contract() {
         let buf = [b'a'; 64];
-        let width = classify_yaml_chars(&buf, 0).unwrap().width;
+        let width = classify_yaml_chars::<true>(&buf, 0).unwrap().width;
 
         match std::env::var("SUCCINCTLY_SIMD") {
             Ok(v) => match parse_simd_clamp(&v) {
@@ -1235,6 +1270,36 @@ mod tests {
         ]
     }
 
+    /// `HAS_CR` must zero the `\r` channel and change *nothing* else (#340).
+    ///
+    /// Both halves matter. If the const failed to suppress the CR mask, the
+    /// optimization would be a no-op that still measured as a win by accident;
+    /// if it perturbed another channel, `skip_unquoted_simd` would start skipping
+    /// over colons or hashes and the parse would silently change shape.
+    #[test]
+    fn test_classify_has_cr_gate_only_affects_the_cr_channel() {
+        // Every structural byte present at once, plus a `\r`, in both a 16-byte
+        // SSE2 chunk and a 32-byte AVX2 one.
+        let input = b"a\rb\nc:d-e f\"g'h\\i#jklmnopqrstuvwxyz0123456789";
+        for &offset in &[0usize, 4, 16] {
+            let with = classify_yaml_chars::<true>(input, offset).unwrap();
+            let without = classify_yaml_chars::<false>(input, offset).unwrap();
+
+            assert_eq!(without.carriage_returns, 0, "CR mask must vanish @{offset}");
+            assert_ne!(
+                with.carriage_returns, 0,
+                "fixture must actually contain a CR in the chunk @{offset}"
+            );
+            assert_eq!(with.width, without.width, "width must not change @{offset}");
+            for ((a, name), (b, _)) in classify_channels(&with)
+                .iter()
+                .zip(classify_channels(&without).iter())
+            {
+                assert_eq!(a, b, "{name} channel changed under HAS_CR=false @{offset}");
+            }
+        }
+    }
+
     /// Per-kernel differential sweep for the classify path (#247, option 2 of
     /// the issue): a lone structural byte at every position 0..40 of an
     /// otherwise-inert buffer, asserted against both kernels directly. The
@@ -1262,7 +1327,7 @@ mod tests {
                 buf[pos] = byte;
 
                 // SSE2 kernel at offset 0: sees bytes 0..16 only.
-                let sse2 = unsafe { classify_yaml_chars_sse2(&buf, 0) };
+                let sse2 = unsafe { classify_yaml_chars_sse2::<true>(&buf, 0) };
                 assert_eq!(sse2.width, 16, "SSE2 must report a 16-byte width");
                 for (i, (mask, name)) in classify_channels(&sse2).iter().enumerate() {
                     let expected = if i == channel && pos < 16 {
@@ -1277,7 +1342,7 @@ mod tests {
                 }
 
                 // SSE2 kernel at offset 16: covers the #231 window 16..31.
-                let sse2_hi = unsafe { classify_yaml_chars_sse2(&buf, 16) };
+                let sse2_hi = unsafe { classify_yaml_chars_sse2::<true>(&buf, 16) };
                 for (i, (mask, name)) in classify_channels(&sse2_hi).iter().enumerate() {
                     let expected = if i == channel && (16..32).contains(&pos) {
                         1u32 << (pos - 16)
@@ -1291,7 +1356,7 @@ mod tests {
                 }
 
                 if run_avx2 {
-                    let avx2 = unsafe { classify_yaml_chars_avx2(&buf, 0) };
+                    let avx2 = unsafe { classify_yaml_chars_avx2::<true>(&buf, 0) };
                     assert_eq!(avx2.width, 32, "AVX2 must report a 32-byte width");
                     let sse2_lo = classify_channels(&sse2);
                     for (i, (mask, name)) in classify_channels(&avx2).iter().enumerate() {
@@ -1337,8 +1402,8 @@ mod tests {
         for byte in terminating.into_iter().chain(passing) {
             let mut buf = [b'a'; 48];
             buf[3] = byte;
-            let class = classify_yaml_chars(&buf, 0).expect("48 bytes available");
-            let stops = class.plain_scalar_terminators() & (1 << 3) != 0;
+            let class = classify_yaml_chars::<true>(&buf, 0).expect("48 bytes available");
+            let stops = class.plain_scalar_terminators::<true>() & (1 << 3) != 0;
 
             assert_eq!(
                 stops,
@@ -1355,8 +1420,29 @@ mod tests {
 
         // An inert chunk sets nothing, so the mask is not simply always hot.
         let inert = [b'a'; 48];
-        let class = classify_yaml_chars(&inert, 0).expect("48 bytes available");
-        assert_eq!(class.plain_scalar_terminators(), 0);
+        let class = classify_yaml_chars::<true>(&inert, 0).expect("48 bytes available");
+        assert_eq!(class.plain_scalar_terminators::<true>(), 0);
+    }
+
+    /// The `HAS_CR == false` specialization drops `\r` from the terminator set —
+    /// the whole point of the const (#340). Sound only because the parser reaches
+    /// this arm only for documents with no `\r` in them at all, so pin the
+    /// remaining three bytes too: the gate must remove the CR arm and nothing
+    /// else.
+    #[test]
+    fn plain_scalar_terminators_without_cr_drops_only_the_cr_arm() {
+        for (byte, stops_ungated) in [(b'\n', true), (b'\r', true), (b':', true), (b'#', true)] {
+            let mut buf = [b'a'; 48];
+            buf[3] = byte;
+            let class = classify_yaml_chars::<false>(&buf, 0).expect("48 bytes available");
+
+            assert_eq!(
+                class.plain_scalar_terminators::<false>() & (1 << 3) != 0,
+                stops_ungated && byte != b'\r',
+                "0x{byte:02x} ({:?}) under HAS_CR == false",
+                byte as char
+            );
+        }
     }
 
     // ========================================================================

--- a/src/yaml/simd/x86.rs
+++ b/src/yaml/simd/x86.rs
@@ -1291,9 +1291,12 @@ mod tests {
                 "fixture must actually contain a CR in the chunk @{offset}"
             );
             assert_eq!(with.width, without.width, "width must not change @{offset}");
+            // carriage_returns is excluded: it is the one channel the gate is
+            // *supposed* to change, already pinned by the two assertions above.
             for ((a, name), (b, _)) in classify_channels(&with)
                 .iter()
                 .zip(classify_channels(&without).iter())
+                .filter(|((_, name), _)| *name != "carriage_returns")
             {
                 assert_eq!(a, b, "{name} channel changed under HAS_CR=false @{offset}");
             }


### PR DESCRIPTION
## Summary

Recovers most of the performance cost #324 (PR #334) paid for CRLF/lone-CR
correctness, via a `Parser<'a, const HAS_CR: bool>` const-generic
specialization: `build_semi_index` does one SIMD existence-scan for `\r`,
then parses with `Parser::<false>` (LF-only, every `\r` arm compiled out —
the pre-#324 codegen) or `Parser::<true>` (the #324 parser verbatim).

- Interleaved `yaml_bench` vs `c5dab403`, excl. block scalars: M4 Pro
  +4.0% → **+0.7%**, 7950X +11.0% → **+4.7%**; x86 block scalars now
  31-34% *faster* than pre-#324.
- End-to-end `dev bench yq` (32 configs) recovers fully: 7950X +5.0% →
  **+0.8%**, M4 Pro +2.3% → **-0.2%** median. CRLF documents unaffected
  (+1.1%/+0.5%, the precheck early-exiting).
- Output byte-identical to the #324 parser across 244 file×query
  configurations on both architectures.
- The one regressed shape is long quoted scalars (+7-12%): the parser
  bulk-skips those at ~15 GB/s, so the precheck's second pass over the
  input is large next to the parse itself — the honest floor for any
  approach that reads the input twice.

The gate is one-directional: `HAS_CR == true` is always correct, and the
whole-input precheck discharges the obligation on `false` — no `\r`
anywhere means no `\r` arm is reachable, in any context. A site left
un-gated is a missed optimization, never a bug.

**Breaking (low-level)**: `succinctly::yaml::simd::classify_yaml_chars`
now takes a `const HAS_CR: bool>` parameter.

Closes #340.

## Test plan

- [x] `cargo test --features simd --lib yaml::` (469 tests) — includes new
      `contains_cr` kernel tests, `both_monomorphizations_agree_on_cr_free_input`,
      and the `is_ws_break_or_eoi_agrees_with_is_seq_indicator_next` /
      `skip_line_break_agrees_with_line_break_len` guards extended to both
      `HAS_CR` monomorphizations
- [x] `cargo test --features cli --test yaml_crlf_tests --test yq_golden_tests`
      (LF≡CRLF≡CR differential harness + golden conformance incl. CRLF/lone-CR reruns)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (aarch64 NEON path)
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Manual review of every `HAS_CR`-gated match-arm reorder for guard-ordering correctness