### PR TITLE
docs(docs): add ADR-0015 keeping BitVec/RankDirectory/SelectIndex as-is

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -24,23 +24,24 @@ by Michael Nygard.
 
 ## Inventory
 
-| ADR                     | Status      | Date       | Title                                                  |
-|-------------------------|-------------|------------|--------------------------------------------------------|
-| [ADR-0000](adr-0000.md) | ✅ Accepted | 2026-07-12 | Use Architecture Decision Records                      |
-| [ADR-0001](adr-0001.md) | ✅ Accepted | 2026-07-12 | Semi-Indexing over DOM Parsing                         |
-| [ADR-0002](adr-0002.md) | ✅ Accepted | 2026-07-12 | Table-Driven PFSM as the Portable JSON Parser          |
-| [ADR-0003](adr-0003.md) | ✅ Accepted | 2026-07-12 | Oracle Parser for YAML                                 |
-| [ADR-0004](adr-0004.md) | ✅ Accepted | 2026-07-12 | Reject Software Prefetching for Large YAML Files (P2.6) |
-| [ADR-0005](adr-0005.md) | ✅ Accepted | 2026-07-12 | Reject SIMD Threshold Tuning (P2.8)                    |
-| [ADR-0006](adr-0006.md) | ✅ Accepted | 2026-07-12 | Reject Branchless Character Classification (P3)        |
-| [ADR-0007](adr-0007.md) | ✅ Accepted | 2026-07-12 | Reject the Flow-Collection SIMD Fast Path (P5)         |
-| [ADR-0008](adr-0008.md) | ✅ Accepted | 2026-07-12 | Reject BMI2 Quote-Indexing for YAML (P6)               |
-| [ADR-0009](adr-0009.md) | ✅ Accepted | 2026-07-12 | Reject a Parse-Time Newline Index (P7)                 |
-| [ADR-0010](adr-0010.md) | ✅ Accepted | 2026-07-12 | Reject AVX-512 SIMD Variants (P8)                      |
-| [ADR-0011](adr-0011.md) | ✅ Accepted | 2026-07-15 | Custom Succinct Structures over Existing Rust Crates   |
-| [ADR-0012](adr-0012.md) | ✅ Accepted | 2026-07-25 | Elias-Fano Line Index over a Dense Bitmap              |
-| [ADR-0013](adr-0013.md) | ✅ Accepted | 2026-07-25 | Reject the SIMD Chunk-Scanner JSON Validator (#130)    |
-| [ADR-0014](adr-0014.md) | ✅ Accepted | 2026-08-03 | Reject Consolidating This Crate's Rank Implementations |
+| ADR                     | Status      | Date       | Title                                                    |
+|-------------------------|-------------|------------|-----------------------------------------------------------|
+| [ADR-0000](adr-0000.md) | ✅ Accepted | 2026-07-12 | Use Architecture Decision Records                        |
+| [ADR-0001](adr-0001.md) | ✅ Accepted | 2026-07-12 | Semi-Indexing over DOM Parsing                           |
+| [ADR-0002](adr-0002.md) | ✅ Accepted | 2026-07-12 | Table-Driven PFSM as the Portable JSON Parser            |
+| [ADR-0003](adr-0003.md) | ✅ Accepted | 2026-07-12 | Oracle Parser for YAML                                   |
+| [ADR-0004](adr-0004.md) | ✅ Accepted | 2026-07-12 | Reject Software Prefetching for Large YAML Files (P2.6)  |
+| [ADR-0005](adr-0005.md) | ✅ Accepted | 2026-07-12 | Reject SIMD Threshold Tuning (P2.8)                      |
+| [ADR-0006](adr-0006.md) | ✅ Accepted | 2026-07-12 | Reject Branchless Character Classification (P3)          |
+| [ADR-0007](adr-0007.md) | ✅ Accepted | 2026-07-12 | Reject the Flow-Collection SIMD Fast Path (P5)           |
+| [ADR-0008](adr-0008.md) | ✅ Accepted | 2026-07-12 | Reject BMI2 Quote-Indexing for YAML (P6)                 |
+| [ADR-0009](adr-0009.md) | ✅ Accepted | 2026-07-12 | Reject a Parse-Time Newline Index (P7)                   |
+| [ADR-0010](adr-0010.md) | ✅ Accepted | 2026-07-12 | Reject AVX-512 SIMD Variants (P8)                        |
+| [ADR-0011](adr-0011.md) | ✅ Accepted | 2026-07-15 | Custom Succinct Structures over Existing Rust Crates     |
+| [ADR-0012](adr-0012.md) | ✅ Accepted | 2026-07-25 | Elias-Fano Line Index over a Dense Bitmap                |
+| [ADR-0013](adr-0013.md) | ✅ Accepted | 2026-07-25 | Reject the SIMD Chunk-Scanner JSON Validator (#130)      |
+| [ADR-0014](adr-0014.md) | ✅ Accepted | 2026-08-03 | Reject Consolidating This Crate's Rank Implementations   |
+| [ADR-0015](adr-0015.md) | ✅ Accepted | 2026-08-05 | Keep BitVec, RankDirectory, and SelectIndex As-Is        |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0015.md
+++ b/docs/adrs/adr-0015.md
@@ -1,0 +1,139 @@
+# ADR-0015: Keep BitVec, RankDirectory, and SelectIndex As-Is
+
+## Status
+
+✅ Accepted
+
+## Context
+
+[ADR-0011](adr-0011.md) established that `BitVec` (backed by `RankDirectory` for
+rank and `SelectIndex` for select) has **no production callers at all** and
+survives as public API only — every parser bypasses it in favour of a
+domain-specific structure (`BalancedParens`'s inline rank, JSON/YAML's
+cumulative-rank `Vec<u32>` arrays, DSV's `DsvIndexLightweight`). That ADR left
+the disposition of the type — "shrink, deprecate or keep" — as an open
+question, tracked as
+[issue #321](https://github.com/rust-works/succinctly/issues/321). This ADR
+answers it.
+
+### The premise, re-verified against the current tree
+
+Two things have changed the shape of the question since #321 was filed, both
+confirmed by grepping the current tree rather than trusting the issue's own
+(now stale) tables:
+
+1. **`CompactRank` is gone.** It never had a caller — its module doc's claim
+   of being "used by YAML index structures" was never true after YAML moved
+   to cumulative `Vec<u32>` arrays. [PR #376](https://github.com/rust-works/succinctly/pull/376)
+   removed it. There is nothing left to decide for this type.
+2. **`SelectIndex` is no longer a special case.** A 2026-08-02 comment on
+   #321 flagged that `BalancedParens`'s `WithSelect` held a live
+   `bits::SelectIndex` field (`src/trees/bp.rs`), which broke the "reachable
+   only through `BitVec`" framing — independent of `BitVec` itself, YAML's
+   `find_bp_at_text_pos` → `yq-locate`/`at_offset` path depended on it. That
+   comment noted the exception would disappear "unless/until #64 lands."
+   [Issue #64](https://github.com/rust-works/succinctly/issues/64) (PR #603)
+   has since landed: `WithCsPoppy` answers `select1` directly from BP's own
+   `rank_l1`/`rank_l2` and never touches `bits::SelectIndex`, and `WithSelect`
+   is now `#[deprecated]`. `SelectIndex`'s only production-shaped caller is
+   therefore itself deprecated dead-end code.
+
+With both changes, the three types are back to being one unit: `BitVec`
+composes `RankDirectory` + `SelectIndex` as its own rank/select
+implementation ([src/bits/bitvec.rs](../../src/bits/bitvec.rs)), and nothing
+in the crate calls `BitVec`.
+
+[ADR-0014](adr-0014.md) — a different, adjacent decision (whether to
+consolidate `RankDirectory` with `BalancedParens`'s inline rank) — re-ran the
+caller grep independently while answering that question and reached the same
+conclusion: *"`BitVec::rank1`/`RankDirectory` have zero production call
+sites... every hit outside `bits/rank.rs` and `bits/bitvec.rs` is a
+doc-comment example, a unit test, or the size-comparison test in
+`text/lines.rs`."* It explicitly declined to resolve the keep/shrink/
+deprecate question, leaving it for this ADR.
+
+One more caller surfaced during this review, narrower than a doc example or
+unit test but not load-bearing either:
+`src/bin/succinctly/corpus_stats.rs:209` builds a throwaway `BitVec` at CLI
+runtime to report *"how much smaller is `LineIndex`/`CompactEndPositions`
+than the dense-bitmap representation they replaced"* — a comparative
+diagnostic printed in the corpus-shape report, not a use of `BitVec`'s
+rank/select to serve a query.
+
+## Decision
+
+We will **keep `BitVec`, `RankDirectory`, and `SelectIndex` as-is** — the
+issue's Option 1. We will not invest in shrinking them (Option 2) and will
+not deprecate them (Option 3).
+
+- **Keeping them is what [ADR-0011](adr-0011.md) already committed to.**
+  ADR-0011's decision to implement succinct structures in-crate rested on one
+  decisive, still-unchanged requirement: no external candidate (`succinct`,
+  `vers-vecs`, `fid`, `bio`, `sux`, `sucds`) has a working `no_std` build.
+  That requirement justifies *offering* a `no_std` rank/select bitvector at
+  all — it was never contingent on the crate's own parsers choosing to use
+  it. `BitVec`/`RankDirectory`/`SelectIndex` are that offering, and nothing
+  has changed since ADR-0011 to undercut it: no candidate crate has fixed its
+  `no_std` build.
+- **A bespoke structure beating a generic one per call site is expected, not
+  a defect to fix.** ADR-0014 made exactly this argument for `RankDirectory`
+  vs. BP's inline rank: different granularity, different select-coupling,
+  each earned against a measured workload. The same reasoning covers JSON/
+  YAML's cumulative-rank arrays and DSV's lightweight index. None of that
+  devalues a generic structure as public API for a caller — internal or
+  external — without a bespoke need of their own.
+- **Shrinking first (Option 2) is unmeasured speculative engineering.**
+  Making `SelectIndex` opt-in/lazy or reclaiming `RankDirectory`'s padding
+  bits has no caller inside this crate to benchmark against, so the work
+  cannot be validated end-to-end here — the same shape of change this
+  project's own optimization discipline has repeatedly rejected elsewhere for
+  lacking a measured, real-workload need (ADR-0004 through ADR-0010: P2.6,
+  P2.8, P3, P5, P8). It would also change the serde wire format a second time
+  for a structure nothing reads.
+- **Deprecating (Option 3) undercuts ADR-0011's own rationale.** Deprecating
+  the only `no_std` rank/select bitvector this crate offers leaves exactly
+  the users ADR-0011 was justified by with nothing. That is a reason to
+  revisit ADR-0011 itself — if `no_std` consumers turn out not to exist in
+  practice, or a candidate crate fixes its `no_std` build — not a reason to
+  deprecate out from under a requirement that hasn't changed.
+
+`CompactRank` requires no decision here: it is already gone (PR #376).
+
+## Consequences
+
+**Positive:**
+
+- No speculative engineering ships ahead of a real need — consistent with
+  this project's YAGNI precedent (ADR-0004 through ADR-0010, ADR-0011,
+  ADR-0014).
+- ADR-0011's `no_std` justification stays honored: the crate continues to
+  offer a working, tested, documented rank/select bitvector to `no_std`
+  consumers who have no in-`alloc`-only alternative.
+- `BitVec`'s public `RankSelect` API, its doctests, and its serde round-trip
+  tests are unaffected.
+- Closes out [issue #321](https://github.com/rust-works/succinctly/issues/321).
+
+**Negative / trade-offs:**
+
+- The crate keeps maintaining `CacheAlignedL1L2`'s ~270 lines of hand-rolled,
+  16-`unsafe`-site cache-aligned allocation machinery
+  ([src/bits/rank.rs](../../src/bits/rank.rs)) for a structure nothing
+  internal calls. ADR-0011 already accepted this cost; this ADR does not
+  reduce it.
+- The space cost ADR-0011 measured (27.5-47.5% resident overhead, winning no
+  category against `vers-vecs` or `sux`) remains unaddressed. A `no_std`
+  consumer who needs better space or speed than this offers still has no
+  alternative in this crate.
+- This question may resurface again without a real caller ever appearing,
+  since nothing about the crate's own architecture drives one — same as
+  ADR-0011 and ADR-0014 before it.
+
+**Revisit this decision if:**
+
+- A real caller — internal or external — appears for `BitVec`'s rank/select,
+  making shrink work (Option 2) cheap to justify and measure end-to-end.
+- A `no_std`-capable external crate ships (mirrors
+  [ADR-0011](adr-0011.md)'s own revisit trigger: "if succinctly drops the
+  `no_std` requirement, or if `sucds` fixes its `no_std` build").
+- The project decides to drop the `no_std` requirement entirely, removing the
+  one decisive justification for keeping these types in-crate.

--- a/src/bits/select.rs
+++ b/src/bits/select.rs
@@ -13,7 +13,10 @@
 //! - `SelectIndex<u32>` halves the samples array. It is only sound for callers
 //!   that bound their length to `u32::MAX` bits, which
 //!   [`BalancedParens`](crate::trees::BalancedParens) asserts at construction —
-//!   its rank directory stores absolute cumulative counts as `u32`.
+//!   its rank directory stores absolute cumulative counts as `u32`. The only
+//!   caller is the deprecated `WithSelect`; BP's live select path,
+//!   `WithCsPoppy`, answers queries from its own `rank_l1`/`rank_l2` and
+//!   never touches `SelectIndex` (see `docs/adrs/adr-0015.md`).
 
 #[cfg(not(test))]
 use alloc::vec::Vec;


### PR DESCRIPTION
## Summary

- Resolves the keep/shrink/deprecate question #321 left open after #228 removed `BitVec`'s last production caller.
- `CompactRank` is already gone (#376). `SelectIndex`'s only remaining caller, `WithSelect`, is itself deprecated in favour of `WithCsPoppy` (#64), so all three types (`BitVec`/`RankDirectory`/`SelectIndex`) are back to being one unit with zero production callers.
- Adds [ADR-0015](docs/adrs/adr-0015.md): keep them as-is. Shrinking is unmeasured speculative work with no in-crate caller to validate against; deprecating would undercut ADR-0011's own `no_std` justification for having them in-crate at all.
- Updates the ADR inventory table and fixes a stale doc-comment in `src/bits/select.rs` that implied `BalancedParens`'s *live* select path still calls into `SelectIndex` (only the deprecated `WithSelect` does).

No functional/code-behavior change — docs and one doc-comment only.

Closes #321

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Re-ran the caller-audit greps from the ADR against HEAD to confirm the stated facts