### PR TITLE
fix(jq): thread path context through the CLI's streaming pipe evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`path`/`parent`/`parent(n)`/`key` (yq's path-context builtins) returned
+  the root-level defaults `[]`/`{}`/`null` instead of the real answer
+  whenever they appeared anywhere in a pipe other than the very first stage**
+  (#554): `.a | path` printed `[]` instead of `["a"]`, `.a | parent` printed
+  `{}` instead of `{"a":1}`. `eval.rs` (the library's full evaluator) tracks
+  path context correctly, threading a `current_path` accumulator through
+  every stage of `eval_pipe` whenever `needs_path_context` finds one of these
+  builtins anywhere in the pipe. But the CLI (`sjq`/`syq`) evaluates through
+  `eval_generic.rs`'s independent, cursor-based `Expr::Pipe` handling, which
+  has no path-accumulator of its own; once a preceding stage collapsed to a
+  plain value, its builtin dispatch bridged only the bare trailing builtin
+  (e.g. `Expr::Builtin(PathNoArg)`) to the full evaluator, discarding the
+  surrounding pipe that `needs_path_context` needs to see. `eval_generic.rs`'s
+  `Expr::Pipe` arm now runs the same `needs_path_context` check `eval_pipe`
+  does and, when it fires, bridges the *whole* remaining pipe (not just the
+  one builtin) to the full evaluator, so the existing path-tracking machinery
+  is reached with the pipe structure intact.
+
 - **`break $label` raised inside `while`/`foreach`/`repeat`/`reduce`/`until`'s
   per-iteration expression raised a spurious error instead of reaching the
   enclosing `label`** (#575): `eval_owned_expr` evaluated the per-iteration

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -302,7 +302,7 @@ fn json_is_truthy<W>(value: &StandardJson<'_, W>) -> bool {
 }
 
 /// Check if an expression contains PathNoArg, Parent, or Key builtins that need path context.
-fn needs_path_context(expr: &Expr) -> bool {
+pub(crate) fn needs_path_context(expr: &Expr) -> bool {
     match expr {
         Expr::Builtin(Builtin::PathNoArg) => true,
         Expr::Builtin(Builtin::Parent) => true,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -20,8 +20,9 @@ use indexmap::IndexMap;
 use super::document::{DocumentCursor, DocumentElements, DocumentFields, DocumentValue};
 use super::eval::{
     compare_values, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
-    numeric_display_string, numeric_key_to_index, owned_bound_to_i64, slice_owned_value,
-    tonumber_from_str, Control, EvalError, EvalSemantics, JqSemantics, QueryResult,
+    needs_path_context, numeric_display_string, numeric_key_to_index, owned_bound_to_i64,
+    slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics, JqSemantics,
+    QueryResult,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Literal};
 use super::slice::{slice_str, SliceBounds};
@@ -749,6 +750,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         Expr::Paren(inner) => eval_single::<S, _>(inner, value, optional, cursor),
 
         Expr::Pipe(exprs) => {
+            // `path`/`parent`/`parent(n)`/`key` need the path accumulated
+            // across every stage of this pipe, which only the full evaluator
+            // tracks (`eval::eval_pipe`'s own `needs_path_context` routing,
+            // `eval.rs:6441-6444`). Bridge the *whole* pipe there rather than
+            // letting a later stage fall through `eval_builtin`'s per-builtin
+            // fallback in isolation, which has no path to give it (#554).
+            if exprs.iter().any(needs_path_context) {
+                let owned = to_owned(&value);
+                return eval_on_owned::<S, _>(&Expr::Pipe(exprs.clone()), owned, optional);
+            }
+
             if exprs.is_empty() {
                 return GenericResult::One(value);
             }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3021,3 +3021,38 @@ fn test_number_literal_overflow_owned_reindex_bridges_via_cli() -> Result<()> {
 
     Ok(())
 }
+
+/// `path`/`parent`/`parent(n)`/`key` used to silently answer `[]`/`{}`/`null`
+/// (the root-level defaults) whenever they weren't the very first pipe stage:
+/// the CLI's streaming evaluator (`eval_generic.rs`) bridged only the bare
+/// trailing builtin to the full evaluator, discarding the pipe structure
+/// `eval.rs`'s `needs_path_context` routing needs to see (#554). Uses
+/// `run_jq_full` (the pre-built binary), not the `cargo run`-based
+/// `run_jq_stdin`, so this is actually covered by `cargo llvm-cov`.
+#[test]
+fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
+    let (output, _, code) = run_jq_full(&["-c", ".a | path"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["a"]"#);
+
+    let (output, _, code) = run_jq_full(&["-c", ".a | parent"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":1}"#);
+
+    let (output, _, code) = run_jq_full(&["-c", ".a | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""a""#);
+
+    let (output, _, code) = run_jq_full(&["-c", ".a.b | parent"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"b":1}"#);
+
+    let (output, _, code) = run_jq_full(
+        &["-c", ".a.b.c | parent(2)"],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"b":{"c":1}}"#);
+
+    Ok(())
+}

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -984,3 +984,57 @@ fn test_object_construction_product_parity_354() {
         assert_parity(json, filter);
     }
 }
+
+/// `path`/`parent`/`parent(n)`/`key` (yq's path-context builtins) only get
+/// their `current_path` threaded through `eval.rs`'s `eval_pipe`, reached
+/// when `needs_path_context` sees one of them anywhere in an `Expr::Pipe`
+/// list (#554). The generic (CLI/cursor) evaluator has its own independent
+/// `Expr::Pipe` handling with no path-accumulator of any kind, and used to
+/// bridge only the bare trailing builtin to the full evaluator once a
+/// preceding stage collapsed to a plain value -- discarding the very pipe
+/// structure `needs_path_context` needs to see. That silently returned the
+/// root-level defaults (`[]`/`{}`/null) for any of these builtins appearing
+/// anywhere but the first pipe stage. Every case here is wrong (mismatched
+/// with `full_outputs`) before the generic evaluator's `Expr::Pipe` arm also
+/// bridges the *whole* pipe once `needs_path_context` fires.
+#[test]
+fn test_path_context_builtins_survive_pipe_parity_554() {
+    for (json, filter, expected) in [
+        // The issue's own repro cases.
+        (br#"{"a":1}"#.as_slice(), ".a | path", r#"["a"]"#),
+        (br#"{"a":1}"#, ".a | parent", r#"{"a":1}"#),
+        (br#"{"a":1}"#, ".a | key", r#""a""#),
+        (br#"{"a":{"b":1}}"#, ".a.b | parent", r#"{"b":1}"#),
+        // `parent(n)`: n=1 matches bare `parent`; n=2 climbs one further.
+        (
+            br#"{"a":{"b":{"c":1}}}"#,
+            ".a.b.c | parent(1)",
+            r#"{"c":1}"#,
+        ),
+        (
+            br#"{"a":{"b":{"c":1}}}"#,
+            ".a.b.c | parent(2)",
+            r#"{"b":{"c":1}}"#,
+        ),
+        // A stage after the path-context builtin keeps consuming its output.
+        (br#"{"a":1}"#, ".a | path | .[0]", r#""a""#),
+        // A multi-output preceding stage (iteration): `key` reports each
+        // element's own key/index, not just the first.
+        (br"[10,20,30]", ".[] | key", "0"),
+        (br#"{"x":1,"y":2}"#, ".[] | key", r#""x""#),
+        // Bare, first-stage usage was already correct -- locked in here
+        // too so a future change can't silently regress it.
+        (br#"{"a":1}"#, "path", "[]"),
+        (br#"{"a":1}"#, "parent", "{}"),
+        (br#"{"a":1}"#, "key", "null"),
+    ] {
+        assert_parity(json, filter);
+        let generic = generic_outputs(json, filter);
+        assert_eq!(
+            as_strs(&generic)[0],
+            expected,
+            "unexpected CLI (generic evaluator) output for `{filter}` on `{}`",
+            String::from_utf8_lossy(json)
+        );
+    }
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3913,3 +3913,32 @@ fn test_yq_outputs_before_an_error_or_break_survive() -> Result<()> {
     assert_eq!(code, 1);
     Ok(())
 }
+
+/// `path`/`parent`/`parent(n)`/`key` used to silently answer `[]`/`{}`/`null`
+/// (the root-level defaults) whenever they weren't the very first pipe stage
+/// (#554), because the CLI's streaming evaluator (`eval_generic.rs`, driving
+/// both `jq` and `yq`) bridged only the bare trailing builtin to the full
+/// evaluator, discarding the pipe structure `eval.rs`'s `needs_path_context`
+/// routing needs to see. This is the only automated coverage of the fix on
+/// the YAML/`YamlCursor` side of `eval_generic.rs` -- `jq_evaluator_parity_tests.rs`
+/// only exercises the JSON side.
+#[test]
+fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a | path", "a: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["a"]"#);
+
+    let (output, code) = run_yq_stdin(".a | parent", "a: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":1}"#);
+
+    let (output, code) = run_yq_stdin(".a | key", "a: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""a""#);
+
+    let (output, code) = run_yq_stdin(".a.b | parent", "a:\n  b: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"b":1}"#);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `path`/`parent`/`parent(n)`/`key` (yq's path-context builtins) silently returned root-level defaults (`[]`/`{}`/`null`) whenever they appeared anywhere in a pipe other than the very first stage, because the CLI's streaming evaluator (`eval_generic.rs`) bridged only the bare trailing builtin to the full evaluator instead of the enclosing pipe, so `eval.rs`'s existing `needs_path_context` routing never fired.
- `eval_generic.rs`'s `Expr::Pipe` arm now runs the same `needs_path_context` check `eval.rs`'s `eval_pipe` already uses and, when it fires, bridges the *whole* remaining pipe (not just the isolated builtin) to the full evaluator, restoring correct path tracking.
- Adds parity coverage (`tests/jq_evaluator_parity_tests.rs`) and CLI-level regression tests for both `jq` and `yq` (`tests/jq_cli_tests.rs`, `tests/yq_cli_tests.rs`), and records the fix in `CHANGELOG.md`.

Fixes #554

## Test plan

- [x] `cargo build --features cli`
- [x] Manually reran every repro command from #554 and confirmed corrected output (`.a | path` → `["a"]`, `.a | parent` → `{"a":1}`, `.a | key` → `"a"`, `.a.b | parent` → `{"b":1}`, yq `.a | path` → `["a"]`)
- [x] Verified the new parity test fails against the pre-fix code (confirmed via `git stash`) and passes after
- [x] `cargo test --features cli,simd,regex,serde` (full suite; one unrelated pre-existing flaky CLI test under parallel contention, passes in isolation)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`