### PR TITLE
test(jq): salvage #650's dsv/sh bench coverage + multi-byte regression tests

### DIFF
--- a/benches/jq_format_bench.rs
+++ b/benches/jq_format_bench.rs
@@ -263,6 +263,8 @@ fn bench_e2e(c: &mut Criterion) {
     const QUERIES: &[(&str, &str)] = &[
         ("csv_records", r".u[] | [.n,.v] | @csv"),
         ("tsv_records", r".u[] | [.n,.v] | @tsv"),
+        ("dsv_records", r#".u[] | [.n,.v] | @dsv("|")"#),
+        ("sh_field", r".u[] | .n | @sh"),
         ("uri_field", r".u[] | .n | @uri"),
         ("html_field", r".u[] | .n | @html"),
         ("json_field", r".u[] | .n | @json"),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21224,10 +21224,47 @@ mod tests {
     }
 
     #[test]
+    fn test_format_csv_multibyte_boundary_647() {
+        // Regression for #647's investigated byte-oriented rewrite of the
+        // quote scan: a multi-byte character directly adjacent to a `"`
+        // byte, in either order, must not attempt an invalid slice.
+        query!(br#"["\u00e9\"b"]"#, "@csv",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "\"é\"\"b\"");
+            }
+        );
+
+        query!(br#"["\"\u00e9"]"#, "@csv",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "\"\"\"é\"");
+            }
+        );
+    }
+
+    #[test]
     fn test_format_tsv() {
         query!(br#"["a", "b", "c"]"#, "@tsv",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "a\tb\tc");
+            }
+        );
+    }
+
+    #[test]
+    fn test_format_tsv_escapes_all_four_chars_647() {
+        // #647's investigated single-pass rewrite replaced four chained
+        // `.replace()` calls; this pins that all four escapes still fire
+        // together, including adjacent escapes with no safe span between
+        // them, regardless of which implementation is in place.
+        query!(br#"["a\\b\tc\nd\re"]"#, "@tsv",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, r"a\\b\tc\nd\re");
+            }
+        );
+
+        query!(br#"["\t\n\r\\"]"#, "@tsv",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, r"\t\n\r\\");
             }
         );
     }
@@ -21334,6 +21371,31 @@ mod tests {
         query!(br#""it's a test""#, "@sh",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "'it'\\''s a test'");
+            }
+        );
+    }
+
+    #[test]
+    fn test_format_sh_multibyte_boundary_647() {
+        // Regression for #647's investigated byte-oriented rewrite of the
+        // quote scan: a multi-byte character directly adjacent to a `'`
+        // byte, in either order, must not attempt an invalid slice.
+        query!(br#""\u00e9'b""#, "@sh",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "'é'\\''b'");
+            }
+        );
+
+        query!(br#""'\u00e9""#, "@sh",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "''\\''é'");
+            }
+        );
+
+        // Array form exercises per-element @sh formatting.
+        query!(br#"["it's", "caf\u00e9", 1, true, null]"#, "@sh",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "'it'\\''s' 'café' 1 true null");
             }
         );
     }


### PR DESCRIPTION
## Summary

#647 investigated eliminating allocation overhead in `@csv`/`@tsv`/`@dsv`/`@sh` (PR #650). An
independent re-measurement found no adoptable end-to-end effect (see #653), so PR #650 is being
**closed without merging** — none of its byte-scan rewrite lands here.

Two pieces from that branch have merit independent of the rewrite and are salvaged in this PR,
verified passing against the current (unchanged) `.replace()`/`format!()`-based implementation:

- `dsv_records`/`sh_field` entries in `benches/jq_format_bench.rs`'s `jq_format/e2e/*` group —
  `@dsv`/`@sh` were missing e2e coverage that `@csv`/`@tsv` already had.
- Three regression tests in `src/jq/eval.rs` pinning multi-byte-boundary output correctness for
  `@csv`/`@sh` and all-four-escape correctness for `@tsv`. These exercise observable behavior
  through the public `query!` macro — no internal helper from PR #650's rewrite is referenced.

No production code changes. Closes #657.

## Test plan

- [x] `cargo test --lib jq::eval::` — 520 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo bench --bench jq_format_bench --no-run` — compiles
- [x] The 3 new regression tests pass against `main`'s existing implementation (not PR #650's
      rewrite), confirming they're implementation-neutral

## Related

- #647 — original investigation issue
- PR #650 — to be closed unmerged; this PR salvages the two reusable pieces from it
- #651 — same salvage pattern, already merged, for the other reusable piece (`@csv`/`@dsv`
  quoting dedup)
- #653 — doc correction recording #647's rejection
- #657 — tracking issue for this salvage