### PR TITLE
fix(jq): break inside while/foreach/repeat/reduce/until reaches its label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`break $label` raised inside `while`/`foreach`/`repeat`/`reduce`/`until`'s
+  per-iteration expression raised a spurious error instead of reaching the
+  enclosing `label`** (#575): `eval_owned_expr` evaluated the per-iteration
+  sub-expression (`cond`/`update`/`extract`), then collapsed the resulting
+  `QueryResult` down to `Result<OwnedValue, EvalError>` — its `Break` arm
+  turned the control-flow signal into a synthetic `"break $label not in
+  label"` `EvalError`, indistinguishable by the time it reached `eval_label`,
+  which only recognizes a real `QueryResult::Break`. So `label $out |
+  while(true; if . >= 1 then break $out else .+1 end)` raised that bogus
+  error and exited 5 instead of matching jq's clean `1`, exit 0. Split
+  `eval_owned_expr` into `eval_owned_expr_ctrl` (returns `Result<OwnedValue,
+  Control>`, keeping `Break` distinct from `Error`, the same fix
+  `eval_slice_bound` already applies to slice bounds) with `eval_owned_expr`
+  now a thin wrapper over it, and switched `eval_while`/`eval_foreach`/
+  `eval_repeat`/`eval_reduce`/`eval_until`'s per-iteration evaluation to the
+  new function so a `break` now propagates as `Control::Break` to the
+  enclosing `label`. The issue named `while`/`foreach`/`repeat`; `reduce` and
+  `until` shared the identical defect via the same helper and are fixed
+  alongside them. Also fixes a secondary bug in `reduce`: `optional` (`?`)
+  used to swallow a `break` the same way it swallows a real error — it no
+  longer does, matching jq's `try`/`?` catching errors, not label breaks.
+
 - **`recurse(f)`/`recurse(f; cond)` swallowed an error raised while
   evaluating `f`/`cond`, treating it as a prune instead of jq's fatal
   error** (#636): `builtin_recurse_f`, `builtin_recurse_cond`, and their

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9808,11 +9808,12 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Substitute $var in update, then evaluate with acc as input
         let substituted = substitute_var(update, var, &input_val);
         // We need to evaluate with acc as the input
-        let acc_result = eval_owned_expr::<S>(&substituted, &acc, optional);
+        let acc_result = eval_owned_expr_ctrl::<S>(&substituted, &acc, optional);
         match acc_result {
             Ok(new_acc) => acc = new_acc,
-            Err(_) if optional => return QueryResult::None,
-            Err(e) => return QueryResult::Error(e),
+            Err(Control::Error(_)) if optional => return QueryResult::None,
+            Err(Control::Error(e)) => return QueryResult::Error(e),
+            Err(Control::Break(label)) => return QueryResult::Break(label),
         }
     }
 
@@ -9880,14 +9881,22 @@ fn eval_owned_fast_path(
     }
 }
 
-/// Evaluate an expression with an OwnedValue as input.
-fn eval_owned_expr<S: EvalSemantics>(
+/// Same evaluator as [`eval_owned_expr`], but keeps a `break` distinguishable
+/// from a real error via [`Control`] instead of collapsing it into a
+/// synthetic "break $label not in label" [`EvalError`] — needed by callers
+/// that run their operand through a loop of their own (`while`, `until`,
+/// `repeat`, `reduce`, `foreach`'s per-iteration UPDATE/EXTRACT) and must let
+/// a `break $label` inside that operand reach its enclosing `label` (#575).
+/// Same fix [`eval_slice_bound`] already applies to slice bounds.
+fn eval_owned_expr_ctrl<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
     optional: bool,
-) -> Result<OwnedValue, EvalError> {
+) -> Result<OwnedValue, Control> {
     if let Some(result) = eval_owned_fast_path(expr, input, optional) {
-        return result.map(|v| v.unwrap_or(OwnedValue::Null));
+        return result
+            .map(|v| v.unwrap_or(OwnedValue::Null))
+            .map_err(Control::Error);
     }
 
     // Create a synthetic JSON from the owned value
@@ -9924,8 +9933,8 @@ fn eval_owned_expr<S: EvalSemantics>(
             }
         }
         QueryResult::None => Ok(OwnedValue::Null),
-        QueryResult::Error(e) => Err(e),
-        QueryResult::Break(label) => Err(EvalError::new(format!("break ${label} not in label"))),
+        QueryResult::Error(e) => Err(Control::Error(e)),
+        QueryResult::Break(label) => Err(Control::Break(label)),
         // Same collapse-to-single-or-array policy as `Many`/`ManyOwned`
         // above; the trailing control is dropped, consistent with how this
         // function already doesn't fork over a multi-output update (a
@@ -9938,6 +9947,18 @@ fn eval_owned_expr<S: EvalSemantics>(
             }
         }
     }
+}
+
+/// Evaluate an expression with an OwnedValue as input.
+fn eval_owned_expr<S: EvalSemantics>(
+    expr: &Expr,
+    input: &OwnedValue,
+    optional: bool,
+) -> Result<OwnedValue, EvalError> {
+    eval_owned_expr_ctrl::<S>(expr, input, optional).map_err(|control| match control {
+        Control::Error(e) => e,
+        Control::Break(label) => EvalError::new(format!("break ${label} not in label")),
+    })
 }
 
 /// Evaluate an expression with an OwnedValue as input, preserving the full
@@ -10032,23 +10053,23 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     for input_val in input_values {
         // Substitute $var and evaluate update with state as input
         let substituted_update = substitute_var(update, var, &input_val);
-        match eval_owned_expr::<S>(&substituted_update, &state, optional) {
+        match eval_owned_expr_ctrl::<S>(&substituted_update, &state, optional) {
             Ok(new_state) => {
                 state = new_state;
                 // If there's an extract expression, evaluate it
                 if let Some(ext) = extract {
                     let substituted_extract = substitute_var(ext, var, &input_val);
-                    match eval_owned_expr::<S>(&substituted_extract, &state, optional) {
+                    match eval_owned_expr_ctrl::<S>(&substituted_extract, &state, optional) {
                         Ok(output) => outputs.push(output),
                         // The steps already produced no longer vanish (#494).
-                        Err(e) => return partial(outputs, Control::Error(e)),
+                        Err(control) => return partial(outputs, control),
                     }
                 } else {
                     // Without extract, output the current state
                     outputs.push(state.clone());
                 }
             }
-            Err(e) => return partial(outputs, Control::Error(e)),
+            Err(control) => return partial(outputs, control),
         }
     }
 
@@ -10279,19 +10300,21 @@ fn eval_until<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     for _ in 0..MAX_ITERATIONS {
         // Check condition
-        match eval_owned_expr::<S>(cond, &current, optional) {
+        match eval_owned_expr_ctrl::<S>(cond, &current, optional) {
             Ok(cond_val) => {
                 if cond_val.is_truthy() {
                     return QueryResult::Owned(current);
                 }
             }
-            Err(e) => return QueryResult::Error(e),
+            Err(Control::Error(e)) => return QueryResult::Error(e),
+            Err(Control::Break(label)) => return QueryResult::Break(label),
         }
 
         // Apply update
-        match eval_owned_expr::<S>(update, &current, optional) {
+        match eval_owned_expr_ctrl::<S>(update, &current, optional) {
             Ok(new_val) => current = new_val,
-            Err(e) => return QueryResult::Error(e),
+            Err(Control::Error(e)) => return QueryResult::Error(e),
+            Err(Control::Break(label)) => return QueryResult::Break(label),
         }
     }
 
@@ -10311,25 +10334,27 @@ fn eval_while<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     for _ in 0..MAX_ITERATIONS {
         // Check condition
-        match eval_owned_expr::<S>(cond, &current, optional) {
+        match eval_owned_expr_ctrl::<S>(cond, &current, optional) {
             Ok(cond_val) => {
                 if !cond_val.is_truthy() {
                     break;
                 }
             }
-            // The values already output no longer vanish (#494):
+            // The values already output no longer vanish (#494), and a
+            // `break $label` inside `cond` reaches its enclosing `label`
+            // instead of degrading into a synthetic error (#575).
             // `while(. < 5; if . == 3 then error("boom") else .+1 end)` on
             // `1` is `1`, `2`, `3`, then the error.
-            Err(e) => return partial(outputs, Control::Error(e)),
+            Err(control) => return partial(outputs, control),
         }
 
         // Output current value
         outputs.push(current.clone());
 
         // Apply update
-        match eval_owned_expr::<S>(update, &current, optional) {
+        match eval_owned_expr_ctrl::<S>(update, &current, optional) {
             Ok(new_val) => current = new_val,
-            Err(e) => return partial(outputs, Control::Error(e)),
+            Err(control) => return partial(outputs, control),
         }
     }
 
@@ -10352,13 +10377,15 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     for _ in 0..MAX_ITERATIONS {
         // Evaluate expr with the original input each time
-        match eval_owned_expr::<S>(expr, &owned, optional) {
+        match eval_owned_expr_ctrl::<S>(expr, &owned, optional) {
             Ok(new_val) => outputs.push(new_val),
             // The values already output no longer vanish, and an error with
             // no prior output surfaces as an error rather than empty output
             // (#495): `repeat(if . > 3 then error("boom") else .+1 end)` on
             // `5` raises immediately with no output, matching jq exactly.
-            Err(e) => return partial(outputs, Control::Error(e)),
+            // A `break $label` reaches its enclosing `label` instead of
+            // degrading into a synthetic error (#575).
+            Err(control) => return partial(outputs, control),
         }
     }
 
@@ -18863,6 +18890,153 @@ mod tests {
         query!(b"null", "label $out | limit(5; 1,2,(3|break $out),4)",
             QueryResult::ManyOwned(vs) => {
                 assert_eq!(prefix_json(&vs), ["1", "2"]);
+            }
+        );
+    }
+
+    #[test]
+    fn regression_issue_575_while_break_reaches_enclosing_label() {
+        // The issue's own example, verified against jq 1.7.1: the label
+        // catches the break cleanly, keeping whatever the loop already
+        // output before it broke.
+        assert_eq!(
+            outputs(
+                b"1",
+                "label $out | while(true; if . >= 1 then break $out else .+1 end)"
+            ),
+            ["1"]
+        );
+        // Without an enclosing label, the break used to degrade into a
+        // synthetic "break $out not in label" error; it now surfaces as a
+        // real `Break`, with the value already output kept as a prefix
+        // (same shape #494 already gives an `error(...)` in this position).
+        query!(
+            b"1",
+            "while(true; if . >= 1 then break $out else .+1 end)",
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(prefix_json(&vs), ["1"]);
+                assert_eq!(label, "out");
+            }
+        );
+        // A break in `cond` (rather than `update`) is caught the same way,
+        // with no output at all since it fires before the first value would
+        // have been emitted.
+        assert_eq!(
+            outputs(b"1", "label $out | while(break $out; .+1)"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn regression_issue_575_foreach_break_reaches_enclosing_label() {
+        // The issue's own example: break in UPDATE.
+        assert_eq!(
+            outputs(
+                b"null",
+                "label $out | foreach (1,2,3) as $x (0; if $x == 2 then break $out else . + $x end)"
+            ),
+            ["1"]
+        );
+        // Break in EXTRACT, verified against jq 1.7.1.
+        assert_eq!(
+            outputs(
+                b"null",
+                "label $out | foreach (1,2,3) as $x (0; .+$x; if $x == 2 then break $out else . end)"
+            ),
+            ["1"]
+        );
+        // Without an enclosing label, UPDATE's break surfaces as a real
+        // `Break`, keeping the outputs already extracted as a prefix.
+        query!(
+            b"null",
+            "foreach (1,2,3) as $x (0; if $x == 2 then break $out else . + $x end)",
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(prefix_json(&vs), ["1"]);
+                assert_eq!(label, "out");
+            }
+        );
+    }
+
+    #[test]
+    fn regression_issue_575_repeat_break_reaches_enclosing_label() {
+        // The issue's own example: breaks on the very first iteration, so
+        // nothing is ever output.
+        assert_eq!(
+            outputs(
+                b"1",
+                "label $out | repeat(if . >= 1 then break $out else .+1 end)"
+            ),
+            Vec::<String>::new()
+        );
+        // Without an enclosing label, the break surfaces as a real `Break`
+        // rather than a synthetic error.
+        query!(
+            b"1",
+            "repeat(if . >= 1 then break $out else .+1 end)",
+            QueryResult::Break(label) => {
+                assert_eq!(label, "out");
+            }
+        );
+    }
+
+    #[test]
+    fn regression_issue_575_reduce_break_reaches_enclosing_label() {
+        // Verified against jq 1.7.1.
+        assert_eq!(
+            outputs(
+                b"null",
+                "label $out | reduce (1,2,3) as $x (0; if $x == 2 then break $out else . + $x end)"
+            ),
+            Vec::<String>::new()
+        );
+        // `reduce` only ever emits its final accumulator, never
+        // intermediates, so without a label the break surfaces bare (no
+        // prefix to preserve) rather than as a synthetic error.
+        query!(
+            b"null",
+            "reduce (1,2,3) as $x (0; if $x == 2 then break $out else . + $x end)",
+            QueryResult::Break(label) => {
+                assert_eq!(label, "out");
+            }
+        );
+        // `optional` (`?`) must never swallow a `break` the way it swallows
+        // a real error — jq's `?` catches errors, not label breaks.
+        // Discriminating test: if the break were (incorrectly) swallowed as
+        // `None` by `optional`, the comma's second operand would still run
+        // and "reached" would be output; since the break must instead
+        // short-circuit the comma and reach the label, "reached" is never
+        // evaluated.
+        assert_eq!(
+            outputs(
+                b"null",
+                r#"label $out | ((reduce (1,2,3) as $x (0; if $x==2 then break $out else .+$x end))?, "reached")"#
+            ),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn regression_issue_575_until_break_reaches_enclosing_label() {
+        // Break in `cond`, verified against jq 1.7.1.
+        assert_eq!(
+            outputs(b"1", "label $out | until(break $out; .+1)"),
+            Vec::<String>::new()
+        );
+        // Break in `update`, verified against jq 1.7.1.
+        assert_eq!(
+            outputs(
+                b"1",
+                "label $out | until(. > 5; if . == 3 then break $out else .+1 end)"
+            ),
+            Vec::<String>::new()
+        );
+        // `until` only ever emits its final value, so without a label the
+        // break surfaces bare rather than as a synthetic error.
+        query!(
+            b"1",
+            "until(break $out; .+1)",
+            QueryResult::Break(label) => {
+                assert_eq!(label, "out");
             }
         );
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2882,6 +2882,49 @@ fn test_uncaught_break_after_output_keeps_the_prefix() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn regression_issue_575_break_in_loop_constructs_reaches_label() -> Result<()> {
+    // A `break $label` raised from inside `while`/`foreach`/`repeat`'s
+    // per-iteration expression used to degrade into a bogus
+    // "break $out not in label" error (exit 5) instead of unwinding to the
+    // enclosing `label` (real jq: clean output, exit 0) — the label never
+    // got a chance to catch it. All three transcripts here are verified
+    // against jq 1.7.1.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | while(true; if . >= 1 then break $out else .+1 end)",
+        ],
+        Some("1"),
+    )?;
+    assert_eq!(stdout, "1\n");
+    assert_eq!(stderr, "");
+    assert_eq!(code, 0);
+
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | repeat(if . >= 1 then break $out else .+1 end)",
+        ],
+        Some("1"),
+    )?;
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    assert_eq!(code, 0);
+
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | foreach (1,2,3) as $x (0; if $x == 2 then break $out else . + $x end)",
+        ],
+        Some("null"),
+    )?;
+    assert_eq!(stdout, "1\n");
+    assert_eq!(stderr, "");
+    assert_eq!(code, 0);
+    Ok(())
+}
+
 /// A `NumberLiteral` that overflows to infinity (e.g. `1e400`) used to render
 /// as garbage like `"NaNE+2147483647"` in every non-JSON text format instead
 /// of `"inf"`/`"-inf"` (#561). `tostring` reaches the fix directly, but


### PR DESCRIPTION
## Description

This PR fixes a critical bug where `break $label` expressions raised inside the per-iteration sub-expressions of `while`, `foreach`, `repeat`, `reduce`, and `until` constructs would incorrectly degrade into a synthetic `"break $label not in label"` error instead of properly reaching their enclosing `label`. The issue caused these constructs to exit with code 5 (error) instead of matching jq's correct behavior of cleanly catching the break with exit code 0.

The root cause was that `eval_owned_expr` collapsed `QueryResult::Break` into an `EvalError`, making it indistinguishable from a real error by the time it reached `eval_label`, which only recognizes `QueryResult::Break`. This PR splits the logic into `eval_owned_expr_ctrl` (which preserves control flow as `Result<OwnedValue, Control>`) and keeps `eval_owned_expr` as a thin wrapper for backward compatibility.

The fix also addresses a secondary bug in `reduce` where `optional` (`?`) incorrectly swallowed a `break` the same way it swallows errors, when it should only suppress errors per jq's semantics.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Related Issue
Fixes #575

## Changes Made

**Core Implementation (src/jq/eval.rs):**
- Added new `eval_owned_expr_ctrl` function that returns `Result<OwnedValue, Control>` instead of collapsing `Break` into an error, keeping control flow signals distinct from real errors
- Modified `eval_owned_expr` to wrap `eval_owned_expr_ctrl`, maintaining backward compatibility for all seven existing call sites
- Updated `eval_while` to use `eval_owned_expr_ctrl` for condition and update evaluation, properly propagating `Control::Break` to enclosing labels
- Updated `eval_foreach` to use `eval_owned_expr_ctrl` for update and extract expression evaluation, preserving break semantics
- Updated `eval_repeat` to use `eval_owned_expr_ctrl`, allowing breaks to reach enclosing labels instead of degrading to errors
- Updated `eval_reduce` to use `eval_owned_expr_ctrl` and properly handle `Control::Break` separately from errors, fixing the `optional` (`?`) swallowing breaks
- Updated `eval_until` to use `eval_owned_expr_ctrl` for both condition and update evaluation

**Test Coverage (src/jq/eval.rs):**
- Added `regression_issue_575_while_break_reaches_enclosing_label` unit test covering break in both condition and update expressions
- Added `regression_issue_575_foreach_break_reaches_enclosing_label` unit test covering break in update and extract expressions
- Added `regression_issue_575_repeat_break_reaches_enclosing_label` unit test covering break in the repeat expression
- Added `regression_issue_575_reduce_break_reaches_enclosing_label` unit test including verification that `optional` no longer swallows breaks
- Added `regression_issue_575_until_break_reaches_enclosing_label` unit test covering break in both condition and update expressions

**Integration Tests (tests/jq_cli_tests.rs):**
- Added `regression_issue_575_break_in_loop_constructs_reaches_label` end-to-end test verifying correct stdout, empty stderr, and exit code 0 for break in while, repeat, and foreach constructs with enclosing labels

**Documentation (CHANGELOG.md):**
- Recorded the issue #575 fix with detailed explanation of the root cause, solution approach, and behavioral changes

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] Five new unit tests added to verify break propagation in all affected constructs (while, foreach, repeat, reduce, until)
- [x] New integration test verifies end-to-end CLI behavior matches jq 1.7.1 exactly
- [x] Tests verify both labeled breaks (caught by enclosing label) and unlabeled breaks (propagating as QueryResult::Break)
- [x] Tests verify the optional (`?`) operator no longer incorrectly swallows breaks

**Manual Testing:**
- [x] Verified against jq 1.7.1 output and exit codes
- [x] Tested break in condition expressions for while and until
- [x] Tested break in update expressions for while, foreach, repeat, reduce, and until
- [x] Tested break in extract expression for foreach
- [x] Tested breaks with and without enclosing labels
- [x] Tested optional operator behavior with breaks

### Test Commands
```bash
cd /Users/jky/wrk/work-trees/succinctly
cargo test regression_issue_575
cargo test --lib jq::eval::tests::regression_issue_575
cargo test regression_issue_575_break_in_loop_constructs_reaches_label -- --test-threads=1
cargo test
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact: the new `eval_owned_expr_ctrl` function maintains identical performance characteristics to the previous implementation, and `eval_owned_expr` is a zero-cost wrapper

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Root Cause Analysis:**
The bug existed because loop constructs (`while`, `foreach`, `repeat`, `reduce`, `until`) evaluate their per-iteration sub-expressions using `eval_owned_expr`, which converts all `QueryResult` variants to `Result<OwnedValue, EvalError>`. When a `break $label` occurs in the sub-expression, it arrives as `QueryResult::Break`, but `eval_owned_expr` converts it to a synthetic `EvalError` with message `"break $label not in label"`. By the time this error reaches `eval_label`, it's indistinguishable from a real error, and the label cannot intercept it properly.

**Solution Approach:**
The fix introduces `eval_owned_expr_ctrl` that preserves the distinction between errors and breaks by returning `Result<OwnedValue, Control>` instead of `Result<OwnedValue, EvalError>`. This is the same approach already used by `eval_slice_bound` for slice bounds. Loop constructs now route their per-iteration evaluation through this new function and properly propagate `Control::Break` to enclosing labels.

**Secondary Bug Fix:**
In `reduce`, the `optional` (`?`) operator was incorrectly swallowing breaks because it was treating them as errors. The fix now properly discriminates between `Control::Error` and `Control::Break`, so `?` only suppresses real errors, not label breaks, matching jq's semantics where `try`/`?` catches errors, not control flow.

**Verification:**
All test cases have been verified against jq 1.7.1 to ensure exact behavioral compatibility. The fix handles both the main case (break reaching an enclosing label) and the edge case (break without an enclosing label, propagating as `QueryResult::Break` with partial output preserved).