### PR TITLE
fix(jq): fan out if/select over a multi-output condition

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1012,6 +1012,87 @@ fn bools_to_result<'a, W: Clone + AsRef<[u64]>>(mut bools: Vec<bool>) -> QueryRe
     }
 }
 
+/// Evaluate `body(bit)` once per truthy-bit of a condition stream, merging
+/// the results in order. Shared by `eval_if` and `builtin_select` so a
+/// multi-output condition (`if (true,false) then "a" else "b" end` /
+/// `select((false,false) and true)`) fans out the same way both call it,
+/// instead of only consulting the condition's first output (#378).
+///
+/// Same borrowed/owned promotion as `eval_comma` (#353): outputs stay
+/// borrowed until an owned/computed body result forces the accumulator to
+/// promote, and a sibling that errors or breaks keeps whatever was already
+/// produced as a `Partial` prefix (#400) rather than discarding it.
+fn eval_fanout<'a, W: Clone + AsRef<[u64]>>(
+    cond_result: QueryResult<'a, W>,
+    mut body: impl FnMut(bool) -> QueryResult<'a, W>,
+) -> QueryResult<'a, W> {
+    let mut bits = Vec::new();
+    let cond_control = push_truthiness(cond_result, &mut bits);
+
+    let mut borrowed: Vec<StandardJson<'a, W>> = Vec::new();
+    let mut owned: Option<Vec<OwnedValue>> = None;
+
+    for bit in bits {
+        match body(bit).materialize_cursor() {
+            QueryResult::One(v) => match owned.as_mut() {
+                Some(acc) => acc.push(to_owned(&v)),
+                None => borrowed.push(v),
+            },
+            QueryResult::OneCursor(_) => {
+                unreachable!("materialize_cursor should have converted this")
+            }
+            QueryResult::Many(vs) => match owned.as_mut() {
+                Some(acc) => acc.extend(vs.iter().map(to_owned)),
+                None => borrowed.extend(vs),
+            },
+            QueryResult::Owned(v) => owned
+                .get_or_insert_with(|| {
+                    core::mem::take(&mut borrowed)
+                        .iter()
+                        .map(to_owned)
+                        .collect()
+                })
+                .push(v),
+            QueryResult::ManyOwned(vs) => owned
+                .get_or_insert_with(|| {
+                    core::mem::take(&mut borrowed)
+                        .iter()
+                        .map(to_owned)
+                        .collect()
+                })
+                .extend(vs),
+            QueryResult::None => {}
+            QueryResult::Error(e) => {
+                return partial(
+                    merge_owned(borrowed, owned.unwrap_or_default()),
+                    Control::Error(e),
+                );
+            }
+            QueryResult::Break(label) => {
+                return partial(
+                    merge_owned(borrowed, owned.unwrap_or_default()),
+                    Control::Break(label),
+                );
+            }
+            QueryResult::Partial(vs, control) => {
+                let mut merged = merge_owned(borrowed, owned.unwrap_or_default());
+                merged.extend(vs);
+                return partial(merged, control);
+            }
+        }
+    }
+
+    match cond_control {
+        Some(control) => partial(merge_owned(borrowed, owned.unwrap_or_default()), control),
+        None => match owned {
+            Some(mut acc) if acc.len() == 1 => QueryResult::Owned(acc.pop().unwrap()),
+            Some(acc) => QueryResult::ManyOwned(acc),
+            None if borrowed.len() == 1 => QueryResult::One(borrowed.pop().unwrap()),
+            None => QueryResult::Many(borrowed),
+        },
+    }
+}
+
 /// Evaluate arithmetic operations.
 fn eval_arithmetic<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     op: ArithOp,
@@ -1545,6 +1626,10 @@ fn eval_alternative<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Evaluate if-then-else expression.
+///
+/// A multi-output condition forks the branches, one evaluation per output
+/// (`if (true,false) then "a" else "b" end` yields `"a"`, `"b"`) — jq
+/// semantics, restored by `eval_fanout` (#378).
 fn eval_if<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     cond: &Expr,
     then_branch: &Expr,
@@ -1552,37 +1637,14 @@ fn eval_if<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate condition
     let cond_result = eval_single::<W, S>(cond, value.clone(), optional);
-
-    // Check if condition is truthy
-    let is_truthy = match &cond_result {
-        QueryResult::One(v) => to_owned(v).is_truthy(),
-        QueryResult::OneCursor(_) => unreachable!("eval_single never produces OneCursor"),
-        QueryResult::Owned(v) => v.is_truthy(),
-        QueryResult::Many(vs) => vs.first().is_some_and(|v| to_owned(v).is_truthy()),
-        QueryResult::ManyOwned(vs) => vs.first().is_some_and(super::value::OwnedValue::is_truthy),
-        QueryResult::None => false,
-        QueryResult::Error(e) => return QueryResult::Error(e.clone()),
-        QueryResult::Break(label) => return QueryResult::Break(label.clone()),
-        // The condition is only ever consulted for its first output (#378,
-        // a separate, already-tracked limitation — a multi-output condition
-        // does not fork the branches). A `Partial` condition is treated the
-        // same as a bare `Error`/`Break` above: the condition is evaluated
-        // once, and — per array/object construction's precedent, verified
-        // against jq — a value-position sub-expression that errors partway
-        // aborts outright rather than exposing a prefix.
-        QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e.clone()),
-        QueryResult::Partial(_, Control::Break(label)) => {
-            return QueryResult::Break(label.clone());
+    eval_fanout(cond_result, |truthy| {
+        if truthy {
+            eval_single::<W, S>(then_branch, value.clone(), optional)
+        } else {
+            eval_single::<W, S>(else_branch, value.clone(), optional)
         }
-    };
-
-    if is_truthy {
-        eval_single::<W, S>(then_branch, value, optional)
-    } else {
-        eval_single::<W, S>(else_branch, value, optional)
-    }
+    })
 }
 
 /// Evaluate try-catch expression.
@@ -2333,42 +2395,24 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: select(condition)
+///
+/// A multi-output condition republishes `value` once per truthy output
+/// (`select((false,false) and true)` yields nothing, matching jq — not the
+/// first-output-only answer `vs.first()` used to give) — restored by
+/// `eval_fanout` (#378).
 fn builtin_select<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     cond: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate condition
     let cond_result = eval_single::<W, S>(cond, value.clone(), optional);
-
-    // Check if condition is truthy
-    let is_truthy = match &cond_result {
-        QueryResult::One(v) => to_owned(v).is_truthy(),
-        QueryResult::OneCursor(_) => unreachable!("eval_single never produces OneCursor"),
-        QueryResult::Owned(v) => v.is_truthy(),
-        QueryResult::Many(vs) => vs.first().is_some_and(|v| to_owned(v).is_truthy()),
-        QueryResult::ManyOwned(vs) => vs.first().is_some_and(super::value::OwnedValue::is_truthy),
-        QueryResult::None => false,
-        QueryResult::Error(e) => return QueryResult::Error(e.clone()),
-        QueryResult::Break(label) => return QueryResult::Break(label.clone()),
-        // The condition is only ever consulted for its first output (#378,
-        // a separate, already-tracked limitation — a multi-output condition
-        // does not fork the branches). A `Partial` condition is treated the
-        // same as a bare `Error`/`Break` above: the condition is evaluated
-        // once, and — per array/object construction's precedent, verified
-        // against jq — a value-position sub-expression that errors partway
-        // aborts outright rather than exposing a prefix.
-        QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e.clone()),
-        QueryResult::Partial(_, Control::Break(label)) => {
-            return QueryResult::Break(label.clone());
+    eval_fanout(cond_result, |truthy| {
+        if truthy {
+            QueryResult::One(value.clone())
+        } else {
+            QueryResult::None
         }
-    };
-
-    if is_truthy {
-        QueryResult::One(value)
-    } else {
-        QueryResult::None
-    }
+    })
 }
 
 /// Builtin: map(f)
@@ -17679,23 +17723,15 @@ mod tests {
                 "x",
                 r#"jq 1.7.1 prints {"a":1,"b":2}, then fails"#,
             ),
-            (
-                b"5",
-                r#"select((true,error("x")))"#,
-                "x",
-                "jq 1.7.1 prints 5, then fails",
-            ),
+            // `select`/`if` fan out over their condition's outputs (#378) —
+            // they forward their operand as a stream, not a value, so they no
+            // longer belong in this list; see
+            // `partial_prefix_survives_the_stream_forwarding_constructs`.
             (
                 b"null",
                 r#""v=\((1,error("x")))""#,
                 "x",
                 r#"jq 1.7.1 prints "v=1", then fails"#,
-            ),
-            (
-                b"null",
-                r#"if (1,error("x")) then "t" else "f" end"#,
-                "x",
-                r#"jq 1.7.1 prints "t", then fails"#,
             ),
             (
                 b"[10,20,30]",
@@ -17743,9 +17779,8 @@ mod tests {
             (b"[1,2]", "map((.,break $out))"),
             (br#"{"a":1}"#, "with_entries((.,break $out))"),
             (b"null", "{a:1,b:(2,break $out)}"),
-            (b"5", "select((true,break $out))"),
+            // `select`/`if`: see the comment in `atomic` above.
             (b"null", r#""v=\((1,break $out))""#),
-            (b"null", r#"if (1,break $out) then "t" else "f" end"#),
             (b"[10,20,30]", ".[(1,break $out)]"),
             (b"[[7],[8]]", "(.[0],(.[1],break $out))[(0+0)]"),
             (br#"{"a":1}"#, "map_values((.,break $out))"),
@@ -17843,6 +17878,37 @@ mod tests {
         query!(b"null", r#"(1,2,error("x")) | empty"#,
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "x");
+            }
+        );
+
+        // `select`/`if` fan out over their condition's outputs (#378), so —
+        // like every other construct in this test — a `Partial` condition
+        // keeps whatever the truthy bits already produced before the
+        // trailing control surfaces. Matches jq 1.7.1 (`select((true,error("x")))`
+        // on `5` prints `5`, then fails; `if (1,error("x")) then "t" else "f" end`
+        // prints `"t"`, then fails).
+        query!(b"5", r#"select((true,error("x")))"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), ["5"]);
+                assert_eq!(e.message, "x");
+            }
+        );
+        query!(b"5", r"select((true,break $out))",
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(prefix_json(&vs), ["5"]);
+                assert_eq!(label, "out");
+            }
+        );
+        query!(b"null", r#"if (1,error("x")) then "t" else "f" end"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#""t""#]);
+                assert_eq!(e.message, "x");
+            }
+        );
+        query!(b"null", r#"if (1,break $out) then "t" else "f" end"#,
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(prefix_json(&vs), [r#""t""#]);
+                assert_eq!(label, "out");
             }
         );
     }
@@ -18211,6 +18277,23 @@ mod tests {
                 assert_eq!(n.as_i64().unwrap(), 1);
             }
         );
+    }
+
+    #[test]
+    fn test_if_multi_output_condition_forks_the_branches() {
+        // jq fans `if`/`select` out over every output of the condition,
+        // running the body once per output rather than consulting only the
+        // first one (#378). Pinned against jq 1.7.1.
+        assert_eq!(
+            outputs(b"null", r#"if (true,false) then "a" else "b" end"#),
+            [r#""a""#, r#""b""#]
+        );
+        assert_eq!(
+            outputs(b"null", r#"if (1==1, 1==2, 1==1) then "t" else "f" end"#),
+            [r#""t""#, r#""f""#, r#""t""#]
+        );
+        // An `empty` condition contributes no bits, so no branch runs at all.
+        assert!(outputs(b"null", r#"if empty then "t" else "f" end"#).is_empty());
     }
 
     #[test]
@@ -18627,10 +18710,21 @@ mod tests {
             }
         );
 
-        // select outputs nothing if condition is false
-        query!(br"2", "select(. > 3)",
-            QueryResult::None => {}
-        );
+        // select outputs nothing if condition is false. `eval_fanout` shares
+        // `eval_comma`'s empty-merge shape (`Many(vec![])`, not a bare
+        // `None`) — `outputs()` is deliberately variant-agnostic about that,
+        // per its own doc comment.
+        assert!(outputs(br"2", "select(. > 3)").is_empty());
+    }
+
+    #[test]
+    fn test_builtin_select_multi_output_condition_forks() {
+        // A multi-output condition republishes the input once per truthy
+        // output instead of only consulting the first one (#378). Pinned
+        // against jq 1.7.1.
+        assert!(outputs(b"1", "select((false,false) and true)").is_empty());
+        assert_eq!(outputs(b"1", "select((true,false) and true)"), ["1"]);
+        assert_eq!(outputs(b"1", "select((true,true))"), ["1", "1"]);
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -159,6 +159,34 @@ fn partial_generic<V: DocumentValue>(
     }
 }
 
+/// Append one truthiness bit per output of a `GenericResult` stream to
+/// `out`. Mirrors [`super::eval::push_truthiness`] for the generic
+/// evaluator's cursor-aware result type — used to fan `select`'s condition
+/// out over every output instead of only its first (#378).
+fn push_generic_truthiness<V: DocumentValue>(
+    result: GenericResult<V>,
+    out: &mut Vec<bool>,
+) -> Option<Control> {
+    match result {
+        GenericResult::One(v) => out.push(to_owned(&v).is_truthy()),
+        GenericResult::OneCursor(c) => out.push(to_owned(&c.value()).is_truthy()),
+        GenericResult::Many(vs) => out.extend(vs.iter().map(|v| to_owned(v).is_truthy())),
+        GenericResult::ManyCursor(cs) => {
+            out.extend(cs.iter().map(|c| to_owned(&c.value()).is_truthy()));
+        }
+        GenericResult::None => {}
+        GenericResult::Owned(v) => out.push(v.is_truthy()),
+        GenericResult::ManyOwned(vs) => out.extend(vs.iter().map(OwnedValue::is_truthy)),
+        GenericResult::Error(e) => return Some(Control::Error(e)),
+        GenericResult::Break(label) => return Some(Control::Break(label)),
+        GenericResult::Partial(vs, control) => {
+            out.extend(vs.iter().map(OwnedValue::is_truthy));
+            return Some(control);
+        }
+    }
+    None
+}
+
 /// Flatten a batch of per-element results into one `Vec<OwnedValue>`.
 ///
 /// `items` must never contain `Error`/`Break`/`Partial` — callers that build
@@ -1181,74 +1209,51 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         }
 
         Builtin::Select(cond) => {
-            // Evaluate condition with cursor context preserved
-            // This is critical for select(di == N) to work correctly
+            // Evaluate condition with cursor context preserved.
+            // This is critical for select(di == N) to work correctly.
             let cond_result = eval_single::<S, _>(cond, value.clone(), false, cursor);
 
-            // Helper to check if an OwnedValue is truthy
-            let is_truthy = |v: &OwnedValue| -> bool {
-                match v {
-                    OwnedValue::Bool(false) | OwnedValue::Null => false,
-                    _ => true, // All other values are truthy
+            let mut bits = Vec::new();
+            let cond_control = push_generic_truthiness(cond_result, &mut bits);
+            let truthy_count = bits.iter().filter(|&&b| b).count();
+
+            // `select` never changes position — every truthy output IS the
+            // input node, so forward the incoming cursor (if any) rather
+            // than dropping it via a plain `One`/`Many`. One republish per
+            // truthy output of a possibly multi-output condition (#378).
+            let pass_n = |n: usize| -> GenericResult<V> {
+                match (n, cursor) {
+                    (0, _) => GenericResult::None,
+                    (1, Some(c)) => GenericResult::OneCursor(c),
+                    (1, None) => GenericResult::One(value.clone()),
+                    (n, Some(c)) => {
+                        GenericResult::ManyCursor(core::iter::repeat(c).take(n).collect())
+                    }
+                    (n, None) => {
+                        GenericResult::Many(core::iter::repeat(value.clone()).take(n).collect())
+                    }
                 }
             };
 
-            // `select` never changes position — the truthy output IS the
-            // input node, so forward the incoming cursor (if any) rather
-            // than dropping it via a plain `One(value)`.
-            let pass =
-                || cursor.map_or(GenericResult::One(value.clone()), GenericResult::OneCursor);
-
-            match cond_result {
-                GenericResult::Owned(ref o) => {
-                    if is_truthy(o) {
-                        pass()
-                    } else {
-                        GenericResult::None
-                    }
+            match cond_control {
+                None => pass_n(truthy_count),
+                // `select(...)? ` swallows the condition's error the same
+                // way `try select(...) catch empty` would — per #400/#494,
+                // that keeps whatever the truthy bits already produced
+                // rather than discarding it too. `break` always propagates,
+                // `optional` or not.
+                Some(Control::Error(_)) if optional => pass_n(truthy_count),
+                Some(control) => {
+                    let prefix: Vec<OwnedValue> = match cursor {
+                        Some(c) => core::iter::repeat_with(|| to_owned(&c.value()))
+                            .take(truthy_count)
+                            .collect(),
+                        None => core::iter::repeat_with(|| to_owned(&value))
+                            .take(truthy_count)
+                            .collect(),
+                    };
+                    partial_generic(prefix, control)
                 }
-                GenericResult::One(v) => {
-                    if is_truthy(&to_owned(&v)) {
-                        pass()
-                    } else {
-                        GenericResult::None
-                    }
-                }
-                GenericResult::OneCursor(c) => {
-                    if is_truthy(&to_owned(&c.value())) {
-                        pass()
-                    } else {
-                        GenericResult::None
-                    }
-                }
-                GenericResult::Error(e) => {
-                    if optional {
-                        GenericResult::None
-                    } else {
-                        GenericResult::Error(e)
-                    }
-                }
-                GenericResult::None => GenericResult::None,
-                GenericResult::Many(_)
-                | GenericResult::ManyOwned(_)
-                | GenericResult::ManyCursor(_) => {
-                    // Multiple results from condition - this is unusual but treat first as condition
-                    // jq behavior: select with multiple outputs uses first truthy value
-                    pass()
-                }
-                GenericResult::Break(label) => GenericResult::Break(label),
-                // The condition is only ever consulted once here (see the
-                // `Many`/`ManyOwned`/`ManyCursor` arm above, a separate,
-                // already-existing limitation) — a `Partial` condition is
-                // conservatively treated the same as a bare `Error`/`Break`.
-                GenericResult::Partial(_, Control::Error(e)) => {
-                    if optional {
-                        GenericResult::None
-                    } else {
-                        GenericResult::Error(e)
-                    }
-                }
-                GenericResult::Partial(_, Control::Break(label)) => GenericResult::Break(label),
             }
         }
 
@@ -2501,6 +2506,30 @@ mod tests {
         assert_eq!(count, 2);
     }
 
+    #[test]
+    fn test_json_select_many_cursor_condition_forks() {
+        // A condition that iterates (`.[]`) evaluates through the
+        // `ManyCursor` arm of `push_generic_truthiness`. `select` forwards
+        // the *outer* cursor once per truthy element, not the elements
+        // themselves (#378). Pinned against jq 1.7.1.
+        let json = b"[true,false,true]";
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse("select(.[])").unwrap();
+
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(
+            result.collect_owned(),
+            vec![
+                OwnedValue::Array(vec![
+                    OwnedValue::Bool(true),
+                    OwnedValue::Bool(false),
+                    OwnedValue::Bool(true)
+                ]);
+                2
+            ]
+        );
+    }
+
     // ========================================================================
     // Phase 23: Position-based navigation tests
     // ========================================================================
@@ -3302,6 +3331,26 @@ mod tests {
             ),
             partial_break(&["10"])
         );
+
+        // `select` fans out over its condition's outputs (#378), so — like
+        // every other stream-forwarding construct above — a `Partial`
+        // condition keeps whatever the truthy bits already produced before
+        // the trailing control surfaces. Matches jq 1.7.1
+        // (`select((true,error("x")))` on `5` prints `5`, then fails).
+        assert_eq!(
+            summarize(b"5", r#"select((true,error("x")))"#),
+            partial_err(&["5"], "x")
+        );
+        assert_eq!(
+            summarize(b"5", "select((true,break $out))"),
+            partial_break(&["5"])
+        );
+        // `select(...)? ` swallows the condition's error like `try select(...)
+        // catch empty` would, but still keeps the truthy bits' output.
+        assert_eq!(
+            summarize(b"5", r#"select((true,error("x")))?"#),
+            Summary::Values(vec!["5".to_string()])
+        );
     }
 
     #[test]
@@ -3325,20 +3374,6 @@ mod tests {
         );
         assert_eq!(
             summarize(b"[[7],[8]]", "(.[0],(.[1],break $out))[(0+0)]"),
-            Summary::Break("out".to_string())
-        );
-
-        // `select`'s condition, in all three of its arms.
-        assert_eq!(
-            summarize(b"5", r#"select((true,error("x")))"#),
-            Summary::Error("x".to_string())
-        );
-        assert_eq!(
-            summarize(b"5", r#"select((true,error("x")))?"#),
-            Summary::None
-        );
-        assert_eq!(
-            summarize(b"5", "select((true,break $out))"),
             Summary::Break("out".to_string())
         );
     }

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -60,9 +60,12 @@
 #
 # comma_literal_before_document (#353) has since been fixed and dropped,
 # leaving 13.
+#
+# if_multi_output_condition (#378) has since been fixed and dropped, leaving
+# 12: `if`/`select` now fan out over every output of the condition instead of
+# consulting only the first one, in both evaluators.
 
 object_construct_cartesian     object_construct   only the first output of each key/value generator is used instead of the cartesian product — #354
-if_multi_output_condition      if_condition       only the first output of a multi-output if-condition is used — #378
 assign_multi_output_rhs        assignment         .a = (1,2) only applies the first RHS output instead of forking once per output — #392
 nan_type                       nan                nan | type reports "null" instead of "number" — #472
 path_recursive_descent         path               path(..) returns only the root path instead of every descendant path — #483

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -54,28 +54,6 @@ fn assert_parity(json: &[u8], filter: &str) {
     );
 }
 
-/// Assert the two evaluators currently DISAGREE, pinning both observed outputs.
-/// When the referenced fix aligns them, the `assert_ne!` fails, forcing whoever
-/// lands the fix to convert this into `assert_parity`.
-fn assert_divergence(json: &[u8], filter: &str, full_expected: &[&str], generic_expected: &[&str]) {
-    let full = full_outputs(json, filter);
-    let generic = generic_outputs(json, filter);
-    assert_eq!(
-        as_strs(&full),
-        full_expected,
-        "full evaluator output changed for `{filter}`"
-    );
-    assert_eq!(
-        as_strs(&generic),
-        generic_expected,
-        "generic evaluator output changed for `{filter}`"
-    );
-    assert_ne!(
-        full, generic,
-        "evaluators now AGREE for `{filter}` -- convert to assert_parity"
-    );
-}
-
 #[test]
 fn test_parity_values_builtin() {
     // `values` drops null inputs.
@@ -218,21 +196,43 @@ fn test_stream_operator_parity_160() {
 
 #[test]
 fn test_multi_output_condition_in_select_parity_160() {
-    // `and`/`or` can now hand `select` a multi-output condition, where the two
-    // evaluators disagree: `builtin_select` (eval.rs) tests the first output,
-    // while eval_generic's `Builtin::Select` treats any multi-output condition
-    // as truthy outright. jq fans the condition out instead, emitting the input
-    // once per truthy output -- so both are wrong, in different ways.
+    // `and`/`or` can hand `select`/`if` a multi-output condition. Before
+    // #378, the two evaluators disagreed about it: `builtin_select`/`eval_if`
+    // (eval.rs) tested only the condition's first output, while eval_generic's
+    // `Builtin::Select` treated any multi-output condition as truthy outright.
+    // jq fans the condition out instead, running the body once per output --
+    // #378 makes both evaluators do that, so this is now `assert_parity`
+    // rather than the `assert_divergence` it was pinned as.
     //
-    // That drift predates #160; #160 only widened what can reach it. Pinned
-    // here rather than fixed, because fixing `select` is the separate
-    // follow-up. jq's answer for the filter below is no output at all, which
-    // is what the full evaluator happens to give.
+    // Every expectation is pinned against jq-1.7.1 first, so parity can't lock
+    // in an agreed-upon wrong answer (this file's header failure mode).
     assert_eq!(
         as_strs(&full_outputs(b"1", "[(false,false) and true]")),
         ["[false,false]"]
     );
-    assert_divergence(b"1", "select((false,false) and true)", &[], &["1"]);
+    assert_eq!(
+        as_strs(&full_outputs(b"1", "select((false,false) and true)")),
+        Vec::<&str>::new(),
+        "full evaluator disagrees with jq"
+    );
+    assert_parity(b"1", "select((false,false) and true)");
+
+    assert_eq!(
+        as_strs(&full_outputs(b"1", "select((true,false) and true)")),
+        ["1"],
+        "full evaluator disagrees with jq"
+    );
+    assert_parity(b"1", "select((true,false) and true)");
+
+    assert_eq!(
+        as_strs(&full_outputs(
+            b"null",
+            r#"if (true,false) then "a" else "b" end"#
+        )),
+        [r#""a""#, r#""b""#],
+        "full evaluator disagrees with jq"
+    );
+    assert_parity(b"null", r#"if (true,false) then "a" else "b" end"#);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

jq fans a condition out: `if`/`select` run their body once per output the
condition stream produces, not just once for the first output. Succinctly
collapsed this in two places, and the two evaluators disagreed about *how*:

```
echo 1 | sjq -c 'select((false,false) and true)'   # => 1        (jq: no output)
echo null | sjq -c 'if (true,false) then "a" else "b" end'
                                                    # => "a"      (jq: "a" "b")
```

- `eval_if`/`builtin_select` (`src/jq/eval.rs`, the full evaluator) only
  consulted `vs.first()` of a multi-output condition.
- `eval_generic`'s own `Builtin::Select` arm (the CLI/generic evaluator) went
  further: it treated *any* `Many`/`ManyOwned`/`ManyCursor` condition as
  truthy outright, without even checking the first element — a second,
  independently wrong implementation.

- **`fix(jq): fan out if/select over a multi-output condition`** — adds
  `eval_fanout`, a helper next to `push_truthiness` (added by #160 for the
  identical bug in `//`/`and`/`or`), and routes `eval_if`/`builtin_select`
  through it instead of a third hand-rolled `vs.first()` copy.
- **`fix(jq): fan out select's condition in the generic evaluator`** — adds
  `push_generic_truthiness` (mirrors `push_truthiness` for `GenericResult`)
  and rewrites the native `Builtin::Select` arm to republish the input (or
  its cursor) once per truthy condition output, preserving the existing
  `optional`/`?` handling but correcting it to match jq's `try`/`catch`
  semantics (keep what the truthy bits already produced instead of
  discarding it).

Flips the pinned `test_multi_output_condition_in_select_parity_160` from
`assert_divergence` to `assert_parity`, and drops `if_multi_output_condition`
from the jq golden known-failures manifest (now passes).

Fixes #378

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` (full suite, all binaries green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the two
      other CI feature-set clippy invocations (SIMD x86, `broadword-yaml`)
- [x] Manually diffed all three of the issue's repro commands against system
      `jq` via the built CLI — byte-for-byte match, including the
      `select(...)?`/error-suppression edge case