### PR TITLE
feat(bench): SSH-based distributed benchmark orchestration

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -118,6 +118,25 @@ input text, assert it never disagrees with the balanced-parens structure the par
 oracle held across the whole real-workload corpus and all 279 valid YAML-suite cases when #106
 added it, and it catches classes of bug that example-based tests cannot reach.
 
+## Fakes Can't Verify Build-Time/Runtime Feature Agreement
+
+When a test double stands in for "produce an artifact, then invoke it" (cross-compile a binary
+then SSH-exec it, build a plugin then load it), the fake only proves the *orchestration logic* is
+correct — it can't prove the *real artifact* actually has what the invoker assumes. Issue #98's
+`bench sync` cross-compiled its deployed binary with `--features cli`, while `bench orchestrate`
+invoked `bench run <name>` on that binary — a subcommand gated behind `--features bench-runner`
+(`cli` is a strict subset). Every `sync.rs` unit test used a `BuildRunner` fake that returns a
+placeholder file, so none of them could have caught this: the fake never runs a real `cargo build`
+and is never invoked by a real remote exec. The gap stayed invisible until a live run against a
+real node failed at the one thing no fake exercises — running the artifact the real build command
+actually produced.
+
+**How to apply:** for any tool that builds-then-executes across a process/host boundary (cross-
+compilation, plugin loading, container images), budget at least one real end-to-end run before
+trusting it — not just fake-backed unit coverage. Unit tests over `BuildRunner`/`RemoteExec`-style
+abstractions verify scheduling and control flow; they cannot verify that the concrete command line
+used to build something produces something the concrete command line used to invoke it can run.
+
 ## Testing Levels
 
 ### Unit Tests (in-module)

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,13 @@ data/bench/generated/
 # Generated benchmark results
 data/bench/results/
 
+# Distributed orchestration run results (issue #98)
+data/bench/distributed/
+
+# Real nodes.yaml encodes machine-specific hostnames/keys; copy from
+# nodes.yaml.example and keep the real one local-only.
+/nodes.yaml
+
 # Real-workload corpus fetched by scripts/sync-bench-corpus.sh (#301).
 # The committed seed lives in tests/data/bench-corpus/seed/; this is the
 # fetched large tier + seed copies, populated on demand and never committed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,13 @@ sjq --input-dsv ',' '.[] | select(.[0] == "Alice")' data.csv
 ./target/release/succinctly bench run yq_bench
 ./target/release/succinctly dev bench yq --queries all  # M2 streaming comparison (memory collected by default)
 ./target/release/succinctly bench run dsv_bench
+
+# Distributed benchmark orchestration across SSH nodes (issue #98)
+cp nodes.yaml.example nodes.yaml && $EDITOR nodes.yaml  # gitignored, machine-specific
+./target/release/succinctly bench nodes --config nodes.yaml --status
+./target/release/succinctly bench sync --config nodes.yaml
+./target/release/succinctly bench orchestrate --config nodes.yaml --all --dry-run
+./target/release/succinctly bench report --current data/bench/distributed/<run_id> --baseline <prior-run>
 ```
 
 ### Multi-call Aliases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +969,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1021,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
 ]
 
@@ -1061,6 +1081,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ scalar-yaml = []
 # kernel to pay for itself. See `succinctly dev select-stats`.
 select-stats = ["std"]
 
-# Unified benchmark runner (succinctly bench list/run)
-bench-runner = ["cli", "dep:chrono"]
+# Unified benchmark runner (succinctly bench list/run/orchestrate/nodes/sync/report)
+bench-runner = ["cli", "dep:chrono", "dep:serde_yaml"]
 
 [dependencies]
 bytemuck = { version = "1.14", features = ["derive"] }
@@ -87,6 +87,7 @@ serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 md5 = { version = "0.8", optional = true }
 ctrlc = { version = "3.4", optional = true }
 chrono = { version = "0.4", optional = true }
+serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -11,6 +11,7 @@ This guide provides complete information for running, interpreting, and document
 - [Types of Benchmarks](#types-of-benchmarks)
 - [When to Run Benchmarks](#when-to-run-benchmarks)
 - [How to Run Benchmarks](#how-to-run-benchmarks)
+- [Distributed Benchmark Orchestration](#distributed-benchmark-orchestration-issue-98)
 - [A/B Benchmarking Method](#ab-benchmarking-method)
 - [Data Generation](#data-generation)
 - [Platforms and Hardware](#platforms-and-hardware)
@@ -311,6 +312,76 @@ cargo bench -- --sample-size 10
 # Warm-up iterations
 cargo bench -- --warm-up-time 1
 ```
+
+---
+
+## Distributed Benchmark Orchestration (issue #98)
+
+The unified benchmark runner (above) runs benchmarks on one machine. `succinctly bench orchestrate` and its companion commands (`nodes`, `sync`, `report`) automate the manual multi-machine workflow this guide otherwise describes by hand (§ "Building both halves on a remote box", § Platforms and Hardware): define your machines once in `nodes.yaml`, then fan the same `bench run` invocations out across all of them over SSH and compare the results.
+
+Requires the `bench-runner` feature (which now also pulls in `serde_yaml` for config parsing):
+
+```bash
+cargo build --release --features bench-runner
+```
+
+### Setup
+
+```bash
+cp nodes.yaml.example nodes.yaml   # gitignored — encodes your machine-specific hosts/keys
+$EDITOR nodes.yaml                 # fill in real hostnames
+succinctly bench nodes --config nodes.yaml --status
+```
+
+A node's `host` is whatever `ssh` accepts as a destination — a Tailscale MagicDNS name (`user@my-mac-mini.tailnet-name.ts.net`) needs no `ssh_key` (Tailscale handles auth) and no `ec2_*` fields; only EC2-backed nodes need `ec2_instance_id`/`ec2_region` (for `bench nodes --start/--stop`) and typically an explicit `ssh_key`. `host: localhost` (or `127.0.0.1`) runs commands directly with no `ssh` wrapper at all — useful both as the always-available "local" node and for a network-free dry run of the whole pipeline.
+
+### `bench nodes` — status, and EC2 start/stop
+
+```bash
+succinctly bench nodes --config nodes.yaml --status   # default when no flag given
+succinctly bench nodes --config nodes.yaml --start     # start any stopped EC2-backed nodes
+succinctly bench nodes --config nodes.yaml --stop      # stop them again (EC2 instances cost money while running)
+```
+
+`bench orchestrate` never auto-starts a stopped EC2 instance — that's a silent, cost-incurring side effect a user should choose explicitly via `--start`.
+
+### `bench sync` — cross-compile and deploy the release binary
+
+```bash
+succinctly bench sync --config nodes.yaml               # sync every node whose reported --version is stale
+succinctly bench sync --config nodes.yaml --node sydney  # sync just one node
+succinctly bench sync --config nodes.yaml --force        # re-sync even if the version already matches
+```
+
+Cross-compiling for a node requires that target's toolchain already installed locally (`rustup target add aarch64-unknown-linux-gnu`, etc.) — `bench sync` doesn't install it for you. A node's `target_triple` disambiguates cases `arch` alone can't (`aarch64-apple-darwin` vs `aarch64-unknown-linux-gnu` are both `aarch64`).
+
+### `bench orchestrate` — run benchmarks across nodes
+
+```bash
+succinctly bench orchestrate --config nodes.yaml --all --dry-run   # show the planned schedule, touch nothing
+succinctly bench orchestrate --config nodes.yaml --all              # sync (unless --no-sync), then run
+succinctly bench orchestrate --config nodes.yaml --arch aarch64 rank_select yaml_bench
+succinctly bench orchestrate --config nodes.yaml --node sydney --no-sync --collect-only
+```
+
+Each node runs on its own thread; within a node, benchmarks execute in isolation-aware "waves" — every benchmark defaults to `exclusive` (it gets a node to itself, since sharing a CPU while criterion measures wall time skews results), overridable per-name via `nodes.yaml`'s `benchmarks:` list:
+
+```yaml
+benchmarks:
+  - name: rank_select
+    isolation: concurrent   # may share a node's `max_concurrent` slots with other concurrent benchmarks
+```
+
+Results land under `coordinator.results_dir` (default `data/bench/distributed/`) as `<run_id>/<node>/<benchmark>/summary.json` (+ `.jsonl`/`.md` for CLI-type benchmarks), plus a per-node `node_info.json` (arch/features), a flattened `results.jsonl`, and a run-level `metadata.json`.
+
+### `bench report` — compare results across nodes/architectures
+
+```bash
+succinctly bench report --current data/bench/distributed/2026-08-07T12-00-00
+succinctly bench report --current <run> --baseline <prior-run> --threshold 0.10
+```
+
+Purely offline (no `nodes.yaml`, no SSH) — reads the `summary.json`/`node_info.json` files a `bench orchestrate` run already produced and writes `<current>/summary.md` with a per-benchmark node comparison table, a per-architecture average-duration table, and (with `--baseline`) a regression table for anything more than `--threshold` (default 10%) slower than the same benchmark on the same node in the baseline run. `--check` verifies the report file is up to date instead of rewriting it (exits non-zero on drift), for CI.
 
 ---
 

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -333,7 +333,9 @@ $EDITOR nodes.yaml                 # fill in real hostnames
 succinctly bench nodes --config nodes.yaml --status
 ```
 
-A node's `host` is whatever `ssh` accepts as a destination — a Tailscale MagicDNS name (`user@my-mac-mini.tailnet-name.ts.net`) needs no `ssh_key` (Tailscale handles auth) and no `ec2_*` fields; only EC2-backed nodes need `ec2_instance_id`/`ec2_region` (for `bench nodes --start/--stop`) and typically an explicit `ssh_key`. `host: localhost` (or `127.0.0.1`) runs commands directly with no `ssh` wrapper at all — useful both as the always-available "local" node and for a network-free dry run of the whole pipeline.
+A node's `host` is whatever `ssh` accepts as a destination; only EC2-backed nodes need `ec2_instance_id`/`ec2_region` (for `bench nodes --start/--stop`) and typically an explicit `ssh_key`. `host: localhost` (or `127.0.0.1`) runs commands directly with no `ssh` wrapper at all — useful both as the always-available "local" node and for a network-free dry run of the whole pipeline.
+
+**Always spell out the username** (`user@host`), even one that matches your local shell's default. Some SSH access layers (mesh VPNs with per-connection ACLs, bastion proxies) enforce their own username policy independent of key-based auth — an omitted username silently falls back to your local machine's username, which such a layer can reject even though the configured key is completely valid. The failure mode looks like a broken key ("permission denied") but is actually a policy check on the wrong identity; `bench nodes --status` reporting a node `unreachable` despite `ssh` working fine by hand is the tell.
 
 ### `bench nodes` — status, and EC2 start/stop
 
@@ -353,7 +355,9 @@ succinctly bench sync --config nodes.yaml --node sydney  # sync just one node
 succinctly bench sync --config nodes.yaml --force        # re-sync even if the version already matches
 ```
 
-Cross-compiling for a node requires that target's toolchain already installed locally (`rustup target add aarch64-unknown-linux-gnu`, etc.) — `bench sync` doesn't install it for you. A node's `target_triple` disambiguates cases `arch` alone can't (`aarch64-apple-darwin` vs `aarch64-unknown-linux-gnu` are both `aarch64`).
+Cross-compiling for a node requires that target's toolchain already installed locally (`rustup target add aarch64-unknown-linux-gnu`, etc.) **and** a linker that can produce that target's binaries — `rustup target add` alone is not enough for a cross-OS target (e.g. macOS host → Linux target; both being `aarch64` doesn't help, the linker still needs to emit ELF, not Mach-O). `bench sync` doesn't install either for you. A node's `target_triple` disambiguates cases `arch` alone can't (`aarch64-apple-darwin` vs `aarch64-unknown-linux-gnu` are both `aarch64`).
+
+If a working cross-linker isn't set up, skip `bench sync` (`--no-sync`) and build natively on the node instead: install a Rust toolchain there (`curl https://sh.rustup.rs | sh`, plus a C toolchain — e.g. `dnf install gcc` on Amazon Linux, needed by several dependencies' build scripts), copy the source over (`rsync -az --exclude .git --exclude target`), and run `cargo build --release --features bench-runner` directly on the node. `bench orchestrate` only cares that a binary with the `bench-runner` feature ends up at `<working_dir>/target/release/succinctly` — it doesn't care how it got there.
 
 ### `bench orchestrate` — run benchmarks across nodes
 

--- a/nodes.yaml.example
+++ b/nodes.yaml.example
@@ -1,0 +1,58 @@
+# Example configuration for `succinctly bench orchestrate` / `nodes` / `sync`
+# (issue #98). Copy this file to `nodes.yaml` (gitignored) and fill in your
+# own machines — don't commit the real file, it encodes machine-specific
+# hostnames/keys.
+#
+#   cp nodes.yaml.example nodes.yaml
+#   succinctly bench nodes --config nodes.yaml --status
+#   succinctly bench orchestrate --config nodes.yaml --all --dry-run
+
+coordinator:
+  # Where aggregated results are written, one subdirectory per run.
+  results_dir: data/bench/distributed
+
+  # "per-node": each node schedules its own work queue independently.
+  # "global": the coordinator manages one work queue across all nodes.
+  # (Read starting Phase 2's scheduler.)
+  parallelism: per-node
+
+  # Timeout for SSH connectivity checks, in seconds.
+  ssh_timeout: 30
+
+  # Timeout for a single benchmark's execution, in seconds.
+  benchmark_timeout: 3600
+
+nodes:
+  # The local machine: no `ssh` wrapper, commands run directly.
+  - name: local
+    host: localhost
+    arch: x86_64
+    features: [avx2, bmi2]
+    max_concurrent: 2
+
+  # A Tailscale-reachable machine. Tailscale handles auth itself, so no
+  # ssh_key is needed — just the MagicDNS name (or `user@host`).
+  - name: example-arm-mac
+    host: user@example-mac.tailnet-name.ts.net
+    arch: aarch64
+    features: [neon]
+    max_concurrent: 1
+    working_dir: /Users/user/succinctly
+    # Only needed if `arch` alone can't determine the right Rust target
+    # triple for cross-compilation (Phase 3) — e.g. aarch64 spans both
+    # aarch64-apple-darwin and aarch64-unknown-linux-gnu.
+    target_triple: aarch64-apple-darwin
+
+  # An EC2 instance reached over a real SSH key (Phase 4 EC2 start/stop is
+  # optional — omit ec2_instance_id/ec2_region for any node you manage
+  # outside this tool).
+  - name: example-ec2-graviton
+    host: ec2-user@ec2-XX-XX-XX-XX.ap-southeast-2.compute.amazonaws.com
+    arch: aarch64
+    features: [neon, sve2]
+    max_concurrent: 4
+    ssh_key: ~/.ssh/aws-example.pem
+    working_dir: /home/ec2-user/succinctly
+    target_triple: aarch64-unknown-linux-gnu
+    ec2_instance_id: i-0123456789abcdef0
+    ec2_region: ap-southeast-2

--- a/src/bin/succinctly/bench_runner/mod.rs
+++ b/src/bin/succinctly/bench_runner/mod.rs
@@ -4,8 +4,13 @@
 //! with automatic metadata tracking.
 
 mod metadata;
+mod orchestrate;
 mod registry;
 mod runner;
 mod utils;
 
+pub use orchestrate::{
+    run_nodes, run_orchestrate, run_report, run_sync, NodesArgs, OrchestrateArgs, ReportArgs,
+    SyncArgs,
+};
 pub use runner::{run_benchmarks, run_list, ListArgs, RunArgs};

--- a/src/bin/succinctly/bench_runner/orchestrate/aggregate.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/aggregate.rs
@@ -1,0 +1,157 @@
+//! Naive result aggregation for Phase 1: concatenate each node's
+//! per-benchmark `*.jsonl` files into one combined `results.jsonl`, plus a
+//! run-level `metadata.json`. Per-node directories (and their `node_info.json`)
+//! are left in place so Phase 5's `report.rs` can build per-architecture
+//! comparisons directly from them without a schema change here.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Run-level metadata written alongside the aggregated results.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunMetadata {
+    pub run_id: String,
+    pub git_commit: Option<String>,
+    pub config_path: String,
+    pub nodes: Vec<String>,
+    pub benchmarks: Vec<String>,
+    pub started_at: String,
+    pub completed_at: String,
+}
+
+/// Concatenate every node's `*.jsonl` result file under `run_dir` into a
+/// single `results.jsonl`. A node directory that's missing or has no JSONL
+/// files is warned about, not treated as fatal — partial results are still
+/// useful. Each `bench run <name>` invocation gets its own
+/// `<node>/<benchmark>/` subdirectory, so this searches recursively rather
+/// than assuming `*.jsonl` sits directly under the node directory.
+pub fn aggregate_results(run_dir: &Path, node_names: &[String]) -> Result<PathBuf> {
+    let combined_path = run_dir.join("results.jsonl");
+    let mut combined = fs::File::create(&combined_path)
+        .with_context(|| format!("Failed to create {}", combined_path.display()))?;
+
+    for node_name in node_names {
+        let node_dir = run_dir.join(node_name);
+        if !node_dir.is_dir() {
+            eprintln!("Warning: no results directory for node '{node_name}', skipping");
+            continue;
+        }
+
+        let mut jsonl_files = find_files_with_extension(&node_dir, "jsonl");
+        jsonl_files.sort();
+
+        if jsonl_files.is_empty() {
+            eprintln!("Warning: node '{node_name}' produced no .jsonl result files");
+            continue;
+        }
+
+        for path in jsonl_files {
+            let content = fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read {}", path.display()))?;
+            for line in content.lines() {
+                if !line.trim().is_empty() {
+                    writeln!(combined, "{line}")?;
+                }
+            }
+        }
+    }
+
+    Ok(combined_path)
+}
+
+/// Recursively collect every file under `dir` whose extension is `ext`.
+/// An unreadable `dir` yields an empty result rather than an error — callers
+/// treat "no files found" as a normal, warn-worthy condition already.
+pub(crate) fn find_files_with_extension(dir: &Path, ext: &str) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return found;
+    };
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            found.extend(find_files_with_extension(&path, ext));
+        } else if path.extension().and_then(|e| e.to_str()) == Some(ext) {
+            found.push(path);
+        }
+    }
+    found
+}
+
+/// Write the run-level `metadata.json`.
+pub fn write_run_metadata(run_dir: &Path, meta: &RunMetadata) -> Result<PathBuf> {
+    let path = run_dir.join("metadata.json");
+    let json = serde_json::to_string_pretty(meta)?;
+    fs::write(&path, json).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn merges_jsonl_nested_under_per_benchmark_subdirectories() {
+        // Each `bench run <name> --output-dir <node>/<name>/` invocation
+        // writes its .jsonl one level under the node dir, not directly in
+        // it — this is the real shape `collect_node_results` downloads.
+        let dir = tempdir().unwrap();
+        let run_dir = dir.path();
+
+        fs::create_dir_all(run_dir.join("local/rank_select")).unwrap();
+        fs::write(
+            run_dir.join("local/rank_select/rank_select.jsonl"),
+            "{\"a\":1}\n",
+        )
+        .unwrap();
+        fs::create_dir_all(run_dir.join("sydney/rank_select")).unwrap();
+        fs::write(
+            run_dir.join("sydney/rank_select/rank_select.jsonl"),
+            "{\"a\":2}\n\n",
+        )
+        .unwrap();
+
+        let combined =
+            aggregate_results(run_dir, &["local".to_string(), "sydney".to_string()]).unwrap();
+
+        let content = fs::read_to_string(combined).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines, vec!["{\"a\":1}", "{\"a\":2}"]);
+    }
+
+    #[test]
+    fn missing_node_dir_is_skipped_not_fatal() {
+        let dir = tempdir().unwrap();
+        let run_dir = dir.path();
+        fs::create_dir_all(run_dir.join("local")).unwrap();
+        fs::write(run_dir.join("local/a.jsonl"), "{}\n").unwrap();
+
+        let combined =
+            aggregate_results(run_dir, &["local".to_string(), "missing".to_string()]).unwrap();
+
+        let content = fs::read_to_string(combined).unwrap();
+        assert_eq!(content.lines().count(), 1);
+    }
+
+    #[test]
+    fn writes_run_metadata() {
+        let dir = tempdir().unwrap();
+        let meta = RunMetadata {
+            run_id: "2026-01-01T00-00-00".to_string(),
+            git_commit: Some("abc123".to_string()),
+            config_path: "nodes.yaml".to_string(),
+            nodes: vec!["local".to_string()],
+            benchmarks: vec!["rank_select".to_string()],
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            completed_at: "2026-01-01T00:01:00Z".to_string(),
+        };
+        let path = write_run_metadata(dir.path(), &meta).unwrap();
+        let content = fs::read_to_string(path).unwrap();
+        assert!(content.contains("abc123"));
+        assert!(content.contains("rank_select"));
+    }
+}

--- a/src/bin/succinctly/bench_runner/orchestrate/config.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/config.rs
@@ -1,0 +1,304 @@
+//! `nodes.yaml` configuration parsing for distributed benchmark orchestration.
+//!
+//! See `nodes.yaml.example` at the repo root for an annotated template.
+
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Top-level orchestration configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    pub coordinator: CoordinatorConfig,
+    pub nodes: Vec<NodeConfig>,
+    /// Per-benchmark isolation overrides; a name not listed here keeps the
+    /// registry's `default_isolation`. See [`super::scheduler::resolve_isolation`].
+    #[serde(default)]
+    pub benchmarks: Vec<BenchmarkOverride>,
+}
+
+/// Overrides a single benchmark's orchestration isolation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BenchmarkOverride {
+    pub name: String,
+    /// `None` means "no override, inherit the registry default" — distinct
+    /// from an explicit isolation value, so a future override field being
+    /// added to this struct can't silently reset isolation via
+    /// `#[serde(default)]` on a bare (non-`Option`) enum.
+    #[serde(default)]
+    pub isolation: Option<crate::bench_runner::registry::Isolation>,
+}
+
+/// Coordinator-wide settings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoordinatorConfig {
+    pub results_dir: PathBuf,
+    /// Per-node vs. global work queue. Reserved for a future global
+    /// work-stealing scheduler; `scheduler.rs` currently always schedules
+    /// per-node regardless of this setting (`Global` is not yet implemented).
+    #[serde(default)]
+    #[allow(dead_code)] // STYLE-0005: reserved for a future global-queue scheduler
+    pub parallelism: Parallelism,
+    #[serde(default = "default_ssh_timeout")]
+    pub ssh_timeout: u64,
+    #[serde(default = "default_benchmark_timeout")]
+    pub benchmark_timeout: u64,
+}
+
+const fn default_ssh_timeout() -> u64 {
+    30
+}
+
+const fn default_benchmark_timeout() -> u64 {
+    3600
+}
+
+/// How the coordinator schedules work across nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum Parallelism {
+    /// Each node schedules its own work queue independently.
+    #[default]
+    PerNode,
+    /// The coordinator manages one global work queue across all nodes.
+    Global,
+}
+
+/// A single benchmark node (local or SSH-reachable).
+#[derive(Debug, Clone, Deserialize)]
+pub struct NodeConfig {
+    pub name: String,
+    /// SSH destination, e.g. `user@host` or a Tailscale MagicDNS name.
+    /// `localhost`/`127.0.0.1` runs commands directly with no `ssh` wrapper.
+    pub host: String,
+    pub arch: Architecture,
+    /// SIMD/CPU features; informational, recorded in each run's
+    /// `node_info.json` for cross-platform result comparisons.
+    #[serde(default)]
+    pub features: Vec<String>,
+    /// How many benchmarks may run concurrently on this node (enforced
+    /// starting Phase 2's scheduler; Phase 1 always runs sequentially).
+    #[serde(default = "default_max_concurrent")]
+    pub max_concurrent: usize,
+    #[serde(default)]
+    pub ssh_key: Option<PathBuf>,
+    #[serde(default)]
+    pub working_dir: Option<PathBuf>,
+    /// Explicit target triple for cross-compilation, e.g. `aarch64-apple-darwin`
+    /// vs `aarch64-unknown-linux-gnu` — `arch` alone can't disambiguate these.
+    #[serde(default)]
+    pub target_triple: Option<String>,
+    /// EC2 instance ID, if this node is EC2-backed — enables `bench nodes
+    /// --start/--stop` and skips SSH probing a known-stopped instance.
+    #[serde(default)]
+    pub ec2_instance_id: Option<String>,
+    #[serde(default)]
+    pub ec2_region: Option<String>,
+}
+
+const fn default_max_concurrent() -> usize {
+    1
+}
+
+impl NodeConfig {
+    /// True if commands should run directly rather than over `ssh`.
+    pub fn is_local(&self) -> bool {
+        self.host == "localhost" || self.host == "127.0.0.1"
+    }
+
+    /// Remote (or local) working directory to `cd` into before running commands.
+    pub fn working_dir_str(&self) -> &str {
+        self.working_dir
+            .as_deref()
+            .and_then(Path::to_str)
+            .unwrap_or(".")
+    }
+
+    /// `ssh_key` with a leading `~` expanded against `$HOME`.
+    pub fn expanded_ssh_key(&self) -> Option<PathBuf> {
+        self.ssh_key.as_deref().map(expand_tilde)
+    }
+}
+
+/// CPU architecture of a node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum Architecture {
+    #[value(name = "x86_64")]
+    X86_64,
+    #[value(name = "aarch64")]
+    Aarch64,
+}
+
+impl fmt::Display for Architecture {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `f.pad(..)`, not `write!(f, ..)` — the latter ignores width/
+        // alignment specifiers like `{:<10}`, which `nodes.rs`'s status
+        // table relies on.
+        f.pad(match self {
+            Self::X86_64 => "x86_64",
+            Self::Aarch64 => "aarch64",
+        })
+    }
+}
+
+/// Expand a leading `~` (or `~/...`) against `$HOME`. Paths without a leading
+/// `~` are returned unchanged.
+pub fn expand_tilde(path: &Path) -> PathBuf {
+    let Ok(rest) = path.strip_prefix("~") else {
+        return path.to_path_buf();
+    };
+    match std::env::var_os("HOME") {
+        Some(home) => PathBuf::from(home).join(rest),
+        None => path.to_path_buf(),
+    }
+}
+
+impl Config {
+    /// Validate cross-field invariants that `serde` alone can't express:
+    /// non-empty node list, unique names, and (if set) a readable `ssh_key`.
+    pub fn validate(&self) -> Result<()> {
+        if self.nodes.is_empty() {
+            anyhow::bail!("nodes.yaml must define at least one node");
+        }
+
+        let mut seen = HashSet::new();
+        for node in &self.nodes {
+            if !seen.insert(node.name.as_str()) {
+                anyhow::bail!("duplicate node name: '{}'", node.name);
+            }
+            if let Some(key) = node.expanded_ssh_key() {
+                if !key.exists() {
+                    anyhow::bail!("node '{}': ssh_key not found: {}", node.name, key.display());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Load and validate a `nodes.yaml` configuration file.
+pub fn load_config(path: &Path) -> Result<Config> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config file: {}", path.display()))?;
+    let config: Config = serde_yaml::from_str(&text)
+        .with_context(|| format!("Failed to parse YAML config: {}", path.display()))?;
+    config.validate()?;
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_yaml() -> &'static str {
+        r"
+coordinator:
+  results_dir: data/bench/distributed
+nodes:
+  - name: local
+    host: localhost
+    arch: x86_64
+  - name: sydney
+    host: ec2-user@example.com
+    arch: aarch64
+    max_concurrent: 4
+"
+    }
+
+    #[test]
+    fn parses_valid_config_with_defaults() {
+        let config: Config = serde_yaml::from_str(sample_yaml()).unwrap();
+        config.validate().unwrap();
+
+        assert_eq!(config.nodes.len(), 2);
+        assert_eq!(config.coordinator.ssh_timeout, 30);
+        assert_eq!(config.coordinator.benchmark_timeout, 3600);
+        assert_eq!(config.coordinator.parallelism, Parallelism::PerNode);
+        assert_eq!(config.nodes[0].max_concurrent, 1);
+        assert_eq!(config.nodes[1].max_concurrent, 4);
+        assert!(config.nodes[0].is_local());
+        assert!(!config.nodes[1].is_local());
+    }
+
+    #[test]
+    fn rejects_invalid_yaml() {
+        let err = serde_yaml::from_str::<Config>("not: [valid, config").unwrap_err();
+        assert!(!err.to_string().is_empty());
+    }
+
+    #[test]
+    fn rejects_empty_node_list() {
+        let config: Config = serde_yaml::from_str(
+            r"
+coordinator:
+  results_dir: data/bench/distributed
+nodes: []
+",
+        )
+        .unwrap();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("at least one node"));
+    }
+
+    #[test]
+    fn rejects_duplicate_node_names() {
+        let config: Config = serde_yaml::from_str(
+            r"
+coordinator:
+  results_dir: data/bench/distributed
+nodes:
+  - name: dup
+    host: localhost
+    arch: x86_64
+  - name: dup
+    host: localhost
+    arch: aarch64
+",
+        )
+        .unwrap();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("duplicate node name"));
+    }
+
+    #[test]
+    fn rejects_missing_ssh_key() {
+        let config: Config = serde_yaml::from_str(
+            r"
+coordinator:
+  results_dir: data/bench/distributed
+nodes:
+  - name: remote
+    host: example.com
+    arch: aarch64
+    ssh_key: /nonexistent/path/to/key.pem
+",
+        )
+        .unwrap();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("ssh_key not found"));
+    }
+
+    #[test]
+    fn expands_tilde_in_ssh_key() {
+        let node = NodeConfig {
+            name: "n".to_string(),
+            host: "h".to_string(),
+            arch: Architecture::X86_64,
+            features: vec![],
+            max_concurrent: 1,
+            ssh_key: Some(PathBuf::from("~/.ssh/id_rsa")),
+            working_dir: None,
+            target_triple: None,
+            ec2_instance_id: None,
+            ec2_region: None,
+        };
+        let expanded = node.expanded_ssh_key().unwrap();
+        assert!(!expanded.to_string_lossy().starts_with('~'));
+    }
+}

--- a/src/bin/succinctly/bench_runner/orchestrate/executor.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/executor.rs
@@ -1,0 +1,570 @@
+//! Phase 2 orchestration executor: isolation-aware parallel execution across
+//! selected nodes, using `scheduler.rs`'s wave packing.
+//!
+//! Each selected node runs on its own thread (`std::thread::scope`); within
+//! a node, waves run sequentially and the jobs inside a wave run
+//! concurrently, bounded by the node's `max_concurrent`. Result download
+//! and aggregation happen after every node finishes executing.
+
+use super::aggregate::{aggregate_results, write_run_metadata, RunMetadata};
+use super::config::{load_config, Architecture, BenchmarkOverride, Config, NodeConfig};
+use super::scheduler::{schedule_node, Wave};
+use super::ssh::RemoteExec;
+use super::sync::{sync_node, BuildRunner};
+use crate::bench_runner::registry::BenchmarkInfo;
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// `succinctly bench orchestrate` — run benchmarks across configured nodes.
+#[derive(Debug, Parser)]
+pub struct OrchestrateArgs {
+    /// Config file describing nodes and coordinator settings
+    #[arg(short, long, default_value = "nodes.yaml")]
+    pub config: PathBuf,
+
+    /// Run only on specific node(s) (repeatable)
+    #[arg(short = 'n', long = "node")]
+    pub node: Vec<String>,
+
+    /// Run only on nodes with this architecture
+    #[arg(short, long)]
+    pub arch: Option<Architecture>,
+
+    /// Benchmark names to run
+    #[arg(value_name = "BENCHMARKS")]
+    pub benchmarks: Vec<String>,
+
+    /// Run all registered benchmarks
+    #[arg(long)]
+    pub all: bool,
+
+    /// Show what would run without executing anything
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Skip the binary sync step during node preparation
+    #[arg(long)]
+    pub no_sync: bool,
+
+    /// Only collect/aggregate results from a prior run, don't execute
+    #[arg(long)]
+    pub collect_only: bool,
+}
+
+/// Run `bench orchestrate`.
+pub fn run_orchestrate(args: OrchestrateArgs) -> Result<()> {
+    // Ctrl+C registration is process-global and can only succeed once, so it
+    // belongs in this real entry point (invoked once per process) rather
+    // than in `run_orchestrate_with` — tests call that directly, in-process,
+    // multiple times, injecting their own cancellation flag instead.
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let handler_flag = Arc::clone(&cancelled);
+    ctrlc::set_handler(move || {
+        handler_flag.store(true, Ordering::SeqCst);
+        eprintln!("\nInterrupted! Finishing in-flight benchmarks, then stopping...");
+    })
+    .context("Failed to set Ctrl+C handler")?;
+
+    run_orchestrate_with(
+        args,
+        &super::ssh::SystemSsh,
+        &super::sync::SystemBuild,
+        &cancelled,
+    )
+}
+
+/// Testable entry point: takes the [`RemoteExec`]/[`BuildRunner`]
+/// implementations and the cancellation flag as parameters, so unit tests
+/// can inject fakes and a fresh local flag instead of touching global
+/// process state or shelling to real `ssh`/`cargo build`.
+pub(crate) fn run_orchestrate_with(
+    args: OrchestrateArgs,
+    remote: &dyn RemoteExec,
+    build: &dyn BuildRunner,
+    cancelled: &AtomicBool,
+) -> Result<()> {
+    let config = load_config(&args.config)?;
+
+    let nodes = select_nodes(&config, &args);
+    if nodes.is_empty() {
+        anyhow::bail!("No nodes selected. Check --node/--arch against nodes.yaml.");
+    }
+
+    let benchmarks = select_benchmarks(&args);
+    if benchmarks.is_empty() {
+        anyhow::bail!("No benchmarks selected. Use --all or specify benchmark names.");
+    }
+
+    let run_id = run_id_now();
+    let run_dir = config.coordinator.results_dir.join(&run_id);
+
+    if args.dry_run {
+        print_dry_run_plan(&nodes, &benchmarks, &config.benchmarks, &run_dir);
+        return Ok(());
+    }
+
+    let started_at = timestamp_now();
+    std::fs::create_dir_all(&run_dir)
+        .with_context(|| format!("Failed to create {}", run_dir.display()))?;
+
+    if !args.collect_only {
+        let print_lock = Mutex::new(());
+        let ssh_timeout = Duration::from_secs(config.coordinator.ssh_timeout);
+        let no_sync = args.no_sync;
+        std::thread::scope(|scope| {
+            for node in &nodes {
+                let config = &config;
+                let benchmarks = &benchmarks;
+                let run_id = &run_id;
+                let print_lock = &print_lock;
+                scope.spawn(move || {
+                    if !no_sync {
+                        if let Err(e) = sync_node(remote, build, node, false, false, ssh_timeout) {
+                            log(
+                                print_lock,
+                                &format!("Warning: sync to node '{}' failed: {e}", node.name),
+                            );
+                        }
+                    }
+                    if let Err(e) = run_node_scheduled(
+                        remote, config, node, benchmarks, run_id, print_lock, cancelled,
+                    ) {
+                        log(
+                            print_lock,
+                            &format!("Warning: node '{}' failed: {e}", node.name),
+                        );
+                    }
+                });
+            }
+        });
+    }
+
+    for node in &nodes {
+        if let Err(e) = collect_node_results(remote, node, &run_id, &run_dir) {
+            eprintln!(
+                "Warning: failed to collect results from node '{}': {e}",
+                node.name
+            );
+        }
+    }
+
+    let node_names: Vec<String> = nodes.iter().map(|n| n.name.clone()).collect();
+    let benchmark_names: Vec<String> = benchmarks.iter().map(|b| b.name.to_string()).collect();
+    aggregate_results(&run_dir, &node_names)?;
+
+    let meta = RunMetadata {
+        run_id: run_id.clone(),
+        git_commit: crate::bench_runner::metadata::collect_git_info()
+            .ok()
+            .map(|g| g.commit),
+        config_path: args.config.display().to_string(),
+        nodes: node_names,
+        benchmarks: benchmark_names,
+        started_at,
+        completed_at: timestamp_now(),
+    };
+    write_run_metadata(&run_dir, &meta)?;
+
+    eprintln!("Orchestration run complete: {}", run_dir.display());
+    Ok(())
+}
+
+fn run_id_now() -> String {
+    chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string()
+}
+
+fn timestamp_now() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// Select nodes matching `--node`/`--arch`, defaulting to all configured
+/// nodes when neither flag is given.
+fn select_nodes<'a>(config: &'a Config, args: &OrchestrateArgs) -> Vec<&'a NodeConfig> {
+    let mut nodes: Vec<&NodeConfig> = config.nodes.iter().collect();
+    if !args.node.is_empty() {
+        nodes.retain(|n| args.node.contains(&n.name));
+    }
+    if let Some(arch) = args.arch {
+        nodes.retain(|n| n.arch == arch);
+    }
+    nodes
+}
+
+/// Select benchmarks from `--all` or positional args, warning (not failing)
+/// on names not present in the registry.
+fn select_benchmarks(args: &OrchestrateArgs) -> Vec<&'static BenchmarkInfo> {
+    use crate::bench_runner::registry::{filter_by_names, BENCHMARKS};
+
+    if args.all {
+        return BENCHMARKS.iter().collect();
+    }
+
+    if !args.benchmarks.is_empty() {
+        let found = filter_by_names(&args.benchmarks);
+        for name in &args.benchmarks {
+            if !found.iter().any(|b| b.name == name) {
+                eprintln!("Warning: unknown benchmark '{name}'");
+            }
+        }
+        return found;
+    }
+
+    Vec::new()
+}
+
+fn print_dry_run_plan(
+    nodes: &[&NodeConfig],
+    benchmarks: &[&'static BenchmarkInfo],
+    overrides: &[BenchmarkOverride],
+    run_dir: &Path,
+) {
+    println!(
+        "Dry run - would execute {} benchmark(s) across {} node(s):",
+        benchmarks.len(),
+        nodes.len()
+    );
+    for node in nodes {
+        println!(
+            "  {} ({}, {}, max_concurrent={})",
+            node.name, node.arch, node.host, node.max_concurrent
+        );
+        let schedule = schedule_node(node, benchmarks, overrides);
+        for (i, wave) in schedule.waves.iter().enumerate() {
+            let names: Vec<&str> = wave.iter().map(|b| b.name).collect();
+            println!("    wave {}: {}", i + 1, names.join(", "));
+        }
+    }
+    println!("Results would be written under: {}", run_dir.display());
+}
+
+/// Connectivity check, then run each wave of `node`'s schedule in order,
+/// stopping (without erroring) before the next wave if `cancelled` is set.
+/// A single benchmark failing does not stop the rest.
+fn run_node_scheduled(
+    remote: &dyn RemoteExec,
+    config: &Config,
+    node: &NodeConfig,
+    benchmarks: &[&'static BenchmarkInfo],
+    run_id: &str,
+    print_lock: &Mutex<()>,
+    cancelled: &AtomicBool,
+) -> Result<()> {
+    let ssh_timeout = Duration::from_secs(config.coordinator.ssh_timeout);
+    let check = remote
+        .exec(node, "echo ok", ssh_timeout)
+        .with_context(|| format!("connectivity check to node '{}' failed", node.name))?;
+    if !check.success() {
+        anyhow::bail!(
+            "connectivity check to node '{}' failed: {}",
+            node.name,
+            check.stderr
+        );
+    }
+
+    let schedule = schedule_node(node, benchmarks, &config.benchmarks);
+    let benchmark_timeout = Duration::from_secs(config.coordinator.benchmark_timeout);
+    let working_dir = node.working_dir_str();
+
+    for wave in &schedule.waves {
+        if cancelled.load(Ordering::SeqCst) {
+            log(
+                print_lock,
+                &format!("[{}] cancelled, stopping before next wave", node.name),
+            );
+            break;
+        }
+        run_wave(
+            remote,
+            node,
+            wave,
+            run_id,
+            working_dir,
+            benchmark_timeout,
+            print_lock,
+        );
+    }
+
+    Ok(())
+}
+
+/// Run every job in `wave` concurrently, joining before returning.
+fn run_wave(
+    remote: &dyn RemoteExec,
+    node: &NodeConfig,
+    wave: &Wave<'static>,
+    run_id: &str,
+    working_dir: &str,
+    benchmark_timeout: Duration,
+    print_lock: &Mutex<()>,
+) {
+    std::thread::scope(|scope| {
+        for benchmark in wave.iter().copied() {
+            scope.spawn(move || {
+                run_one_benchmark(
+                    remote,
+                    node,
+                    benchmark.name,
+                    run_id,
+                    working_dir,
+                    benchmark_timeout,
+                    print_lock,
+                );
+            });
+        }
+    });
+}
+
+fn run_one_benchmark(
+    remote: &dyn RemoteExec,
+    node: &NodeConfig,
+    name: &str,
+    run_id: &str,
+    working_dir: &str,
+    benchmark_timeout: Duration,
+    print_lock: &Mutex<()>,
+) {
+    let remote_output_dir = format!("/tmp/bench-{run_id}/{name}");
+    let command = format!(
+        "cd {working_dir} && ./target/release/succinctly bench run {name} --output-dir {remote_output_dir}"
+    );
+    log(print_lock, &format!("[{}] running {name}...", node.name));
+    match remote.exec(node, &command, benchmark_timeout) {
+        Ok(result) if result.success() => {
+            log(print_lock, &format!("[{}] {name} OK", node.name));
+        }
+        Ok(result) => {
+            log(
+                print_lock,
+                &format!(
+                    "Warning: benchmark '{name}' failed on node '{}': {}",
+                    node.name, result.stderr
+                ),
+            );
+        }
+        Err(e) => {
+            log(
+                print_lock,
+                &format!(
+                    "Warning: benchmark '{name}' errored on node '{}': {e}",
+                    node.name
+                ),
+            );
+        }
+    }
+}
+
+/// `eprintln!` serialized behind `print_lock` so concurrent node/wave
+/// threads never interleave partial lines.
+fn log(print_lock: &Mutex<()>, message: &str) {
+    let _guard = print_lock.lock().unwrap();
+    eprintln!("{message}");
+}
+
+/// Download a node's results directory, write its `node_info.json`, and
+/// best-effort clean up the remote scratch directory.
+fn collect_node_results(
+    remote: &dyn RemoteExec,
+    node: &NodeConfig,
+    run_id: &str,
+    run_dir: &Path,
+) -> Result<()> {
+    let local_dir = run_dir.join(&node.name);
+    let remote_dir = format!("/tmp/bench-{run_id}");
+    remote.download(node, &remote_dir, &local_dir, Duration::from_secs(30))?;
+
+    std::fs::create_dir_all(&local_dir)
+        .with_context(|| format!("Failed to create {}", local_dir.display()))?;
+    let info = serde_json::json!({
+        "name": node.name,
+        "host": node.host,
+        "arch": node.arch,
+        "features": node.features,
+    });
+    std::fs::write(
+        local_dir.join("node_info.json"),
+        serde_json::to_string_pretty(&info)?,
+    )
+    .with_context(|| format!("Failed to write {}/node_info.json", local_dir.display()))?;
+
+    // Best-effort: a failed cleanup shouldn't fail the whole collection step.
+    let _ = remote.exec(
+        node,
+        &format!("rm -rf {remote_dir}"),
+        Duration::from_secs(30),
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{FakeBuild, FakeExec};
+    use super::*;
+
+    fn args(config: PathBuf, extra: &[&str]) -> OrchestrateArgs {
+        let mut argv = vec!["orchestrate", "--config"];
+        let config_str = config.to_str().unwrap().to_string();
+        argv.push(&config_str);
+        argv.extend_from_slice(extra);
+        OrchestrateArgs::try_parse_from(argv).unwrap()
+    }
+
+    fn write_config(dir: &Path, yaml: &str) -> PathBuf {
+        let path = dir.join("nodes.yaml");
+        std::fs::write(&path, yaml).unwrap();
+        path
+    }
+
+    fn run(parsed: OrchestrateArgs, remote: &dyn RemoteExec) -> Result<()> {
+        run_orchestrate_with(parsed, remote, &FakeBuild::new(), &AtomicBool::new(false))
+    }
+
+    const TWO_NODE_YAML: &str = r"
+coordinator:
+  results_dir: data/bench/distributed
+nodes:
+  - name: local
+    host: localhost
+    arch: x86_64
+  - name: sydney
+    host: sydney.example.com
+    arch: aarch64
+";
+
+    #[test]
+    fn select_nodes_filters_by_name_and_arch() {
+        let config: Config = serde_yaml::from_str(TWO_NODE_YAML).unwrap();
+
+        let a = OrchestrateArgs {
+            config: PathBuf::new(),
+            node: vec!["sydney".to_string()],
+            arch: None,
+            benchmarks: vec![],
+            all: false,
+            dry_run: false,
+            no_sync: false,
+            collect_only: false,
+        };
+        assert_eq!(select_nodes(&config, &a).len(), 1);
+
+        let b = OrchestrateArgs {
+            config: PathBuf::new(),
+            node: vec![],
+            arch: Some(Architecture::Aarch64),
+            benchmarks: vec![],
+            all: false,
+            dry_run: false,
+            no_sync: false,
+            collect_only: false,
+        };
+        let filtered = select_nodes(&config, &b);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "sydney");
+    }
+
+    #[test]
+    fn dry_run_never_calls_exec() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config(dir.path(), TWO_NODE_YAML);
+        let parsed = args(config_path, &["--all", "--dry-run"]);
+
+        let fake = FakeExec::new();
+        run(parsed, &fake).unwrap();
+
+        assert!(fake.calls().is_empty());
+    }
+
+    #[test]
+    fn sequential_run_executes_each_selected_benchmark() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "coordinator:\n  results_dir: {}\nnodes:\n  - name: local\n    host: localhost\n    arch: x86_64\n",
+            dir.path().join("results").display()
+        );
+        let config_path = write_config(dir.path(), &yaml);
+        let parsed = args(config_path, &["rank_select"]);
+
+        let fake = FakeExec::new();
+        run(parsed, &fake).unwrap();
+
+        let calls = fake.calls();
+        // connectivity check + 1 benchmark + cleanup = 3 exec calls
+        assert_eq!(calls.len(), 3);
+        assert!(calls[0].1.contains("echo ok"));
+        assert!(calls[1].1.contains("bench run rank_select"));
+        assert!(calls[2].1.contains("rm -rf"));
+    }
+
+    #[test]
+    fn one_node_failure_does_not_abort_others() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "coordinator:\n  results_dir: {}\nnodes:\n  - name: bad\n    host: unreachable.example.com\n    arch: x86_64\n  - name: local\n    host: localhost\n    arch: x86_64\n",
+            dir.path().join("results").display()
+        );
+        let config_path = write_config(dir.path(), &yaml);
+        let parsed = args(config_path, &["rank_select"]);
+
+        let fake = FakeExec::new().fail_connectivity_check("bad");
+        // Should not error even though node 'bad' fails its connectivity check.
+        run(parsed, &fake).unwrap();
+
+        let calls = fake.calls();
+        assert!(calls
+            .iter()
+            .any(|(node, cmd)| node == "local" && cmd.contains("bench run")));
+    }
+
+    #[test]
+    fn max_concurrency_is_respected_across_concurrent_benchmarks() {
+        // rank_select/balanced_parens/bp_select_micro/elias_fano are all
+        // Core-category, registry-default Exclusive — override them all to
+        // Concurrent so this test observes real parallelism.
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "coordinator:\n  results_dir: {}\nnodes:\n  - name: local\n    host: localhost\n    arch: x86_64\n    max_concurrent: 2\nbenchmarks:\n  - name: rank_select\n    isolation: concurrent\n  - name: balanced_parens\n    isolation: concurrent\n  - name: bp_select_micro\n    isolation: concurrent\n  - name: elias_fano\n    isolation: concurrent\n",
+            dir.path().join("results").display()
+        );
+        let config_path = write_config(dir.path(), &yaml);
+        let parsed = args(
+            config_path,
+            &[
+                "rank_select",
+                "balanced_parens",
+                "bp_select_micro",
+                "elias_fano",
+            ],
+        );
+
+        let fake = FakeExec::new();
+        run(parsed, &fake).unwrap();
+
+        assert!(fake.max_concurrent_seen() >= 2);
+        assert!(fake.max_concurrent_seen() <= 2);
+    }
+
+    #[test]
+    fn exclusive_benchmarks_never_overlap_on_the_same_node() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "coordinator:\n  results_dir: {}\nnodes:\n  - name: local\n    host: localhost\n    arch: x86_64\n    max_concurrent: 4\n",
+            dir.path().join("results").display()
+        );
+        let config_path = write_config(dir.path(), &yaml);
+        // All default to Exclusive in the registry: run several at once and
+        // confirm we never observe more than 1 concurrent exec call, aside
+        // from the fact that the connectivity check + cleanup are also
+        // `exec` calls (but those never overlap benchmark execution either,
+        // since they're outside the wave loop).
+        let parsed = args(config_path, &["rank_select", "balanced_parens"]);
+
+        let fake = FakeExec::new();
+        run(parsed, &fake).unwrap();
+
+        assert_eq!(fake.max_concurrent_seen(), 1);
+    }
+}

--- a/src/bin/succinctly/bench_runner/orchestrate/mod.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/mod.rs
@@ -1,0 +1,23 @@
+//! SSH-based distributed benchmark orchestration (issue #98).
+//!
+//! Extends the unified benchmark runner (`bench_runner::{list,run}`) with
+//! commands that fan the existing benchmark suite out across multiple
+//! SSH-reachable nodes and aggregate the results. See `nodes.yaml.example`
+//! at the repo root for the configuration format.
+
+mod aggregate;
+mod config;
+mod executor;
+mod nodes;
+mod report;
+mod scheduler;
+mod ssh;
+mod sync;
+
+#[cfg(test)]
+mod test_support;
+
+pub use executor::{run_orchestrate, OrchestrateArgs};
+pub use nodes::{run_nodes, NodesArgs};
+pub use report::{run_report, ReportArgs};
+pub use sync::{run_sync, SyncArgs};

--- a/src/bin/succinctly/bench_runner/orchestrate/nodes.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/nodes.rs
@@ -1,0 +1,336 @@
+//! Node status and EC2 lifecycle management (Phase 4, issue #98).
+//!
+//! `bench nodes` reports each configured node's reachability (and, for
+//! EC2-backed nodes, instance state), and can start/stop those instances.
+//! AWS CLI invocation is a distinct local side effect from SSH exec, so it
+//! gets its own thin [`Ec2Control`] abstraction — the same
+//! dependency-injection shape as `sync.rs`'s `BuildRunner`.
+//!
+//! `bench orchestrate` deliberately does **not** auto-start a stopped EC2
+//! node — that's a silent, cost-incurring side effect a user should choose
+//! explicitly via `bench nodes --start`.
+
+use super::config::{load_config, Config, NodeConfig};
+use super::ssh::RemoteExec;
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+/// `succinctly bench nodes` — report node status, or start/stop EC2 instances.
+#[derive(Debug, Parser)]
+pub struct NodesArgs {
+    /// Config file describing nodes and coordinator settings
+    #[arg(short, long, default_value = "nodes.yaml")]
+    pub config: PathBuf,
+
+    /// Start any stopped EC2 instances among the configured nodes
+    #[arg(long)]
+    pub start: bool,
+
+    /// Stop any running EC2 instances among the configured nodes
+    #[arg(long)]
+    pub stop: bool,
+
+    /// Show detailed node status (the default when no flag is given)
+    #[arg(long)]
+    pub status: bool,
+}
+
+/// Run `bench nodes`.
+pub fn run_nodes(args: NodesArgs) -> Result<()> {
+    run_nodes_with(args, &super::ssh::SystemSsh, &SystemAwsCli)
+}
+
+pub(crate) fn run_nodes_with(
+    args: NodesArgs,
+    remote: &dyn RemoteExec,
+    ec2: &dyn Ec2Control,
+) -> Result<()> {
+    let config = load_config(&args.config)?;
+
+    if args.start {
+        for_each_ec2_node(&config, ec2, "starting", &|ec2, id, region| {
+            ec2.start(id, region)
+        });
+        return Ok(());
+    }
+
+    if args.stop {
+        for_each_ec2_node(&config, ec2, "stopping", &|ec2, id, region| {
+            ec2.stop(id, region)
+        });
+        return Ok(());
+    }
+
+    print_status_table(&config, remote, ec2);
+    Ok(())
+}
+
+fn for_each_ec2_node(
+    config: &Config,
+    ec2: &dyn Ec2Control,
+    verb: &str,
+    action: &dyn Fn(&dyn Ec2Control, &str, &str) -> Result<()>,
+) {
+    let mut acted = false;
+    for node in &config.nodes {
+        if let Some(id) = &node.ec2_instance_id {
+            acted = true;
+            let region = node.ec2_region.as_deref().unwrap_or_default();
+            eprintln!("[{}] {verb} EC2 instance {id}...", node.name);
+            if let Err(e) = action(ec2, id, region) {
+                eprintln!("Warning: failed to {verb} node '{}': {e}", node.name);
+            }
+        }
+    }
+    if !acted {
+        eprintln!("No EC2-backed nodes (with ec2_instance_id) in this config.");
+    }
+}
+
+fn print_status_table(config: &Config, remote: &dyn RemoteExec, ec2: &dyn Ec2Control) {
+    println!("{:<20} {:<10} {:<12} HOST", "NAME", "ARCH", "STATUS");
+    println!("{:-<20} {:-<10} {:-<12} {:-<20}", "", "", "", "");
+    for node in &config.nodes {
+        let status = node_status(node, remote, ec2);
+        println!(
+            "{:<20} {:<10} {:<12} {}",
+            node.name, node.arch, status, node.host
+        );
+    }
+}
+
+fn node_status(node: &NodeConfig, remote: &dyn RemoteExec, ec2: &dyn Ec2Control) -> String {
+    if let Some(id) = &node.ec2_instance_id {
+        let region = node.ec2_region.as_deref().unwrap_or_default();
+        match ec2.describe(id, region) {
+            Ok(Ec2State::Stopped) => return "stopped".to_string(),
+            Ok(Ec2State::Other(state)) => return state,
+            Ok(Ec2State::Running) => {} // fall through to an SSH reachability check
+            Err(_) => return "unknown".to_string(),
+        }
+    }
+
+    if node.is_local() {
+        return "ready".to_string();
+    }
+
+    match remote.exec(node, "echo ok", Duration::from_secs(5)) {
+        Ok(out) if out.success() => "ready".to_string(),
+        _ => "unreachable".to_string(),
+    }
+}
+
+/// An EC2 instance's reported state, collapsed to the cases this tool acts
+/// on (`Running`/`Stopped`) plus a catch-all for AWS's other states
+/// (`pending`, `stopping`, `terminated`, …), surfaced verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Ec2State {
+    Running,
+    Stopped,
+    Other(String),
+}
+
+/// Abstraction over AWS EC2 instance control — the local (non-`RemoteExec`,
+/// non-`BuildRunner`) side effect specific to `bench nodes`. `SystemAwsCli`
+/// shells to the real `aws` CLI; tests use an in-memory fake instead.
+pub trait Ec2Control: Send + Sync {
+    fn describe(&self, instance_id: &str, region: &str) -> Result<Ec2State>;
+    fn start(&self, instance_id: &str, region: &str) -> Result<()>;
+    fn stop(&self, instance_id: &str, region: &str) -> Result<()>;
+}
+
+/// Real implementation: shells to the system `aws` CLI. Requires the AWS
+/// CLI to be installed and configured with credentials for `region` — a
+/// documented precondition, not something this tool sets up.
+pub struct SystemAwsCli;
+
+impl Ec2Control for SystemAwsCli {
+    fn describe(&self, instance_id: &str, region: &str) -> Result<Ec2State> {
+        let output = Command::new("aws")
+            .args([
+                "ec2",
+                "describe-instances",
+                "--instance-ids",
+                instance_id,
+                "--region",
+                region,
+                "--query",
+                "Reservations[0].Instances[0].State.Name",
+                "--output",
+                "text",
+            ])
+            .output()
+            .context("failed to spawn aws ec2 describe-instances")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "aws ec2 describe-instances failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(match state.as_str() {
+            "running" => Ec2State::Running,
+            "stopped" => Ec2State::Stopped,
+            other => Ec2State::Other(other.to_string()),
+        })
+    }
+
+    fn start(&self, instance_id: &str, region: &str) -> Result<()> {
+        run_aws_ec2(&[
+            "start-instances",
+            "--instance-ids",
+            instance_id,
+            "--region",
+            region,
+        ])
+    }
+
+    fn stop(&self, instance_id: &str, region: &str) -> Result<()> {
+        run_aws_ec2(&[
+            "stop-instances",
+            "--instance-ids",
+            instance_id,
+            "--region",
+            region,
+        ])
+    }
+}
+
+fn run_aws_ec2(args: &[&str]) -> Result<()> {
+    let mut full_args = vec!["ec2"];
+    full_args.extend_from_slice(args);
+    let output = Command::new("aws")
+        .args(&full_args)
+        .output()
+        .context("failed to spawn aws ec2")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "aws {}: {}",
+            full_args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::config::Architecture;
+    use super::super::test_support::{FakeAwsCli, FakeExec};
+    use super::*;
+
+    fn config_yaml() -> &'static str {
+        r"
+coordinator:
+  results_dir: data/bench/distributed
+nodes:
+  - name: local
+    host: localhost
+    arch: x86_64
+  - name: tailscale-node
+    host: user@example.ts.net
+    arch: aarch64
+  - name: ec2-node
+    host: ec2-user@example.com
+    arch: aarch64
+    ec2_instance_id: i-0123456789abcdef0
+    ec2_region: us-east-1
+"
+    }
+
+    fn args(config: PathBuf, extra: &[&str]) -> NodesArgs {
+        let mut argv = vec!["nodes", "--config"];
+        let config_str = config.to_str().unwrap().to_string();
+        argv.push(&config_str);
+        argv.extend_from_slice(extra);
+        NodesArgs::try_parse_from(argv).unwrap()
+    }
+
+    fn write_config(dir: &std::path::Path, yaml: &str) -> PathBuf {
+        let path = dir.join("nodes.yaml");
+        std::fs::write(&path, yaml).unwrap();
+        path
+    }
+
+    #[test]
+    fn start_only_acts_on_ec2_backed_nodes() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config(dir.path(), config_yaml());
+        let parsed = args(config_path, &["--start"]);
+
+        let ec2 = FakeAwsCli::new();
+        run_nodes_with(parsed, &FakeExec::new(), &ec2).unwrap();
+
+        assert_eq!(ec2.start_calls(), vec!["i-0123456789abcdef0".to_string()]);
+        assert!(ec2.stop_calls().is_empty());
+    }
+
+    #[test]
+    fn stop_only_acts_on_ec2_backed_nodes() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config(dir.path(), config_yaml());
+        let parsed = args(config_path, &["--stop"]);
+
+        let ec2 = FakeAwsCli::new();
+        run_nodes_with(parsed, &FakeExec::new(), &ec2).unwrap();
+
+        assert_eq!(ec2.stop_calls(), vec!["i-0123456789abcdef0".to_string()]);
+        assert!(ec2.start_calls().is_empty());
+    }
+
+    #[test]
+    fn status_reports_stopped_for_stopped_ec2_node_without_ssh_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config(dir.path(), config_yaml());
+        let parsed = args(config_path, &["--status"]);
+
+        let ec2 = FakeAwsCli::new().set_state("i-0123456789abcdef0", Ec2State::Stopped);
+        let remote = FakeExec::new();
+        run_nodes_with(parsed, &remote, &ec2).unwrap();
+
+        // A stopped instance must never be SSH-probed.
+        assert!(!remote.calls().iter().any(|(n, _)| n == "ec2-node"));
+    }
+
+    #[test]
+    fn status_probes_ssh_for_non_ec2_remote_nodes() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config(dir.path(), config_yaml());
+        let parsed = args(config_path, &["--status"]);
+
+        let ec2 = FakeAwsCli::new().set_state("i-0123456789abcdef0", Ec2State::Running);
+        let remote = FakeExec::new();
+        run_nodes_with(parsed, &remote, &ec2).unwrap();
+
+        assert!(remote
+            .calls()
+            .iter()
+            .any(|(n, cmd)| n == "tailscale-node" && cmd.contains("echo ok")));
+        // Local nodes are always "ready" without an SSH round-trip.
+        assert!(!remote.calls().iter().any(|(n, _)| n == "local"));
+    }
+
+    #[test]
+    fn node_status_local_is_always_ready() {
+        let node = NodeConfig {
+            name: "local".to_string(),
+            host: "localhost".to_string(),
+            arch: Architecture::X86_64,
+            features: vec![],
+            max_concurrent: 1,
+            ssh_key: None,
+            working_dir: None,
+            target_triple: None,
+            ec2_instance_id: None,
+            ec2_region: None,
+        };
+        assert_eq!(
+            node_status(&node, &FakeExec::new(), &FakeAwsCli::new()),
+            "ready"
+        );
+    }
+}

--- a/src/bin/succinctly/bench_runner/orchestrate/report.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/report.rs
@@ -1,0 +1,452 @@
+//! Cross-node/cross-architecture reporting (Phase 5, issue #98).
+//!
+//! Pure, SSH-free, offline: reads the `summary.json` each `bench run`
+//! invocation already writes under `<run_dir>/<node>/<benchmark>/`, plus
+//! each node's `node_info.json` (for `arch`), and builds a markdown report
+//! comparing benchmarks across nodes and architectures. Optionally flags
+//! regressions against a prior run of the same shape via `--baseline`.
+//! Deliberately separate from `aggregate.rs`: aggregation is a step inside
+//! `bench orchestrate`'s SSH-driven run; reporting needs neither `nodes.yaml`
+//! nor SSH, so it's its own standalone `bench report` subcommand.
+
+use super::config::Architecture;
+use crate::bench_runner::runner::RunSummary;
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// `succinctly bench report` — compare orchestrated benchmark results
+/// across nodes/architectures, optionally against a prior baseline run.
+#[derive(Debug, Parser)]
+pub struct ReportArgs {
+    /// Run directory to report on (e.g. data/bench/distributed/<run_id>)
+    #[arg(short = 'c', long = "current")]
+    pub current: PathBuf,
+
+    /// A prior run directory of the same shape, to flag regressions against
+    #[arg(short, long)]
+    pub baseline: Option<PathBuf>,
+
+    /// Regression threshold as a fraction (0.10 = flag anything >10% slower)
+    #[arg(long, default_value_t = 0.10)]
+    pub threshold: f64,
+
+    /// Where to write the markdown report (default: <current>/summary.md)
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+
+    /// Check the report matches the file at the output path instead of
+    /// writing it (exits non-zero on mismatch or if the file is missing)
+    #[arg(long)]
+    pub check: bool,
+}
+
+/// Run `bench report`.
+pub fn run_report(args: ReportArgs) -> Result<()> {
+    let current = collect_runs(&args.current)
+        .with_context(|| format!("Failed to collect results from {}", args.current.display()))?;
+    if current.is_empty() {
+        anyhow::bail!(
+            "No summary.json files found under {}",
+            args.current.display()
+        );
+    }
+
+    let baseline = args.baseline.as_deref().map(collect_runs).transpose()?;
+    let report = render_report(&current, baseline.as_deref(), args.threshold);
+
+    let output_path = args
+        .output
+        .clone()
+        .unwrap_or_else(|| args.current.join("summary.md"));
+
+    if args.check {
+        let existing = fs::read_to_string(&output_path)
+            .with_context(|| format!("Failed to read {}", output_path.display()))?;
+        if existing != report {
+            anyhow::bail!(
+                "{} is out of date; run `bench report` (without --check) to regenerate",
+                output_path.display()
+            );
+        }
+        eprintln!("{} is up to date", output_path.display());
+        return Ok(());
+    }
+
+    fs::write(&output_path, &report)
+        .with_context(|| format!("Failed to write {}", output_path.display()))?;
+    eprintln!("Wrote {}", output_path.display());
+    Ok(())
+}
+
+/// One benchmark's result on one node, joined with that node's architecture.
+#[derive(Debug, Clone)]
+struct BenchmarkRun {
+    node: String,
+    arch: Option<Architecture>,
+    benchmark: String,
+    duration_seconds: f64,
+    success: bool,
+}
+
+#[derive(Deserialize)]
+struct NodeInfo {
+    #[serde(default)]
+    arch: Option<Architecture>,
+}
+
+/// Walk `run_dir`'s immediate node subdirectories, reading each one's
+/// `node_info.json` (for `arch`) and every `summary.json` found underneath
+/// (recursively — one per `bench run <name>` invocation).
+fn collect_runs(run_dir: &Path) -> Result<Vec<BenchmarkRun>> {
+    let mut runs = Vec::new();
+    let entries =
+        fs::read_dir(run_dir).with_context(|| format!("Failed to read {}", run_dir.display()))?;
+
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue; // skip results.jsonl / metadata.json / summary.md
+        }
+        let node_dir = entry.path();
+        let node_name = entry.file_name().to_string_lossy().to_string();
+
+        let arch = fs::read_to_string(node_dir.join("node_info.json"))
+            .ok()
+            .and_then(|text| serde_json::from_str::<NodeInfo>(&text).ok())
+            .and_then(|info| info.arch);
+
+        for summary_path in find_files_named(&node_dir, "summary.json") {
+            let text = fs::read_to_string(&summary_path)
+                .with_context(|| format!("Failed to read {}", summary_path.display()))?;
+            let summary: RunSummary = serde_json::from_str(&text)
+                .with_context(|| format!("Failed to parse {}", summary_path.display()))?;
+            for result in summary.results {
+                runs.push(BenchmarkRun {
+                    node: node_name.clone(),
+                    arch,
+                    benchmark: result.name,
+                    duration_seconds: result.duration_seconds,
+                    success: result.success,
+                });
+            }
+        }
+    }
+
+    Ok(runs)
+}
+
+/// Recursively collect every file under `dir` named exactly `filename`.
+fn find_files_named(dir: &Path, filename: &str) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return found;
+    };
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            found.extend(find_files_named(&path, filename));
+        } else if path.file_name().and_then(|n| n.to_str()) == Some(filename) {
+            found.push(path);
+        }
+    }
+    found
+}
+
+fn render_report(
+    current: &[BenchmarkRun],
+    baseline: Option<&[BenchmarkRun]>,
+    threshold: f64,
+) -> String {
+    let mut out = String::from("# Orchestrated Benchmark Report\n\n");
+    render_per_benchmark_table(&mut out, current);
+    render_per_arch_table(&mut out, current);
+    if let Some(baseline) = baseline {
+        render_regressions(&mut out, current, baseline, threshold);
+    }
+    out
+}
+
+fn sorted_unique_nodes(runs: &[BenchmarkRun]) -> Vec<&str> {
+    let mut nodes: Vec<&str> = runs.iter().map(|r| r.node.as_str()).collect();
+    nodes.sort_unstable();
+    nodes.dedup();
+    nodes
+}
+
+fn render_per_benchmark_table(out: &mut String, runs: &[BenchmarkRun]) {
+    out.push_str("## Per-Benchmark Comparison\n\n");
+
+    let mut by_benchmark: BTreeMap<&str, Vec<&BenchmarkRun>> = BTreeMap::new();
+    for run in runs {
+        by_benchmark
+            .entry(run.benchmark.as_str())
+            .or_default()
+            .push(run);
+    }
+    let nodes = sorted_unique_nodes(runs);
+
+    out.push_str("| Benchmark |");
+    for node in &nodes {
+        out.push_str(&format!(" {node} |"));
+    }
+    out.push_str("\n|---|");
+    for _ in &nodes {
+        out.push_str("---|");
+    }
+    out.push('\n');
+
+    for (benchmark, entries) in &by_benchmark {
+        out.push_str(&format!("| {benchmark} |"));
+        for node in &nodes {
+            match entries.iter().find(|r| r.node == *node) {
+                Some(r) if r.success => out.push_str(&format!(" {:.3}s |", r.duration_seconds)),
+                Some(_) => out.push_str(" FAILED |"),
+                None => out.push_str(" - |"),
+            }
+        }
+        out.push('\n');
+    }
+    out.push('\n');
+}
+
+fn render_per_arch_table(out: &mut String, runs: &[BenchmarkRun]) {
+    out.push_str("## Per-Architecture Average Duration\n\n");
+    out.push_str("| Architecture | Avg Duration (s) | Benchmarks |\n|---|---|---|\n");
+
+    let mut by_arch: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    for run in runs.iter().filter(|r| r.success) {
+        let key = run
+            .arch
+            .map_or_else(|| "unknown".to_string(), |a| a.to_string());
+        by_arch.entry(key).or_default().push(run.duration_seconds);
+    }
+
+    for (arch, durations) in &by_arch {
+        let avg = durations.iter().sum::<f64>() / durations.len() as f64;
+        out.push_str(&format!("| {arch} | {avg:.3} | {} |\n", durations.len()));
+    }
+    out.push('\n');
+}
+
+fn render_regressions(
+    out: &mut String,
+    current: &[BenchmarkRun],
+    baseline: &[BenchmarkRun],
+    threshold: f64,
+) {
+    out.push_str(&format!(
+        "## Regressions (> {:.0}% slower than baseline)\n\n",
+        threshold * 100.0
+    ));
+
+    let mut flagged = Vec::new();
+    for cur in current.iter().filter(|r| r.success) {
+        let Some(base) = baseline
+            .iter()
+            .find(|b| b.success && b.node == cur.node && b.benchmark == cur.benchmark)
+        else {
+            continue;
+        };
+        if base.duration_seconds <= 0.0 {
+            continue;
+        }
+        let change = (cur.duration_seconds - base.duration_seconds) / base.duration_seconds;
+        if change > threshold {
+            flagged.push((
+                &cur.node,
+                &cur.benchmark,
+                base.duration_seconds,
+                cur.duration_seconds,
+                change,
+            ));
+        }
+    }
+
+    if flagged.is_empty() {
+        out.push_str("No regressions detected.\n\n");
+        return;
+    }
+
+    out.push_str(
+        "| Node | Benchmark | Baseline (s) | Current (s) | Change |\n|---|---|---|---|---|\n",
+    );
+    for (node, benchmark, base, cur, change) in flagged {
+        out.push_str(&format!(
+            "| {node} | {benchmark} | {base:.3} | {cur:.3} | +{:.1}% |\n",
+            change * 100.0
+        ));
+    }
+    out.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bench_runner::runner::BenchmarkResult;
+    use tempfile::tempdir;
+
+    fn write_summary(dir: &Path, node: &str, benchmark: &str, duration: f64, success: bool) {
+        let out_dir = dir.join(node).join(benchmark);
+        fs::create_dir_all(&out_dir).unwrap();
+        let summary = RunSummary {
+            metadata: None,
+            results: vec![BenchmarkResult {
+                name: benchmark.to_string(),
+                category: "core".to_string(),
+                bench_type: "criterion".to_string(),
+                success,
+                duration_seconds: duration,
+                exit_code: Some(i32::from(!success)),
+                error_message: None,
+            }],
+            total_duration_seconds: duration,
+            passed: usize::from(success),
+            failed: usize::from(!success),
+            skipped: 0,
+        };
+        fs::write(
+            out_dir.join("summary.json"),
+            serde_json::to_string(&summary).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn write_node_info(dir: &Path, node: &str, arch: Architecture) {
+        fs::write(
+            dir.join(node).join("node_info.json"),
+            format!(r#"{{"name":"{node}","arch":"{arch}"}}"#),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn collects_nested_summaries_and_joins_arch() {
+        let dir = tempdir().unwrap();
+        write_summary(dir.path(), "local", "rank_select", 1.5, true);
+        write_node_info(dir.path(), "local", Architecture::X86_64);
+
+        let runs = collect_runs(dir.path()).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].node, "local");
+        assert_eq!(runs[0].benchmark, "rank_select");
+        assert_eq!(runs[0].arch, Some(Architecture::X86_64));
+    }
+
+    #[test]
+    fn per_benchmark_table_lists_all_nodes_even_when_missing() {
+        let dir = tempdir().unwrap();
+        write_summary(dir.path(), "local", "rank_select", 1.0, true);
+        write_node_info(dir.path(), "local", Architecture::X86_64);
+        write_summary(dir.path(), "sydney", "yaml_bench", 2.0, true);
+        write_node_info(dir.path(), "sydney", Architecture::Aarch64);
+
+        let runs = collect_runs(dir.path()).unwrap();
+        let report = render_report(&runs, None, 0.10);
+
+        assert!(report.contains("| rank_select | 1.000s | - |"));
+        assert!(report.contains("| yaml_bench | - | 2.000s |"));
+    }
+
+    #[test]
+    fn per_arch_table_averages_across_nodes() {
+        let dir = tempdir().unwrap();
+        write_summary(dir.path(), "a", "x", 1.0, true);
+        write_node_info(dir.path(), "a", Architecture::X86_64);
+        write_summary(dir.path(), "b", "y", 3.0, true);
+        write_node_info(dir.path(), "b", Architecture::X86_64);
+
+        let runs = collect_runs(dir.path()).unwrap();
+        let report = render_report(&runs, None, 0.10);
+
+        assert!(report.contains("| x86_64 | 2.000 | 2 |"));
+    }
+
+    #[test]
+    fn failed_benchmarks_are_excluded_from_arch_average_but_shown_in_table() {
+        let dir = tempdir().unwrap();
+        write_summary(dir.path(), "a", "x", 1.0, false);
+        write_node_info(dir.path(), "a", Architecture::X86_64);
+
+        let runs = collect_runs(dir.path()).unwrap();
+        let report = render_report(&runs, None, 0.10);
+
+        assert!(report.contains("| x | FAILED |"));
+        assert!(!report.contains("x86_64 | 1.000"));
+    }
+
+    #[test]
+    fn regression_flagged_when_over_threshold() {
+        let baseline_dir = tempdir().unwrap();
+        write_summary(baseline_dir.path(), "local", "rank_select", 1.0, true);
+        write_node_info(baseline_dir.path(), "local", Architecture::X86_64);
+        let baseline = collect_runs(baseline_dir.path()).unwrap();
+
+        let current_dir = tempdir().unwrap();
+        write_summary(current_dir.path(), "local", "rank_select", 1.5, true);
+        write_node_info(current_dir.path(), "local", Architecture::X86_64);
+        let current = collect_runs(current_dir.path()).unwrap();
+
+        let report = render_report(&current, Some(&baseline), 0.10);
+        assert!(report.contains("rank_select"));
+        assert!(report.contains("+50.0%"));
+    }
+
+    #[test]
+    fn no_regression_reported_within_threshold() {
+        let baseline_dir = tempdir().unwrap();
+        write_summary(baseline_dir.path(), "local", "rank_select", 1.0, true);
+        write_node_info(baseline_dir.path(), "local", Architecture::X86_64);
+        let baseline = collect_runs(baseline_dir.path()).unwrap();
+
+        let current_dir = tempdir().unwrap();
+        write_summary(current_dir.path(), "local", "rank_select", 1.02, true);
+        write_node_info(current_dir.path(), "local", Architecture::X86_64);
+        let current = collect_runs(current_dir.path()).unwrap();
+
+        let report = render_report(&current, Some(&baseline), 0.10);
+        assert!(report.contains("No regressions detected."));
+    }
+
+    #[test]
+    fn check_mode_detects_drift() {
+        let dir = tempdir().unwrap();
+        write_summary(dir.path(), "local", "rank_select", 1.0, true);
+        write_node_info(dir.path(), "local", Architecture::X86_64);
+
+        let output = dir.path().join("summary.md");
+        let args = ReportArgs {
+            current: dir.path().to_path_buf(),
+            baseline: None,
+            threshold: 0.10,
+            output: Some(output.clone()),
+            check: false,
+        };
+        run_report(args).unwrap();
+        let first_write = fs::read_to_string(&output).unwrap();
+
+        // --check against the file we just wrote: matches, succeeds.
+        let check_args = ReportArgs {
+            current: dir.path().to_path_buf(),
+            baseline: None,
+            threshold: 0.10,
+            output: Some(output.clone()),
+            check: true,
+        };
+        run_report(check_args).unwrap();
+
+        // Now drift the committed file and confirm --check catches it.
+        fs::write(&output, format!("{first_write}stale\n")).unwrap();
+        let check_args = ReportArgs {
+            current: dir.path().to_path_buf(),
+            baseline: None,
+            threshold: 0.10,
+            output: Some(output.clone()),
+            check: true,
+        };
+        assert!(run_report(check_args).is_err());
+    }
+}

--- a/src/bin/succinctly/bench_runner/orchestrate/scheduler.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/scheduler.rs
@@ -1,0 +1,189 @@
+//! Isolation-aware work scheduling (Phase 2, issue #98).
+//!
+//! Decides, for each selected node, which benchmarks run in which "wave" —
+//! a batch of jobs that execute concurrently, bounded by `max_concurrent`.
+//! Exclusive benchmarks always get a solo wave. This is pure data
+//! transformation: no threads, no I/O, fully unit-testable — `executor.rs`
+//! is the only module that turns a [`NodeSchedule`] into real work.
+
+use super::config::{BenchmarkOverride, NodeConfig};
+use crate::bench_runner::registry::{BenchmarkInfo, Isolation};
+
+/// A batch of benchmarks that run concurrently on a node (bounded by
+/// `max_concurrent`), or a single exclusive benchmark.
+pub type Wave<'a> = Vec<&'a BenchmarkInfo>;
+
+/// One node's ordered list of waves, run sequentially wave-by-wave.
+#[derive(Debug)]
+pub struct NodeSchedule<'a> {
+    pub waves: Vec<Wave<'a>>,
+}
+
+/// Resolve a benchmark's isolation: an explicit `nodes.yaml` override wins;
+/// otherwise fall back to the registry's `default_isolation`.
+pub fn resolve_isolation(benchmark: &BenchmarkInfo, overrides: &[BenchmarkOverride]) -> Isolation {
+    overrides
+        .iter()
+        .find(|o| o.name == benchmark.name)
+        .and_then(|o| o.isolation)
+        .unwrap_or(benchmark.default_isolation)
+}
+
+/// Build a wave schedule for `node`, preserving `benchmarks`' relative
+/// order: each `Exclusive` benchmark closes out any in-progress concurrent
+/// wave and gets its own solo wave; `Concurrent` benchmarks pack into waves
+/// of at most `node.max_concurrent` (clamped to at least 1).
+pub fn schedule_node<'a>(
+    node: &NodeConfig,
+    benchmarks: &[&'a BenchmarkInfo],
+    overrides: &[BenchmarkOverride],
+) -> NodeSchedule<'a> {
+    let max_concurrent = node.max_concurrent.max(1);
+    let mut waves: Vec<Wave<'a>> = Vec::new();
+    let mut current_wave: Wave<'a> = Vec::new();
+
+    for &benchmark in benchmarks {
+        match resolve_isolation(benchmark, overrides) {
+            Isolation::Exclusive => {
+                if !current_wave.is_empty() {
+                    waves.push(std::mem::take(&mut current_wave));
+                }
+                waves.push(vec![benchmark]);
+            }
+            Isolation::Concurrent => {
+                current_wave.push(benchmark);
+                if current_wave.len() >= max_concurrent {
+                    waves.push(std::mem::take(&mut current_wave));
+                }
+            }
+        }
+    }
+    if !current_wave.is_empty() {
+        waves.push(current_wave);
+    }
+
+    NodeSchedule { waves }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bench_runner::registry::{BenchmarkCategory, BenchmarkType};
+
+    fn benchmark(name: &'static str, isolation: Isolation) -> BenchmarkInfo {
+        BenchmarkInfo {
+            name,
+            description: "test",
+            category: BenchmarkCategory::Core,
+            bench_type: BenchmarkType::Criterion,
+            criterion_name: Some(name),
+            cli_subcommand: None,
+            working_dir: ".",
+            default_isolation: isolation,
+        }
+    }
+
+    fn node(max_concurrent: usize) -> NodeConfig {
+        NodeConfig {
+            name: "n".to_string(),
+            host: "localhost".to_string(),
+            arch: super::super::config::Architecture::X86_64,
+            features: vec![],
+            max_concurrent,
+            ssh_key: None,
+            working_dir: None,
+            target_triple: None,
+            ec2_instance_id: None,
+            ec2_region: None,
+        }
+    }
+
+    #[test]
+    fn resolve_isolation_falls_back_to_registry_default() {
+        let b = benchmark("a", Isolation::Exclusive);
+        assert_eq!(resolve_isolation(&b, &[]), Isolation::Exclusive);
+    }
+
+    #[test]
+    fn resolve_isolation_honors_explicit_override() {
+        let b = benchmark("a", Isolation::Exclusive);
+        let overrides = vec![BenchmarkOverride {
+            name: "a".to_string(),
+            isolation: Some(Isolation::Concurrent),
+        }];
+        assert_eq!(resolve_isolation(&b, &overrides), Isolation::Concurrent);
+    }
+
+    #[test]
+    fn resolve_isolation_ignores_override_with_no_isolation_field() {
+        // An override entry present for a different reason, with no
+        // `isolation` set, must NOT reset isolation to Concurrent.
+        let b = benchmark("a", Isolation::Exclusive);
+        let overrides = vec![BenchmarkOverride {
+            name: "a".to_string(),
+            isolation: None,
+        }];
+        assert_eq!(resolve_isolation(&b, &overrides), Isolation::Exclusive);
+    }
+
+    #[test]
+    fn exclusive_benchmarks_each_get_a_solo_wave() {
+        let n = node(4);
+        let a = benchmark("a", Isolation::Exclusive);
+        let b = benchmark("b", Isolation::Exclusive);
+        let schedule = schedule_node(&n, &[&a, &b], &[]);
+
+        assert_eq!(schedule.waves.len(), 2);
+        assert_eq!(schedule.waves[0], vec![&a]);
+        assert_eq!(schedule.waves[1], vec![&b]);
+    }
+
+    #[test]
+    fn concurrent_benchmarks_pack_up_to_max_concurrent() {
+        let n = node(2);
+        let a = benchmark("a", Isolation::Concurrent);
+        let b = benchmark("b", Isolation::Concurrent);
+        let c = benchmark("c", Isolation::Concurrent);
+        let schedule = schedule_node(&n, &[&a, &b, &c], &[]);
+
+        assert_eq!(schedule.waves.len(), 2);
+        assert_eq!(schedule.waves[0], vec![&a, &b]);
+        assert_eq!(schedule.waves[1], vec![&c]);
+    }
+
+    #[test]
+    fn mixed_exclusive_and_concurrent_never_share_a_wave() {
+        let n = node(4);
+        let a = benchmark("a", Isolation::Concurrent);
+        let b = benchmark("b", Isolation::Exclusive);
+        let c = benchmark("c", Isolation::Concurrent);
+        let schedule = schedule_node(&n, &[&a, &b, &c], &[]);
+
+        // a's in-progress concurrent wave closes out before b's solo wave;
+        // c starts a fresh wave afterward.
+        assert_eq!(schedule.waves.len(), 3);
+        assert_eq!(schedule.waves[0], vec![&a]);
+        assert_eq!(schedule.waves[1], vec![&b]);
+        assert_eq!(schedule.waves[2], vec![&c]);
+
+        for wave in &schedule.waves {
+            let all_exclusive = wave
+                .iter()
+                .all(|b| resolve_isolation(b, &[]) == Isolation::Exclusive);
+            let all_concurrent = wave
+                .iter()
+                .all(|b| resolve_isolation(b, &[]) == Isolation::Concurrent);
+            assert!(all_exclusive || all_concurrent);
+        }
+    }
+
+    #[test]
+    fn max_concurrent_of_zero_is_clamped_to_one() {
+        let n = node(0);
+        let a = benchmark("a", Isolation::Concurrent);
+        let b = benchmark("b", Isolation::Concurrent);
+        let schedule = schedule_node(&n, &[&a, &b], &[]);
+
+        assert_eq!(schedule.waves.len(), 2);
+    }
+}

--- a/src/bin/succinctly/bench_runner/orchestrate/ssh.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/ssh.rs
@@ -1,0 +1,380 @@
+//! Remote command execution abstraction for SSH-based orchestration.
+//!
+//! [`RemoteExec`] lets scheduler/executor/sync logic run against either the
+//! real `ssh`/`scp` system binaries ([`SystemSsh`]) or, in tests, a canned
+//! fake (`test_support::FakeExec`) — without either side knowing which.
+//! [`SystemSsh`] special-cases nodes whose `host` is `localhost`/`127.0.0.1`:
+//! commands run directly (no `ssh` wrapper) and transfers become plain file
+//! copies, so the local-node path is real end-to-end and CI-testable without
+//! any network access.
+
+use super::config::NodeConfig;
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Output of a remote (or local) command execution.
+#[derive(Debug, Clone, Default)]
+pub struct ExecOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+impl ExecOutput {
+    pub fn success(&self) -> bool {
+        self.exit_code == 0
+    }
+}
+
+/// Abstraction over "run a command on a node" / "copy files to/from a node".
+pub trait RemoteExec: Send + Sync {
+    /// Run `command` on `node`, killing it if it hasn't exited after `timeout`.
+    fn exec(&self, node: &NodeConfig, command: &str, timeout: Duration) -> Result<ExecOutput>;
+
+    /// Upload a single local file to a remote path.
+    fn upload(
+        &self,
+        node: &NodeConfig,
+        local: &Path,
+        remote: &str,
+        connect_timeout: Duration,
+    ) -> Result<()>;
+
+    /// Download the *contents* of a remote directory into a local directory
+    /// (the remote directory itself is not nested inside `local`).
+    fn download(
+        &self,
+        node: &NodeConfig,
+        remote_dir: &str,
+        local_dir: &Path,
+        connect_timeout: Duration,
+    ) -> Result<()>;
+}
+
+/// Real implementation: shells out to the system `ssh`/`scp` binaries.
+pub struct SystemSsh;
+
+impl RemoteExec for SystemSsh {
+    fn exec(&self, node: &NodeConfig, command: &str, timeout: Duration) -> Result<ExecOutput> {
+        if node.is_local() {
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg(command);
+            return run_with_timeout(cmd, timeout);
+        }
+
+        let args = build_ssh_args(node, command, timeout);
+        let mut cmd = Command::new("ssh");
+        cmd.args(&args);
+        run_with_timeout(cmd, timeout)
+            .with_context(|| format!("ssh exec on node '{}' failed", node.name))
+    }
+
+    fn upload(
+        &self,
+        node: &NodeConfig,
+        local: &Path,
+        remote: &str,
+        connect_timeout: Duration,
+    ) -> Result<()> {
+        if node.is_local() {
+            if let Some(parent) = Path::new(remote).parent() {
+                fs::create_dir_all(parent).ok();
+            }
+            fs::copy(local, remote)
+                .with_context(|| format!("local copy {} -> {remote} failed", local.display()))?;
+            return Ok(());
+        }
+
+        let args = build_scp_args(node, local, remote, true, connect_timeout);
+        let output = Command::new("scp")
+            .args(&args)
+            .output()
+            .with_context(|| format!("failed to spawn scp for node '{}'", node.name))?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "scp upload to node '{}' failed: {}",
+                node.name,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Ok(())
+    }
+
+    fn download(
+        &self,
+        node: &NodeConfig,
+        remote_dir: &str,
+        local_dir: &Path,
+        connect_timeout: Duration,
+    ) -> Result<()> {
+        if node.is_local() {
+            return copy_dir_contents(Path::new(remote_dir), local_dir);
+        }
+
+        fs::create_dir_all(local_dir)
+            .with_context(|| format!("Failed to create {}", local_dir.display()))?;
+
+        // Trailing "/." makes scp copy the directory's *contents* into
+        // local_dir, matching the localhost branch's behavior above.
+        let remote_spec = format!("{remote_dir}/.");
+        let args = build_scp_args(node, local_dir, &remote_spec, false, connect_timeout);
+        let output = Command::new("scp")
+            .args(&args)
+            .output()
+            .with_context(|| format!("failed to spawn scp for node '{}'", node.name))?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "scp download from node '{}' failed: {}",
+                node.name,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Build the argument list for an `ssh` invocation. Pure and separately
+/// testable — the actual `.output()`/spawn call is left to `SystemSsh`.
+pub(crate) fn build_ssh_args(node: &NodeConfig, command: &str, timeout: Duration) -> Vec<String> {
+    let mut args = Vec::new();
+    if let Some(key) = node.expanded_ssh_key() {
+        args.push("-i".to_string());
+        args.push(key.display().to_string());
+    }
+    args.push("-o".to_string());
+    args.push("StrictHostKeyChecking=accept-new".to_string());
+    args.push("-o".to_string());
+    args.push(format!("ConnectTimeout={}", connect_timeout_secs(timeout)));
+    args.push(node.host.clone());
+    args.push(command.to_string());
+    args
+}
+
+/// Build the argument list for an `scp` invocation. `local` is always the
+/// local-side path and `remote` the remote-side path string — for `upload`,
+/// local is the source and remote the destination; for a download, it's the
+/// reverse. Pure and separately testable, like [`build_ssh_args`].
+pub(crate) fn build_scp_args(
+    node: &NodeConfig,
+    local: &Path,
+    remote: &str,
+    upload: bool,
+    connect_timeout: Duration,
+) -> Vec<String> {
+    let mut args = Vec::new();
+    if let Some(key) = node.expanded_ssh_key() {
+        args.push("-i".to_string());
+        args.push(key.display().to_string());
+    }
+    args.push("-o".to_string());
+    args.push("StrictHostKeyChecking=accept-new".to_string());
+    args.push("-o".to_string());
+    args.push(format!(
+        "ConnectTimeout={}",
+        connect_timeout_secs(connect_timeout)
+    ));
+    args.push("-r".to_string());
+
+    let local_spec = local.display().to_string();
+    let remote_spec = format!("{}:{remote}", node.host);
+    if upload {
+        args.push(local_spec);
+        args.push(remote_spec);
+    } else {
+        args.push(remote_spec);
+        args.push(local_spec);
+    }
+    args
+}
+
+fn connect_timeout_secs(timeout: Duration) -> u64 {
+    timeout.as_secs().clamp(1, 10)
+}
+
+/// Spawn `cmd`, draining stdout/stderr on background threads (so a chatty
+/// child can never deadlock on a full pipe while we're polling), and kill it
+/// if it hasn't exited after `timeout`.
+fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExecOutput> {
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to spawn process")?;
+
+    let mut stdout_pipe = child.stdout.take().context("child had no stdout pipe")?;
+    let mut stderr_pipe = child.stderr.take().context("child had no stderr pipe")?;
+
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout_pipe.read_to_string(&mut buf);
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stderr_pipe.read_to_string(&mut buf);
+        buf
+    });
+
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().context("failed to poll child status")? {
+            break status;
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("command timed out after {timeout:?}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+
+    let stdout = stdout_handle.join().unwrap_or_default();
+    let stderr = stderr_handle.join().unwrap_or_default();
+
+    Ok(ExecOutput {
+        stdout,
+        stderr,
+        exit_code: status.code().unwrap_or(-1),
+    })
+}
+
+/// Recursively copy the *contents* of `src` into `dst` (creating `dst` if
+/// needed). Used by [`SystemSsh`] for localhost "transfers", which are just
+/// same-filesystem copies. Missing `src` is not an error — a node that
+/// produced no results yet is a normal, reportable-elsewhere condition.
+fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
+    if !src.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(dst).with_context(|| format!("Failed to create {}", dst.display()))?;
+    for entry in fs::read_dir(src).with_context(|| format!("Failed to read {}", src.display()))? {
+        let entry = entry?;
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_contents(&entry.path(), &dst_path)?;
+        } else {
+            fs::copy(entry.path(), &dst_path).with_context(|| {
+                format!(
+                    "Failed to copy {} -> {}",
+                    entry.path().display(),
+                    dst_path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::config::Architecture;
+    use super::*;
+
+    fn node(host: &str) -> NodeConfig {
+        NodeConfig {
+            name: "n".to_string(),
+            host: host.to_string(),
+            arch: Architecture::X86_64,
+            features: vec![],
+            max_concurrent: 1,
+            ssh_key: None,
+            working_dir: None,
+            target_triple: None,
+            ec2_instance_id: None,
+            ec2_region: None,
+        }
+    }
+
+    #[test]
+    fn ssh_args_without_key() {
+        let args = build_ssh_args(&node("example.com"), "echo hi", Duration::from_secs(5));
+        assert!(!args.iter().any(|a| a == "-i"));
+        assert!(args.contains(&"ConnectTimeout=5".to_string()));
+        assert_eq!(args.last().unwrap(), "echo hi");
+        assert_eq!(args[args.len() - 2], "example.com");
+    }
+
+    #[test]
+    fn ssh_args_with_key() {
+        let mut n = node("example.com");
+        n.ssh_key = Some(std::path::PathBuf::from("/tmp/key.pem"));
+        let args = build_ssh_args(&n, "echo hi", Duration::from_secs(30));
+        assert_eq!(args[0], "-i");
+        assert_eq!(args[1], "/tmp/key.pem");
+        // ConnectTimeout is capped at 10s even for a long overall timeout.
+        assert!(args.contains(&"ConnectTimeout=10".to_string()));
+    }
+
+    #[test]
+    fn connect_timeout_is_clamped() {
+        assert_eq!(connect_timeout_secs(Duration::from_secs(0)), 1);
+        assert_eq!(connect_timeout_secs(Duration::from_secs(3)), 3);
+        assert_eq!(connect_timeout_secs(Duration::from_secs(3600)), 10);
+    }
+
+    #[test]
+    fn localhost_exec_runs_directly() {
+        let out = SystemSsh
+            .exec(&node("localhost"), "echo hello", Duration::from_secs(5))
+            .unwrap();
+        assert!(out.success());
+        assert_eq!(out.stdout.trim(), "hello");
+    }
+
+    #[test]
+    fn localhost_exec_captures_nonzero_exit() {
+        let out = SystemSsh
+            .exec(&node("127.0.0.1"), "exit 3", Duration::from_secs(5))
+            .unwrap();
+        assert_eq!(out.exit_code, 3);
+        assert!(!out.success());
+    }
+
+    #[test]
+    fn localhost_exec_times_out() {
+        let err = SystemSsh
+            .exec(&node("localhost"), "sleep 5", Duration::from_millis(100))
+            .unwrap_err();
+        assert!(err.to_string().contains("timed out"));
+    }
+
+    #[test]
+    fn localhost_download_copies_directory_contents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        fs::create_dir_all(src.join("nested")).unwrap();
+        fs::write(src.join("a.jsonl"), "{}\n").unwrap();
+        fs::write(src.join("nested/b.jsonl"), "{}\n").unwrap();
+
+        SystemSsh
+            .download(
+                &node("localhost"),
+                src.to_str().unwrap(),
+                &dst,
+                Duration::from_secs(5),
+            )
+            .unwrap();
+
+        assert!(dst.join("a.jsonl").exists());
+        assert!(dst.join("nested/b.jsonl").exists());
+    }
+
+    #[test]
+    fn localhost_download_missing_source_is_not_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dst = tmp.path().join("dst");
+        SystemSsh
+            .download(
+                &node("localhost"),
+                tmp.path().join("missing").to_str().unwrap(),
+                &dst,
+                Duration::from_secs(5),
+            )
+            .unwrap();
+    }
+}

--- a/src/bin/succinctly/bench_runner/orchestrate/sync.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/sync.rs
@@ -172,8 +172,8 @@ pub trait BuildRunner: Send + Sync {
     fn cross_compile(&self, target_triple: &str) -> Result<PathBuf>;
 }
 
-/// Real implementation: `cargo build --release --target <triple> --features cli`.
-/// Requires the target's toolchain to already be installed
+/// Real implementation: `cargo build --release --target <triple> --features
+/// bench-runner`. Requires the target's toolchain to already be installed
 /// (`rustup target add <triple>`) — that's a documented precondition, not
 /// something this tool installs.
 pub struct SystemBuild;
@@ -187,7 +187,7 @@ impl BuildRunner for SystemBuild {
                 "--target",
                 target_triple,
                 "--features",
-                "cli",
+                "bench-runner",
             ])
             .status()
             .context("failed to spawn cargo build")?;

--- a/src/bin/succinctly/bench_runner/orchestrate/sync.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/sync.rs
@@ -1,0 +1,343 @@
+//! Binary sync (Phase 3, issue #98): cross-compile the release binary for a
+//! node's target triple, upload it if the node's reported version differs
+//! from the local one (or `--force`), and re-verify afterward.
+//!
+//! Cross-compilation itself is a local side effect (unlike everything else
+//! in `orchestrate/`, which talks to a node via [`RemoteExec`]), so it gets
+//! its own small [`BuildRunner`] abstraction — the same dependency-injection
+//! shape as `ssh.rs`'s `RemoteExec`, so tests never shell out to a real
+//! `cargo build`.
+
+use super::config::{load_config, Architecture, Config, NodeConfig};
+use super::ssh::RemoteExec;
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+/// `succinctly bench sync` — cross-compile and deploy the release binary to
+/// configured nodes.
+#[derive(Debug, Parser)]
+pub struct SyncArgs {
+    /// Config file describing nodes and coordinator settings
+    #[arg(short, long, default_value = "nodes.yaml")]
+    pub config: PathBuf,
+
+    /// Sync only specific node(s) (repeatable)
+    #[arg(short = 'n', long = "node")]
+    pub node: Vec<String>,
+
+    /// Force sync even if the reported version already matches
+    #[arg(long)]
+    pub force: bool,
+
+    /// Show what would sync without cross-compiling or uploading
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+/// Run `bench sync`.
+pub fn run_sync(args: SyncArgs) -> Result<()> {
+    run_sync_with(args, &super::ssh::SystemSsh, &SystemBuild)
+}
+
+pub(crate) fn run_sync_with(
+    args: SyncArgs,
+    remote: &dyn RemoteExec,
+    build: &dyn BuildRunner,
+) -> Result<()> {
+    let config = load_config(&args.config)?;
+    let nodes = select_nodes(&config, &args.node);
+    if nodes.is_empty() {
+        anyhow::bail!("No nodes selected. Check --node against nodes.yaml.");
+    }
+
+    let connect_timeout = Duration::from_secs(config.coordinator.ssh_timeout);
+    for node in &nodes {
+        if let Err(e) = sync_node(
+            remote,
+            build,
+            node,
+            args.force,
+            args.dry_run,
+            connect_timeout,
+        ) {
+            eprintln!("Warning: sync to node '{}' failed: {e}", node.name);
+        }
+    }
+
+    Ok(())
+}
+
+fn select_nodes<'a>(config: &'a Config, names: &[String]) -> Vec<&'a NodeConfig> {
+    let mut nodes: Vec<&NodeConfig> = config.nodes.iter().collect();
+    if !names.is_empty() {
+        nodes.retain(|n| names.contains(&n.name));
+    }
+    nodes
+}
+
+/// Map a node's architecture (+ optional explicit `target_triple`) to a Rust
+/// target triple. The explicit override is needed because `arch` alone
+/// can't disambiguate e.g. `aarch64-apple-darwin` vs
+/// `aarch64-unknown-linux-gnu`.
+pub(crate) fn target_triple_for(arch: Architecture, explicit: Option<&str>) -> String {
+    if let Some(triple) = explicit {
+        return triple.to_string();
+    }
+    match arch {
+        Architecture::X86_64 => "x86_64-unknown-linux-gnu".to_string(),
+        Architecture::Aarch64 => "aarch64-unknown-linux-gnu".to_string(),
+    }
+}
+
+fn local_version_string() -> String {
+    format!("succinctly {}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Check-and-conditionally-sync one node: skips local nodes entirely (a
+/// no-op, there's nothing to upload to), checks the remote `--version`
+/// against the local build, and only cross-compiles/uploads/re-verifies if
+/// they differ (or `--force`).
+pub(crate) fn sync_node(
+    remote: &dyn RemoteExec,
+    build: &dyn BuildRunner,
+    node: &NodeConfig,
+    force: bool,
+    dry_run: bool,
+    connect_timeout: Duration,
+) -> Result<()> {
+    if node.is_local() {
+        eprintln!("[{}] local node, sync is a no-op", node.name);
+        return Ok(());
+    }
+
+    let working_dir = node.working_dir_str();
+    let version_cmd = format!("cd {working_dir} && ./target/release/succinctly --version");
+    let remote_version = remote
+        .exec(node, &version_cmd, connect_timeout)
+        .ok()
+        .filter(super::ssh::ExecOutput::success)
+        .map(|r| r.stdout.trim().to_string());
+
+    let local_version = local_version_string();
+    let up_to_date = !force && remote_version.as_deref() == Some(local_version.as_str());
+
+    if up_to_date {
+        eprintln!("[{}] up to date ({local_version})", node.name);
+        return Ok(());
+    }
+
+    let triple = target_triple_for(node.arch, node.target_triple.as_deref());
+
+    if dry_run {
+        eprintln!(
+            "[{}] dry run: would cross-compile for {triple} and upload",
+            node.name
+        );
+        return Ok(());
+    }
+
+    eprintln!("[{}] syncing (target {triple})...", node.name);
+    let local_binary = build
+        .cross_compile(&triple)
+        .with_context(|| format!("cross-compile for {triple} failed"))?;
+
+    let remote_dir = format!("{working_dir}/target/release");
+    let _ = remote.exec(node, &format!("mkdir -p {remote_dir}"), connect_timeout);
+
+    let remote_binary = format!("{remote_dir}/succinctly");
+    remote.upload(node, &local_binary, &remote_binary, connect_timeout)?;
+
+    let verify = remote.exec(node, &version_cmd, connect_timeout)?;
+    if !verify.success() {
+        anyhow::bail!(
+            "post-upload version check failed on node '{}': {}",
+            node.name,
+            verify.stderr
+        );
+    }
+    eprintln!("[{}] synced: {}", node.name, verify.stdout.trim());
+
+    Ok(())
+}
+
+/// Abstraction over "produce a release binary for this target triple" — the
+/// one local (non-`RemoteExec`) side effect in `orchestrate/`. `SystemBuild`
+/// shells to a real `cargo build`; tests use a fake that returns a path to a
+/// small stand-in file instead of cross-compiling for real.
+pub trait BuildRunner: Send + Sync {
+    /// Returns the path to the built binary on success.
+    fn cross_compile(&self, target_triple: &str) -> Result<PathBuf>;
+}
+
+/// Real implementation: `cargo build --release --target <triple> --features cli`.
+/// Requires the target's toolchain to already be installed
+/// (`rustup target add <triple>`) — that's a documented precondition, not
+/// something this tool installs.
+pub struct SystemBuild;
+
+impl BuildRunner for SystemBuild {
+    fn cross_compile(&self, target_triple: &str) -> Result<PathBuf> {
+        let status = Command::new("cargo")
+            .args([
+                "build",
+                "--release",
+                "--target",
+                target_triple,
+                "--features",
+                "cli",
+            ])
+            .status()
+            .context("failed to spawn cargo build")?;
+        if !status.success() {
+            anyhow::bail!("cargo build --target {target_triple} failed");
+        }
+
+        let path = PathBuf::from(format!("target/{target_triple}/release/succinctly"));
+        if !path.exists() {
+            anyhow::bail!(
+                "expected cross-compiled binary not found at {}",
+                path.display()
+            );
+        }
+        Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ssh::ExecOutput;
+    use super::super::test_support::{FakeBuild, FakeExec};
+    use super::*;
+
+    fn node(name: &str, target_triple: Option<&str>) -> NodeConfig {
+        NodeConfig {
+            name: name.to_string(),
+            host: "example.com".to_string(),
+            arch: Architecture::Aarch64,
+            features: vec![],
+            max_concurrent: 1,
+            ssh_key: None,
+            working_dir: None,
+            target_triple: target_triple.map(str::to_string),
+            ec2_instance_id: None,
+            ec2_region: None,
+        }
+    }
+
+    #[test]
+    fn target_triple_prefers_explicit_override() {
+        assert_eq!(
+            target_triple_for(Architecture::Aarch64, Some("aarch64-apple-darwin")),
+            "aarch64-apple-darwin"
+        );
+    }
+
+    #[test]
+    fn target_triple_falls_back_by_arch() {
+        assert_eq!(
+            target_triple_for(Architecture::X86_64, None),
+            "x86_64-unknown-linux-gnu"
+        );
+        assert_eq!(
+            target_triple_for(Architecture::Aarch64, None),
+            "aarch64-unknown-linux-gnu"
+        );
+    }
+
+    #[test]
+    fn matching_version_skips_cross_compile_and_upload() {
+        let n = node("sydney", None);
+        let fake = FakeExec::new().respond(
+            "sydney",
+            "--version",
+            ExecOutput {
+                stdout: local_version_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+        let build = FakeBuild::new();
+
+        sync_node(&fake, &build, &n, false, false, Duration::from_secs(5)).unwrap();
+
+        assert_eq!(build.call_count(), 0);
+        assert!(!fake.calls().iter().any(|(_, cmd)| cmd.contains("mkdir")));
+    }
+
+    #[test]
+    fn mismatched_version_triggers_cross_compile_and_upload() {
+        let n = node("sydney", None);
+        let fake = FakeExec::new().respond(
+            "sydney",
+            "--version",
+            ExecOutput {
+                stdout: "succinctly 0.0.1-stale".to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+        let build = FakeBuild::new();
+
+        sync_node(&fake, &build, &n, false, false, Duration::from_secs(5)).unwrap();
+
+        assert_eq!(build.call_count(), 1);
+        assert_eq!(
+            build.last_triple(),
+            Some("aarch64-unknown-linux-gnu".to_string())
+        );
+    }
+
+    #[test]
+    fn force_triggers_cross_compile_even_when_versions_match() {
+        let n = node("sydney", None);
+        let fake = FakeExec::new().respond(
+            "sydney",
+            "--version",
+            ExecOutput {
+                stdout: local_version_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+        let build = FakeBuild::new();
+
+        sync_node(&fake, &build, &n, true, false, Duration::from_secs(5)).unwrap();
+
+        assert_eq!(build.call_count(), 1);
+    }
+
+    #[test]
+    fn dry_run_never_cross_compiles() {
+        let n = node("sydney", None);
+        let fake = FakeExec::new().respond(
+            "sydney",
+            "--version",
+            ExecOutput {
+                stdout: "succinctly 0.0.1-stale".to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+        let build = FakeBuild::new();
+
+        sync_node(&fake, &build, &n, false, true, Duration::from_secs(5)).unwrap();
+
+        assert_eq!(build.call_count(), 0);
+    }
+
+    #[test]
+    fn local_node_is_always_a_no_op() {
+        let mut n = node("local", None);
+        n.host = "localhost".to_string();
+        let fake = FakeExec::new();
+        let build = FakeBuild::new();
+
+        sync_node(&fake, &build, &n, true, false, Duration::from_secs(5)).unwrap();
+
+        assert!(fake.calls().is_empty());
+        assert_eq!(build.call_count(), 0);
+    }
+}

--- a/src/bin/succinctly/bench_runner/orchestrate/test_support.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/test_support.rs
@@ -1,0 +1,213 @@
+//! Test-only fakes for `RemoteExec`/`BuildRunner`/`Ec2Control`, used by
+//! orchestration unit tests so they never need a real SSH connection,
+//! `cargo build`, or `aws` CLI invocation.
+
+use super::config::NodeConfig;
+use super::nodes::{Ec2Control, Ec2State};
+use super::ssh::{ExecOutput, RemoteExec};
+use super::sync::BuildRunner;
+use anyhow::Result;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::Duration;
+
+/// Records every `exec` call (as `(node_name, command)`) and lets tests
+/// script specific failures, responses, or observe concurrency, all
+/// in-memory.
+#[derive(Default)]
+pub(crate) struct FakeExec {
+    calls: Mutex<Vec<(String, String)>>,
+    fail_connectivity: Mutex<HashSet<String>>,
+    /// `(node_name, command_substring, canned_output)`, checked in order —
+    /// first match wins. Falls back to a generic success response.
+    responses: Mutex<Vec<(String, String, ExecOutput)>>,
+    running: AtomicUsize,
+    max_concurrent_seen: AtomicUsize,
+}
+
+impl FakeExec {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Make the connectivity check (`echo ok`) fail for a specific node.
+    pub fn fail_connectivity_check(self, node_name: &str) -> Self {
+        self.fail_connectivity
+            .lock()
+            .unwrap()
+            .insert(node_name.to_string());
+        self
+    }
+
+    /// Script a canned response for any command on `node_name` containing
+    /// `command_substring` (e.g. `"--version"`).
+    pub fn respond(self, node_name: &str, command_substring: &str, output: ExecOutput) -> Self {
+        self.responses.lock().unwrap().push((
+            node_name.to_string(),
+            command_substring.to_string(),
+            output,
+        ));
+        self
+    }
+
+    pub fn calls(&self) -> Vec<(String, String)> {
+        self.calls.lock().unwrap().clone()
+    }
+
+    /// Highest number of concurrently in-flight `exec` calls observed so
+    /// far — used by Phase 2's max-concurrency / exclusivity assertions.
+    pub fn max_concurrent_seen(&self) -> usize {
+        self.max_concurrent_seen.load(Ordering::SeqCst)
+    }
+}
+
+impl RemoteExec for FakeExec {
+    fn exec(&self, node: &NodeConfig, command: &str, _timeout: Duration) -> Result<ExecOutput> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((node.name.clone(), command.to_string()));
+
+        let now_running = self.running.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_concurrent_seen
+            .fetch_max(now_running, Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(5));
+        self.running.fetch_sub(1, Ordering::SeqCst);
+
+        if command == "echo ok" && self.fail_connectivity.lock().unwrap().contains(&node.name) {
+            return Ok(ExecOutput {
+                stdout: String::new(),
+                stderr: "connection refused".to_string(),
+                exit_code: 1,
+            });
+        }
+
+        for (n, sub, output) in self.responses.lock().unwrap().iter() {
+            if n == &node.name && command.contains(sub.as_str()) {
+                return Ok(output.clone());
+            }
+        }
+
+        Ok(ExecOutput {
+            stdout: "ok".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+        })
+    }
+
+    fn upload(
+        &self,
+        _node: &NodeConfig,
+        _local: &Path,
+        _remote: &str,
+        _connect_timeout: Duration,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn download(
+        &self,
+        _node: &NodeConfig,
+        _remote_dir: &str,
+        local_dir: &Path,
+        _connect_timeout: Duration,
+    ) -> Result<()> {
+        std::fs::create_dir_all(local_dir)?;
+        Ok(())
+    }
+}
+
+/// Records `cross_compile` calls and returns a small stand-in file instead
+/// of running a real `cargo build`.
+#[derive(Default)]
+pub(crate) struct FakeBuild {
+    calls: Mutex<Vec<String>>,
+}
+
+impl FakeBuild {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn call_count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+
+    pub fn last_triple(&self) -> Option<String> {
+        self.calls.lock().unwrap().last().cloned()
+    }
+}
+
+impl BuildRunner for FakeBuild {
+    fn cross_compile(&self, target_triple: &str) -> Result<PathBuf> {
+        self.calls.lock().unwrap().push(target_triple.to_string());
+
+        let mut path = std::env::temp_dir();
+        path.push(format!("fake-succinctly-{target_triple}"));
+        std::fs::write(&path, b"fake binary")?;
+        Ok(path)
+    }
+}
+
+/// Records `start`/`stop` calls and lets tests script a per-instance
+/// [`Ec2State`] for `describe`, all in-memory.
+#[derive(Default)]
+pub(crate) struct FakeAwsCli {
+    states: Mutex<HashMap<String, Ec2State>>,
+    start_calls: Mutex<Vec<String>>,
+    stop_calls: Mutex<Vec<String>>,
+}
+
+impl FakeAwsCli {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Script `describe(instance_id, ..)` to return `state`. Instances with
+    /// no scripted state default to `Ec2State::Running`.
+    pub fn set_state(self, instance_id: &str, state: Ec2State) -> Self {
+        self.states
+            .lock()
+            .unwrap()
+            .insert(instance_id.to_string(), state);
+        self
+    }
+
+    pub fn start_calls(&self) -> Vec<String> {
+        self.start_calls.lock().unwrap().clone()
+    }
+
+    pub fn stop_calls(&self) -> Vec<String> {
+        self.stop_calls.lock().unwrap().clone()
+    }
+}
+
+impl Ec2Control for FakeAwsCli {
+    fn describe(&self, instance_id: &str, _region: &str) -> Result<Ec2State> {
+        Ok(self
+            .states
+            .lock()
+            .unwrap()
+            .get(instance_id)
+            .cloned()
+            .unwrap_or(Ec2State::Running))
+    }
+
+    fn start(&self, instance_id: &str, _region: &str) -> Result<()> {
+        self.start_calls
+            .lock()
+            .unwrap()
+            .push(instance_id.to_string());
+        Ok(())
+    }
+
+    fn stop(&self, instance_id: &str, _region: &str) -> Result<()> {
+        self.stop_calls
+            .lock()
+            .unwrap()
+            .push(instance_id.to_string());
+        Ok(())
+    }
+}

--- a/src/bin/succinctly/bench_runner/registry.rs
+++ b/src/bin/succinctly/bench_runner/registry.rs
@@ -73,8 +73,35 @@ impl fmt::Display for BenchmarkType {
     }
 }
 
+/// Isolation requirement for orchestrated (multi-node) execution (issue #98).
+///
+/// Every benchmark here is timing/RSS-sensitive, so the registry default is
+/// `Exclusive`; `nodes.yaml`'s `benchmarks[].isolation` overrides loosen
+/// specific benchmarks to `Concurrent` on beefy nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Isolation {
+    /// Needs the whole node — no other benchmark runs alongside it.
+    Exclusive,
+    /// May share the node with other `Concurrent` benchmarks.
+    Concurrent,
+}
+
+impl fmt::Display for Isolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `f.pad(..)`, not `write!(f, ..)` — the latter would silently
+        // ignore width/alignment specifiers like `{:<10}` (see Architecture's
+        // Display impl in orchestrate/config.rs for the same fix, caught by
+        // a real `bench nodes --status` misalignment).
+        f.pad(match self {
+            Self::Exclusive => "exclusive",
+            Self::Concurrent => "concurrent",
+        })
+    }
+}
+
 /// Benchmark metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BenchmarkInfo {
     /// Unique identifier (e.g., "rank_select", "yaml_bench")
     pub name: &'static str,
@@ -90,6 +117,9 @@ pub struct BenchmarkInfo {
     pub cli_subcommand: Option<&'static str>,
     /// Working directory (relative to repo root)
     pub working_dir: &'static str,
+    /// Default orchestration isolation (issue #98); overridable per-name via
+    /// `nodes.yaml`'s `benchmarks[].isolation`.
+    pub default_isolation: Isolation,
 }
 
 /// Static registry of all benchmarks.
@@ -103,6 +133,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("rank_select"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "balanced_parens",
@@ -112,6 +143,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("balanced_parens"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "bp_select_micro",
@@ -121,6 +153,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("bp_select_micro"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "elias_fano",
@@ -130,6 +163,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("elias_fano"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "popcount_strategies",
@@ -139,6 +173,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("popcount_strategies"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "neon_movemask",
@@ -148,6 +183,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("neon_movemask"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     // ========== JSON ==========
     BenchmarkInfo {
@@ -158,6 +194,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("json_pipeline"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "json_simd_indexing",
@@ -167,6 +204,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("json_simd_indexing"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "json_simd_cursor",
@@ -176,6 +214,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("json_simd_cursor"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "json_simd_full",
@@ -185,6 +224,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("json_simd_full"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "pfsm_vs_simd",
@@ -194,6 +234,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("pfsm_vs_simd"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "pfsm_vs_scalar",
@@ -203,6 +244,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("pfsm_vs_scalar"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "jq_comparison",
@@ -212,6 +254,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("jq_comparison"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "jq_string_ops_bench",
@@ -221,6 +264,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("jq_string_ops_bench"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "jq_bench",
@@ -230,6 +274,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: None,
         cli_subcommand: Some("jq"),
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "json_validate_bench",
@@ -239,6 +284,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("json_validate_bench"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     // ========== YAML ==========
     BenchmarkInfo {
@@ -249,6 +295,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("yaml_bench"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "yaml_anchor_micro",
@@ -258,6 +305,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("yaml_anchor_micro"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "yaml_transcode_micro",
@@ -267,6 +315,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("yaml_transcode_micro"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "yaml_type_stack_micro",
@@ -276,6 +325,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("yaml_type_stack_micro"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "yq_comparison",
@@ -285,6 +335,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("yq_comparison"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "yq_select",
@@ -294,6 +345,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("yq_select"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "yq_bench",
@@ -303,6 +355,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: None,
         cli_subcommand: Some("yq"),
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     // ========== DSV ==========
     BenchmarkInfo {
@@ -313,6 +366,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("dsv_bench"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "dsv_cli",
@@ -322,6 +376,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: None,
         cli_subcommand: Some("dsv"),
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     // ========== TEXT ==========
     BenchmarkInfo {
@@ -332,6 +387,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("line_index"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "utf8_validate_bench",
@@ -341,6 +397,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("utf8_validate_bench"),
         cli_subcommand: None,
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "utf8_bench",
@@ -350,6 +407,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: None,
         cli_subcommand: Some("utf8"),
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     // ========== CORPUS ==========
     BenchmarkInfo {
@@ -360,6 +418,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: None,
         cli_subcommand: Some("corpus-stats"),
         working_dir: ".",
+        default_isolation: Isolation::Exclusive,
     },
     // ========== CROSS-PARSER ==========
     BenchmarkInfo {
@@ -370,6 +429,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("json_parsers"),
         cli_subcommand: None,
         working_dir: "bench-compare",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "yaml_parsers",
@@ -379,6 +439,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("yaml_parsers"),
         cli_subcommand: None,
         working_dir: "bench-compare",
+        default_isolation: Isolation::Exclusive,
     },
     BenchmarkInfo {
         name: "succinct_libs",
@@ -388,6 +449,7 @@ pub static BENCHMARKS: &[BenchmarkInfo] = &[
         criterion_name: Some("succinct_libs"),
         cli_subcommand: None,
         working_dir: "bench-compare",
+        default_isolation: Isolation::Exclusive,
     },
 ];
 

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -259,6 +259,14 @@ enum BenchRunnerSubcommand {
     List(bench_runner::ListArgs),
     /// Run one or more benchmarks
     Run(bench_runner::RunArgs),
+    /// Run benchmarks across configured SSH nodes (issue #98)
+    Orchestrate(bench_runner::OrchestrateArgs),
+    /// Cross-compile and deploy the release binary to configured nodes (issue #98)
+    Sync(bench_runner::SyncArgs),
+    /// Report node status, or start/stop EC2 instances (issue #98)
+    Nodes(bench_runner::NodesArgs),
+    /// Compare orchestrated results across nodes/architectures (issue #98)
+    Report(bench_runner::ReportArgs),
 }
 
 /// Default alias names installed by `install-aliases`.
@@ -1340,6 +1348,10 @@ fn main() -> Result<()> {
         Command::Bench(bench_cmd) => match bench_cmd.command {
             BenchRunnerSubcommand::List(args) => bench_runner::run_list(args),
             BenchRunnerSubcommand::Run(args) => bench_runner::run_benchmarks(args),
+            BenchRunnerSubcommand::Orchestrate(args) => bench_runner::run_orchestrate(args),
+            BenchRunnerSubcommand::Sync(args) => bench_runner::run_sync(args),
+            BenchRunnerSubcommand::Nodes(args) => bench_runner::run_nodes(args),
+            BenchRunnerSubcommand::Report(args) => bench_runner::run_report(args),
         },
         Command::Text(text_cmd) => match text_cmd.command {
             TextSubcommand::Validate(validate_cmd) => match validate_cmd.command {

--- a/tests/orchestrate_cli_tests.rs
+++ b/tests/orchestrate_cli_tests.rs
@@ -1,0 +1,141 @@
+//! End-to-end CLI coverage for `succinctly bench orchestrate` (issue #98).
+//!
+//! These spawn the built binary directly (the `locate_cli_tests.rs` pattern).
+//! Real multi-node runs over Tailscale SSH are manual-only — see
+//! `docs/guides/benchmarking.md`'s "Distributed Benchmark Orchestration"
+//! section for that runbook. What's covered here is everything that doesn't
+//! need real network access: config validation, and the localhost path
+//! (`SystemSsh`'s `is_local()` bypass runs commands directly with no `ssh`
+//! involved), which is real orchestration plumbing end-to-end, not a mock.
+#![cfg(feature = "bench-runner")]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_succinctly")
+}
+
+fn run(args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn succinctly");
+    (
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn write_config(dir: &Path, yaml: &str) -> String {
+    let path = dir.join("nodes.yaml");
+    fs::write(&path, yaml).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+fn local_only_yaml(results_dir: &Path) -> String {
+    format!(
+        "coordinator:\n  results_dir: {}\nnodes:\n  - name: local\n    host: localhost\n    arch: x86_64\n",
+        results_dir.display()
+    )
+}
+
+#[test]
+fn orchestrate_rejects_missing_config() {
+    let (_, stderr, code) = run(&[
+        "bench",
+        "orchestrate",
+        "--config",
+        "/nonexistent/nodes.yaml",
+        "--all",
+    ]);
+
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Failed to read config file"), "{stderr}");
+}
+
+#[test]
+fn orchestrate_rejects_invalid_yaml() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = write_config(dir.path(), "not: [valid, yaml");
+
+    let (_, stderr, code) = run(&["bench", "orchestrate", "--config", &config, "--all"]);
+
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Failed to parse YAML config"), "{stderr}");
+}
+
+#[test]
+fn orchestrate_rejects_unknown_node_selection() {
+    let dir = tempfile::tempdir().unwrap();
+    let results_dir = dir.path().join("results");
+    let config = write_config(dir.path(), &local_only_yaml(&results_dir));
+
+    let (_, stderr, code) = run(&[
+        "bench",
+        "orchestrate",
+        "--config",
+        &config,
+        "--node",
+        "nonexistent",
+        "--all",
+    ]);
+
+    assert_ne!(code, 0);
+    assert!(stderr.contains("No nodes selected"), "{stderr}");
+}
+
+#[test]
+fn orchestrate_dry_run_prints_plan_without_side_effects() {
+    let dir = tempfile::tempdir().unwrap();
+    let results_dir = dir.path().join("results");
+    let config = write_config(dir.path(), &local_only_yaml(&results_dir));
+
+    let (stdout, stderr, code) = run(&[
+        "bench",
+        "orchestrate",
+        "--config",
+        &config,
+        "--dry-run",
+        "corpus_stats",
+    ]);
+
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("Dry run"), "{stdout}");
+    assert!(stdout.contains("corpus_stats"), "{stdout}");
+    assert!(
+        !results_dir.exists(),
+        "dry-run must not create the results dir"
+    );
+}
+
+/// Runs the real `SystemSsh` localhost path end-to-end: connectivity check,
+/// benchmark exec, result download, aggregation, and metadata — all real
+/// code, no `RemoteExec` fake. Whether the nested `bench run corpus_stats`
+/// subprocess itself succeeds depends on whether a release binary happens to
+/// be built already; either way the orchestration plumbing must complete
+/// with exit 0 and produce its result files.
+#[test]
+fn orchestrate_local_only_node_runs_end_to_end() {
+    let dir = tempfile::tempdir().unwrap();
+    let results_dir = dir.path().join("results");
+    let config = write_config(dir.path(), &local_only_yaml(&results_dir));
+
+    let (_, stderr, code) = run(&["bench", "orchestrate", "--config", &config, "corpus_stats"]);
+
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stderr.contains("Orchestration run complete"), "{stderr}");
+
+    let run_dirs: Vec<_> = fs::read_dir(&results_dir)
+        .expect("results dir should exist")
+        .filter_map(std::result::Result::ok)
+        .collect();
+    assert_eq!(run_dirs.len(), 1, "expected exactly one run directory");
+    let run_dir = run_dirs[0].path();
+
+    assert!(run_dir.join("metadata.json").exists());
+    assert!(run_dir.join("results.jsonl").exists());
+    assert!(run_dir.join("local/node_info.json").exists());
+}


### PR DESCRIPTION
## Summary
- Implements distributed benchmark orchestration across SSH-reachable nodes (#98): `nodes.yaml` config parsing, isolation-aware wave scheduling, binary sync (cross-compile + deploy), EC2 lifecycle management, and cross-node result aggregation/reporting, wired up as `bench orchestrate` / `bench sync` / `bench nodes` / `bench report` CLI subcommands
- Adds end-to-end CLI tests and documents the full workflow in `docs/guides/benchmarking.md`
- Fixes a bug found during live validation against a real EC2 node: `bench sync` cross-compiled deployed binaries with `--features cli` instead of `--features bench-runner`, so a synced binary would be missing the `bench` subcommand `bench orchestrate` needs to invoke on it
- Records the general lesson (fakes standing in for "build then invoke across a process boundary" can't catch build/runtime feature mismatches) in the testing skill, plus an SSH-ACL-by-username gotcha and a cross-compile-toolchain workaround in the benchmarking guide

## Test plan
- [x] `cargo test` — all 49 `orchestrate::` unit tests pass
- [x] `cargo build --release --features bench-runner`
- [x] End-to-end CLI tests (`tests/orchestrate_cli_tests.rs`)
- [x] Live validation: `bench orchestrate` against a real EC2 Graviton4 node over SSH — `rank_select` (325.7s) and `popcount_strategies` (945.4s) both passed, results/`node_info.json` aggregated correctly
- [ ] `bench sync`'s cross-compile step itself not yet exercised live (validated by building natively on the remote node instead, since no local aarch64-Linux cross-linker was available)
- [ ] `.jsonl` / `bench report` comparison path not yet exercised live (only run against Criterion-type benchmarks, which report pass/fail + duration only — `.jsonl` is produced by CLI-type benchmarks like `jq_bench`/`yq_bench`)

Addresses #98.