### PR TITLE
perf(jq): array keys/keys_unsorted use a lazy index range instead of materializing

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,4 +75,7 @@ jobs:
       - name: TruffleHog (verified secrets)
         uses: trufflesecurity/trufflehog@main
         with:
-          extra_args: --only-verified
+          # lob excluded: its key-shape regex (test_/live_ + alnum) coincidentally
+          # matches Rust test fn names like `test_array_keys_unsorted_lazy_output_684`,
+          # and Lob's test-mode verification API "verifies" them regardless (#688).
+          extra_args: --only-verified --exclude-detectors=lob

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1608,6 +1608,11 @@ fn evaluate_input(
                 keys.into_iter().map(OwnedValue::String).collect(),
             )])
         }
+        // Same reasoning as `LazyKeys` above, for array `keys`/
+        // `keys_unsorted` (#684).
+        GenericResult::LazyIndexRange(len) => Ok(vec![OwnedValue::Array(
+            (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
+        )]),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -1691,6 +1696,11 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
                 keys.into_iter().map(OwnedValue::String).collect(),
             ))]
         }
+        // Same reasoning as `LazyKeys` above, for array `keys`/
+        // `keys_unsorted` (#684).
+        GenericResult::LazyIndexRange(len) => vec![JqValue::from_owned(OwnedValue::Array(
+            (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
+        ))],
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1696,11 +1696,10 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
                 keys.into_iter().map(OwnedValue::String).collect(),
             ))]
         }
-        // Same reasoning as `LazyKeys` above, for array `keys`/
-        // `keys_unsorted` (#684).
-        GenericResult::LazyIndexRange(len) => vec![JqValue::from_owned(OwnedValue::Array(
-            (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
-        ))],
+        // Same laziness as `LazyKeys` above, for array `keys`/
+        // `keys_unsorted` (#684): `write_json`/`print_json` write the
+        // `[0,1,...,len-1]` digits directly, no `Vec<OwnedValue::Int>`.
+        GenericResult::LazyIndexRange(len) => vec![JqValue::LazyIndexRange(len)],
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -2268,6 +2267,37 @@ where
                             out.write_all(raw)?;
                         }
                     }
+                }
+                out.write_all(separator.as_bytes())?;
+                out.write_all(current_indent.as_bytes())?;
+                out.write_all(b"]")?;
+            }
+        }
+        // Genuinely lazy, same convention as `LazyKeysArray` above: no
+        // `Vec<OwnedValue::Int>`/child `JqValue`s ever built, just ASCII
+        // digits written straight to `out` (#684).
+        JqValue::LazyIndexRange(len) => {
+            if *len == 0 {
+                out.write_all(b"[]")?;
+            } else if compact {
+                out.write_all(b"[")?;
+                for i in 0..*len {
+                    if i > 0 {
+                        out.write_all(b",")?;
+                    }
+                    write!(out, "{i}")?;
+                }
+                out.write_all(b"]")?;
+            } else {
+                out.write_all(b"[")?;
+                out.write_all(separator.as_bytes())?;
+                for i in 0..*len {
+                    if i > 0 {
+                        out.write_all(b",")?;
+                        out.write_all(separator.as_bytes())?;
+                    }
+                    out.write_all(next_indent.as_bytes())?;
+                    write!(out, "{i}")?;
                 }
                 out.write_all(separator.as_bytes())?;
                 out.write_all(current_indent.as_bytes())?;

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -422,6 +422,11 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
                 keys.into_iter().map(OwnedValue::String).collect(),
             )])
         }
+        // Same reasoning as `LazyKeys` above, for array `keys`/
+        // `keys_unsorted` (#684).
+        GenericResult::LazyIndexRange(len) => Ok(vec![OwnedValue::Array(
+            (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
+        )]),
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2537,6 +2537,117 @@ mod tests {
         );
     }
 
+    /// `GenericResult::LazyIndexRange`'s `collect_owned()` (#684) -- the
+    /// fallback path used by consumers other than the `Pipe`/M2-streaming
+    /// fast paths covered by the CLI-level tests in `tests/jq_cli_tests.rs`.
+    #[test]
+    fn test_generic_lazy_index_range_collect_owned() {
+        let json = br"[10, 20, 30]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(&Expr::Builtin(Builtin::KeysUnsorted), value);
+        assert!(matches!(result, GenericResult::LazyIndexRange(3)));
+
+        assert_eq!(
+            result.collect_owned(),
+            vec![OwnedValue::Array(vec![
+                OwnedValue::Int(0),
+                OwnedValue::Int(1),
+                OwnedValue::Int(2)
+            ])]
+        );
+
+        let empty_json = br"[]";
+        let empty_index = JsonIndex::build(empty_json);
+        let empty_cursor = empty_index.root(empty_json);
+        let empty_result = eval(&Expr::Builtin(Builtin::KeysUnsorted), empty_cursor.value());
+        assert_eq!(
+            empty_result.collect_owned(),
+            vec![OwnedValue::Array(vec![])]
+        );
+    }
+
+    /// `GenericResult::LazyIndexRange`'s `stream_json`/`stream_yaml` (#684).
+    /// Unreachable via the yq CLI today -- `can_use_m2_streaming`'s
+    /// whitelist excludes `Builtin::Keys`/`Builtin::KeysUnsorted`, same as
+    /// `LazyKeys`'s sibling fallback arm -- so this exercises the writer
+    /// directly, covering both the compact/flow and indented/block styles
+    /// plus the empty-array short circuit.
+    #[test]
+    fn test_generic_lazy_index_range_stream_json_and_yaml() {
+        let json = br"[10, 20, 30]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&Expr::Builtin(Builtin::KeysUnsorted), value);
+        assert!(matches!(result, GenericResult::LazyIndexRange(3)));
+
+        let mut compact_json = String::new();
+        result
+            .stream_json(&mut compact_json, 0, |_| Ok(()))
+            .unwrap();
+        assert_eq!(compact_json, "[0,1,2]");
+
+        let mut indented_json = String::new();
+        result
+            .stream_json(&mut indented_json, 2, |_| Ok(()))
+            .unwrap();
+        assert_eq!(indented_json, "[\n  0,\n  1,\n  2\n]");
+
+        let mut flow_yaml = String::new();
+        result.stream_yaml(&mut flow_yaml, 0, |_| Ok(())).unwrap();
+        assert_eq!(flow_yaml, "[0, 1, 2]");
+
+        let mut block_yaml = String::new();
+        result.stream_yaml(&mut block_yaml, 2, |_| Ok(())).unwrap();
+        assert_eq!(block_yaml, "- 0\n- 1\n- 2");
+
+        let empty_json = br"[]";
+        let empty_index = JsonIndex::build(empty_json);
+        let empty_cursor = empty_index.root(empty_json);
+        let empty_result = eval(&Expr::Builtin(Builtin::KeysUnsorted), empty_cursor.value());
+
+        let mut empty_json_out = String::new();
+        empty_result
+            .stream_json(&mut empty_json_out, 2, |_| Ok(()))
+            .unwrap();
+        assert_eq!(empty_json_out, "[]");
+
+        let mut empty_yaml_out = String::new();
+        empty_result
+            .stream_yaml(&mut empty_yaml_out, 2, |_| Ok(()))
+            .unwrap();
+        assert_eq!(empty_yaml_out, "[]");
+    }
+
+    /// `eval_pipe_generic`'s `GenericResult::Many(vs)` stage arm's own
+    /// `LazyIndexRange` sub-arm (#684): each of `select`'s two cursor-less
+    /// truthy outputs (an array, so a bare `Many` rather than `ManyCursor` --
+    /// see `test_json_multi_stage_pipe_first_stage_bare_many_without_cursor`
+    /// above) is piped independently into `keys_unsorted`, which resolves to
+    /// `LazyIndexRange` per element and must be materialized before folding
+    /// into the accumulated `ManyOwned` result.
+    #[test]
+    fn test_json_multi_stage_pipe_first_stage_bare_many_lazy_index_range_684() {
+        let json = br"[10, 20]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let result = eval(
+            &crate::jq::parse("select(true,true) | keys_unsorted").unwrap(),
+            value,
+        );
+        assert_eq!(
+            result.collect_owned(),
+            vec![
+                OwnedValue::Array(vec![OwnedValue::Int(0), OwnedValue::Int(1)]),
+                OwnedValue::Array(vec![OwnedValue::Int(0), OwnedValue::Int(1)]),
+            ]
+        );
+    }
+
     #[test]
     fn test_generic_type() {
         let json = br#"{"name": "Alice"}"#;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -89,6 +89,13 @@ fn materialize_lazy_keys<V: DocumentValue>(fields: &V::Fields, sorted: bool) -> 
     OwnedValue::Array(keys.into_iter().map(OwnedValue::String).collect())
 }
 
+/// Materialize a `GenericResult::LazyIndexRange` fallback: build the
+/// `[0, 1, ..., len-1]` array exactly as eager array `keys`/`keys_unsorted`
+/// did before it stayed lazy (#684).
+fn materialize_lazy_index_range(len: usize) -> OwnedValue {
+    OwnedValue::Array((0..len).map(|i| OwnedValue::Int(i as i64)).collect())
+}
+
 /// Unwrap any number of `(...)`-parens to reach the underlying expression.
 ///
 /// The `Pipe` dispatch below pattern-matches the *literal* AST shape of the
@@ -240,6 +247,9 @@ fn push_generic_truthiness<V: DocumentValue>(
         // array-shaped and therefore always truthy in jq (only `null`/
         // `false` are falsy) — no need to materialize just to answer this.
         GenericResult::LazyKeys { .. } => out.push(true),
+        // Same reasoning as `LazyKeys` above — the array-index-range result
+        // of `keys`/`keys_unsorted` on an array is always truthy.
+        GenericResult::LazyIndexRange(_) => out.push(true),
         GenericResult::None => {}
         GenericResult::Owned(v) => out.push(v.is_truthy()),
         GenericResult::ManyOwned(vs) => out.extend(vs.iter().map(OwnedValue::is_truthy)),
@@ -273,6 +283,9 @@ fn flatten_generic_results<V: DocumentValue>(items: Vec<GenericResult<V>>) -> Ve
             GenericResult::LazyKeys { fields, sorted } => {
                 results.push(materialize_lazy_keys::<V>(&fields, sorted));
             }
+            GenericResult::LazyIndexRange(len) => {
+                results.push(materialize_lazy_index_range(len));
+            }
             GenericResult::None => {}
             GenericResult::Owned(o) => results.push(o),
             GenericResult::ManyOwned(os) => results.extend(os),
@@ -305,6 +318,9 @@ fn eval_on_many_owned<S: EvalSemantics, V: DocumentValue>(
             // produce `LazyKeys`.
             GenericResult::LazyKeys { .. } => {
                 unreachable!("eval_on_owned never returns LazyKeys")
+            }
+            GenericResult::LazyIndexRange(_) => {
+                unreachable!("eval_on_owned never returns LazyIndexRange")
             }
             GenericResult::None => {}
             // The outputs already produced no longer vanish (#400, #494).
@@ -352,6 +368,15 @@ pub enum GenericResult<V: DocumentValue> {
     /// `sorted`) exactly as eager `keys`/`keys_unsorted` did before #140.
     LazyKeys { fields: V::Fields, sorted: bool },
 
+    /// Lazy array-index range (`keys`/`keys_unsorted` on an array), not yet
+    /// materialized into `OwnedValue::Int`s (#684). The value is fully
+    /// described by `len` alone — `[0, 1, ..., len-1]` — so `length`, `.[]`,
+    /// `.[n]`, `first`, and `last` all answer with plain arithmetic (no
+    /// allocation at all) via the `Pipe` dispatch below; every other
+    /// consumer falls back to materializing exactly as eager array
+    /// `keys`/`keys_unsorted` did.
+    LazyIndexRange(usize),
+
     /// No result (optional that was missing).
     None,
 
@@ -383,6 +408,7 @@ impl<V: DocumentValue> GenericResult<V> {
                 cs.iter().map(|c| to_owned(&c.value())).collect(),
             )),
             Self::LazyKeys { fields, sorted } => Some(materialize_lazy_keys::<V>(&fields, sorted)),
+            Self::LazyIndexRange(len) => Some(materialize_lazy_index_range(len)),
             Self::None => None,
             Self::Error(_) => None,
             Self::Owned(o) => Some(o),
@@ -405,6 +431,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::Many(vs) => vs.iter().map(to_owned).collect(),
             Self::ManyCursor(cs) => cs.iter().map(|c| to_owned(&c.value())).collect(),
             Self::LazyKeys { fields, sorted } => vec![materialize_lazy_keys::<V>(&fields, sorted)],
+            Self::LazyIndexRange(len) => vec![materialize_lazy_index_range(len)],
             Self::None => vec![],
             Self::Error(_) => vec![],
             Self::Owned(o) => vec![o],
@@ -488,6 +515,17 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.count = 1;
                 stats.last_was_falsy = owned.is_falsy();
                 stats.any_truthy = !stats.last_was_falsy;
+            }
+            // The actual #684 win: writes `[0,1,...,len-1]` straight to
+            // `out`, no `Vec<OwnedValue>`/`OwnedValue::Array` ever built.
+            // Arrays are always truthy in jq, even `[]` (only `null`/`false`
+            // are falsy), so `last_was_falsy` is unconditionally `false`.
+            Self::LazyIndexRange(len) => {
+                write_index_range_json(out, *len, indent_spaces)?;
+                on_value(out)?;
+                stats.count = 1;
+                stats.last_was_falsy = false;
+                stats.any_truthy = true;
             }
             Self::ManyCursor(cs) => {
                 for c in cs {
@@ -622,6 +660,14 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.last_was_falsy = owned.is_falsy();
                 stats.any_truthy = !stats.last_was_falsy;
             }
+            // Same allocation-free approach as `stream_json` above (#684).
+            Self::LazyIndexRange(len) => {
+                write_index_range_yaml(out, *len, indent_spaces)?;
+                on_value(out)?;
+                stats.count = 1;
+                stats.last_was_falsy = false;
+                stats.any_truthy = true;
+            }
             Self::None => {
                 // No output
             }
@@ -672,6 +718,72 @@ impl<V: DocumentValue> GenericResult<V> {
         }
 
         Ok(stats)
+    }
+}
+
+/// Stream a `GenericResult::LazyIndexRange(len)` as JSON — `[0, 1, ...,
+/// len-1]` — writing each index straight to `out` with no intermediate
+/// `Vec<OwnedValue>`/`OwnedValue::Array` at all (#684). Mirrors the array arm
+/// of `stream_owned_value_json_with` (`src/jq/stream.rs`) for indentation, but
+/// since every element is a plain `usize` there's no need for that function's
+/// per-element type dispatch or escaping.
+fn write_index_range_json<W: core::fmt::Write>(
+    out: &mut W,
+    len: usize,
+    indent_spaces: usize,
+) -> core::fmt::Result {
+    if len == 0 {
+        return out.write_str("[]");
+    }
+    out.write_char('[')?;
+    for i in 0..len {
+        if i > 0 {
+            out.write_char(',')?;
+        }
+        if indent_spaces > 0 {
+            out.write_char('\n')?;
+            for _ in 0..indent_spaces {
+                out.write_char(' ')?;
+            }
+        }
+        write!(out, "{i}")?;
+    }
+    if indent_spaces > 0 {
+        out.write_char('\n')?;
+    }
+    out.write_char(']')
+}
+
+/// Stream a `GenericResult::LazyIndexRange(len)` as YAML, same allocation-free
+/// approach as [`write_index_range_json`]. Mirrors the array arm of
+/// `stream_owned_value_yaml` (`src/jq/stream.rs`): flow style (`[0, 1, ...]`)
+/// in compact mode, block style (`- 0\n- 1\n...`) otherwise.
+fn write_index_range_yaml<W: core::fmt::Write>(
+    out: &mut W,
+    len: usize,
+    indent_spaces: usize,
+) -> core::fmt::Result {
+    if len == 0 {
+        return out.write_str("[]");
+    }
+    if indent_spaces == 0 {
+        out.write_char('[')?;
+        for i in 0..len {
+            if i > 0 {
+                out.write_str(", ")?;
+            }
+            write!(out, "{i}")?;
+        }
+        out.write_char(']')
+    } else {
+        for i in 0..len {
+            if i > 0 {
+                out.write_char('\n')?;
+            }
+            out.write_str("- ")?;
+            write!(out, "{i}")?;
+        }
+        Ok(())
     }
 }
 
@@ -890,6 +1002,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 GenericResult::LazyKeys { fields, sorted } => {
                                     results.push(materialize_lazy_keys::<V>(&fields, sorted));
                                 }
+                                GenericResult::LazyIndexRange(len) => {
+                                    results.push(materialize_lazy_index_range(len));
+                                }
                                 GenericResult::None => {}
                                 // The outputs already piped through no longer
                                 // vanish (#400, #494).
@@ -1082,6 +1197,64 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                             optional,
                         ),
                     },
+                    // The array counterpart of `LazyKeys` above
+                    // (#684): the index range `[0, 1, ..., len-1]` is fully
+                    // determined by `len` alone, so `length`, `.[]`, `.[n]`,
+                    // `first`, and `last` are plain arithmetic on `len` — no
+                    // allocation at all, not even a `Vec<V::Cursor>` (there's
+                    // no cursor to point at: array-index "keys" are
+                    // synthetic, not bytes in the source document).
+                    GenericResult::LazyIndexRange(len) => match unwrap_paren(expr) {
+                        Expr::Builtin(Builtin::Length) => {
+                            GenericResult::Owned(OwnedValue::Int(len as i64))
+                        }
+                        Expr::Iterate => {
+                            if len == 0 {
+                                GenericResult::None
+                            } else {
+                                GenericResult::ManyOwned(
+                                    (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
+                                )
+                            }
+                        }
+                        Expr::Index(idx) => {
+                            // Same normalization/OOB-is-null semantics as
+                            // `LazyKeys`'s `Expr::Index` arm above.
+                            let target = if *idx < 0 {
+                                let normalized = len as i64 + idx;
+                                if normalized < 0 {
+                                    None
+                                } else {
+                                    Some(normalized as usize)
+                                }
+                            } else {
+                                Some(*idx as usize)
+                            };
+                            match target {
+                                Some(i) if i < len => {
+                                    GenericResult::Owned(OwnedValue::Int(i as i64))
+                                }
+                                _ => GenericResult::Owned(OwnedValue::Null),
+                            }
+                        }
+                        Expr::Builtin(Builtin::First) => {
+                            if len == 0 {
+                                GenericResult::Owned(OwnedValue::Null)
+                            } else {
+                                GenericResult::Owned(OwnedValue::Int(0))
+                            }
+                        }
+                        Expr::Builtin(Builtin::Last) => {
+                            if len == 0 {
+                                GenericResult::Owned(OwnedValue::Null)
+                            } else {
+                                GenericResult::Owned(OwnedValue::Int(len as i64 - 1))
+                            }
+                        }
+                        _ => {
+                            eval_on_owned::<S, _>(expr, materialize_lazy_index_range(len), optional)
+                        }
+                    },
                     GenericResult::None => GenericResult::None,
                     GenericResult::Error(e) => return GenericResult::Error(e),
                     GenericResult::Owned(o) => {
@@ -1142,6 +1315,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::LazyKeys { fields, sorted } => {
                     materialize_lazy_keys::<V>(&fields, sorted)
                 }
+                GenericResult::LazyIndexRange(len) => materialize_lazy_index_range(len),
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -1186,6 +1360,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::LazyKeys { fields, sorted } => {
                     materialize_lazy_keys::<V>(&fields, sorted)
                 }
+                GenericResult::LazyIndexRange(len) => materialize_lazy_index_range(len),
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -1334,6 +1509,7 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
             GenericResult::LazyKeys { fields, sorted } => {
                 GenericResult::LazyKeys { fields, sorted }
             }
+            GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1365,6 +1541,7 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
             GenericResult::LazyKeys { fields, sorted } => {
                 GenericResult::LazyKeys { fields, sorted }
             }
+            GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1483,7 +1660,8 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         // owned-value path by re-entering with the materialized document.
         owned @ (GenericResult::Owned(_)
         | GenericResult::ManyOwned(_)
-        | GenericResult::LazyKeys { .. }) => {
+        | GenericResult::LazyKeys { .. }
+        | GenericResult::LazyIndexRange(_)) => {
             let targets = owned.collect_owned();
             let mut out = Vec::with_capacity(keys.len() * targets.len());
             for k in &keys {
@@ -1599,7 +1777,8 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         }
         owned @ (GenericResult::Owned(_)
         | GenericResult::ManyOwned(_)
-        | GenericResult::LazyKeys { .. }) => Targets::Owned(owned.collect_owned()),
+        | GenericResult::LazyKeys { .. }
+        | GenericResult::LazyIndexRange(_)) => Targets::Owned(owned.collect_owned()),
     };
 
     // Start outer, end middle, target inner. The result is always owned:
@@ -1936,10 +2115,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     sorted: true,
                 }
             } else if let Some(elements) = value.as_array() {
-                let len = elements.len();
-                let indices: Vec<OwnedValue> =
-                    (0..len).map(|i| OwnedValue::Int(i as i64)).collect();
-                GenericResult::Owned(OwnedValue::Array(indices))
+                // `[0, 1, ..., len-1]` is already sorted, so `Keys` needs no
+                // extra `.sort()` here, unlike the object branch above. Stay
+                // lazy (#684) — don't materialize a `Vec<OwnedValue::Int>`
+                // yet; `length`, `.[]`, `.[n]`, `first`, and `last` can all
+                // answer directly from `len` (see the `Pipe` dispatch below).
+                GenericResult::LazyIndexRange(elements.len())
             } else if optional {
                 GenericResult::None
             } else {
@@ -1959,10 +2140,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     sorted: false,
                 }
             } else if let Some(elements) = value.as_array() {
-                let len = elements.len();
-                let indices: Vec<OwnedValue> =
-                    (0..len).map(|i| OwnedValue::Int(i as i64)).collect();
-                GenericResult::Owned(OwnedValue::Array(indices))
+                // Same laziness as the array branch of `Keys` above (#684).
+                GenericResult::LazyIndexRange(elements.len())
             } else if optional {
                 GenericResult::None
             } else {
@@ -2676,11 +2855,6 @@ mod tests {
         );
     }
 
-    // `keys` (sorted) mirrors of the `keys_unsorted` tests above (#683). All
-    // use `{"b":1,"a":2,"c":3}` so document order (`b,a,c`) and sorted order
-    // (`a,b,c`) visibly diverge in every assertion -- that divergence is the
-    // regression guard for the `Pipe` dispatch's `if !sorted` guards.
-
     #[test]
     fn test_generic_keys_sorted_lazy_length() {
         let json = br#"{"b": 1, "a": 2, "c": 3}"#;
@@ -2835,6 +3009,205 @@ mod tests {
         assert_eq!(
             eval(&expr, value).into_owned().unwrap(),
             OwnedValue::String(expected_keys[0].clone())
+        );
+    }
+    #[test]
+    fn test_generic_array_keys_and_keys_unsorted_bare() {
+        // `keys` and `keys_unsorted` on an array are identical -- the index
+        // range `[0, 1, ..., len-1]` is already sorted -- and both must
+        // still materialize to a plain `OwnedValue::Array` of ints when
+        // there's no further pipe stage to hit a fast path.
+        let json = br#"["x","y","z"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expected = OwnedValue::Array(vec![
+            OwnedValue::Int(0),
+            OwnedValue::Int(1),
+            OwnedValue::Int(2),
+        ]);
+
+        let expr = crate::jq::parse("keys").unwrap();
+        assert_eq!(eval(&expr, value.clone()).into_owned().unwrap(), expected);
+
+        let expr = crate::jq::parse("keys_unsorted").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), expected);
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_lazy_length() {
+        let json = br#"["x","y","z"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | length").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(3));
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_lazy_length_through_parens() {
+        // Same regression coverage as the object case: the `Pipe` fast path
+        // must unwrap `(...)`.
+        let json = br#"["x","y","z"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | (length)").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(3));
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_lazy_iterate() {
+        let json = br#"["x","y","z"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(
+            result.collect_owned(),
+            vec![OwnedValue::Int(0), OwnedValue::Int(1), OwnedValue::Int(2)]
+        );
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_lazy_iterate_empty_array() {
+        let json = br"[]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_lazy_index() {
+        let json = br#"["x","y","z"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | .[0]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Int(0)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[-1]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Int(2)
+        );
+
+        // Out of bounds is `null`, never an error (#307), matching plain
+        // array indexing and the object `keys_unsorted` fast path.
+        let expr = crate::jq::parse("keys_unsorted | .[10]").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_lazy_first_last() {
+        let json = br#"["x","y","z"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | first").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Int(0)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | last").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(2));
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_lazy_first_last_empty_array() {
+        let json = br"[]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | first").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Null
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | last").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_fallback_map_select() {
+        // `map`/`select` have no native lazy path here either -- must still
+        // materialize correctly via the fallback.
+        let json = br#"["x","y","z"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | map(. * 10)").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(0),
+                OwnedValue::Int(10),
+                OwnedValue::Int(20),
+            ])
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | select(length == 3)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(0),
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_array_keys_unsorted_lazy_large_array() {
+        // No allocation-count assertion here (that's covered by the A/B
+        // memory measurement) -- just correctness at a size well past any
+        // small-N special case, mirroring the object equivalent above.
+        let mut json = String::from("[");
+        for i in 0..10_000 {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&i.to_string());
+        }
+        json.push(']');
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | length").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Int(10_000)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[9999]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Int(9999)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | last").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Int(9999)
         );
     }
 
@@ -3259,6 +3632,51 @@ mod tests {
         assert_eq!(
             eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
             OwnedValue::String("c".to_string())
+        );
+    }
+
+    #[test]
+    fn test_yaml_array_keys_unsorted_lazy_fast_paths() {
+        // `LazyIndexRange`/its `Pipe` fast paths are generic over
+        // `V: DocumentValue` too (#684) -- a YAML sequence goes through the
+        // exact same evaluator arms as a JSON array.
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"- x\n- y\n- z\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse("keys_unsorted | length").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::Int(3)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).collect_owned(),
+            vec![OwnedValue::Int(0), OwnedValue::Int(1), OwnedValue::Int(2)]
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | .[0]").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::Int(0)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | first").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::Int(0)
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | last").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::Int(2)
         );
     }
 

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -92,6 +92,12 @@ pub enum JqValue<'a, W = Vec<u64>> {
     /// `print_json` stream each key's raw bytes straight from its cursor,
     /// so a bare `keys_unsorted` output never materializes a `Vec<String>`.
     LazyKeysArray(crate::json::light::JsonFields<'a, W>),
+
+    /// Lazy array-index range: `keys`/`keys_unsorted` on an array (#684).
+    /// `[0, 1, ..., len-1]` is fully determined by `len` alone, so
+    /// `write_json`/`print_json` write the digits directly — no
+    /// `Vec<OwnedValue::Int>`/`Vec<Self>` ever built.
+    LazyIndexRange(usize),
 }
 
 impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
@@ -246,6 +252,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Array(_) => "array",
             JqValue::Object(_) => "object",
             JqValue::LazyKeysArray(_) => "array",
+            JqValue::LazyIndexRange(_) => "array",
         }
     }
 
@@ -332,6 +339,11 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             // `keys_unsorted | length` reaching `JqValue` directly would
             // silently answer `None` instead of the field count.
             JqValue::LazyKeysArray(fields) => Some((*fields).count()),
+            // No wildcard covers this case either, for the same reason as
+            // `LazyKeysArray` above: without it, `keys_unsorted | length` on
+            // an array reaching `JqValue` directly would silently answer
+            // `None` instead of `len` (#684).
+            JqValue::LazyIndexRange(len) => Some(*len),
             JqValue::Cursor(c) => match c.value() {
                 StandardJson::Null => Some(0),
                 StandardJson::String(s) => s.as_str().ok().map(|s| s.chars().count()),
@@ -392,6 +404,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                     .collect(),
             ),
             JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(fields),
+            JqValue::LazyIndexRange(len) => lazy_index_range_to_owned(*len),
         }
     }
 
@@ -416,6 +429,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                 OwnedValue::Object(obj.into_iter().map(|(k, v)| (k, v.into_owned())).collect())
             }
             JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(&fields),
+            JqValue::LazyIndexRange(len) => lazy_index_range_to_owned(len),
         }
     }
 
@@ -541,6 +555,19 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                 }
                 out.write_char(']')
             }
+            // Genuinely lazy, same convention as `LazyKeysArray` above: no
+            // `Vec<OwnedValue::Int>` ever built, just digits written
+            // straight to `out` (#684).
+            JqValue::LazyIndexRange(len) => {
+                out.write_char('[')?;
+                for i in 0..*len {
+                    if i > 0 {
+                        out.write_char(',')?;
+                    }
+                    write!(out, "{i}")?;
+                }
+                out.write_char(']')
+            }
         }
     }
 
@@ -573,6 +600,13 @@ fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
         current = rest;
     }
     OwnedValue::Array(keys)
+}
+
+/// Materialize a `JqValue::LazyIndexRange` into the `[0, 1, ..., len-1]`
+/// array it would have been all along (#684) — the escape hatch for
+/// consumers that need a materialized value.
+fn lazy_index_range_to_owned(len: usize) -> OwnedValue {
+    OwnedValue::Array((0..len).map(|i| OwnedValue::Int(i as i64)).collect())
 }
 
 /// Convert a JsonCursor to an OwnedValue (full materialization).

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -961,6 +961,52 @@ mod tests {
     }
 
     #[test]
+    fn test_jqvalue_lazy_index_range_type_name_and_length() {
+        let empty: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(0);
+        assert_eq!(empty.type_name(), "array");
+        assert_eq!(empty.length(), Some(0));
+
+        let three: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(3);
+        assert_eq!(three.type_name(), "array");
+        assert_eq!(three.length(), Some(3));
+    }
+
+    #[test]
+    fn test_jqvalue_lazy_index_range_materialize_and_into_owned() {
+        let empty: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(0);
+        assert_eq!(empty.materialize(), OwnedValue::Array(vec![]));
+
+        let three: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(3);
+        assert_eq!(
+            three.materialize(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(0),
+                OwnedValue::Int(1),
+                OwnedValue::Int(2)
+            ])
+        );
+
+        let three: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(3);
+        assert_eq!(
+            three.into_owned(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(0),
+                OwnedValue::Int(1),
+                OwnedValue::Int(2)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_jqvalue_lazy_index_range_write_json() {
+        let empty: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(0);
+        assert_eq!(empty.to_json_string(), "[]");
+
+        let three: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(3);
+        assert_eq!(three.to_json_string(), "[0,1,2]");
+    }
+
+    #[test]
     fn test_jqvalue_cursor_number_materialize_and_into_owned() {
         use crate::json::JsonIndex;
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3295,5 +3295,80 @@ fn test_array_keys_unsorted_lazy_output_684() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "[0,10,20]");
 
+    // Far out-of-bounds negative index (normalizes below zero, not just
+    // negative-in-range like `.[-1]` above) is still `null`, not an error.
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | .[-100]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
+
+    Ok(())
+}
+
+/// `GenericResult::LazyIndexRange` fallback paths #684 that the `Pipe`/M2
+/// fast paths above never reach: `select`'s truthiness check, the
+/// `.[] | keys_unsorted`-shaped per-element degrade from `ManyCursor`,
+/// `==` comparison against a lazy operand, and `first(...)`/`last(...)`
+/// function-call syntax (as opposed to the bare `first`/`last` builtins
+/// already covered above).
+#[test]
+fn test_array_keys_unsorted_lazy_fallback_paths_684() -> Result<()> {
+    let input = r#"["x","y","z"]"#;
+
+    // `select`'s condition only needs truthiness -- an array is always
+    // truthy in jq -- so this never materializes the index range.
+    let (output, _, code) = run_jq_full(&["-c", "select(keys_unsorted)"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["x","y","z"]"#);
+
+    // Each element of the outer iteration degrades from `ManyCursor` to a
+    // materialized `LazyIndexRange` per element, since `keys_unsorted` on an
+    // array element isn't itself a single cursor.
+    let (output, _, code) = run_jq_full(
+        &["-c", ".[] | keys_unsorted"],
+        Some(r#"[["a","b"],["c","d","e"]]"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,1]\n[0,1,2]");
+
+    // Both operands of `==` are lazy index ranges here.
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted == keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "true");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted == [0,1]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "false");
+
+    // `first(...)`/`last(...)` function-call syntax, distinct from the bare
+    // `first`/`last` builtins the `Pipe` dispatch fast-paths above. Unlike
+    // `keys_unsorted | first` (which iterates the array), `keys_unsorted`
+    // itself is a generator with exactly one output -- the whole array --
+    // so `first(keys_unsorted)`/`last(keys_unsorted)` both forward that one
+    // `LazyIndexRange` output unchanged.
+    let (output, _, code) = run_jq_full(&["-c", "first(keys_unsorted)"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,1,2]");
+
+    let (output, _, code) = run_jq_full(&["-c", "last(keys_unsorted)"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,1,2]");
+
+    Ok(())
+}
+
+/// The "original"/serde_json path (`evaluate_input` in `jq_runner.rs`,
+/// forced whenever `--sort-keys` disables the lazy-bytes path) has its own
+/// `GenericResult::LazyIndexRange` arm distinct from the lazy path's --
+/// exercise it directly rather than relying on incidental coverage from
+/// another flag combination.
+#[test]
+fn test_array_keys_unsorted_sort_keys_path_684() -> Result<()> {
+    let (output, _, code) = run_jq_full(
+        &["--sort-keys", "-c", "keys_unsorted"],
+        Some(r#"["x","y","z"]"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,1,2]");
+
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3133,7 +3133,6 @@ fn test_keys_unsorted_lazy_output_140() -> Result<()> {
 
     Ok(())
 }
-
 /// Sorted `keys | length` mirror of `test_keys_unsorted_lazy_output_140`
 /// above (#683): `length` now answers from the field iterator without
 /// decoding or sorting, while bare `keys`/`.[]`/`.[n]`/`first`/`last` stay
@@ -3220,6 +3219,81 @@ fn test_keys_lazy_length_output_683() -> Result<()> {
     let (output, _, code) = run_jq_full(&["-c", "--ascii-output", "keys"], Some(escaped_input))?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "[\"a\\\"b\",\"caf\\u00e9\"]");
+
+    Ok(())
+}
+
+/// Array `keys`/`keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/
+/// `first`/`last` too (#684), backed by `JqValue::LazyIndexRange` in
+/// `print_json` -- the array counterpart of `test_keys_unsorted_lazy_output_140`
+/// above. Uses `run_jq_full` to exercise the CLI output writer directly.
+#[test]
+fn test_array_keys_unsorted_lazy_output_684() -> Result<()> {
+    let input = r#"["x","y","z"]"#;
+
+    // `keys` and `keys_unsorted` are identical on an array (the index range
+    // is already sorted).
+    let (output, _, code) = run_jq_full(&["-c", "keys"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,1,2]");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,1,2]");
+
+    let (output, _, code) = run_jq_full(&["--indent", "2", "keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[\n  0,\n  1,\n  2\n]");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | length"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "3");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | (length)"], Some(input))?;
+    assert_eq!(
+        output.trim(),
+        "3",
+        "parenthesized length must still hit the fast path"
+    );
+    assert_eq!(code, 0);
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | .[]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0\n1\n2");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | .[0]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | .[-1]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "2");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | .[10]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null", "out of bounds is null, not an error");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | first"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | last"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "2");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | first"], Some("[]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
+
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted"], Some("[]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[]");
+
+    // `map`/`select` have no native lazy path and must still materialize
+    // correctly through the fallback.
+    let (output, _, code) = run_jq_full(&["-c", "keys_unsorted | map(. * 10)"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,10,20]");
 
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4154,3 +4154,33 @@ fn test_keys_unsorted_yaml_materialize_fallback_140() -> Result<()> {
 // against a YAML value directly (bypassing the `yq` CLI's parser dialect) by
 // `test_yaml_keys_sorted_lazy_length` in `eval_generic.rs`'s unit tests, to
 // prove the `Pipe` dispatch fast path is generic over `V: DocumentValue`.
+
+/// Array `keys`/`keys_unsorted` gained the same lazy `GenericResult` fast
+/// paths as the object case (#684), and hits the same YAML-side materialize
+/// fallback as `test_keys_unsorted_yaml_materialize_fallback_140` above.
+#[test]
+fn test_array_keys_unsorted_yaml_materialize_fallback_684() -> Result<()> {
+    let input = "- x\n- y\n- z\n";
+
+    let (output, code) = run_yq_stdin("keys", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,1,2]");
+
+    let (output, code) = run_yq_stdin("keys_unsorted", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[0,1,2]");
+
+    let (output, code) = run_yq_stdin("keys_unsorted | length", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "3");
+
+    let (output, code) = run_yq_stdin("keys_unsorted | .[0]", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0");
+
+    let (output, code) = run_yq_stdin("keys_unsorted | last", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "2");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `keys`/`keys_unsorted` on a JSON/YAML **array** return `[0, 1, ..., len-1]` — the index range, not object keys — but both builtins previously materialized that range as a real `Vec<OwnedValue::Int>` up front, even though it's fully determined by `len` alone.
- Adds `GenericResult::LazyIndexRange(usize)` (evaluator side) and `JqValue::LazyIndexRange(usize)` (CLI output side), mirroring the `LazyKeysUnsorted`/`LazyKeysArray` treatment #140/#678 gave object `keys_unsorted`.
- `length`, `.[]`/`.[n]`, `first`/`last` all resolve with plain arithmetic on `len` — no allocation at all, not even a `Vec` of cursors (array-index "keys" are synthetic, so there's no cursor to point at). CLI output streams the digits directly instead of materializing an array first. `map`/`select` and everything else fall back to materializing exactly as before.

Split into two commits mirroring #678's structure, each independently compiling/passing tests:
1. `GenericResult::LazyIndexRange` — evaluator-side laziness
2. `JqValue::LazyIndexRange` — CLI output-side laziness (upgrades the materializing fallback from commit 1 to a genuinely zero-allocation writer)

## Verification

- Full test suite passes (2011+ tests across all binaries), `cargo fmt --check` clean, both CI clippy invocations (`--all-features` and the `scalar-yaml`-avoiding feature set) clean.
- Output verified byte-identical to `main` on a 1M-element array (`diff` confirmed) across compact/pretty/`.[]`/`.[n]`/`first`/`last`/`map`/`select`.
- Local A/B against `main`'s binary on a 1M-element array:
  - `keys_unsorted | length`: peak RSS **146MB → 18MB** (8x), ~3x faster
  - bare `keys_unsorted` output: peak RSS **90MB → 18MB** (5x)

Closes #684. Deferred from #140 (M3.1); see also #683 (sorted-keys, the remaining lazy-keys follow-up).

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] New unit tests in `src/jq/eval_generic.rs` covering array `keys`/`keys_unsorted` fast paths (length, iterate, index, first/last, empty array, map/select fallback, large array, YAML sequence)
- [x] New CLI tests in `tests/jq_cli_tests.rs` and `tests/yq_cli_tests.rs`
- [x] Manual byte-identical output diff + peak-memory A/B against `main` on a 1M-element array