### PR TITLE
fix(bench): stop yaml_bench anchors group panicking on UnknownAnchor

### DIFF
--- a/benches/yaml_bench.rs
+++ b/benches/yaml_bench.rs
@@ -157,13 +157,16 @@ fn generate_anchor_heavy(pairs: usize) -> Vec<u8> {
             // Medium anchor names (16-24 chars)
             yaml.extend_from_slice(format!("setting_{i}: &anchor_medium_{i} val{i}\n").as_bytes());
         } else {
-            // Reference previous anchors with aliases
-            let ref_idx = i.saturating_sub(3);
-            if ref_idx % 3 == 0 {
+            // Reference previous anchors with aliases. i % 3 == 2 here, so
+            // i - 1 (i%3==1, medium) and i - 2 (i%3==0, long) are always the
+            // two immediately preceding *definitions*, never references.
+            if (i / 3) % 2 == 0 {
+                let ref_idx = i - 2;
                 yaml.extend_from_slice(
                     format!("ref_{i}: *config_anchor_very_long_name_{ref_idx}\n").as_bytes(),
                 );
             } else {
+                let ref_idx = i - 1;
                 yaml.extend_from_slice(format!("ref_{i}: *anchor_medium_{ref_idx}\n").as_bytes());
             }
         }


### PR DESCRIPTION
## Summary
- `generate_anchor_heavy()` in `benches/yaml_bench.rs` derived alias targets via `i.saturating_sub(3)`, which lands on the same `i % 3` residue as `i` itself — so for `pairs >= 6`, reference iterations (`i % 3 == 2`) could target a prior *reference* index instead of a definition
- This aborted `cargo bench --bench yaml_bench` with `UnknownAnchor` partway through the `anchors` group, which also blocked the downstream `prose_scalars` and `crlf` groups since Criterion doesn't catch panics per-benchmark
- Reference iterations now target `i-1` or `i-2` — the two immediately preceding indices, which are always definitions by construction

Fixes #594

## Test plan
- [x] `cargo bench --bench yaml_bench -- 'anchors'` completes all 7 ids without panicking
- [x] `cargo clippy --benches --all-features -- -D warnings` clean
- [x] Full `cargo bench --bench yaml_bench` (all 11 groups) verified on both sanctioned benchmark boxes with no panics:
  - ARM M4 Pro (johns-mac-mini)
  - x86_64 Zen 4 / AVX-512 (terminus)