### PR TITLE
refactor(jq): dedup @csv/@dsv string-quoting logic

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3999,6 +3999,15 @@ fn format_urid(value: &OwnedValue, optional: bool) -> Result<String, EvalError> 
     }
 }
 
+/// Quote a CSV/DSV string field: wrap in `"..."`, doubling inner `"`.
+///
+/// jq unconditionally double-quotes every string field (inner `"` doubled),
+/// regardless of whether it contains a delimiter — see #306. Shared by
+/// `format_csv` and `format_dsv` so the quoting rule has one definition — see #651.
+fn quote_csv_field(s: &str) -> String {
+    format!("\"{}\"", s.replace('"', "\"\""))
+}
+
 /// @csv - CSV format (for arrays)
 fn format_csv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
     match value {
@@ -4006,10 +4015,7 @@ fn format_csv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
             let parts: Vec<String> = arr
                 .iter()
                 .map(|v| match v {
-                    // jq unconditionally double-quotes every string field
-                    // (inner `"` doubled), regardless of whether it contains a
-                    // delimiter — see #306.
-                    OwnedValue::String(s) => format!("\"{}\"", s.replace('"', "\"\"")),
+                    OwnedValue::String(s) => quote_csv_field(s),
                     OwnedValue::Null => String::new(),
                     other => owned_to_string(other),
                 })
@@ -4051,9 +4057,7 @@ fn format_dsv(value: &OwnedValue, delimiter: &str, optional: bool) -> Result<Str
             let parts: Vec<String> = arr
                 .iter()
                 .map(|v| match v {
-                    // Match @csv: always double-quote string fields (inner `"`
-                    // doubled) so @dsv(",") stays byte-identical to @csv — #306.
-                    OwnedValue::String(s) => format!("\"{}\"", s.replace('"', "\"\"")),
+                    OwnedValue::String(s) => quote_csv_field(s),
                     OwnedValue::Null => String::new(),
                     other => owned_to_string(other),
                 })


### PR DESCRIPTION
## Summary
- `format_csv` and `format_dsv` in `src/jq/eval.rs` duplicated the exact same string-quoting expression verbatim. Extracted it into one shared `quote_csv_field` helper used by both.
- This is the one part of #647 / PR #650 worth keeping. PR #650's byte-scanning rewrite and its performance claims were unverified/fabricated and should not be merged — this PR carries no performance claim and is correctness-neutral (gated on existing tests passing unchanged).

Closes #651

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --features cli,simd,regex,serde` — full suite passes (1986+ tests, 0 failures)
- [x] Manual check: `@csv` and `@dsv(",")` produce identical, correctly-quoted output for strings containing `"`