### PR TITLE
perf(yq): stream keys_unsorted output lazily

### DIFF
--- a/docs/plan/yq.md
+++ b/docs/plan/yq.md
@@ -486,7 +486,63 @@ fn yaml_to_owned_value(index: &YamlIndex) -> OwnedValue {
 }
 ```
 
-Future optimization: lazy cursor-based evaluation (like JSON implementation).
+Lazy cursor-based evaluation (like the JSON implementation) landed as the M2/M2.5
+streaming fast path (`GenericResult::stream_json`/`stream_yaml`, `can_use_m2_streaming`
+in `src/bin/succinctly/yq_runner.rs`) — see the note immediately below for how
+`keys_unsorted` specifically was made to fit it.
+
+### Lazy `keys_unsorted` output (#685)
+
+`keys_unsorted` on a YAML mapping already produced a lazy `GenericResult::LazyKeysUnsorted`
+(#140/#678), but `yq_runner.rs`'s CLI output boundary always materialized it into an owned
+`Vec<String>` before printing — unlike JSON's `jq`, which streams it via `JqValue::LazyKeysArray`
+(`src/jq/lazy.rs`). Issue #685 framed the fix as a choice between (A) a YAML-specific lazy
+value type parallel to `JqValue`, or (B) generalizing `JqValue` over cursor type.
+
+Neither was used. `JqValue::LazyKeysArray`'s streaming loop depends on `JsonFields: Copy`
+(`let mut current = *fields`); `YamlFields` can never be `Copy` — its `FieldsInner` is
+`Direct(Option<YamlCursor>)` *or* `Merged { entries: Rc<Vec<(YamlCursor, YamlCursor)>>, index }`
+for `<<: *anchor` merge-key resolution, and the `Rc`-holding variant rules out a bitwise copy.
+Generalizing `JqValue` over cursor type would mean changing that bound to `Clone` throughout
+`jq_runner.rs`'s hot path too, for a type that didn't need to change.
+
+Instead, `GenericResult::stream_json`/`stream_yaml` (`src/jq/eval_generic.rs`) — already
+generic over `V: DocumentValue`, already the exact machinery `yq_runner.rs`'s M2/M2.5 fast
+path calls — got real implementations for their one remaining eager arm
+(`LazyKeysUnsorted`), added as `stream_lazy_keys_json`/`stream_lazy_keys_yaml` in
+`src/jq/stream.rs`. Both mirror the `Array` arms of `stream_owned_value_json_with`/
+`stream_owned_value_yaml` exactly (same empty-check, same flow/block/indent framing), but
+pull one key at a time from `fields.clone()` + `uncons()` instead of walking a pre-built
+slice — no `Vec<String>`/`OwnedValue::Array` is ever built. `can_use_m2_streaming` was
+extended to admit `Builtin::KeysUnsorted`, so `syq 'keys_unsorted'` (and pipe compositions
+like `.foo | keys_unsorted`) now route through this path under the same default-flag
+conditions every other M2 query already requires.
+
+This is effectively option (B) — generalizing over value/cursor type — just realized at the
+streaming-function layer that was already generic, rather than by generalizing the `JqValue`
+enum tree. It reuses tested escaping logic (`stream_json_string`/`stream_yaml_string`),
+leaves `jq_runner.rs`/`JqValue` untouched, and is a much smaller diff than either option the
+issue proposed. `evaluate_yaml_cursor`'s DOM-path `LazyKeysUnsorted` arm is intentionally
+unchanged: it remains the correct materializing fallback for flag combinations
+(`--sort-keys`, color, `--tab`, `--slurp`, `--null-input`, named vars) that already force
+the DOM path for every other query shape, not a `keys_unsorted`-specific gap. Note that
+`-I0` (compact) satisfies the M2 gate on its own regardless of those flags
+(`output_config.compact || ...`), so exercising the DOM path in compact mode specifically
+needs `--arg` (an unused named variable), not `--sort-keys` — `--sort-keys` alone only forces
+DOM in pretty mode.
+
+Sanity-checked (not a formal interleaved A/B benchmark) on a 500K-key flat mapping (8.8 MB):
+`syq -o json -I0 'keys_unsorted'` (M2 lazy path) peaked at 84 MB / 0.14s versus 136 MB / 0.20s
+for the same query forced onto the DOM path via `--arg` — output byte-identical in both, ~40%
+less peak memory and ~30% faster, consistent with no longer building a 500K-entry `Vec<String>`.
+
+One casualty: `keys_unsorted` has no yq golden-fixture coverage (`tests/data/yq-golden/`)
+because the pinned oracle, `mikefarah/yq v4.53.3`, rejects the identifier at the lexer level
+(`Error: 1:5: lexer: invalid input text "_unsorted"`) — it doesn't implement this builtin at
+all. Coverage instead lives in `tests/yq_cli_tests.rs` (byte-identity checks between the M2
+lazy path and the DOM path forced via `--arg`/`--sort-keys`) and direct unit tests in
+`src/jq/eval_generic.rs` (`test_yaml_keys_unsorted_stream_lazy_685` and its merge-key
+counterpart).
 
 ---
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -400,19 +400,23 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         GenericResult::OneCursor(c) => Ok(vec![to_owned(&c.value())]),
         GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).collect()),
         GenericResult::ManyCursor(cs) => Ok(cs.iter().map(|c| to_owned(&c.value())).collect()),
-        // Fallback: materialize. YAML has no lazy-output concept today —
-        // `yq_runner.rs` never builds a `JqValue` — so unlike the JSON `jq`
-        // runner, this is the only path available here; a genuinely lazy
-        // YAML `keys_unsorted` output is deferred to a follow-up issue
-        // (#140). Sort iff `sorted` (#683), matching eager `Keys` -- though
-        // in practice `sorted` is always `false` here: `run_yq` always
-        // parses in `ParserMode::Yq`, where the `keys` keyword itself
-        // resolves to `Builtin::KeysUnsorted` (matching real yq's document-
-        // order semantics, see `parser.rs`'s `keys`/`keys_unsorted`
-        // handling), so `Builtin::Keys` can never reach this arm through the
-        // `yq` CLI. Handled anyway for exhaustiveness and because the
-        // generic evaluator is shared with `jq` (#140's `Pipe` dispatch is
-        // generic over `V: DocumentValue`).
+        // This is the DOM/slow path (`evaluate_yaml_direct_filtered`'s
+        // fallback), reached only when `can_use_m2_streaming` rejects the
+        // expression or a flag (`--sort-keys`, color, `--tab`, `--slurp`,
+        // `--null-input`, named vars, ...) forces DOM output for every query
+        // shape, not just `keys_unsorted`. `syq 'keys_unsorted'` under
+        // default flags takes the M2 fast path instead, which streams each
+        // key from `fields` without materializing (#685); this arm stays a
+        // plain materializing fallback since the DOM path materializes
+        // everything else here too. Sort iff `sorted` (#683) -- though in
+        // practice `sorted` is always `false` here: `run_yq` always parses
+        // in `ParserMode::Yq`, where the `keys` keyword itself resolves to
+        // `Builtin::KeysUnsorted` (matching real yq's document-order
+        // semantics, see `parser.rs`'s `keys`/`keys_unsorted` handling), so
+        // `Builtin::Keys` can never reach this arm through the `yq` CLI.
+        // Handled anyway for exhaustiveness and because the generic
+        // evaluator is shared with `jq` (#140's `Pipe` dispatch is generic
+        // over `V: DocumentValue`).
         GenericResult::LazyKeys { fields, sorted } => {
             let mut keys = fields.keys();
             if sorted {
@@ -992,9 +996,10 @@ fn build_args_var(context: &EvalContext) -> OwnedValue {
 /// - Iteration: `.[]`
 /// - Chained navigation: `.field[0].name`
 /// - Optional variants: `.field?`, `.[0]?`, `.[]?`
+/// - `keys_unsorted` (streams lazily via `GenericResult::LazyKeys { sorted: false, .. }`, #685)
 ///
 /// Expressions that require OwnedValue construction cannot use M2:
-/// - Builtins like `length`, `keys`, `map`
+/// - Builtins like `length`, `keys` (sorted), `map`
 /// - Array/object construction: `[...]`, `{...}`
 /// - Arithmetic, comparison, and logic operators
 /// - String interpolation
@@ -1028,6 +1033,13 @@ fn can_use_m2_streaming(expr: &Expr) -> bool {
         Expr::FirstExpr(_) | Expr::LastExpr(_) => true,
         Expr::Builtin(Builtin::FirstStream(_) | Builtin::LastStream(_)) => true,
         Expr::IndexExpr { .. } => true,
+
+        // `keys_unsorted` on a mapping produces `GenericResult::LazyKeys { sorted: false, .. }`,
+        // which `GenericResult::stream_json`/`stream_yaml` now stream directly
+        // from the field cursor (#685) instead of materializing a `Vec<String>`
+        // first. On an array input it already returns `GenericResult::Owned`
+        // cheaply, so this only changes routing for the mapping case.
+        Expr::Builtin(Builtin::KeysUnsorted) => true,
 
         // Everything else requires OwnedValue
         _ => false,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -501,20 +501,26 @@ impl<V: DocumentValue> GenericResult<V> {
                 }
                 stats.count = vs.len();
             }
-            // Fallback: materialize. `keys`/`keys_unsorted`-involving
-            // expressions never reach M2 streaming today
-            // (`can_use_m2_streaming`'s whitelist excludes `Builtin::Keys`/
-            // `Builtin::KeysUnsorted`, `yq_runner.rs`), so this arm exists
-            // only to keep the match exhaustive; a real streaming
-            // implementation (writing each key's raw bytes as it's pulled
-            // from `fields`) is future work if M2 ever grows to cover these.
             Self::LazyKeys { fields, sorted } => {
-                let owned = materialize_lazy_keys::<V>(fields, *sorted);
-                owned.stream_json(out, indent_spaces)?;
+                if *sorted {
+                    // Fallback: materialize+sort. Sorting requires seeing
+                    // every key first, so this can't stream lazily like the
+                    // unsorted case below.
+                    let owned = materialize_lazy_keys::<V>(fields, true);
+                    owned.stream_json(out, indent_spaces)?;
+                } else {
+                    // Genuinely lazy (#685): each key is pulled from
+                    // `fields` and written straight to `out` as it's
+                    // produced — no `Vec<String>` or `OwnedValue::Array` is
+                    // ever built. Reachable from `yq_runner.rs`'s M2 fast
+                    // path now that `can_use_m2_streaming` admits
+                    // `Builtin::KeysUnsorted`.
+                    crate::jq::stream::stream_lazy_keys_json(fields, out, indent_spaces)?;
+                }
                 on_value(out)?;
                 stats.count = 1;
-                stats.last_was_falsy = owned.is_falsy();
-                stats.any_truthy = !stats.last_was_falsy;
+                stats.last_was_falsy = false;
+                stats.any_truthy = true;
             }
             // The actual #684 win: writes `[0,1,...,len-1]` straight to
             // `out`, no `Vec<OwnedValue>`/`OwnedValue::Array` ever built.
@@ -650,15 +656,21 @@ impl<V: DocumentValue> GenericResult<V> {
                 }
                 stats.count = cs.len();
             }
-            // Fallback: materialize. See `stream_json`'s `LazyKeys` arm
-            // above — same reasoning (unreachable via M2 today).
             Self::LazyKeys { fields, sorted } => {
-                let owned = materialize_lazy_keys::<V>(fields, *sorted);
-                owned.stream_yaml(out, indent_spaces)?;
+                if *sorted {
+                    // Fallback: materialize+sort. See `stream_json`'s
+                    // `LazyKeys` arm above — same reasoning.
+                    let owned = materialize_lazy_keys::<V>(fields, true);
+                    owned.stream_yaml(out, indent_spaces)?;
+                } else {
+                    // Genuinely lazy (#685): see `stream_json`'s
+                    // `LazyKeys` arm above — same reasoning, YAML target.
+                    crate::jq::stream::stream_lazy_keys_yaml(fields, out, indent_spaces)?;
+                }
                 on_value(out)?;
                 stats.count = 1;
-                stats.last_was_falsy = owned.is_falsy();
-                stats.any_truthy = !stats.last_was_falsy;
+                stats.last_was_falsy = false;
+                stats.any_truthy = true;
             }
             // Same allocation-free approach as `stream_json` above (#684).
             Self::LazyIndexRange(len) => {
@@ -3654,9 +3666,10 @@ mod tests {
     fn test_yaml_keys_unsorted_lazy_fast_paths() {
         // `LazyKeys`/its `Pipe` fast paths are generic over
         // `V: DocumentValue`, so a YAML mapping goes through the exact same
-        // evaluator arms as a JSON object (#140) -- only `yq_runner.rs`'s
-        // CLI output boundary still materializes unconditionally, since
-        // YAML has no `JqValue`-equivalent lazy output today.
+        // evaluator arms as a JSON object (#140). The bare-array case (no
+        // `Pipe` fast path applies) is covered separately by
+        // `test_yaml_keys_unsorted_stream_lazy_685`, which now also streams
+        // lazily at the CLI output boundary (#685).
         use crate::yaml::YamlIndex;
 
         let yaml = b"b: 1\na: 2\nc: 3\n";
@@ -3789,6 +3802,76 @@ mod tests {
             eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
             OwnedValue::Int(2)
         );
+    }
+
+    #[test]
+    fn test_yaml_keys_unsorted_stream_lazy_685() {
+        // `GenericResult::stream_json`/`stream_yaml`'s `LazyKeys` arm
+        // now writes each key straight from `fields` instead of falling back
+        // to `materialize_lazy_keys` — this asserts the exact bytes produced,
+        // for both output formats and both compact/indented modes (#685).
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"b: 1\na: 2\nc: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse("keys_unsorted").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert!(matches!(
+            result,
+            GenericResult::LazyKeys { sorted: false, .. }
+        ));
+
+        let mut out = String::new();
+        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, r#"["b","a","c"]"#);
+
+        let mut out = String::new();
+        result.stream_json(&mut out, 2, |_| Ok(())).unwrap();
+        assert_eq!(out, "[\n  \"b\",\n  \"a\",\n  \"c\"\n]");
+
+        let mut out = String::new();
+        result.stream_yaml(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, "[b, a, c]");
+
+        let mut out = String::new();
+        result.stream_yaml(&mut out, 2, |_| Ok(())).unwrap();
+        assert_eq!(out, "- b\n- a\n- c");
+    }
+
+    #[test]
+    fn test_yaml_keys_unsorted_stream_lazy_merge_key_685() {
+        // Same as above but resolved through a `<<: *anchor` merge key,
+        // exercising `YamlFields`'s `Merged` variant (an `Rc`-shared entry
+        // list) through the new streaming path rather than the plain
+        // cursor-walk `Direct` variant JSON's `JsonFields` always uses.
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"defaults: &defaults\n  b: 1\n  a: 2\nitem:\n  <<: *defaults\n  c: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".item | keys_unsorted").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert!(matches!(
+            result,
+            GenericResult::LazyKeys { sorted: false, .. }
+        ));
+
+        let mut out = String::new();
+        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, r#"["b","a","c"]"#);
+
+        let mut out = String::new();
+        result.stream_yaml(&mut out, 2, |_| Ok(())).unwrap();
+        assert_eq!(out, "- b\n- a\n- c");
     }
 
     #[test]

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -22,6 +22,7 @@
 
 use alloc::string::{String, ToString};
 
+use super::document::DocumentFields;
 use super::escape::{write_json_body_jq, write_json_body_yq};
 use super::value::{format_number_jq_compat, NumberRepr, OwnedValue};
 use crate::yaml::format_float_with_fraction;
@@ -275,6 +276,49 @@ fn stream_json_string<W: core::fmt::Write>(
     out.write_char('"')
 }
 
+/// Stream a `DocumentFields`' keys (`keys_unsorted`) as a JSON array without
+/// an intermediate `Vec<String>`/`OwnedValue::Array` (#685).
+///
+/// The lazy counterpart of `stream_owned_value_json_with`'s `Array` arm
+/// above, pulling one key at a time from `uncons()` instead of walking a
+/// materialized slice. `GenericResult::LazyKeys { sorted: false, .. }` is
+/// always the entire top-level result (never nested inside another
+/// container), so unlike the function it mirrors this has no
+/// `current_indent` parameter — it's always 0.
+pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
+    fields: &F,
+    out: &mut W,
+    indent_spaces: usize,
+) -> core::fmt::Result {
+    if fields.is_empty() {
+        return out.write_str("[]");
+    }
+    out.write_char('[')?;
+    let mut current = fields.clone();
+    let mut i = 0usize;
+    while let Some((field, rest)) = current.uncons() {
+        // `key_str()` is expected to always return `Some` (see its doc
+        // comment on `DocumentField`); a field with no stringifiable key is
+        // silently skipped, matching `DocumentFields::keys()`'s default walk.
+        if let Some(key) = field.key_str() {
+            if i > 0 {
+                out.write_char(',')?;
+            }
+            if indent_spaces > 0 {
+                out.write_char('\n')?;
+                write_indent(out, indent_spaces)?;
+            }
+            stream_json_string(out, &key, write_json_body_yq)?;
+            i += 1;
+        }
+        current = rest;
+    }
+    if indent_spaces > 0 {
+        out.write_char('\n')?;
+    }
+    out.write_char(']')
+}
+
 // ============================================================================
 // YAML Streaming
 // ============================================================================
@@ -446,6 +490,56 @@ pub fn stream_yaml_string<W: core::fmt::Write>(out: &mut W, s: &str) -> core::fm
         stream_yaml_double_quoted(out, s)
     } else {
         out.write_str(s)
+    }
+}
+
+/// Stream a `DocumentFields`' keys (`keys_unsorted`) as YAML without an
+/// intermediate `Vec<String>`/`OwnedValue::Array` (#685).
+///
+/// The YAML counterpart of `stream_lazy_keys_json` above, mirroring
+/// `stream_owned_value_yaml`'s `Array` arm. Keys are always plain strings,
+/// never nested containers, so this omits that arm's "nested container gets
+/// its own indented line" branch, and — like `stream_lazy_keys_json` — has no
+/// `current_indent` parameter, since `LazyKeys { sorted: false, .. }` is
+/// always the entire top-level result.
+pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
+    fields: &F,
+    out: &mut W,
+    indent_spaces: usize,
+) -> core::fmt::Result {
+    if fields.is_empty() {
+        return out.write_str("[]");
+    }
+    let mut current = fields.clone();
+    let mut i = 0usize;
+    if indent_spaces == 0 {
+        // Flow style
+        out.write_char('[')?;
+        while let Some((field, rest)) = current.uncons() {
+            if let Some(key) = field.key_str() {
+                if i > 0 {
+                    out.write_str(", ")?;
+                }
+                stream_yaml_string(out, &key)?;
+                i += 1;
+            }
+            current = rest;
+        }
+        out.write_char(']')
+    } else {
+        // Block style
+        while let Some((field, rest)) = current.uncons() {
+            if let Some(key) = field.key_str() {
+                if i > 0 {
+                    out.write_char('\n')?;
+                }
+                out.write_str("- ")?;
+                stream_yaml_string(out, &key)?;
+                i += 1;
+            }
+            current = rest;
+        }
+        Ok(())
     }
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -853,10 +853,64 @@ fn test_inplace_multi_doc_field_navigation() -> Result<()> {
     Ok(())
 }
 
-/// #478: filters outside `can_use_m2_streaming` (e.g. `keys`) must still
-/// fall back to the pre-existing DOM path for `--inplace`.
+/// #478: filters outside `can_use_m2_streaming` must still fall back to the
+/// pre-existing DOM path for `--inplace`. `keys` was the original example
+/// here, but #685 admitted `Builtin::KeysUnsorted` (what `keys` parses to in
+/// `ParserMode::Yq`) into the M2 whitelist, so it no longer exercises this
+/// fallback -- `length` still requires `OwnedValue` construction (see
+/// `can_use_m2_streaming`'s doc comment) and stands in instead. A two-document
+/// file also drives the DOM loop's multi-doc `---` separator logic, which a
+/// single document can't reach.
 #[test]
 fn test_inplace_non_m2_filter_still_works() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\nb: 2\n---\nc: 3")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("length")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "---\n2\n---\n1\n");
+    Ok(())
+}
+
+/// `--inplace`'s DOM fallback loop applies `--doc` filtering with its own
+/// `continue`-past-non-matching-documents branch, separate from the
+/// multi-doc `---` separator logic `test_inplace_non_m2_filter_still_works`
+/// covers -- exercise it too so both branches of that loop are reached.
+#[test]
+fn test_inplace_non_m2_filter_doc_filter_still_works() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\nb: 2\n---\nc: 3")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("--doc")
+        .arg("1")
+        .arg("length")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "1\n");
+    Ok(())
+}
+
+/// #685: `keys`/`keys_unsorted` becoming M2-eligible means `--inplace 'keys'`
+/// now takes the fast path above (`can_inplace_yaml_fast_path`) instead of
+/// the DOM fallback `test_inplace_non_m2_filter_still_works` covers --
+/// confirm that path still rewrites the file correctly.
+#[test]
+fn test_inplace_keys_unsorted_m2_fast_path_685() -> Result<()> {
     let mut input_file = NamedTempFile::new()?;
     writeln!(input_file, "a: 1\nb: 2")?;
 
@@ -4118,18 +4172,28 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
 }
 
 /// `keys_unsorted` gained a lazy `GenericResult`/evaluator path shared with
-/// `jq` (#140), but `yq_runner.rs` has no `JqValue`-equivalent lazy output
-/// concept, so its `evaluate_yaml_cursor` boundary still materializes
-/// unconditionally (deferred to a follow-up issue). This just confirms that
-/// materialize fallback still produces correct, unchanged output on the YAML
-/// side.
+/// `jq` (#140); `yq_runner.rs`'s CLI output boundary now streams it lazily
+/// too, via `can_use_m2_streaming` admitting `Builtin::KeysUnsorted` and
+/// `GenericResult::stream_json`/`stream_yaml`'s `LazyKeys { sorted: false, .. }` arms
+/// writing each key straight from `fields` (#685) — no `Vec<String>` or
+/// `OwnedValue::Array` is built. Covers every M2-reachable output shape
+/// (compact/pretty JSON, compact/pretty YAML) plus `length`/`.[0]`, which
+/// were already lazy before this issue.
 #[test]
-fn test_keys_unsorted_yaml_materialize_fallback_140() -> Result<()> {
+fn test_keys_unsorted_yaml_lazy_output_685() -> Result<()> {
     let input = "b: 1\na: 2\nc: 3\n";
 
     let (output, code) = run_yq_stdin("keys_unsorted", input, &["-o", "json", "-I0"])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"["b","a","c"]"#);
+
+    let (output, code) = run_yq_stdin("keys_unsorted", input, &["-o", "json", "-I2"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[\n  \"b\",\n  \"a\",\n  \"c\"\n]");
+
+    let (output, code) = run_yq_stdin("keys_unsorted", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "- b\n- a\n- c");
 
     let (output, code) = run_yq_stdin("keys_unsorted | length", input, &["-o", "json", "-I0"])?;
     assert_eq!(code, 0);
@@ -4142,8 +4206,35 @@ fn test_keys_unsorted_yaml_materialize_fallback_140() -> Result<()> {
     Ok(())
 }
 
+/// `stream_lazy_keys_json`/`stream_lazy_keys_yaml`'s empty-`fields` early
+/// return (`"[]"`, skipping the `uncons()` loop entirely) is only reachable
+/// with zero mapping entries -- `test_keys_unsorted_yaml_lazy_output_685`'s
+/// fixture always has three, so it never exercises this arm (#685).
+#[test]
+fn test_keys_unsorted_yaml_lazy_output_empty_685() -> Result<()> {
+    let input = "{}\n";
+
+    let (output, code) = run_yq_stdin("keys_unsorted", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[]");
+
+    let (output, code) = run_yq_stdin("keys_unsorted", input, &["-o", "json", "-I2"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[]");
+
+    let (output, code) = run_yq_stdin("keys_unsorted", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[]");
+
+    let (output, code) = run_yq_stdin("keys_unsorted", input, &["-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[]");
+
+    Ok(())
+}
+
 // Note (#683): there is no sorted-`keys` CLI test mirroring
-// `test_keys_unsorted_yaml_materialize_fallback_140` here, because `keys` is
+// `test_keys_unsorted_yaml_lazy_output_685` here, because `keys` is
 // unreachable via the `yq` CLI's own dialect -- `run_yq` always parses in
 // `ParserMode::Yq`, where the `keys` keyword itself resolves to
 // `Builtin::KeysUnsorted` (matching real yq's document-order semantics; see
@@ -4181,6 +4272,57 @@ fn test_array_keys_unsorted_yaml_materialize_fallback_684() -> Result<()> {
     let (output, code) = run_yq_stdin("keys_unsorted | last", input, &["-o", "json", "-I0"])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "2");
+
+    Ok(())
+}
+
+/// Flags that force the DOM path must still agree byte-for-byte with the M2
+/// lazy path above — `evaluate_yaml_cursor`'s `LazyKeys { sorted: false, .. }`
+/// arm ([yq_runner.rs]) stays a materializing fallback for those flag
+/// combinations rather than a `keys_unsorted`-specific gap (#685).
+///
+/// `-I0` (compact) satisfies `can_json_fast_path`/`can_yaml_fast_path` on its
+/// own (`output_config.compact || ...`), so `--sort-keys` alone does *not*
+/// force DOM in compact mode — only in pretty mode, where it's excluded via
+/// `can_stream_pretty`. `--arg` (an unused named variable) forces DOM
+/// unconditionally via `context.named.is_empty()`, so it's used for the
+/// compact case instead.
+#[test]
+fn test_keys_unsorted_yaml_dom_fallback_matches_lazy_685() -> Result<()> {
+    let input = "b: 1\na: 2\nc: 3\n";
+
+    let (lazy, _) = run_yq_stdin("keys_unsorted", input, &["-o", "json", "-I0"])?;
+    let (dom, code) = run_yq_stdin(
+        "keys_unsorted",
+        input,
+        &["--arg", "_unused", "x", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(lazy, dom);
+
+    let (lazy, _) = run_yq_stdin("keys_unsorted", input, &[])?;
+    let (dom, code) = run_yq_stdin("keys_unsorted", input, &["--sort-keys"])?;
+    assert_eq!(code, 0);
+    assert_eq!(lazy, dom);
+
+    Ok(())
+}
+
+/// `keys_unsorted` on a mapping resolved through a `<<: *anchor` merge key
+/// exercises `YamlFields`'s `Merged` variant (an `Rc`-shared entry list, the
+/// reason `YamlFields` can't be `Copy` the way `JsonFields` is) through the
+/// new lazy path — must still stream in merge-then-local order.
+#[test]
+fn test_keys_unsorted_yaml_merge_key_lazy_685() -> Result<()> {
+    let input = "defaults: &defaults\n  b: 1\n  a: 2\nitem:\n  <<: *defaults\n  c: 3\n";
+
+    let (output, code) = run_yq_stdin(".item | keys_unsorted", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["b","a","c"]"#);
+
+    let (output, code) = run_yq_stdin(".item | keys_unsorted", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "- b\n- a\n- c");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`syq`'s `keys_unsorted` always materialized a `Vec<String>` before output, unlike JSON's `jq` which streams it via `JqValue::LazyKeysArray` (#140/#678). This closes that gap for YAML.

- **`perf(jq)`**: adds `stream_lazy_keys_json`/`stream_lazy_keys_yaml` (`src/jq/stream.rs`), generic over `DocumentFields`, and wires them into `GenericResult::stream_json`/`stream_yaml`'s `LazyKeysUnsorted` arms — each key streams straight from the field cursor, no `Vec<String>`/`OwnedValue::Array` is ever built.
- **`perf(cli)`**: admits `Builtin::KeysUnsorted` into `yq_runner.rs`'s `can_use_m2_streaming` gate so `syq 'keys_unsorted'` (and pipe compositions like `.foo | keys_unsorted`) actually route through the new lazy path.
- **`docs(yq)`**: records the design decision in `docs/plan/yq.md`.

### Design note

Issue #685 posed this as a choice between a YAML-specific lazy value type parallel to `JqValue`, or generalizing `JqValue` over cursor type. Neither was used: `JqValue::LazyKeysArray` depends on `JsonFields: Copy`, which `YamlFields` can never satisfy (its `Merged` variant, used for `<<: *anchor` merge-key resolution, holds an `Rc`). Extending the already-generic `GenericResult::stream_json`/`stream_yaml` — already yq's M2 fast-output path — avoided that bound change entirely and left `jq_runner.rs`/`JqValue` untouched. Full rationale in `docs/plan/yq.md`.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green (2002 lib tests, 241 yq CLI tests, golden tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second feature-set invocation — both clean
- [x] New CLI tests cover compact/pretty JSON and YAML output, a `<<: *anchor` merge-key mapping (exercises `YamlFields`'s non-`Copy` `Merged` variant), and byte-identity between the M2 path and the DOM fallback (forced via `--arg`/`--sort-keys`)
- [x] New `eval_generic.rs` unit tests assert exact streamed bytes directly
- [x] No golden-fixture coverage possible for `keys_unsorted`: the pinned oracle `mikefarah/yq v4.53.3` doesn't implement the builtin (lexer rejects the identifier) — documented in the design note
- [x] Manually measured on a 500K-key flat mapping: M2 path peaks at 84 MB / 0.14s vs 136 MB / 0.20s forced onto DOM, output byte-identical

Closes #685