### PR TITLE
chore(build): bump bench-compare rkyv to 0.8.17 to fix RUSTSEC advisories

### DIFF
--- a/bench-compare/Cargo.lock
+++ b/bench-compare/Cargo.lock
@@ -664,6 +664,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,12 +1337,12 @@ checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 
 [[package]]
 name = "rkyv"
-version = "0.8.13"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2e88acca7157d83d789836a3987dafc12bc3d88a050e54b8fe9ea4aaa29d20"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -1349,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.13"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6dffea3c91fa91a3c0fc8a061b0e27fef25c6304728038a6d6bcb1c58ba9bd"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

- `cargo audit -f bench-compare/Cargo.lock` flags rkyv 0.8.13 (pulled in transitively via `faststr`) for three advisories, all fixed in `>=0.8.17`:
  - RUSTSEC-2026-0233 — use-after-free during deserialization of crafted archives
  - RUSTSEC-2026-0234 — OOB reads in archives containing hash tables
  - RUSTSEC-2026-0235 — OOB reads in archives containing Rc/Arc
- `cargo update -p rkyv --precise 0.8.17` bumps `rkyv` and `rkyv_derive` 0.8.13 -> 0.8.17, pulling in `hashbrown 0.17.1` as a new transitive dep. Lockfile-only change, no source edits.
- Follows the same pattern as the earlier standalone lockfile fix in #548/cffdcf2e.

Fixes #637.

## Test plan

- [x] `cargo audit -f Cargo.lock` (from `bench-compare/`) — 0 vulnerabilities, only the 2 pre-existing allowed unmaintained-crate warnings remain
- [x] `cargo check` in `bench-compare/` — builds clean