### PR TITLE
fix(yq): preserve duplicate mapping keys in --slurp and --inplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -717,17 +717,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through cursor streaming: multi-file pretty output no longer emits a
   spurious leading `---` before the first document.
 
-  Not fixed by this change, since the M2 fast path only gives `Expr::Identity`
-  a true cursor result — `Field`/`Index`/`Iterate` still evaluate to an owned
-  `GenericResult::One`/`Many` and go through `to_owned()` when streamed, so a
-  duplicate key *nested inside* a navigated field (`.a` where `a`'s value has
-  a repeated key) still collapses, in both compact and pretty output, exactly
-  as before this fix (tracked as a comment on #443, which already covers the
-  same `to_owned()`/`IndexMap` mechanism for `to_entries`); `--slurp`,
-  `--inplace` (`yaml_to_owned_value`), and `jq --preserve-input` pretty output
-  (`standard_json_to_jq_value`, gated by `jq_runner.rs`'s
-  `can_use_raw_identity`) go through their own separate, still-`IndexMap`-backed
-  conversions and are tracked in #478.
+  Not fixed by this change at the time: the M2 fast path only gave
+  `Expr::Identity` a true cursor result — `Field`/`Index`/`Iterate` still
+  evaluated to an owned `GenericResult::One`/`Many` and went through
+  `to_owned()` when streamed, so a duplicate key *nested inside* a navigated
+  field (`.a` where `a`'s value has a repeated key) still collapsed, in both
+  compact and pretty output (tracked as a comment on #443, which already
+  covers the same `to_owned()`/`IndexMap` mechanism for `to_entries`).
+  **Since resolved by #532** (`Expr::Identity => GenericResult::OneCursor`,
+  which also converted `Field`/`Index`/`Iterate` to `OneCursor`/`ManyCursor`).
+  `--slurp`, `--inplace` (`yaml_to_owned_value`), and `jq --preserve-input`
+  pretty output (`standard_json_to_jq_value`, gated by `jq_runner.rs`'s
+  `can_use_raw_identity`) went through their own separate, still-`IndexMap`
+  -backed conversions — see #478 below for resolution.
+
+- **`yq --slurp '.'` and `yq --inplace '.'` still silently dropped duplicate
+  mapping keys after #442** (#478): `yq --slurp '.'` on `a: 1\na: 2` printed
+  `a: 2` instead of keeping both entries inside the slurped element, and
+  `yq --inplace '.'` on the same input wrote `a: 2` back to the file,
+  diverging from real `yq --inplace` v4.53.3's `a: 1\na: 2`. Cause: both
+  went through `yaml_to_owned_value()` (`yq_runner.rs`), and `--slurp`'s
+  result was re-collapsed a second time by the `IndexMap`-backed
+  `standard_json_to_owned()` inside `evaluate_input`'s JSON round-trip —
+  neither was reached by #442's fix, which only widened `Expr::Identity`'s
+  path to stdout. (#478's third listed site, `jq --preserve-input` pretty
+  output, turned out to already be fixed incidentally by #532, merged
+  before this fix; only a regression test was added for it here.)
+
+  Fix: `--inplace` now reuses the M2 cursor-streaming machinery for the same
+  shapes `can_use_m2_streaming` already accepts (`.`, `.field`, `.[n]`,
+  `.[]`, and pipes/parens/`?` of those), via new
+  `can_inplace_json_fast_path`/`can_inplace_yaml_fast_path` gates that mirror
+  `can_json_fast_path`/`can_yaml_fast_path` but write into a per-file buffer
+  instead of stdout before the existing `fs::write`. `--slurp` gets a
+  narrower, identity-only fast path (a non-trivial filter over the slurped
+  array still needs real evaluation) backed by a new
+  `yaml::stream_yaml_sequence()` helper: every source is parsed up front
+  into an owned `(bytes, YamlIndex)` pair so their cursors can share one
+  `Vec`'s lifetime, then streamed into a single YAML sequence using the same
+  container-vs-scalar block/flow rendering `stream_yaml_value`'s `Sequence`
+  arm already uses — reused rather than re-derived, so multi-document slurp
+  output matches single-document M2 streaming byte-for-byte. `-o json
+  --slurp` still uses the slow DOM path, the same explicit, documented scope
+  limit `sort_keys`/color/`--tab` already have on the gates above.
+
+  Not fixed by this change: `standard_json_to_jq_value()` is still reachable
+  and lossy through `Builtin::First`/`Builtin::Last` and `Pipe`'s
+  stage-advance re-entry (e.g. `jq --preserve-input 'first(.[])'` on
+  `[{"a":1,"a":2}]` collapses to one `"a"`), found while verifying the
+  `--preserve-input` fix above — filed as #607.
 
 - **The strict YAML validator accepted a flow-collection anchor immediately
   followed by an alias** (#452): `[&a *a]` and `{k: &a *a}` passed

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -15,7 +15,8 @@ use succinctly::jq::{self, Builtin, Expr, OwnedValue, QueryResult, YqSemantics};
 use succinctly::json::light::StandardJson;
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
-    format_float_with_fraction, resolve_plain, ResolvedScalar, YamlCursor, YamlIndex, YamlValue,
+    format_float_with_fraction, resolve_plain, stream_yaml_sequence, ResolvedScalar, YamlCursor,
+    YamlIndex, YamlValue,
 };
 
 use super::{InputFormat, OutputFormat, YqCommand};
@@ -1339,6 +1340,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && context.named.is_empty();
     let can_inplace_fast_path = can_inplace_json_fast_path || can_inplace_yaml_fast_path;
 
+    // `--slurp`'s fast path (#478) is narrower than the two gates above:
+    // scoped to plain identity only (`is_identity`, not the broader
+    // `is_m2_streamable` set), since a non-trivial filter over the slurped
+    // array needs real evaluation. `-o json --slurp` still uses the slow
+    // DOM path below — an explicit, documented scope limit rather than a
+    // silent gap, matching `sort_keys`/color/tab already being excluded
+    // from the gates above.
+    let can_slurp_fast_path = is_identity
+        && can_stream_pretty
+        && output_config.output_format == OutputFormat::Yaml
+        && !args.null_input
+        && !args.raw_input
+        && context.named.is_empty();
+
     // Indent width for the fast path's streamers. YAML's `-I0` is a special
     // case: real `yq` treats it as "use the library default" (4 spaces),
     // and succinctly's existing (pre-#442) compact-YAML fast path hardcodes
@@ -1640,7 +1655,6 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         }
     } else if args.slurp {
         // Handle --slurp: collect all documents from all inputs into an array
-        let mut all_docs: Vec<OwnedValue> = Vec::new();
 
         // Collect input sources
         let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
@@ -1666,31 +1680,105 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             sources
         };
 
-        // Parse all inputs and collect documents
-        let mut global_doc_index: usize = 0;
-        for (bytes, format) in &input_sources {
-            let inputs = parse_input(bytes, *format)?;
-            for input in inputs {
-                // Apply --doc filter if specified
-                if let Some(target_doc) = args.document {
-                    if global_doc_index == target_doc {
+        if can_slurp_fast_path {
+            // M2 streaming fast path (#478): stream each source's document
+            // cursor(s) directly into one combined YAML sequence, skipping
+            // the OwnedValue DOM. `evaluate_input`'s JSON round-trip below
+            // would otherwise re-collapse duplicate mapping keys even if the
+            // initial conversion into it didn't (the array-builder step
+            // has its own `IndexMap`-backed collapse).
+            //
+            // Two-phase: parse every source into an owned `(bytes, YamlIndex)`
+            // pair first, so all sources stay alive together — `YamlCursor`
+            // borrows both `text` and `index` with the same lifetime, so
+            // cursors from different sources can't be collected into one
+            // `Vec` unless their backing bytes/index all outlive that `Vec`.
+            let mut parsed_sources: Vec<(Vec<u8>, YamlIndex<Vec<u64>>)> =
+                Vec::with_capacity(input_sources.len());
+            for (bytes, _format) in input_sources {
+                let index = YamlIndex::build(&bytes)
+                    .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
+                parsed_sources.push((bytes, index));
+            }
+
+            let mut cursors = Vec::new();
+            let mut global_doc_index: usize = 0;
+            for (bytes, index) in &parsed_sources {
+                let root = index.root(bytes);
+                match root.value() {
+                    YamlValue::Sequence(mut docs) => {
+                        while let Some((cursor, rest)) = docs.uncons_cursor() {
+                            let should_process = args
+                                .document
+                                .map_or(true, |target| global_doc_index == target);
+                            if should_process {
+                                cursors.push(cursor);
+                            }
+                            global_doc_index += 1;
+                            docs = rest;
+                        }
+                    }
+                    _ => {
+                        // Defensive fallback only, matching the stdout/inplace
+                        // M2 paths: the root cursor always reports the virtual
+                        // document sequence, so real documents go through the
+                        // Sequence arm above.
+                        let should_process = args
+                            .document
+                            .map_or(true, |target| global_doc_index == target);
+                        if should_process {
+                            if let Some(doc_cursor) = root.first_child() {
+                                cursors.push(doc_cursor);
+                            }
+                        }
+                        global_doc_index += 1;
+                    }
+                }
+            }
+
+            if args.exit_status {
+                // `--slurp '.'` always yields exactly one (array) result, and
+                // a non-empty array is truthy regardless of its elements —
+                // matching jq/yq `-e` semantics for arrays.
+                any_truthy = true;
+            }
+            stream_yaml_sequence(
+                cursors.iter().copied(),
+                &mut FmtWriter(&mut writer),
+                0,
+                yaml_indent_spaces,
+            )
+            .map_err(|_| anyhow::anyhow!("Write error"))?;
+            writeln!(writer)?;
+        } else {
+            let mut all_docs: Vec<OwnedValue> = Vec::new();
+
+            // Parse all inputs and collect documents
+            let mut global_doc_index: usize = 0;
+            for (bytes, format) in &input_sources {
+                let inputs = parse_input(bytes, *format)?;
+                for input in inputs {
+                    // Apply --doc filter if specified
+                    if let Some(target_doc) = args.document {
+                        if global_doc_index == target_doc {
+                            all_docs.push(input);
+                        }
+                    } else {
                         all_docs.push(input);
                     }
-                } else {
-                    all_docs.push(input);
+                    global_doc_index += 1;
                 }
-                global_doc_index += 1;
             }
-        }
 
-        // Create slurped array and evaluate
-        let slurped = OwnedValue::Array(all_docs);
-        let results = evaluate_input(&slurped, &program.expr, &mut sink)?;
-        let mut split_doc_state = SplitDocState::new(has_split_doc);
-        for result in results {
-            split_doc_state.write_separator(&mut writer, &output_config)?;
-            any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-            output_value(&mut writer, &result, &output_config)?;
+            // Create slurped array and evaluate
+            let slurped = OwnedValue::Array(all_docs);
+            let results = evaluate_input(&slurped, &program.expr, &mut sink)?;
+            let mut split_doc_state = SplitDocState::new(has_split_doc);
+            for result in results {
+                split_doc_state.write_separator(&mut writer, &output_config)?;
+                any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
+                output_value(&mut writer, &result, &output_config)?;
+            }
         }
     } else if args.inplace {
         // Handle --inplace: process each file and write back to it

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1315,6 +1315,30 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && context.named.is_empty();
     let can_fast_path = can_json_fast_path || can_yaml_fast_path;
 
+    // `--inplace`'s own copy of the M2 gate (#478): identical conditions to
+    // `can_json_fast_path`/`can_yaml_fast_path` above, but requiring
+    // `args.inplace` instead of excluding it. Kept as a separate pair rather
+    // than folding into the gate above because inplace output targets a
+    // per-file buffer (then `fs::write`), not the shared stdout `writer`
+    // the block below uses — the two loops have different write targets and
+    // per-file `---` separator resets, so they stay as distinct branches
+    // that happen to share the same underlying `stream_cursor!` macro.
+    let can_inplace_json_fast_path = is_m2_streamable
+        && (output_config.compact || (can_stream_pretty && !args.ascii_output))
+        && output_config.output_format == OutputFormat::Json
+        && !args.null_input
+        && !args.raw_input
+        && args.inplace
+        && context.named.is_empty();
+    let can_inplace_yaml_fast_path = is_m2_streamable
+        && (output_config.compact || can_stream_pretty)
+        && output_config.output_format == OutputFormat::Yaml
+        && !args.null_input
+        && !args.raw_input
+        && args.inplace
+        && context.named.is_empty();
+    let can_inplace_fast_path = can_inplace_json_fast_path || can_inplace_yaml_fast_path;
+
     // Indent width for the fast path's streamers. YAML's `-I0` is a special
     // case: real `yq` treats it as "use the library default" (4 spaces),
     // and succinctly's existing (pre-#442) compact-YAML fast path hardcodes
@@ -1330,22 +1354,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     };
     let json_indent_spaces: usize = args.indent as usize;
 
-    if can_fast_path {
-        // M2 streaming fast path: evaluate expression and stream results directly
-        // Track global document index across all files for --doc filtering
-        let mut global_doc_index: usize = 0;
-        // Whether any document has produced YAML output yet — drives `---`
-        // separator placement between documents (#175).
-        let mut yaml_doc_streamed = false;
-
-        // Helper macro to stream cursor results (avoiding closure borrow issues)
-        macro_rules! stream_cursor {
-            ($cursor:expr, $writer:expr) => {{
-                if can_yaml_fast_path {
+    // Helper macro to stream cursor results (avoiding closure borrow issues).
+    // Defined here (rather than inside the `if can_fast_path` block below) so
+    // both the stdout M2 path and `--inplace`'s fast path (#478) can reuse
+    // it. `$is_yaml` is threaded through explicitly rather than closing over
+    // `can_yaml_fast_path` by name, and `yaml_doc_streamed`/`any_truthy`/
+    // `sink` resolve, at each call site, to whichever same-named local is in
+    // scope there — each branch below declares its own `yaml_doc_streamed`.
+    macro_rules! stream_cursor {
+            ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr) => {{
+                if $is_yaml {
                     // M2 YAML path: YAML output streaming
                     if is_identity {
                         // P9 path: stream directly without evaluation
-                        emit_yaml_doc_separator($writer, &mut yaml_doc_streamed, true)?;
+                        emit_yaml_doc_separator($writer, $doc_streamed, true)?;
                         $cursor
                             .stream_yaml(&mut FmtWriter($writer), yaml_indent_spaces)
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
@@ -1364,7 +1386,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         ) && !matches!(&result, GenericResult::Many(vs) if vs.is_empty())
                             && !matches!(&result, GenericResult::ManyCursor(cs) if cs.is_empty())
                             && !matches!(&result, GenericResult::ManyOwned(vs) if vs.is_empty());
-                        emit_yaml_doc_separator($writer, &mut yaml_doc_streamed, will_output)?;
+                        emit_yaml_doc_separator($writer, $doc_streamed, will_output)?;
                         let stats = result
                             .stream_yaml(&mut FmtWriter($writer), yaml_indent_spaces, |w| {
                                 w.write_str("\n")
@@ -1409,6 +1431,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }};
         }
 
+    if can_fast_path {
+        // M2 streaming fast path: evaluate expression and stream results directly
+        // Track global document index across all files for --doc filtering
+        let mut global_doc_index: usize = 0;
+        // Whether any document has produced YAML output yet — drives `---`
+        // separator placement between documents (#175).
+        let mut yaml_doc_streamed = false;
+
         if input_files.is_empty() {
             let yaml_bytes = read_stdin()?;
             let fmt = resolve_input_format(args.input_format, None);
@@ -1428,7 +1458,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             .document
                             .map_or(true, |target| global_doc_index == target);
                         if should_process {
-                            stream_cursor!(cursor, &mut writer);
+                            stream_cursor!(
+                                cursor,
+                                &mut writer,
+                                can_yaml_fast_path,
+                                &mut yaml_doc_streamed
+                            );
                         }
                         global_doc_index += 1;
                         docs = rest;
@@ -1464,7 +1499,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         } else {
                             // M2 path: need to get the actual document cursor
                             if let Some(doc_cursor) = root.first_child() {
-                                stream_cursor!(doc_cursor, &mut writer);
+                                stream_cursor!(
+                                    doc_cursor,
+                                    &mut writer,
+                                    can_yaml_fast_path,
+                                    &mut yaml_doc_streamed
+                                );
                             }
                         }
                     }
@@ -1492,7 +1532,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 .document
                                 .map_or(true, |target| global_doc_index == target);
                             if should_process {
-                                stream_cursor!(cursor, &mut writer);
+                                stream_cursor!(
+                                    cursor,
+                                    &mut writer,
+                                    can_yaml_fast_path,
+                                    &mut yaml_doc_streamed
+                                );
                             }
                             global_doc_index += 1;
                             docs = rest;
@@ -1532,7 +1577,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             } else {
                                 // M2 path: need to get the actual document cursor
                                 if let Some(doc_cursor) = root.first_child() {
-                                    stream_cursor!(doc_cursor, &mut writer);
+                                    stream_cursor!(
+                                        doc_cursor,
+                                        &mut writer,
+                                        can_yaml_fast_path,
+                                        &mut yaml_doc_streamed
+                                    );
                                 }
                             }
                         }
@@ -1658,11 +1708,87 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             {
                 return Ok(code);
             }
-            let inputs = parse_input(&input_bytes, format)?;
 
-            // Collect all output into a buffer
             let mut output_buffer = Vec::new();
-            {
+
+            if can_inplace_fast_path {
+                // M2 streaming fast path (#478): stream cursor results
+                // directly into this file's buffer, skipping the OwnedValue
+                // DOM (and its IndexMap, which cannot represent duplicate
+                // mapping keys) the same way the stdout M2 path above does.
+                let index = YamlIndex::build(&input_bytes)
+                    .map_err(|e| anyhow::anyhow!("YAML parse error in {file_path}: {e}"))?;
+                let root = index.root(&input_bytes);
+
+                {
+                    let mut buf_writer = BufWriter::new(&mut output_buffer);
+                    // `---` separators start fresh per file, unlike the
+                    // stdout path where they persist across all input files.
+                    let mut yaml_doc_streamed = false;
+
+                    match root.value() {
+                        YamlValue::Sequence(mut docs) => {
+                            while let Some((cursor, rest)) = docs.uncons_cursor() {
+                                let should_process = args
+                                    .document
+                                    .map_or(true, |target| global_doc_index == target);
+                                if should_process {
+                                    stream_cursor!(
+                                        cursor,
+                                        &mut buf_writer,
+                                        can_inplace_yaml_fast_path,
+                                        &mut yaml_doc_streamed
+                                    );
+                                }
+                                global_doc_index += 1;
+                                docs = rest;
+                            }
+                        }
+                        _ => {
+                            // Single document case. See the stdout M2 path's
+                            // identical fallback above: the root cursor
+                            // always reports the virtual document sequence,
+                            // so real documents go through the Sequence arm.
+                            let should_process = args
+                                .document
+                                .map_or(true, |target| global_doc_index == target);
+                            if should_process {
+                                if is_identity {
+                                    if can_inplace_yaml_fast_path {
+                                        root.stream_yaml_document(
+                                            &mut FmtWriter(&mut buf_writer),
+                                            yaml_indent_spaces,
+                                        )
+                                        .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                    } else {
+                                        root.stream_json_document(
+                                            &mut FmtWriter(&mut buf_writer),
+                                            json_indent_spaces,
+                                        )
+                                        .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                    }
+                                    writeln!(buf_writer)?;
+                                    if args.exit_status {
+                                        any_truthy |=
+                                            root.first_child().is_some_and(|c| !c.is_falsy());
+                                    }
+                                } else if let Some(doc_cursor) = root.first_child() {
+                                    stream_cursor!(
+                                        doc_cursor,
+                                        &mut buf_writer,
+                                        can_inplace_yaml_fast_path,
+                                        &mut yaml_doc_streamed
+                                    );
+                                }
+                            }
+                            global_doc_index += 1;
+                        }
+                    }
+                    buf_writer.flush()?;
+                }
+            } else {
+                let inputs = parse_input(&input_bytes, format)?;
+
                 let mut buf_writer = BufWriter::new(&mut output_buffer);
                 // Count matching docs for multi-doc separator logic
                 let matching_docs: usize = if let Some(target_doc) = args.document {
@@ -1704,8 +1830,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     }
                 }
                 buf_writer.flush()?;
+                global_doc_index += inputs.len();
             }
-            global_doc_index += inputs.len();
 
             // Write the output back to the file
             std::fs::write(path, &output_buffer)

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5124,6 +5124,69 @@ fn write_yaml_indent<Out: core::fmt::Write>(out: &mut Out, spaces: usize) -> cor
     Ok(())
 }
 
+/// Stream independent document cursors as a single YAML sequence (block or
+/// flow style), without materializing an `OwnedValue` DOM.
+///
+/// Unlike [`YamlCursor::stream_yaml_value`]'s `Sequence` arm, the cursors
+/// here need not share one `YamlIndex` — each may come from its own
+/// document/source. This is what lets `--slurp` wrap multiple slurped
+/// documents into one array while preserving duplicate mapping keys within
+/// each (#478); an `OwnedValue`-based `IndexMap` cannot represent those.
+///
+/// Mirrors the `Sequence` block/flow-style rendering in `stream_yaml_value`
+/// exactly (same container-vs-scalar branching, same empty-sequence `"[]"`
+/// shortcut) so multi-document slurped output matches single-document M2
+/// streaming byte-for-byte.
+pub fn stream_yaml_sequence<'a, W, I, Out>(
+    cursors: I,
+    out: &mut Out,
+    current_indent: usize,
+    indent_spaces: usize,
+) -> core::fmt::Result
+where
+    W: AsRef<[u64]> + 'a,
+    I: IntoIterator<Item = YamlCursor<'a, W>>,
+    Out: core::fmt::Write,
+{
+    let mut iter = cursors.into_iter().peekable();
+    if iter.peek().is_none() {
+        return out.write_str("[]");
+    }
+    if indent_spaces == 0 {
+        // Flow style
+        out.write_char('[')?;
+        let mut first = true;
+        for cursor in iter {
+            if !first {
+                out.write_str(", ")?;
+            }
+            first = false;
+            cursor.stream_yaml_value(out, 0, 0)?;
+        }
+        out.write_char(']')
+    } else {
+        // Block style
+        let mut first = true;
+        for cursor in iter {
+            if !first {
+                out.write_char('\n')?;
+                write_yaml_indent(out, current_indent)?;
+            }
+            first = false;
+            if is_yaml_cursor_container(&cursor) {
+                out.write_char('-')?;
+                out.write_char('\n')?;
+                write_yaml_indent(out, current_indent + indent_spaces)?;
+                cursor.stream_yaml_value(out, current_indent + indent_spaces, indent_spaces)?;
+            } else {
+                out.write_str("- ")?;
+                cursor.stream_yaml_value(out, current_indent + indent_spaces, indent_spaces)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Stream a YAML string value with smart quoting.
 /// Write a non-`String` mapping key as a YAML scalar (issue #222).
 ///

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5127,7 +5127,7 @@ fn write_yaml_indent<Out: core::fmt::Write>(out: &mut Out, spaces: usize) -> cor
 /// Stream independent document cursors as a single YAML sequence (block or
 /// flow style), without materializing an `OwnedValue` DOM.
 ///
-/// Unlike [`YamlCursor::stream_yaml_value`]'s `Sequence` arm, the cursors
+/// Unlike `YamlCursor::stream_yaml_value`'s `Sequence` arm, the cursors
 /// here need not share one `YamlIndex` — each may come from its own
 /// document/source. This is what lets `--slurp` wrap multiple slurped
 /// documents into one array while preserving duplicate mapping keys within

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6004,6 +6004,29 @@ mod tests {
     }
 
     #[test]
+    fn test_stream_yaml_sequence_flow_style() {
+        // #478: `stream_yaml_sequence` mirrors `stream_yaml_value`'s Sequence
+        // flow/block duality, but its only caller (`--slurp`) always maps
+        // `-I0` to indent_spaces=2 (yq_runner.rs's documented compact-YAML
+        // quirk), so the flow-style (indent_spaces == 0) branch is
+        // unreachable from the CLI. Exercise it directly as a library
+        // caller would, combining cursors from two independent sources
+        // (the reason this function exists over reusing `stream_yaml_value`'s
+        // own Sequence arm, which requires one shared `YamlIndex`).
+        let bytes_a = b"a: 1\n".to_vec();
+        let index_a = YamlIndex::build(&bytes_a).unwrap();
+        let bytes_b = b"b: 2\n".to_vec();
+        let index_b = YamlIndex::build(&bytes_b).unwrap();
+
+        let cursor_a = index_a.root(&bytes_a).first_child().unwrap();
+        let cursor_b = index_b.root(&bytes_b).first_child().unwrap();
+
+        let mut out = String::new();
+        stream_yaml_sequence([cursor_a, cursor_b], &mut out, 0, 0).unwrap();
+        assert_eq!(out, "[{a: 1}, {b: 2}]");
+    }
+
+    #[test]
     fn test_stream_yaml_quoted_scalars_stay_quoted() {
         // #175: quoted source scalars are genuine strings and must keep their
         // quoting style so they don't turn into numbers/booleans on re-parse.

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -270,8 +270,8 @@ pub(crate) enum QuotedSpanEnd {
 pub use error::YamlError;
 pub use index::YamlIndex;
 pub use light::{
-    format_float_with_fraction, ChompingIndicator, YamlCursor, YamlElements, YamlField, YamlFields,
-    YamlNumber, YamlString, YamlValue,
+    format_float_with_fraction, stream_yaml_sequence, ChompingIndicator, YamlCursor, YamlElements,
+    YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
 pub use scalar::{resolve_plain, ResolvedScalar};

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1507,6 +1507,27 @@ fn test_number_formatting_array_iteration() -> Result<()> {
     Ok(())
 }
 
+/// #478 item 3: `jq --preserve-input '.'` in pretty mode (no `-c`) used to
+/// collapse duplicate object keys via `standard_json_to_jq_value`'s
+/// `IndexMap`, unlike its own `-c` output. Fixed incidentally by #532's
+/// `Expr::Identity => GenericResult::OneCursor` change, which routes
+/// identity through the cursor-based `print_json` path in both modes —
+/// pinned here as a regression guard rather than a code change.
+#[test]
+fn test_preserve_input_pretty_preserves_duplicate_keys() -> Result<()> {
+    let input = r#"{"a":1,"a":2}"#;
+
+    let (compact, code) = run_jq_stdin(".", input, &["-c", "--preserve-input"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact.trim(), r#"{"a":1,"a":2}"#);
+
+    let (pretty, code) = run_jq_stdin(".", input, &["--preserve-input"])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty, "{\n  \"a\": 1,\n  \"a\": 2\n}\n");
+
+    Ok(())
+}
+
 #[test]
 fn test_jq_compat_default() -> Result<()> {
     // Test that jq-compat is now the default behavior

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -667,6 +667,45 @@ fn test_duplicate_mapping_key_survives_slurp_multiple_sources() -> Result<()> {
     Ok(())
 }
 
+/// #478: `can_slurp_fast_path` tracks `-e`/`--exit-status` by inspecting the
+/// built cursor list directly (`any_truthy = true` whenever `--slurp`
+/// produces its one array result), a separate code path from the non-slurp
+/// M2 fast path's per-cursor `is_falsy()` check. Exercise it directly so
+/// that branch runs at least once.
+#[test]
+fn test_slurp_exit_status_fast_path() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a: 1\n", &["--slurp", "-e"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "-\n  a: 1\n");
+    Ok(())
+}
+
+/// #478: when `--doc N` filters out every input document, `can_slurp_fast_path`
+/// builds an empty cursor list and streams it via `stream_yaml_sequence`,
+/// whose empty-iterator early return (`"[]"`) is otherwise never exercised
+/// by the duplicate-key-preservation tests above (they always match at
+/// least one document).
+#[test]
+fn test_slurp_doc_filter_no_match_yields_empty_array() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a: 1\n", &["--slurp", "--doc", "5"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[]\n");
+    Ok(())
+}
+
+/// #478: `stream_yaml_sequence`'s block-style rendering has a container vs.
+/// scalar branch per slurped item (mirroring `stream_yaml_value`'s `Sequence`
+/// arm); the tests above only slurp mapping documents, which always take the
+/// container branch. Bare scalar documents take the `"- "` scalar branch
+/// instead.
+#[test]
+fn test_slurp_scalar_documents_use_block_style_dash_items() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a\n---\nb\n", &["--slurp"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- a\n- b\n");
+    Ok(())
+}
+
 /// #478: `--inplace '.'` went through the same lossy `yaml_to_owned_value`
 /// path as `--slurp`, unlike plain `yq '.'` which #442 already fixed.
 /// Real `yq --inplace` v4.53.3 keeps both `a:` entries on this input.
@@ -711,6 +750,30 @@ fn test_inplace_field_navigation_still_works() -> Result<()> {
     Ok(())
 }
 
+/// #478: the `--inplace` fast path's per-file loop iterates the root's
+/// virtual document sequence directly (`docs.uncons_cursor()`), rather than
+/// the `first_child()` single-document fallback the other `--inplace` tests
+/// above exercise implicitly. A multi-document file with a non-identity
+/// filter drives that loop through more than one `stream_cursor!` call.
+#[test]
+fn test_inplace_multi_doc_field_navigation() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a:\n  b: 1\n---\na:\n  b: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg(".a")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "b: 1\n---\nb: 2\n");
+    Ok(())
+}
+
 /// #478: filters outside `can_use_m2_streaming` (e.g. `keys`) must still
 /// fall back to the pre-existing DOM path for `--inplace`.
 #[test]
@@ -729,6 +792,33 @@ fn test_inplace_non_m2_filter_still_works() -> Result<()> {
     assert!(output.status.success());
     let rewritten = std::fs::read_to_string(input_file.path())?;
     assert_eq!(rewritten, "- a\n- b\n");
+    Ok(())
+}
+
+/// #478: `--inplace` has its own JSON-output M2 fast path gate
+/// (`can_inplace_json_fast_path`), separate from the YAML-output one
+/// (`can_inplace_yaml_fast_path`) exercised by the tests above, which all
+/// default to YAML output. Cover the JSON-output gate directly.
+#[test]
+fn test_inplace_json_output_fast_path() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\nb: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-o")
+        .arg("json")
+        .arg("-I")
+        .arg("0")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "{\"a\":1,\"b\":2}\n");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -622,6 +622,116 @@ fn test_duplicate_mapping_key_to_entries_json_compact() -> Result<()> {
     Ok(())
 }
 
+/// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion
+/// (`yaml_to_owned_value`) #442 didn't touch, so it kept collapsing
+/// duplicate keys within each slurped element even after plain `yq '.'`
+/// was fixed. Must now match [`test_duplicate_mapping_key_survives_yaml_output`]
+/// on the same input, just wrapped in the slurped array.
+#[test]
+fn test_duplicate_mapping_key_survives_slurp() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (pretty, code) = run_yq_stdin(".", yaml, &["--slurp"])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty, "-\n  a: 1\n  a: 2\n");
+
+    let (compact, code) = run_yq_stdin(".", yaml, &["--slurp", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "-\n  a: 1\n  a: 2\n");
+
+    Ok(())
+}
+
+/// #478: like [`test_duplicate_mapping_key_survives_slurp`], `--slurp`
+/// combining documents from multiple sources into one array must preserve
+/// duplicate keys within each source, not just across sources.
+#[test]
+fn test_duplicate_mapping_key_survives_slurp_multiple_sources() -> Result<()> {
+    let mut file_a = NamedTempFile::new()?;
+    writeln!(file_a, "a: 1\na: 2")?;
+    let mut file_b = NamedTempFile::new()?;
+    writeln!(file_b, "b: 3")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("--slurp")
+        .arg(".")
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(output.status.success());
+    assert_eq!(stdout, "-\n  a: 1\n  a: 2\n-\n  b: 3\n");
+    Ok(())
+}
+
+/// #478: `--inplace '.'` went through the same lossy `yaml_to_owned_value`
+/// path as `--slurp`, unlike plain `yq '.'` which #442 already fixed.
+/// Real `yq --inplace` v4.53.3 keeps both `a:` entries on this input.
+#[test]
+fn test_duplicate_mapping_key_survives_inplace() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\na: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "a: 1\na: 2\n");
+    Ok(())
+}
+
+/// #478: the `--inplace` fast path is scoped to M2-streamable expressions
+/// (identity/field/index/iterate); confirm field navigation still rewrites
+/// the file correctly, not just plain identity.
+#[test]
+fn test_inplace_field_navigation_still_works() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a:\n  b: 1\n  c: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg(".a")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "b: 1\nc: 2\n");
+    Ok(())
+}
+
+/// #478: filters outside `can_use_m2_streaming` (e.g. `keys`) must still
+/// fall back to the pre-existing DOM path for `--inplace`.
+#[test]
+fn test_inplace_non_m2_filter_still_works() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\nb: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("keys")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "- a\n- b\n");
+    Ok(())
+}
+
 #[test]
 fn test_compact_json_output() -> Result<()> {
     let yaml = r"


### PR DESCRIPTION
## Summary

Follow-up to #442, which fixed `yq '.'` (and simple navigation) so pretty-printed output no longer silently drops duplicate YAML/JSON mapping keys, by streaming values off the document cursor instead of materializing an `IndexMap`-backed `OwnedValue`. #442 named three call sites its fix didn't reach; this closes #478, the tracking issue for those:

- `yq --slurp '.'` collapsed duplicate keys within a slurped element (`a: 1\na: 2` → `a: 2`). Fixed with a new `stream_yaml_sequence()` helper in `yaml/light.rs` that streams independent document cursors into one YAML sequence, reusing the existing block/flow `Sequence` rendering rather than re-deriving it — wired into a new identity-only `--slurp` fast path.
- `yq --inplace '.'` wrote the same collapsed result back to the file, diverging from real `yq --inplace` v4.53.3. Fixed by giving `--inplace` its own copy of the M2 streaming gate so it reuses the same cursor-streaming machinery as the stdout path, writing into a per-file buffer instead.
- `jq --preserve-input '.'` (pretty, no `-c`) — the third item #478 listed — turned out to already be fixed incidentally by #532 (`Expr::Identity => GenericResult::OneCursor`), merged before this work started. No code change; added a regression test.

Both new fast paths fall back to the pre-existing DOM path for query shapes/output combinations they don't cover (e.g. `-o json --slurp`, filters like `keys`/`map(...)`) — the same explicit, documented scope limits the stdout M2 path already has for `sort_keys`/color/`--tab`.

While verifying the `--preserve-input` fix, found that `standard_json_to_jq_value()` is still reachable and lossy through `Builtin::First`/`Builtin::Last` and `Pipe`'s stage-advance re-entry (e.g. `jq --preserve-input 'first(.[])'`). Out of scope here; filed as #607.

## Commits

- `fix(yq): stream --inplace through the M2 cursor fast path`
- `fix(yaml, yq): stream --slurp identity through cursors`
- `test(yq): cover duplicate-key preservation for --slurp/--inplace`
- `test(jq): pin duplicate-key preservation for --preserve-input pretty`
- `docs: update CHANGELOG for #478 and correct a stale #442 note`

Closes #478.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite, 1866+ tests, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's second, non-`scalar-yaml` invocation) — clean
- [x] `./scripts/build.sh` — clean
- [x] Manually verified all three of #478's original repro commands now match real `yq`/`jq`
- [x] Verified the `--inplace`-only intermediate commit builds and passes standalone before the `--slurp` commit is layered on top