### PR TITLE
perf(jq): avoid materializing a navigated container key/bound just to reject it

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -287,6 +287,26 @@ fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> OwnedValue 
     }
 }
 
+/// Materialize a key/slice-bound candidate just enough to classify it.
+///
+/// `index_one`/[`EvalError::cannot_index`] and `SliceBounds::resolved_bound`
+/// never inspect an Array/Object candidate's *contents* — only its type
+/// name, to build the `Cannot index ... with array/object`/`Array or string
+/// slice indices must be integers` message — so a full recursive [`to_owned`]
+/// of a large navigated container candidate is pure waste when it can only
+/// ever be rejected on type. Mirrors [`json_is_truthy`]'s existing "classify
+/// without paying for `to_owned`'s full deep copy" idiom, for the same
+/// reason: `.. | .[.k]?` visits every node in a tree, and on a
+/// linear-nesting document `.k`'s value at depth *i* is the entire
+/// remaining subtree (#626).
+fn to_owned_key_shape<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> OwnedValue {
+    match value {
+        StandardJson::Array(_) => OwnedValue::Array(Vec::new()),
+        StandardJson::Object(_) => OwnedValue::Object(IndexMap::new()),
+        other => to_owned(other),
+    }
+}
+
 /// jq truthiness of a borrowed value: everything except `null` and `false`.
 ///
 /// Equivalent to `to_owned(value).is_truthy()` — [`to_owned`] maps
@@ -6839,8 +6859,8 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // (3) Keys first: an empty key stream must not evaluate the target.
     let keys = match eval_single::<W, S>(key, value.clone(), false).materialize_cursor() {
-        QueryResult::One(v) => vec![to_owned(&v)],
-        QueryResult::Many(vs) => vs.iter().map(to_owned).collect(),
+        QueryResult::One(v) => vec![to_owned_key_shape(&v)],
+        QueryResult::Many(vs) => vs.iter().map(to_owned_key_shape).collect(),
         QueryResult::Owned(v) => vec![v],
         QueryResult::ManyOwned(vs) => vs,
         QueryResult::None => return QueryResult::None,
@@ -7050,8 +7070,8 @@ fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         return Ok(vec![None]);
     };
     let raw: Vec<OwnedValue> = match eval_single::<W, S>(expr, value, false).materialize_cursor() {
-        QueryResult::One(v) => vec![to_owned(&v)],
-        QueryResult::Many(vs) => vs.iter().map(to_owned).collect(),
+        QueryResult::One(v) => vec![to_owned_key_shape(&v)],
+        QueryResult::Many(vs) => vs.iter().map(to_owned_key_shape).collect(),
         QueryResult::Owned(v) => vec![v],
         QueryResult::ManyOwned(vs) => vs,
         QueryResult::None => return Ok(Vec::new()),

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -199,6 +199,55 @@ fn test_key_of_an_unindexable_kind_errors_even_on_a_container() {
     );
 }
 
+/// #626: an array/object key *navigated* out of the document (as opposed to
+/// a literal `[...]`/`{...}` key, which is already `Owned` and never reaches
+/// this code) used to be fully deep-copied via `to_owned` just to discover
+/// it is the wrong kind. The error message only ever names the key's type,
+/// never its contents, so the fix (`to_owned_key_shape` in `eval.rs`)
+/// materializes a cheap empty placeholder for a container key instead —
+/// this pins that the placeholder still reports the correct type and that a
+/// scalar key navigated the same way is unaffected.
+#[test]
+fn test_navigated_container_key_errors_on_type_without_needing_its_contents() {
+    check(
+        r#"{"a":1,"obj":{"x":1,"y":2,"z":3}}"#,
+        ".[.obj]",
+        Outcome::error("Cannot index object with object"),
+    );
+    check(
+        r#"{"a":1,"arr":[1,2,3]}"#,
+        ".[.arr]",
+        Outcome::error("Cannot index object with array"),
+    );
+    // `?` still suppresses it, same as a literal container key does above.
+    check(r#"{"a":1,"obj":{"x":1}}"#, ".[.obj]?", Outcome::values(&[]));
+    // A navigated *scalar* key is unaffected — still the real value, not a
+    // placeholder.
+    check(r#"{"a":1,"k":"a"}"#, ".[.k]", Outcome::values(&["1"]));
+}
+
+/// Same pattern, `eval_slice_bound`'s twin fix: a bound navigated to a large
+/// container only ever needs to be told apart from a number, never read.
+#[test]
+fn test_navigated_container_slice_bound_errors_without_needing_its_contents() {
+    check(
+        r#"{"list":[1,2,3],"bound":{"x":1,"y":2}}"#,
+        ".list[.bound:2]",
+        Outcome::error("Array/string slice indices must be integers"),
+    );
+    check(
+        r#"{"list":[1,2,3],"bound":[9,9,9]}"#,
+        ".list[.bound:2]",
+        Outcome::error("Array/string slice indices must be integers"),
+    );
+    // A navigated numeric bound still resolves normally.
+    check(
+        r#"{"list":[1,2,3],"bound":1}"#,
+        ".list[.bound:]",
+        Outcome::values(&["[2,3]"]),
+    );
+}
+
 #[test]
 fn test_optional_suppresses_the_indexing_error_only() {
     // `?` covers the indexing, so a bad container or a bad key kind yields no


### PR DESCRIPTION
## Summary

- `eval_index_expr`/`eval_slice_bound` (`src/jq/eval.rs`) unconditionally called `to_owned()` on a computed key/slice-bound before checking whether it was even a usable type (string/number). On a linear-nesting document, a navigated key's value can be the entire remaining subtree, so this was O(subtree) work per node visited by `..` — the quadratic blowup #626 measured (originally attributed there to `push_recursive_branches`/`resolve_recurse`, which turned out to be unreachable from that benchmark; corrected on the issue, with the real bug split out to #668 and a likely-analogous CLI-facing bug flagged in #669).
- `index_one`/`EvalError::cannot_index` and `SliceBounds::resolved_bound` only ever need an Array/Object candidate's *type name* for their error message, never its contents, so the new `to_owned_key_shape` helper materializes a cheap empty placeholder for those instead of a full recursive copy — mirroring the existing `json_is_truthy` shortcut in the same file.
- Fixes #626.

## Test plan

- [x] New regression tests (`test_navigated_container_key_errors_on_type_without_needing_its_contents`, `test_navigated_container_slice_bound_errors_without_needing_its_contents`) confirm error messages/values are unchanged on both evaluators, and that a navigated *scalar* key/bound still resolves to its real value.
- [x] Existing `tests/jq_recurse_depth_tests.rs` depth-300 correctness pin passes unchanged.
- [x] `cargo bench --bench jq_recurse_depth_bench`: depth 400 11.7ms → 93µs (~99% faster); scaling flattened from quadratic (~18.5x over 100→400) to linear (~4.8x, matching the 4x depth increase).
- [x] Full `cargo test --features cli,simd,regex,serde` suite passes (0 failures).
- [x] Both CI clippy invocations (`--all-features` and the SIMD-inclusive feature set) pass with `-D warnings`.