### PR TITLE
F6: Expose WithCsPoppy's sample rate as a tuning knob

### DIFF
--- a/docs/plan/cspoppy.md
+++ b/docs/plan/cspoppy.md
@@ -417,7 +417,7 @@ array further beyond Step B's `u32`. Should be evaluated together with
 [compact-index-investigation.md](compact-index-investigation.md), which proposes
 EF for the YAML position arrays.
 
-### F6 — Sample rate as a tuning knob — issue #601
+### F6 — Sample rate as a tuning knob — issue #601 — **implemented** ✅
 
 At `u32` samples the overhead is `32 × density / rate`:
 
@@ -428,9 +428,19 @@ At `u32` samples the overhead is `32 × density / rate`:
 | 512         | 3.125%     | 0.781%  | 0.063%  |
 | 8192        | 0.195%     | 0.049%  | 0.004%  |
 
-Rate 512 halves Step B again, at the cost of a wider binary-search bracket.
-Cheap to expose via `Config` once B lands; needs measurement to justify a
-non-default. Default stays **256** so existing tuning keeps its meaning.
+Exposed exactly as this section predicted — via the existing crate-level
+`Config::select_sample_rate` (already `BitVec`'s knob for `SelectIndex`),
+not a new type. `WithCsPoppy::build_with_rate` takes the rate explicitly;
+`BalancedParens::new_with_cspoppy_config`/`from_words_with_cspoppy_config`
+thread a `Config` through to it, and the un-suffixed constructors stay
+`Config::default()` (rate 256) so #64's measured numbers keep their meaning.
+`WithCsPoppy` now stores the rate it was built with (`rate()` accessor)
+instead of assuming the crate-wide constant, so a stray 0 is clamped to 1
+(matches `SelectIndex::build`'s guard) rather than looping forever.
+
+Shipping the knob does not itself justify a non-default rate — that still
+needs the measurement this section originally called for. YAML's own
+`YamlIndex` construction is unchanged and keeps rate 256.
 
 ### F7 — `select0` — issue #602
 

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -3308,6 +3308,148 @@ mod tests {
         );
     }
 
+    // ========================================================================
+    // WithCsPoppy sample rate as a tuning knob (#601)
+    // ========================================================================
+
+    /// `new_with_cspoppy_config(.., Config::default())` must be indistinguishable
+    /// from the plain constructor: same memory, same answers.
+    #[test]
+    fn test_cspoppy_config_default_matches_plain_constructor() {
+        let pairs = 10_000;
+        let (words, len) = balanced_words(pairs);
+
+        let plain = BalancedParens::new_with_cspoppy(words.clone(), len);
+        let configured = BalancedParens::new_with_cspoppy_config(words, len, Config::default());
+
+        assert_eq!(plain.select_heap_size(), configured.select_heap_size());
+        for k in [0, 1, 255, 256, 257, pairs - 1] {
+            assert_eq!(plain.select1(k), configured.select1(k), "select1({k})");
+        }
+    }
+
+    /// A non-default sample rate must not change a single `select1` answer —
+    /// only the density of the index built to answer it.
+    #[test]
+    fn test_cspoppy_custom_rate_matches_default_answers() {
+        for (label, words, len) in cspoppy_fixtures() {
+            let default_rate =
+                BalancedParens::<_, WithCsPoppy>::from_words_with_cspoppy(&words[..], len);
+
+            for rate in [1u32, 64, 512, 8192] {
+                let custom = BalancedParens::<_, WithCsPoppy>::from_words_with_cspoppy_config(
+                    &words[..],
+                    len,
+                    Config {
+                        select_sample_rate: rate,
+                    },
+                );
+
+                assert_eq!(
+                    custom.total_ones(),
+                    default_rate.total_ones(),
+                    "{label} @ rate {rate}: total_ones"
+                );
+                for k in 0..default_rate.total_ones() {
+                    assert_eq!(
+                        custom.select1(k),
+                        default_rate.select1(k),
+                        "{label} @ rate {rate}: select1({k})"
+                    );
+                }
+                assert_eq!(
+                    custom.select1(default_rate.total_ones()),
+                    default_rate.select1(default_rate.total_ones()),
+                    "{label} @ rate {rate}: select1(total_ones)"
+                );
+            }
+        }
+    }
+
+    /// Halving the rate should roughly double the index; doubling it should
+    /// roughly halve it — the density relationship #601 documents.
+    #[test]
+    fn test_cspoppy_custom_rate_scales_heap_size() {
+        let pairs = 100_000;
+        let (words, len) = balanced_words(pairs);
+
+        for rate in [64u32, 256, 512, 8192] {
+            let bp = BalancedParens::new_with_cspoppy_config(
+                words.clone(),
+                len,
+                Config {
+                    select_sample_rate: rate,
+                },
+            );
+            assert_eq!(
+                bp.select_heap_size(),
+                pairs.div_ceil(rate as usize) * 4,
+                "rate {rate}: unexpected select index size"
+            );
+        }
+    }
+
+    /// A configured rate of 0 must not hang or panic; it behaves like rate 1
+    /// (matches `SelectIndex::build`'s guard).
+    #[test]
+    fn test_cspoppy_rate_zero_treated_as_one() {
+        let (words, len) = balanced_words(100);
+        let total_ones = len / 2;
+
+        let zero = WithCsPoppy::build_with_rate(&words, total_ones, 0);
+        let one = WithCsPoppy::build_with_rate(&words, total_ones, 1);
+
+        assert_eq!(zero.rate(), 1);
+        assert_eq!(zero.rate(), one.rate());
+    }
+
+    /// `Default` must produce an empty index at the crate's default rate, the
+    /// same starting point `#[derive(Default)]` gave before the rate field
+    /// existed.
+    #[test]
+    fn test_cspoppy_default() {
+        let default = WithCsPoppy::default();
+        assert_eq!(default.rate(), CS_POPPY_SAMPLE_RATE);
+        assert_eq!(default.heap_size(), 0);
+    }
+
+    /// The `SelectSupport::build` trait method (used by any generic caller,
+    /// even though every concrete `WithCsPoppy` constructor in this crate
+    /// goes through `build_with_rate` directly) must match
+    /// `build_with_rate(.., CS_POPPY_SAMPLE_RATE)`.
+    #[test]
+    fn test_cspoppy_select_support_build_matches_default_rate() {
+        for (label, words, len) in cspoppy_fixtures() {
+            let indexed = BalancedParens::<_, NoSelect>::from_words(&words[..], len);
+            let total_ones = indexed.total_ones();
+
+            let via_trait = <WithCsPoppy as SelectSupport>::build(&words, total_ones);
+            let via_rate = WithCsPoppy::build_with_rate(&words, total_ones, CS_POPPY_SAMPLE_RATE);
+
+            assert_eq!(via_trait.rate(), via_rate.rate(), "{label}: rate");
+            assert_eq!(
+                via_trait.heap_size(),
+                via_rate.heap_size(),
+                "{label}: heap_size"
+            );
+
+            let ctx = BpSelectCtx {
+                words: &words,
+                len,
+                total_ones,
+                rank_l1: &indexed.rank_l1,
+                rank_l2: &indexed.rank_l2,
+            };
+            for k in 0..total_ones {
+                assert_eq!(
+                    via_trait.select1(ctx, k),
+                    via_rate.select1(ctx, k),
+                    "{label}: select1({k})"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_no_select_is_zero_sized() {
         // JSON's path must stay free: NoSelect is a ZST and retains nothing.

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::bits::{scan_select, SelectIndex};
 use crate::util::broadword::select_in_word;
+use crate::Config;
 
 // ============================================================================
 // Select support traits for zero-cost abstraction
@@ -190,10 +191,12 @@ impl SelectSupport for WithSelect {
     }
 }
 
-/// Sample rate for [`WithCsPoppy`]: one sample per this many 1-bits.
+/// Default sample rate for [`WithCsPoppy`]: one sample per this many 1-bits.
 ///
 /// Matches [`SelectIndex`]'s default so existing tuning keeps its meaning.
-const CS_POPPY_SAMPLE_RATE: usize = 256;
+/// Override per-build via [`Config::select_sample_rate`] and
+/// [`WithCsPoppy::build_with_rate`] (#601).
+const CS_POPPY_SAMPLE_RATE: u32 = 256;
 
 /// Combined-sampling select support (CS-Poppy), the preferred choice for YAML.
 ///
@@ -214,9 +217,12 @@ const CS_POPPY_SAMPLE_RATE: usize = 256;
 ///
 /// # Space
 ///
-/// 4 bytes per `CS_POPPY_SAMPLE_RATE` ones: 6.25% of the bitmap at balanced-
-/// parenthesis density, against [`WithSelect`]'s 12.5% and the 25% that pair
-/// cost before it was narrowed (#64).
+/// 4 bytes per sample rate's worth of ones: 6.25% of the bitmap at balanced-
+/// parenthesis density and the default rate of 256, against [`WithSelect`]'s
+/// 12.5% and the 25% that pair cost before it was narrowed (#64). The rate is
+/// tunable — see [`build_with_rate`](WithCsPoppy::build_with_rate) and
+/// [`Config::select_sample_rate`] — trading index memory for a wider
+/// `select1` search bracket (#601).
 ///
 /// # Example
 ///
@@ -229,18 +235,40 @@ const CS_POPPY_SAMPLE_RATE: usize = 256;
 /// assert_eq!(bp.select1(2), Some(3)); // third open
 /// assert_eq!(bp.select1(3), None);    // only three opens
 /// ```
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WithCsPoppy {
-    /// Rank-block index containing every `CS_POPPY_SAMPLE_RATE`-th 1-bit.
+    /// Rank-block index containing every `rate`-th 1-bit.
     ///
     /// `u32` is sound because `build_bp_index` asserts `len <= u32::MAX` bits,
     /// bounding the block count to 2^23.
     samples: Vec<u32>,
+    /// Sample rate this index was built with (see [`CS_POPPY_SAMPLE_RATE`]).
+    rate: u32,
 }
 
-impl SelectSupport for WithCsPoppy {
-    fn build(words: &[u64], total_ones: usize) -> Self {
+impl Default for WithCsPoppy {
+    fn default() -> Self {
+        Self {
+            samples: Vec::new(),
+            rate: CS_POPPY_SAMPLE_RATE,
+        }
+    }
+}
+
+impl WithCsPoppy {
+    /// Builds combined-sampling select support at a custom sample rate.
+    ///
+    /// [`SelectSupport::build`] calls this with [`CS_POPPY_SAMPLE_RATE`] (256).
+    /// Lower rates spend more memory for a narrower `select1` search bracket;
+    /// higher rates spend less memory for a wider one — see the module-level
+    /// space table (#601).
+    ///
+    /// A `rate` of 0 is treated as 1, matching [`SelectIndex::build`].
+    pub fn build_with_rate(words: &[u64], total_ones: usize, rate: u32) -> Self {
+        let rate = rate.max(1);
+        let rate_usize = rate as usize;
+
         // INVARIANT: as for WithSelect, `total_ones` counts only bits below
         // `len` (build_bp_index masks the final partial word, #188). Stray
         // 1-bits above `len` can therefore only appear above every sampled
@@ -248,10 +276,11 @@ impl SelectSupport for WithCsPoppy {
         if words.is_empty() || total_ones == 0 {
             return Self {
                 samples: Vec::new(),
+                rate,
             };
         }
 
-        let mut samples = Vec::with_capacity(total_ones / CS_POPPY_SAMPLE_RATE + 1);
+        let mut samples = Vec::with_capacity(total_ones / rate_usize + 1);
         let mut count: usize = 0;
         let mut next_sample = 0usize;
 
@@ -265,13 +294,26 @@ impl SelectSupport for WithCsPoppy {
                     "block index {block} exceeds u32; len must be <= u32::MAX bits (#188)"
                 );
                 samples.push(block as u32);
-                next_sample += CS_POPPY_SAMPLE_RATE;
+                next_sample += rate_usize;
             }
 
             count += pop;
         }
 
-        Self { samples }
+        Self { samples, rate }
+    }
+
+    /// Returns the sample rate this index was built with.
+    #[inline]
+    pub fn rate(&self) -> u32 {
+        self.rate
+    }
+}
+
+impl SelectSupport for WithCsPoppy {
+    #[inline]
+    fn build(words: &[u64], total_ones: usize) -> Self {
+        Self::build_with_rate(words, total_ones, CS_POPPY_SAMPLE_RATE)
     }
 
     fn select1(&self, ctx: BpSelectCtx<'_>, k: usize) -> Option<usize> {
@@ -280,9 +322,9 @@ impl SelectSupport for WithCsPoppy {
         }
 
         // 1. Bracket the answer between consecutive samples. sample[i] holds the
-        //    block of the (i * RATE)-th one, and k lies in [i*RATE, (i+1)*RATE),
+        //    block of the (i * rate)-th one, and k lies in [i*rate, (i+1)*rate),
         //    so the target block lies in [sample[i], sample[i+1]].
-        let sample_idx = k / CS_POPPY_SAMPLE_RATE;
+        let sample_idx = k / self.rate as usize;
         let last_block = ctx.rank_l1.len() - 1;
         let lo = *self
             .samples
@@ -2104,7 +2146,9 @@ impl BalancedParens<Vec<u64>, WithCsPoppy> {
     /// Build from an owned bitvector with combined-sampling select support.
     ///
     /// Preferred over [`new_with_select`](BalancedParens::new_with_select): same
-    /// queries, a quarter of the select-index memory (#64).
+    /// queries, a quarter of the select-index memory (#64). Uses the default
+    /// sample rate (256) — see
+    /// [`new_with_cspoppy_config`](Self::new_with_cspoppy_config) to tune it.
     ///
     /// Bits at or above `len` in the final word are cleared, so stray 1-bits
     /// cannot skew `total_ones`/`rank1`/`select1` (#188).
@@ -2113,9 +2157,29 @@ impl BalancedParens<Vec<u64>, WithCsPoppy> {
     ///
     /// Panics if `len` exceeds `u32::MAX` bits (#188): the rank directory
     /// stores absolute cumulative counts as `u32`.
-    pub fn new_with_cspoppy(mut words: Vec<u64>, len: usize) -> Self {
+    pub fn new_with_cspoppy(words: Vec<u64>, len: usize) -> Self {
+        Self::new_with_cspoppy_config(words, len, Config::default())
+    }
+
+    /// Build from an owned bitvector with combined-sampling select support,
+    /// at the sample rate given by [`Config::select_sample_rate`].
+    ///
+    /// A lower rate spends more memory for a narrower `select1` search
+    /// bracket; a higher rate spends less memory for a wider one (#601). The
+    /// default (256, [`new_with_cspoppy`](Self::new_with_cspoppy)) matches
+    /// this crate's other tuned indices — deviate only once measurement
+    /// justifies it.
+    ///
+    /// Bits at or above `len` in the final word are cleared, so stray 1-bits
+    /// cannot skew `total_ones`/`rank1`/`select1` (#188).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds `u32::MAX` bits (#188): the rank directory
+    /// stores absolute cumulative counts as `u32`.
+    pub fn new_with_cspoppy_config(mut words: Vec<u64>, len: usize, config: Config) -> Self {
         mask_final_word_in_place(&mut words, len);
-        Self::assemble(words, len)
+        Self::assemble_with_rate(words, len, config.select_sample_rate)
     }
 }
 
@@ -2125,7 +2189,9 @@ impl<W: AsRef<[u64]>> BalancedParens<W, WithCsPoppy> {
     /// Preferred over
     /// [`from_words_with_select`](BalancedParens::from_words_with_select): same
     /// queries, a quarter of the select-index memory (#64). Useful for borrowed
-    /// data, e.g. from mmap.
+    /// data, e.g. from mmap. Uses the default sample rate (256) — see
+    /// [`from_words_with_cspoppy_config`](Self::from_words_with_cspoppy_config)
+    /// to tune it.
     ///
     /// The storage is not mutated: stray 1-bits at or above `len` in the final
     /// word are ignored when counting (masked on read), so they cannot skew
@@ -2136,16 +2202,33 @@ impl<W: AsRef<[u64]>> BalancedParens<W, WithCsPoppy> {
     /// Panics if `len` exceeds `u32::MAX` bits (#188): the rank directory
     /// stores absolute cumulative counts as `u32`.
     pub fn from_words_with_cspoppy(words: W, len: usize) -> Self {
-        Self::assemble(words, len)
+        Self::from_words_with_cspoppy_config(words, len, Config::default())
     }
-}
 
-impl<W: AsRef<[u64]>, S: SelectSupport> BalancedParens<W, S> {
-    /// Build every index from `words`, without mutating the storage.
+    /// Build from a generic storage type with combined-sampling select
+    /// support, at the sample rate given by [`Config::select_sample_rate`].
     ///
-    /// Shared by the select-enabled constructors; the owned ones mask the final
-    /// word before calling in.
-    fn assemble(words: W, len: usize) -> Self {
+    /// See [`new_with_cspoppy_config`](BalancedParens::new_with_cspoppy_config)
+    /// for the rate trade-off (#601). Useful for borrowed data, e.g. from mmap.
+    ///
+    /// The storage is not mutated: stray 1-bits at or above `len` in the final
+    /// word are ignored when counting (masked on read), so they cannot skew
+    /// `total_ones`/`rank1`/`select1` (#188).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` exceeds `u32::MAX` bits (#188): the rank directory
+    /// stores absolute cumulative counts as `u32`.
+    pub fn from_words_with_cspoppy_config(words: W, len: usize, config: Config) -> Self {
+        Self::assemble_with_rate(words, len, config.select_sample_rate)
+    }
+
+    /// Build every index from `words` at a custom CS-Poppy sample rate,
+    /// without mutating the storage.
+    ///
+    /// Shared by every `WithCsPoppy` constructor; the owned ones mask the
+    /// final word before calling in.
+    fn assemble_with_rate(words: W, len: usize, rate: u32) -> Self {
         let (
             l0_min_excess,
             l0_word_excess,
@@ -2158,7 +2241,7 @@ impl<W: AsRef<[u64]>, S: SelectSupport> BalancedParens<W, S> {
             total_ones,
         ) = build_bp_index(words.as_ref(), len);
 
-        let select = S::build(words.as_ref(), total_ones);
+        let select = WithCsPoppy::build_with_rate(words.as_ref(), total_ones, rate);
 
         Self {
             words,

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -3568,6 +3568,32 @@ mod tests {
         }
     }
 
+    /// Coverage stabilizer, same rationale as
+    /// `test_find_close_crosses_l2_block_boundary` above (issue #220): the
+    /// remaining flaky branch is `find_close_from`'s `State::FromL2` landing
+    /// exactly at `len` after skipping a whole L2 block (i.e. the search runs
+    /// off the end of the structure right on an L2-aligned boundary), which
+    /// proptest only stumbles into by chance.
+    ///
+    /// An all-opens bitvector spanning exactly two L2 blocks (2 * 65536 bits)
+    /// forces this deterministically: `find_close(0)` never finds a match, so
+    /// excess only grows and every level skips wholesale, and the second
+    /// (last) L2 block's skip lands pos exactly on `len`.
+    #[test]
+    fn test_find_close_l2_skip_lands_exactly_at_len() {
+        const L2_SPAN: usize = 64 * FACTOR_L1 * FACTOR_L2;
+        let len = 2 * L2_SPAN;
+        let words = vec![u64::MAX; len / 64];
+
+        let bp = BalancedParens::new(words.clone(), len);
+        assert_eq!(bp.find_close(0), None);
+        assert_eq!(
+            bp.find_close(0),
+            find_close(&words, len, 0),
+            "find_close(0) mismatch: accelerated vs linear scan"
+        );
+    }
+
     #[test]
     fn test_word_min_excess() {
         // "()" = 0b01 - open at 0, close at 1

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -259,7 +259,7 @@ impl Default for WithCsPoppy {
 impl WithCsPoppy {
     /// Builds combined-sampling select support at a custom sample rate.
     ///
-    /// [`SelectSupport::build`] calls this with [`CS_POPPY_SAMPLE_RATE`] (256).
+    /// [`SelectSupport::build`] calls this with `CS_POPPY_SAMPLE_RATE` (256).
     /// Lower rates spend more memory for a narrower `select1` search bracket;
     /// higher rates spend less memory for a wider one — see the module-level
     /// space table (#601).


### PR DESCRIPTION
## Summary

- `WithCsPoppy` (#64) hardcoded a 256-sample select rate; this exposes it as a runtime knob via the crate's existing `Config::select_sample_rate` — the same field `BitVec::with_config` already uses for `SelectIndex` — rather than inventing a new type.
- `WithCsPoppy::build_with_rate` builds at an explicit rate and `WithCsPoppy::rate()` reports it back; `SelectSupport::build` (the default path) still calls it with the crate's 256 default. A rate of 0 is clamped to 1, matching `SelectIndex::build`'s existing guard, instead of looping forever.
- `BalancedParens::new_with_cspoppy_config` / `from_words_with_cspoppy_config` thread a `Config` through to the new build path. The un-suffixed constructors keep `Config::default()` (rate 256), so #64's measured numbers are unaffected and `YamlIndex` (the only real consumer) is unchanged.
- `docs/plan/cspoppy.md`'s F6 section is marked implemented, noting a non-default rate still needs its own measurement before it's worth shipping as a new default.

Closes #601

## Test plan

- [x] `cargo test --lib` (1915 passed) — includes 4 new tests: default-config parity with the plain constructor, `select1` answers unchanged across rates 1/64/512/8192 against the existing combined-sampling stress fixtures, heap-size scaling with rate, and the rate-0 guard
- [x] `cargo test --doc trees::bp`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `./scripts/build.sh`