### PR TITLE
docs: confirm #595's block_scalars build regression is a layout artifact

### DIFF
--- a/docs/plan/cspoppy.md
+++ b/docs/plan/cspoppy.md
@@ -326,6 +326,70 @@ behind it so it can be revisited if `find_bp_at_text_pos` ever moves onto a
 hotter path, or if the `block_scalars` anomaly resurfaces with `perf` evidence
 attributing it to this change after all.
 
+### 5b. Issue #595 follow-up (2026-08-06): confirmed layout artifact, not logic
+
+Settled the "layout, not logic" question the Verdict above deferred, using
+`valgrind --tool=cachegrind` (built from source into `~/local` on `terminus`,
+no root needed — WSL2 has neither `perf` hardware counters nor an installed
+`valgrind`) in place of the `perf stat -e instructions,cycles` comparison
+originally proposed: cachegrind's binary instrumentation needs no hardware
+counter access and directly simulates L1/LL instruction-cache misses, which
+is exactly the mechanism the layout theory needs to demonstrate.
+
+New tooling: `examples/block_scalars_harness.rs` (fixed-iteration
+`YamlIndex::build` loop per `block_scalars` shape — criterion's adaptive,
+timing-based sampling breaks under cachegrind's ~20-50x slowdown) and
+`scripts/perf-ab.py` (interleaved A/B over `cachegrind`/`perf`/wall-clock,
+same interleave/identity-gate/control-copy rules as `scripts/ab-cli.py`).
+Commits compared: `becd1b8d` (pre-CS-Poppy, PR #603's base) vs `09158571`
+(PR #603's merge) — the same range the Criterion 4 measurement above used.
+The checksum identity gate passed on all 7 shapes on every host (byte-for-byte
+identical `YamlIndex` structure before/after, confirming the BP-structure
+inspection above).
+
+**Zen 4 (`terminus`), `--tool cachegrind`, 5 interleaved reps × 50 iterations:**
+
+| shape             | Ir Δ  | I1mr Δ | ILmr Δ |
+|-------------------|-------|--------|--------|
+| 10x10lines        | -0.0% | +27.3% | -0.4%  |
+| 50x50lines        | -0.0% | +22.5% | -0.5%  |
+| 100x100lines      | -0.0% | +17.4% | -0.5%  |
+| 10x1000lines      | -0.0% | +23.4% | -0.5%  |
+| long_10x100lines  | -0.0% | +27.7% | -0.4%  |
+| long_50x100lines  | -0.0% | +14.2% | -0.4%  |
+| long_100x100lines | -0.0% | +11.8% | -0.4%  |
+
+Instructions retired (`Ir`) are flat to four significant figures on every
+shape — confirms CS-Poppy's `build()` does essentially zero extra work on this
+workload's fixed 7-word/404-bit BP, exactly as the manual inspection above
+predicted. **L1 instruction-cache misses (`I1mr`) rise 11.8-27.7%** — closely
+tracking the original 12-28% wall-clock regression range — while LL misses
+stay flat to slightly improved (the effect is L1-local, consistent with a
+hot-loop alignment/layout shift rather than a genuinely larger working set).
+This is the deciding signature issue #595 asked for: same work, different
+cache behaviour, not real extra work.
+
+A same-harness, same-binaries wall-clock reproduction on `terminus`
+immediately after (200 iterations × 9 reps) showed a smaller +2% median
+regression (range -0.8%..+6.2%) rather than the original 12-28% — plausibly
+because this harness's tight single-process loop reaches a hotter, more
+consistent icache steady-state than criterion's start/stop sampling harness.
+Reported for transparency; it doesn't affect the Ir/I1mr conclusion, which
+holds within a single cachegrind-instrumented run of the same loop.
+
+**M4 Pro (`johns-mac-mini`), `--tool wallclock`, 9 interleaved reps × 200
+iterations, reproduced twice:** `10x10lines`/`50x50lines`/`100x100lines`/
+`10x1000lines` neutral (-1.0%..+0.4%), matching the original finding above.
+Unexpectedly, the three `long_*` shapes (long lines, P2.7's SIMD stress
+variant) improved a reproducible **7.4-9.3%** — the opposite of a regression,
+and not something this branch's logic obviously explains. Flagged as a new,
+separate observation rather than chased further here — out of scope for #595,
+which only asked about the x86 regression.
+
+**Conclusion: #595 closed as "expected, no action" — confirmed binary
+code-layout artifact, not a CS-Poppy logic regression.** The ARM `long_*`
+improvement is worth its own follow-up issue if someone wants to chase it.
+
 ---
 
 ## 6. Future developments

--- a/examples/block_scalars_harness.rs
+++ b/examples/block_scalars_harness.rs
@@ -1,0 +1,89 @@
+//! Standalone, fixed-shot `YamlIndex::build` harness for a single `yaml/block_scalars`
+//! shape from `benches/yaml_bench.rs`, for use under `valgrind --tool=cachegrind` or
+//! `perf stat -e instructions,cycles` (issue #595).
+//!
+//! Criterion's adaptive, timing-based iteration count doesn't work under instrumentation
+//! that slows execution 20-50x — the two binaries being compared would end up running a
+//! different number of iterations, making total instruction counts incomparable. This
+//! harness runs a fixed iteration count instead.
+//!
+//! Run with:
+//! ```bash
+//! cargo build --release --example block_scalars_harness
+//! valgrind --tool=cachegrind ./target/release/examples/block_scalars_harness long_100x100lines 50
+//! ```
+
+use std::env;
+use succinctly::yaml::YamlIndex;
+
+/// Mirrors `generate_block_scalars` in `benches/yaml_bench.rs`.
+fn generate_block_scalars(count: usize, lines_per_block: usize) -> Vec<u8> {
+    let mut yaml = Vec::with_capacity(count * lines_per_block * 50);
+    for i in 0..count {
+        yaml.extend_from_slice(format!("block{i}: |\n").as_bytes());
+        for j in 0..lines_per_block {
+            yaml.extend_from_slice(format!("  This is line {j} of block scalar {i}\n").as_bytes());
+        }
+    }
+    yaml
+}
+
+/// Mirrors `generate_long_block_scalars` in `benches/yaml_bench.rs`.
+fn generate_long_block_scalars(count: usize, lines_per_block: usize) -> Vec<u8> {
+    let mut yaml = Vec::with_capacity(count * lines_per_block * 100);
+    let long_line = "x".repeat(80);
+    for i in 0..count {
+        yaml.extend_from_slice(format!("content{i}: |\n").as_bytes());
+        for _ in 0..lines_per_block {
+            yaml.extend_from_slice(format!("  {long_line}\n").as_bytes());
+        }
+    }
+    yaml
+}
+
+fn shape(name: &str) -> Vec<u8> {
+    match name {
+        "10x10lines" => generate_block_scalars(10, 10),
+        "50x50lines" => generate_block_scalars(50, 50),
+        "100x100lines" => generate_block_scalars(100, 100),
+        "10x1000lines" => generate_block_scalars(10, 1000),
+        "long_10x100lines" => generate_long_block_scalars(10, 100),
+        "long_50x100lines" => generate_long_block_scalars(50, 100),
+        "long_100x100lines" => generate_long_block_scalars(100, 100),
+        other => {
+            eprintln!("unknown shape {other:?} - see yaml/block_scalars in benches/yaml_bench.rs");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let shape_name = args.get(1).map_or("long_100x100lines", String::as_str);
+    let iterations: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(50);
+
+    let yaml = shape(shape_name);
+
+    // Cheap structural fingerprint, summed across iterations, for the output-identity
+    // gate (docs/guides/benchmarking.md rule 4): if the "before" and "after" binaries
+    // build different index shapes, the checksum diverges even though nothing here
+    // depends on wall-clock time. Deliberately avoids `select_heap_size()` — it doesn't
+    // exist on the pre-CS-Poppy (`WithSelect`) commit this harness must also compile
+    // against unmodified.
+    let mut checksum: u64 = 0;
+    for _ in 0..iterations {
+        let index = YamlIndex::build(std::hint::black_box(yaml.as_slice())).unwrap();
+        checksum = checksum
+            .wrapping_add(index.bp().len() as u64)
+            .wrapping_add(index.bp().total_ones() as u64)
+            .wrapping_add(index.bp().words().len() as u64)
+            .wrapping_add(index.ib_len() as u64)
+            .wrapping_add(index.ty_len() as u64);
+        std::hint::black_box(&index);
+    }
+
+    println!(
+        "shape={shape_name} doc_bytes={} iterations={iterations} checksum={checksum}",
+        yaml.len()
+    );
+}

--- a/scripts/perf-ab.py
+++ b/scripts/perf-ab.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Interleaved instructions/cache-miss A/B for two `block_scalars_harness` binaries.
+
+Companion to scripts/ab-cli.py, built for issue #595: distinguish "same work, worse
+code layout" from "a real logic regression" for the yaml/block_scalars build-time
+delta between pre- and post-#64 (CS-Poppy) `main`. Wall-clock A/B can't tell those
+apart; this drives instruction/cache-miss counters instead, which don't move for a
+pure layout shift the way cycles do.
+
+Default tool is `cachegrind` (valgrind's binary-instrumentation instruction/cache
+simulator): it needs no hardware perf-counter access, which matters because the
+pinned x86 bench host (terminus, WSL2) cannot use `perf stat` counters. Pass
+`--tool perf` on a host where `perf stat -e instructions,cycles` works instead, or
+`--tool wallclock` (min/median ms, no extra tool needed — e.g. on the ARM cross-check
+box, which has neither valgrind nor perf) to reproduce the original criterion-based
+signal with this same harness/interleaving.
+
+Build the two binaries first (see docs/guides/benchmarking.md § "Building both
+halves on a remote box" for the reverse-patch/tarball recipe, or just check out
+and build the two commits directly):
+
+    cargo build --release --example block_scalars_harness   # in each checkout
+
+Then:
+
+    scripts/perf-ab.py --before ./succ-before/target/release/examples/block_scalars_harness \\
+        --after ./succ-after/target/release/examples/block_scalars_harness
+
+Standard library only; no third-party dependencies.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+# All seven yaml/block_scalars ids from benches/yaml_bench.rs.
+ALL_SHAPES = [
+    "10x10lines",
+    "50x50lines",
+    "100x100lines",
+    "10x1000lines",
+    "long_10x100lines",
+    "long_50x100lines",
+    "long_100x100lines",
+]
+
+CACHEGRIND_PATTERNS = {
+    "Ir": re.compile(r"I\s+refs:\s+([\d,]+)"),
+    "I1mr": re.compile(r"I1\s+misses:\s+([\d,]+)"),
+    "ILmr": re.compile(r"LLi misses:\s+([\d,]+)"),
+}
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Interleaved instructions/cache-miss A/B for block_scalars_harness.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("\n\n", 1)[1],
+    )
+    p.add_argument("--before", required=True, help="baseline harness binary")
+    p.add_argument("--after", help="binary under test (omit with --control)")
+    p.add_argument("--tool", choices=["cachegrind", "perf", "wallclock"], default="cachegrind")
+    p.add_argument("--valgrind-bin", default="valgrind",
+                   help="path to valgrind (e.g. a rootless ~/local/bin/valgrind build)")
+    p.add_argument("--perf-bin", default="perf", help="path to perf")
+    p.add_argument("--shapes", nargs="*", default=ALL_SHAPES,
+                   help="block_scalars shape ids to run (default: all seven)")
+    p.add_argument("--iterations", type=int, default=50,
+                   help="YamlIndex::build iterations per harness invocation "
+                        "(amortizes process-startup and instrumentation overhead)")
+    p.add_argument("--reps", type=int, default=5, help="repetitions per shape")
+    p.add_argument("--control", action="store_true",
+                   help="measure --before against a copy of itself (noise floor)")
+    p.add_argument("--no-identity", action="store_true",
+                   help="skip the checksum identity gate — for control runs")
+    p.add_argument("--force", action="store_true",
+                   help="run even if the machine looks busy")
+    return p.parse_args(argv)
+
+
+def machine_warnings():
+    """Rule 6 (docs/guides/benchmarking.md): on Linux the load average is trustworthy."""
+    warnings = []
+    if sys.platform != "darwin":
+        load1 = os.getloadavg()[0]
+        if load1 > 1.0:
+            warnings.append(f"1-minute load average is {load1:.2f}")
+    # "perf stat"/"perf record", not bare "perf" — a bare pattern self-matches this
+    # script's own name (perf-ab.py) via `pgrep -f`.
+    raw = subprocess.run(["pgrep", "-fl", "cargo|rustc|criterion|claude|valgrind|perf (stat|record)"],
+                         capture_output=True, text=True, check=False).stdout
+    # `-f` matches the full cmdline (which, over Tailscale SSH, is a "tailscaled be-child
+    # ssh ... --cmd=<this remote command>" wrapper whose own argv contains the full command
+    # being run — including this search pattern itself, so it always self-matches) but `-l`
+    # only *prints* the short comm name, which is just "tailscaled" — never a genuine
+    # competing benchmark process, so it's always safe to drop from this check. Also drop
+    # our own PID: --valgrind-bin/--perf-bin's path literally contains "valgrind"/"perf".
+    own_pid = str(os.getpid())
+    busy = "\n".join(line for line in raw.splitlines()
+                     if line.split(None, 1)[1:2] != ["tailscaled"]
+                     and line.split(None, 1)[:1] != [own_pid])
+    if busy.strip():
+        warnings.append("build/agent/profiler processes are running:\n    "
+                        + "\n    ".join(busy.strip().splitlines()[:5]))
+    return warnings
+
+
+def run_checksum(binary, shape, iterations):
+    """Run the harness once, plainly, to read its stdout summary line."""
+    out = subprocess.run([binary, shape, str(iterations)],
+                         capture_output=True, text=True, check=True).stdout.strip()
+    m = re.search(r"checksum=(\d+)", out)
+    if not m:
+        sys.exit(f"could not parse harness output: {out!r}")
+    return out, int(m.group(1))
+
+
+def gate_identity(args, shapes):
+    """A faster binary that built a different index is not a win."""
+    checked = differences = 0
+    for shape in shapes:
+        checked += 1
+        _, before_cksum = run_checksum(args.before, shape, args.iterations)
+        _, after_cksum = run_checksum(args.after, shape, args.iterations)
+        if before_cksum != after_cksum:
+            differences += 1
+            print(f"  DIFF  {shape}  before={before_cksum} after={after_cksum}")
+    print(f"  identity: {checked} shapes, {differences} differences")
+    return differences == 0
+
+
+def run_cachegrind(valgrind_bin, binary, shape, iterations):
+    with tempfile.TemporaryDirectory() as tmp:
+        log = os.path.join(tmp, "cg.log")
+        cmd = [valgrind_bin, "--tool=cachegrind", "--cache-sim=yes", f"--log-file={log}",
+               "--cachegrind-out-file=" + os.path.join(tmp, "cg.out"),
+               binary, shape, str(iterations)]
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        with open(log) as f:
+            text = f.read()
+    result = {}
+    for key, pattern in CACHEGRIND_PATTERNS.items():
+        m = pattern.search(text)
+        if not m:
+            sys.exit(f"could not find {key} in cachegrind output:\n{text}")
+        result[key] = int(m.group(1).replace(",", ""))
+    return result
+
+
+def run_perf(perf_bin, binary, shape, iterations):
+    with tempfile.TemporaryDirectory() as tmp:
+        out = os.path.join(tmp, "perf.csv")
+        cmd = [perf_bin, "stat", "-x", ",", "-e", "instructions,cycles", "-o", out,
+               "--", binary, shape, str(iterations)]
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        with open(out) as f:
+            rows = [line.strip().split(",") for line in f if line.strip() and not line.startswith("#")]
+    result = {}
+    for row in rows:
+        value, event = row[0], row[2]
+        if event in ("instructions", "cycles"):
+            result[event] = int(value)
+    if "instructions" not in result or "cycles" not in result:
+        sys.exit(f"could not parse perf stat output:\n{rows}")
+    return {"Ir": result["instructions"], "cycles": result["cycles"]}
+
+
+def run_wallclock(binary, shape, iterations):
+    t0 = time.perf_counter()
+    subprocess.run([binary, shape, str(iterations)],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+    return {"ms": (time.perf_counter() - t0) * 1000.0}
+
+
+def measure_once(args, binary, shape):
+    if args.tool == "cachegrind":
+        return run_cachegrind(args.valgrind_bin, binary, shape, args.iterations)
+    if args.tool == "perf":
+        return run_perf(args.perf_bin, binary, shape, args.iterations)
+    return run_wallclock(binary, shape, args.iterations)
+
+
+def measure(args, shape):
+    """Alternate the binaries within each repetition (never in halves)."""
+    measure_once(args, args.before, shape)  # warm up, discarded
+    measure_once(args, args.after, shape)
+    before, after = [], []
+    for i in range(args.reps):
+        if i % 2 == 0:
+            before.append(measure_once(args, args.before, shape))
+            after.append(measure_once(args, args.after, shape))
+        else:
+            after.append(measure_once(args, args.after, shape))
+            before.append(measure_once(args, args.before, shape))
+    return before, after
+
+
+def agg_min(runs, key):
+    return min(r[key] for r in runs)
+
+
+def agg_median(runs, key):
+    return statistics.median(r[key] for r in runs)
+
+
+def metric_specs(tool):
+    """(column label, dict key, aggregator) triples — one per report column. cachegrind
+    reports medians of three counters (instructions, L1 and LL icache misses — L1 is the
+    one a hot-loop layout/alignment shift actually stresses; LL is included too since it's
+    free from the same run). perf reports instructions and cycles. wallclock has only one
+    counter (ms), so it reports min and median of the same field instead, matching
+    scripts/ab-cli.py's convention."""
+    if tool == "cachegrind":
+        return [("Ir", "Ir", agg_median), ("I1mr", "I1mr", agg_median), ("ILmr", "ILmr", agg_median)]
+    if tool == "perf":
+        return [("Ir", "Ir", agg_median), ("cycles", "cycles", agg_median)]
+    return [("min ms", "ms", agg_min), ("median ms", "ms", agg_median)]
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    control_copy = None
+    if args.control:
+        if args.after:
+            sys.exit("--control replaces --after with a copy of --before; pass only one")
+        fd, control_copy = tempfile.mkstemp(prefix="perf-ab-control-")
+        os.close(fd)
+        shutil.copy2(args.before, control_copy)
+        os.chmod(control_copy, 0o755)
+        args.after = control_copy
+        args.no_identity = True
+    elif not args.after:
+        sys.exit("--after is required (or use --control)")
+
+    if args.tool == "cachegrind" and shutil.which(args.valgrind_bin) is None:
+        sys.exit(f"valgrind not found at {args.valgrind_bin!r} — install it, pass --valgrind-bin, "
+                 f"or use --tool perf")
+    if args.tool == "perf" and shutil.which(args.perf_bin) is None:
+        sys.exit(f"perf not found at {args.perf_bin!r} — pass --perf-bin or use --tool cachegrind")
+
+    warnings = machine_warnings()
+    for w in warnings:
+        print(f"WARNING: {w}")
+    if warnings and not args.force:
+        sys.exit("machine does not look idle; fix the above or pass --force")
+
+    print(f"before={args.before}")
+    print(f"after ={args.after}" + ("  (copy of --before: noise floor)" if args.control else ""))
+    print(f"tool={args.tool} shapes={args.shapes} iterations={args.iterations} reps={args.reps}")
+    print()
+
+    if not args.no_identity:
+        print("checksum identity gate:")
+        if not gate_identity(args, args.shapes):
+            sys.exit("checksums differ — fix that before believing any instruction-count delta")
+        print()
+
+    specs = metric_specs(args.tool)
+    col = " ".join(f"{'before ' + lbl:>14} {'after ' + lbl:>14} {lbl + ' d':>7}" for lbl, _, _ in specs)
+    header = f"{'shape':<20} {col}"
+    print(header)
+    print("-" * len(header))
+    deltas = [[] for _ in specs]
+    try:
+        for shape in args.shapes:
+            before, after = measure(args, shape)
+            row = [shape]
+            for i, (lbl, key, agg) in enumerate(specs):
+                b, a = agg(before, key), agg(after, key)
+                d = (a / b - 1) * 100 if b else float("nan")
+                deltas[i].append(d)
+                row.append(f"{b:>14,.2f} {a:>14,.2f} {d:>+6.1f}%")
+            print(f"{row[0]:<20} " + " ".join(row[1:]))
+            sys.stdout.flush()
+    finally:
+        if control_copy:
+            os.unlink(control_copy)
+
+    print()
+    for (lbl, _, _), ds in zip(specs, deltas):
+        print(f"{lbl} median delta: {statistics.median(ds):+.2f}%   "
+              f"range: {min(ds):+.1f}%..{max(ds):+.1f}%")
+    print()
+    if args.tool == "wallclock":
+        print("Wall-clock only — cannot distinguish layout artifact from real extra work.")
+        print("Use --tool cachegrind/perf on x86 to tell those apart (issue #595).")
+    else:
+        label1 = specs[0][0]
+        rest = "/".join(s[0] for s in specs[1:])
+        print(f"{label1} ~flat + {rest} moving = layout/cache artifact (issue #595's theory).")
+        print(f"{label1} moving with {rest} = real extra work — reopen #64's Step-B decision.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #595. Settles the "layout, not logic" question deferred by #64/CS-Poppy's §5a Verdict in `docs/plan/cspoppy.md`.

Built `valgrind` from source into `~/local` on `terminus` (no root needed — apt requires a password and WSL2 has no `perf` hardware-counter access either) and ran a cachegrind A/B between the commit just before CS-Poppy merged (`becd1b8d`) and the merge commit itself (`09158571`) on all 7 `yaml/block_scalars` shapes:

| shape | Ir Δ (instructions) | I1mr Δ (L1 icache misses) | ILmr Δ (LL misses) |
|---|---|---|---|
| all 7 shapes | flat, **-0.0%** | **+11.8% to +27.7%** | flat, **-0.4% to -0.5%** |

Instructions retired are unchanged — CS-Poppy's `build()` does no extra work on this workload's fixed 7-word/404-bit BP structure — while L1 instruction-cache misses jump 12-28%, closely tracking the original wall-clock regression. LL misses stay flat, so the effect is L1-local. This is the deciding signature #595 asked for: same work, worse cache behavior from a binary code-layout shift, not a real regression in CS-Poppy's select-support logic. Checksums matched exactly between both binaries on every shape (output identity confirmed).

Also surfaced, and reproduced twice, an unrelated finding: the `long_*` block-scalar shapes improved a reproducible 7.4-9.3% on the M4 Pro cross-check — the opposite of a regression, unexplained, out of scope here. Will file as a separate follow-up issue.

- **`examples/block_scalars_harness.rs`** — fixed-iteration `YamlIndex::build` harness for a single `block_scalars` shape (criterion's adaptive timing-based sampling breaks under cachegrind's ~20-50x slowdown).
- **`scripts/perf-ab.py`** — interleaved A/B over `cachegrind`/`perf`/wall-clock, the instructions/cache-miss counterpart to `scripts/ab-cli.py`, same interleave/identity-gate/control-copy rules.
- **`docs/plan/cspoppy.md`** — §5b records the full findings and numbers.

No `src/` changes — this is diagnostic tooling plus a documentation update, zero behavior change.

## Test plan

- [x] `cargo build --release --example block_scalars_harness`
- [x] `cargo clippy --release --example block_scalars_harness --all-features -- -D warnings`
- [x] `cargo clippy --release --example block_scalars_harness --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo fmt --check`
- [x] `python3 -m py_compile scripts/perf-ab.py`
- [x] Cachegrind A/B reproduced on Zen 4 (`terminus`)
- [x] Wall-clock A/B reproduced twice on ARM (`johns-mac-mini`)