### PR TITLE
fix(cli): yq preserves duplicate keys for first/last/computed indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -840,6 +840,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (JSON-only), and large enough in its own right to need separate
   investigation.
 
+- **`yq 'first(.[])'`/`'last(.[])'`/a computed index (`.[(expr)]`) still
+  collapsed duplicate mapping keys** (#631), the `yq`-side follow-up #607
+  above left open: `eval_generic.rs`'s evaluator already threaded
+  `GenericResult::OneCursor`/`ManyCursor` through these shapes correctly
+  (that was #607's fix, shared by both `jq` and `yq`), but `yq_runner.rs`
+  never had a `jq_runner.rs`-style `generic_result_to_jq_values` that could
+  take advantage of it — every expression not covered by `can_use_m2_streaming`
+  (identity/field/index/iterate navigation and pipes/parens/`?` of those) fell
+  through `evaluate_yaml_cursor`'s unconditional `to_owned()` DOM path instead,
+  the same `IndexMap`-backed bridge #442/#478 fixed for plain `.`/`.[0]` but
+  never widened past literal navigation.
+
+  Fixed by widening `can_use_m2_streaming` to also treat `Expr::FirstExpr`/
+  `LastExpr` (`first(f)`/`last(f)`), `Builtin::FirstStream`/`LastStream` (the
+  second AST spelling the parser produces for the same syntax, see #607's
+  note), and `Expr::IndexExpr` (computed indexing) as streamable — the
+  existing M2 fast path's non-identity branch already evaluates via
+  `eval_with_cursor_using` and renders through `GenericResult::stream_yaml`/
+  `stream_json`, which handle every `GenericResult` variant (cursor and owned
+  alike) uniformly, so no new rendering code was needed. `yq 'first(.[])'`
+  now streams through the exact same mechanism as `yq '.[0]'` on the same
+  input, matching it byte-for-byte instead of merely agreeing on the
+  duplicate-key count.
+
 - **The strict YAML validator accepted a flow-collection anchor immediately
   followed by an alias** (#452): `[&a *a]` and `{k: &a *a}` passed
   `succinctly yaml validate`, which `yq` rejects — an anchor property cannot

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -989,6 +989,19 @@ fn can_use_m2_streaming(expr: &Expr) -> bool {
         // Parentheses don't affect streamability
         Expr::Paren(inner) => can_use_m2_streaming(inner),
 
+        // first(f)/last(f) (both AST spellings the parser produces, see
+        // `Expr::FirstExpr`/`LastExpr` doc comments) and computed indexing
+        // `.[(expr)]` all thread a cursor through natively in
+        // `eval_generic.rs` (#607), so their `GenericResult` streams exactly
+        // like plain navigation instead of needing OwnedValue construction.
+        // Streaming through `eval_with_cursor_using` here (rather than
+        // `evaluate_yaml_cursor`'s unconditional `to_owned()` DOM path) is
+        // also what keeps duplicate mapping keys intact for these shapes,
+        // matching `.[0]` on the same input (#631).
+        Expr::FirstExpr(_) | Expr::LastExpr(_) => true,
+        Expr::Builtin(Builtin::FirstStream(_) | Builtin::LastStream(_)) => true,
+        Expr::IndexExpr { .. } => true,
+
         // Everything else requires OwnedValue
         _ => false,
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -757,6 +757,56 @@ fn test_duplicate_mapping_key_survives_inplace() -> Result<()> {
     Ok(())
 }
 
+/// #631: `first(.[])`/`last(.[])` (the `Expr::FirstExpr`/`LastExpr` one-arg
+/// stream form `first(f)`/`last(f)` compiles to) fell through
+/// `evaluate_yaml_cursor`'s unconditional `to_owned()` DOM path, unlike
+/// `.[0]` which #442 already routed through the M2 cursor-streaming fast
+/// path. `eval_generic.rs` itself threads `GenericResult::OneCursor`/
+/// `ManyCursor` through these shapes correctly since #607 — but that alone
+/// wasn't enough for `yq`: unlike `jq_runner.rs`'s
+/// `generic_result_to_jq_values`, `evaluate_yaml_cursor` never special-cased
+/// cursor results, so `yq` kept collapsing duplicate keys. Fixed by widening
+/// `can_use_m2_streaming` so these shapes stream through the same fast path
+/// `.[0]` uses, instead of expanding `evaluate_yaml_cursor` itself.
+#[test]
+fn test_duplicate_mapping_key_survives_first_last_stream() -> Result<()> {
+    let yaml = "- a: 1\n  a: 2\n- b: 3\n  b: 4\n";
+
+    let (first, code) = run_yq_stdin("first(.[])", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(first, "a: 1\na: 2\n");
+
+    let (last, code) = run_yq_stdin("last(.[])", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(last, "b: 3\nb: 4\n");
+
+    let (first_json, code) = run_yq_stdin("first(.[])", yaml, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(first_json, "{\"a\":1,\"a\":2}\n");
+
+    Ok(())
+}
+
+/// #631: computed indexing (`.[(expr)]`, `Expr::IndexExpr`) is the same bug
+/// class via a different AST node than `first`/`last` above. `.[0]`
+/// (`Expr::Index`, a literal the parser folds at parse time) already
+/// preserved duplicate keys, but `.[(1-1)]` — forced past that folding —
+/// did not, until `Expr::IndexExpr` was added to `can_use_m2_streaming` too.
+#[test]
+fn test_duplicate_mapping_key_survives_computed_index() -> Result<()> {
+    let yaml = "- a: 1\n  a: 2\n- b: 3\n  b: 4\n";
+
+    let (pretty, code) = run_yq_stdin(".[(1-1)]", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty, "a: 1\na: 2\n");
+
+    let (compact, code) = run_yq_stdin(".[(1-1)]", yaml, &["-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "a: 1\na: 2\n");
+
+    Ok(())
+}
+
 /// #478: the `--inplace` fast path is scoped to M2-streamable expressions
 /// (identity/field/index/iterate); confirm field navigation still rewrites
 /// the file correctly, not just plain identity.


### PR DESCRIPTION
## Summary

- `evaluate_yaml_cursor` unconditionally materialized results through `to_owned()` into an `IndexMap`-backed `OwnedValue`, which cannot hold duplicate mapping keys — reached whenever `can_use_m2_streaming()` didn't recognize an expression as streamable.
- Widens `can_use_m2_streaming()` to also treat `first(f)`/`last(f)` (`Expr::FirstExpr`/`LastExpr`, and the `Builtin::FirstStream`/`LastStream` spelling) and computed indexing (`Expr::IndexExpr`, e.g. `.[(1-1)]`) as streamable, since `eval_generic.rs` already threads `GenericResult::OneCursor`/`ManyCursor` through them natively (#607). These now stream through the same M2 fast path `.[0]` already uses.
- `yq 'first(.[])'` now matches `yq '.[0]'` byte-for-byte on the same input instead of collapsing to the last duplicate key.

Fixes #631 (yq-side follow-up to #607, the JSON/`jq` analogue).

## Test plan

- [x] `printf -- '- a: 1\n  a: 2\n- b: 3\n  b: 4\n' | succinctly yq 'first(.[])'` and `'.[(1-1)]'` now output both `a: 1` and `a: 2`, matching `.[0]`
- [x] New regression tests in `tests/yq_cli_tests.rs`; confirmed they fail without the fix
- [x] `cargo test --features cli,simd,regex` — full suite green (0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean (scalar-yaml blind-spot check)