### PR TITLE
docs(docs): add ADR-0014 rejecting rank-implementation consolidation

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -40,6 +40,7 @@ by Michael Nygard.
 | [ADR-0011](adr-0011.md) | ✅ Accepted | 2026-07-15 | Custom Succinct Structures over Existing Rust Crates   |
 | [ADR-0012](adr-0012.md) | ✅ Accepted | 2026-07-25 | Elias-Fano Line Index over a Dense Bitmap              |
 | [ADR-0013](adr-0013.md) | ✅ Accepted | 2026-07-25 | Reject the SIMD Chunk-Scanner JSON Validator (#130)    |
+| [ADR-0014](adr-0014.md) | ✅ Accepted | 2026-08-03 | Reject Consolidating This Crate's Rank Implementations |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0014.md
+++ b/docs/adrs/adr-0014.md
@@ -29,7 +29,7 @@ The issue was corrected in a same-day comment before this ADR was written.
   ([src/lib.rs:135](../../src/lib.rs#L135),
   [src/bits/bitvec.rs:211](../../src/bits/bitvec.rs#L211)).
 - **BP's inline rank** — `rank_l1: Vec<u32>` / `rank_l2: Vec<u64>`
-  ([src/trees/bp.rs:1487-1491](../../src/trees/bp.rs#L1487-L1491)), 96 bits per
+  ([src/trees/bp.rs:1707-1711](../../src/trees/bp.rs#L1707-L1711)), 96 bits per
   512-bit block, **18.75% overhead**. It is a pair of inherent fields on
   `BalancedParens<W, S>`, not an implementor of `RankSelect` — `BalancedParens`
   is generic over storage (`W`) and select support (`S: SelectSupport`), which a
@@ -59,9 +59,9 @@ Grepped against the current tree, not assumed:
 ### The two are coupled to different, incompatible constraints
 
 Per `docs/plan/cspoppy.md` §1.3 and §6/F1 — written for
-[issue #64](https://github.com/rust-works/succinctly/issues/64) and its
-(currently open, unmerged) PR #603 — BP's rank shape is not an accident to clean
-up:
+[issue #64](https://github.com/rust-works/succinctly/issues/64) and shipped by
+[PR #603](https://github.com/rust-works/succinctly/pull/603), which merged
+`WithCsPoppy` and closed #64 — BP's rank shape is not an accident to clean up:
 
 - BP's `rank_l1` is deliberately finer-grained (512-bit blocks) than a generic
   Poppy directory's coarser 2048-bit superblock, and that granularity is exactly
@@ -78,11 +78,24 @@ up:
   rank — it doesn't change this calculus, it sharpens it: `BitVec` would then
   have two candidate layouts of its own, still none shared with BP.
 
+`docs/plan/cspoppy.md` §6/F3 (written the same day as the issue correction
+above) suggested this ADR was "still worth doing once F2 exists," since F2
+would add a third layout. The bullet above is the answer to that suggestion,
+not an oversight of it: F2 sharpens rather than changes the calculus, so there
+is no reason to wait for it before deciding. If F2's implementation turns out
+to disagree with that prediction, revisit this ADR rather than treating it as
+having preempted F2.
+
 ### Precedent
 
-This project has an established pattern of rejecting speculative unification
-that isn't backed by a measured need — see ADR-0004 through ADR-0010 — rather
-than build an abstraction ahead of a caller that needs it.
+This project has an established discipline of rejecting speculative
+engineering that isn't backed by a measured need: ADR-0004 through ADR-0010
+reject optimizations that micro-benchmarks favoured but end-to-end measurement
+didn't justify, and ADR-0011 rejects external rank/select crates in favour of
+build-vs-buy criteria the in-crate code actually meets. This decision applies
+the same discipline one level up — to structure, not code paths or
+dependencies — by declining to merge two working implementations into one
+shared abstraction ahead of a caller that needs it.
 
 ## Decision
 
@@ -103,7 +116,7 @@ worth paying for:
 Neither serves a caller that exists. The existing public `RankSelect` trait
 already gives callers a nominal common interface; extending it to `BalancedParens`
 was deliberately not done because BP's rank/select need generic parameters
-(`W`, `S: SelectSupport`, and — per `cspoppy.md`'s planned `BpSelectCtx` — direct
+(`W`, `S: SelectSupport`, and — per `BpSelectCtx`, shipped by PR #603 — direct
 access to `rank_l1`/`rank_l2`) that a `&self`-only trait can't carry.
 
 ## Consequences
@@ -111,7 +124,7 @@ access to `rank_l1`/`rank_l2`) that a `&self`-only trait can't carry.
 **Positive:**
 
 - No speculative abstraction is built ahead of a real need — consistent with
-  this project's YAGNI precedent (ADR-0004 through ADR-0010).
+  this project's YAGNI precedent (ADR-0004 through ADR-0010, ADR-0011).
 - BP's `select1` keeps the finer-grained `rank_l1` that CS-Poppy's combined
   sampling (#64) depends on; nothing about this decision touches that work.
 - `BitVec`'s public `RankSelect` API is unaffected.

--- a/docs/adrs/adr-0014.md
+++ b/docs/adrs/adr-0014.md
@@ -23,17 +23,16 @@ The issue was corrected in a same-day comment before this ADR was written.
 
 - **`RankDirectory`** ([src/bits/rank.rs](../../src/bits/rank.rs)) — a 3-level
   Poppy-style directory storing one cache-aligned 128-bit entry (L1 + packed L2
-  offsets) per 512-bit block, **25% overhead**. It backs `BitVec`
-  ([src/bits/bitvec.rs:52](../../src/bits/bitvec.rs#L52)), which is the sole
+  offsets) per 512-bit block, **25% overhead**. It backs `BitVec`'s `rank_dir`
+  field ([src/bits/bitvec.rs](../../src/bits/bitvec.rs)), which is the sole
   implementor of the public `RankSelect` trait
-  ([src/lib.rs:137](../../src/lib.rs#L137),
-  [src/bits/bitvec.rs:211](../../src/bits/bitvec.rs#L211)).
-- **BP's inline rank** — `rank_l1: Vec<u32>` / `rank_l2: Vec<u64>`
-  ([src/trees/bp.rs:1707-1711](../../src/trees/bp.rs#L1707-L1711)), 96 bits per
-  512-bit block, **18.75% overhead**. It is a pair of inherent fields on
-  `BalancedParens<W, S>`, not an implementor of `RankSelect` — `BalancedParens`
-  is generic over storage (`W`) and select support (`S: SelectSupport`), which a
-  plain `&self -> usize` trait can't express.
+  ([src/lib.rs](../../src/lib.rs)).
+- **BP's inline rank** — `rank_l1: Vec<u32>` / `rank_l2: Vec<u64>` inherent
+  fields on `BalancedParens<W, S>` ([src/trees/bp.rs](../../src/trees/bp.rs)),
+  96 bits per 512-bit block, **18.75% overhead**. Not an implementor of
+  `RankSelect` — `BalancedParens` is generic over storage (`W`) and select
+  support (`S: SelectSupport`), which a plain `&self -> usize` trait can't
+  express.
 
 If [F2 (#597)](https://github.com/rust-works/succinctly/issues/597), a true
 Poppy rank layout for `BitVec` (L0 + packed L1/L2, 3.125% overhead), is built,
@@ -52,9 +51,9 @@ Grepped against the current tree, not assumed:
   production callers at all and survives as public API only" — still true three
   weeks later.
 - **`BalancedParens::rank1` is genuinely hot.** It is called from real
-  cursor-navigation and query paths: `json/locate.rs:99,111`,
-  `json/light.rs:547,842,851`, `yaml/index.rs:198,211,222`,
-  `yaml/light.rs:1032`.
+  cursor-navigation and query paths in `json/locate.rs`, `json/light.rs`,
+  `yaml/index.rs`, and `yaml/light.rs` (binary-searching BP position from an
+  interest-bit index, and mapping a BP position back to an open-tag index).
 
 ### The two are coupled to different, incompatible constraints
 

--- a/docs/adrs/adr-0014.md
+++ b/docs/adrs/adr-0014.md
@@ -1,0 +1,138 @@
+# ADR-0014: Reject Consolidating This Crate's Rank Implementations
+
+## Status
+
+✅ Accepted
+
+## Context
+
+Succinctly has two separate rank implementations today, raised as a question in
+[issue #598](https://github.com/rust-works/succinctly/issues/598) (F3, deferred
+from #64's `docs/plan/cspoppy.md` §6): should they be consolidated into one
+parameterised structure, or are they genuinely justified as separate?
+
+**This record checks the premise before answering it.** The issue's own summary
+table was stale — it listed a third structure, `CompactRank` (3.52%, two-level),
+citing `src/bits/compact_rank.rs`. That file does not exist and never did in this
+form: `CompactRank` was deleted from the crate in #321, and the rank indices it
+replaced went back to cumulative `Vec<u32>` arrays (see
+[docs/plan/yaml-index-post-compactrank.md](../plan/yaml-index-post-compactrank.md)).
+The issue was corrected in a same-day comment before this ADR was written.
+
+### The two implementations, verified against the current tree
+
+- **`RankDirectory`** ([src/bits/rank.rs](../../src/bits/rank.rs)) — a 3-level
+  Poppy-style directory storing one cache-aligned 128-bit entry (L1 + packed L2
+  offsets) per 512-bit block, **25% overhead**. It backs `BitVec`
+  ([src/bits/bitvec.rs:52](../../src/bits/bitvec.rs#L52)), which is the sole
+  implementor of the public `RankSelect` trait
+  ([src/lib.rs:135](../../src/lib.rs#L135),
+  [src/bits/bitvec.rs:211](../../src/bits/bitvec.rs#L211)).
+- **BP's inline rank** — `rank_l1: Vec<u32>` / `rank_l2: Vec<u64>`
+  ([src/trees/bp.rs:1487-1491](../../src/trees/bp.rs#L1487-L1491)), 96 bits per
+  512-bit block, **18.75% overhead**. It is a pair of inherent fields on
+  `BalancedParens<W, S>`, not an implementor of `RankSelect` — `BalancedParens`
+  is generic over storage (`W`) and select support (`S: SelectSupport`), which a
+  plain `&self -> usize` trait can't express.
+
+If [F2 (#597)](https://github.com/rust-works/succinctly/issues/597), a true
+Poppy rank layout for `BitVec` (L0 + packed L1/L2, 3.125% overhead), is built,
+that becomes a *third* implementation — still layered under `BitVec` only, as
+discussed below.
+
+### Who actually calls each one
+
+Grepped against the current tree, not assumed:
+
+- **`BitVec::rank1`/`RankDirectory` have zero production call sites.** Every hit
+  outside `bits/rank.rs` and `bits/bitvec.rs` is a doc-comment example, a unit
+  test, or the size-comparison test in `text/lines.rs` (`LineIndex` replaced the
+  `BitVec`-backed newline bitmaps under [ADR-0012](adr-0012.md) / #228). This
+  reconfirms [ADR-0011](adr-0011.md)'s finding that `BitVec` "now has no
+  production callers at all and survives as public API only" — still true three
+  weeks later.
+- **`BalancedParens::rank1` is genuinely hot.** It is called from real
+  cursor-navigation and query paths: `json/locate.rs:99,111`,
+  `json/light.rs:547,842,851`, `yaml/index.rs:198,211,222`,
+  `yaml/light.rs:1032`.
+
+### The two are coupled to different, incompatible constraints
+
+Per `docs/plan/cspoppy.md` §1.3 and §6/F1 — written for
+[issue #64](https://github.com/rust-works/succinctly/issues/64) and its
+(currently open, unmerged) PR #603 — BP's rank shape is not an accident to clean
+up:
+
+- BP's `rank_l1` is deliberately finer-grained (512-bit blocks) than a generic
+  Poppy directory's coarser 2048-bit superblock, and that granularity is exactly
+  what makes CS-Poppy's combined-sampling `select1` possible: it does a
+  `partition_point` over `rank_l1` plus a `rank_l2` unpack, touching no bitmap
+  words at all. [F1 (#596)](https://github.com/rust-works/succinctly/issues/596)
+  found `rank_l2` now has *two* consumers — `rank1` and `select1`'s word-locate
+  step — a real functional coupling between BP's rank layout and its select
+  design, not incidental duplication.
+- `RankDirectory` has no such coupling: `BitVec`'s select is a separate sampled
+  `SelectIndex`, not driven off the rank array. And per the caller check above,
+  nothing depends on `RankDirectory`'s shape today.
+- F2 would add a third rank layout, but still only for `BitVec`'s (caller-less)
+  rank — it doesn't change this calculus, it sharpens it: `BitVec` would then
+  have two candidate layouts of its own, still none shared with BP.
+
+### Precedent
+
+This project has an established pattern of rejecting speculative unification
+that isn't backed by a measured need — see ADR-0004 through ADR-0010 — rather
+than build an abstraction ahead of a caller that needs it.
+
+## Decision
+
+We will **not** consolidate `RankDirectory` and BP's inline rank into one
+parameterised structure. They stay separate.
+
+A shared structure would have to satisfy one of two constraints, and neither is
+worth paying for:
+
+1. **Generalise to BP's finer granularity and select-coupling.** This is pure
+   added complexity for `RankDirectory`, which — per the caller check above —
+   has zero production callers to benefit from it today.
+2. **Fall back to `RankDirectory`'s coarser, select-decoupled shape.** This
+   would regress BP's `select1` back to popcounting up to 7 words per query,
+   undoing exactly what the CS-Poppy work (#64) built BP's finer `rank_l1` to
+   avoid.
+
+Neither serves a caller that exists. The existing public `RankSelect` trait
+already gives callers a nominal common interface; extending it to `BalancedParens`
+was deliberately not done because BP's rank/select need generic parameters
+(`W`, `S: SelectSupport`, and — per `cspoppy.md`'s planned `BpSelectCtx` — direct
+access to `rank_l1`/`rank_l2`) that a `&self`-only trait can't carry.
+
+## Consequences
+
+**Positive:**
+
+- No speculative abstraction is built ahead of a real need — consistent with
+  this project's YAGNI precedent (ADR-0004 through ADR-0010).
+- BP's `select1` keeps the finer-grained `rank_l1` that CS-Poppy's combined
+  sampling (#64) depends on; nothing about this decision touches that work.
+- `BitVec`'s public `RankSelect` API is unaffected.
+
+**Negative / trade-offs:**
+
+- The crate carries two rank implementations to maintain, test, and keep
+  correct across x86_64/ARM64, rather than one.
+- `RankDirectory` remains unjustified by any current caller. This is the same
+  open question ADR-0011 already left standing for `BitVec` as a whole, not a
+  new one this ADR introduces — and this decision does not resolve it, since
+  removing `RankDirectory` (rather than parameterising it) was out of scope for
+  the question #598 asked.
+- If F2 (#597) is built, the crate will have three rank implementations, two of
+  them (`RankDirectory` and F2's Poppy layout) serving the same caller-less
+  `BitVec`. That is a separate, narrower question — whether `BitVec` needs two
+  layouts of its own — and is not what this ADR decides.
+
+**Revisit this decision if:**
+
+- A hot caller appears for `BitVec`'s rank (reversing the zero-callers finding
+  above), making a shared abstraction cheap to justify.
+- BP's select design changes such that it no longer needs finer-than-Poppy
+  granularity, removing the coupling that keeps its rank shape distinct.

--- a/docs/adrs/adr-0014.md
+++ b/docs/adrs/adr-0014.md
@@ -26,7 +26,7 @@ The issue was corrected in a same-day comment before this ADR was written.
   offsets) per 512-bit block, **25% overhead**. It backs `BitVec`
   ([src/bits/bitvec.rs:52](../../src/bits/bitvec.rs#L52)), which is the sole
   implementor of the public `RankSelect` trait
-  ([src/lib.rs:135](../../src/lib.rs#L135),
+  ([src/lib.rs:137](../../src/lib.rs#L137),
   [src/bits/bitvec.rs:211](../../src/bits/bitvec.rs#L211)).
 - **BP's inline rank** — `rank_l1: Vec<u32>` / `rank_l2: Vec<u64>`
   ([src/trees/bp.rs:1707-1711](../../src/trees/bp.rs#L1707-L1711)), 96 bits per


### PR DESCRIPTION
## Summary

- Adds ADR-0014, answering #598 (F3): whether `RankDirectory` (BitVec, 25% overhead) and BP's inline `rank_l1`/`rank_l2` (18.75% overhead) should be consolidated into one parameterised rank structure.
- Decision: reject consolidation. `RankDirectory` has zero production callers (verified by grep), while BP's rank is hot cursor-navigation code whose finer 512-bit granularity is exactly what makes CS-Poppy's combined-sampling `select1` (#64, PR #603) possible. A shared structure would either add unjustified complexity to the unused path or regress the used one.
- Updates the `docs/adrs/README.md` inventory table with the new entry.

## Test plan

- [x] Docs-only change; no code paths affected.
- [x] Self-reviewed against the `review-adr` skill's four dimensions (structural accuracy, project conformance, decision quality, implementation quality) — passed clean.
- [x] Every file/line/percentage/issue-number citation re-verified against the current tree.

Closes #598