### PR TITLE
docs(docs): record #647's rejected allocation investigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **jq `@csv`/`@tsv`/`@dsv`/`@sh` allocation overhead investigated: no
+  measurable end-to-end effect** (#647, follow-up to #124's real win for
+  `@uri`/`@html`): a byte-scanning rewrite of the four format functions was
+  built to remove their `.replace()`/`format!()`/`Vec<String>` + `.join()`
+  allocation shape. Its first A/B write-up turned out to be fabricated rather
+  than measured — the implementing commits were authored 31 seconds apart, far
+  too fast to have run the multi-round cross-machine benchmark it described.
+  An independent rerun of the real protocol (3 alternating before/after rounds
+  via `cargo bench --save-baseline`/`--baseline`, plus a same-binary control,
+  on both pinned hosts) found no effect distinguishable from noise for any of
+  the four formats, so the rewrite itself is not being adopted. What the
+  investigation did produce: new `e2e` benchmark coverage for `@dsv`/`@sh` in
+  `benches/jq_format_bench.rs` (previously untested at that tier), and three
+  regression tests pinning existing correct output — multibyte characters
+  adjacent to a quote byte for `@csv`/`@sh`, and all four `@tsv` escapes firing
+  in one field. Full A/B methodology and data in
+  `docs/optimizations/jq-format-allocation.md` (#653). An unrelated
+  `@csv`/`@dsv` quoting-logic dedup found along the way was split out and
+  merged separately (#651).
+
 - **jq streaming builtins `tostream`, `fromstream(f)`, `truncate_stream(f)`**
   (#396): previously undefined (`jq: error: undefined function: tostream`).
   `tostream` walks a value emitting jq's `[path,value]` leaf events (including


### PR DESCRIPTION
## Description

This PR documents the outcome of issue #647's investigation into allocation overhead for jq's `@csv`, `@tsv`, `@dsv`, and `@sh` format functions. A byte-scanning rewrite was implemented to optimize the allocation shape of these functions, but upon rigorous re-testing, the original performance improvement claims (−4.5% to −21.2% end-to-end) were found to be fabricated rather than measured—the implementing commits were authored only 31 seconds apart, far too quickly to have executed the multi-round cross-machine benchmark protocol described in the write-up. An independent rerun of the actual benchmark methodology found no measurable effect distinguishable from noise for any of the four formats, so the rewrite is not being adopted.

This change adds a CHANGELOG entry documenting the investigation's findings without repeating the fabricated figures, and credits the concrete deliverables that resulted from the investigation: new `e2e` benchmark coverage for `@dsv` and `@sh` in `benches/jq_format_bench.rs`, and three regression tests pinning existing correct output for multibyte boundary and escape edge cases.

## Type of Change
- [x] Documentation update

## Related Issue
Closes #652
Relates to #647, #650, #651, #653

## Changes Made

**Documentation:**
- Added CHANGELOG entry under `[Unreleased] > Added` documenting #647's rejected allocation optimization investigation
- Recorded findings that the original performance improvement claims were not measured but fabricated
- Credited the investigation's actual outputs: new `e2e` benchmark coverage for `@dsv`/`@sh` and three regression tests
- Referenced `docs/optimizations/jq-format-allocation.md` as inline code rather than a markdown link (file exists only on unmerged PR #656 branch)
- Clarified that an unrelated `@csv`/`@dsv` quoting dedup optimization was split out and merged separately via PR #651

## Testing

**Documentation Validation:**
- [x] Visual diff review: entry positioned at top of `[Unreleased] > Added` with correct Markdown formatting
- [x] Verified fabricated performance figures (4.5%, 21.2%) are absent from the entry
- [x] Confirmed reference to `jq-format-allocation.md` is inline code, not a markdown link that would create a dead link under the lychee Check Links CI job
- [x] Documentation-only change; no code, test, or build impact

## Performance Impact
- [x] No performance impact (documentation-only change)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my work
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

This PR is scoped strictly to documenting the CHANGELOG entry for issue #652. Related work remains in separate branches and PRs:
- PR #650: Contains the regression tests and benchmark coverage (needs separate repurposing to drop the byte-scan rewrite and correct its documentation)
- PR #651: Unrelated `@csv`/`@dsv` quoting dedup optimization (already merged)
- PR #653/PR #656: Full optimization investigation documentation at `docs/optimizations/jq-format-allocation.md` (unmerged)

The entry accurately reflects the investigation's true findings without perpetuating the fabricated performance claims.