### PR TITLE
perf(jq): spike lazy keys_unsorted to de-risk #140 (#666)

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -10,6 +10,7 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
+use succinctly::jq::document::DocumentFields;
 use succinctly::jq::eval_generic::{eval_with_cursor, to_owned as generic_to_owned, GenericResult};
 use succinctly::jq::{self, format_number_jq_compat, Expr, JqValue, OwnedValue, Program};
 use succinctly::json::light::{JsonCursor, StandardJson};
@@ -1592,6 +1593,14 @@ fn evaluate_input(
         GenericResult::ManyCursor(cs) => {
             Ok(cs.iter().map(|c| generic_to_owned(&c.value())).collect())
         }
+        // Fallback: materialize (issue #666 spike). This runner boundary
+        // never sees a fast-pathed `keys_unsorted | length` — that's fully
+        // resolved to `Owned(Int(..))` inside the evaluator before it gets
+        // here — so this only fires for `keys_unsorted` alone or piped into
+        // something other than `length`.
+        GenericResult::LazyKeysUnsorted(fields) => Ok(vec![OwnedValue::Array(
+            fields.keys().into_iter().map(OwnedValue::String).collect(),
+        )]),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -1654,6 +1663,10 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
             .collect(),
         // ManyCursor: same lazy-cursor efficiency as OneCursor, per element.
         GenericResult::ManyCursor(cs) => cs.into_iter().map(JqValue::Cursor).collect(),
+        // Stays lazy all the way to output (issue #666 spike): a bare
+        // `keys_unsorted` never materializes a `Vec<String>` — `write_json`
+        // streams each key's raw bytes straight from `fields`.
+        GenericResult::LazyKeysUnsorted(fields) => vec![JqValue::LazyKeysArray(fields)],
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -2156,6 +2169,55 @@ where
                 out.write_all(separator.as_bytes())?;
                 out.write_all(current_indent.as_bytes())?;
                 out.write_all(b"}")?;
+            }
+        }
+        // Genuinely lazy (issue #666 spike): stream each key's raw bytes
+        // straight from its cursor, same zero-copy convention as
+        // `JqValue::Cursor`'s `StandardJson::Object` arm above — never
+        // collects a `Vec<String>` first.
+        JqValue::LazyKeysArray(fields) => {
+            use succinctly::json::light::StandardJson as SJ;
+            if fields.is_empty() {
+                out.write_all(b"[]")?;
+            } else {
+                out.write_all(b"[")?;
+                if !compact {
+                    out.write_all(separator.as_bytes())?;
+                }
+                for (i, field) in (*fields).enumerate() {
+                    if i > 0 {
+                        out.write_all(b",")?;
+                        if !compact {
+                            out.write_all(separator.as_bytes())?;
+                        }
+                    }
+                    if !compact {
+                        out.write_all(next_indent.as_bytes())?;
+                    }
+                    if let SJ::String(k) = field.key() {
+                        let raw = k.raw_bytes();
+                        let content = &raw[1..raw.len().saturating_sub(1)];
+                        if !config.ascii_output && !content.contains(&b'\\') {
+                            out.write_all(raw)?;
+                        } else if let Ok(decoded) = k.as_str() {
+                            out.write_all(b"\"")?;
+                            let escaped = if config.ascii_output {
+                                escape_json_string_ascii(&decoded)
+                            } else {
+                                escape_json_string(&decoded)
+                            };
+                            out.write_all(escaped.as_bytes())?;
+                            out.write_all(b"\"")?;
+                        } else {
+                            out.write_all(raw)?;
+                        }
+                    }
+                }
+                if !compact {
+                    out.write_all(separator.as_bytes())?;
+                    out.write_all(current_indent.as_bytes())?;
+                }
+                out.write_all(b"]")?;
             }
         }
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
-use succinctly::jq::document::DocumentCursor;
+use succinctly::jq::document::{DocumentCursor, DocumentFields};
 use succinctly::jq::eval_generic::{eval_with_cursor_using, to_owned, GenericResult};
 use succinctly::jq::{self, Builtin, Expr, OwnedValue, QueryResult, YqSemantics};
 use succinctly::json::light::StandardJson;
@@ -400,6 +400,14 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         GenericResult::OneCursor(c) => Ok(vec![to_owned(&c.value())]),
         GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).collect()),
         GenericResult::ManyCursor(cs) => Ok(cs.iter().map(|c| to_owned(&c.value())).collect()),
+        // Fallback: materialize (issue #666 spike). YAML has no lazy-output
+        // concept today — `yq_runner.rs` never builds a `JqValue` — so
+        // unlike the JSON `jq` runner, this is the only path available
+        // here; a genuinely lazy YAML `keys_unsorted` output is out of
+        // scope for this slice.
+        GenericResult::LazyKeysUnsorted(fields) => Ok(vec![OwnedValue::Array(
+            fields.keys().into_iter().map(OwnedValue::String).collect(),
+        )]),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -73,6 +73,15 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
     }
 }
 
+/// Materialize a `GenericResult::LazyKeysUnsorted` fallback: decode every key
+/// exactly as `Builtin::KeysUnsorted` did before issue #666's spike.
+///
+/// Every consumer other than `length` (see the `Pipe` fast path) goes through
+/// here — this is the "escape hatch" #140 anticipated.
+fn materialize_lazy_keys<V: DocumentValue>(fields: &V::Fields) -> OwnedValue {
+    OwnedValue::Array(fields.keys().into_iter().map(OwnedValue::String).collect())
+}
+
 /// Convert a StandardJson value to an OwnedValue.
 fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(
     value: &crate::json::light::StandardJson<'_, W>,
@@ -205,6 +214,10 @@ fn push_generic_truthiness<V: DocumentValue>(
         GenericResult::ManyCursor(cs) => {
             out.extend(cs.iter().map(|c| to_owned(&c.value()).is_truthy()));
         }
+        // An unsorted-keys array, materialized or not, is array-shaped and
+        // therefore always truthy in jq (only `null`/`false` are falsy) — no
+        // need to materialize just to answer this.
+        GenericResult::LazyKeysUnsorted(_) => out.push(true),
         GenericResult::None => {}
         GenericResult::Owned(v) => out.push(v.is_truthy()),
         GenericResult::ManyOwned(vs) => out.extend(vs.iter().map(OwnedValue::is_truthy)),
@@ -235,6 +248,9 @@ fn flatten_generic_results<V: DocumentValue>(items: Vec<GenericResult<V>>) -> Ve
             GenericResult::ManyCursor(cs) => {
                 results.extend(cs.iter().map(|c| to_owned(&c.value())));
             }
+            GenericResult::LazyKeysUnsorted(fields) => {
+                results.push(materialize_lazy_keys::<V>(&fields));
+            }
             GenericResult::None => {}
             GenericResult::Owned(o) => results.push(o),
             GenericResult::ManyOwned(os) => results.extend(os),
@@ -260,6 +276,13 @@ fn eval_on_many_owned<S: EvalSemantics, V: DocumentValue>(
             GenericResult::Many(_) => unreachable!("eval_on_owned never returns Many"),
             GenericResult::ManyCursor(_) => {
                 unreachable!("eval_on_owned never returns ManyCursor")
+            }
+            // `eval_on_owned` re-evaluates through the JSON-only `QueryResult`
+            // path (`eval.rs`), which has no lazy-keys concept — only this
+            // module's own `Builtin::KeysUnsorted` arm ever produces
+            // `LazyKeysUnsorted`.
+            GenericResult::LazyKeysUnsorted(_) => {
+                unreachable!("eval_on_owned never returns LazyKeysUnsorted")
             }
             GenericResult::None => {}
             // The outputs already produced no longer vanish (#400, #494).
@@ -296,6 +319,14 @@ pub enum GenericResult<V: DocumentValue> {
     /// e.g. `.[]`), enabling `line`/`column` on each element.
     ManyCursor(Vec<V::Cursor>),
 
+    /// Lazy, unsorted object keys (`keys_unsorted` on an object), not yet
+    /// materialized into strings. Spike for issue #666 / #140: lets
+    /// `keys_unsorted | length` answer from the field iterator alone
+    /// (`DocumentFields::len()`, O(n) no-alloc) instead of decoding every
+    /// key into an owned `String` first. Any consumer other than `length`
+    /// falls back to materializing exactly as before.
+    LazyKeysUnsorted(V::Fields),
+
     /// No result (optional that was missing).
     None,
 
@@ -326,6 +357,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::ManyCursor(cs) => Some(OwnedValue::Array(
                 cs.iter().map(|c| to_owned(&c.value())).collect(),
             )),
+            Self::LazyKeysUnsorted(fields) => Some(materialize_lazy_keys::<V>(&fields)),
             Self::None => None,
             Self::Error(_) => None,
             Self::Owned(o) => Some(o),
@@ -347,6 +379,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::OneCursor(c) => vec![to_owned(&c.value())],
             Self::Many(vs) => vs.iter().map(to_owned).collect(),
             Self::ManyCursor(cs) => cs.iter().map(|c| to_owned(&c.value())).collect(),
+            Self::LazyKeysUnsorted(fields) => vec![materialize_lazy_keys::<V>(&fields)],
             Self::None => vec![],
             Self::Error(_) => vec![],
             Self::Owned(o) => vec![o],
@@ -415,6 +448,19 @@ impl<V: DocumentValue> GenericResult<V> {
                     stats.any_truthy |= !stats.last_was_falsy;
                 }
                 stats.count = vs.len();
+            }
+            // Fallback: materialize (issue #666 spike). A real streaming
+            // implementation here — writing each key's raw bytes as it's
+            // pulled from `fields` instead of collecting a `Vec` first —
+            // is exactly the kind of extra work #140's full plan would need
+            // that this slice deliberately doesn't build.
+            Self::LazyKeysUnsorted(fields) => {
+                let owned = materialize_lazy_keys::<V>(fields);
+                owned.stream_json(out, indent_spaces)?;
+                on_value(out)?;
+                stats.count = 1;
+                stats.last_was_falsy = owned.is_falsy();
+                stats.any_truthy = !stats.last_was_falsy;
             }
             Self::ManyCursor(cs) => {
                 for c in cs {
@@ -538,6 +584,15 @@ impl<V: DocumentValue> GenericResult<V> {
                     stats.any_truthy |= !stats.last_was_falsy;
                 }
                 stats.count = cs.len();
+            }
+            // Fallback: materialize (issue #666 spike; see `stream_json`).
+            Self::LazyKeysUnsorted(fields) => {
+                let owned = materialize_lazy_keys::<V>(fields);
+                owned.stream_yaml(out, indent_spaces)?;
+                on_value(out)?;
+                stats.count = 1;
+                stats.last_was_falsy = owned.is_falsy();
+                stats.any_truthy = !stats.last_was_falsy;
             }
             Self::None => {
                 // No output
@@ -804,6 +859,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 GenericResult::ManyCursor(cs) => {
                                     results.extend(cs.iter().map(|c| to_owned(&c.value())));
                                 }
+                                GenericResult::LazyKeysUnsorted(fields) => {
+                                    results.push(materialize_lazy_keys::<V>(&fields));
+                                }
                                 GenericResult::None => {}
                                 // The outputs already piped through no longer
                                 // vanish (#400, #494).
@@ -895,6 +953,21 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                             }
                         };
                     }
+                    // Spike #666: the whole point. `length` answers from the
+                    // field iterator directly (O(n), no allocation) — no
+                    // decode, no `Vec`, no reserialize/reindex round-trip.
+                    // Anything else falls back to materializing exactly as
+                    // `KeysUnsorted` did before this change.
+                    GenericResult::LazyKeysUnsorted(fields) => match expr {
+                        Expr::Builtin(Builtin::Length) => {
+                            GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
+                        }
+                        _ => {
+                            let owned_keys: Vec<OwnedValue> =
+                                fields.keys().into_iter().map(OwnedValue::String).collect();
+                            eval_on_owned::<S, _>(expr, OwnedValue::Array(owned_keys), optional)
+                        }
+                    },
                     GenericResult::None => GenericResult::None,
                     GenericResult::Error(e) => return GenericResult::Error(e),
                     GenericResult::Owned(o) => {
@@ -952,6 +1025,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Owned(o) => o,
                 GenericResult::One(v) => to_owned(&v),
                 GenericResult::OneCursor(c) => to_owned(&c.value()),
+                GenericResult::LazyKeysUnsorted(fields) => materialize_lazy_keys::<V>(&fields),
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -993,6 +1067,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Owned(o) => o,
                 GenericResult::One(v) => to_owned(&v),
                 GenericResult::OneCursor(c) => to_owned(&c.value()),
+                GenericResult::LazyKeysUnsorted(fields) => materialize_lazy_keys::<V>(&fields),
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -1135,6 +1210,10 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
                 Some(v) => GenericResult::Owned(v),
                 None => GenericResult::None,
             },
+            // `inner`'s stream has exactly one output (the whole
+            // `keys_unsorted` result) — forward it unchanged, same as
+            // `Owned`/`OneCursor` above, so laziness survives `last(...)`.
+            GenericResult::LazyKeysUnsorted(fields) => GenericResult::LazyKeysUnsorted(fields),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1162,6 +1241,8 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
                 Some(v) => GenericResult::Owned(v),
                 None => GenericResult::None,
             },
+            // Same forwarding as the `want_last` branch above.
+            GenericResult::LazyKeysUnsorted(fields) => GenericResult::LazyKeysUnsorted(fields),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1278,7 +1359,9 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         // An owned target (a computed, non-navigational left side) has no
         // borrowed representation here; round-trip it through the shared
         // owned-value path by re-entering with the materialized document.
-        owned @ (GenericResult::Owned(_) | GenericResult::ManyOwned(_)) => {
+        owned @ (GenericResult::Owned(_)
+        | GenericResult::ManyOwned(_)
+        | GenericResult::LazyKeysUnsorted(_)) => {
             let targets = owned.collect_owned();
             let mut out = Vec::with_capacity(keys.len() * targets.len());
             for k in &keys {
@@ -1392,9 +1475,9 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         GenericResult::ManyCursor(cs) => {
             Targets::Borrowed(cs.iter().map(DocumentCursor::value).collect())
         }
-        owned @ (GenericResult::Owned(_) | GenericResult::ManyOwned(_)) => {
-            Targets::Owned(owned.collect_owned())
-        }
+        owned @ (GenericResult::Owned(_)
+        | GenericResult::ManyOwned(_)
+        | GenericResult::LazyKeysUnsorted(_)) => Targets::Owned(owned.collect_owned()),
     };
 
     // Start outer, end middle, target inner. The result is always owned:
@@ -1739,10 +1822,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::KeysUnsorted => {
             if let Some(fields) = value.as_object() {
-                let keys = fields.keys();
-                let owned_keys: Vec<OwnedValue> =
-                    keys.into_iter().map(OwnedValue::String).collect();
-                GenericResult::Owned(OwnedValue::Array(owned_keys))
+                // Spike #666: stay lazy here — don't decode every key into an
+                // owned String yet. `length` can answer from `fields.len()`
+                // alone (see the `Pipe` arm below); anything else falls back
+                // to materializing exactly as before.
+                GenericResult::LazyKeysUnsorted(fields)
             } else if let Some(elements) = value.as_array() {
                 let len = elements.len();
                 let indices: Vec<OwnedValue> =

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -86,6 +86,13 @@ pub enum JqValue<'a, W = Vec<u64>> {
     /// Created when constructing objects with `{a: .x, b: .y + 1}`.
     /// Keys are always strings, values can be lazy or materialized.
     Object(IndexMap<String, Self>),
+
+    /// Lazy array of `keys_unsorted` results, backed by an object field
+    /// iterator — not yet decoded into `String`s. Spike for issue #666 /
+    /// #140: `write_json` streams each key's raw bytes straight from its
+    /// cursor, so a bare `keys_unsorted` output never materializes a
+    /// `Vec<String>`.
+    LazyKeysArray(crate::json::light::JsonFields<'a, W>),
 }
 
 impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
@@ -239,6 +246,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::String(_) => "string",
             JqValue::Array(_) => "array",
             JqValue::Object(_) => "object",
+            JqValue::LazyKeysArray(_) => "array",
         }
     }
 
@@ -321,6 +329,10 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::String(s) => Some(s.chars().count()),
             JqValue::Array(arr) => Some(arr.len()),
             JqValue::Object(obj) => Some(obj.len()),
+            // No wildcard covers this case (issue #666 spike): without this
+            // arm, `keys_unsorted | length` reaching `JqValue` directly would
+            // silently answer `None` instead of the field count.
+            JqValue::LazyKeysArray(fields) => Some((*fields).count()),
             JqValue::Cursor(c) => match c.value() {
                 StandardJson::Null => Some(0),
                 StandardJson::String(s) => s.as_str().ok().map(|s| s.chars().count()),
@@ -380,6 +392,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                     .map(|(k, v)| (k.clone(), v.materialize()))
                     .collect(),
             ),
+            JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(fields),
         }
     }
 
@@ -403,6 +416,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Object(obj) => {
                 OwnedValue::Object(obj.into_iter().map(|(k, v)| (k, v.into_owned())).collect())
             }
+            JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(&fields),
         }
     }
 
@@ -491,6 +505,43 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                 }
                 out.write_char('}')
             }
+            // Genuinely lazy (issue #666 spike): each key's raw bytes come
+            // straight from its cursor — already a valid, already-escaped
+            // JSON string token — so this never allocates a `String` per
+            // key, unlike `JqValue::Object`/`Array` above.
+            JqValue::LazyKeysArray(fields) => {
+                out.write_char('[')?;
+                let mut current = *fields;
+                let mut first = true;
+                while let Some((field, rest)) = current.uncons() {
+                    if !first {
+                        out.write_char(',')?;
+                    }
+                    first = false;
+                    match field.key_cursor().raw_bytes() {
+                        Some(bytes) => {
+                            let s = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;
+                            out.write_str(s)?;
+                        }
+                        // Defensive fallback; JSON object keys are always
+                        // string tokens with a text range, so this is not
+                        // expected to be reached.
+                        None => {
+                            if let StandardJson::String(k) = field.key() {
+                                out.write_char('"')?;
+                                if let Ok(s) = k.as_str() {
+                                    write_json_body_jq(out, &s)?;
+                                }
+                                out.write_char('"')?;
+                            } else {
+                                out.write_str("null")?;
+                            }
+                        }
+                    }
+                    current = rest;
+                }
+                out.write_char(']')
+            }
         }
     }
 
@@ -504,6 +555,24 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
         let _ = self.write_json(&mut out);
         out
     }
+}
+
+/// Materialize a `JqValue::LazyKeysArray` into the `Vec<String>` array it
+/// would have been all along (issue #666 spike escape hatch).
+fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
+    fields: &crate::json::light::JsonFields<'_, W>,
+) -> OwnedValue {
+    let mut keys = Vec::new();
+    let mut current = *fields;
+    while let Some((field, rest)) = current.uncons() {
+        if let StandardJson::String(k) = field.key() {
+            if let Ok(s) = k.as_str() {
+                keys.push(OwnedValue::String(s.into_owned()));
+            }
+        }
+        current = rest;
+    }
+    OwnedValue::Array(keys)
 }
 
 /// Convert a JsonCursor to an OwnedValue (full materialization).

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1087,6 +1087,15 @@ impl<'a, W: AsRef<[u64]>> JsonField<'a, W> {
     pub fn value_cursor(&self) -> JsonCursor<'a, W> {
         self.value_cursor
     }
+
+    /// Get the key cursor directly.
+    ///
+    /// This allows raw-byte access to the key (`raw_bytes()`) without
+    /// decoding through `StandardJson::String` first.
+    #[inline]
+    pub fn key_cursor(&self) -> JsonCursor<'a, W> {
+        self.key_cursor
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Throwaway spike for #666, precursor to #140. Prototypes `GenericResult::LazyKeysUnsorted` + `JqValue::LazyKeysArray` so `keys_unsorted | length` and bare `keys_unsorted` answer from the object's field iterator directly instead of decoding every key into an owned `String` first — avoiding the reserialize + `JsonIndex`-rebuild round trip `keys_unsorted | length` previously went through via `eval_on_owned`.

**Not intended to merge as-is** — per #666's scope, the deliverable is the finding, not the code. Opened as a draft PR for reference alongside the findings.

Full write-up: https://github.com/rust-works/succinctly/issues/666#issuecomment-5224198817

## Measured results

Interleaved A/B (`/usr/bin/time -l`, median of 7 reps), 100K-field synthetic object, output byte-identical to baseline on every query/edge case tested:

| Query | Before RSS | After RSS | Reduction | Time |
|---|---|---|---|---|
| `keys_unsorted \| length` | 29.29 MB | 10.90 MB | **63% (2.7x)** | 20ms → 10ms |
| `keys_unsorted` | 24.59 MB | 10.80 MB | **56% (2.3x)** | 20ms → 10ms |

At 100K fields the after-RSS for `keys_unsorted | length` lands within noise of plain `length` alone (10.86 MB) — key materialization overhead is eliminated down to the process floor.

## Invasiveness findings (the actual point of #666)

- `GenericResult<V>`: 14 exhaustive match sites needed a new arm (compiler-forced) — more than the ~11 statically estimated. Most are 1-3 lines via one shared materialize-fallback helper; 2 forward unchanged for free (`first`/`last`).
- `QueryResult` (`eval.rs`): **zero** sites touched — confirmed the live CLI path never routes this query shape through it, contra #140's original assumption.
- `JqValue`: 1 new variant, 3 compile-forced sites + 1 wildcard-covered site that's silently wrong unless updated, plus genuine new streaming logic in `write_json`/`print_json`.
- Runner boundary: `jq_runner.rs` (2 sites + `print_json`), `yq_runner.rs` (1 site — YAML has no lazy-output concept today).

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` (lib + integration suites, run in isolation to avoid known cargo-lock contention flakiness)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Output byte-identical vs. pre-change binary across `keys_unsorted`, `keys_unsorted | length`, `keys_unsorted | .[0]`, `last`, `first`, `map`, `sort`, comparisons, nested `.[] | keys_unsorted`, empty object, and the YAML `yq` side
- [x] Interleaved A/B memory/time measurement at 10K and 100K fields