### PR TITLE
fix(jq, cli): give eval_single a native Expr::Paren arm

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -710,6 +710,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
 
         Expr::Optional(inner) => eval_single::<S, _>(inner, value, true, cursor),
 
+        // Parens are transparent to cursor-based evaluation: handled natively
+        // (like `Expr::Optional` above) so `(.)` and friends keep threading
+        // the cursor instead of falling to the `to_owned()` bridge below,
+        // which collapses duplicate mapping keys (#614).
+        Expr::Paren(inner) => eval_single::<S, _>(inner, value, optional, cursor),
+
         Expr::Pipe(exprs) => {
             if exprs.is_empty() {
                 return GenericResult::One(value);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -595,6 +595,35 @@ fn test_duplicate_mapping_key_survives_yaml_output() -> Result<()> {
     Ok(())
 }
 
+/// `(.)` is semantically identical to `.`, but before the fix for #614 it
+/// took a different code path: `can_use_m2_streaming` treated
+/// `Expr::Paren(Expr::Identity)` as streamable, yet the stricter
+/// `is_identity` check that unlocks direct cursor streaming required a bare
+/// `Expr::Identity`, so `(.)` fell through to `eval_generic::eval_single`'s
+/// `to_owned()` bridge and silently collapsed duplicate keys instead.
+#[test]
+fn test_duplicate_mapping_key_survives_parenthesized_identity() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (pretty, code) = run_yq_stdin("(.)", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty, "a: 1\na: 2\n");
+
+    let (compact, code) = run_yq_stdin("(.)", yaml, &["-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "a: 1\na: 2\n");
+
+    let (json_pretty, code) = run_yq_stdin("(.)", yaml, &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(json_pretty, "{\n  \"a\": 1,\n  \"a\": 2\n}\n");
+
+    let (json_compact, code) = run_yq_stdin("(.)", yaml, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(json_compact, "{\"a\":1,\"a\":2}\n");
+
+    Ok(())
+}
+
 #[test]
 fn test_duplicate_mapping_key_to_entries_preserves_both() -> Result<()> {
     // Unlike `.a` field access (last-wins, #174), `to_entries` must pass


### PR DESCRIPTION
## Summary

- `Expr::Paren` had no native arm in `eval_generic::eval_single`, so parenthesized expressions like `(.)` fell through to the `to_owned()` bridge, which collapses duplicate YAML/JSON mapping keys before the full evaluator runs.
- Adds `Expr::Paren(inner) => eval_single::<S, _>(inner, value, optional, cursor)`, mirroring the existing `Expr::Optional` arm here and the equivalent arm already present in the non-generic `eval.rs`, so parens stay transparent to cursor-based evaluation.

Fixes #614.

## Test plan

- [x] `succinctly yq '(.)'` on a document with duplicate mapping keys now preserves both keys (pretty/compact, YAML/JSON output), matching plain `succinctly yq '.'`.
- [x] New regression test `test_duplicate_mapping_key_survives_parenthesized_identity` in `tests/yq_cli_tests.rs`.
- [x] Full test suite (`cargo test --features cli,simd,regex,serde`) passes, including all 217 `yq_cli_tests`.
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings` is clean.

## Known scope gap

#614's acceptance criteria also list `succinctly yq --inplace '(.)'`. That path does **not** go through `eval_generic::eval_single` on `main` today — `--inplace` still uses the eager `parse_input`/`evaluate_input` OwnedValue conversion, which collapses duplicate keys for *any* expression, Paren or not (verified: `--inplace '.'` collapses identically to `--inplace '(.)'` on `main`). Wiring `--inplace` onto the M2 cursor path is tracked separately by #478 (open, not yet merged).

Confirmed by testing: applying this PR's `eval_generic.rs` change on top of #478's branch makes `--inplace '(.)'` preserve duplicate keys correctly. The two fixes are independent and additive — `--inplace '(.)'` will be fully fixed once both are merged, in either order. No further code change is needed here for that case.