### PR TITLE
fix(jq): stop `?`/`try` conflating a caught error with genuine empty

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -444,7 +444,42 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
         },
 
-        Expr::Optional(inner) => eval_single::<W, S>(inner, value, true),
+        // `.[EXPR]?`/`.[S:E]?`: jq's `?` here guards only the *final*
+        // indexing/slicing operation, not evaluation of the bracket's own
+        // key/bounds sub-expression — verified against jq 1.7.1:
+        // `echo '"a"' | jq '.[.k]?'` still raises (exit 5, "Cannot index
+        // string with string \"k\""), even though the whole `.[.k]` is
+        // syntactically inside the `?`. Wrapping in one more layer (a paren,
+        // a pipe stage, or plain `try`) *does* catch it — `jq '(.[.k])?'`,
+        // `jq '(.[.k] | .+1)?'`, and `jq 'try .[.k]'` all exit 0 — so this is
+        // specific to the bare bracket-then-`?` postfix form, which is the
+        // only shape that reaches here (that form and no other parses
+        // straight to `Expr::Optional(Expr::IndexExpr { .. })` /
+        // `Expr::Optional(Expr::SliceExpr { .. })`; every other spelling
+        // interposes a `Paren`/`Pipe`/`Try` node this arm doesn't match).
+        // `eval_index_expr`/`eval_slice_expr` already implement this split
+        // (they evaluate the key/bounds with a hardcoded `optional: false`
+        // and only consult the ambient `optional` for their own final
+        // index/slice step), so preserve the direct "just forward
+        // `optional`, don't wrap in a catch" dispatch here — routing it
+        // through `eval_try` below like every other expression would catch
+        // the key/bounds error too, which is too broad.
+        Expr::Optional(inner)
+            if matches!(**inner, Expr::IndexExpr { .. } | Expr::SliceExpr { .. }) =>
+        {
+            eval_single::<W, S>(inner, value, true)
+        }
+
+        // `E?` is sugar for `try E` (no catch handler): evaluate `inner`
+        // with the ambient `optional` — not forced `true` — so nested
+        // leaves raise real errors instead of each independently
+        // self-suppressing, and let `eval_try`'s existing catch-once logic
+        // decide whether to swallow the *aggregate* result. Forcing
+        // `optional = true` down the whole subtree (the old behavior) let a
+        // masked error inside a combinator (comma, reduce/foreach/while/
+        // until) look exactly like ordinary `empty` to that combinator,
+        // which then wrongly kept going instead of stopping (#693).
+        Expr::Optional(inner) => eval_try::<W, S>(inner, None, value, optional),
 
         Expr::Pipe(exprs) => eval_pipe::<W, S>(exprs, value, optional),
 
@@ -1005,15 +1040,16 @@ fn eval_owned_expr_fork<S: EvalSemantics>(
 /// a construct's own legitimate prior output and only silences a trailing
 /// `Error`, it does not discard everything.
 ///
-/// A `Break` always propagates via `partial` here, uncaught by `optional`.
-/// That is *not* what real jq does — `label $out | (1, (reduce (1,2) as $x
-/// (0; break $out))?, 4)` gives jq's `1`, `4` (its `?` does swallow an
-/// escaping `break` whose matching `label` sits outside it) — but this
-/// codebase's `?`/`try` machinery doesn't catch a `break` anywhere else
-/// either (`Expr::Optional`'s own dispatch has the identical gap, confirmed
-/// reproducible on `main`, i.e. predating #534). This function deliberately
-/// stays consistent with that pre-existing, cross-cutting limitation rather
-/// than fixing it in isolation for just these four constructs.
+/// A `Break` always propagates via `partial` here, uncaught by `optional` —
+/// deliberately: `label $out | (1, (reduce (1,2) as $x (0; break $out))?,
+/// 4)` gives jq's `1`, `4` (its `?` does swallow an escaping `break` whose
+/// matching `label` sits outside it), and this codebase now matches that
+/// too (#693), but the catch happens one level up, at the `?`/`try`
+/// boundary wrapping whichever fork construct raised the `Break` —
+/// `eval_try`/`Expr::Optional`'s dispatch, not here. This function only
+/// ever sees `optional` after that boundary has already had its chance to
+/// react, so it correctly leaves `Break` alone and only ever silences a
+/// trailing `Error`.
 fn finish_fork<'a, W>(
     outputs: Vec<OwnedValue>,
     control: Option<Control>,
@@ -19558,19 +19594,30 @@ mod tests {
                 assert_eq!(label, "out");
             }
         );
-        // `optional` (`?`) must never swallow a `break` the way it swallows
-        // a real error — jq's `?` catches errors, not label breaks.
-        // Discriminating test: if the break were (incorrectly) swallowed as
-        // `None` by `optional`, the comma's second operand would still run
-        // and "reached" would be output; since the break must instead
-        // short-circuit the comma and reach the label, "reached" is never
-        // evaluated.
+        // Corrected by #693 (was asserted the other way, unverified — see
+        // below): `?` *does* swallow an escaping `break` the same way it
+        // swallows a real error, exactly like `try` already does (#562) —
+        // jq defines `E?` as sugar for `try E`, and it does not
+        // special-case `break`. Re-verified directly against jq 1.7.1 three
+        // ways (`?`, `try` with no catch, and the bare/uncaught form for
+        // contrast) immediately before writing this assertion:
+        // `jq -n 'label $out | ((reduce (1,2,3) as $x (0; if $x==2 then
+        // break $out else .+$x end))?, "reached")'` prints `"reached"`
+        // (`?` catches the break, so the comma continues); the `try`
+        // spelling prints the same; the bare form with no `?`/`try` at all
+        // prints nothing (the break escapes uncaught to `label $out`,
+        // which then discards the rest of the comma). This test previously
+        // asserted the *bare* form's behavior for the `?`-wrapped query —
+        // an assumption that went unverified because, pre-#693, this
+        // codebase's `Expr::Optional` never caught a `break` at all, so the
+        // (wrong) expectation and the (buggy) implementation happened to
+        // agree.
         assert_eq!(
             outputs(
                 b"null",
                 r#"label $out | ((reduce (1,2,3) as $x (0; if $x==2 then break $out else .+$x end))?, "reached")"#
             ),
-            Vec::<String>::new()
+            ["\"reached\""]
         );
     }
 
@@ -22775,12 +22822,29 @@ mod tests {
     }
 
     #[test]
-    fn test_reduce_init_partial_error_swallowed_when_optional() {
-        // INIT `(1,$nope)` produces `Partial([1], Control::Error(_))` — under
-        // `?` this whole prefix is discarded, not just the error.
+    fn test_reduce_init_partial_error_still_runs_the_fork_from_its_prefix_value() {
+        // Corrected by #693 (was asserted the other way, unverified — see
+        // below): INIT `(1,$nope)` produces `Partial([1], Control::Error(_))`
+        // — under `?` only the trailing error is swallowed; the `1` INIT
+        // already validly produced still forks and runs to completion,
+        // matching this codebase's own "outputs already produced don't
+        // vanish" contract (`partial()`/`prepend()`/`finish_fork`'s doc
+        // comments) and jq's actual behavior. `$nope` (an undefined
+        // variable) is a *compile*-time error in real jq, so it can't be
+        // run directly there to check; re-verified the identical shape with
+        // a *runtime* error instead immediately before writing this
+        // assertion: `jq -n '[1,2,3] | (reduce .[] as $x ((1,error("boom"));
+        // .+$x))?'` prints `7` — i.e. the fork from INIT's `1` runs
+        // `1+1=2, 2+2=4, 4+3=7` to completion, exactly like this test now
+        // expects. This test previously asserted the whole prefix was
+        // discarded — an assumption that went unverified because, pre-#693,
+        // this codebase's `Expr::Optional` self-suppressed every leaf error
+        // it wrapped (including `$nope`'s—see the `$nope` explainer above),
+        // so the (wrong) expectation and the (buggy) implementation
+        // happened to agree.
         assert_eq!(
             outputs(b"[1,2,3]", "(reduce .[] as $x ((1,$nope); .+$x))?"),
-            Vec::<String>::new()
+            ["7"]
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20173,6 +20173,13 @@ mod tests {
         // No handler at all: the prefix is kept and the error swallowed.
         assert_eq!(outputs(b"null", r#"try (1,2,error("x"))"#), ["1", "2"]);
         assert_eq!(outputs(b"null", r#"(1,2,error("x"))?"#), ["1", "2"]);
+        // The error-in-last-position cases above happen to be numerically
+        // correct even under #693's bug (nothing follows the error to wrongly
+        // continue to). An operand *after* the masked error is the case that
+        // actually distinguishes correct behavior: jq stops at the error and
+        // never reaches `2`.
+        assert_eq!(outputs(b"null", r#"try (1,error("x"),2)"#), ["1"]);
+        assert_eq!(outputs(b"null", r#"(1,error("x"),2)?"#), ["1"]);
         // A handler that fails in turn: the two prefixes concatenate and the
         // handler's own control terminates the stream.
         query!(b"null", r#"try (1,2,error("x")) catch error("y")"#,
@@ -22917,6 +22924,73 @@ mod tests {
                 "label $lbl | foreach .[] as $x (break $lbl; .+$x)"
             ),
             Vec::<String>::new()
+        );
+    }
+
+    // #693: `$nope` (above) is the *one* leaf that never self-suppressed via
+    // the old ambient-`optional` bug, so the tests above never actually
+    // exercised the failure mode from the issue — a `?`-wrapped fork
+    // construct whose UPDATE/COND step raises via `error(...)` (the
+    // realistic case). These pin that directly, against pinned `jq 1.7.1`
+    // output.
+
+    #[test]
+    fn test_693_reduce_update_error_swallowed_by_optional() {
+        // Before the fix: UPDATE's `error("boom")` self-suppressed to `None`
+        // at the leaf (ambient `optional = true`), so `eval_reduce` never saw
+        // an `Error`/`Partial` to abort on, and `.` (the unbound accumulator)
+        // read back as `null` — `(reduce (1) as $x (0; error("boom")))?`
+        // wrongly produced `null` instead of stopping with no output.
+        assert_eq!(
+            outputs(b"null", r#"(reduce (1) as $x (0; error("boom")))?"#),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_693_foreach_update_error_aborts_every_fork_not_just_the_current_one() {
+        // Multi-output INIT `(10,20)` forks foreach over two accumulators.
+        // Before the fix, fork 1's masked error "recovered" to a bound
+        // `null` instead of aborting, and fork 2 — which real jq's `?` never
+        // attempts once fork 1 errors — ran anyway, wrongly producing
+        // `[2,21,23]`.
+        assert_eq!(
+            outputs(
+                b"null",
+                r#"(foreach (1,2) as $x ((10,20); if .==10 then error("boom") else .+$x end))?"#
+            ),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_693_while_stops_at_the_masked_error_instead_of_burning_the_step_budget() {
+        // Before the fix, the masked error inside `while`'s UPDATE never
+        // reached `until_step`/`while_step`'s abort check, so the loop spun
+        // through `0..12` repeatedly until `WHILE_UNTIL_MAX_STEPS` tripped.
+        assert_eq!(
+            outputs(
+                b"null",
+                "(10|while(. < 30; if . == 12 then error(\"boom\"), 0 else .+1 end))?"
+            ),
+            ["10", "11", "12"]
+        );
+    }
+
+    #[test]
+    fn test_693_optional_around_a_fork_construct_also_catches_an_escaping_break() {
+        // `finish_fork` deliberately never special-cases `Break` (see its doc
+        // comment) — catching one is the wrapping `?`/`try` boundary's job.
+        // Before this fix, `Expr::Optional`'s dispatch had no such boundary
+        // logic, so the `break $out` inside the `reduce` escaped straight
+        // past the `?` and was caught by `label $out` one step too early,
+        // wrongly producing `[1]` instead of jq's `[1,4]`.
+        assert_eq!(
+            outputs(
+                b"null",
+                "label $out | (1, (reduce (1,2) as $x (0; break $out))?, 4)"
+            ),
+            ["1", "4"]
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23175,6 +23175,96 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_isvalid_reaches_every_builtins_own_optional_guard() {
+        // `isvalid(EXPR)` is the one surviving construct that still evaluates
+        // `EXPR` with `optional` forced `true` for the whole subtree
+        // (`builtin_isvalid` does this deliberately, not by accident: without
+        // it, a fork construct — comma/reduce/foreach — that errors partway
+        // through would come back as `Partial`, which `isvalid`'s own
+        // three-arm match doesn't special-case and would wrongly count as
+        // "valid"). Every other route to `optional = true` was removed by
+        // #693 — `E?`/`try E` now evaluate `E` with the *ambient* `optional`
+        // and catch the aggregate result once via `eval_try`, rather than
+        // broadcasting `true` down the whole subtree the way the pre-#693
+        // bug did. That leaves each of these builtins' own internal
+        // `_ if optional => ...` arm reachable only through `isvalid`, so
+        // this is regression coverage for #698 (indirect coverage lost by
+        // #693's fix, all of it real behavior — `isvalid` correctly
+        // reporting `false` — not dead code): pin one case per remaining
+        // caller so a future refactor can't silently make `isvalid` stop
+        // noticing one of these error shapes.
+        for expr in [
+            "isvalid(.[])",
+            "isvalid(keys)",
+            "isvalid(keys_unsorted)",
+            r#"isvalid(contains("a"))"#,
+            r#"isvalid(inside("a"))"#,
+            "isvalid(bsearch(2))",
+        ] {
+            query!(br"1", expr,
+                QueryResult::Owned(OwnedValue::Bool(false)) => {}
+            );
+        }
+
+        // The `@format` builtins' own `_ if optional` arm is unlike the
+        // others above: it doesn't produce `None`, it produces `Ok(String::
+        // new())` — under `optional`, a value the format can't handle
+        // renders as `""` rather than failing at all, so `isvalid` sees a
+        // genuine success and reports `true`, not `false`.
+        for expr in [
+            "isvalid(@urid)",
+            "isvalid(@csv)",
+            "isvalid(@tsv)",
+            r#"isvalid(@dsv("|"))"#,
+            "isvalid(@base64)",
+            "isvalid(@base64d)",
+        ] {
+            query!(br"1", expr,
+                QueryResult::Owned(OwnedValue::Bool(true)) => {}
+            );
+        }
+
+        // `error(...)` itself.
+        query!(br"1", r#"isvalid(error("x"))"#,
+            QueryResult::Owned(OwnedValue::Bool(false)) => {}
+        );
+
+        // Assignment/update/del: the write-time path traversal fails one
+        // level down (`.a` is `1`, not an object, so `.b` can't be written
+        // into it), and `set_path`/`update_path`/`delete_at_path` have no
+        // `optional` of their own — it's `eval_assign`/`eval_update`/
+        // `builtin_del`'s *own* ambient `optional` (forced by `isvalid`)
+        // that decides whether the failure is swallowed.
+        for expr in [
+            "isvalid(.a.b = 5)",
+            r#"isvalid(.a |= error("x"))"#,
+            "isvalid(del(.a.b))",
+        ] {
+            query!(br#"{"a":1}"#, expr,
+                QueryResult::Owned(OwnedValue::Bool(false)) => {}
+            );
+        }
+
+        // reduce/foreach: `limit(-1; 1)` errors unconditionally (it has no
+        // `optional` arm of its own), so it's the one construct that can
+        // still leak a genuine `Error`/`Partial` control past a leaf's own
+        // self-suppression and into `eval_reduce`/`eval_foreach`/
+        // `finish_fork`'s own optional-guards, one per INIT/SOURCE/fork-loop
+        // site.
+        for expr in [
+            "isvalid(reduce (1,2) as $x (0; limit(-1;1)))",
+            "isvalid(reduce (1,2) as $x (limit(-1;1); .+$x))",
+            "isvalid(reduce (1,2) as $x ((1,limit(-1;1)); .+$x))",
+            "isvalid(foreach limit(-1;1) as $x (0; .+$x))",
+            "isvalid(foreach (1,2) as $x (limit(-1;1); .+$x))",
+        ] {
+            query!(br"1", expr,
+                QueryResult::Owned(OwnedValue::Bool(false)) => {}
+            );
+        }
+    }
+
     // =========================================================================
     // Phase 9 Tests: Destructuring and Function Definitions
     // =========================================================================

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3593,6 +3593,47 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_optional_around_native_pipe_fanout_empty_prefix() {
+        // Sibling to the test above: the error hits on the very *first*
+        // fan-out element, so the `Partial` prefix collected before it is
+        // empty. Exercises `Expr::Optional`'s `prefix.len() == 0` arm
+        // (eval_generic.rs), which the `.==2` case above can't reach since
+        // it always leaves a one-element prefix. Confirmed against real jq
+        // 1.7.1: `(.[] | if .==1 then error("boom") else . end)?` on
+        // `[1,2,3]` prints nothing.
+        let json = br"[1, 2, 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse(r#"(.[] | if .==1 then error("boom") else . end)?"#).unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+    }
+
+    #[test]
+    fn test_generic_optional_around_native_pipe_fanout_multi_element_prefix() {
+        // Sibling to the two tests above: the error hits after more than
+        // one fan-out element has already succeeded, so the `Partial`
+        // prefix holds multiple values. Exercises `Expr::Optional`'s
+        // `prefix.len() > 1` arm (eval_generic.rs), which neither the
+        // one-element nor the zero-element case above can reach. Confirmed
+        // against real jq 1.7.1: `(.[] | if .==3 then error("boom") else .
+        // end)?` on `[1,2,3,4]` prints `1` then `2`.
+        let json = br"[1, 2, 3, 4]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse(r#"(.[] | if .==3 then error("boom") else . end)?"#).unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(
+            result.collect_owned(),
+            vec![OwnedValue::Int(1), OwnedValue::Int(2)]
+        );
+    }
+
+    #[test]
     fn test_yaml_generic_array() {
         use crate::yaml::YamlIndex;
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3570,6 +3570,29 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_optional_around_native_pipe_fanout_stops_at_the_first_error() {
+        // #693: `Expr::Optional`'s own native arm (not the `eval_on_owned`/
+        // wildcard bridge to `eval::eval`) used to force `optional = true`
+        // down the whole wrapped subtree, so each element of the native
+        // `Iterate` -> `Pipe` fan-out independently self-suppressed its own
+        // error via the bridge's own `optional`-aware wrapping, and the
+        // fan-out wrongly kept going past it. Confirmed reachable through
+        // the actual `succinctly jq`/`yq` CLIs, which call this native path
+        // (`eval_with_cursor`) by default, not just via `eval()` directly:
+        // `echo '[1,2,3]' | succinctly jq '(.[] | if .==2 then
+        // error("boom") else . end)?'` printed `1` and `3` pre-fix; real jq
+        // 1.7.1 prints only `1`.
+        let json = br"[1, 2, 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse(r#"(.[] | if .==2 then error("boom") else . end)?"#).unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(result.collect_owned(), vec![OwnedValue::Int(1)]);
+    }
+
+    #[test]
     fn test_yaml_generic_array() {
         use crate::yaml::YamlIndex;
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -948,7 +948,42 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             }
         }
 
-        Expr::Optional(inner) => eval_single::<S, _>(inner, value, true, cursor),
+        // `.[EXPR]?`/`.[S:E]?`: mirrors `eval::eval_single`'s identical
+        // special case (see its comment for the jq-1.7.1-verified reasoning)
+        // — `?` on a bare bracket-index/slice postfix guards only the final
+        // index/slice step, not the bracket's own key/bounds sub-expression.
+        // This file's own `eval_index_expr`/`eval_slice_expr` (below)
+        // already evaluate key/bounds with a hardcoded `optional: false` and
+        // only consult the ambient `optional` for their final step, so
+        // preserve the direct forwarding dispatch here instead of the
+        // catch-everything arm below, which would catch the key/bounds
+        // error too.
+        Expr::Optional(inner)
+            if matches!(**inner, Expr::IndexExpr { .. } | Expr::SliceExpr { .. }) =>
+        {
+            eval_single::<S, _>(inner, value, true, cursor)
+        }
+
+        // `E?` is sugar for `try E`: evaluate `inner` with the ambient
+        // `optional` (not forced `true`) and catch the aggregate result
+        // exactly once here, mirroring `eval::eval_try` (there is no local
+        // `Expr::Try`/combinator handling in this file to delegate to —
+        // those already bridge to `eval::eval`, which implements this same
+        // pattern). Forcing `optional = true` down the whole subtree let a
+        // masked error inside a natively-evaluated `Pipe` fan-out look like
+        // ordinary `empty`, so the fan-out wrongly kept going instead of
+        // stopping (#693).
+        Expr::Optional(inner) => match eval_single::<S, _>(inner, value, optional, cursor) {
+            GenericResult::Error(_) | GenericResult::Break(_) => GenericResult::None,
+            GenericResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => {
+                match prefix.len() {
+                    0 => GenericResult::None,
+                    1 => GenericResult::Owned(prefix.into_iter().next().unwrap()),
+                    _ => GenericResult::ManyOwned(prefix),
+                }
+            }
+            other => other,
+        },
 
         // Parens are transparent to cursor-based evaluation: handled natively
         // (like `Expr::Optional` above) so `(.)` and friends keep threading

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -975,9 +975,14 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // stopping (#693).
         Expr::Optional(inner) => match eval_single::<S, _>(inner, value, optional, cursor) {
             GenericResult::Error(_) | GenericResult::Break(_) => GenericResult::None,
+            // `prefix` is never empty here: `partial_generic` (and
+            // `eval::partial`, its mirror) already collapse an empty prefix
+            // to the bare `Error`/`Break` variant above before a `Partial`
+            // ever gets constructed (#400, #494) — the same invariant the
+            // unconditional `.next().unwrap()` elsewhere in this file (e.g.
+            // `eval_first_or_last_generic`) relies on.
             GenericResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => {
                 match prefix.len() {
-                    0 => GenericResult::None,
                     1 => GenericResult::Owned(prefix.into_iter().next().unwrap()),
                     _ => GenericResult::ManyOwned(prefix),
                 }
@@ -3593,12 +3598,17 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_optional_around_native_pipe_fanout_empty_prefix() {
+    fn test_generic_optional_around_native_pipe_fanout_error_on_first_element() {
         // Sibling to the test above: the error hits on the very *first*
-        // fan-out element, so the `Partial` prefix collected before it is
-        // empty. Exercises `Expr::Optional`'s `prefix.len() == 0` arm
-        // (eval_generic.rs), which the `.==2` case above can't reach since
-        // it always leaves a one-element prefix. Confirmed against real jq
+        // fan-out element, so there's no prefix to collect at all — the
+        // native `Many`/`ManyCursor` fan-out arms return a bare
+        // `GenericResult::Error` directly rather than ever constructing a
+        // `Partial`, so this lands on `Expr::Optional`'s
+        // `GenericResult::Error(_) => GenericResult::None` arm
+        // (eval_generic.rs), not the `Partial` arm below it. (There is no
+        // `prefix.len() == 0` case to exercise: `partial_generic` collapses
+        // an empty prefix to a bare `Error`/`Break` before `Partial` is ever
+        // constructed, so that arm doesn't exist.) Confirmed against real jq
         // 1.7.1: `(.[] | if .==1 then error("boom") else . end)?` on
         // `[1,2,3]` prints nothing.
         let json = br"[1, 2, 3]";
@@ -3616,10 +3626,10 @@ mod tests {
         // Sibling to the two tests above: the error hits after more than
         // one fan-out element has already succeeded, so the `Partial`
         // prefix holds multiple values. Exercises `Expr::Optional`'s
-        // `prefix.len() > 1` arm (eval_generic.rs), which neither the
-        // one-element nor the zero-element case above can reach. Confirmed
-        // against real jq 1.7.1: `(.[] | if .==3 then error("boom") else .
-        // end)?` on `[1,2,3,4]` prints `1` then `2`.
+        // `prefix.len() > 1` arm (eval_generic.rs), which the one-element
+        // case above can't reach. Confirmed against real jq 1.7.1:
+        // `(.[] | if .==3 then error("boom") else . end)?` on `[1,2,3,4]`
+        // prints `1` then `2`.
         let json = br"[1, 2, 3, 4]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -188,14 +188,17 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     let index = JsonIndex::build(json_bytes);
     let cursor = index.root(json_bytes);
 
-    let wrapped;
-    let expr = if optional {
-        wrapped = Expr::Optional(Box::new(expr.clone()));
-        &wrapped
-    } else {
-        expr
-    };
-
+    // No `if optional { wrap in Expr::Optional }` here: every public entry
+    // point (`eval`/`eval_using`/`eval_with_cursor`/`eval_with_cursor_using`)
+    // starts a fresh evaluation at `optional = false`, and after #693 the
+    // only place this module ever forces `optional = true` is the
+    // `IndexExpr`/`SliceExpr` special case in `eval_single`'s `Expr::
+    // Optional` arm — which only threads it into `index_one_generic`/
+    // `slice_one_generic`/`index_owned_by_key`, never into a call that
+    // reaches this function. So `optional` is always `false` here; an
+    // `Error` this bridge returns is caught, if at all, by the *caller's*
+    // own `Expr::Optional`/`eval_try`-style boundary, not by wrapping it a
+    // second time here.
     match full_eval::<Vec<u64>, S>(expr, cursor) {
         QueryResult::One(v) => GenericResult::Owned(standard_json_to_owned(&v)),
         QueryResult::OneCursor(c) => GenericResult::Owned(standard_json_to_owned(&c.value())),
@@ -895,9 +898,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // errored while `null | .[$n]` — the same query, and the same
                 // rule in `index_one_generic` — returned null.
                 GenericResult::Owned(OwnedValue::Null)
-            } else if optional {
-                GenericResult::None
             } else {
+                // No `optional`-guarded arm here (unlike `index_one_generic`,
+                // the computed-key sibling this literal `.[N]` form doesn't
+                // share code with): `.[N]?` parses straight to
+                // `Expr::Optional(Expr::Index(N))`, which isn't
+                // `IndexExpr`/`SliceExpr`, so #693's dispatch never forces
+                // `optional = true` into this arm — it evaluates `Expr::
+                // Index` at the ambient `optional` (normally `false`) and
+                // lets the outer `Expr::Optional`/`eval_try`-style catch
+                // convert the resulting `Error` to `None` once, same
+                // externally-observable result via a different path.
                 GenericResult::Error(EvalError::cannot_index_with_type(
                     value.type_name(),
                     "number",
@@ -1480,21 +1491,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             let index = JsonIndex::build(json_bytes);
             let cursor = index.root(json_bytes);
 
-            // The full evaluator always starts a fresh `eval()` with
-            // `optional = false`, so an ambient `optional = true` here (e.g.
-            // `(.a + .b)?`, `first(.[])?`) would otherwise be silently
-            // dropped at this bridge instead of suppressing the error, as it
-            // does for the natively-handled arms above. Re-wrap in
-            // `Expr::Optional` so the full evaluator's own (nuanced) handling
-            // of `?` sees it, same as the `eval_on_owned` builtin-fallback
-            // bridge below (#367, #386).
-            let wrapped;
-            let expr = if optional {
-                wrapped = Expr::Optional(Box::new(expr.clone()));
-                &wrapped
-            } else {
-                expr
-            };
+            // No `if optional { wrap in Expr::Optional }` here (see
+            // `eval_on_owned`'s matching comment): this `_` arm is only
+            // reached when `expr` itself isn't one of the natively-matched
+            // variants above, and after #693 the only way this function
+            // (`eval_single`) is ever called with `optional = true` is the
+            // `IndexExpr`/`SliceExpr` special case a few arms up — which
+            // matches *before* falling through to this wildcard, so it never
+            // lands here. Every other caller threads the ambient `optional`,
+            // which starts `false` at every public entry point. Whatever
+            // `Error` `full_eval` returns below is caught, if at all, by the
+            // *caller's* own `Expr::Optional`/`eval_try`-style boundary.
 
             // Evaluate using the full evaluator
             match full_eval::<Vec<u64>, S>(expr, cursor) {
@@ -1991,12 +1998,19 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
             match cond_control {
                 None => pass_n(truthy_count),
-                // `select(...)? ` swallows the condition's error the same
-                // way `try select(...) catch empty` would — per #400/#494,
-                // that keeps whatever the truthy bits already produced
-                // rather than discarding it too. `break` always propagates,
-                // `optional` or not.
-                Some(Control::Error(_)) if optional => pass_n(truthy_count),
+                // No `optional`-guarded arm here: `eval_builtin`'s own
+                // `optional` (as opposed to `cond`'s, which is hardcoded
+                // `false` above regardless) is never `true` for
+                // `Builtin::Select` after #693 — `select(...)?` isn't
+                // `IndexExpr`/`SliceExpr`, so it goes through the generic
+                // `Expr::Optional`/`eval_try`-style catch below at the
+                // *ambient* `optional`, not a forced one. That catch takes
+                // the `Partial` this arm below still constructs and keeps
+                // only its prefix — cursor-preserving `pass_n(truthy_count)`
+                // would have been the more precise answer (line/column
+                // survive on the already-produced outputs), but nothing can
+                // observe the difference: reinstate it if some future
+                // dispatch path starts forcing `optional = true` here.
                 Some(control) => {
                     let prefix: Vec<OwnedValue> = match cursor {
                         Some(c) => core::iter::repeat_with(|| to_owned(&c.value()))
@@ -2248,9 +2262,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     f = rest;
                 }
                 GenericResult::Owned(OwnedValue::Array(entries))
-            } else if optional {
-                GenericResult::None
             } else {
+                // No `optional`-guarded arm here: `Builtin::ToEntries` isn't
+                // `IndexExpr`/`SliceExpr`, so #693's dispatch never forces
+                // `optional = true` into this native arm — `to_entries?`
+                // evaluates it at the ambient `optional` (normally `false`)
+                // and lets the outer `Expr::Optional`/`eval_try`-style catch
+                // convert the resulting `Error` to `None` once instead.
                 GenericResult::Error(EvalError::has_no_keys(&to_owned(&value)))
             }
         }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2656,6 +2656,26 @@ fn test_uncaught_error_exits_5() -> Result<()> {
 }
 
 #[test]
+fn test_693_optional_around_stream_stops_at_the_first_error() -> Result<()> {
+    // The `jq`/`yq` CLIs' default path evaluates through `eval_generic`'s
+    // native cursor-based evaluator (`jq_runner.rs`'s `evaluate_input`/
+    // `evaluate_bytes_lazy`), not the `eval.rs`-level `eval()` API directly
+    // — so a fix that only touched `eval.rs` would leave this reachable
+    // through the shipped binary. Verified against jq 1.7.1: `jq -n '[1,2,3]
+    // | (.[] | if .==2 then error("boom") else . end)?'` prints only `1`.
+    // Pre-#693 this codebase's binary printed `1` and `3` (the masked error
+    // at the second element self-suppressed instead of stopping the
+    // fan-out).
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"(.[] | if .==2 then error("boom") else . end)?"#],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, "1\n");
+    Ok(())
+}
+
+#[test]
 fn test_uncaught_type_error_exits_5() -> Result<()> {
     // Internal errors carry no payload, so no `(not a string)` marker. The
     // wording still differs from jq's ("Cannot index number with string") --

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -322,27 +322,40 @@ fn test_formats_non_finite_owned_pipe_parity() {
 }
 
 /// `?` on a format applied to a *constructed* value (arithmetic, array/object
-/// construction, ...) must still suppress a type-mismatch error. These formats
-/// suppress it internally (`format_csv`/`format_tsv`/`format_dsv`/
-/// `format_base64`/`format_base64d`/`format_urid` return `Ok("")` rather than
-/// `Err` when their `optional` argument is set) -- that is the only mechanism
-/// that makes `?` work here, there is no separate `Expr::Optional`-catches-
-/// `Error` fallback for this path. A constructed value reaches the format via
-/// `eval_on_owned`'s fast path (#124), which must therefore forward the real
-/// `optional` flag rather than hardcoding `false`.
+/// construction, ...) must still suppress a type-mismatch error, producing no
+/// output at all -- verified against jq 1.7.1 (`jq -n '(1+1 | @csv)?'` and
+/// the `@tsv`/`@base64`/`@base64d`/`@urid` siblings all produce nothing, exit
+/// 0; `@dsv` has no jq equivalent to check directly, since it's this crate's
+/// own extension, but shares `format_csv`'s exact suppression code path).
+///
+/// Before #693, `format_csv`/`format_tsv`/`format_dsv`/`format_base64`/
+/// `format_base64d`/`format_urid`'s own `_ if optional => Ok(String::new())`
+/// arm was the *only* thing that made `?` work here -- there was no separate
+/// `Expr::Optional`-catches-`Error` fallback for this path, so a suppressed
+/// format fell back to the empty *string* `""` (a real output) rather than
+/// true suppression (no output), because `format_owned` returns `Result<
+/// String, EvalError>` with no way to spell "no result". That workaround is
+/// still in place (a constructed value still reaches the format via
+/// `eval_on_owned`'s fast path (#124), forwarding the real ambient
+/// `optional`) but is now moot for the bare `(EXPR | @format)?` shape tested
+/// here: `Expr::Optional`'s new catch-after-the-fact dispatch evaluates the
+/// pipe with `optional` forced to `false`, so the format leaf raises a real
+/// `Error` instead of self-suppressing to `""`, and that real error is what
+/// gets caught -- correctly producing no output, matching jq. The old
+/// pinned `""` was never jq-verified and was wrong.
 #[test]
 fn test_formats_optional_owned_type_error_parity_124() {
-    for (json, filter, expected) in [
-        (b"null".as_slice(), "(1+1 | @csv)?", r#""""#),
-        (b"null", "(1+1 | @tsv)?", r#""""#),
-        (b"null", r#"(1+1 | @dsv("|"))?"#, r#""""#),
-        (b"null", "(1+1 | @base64)?", r#""""#),
-        (b"null", "(1+1 | @base64d)?", r#""""#),
-        (b"null", "(1+1 | @urid)?", r#""""#),
+    for (json, filter) in [
+        (b"null".as_slice(), "(1+1 | @csv)?"),
+        (b"null", "(1+1 | @tsv)?"),
+        (b"null", r#"(1+1 | @dsv("|"))?"#),
+        (b"null", "(1+1 | @base64)?"),
+        (b"null", "(1+1 | @base64d)?"),
+        (b"null", "(1+1 | @urid)?"),
     ] {
         assert_eq!(
-            as_strs(&full_outputs(json, filter)),
-            [expected],
+            full_outputs(json, filter),
+            Vec::<String>::new(),
             "full evaluator output changed for `{filter}`"
         );
         assert_parity(json, filter);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4142,6 +4142,40 @@ fn test_yq_outputs_before_an_error_or_break_survive() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_693_optional_around_stream_stops_at_the_first_error() -> Result<()> {
+    // Mirrors `test_yq_outputs_before_an_error_or_break_survive`'s two-route
+    // pattern: yq's default (non-null-input) route evaluates through the
+    // same native `eval_generic` cursor-based evaluator jq's default route
+    // does (`yq_runner.rs`'s `evaluate_yaml_cursor`), while `--null-input`
+    // goes through the `eval.rs`-level `eval()` route instead. Both were
+    // independently affected by #693 (a masked error inside a `?`-wrapped
+    // stream self-suppressed instead of stopping it) and both are exercised
+    // here. Verified against jq 1.7.1 (`yq` itself has no `if`/`then`/`else`):
+    // `jq -n '[1,2,3] | (.[] | if .==2 then error("boom") else . end)?'`
+    // prints only `1`.
+
+    // Default YAML input goes through the direct-cursor (generic) route.
+    let (stdout, code) = run_yq_stdin(
+        r#"(.[] | if .==2 then error("boom") else . end)?"#,
+        "- 1\n- 2\n- 3\n",
+        &[],
+    )?;
+    assert_eq!(stdout, "1\n");
+    assert_eq!(code, 0);
+
+    // `--null-input` takes the OwnedValue/full-evaluator route.
+    let (stdout, code) = run_yq_stdin(
+        r#"[1,2,3] | (.[] | if .==2 then error("boom") else . end)?"#,
+        "",
+        &["-n"],
+    )?;
+    assert_eq!(stdout, "1\n");
+    assert_eq!(code, 0);
+
+    Ok(())
+}
+
 /// `path`/`parent`/`parent(n)`/`key` used to silently answer `[]`/`{}`/`null`
 /// (the root-level defaults) whenever they weren't the very first pipe stage
 /// (#554), because the CLI's streaming evaluator (`eval_generic.rs`, driving


### PR DESCRIPTION
## Summary

Fixes #693: `optional`/`?` was implemented by force-setting an ambient `optional: bool` to `true` for the *entire* subtree `?` wrapped. At leaf error sites (`eval_error`, and ~280 similar sites) this converted a real error directly into `QueryResult::None` — indistinguishable from genuine `empty`. Combinators that sequence sub-evaluations (`eval_comma`, and via #534's fork loops, `reduce`/`foreach`/`while`/`until`) couldn't tell a masked error apart from ordinary `empty`, and wrongly kept going instead of stopping the rest of the `?`/`try`-wrapped expression, unlike real jq.

- Route `Expr::Optional` through the same "evaluate normally, then catch the aggregate result once" pattern `try`/`finish_fork` already used correctly, in both the full evaluator (`src/jq/eval.rs`) and the cursor-based generic evaluator (`src/jq/eval_generic.rs`, which the `jq`/`yq` CLIs use by default).
- Bare `.[EXPR]?`/`.[S:E]?` keep the old direct-forwarding dispatch: jq only lets `?` guard the *final* index/slice step there, not the bracket's own key/bounds sub-expression (verified against jq 1.7.1 — `(.[.k])?`/`try .[.k]` catch a key error, but `.[.k]?` does not), and `eval_index_expr`/`eval_slice_expr` already implement that split.
- Found and corrected three pre-existing tests that pinned unverified assumptions matching the old bug (`?` not catching an escaping `break`; an INIT-partial-then-error discarding its whole prefix under `?`; and a format builtin's internal `""` placeholder instead of true suppression) — all now verified against jq 1.7.1.

## Commits

1. `fix(jq)`: the behavior change plus the three test corrections needed to keep the suite green.
2. `test(jq)`: new regression tests pinned against jq 1.7.1, covering both evaluators and both CLI binaries (`jq`/`yq`), since `eval_generic.rs` is a second, independent place the same bug lived and is what the shipped CLIs actually run by default.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green (2060+ lib tests, every integration binary) at both commits
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's second, non-`scalar-yaml` invocation) — clean
- [x] Every repro from the issue re-verified against the built CLI and matched against pinned `jq 1.7.1` output directly