### PR TITLE
jq: accept computed expressions as slice bounds

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -390,6 +390,13 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
             target: Box::new(rewrite_namespaced_calls(*target)),
             key: Box::new(rewrite_namespaced_calls(*key)),
         },
+        // Same reasoning as `IndexExpr`: a namespaced call can appear in the
+        // target or either bound — `.[ns::f():ns::g()]`.
+        Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
+            target: Box::new(rewrite_namespaced_calls(*target)),
+            start: start.map(|e| Box::new(rewrite_namespaced_calls(*e))),
+            end: end.map(|e| Box::new(rewrite_namespaced_calls(*e))),
+        },
         // Expressions that don't contain sub-expressions - return as-is
         Expr::Identity
         | Expr::Field(_)

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1166,6 +1166,13 @@ fn contains_split_doc(expr: &Expr) -> bool {
         // Terminal expressions that cannot contain split_doc
         // Both halves hold sub-expressions, so `split_doc` can hide in either.
         Expr::IndexExpr { target, key } => contains_split_doc(target) || contains_split_doc(key),
+        // Same reasoning as `IndexExpr`: `split_doc` can hide in the target
+        // or either bound.
+        Expr::SliceExpr { target, start, end } => {
+            contains_split_doc(target)
+                || start.as_deref().is_some_and(contains_split_doc)
+                || end.as_deref().is_some_and(contains_split_doc)
+        }
         Expr::Identity
         | Expr::Field(_)
         | Expr::Index(_)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23815,6 +23815,227 @@ mod tests {
         ]);
     }
 
+    /// #499: `needs_path_context` mirrors `IndexExpr`'s target/key check
+    /// (#360) for a computed slice's target and both bounds — a `path`/
+    /// `parent`/`key` builtin (yq's no-arg path-context extensions) hiding in
+    /// any of the three must still be found, or `eval_pipe` would run the
+    /// pipe without the path context those builtins read.
+    #[test]
+    fn test_needs_path_context_descends_into_slice_expr() {
+        let path_ctx = Expr::Builtin(Builtin::PathNoArg);
+        let plain = Expr::Literal(Literal::Int(0));
+
+        // Hidden in the target.
+        assert!(needs_path_context(&Expr::slice_by(
+            path_ctx.clone(),
+            Some(plain.clone()),
+            Some(plain.clone()),
+        )));
+        // Hidden in the start bound (target and end plain).
+        assert!(needs_path_context(&Expr::slice_by(
+            Expr::Identity,
+            Some(path_ctx.clone()),
+            Some(plain.clone()),
+        )));
+        // Hidden in the end bound (target and start plain).
+        assert!(needs_path_context(&Expr::slice_by(
+            Expr::Identity,
+            Some(plain.clone()),
+            Some(path_ctx),
+        )));
+        // None of the three need it.
+        assert!(!needs_path_context(&Expr::slice_by(
+            Expr::Identity,
+            Some(plain.clone()),
+            Some(plain),
+        )));
+    }
+
+    /// #499: `eval_slice_expr` (plain reads, no `=`/`|=`/`path()`/`del()`)
+    /// covering the shapes `test_computed_slice_bounds` doesn't reach — every
+    /// case there goes through path resolution (`resolve_slice_expr`), a
+    /// separate function with its own copy of this logic, so none of it
+    /// exercised the read-mode evaluator at all. `(0+0)`/`(2+0)` stand in for
+    /// a bound that must stay dynamic; a bare `(0)`/`(2)` folds back to the
+    /// literal `Expr::Slice` fast path (`test_slice_bounds_accept_the_same_
+    /// spellings`) and would silently test the wrong code entirely. Every
+    /// case was checked against jq 1.7.1 directly.
+    #[test]
+    fn test_computed_slice_bounds_read_mode() {
+        assert_outcomes(&[
+            // Fast path: a resolved `(0, None)` bound still returns the
+            // target unchanged, same as the literal `.[0:]` shape.
+            (b"[1,2,3,4,5]", ".[(0+0):]", Ok("[1,2,3,4,5]")),
+            // A bound that's a plain field read, not an arithmetic
+            // expression — unlike every `(n+0)` bound elsewhere in this
+            // test, this resolves to a *borrowed* value straight from the
+            // document rather than a freshly computed owned one.
+            (
+                br#"{"a":[1,2,3,4,5],"k1":1,"k2":3}"#,
+                ".a[.k1:.k2]",
+                Ok("[2,3]"),
+            ),
+            // A bound that fans out to more than one borrowed value.
+            (
+                br#"{"a":[1,2,3,4,5],"x":0,"y":1}"#,
+                "[.a[(.x,.y):(3+0)]]",
+                Ok("[[1,2,3],[2,3]]"),
+            ),
+            // A borrowed target that slices to `null` (slicing `null` is
+            // always `null`) and one that fails to slice at all.
+            (br#"{"a":null}"#, ".a[(0+0):(2+0)]", Ok("null")),
+            (
+                br#"{"a":5}"#,
+                ".a[(0+0):(2+0)]",
+                Err("Cannot index number with object"),
+            ),
+            // The same borrowed failure, but `?`-guarded: the slice attempt
+            // is pruned rather than propagated — the borrowed-value
+            // counterpart to the owned-boolean case below.
+            (br#"{"a":5}"#, ".a[(0+0):(2+0)]?", Ok("")),
+            // The target's own evaluation can fail before slicing is ever
+            // attempted — distinct from the case above, where `.a` resolves
+            // fine and it's the slice application that fails.
+            (
+                b"5",
+                ".a[(0+0):(2+0)]",
+                Err(r#"Cannot index number with string "a""#),
+            ),
+            // A target that fans out to more than one borrowed value.
+            (
+                br#"{"a":[1,2,3],"b":[4,5,6]}"#,
+                "[(.a,.b)[(0+0):(2+0)]]",
+                Ok("[[1,2],[4,5]]"),
+            ),
+            // An owned target (freshly constructed, not borrowed from the
+            // document): single value, then a fan-out of several.
+            (b"null", "([1,2,3])[(0+0):(2+0)]", Ok("[1,2]")),
+            (
+                b"null",
+                "[([1,2,3],[4,5,6])[(0+0):(2+0)]]",
+                Ok("[[1,2],[4,5]]"),
+            ),
+            // A target with no output at all.
+            (b"null", "empty[(0+0):(2+0)]", Ok("")),
+            // A target that breaks out of an enclosing label — the whole
+            // slice contributes nothing, same as `IndexExpr`'s identically
+            // conservative target handling (see `eval_index_expr`'s key
+            // stream, which this mirrors).
+            (b"null", "label $out | (break $out)[(0+0):(2+0)]", Ok("")),
+            (
+                b"null",
+                "label $out | (1,2,break $out)[(0+0):(2+0)]",
+                Ok(""),
+            ),
+            // A target whose stream errors part-way through: the error wins,
+            // and (like the break case above) the values already produced
+            // are not carried forward — the same conservative trade-off
+            // `eval_index_expr` already makes for its key/target streams.
+            (b"null", "(1,2,error(\"boom\"))[(0+0):(2+0)]", Err("boom")),
+            // Owned targets of every slice-able kind, plus the two ways an
+            // unsliceable one is refused.
+            (b"null", "(null)[(0+0):(2+0)]", Ok("null")),
+            (b"null", r#"("hello")[(0+0):(2+0)]"#, Ok(r#""he""#)),
+            (b"null", "(true)[(0+0):(2+0)]?", Ok("")),
+            (
+                b"null",
+                "(true)[(0+0):(2+0)]",
+                Err("Cannot index boolean with object"),
+            ),
+            // A start-bound evaluation failure, and the same on the end
+            // bound — each is its own call site in `eval_slice_expr`.
+            (
+                b"[1,2,3]",
+                r".[(.x+0):(2+0)]",
+                Err(r#"Cannot index array with string "x""#),
+            ),
+            (
+                b"[1,2,3]",
+                r".[(0+0):(.x+0)]",
+                Err(r#"Cannot index array with string "x""#),
+            ),
+            // A `break` from inside a bound must reach the enclosing label
+            // as a real break, not a synthetic "not in label" error — on
+            // both the start and the end bound.
+            (b"[1,2,3]", "label $out | .[(break $out):(2+0)]", Ok("")),
+            (b"[1,2,3]", "label $out | .[(0+0):(break $out)]", Ok("")),
+            // A bound whose stream breaks (or errors) after already
+            // producing values: same conservative trade-off as the target
+            // case above, applied to the bound stream instead.
+            (b"[1,2,3]", "label $out | .[(1,2,break $out):(2+0)]", Ok("")),
+            (b"[1,2,3]", r#".[(1,2,error("boom")):(2+0)]"#, Err("boom")),
+        ]);
+    }
+
+    /// #499: `resolve_slice_expr`/`resolve_slice_bound` (the path-mode
+    /// evaluator behind `=`, `|=`, `path()`, `del()`) shapes
+    /// `test_computed_slice_bounds` doesn't reach: every bound there either
+    /// resolves to a number or fails to *evaluate* at all, so the
+    /// empty-bound-stream short-circuit and the "resolved bounds don't apply
+    /// to this target" refusal never ran. Checked against jq 1.7.1 directly.
+    #[test]
+    fn test_computed_slice_bounds_path_mode_edge_cases() {
+        assert_outcomes(&[
+            // An empty start (or end) bound stream in path mode is a no-op,
+            // the same short-circuit `test_computed_slice_bounds` already
+            // covers for read mode.
+            (
+                br#"{"a":[1,2,3]}"#,
+                r#".a[empty:2] = ["x"]"#,
+                Ok(r#"{"a":[1,2,3]}"#),
+            ),
+            (
+                br#"{"a":[1,2,3]}"#,
+                r#".a[0:empty] = ["x"]"#,
+                Ok(r#"{"a":[1,2,3]}"#),
+            ),
+            // An omitted bound alongside a dynamic one on the other side —
+            // "open on this side" in path mode, same as read mode.
+            (
+                br#"{"a":[1,2,3,4,5],"k2":3}"#,
+                r#".a[:.k2] = ["x"]"#,
+                Ok(r#"{"a":["x",4,5],"k2":3}"#),
+            ),
+            (
+                br#"{"a":[1,2,3,4,5],"k1":2}"#,
+                r#".a[.k1:] = ["x"]"#,
+                Ok(r#"{"a":[1,2,"x"],"k1":2}"#),
+            ),
+            // Resolved bounds that reach an unsliceable target: `?` prunes
+            // just that branch, and its absence propagates the error — the
+            // same two spellings `resolve_index_expr` distinguishes for a
+            // computed key.
+            (b"5", r#".[(0+0):(2+0)]? = ["x"]"#, Ok("5")),
+            (
+                b"5",
+                r#".[(0+0):(2+0)] = ["x"]"#,
+                Err("Cannot index number with object"),
+            ),
+        ]);
+    }
+
+    /// #499: a computed slice's target and bounds must round-trip through
+    /// user-defined function expansion (`expand_func_calls`/
+    /// `substitute_func_param`) the same way `IndexExpr`'s target/key already
+    /// do — a call or parameter hiding in any of the three must still be
+    /// found and substituted.
+    #[test]
+    fn test_computed_slice_bounds_in_user_defined_functions() {
+        assert_outcomes(&[
+            // A function parameter used as a dynamic bound.
+            (b"[1,2,3,4]", "def f($n): .[$n:3]; f(1)", Ok("[2,3]")),
+            // A recursive-call site hiding in the bound of a different
+            // slice, and in its target.
+            (b"[1,2,3,4]", "def f: 1; .[(f):(3)]", Ok("[2,3]")),
+            (
+                br#"{"a":[1,2,3,4]}"#,
+                "def f: .a; (f)[(1):(3)]",
+                Ok("[2,3]"),
+            ),
+            (b"[1,2,3,4]", "def f: 3; .[(1):(f)]", Ok("[2,3]")),
+        ]);
+    }
+
     #[test]
     fn test_set_path_and_get_path_mut_autovivify_null_directly() {
         // Direct-function coverage for the three walkers `autovivify_object`/
@@ -25859,6 +26080,92 @@ mod tests {
         #[cfg(debug_assertions)]
         #[should_panic(expected = "unresolved computed index reached path tracking")]
         fn test_path_tracking_refuses_an_unresolved_key_mid_pipe() {
+            let mut reached = Vec::new();
+            let pipe = Expr::Pipe(vec![unresolved(), Expr::Field("a".to_string())]);
+            let _ = walk_path::<JqSemantics>(&pipe, &OwnedValue::Null, &[], &mut reached, false);
+        }
+    }
+
+    // ========== #499: the unresolved-computed-slice guards ==========
+
+    /// Same reasoning as [`computed_key_guards`], one level up: every path
+    /// walker refuses an unresolved [`Expr::SliceExpr`] just as loudly as it
+    /// refuses an unresolved [`Expr::IndexExpr`], and for the same reason —
+    /// [`resolve_dynamic_indexes`] rewrites a computed slice into its static
+    /// components before any of these run, so a hit here means a new path
+    /// context was wired up without going through that pre-pass.
+    mod computed_slice_guards {
+        use super::*;
+
+        /// `.[$a:$b]` left unresolved — what each walker below is handed.
+        fn unresolved() -> Expr {
+            Expr::slice_by(
+                Expr::Identity,
+                Some(Expr::Var("a".to_string())),
+                Some(Expr::Var("b".to_string())),
+            )
+        }
+
+        #[test]
+        fn test_set_path_refuses_an_unresolved_slice() {
+            let mut root = OwnedValue::Null;
+            let err = set_path(&mut root, &unresolved(), OwnedValue::Int(1)).unwrap_err();
+            assert_eq!(
+                err.message,
+                "internal error: unresolved computed slice in assignment path"
+            );
+        }
+
+        #[test]
+        fn test_get_path_mut_refuses_an_unresolved_slice() {
+            let mut root = OwnedValue::Null;
+            let err = get_path_mut(&mut root, &[unresolved()]).unwrap_err();
+            assert_eq!(
+                err.message,
+                "internal error: unresolved computed slice in path component"
+            );
+        }
+
+        #[test]
+        fn test_update_path_refuses_an_unresolved_slice() {
+            let mut root = OwnedValue::Null;
+            let err = update_path::<JqSemantics>(&mut root, &unresolved(), &Expr::Identity, false)
+                .unwrap_err();
+            assert_eq!(
+                err.message,
+                "internal error: unresolved computed slice in update path"
+            );
+        }
+
+        #[test]
+        fn test_delete_at_path_refuses_an_unresolved_slice() {
+            let mut root = OwnedValue::Null;
+            let err = delete_at_path(&mut root, &unresolved(), false).unwrap_err();
+            assert_eq!(
+                err.message,
+                "internal error: unresolved computed slice in delete path"
+            );
+        }
+
+        #[test]
+        #[cfg(debug_assertions)]
+        #[should_panic(expected = "unresolved computed slice reached path tracking")]
+        fn test_path_tracking_refuses_an_unresolved_slice() {
+            let mut reached = Vec::new();
+            let _ = walk_path::<JqSemantics>(
+                &unresolved(),
+                &OwnedValue::Null,
+                &[],
+                &mut reached,
+                false,
+            );
+        }
+
+        /// The same guard reached mid-pipe rather than as the last step.
+        #[test]
+        #[cfg(debug_assertions)]
+        #[should_panic(expected = "unresolved computed slice reached path tracking")]
+        fn test_path_tracking_refuses_an_unresolved_slice_mid_pipe() {
             let mut reached = Vec::new();
             let pipe = Expr::Pipe(vec![unresolved(), Expr::Field("a".to_string())]);
             let _ = walk_path::<JqSemantics>(&pipe, &OwnedValue::Null, &[], &mut reached, false);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -313,6 +313,11 @@ fn needs_path_context(expr: &Expr) -> bool {
         Expr::Optional(inner) => needs_path_context(inner),
         Expr::Comma(exprs) => exprs.iter().any(needs_path_context),
         Expr::IndexExpr { target, key } => needs_path_context(target) || needs_path_context(key),
+        Expr::SliceExpr { target, start, end } => {
+            needs_path_context(target)
+                || start.as_deref().is_some_and(needs_path_context)
+                || end.as_deref().is_some_and(needs_path_context)
+        }
         Expr::If {
             cond,
             then_branch,
@@ -343,6 +348,10 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Expr::Index(idx) => index_array_by_position::<W>(value, *idx, optional),
 
         Expr::IndexExpr { target, key } => eval_index_expr::<W, S>(target, key, value, optional),
+
+        Expr::SliceExpr { target, start, end } => {
+            eval_slice_expr::<W, S>(target, start, end, value, optional)
+        }
 
         Expr::Slice { start, end } => match value {
             StandardJson::Array(elements) => {
@@ -6765,6 +6774,187 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Evaluate `E[S:T]` — slicing by computed bounds.
+///
+/// jq compiles this as `S as $s | T as $t | E | .[$s:$t]`, the same
+/// desugaring [`eval_index_expr`] documents for `E[K]`, with the same three
+/// load-bearing consequences (verified against jq 1.7.1):
+///
+/// 1. `S` and `T` are evaluated against *this node's* input, not `E`'s
+///    output.
+/// 2. The streams nest `S` outer, `T` middle, `E` inner:
+///    `[1,2,3,4,5][(0,1):(3,4)]` is
+///    `[[1,2,3],[1,2,3,4],[2,3],[2,3,4]]`.
+/// 3. An empty `S` or `T` stream short-circuits *before* the next stage
+///    runs: `(error("boom"))[0:empty]` is `[]`, not an error.
+///
+/// `optional` reaches only the final application of the resolved bounds to
+/// the target — the synthesized [`Expr::Slice`] this delegates to, which
+/// already carries the identical `optional`-gated "cannot index with type
+/// object" refusal a literal slice has. It reaches neither `S`/`T`'s
+/// evaluation nor a resolved-but-non-numeric bound: `"str" | .[0:.k]?` and
+/// `null | .[("x"):2]?` both still raise, matching a literal computed key
+/// (`.[.k]?` still raises on a string target) rather than
+/// `key_to_path_component`'s optional-gated type check.
+fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    target: &Expr,
+    start: &Option<Box<Expr>>,
+    end: &Option<Box<Expr>>,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    let starts = match eval_slice_bound::<W, S>(start, value.clone(), f64::floor) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
+    if starts.is_empty() {
+        return QueryResult::None;
+    }
+    let ends = match eval_slice_bound::<W, S>(end, value.clone(), f64::ceil) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
+    if ends.is_empty() {
+        return QueryResult::None;
+    }
+
+    let targets = eval_single::<W, S>(target, value, false).materialize_cursor();
+
+    // Borrowed and owned targets are kept apart so the common (borrowed) case
+    // never materializes the document — mirrors `eval_index_expr`.
+    enum Targets<'a, W> {
+        Borrowed(Vec<StandardJson<'a, W>>),
+        Owned(Vec<OwnedValue>),
+    }
+    let targets = match targets {
+        QueryResult::One(v) => Targets::Borrowed(vec![v]),
+        QueryResult::Many(vs) => Targets::Borrowed(vs),
+        QueryResult::Owned(v) => Targets::Owned(vec![v]),
+        QueryResult::ManyOwned(vs) => Targets::Owned(vs),
+        QueryResult::None => return QueryResult::None,
+        QueryResult::Error(e) => return QueryResult::Error(e),
+        QueryResult::Break(label) => return QueryResult::Break(label),
+        QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
+        QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
+        QueryResult::Partial(_, Control::Break(label)) => return QueryResult::Break(label),
+    };
+
+    // S outer, T middle, E inner (point 2 above). The result is always
+    // owned: slicing constructs a new array/string (see `eval_single`'s
+    // `Expr::Slice` arm), so there is nothing to borrow except its rare
+    // whole-value fast paths, which `to_owned` below just copies out of.
+    let mut out: Vec<OwnedValue> = Vec::with_capacity(starts.len() * ends.len());
+    match &targets {
+        Targets::Borrowed(ts) => {
+            for s in &starts {
+                for e in &ends {
+                    let slice_expr = Expr::Slice { start: *s, end: *e };
+                    for t in ts {
+                        match eval_single::<W, S>(&slice_expr, t.clone(), optional) {
+                            QueryResult::One(v) => out.push(to_owned(&v)),
+                            QueryResult::Owned(v) => out.push(v),
+                            QueryResult::None => {}
+                            QueryResult::Error(e) => return QueryResult::Error(e),
+                            _ => unreachable!("Expr::Slice yields only One/Owned/None/Error"),
+                        }
+                    }
+                }
+            }
+        }
+        Targets::Owned(ts) => {
+            for s in &starts {
+                for e in &ends {
+                    for t in ts {
+                        match slice_owned_value(t, *s, *e, optional) {
+                            Ok(Some(v)) => out.push(v),
+                            Ok(None) => {}
+                            Err(e) => return QueryResult::Error(e),
+                        }
+                    }
+                }
+            }
+        }
+    }
+    match out.len() {
+        1 => QueryResult::Owned(out.pop().expect("len checked")),
+        _ => QueryResult::ManyOwned(out),
+    }
+}
+
+/// Evaluate one slice bound (`start` or `end`) against `value`, collecting
+/// its output stream and rounding each resolved number the way
+/// `Expr::Slice` needs it stored — floor for a start bound, ceil for an end
+/// bound, so a fractional dynamic bound still widens the slice the way a
+/// literal one does (`SliceBounds::resolve` re-applies the same floor/ceil
+/// to whatever `Expr::Slice` carries, so rounding here first is transparent
+/// to it — see `slice.rs`'s doc comment). A missing bound (`None`) is a
+/// single `None` — "this side is open" — not an empty stream.
+fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    bound: &Option<Box<Expr>>,
+    value: StandardJson<'_, W>,
+    round: fn(f64) -> f64,
+) -> Result<Vec<Option<i64>>, EvalError> {
+    let Some(expr) = bound else {
+        return Ok(vec![None]);
+    };
+    let raw: Vec<OwnedValue> = match eval_single::<W, S>(expr, value, false).materialize_cursor() {
+        QueryResult::One(v) => vec![to_owned(&v)],
+        QueryResult::Many(vs) => vs.iter().map(to_owned).collect(),
+        QueryResult::Owned(v) => vec![v],
+        QueryResult::ManyOwned(vs) => vs,
+        QueryResult::None => return Ok(Vec::new()),
+        QueryResult::Error(e) => return Err(e),
+        QueryResult::Break(label) => {
+            return Err(EvalError::new(format!("break ${label} not in label")))
+        }
+        QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
+        QueryResult::Partial(_, Control::Error(e)) => return Err(e),
+        QueryResult::Partial(_, Control::Break(label)) => {
+            return Err(EvalError::new(format!("break ${label} not in label")))
+        }
+    };
+    raw.iter().map(|v| owned_bound_to_i64(v, round)).collect()
+}
+
+/// Classify a resolved bound value the way jq's slice descriptor does
+/// (`SliceBounds::resolved_bound`), then round it to the integer
+/// `Expr::Slice` stores. Shared between [`eval_slice_bound`] (read mode) and
+/// `resolve_slice_bound` (path mode).
+fn owned_bound_to_i64(v: &OwnedValue, round: fn(f64) -> f64) -> Result<Option<i64>, EvalError> {
+    Ok(SliceBounds::resolved_bound(v)?.map(|f| round(f) as i64))
+}
+
+/// Apply a resolved slice directly to an owned value.
+///
+/// Slicing is a plain `Vec`/`&str` operation once the bounds are known, so
+/// this mirrors `eval_single`'s `Expr::Slice` arm (minus its cursor-only
+/// fast paths, which only matter for borrowed input) rather than paying for
+/// `eval_owned_input`'s serialize/reparse round-trip.
+fn slice_owned_value(
+    target: &OwnedValue,
+    start: Option<i64>,
+    end: Option<i64>,
+    optional: bool,
+) -> Result<Option<OwnedValue>, EvalError> {
+    match target {
+        OwnedValue::Array(items) => {
+            let range = SliceBounds::from_literals(start, end).resolve(items.len());
+            Ok(Some(OwnedValue::Array(items[range].to_vec())))
+        }
+        OwnedValue::Null => Ok(Some(OwnedValue::Null)),
+        OwnedValue::String(s) => {
+            let len = s.chars().count();
+            let range = SliceBounds::from_literals(start, end).resolve(len);
+            Ok(Some(OwnedValue::String(slice::slice_str(s, range))))
+        }
+        _ if optional => Ok(None),
+        other => Err(EvalError::cannot_index_with_type(
+            owned_type_name(other),
+            "object",
+        )),
+    }
+}
+
 /// Get element at index (supports negative indexing).
 ///
 /// Uses `get_fast` for O(n) BP operations + O(log n) IB select,
@@ -7184,6 +7374,9 @@ fn set_path(
         Expr::IndexExpr { .. } => Err(EvalError::new(
             "internal error: unresolved computed index in assignment path",
         )),
+        Expr::SliceExpr { .. } => Err(EvalError::new(
+            "internal error: unresolved computed slice in assignment path",
+        )),
         _ => Err(EvalError::new(
             "cannot use expression as assignment target".to_string(),
         )),
@@ -7364,6 +7557,11 @@ fn get_path_mut<'a>(
                     "internal error: unresolved computed index in path component",
                 ))
             }
+            Expr::SliceExpr { .. } => {
+                return Err(EvalError::new(
+                    "internal error: unresolved computed slice in path component",
+                ))
+            }
             _ => return Err(EvalError::new("invalid path component")),
         };
     }
@@ -7535,6 +7733,9 @@ fn update_path<S: EvalSemantics>(
         Expr::IndexExpr { .. } => Err(EvalError::new(
             "internal error: unresolved computed index in update path",
         )),
+        Expr::SliceExpr { .. } => Err(EvalError::new(
+            "internal error: unresolved computed slice in update path",
+        )),
         _ => Err(EvalError::new("cannot use expression as update target")),
     }
 }
@@ -7580,7 +7781,7 @@ fn owned_type_name(value: &OwnedValue) -> &'static str {
 /// so programs with neither shape skip the pre-pass entirely.
 fn needs_path_prepass(expr: &Expr) -> bool {
     match expr {
-        Expr::IndexExpr { .. } | Expr::Comma(_) => true,
+        Expr::IndexExpr { .. } | Expr::SliceExpr { .. } | Expr::Comma(_) => true,
         Expr::Pipe(exprs) => exprs.iter().any(needs_path_prepass),
         Expr::Optional(inner) | Expr::Paren(inner) => needs_path_prepass(inner),
         _ => false,
@@ -7698,6 +7899,13 @@ fn resolve_node<S: EvalSemantics>(
             // this arm still wants to see only the bare shape.
             Expr::IndexExpr { target, key } => resolve_index_expr::<S>(target, key, value, true),
 
+            // `E[S:T]?` is the same bare shape for slice bounds: only a
+            // failure to *slice* is covered, never `E`, `S`, or `T`'s own
+            // evaluation — see `resolve_slice_expr`'s doc comment.
+            Expr::SliceExpr { target, start, end } => {
+                resolve_slice_expr::<S>(target, start, end, value, true)
+            }
+
             // Every other `?`-wrapped node (`.foo?`, `.[0]?`, ...): evaluation
             // and indexing are the same step, so any failure anywhere
             // underneath is the failure to index, and `?` covers all of it.
@@ -7761,6 +7969,10 @@ fn resolve_node<S: EvalSemantics>(
         },
 
         Expr::IndexExpr { target, key } => resolve_index_expr::<S>(target, key, value, false),
+
+        Expr::SliceExpr { target, start, end } => {
+            resolve_slice_expr::<S>(target, start, end, value, false)
+        }
 
         // `..` fans out to every node in the tree (pre-order, self before
         // children), so each needs its own Field/Index chain rather than the
@@ -8021,6 +8233,86 @@ fn resolve_index_expr<S: EvalSemantics>(
     Ok(out)
 }
 
+/// Resolve `E[S:T]` in path context, with or without a trailing `?`.
+///
+/// The two spellings differ in one thing only, same as [`resolve_index_expr`]:
+/// what happens when the resolved bounds cannot be applied to the container
+/// they reached. `E[S:T]` propagates that failure; `E[S:T]?` prunes just
+/// that branch, because a failure to *slice* is exactly what `?` covers.
+///
+/// Two rules the shared body carries, both verified against jq 1.7.1 (see
+/// [`eval_slice_expr`]'s doc comment for the full detail):
+///
+/// - `S` and `T` are evaluated before `E`, in that order, and an empty bound
+///   stream short-circuits before the next stage runs — including before
+///   `E` runs at all.
+/// - `?` covers only the final application of the resolved bounds to the
+///   target, never `S`/`T`'s own evaluation nor a resolved-but-non-numeric
+///   bound (`Array/string slice indices must be integers` is not swallowed
+///   either) — unlike [`resolve_index_expr`]'s `key_to_path_component`,
+///   whose optional-gated type check is *not* the shape to copy here.
+fn resolve_slice_expr<S: EvalSemantics>(
+    target: &Expr,
+    start: &Option<Box<Expr>>,
+    end: &Option<Box<Expr>>,
+    value: &OwnedValue,
+    optional: bool,
+) -> Result<Vec<PathBranch>, EvalError> {
+    let starts = resolve_slice_bound::<S>(start, value, f64::floor)?;
+    if starts.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ends = resolve_slice_bound::<S>(end, value, f64::ceil)?;
+    if ends.is_empty() {
+        return Ok(Vec::new());
+    }
+    let target_branches = resolve_node::<S>(target, value)?;
+
+    let mut out = Vec::with_capacity(starts.len() * ends.len() * target_branches.len());
+    for s in &starts {
+        for e in &ends {
+            let slice_expr = Expr::Slice { start: *s, end: *e };
+            for (components, target_value) in &target_branches {
+                // `false`, not `optional`: the failure has to arrive as an
+                // error for the two spellings to be told apart here, same
+                // as `resolve_index_expr`'s `index_one_owned` call.
+                let next_value = match slice_owned_value(target_value, *s, *e, false) {
+                    Ok(v) => v.expect("non-optional slice yields a value or errors"),
+                    Err(_) if optional => continue,
+                    Err(e) => return Err(e),
+                };
+                let mut path = components.clone();
+                path.push(if optional {
+                    Expr::Optional(Box::new(slice_expr.clone()))
+                } else {
+                    slice_expr.clone()
+                });
+                out.push((path, next_value));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Evaluate one slice bound (`start` or `end`) in path context.
+///
+/// Mirrors [`eval_slice_bound`] (read mode): a missing bound is a single
+/// `None` — "this side is open" — not an empty stream, and a resolved
+/// number is rounded the way [`owned_bound_to_i64`] documents.
+fn resolve_slice_bound<S: EvalSemantics>(
+    bound: &Option<Box<Expr>>,
+    value: &OwnedValue,
+    round: fn(f64) -> f64,
+) -> Result<Vec<Option<i64>>, EvalError> {
+    let Some(expr) = bound else {
+        return Ok(vec![None]);
+    };
+    eval_owned_multi::<S>(expr, value)?
+        .iter()
+        .map(|v| owned_bound_to_i64(v, round))
+        .collect()
+}
+
 /// Thread a value through a run of static path components, without expanding
 /// them.
 ///
@@ -8209,6 +8501,16 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
         Expr::IndexExpr { target, key } => Expr::IndexExpr {
             target: Box::new(substitute_var(target, var_name, replacement)),
             key: Box::new(substitute_var(key, var_name, replacement)),
+        },
+        // Same reasoning as `IndexExpr`: `$a`/`$b` in `.[$a:$b]` must resolve.
+        Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
+            target: Box::new(substitute_var(target, var_name, replacement)),
+            start: start
+                .as_deref()
+                .map(|e| Box::new(substitute_var(e, var_name, replacement))),
+            end: end
+                .as_deref()
+                .map(|e| Box::new(substitute_var(e, var_name, replacement))),
         },
         Expr::RecursiveDescent => Expr::RecursiveDescent,
         Expr::Optional(e) => Expr::Optional(Box::new(substitute_var(e, var_name, replacement))),
@@ -10284,6 +10586,9 @@ fn walk_path<S: EvalSemantics>(
         Expr::IndexExpr { .. } => {
             debug_assert!(false, "unresolved computed index reached path tracking");
         }
+        Expr::SliceExpr { .. } => {
+            debug_assert!(false, "unresolved computed slice reached path tracking");
+        }
 
         // Expressions with no path-tracking arm — `..`, `recurse`, `select`,
         // arithmetic — name no path (#483). `builtin_path` renders that as no
@@ -11810,6 +12115,9 @@ fn delete_at_path(
         // of being reported as a user error.
         Expr::IndexExpr { .. } => Err(EvalError::new(
             "internal error: unresolved computed index in delete path",
+        )),
+        Expr::SliceExpr { .. } => Err(EvalError::new(
+            "internal error: unresolved computed slice in delete path",
         )),
         _ => Err(EvalError::new("cannot use expression as delete target")),
     }
@@ -15462,6 +15770,15 @@ fn expand_func_calls(expr: &Expr, func_name: &str, params: &[String], body: &Exp
             target: Box::new(expand_func_calls(target, func_name, params, body)),
             key: Box::new(expand_func_calls(key, func_name, params, body)),
         },
+        Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
+            target: Box::new(expand_func_calls(target, func_name, params, body)),
+            start: start
+                .as_deref()
+                .map(|e| Box::new(expand_func_calls(e, func_name, params, body))),
+            end: end
+                .as_deref()
+                .map(|e| Box::new(expand_func_calls(e, func_name, params, body))),
+        },
         Expr::RecursiveDescent => Expr::RecursiveDescent,
         Expr::Optional(e) => {
             Expr::Optional(Box::new(expand_func_calls(e, func_name, params, body)))
@@ -15716,6 +16033,15 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
         Expr::IndexExpr { target, key } => Expr::IndexExpr {
             target: Box::new(substitute_func_param(target, param, arg)),
             key: Box::new(substitute_func_param(key, param, arg)),
+        },
+        Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
+            target: Box::new(substitute_func_param(target, param, arg)),
+            start: start
+                .as_deref()
+                .map(|e| Box::new(substitute_func_param(e, param, arg))),
+            end: end
+                .as_deref()
+                .map(|e| Box::new(substitute_func_param(e, param, arg))),
         },
         Expr::RecursiveDescent => Expr::RecursiveDescent,
         Expr::Optional(e) => Expr::Optional(Box::new(substitute_func_param(e, param, arg))),
@@ -23386,6 +23712,101 @@ mod tests {
             "(.a, .a.a?) = 7",
             Err(r#"Cannot index number with string "a""#),
         )]);
+    }
+
+    /// #499: slice bounds accept any expression, evaluated with the same
+    /// discipline as a computed index key (`resolve_index_expr`). Every case
+    /// here was checked against jq 1.7.1 directly.
+    #[test]
+    fn test_computed_slice_bounds() {
+        assert_outcomes(&[
+            // The issue's own repro: a computed start bound, evaluated
+            // against the root (not against `.a`).
+            (
+                br#"{"a":[1,2,3],"k":1}"#,
+                r#".a[.k:2]? = ["x"]"#,
+                Ok(r#"{"a":[1,"x",3],"k":1}"#),
+            ),
+            // A bound-evaluation failure is not covered by a trailing `?` —
+            // `.x` on an array raises before the slice is ever applied.
+            (
+                b"[1,2,3]",
+                r#".[(.x):2]? = ["y"]"#,
+                Err(r#"Cannot index array with string "x""#),
+            ),
+            // Same rule on the end bound, and on a string target.
+            (
+                br#""str""#,
+                ".[0:.k]? = 5",
+                Err(r#"Cannot index string with string "k""#),
+            ),
+            // A bound that resolves successfully but isn't a number is also
+            // not covered by `?` — unlike a computed key's `key_to_path_component`
+            // type check, which `?` *does* cover.
+            (
+                b"null",
+                r#".[("x"):2]? = 5"#,
+                Err("Array/string slice indices must be integers"),
+            ),
+            // Only the final "target isn't sliceable" failure is what `?`
+            // covers.
+            (b"5", r#".[0:2]? = ["x"]"#, Ok("5")),
+            // The target's own evaluation failure is not covered either.
+            (
+                br#""str""#,
+                r#".a[0:2]? = ["x"]"#,
+                Err(r#"Cannot index string with string "a""#),
+            ),
+            // An empty start (or end) bound stream short-circuits before the
+            // next stage runs — including before the target is ever touched.
+            (b"[1,2,3]", "[(error(\"boom\"))[0:empty]]", Ok("[]")),
+            (b"[1,2,3]", "[(error(\"boom\"))[empty:2]]", Ok("[]")),
+            // A `null` bound is "open on this side", same as an omitted one.
+            (b"[1,2,3,4,5]", ".[(null):(3)]", Ok("[1,2,3]")),
+            // A fractional dynamic bound still floors the start / ceils the
+            // end, exactly like a literal one.
+            (b"[1,2,3,4,5]", ".[(1.7):(2.9)]", Ok("[2,3]")),
+            // Multi-value bounds fan out start-outer, end-middle,
+            // target-inner — the same nesting order jq's `S as $s | T as $t
+            // | E | .[$s:$t]` desugaring produces.
+            (
+                b"[1,2,3,4,5]",
+                "[.[(0,1):(3,4)]]",
+                Ok("[[1,2,3],[1,2,3,4],[2,3],[2,3,4]]"),
+            ),
+            // `path()`, `del()` and `|=` all round-trip through a computed
+            // slice, the same as they do through a computed key.
+            (
+                br#"{"a":[1,2,3],"k1":0,"k2":2}"#,
+                "path(.a[.k1:.k2])",
+                Ok(r#"["a",{"start":0,"end":2}]"#),
+            ),
+            (
+                br#"{"a":[1,2,3],"k1":0,"k2":2}"#,
+                "del(.a[.k1:.k2])",
+                Ok(r#"{"a":[3],"k1":0,"k2":2}"#),
+            ),
+            (
+                br#"{"a":[1,2,3],"k1":0,"k2":2}"#,
+                ".a[.k1:.k2] |= map(.*10)",
+                Ok(r#"{"a":[10,20,3],"k1":0,"k2":2}"#),
+            ),
+            // A dynamic slice can be a mid-chain component, not just the
+            // final one — including under `?`, which (unlike the fully
+            // static `.a[1:2]?[0]` shape — a separate, pre-existing gap)
+            // goes through the computed-key prepass and so has its
+            // `Expr::Optional` wrapper stripped before `set_path` runs.
+            (
+                br#"{"a":[1,2,3,4],"k1":0,"k2":2}"#,
+                ".a[.k1:.k2][0] = 9",
+                Ok(r#"{"a":[9,2,3,4],"k1":0,"k2":2}"#),
+            ),
+            (
+                br#"{"a":[1,2,3,4],"k1":0,"k2":2}"#,
+                ".a[.k1:.k2]?[0] = 9",
+                Ok(r#"{"a":[9,2,3,4],"k1":0,"k2":2}"#),
+            ),
+        ]);
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6805,14 +6805,16 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let starts = match eval_slice_bound::<W, S>(start, value.clone(), f64::floor) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(Control::Error(e)) => return QueryResult::Error(e),
+        Err(Control::Break(label)) => return QueryResult::Break(label),
     };
     if starts.is_empty() {
         return QueryResult::None;
     }
     let ends = match eval_slice_bound::<W, S>(end, value.clone(), f64::ceil) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(Control::Error(e)) => return QueryResult::Error(e),
+        Err(Control::Break(label)) => return QueryResult::Break(label),
     };
     if ends.is_empty() {
         return QueryResult::None;
@@ -6889,11 +6891,18 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// to whatever `Expr::Slice` carries, so rounding here first is transparent
 /// to it — see `slice.rs`'s doc comment). A missing bound (`None`) is a
 /// single `None` — "this side is open" — not an empty stream.
+///
+/// Errors as [`Control`], not [`EvalError`], so a `break` inside the bound
+/// (`label $out | .[(break $out):2]`) reaches the enclosing label as a real
+/// break instead of degrading into a synthetic "break $out not in label"
+/// error — [`eval_index_expr`]'s key evaluation, which returns `QueryResult`
+/// directly, already gets this right; the narrower `Result<_, EvalError>`
+/// this shares with [`owned_bound_to_i64`] needs `Control` to keep up.
 fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     bound: &Option<Box<Expr>>,
     value: StandardJson<'_, W>,
     round: fn(f64) -> f64,
-) -> Result<Vec<Option<i64>>, EvalError> {
+) -> Result<Vec<Option<i64>>, Control> {
     let Some(expr) = bound else {
         return Ok(vec![None]);
     };
@@ -6903,17 +6912,14 @@ fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Owned(v) => vec![v],
         QueryResult::ManyOwned(vs) => vs,
         QueryResult::None => return Ok(Vec::new()),
-        QueryResult::Error(e) => return Err(e),
-        QueryResult::Break(label) => {
-            return Err(EvalError::new(format!("break ${label} not in label")))
-        }
+        QueryResult::Error(e) => return Err(Control::Error(e)),
+        QueryResult::Break(label) => return Err(Control::Break(label)),
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
-        QueryResult::Partial(_, Control::Error(e)) => return Err(e),
-        QueryResult::Partial(_, Control::Break(label)) => {
-            return Err(EvalError::new(format!("break ${label} not in label")))
-        }
+        QueryResult::Partial(_, control) => return Err(control),
     };
-    raw.iter().map(|v| owned_bound_to_i64(v, round)).collect()
+    raw.iter()
+        .map(|v| owned_bound_to_i64(v, round).map_err(Control::Error))
+        .collect()
 }
 
 /// Classify a resolved bound value the way jq's slice descriptor does

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -59,6 +59,28 @@ pub enum Expr {
         key: Box<Self>,
     },
 
+    /// Slice by a computed bound: `.[$a:$b]`, `.[.k:2]`, `E[S:T]` where at
+    /// least one bound isn't an integer literal.
+    ///
+    /// jq compiles `E[S:T]` as `S as $s | T as $t | E | .[$s:$t]`, the same
+    /// desugaring [`Expr::IndexExpr`] documents for `E[K]` — `S`/`T` are
+    /// evaluated against *this node's* input, not `E`'s output, which is why
+    /// this variant carries its own `target` instead of flattening into
+    /// [`Expr::Pipe`]. `S` is evaluated outer, `T` middle, `E` inner.
+    ///
+    /// A bound that fully folds to an integer literal never reaches here:
+    /// the parser keeps producing plain [`Expr::Slice`] whenever *both*
+    /// present bounds are constant, so the existing fast path and every
+    /// [`Expr::Slice`] match site are untouched.
+    SliceExpr {
+        /// The value being sliced — the postfix chain so far.
+        target: Box<Self>,
+        /// The start bound, evaluated against this node's own input.
+        start: Option<Box<Self>>,
+        /// The end bound, evaluated against this node's own input.
+        end: Option<Box<Self>>,
+    },
+
     /// Optional access: `.foo?` - returns null instead of error if missing
     Optional(Box<Self>),
 
@@ -1060,6 +1082,15 @@ impl Expr {
     /// Create a slice expression.
     pub fn slice(start: Option<i64>, end: Option<i64>) -> Self {
         Self::Slice { start, end }
+    }
+
+    /// Create a computed-bounds slice expression: `target[start:end]`.
+    pub fn slice_by(target: Self, start: Option<Self>, end: Option<Self>) -> Self {
+        Self::SliceExpr {
+            target: Box::new(target),
+            start: start.map(Box::new),
+            end: end.map(Box::new),
+        }
     }
 
     /// Make this expression optional.

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -86,19 +86,36 @@ enum Bracket {
     Static(Expr),
     /// `[expr]` with a computed key; the caller supplies the target.
     Dynamic { key: Expr, optional: bool },
+    /// `[start:end]` with at least one computed bound; the caller supplies
+    /// the target. See [`Expr::SliceExpr`].
+    DynamicSlice {
+        start: Option<Expr>,
+        end: Option<Expr>,
+        optional: bool,
+    },
 }
 
 /// Attach a parsed bracket to the postfix chain built so far.
 ///
 /// A dynamic key captures the chain as its `target`, because the key is
 /// evaluated against the chain's *input* — `.a[.k]` reads `.k` from the chain
-/// input, not from `.a`.
+/// input, not from `.a`. A dynamic slice bound is the same rule applied to
+/// `.a[.k1:.k2]`.
 fn push_bracket(chain: &mut Vec<Expr>, bracket: Bracket) {
     match bracket {
         Bracket::Static(expr) => chain.push(expr),
         Bracket::Dynamic { key, optional } => {
             let target = Expr::pipe(core::mem::take(chain));
             let node = Expr::index_by(target, key);
+            chain.push(if optional { node.optional() } else { node });
+        }
+        Bracket::DynamicSlice {
+            start,
+            end,
+            optional,
+        } => {
+            let target = Expr::pipe(core::mem::take(chain));
+            let node = Expr::slice_by(target, start, end);
             chain.push(if optional { node.optional() } else { node });
         }
     }
@@ -623,16 +640,12 @@ impl<'a> Parser<'a> {
             let end = self.parse_slice_bound()?;
             self.skip_ws();
             self.expect(']')?;
-            return Ok(Bracket::Static(Expr::Slice {
-                start: None,
-                end: Some(end),
-            }));
+            return Ok(Self::finish_slice(None, Some(end)));
         }
 
         // Parse the bracket contents as a full expression. `:` can never be
         // consumed by an expression here — object construction needs `{`, and a
         // namespaced call needs `::` — so it reliably marks a slice.
-        let key_start = self.pos;
         let key = self.parse_expr()?;
         self.skip_ws();
 
@@ -648,30 +661,20 @@ impl<'a> Parser<'a> {
                 })
             }
             Some(':') => {
-                // `[n:]` or `[n:m]` - slice. Bounds must still fold to an
-                // integer literal; expression-valued bounds (`.[$a:$b]`) are
-                // not supported yet.
-                let first = Self::fold_int_literal(&key)
-                    .ok_or_else(|| Self::slice_bound_error(key_start))?;
+                // `[n:]` or `[n:m]` - slice.
                 self.next();
                 self.skip_ws();
 
                 if self.peek() == Some(']') {
                     // `[n:]` - slice from n to end
                     self.next();
-                    Ok(Bracket::Static(Expr::Slice {
-                        start: Some(first),
-                        end: None,
-                    }))
+                    Ok(Self::finish_slice(Some(key), None))
                 } else {
                     // `[n:m]` - slice from n to m
                     let second = self.parse_slice_bound()?;
                     self.skip_ws();
                     self.expect(']')?;
-                    Ok(Bracket::Static(Expr::Slice {
-                        start: Some(first),
-                        end: Some(second),
-                    }))
+                    Ok(Self::finish_slice(Some(key), Some(second)))
                 }
             }
             Some(c) => Err(ParseError::new(
@@ -682,6 +685,30 @@ impl<'a> Parser<'a> {
                 "expected ']' or ':', found end of input",
                 self.pos,
             )),
+        }
+    }
+
+    /// Decide whether a slice's bounds are both constant (the existing
+    /// [`Expr::Slice`] fast path) or need runtime evaluation
+    /// ([`Expr::SliceExpr`], attached to a target by the caller — see
+    /// [`Bracket::DynamicSlice`]). Each bound folds independently, so
+    /// `.[1:.k]` (one literal, one dynamic) still becomes dynamic.
+    fn finish_slice(start: Option<Expr>, end: Option<Expr>) -> Bracket {
+        let start_i64 = start.as_ref().and_then(Self::fold_int_literal);
+        let end_i64 = end.as_ref().and_then(Self::fold_int_literal);
+        let start_dynamic = start.is_some() && start_i64.is_none();
+        let end_dynamic = end.is_some() && end_i64.is_none();
+        if start_dynamic || end_dynamic {
+            Bracket::DynamicSlice {
+                start,
+                end,
+                optional: false,
+            }
+        } else {
+            Bracket::Static(Expr::Slice {
+                start: start_i64,
+                end: end_i64,
+            })
         }
     }
 
@@ -716,20 +743,15 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// The error both slice bounds report when they do not fold.
-    fn slice_bound_error(pos: usize) -> ParseError {
-        ParseError::new("slice bounds must be integer literals", pos)
-    }
-
     /// Parse one slice bound.
     ///
     /// Both bounds go through here so they accept the same spellings. Parsing
     /// only the *first* as an expression would let `.[(1):3]` compile while
-    /// `.[1:(3)]` did not — an asymmetry with no grammar behind it.
-    fn parse_slice_bound(&mut self) -> Result<i64, ParseError> {
-        let start = self.pos;
-        let bound = self.parse_expr()?;
-        Self::fold_int_literal(&bound).ok_or_else(|| Self::slice_bound_error(start))
+    /// `.[1:(3)]` did not — an asymmetry with no grammar behind it. The
+    /// caller (`Self::finish_slice`) decides whether the parsed expression
+    /// folds to a literal or needs runtime evaluation.
+    fn parse_slice_bound(&mut self) -> Result<Expr, ParseError> {
+        self.parse_expr()
     }
 
     /// Parse an index bracket and check for optional marker.
@@ -742,6 +764,11 @@ impl<'a> Parser<'a> {
                 Bracket::Static(expr) => Bracket::Static(Expr::Optional(expr.into())),
                 Bracket::Dynamic { key, .. } => Bracket::Dynamic {
                     key,
+                    optional: true,
+                },
+                Bracket::DynamicSlice { start, end, .. } => Bracket::DynamicSlice {
+                    start,
+                    end,
                     optional: true,
                 },
             })
@@ -4718,7 +4745,6 @@ mod tests {
         // Note: "foo" now parses as FuncCall{name:"foo", args:[]} - valid syntax for user functions
         assert!(parse(".[").is_err()); // unclosed bracket
         assert!(parse(".[1 2]").is_err()); // missing ']' after the key
-        assert!(parse(".[$a:$b]").is_err()); // slice bounds must be integer literals
         assert!(parse(".123").is_err()); // field starting with number
         assert!(parse("{").is_err()); // unclosed brace
         assert!(parse("[").is_err()); // unclosed bracket
@@ -5158,17 +5184,29 @@ mod tests {
             assert_eq!(parse(src).unwrap(), Expr::Slice { start, end }, "`{src}`");
         }
 
-        // A bound that does not fold is still rejected, on either side, and
-        // says why rather than complaining about a digit.
-        for src in [".[$a:1]", ".[1:$b]", ".[:$b]"] {
-            let err = parse(src).unwrap_err();
-            assert!(
-                err.message
-                    .contains("slice bounds must be integer literals"),
-                "`{src}` gave: {}",
-                err.message
-            );
-        }
+        // A bound that does not fold to a literal becomes `Expr::SliceExpr`
+        // instead of a parse error (#499), on either side, and independently
+        // of whether the other bound folds.
+        assert_eq!(
+            parse(".[$a:1]").unwrap(),
+            Expr::slice_by(
+                Expr::Identity,
+                Some(Expr::Var("a".into())),
+                Some(Expr::Literal(Literal::Int(1))),
+            )
+        );
+        assert_eq!(
+            parse(".[1:$b]").unwrap(),
+            Expr::slice_by(
+                Expr::Identity,
+                Some(Expr::Literal(Literal::Int(1))),
+                Some(Expr::Var("b".into())),
+            )
+        );
+        assert_eq!(
+            parse(".[:$b]").unwrap(),
+            Expr::slice_by(Expr::Identity, None, Some(Expr::Var("b".into())))
+        );
     }
 
     /// The nesting shape is what encodes jq's key scoping: every key in a
@@ -5224,6 +5262,70 @@ mod tests {
         assert_eq!(
             parse(".[$k]?").unwrap(),
             Expr::index_by(Expr::Identity, Expr::Var("k".into())).optional()
+        );
+    }
+
+    /// Same nesting shape as `test_dynamic_index_shapes`, for slice bounds
+    /// that don't fold to a literal (#499): `SliceExpr` carries its own
+    /// `target` for the same reason `IndexExpr` does — a bound is evaluated
+    /// against the chain's input, not against the target's output.
+    #[test]
+    fn test_dynamic_slice_shapes() {
+        assert_eq!(
+            parse(".[$a:$b]").unwrap(),
+            Expr::slice_by(
+                Expr::Identity,
+                Some(Expr::Var("a".into())),
+                Some(Expr::Var("b".into())),
+            )
+        );
+
+        // `.a[.k1:.k2]`: the bounds hang off the node, not off `.a`.
+        assert_eq!(
+            parse(".a[.k1:.k2]").unwrap(),
+            Expr::slice_by(
+                Expr::Field("a".into()),
+                Some(Expr::Field("k1".into())),
+                Some(Expr::Field("k2".into())),
+            )
+        );
+
+        // `.a[.k1:.k2].b[.j1:.j2]`: the second target is the whole chain so far.
+        assert_eq!(
+            parse(".a[.k1:.k2].b[.j1:.j2]").unwrap(),
+            Expr::slice_by(
+                Expr::Pipe(vec![
+                    Expr::slice_by(
+                        Expr::Field("a".into()),
+                        Some(Expr::Field("k1".into())),
+                        Some(Expr::Field("k2".into())),
+                    ),
+                    Expr::Field("b".into()),
+                ]),
+                Some(Expr::Field("j1".into())),
+                Some(Expr::Field("j2".into())),
+            )
+        );
+
+        // `?` wraps the whole node, not a bound.
+        assert_eq!(
+            parse(".[$a:$b]?").unwrap(),
+            Expr::slice_by(
+                Expr::Identity,
+                Some(Expr::Var("a".into())),
+                Some(Expr::Var("b".into())),
+            )
+            .optional()
+        );
+
+        // A dynamic bound composes with an `IndexExpr` target and vice versa.
+        assert_eq!(
+            parse(".[.k][$a:$b]").unwrap(),
+            Expr::slice_by(
+                Expr::index_by(Expr::Identity, Expr::Field("k".into())),
+                Some(Expr::Var("a".into())),
+                Some(Expr::Var("b".into())),
+            )
         );
     }
 

--- a/src/jq/slice.rs
+++ b/src/jq/slice.rs
@@ -59,6 +59,17 @@ impl SliceBounds {
         })
     }
 
+    /// Classify one resolved bound value the way a descriptor slot is
+    /// classified — `null` is "open on this side", a number is that number,
+    /// anything else is jq's `Array/string slice indices must be integers`.
+    ///
+    /// Exposed for `E[S:T]` (`Expr::SliceExpr`), whose bounds are ordinary
+    /// expressions evaluated at runtime to an `OwnedValue`, not a
+    /// pre-validated descriptor object.
+    pub(crate) fn resolved_bound(v: &OwnedValue) -> Result<Option<f64>, EvalError> {
+        bound(Some(v))
+    }
+
     /// The element range this names against a container of length `len`.
     ///
     /// jq's `parse_slice`: floor the start and ceil the end (so a fractional

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -65,13 +65,13 @@
 # 12: `if`/`select` now fan out over every output of the condition instead of
 # consulting only the first one, in both evaluators.
 #
-# nan_type (#472) has since been fixed and dropped, leaving 11.
+# nan_type (#472) and slice_computed_bounds (#499) have since been fixed and
+# dropped, leaving 10.
 
 object_construct_cartesian     object_construct   only the first output of each key/value generator is used instead of the cartesian product — #354
 assign_multi_output_rhs        assignment         .a = (1,2) only applies the first RHS output instead of forking once per output — #392
 path_recursive_descent         path               path(..) returns only the root path instead of every descendant path — #483
 recurse_null_child             recurse            recurse on {"a":null} stops before visiting the null leaf — #490
-slice_computed_bounds          slice              computed slice bounds (.a[.k:2]) are a parse error; only integer literals are accepted — #499
 reduce_multi_output_init       reduce             a multi-output reduce INIT forks in jq; only the first init output is used — #534
 foreach_multi_output_init      foreach            a multi-output foreach INIT forks in jq; only the first init output is used — #534
 reduce_update_zero_output      reduce             a comma in reduce's UPDATE clause is a compile error; jq keeps only UPDATE's last output as the new state, discarding earlier ones — #534

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3362,6 +3362,32 @@ fn test_computed_key_in_index_brackets() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_split_doc_hides_in_computed_slice_bounds() -> Result<()> {
+    // Same reasoning as `test_computed_key_in_index_brackets`, for a computed
+    // slice's target and bounds (#499). `contains_split_doc` has to descend
+    // into all three, or a `split_doc` hiding in one is scanned as an opaque
+    // leaf and the stream never gets its `---` separators.
+    let yaml = "[[1,2,3,4],[5,6,7,8]]\n";
+    let expected = "- 2\n- 3\n---\n- 6\n- 7\n";
+
+    // Hidden in the start bound.
+    let (output, code) = run_yq_stdin(".[] | .[(1|split_doc):(3)]", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, expected);
+
+    // Hidden in the end bound.
+    let (output, code) = run_yq_stdin(".[] | .[(1):(3|split_doc)]", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, expected);
+
+    // Hidden in the target.
+    let (output, code) = run_yq_stdin(".[] | (split_doc)[(1):(3)]", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, expected);
+    Ok(())
+}
+
 // =============================================================================
 // Whole-float representation — #169
 // =============================================================================


### PR DESCRIPTION
## Summary

- Slice bounds only accepted integer literals (`.[1:3]`); any expression bound (`.a[.k:2]`, `.[(.x):2]`, `.[0:.k]`) was refused at parse time with `slice bounds must be integer literals`, even though jq accepts and evaluates any expression there.
- `Expr::SliceExpr { target, start, end }` mirrors `Expr::IndexExpr`'s computed-key design. A bound that folds to a literal still produces the existing `Expr::Slice { start: Option<i64>, end: Option<i64> }` unchanged, so the fast path and every existing `Expr::Slice` call site are untouched — this only kicks in when at least one bound is a genuine expression.
- Evaluation and path resolution reuse `resolve_index_expr`'s discipline (established for #413/#482), verified directly against jq 1.7.1:
  - Bounds evaluate before the target — start outer, end middle, target inner, matching jq's `S as $s | T as $t | E | .[$s:$t]` desugaring — and an empty start/end stream short-circuits before the next stage runs.
  - A trailing `?` covers only the final "apply resolved bounds to target" step — not a bound's own evaluation failure, not the target's own evaluation failure, and not a bound that resolves successfully but isn't a number (`Array/string slice indices must be integers`).
  - A fractional dynamic bound still floors the start / ceils the end, same as a literal one.
- `eval_slice_expr` (read mode) and `resolve_slice_expr` (path mode, covering `=`, `|=`, `del()`, `path()`) both delegate the actual slicing to the existing `Expr::Slice` machinery once bounds are resolved — `SliceBounds`, `through_slice`, and `split_at_slice` needed no changes.
- Drops `slice_computed_bounds` from the jq-golden known-failures manifest — it was pinned there for exactly this bug and now passes.

Fixes #499

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` (full suite, incl. `jq_golden_conformance`, evaluator parity, and doc tests) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the two other feature-matrix clippy invocations `ci.yml` runs — clean
- [x] New unit coverage: `test_dynamic_slice_shapes` (parser) and `test_computed_slice_bounds` (eval, 15 cases) covering the issue's own repro plus every jq-oracle-verified edge case (bound-eval errors, non-numeric resolved bounds, empty-stream short-circuit, multi-value fan-out order, fractional bounds, `path()`/`del()`/`|=`, mid-chain continuation)
- [x] Manually diffed `sjq` output against real `jq` for every case above — byte-for-byte match