### PR TITLE
perf(jq): lazy keys_unsorted streaming (M3.1)

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -10,6 +10,7 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
+use succinctly::jq::document::DocumentFields;
 use succinctly::jq::eval_generic::{eval_with_cursor, to_owned as generic_to_owned, GenericResult};
 use succinctly::jq::{self, format_number_jq_compat, Expr, JqValue, OwnedValue, Program};
 use succinctly::json::light::{JsonCursor, StandardJson};
@@ -1592,6 +1593,14 @@ fn evaluate_input(
         GenericResult::ManyCursor(cs) => {
             Ok(cs.iter().map(|c| generic_to_owned(&c.value())).collect())
         }
+        // Fallback: materialize. This runner boundary never sees a
+        // fast-pathed `keys_unsorted | length`/`.[]`/`.[n]`/`first`/`last`
+        // — those are fully resolved inside the evaluator's `Pipe` dispatch
+        // before it gets here — so this only fires for `keys_unsorted`
+        // alone, or piped into something else (`map`, `select`, ...).
+        GenericResult::LazyKeysUnsorted(fields) => Ok(vec![OwnedValue::Array(
+            fields.keys().into_iter().map(OwnedValue::String).collect(),
+        )]),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -1654,6 +1663,14 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
             .collect(),
         // ManyCursor: same lazy-cursor efficiency as OneCursor, per element.
         GenericResult::ManyCursor(cs) => cs.into_iter().map(JqValue::Cursor).collect(),
+        // Fallback: materialize. This runner boundary never sees a
+        // fast-pathed `keys_unsorted | length`/`.[]`/`.[n]`/`first`/`last`
+        // — those are fully resolved inside the evaluator's `Pipe` dispatch
+        // before it gets here — so this only fires for `keys_unsorted`
+        // alone, or piped into something else (`map`, `select`, ...).
+        GenericResult::LazyKeysUnsorted(fields) => vec![JqValue::from_owned(OwnedValue::Array(
+            fields.keys().into_iter().map(OwnedValue::String).collect(),
+        ))],
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1663,14 +1663,10 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
             .collect(),
         // ManyCursor: same lazy-cursor efficiency as OneCursor, per element.
         GenericResult::ManyCursor(cs) => cs.into_iter().map(JqValue::Cursor).collect(),
-        // Fallback: materialize. This runner boundary never sees a
-        // fast-pathed `keys_unsorted | length`/`.[]`/`.[n]`/`first`/`last`
-        // — those are fully resolved inside the evaluator's `Pipe` dispatch
-        // before it gets here — so this only fires for `keys_unsorted`
-        // alone, or piped into something else (`map`, `select`, ...).
-        GenericResult::LazyKeysUnsorted(fields) => vec![JqValue::from_owned(OwnedValue::Array(
-            fields.keys().into_iter().map(OwnedValue::String).collect(),
-        ))],
+        // Stays lazy all the way to output: a bare `keys_unsorted` never
+        // materializes a `Vec<String>` — `write_json`/`print_json` stream
+        // each key's raw bytes straight from `fields`.
+        GenericResult::LazyKeysUnsorted(fields) => vec![JqValue::LazyKeysArray(fields)],
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -2173,6 +2169,75 @@ where
                 out.write_all(separator.as_bytes())?;
                 out.write_all(current_indent.as_bytes())?;
                 out.write_all(b"}")?;
+            }
+        }
+        // Genuinely lazy: stream each key's raw bytes straight from its
+        // cursor, same zero-copy convention as `JqValue::Cursor`'s
+        // `StandardJson::Object` arm above — never collects a `Vec<String>`
+        // first. Compact/pretty duplicated as two full loops, matching the
+        // `StandardJson::Array`/`StandardJson::Object` arms above rather
+        // than branching mid-loop.
+        JqValue::LazyKeysArray(fields) => {
+            use succinctly::json::light::StandardJson as SJ;
+            if fields.is_empty() {
+                out.write_all(b"[]")?;
+            } else if compact {
+                out.write_all(b"[")?;
+                for (i, field) in (*fields).enumerate() {
+                    if i > 0 {
+                        out.write_all(b",")?;
+                    }
+                    if let SJ::String(k) = field.key() {
+                        let raw = k.raw_bytes();
+                        let content = &raw[1..raw.len().saturating_sub(1)];
+                        if !config.ascii_output && !content.contains(&b'\\') {
+                            out.write_all(raw)?;
+                        } else if let Ok(decoded) = k.as_str() {
+                            out.write_all(b"\"")?;
+                            let escaped = if config.ascii_output {
+                                escape_json_string_ascii(&decoded)
+                            } else {
+                                escape_json_string(&decoded)
+                            };
+                            out.write_all(escaped.as_bytes())?;
+                            out.write_all(b"\"")?;
+                        } else {
+                            out.write_all(raw)?;
+                        }
+                    }
+                }
+                out.write_all(b"]")?;
+            } else {
+                out.write_all(b"[")?;
+                out.write_all(separator.as_bytes())?;
+                for (i, field) in (*fields).enumerate() {
+                    if i > 0 {
+                        out.write_all(b",")?;
+                        out.write_all(separator.as_bytes())?;
+                    }
+                    out.write_all(next_indent.as_bytes())?;
+                    if let SJ::String(k) = field.key() {
+                        let raw = k.raw_bytes();
+                        let content = &raw[1..raw.len().saturating_sub(1)];
+                        if !config.ascii_output && !content.contains(&b'\\') {
+                            out.write_all(raw)?;
+                        } else if let Ok(decoded) = k.as_str() {
+                            out.write_all(b"\"")?;
+                            let escaped = if config.ascii_output {
+                                escape_json_string_ascii(&decoded)
+                            } else {
+                                escape_json_string(&decoded)
+                            };
+                            out.write_all(escaped.as_bytes())?;
+                            out.write_all(b"\"")?;
+                        } else {
+                            out.write_all(raw)?;
+                        }
+                    }
+                }
+                out.write_all(separator.as_bytes())?;
+                out.write_all(current_indent.as_bytes())?;
+                out.write_all(b"]")?;
             }
         }
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
-use succinctly::jq::document::DocumentCursor;
+use succinctly::jq::document::{DocumentCursor, DocumentFields};
 use succinctly::jq::eval_generic::{eval_with_cursor_using, to_owned, GenericResult};
 use succinctly::jq::{self, Builtin, Expr, OwnedValue, QueryResult, YqSemantics};
 use succinctly::json::light::StandardJson;
@@ -400,6 +400,14 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         GenericResult::OneCursor(c) => Ok(vec![to_owned(&c.value())]),
         GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).collect()),
         GenericResult::ManyCursor(cs) => Ok(cs.iter().map(|c| to_owned(&c.value())).collect()),
+        // Fallback: materialize. YAML has no lazy-output concept today —
+        // `yq_runner.rs` never builds a `JqValue` — so unlike the JSON `jq`
+        // runner, this is the only path available here; a genuinely lazy
+        // YAML `keys_unsorted` output is deferred to a follow-up issue
+        // (#140).
+        GenericResult::LazyKeysUnsorted(fields) => Ok(vec![OwnedValue::Array(
+            fields.keys().into_iter().map(OwnedValue::String).collect(),
+        )]),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -296,6 +296,8 @@ pub struct DocumentField<V, C> {
     pub key: V,
     /// The field value.
     pub value: V,
+    /// Cursor to the key (for lazy key-array navigation, e.g. `keys_unsorted`).
+    pub key_cursor: C,
     /// Cursor to the value (for efficient sub-navigation).
     pub value_cursor: C,
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -73,6 +73,32 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
     }
 }
 
+/// Materialize a `GenericResult::LazyKeysUnsorted` fallback: decode every key
+/// exactly as `Builtin::KeysUnsorted` did before it stayed lazy.
+///
+/// Every consumer other than the native fast paths (`length`, `.[]`, `.[n]`,
+/// `first`, `last` — see the `Pipe` dispatch below) goes through here; this
+/// is the escape hatch #140 anticipated for everything else (`map`,
+/// `select`, comparisons, ...).
+fn materialize_lazy_keys<V: DocumentValue>(fields: &V::Fields) -> OwnedValue {
+    OwnedValue::Array(fields.keys().into_iter().map(OwnedValue::String).collect())
+}
+
+/// Unwrap any number of `(...)`-parens to reach the underlying expression.
+///
+/// The `Pipe` dispatch below pattern-matches the *literal* AST shape of the
+/// next stage to decide whether a `LazyKeysUnsorted` fast path applies —
+/// without this, `keys_unsorted | (length)` would miss the fast path that
+/// `keys_unsorted | length` hits, even though parens are semantically
+/// transparent everywhere else in this evaluator (see `Expr::Paren`'s own
+/// arm above).
+fn unwrap_paren(mut expr: &Expr) -> &Expr {
+    while let Expr::Paren(inner) = expr {
+        expr = inner;
+    }
+    expr
+}
+
 /// Convert a StandardJson value to an OwnedValue.
 fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(
     value: &crate::json::light::StandardJson<'_, W>,
@@ -205,6 +231,10 @@ fn push_generic_truthiness<V: DocumentValue>(
         GenericResult::ManyCursor(cs) => {
             out.extend(cs.iter().map(|c| to_owned(&c.value()).is_truthy()));
         }
+        // An unsorted-keys array, materialized or not, is array-shaped and
+        // therefore always truthy in jq (only `null`/`false` are falsy) — no
+        // need to materialize just to answer this.
+        GenericResult::LazyKeysUnsorted(_) => out.push(true),
         GenericResult::None => {}
         GenericResult::Owned(v) => out.push(v.is_truthy()),
         GenericResult::ManyOwned(vs) => out.extend(vs.iter().map(OwnedValue::is_truthy)),
@@ -235,6 +265,9 @@ fn flatten_generic_results<V: DocumentValue>(items: Vec<GenericResult<V>>) -> Ve
             GenericResult::ManyCursor(cs) => {
                 results.extend(cs.iter().map(|c| to_owned(&c.value())));
             }
+            GenericResult::LazyKeysUnsorted(fields) => {
+                results.push(materialize_lazy_keys::<V>(&fields));
+            }
             GenericResult::None => {}
             GenericResult::Owned(o) => results.push(o),
             GenericResult::ManyOwned(os) => results.extend(os),
@@ -260,6 +293,13 @@ fn eval_on_many_owned<S: EvalSemantics, V: DocumentValue>(
             GenericResult::Many(_) => unreachable!("eval_on_owned never returns Many"),
             GenericResult::ManyCursor(_) => {
                 unreachable!("eval_on_owned never returns ManyCursor")
+            }
+            // `eval_on_owned` re-evaluates through the JSON-only `QueryResult`
+            // path (`eval.rs`), which has no lazy-keys concept — only this
+            // module's own `Builtin::KeysUnsorted` arm ever produces
+            // `LazyKeysUnsorted`.
+            GenericResult::LazyKeysUnsorted(_) => {
+                unreachable!("eval_on_owned never returns LazyKeysUnsorted")
             }
             GenericResult::None => {}
             // The outputs already produced no longer vanish (#400, #494).
@@ -296,6 +336,13 @@ pub enum GenericResult<V: DocumentValue> {
     /// e.g. `.[]`), enabling `line`/`column` on each element.
     ManyCursor(Vec<V::Cursor>),
 
+    /// Lazy, unsorted object keys (`keys_unsorted` on an object), not yet
+    /// materialized into strings (#140). `length`, `.[]`, `.[n]`, `first`,
+    /// and `last` all answer directly from the field iterator (no `Vec`, no
+    /// per-key decode) via the `Pipe` dispatch below; every other consumer
+    /// falls back to materializing exactly as eager `keys_unsorted` did.
+    LazyKeysUnsorted(V::Fields),
+
     /// No result (optional that was missing).
     None,
 
@@ -326,6 +373,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::ManyCursor(cs) => Some(OwnedValue::Array(
                 cs.iter().map(|c| to_owned(&c.value())).collect(),
             )),
+            Self::LazyKeysUnsorted(fields) => Some(materialize_lazy_keys::<V>(&fields)),
             Self::None => None,
             Self::Error(_) => None,
             Self::Owned(o) => Some(o),
@@ -347,6 +395,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::OneCursor(c) => vec![to_owned(&c.value())],
             Self::Many(vs) => vs.iter().map(to_owned).collect(),
             Self::ManyCursor(cs) => cs.iter().map(|c| to_owned(&c.value())).collect(),
+            Self::LazyKeysUnsorted(fields) => vec![materialize_lazy_keys::<V>(&fields)],
             Self::None => vec![],
             Self::Error(_) => vec![],
             Self::Owned(o) => vec![o],
@@ -415,6 +464,21 @@ impl<V: DocumentValue> GenericResult<V> {
                     stats.any_truthy |= !stats.last_was_falsy;
                 }
                 stats.count = vs.len();
+            }
+            // Fallback: materialize. `keys_unsorted`-involving expressions
+            // never reach M2 streaming today (`can_use_m2_streaming`'s
+            // whitelist excludes `Builtin::KeysUnsorted`, `yq_runner.rs`),
+            // so this arm exists only to keep the match exhaustive; a real
+            // streaming implementation (writing each key's raw bytes as
+            // it's pulled from `fields`) is future work if M2 ever grows to
+            // cover `keys_unsorted`.
+            Self::LazyKeysUnsorted(fields) => {
+                let owned = materialize_lazy_keys::<V>(fields);
+                owned.stream_json(out, indent_spaces)?;
+                on_value(out)?;
+                stats.count = 1;
+                stats.last_was_falsy = owned.is_falsy();
+                stats.any_truthy = !stats.last_was_falsy;
             }
             Self::ManyCursor(cs) => {
                 for c in cs {
@@ -538,6 +602,16 @@ impl<V: DocumentValue> GenericResult<V> {
                     stats.any_truthy |= !stats.last_was_falsy;
                 }
                 stats.count = cs.len();
+            }
+            // Fallback: materialize. See `stream_json`'s `LazyKeysUnsorted`
+            // arm above — same reasoning (unreachable via M2 today).
+            Self::LazyKeysUnsorted(fields) => {
+                let owned = materialize_lazy_keys::<V>(fields);
+                owned.stream_yaml(out, indent_spaces)?;
+                on_value(out)?;
+                stats.count = 1;
+                stats.last_was_falsy = owned.is_falsy();
+                stats.any_truthy = !stats.last_was_falsy;
             }
             Self::None => {
                 // No output
@@ -804,6 +878,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 GenericResult::ManyCursor(cs) => {
                                     results.extend(cs.iter().map(|c| to_owned(&c.value())));
                                 }
+                                GenericResult::LazyKeysUnsorted(fields) => {
+                                    results.push(materialize_lazy_keys::<V>(&fields));
+                                }
                                 GenericResult::None => {}
                                 // The outputs already piped through no longer
                                 // vanish (#400, #494).
@@ -895,6 +972,97 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                             }
                         };
                     }
+                    // The whole point of `LazyKeysUnsorted`: `length`, `.[]`,
+                    // `.[n]`, `first`, and `last` all answer directly from
+                    // the field iterator (no decode, no `Vec`, no
+                    // reserialize/reindex round-trip) by mirroring the same
+                    // shapes' handling for real arrays elsewhere in this
+                    // file (`Expr::Index`/`Expr::Iterate` above,
+                    // `Builtin::First`/`Builtin::Last`/`Builtin::Length` in
+                    // `eval_builtin`). `map`/`select` and everything else
+                    // fall back to materializing exactly as eager
+                    // `KeysUnsorted` did — `eval_generic.rs` has no native
+                    // lazy `map`/`select` for *any* value today (even a
+                    // materialized array's `map` round-trips through
+                    // `eval_on_owned`), so there's no cheap win available
+                    // here without a broader, unrelated architecture change.
+                    GenericResult::LazyKeysUnsorted(fields) => match unwrap_paren(expr) {
+                        Expr::Builtin(Builtin::Length) => {
+                            GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
+                        }
+                        Expr::Iterate => {
+                            let mut cursors = Vec::new();
+                            let mut current = fields;
+                            while let Some((field, rest)) = current.uncons() {
+                                cursors.push(field.key_cursor);
+                                current = rest;
+                            }
+                            if cursors.is_empty() {
+                                GenericResult::None
+                            } else {
+                                GenericResult::ManyCursor(cursors)
+                            }
+                        }
+                        Expr::Index(idx) => {
+                            // Negative indices need the length to normalize
+                            // against, same as `Expr::Index`'s array arm
+                            // above; positive indices skip straight to the
+                            // walk. Out-of-bounds is `null`, never an error
+                            // (#307), matching that same arm.
+                            let target = if *idx < 0 {
+                                let len = fields.len();
+                                let normalized = len as i64 + idx;
+                                if normalized < 0 {
+                                    None
+                                } else {
+                                    Some(normalized as usize)
+                                }
+                            } else {
+                                Some(*idx as usize)
+                            };
+                            match target {
+                                Some(target) => {
+                                    let mut current = fields;
+                                    let mut found = None;
+                                    let mut i = 0usize;
+                                    while let Some((field, rest)) = current.uncons() {
+                                        if i == target {
+                                            found = Some(field.key_cursor);
+                                            break;
+                                        }
+                                        current = rest;
+                                        i += 1;
+                                    }
+                                    match found {
+                                        Some(c) => GenericResult::OneCursor(c),
+                                        None => GenericResult::Owned(OwnedValue::Null),
+                                    }
+                                }
+                                None => GenericResult::Owned(OwnedValue::Null),
+                            }
+                        }
+                        Expr::Builtin(Builtin::First) => match fields.uncons() {
+                            Some((field, _)) => GenericResult::OneCursor(field.key_cursor),
+                            None => GenericResult::Owned(OwnedValue::Null),
+                        },
+                        Expr::Builtin(Builtin::Last) => {
+                            let mut current = fields;
+                            let mut last_cursor = None;
+                            while let Some((field, rest)) = current.uncons() {
+                                last_cursor = Some(field.key_cursor);
+                                current = rest;
+                            }
+                            match last_cursor {
+                                Some(c) => GenericResult::OneCursor(c),
+                                None => GenericResult::Owned(OwnedValue::Null),
+                            }
+                        }
+                        _ => {
+                            let owned_keys: Vec<OwnedValue> =
+                                fields.keys().into_iter().map(OwnedValue::String).collect();
+                            eval_on_owned::<S, _>(expr, OwnedValue::Array(owned_keys), optional)
+                        }
+                    },
                     GenericResult::None => GenericResult::None,
                     GenericResult::Error(e) => return GenericResult::Error(e),
                     GenericResult::Owned(o) => {
@@ -952,6 +1120,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Owned(o) => o,
                 GenericResult::One(v) => to_owned(&v),
                 GenericResult::OneCursor(c) => to_owned(&c.value()),
+                GenericResult::LazyKeysUnsorted(fields) => materialize_lazy_keys::<V>(&fields),
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -993,6 +1162,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Owned(o) => o,
                 GenericResult::One(v) => to_owned(&v),
                 GenericResult::OneCursor(c) => to_owned(&c.value()),
+                GenericResult::LazyKeysUnsorted(fields) => materialize_lazy_keys::<V>(&fields),
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -1135,6 +1305,10 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
                 Some(v) => GenericResult::Owned(v),
                 None => GenericResult::None,
             },
+            // `inner`'s stream has exactly one output (the whole
+            // `keys_unsorted` result) — forward it unchanged, same as
+            // `Owned`/`OneCursor` above, so laziness survives `last(...)`.
+            GenericResult::LazyKeysUnsorted(fields) => GenericResult::LazyKeysUnsorted(fields),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1162,6 +1336,8 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
                 Some(v) => GenericResult::Owned(v),
                 None => GenericResult::None,
             },
+            // Same forwarding as the `want_last` branch above.
+            GenericResult::LazyKeysUnsorted(fields) => GenericResult::LazyKeysUnsorted(fields),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1278,7 +1454,9 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         // An owned target (a computed, non-navigational left side) has no
         // borrowed representation here; round-trip it through the shared
         // owned-value path by re-entering with the materialized document.
-        owned @ (GenericResult::Owned(_) | GenericResult::ManyOwned(_)) => {
+        owned @ (GenericResult::Owned(_)
+        | GenericResult::ManyOwned(_)
+        | GenericResult::LazyKeysUnsorted(_)) => {
             let targets = owned.collect_owned();
             let mut out = Vec::with_capacity(keys.len() * targets.len());
             for k in &keys {
@@ -1392,9 +1570,9 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         GenericResult::ManyCursor(cs) => {
             Targets::Borrowed(cs.iter().map(DocumentCursor::value).collect())
         }
-        owned @ (GenericResult::Owned(_) | GenericResult::ManyOwned(_)) => {
-            Targets::Owned(owned.collect_owned())
-        }
+        owned @ (GenericResult::Owned(_)
+        | GenericResult::ManyOwned(_)
+        | GenericResult::LazyKeysUnsorted(_)) => Targets::Owned(owned.collect_owned()),
     };
 
     // Start outer, end middle, target inner. The result is always owned:
@@ -1739,10 +1917,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::KeysUnsorted => {
             if let Some(fields) = value.as_object() {
-                let keys = fields.keys();
-                let owned_keys: Vec<OwnedValue> =
-                    keys.into_iter().map(OwnedValue::String).collect();
-                GenericResult::Owned(OwnedValue::Array(owned_keys))
+                // Stay lazy here — don't decode every key into an owned
+                // String yet. `length`, `.[]`, `.[n]`, `first`, and `last`
+                // can all answer directly from `fields` (see the `Pipe`
+                // dispatch below); anything else falls back to materializing
+                // exactly as before (#140).
+                GenericResult::LazyKeysUnsorted(fields)
             } else if let Some(elements) = value.as_array() {
                 let len = elements.len();
                 let indices: Vec<OwnedValue> =
@@ -2246,6 +2426,222 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_keys_unsorted_lazy_length() {
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | length").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(3));
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_length_through_parens() {
+        // Regression: the `Pipe` fast path must unwrap `(...)` so
+        // `keys_unsorted | (length)` hits the same lazy path as
+        // `keys_unsorted | length`, not the materialize fallback.
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | (length)").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(3));
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_iterate() {
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(
+            result.collect_owned(),
+            vec![
+                OwnedValue::String("b".to_string()),
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("c".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_iterate_empty_object() {
+        let json = br"{}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_index() {
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | .[0]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::String("b".to_string())
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[-1]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::String("c".to_string())
+        );
+
+        // Out of bounds is `null`, never an error (#307), matching plain
+        // array indexing.
+        let expr = crate::jq::parse("keys_unsorted | .[10]").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_first_last() {
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | first").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::String("b".to_string())
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | last").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::String("c".to_string())
+        );
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_first_last_empty_object() {
+        let json = br"{}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | first").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Null
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | last").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_index_then_continue() {
+        // The fast path must produce a real cursor, not just a bare value
+        // -- downstream operations (`ascii_upcase` here) need to keep
+        // working after `.[]`/`.[0]` on a lazy keys array.
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | .[] | ascii_upcase").unwrap();
+        let result = eval(&expr, value.clone());
+        assert_eq!(
+            result.collect_owned(),
+            vec![
+                OwnedValue::String("B".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("C".to_string()),
+            ]
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[0] | ascii_upcase").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::String("B".to_string())
+        );
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_fallback_map_select() {
+        // `map`/`select` have no native lazy path -- `eval_generic.rs` has
+        // no native `Builtin::Map` arm at all (see the `Pipe` dispatch's
+        // `LazyKeysUnsorted` arm doc comment) -- so these must still
+        // materialize correctly via the fallback.
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase)").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("B".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("C".to_string()),
+            ])
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | select(length == 3)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("b".to_string()),
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("c".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_large_object() {
+        // No allocation-count assertion here (that's covered by the A/B
+        // memory measurement) -- just correctness at a size well past any
+        // small-N special case.
+        let mut json = String::from("{");
+        for i in 0..10_000 {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&format!(r#""k{i}":{i}"#));
+        }
+        json.push('}');
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | length").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Int(10_000)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[9999]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::String("k9999".to_string())
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | last").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::String("k9999".to_string())
+        );
+    }
+
+    #[test]
     fn test_generic_pipe() {
         let json = br#"{"users": [{"name": "Alice"}, {"name": "Bob"}]}"#;
         let index = JsonIndex::build(json);
@@ -2570,6 +2966,57 @@ mod tests {
                 OwnedValue::Int(2),
                 OwnedValue::Int(3),
             ])
+        );
+    }
+
+    #[test]
+    fn test_yaml_keys_unsorted_lazy_fast_paths() {
+        // `LazyKeysUnsorted`/its `Pipe` fast paths are generic over
+        // `V: DocumentValue`, so a YAML mapping goes through the exact same
+        // evaluator arms as a JSON object (#140) -- only `yq_runner.rs`'s
+        // CLI output boundary still materializes unconditionally, since
+        // YAML has no `JqValue`-equivalent lazy output today.
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"b: 1\na: 2\nc: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse("keys_unsorted | length").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::Int(3)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).collect_owned(),
+            vec![
+                OwnedValue::String("b".to_string()),
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("c".to_string()),
+            ]
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[0]").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::String("b".to_string())
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | first").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::String("b".to_string())
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | last").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::String("c".to_string())
         );
     }
 
@@ -3022,6 +3469,7 @@ mod tests {
         let index = JsonIndex::build(doc);
         let c0 = index.root(doc);
         let c1 = index.root(doc);
+        let c2 = index.root(doc);
         let results = vec![
             eval(&Expr::Field("a".to_string()), c0.value()), // single value
             eval(
@@ -3041,6 +3489,12 @@ mod tests {
                 Control::Error(EvalError::new("late")),
             ),
             GenericResult::Partial(vec![OwnedValue::Int(3)], Control::Break("lbl".to_string())),
+            // Appended at the end (#140) so it doesn't disturb the fixed
+            // positional indices every other assertion in this test relies
+            // on: LazyKeysUnsorted, exercised the same way as every other
+            // variant by the `stream_json`/`stream_yaml`/`into_owned` loops
+            // below.
+            eval(&Expr::Builtin(Builtin::KeysUnsorted), c2.value()),
         ];
 
         // is_error / error / is_single_cursor (borrow &self)
@@ -3172,6 +3626,13 @@ mod tests {
         // `collect_owned`, which keeps the prefix (checked separately).
         assert_eq!(owned[7], None); // Partial(_, Error)
         assert_eq!(owned[8], None); // Partial(_, Break)
+        assert_eq!(
+            owned[9],
+            Some(OwnedValue::Array(vec![
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("b".to_string()),
+            ]))
+        ); // LazyKeysUnsorted
     }
 
     #[test]

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -86,6 +86,12 @@ pub enum JqValue<'a, W = Vec<u64>> {
     /// Created when constructing objects with `{a: .x, b: .y + 1}`.
     /// Keys are always strings, values can be lazy or materialized.
     Object(IndexMap<String, Self>),
+
+    /// Lazy array of `keys_unsorted` results, backed by an object field
+    /// iterator — not yet decoded into `String`s (#140). `write_json` and
+    /// `print_json` stream each key's raw bytes straight from its cursor,
+    /// so a bare `keys_unsorted` output never materializes a `Vec<String>`.
+    LazyKeysArray(crate::json::light::JsonFields<'a, W>),
 }
 
 impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
@@ -239,6 +245,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::String(_) => "string",
             JqValue::Array(_) => "array",
             JqValue::Object(_) => "object",
+            JqValue::LazyKeysArray(_) => "array",
         }
     }
 
@@ -321,6 +328,10 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::String(s) => Some(s.chars().count()),
             JqValue::Array(arr) => Some(arr.len()),
             JqValue::Object(obj) => Some(obj.len()),
+            // No wildcard covers this case: without this arm,
+            // `keys_unsorted | length` reaching `JqValue` directly would
+            // silently answer `None` instead of the field count.
+            JqValue::LazyKeysArray(fields) => Some((*fields).count()),
             JqValue::Cursor(c) => match c.value() {
                 StandardJson::Null => Some(0),
                 StandardJson::String(s) => s.as_str().ok().map(|s| s.chars().count()),
@@ -380,6 +391,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                     .map(|(k, v)| (k.clone(), v.materialize()))
                     .collect(),
             ),
+            JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(fields),
         }
     }
 
@@ -403,6 +415,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Object(obj) => {
                 OwnedValue::Object(obj.into_iter().map(|(k, v)| (k, v.into_owned())).collect())
             }
+            JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(&fields),
         }
     }
 
@@ -491,6 +504,43 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                 }
                 out.write_char('}')
             }
+            // Genuinely lazy: each key's raw bytes come straight from its
+            // cursor — already a valid, already-escaped JSON string token —
+            // so this never allocates a `String` per key, unlike
+            // `JqValue::Object`/`Array` above.
+            JqValue::LazyKeysArray(fields) => {
+                out.write_char('[')?;
+                let mut current = *fields;
+                let mut first = true;
+                while let Some((field, rest)) = current.uncons() {
+                    if !first {
+                        out.write_char(',')?;
+                    }
+                    first = false;
+                    match field.key_cursor().raw_bytes() {
+                        Some(bytes) => {
+                            let s = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;
+                            out.write_str(s)?;
+                        }
+                        // Defensive fallback; JSON object keys are always
+                        // string tokens with a text range, so this is not
+                        // expected to be reached.
+                        None => {
+                            if let StandardJson::String(k) = field.key() {
+                                out.write_char('"')?;
+                                if let Ok(s) = k.as_str() {
+                                    write_json_body_jq(out, &s)?;
+                                }
+                                out.write_char('"')?;
+                            } else {
+                                out.write_str("null")?;
+                            }
+                        }
+                    }
+                    current = rest;
+                }
+                out.write_char(']')
+            }
         }
     }
 
@@ -504,6 +554,25 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
         let _ = self.write_json(&mut out);
         out
     }
+}
+
+/// Materialize a `JqValue::LazyKeysArray` into the `Vec<String>` array it
+/// would have been all along — the escape hatch for consumers that need a
+/// materialized value (`sort_keys`, color output, etc.).
+fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
+    fields: &crate::json::light::JsonFields<'_, W>,
+) -> OwnedValue {
+    let mut keys = Vec::new();
+    let mut current = *fields;
+    while let Some((field, rest)) = current.uncons() {
+        if let StandardJson::String(k) = field.key() {
+            if let Ok(s) = k.as_str() {
+                keys.push(OwnedValue::String(s.into_owned()));
+            }
+        }
+        current = rest;
+    }
+    OwnedValue::Array(keys)
 }
 
 /// Convert a JsonCursor to an OwnedValue (full materialization).

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1087,6 +1087,15 @@ impl<'a, W: AsRef<[u64]>> JsonField<'a, W> {
     pub fn value_cursor(&self) -> JsonCursor<'a, W> {
         self.value_cursor
     }
+
+    /// Get the key cursor directly.
+    ///
+    /// This allows raw-byte access to the key (`raw_bytes()`) without
+    /// decoding through `StandardJson::String` first.
+    #[inline]
+    pub fn key_cursor(&self) -> JsonCursor<'a, W> {
+        self.key_cursor
+    }
 }
 
 // ============================================================================
@@ -1698,6 +1707,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
             DocumentField {
                 key: field.key(),
                 value: field.value(),
+                key_cursor: field.key_cursor(),
                 value_cursor: field.value_cursor(),
             },
             rest,

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3499,6 +3499,15 @@ impl<'a, W: AsRef<[u64]>> YamlField<'a, W> {
     pub fn value_cursor(&self) -> YamlCursor<'a, W> {
         self.value_cursor
     }
+
+    /// Get the key cursor directly.
+    ///
+    /// This allows raw-byte access to the key without decoding through
+    /// `YamlValue` first.
+    #[inline]
+    pub fn key_cursor(&self) -> YamlCursor<'a, W> {
+        self.key_cursor
+    }
 }
 
 // ============================================================================
@@ -5063,6 +5072,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for YamlFields<'a, W> {
             DocumentField {
                 key: field.key(),
                 value: field.value(),
+                key_cursor: field.key_cursor(),
                 value_cursor: field.value_cursor(),
             },
             rest,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3056,3 +3056,80 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
 
     Ok(())
 }
+
+/// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
+/// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
+/// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that
+/// writer directly, both compact and pretty, rather than just the evaluator
+/// (already covered by `eval_generic.rs`'s unit tests).
+#[test]
+fn test_keys_unsorted_lazy_output_140() -> Result<()> {
+    let input = r#"{"b":1,"a":2,"c":3}"#;
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["b","a","c"]"#);
+
+    let (output, _, code) = run_jq_full(&["--indent", "2", "keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[\n  \"b\",\n  \"a\",\n  \"c\"\n]");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | length"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "3");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | (length)"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output.trim(),
+        "3",
+        "parenthesized length must still hit the fast path"
+    );
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | .[]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "\"b\"\n\"a\"\n\"c\"");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | .[0]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""b""#);
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | .[10]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null", "out of bounds is null, not an error");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | first"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""b""#);
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | last"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""c""#);
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | first"], Some("{}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
+
+    // `map`/`select` have no native lazy path and must still materialize
+    // correctly through the fallback.
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | map(ascii_upcase)"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["B","A","C"]"#);
+
+    // Escaped/non-ASCII keys go through the zero-copy raw-bytes path only
+    // when safe; otherwise decode-and-reescape, same as a regular object's
+    // keys.
+    let escaped_input = "{\"a\\\"b\":1,\"caf\u{e9}\":2}";
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted"], Some(escaped_input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[\"a\\\"b\",\"caf\u{e9}\"]");
+
+    let (output, _, code) = run_jq_full(
+        &["-c", "--ascii-output", "keys_unsorted"],
+        Some(escaped_input),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[\"a\\\"b\",\"caf\\u00e9\"]");
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4116,3 +4116,28 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
 
     Ok(())
 }
+
+/// `keys_unsorted` gained a lazy `GenericResult`/evaluator path shared with
+/// `jq` (#140), but `yq_runner.rs` has no `JqValue`-equivalent lazy output
+/// concept, so its `evaluate_yaml_cursor` boundary still materializes
+/// unconditionally (deferred to a follow-up issue). This just confirms that
+/// materialize fallback still produces correct, unchanged output on the YAML
+/// side.
+#[test]
+fn test_keys_unsorted_yaml_materialize_fallback_140() -> Result<()> {
+    let input = "b: 1\na: 2\nc: 3\n";
+
+    let (output, code) = run_yq_stdin("keys_unsorted", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["b","a","c"]"#);
+
+    let (output, code) = run_yq_stdin("keys_unsorted | length", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "3");
+
+    let (output, code) = run_yq_stdin("keys_unsorted | .[0]", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""b""#);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the core scope of #140 (M3.1): `keys_unsorted` on JSON objects
no longer materializes a `Vec<String>` of decoded keys up front. This
builds on the throwaway spike from #666 (branch `issue-666-lazy-keys-spike`,
not merged), hardening and extending it per that issue's go/no-go findings.

- `GenericResult::LazyKeysUnsorted(V::Fields)` wraps the object's field
  iterator instead of decoding every key. The `Pipe` dispatch answers
  `length`, `.[]`, `.[n]` (literal index, null on out-of-bounds per #307),
  and bare `first`/`last` natively from the field iterator — no `Vec`, no
  per-key decode — mirroring the existing array-handling code in
  `eval_generic.rs`. Everything else (`map`, `select`, comparisons, ...)
  falls back to materializing exactly as eager `keys_unsorted` did.
- `JqValue::LazyKeysArray` carries the same laziness through to CLI output:
  `write_json`/`print_json` stream each key's raw bytes straight from its
  cursor instead of collecting a `Vec<String>` first.
- Because the fast paths are generic over `V: DocumentValue`, they apply to
  YAML mappings too "for free" at the evaluator level — only the CLI output
  boundary still materializes for `yq` (`yq_runner.rs` has no
  `JqValue`-equivalent lazy output path today).

**Explicitly out of scope for this PR** (deferred to follow-up issues, per
plan): sorted `keys`, array `keys`/`keys_unsorted` as a lazy range, YAML-side
lazy output, and generic lazy `map`/`select` in `eval_generic.rs` (that last
one turned out to not exist for *any* value today, even real arrays — making
it lazy for `keys_unsorted` specifically would mean building it generally,
a bigger unrelated change).

## Commits

1. `refactor(jq): expose key_cursor on JsonField/YamlField/DocumentField` —
   infra: a `key_cursor` accessor/field needed to reach a field's key cursor
   from fully generic code, not just JSON-concrete code.
2. `perf(jq): stream keys_unsorted lazily via GenericResult::LazyKeysUnsorted` —
   the evaluator-side laziness described above.
3. `perf(jq): stream keys_unsorted output lazily via JqValue::LazyKeysArray` —
   carries the laziness through to CLI output.

Each commit builds and passes clippy + the full test suite on its own.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the
      `cli,simd,regex,serde` variant (catches the `scalar-yaml` blind spot)
- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] New unit tests in `eval_generic.rs` for `length`/`.[]`/`.[n]`/`first`/
      `last`/paren-unwrap/large-object(10K fields)/chained-continuation, plus
      a YAML-mapping test confirming the fast paths apply there too
- [x] New CLI integration tests (`jq_cli_tests.rs`, `yq_cli_tests.rs`)
      covering compact/pretty output, escaped/non-ASCII keys, and the YAML
      materialize-fallback path
- [x] Output verified byte-identical against pre-change `main` across ~45
      query/format/edge-case combinations on a 100K-field object
- [x] Local interleaved A/B (not the pinned ARM/x86 benchmark boxes) confirms
      real wins beyond `length` alone: `.[n]`/`first`/`last` ~2.4-2.6x
      memory, `.[]` ~1.6x, `length`/bare `keys_unsorted` ~2.2-2.4x — in the
      same ballpark as #666's original spike measurement (2.3-2.7x, ~2x
      speedup at 100K fields)

Refs #140, #666, #53.