### PR TITLE
yaml: support tags (!!str, !custom, verbatim)

### DIFF
--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -26,24 +26,34 @@ path:
 
 | Dimension                              | Result              | Meaning                                        |
 |----------------------------------------|---------------------|------------------------------------------------|
-| **Load** (valid YAML, output compared) | **235/279 = 84.2%** | Parses and produces the JSON the suite expects |
-| **Reject** (invalid YAML, must fail)   | **70/94 = 74.5%**   | Refused by the loader or the opt-in validator  |
-| **Parse** (valid YAML, no JSON form)   | **27/29 = 93.1%**   | Parses without error                           |
+| **Load** (valid YAML, output compared) | **267/279 = 95.7%** | Parses and produces the JSON the suite expects |
+| **Reject** (invalid YAML, must fail)   | **66/94 = 70.2%**   | Refused by the loader or the opt-in validator  |
+| **Parse** (valid YAML, no JSON form)   | **29/29 = 100.0%**  | Parses without error                           |
 
 The **Reject** figure is what the conformance harness rejects with the opt-in
 validator enabled (loader OR validator, see below). The *default non-validating
-loader alone* still rejects only 12/94 (12.8%) by design — the opt-in validator
+loader alone* rejects only 8/94 (8.5%) by design — the opt-in validator
 ([#223](https://github.com/rust-works/succinctly/issues/223)) closes 58 more.
 
-The 70 non-passing cases are enumerated individually, with a category and reason, in
+[#224](https://github.com/rust-works/succinctly/issues/224) (tag support) moved the Load
+figure from 235/279 (84.2%) to 267/279, the largest single jump on this page, and closed
+both `parse` failures. It also *cost* 4 cases on the Reject side: `check_unsupported`'s
+blanket `!` rejection used to incidentally reject 4 documents whose real defect is
+something else entirely (a malformed tag, an unindented anchor target, a directive with no
+document footer before it) — implementing real tag resolution means those 4 are structurally
+absorbed like any other invalid input the non-validating loader doesn't check for, dropping
+the loader-alone figure from 12/94 to 8/94. See
+[Tags — resolved](#tags--resolved-224) below.
+
+The 40 non-passing cases are enumerated individually, with a category and reason, in
 [`tests/data/yaml-test-suite-known-failures.txt`](../../../tests/data/yaml-test-suite-known-failures.txt).
 That file is the machine-readable source of truth; the test asserts it matches reality
 exactly, so it cannot silently drift from this page.
 
 ## Validation: default loader vs. the opt-in validator
 
-**The default loader is non-validating by design.** `YamlIndex::build` rejects 12 of the
-suite's 94 invalid documents; the other 82 are accepted and produce a value.
+**The default loader is non-validating by design.** `YamlIndex::build` rejects 8 of the
+suite's 94 invalid documents; the other 86 are accepted and produce a value.
 
 This follows from semi-indexing. The index records *structure* — where values start and
 end, and how they nest — not grammar conformance. The parser is a structure recognizer:
@@ -56,37 +66,43 @@ it is 5-10x faster than `yq`.
 [`succinctly yaml validate`](../../guides/cli.md) / `syq --validate` runs a separate strict
 pass ([`src/yaml/validate.rs`](../../../src/yaml/validate.rs)) before indexing — mirroring
 `json validate` / `sjq --validate`, so the default path pays nothing. It rejects **58 of
-the 82** documents below with zero false positives on the valid corpus (a guardrail test,
+the 86** documents below with zero false positives on the valid corpus (a guardrail test,
 `validator_accepts_all_valid_cases`, enforces that). The conformance harness treats a
 must-fail case as handled if the loader *or* the validator rejects it, which is why the
-Reject figure above is 70/94 rather than 12/94.
+Reject figure above is 66/94 rather than 8/94.
 
-The 24 documents the validator does not yet reject (marked `lax:*` in the manifest) need
+The 28 documents the validator does not yet reject (marked `lax:*` in the manifest) need
 deeper structural analysis — cross-line anchor binding, block-scalar content indentation,
-flow multi-line implicit keys — and are tracked in
-[#223](https://github.com/rust-works/succinctly/issues/223).
+flow multi-line implicit keys, malformed tag syntax — and are tracked in
+[#223](https://github.com/rust-works/succinctly/issues/223) (`lax:tags` under #224, see
+below).
 
-The 82 accepted-but-invalid documents (of which the validator now rejects 58) break down as:
+The 28 documents still lax today (neither the loader nor the validator rejects them) break
+down as:
 
-| Category           | Cases | What is not checked                          |
-|--------------------|-------|----------------------------------------------|
-| `lax:mapping`      | 14    | Mapping and implicit-key rules               |
-| `lax:documents`    | 12    | Directive and document-marker placement      |
-| `lax:flow`         | 11    | Flow collection syntax                       |
-| `lax:tabs`         | 8     | Tabs where indentation is expected           |
-| `lax:indentation`  | 7     | Indentation consistency                      |
-| `lax:other`        | 7     | Assorted                                     |
-| `lax:quoting`      | 6     | Quoting and escape sequences                 |
-| `lax:block-scalar` | 6     | Block scalar header validity (`\|--` parses) |
-| `lax:anchors`      | 6     | Anchor and alias rules                       |
-| `lax:comments`     | 5     | Comment placement                            |
+| Category           | Cases | What is not checked                                     |
+|---------------------|------|-----------------------------------------------------------|
+| `lax:mapping`      | 5     | Mapping and implicit-key rules                          |
+| `lax:indentation`  | 5     | Indentation consistency                                 |
+| `lax:flow`         | 4     | Flow collection syntax                                  |
+| `lax:anchors`      | 4     | Anchor and alias rules, incl. an unindented tag target (#224) |
+| `lax:documents`    | 3     | Directive and document-marker placement, incl. a mid-stream `%TAG` (#224) |
+| `lax:tags`         | 2     | Malformed tag syntax (disallowed flow indicators) — #224 |
+| `lax:comments`     | 2     | Comment placement                                       |
+| `lax:block-scalar` | 2     | Block scalar header validity (`\|--` parses)             |
+| `lax:tabs`         | 1     | Tabs where indentation is expected                       |
+
+This table is the current *remainder* — cases the validator has not yet caught up to — not
+a fixed accounting of the original 86; earlier revisions of this page also carried
+`lax:other` and `lax:quoting` rows that the validator has since closed out entirely.
 
 The opt-in validation mode now exists ([#223](https://github.com/rust-works/succinctly/issues/223)),
 mirroring the JSON side's `succinctly json validate` / `sjq --validate`. Validation is a
 separate pass run before indexing, so the default path pays nothing for it — see
-[`src/yaml/validate.rs`](../../../src/yaml/validate.rs). The 82 cases above were its
+[`src/yaml/validate.rs`](../../../src/yaml/validate.rs). The 86 cases above were its
 acceptance criteria; it rejects 58 of them today (each `lax:*` line removed from the
-manifest is a case now rejected), with the 24 harder cases still tracked in #223.
+manifest is a case now rejected), with the 28 harder cases still tracked in #223 (`lax:tags`
+under #224).
 
 ### What "accepted" means: the text is kept, not dropped
 
@@ -180,8 +196,8 @@ input breaks a rule the index could otherwise ignore. Rejecting the rest of what
 calls invalid is the validator's job.
 
 Neither costs this page's conformance numbers anything: no case in the corpus contains an
-alias to an out-of-scope anchor, so the 12/94 loader figure, the 82 accepted-but-invalid
-documents and the `lax:anchors` row are unmoved by #372.
+alias to an out-of-scope anchor, so the loader-alone reject figure, the accepted-but-invalid
+document count, and the `lax:anchors` row are unmoved by #372.
 
 ### The other ways `YamlIndex::build` fails
 
@@ -189,10 +205,10 @@ Structure aside, `build` still refuses input it has no reading for at all. None 
 a conformance check either — they are an absent feature, bytes it cannot tokenize, and the
 index's own ceilings:
 
-| Rejected                                        | Example      | `YamlError`           |
-|-------------------------------------------------|--------------|-----------------------|
-| A tag in node position (absent feature, below)  | `a: !!str 1` | `TagNotSupported`     |
-| A tab where block structure expects indentation | `\ta: 1`     | `TabIndentation`      |
+| Rejected                                        | Example        | `YamlError`           |
+|-------------------------------------------------|----------------|-----------------------|
+| An unterminated verbatim tag                    | `a: !<foo b: 1`| `InvalidTag`          |
+| A tab where block structure expects indentation | `\ta: 1`       | `TabIndentation`      |
 | A quote with no close before end of input       | `a: "x`      | `UnclosedQuote`       |
 | Input ending inside a flow collection or escape | `a: {k: 1`   | `UnexpectedEof`       |
 | A flow item not followed by `,` or its closer   | `a: [[1] 2]` | `UnexpectedCharacter` |
@@ -218,133 +234,101 @@ $ printf 'a: [1 2]\n' | succinctly yq -o json -I0 '.'
 ```
 
 The loader stops where it cannot continue, not where a rule is broken — which is why the
-11 `lax:flow` cases above survive it.
+`lax:flow` cases above survive it.
 
-## Unsupported features
+## Tags — resolved (#224)
 
-These are absent rather than wrong, and account for 33 of the 44 load failures.
+`!!str`, `!custom`, and verbatim `!<tag:...>` resolve now, matching real `yq`. The 5
+core-schema tags (`!!str`/`!!null`/`!!bool`/`!!int`/`!!float`) force scalar-type coercion —
+regardless of quoting style, so `!!int "5"` is the number `5`, not the string `"5"`. Any
+other tag (a custom tag, `!!seq`/`!!map`/`!!set`/`!!omap`, a `%TAG`-shorthand tag, verbatim
+`!<...>`) does not change resolution — JSON has no way to represent those distinctly from an
+ordinary map/seq/scalar anyway.
 
-### Tags — 35 cases (33 load, 2 parse)
-
-`!!str`, `!custom`, and verbatim `!<tag:...>` are not supported. In block context the
-parser rejects *some* positions:
+**Output**: JSON drops every tag, since JSON has no tag syntax. YAML output re-emits the tag
+verbatim on the scalar or key it decorated, matching `yq` — but not yet on a whole tagged
+mapping/sequence (`!!seq [1, 2]`), which YAML output still drops; JSON was unaffected by this
+gap either way, since it drops collection tags too.
 
 ```
 $ echo 'a: !!str 1' | succinctly yq '.'
-Error: YAML parse error: tags (!) not supported at offset 3
-```
-
-— but not all of them; see [Tag rejection is not uniform in block context](#tag-rejection-is-not-uniform-in-block-context-664)
-below for the paths that silently absorb the tag as scalar text instead of rejecting it.
-
-Flow context rejects them the same way, in every position tested — sequence item, mapping
-value, mapping key, and the explicit `? k : v` form
-([#369](https://github.com/rust-works/succinctly/issues/369); before that fix flow context
-absorbed the tag into the scalar, so `[!!str a]` yielded the string `"!!str a"`):
-
-```
-$ echo 'a: [!!str x]' | succinctly yq '.'
-Error: YAML parse error: tags (!) not supported at offset 4
+a: !!str 1
+$ echo 'a: !!str 1' | succinctly yq -o json -I0 '.'
+{"a":"1"}
+$ echo 'a: [!!str x]' | succinctly yq -o json -I0 '.'
+{"a":["x"]}
 ```
 
 A `!` *inside* plain scalar content is not an indicator and remains ordinary text in both
-contexts — `[x!y]` is `["x!y"]`, `a: hello!world` is `"hello!world"`. Only a `!` starting a
-node is a tag.
+block and flow context — `[x!y]` is `["x!y"]`, `a: hello!world` is `"hello!world"`. Only a
+`!` starting a node is a tag.
 
-Tag *support* is tracked in [#224](https://github.com/rust-works/succinctly/issues/224);
-these 35 cases stay failures until it lands. Two of them (`CC74`, `P76L`) are `%TAG`
-directive cases: the directive line itself is recognized (see
-[Directives — resolved](#directives--resolved) below), but the shorthand tag it defines is
-still rejected when applied to a node, the same as any other tag.
+`CC74`/`P76L` (`%TAG`-defined shorthand tags applied to a node) and the flow-context cases
+[#369](https://github.com/rust-works/succinctly/issues/369) closed (sequence item, mapping
+value, mapping key, explicit `? k : v`) all resolve the same way — `%TAG` handle resolution
+to a full URI was not implemented, since JSON output never surfaces it; a shorthand tag like
+`!e!foo` is tokenized and dropped exactly like any other non-core-schema tag, which is
+sufficient for both cases to pass.
 
-### Tag rejection is not uniform in block context (#664)
+One divergence remains, tracked as `tags`/`S4JQ` in the manifest: YAML 1.2's "conventional
+resolution" for a bare `!` (the non-specific tag, no suffix) forces `!!str`, but real `yq`
+v4.53.3 leaves the content's natural type untouched (`! 12` stays the number `12`, not
+`"12"`). We follow `yq`, the same policy as [`FRK4`](#frk4-a-divergence-the-ledger-cannot-see)/
+[`JEF9/02`](#jef902-the-one-case-where-we-follow-yq-over-the-suite) below.
 
-[#664](https://github.com/rust-works/succinctly/issues/664) audited every scalar/key entry
-path in `src/yaml/parser.rs` against `check_unsupported` (the single function meant to reject
-a leading `!` everywhere) ahead of #224 landing real tag support — so #224 closes actual gaps
-rather than papering over ones nobody enumerated. It is audit-and-test-only; the gaps below
-are pinned with regression tests in `tests/yq_cli_tests.rs` (the `test_yaml_tag_gate_gap_*`
-tests) rather than fixed, since fixing them is #224's job.
+**Explicit tag introspection**: `YamlCursor::explicit_tag() -> Option<&str>`
+(`src/yaml/light.rs`) returns the literal source tag, distinct from the pre-existing
+`YamlCursor::tag()`, which returns an *inferred* type label from the resolved value's shape
+(now consistent with `explicit_tag`'s effect, since an explicit core-schema tag changes what
+gets inferred). See [docs/parsing/yaml.md § Tag Resolution](../../parsing/yaml.md) for the
+storage design (a `BTreeMap<usize, String>` on `YamlIndex`, mirroring the anchor table) and
+one documented gap: the lazy, cursor-free half of the jq evaluator (`src/jq/eval_generic.rs`'s
+`to_owned`, shared with JSON) is not tag-aware, so `succinctly yq '.a | type'` on a tagged
+scalar can still answer from untagged inference even though `succinctly yq '.'`'s JSON output
+for the same input is always correct.
 
-**19 distinct entry paths were enumerated; 13 are ungated**, collapsing into 6 root causes:
+### How the gaps were closed (#664 → #224)
 
-1. **`parse_document_line`'s gate runs before indentation is skipped**
-   (`parser.rs:4269` vs. `count_indent`/`advance_by` at `4272-4303`). It peeks the line's
-   literal first byte — a space for any indented line — not the node's first byte.
-   `!!str x` (column 0) is rejected; `  !!str x` (indented, still a bare document scalar) is
-   not, and yields `"!!str x"`.
-2. **`parse_block_node`'s two scalar-dispatch arms never call `check_unsupported`
-   themselves** (the anchor arm at `4416-4441`, the plain catch-all at `4457-4490`). This is
-   the shared block-context dispatcher — `parse_document_line` and `parse_inline_document_value`
-   both funnel into it — and it's where every "value deferred to the next line" case from
-   `parse_sequence_item`, `parse_mapping_entry`, `parse_compact_mapping_entry`,
-   `parse_explicit_key`, and `parse_explicit_value` eventually lands, ungated and (per root
-   cause 1) not reliably backstopped either. This includes `parse_inline_document_value`
-   (`1061-1081`, content after `---`) — already flagged in its own doc comment as #224's to
-   settle, and the mechanism behind the `J7PZ` corpus case (`--- !!omap`): the tag is absorbed
-   as a complete document-root scalar, so the sequence on the following lines starts a
-   *second* document — one YAML input streams as two JSON documents.
-3. **`parse_mapping_entry`'s next-line plain-scalar branch (`2204-2232`)** parses the
-   deferred value inline, bypassing the function's own gate at `2237` (which only guards the
-   sibling same-line branch).
-4. **Anchor-then-value asymmetry** in `parse_mapping_entry` (`2237` before the `&anchor`
-   check at `2240`) and `parse_compact_mapping_entry` (`1926` before `1927`): both check once,
-   *before* testing for an anchor, then dispatch the value inline with no second check after
-   consuming it. `parse_sequence_item` and the flow-context inner loops avoid this by
-   construction — they consume the anchor themselves, then delegate the scalar dispatch to
-   `parse_value` or `parse_flow_scalar`, which re-check independently at their own entry.
-5. **`parse_explicit_value` (`2582`) has zero `check_unsupported` calls**, for the same-line
-   value, the next-line value, the anchor-then-value form, or its compact-mapping-value arm.
-6. **No block-context key parser gates the key itself** (`parse_mapping_entry`,
-   `parse_compact_mapping_entry`, `parse_explicit_key` at `2364`, whose inline-key dispatch at
-   `2566-2572` has no gate at all). Every currently-rejected tagged key is explained by root
-   cause 1's column-0 accident or `parse_sequence_item`'s pre-dispatch check (`1734`, which
-   runs unconditionally right after `- `, before any compact-mapping-key dispatch is even
-   decided) — not by deliberate key gating.
+Landing this took two issues. [#664](https://github.com/rust-works/succinctly/issues/664)
+audited every scalar/key entry path in `src/yaml/parser.rs` against `check_unsupported` (the
+single function that used to reject a leading `!` everywhere) and found 19 distinct entry
+paths, 13 of them ungated — meaning 13 different places silently absorbed a tag as scalar
+text instead of rejecting it, collapsing into 6 root causes: indentation-skip ordering in
+`parse_document_line`; `parse_block_node`'s two scalar-dispatch arms never gating themselves
+(the highest-leverage gap, since most deferred-value paths funnel through it — including the
+mechanism behind corpus case `J7PZ`, `--- !!omap`, where the tag used to be absorbed as a
+complete document-root scalar and the sequence on the following lines started a *second*
+document); a next-line branch in `parse_mapping_entry` bypassing its own same-line-only gate;
+anchor-then-value ordering checking the gate before consuming the anchor with no second check
+after; `parse_explicit_value` having zero gates anywhere; and no block-context key parser
+gating the key itself. Flow context was already fully gated at every position by contrast —
+[#369](https://github.com/rust-works/succinctly/issues/369) had closed it earlier. #664 was
+audit-and-test-only: it pinned every gap with a regression test in `tests/yq_cli_tests.rs`
+(`test_yaml_tag_gate_gap_*`) rather than fixing them, so #224 would close *actual* gaps
+rather than paper over ones nobody had enumerated.
 
-Flow context (mapping/sequence values, implicit and explicit keys, including every
-anchor-then-tag combination) is **fully gated**: `parse_flow_scalar`,
-`parse_flow_unquoted_key`, and `parse_explicit_flow_unquoted_key` each re-check
-`check_unsupported` at their own entry, so anchor consumption never leaves a stale check
-behind the way it does in block context. This matches the existing
-`test_yaml_flow_context_rejects_tags_like_block_context` (#369) coverage.
+#224 replaced `check_unsupported` (deleted; every one of its non-`!` arms was already a
+no-op, so once `!` stopped erroring the function did nothing at all) with real tag parsing —
+`Parser::parse_tag`/`scan_tag_extent` for the lexer, `parse_node_properties`/
+`record_key_properties` for consuming `&anchor` and/or `!tag` together, in either order, at
+every node-start position (mirroring how anchors were already consumed, and fixing all 6 root
+causes as one shared change rather than 13 separate patches). The `test_yaml_tag_gate_gap_*`
+tests now assert the closed behavior instead of pinning the gap, under their original names.
 
-| #  | Entry path                                               | Owning function                                              | Gated?                                                                      |
-|----|----------------------------------------------------------|--------------------------------------------------------------|-----------------------------------------------------------------------------|
-| 1  | Sequence item value, right after `- `                    | `parse_sequence_item` → `parse_sequence_item_inner` (`1682`) | Yes (`1734`)                                                                |
-| 2  | Sequence item value deferred to next line                | `parse_sequence_item` → `parse_block_node`                   | No (root cause 2)                                                           |
-| 3  | Compact mapping key                                      | `parse_compact_mapping_entry` (`1860`)                       | No in general (root cause 6); yes when reached via `- ` (root cause 6 note) |
-| 4  | Compact mapping value, same line, no anchor              | `parse_compact_mapping_entry`                                | Yes (`1926`)                                                                |
-| 5  | Compact mapping value, same line, after `&anchor`        | `parse_compact_mapping_entry`                                | No (root cause 4)                                                           |
-| 6  | Compact mapping value, next line                         | `parse_compact_mapping_entry` → `parse_block_node`           | No (root cause 2)                                                           |
-| 7  | Mapping key                                              | `parse_mapping_entry` (`2015`)                               | No (root cause 6)                                                           |
-| 8  | Mapping value, same line, no anchor                      | `parse_mapping_entry`                                        | Yes (`2237`)                                                                |
-| 9  | Mapping value, same line, after `&anchor`                | `parse_mapping_entry`                                        | No (root cause 4)                                                           |
-| 10 | Mapping value, next line, plain-scalar catch-all         | `parse_mapping_entry` (`2204-2232`)                          | No (root cause 3)                                                           |
-| 11 | Mapping value, next line, sequence/flow/anchor lookahead | `parse_mapping_entry` → `parse_block_node`                   | No (root cause 2)                                                           |
-| 12 | Explicit key                                             | `parse_explicit_key` (`2364`)                                | No (root cause 6)                                                           |
-| 13 | Explicit key, sequence-as-key value dispatch             | `parse_explicit_key` → `parse_value`                         | Yes (`2698`)                                                                |
-| 14 | Explicit value (all forms)                               | `parse_explicit_value` (`2582`)                              | No (root cause 5)                                                           |
-| 15 | General block value dispatcher                           | `parse_value` (`2697`)                                       | Yes (`2698`)                                                                |
-| 16 | Per-line block dispatch entry                            | `parse_document_line` (`4268`)                               | Partially (root cause 1)                                                    |
-| 17 | Anchor-prefixed scalar, non-mapping-key                  | `parse_block_node` (`4416-4441`)                             | No (root cause 2)                                                           |
-| 18 | Plain scalar catch-all                                   | `parse_block_node` (`4457-4490`)                             | No (root cause 2)                                                           |
-| 19 | Content after `---` on the same line                     | `parse_inline_document_value` (`1061-1081`)                  | No (root cause 2)                                                           |
+Two bugs surfaced only once tags could reach positions anchors already could:
+- A tag immediately before a multi-line flow value (`k: !!seq\n  [a, b]`) left the parser
+  positioned on the line break, so the following `[`/`{` check missed and absorbed the
+  bracket as scalar text (corpus case `EHF6`). The same gap already existed for a bare
+  anchor in that position, since `parse_anchor`'s own whitespace skip is inline-only too;
+  fixed for both by adding a flow-whitespace-aware property-consumption path
+  (`parse_flow_node_properties`) at the two flow call sites that need it.
+- A bare tag with nothing after it (`- !!str` as the last sequence item) needs a real BP node
+  to resolve against, the same as an anchor does — but the null-value-synthesis check that
+  used to gate only on "was there an anchor" silently dropped a tag-only property instead of
+  resolving it to `""` (corpus case `LE5A`). Fixed by widening that check to "was there any
+  property."
 
-**Explicitly excluded from this audit's fixes:**
-- `src/yaml/mod.rs`'s module doc comment and `parser.rs`'s own comments (e.g.
-  `parse_inline_document_value`'s doc comment, and
-  `test_yaml_flow_context_rejects_tags_like_block_context`'s old claim that "block context has
-  always errored on `!`") were also stale or imprecise; the test comment was corrected as part
-  of #664, but `src/` comments were left for #224 since #664 makes no `src/` changes.
-- `src/yaml/validate.rs`'s `check_block_indent`/`check_root_kind` reuse the same indicator
-  bytes (`&`, `*`, `!`) for a structural check, but that's the separate, opt-in strict
-  validator, not `check_unsupported` — out of scope here.
-- Whether *all* key positions (row 6 above) belong in this gate, versus only the
-  explicit-key case the original issue text called out, is a judgment call #664 left open
-  rather than deciding unilaterally; #224 (or a follow-up) should settle it.
-
-### A flow collection as a same-line explicit key
+## A flow collection as a same-line explicit key
 
 `? []: x` — a *flow* collection followed by a value indicator on the same line —
 still diverges from `yq`. The whole `[]: x` is a compact block mapping used as the
@@ -473,13 +457,18 @@ floats render as integers on the streaming path, `1.0` → `1` —
 [#168](https://github.com/rust-works/succinctly/issues/168) /
 [#170](https://github.com/rust-works/succinctly/issues/170)).
 
-## Full accounting of the 44 load failures
+## Full accounting of the 12 load failures
 
 | Category     | Cases | Cause                                                             |
 |--------------|-------|-------------------------------------------------------------------|
-| `tags`       | 33    | Tags not supported (above)                                        |
-| `structure`  | 4     | Document end markers; anchors with colons in the name             |
 | `scalars`    | 7     | Zero-indented block scalars; tabs; trailing whitespace            |
+| `structure`  | 4     | Document end markers; anchors with colons in the name             |
+| `tags`       | 1     | `S4JQ`: non-specific `!` resolution follows `yq` over the spec (above) |
+
+`tags` was 33 (31 load, 2 parse) until [#224](https://github.com/rust-works/succinctly/issues/224)
+implemented real tag resolution (see [Tags — resolved](#tags--resolved-224) above); 32 of
+those 33 load cases cleared outright, and the 2 parse failures (`FH7J`, `UKK6/02`) cleared
+too. Only `S4JQ` remains, for the yq-vs-spec divergence described above.
 
 `directives` was 16 until [#225](https://github.com/rust-works/succinctly/issues/225) (see
 [Directives — resolved](#directives--resolved) above); the category no longer exists.
@@ -534,8 +523,6 @@ spaces-only line (`>1+` over `   ` gives `""`, `yq` gives `"  "`). And a content
 with an explicit indicator swallows the line after it, dropping that key outright — `a: |2+`
 over `b: 2` loses `b`, which is why the `empty_block_scalars_keep_contentless` fixture orders
 its `explicit_indent` case last.
-
-The two `parse` failures (`FH7J`, `UKK6/02`) are also tags.
 
 ### `FRK4`: a divergence the ledger cannot see
 

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -285,7 +285,8 @@ storage design (a `BTreeMap<usize, String>` on `YamlIndex`, mirroring the anchor
 one documented gap: the lazy, cursor-free half of the jq evaluator (`src/jq/eval_generic.rs`'s
 `to_owned`, shared with JSON) is not tag-aware, so `succinctly yq '.a | type'` on a tagged
 scalar can still answer from untagged inference even though `succinctly yq '.'`'s JSON output
-for the same input is always correct.
+for the same input is always correct. Tracked as
+[#747](https://github.com/rust-works/succinctly/issues/747).
 
 ### How the gaps were closed (#664 → #224)
 

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -667,40 +667,66 @@ For efficient key extraction, store key end positions:
 
 **Note**: Value type interpretation (is `true` a boolean or string?) is handled at a higher level than the cursor API. The semi-index is concerned only with structure, not semantics.
 
-### 6. Tag Resolution
+### 6. Tag Resolution — implemented (#224)
 
-**Decision**: The cursor API is type-agnostic. Tags are recorded structurally but interpretation is deferred.
-
-YAML tags affect interpretation:
+**Shipped decision**: an explicit tag is recorded structurally, exactly like an anchor, and
+resolution happens where the cursor already resolves plain scalars — not deferred to a
+separate higher-level type the way this section originally proposed.
 
 ```yaml
-date: 2024-01-15      # Might be Date or String
-explicit: !!str 2024-01-15  # Definitely String
+date: 2024-01-15            # core-schema inference: unquoted, not tagged -> string (no date type)
+explicit: !!str 2024-01-15  # tag forces string, regardless of what inference would say
+quoted: !!int "42"          # tag forces int even though quoting would otherwise force string
 ```
 
-**Cursor API Scope**:
+**Storage**: `YamlIndex` holds `tags: BTreeMap<usize, String>` (BP position → raw tag text,
+e.g. `"!!str"`), populated during parsing by `Parser::parse_tag`/`parse_node_properties`. This
+mirrors the anchor table's own `BTreeMap<usize, String>` precedent (§1 above) rather than a
+bitpacked structure — a tag, like an anchor, is comparatively rare and has no fixed-width
+encoding, so the succinct-structure bar the rest of the index holds to does not apply here
+either. Unlike anchors, a tag needs no reverse name→position map: nothing resolves to a tag by
+reference the way an alias resolves to an anchor.
 
-The semi-index cursor provides:
-- `raw_value() -> &[u8]` - Raw bytes of scalar
-- `has_tag() -> bool` - Whether explicit tag present
-- `tag() -> Option<&str>` - The tag if present (`!!str`, `!custom`, etc.)
+**Cursor API** (`src/yaml/light.rs`):
+- `YamlCursor::explicit_tag() -> Option<&str>` — the literal source tag, or `None`. This is
+  the method this section originally called `tag()`; that name was already taken by an
+  *inferred* type label (`"!!str"`/`"!!int"`/… derived from the resolved value's shape, used
+  before #224 for introspection) which `explicit_tag` does not replace — `YamlCursor::tag()`
+  now checks `explicit_tag()` first and falls back to inference, so the two stay consistent
+  rather than able to disagree.
+- `src/yaml/scalar.rs`'s `resolve_tagged(text, tag) -> Option<ResolvedScalar>` forces
+  resolution for the 5 core-schema tags (`!!str`/`!!null`/`!!bool`/`!!int`/`!!float`),
+  matching `yq`'s behavior of applying tag coercion regardless of quoting style. Returns
+  `None` for any other tag (custom, `!!seq`/`!!map`/`!!set`/`!!omap`, verbatim, or no tag),
+  meaning "resolve naturally instead" via the existing `resolve_plain`.
 
-The cursor does **not** provide:
-- `as_bool()`, `as_int()`, `as_date()` - Type coercion
-- Automatic type inference based on YAML 1.2 core schema
+**Output surfaces differ**: JSON has no tag syntax, so `write_json_to`/`stream_json_value`
+always drop the tag (after using it for resolution). YAML output
+(`YamlCursor::stream_yaml_value`) has tag syntax, and matches `yq` by re-emitting the tag
+verbatim ahead of the scalar/key it decorated — `a: !!str 1` round-trips as `a: !!str 1`, not
+`a: 1`. That re-emission covers scalars and keys but not yet a tag on a whole
+mapping/sequence (`!!seq [1, 2]`), left as a follow-up since it needs the tag written on the
+*key's* line for block-style output rather than at the collection's own recursive call.
 
-**Rationale**:
+**What did *not* change**: the cursor still has no `as_bool()`/`as_int()`/`as_date()` —
+resolution stays scalar-*type* coercion (does this text read as a bool/int/float/string/null),
+not schema validation or domain types. That boundary, and the reasoning for it, is exactly
+what this section originally argued for; only the tag-storage mechanism and the API surface
+(`explicit_tag()`, not `has_tag()`/`tag()`) differ from the original proposal.
 
-| Concern              | Cursor API | Higher-level API |
-|----------------------|------------|------------------|
-| Structure navigation | ✓          | ✓                |
-| Byte ranges          | ✓          | ✓                |
-| Raw value access     | ✓          | ✓                |
-| Tag presence         | ✓          | ✓                |
-| Type coercion        | ✗          | ✓                |
-| Schema validation    | ✗          | ✓                |
-
-This separation keeps the index small and fast. A higher-level `YamlValue` type can implement schema-aware parsing on top of the cursor.
+**One consumer this section didn't anticipate**: the jq-integrated evaluator has two paths —
+materializing to `OwnedValue` (`yaml_to_owned_value` in `src/bin/succinctly/yq_runner.rs`,
+`yaml_value_to_owned` in `src/jq/eval.rs`) and a lazy cursor-based evaluator
+(`src/jq/eval_generic.rs`'s `to_owned`, generic over `DocumentValue` for both JSON and YAML).
+The materializing path is tag-aware; the lazy path is not, since `DocumentValue` operates on
+an already-extracted `YamlValue` with no `bp_pos` to look a tag up with. So `succinctly yq
+'.'`'s JSON output is always correct, but `succinctly yq '.a | type'` on a tagged scalar can
+still answer from the untagged inference. Documented as a known limitation at the
+`DocumentValue for YamlValue` impl in `light.rs`; fixing it needs threading a cursor through
+`to_owned`'s recursion (the pieces exist: `DocumentField::value_cursor`,
+`DocumentElements::uncons_cursor`) or embedding the tag in `YamlValue::String` itself, which
+fans out to ~90 pattern-match sites across 6 files — left as a follow-up rather than an
+under-tested change to an evaluator shared with JSON.
 
 ### 7. Testing Strategy
 

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -726,7 +726,8 @@ still answer from the untagged inference. Documented as a known limitation at th
 `to_owned`'s recursion (the pieces exist: `DocumentField::value_cursor`,
 `DocumentElements::uncons_cursor`) or embedding the tag in `YamlValue::String` itself, which
 fans out to ~90 pattern-match sites across 6 files — left as a follow-up rather than an
-under-tested change to an evaluator shared with JSON.
+under-tested change to an evaluator shared with JSON. Tracked as
+[#747](https://github.com/rust-works/succinctly/issues/747).
 
 ### 7. Testing Strategy
 

--- a/src/bin/succinctly/yaml_generators.rs
+++ b/src/bin/succinctly/yaml_generators.rs
@@ -563,6 +563,10 @@ fn generate_anchors(target_size: usize, seed: Option<u64>) -> String {
             yaml.push_str(&format!("  policy: &{}\n", long(group)));
             yaml.push_str("    enabled: true\n");
             yaml.push_str(&format!("    weight: {}\n", group % 10));
+            // A tagged scalar (#224): forces a number-shaped value to stay a
+            // string, the realistic reason `!!str` shows up in hand-written
+            // YAML (a zone/version code that must not be parsed as a number).
+            yaml.push_str(&format!("  zone: !!str {group}\n"));
             // Anchored scalars as sequence items
             yaml.push_str("  shared:\n");
             yaml.push_str(&format!("    - &s{group} shared-value-{group}\n"));

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -6,6 +6,7 @@
 use anyhow::{Context, Result};
 use core::fmt::Write as FmtWrite;
 use indexmap::IndexMap;
+use std::borrow::Cow;
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
@@ -15,8 +16,8 @@ use succinctly::jq::{self, Builtin, Expr, OwnedValue, QueryResult, YqSemantics};
 use succinctly::json::light::StandardJson;
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
-    format_float_with_fraction, resolve_plain, stream_yaml_sequence, ResolvedScalar, YamlCursor,
-    YamlIndex, YamlValue,
+    format_float_with_fraction, resolve_plain, resolve_tagged, stream_yaml_sequence,
+    ResolvedScalar, YamlCursor, YamlIndex, YamlValue,
 };
 
 use super::{InputFormat, OutputFormat, YqCommand};
@@ -98,13 +99,39 @@ impl OutputConfig {
     }
 }
 
+/// Convert an already-resolved scalar to `OwnedValue`. `str_value` is the
+/// original source text, used only for the `Str` case.
+fn resolved_scalar_to_owned(resolved: ResolvedScalar, str_value: Cow<'_, str>) -> OwnedValue {
+    match resolved {
+        ResolvedScalar::Null => OwnedValue::Null,
+        ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
+        ResolvedScalar::Int(n) => OwnedValue::Int(n),
+        ResolvedScalar::Float(f) => OwnedValue::Float(f),
+        ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
+    }
+}
+
 /// Convert a YAML value to an OwnedValue for jq evaluation.
-fn yaml_to_owned_value<W: AsRef<[u64]>>(value: YamlValue<'_, W>) -> Result<OwnedValue> {
-    match value {
+///
+/// Takes a cursor rather than a bare `YamlValue`: an explicit tag
+/// (`!!str`, `!!int`, …) lives on the cursor's `bp_pos`
+/// ([`YamlCursor::explicit_tag`]), not on the extracted value, and forces
+/// resolution regardless of quoting style — `!!int "5"` converts to the
+/// number 5, matching real `yq` (#224). Every recursive call passes a
+/// cursor too (`field.value_cursor()`, `YamlElements::uncons_cursor`), so a
+/// tag on a nested element is never lost.
+fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<OwnedValue> {
+    match cursor.value() {
         YamlValue::String(s) => {
             let str_value = s
                 .as_str()
                 .map_err(|e| anyhow::anyhow!("invalid YAML string: {e}"))?;
+
+            if let Some(explicit) = cursor.explicit_tag() {
+                if let Some(resolved) = resolve_tagged(&str_value, explicit) {
+                    return Ok(resolved_scalar_to_owned(resolved, str_value));
+                }
+            }
 
             // Quoted strings should always be treated as strings (yq-compatible behavior)
             // Only unquoted scalars should undergo type detection
@@ -113,13 +140,10 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(value: YamlValue<'_, W>) -> Result<Owned
             }
 
             // Resolve plain scalars per the YAML 1.2 core schema
-            Ok(match resolve_plain(&str_value) {
-                ResolvedScalar::Null => OwnedValue::Null,
-                ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
-                ResolvedScalar::Int(n) => OwnedValue::Int(n),
-                ResolvedScalar::Float(f) => OwnedValue::Float(f),
-                ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
-            })
+            Ok(resolved_scalar_to_owned(
+                resolve_plain(&str_value),
+                str_value,
+            ))
         }
         YamlValue::Mapping(fields) => {
             let mut map = IndexMap::new();
@@ -128,22 +152,24 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(value: YamlValue<'_, W>) -> Result<Owned
                 // its content, any other complex key stringifies to "", and the
                 // entry is always kept — matching the streaming/DOM emit paths.
                 let key = field.key().key_string().into_owned();
-                let value = yaml_to_owned_value(field.value())?;
+                let value = yaml_to_owned_value(field.value_cursor())?;
                 map.insert(key, value);
             }
             Ok(OwnedValue::Object(map))
         }
         YamlValue::Sequence(elements) => {
             let mut arr = Vec::new();
-            for elem in elements {
-                arr.push(yaml_to_owned_value(elem)?);
+            let mut rest = elements;
+            while let Some((elem_cursor, next)) = rest.uncons_cursor() {
+                arr.push(yaml_to_owned_value(elem_cursor)?);
+                rest = next;
             }
             Ok(OwnedValue::Array(arr))
         }
         YamlValue::Alias { target, .. } => {
             // Resolve alias by following the target cursor
             if let Some(target_cursor) = target {
-                yaml_to_owned_value(target_cursor.value())
+                yaml_to_owned_value(target_cursor)
             } else {
                 // Unresolved alias - treat as null
                 Ok(OwnedValue::Null)
@@ -260,12 +286,17 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
             match root.value() {
                 YamlValue::Sequence(docs) => {
                     let mut values = Vec::new();
-                    for doc in docs {
-                        values.push(yaml_to_owned_value(doc)?);
+                    let mut rest = docs;
+                    while let Some((doc_cursor, next)) = rest.uncons_cursor() {
+                        values.push(yaml_to_owned_value(doc_cursor)?);
+                        rest = next;
                     }
                     Ok(values)
                 }
-                other => Ok(vec![yaml_to_owned_value(other)?]),
+                // Documents are always wrapped in a virtual root sequence, so
+                // this is defensive; `root` itself is this single document's
+                // cursor either way.
+                _ => Ok(vec![yaml_to_owned_value(root)?]),
             }
         }
     }
@@ -2104,7 +2135,7 @@ mod tests {
 
         // Root is a document array, get first doc
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     assert_eq!(
@@ -2125,7 +2156,7 @@ mod tests {
         let root = index.root(yaml);
 
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     assert_eq!(map.get("age"), Some(&OwnedValue::Int(30)));
@@ -2173,7 +2204,7 @@ mod tests {
         let root = index.root(yaml);
 
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     assert_eq!(map.get("active"), Some(&OwnedValue::Bool(true)));
@@ -2191,7 +2222,7 @@ mod tests {
         let root = index.root(yaml);
 
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     assert_eq!(map.get("value"), Some(&OwnedValue::Null));
@@ -2210,7 +2241,7 @@ mod tests {
         let root = index.root(yaml);
 
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     if let Some(OwnedValue::Array(arr)) = map.get("items") {
@@ -2236,7 +2267,7 @@ mod tests {
         let root = index.root(yaml);
 
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     if let Some(OwnedValue::Object(person)) = map.get("person") {
@@ -2263,7 +2294,7 @@ mod tests {
         let root = index.root(yaml);
 
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     if let Some(OwnedValue::Array(arr)) = map.get("items") {
@@ -2289,7 +2320,7 @@ mod tests {
         let root = index.root(yaml);
 
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     if let Some(OwnedValue::Object(person)) = map.get("person") {
@@ -2316,7 +2347,7 @@ mod tests {
         let root = index.root(yaml);
 
         if let YamlValue::Sequence(docs) = root.value() {
-            if let Some(doc) = docs.into_iter().next() {
+            if let Some((doc, _)) = docs.uncons_cursor() {
                 let value = yaml_to_owned_value(doc).unwrap();
                 if let OwnedValue::Object(map) = value {
                     if let Some(OwnedValue::Object(level1)) = map.get("root") {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14922,20 +14922,23 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 let root = index.root(&file_bytes);
                 // YAML documents are wrapped in a sequence at the root
                 match root.value() {
-                    crate::yaml::YamlValue::Sequence(docs) => {
+                    crate::yaml::YamlValue::Sequence(mut docs) => {
                         // If single document, return it directly; otherwise return array
-                        let doc_values: Vec<OwnedValue> =
-                            docs.into_iter().map(|v| yaml_value_to_owned(v)).collect();
+                        let mut doc_values = Vec::new();
+                        while let Some((doc_cursor, rest)) = docs.uncons_cursor() {
+                            doc_values.push(yaml_value_to_owned(doc_cursor));
+                            docs = rest;
+                        }
                         if doc_values.len() == 1 {
                             QueryResult::Owned(doc_values.into_iter().next().unwrap())
                         } else {
                             QueryResult::Owned(OwnedValue::Array(doc_values))
                         }
                     }
-                    other => {
-                        // Single value at root
-                        QueryResult::Owned(yaml_value_to_owned(other))
-                    }
+                    // Documents are always wrapped in a virtual root sequence,
+                    // so this is defensive; `root` itself is this single
+                    // document's cursor either way.
+                    _ => QueryResult::Owned(yaml_value_to_owned(root)),
                 }
             }
             Err(_) if optional => QueryResult::None,
@@ -14946,25 +14949,42 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
-/// Convert a YAML value to OwnedValue (helper for load)
+/// Convert a YAML value to OwnedValue (helper for `load`).
+///
+/// Takes a cursor rather than a bare `YamlValue`: an explicit tag (`!!str`,
+/// `!!int`, …) lives on the cursor's `bp_pos` (`YamlCursor::explicit_tag`),
+/// not on the extracted value, and forces resolution regardless of quoting
+/// style — mirrors `yq_runner.rs`'s `yaml_to_owned_value` (#224).
 #[cfg(feature = "std")]
 fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
-    value: crate::yaml::YamlValue<'_, W>,
+    cursor: crate::yaml::YamlCursor<'_, W>,
 ) -> OwnedValue {
-    use crate::yaml::{resolve_plain, ResolvedScalar, YamlValue};
+    use crate::yaml::{resolve_plain, resolve_tagged, ResolvedScalar, YamlValue};
 
-    match value {
+    match cursor.value() {
         YamlValue::Null => OwnedValue::Null,
         YamlValue::String(s) => {
             // Get the string value
             let str_value = match s.as_str() {
-                Ok(cow) => cow.into_owned(),
+                Ok(cow) => cow,
                 Err(_) => return OwnedValue::Null,
             };
 
+            if let Some(explicit) = cursor.explicit_tag() {
+                if let Some(resolved) = resolve_tagged(&str_value, explicit) {
+                    return match resolved {
+                        ResolvedScalar::Null => OwnedValue::Null,
+                        ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
+                        ResolvedScalar::Int(n) => OwnedValue::Int(n),
+                        ResolvedScalar::Float(f) => OwnedValue::Float(f),
+                        ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
+                    };
+                }
+            }
+
             // Quoted strings are kept as strings
             if !s.is_unquoted() {
-                return OwnedValue::String(str_value);
+                return OwnedValue::String(str_value.into_owned());
             }
 
             // Resolve plain scalars per the YAML 1.2 core schema
@@ -14973,11 +14993,15 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
                 ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
                 ResolvedScalar::Int(n) => OwnedValue::Int(n),
                 ResolvedScalar::Float(f) => OwnedValue::Float(f),
-                ResolvedScalar::Str => OwnedValue::String(str_value),
+                ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
             }
         }
-        YamlValue::Sequence(elements) => {
-            let items: Vec<OwnedValue> = elements.into_iter().map(yaml_value_to_owned).collect();
+        YamlValue::Sequence(mut elements) => {
+            let mut items = Vec::new();
+            while let Some((elem_cursor, rest)) = elements.uncons_cursor() {
+                items.push(yaml_value_to_owned(elem_cursor));
+                elements = rest;
+            }
             OwnedValue::Array(items)
         }
         YamlValue::Mapping(fields) => {
@@ -14988,13 +15012,13 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
                         Ok(cow) => cow.into_owned(),
                         Err(_) => continue,
                     },
-                    other => {
+                    _ => {
                         // Non-string keys - convert to string representation
-                        let v = yaml_value_to_owned(other);
+                        let v = yaml_value_to_owned(field.key_cursor());
                         v.to_json()
                     }
                 };
-                let value = yaml_value_to_owned(field.value());
+                let value = yaml_value_to_owned(field.value_cursor());
                 map.insert(key, value);
             }
             OwnedValue::Object(map)
@@ -15002,7 +15026,7 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
         YamlValue::Alias { target, .. } => {
             // Resolve alias by following the target cursor
             if let Some(target_cursor) = target {
-                yaml_value_to_owned(target_cursor.value())
+                yaml_value_to_owned(target_cursor)
             } else {
                 OwnedValue::Null
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -29102,6 +29102,162 @@ mod tests {
                 }
             });
         }
+
+        // ========== #224: explicit tag resolution in yaml_value_to_owned ==========
+
+        #[test]
+        fn test_load_yaml_explicit_tag_resolution() {
+            // An explicit core-schema tag forces the resolved type regardless of
+            // what the quoting/plain-scalar shape would otherwise imply: `!!null
+            // "~"` and `!!bool "yes"` are quoted (so unquoted plain-scalar
+            // resolution never runs), and `!!str 1` is unquoted (so plain-scalar
+            // resolution would otherwise produce a number) - the tag wins in
+            // every case.
+            // `12.5` rather than `3.14`: clippy's `approx_constant` lint flags
+            // float literals close to well-known math constants like PI.
+            // `f: !custom "5"` isn't one of the 5 core-schema tags, so
+            // `resolve_tagged` returns `None` and the code must fall through
+            // past the tag check to the quoted-string-preservation check
+            // below it, staying a string rather than resolving.
+            let yaml = "a: !!null \"~\"\n\
+                        b: !!bool \"yes\"\n\
+                        c: !!int \"42\"\n\
+                        d: !!float \"12.5\"\n\
+                        e: !!str 1\n\
+                        f: !custom \"5\"\n";
+            with_temp_file("load_test_explicit_tags.yaml", yaml, |path| {
+                let json_bytes: &[u8] = b"null";
+                let index = JsonIndex::build(json_bytes);
+                let cursor = index.root(json_bytes);
+                let query = format!(r#"load("{path}")"#);
+                let expr = parse(&query).unwrap();
+                match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+                    QueryResult::Owned(OwnedValue::Object(obj)) => {
+                        assert_eq!(obj.get("a"), Some(&OwnedValue::Null));
+                        assert_eq!(obj.get("b"), Some(&OwnedValue::Bool(true)));
+                        assert_eq!(obj.get("c"), Some(&OwnedValue::Int(42)));
+                        assert_eq!(obj.get("d"), Some(&OwnedValue::Float(12.5)));
+                        assert_eq!(obj.get("e"), Some(&OwnedValue::String("1".to_string())));
+                        assert_eq!(obj.get("f"), Some(&OwnedValue::String("5".to_string())));
+                    }
+                    other => panic!("unexpected result: {other:?}"),
+                }
+            });
+        }
+
+        #[test]
+        fn test_load_yaml_quoted_string_not_coerced_without_tag() {
+            // Without an explicit tag, a quoted scalar is kept as a string even
+            // though its content looks numeric - only an untagged *plain*
+            // scalar goes through resolve_plain's type inference.
+            with_temp_file(
+                "load_test_quoted_no_tag.yaml",
+                "quoted: \"42\"\nplain: 42\n",
+                |path| {
+                    let json_bytes: &[u8] = b"null";
+                    let index = JsonIndex::build(json_bytes);
+                    let cursor = index.root(json_bytes);
+                    let query = format!(r#"load("{path}")"#);
+                    let expr = parse(&query).unwrap();
+                    match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+                        QueryResult::Owned(OwnedValue::Object(obj)) => {
+                            assert_eq!(
+                                obj.get("quoted"),
+                                Some(&OwnedValue::String("42".to_string()))
+                            );
+                            assert_eq!(obj.get("plain"), Some(&OwnedValue::Int(42)));
+                        }
+                        other => panic!("unexpected result: {other:?}"),
+                    }
+                },
+            );
+        }
+
+        #[test]
+        fn test_load_yaml_non_string_mapping_key() {
+            // A non-scalar (sequence) explicit key falls through the
+            // `YamlValue::String` arm of the key match and is instead converted
+            // recursively via yaml_value_to_owned(...).to_json() - so the
+            // resulting object key is the compact JSON rendering of the key,
+            // `[1,2]` (no spaces; see OwnedValue::to_json's Array case).
+            //
+            // Uses a block-sequence explicit key (`? - 1` / `  - 2`) rather
+            // than a flow-sequence key (`? [1, 2]`): `parse_explicit_key`'s `[`/`{`
+            // arms wrap `parse_flow_sequence`/`parse_flow_mapping` in an extra,
+            // untyped `write_bp_open`/`write_bp_close` pair even though those
+            // callees already open and close their own container node, so a
+            // flow-sequence explicit key currently decodes as a sequence
+            // wrapping the real sequence (`[[1,2]]`) instead of the key itself.
+            // That double-wrap predates this PR (`a7384db6`, explicit-key
+            // support) and is unrelated to tag resolution, so it's left alone
+            // here - reported separately rather than fixed as a drive-by.
+            with_temp_file(
+                "load_test_complex_key.yaml",
+                "? - 1\n  - 2\n: value\n",
+                |path| {
+                    let json_bytes: &[u8] = b"null";
+                    let index = JsonIndex::build(json_bytes);
+                    let cursor = index.root(json_bytes);
+                    let query = format!(r#"load("{path}")"#);
+                    let expr = parse(&query).unwrap();
+                    match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+                        QueryResult::Owned(OwnedValue::Object(obj)) => {
+                            assert_eq!(obj.len(), 1);
+                            assert_eq!(
+                                obj.get("[1,2]"),
+                                Some(&OwnedValue::String("value".to_string()))
+                            );
+                        }
+                        other => panic!("unexpected result: {other:?}"),
+                    }
+                },
+            );
+        }
+
+        #[test]
+        fn test_load_yaml_alias_resolution() {
+            with_temp_file("load_test_alias.yaml", "a: &x hello\nb: *x\n", |path| {
+                let json_bytes: &[u8] = b"null";
+                let index = JsonIndex::build(json_bytes);
+                let cursor = index.root(json_bytes);
+                let query = format!(r#"load("{path}")"#);
+                let expr = parse(&query).unwrap();
+                match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+                    QueryResult::Owned(OwnedValue::Object(obj)) => {
+                        assert_eq!(obj.get("a"), Some(&OwnedValue::String("hello".to_string())));
+                        assert_eq!(obj.get("b"), Some(&OwnedValue::String("hello".to_string())));
+                    }
+                    other => panic!("unexpected result: {other:?}"),
+                }
+            });
+        }
+
+        #[test]
+        fn test_load_yaml_alias_preserves_tag_on_anchored_node() {
+            // yaml_value_to_owned's Alias arm recurses on the *target cursor*
+            // (`yaml_value_to_owned(target_cursor)`), not a bare value, so a tag
+            // sitting on the anchored node survives the alias hop - matching
+            // yq_runner.rs's yaml_to_owned_value and
+            // tests/yq_cli_tests.rs::test_yaml_anchored_tag_in_seq_item_resolves.
+            with_temp_file(
+                "load_test_alias_tag.yaml",
+                "a: &x !!int \"5\"\nb: *x\n",
+                |path| {
+                    let json_bytes: &[u8] = b"null";
+                    let index = JsonIndex::build(json_bytes);
+                    let cursor = index.root(json_bytes);
+                    let query = format!(r#"load("{path}")"#);
+                    let expr = parse(&query).unwrap();
+                    match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+                        QueryResult::Owned(OwnedValue::Object(obj)) => {
+                            assert_eq!(obj.get("a"), Some(&OwnedValue::Int(5)));
+                            assert_eq!(obj.get("b"), Some(&OwnedValue::Int(5)));
+                        }
+                        other => panic!("unexpected result: {other:?}"),
+                    }
+                },
+            );
+        }
     }
 
     // ========== #360: the unresolved-computed-key guards ==========

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14961,6 +14961,20 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
 ) -> OwnedValue {
     use crate::yaml::{resolve_plain, resolve_tagged, ResolvedScalar, YamlValue};
 
+    // Convert an already-resolved scalar to `OwnedValue`. `str_value` is the
+    // original source text, used only for the `Str` case. Mirrors
+    // `yq_runner.rs`'s `resolved_scalar_to_owned`, which can't be shared
+    // directly since that lives in the CLI binary, not this library crate.
+    fn resolved_scalar_to_owned(resolved: ResolvedScalar, str_value: Cow<'_, str>) -> OwnedValue {
+        match resolved {
+            ResolvedScalar::Null => OwnedValue::Null,
+            ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
+            ResolvedScalar::Int(n) => OwnedValue::Int(n),
+            ResolvedScalar::Float(f) => OwnedValue::Float(f),
+            ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
+        }
+    }
+
     match cursor.value() {
         YamlValue::Null => OwnedValue::Null,
         YamlValue::String(s) => {
@@ -14972,13 +14986,7 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
 
             if let Some(explicit) = cursor.explicit_tag() {
                 if let Some(resolved) = resolve_tagged(&str_value, explicit) {
-                    return match resolved {
-                        ResolvedScalar::Null => OwnedValue::Null,
-                        ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
-                        ResolvedScalar::Int(n) => OwnedValue::Int(n),
-                        ResolvedScalar::Float(f) => OwnedValue::Float(f),
-                        ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
-                    };
+                    return resolved_scalar_to_owned(resolved, str_value);
                 }
             }
 
@@ -14988,13 +14996,7 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
             }
 
             // Resolve plain scalars per the YAML 1.2 core schema
-            match resolve_plain(&str_value) {
-                ResolvedScalar::Null => OwnedValue::Null,
-                ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
-                ResolvedScalar::Int(n) => OwnedValue::Int(n),
-                ResolvedScalar::Float(f) => OwnedValue::Float(f),
-                ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
-            }
+            resolved_scalar_to_owned(resolve_plain(&str_value), str_value)
         }
         YamlValue::Sequence(mut elements) => {
             let mut items = Vec::new();

--- a/src/yaml/error.rs
+++ b/src/yaml/error.rs
@@ -93,10 +93,23 @@ pub enum YamlError {
         name: String,
     },
 
-    /// Tag not supported.
+    /// Tag not supported - kept for backwards compatibility but no longer used.
+    #[deprecated(note = "Tags are now supported (#224)")]
     TagNotSupported {
         /// Byte offset of the `!`
         offset: usize,
+    },
+
+    /// Malformed tag syntax (e.g. an unterminated verbatim `!<...>` tag).
+    ///
+    /// A bare `!` alone is the YAML 1.2 non-specific tag and is valid, not an
+    /// error - this variant is only for syntax the tag lexer cannot make
+    /// sense of at all.
+    InvalidTag {
+        /// Byte offset of the `!`
+        offset: usize,
+        /// Reason for invalidity
+        reason: &'static str,
     },
 
     /// Empty input.
@@ -202,8 +215,13 @@ impl fmt::Display for YamlError {
             Self::UnknownAnchor { offset, name } => {
                 write!(f, "unknown anchor '{name}' referenced at offset {offset}")
             }
+            #[allow(deprecated)]
+            // STYLE-0004: Display arm for a deprecated error variant kept for back-compat
             Self::TagNotSupported { offset } => {
                 write!(f, "tags (!) not supported at offset {offset}")
+            }
+            Self::InvalidTag { offset, reason } => {
+                write!(f, "invalid tag at offset {offset}: {reason}")
             }
             Self::EmptyInput => {
                 write!(f, "empty input")
@@ -339,9 +357,22 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // STYLE-0004: test intentionally exercises a deprecated variant's Display arm
     fn test_tag_not_supported_display() {
         let err = YamlError::TagNotSupported { offset: 8 };
         assert_eq!(err.to_string(), "tags (!) not supported at offset 8");
+    }
+
+    #[test]
+    fn test_invalid_tag_display() {
+        let err = YamlError::InvalidTag {
+            offset: 4,
+            reason: "unterminated verbatim tag",
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid tag at offset 4: unterminated verbatim tag"
+        );
     }
 
     #[test]

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -66,6 +66,12 @@ pub struct YamlIndex<W = Vec<u64>> {
     bp_to_anchor: BTreeMap<usize, String>,
     /// Alias references: BP position of alias → target BP position (resolved at parse time)
     aliases: BTreeMap<usize, usize>,
+    /// Explicit source tags: BP position → raw tag text (`"!!str"`, `"!custom"`, etc.).
+    ///
+    /// Unlike anchors, a tag has no forward name→position map: nothing
+    /// resolves to a tag by reference the way an alias resolves to an
+    /// anchor, so this is a single side table, not three (#224).
+    tags: BTreeMap<usize, String>,
     /// Line starts for line/column lookup (built lazily on first use).
     /// Only needed by `to_line_column()` and `to_offset()` (used by the
     /// `yq-locate` CLI and the `at_position` jq builtin).
@@ -129,6 +135,7 @@ impl YamlIndex<Vec<u64>> {
             anchors: semi.anchors,
             bp_to_anchor,
             aliases: semi.aliases,
+            tags: semi.tags,
             lines: OnceCell::new(),
         };
         index.validate_alias_acyclicity()?;
@@ -153,6 +160,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         containers: W,
         anchors: BTreeMap<String, usize>,
         aliases: BTreeMap<usize, usize>,
+        tags: BTreeMap<usize, String>,
     ) -> Self {
         let ib_rank = build_ib_rank(ib.as_ref());
         let containers_rank = build_containers_rank(containers.as_ref());
@@ -180,6 +188,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             anchors,
             bp_to_anchor,
             aliases,
+            tags,
             lines: OnceCell::new(),
         }
     }
@@ -447,6 +456,18 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         self.bp_to_anchor
             .get(&bp_pos)
             .map(alloc::string::String::as_str)
+    }
+
+    /// Get the explicit source tag for a BP position (`"!!str"`, `"!custom"`,
+    /// `"!<tag:example.com,2000:foo>"`, etc.).
+    ///
+    /// Returns `None` if the node has no explicit tag. Distinct from
+    /// [`YamlCursor::tag`](super::light::YamlCursor::tag), which returns an
+    /// *inferred* type label derived from the value's shape rather than the
+    /// source text.
+    #[inline]
+    pub fn get_tag(&self, bp_pos: usize) -> Option<&str> {
+        self.tags.get(&bp_pos).map(alloc::string::String::as_str)
     }
 
     /// Resolve an alias at the given BP position to a cursor pointing to

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1345,4 +1345,66 @@ mod tests {
             );
         }
     }
+
+    // ------------------------------------------------------------------------
+    // from_parts (#224: tags round-trip)
+    // ------------------------------------------------------------------------
+
+    /// `from_parts` is the public constructor for loading pre-serialized index
+    /// data (mirrors `SimpleJsonIndex::from_parts` in `json/simple_light.rs`).
+    /// Unlike its JSON siblings it had no direct test at all - build a
+    /// `YamlIndex` normally, tear it back down into the raw parts via
+    /// `build_semi_index` (the same function `YamlIndex::build` itself calls),
+    /// reconstruct through `from_parts`, and check the reconstructed index
+    /// behaves identically. The `tags` map is this PR's new field, so the
+    /// fixture carries an explicit tag (`!!str`) specifically to exercise it,
+    /// not just the fields `from_parts` already had before #224.
+    #[test]
+    fn test_from_parts_round_trip_with_tags() {
+        let yaml: &[u8] = b"a: !!str 1\n";
+
+        let built = YamlIndex::build(yaml).expect("should parse");
+
+        let semi = build_semi_index(yaml).expect("should parse");
+        let reconstructed = YamlIndex::from_parts(
+            semi.ib,
+            semi.ib_len,
+            semi.bp,
+            semi.bp_len,
+            semi.ty,
+            semi.ty_len,
+            semi.bp_to_text,
+            semi.bp_to_text_end,
+            semi.containers,
+            semi.anchors,
+            semi.aliases,
+            semi.tags,
+        );
+
+        // Same document either way, and the tag did its job: `!!str` forces
+        // the plain scalar `1` to resolve as the string "1", not the number 1.
+        let expected_json = r#"[{"a":"1"}]"#;
+        assert_eq!(built.root(yaml).to_json(), expected_json);
+        assert_eq!(reconstructed.root(yaml).to_json(), expected_json);
+
+        // The tag itself must survive the round trip too, not just its
+        // effect on resolution - look it up by the tagged value's own BP
+        // position on both indexes.
+        let fields = match built.root(yaml).value() {
+            crate::yaml::YamlValue::Sequence(mut docs) => match docs.next().expect("one doc") {
+                crate::yaml::YamlValue::Mapping(fields) => fields,
+                other => panic!("expected mapping, got {other:?}"),
+            },
+            other => panic!("expected root sequence, got {other:?}"),
+        };
+        let (field, _rest) = fields.uncons().expect("one field");
+        let value_bp_pos = field.value_cursor().bp_position();
+
+        assert_eq!(built.get_tag(value_bp_pos), Some("!!str"));
+        assert_eq!(
+            reconstructed.get_tag(value_bp_pos),
+            Some("!!str"),
+            "tags map must survive from_parts round trip"
+        );
+    }
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -8582,6 +8582,53 @@ mod tests {
     }
 
     #[test]
+    fn test_style_value_with_anchor_and_tag_is_unaffected() {
+        // A value cursor's `text_position()` already resolves past any
+        // leading `&anchor`/`!tag` property, so `style()` reports the
+        // underlying scalar's/container's own style regardless of what
+        // precedes it (#224).
+        for (name, yaml, expected) in [
+            ("anchor only", &b"key: &a \"quoted\"\n"[..], "double"),
+            ("tag only", &b"key: !!str \"quoted\"\n"[..], "double"),
+            (
+                "anchor then tag",
+                &b"key: &a !!str \"quoted\"\n"[..],
+                "double",
+            ),
+            ("anchor on flow mapping", &b"key: &a {a: 1}\n"[..], "flow"),
+        ] {
+            let index = YamlIndex::build(yaml).unwrap();
+            let root = index.root(yaml);
+            if let YamlValue::Mapping(fields) = first_doc(root) {
+                if let Some(field) = fields.into_iter().next() {
+                    let cursor = field.value_cursor();
+                    assert_eq!(cursor.style(), expected, "{name}");
+                    continue;
+                }
+            }
+            panic!("Could not find value for {name}");
+        }
+    }
+
+    #[test]
+    fn test_style_tagged_flow_key_skips_the_property_prefix() {
+        // Unlike value cursors, a *key* cursor's `text_position()` points
+        // straight at a leading `!tag` rather than past it - `style()` must
+        // call `skip_properties_and_whitespace` itself to find the key's
+        // actual quoting style (#224).
+        let yaml = b"{!!str \"k\": v}\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let root = index.root(yaml);
+        if let YamlValue::Mapping(fields) = first_doc(root) {
+            if let Some(field) = fields.into_iter().next() {
+                assert_eq!(field.key_cursor().style(), "double");
+                return;
+            }
+        }
+        panic!("Could not find field");
+    }
+
+    #[test]
     fn test_tag_string() {
         let yaml = b"key: hello";
         let index = YamlIndex::build(yaml).unwrap();
@@ -8697,6 +8744,58 @@ mod tests {
         assert_eq!(value_tag(b"key: .5"), "!!float");
     }
 
+    /// `test_tag_string`/`_int`/`_bool`/`_null`/`_float`/`_core_schema_resolution`
+    /// above all use untagged plain scalars, so none of them exercise the
+    /// `explicit_tag()` branch inside `tag()` - only its plain-scalar
+    /// fallback. An explicit core-schema tag forces that resolution
+    /// regardless of the content's own shape or quoting; a non-core-schema
+    /// tag does not, and falls through to the same plain-scalar inference
+    /// instead (#224).
+    #[test]
+    fn test_tag_explicit_core_schema_tag_forces_resolution() {
+        assert_eq!(value_tag(b"key: !!str 1"), "!!str");
+        assert_eq!(value_tag(b"key: !!int \"5\""), "!!int");
+        // A custom tag doesn't change tag(); "v" is plain, so it still infers
+        // !!str from resolve_plain.
+        assert_eq!(value_tag(b"key: !custom v"), "!!str");
+    }
+
+    /// `is_falsy` (the `DocumentCursor` trait method backing `select`,
+    /// `if/then/else`, and `//`) must honor an explicit tag's resolution, not
+    /// the scalar's own quoting - a quoted non-empty string is ordinarily
+    /// truthy, but `!!bool "false"` and `!!null "~"` are both falsy because
+    /// the tag forces that resolution (#224).
+    #[test]
+    fn test_is_falsy_uses_the_resolved_tagged_value() {
+        for (name, yaml, expect_falsy) in [
+            (
+                "tagged bool false, quoted",
+                &b"a: !!bool \"false\"\n"[..],
+                true,
+            ),
+            ("tagged null, quoted", &b"a: !!null \"~\"\n"[..], true),
+            (
+                "tagged bool true, quoted",
+                &b"a: !!bool \"true\"\n"[..],
+                false,
+            ),
+            // Sanity check: the same quoted content, untagged, is truthy -
+            // the behavior the tagged cases above must diverge from.
+            ("untagged quoted false", &b"a: \"false\"\n"[..], false),
+        ] {
+            let index = YamlIndex::build(yaml).unwrap();
+            let root = index.root(yaml);
+            if let YamlValue::Mapping(fields) = first_doc(root) {
+                if let Some(field) = fields.into_iter().next() {
+                    let cursor = field.value_cursor();
+                    assert_eq!(cursor.is_falsy(), expect_falsy, "{name}");
+                    continue;
+                }
+            }
+            panic!("Could not find value for {name}");
+        }
+    }
+
     /// Returns `to_json` for a document (exercises the buffer transcoder).
     /// The root wraps documents in an implicit sequence, hence `[...]`.
     #[track_caller]
@@ -8729,6 +8828,29 @@ mod tests {
         assert_eq!(doc_json(b"a: |-\n  true\n"), r#"[{"a":"true"}]"#);
         assert_eq!(doc_json(b"a: |-\n  null\n"), r#"[{"a":"null"}]"#);
         assert_eq!(doc_json(b"a: >-\n  42\n"), r#"[{"a":"42"}]"#);
+    }
+
+    /// A tag that isn't one of the 5 core-schema tags (`!custom`) makes
+    /// `resolve_tagged` return `None`, so both JSON emitters must fall
+    /// through to ordinary scalar transcoding rather than resolving -
+    /// exercised on both the buffered (`to_json`/`write_json_to`) and
+    /// streaming (`stream_json`/`stream_json_value`) paths (#224).
+    #[test]
+    fn test_custom_tag_falls_through_to_plain_transcoding() {
+        let yaml = b"a: !custom hello\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let root = index.root(yaml);
+        if let YamlValue::Mapping(fields) = first_doc(root) {
+            if let Some(field) = fields.into_iter().next() {
+                let cursor = field.value_cursor();
+                assert_eq!(cursor.to_json(), "\"hello\"");
+                let mut streamed = String::new();
+                cursor.stream_json(&mut streamed, 0).expect("streams");
+                assert_eq!(streamed, "\"hello\"");
+                return;
+            }
+        }
+        panic!("Could not find value");
     }
 
     #[test]
@@ -9540,6 +9662,20 @@ mod tests {
             b"a:\n  -\n  - y\n  - k: v\n",
             b"[\n  - x,\n  y\n]\n",
             b"- &a x\n- *a\n",
+            // A quoted string element: hits `write_yaml_value_as_json`'s
+            // direct-transcode-succeeds fast path for a quoted *value*
+            // (#224).
+            b"- \"q\"\n- y\n",
+            // A mapping element with a quoted key: same fast path, for a
+            // quoted *key* this time.
+            b"- \"k\": v\n",
+            // A mapping element whose key is an alias (not a `YamlValue::String`):
+            // the non-string-key fallback branch (resolves via `key_string()`).
+            b"- &a x\n- *a: v\n",
+            // A nested sequence with 2+ items as a top-level element: hits
+            // the comma-insertion branch for the second+ item of a *nested*
+            // sequence.
+            b"- - a\n  - b\n- y\n",
         ];
         for yaml in inputs {
             let index = YamlIndex::build(yaml).expect("builds");
@@ -9617,6 +9753,32 @@ mod tests {
                 "round-trip changed {what}"
             );
         }
+    }
+
+    /// Flow-style sibling of `tests/yq_cli_tests.rs`'s
+    /// `test_yaml_default_output_preserves_the_literal_tag`, which only
+    /// covers the block-style key case (`!!str key: value`). A flow
+    /// mapping's key has its own, separate
+    /// `field.key_cursor().explicit_tag()` check in `stream_yaml_value`'s
+    /// `indent_spaces == 0` arm - reached only by flow-style output, which
+    /// the CLI's default YAML output never produces (`-I0` is remapped to
+    /// `-I2` for YAML, matching real `yq`), so this calls `stream_yaml`
+    /// directly instead of going through the CLI (#224).
+    #[test]
+    fn test_stream_yaml_flow_mapping_preserves_tagged_key() {
+        let yaml = b"a: {!!str k: v}\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let root = index.root(yaml);
+        if let YamlValue::Mapping(fields) = first_doc(root) {
+            if let Some(field) = fields.into_iter().next() {
+                let cursor = field.value_cursor();
+                let mut out = String::new();
+                cursor.stream_yaml(&mut out, 0).expect("streams");
+                assert_eq!(out, "{!!str k: v}");
+                return;
+            }
+        }
+        panic!("Could not find value");
     }
 
     /// Helper: render a `YamlValue` as JSON, matching `to_json`'s output.

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -4973,10 +4973,10 @@ impl<'a, W: AsRef<[u64]>> YamlValue<'a, W> {
     }
 }
 
-// KNOWN LIMITATION (#224): the typed getters below (`is_null`, `as_bool`,
-// `as_i64`, `as_f64`, `type_name`) are not tag-aware, unlike every JSON
-// output path (`write_json_to`/`stream_json_value`) and the CLI's
-// `yaml_to_owned_value`. A bare `YamlValue` has no `bp_pos` to look an
+// KNOWN LIMITATION (#224, tracked as #747): the typed getters below
+// (`is_null`, `as_bool`, `as_i64`, `as_f64`, `type_name`) are not tag-aware,
+// unlike every JSON output path (`write_json_to`/`stream_json_value`) and the
+// CLI's `yaml_to_owned_value`. A bare `YamlValue` has no `bp_pos` to look an
 // explicit tag up with — only a `YamlCursor` does (`explicit_tag()`) — and
 // `crate::jq::eval_generic::to_owned`, the generic evaluator's lazy
 // materializer backing `select`, `==`, arithmetic, and `type` on the

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1492,10 +1492,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         out.write_char('\n')?;
                         write_yaml_indent(out, next_indent)?;
                     }
-                    // Recurse via the cursor, not `stream_yaml_value_as_json`
-                    // on the extracted `YamlValue`: an element's own tag
-                    // lives on its cursor's `bp_pos`, which a bare
-                    // `YamlValue` has already lost (#224).
+                    // Recurse via the cursor, not the extracted `YamlValue`:
+                    // an element's own tag lives on its cursor's `bp_pos`,
+                    // which a bare `YamlValue` has already lost (#224).
                     cursor.stream_json_value(out, next_indent, indent_spaces)?;
                 }
                 if indent_spaces > 0 {
@@ -2625,120 +2624,6 @@ fn write_resolved_scalar_as_json(output: &mut String, resolved: ResolvedScalar, 
 // ============================================================================
 // Streaming JSON Output (core::fmt::Write based)
 // ============================================================================
-
-/// Stream a YAML value as JSON from a bare `YamlValue` with no cursor of its
-/// own. The streaming twin of [`write_yaml_value_as_json`] - see its doc
-/// comment for why no production call site reaches this anymore (#224).
-#[allow(dead_code)] // STYLE-0005: used in tests
-fn stream_yaml_value_as_json<W: AsRef<[u64]>, Out: core::fmt::Write>(
-    out: &mut Out,
-    value: YamlValue<'_, W>,
-    current_indent: usize,
-    indent_spaces: usize,
-) -> core::fmt::Result {
-    match value {
-        YamlValue::Null => out.write_str("null"),
-        YamlValue::String(s) => match stream_yaml_string_to_json(out, &s) {
-            Ok(true) => Ok(()),
-            Ok(false) => {
-                if let Ok(str_val) = s.as_str() {
-                    if s.is_unquoted() {
-                        // Plain scalar - resolve per the core schema
-                        stream_yaml_scalar_as_json(out, &str_val)
-                    } else {
-                        // Block scalars are always strings
-                        stream_json_string(out, &str_val)
-                    }
-                } else {
-                    out.write_str("null")
-                }
-            }
-            Err(_) => out.write_str("null"),
-        },
-        YamlValue::Mapping(fields) => {
-            if fields.is_empty() {
-                return out.write_str("{}");
-            }
-            out.write_char('{')?;
-            let next_indent = current_indent + indent_spaces;
-            let mut first = true;
-            for field in fields {
-                if !first {
-                    out.write_char(',')?;
-                }
-                first = false;
-                if indent_spaces > 0 {
-                    out.write_char('\n')?;
-                    write_yaml_indent(out, next_indent)?;
-                }
-
-                if let YamlValue::String(s) = field.key() {
-                    match stream_yaml_string_to_json(out, &s) {
-                        Ok(true) => {}
-                        Ok(false) | Err(_) => {
-                            if let Ok(key_str) = s.as_str() {
-                                stream_json_string(out, &key_str)?;
-                            } else {
-                                out.write_str("\"\"")?;
-                            }
-                        }
-                    }
-                } else {
-                    // Alias/complex key (#222): resolve alias-to-scalar,
-                    // else "" — the entry is kept, never dropped
-                    stream_json_string(out, &field.key().key_string())?;
-                }
-
-                out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
-                field
-                    .value_cursor()
-                    .stream_json_value(out, next_indent, indent_spaces)?;
-            }
-            if indent_spaces > 0 {
-                out.write_char('\n')?;
-                write_yaml_indent(out, current_indent)?;
-            }
-            out.write_char('}')
-        }
-        YamlValue::Sequence(elements) => {
-            if elements.is_empty() {
-                return out.write_str("[]");
-            }
-            out.write_char('[')?;
-            let next_indent = current_indent + indent_spaces;
-            let mut first = true;
-            let mut rest = elements;
-            while let Some((cursor, next)) = rest.uncons_cursor() {
-                if !first {
-                    out.write_char(',')?;
-                }
-                first = false;
-                rest = next;
-                if indent_spaces > 0 {
-                    out.write_char('\n')?;
-                    write_yaml_indent(out, next_indent)?;
-                }
-                // A child element does have a cursor even though this
-                // function's own top-level `value` doesn't - use it so a
-                // nested element's tag isn't lost either.
-                cursor.stream_json_value(out, next_indent, indent_spaces)?;
-            }
-            if indent_spaces > 0 {
-                out.write_char('\n')?;
-                write_yaml_indent(out, current_indent)?;
-            }
-            out.write_char(']')
-        }
-        YamlValue::Alias { target, .. } => {
-            if let Some(target_cursor) = target {
-                target_cursor.stream_json_value(out, current_indent, indent_spaces)
-            } else {
-                out.write_str("null")
-            }
-        }
-        YamlValue::Error(_) => out.write_str("null"),
-    }
-}
 
 /// Stream a string with JSON escaping.
 fn stream_json_string<Out: core::fmt::Write>(out: &mut Out, s: &str) -> core::fmt::Result {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -24,7 +24,7 @@ use std::string::ToString;
 
 use super::index::YamlIndex;
 use super::line_break::{is_line_break, line_break_len, line_break_len_before};
-use super::scalar::{could_be_null_or_bool, resolve_plain, ResolvedScalar};
+use super::scalar::{could_be_null_or_bool, resolve_plain, resolve_tagged, ResolvedScalar};
 use super::{starts_inline_seq_entry, starts_seq_entry};
 use crate::util::simd::escape::find_json_escape;
 
@@ -203,15 +203,15 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             return self.parse_alias_value(text_pos);
         }
 
-        // Check for anchor - if present, skip past it to get the actual value
-        // Anchors look like: &anchor_name value
-        let effective_text_pos = if byte == b'&' {
-            self.skip_anchor_and_whitespace(text_pos)
+        // Check for a property (anchor and/or tag) - if present, skip past it
+        // to get the actual value. Anchors look like: &anchor_name value
+        let effective_text_pos = if matches!(byte, b'&' | b'!') {
+            self.skip_properties_and_whitespace(text_pos)
         } else {
             text_pos
         };
 
-        // If we're past the end after skipping anchor, this is an anchored null
+        // If we're past the end after skipping the property, this is a null
         if effective_text_pos >= self.text.len() {
             return YamlValue::Null;
         }
@@ -363,31 +363,50 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         }
     }
 
-    /// Skip past an anchor definition and any following whitespace.
+    /// Skip past a leading `&anchor` and/or `!tag` (either order, each at
+    /// most once) and any following whitespace.
     ///
     /// Anchor syntax: `&name` where name can contain alphanumerics, underscores,
     /// hyphens, and colons.
     ///
-    /// Returns the position of the first non-whitespace character after the anchor,
-    /// or the end of text if nothing follows.
-    fn skip_anchor_and_whitespace(&self, start: usize) -> usize {
-        // Skip the '&'
-        let mut pos = start + 1;
-
-        // Skip anchor name characters (per YAML spec, anchors can contain
-        // alphanumerics, underscores, hyphens, and also colons in some contexts)
-        while pos < self.text.len() {
-            match self.text[pos] {
-                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b':' => pos += 1,
+    /// A key's or value's BP node can be opened *before* its property is
+    /// consumed (`record_key_tag`/`record_key_anchor`'s `bp_pos - 1`
+    /// convention in `parser.rs`), so the node's recorded text span still
+    /// starts at the property text — this is where that gets stripped away
+    /// at decode time. `parser.rs`'s `parse_node_properties` is the
+    /// parse-time analogue for nodes whose BP opens *after* property
+    /// consumption (#224 generalized this from anchor-only).
+    ///
+    /// Returns the position of the first non-whitespace character after the
+    /// last property, or the end of text if nothing follows.
+    fn skip_properties_and_whitespace(&self, start: usize) -> usize {
+        let mut pos = start;
+        loop {
+            match self.text.get(pos) {
+                Some(b'&') => {
+                    pos += 1;
+                    // Anchor name characters (per YAML spec, anchors can
+                    // contain alphanumerics, underscores, hyphens, and also
+                    // colons in some contexts).
+                    while pos < self.text.len() {
+                        match self.text[pos] {
+                            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b':' => {
+                                pos += 1;
+                            }
+                            _ => break,
+                        }
+                    }
+                }
+                Some(b'!') => {
+                    let (end, _) = super::parser::scan_tag_extent(self.text, pos);
+                    pos = end;
+                }
                 _ => break,
             }
+            while pos < self.text.len() && matches!(self.text[pos], b' ' | b'\t') {
+                pos += 1;
+            }
         }
-
-        // Skip whitespace after anchor name
-        while pos < self.text.len() && (self.text[pos] == b' ' || self.text[pos] == b'\t') {
-            pos += 1;
-        }
-
         pos
     }
 
@@ -1095,11 +1114,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // Check if this is the root document array with a single document
         if self.bp_pos == 0 {
             if let YamlValue::Sequence(elements) = self.value() {
-                let mut iter = elements.into_iter();
-                if let Some(first) = iter.next() {
-                    if iter.next().is_none() {
-                        // Single document - output it directly without array wrapper
-                        write_yaml_value_as_json(&mut output, first);
+                if let Some((first_cursor, rest)) = elements.uncons_cursor() {
+                    if rest.uncons_cursor().is_none() {
+                        // Single document - output it directly without array
+                        // wrapper. Via the cursor, not the extracted
+                        // `YamlValue`: the document's own tag lives on its
+                        // cursor's `bp_pos` (#224).
+                        first_cursor.write_json_to(&mut output);
                         return output;
                     }
                 }
@@ -1153,11 +1174,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // Check if this is the root document array with a single document
         if self.bp_pos == 0 {
             if let YamlValue::Sequence(elements) = self.value() {
-                let mut iter = elements.into_iter();
-                if let Some(first) = iter.next() {
-                    if iter.next().is_none() {
-                        // Single document - output it directly without array wrapper
-                        return stream_yaml_value_as_json(out, first, 0, indent_spaces);
+                if let Some((first_cursor, rest)) = elements.uncons_cursor() {
+                    if rest.uncons_cursor().is_none() {
+                        // Single document - output it directly without array
+                        // wrapper. Via the cursor, not the extracted
+                        // `YamlValue`: the document's own tag lives on its
+                        // cursor's `bp_pos` (#224).
+                        return first_cursor.stream_json_value(out, 0, indent_spaces);
                     }
                 }
             }
@@ -1215,7 +1238,18 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     ) -> core::fmt::Result {
         match self.value() {
             YamlValue::Null => out.write_str("null"),
-            YamlValue::String(s) => stream_yaml_string_value(out, &s),
+            YamlValue::String(s) => {
+                // YAML output (unlike JSON) has tag syntax, so an explicit
+                // tag is preserved verbatim rather than dropped - matching
+                // real `yq`, which re-emits `!!str 1`/`!!int "5"`/`!custom v`
+                // as-is rather than only letting the tag affect resolution
+                // (#224).
+                if let Some(tag) = self.explicit_tag() {
+                    out.write_str(tag)?;
+                    out.write_char(' ')?;
+                }
+                stream_yaml_string_value(out, &s)
+            }
             YamlValue::Mapping(fields) => {
                 if fields.is_empty() {
                     return out.write_str("{}");
@@ -1231,6 +1265,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         first = false;
                         // Write key
                         if let YamlValue::String(s) = field.key() {
+                            if let Some(tag) = field.key_cursor().explicit_tag() {
+                                out.write_str(tag)?;
+                                out.write_char(' ')?;
+                            }
                             stream_yaml_string_value(out, &s)?;
                         } else {
                             stream_yaml_nonstring_key(out, &field.key())?;
@@ -1250,6 +1288,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         first = false;
                         // Write key
                         if let YamlValue::String(s) = field.key() {
+                            if let Some(tag) = field.key_cursor().explicit_tag() {
+                                out.write_str(tag)?;
+                                out.write_char(' ')?;
+                            }
                             stream_yaml_string_value(out, &s)?;
                         } else {
                             stream_yaml_nonstring_key(out, &field.key())?;
@@ -1355,6 +1397,18 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         match self.value() {
             YamlValue::Null => out.write_str("null"),
             YamlValue::String(s) => {
+                // An explicit core-schema tag (`!!str`, `!!int`, …) forces
+                // resolution regardless of quoting style - `!!int "5"` is the
+                // number 5, not the string "5" - so it's checked before the
+                // direct transcoding optimization below, which otherwise
+                // always treats a quoted/block scalar as a string (#224).
+                if let Some(explicit) = self.explicit_tag() {
+                    if let Ok(str_val) = s.as_str() {
+                        if let Some(resolved) = resolve_tagged(&str_val, explicit) {
+                            return stream_resolved_scalar_as_json(out, resolved, &str_val);
+                        }
+                    }
+                }
                 // Direct transcoding optimization
                 match stream_yaml_string_to_json(out, &s) {
                     Ok(true) => Ok(()), // Written directly as JSON string
@@ -1427,16 +1481,22 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 out.write_char('[')?;
                 let next_indent = current_indent + indent_spaces;
                 let mut first = true;
-                for elem in elements {
+                let mut rest = elements;
+                while let Some((cursor, next)) = rest.uncons_cursor() {
                     if !first {
                         out.write_char(',')?;
                     }
                     first = false;
+                    rest = next;
                     if indent_spaces > 0 {
                         out.write_char('\n')?;
                         write_yaml_indent(out, next_indent)?;
                     }
-                    stream_yaml_value_as_json(out, elem, next_indent, indent_spaces)?;
+                    // Recurse via the cursor, not `stream_yaml_value_as_json`
+                    // on the extracted `YamlValue`: an element's own tag
+                    // lives on its cursor's `bp_pos`, which a bare
+                    // `YamlValue` has already lost (#224).
+                    cursor.stream_json_value(out, next_indent, indent_spaces)?;
                 }
                 if indent_spaces > 0 {
                     out.write_char('\n')?;
@@ -1460,6 +1520,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         match self.value() {
             YamlValue::Null => output.push_str("null"),
             YamlValue::String(s) => {
+                // An explicit core-schema tag forces resolution regardless of
+                // quoting style - see the mirrored check in `stream_json_value` (#224).
+                if let Some(explicit) = self.explicit_tag() {
+                    if let Ok(str_val) = s.as_str() {
+                        if let Some(resolved) = resolve_tagged(&str_val, explicit) {
+                            write_resolved_scalar_as_json(output, resolved, &str_val);
+                            return;
+                        }
+                    }
+                }
                 // Direct transcoding optimization (avoids intermediate allocation for quoted strings)
                 match write_yaml_string_to_json(output, &s) {
                     Ok(true) => {} // Written directly as JSON string
@@ -1517,14 +1587,19 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             YamlValue::Sequence(elements) => {
                 output.push('[');
                 let mut first = true;
-                for elem in elements {
+                let mut rest = elements;
+                while let Some((cursor, next)) = rest.uncons_cursor() {
                     if !first {
                         output.push(',');
                     }
                     first = false;
+                    rest = next;
 
-                    // For sequences, we get YamlValue not cursor, so need to handle inline
-                    write_yaml_value_as_json(output, elem);
+                    // Recurse via the cursor, not `write_yaml_value_as_json`
+                    // on the extracted `YamlValue`: an element's own tag
+                    // lives on its cursor's `bp_pos`, which a bare
+                    // `YamlValue` has already lost (#224).
+                    cursor.write_json_to(output);
                 }
                 output.push(']');
             }
@@ -1560,6 +1635,25 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     #[inline]
     pub fn anchor(&self) -> Option<&str> {
         self.index.get_anchor_name(self.bp_pos)
+    }
+
+    /// Get the explicit YAML tag written on this node in the source
+    /// (`"!!str"`, `"!custom"`, `"!<tag:example.com,2000:foo>"`, …).
+    ///
+    /// Returns `None` if the node has no explicit tag. Distinct from
+    /// [`Self::tag`], which returns an *inferred* type label derived from the
+    /// value's shape rather than the source text, and never reflects an
+    /// explicit tag even when one is present (#224).
+    ///
+    /// # Example
+    /// ```ignore
+    /// let yaml = b"a: !!str 1";
+    /// let index = YamlIndex::build(yaml).unwrap();
+    /// // Navigate to the value and call .explicit_tag() to get Some("!!str")
+    /// ```
+    #[inline]
+    pub fn explicit_tag(&self) -> Option<&str> {
+        self.index.get_tag(self.bp_pos)
     }
 
     /// Get the anchor name that this alias references.
@@ -1721,9 +1815,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             return "";
         }
 
-        // Skip anchor if present
-        let effective_pos = if self.text[text_pos] == b'&' {
-            self.skip_anchor_and_whitespace(text_pos)
+        // Skip a leading property (anchor and/or tag) if present
+        let effective_pos = if matches!(self.text[text_pos], b'&' | b'!') {
+            self.skip_properties_and_whitespace(text_pos)
         } else {
             text_pos
         };
@@ -1753,13 +1847,29 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// - `"!!seq"` for sequences (arrays)
     /// - `"!!map"` for mappings (objects)
     ///
-    /// Note: This returns inferred tags. Explicit tags in the YAML source
-    /// (like `!mytag`) are not currently preserved.
+    /// Note: This is the tag of the node's *resolved* value, not necessarily
+    /// its literal source text. One of the 5 core-schema tags (`!!str`,
+    /// `!!null`, `!!bool`, `!!int`, `!!float`) written explicitly in the
+    /// source forces that resolution (`!!str 1` returns `"!!str"`, not the
+    /// `"!!int"` the bare content would infer); any other explicit tag (a
+    /// custom tag, `!!seq`, `!!map`, …) does not change it, and this falls
+    /// through to inferring from the content instead. Use
+    /// [`Self::explicit_tag`] for the literal source-level tag text, which is
+    /// `None` unless one was actually written (#224).
     pub fn tag(&self) -> &'static str {
         match self.value() {
             YamlValue::Null => "!!null",
             YamlValue::String(s) => {
-                // Infer type from plain scalars per the YAML 1.2 core schema
+                if let Some(explicit) = self.explicit_tag() {
+                    if let Ok(str_val) = s.as_str() {
+                        if let Some(resolved) = resolve_tagged(&str_val, explicit) {
+                            return resolved.tag();
+                        }
+                    }
+                }
+                // No explicit tag, or not one of the 5 core-schema tags -
+                // infer type from plain scalars per the YAML 1.2 core
+                // schema; quoted/block scalars are always strings.
                 if s.is_unquoted() {
                     if let Ok(str_val) = s.as_str() {
                         return resolve_plain(&str_val).tag();
@@ -1889,7 +1999,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     }
 }
 
-/// Write a YAML value as JSON (for sequence elements where we don't have a cursor).
+/// Write a YAML value as JSON from a bare `YamlValue` with no cursor of its
+/// own — e.g. one already extracted via `YamlElements::uncons`/`get`.
+///
+/// No production call site reaches this anymore (#224): every real path
+/// recurses via a cursor instead (`YamlElements::uncons_cursor` +
+/// `YamlCursor::write_json_to`), since a node's own tag lives on its
+/// `bp_pos`, which a bare `YamlValue` has already lost. Kept as the
+/// value-only half of `test_sequence_element_accessors_agree`, which asserts
+/// `uncons`/`get`/`uncons_cursor` all produce identical JSON (#332).
+#[allow(dead_code)] // STYLE-0005: used in tests
 fn write_yaml_value_as_json<W: AsRef<[u64]>>(output: &mut String, value: YamlValue<'_, W>) {
     match value {
         YamlValue::Null => output.push_str("null"),
@@ -1949,12 +2068,17 @@ fn write_yaml_value_as_json<W: AsRef<[u64]>>(output: &mut String, value: YamlVal
         YamlValue::Sequence(elements) => {
             output.push('[');
             let mut first = true;
-            for elem in elements {
+            let mut rest = elements;
+            while let Some((cursor, next)) = rest.uncons_cursor() {
                 if !first {
                     output.push(',');
                 }
                 first = false;
-                write_yaml_value_as_json(output, elem);
+                rest = next;
+                // A child element does have a cursor even though this
+                // function's own top-level `value` doesn't - use it so a
+                // nested element's tag isn't lost either.
+                cursor.write_json_to(output);
             }
             output.push(']');
         }
@@ -2478,7 +2602,15 @@ fn write_f64(output: &mut String, f: f64) {
 /// source text (hex/octal like `0x2A` must appear as `42` in JSON).
 #[inline]
 fn write_yaml_scalar_as_json(output: &mut String, str_val: &str) {
-    match resolve_plain(str_val) {
+    write_resolved_scalar_as_json(output, resolve_plain(str_val), str_val);
+}
+
+/// Write an already-resolved scalar as JSON. `str_val` is the original
+/// source text, used only for the `Str` case (and only if `resolved` didn't
+/// come from resolving it, e.g. tag-forced `!!str` on non-string content).
+#[inline]
+fn write_resolved_scalar_as_json(output: &mut String, resolved: ResolvedScalar, str_val: &str) {
+    match resolved {
         ResolvedScalar::Null => output.push_str("null"),
         ResolvedScalar::Bool(true) => output.push_str("true"),
         ResolvedScalar::Bool(false) => output.push_str("false"),
@@ -2494,7 +2626,10 @@ fn write_yaml_scalar_as_json(output: &mut String, str_val: &str) {
 // Streaming JSON Output (core::fmt::Write based)
 // ============================================================================
 
-/// Stream a YAML value as JSON (for sequence elements where we don't have a cursor).
+/// Stream a YAML value as JSON from a bare `YamlValue` with no cursor of its
+/// own. The streaming twin of [`write_yaml_value_as_json`] - see its doc
+/// comment for why no production call site reaches this anymore (#224).
+#[allow(dead_code)] // STYLE-0005: used in tests
 fn stream_yaml_value_as_json<W: AsRef<[u64]>, Out: core::fmt::Write>(
     out: &mut Out,
     value: YamlValue<'_, W>,
@@ -2572,16 +2707,21 @@ fn stream_yaml_value_as_json<W: AsRef<[u64]>, Out: core::fmt::Write>(
             out.write_char('[')?;
             let next_indent = current_indent + indent_spaces;
             let mut first = true;
-            for elem in elements {
+            let mut rest = elements;
+            while let Some((cursor, next)) = rest.uncons_cursor() {
                 if !first {
                     out.write_char(',')?;
                 }
                 first = false;
+                rest = next;
                 if indent_spaces > 0 {
                     out.write_char('\n')?;
                     write_yaml_indent(out, next_indent)?;
                 }
-                stream_yaml_value_as_json(out, elem, next_indent, indent_spaces)?;
+                // A child element does have a cursor even though this
+                // function's own top-level `value` doesn't - use it so a
+                // nested element's tag isn't lost either.
+                cursor.stream_json_value(out, next_indent, indent_spaces)?;
             }
             if indent_spaces > 0 {
                 out.write_char('\n')?;
@@ -3021,7 +3161,18 @@ fn stream_yaml_scalar_as_json<Out: core::fmt::Write>(
     out: &mut Out,
     str_val: &str,
 ) -> core::fmt::Result {
-    match resolve_plain(str_val) {
+    stream_resolved_scalar_as_json(out, resolve_plain(str_val), str_val)
+}
+
+/// Stream an already-resolved scalar as JSON. `str_val` is the original
+/// source text, used only for the `Str` case (and only if `resolved` didn't
+/// come from resolving it, e.g. tag-forced `!!str` on non-string content).
+fn stream_resolved_scalar_as_json<Out: core::fmt::Write>(
+    out: &mut Out,
+    resolved: ResolvedScalar,
+    str_val: &str,
+) -> core::fmt::Result {
+    match resolved {
         ResolvedScalar::Null => out.write_str("null"),
         ResolvedScalar::Bool(true) => out.write_str("true"),
         ResolvedScalar::Bool(false) => out.write_str("false"),
@@ -4884,16 +5035,24 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
         // A value is falsy if it's null or false
         match self.value() {
             YamlValue::Null => true,
-            YamlValue::String(s) if s.is_unquoted() => {
-                if let Ok(str_val) = s.as_str() {
-                    could_be_null_or_bool(&str_val)
-                        && matches!(
-                            resolve_plain(&str_val),
+            YamlValue::String(s) => {
+                let Ok(str_val) = s.as_str() else {
+                    return false;
+                };
+                if let Some(explicit) = self.explicit_tag() {
+                    if let Some(resolved) = resolve_tagged(&str_val, explicit) {
+                        return matches!(
+                            resolved,
                             ResolvedScalar::Null | ResolvedScalar::Bool(false)
-                        )
-                } else {
-                    false
+                        );
+                    }
                 }
+                s.is_unquoted()
+                    && could_be_null_or_bool(&str_val)
+                    && matches!(
+                        resolve_plain(&str_val),
+                        ResolvedScalar::Null | ResolvedScalar::Bool(false)
+                    )
             }
             _ => false,
         }
@@ -4929,6 +5088,22 @@ impl<'a, W: AsRef<[u64]>> YamlValue<'a, W> {
     }
 }
 
+// KNOWN LIMITATION (#224): the typed getters below (`is_null`, `as_bool`,
+// `as_i64`, `as_f64`, `type_name`) are not tag-aware, unlike every JSON
+// output path (`write_json_to`/`stream_json_value`) and the CLI's
+// `yaml_to_owned_value`. A bare `YamlValue` has no `bp_pos` to look an
+// explicit tag up with — only a `YamlCursor` does (`explicit_tag()`) — and
+// `crate::jq::eval_generic::to_owned`, the generic evaluator's lazy
+// materializer backing `select`, `==`, arithmetic, and `type` on the
+// cursor-evaluator path, calls these directly on a `DocumentValue` with no
+// cursor in scope. So `echo 'a: !!str 1' | succinctly yq '.a | type'` says
+// `"number"`, not `"string"` — while `succinctly yq '.'`'s JSON output for
+// the same input is correct. Fixing this needs either threading a cursor
+// through `to_owned`'s recursion (it can: `DocumentField::value_cursor` and
+// `DocumentElements::uncons_cursor` already exist) or embedding the tag in
+// `YamlValue::String` itself, which fans out to ~90 pattern-match sites
+// across 6 files. Scoped out of #224 as a follow-up rather than risking an
+// under-tested change to a evaluator shared with JSON this late.
 impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     type Cursor = YamlCursor<'a, W>;
     type Fields = YamlFields<'a, W>;

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -19,12 +19,17 @@
 //! - Comments (ignored in block context)
 //! - `%YAML` / `%TAG` directives — recognized and consumed; a directive's version/handle
 //!   is not surfaced (issue #225)
-//!
-//! # Not supported
-//!
-//! - Tags (`!!str`, `!custom`, verbatim `!<...>`) — rejected in block context, absorbed
-//!   as scalar text in flow context, including a shorthand tag defined by a `%TAG`
-//!   directive (issue #224)
+//! - Tags (`!!str`, `!custom`, verbatim `!<...>`) — resolved, matching `yq`: the 5
+//!   core-schema tags (`!!str`/`!!null`/`!!bool`/`!!int`/`!!float`) force scalar-type
+//!   coercion regardless of quoting style; any other tag (a custom tag,
+//!   `!!seq`/`!!map`/`!!set`/`!!omap`, a `%TAG`-shorthand tag, verbatim) does not change
+//!   resolution (issue #224). JSON output drops the tag either way, since JSON has no tag
+//!   syntax; YAML output re-emits it verbatim on the scalar or key it decorated (matching
+//!   `yq`), though a tag on a whole mapping/sequence (`!!seq [1, 2]`) is not yet preserved
+//!   on that path. The explicit source tag, if any, is available via
+//!   `YamlCursor::explicit_tag` — distinct from the pre-existing `YamlCursor::tag`, which
+//!   is an *inferred* type label derived from the resolved value's shape, not the
+//!   source text.
 //!
 //! # Validation
 //!
@@ -274,7 +279,7 @@ pub use light::{
     YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
-pub use scalar::{resolve_plain, ResolvedScalar};
+pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};
 
 #[cfg(test)]
 mod tests {

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -113,6 +113,8 @@ pub struct SemiIndex {
     pub anchors: BTreeMap<String, usize>,
     /// Alias references: BP position of alias → target BP position (resolved at parse time)
     pub aliases: BTreeMap<usize, usize>,
+    /// Explicit source tags: BP position → raw tag text (see [`YamlIndex::get_tag`](super::index::YamlIndex::get_tag))
+    pub tags: BTreeMap<usize, String>,
 }
 
 /// Maximum nesting depth for recursively-parsed constructs (flow collections
@@ -168,6 +170,8 @@ struct Parser<'a, const HAS_CR: bool> {
     anchors: BTreeMap<String, usize>,
     /// Aliases collected during parsing: bp_pos → target bp_pos (resolved at parse time)
     aliases: BTreeMap<usize, usize>,
+    /// Explicit source tags collected during parsing: bp_pos → raw tag text
+    tags: BTreeMap<usize, String>,
 
     // Document tracking
     /// Whether we're currently inside a document
@@ -249,6 +253,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             current_type: None,
             anchors: BTreeMap::new(),
             aliases: BTreeMap::new(),
+            tags: BTreeMap::new(),
             in_document: false,
             document_start_bp_pos: 0,
             pending_explicit_key: None,
@@ -901,20 +906,40 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         false
     }
 
-    /// Check whether an anchor at the current position prefixes a mapping entry
-    /// rather than the anchored node itself, as in `&a k: v`. In that shape the
-    /// anchor binds to the *key*, so the caller must leave it for the mapping
-    /// parser instead of consuming it (see `parse_mapping_entry`, which records
-    /// the key's own BP position).
+    /// Check whether the node property/properties (`&anchor`, `!tag`, or both,
+    /// in either order) at the current position prefix a mapping entry rather
+    /// than the node itself, as in `&a k: v` or `!!str k: v`. In that shape
+    /// the property binds to the *key*, so the caller must leave it for the
+    /// mapping parser instead of consuming it (see `parse_mapping_entry`,
+    /// which records the key's own BP position) — generalizes what was
+    /// `anchor_prefixes_mapping_entry` (anchor-only) before #224 gave tags
+    /// the same "prefixes a key" ambiguity anchors already had.
     ///
-    /// Assumes `self.peek() == Some(b'&')`. Restores `self.pos` before returning.
-    fn anchor_prefixes_mapping_entry(&mut self) -> bool {
+    /// Assumes `self.peek()` is `Some(b'&')` or `Some(b'!')`. Restores
+    /// `self.pos` before returning.
+    fn node_properties_prefix_mapping_entry(&mut self) -> bool {
         let saved_pos = self.pos;
-        // Skip `&` and the anchor name. Deliberately uses the scanner rather
-        // than `parse_anchor_name`, which errors on an empty name and would turn
-        // this speculative lookahead into a hard parse failure on `- & x: y`.
-        self.pos = super::simd::parse_anchor_name(self.input, self.pos + 1);
-        self.skip_inline_whitespace();
+        loop {
+            match self.peek() {
+                Some(b'&') => {
+                    // Skip `&` and the anchor name. Deliberately uses the
+                    // scanner rather than `parse_anchor_name`, which errors on
+                    // an empty name and would turn this speculative lookahead
+                    // into a hard parse failure on `- & x: y`.
+                    self.pos = super::simd::parse_anchor_name(self.input, self.pos + 1);
+                    self.skip_inline_whitespace();
+                }
+                Some(b'!') => {
+                    // Permissive twin of `parse_tag`, for the same reason:
+                    // a malformed tag must not turn this speculative
+                    // lookahead into a hard parse failure.
+                    let (end, _) = scan_tag_extent(self.input, self.pos);
+                    self.pos = end;
+                    self.skip_inline_whitespace();
+                }
+                _ => break,
+            }
+        }
         // `looks_like_mapping_entry` does not stop at `#`, so a trailing comment
         // containing `: ` would otherwise read as a mapping entry.
         let result = !self.at_line_end() && self.looks_like_mapping_entry();
@@ -958,33 +983,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 break;
             }
         }
-    }
-
-    /// Check for unsupported YAML features (Phase 4: anchors and aliases now supported).
-    fn check_unsupported(&self) -> Result<(), YamlError> {
-        if let Some(b) = self.peek() {
-            match b {
-                // Flow style is supported in Phase 2+
-                b'{' | b'[' => {
-                    // Allowed - will be parsed by parse_flow_*
-                }
-                // Block scalars are supported in Phase 3+
-                b'|' | b'>' => {
-                    // Allowed - will be parsed by parse_block_scalar()
-                }
-                // Anchors and aliases are supported in Phase 4+
-                b'&' | b'*' => {
-                    // Allowed - will be parsed by parse_anchor() or parse_alias()
-                }
-                // Explicit keys (`?`) are now supported
-                b'?' => {}
-                b'!' => {
-                    return Err(YamlError::TagNotSupported { offset: self.pos });
-                }
-                _ => {}
-            }
-        }
-        Ok(())
     }
 
     /// Check if we're at a document start marker (`---`).
@@ -1069,10 +1067,14 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // materialized. Calling `parse_block_scalar` directly keeps `--- |` on
         // the path it has always taken.
         //
-        // A tag is the other asymmetry, and deliberately left alone here:
-        // `check_unsupported` runs in `parse_document_line` but not on this
-        // path, so `--- !!str x` indexes as a scalar where a bare `!!str x` is
-        // rejected. That is #224's to settle, not this dispatch's.
+        // A tag is resolved the same way an anchor already is here: this
+        // dispatch has no arm of its own for either, so `--- !!str x` (like
+        // `--- &a x`) falls through to `parse_block_node(0)`, whose combined
+        // `&`/`!` arm consumes it before dispatching the value (#224). That
+        // also means a tag immediately before `|`/`>` on this line
+        // (`--- !!str |`) takes the same generic-scalar path an anchor in
+        // that position already does, rather than this function's dedicated
+        // block-scalar arm — parity with the anchor case, not a new gap.
         if matches!(self.peek(), Some(b'|' | b'>')) {
             return self.parse_block_scalar(0);
         }
@@ -1731,19 +1733,22 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.advance(); // -
         self.skip_inline_whitespace();
 
-        self.check_unsupported()?;
-
-        // An anchor prefixes the item's value, so consume it here — before the
-        // dispatch below, which would otherwise test its predicates against the
-        // `&name` instead of the value and mis-classify the item (#328).
+        // A node property (`&anchor` and/or `!tag`, either order) prefixes the
+        // item's value, so consume it here — before the dispatch below, which
+        // would otherwise test its predicates against the property text
+        // instead of the value and mis-classify the item (#328; tags follow
+        // the same rule, #224).
         //
-        // The exception is `- &a k: v`, where the anchor binds to the *key* of
-        // the compact mapping (matching yq); that shape is left for
-        // parse_compact_mapping_entry to record.
-        let anchored_item = self.peek() == Some(b'&') && !self.anchor_prefixes_mapping_entry();
-        if anchored_item {
-            self.parse_anchor()?;
-        }
+        // The exception is `- &a k: v` / `- !!str k: v`, where the property
+        // binds to the *key* of the compact mapping (matching yq); that shape
+        // is left for parse_compact_mapping_entry to record.
+        let prefixed_item = matches!(self.peek(), Some(b'&' | b'!'))
+            && !self.node_properties_prefix_mapping_entry();
+        let had_property = if prefixed_item {
+            self.parse_node_properties()?
+        } else {
+            false
+        };
 
         // Track the sequence item on the stack so close_deeper_indents can close it.
         // We use indent + 1 as a virtual indent - any content at indent > indent
@@ -1756,12 +1761,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Check what follows
         if self.at_line_end() {
-            // An anchor records the *next* BP position as its target, so an
-            // anchored item whose value turns out to be null needs an explicit
-            // empty node to point at — otherwise the anchor would land on a
-            // sibling's open, or on a close bit. parse_mapping_entry does the
-            // same for `key: &a` with no value.
-            if anchored_item && self.following_value_is_null(indent) {
+            // An anchor records the *next* BP position as its target, and a
+            // tag is looked up *at* that position (`self.tags`), so a
+            // property-prefixed item whose value turns out to be null needs
+            // an explicit empty node for either to resolve against —
+            // otherwise the anchor/tag would land on a sibling's open, on a
+            // close bit, or (for a tag) nowhere at all, silently dropping it
+            // (corpus case LE5A: `- !!str` with nothing after must resolve
+            // to `""`, not `null` — #224). parse_mapping_entry does the same
+            // for `key: &a` / `key: !!str` with no value.
+            if had_property && self.following_value_is_null(indent) {
                 self.set_ib();
                 self.write_bp_open();
                 self.write_bp_close();
@@ -1870,10 +1879,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Open key node
         self.write_bp_open();
 
-        // Check for anchor on key (`- &a k: v`) - record it pointing to this key
-        if self.peek() == Some(b'&') {
-            self.record_key_anchor()?;
-        }
+        // Check for a property on the key (`- &a k: v` / `- !!str k: v`) -
+        // record it pointing to this key.
+        self.record_key_properties()?;
 
         // Parse the key
         let key_end = match self.peek() {
@@ -1921,12 +1929,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // `  b: 1` was always right. This was the last one that did not.
         //
         // `- k: &a 1` also never registered the anchor before this, so a later
-        // `*a` resolved to nothing (#372).
+        // `*a` resolved to nothing (#372). Tags follow the same rule (#224).
         if !self.at_line_end() {
-            self.check_unsupported()?;
-            if self.peek() == Some(b'&') {
-                self.parse_anchor()?;
-            }
+            self.parse_node_properties()?;
         }
 
         // Parse value
@@ -1970,7 +1975,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // placeholder is conditional. `test_every_anchor_targets_an_open_bit`
             // is the whole-corpus guard on that.
         } else {
-            // Inline value (`check_unsupported` ran above)
+            // Inline value (`parse_node_properties` ran above)
             match self.peek() {
                 Some(b'*') => {
                     // `parse_alias` opens and closes its own node. `- k: *a` never
@@ -2048,10 +2053,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Open key node
         self.write_bp_open();
 
-        // Check for anchor on key - record it pointing to this key BP
-        if self.peek() == Some(b'&') {
-            self.record_key_anchor()?;
-        }
+        // Check for a property on the key - record it pointing to this key BP
+        self.record_key_properties()?;
 
         // Parse the key - check for empty key first (colon at start)
         let key_end = if self.peek() == Some(b':') {
@@ -2196,8 +2199,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     self.pos = saved_pos;
                     return Ok(());
                 }
-                Some(b'&' | b'*') => {
-                    // Anchor or alias on its own line - will be handled by main loop
+                Some(b'&' | b'*' | b'!') => {
+                    // Anchor, alias, or tag on its own line - will be handled
+                    // by main loop (parse_block_node, which calls
+                    // parse_node_properties). Without `!` here a tagged
+                    // deferred value fell to the `_` catch-all below and was
+                    // parsed inline instead, bypassing property consumption
+                    // (#224, #664 root cause 3).
                     self.pos = saved_pos;
                     return Ok(());
                 }
@@ -2234,14 +2242,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         }
 
         {
-            self.check_unsupported()?;
-
-            // Check for anchor first - it prefixes the actual value
-            let anchor_name = if self.peek() == Some(b'&') {
-                Some(self.parse_anchor()?)
-            } else {
-                None
-            };
+            // Consume any leading `&anchor` and/or `!tag` - they prefix the
+            // actual value.
+            self.parse_node_properties()?;
 
             // After anchor, check if value continues on next line
             if self.at_line_end() {
@@ -2351,9 +2354,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     self.write_bp_close();
                 }
             }
-
-            // Suppress unused warning for anchor_name
-            let _ = anchor_name;
         }
 
         Ok(())
@@ -2392,11 +2392,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Skip whitespace/comments after `?`
         self.skip_inline_whitespace();
 
-        // Check for anchor before key
-        if self.peek() == Some(b'&') {
-            let _ = self.parse_anchor()?;
-            self.skip_inline_whitespace();
-        }
+        // Check for a property before the key
+        self.parse_node_properties()?;
 
         // Check what the key is
         if self.at_line_end() {
@@ -2592,22 +2589,20 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Skip whitespace after `:`
         self.skip_inline_whitespace();
 
-        // Check for anchor
-        let anchored_value = self.peek() == Some(b'&');
-        if anchored_value {
-            let _ = self.parse_anchor()?;
-            self.skip_inline_whitespace();
-        }
+        // Check for a property (anchor and/or tag)
+        let had_property = self.parse_node_properties()?;
 
         // Check if value is on this line or next
         if self.at_line_end() {
-            // An anchor on a value that turns out to be null needs an explicit
-            // node to point at, or it dangles on whatever BP bit comes next -
-            // a close, or the open of an unrelated node. `? e` / `: &a` then
-            // `z: *a` resolved the alias to the *key* `z`, and inside a
-            // sequence the anchor landed on the alias's own open and tripped a
-            // spurious cycle rejection.
-            if anchored_value && self.following_value_is_null(indent) {
+            // A property on a value that turns out to be null needs an
+            // explicit node to resolve against, or it dangles on whatever BP
+            // bit comes next - a close, or the open of an unrelated node.
+            // `? e` / `: &a` then `z: *a` resolved the alias to the *key*
+            // `z`, and inside a sequence the anchor landed on the alias's
+            // own open and tripped a spurious cycle rejection. A tag with
+            // nothing after it (`? e` / `: !!str`) needs the same treatment
+            // so it resolves to `""` rather than being dropped (#224).
+            if had_property && self.following_value_is_null(indent) {
                 self.set_ib();
                 self.write_bp_open();
                 self.write_bp_close();
@@ -2695,13 +2690,11 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
     /// Parse a value (could be scalar or nested structure).
     fn parse_value(&mut self, min_indent: usize) -> Result<(), YamlError> {
-        self.check_unsupported()?;
-
-        // Check for anchor first - it prefixes the actual value
-        if self.peek() == Some(b'&') {
-            self.parse_anchor()?;
-            // Now parse the actual value that follows
-        }
+        // Check for a property first - it prefixes the actual value. Callers
+        // that already consumed one (e.g. parse_sequence_item_inner) leave
+        // nothing here, so this is a no-op re-check rather than a second
+        // consumption.
+        self.parse_node_properties()?;
 
         // Check for alias - this IS the value (no value follows)
         if self.peek() == Some(b'*') {
@@ -3152,12 +3145,11 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // keys. This is an implicit single-pair mapping: [ key : value ]
                 self.parse_implicit_flow_mapping_entry()?;
             } else {
-                // Not a key:value pair - an anchor or alias here prefixes a
-                // standalone value instead (`[&x a, *x]`), so it's consumed
-                // only now that the pair check has ruled that out.
-                if self.peek() == Some(b'&') {
-                    self.parse_anchor()?;
-                }
+                // Not a key:value pair - a property (anchor and/or tag) or an
+                // alias here prefixes a standalone value instead
+                // (`[&x a, *x]`, `[!!str a]`), so it's consumed only now that
+                // the pair check has ruled that out.
+                self.parse_flow_node_properties()?;
                 if self.peek() == Some(b'*') {
                     self.parse_alias()?;
                 } else {
@@ -3273,13 +3265,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.advance(); // Skip `:`
                 self.skip_flow_whitespace();
 
-                // Parse value - check for anchor or alias first
-                // Check for anchor prefix on value
-                let _anchor_name = if self.peek() == Some(b'&') {
-                    Some(self.parse_anchor()?)
-                } else {
-                    None
-                };
+                // Parse value - check for a property or alias first
+                // Check for a property prefix on the value
+                self.parse_flow_node_properties()?;
 
                 // Check for alias (standalone value)
                 if self.peek() == Some(b'*') {
@@ -3348,12 +3336,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// The caller must **not** record an end position in that case — see
     /// [`Self::set_bp_text_end`].
     fn parse_flow_key(&mut self) -> Result<bool, YamlError> {
-        // Check for anchor on key. The caller already opened the key's BP node,
-        // so this records `bp_pos - 1`; using `parse_anchor` here bound the
-        // anchor to the key's close bit, and aliases to it resolved to the
-        // *value* instead of the key (corpus case CN3R).
-        if self.peek() == Some(b'&') {
-            self.record_key_anchor()?;
+        // Check for a property (anchor and/or tag, either order) on the key.
+        // The caller already opened the key's BP node, so this records
+        // `bp_pos - 1`; using `parse_anchor` here bound the anchor to the
+        // key's close bit, and aliases to it resolved to the *value* instead
+        // of the key (corpus case CN3R). Tags follow the same convention
+        // (#224).
+        loop {
+            match self.peek() {
+                Some(b'&') => self.record_key_anchor()?,
+                Some(b'!') => self.record_key_tag()?,
+                _ => break,
+            }
             self.skip_flow_whitespace();
         }
 
@@ -3397,13 +3391,14 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Stops at `:`, `,`, `}`, `]`, or whitespace before those.
     /// Handles multiline keys (continues across newlines with proper indentation).
     fn parse_flow_unquoted_key(&mut self) -> Result<usize, YamlError> {
-        // #369: reject a tag at the start of a flow key. `parse_flow_key` is
-        // the only caller, from two call sites (the flow-mapping key and,
-        // since #409, the flow-sequence implicit-entry key); it dispatches
-        // anchors, aliases and nested containers first and lands here with
-        // `pos` at the key's first byte, so this one gate covers the whole
-        // plain-key path from both sites.
-        self.check_unsupported()?;
+        // #224 (was #369's reject-only gate): consume a tag at the start of a
+        // flow key. `parse_flow_key` is the only caller, from two call sites
+        // (the flow-mapping key and, since #409, the flow-sequence
+        // implicit-entry key); it already loops over `&`/`!` and lands here
+        // with `pos` at the key's first byte, so this is a no-op re-check in
+        // practice — kept so this function stays self-sufficient the way
+        // `parse_flow_scalar` and `parse_explicit_flow_unquoted_key` are.
+        self.record_flow_tag()?;
 
         let start = self.pos;
 
@@ -3500,13 +3495,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
     /// Parse a scalar value in flow context (string or unquoted).
     fn parse_flow_scalar(&mut self) -> Result<usize, YamlError> {
-        // #369: reject a tag at the start of a flow node, the way block context
-        // always has. Without this the `_` arm below reads `!!str x` as plain
-        // scalar *content*, silently yielding the string "!!str x". `pos` is at
-        // a node start here — anchors, aliases and nested containers are all
-        // dispatched by the caller before this point — so a leading `!` is an
-        // indicator, while a `!` inside content is never seen by this check.
-        self.check_unsupported()?;
+        // #224 (was #369's reject-only gate): consume a tag at the start of a
+        // flow node, the way block context does. Without this the `_` arm
+        // below reads `!!str x` as plain scalar *content*, yielding the
+        // string "!!str x" instead of resolving the tag. `pos` is at a node
+        // start here — anchors, aliases and nested containers are all
+        // dispatched by the caller before this point, though not on every
+        // path (some callers, like the flow-sequence `[k: v]` shorthand's
+        // value, don't strip an anchor first) — so this stays self-sufficient
+        // rather than assuming the caller always did it, the same reason
+        // `record_key_tag` exists alongside `parse_node_properties`. A `!`
+        // inside content is never seen by this check.
+        self.record_flow_tag()?;
 
         let end = match self.peek() {
             Some(b'"') => {
@@ -3608,9 +3608,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// #402; `test_yaml_flow_explicit_key_colon_before_a_flow_indicator_is_content` is
     /// the only guard, since FRK4 is a parses-only corpus case.
     fn parse_explicit_flow_unquoted_key(&mut self) -> Result<usize, YamlError> {
-        // #369: the `? key : value` form in flow context is a fourth way to
-        // reach a plain scalar at node start.
-        self.check_unsupported()?;
+        // #224 (was #369's reject-only gate): the `? key : value` form in flow
+        // context is a fourth way to reach a plain scalar at node start.
+        // `parse_explicit_flow_key_node` dispatches here with nothing
+        // stripped first (it has no anchor/tag handling of its own), so this
+        // is where a leading tag genuinely gets consumed for this form.
+        self.record_flow_tag()?;
 
         let start = self.pos;
 
@@ -4083,6 +4086,150 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         Ok(())
     }
 
+    // =========================================================================
+    // Tag parsing (#224)
+    // =========================================================================
+
+    /// Parse a tag (`!`, `!!suffix`, `!suffix`, `!handle!suffix`, or
+    /// `!<verbatim>`) at the current position, returning its raw text
+    /// (including the leading `!`/`!!`/`!<...>`).
+    ///
+    /// Does not record it anywhere or skip trailing whitespace — callers
+    /// combine this with anchor handling and decide the right `bp_pos`
+    /// convention (see [`Self::parse_node_properties`] and
+    /// [`Self::record_key_tag`]), the same split `parse_anchor_name` has from
+    /// `parse_anchor`/`record_key_anchor`.
+    fn parse_tag(&mut self) -> Result<String, YamlError> {
+        let start = self.pos;
+        let (end, ok) = scan_tag_extent(self.input, start);
+        if !ok {
+            return Err(YamlError::InvalidTag {
+                offset: start,
+                reason: "unterminated verbatim tag (missing closing '>')",
+            });
+        }
+        self.pos = end;
+        core::str::from_utf8(&self.input[start..end])
+            .map(str::to_string)
+            .map_err(|_| YamlError::InvalidUtf8 { offset: start })
+    }
+
+    /// Consume any combination of a leading `&anchor` and/or `!tag` before a
+    /// node not yet opened, in either order (YAML 1.2's node properties,
+    /// `c-ns-properties`), skipping whitespace after each. Anchors are
+    /// recorded via [`Self::parse_anchor`] as before; the tag, if present, is
+    /// recorded into `self.tags` at the current `self.bp_pos` — the position
+    /// the node that follows will occupy once opened, the same assumption
+    /// `parse_anchor` alone already made.
+    ///
+    /// Returns whether any property was present. Some callers need that to
+    /// synthesize an empty node for an otherwise-null value: an anchor
+    /// records the *next* BP position as its target, and a tag is looked up
+    /// *at* that position (`self.tags`), so either would otherwise land on a
+    /// sibling's open, on a close bit, or nowhere at all — silently dropping
+    /// a bare `!!str` with no value instead of resolving it to `""` (corpus
+    /// case LE5A, #224).
+    ///
+    /// Callers that have already opened the node (a mapping key) want
+    /// [`Self::record_key_properties`] instead.
+    fn parse_node_properties(&mut self) -> Result<bool, YamlError> {
+        let mut had_property = false;
+        loop {
+            match self.peek() {
+                Some(b'&') => {
+                    self.parse_anchor()?;
+                    had_property = true;
+                }
+                Some(b'!') => {
+                    let tag = self.parse_tag()?;
+                    self.tags.insert(self.bp_pos, tag);
+                    self.skip_inline_whitespace();
+                    had_property = true;
+                }
+                _ => break,
+            }
+        }
+        Ok(had_property)
+    }
+
+    /// Flow-context twin of [`Self::parse_node_properties`]: same loop and
+    /// `bp_pos` convention, but skips flow whitespace (which, unlike inline
+    /// whitespace, crosses line breaks) after each property instead of only
+    /// same-line whitespace.
+    ///
+    /// Without this, `k: !!seq\n  [a, b]` inside a flow mapping left `pos` on
+    /// the line break after the tag, so the `[`/`{` check the caller makes
+    /// next saw `\n` instead and fell to the scalar arm, absorbing the
+    /// literal `[a, b]` as unquoted text (corpus case EHF6). The same gap
+    /// already existed for a bare anchor in this position — `parse_anchor`'s
+    /// own internal skip is inline-only too — so this fixes both together
+    /// rather than leaving tags inconsistent with anchors.
+    fn parse_flow_node_properties(&mut self) -> Result<bool, YamlError> {
+        let mut had_property = false;
+        loop {
+            match self.peek() {
+                Some(b'&') => {
+                    self.parse_anchor()?;
+                    self.skip_flow_whitespace();
+                    had_property = true;
+                }
+                Some(b'!') => {
+                    let tag = self.parse_tag()?;
+                    self.tags.insert(self.bp_pos, tag);
+                    self.skip_flow_whitespace();
+                    had_property = true;
+                }
+                _ => break,
+            }
+        }
+        Ok(had_property)
+    }
+
+    /// Record a tag that prefixes a mapping key whose BP node is already
+    /// open, as in `!!str k: v`. Mirrors [`Self::record_key_anchor`]'s
+    /// `bp_pos - 1` convention: the key's open was already written, so the
+    /// tag names *that* position, not the position a fresh [`Self::parse_tag`]
+    /// caller (not yet opened) would use.
+    fn record_key_tag(&mut self) -> Result<(), YamlError> {
+        debug_assert_eq!(self.peek(), Some(b'!'));
+        let tag = self.parse_tag()?;
+        self.skip_inline_whitespace();
+        self.tags.insert(self.bp_pos - 1, tag);
+        Ok(())
+    }
+
+    /// Consume any combination of a leading `&anchor` and/or `!tag` prefixing
+    /// a mapping key whose BP node is already open, in either order — the
+    /// already-open twin of [`Self::parse_node_properties`], combining
+    /// [`Self::record_key_anchor`] and [`Self::record_key_tag`].
+    fn record_key_properties(&mut self) -> Result<(), YamlError> {
+        loop {
+            match self.peek() {
+                Some(b'&') => self.record_key_anchor()?,
+                Some(b'!') => self.record_key_tag()?,
+                _ => break,
+            }
+        }
+        Ok(())
+    }
+
+    /// Consume a leading `!tag` when the enclosing node's BP is already open
+    /// (`bp_pos - 1`), recording it and skipping flow whitespace after. The
+    /// flow-context, value-or-key-agnostic twin of [`Self::record_key_tag`],
+    /// shared by [`Self::parse_flow_unquoted_key`], [`Self::parse_flow_scalar`],
+    /// and [`Self::parse_explicit_flow_unquoted_key`] — each of those
+    /// independently re-checks at its own entry so property consumption never
+    /// leaves a stale check behind, the same reason `check_unsupported` used
+    /// to be called at all three (#369).
+    fn record_flow_tag(&mut self) -> Result<(), YamlError> {
+        if self.peek() == Some(b'!') {
+            let tag = self.parse_tag()?;
+            self.tags.insert(self.bp_pos - 1, tag);
+            self.skip_flow_whitespace();
+        }
+        Ok(())
+    }
+
     /// Main parsing loop.
     fn parse(&mut self) -> Result<SemiIndex, YamlError> {
         if self.input.is_empty() {
@@ -4149,6 +4296,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             ty_len: self.ty_pos,
             anchors: core::mem::take(&mut self.anchors),
             aliases: core::mem::take(&mut self.aliases),
+            tags: core::mem::take(&mut self.tags),
         })
     }
 
@@ -4266,8 +4414,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
     /// Parse a single line of document content.
     fn parse_document_line(&mut self) -> Result<(), YamlError> {
-        self.check_unsupported()?;
-
         // Count indentation - but handle tabs specially for flow structures
         let indent = match self.count_indent() {
             Ok(n) => n,
@@ -4381,36 +4527,43 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.close_deeper_indents(indent);
                 self.parse_value(indent)?;
             }
-            Some(b'&') => {
-                // Anchor - check if this is `&anchor key: value` (anchor on mapping key)
-                // In that case, let parse_mapping_entry handle the anchor so it points
-                // to the key, not the mapping container.
+            Some(b'&' | b'!') => {
+                // Anchor and/or tag (either order) - check if this is
+                // `&anchor key: value` / `!!str key: value` (property on a
+                // mapping key). In that case, let parse_mapping_entry handle
+                // it so it points to the key, not the mapping container.
+                //
+                // This is the shared block-context dispatcher — every "value
+                // deferred to the next line" case from parse_sequence_item,
+                // parse_mapping_entry, parse_compact_mapping_entry,
+                // parse_explicit_key, and parse_explicit_value eventually
+                // lands here, so fixing property consumption in this one arm
+                // closes most of #664's audit at once (#224).
                 self.close_deeper_indents(indent);
 
-                // Look ahead to see if this is `&anchor key:` pattern
-                if self.anchor_prefixes_mapping_entry() {
-                    // Let parse_mapping_entry handle the anchor
+                // Look ahead to see if this is a `key:` pattern
+                if self.node_properties_prefix_mapping_entry() {
+                    // Let parse_mapping_entry handle the property
                     self.parse_mapping_entry(indent)?;
                 } else {
-                    // Parse anchor here for non-mapping-key cases
-                    let _anchor_name = self.parse_anchor()?;
-                    // Skip any whitespace after anchor
-                    self.skip_inline_whitespace();
+                    // Consume any leading `&anchor` and/or `!tag`, in either
+                    // order, for non-mapping-key cases
+                    self.parse_node_properties()?;
                     // Check what follows
                     match self.peek() {
                         Some(b'\n' | b'\r') | None => {
-                            // Anchor with value on next line - will be parsed in next iteration
+                            // Property with value on next line - will be parsed in next iteration
                         }
                         // Keep this guard on one line: rustfmt splitting the
                         // `matches!` across lines gives the opening line its own
                         // coverage region that never reports as executed, even
                         // though the arm body does.
                         Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
-                            // Anchor before block sequence on same line
+                            // Property before block sequence on same line
                             self.parse_sequence_item(indent)?;
                         }
                         Some(b'{' | b'[') => {
-                            // Anchor before flow collection
+                            // Property before flow collection
                             self.parse_value(indent)?;
                         }
                         _ => {
@@ -4493,6 +4646,69 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         Ok(())
     }
+}
+
+/// Scan a tag's raw extent starting at a `!` in `bytes[start..]` (must be
+/// `b'!'`), returning `(end, ok)`.
+///
+/// `ok` is `false` only for a verbatim tag (`!<...>`) that never finds its
+/// closing `>` before whitespace, a line break, or end of input — every
+/// other shape (`!`, `!!suffix`, `!suffix`, `!handle!suffix`) always
+/// succeeds, since a short or empty suffix is still a valid (if unusual)
+/// tag. A bare `!` alone is the YAML 1.2 non-specific tag.
+///
+/// A suffix ends at whitespace, a line break, end of input, or a flow
+/// indicator (`,[]{}`) — excluded from `ns-tag-char` everywhere per YAML 1.2
+/// §5.5, not just inside flow collections, so this one scan serves both
+/// block and flow context.
+///
+/// A free function (not a `Parser` method) so `light.rs`'s decode-time value
+/// reader can share it too: a mapping key's BP node is opened *before* its
+/// property is consumed (`record_key_tag`'s `bp_pos - 1` convention), so the
+/// key's recorded text span still starts at the tag, exactly as it already
+/// does for anchors — `YamlCursor::value`'s `skip_anchor_and_whitespace`
+/// exists for the same reason and this is its tag counterpart.
+///
+/// Permissive by design: shared by the strict [`Parser::parse_tag`] (which
+/// turns `ok == false` into `InvalidTag`) and the speculative
+/// [`Parser::node_properties_prefix_mapping_entry`] lookahead, which cannot
+/// error mid-peek — the same reason `parse_anchor_name` has a permissive
+/// twin in [`simd::parse_anchor_name`].
+pub(crate) fn scan_tag_extent(bytes: &[u8], start: usize) -> (usize, bool) {
+    debug_assert_eq!(bytes.get(start), Some(&b'!'));
+    let mut i = start + 1;
+
+    if bytes.get(i) == Some(&b'<') {
+        i += 1;
+        loop {
+            match bytes.get(i) {
+                Some(b'>') => return (i + 1, true),
+                Some(b) if !matches!(b, b' ' | b'\t' | b'\n' | b'\r') => i += 1,
+                _ => return (i, false), // whitespace/break/EOF before `>`
+            }
+        }
+    }
+
+    if bytes.get(i) == Some(&b'!') {
+        i += 1; // secondary handle `!!`
+    } else {
+        let word_start = i;
+        while matches!(bytes.get(i), Some(b) if b.is_ascii_alphanumeric() || *b == b'-') {
+            i += 1;
+        }
+        if i > word_start && bytes.get(i) == Some(&b'!') {
+            i += 1; // named handle `!handle!`
+        }
+    }
+
+    while matches!(
+        bytes.get(i),
+        Some(b) if !matches!(b, b' ' | b'\t' | b'\n' | b'\r' | b',' | b'[' | b']' | b'{' | b'}')
+    ) {
+        i += 1;
+    }
+
+    (i, true)
 }
 
 /// Build a semi-index from YAML input.

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -5756,4 +5756,145 @@ mod tests {
             }
         }
     }
+
+    /// A verbatim tag (`!<...>`) that hits whitespace before its closing `>`
+    /// is malformed - `scan_tag_extent` bails out at the space rather than
+    /// treating it as part of the tag, and `parse_tag` turns that into
+    /// `InvalidTag`.
+    #[test]
+    fn verbatim_tag_unterminated_before_whitespace_is_invalid_tag() {
+        let err = build_semi_index(b"a: !<foo bar\n").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                YamlError::InvalidTag {
+                    offset: 3,
+                    reason: "unterminated verbatim tag (missing closing '>')",
+                }
+            ),
+            "expected InvalidTag at offset 3, got {err:?}"
+        );
+    }
+
+    /// Same malformed-verbatim-tag case, but the input ends before the
+    /// closing `>` is ever found - `scan_tag_extent`'s scan loop must reject
+    /// end-of-input the same way it rejects whitespace, not run off the end
+    /// of the buffer.
+    #[test]
+    fn verbatim_tag_unterminated_at_eof_is_invalid_tag() {
+        let err = build_semi_index(b"a: !<foo").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                YamlError::InvalidTag {
+                    offset: 3,
+                    reason: "unterminated verbatim tag (missing closing '>')",
+                }
+            ),
+            "expected InvalidTag at offset 3, got {err:?}"
+        );
+    }
+
+    /// A multi-line plain scalar must stop folding when the next line is a
+    /// lone `: ` (explicit-key value indicator), rather than swallowing it as
+    /// scalar content - the guard in
+    /// `parse_unquoted_value_with_indent_impl` that checks
+    /// `next_char == b':' && is_ws_break_or_eoi(..)` alongside
+    /// `indent_allows_continuation`.
+    ///
+    /// The extra indentation on both lines matters for actually exercising
+    /// that guard: `indent_allows_continuation` only becomes `true` (and the
+    /// `&&`-chain only reaches the colon check) when the next line is
+    /// indented *past* the key's `start_indent` (here, past the mapping's
+    /// indent of 0) - a bare `"? a\n: 1\n"` never reaches the check at all,
+    /// since `next_indent (0) > start_indent (0)` is already false and the
+    /// rest of the condition short-circuits. `"  : 1"` is still less
+    /// indented than the key `a` itself (column 4), matching the YAML-1.2
+    /// corpus shape (id `35KP`, "Tags for Root Objects") that used to
+    /// exercise this before this PR's tag-support change routed that corpus
+    /// case through a different path (#224).
+    #[test]
+    fn multiline_plain_scalar_stops_before_explicit_value_indicator() {
+        let yaml: &[u8] = b"?   a\n  : 1\n";
+        let index = crate::yaml::YamlIndex::build(yaml).unwrap();
+        let cursor = index.root(yaml);
+        assert_eq!(
+            cursor.to_json(),
+            r#"[{"a":1}]"#,
+            "explicit key 'a' must map to 1, not swallow the ': 1' line into the key scalar"
+        );
+    }
+
+    /// `parse_value`'s `Some(b'-') if is_ws_break_or_eoi(..)` arm — an
+    /// inline-sequence-item fallback for a `-` that reaches `parse_value`
+    /// itself rather than being intercepted by a caller's own copy of the
+    /// same check — is still reachable after this PR replaced single
+    /// `parse_anchor()` calls with looping `parse_node_properties()` calls in
+    /// both `parse_value` and `parse_sequence_item_inner`.
+    ///
+    /// That refactor *does* make the arm dead for the scenario the arm's own
+    /// comment names (`- &a &b - x`, a sequence item): `parse_sequence_item_inner`
+    /// now consumes *both* leading anchors in one loop and its own `Some(b'-')`
+    /// check (just above the property loop's result) catches the inner dash
+    /// directly, never delegating to `parse_value` at all - confirmed by
+    /// coverage (`- &a &b - x\n` alone does not hit this arm).
+    ///
+    /// It stays reachable through a different caller: `parse_explicit_key`'s
+    /// "sequence as key" arm (`? - ...`) skips only the *first* `-` and then
+    /// calls `parse_value` unconditionally for whatever follows, with no
+    /// dash-precheck of its own (unlike `parse_sequence_item_inner` and
+    /// `parse_mapping_entry`). A second `-` there - anchored or not - lands
+    /// on this exact arm. Confirmed via `cargo llvm-cov`: this input hits
+    /// parser.rs:2741-2742, `"- &a &b - x\n"` alone does not.
+    #[test]
+    fn explicit_key_double_anchored_nested_dash_reaches_parse_value_dash_arm() {
+        let yaml: &[u8] = b"? - &a &b - x\n: v\n";
+        let index = crate::yaml::YamlIndex::build(yaml).expect("should parse");
+        let root = index.root(yaml);
+        let doc0 = match root.value() {
+            crate::yaml::YamlValue::Sequence(mut docs) => docs.next().expect("one document"),
+            other => panic!("expected root sequence, got {other:?}"),
+        };
+        let fields = match doc0 {
+            crate::yaml::YamlValue::Mapping(fields) => fields,
+            other => panic!("expected mapping, got {other:?}"),
+        };
+        let (field, rest) = fields.uncons().expect("mapping has one field");
+        assert!(rest.is_empty(), "mapping must have exactly one field");
+
+        // Key: a sequence (from `? - ...`) whose single element is itself a
+        // sequence (the nested `- x`, opened by this PR's arm) containing "x".
+        match field.key() {
+            crate::yaml::YamlValue::Sequence(mut outer) => {
+                let inner = outer.next().expect("outer sequence has one element");
+                assert!(
+                    outer.next().is_none(),
+                    "outer sequence has only one element"
+                );
+                match inner {
+                    crate::yaml::YamlValue::Sequence(mut inner_seq) => {
+                        let x = inner_seq.next().expect("inner sequence has one element");
+                        assert!(
+                            inner_seq.next().is_none(),
+                            "inner sequence has only one element"
+                        );
+                        match x {
+                            crate::yaml::YamlValue::String(s) => {
+                                assert_eq!(s.as_str().unwrap(), "x");
+                            }
+                            other => panic!("expected string 'x', got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected nested sequence key, got {other:?}"),
+                }
+            }
+            other => panic!("expected sequence key, got {other:?}"),
+        }
+
+        // Value: the explicit value `v` on the following line.
+        match field.value_cursor().value() {
+            crate::yaml::YamlValue::String(s) => assert_eq!(s.as_str().unwrap(), "v"),
+            other => panic!("expected string 'v' value, got {other:?}"),
+        }
+    }
 }

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -202,6 +202,61 @@ fn parse_float(s: &str) -> ResolvedScalar {
     }
 }
 
+/// Force-resolves a scalar's value under an explicit YAML tag.
+///
+/// Handles the 5 core-schema tags (`!!str`, `!!null`, `!!bool`, `!!int`,
+/// `!!float`), matching real `yq`'s behavior of applying tag coercion
+/// *regardless of quoting style* — even a quoted `!!int "5"` becomes the
+/// number `5`, not the string `"5"`. Returns `None` for any other tag (a
+/// custom tag, `!!seq`, `!!map`, `!!set`, `!!omap`, verbatim, or no tag at
+/// all), meaning "no override — resolve naturally instead" (`resolve_plain`
+/// for a plain scalar, `Str` for quoted/block).
+///
+/// Divergence from `yq`: content that cannot be coerced to the forced numeric
+/// type (`!!int "abc"`, `!!int -0x2A`) resolves to [`Str`](ResolvedScalar::Str)
+/// here rather than reproducing `yq`'s behavior for that input, which is to
+/// accept it at parse time and then crash formatting JSON output
+/// (`strconv.ParseInt: parsing "abc": invalid syntax`). This loader is
+/// non-validating by design and absorbs what it cannot make sense of rather
+/// than erroring — see `docs/compliance/yaml/limitations.md`.
+///
+/// `!!int`/`!!float` reuse [`resolve_plain`]'s core-schema numeric grammar
+/// (so `!!int 0x2A` is `42`, matching `yq`) rather than a bare
+/// `str::parse`, and `!!float` additionally accepts int-shaped text
+/// (`!!float 5` is `5.0`, matching `yq`) by widening a resolved `Int` —
+/// including a hex/octal one (`!!float 0x2A` is `42.0`), where real `yq`
+/// instead crashes: its float parser, unlike its int parser, does not
+/// understand the `0x`/`0o` prefix.
+///
+/// `!!bool` matches the classic YAML 1.1 word list
+/// (`y`/`yes`/`true`/`on`, and their `n`/`no`/`false`/`off` negatives)
+/// case-insensitively, which is *broader* than `resolve_plain`'s core
+/// schema `true`/`True`/`TRUE`/`false`/`False`/`FALSE` — an explicit `!!bool`
+/// tag opts back into the legacy spellings the core schema otherwise
+/// excludes to avoid the Norway problem. Anything else (`t`, `1`, `xyz`, …)
+/// resolves to `false`, matching `yq`'s zero-value fallback.
+#[must_use]
+pub fn resolve_tagged(text: &str, tag: &str) -> Option<ResolvedScalar> {
+    match tag {
+        "!!str" => Some(ResolvedScalar::Str),
+        "!!null" => Some(ResolvedScalar::Null),
+        "!!bool" => Some(ResolvedScalar::Bool(matches!(
+            text.to_ascii_lowercase().as_str(),
+            "y" | "yes" | "true" | "on"
+        ))),
+        "!!int" => Some(match resolve_plain(text) {
+            ResolvedScalar::Int(n) => ResolvedScalar::Int(n),
+            _ => ResolvedScalar::Str,
+        }),
+        "!!float" => Some(match resolve_plain(text) {
+            ResolvedScalar::Float(f) => ResolvedScalar::Float(f),
+            ResolvedScalar::Int(n) => ResolvedScalar::Float(n as f64),
+            _ => ResolvedScalar::Str,
+        }),
+        _ => None,
+    }
+}
+
 /// Returns true if a plain scalar could resolve to null or bool at all.
 ///
 /// A cheap pre-filter for callers that only need the null/bool answer
@@ -370,5 +425,100 @@ mod tests {
         assert_eq!(Int(1).type_name(), "number");
         assert_eq!(Float(1.0).type_name(), "number");
         assert_eq!(Str.type_name(), "string");
+    }
+
+    // Every case below was checked against real `yq` v4.53.3
+    // (`echo 'a: !!TAG CONTENT' | yq -o=json -`) while writing `resolve_tagged`.
+
+    #[test]
+    fn tagged_str_forces_string_regardless_of_content() {
+        assert_eq!(resolve_tagged("1", "!!str"), Some(Str));
+        assert_eq!(resolve_tagged("true", "!!str"), Some(Str));
+        assert_eq!(resolve_tagged("null", "!!str"), Some(Str));
+        assert_eq!(resolve_tagged("", "!!str"), Some(Str));
+    }
+
+    #[test]
+    fn tagged_null_forces_null_regardless_of_content() {
+        assert_eq!(resolve_tagged("foo", "!!null"), Some(Null));
+        assert_eq!(resolve_tagged("", "!!null"), Some(Null));
+        assert_eq!(resolve_tagged("~", "!!null"), Some(Null));
+    }
+
+    #[test]
+    fn tagged_bool_accepts_the_yaml_11_word_list_case_insensitively() {
+        for s in [
+            "y", "Y", "yes", "Yes", "YES", "true", "True", "TrUe", "on", "On", "ON",
+        ] {
+            assert_eq!(
+                resolve_tagged(s, "!!bool"),
+                Some(Bool(true)),
+                "input: {s:?}"
+            );
+        }
+        for s in [
+            "n",
+            "no",
+            "No",
+            "NO",
+            "false",
+            "False",
+            "off",
+            "Off",
+            "OFF",
+            "t",
+            "T",
+            "1",
+            "0",
+            "randomjunk",
+            "",
+        ] {
+            assert_eq!(
+                resolve_tagged(s, "!!bool"),
+                Some(Bool(false)),
+                "input: {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tagged_int_reuses_core_schema_numeric_grammar() {
+        assert_eq!(resolve_tagged("5", "!!int"), Some(Int(5)));
+        assert_eq!(resolve_tagged("-5", "!!int"), Some(Int(-5)));
+        assert_eq!(resolve_tagged("0x2A", "!!int"), Some(Int(42)));
+        // Content that doesn't parse as an int falls back to Str rather than
+        // reproducing yq's marshal-time crash for this input.
+        assert_eq!(resolve_tagged("abc", "!!int"), Some(Str));
+        assert_eq!(resolve_tagged("3.5", "!!int"), Some(Str));
+        assert_eq!(resolve_tagged("", "!!int"), Some(Str));
+        assert_eq!(resolve_tagged("-0x2A", "!!int"), Some(Str));
+    }
+
+    #[test]
+    fn tagged_float_widens_int_shaped_text_and_falls_back_on_failure() {
+        assert_eq!(resolve_tagged("3", "!!float"), Some(Float(3.0)));
+        assert_eq!(resolve_tagged("3.5", "!!float"), Some(Float(3.5)));
+        assert_eq!(resolve_tagged("abc", "!!float"), Some(Str));
+        // Widening reuses resolve_plain's Int arm uniformly, so a hex int
+        // widens too - real `yq`'s plain float parser cannot read "0x2A" and
+        // crashes formatting output for it, one of the divergences this
+        // function's doc comment calls out.
+        assert_eq!(resolve_tagged("0x2A", "!!float"), Some(Float(42.0)));
+    }
+
+    #[test]
+    fn untagged_and_non_core_schema_tags_return_none() {
+        // No override for a custom tag, a collection tag, or no tag at all -
+        // the caller falls back to natural resolution.
+        for tag in [
+            "!custom",
+            "!!set",
+            "!!omap",
+            "!!map",
+            "!!seq",
+            "!<tag:x,2000:y>",
+        ] {
+            assert_eq!(resolve_tagged("1", tag), None, "tag: {tag}");
+        }
     }
 }

--- a/src/yaml/simd/broadword.rs
+++ b/src/yaml/simd/broadword.rs
@@ -64,6 +64,31 @@ const fn extract_mask_u64(x: u64) -> u8 {
     ((x >> 7).wrapping_mul(MAGIC) >> 56) as u8
 }
 
+/// Find bytes equal to `target` in `chunk`, returning an exact per-byte
+/// mask (bit `i` set iff byte `i` equals `target`).
+///
+/// `has_zero_byte`'s subtraction trick never misses a real match, but it can
+/// report a false positive in the byte immediately following one: the borrow
+/// chain from a genuine zero byte ripples into the next byte and sets its
+/// high bit too, whenever that next byte's XOR distance from `target` is
+/// exactly 1 (e.g. two spaces then `!`, since `'!' ^ ' ' == 0x01`). Real
+/// match runs are the uncommon case, so re-checking only the candidate bits
+/// against the source bytes is cheap and makes the mask exact.
+#[inline(always)]
+fn find_byte_mask(chunk: u64, target: u8) -> u8 {
+    let candidate = extract_mask_u64(find_byte(chunk, target));
+    let mut verified = candidate;
+    let mut bits = candidate;
+    while bits != 0 {
+        let i = bits.trailing_zeros();
+        if ((chunk >> (8 * i)) & 0xFF) as u8 != target {
+            verified &= !(1 << i);
+        }
+        bits &= bits - 1;
+    }
+    verified
+}
+
 /// YAML character classification result using broadword operations.
 /// Each field is a u8 bitmask for 8 bytes (one bit per byte position).
 #[derive(Debug, Clone, Copy, Default)]
@@ -126,27 +151,16 @@ pub fn classify_yaml_chars_broadword(
     // Load 8 bytes as a u64
     let chunk = u64::from_le_bytes(input[offset..offset + 8].try_into().unwrap());
 
-    // Find each character type using broadword operations
-    let newlines = find_byte(chunk, b'\n');
-    let carriage_returns = find_byte(chunk, b'\r');
-    let colons = find_byte(chunk, b':');
-    let hyphens = find_byte(chunk, b'-');
-    let spaces = find_byte(chunk, b' ');
-    let quotes_double = find_byte(chunk, b'"');
-    let quotes_single = find_byte(chunk, b'\'');
-    let backslashes = find_byte(chunk, b'\\');
-    let hash = find_byte(chunk, b'#');
-
     Some(YamlCharClassBroadword {
-        newlines: extract_mask_u64(newlines),
-        carriage_returns: extract_mask_u64(carriage_returns),
-        colons: extract_mask_u64(colons),
-        hyphens: extract_mask_u64(hyphens),
-        spaces: extract_mask_u64(spaces),
-        quotes_double: extract_mask_u64(quotes_double),
-        quotes_single: extract_mask_u64(quotes_single),
-        backslashes: extract_mask_u64(backslashes),
-        hash: extract_mask_u64(hash),
+        newlines: find_byte_mask(chunk, b'\n'),
+        carriage_returns: find_byte_mask(chunk, b'\r'),
+        colons: find_byte_mask(chunk, b':'),
+        hyphens: find_byte_mask(chunk, b'-'),
+        spaces: find_byte_mask(chunk, b' '),
+        quotes_double: find_byte_mask(chunk, b'"'),
+        quotes_single: find_byte_mask(chunk, b'\''),
+        backslashes: find_byte_mask(chunk, b'\\'),
+        hash: find_byte_mask(chunk, b'#'),
     })
 }
 
@@ -205,8 +219,8 @@ pub fn classify_yaml_chars_16(input: &[u8], offset: usize) -> Option<YamlCharCla
     // Process both chunks for each character type
     #[inline(always)]
     fn classify_both(c0: u64, c1: u64, target: u8) -> u16 {
-        let m0 = extract_mask_u64(find_byte(c0, target)) as u16;
-        let m1 = extract_mask_u64(find_byte(c1, target)) as u16;
+        let m0 = find_byte_mask(c0, target) as u16;
+        let m1 = find_byte_mask(c1, target) as u16;
         m0 | (m1 << 8)
     }
 
@@ -240,13 +254,13 @@ pub fn find_quote_or_escape_broadword(input: &[u8], start: usize, end: usize) ->
     // Process 8 bytes at a time
     while offset + 8 <= len {
         let chunk = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
-        let quotes = find_byte(chunk, b'"');
-        let backslashes = find_byte(chunk, b'\\');
+        let quotes = find_byte_mask(chunk, b'"');
+        let backslashes = find_byte_mask(chunk, b'\\');
         let matches = quotes | backslashes;
 
         if matches != 0 {
             // Found a match - return position of first match
-            return Some(offset + (matches.trailing_zeros() / 8) as usize);
+            return Some(offset + matches.trailing_zeros() as usize);
         }
 
         offset += 8;
@@ -276,10 +290,10 @@ pub fn find_single_quote_broadword(input: &[u8], start: usize, end: usize) -> Op
     // Process 8 bytes at a time
     while offset + 8 <= len {
         let chunk = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
-        let matches = find_byte(chunk, b'\'');
+        let matches = find_byte_mask(chunk, b'\'');
 
         if matches != 0 {
-            return Some(offset + (matches.trailing_zeros() / 8) as usize);
+            return Some(offset + matches.trailing_zeros() as usize);
         }
 
         offset += 8;
@@ -310,17 +324,13 @@ pub fn count_leading_spaces_broadword(input: &[u8], start: usize) -> usize {
     while offset + 8 <= len {
         let chunk = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
 
-        // `find_byte` sets the high bit of every byte that IS a space, so all
-        // eight being spaces means exactly `HI_BYTES`.
-        let space_matches = find_byte(chunk, b' ');
-        if space_matches != HI_BYTES {
-            // Found a non-space - count spaces up to it
-            // Invert the mask: spaces have high bit set, non-spaces don't
-            // We want to find the first non-space
-            let non_space_mask = !space_matches & HI_BYTES;
-            if non_space_mask != 0 {
-                return offset + (non_space_mask.trailing_zeros() / 8) as usize;
-            }
+        // `find_byte_mask` sets bit `i` iff byte `i` is a space, so all eight
+        // being spaces means exactly `0xFF`.
+        let space_mask = find_byte_mask(chunk, b' ');
+        if space_mask != 0xFF {
+            // Found a non-space - count spaces up to it.
+            let non_space_mask = !space_mask;
+            return offset + non_space_mask.trailing_zeros() as usize;
         }
 
         offset += 8;
@@ -342,10 +352,10 @@ pub fn find_newline_broadword(input: &[u8], start: usize) -> Option<usize> {
     // Process 8 bytes at a time
     while offset + 8 <= len {
         let chunk = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
-        let matches = find_byte(chunk, b'\n');
+        let matches = find_byte_mask(chunk, b'\n');
 
         if matches != 0 {
-            return Some(offset + (matches.trailing_zeros() / 8) as usize);
+            return Some(offset + matches.trailing_zeros() as usize);
         }
 
         offset += 8;
@@ -369,6 +379,53 @@ mod tests {
         let colon_mask = find_byte(chunk, b':');
         assert_ne!(colon_mask, 0);
         assert_eq!(colon_mask.trailing_zeros() / 8, 5);
+    }
+
+    /// `has_zero_byte`'s subtraction trick can produce a false-positive
+    /// candidate bit in the byte immediately after a genuine match, whenever
+    /// that byte's XOR distance from the target is exactly 1 (e.g. a space
+    /// then `!`, since `'!' ^ ' ' == 0x01`) -- the borrow chain from the real
+    /// match ripples forward and flips the next byte's high bit too. This
+    /// mismatch fed straight into `count_leading_spaces_broadword`, which
+    /// under-detected the indentation-ending byte and corrupted YAML tag
+    /// parsing (yaml-test-suite cases BU8L / HMQ5 / 7FWL) under the
+    /// `broadword-yaml` feature. `find_byte_mask` re-verifies candidate bits
+    /// against the source bytes to correct this; this test checks it against
+    /// a plain byte-by-byte scan for every rotation of the adjacency.
+    #[test]
+    fn find_byte_mask_matches_scalar_reference_for_adjacent_matches() {
+        fn scalar_mask(bytes: &[u8; 8], target: u8) -> u8 {
+            let mut mask = 0u8;
+            for (i, &b) in bytes.iter().enumerate() {
+                if b == target {
+                    mask |= 1 << i;
+                }
+            }
+            mask
+        }
+
+        let cases: &[(&[u8; 8], u8)] = &[
+            (b"  !!!!!!", b' '),
+            (b" !!!!!!!", b' '),
+            (b"!!!!!!! ", b' '),
+            (b"!  !!!!!", b' '),
+            (b"!!!!!!!!", b' '),
+            (b"        ", b' '),
+            (b"a!bcdefg", b' '),
+        ];
+
+        for (bytes, target) in cases {
+            let chunk = u64::from_le_bytes(**bytes);
+            let expected = scalar_mask(bytes, *target);
+            let actual = find_byte_mask(chunk, *target);
+            assert_eq!(
+                actual,
+                expected,
+                "mismatch for {:?} target {:?}: got {actual:08b}, want {expected:08b}",
+                core::str::from_utf8(*bytes),
+                *target as char,
+            );
+        }
     }
 
     #[test]
@@ -459,6 +516,19 @@ mod tests {
         let mut input = vec![b' '; 50];
         input.extend_from_slice(b"content");
         assert_eq!(count_leading_spaces_broadword(&input, 0), 50);
+    }
+
+    /// Regression test: a tag marker (`!`) right after leading spaces used to
+    /// get swallowed as if it were more indentation, because `find_byte`'s
+    /// false-positive on the byte after a match (see
+    /// `find_byte_mask_matches_scalar_reference_for_adjacent_matches`) made
+    /// `count_leading_spaces_broadword` overcount. This mirrors the
+    /// yaml-test-suite BU8L/HMQ5 failures, which lost the `!` entirely under
+    /// the `broadword-yaml` feature.
+    #[test]
+    fn test_broadword_count_leading_spaces_stops_at_tag_marker() {
+        assert_eq!(count_leading_spaces_broadword(b"  !!bar baz", 0), 2);
+        assert_eq!(count_leading_spaces_broadword(b" !!str bar", 0), 1);
     }
 
     #[test]

--- a/tests/data/bench-corpus/NOTICES.md
+++ b/tests/data/bench-corpus/NOTICES.md
@@ -80,5 +80,7 @@ Either way, regenerate both reports afterwards — the commands are in
 Test-parse any candidate before committing it (`succinctly yq -o json '.' <file>`).
 `ingest_yaml` turns a parse failure into an error that aborts the whole report, and
 plausible-looking sources do fail: the densest bare-dash file found during the #326
-search was an AWS CloudFormation template, which is unusable here because its
-`!Ref`/`!GetAtt` shorthand tags hit `YamlError::TagNotSupported`.
+search was an AWS CloudFormation template, excluded at the time because its
+`!Ref`/`!GetAtt` shorthand tags hit `YamlError::TagNotSupported`. Tags resolve instead
+of erroring as of #224, so that specific reason no longer applies — re-test-parse before
+assuming the file is a viable candidate now, since it was never otherwise vetted.

--- a/tests/data/yaml-test-suite-known-failures.txt
+++ b/tests/data/yaml-test-suite-known-failures.txt
@@ -10,7 +10,10 @@
 #
 # Categories
 # ----------
-#   tags        !!str / !custom / verbatim tags are not supported at all. -> #224
+#   tags        Tag *support* landed in #224. One case remains: S4JQ, where the
+#               spec and `yq` disagree on what a bare `!` (non-specific tag)
+#               resolves to and we follow `yq` (same policy as FRK4/JEF9/02
+#               below) — not an absent feature.
 #   lax:*       Invalid input that indexing accepts because it does not validate.
 #               This is a property of the default mode, not a defect: succinctly
 #               is a non-validating loader. Rejecting these is the job of the
@@ -19,78 +22,53 @@
 #               must-fail case as handled if the loader OR that validator rejects
 #               it, so the `lax:*` entries that remain here are the cases the
 #               validator does not yet reject (deeper structural analysis). -> #223
+#               `lax:tags` (LHL4, U99R) is the tag-specific slice of this: a
+#               malformed tag (disallowed characters, a `%TAG`-mid-stream
+#               placement) is absorbed rather than rejected, the same as every
+#               other `lax:*` construct — #224 implemented tag *resolution*,
+#               not tag *validation*, matching the rest of this loader.
 #   scalars     Scalar content or block-scalar folding differs from the spec.
 #               Not yet individually triaged.
 #   structure   Document or block structure differs from the spec. Not yet
 #               individually triaged.
 
-2AUY      tags              tags (!) not supported — #224
 2CMS      lax:mapping       mapping/key rules not validated — #223
 2SXE      structure         document/block structure differs from spec
-2XXW      tags              tag shorthand emitted as scalar text — #224
-33X3      tags              tags (!) not supported — #224
-35KP      tags              tags (!) not supported — #224
 4JVG      lax:anchors       anchor/alias rules not validated — #223
-52DL      tags              tags (!) not supported — #224
-565N      tags              tags (!) not supported — #224
-57H4      tags              tags (!) not supported — #224
 5LLU      lax:indentation   indentation not validated — #223
-5TYM      tags              tags (!) not supported — #224
-6CK3      tags              tags (!) not supported — #224
-6JWB      tags              tags (!) not supported — #224
-6WLZ      tags              tags (!) not supported — #224
-735Y      tags              tags (!) not supported — #224
-74H7      tags              tags (!) not supported — #224
-7FWL      tags              tags (!) not supported — #224
-8MK2      tags              tags (!) not supported — #224
 8XDJ      lax:comments      comment placement not validated — #223
 9C9N      lax:indentation   indentation not validated — #223
-9KAX      tags              tags (!) not supported — #224
+9HCY      lax:documents     mid-stream `%TAG` directive (no `...` footer before it) absorbed as scalar text rather than rejected — #223 (surfaced by #224: previously masked by tags erroring at column 0 before the directive was ever reached)
 9KBC      lax:mapping       mapping/key rules not validated — #223
-9WXW      tags              tags (!) not supported — #224
 AVM7      scalars           scalar content/folding differs from spec
 BF9H      lax:comments      comment placement not validated — #223
-BU8L      tags              tag shorthand emitted as scalar text — #224
 C2SP      lax:flow          flow syntax not validated — #223
-C4HZ      tags              tags (!) not supported — #224
-CC74      tags              tags (!) not supported — #224
-CUP7      tags              tags (!) not supported — #224
 CXX2      lax:anchors       anchor/alias rules not validated — #223
 DK3J      scalars           scalar content/folding differs from spec
 DK4H      lax:mapping       mapping/key rules not validated — #223
-EHF6      tags              tags (!) not supported — #224
 EW3V      lax:mapping       mapping/key rules not validated — #223
-F2C7      tags              tags (!) not supported — #224
-FH7J      tags              tags (!) not supported — #224
 FP8R      scalars           scalar content/folding differs from spec
 G9HC      lax:indentation   indentation not validated — #223
 GT5M      lax:anchors       anchor/alias rules not validated — #223
-HMQ5      tags              tags (!) not supported — #224
+H7J7      lax:anchors       anchored key's value on the next line, unindented relative to the key (`key: &x` / `!!map` at the same column) — read as null per indentation, but the tag's own deferred mapping content is then dropped rather than rejected — #223 (surfaced by #224 the same way as 9HCY)
 HU3P      lax:mapping       mapping/key rules not validated — #223
-J7PZ      tags              tag shorthand emitted as scalar text — #224
 JEF9/02   scalars           blank final line with no break — follows yq, which gives "" — #344
 KS4U      lax:flow          flow syntax not validated — #223
 L24T/00   scalars           scalar content/folding differs from spec
-L94M      tags              tag shorthand emitted as scalar text — #224
-LE5A      tags              tags (!) not supported — #224
+LHL4      lax:tags          tag containing a disallowed flow indicator (`!invalid{}tag`) absorbed as text/flow-mapping rather than rejected — #224
 M5C3      scalars           scalar content/folding differs from spec
 M7A3      structure         bare document / `...` end-marker mis-parsed (both paths agree)
 MUS6/01   lax:documents     directive/document rules not validated — #223
-P76L      tags              tags (!) not supported — #224
 QLJ7      lax:documents     directive/document rules not validated — #223
-S4JQ      tags              tags (!) not supported — #224
+S4JQ      tags              non-specific tag (`!` alone) resolution: spec's "conventional resolution" forces `!!str`, but real yq v4.53.3 leaves the content's natural type untouched (`! 12` stays the number 12) — we follow yq, the same policy as FRK4/JEF9/02 — #224
 S98Z      lax:block-scalar  block scalar header not validated — #223
 T833      lax:flow          flow syntax not validated — #223
-U3C3      tags              tags (!) not supported — #224
 U44R      lax:indentation   indentation not validated — #223
+U99R      lax:tags          tag containing a disallowed flow indicator (`!!str,`) absorbed as text (block context has no special meaning for `,`) rather than rejected — #224
 UGM3      structure         document/block structure differs from spec
-UKK6/02   tags              tags (!) not supported — #224
 VJP3/00   lax:flow          flow syntax not validated — #223
 W4TN      scalars           scalar content/folding differs from spec
 W5VH      structure         document/block structure differs from spec
 W9L4      lax:block-scalar  block scalar header not validated — #223
-WZ62      tags              tag shorthand emitted as scalar text — #224
 Y79Y/003  lax:tabs          tab handling not validated — #223
-Z67P      tags              tags (!) not supported — #224
-Z9M4      tags              tags (!) not supported — #224
 ZVH3      lax:indentation   indentation not validated — #223

--- a/tests/yaml_bench_suite_coverage.rs
+++ b/tests/yaml_bench_suite_coverage.rs
@@ -86,6 +86,7 @@ const REQUIRED: &[Feature] = &[
     Feature::ExplicitKey,
     Feature::MultiDocument,
     Feature::MergeKey,
+    Feature::Tag,
 ];
 
 /// Constructs deliberately kept out of the suite, with the reason. Generating
@@ -95,10 +96,10 @@ const REQUIRED: &[Feature] = &[
 /// When one is fixed, delete its row here and give it a pattern: this test
 /// turns the fix into a required edit rather than leaving the coverage gap in
 /// place.
-const OUT_OF_SCOPE: &[(Feature, &str)] = &[(
-    Feature::Tag,
-    "rejected outright in block context (documented non-support in src/yaml/mod.rs)",
-)];
+///
+/// Empty since #224: tags (the only entry) resolve now, matching `yq`, so
+/// they moved to `REQUIRED` and got a pattern (`generate_anchors`) instead.
+const OUT_OF_SCOPE: &[(Feature, &str)] = &[];
 
 /// The feature each pattern added by #327 exists to carry.
 const HEADLINE: &[(&str, &[Feature])] = &[
@@ -225,6 +226,9 @@ fn features_of(pattern: &str, bytes: &[u8]) -> BTreeSet<Feature> {
         if index.is_alias(p) {
             found.insert(Feature::Alias);
         }
+        if index.get_tag(p).is_some() {
+            found.insert(Feature::Tag);
+        }
     }
 
     // The root is a virtual sequence of documents: more than one child means a
@@ -245,17 +249,15 @@ fn features_of(pattern: &str, bytes: &[u8]) -> BTreeSet<Feature> {
         _ => walk(root, &mut found),
     }
 
-    // Three constructs the index does not distinguish after the fact: an
-    // explicit key is an ordinary key once indexed, a tag would have failed
-    // the build above, and a merge key (#171) is resolved away into ordinary
-    // fields by `YamlFields` — a successfully merged mapping has no literal
-    // "<<" left for a tree walk to find.
+    // Two constructs the index does not distinguish after the fact: an
+    // explicit key is an ordinary key once indexed, and a merge key (#171) is
+    // resolved away into ordinary fields by `YamlFields` — a successfully
+    // merged mapping has no literal "<<" left for a tree walk to find. A tag
+    // *is* index-visible (`YamlIndex::get_tag`, #224) and detected in the BP
+    // scan above, unlike these two.
     let text = String::from_utf8_lossy(bytes);
     if text.starts_with("? ") || text.contains("\n? ") {
         found.insert(Feature::ExplicitKey);
-    }
-    if text.contains("!!") {
-        found.insert(Feature::Tag);
     }
     if text.contains("<<:") {
         found.insert(Feature::MergeKey);
@@ -295,6 +297,10 @@ fn detector_finds_every_feature_it_claims_to() {
         (Feature::ExplicitKey, "? key\n: value\n"),
         (Feature::MultiDocument, "---\na: 1\n---\nb: 2\n"),
         (Feature::MergeKey, "base: &b\n  a: 1\nc:\n  <<: *b\n"),
+        // Tags resolve now (#224) and are index-visible via
+        // `YamlIndex::get_tag`, detected in the same BP scan as anchors and
+        // aliases rather than the text-based fallback the other two still need.
+        (Feature::Tag, "a: !!str 1\n"),
     ];
 
     for (feature, yaml) in cases {
@@ -305,13 +311,6 @@ fn detector_finds_every_feature_it_claims_to() {
             feature.name()
         );
     }
-
-    // Tags never reach the index — the parser rejects them — so the tag check
-    // is text-based and is pinned separately.
-    assert!(
-        YamlIndex::build(b"a: !!str 1\n").is_err(),
-        "tags now parse; the Tag detection here needs to move to the index"
-    );
 }
 
 #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1005,6 +1005,75 @@ fn test_inplace_json_output_fast_path() -> Result<()> {
     Ok(())
 }
 
+/// #224: `--slurp` with `-o json` is the one combination `can_slurp_fast_path`
+/// always excludes (it requires YAML output), so it routes through the slow
+/// `parse_input` -> `yaml_to_owned_value` -> `resolved_scalar_to_owned` DOM
+/// path instead of the M2 cursor streamer. The extensive tag/alias tests
+/// added by #224 elsewhere in this file all exercise the direct/M2 path
+/// (`-o=json` without `--slurp`), leaving this DOM path's
+/// `ResolvedScalar::Float` arm uncovered.
+#[test]
+fn test_slurp_json_float_scalar_through_dom_path() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "pi: 3.14\n", &["--slurp", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"[{"pi":3.14}]"#);
+    Ok(())
+}
+
+/// #224: like [`test_slurp_json_float_scalar_through_dom_path`], forces the
+/// DOM path via `--slurp -o json`, but exercises `yaml_to_owned_value`'s
+/// explicit-tag check (`cursor.explicit_tag()` + `resolve_tagged`) instead —
+/// the DOM path's copy of the core fix under test in this PR. Mirrors the
+/// already-tested direct-path case (`test_yaml_anchored_tag_in_seq_item_resolves`,
+/// `test_yaml_default_output_preserves_the_literal_tag`'s "value, quoted"
+/// case) where a core-schema tag forces resolution regardless of quoting:
+/// `!!int "5"` becomes the number `5`, not the string `"5"`.
+#[test]
+fn test_slurp_json_explicit_tag_through_dom_path() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a: !!int \"5\"\n", &["--slurp", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"[{"a":5}]"#);
+    Ok(())
+}
+
+/// #224: sibling of the test above, but the explicit tag (`!custom`) isn't
+/// one of the 5 core-schema tags, so `resolve_tagged` returns `None` and
+/// `yaml_to_owned_value` must fall through past the tag check to the
+/// quoted-string-preservation check below it, rather than resolving.
+#[test]
+fn test_slurp_json_custom_tag_falls_through_on_dom_path() -> Result<()> {
+    let (output, code) =
+        run_yq_stdin(".", "a: !custom \"5\"\n", &["--slurp", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"[{"a":"5"}]"#);
+    Ok(())
+}
+
+/// #224: like the two tests above, forces `--slurp -o json`'s DOM path, this
+/// time through `yaml_to_owned_value`'s `YamlValue::Alias` arm. That arm now
+/// recurses on the target *cursor* rather than a bare `YamlValue`, since a
+/// tag on the aliased node lives on the cursor's `bp_pos` and a bare value
+/// has already lost it. Checks a plain aliased scalar first, then — mirroring
+/// the direct-path `test_yaml_anchored_tag_in_seq_item_resolves` — an aliased
+/// node whose *source* carries an explicit tag, which is the only case that
+/// can tell "cursor passed through" apart from "bare value passed through".
+#[test]
+fn test_slurp_json_alias_through_dom_path() -> Result<()> {
+    let (plain, code) = run_yq_stdin(".", "a: &x 1\nb: *x\n", &["--slurp", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(plain.trim(), r#"[{"a":1,"b":1}]"#);
+
+    let (tagged, code) = run_yq_stdin(
+        ".",
+        "items:\n  - &a !!str x\n  - *a\n",
+        &["--slurp", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(tagged.trim(), r#"[{"items":["x","x"]}]"#);
+
+    Ok(())
+}
+
 #[test]
 fn test_compact_json_output() -> Result<()> {
     let yaml = r"

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1468,112 +1468,145 @@ fn test_yaml_anchor_on_compact_mapping_key_binds_to_key() -> Result<()> {
 }
 
 #[test]
-fn test_yaml_anchored_tag_in_seq_item_is_rejected() -> Result<()> {
-    // Consuming the anchor before dispatching means the tag is now seen rather
-    // than absorbed into a plain scalar, so `- &a !!str x` errors instead of
-    // silently yielding the string "!!str x". Tags are documented non-support
-    // (#224); `a: !!str 1` already errored the same way.
-    let input = "items:\n  - &a !!str x\n";
-    let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".", input, &[])?;
-    assert_eq!(exit_code, 1, "expected clean error exit, stderr: {stderr}");
-    assert_eq!(stdout, "");
-    assert!(
-        stderr.contains("tags (!) not supported"),
-        "stderr should name the tag: {stderr}"
-    );
+fn test_yaml_anchored_tag_in_seq_item_resolves() -> Result<()> {
+    // Consuming the anchor before dispatching means the tag is seen rather
+    // than absorbed into a plain scalar, so `- &a !!str x` resolves to the
+    // string "x" (matching yq: the tag forces the type, then is dropped from
+    // output) rather than erroring or yielding the literal text "!!str x"
+    // (#224). The anchor still resolves too.
+    let input = "items:\n  - &a !!str x\n  - *a\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"items":["x","x"]}"#);
     Ok(())
 }
 
 #[test]
-fn test_yaml_flow_context_rejects_tags_like_block_context() -> Result<()> {
-    // #369. Flow context fell through to the plain-scalar readers and absorbed
-    // the tag as text, so `a: [!!str x]` yielded the *string* `"!!str x"`.
-    // Silently wrong data is worse than a refusal, which is why this is a bug
-    // in its own right rather than something that waits for tag support
-    // (#224). Flow context is fully gated for every position tested below —
-    // unlike block context, which is not: see the `test_yaml_tag_gate_gap_*`
-    // tests following this one, added by the #664 audit.
+fn test_yaml_flow_context_resolves_tags_like_block_context() -> Result<()> {
+    // #369 made flow context *reject* a tag the way block context did, rather
+    // than absorbing it as scalar text (`a: [!!str x]` used to yield the
+    // string `"!!str x"`). #224 replaced that rejection with real resolution
+    // everywhere, in both contexts uniformly — so every position below now
+    // drops the tag from output (and lets a core-schema tag force the type)
+    // instead of erroring.
     //
     // Every flow position that reaches a plain-scalar reader. The last two are
     // the ones no other case covers: an implicit `k: v` entry inside a flow
     // *sequence* enters through `parse_flow_key` (shared with the flow-mapping
     // key site since #409), and the explicit `? k : v` form through
-    // `parse_explicit_flow_unquoted_key`. Without them, deleting either gate
+    // `parse_explicit_flow_unquoted_key`. Without them, breaking either path
     // leaves this test green.
-    for (name, input) in [
-        ("seq item", "a: [!!str x]\n"),
-        ("mapping value", "a: {k: !custom v}\n"),
-        ("mapping key", "a: {!!str k: v}\n"),
-        ("seq item with a plain sibling", "a: [!custom x, plain]\n"),
-        ("implicit entry key in a seq", "a: [!!str k: v]\n"),
-        ("explicit key", "a: [? !!str k : v]\n"),
+    for (name, input, expected) in [
+        ("seq item", "a: [!!str x]\n", r#"{"a":["x"]}"#),
+        ("mapping value", "a: {k: !custom v}\n", r#"{"a":{"k":"v"}}"#),
+        ("mapping key", "a: {!!str k: v}\n", r#"{"a":{"k":"v"}}"#),
+        (
+            "seq item with a plain sibling",
+            "a: [!custom x, plain]\n",
+            r#"{"a":["x","plain"]}"#,
+        ),
+        (
+            "implicit entry key in a seq",
+            "a: [!!str k: v]\n",
+            r#"{"a":[{"k":"v"}]}"#,
+        ),
+        (
+            "explicit key",
+            "a: [? !!str k : v]\n",
+            r#"{"a":[{"k":"v"}]}"#,
+        ),
         // #402 routed the flow *mapping*'s explicit key through the same reader.
-        // Without this the gate could be dropped from that path unnoticed.
-        ("explicit key in a mapping", "a: {? !!str k : v}\n"),
+        // Without this the tag could be dropped from that path unnoticed.
+        (
+            "explicit key in a mapping",
+            "a: {? !!str k : v}\n",
+            r#"{"a":{"k":"v"}}"#,
+        ),
     ] {
-        let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".", input, &[])?;
-        assert_eq!(exit_code, 1, "{name}: expected clean error exit: {stderr}");
-        assert_eq!(stdout, "", "{name}: nothing should reach stdout");
-        assert!(
-            stderr.contains("tags (!) not supported"),
-            "{name}: stderr should name the tag: {stderr}"
-        );
+        let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+        assert_eq!(exit_code, 0, "{name}: expected clean success");
+        assert_eq!(output.trim(), expected, "{name}");
     }
     Ok(())
 }
 
-// The following `test_yaml_tag_gate_gap_*` tests are the #664 audit's output:
-// they pin *today's wrong* behavior (`exit_code == 0`, tag text silently
-// absorbed) for every block-context path found ungated against
-// `check_unsupported` (`src/yaml/parser.rs`). Each is expected to start
-// failing once #224 implements real tag support and these paths reject or
-// handle the tag instead of absorbing it — that failure is the signal a gap
-// closed. See `docs/compliance/yaml/limitations.md` for the full audit
-// (root causes, file:line references, and the complete gated/ungated table).
+#[test]
+fn test_yaml_default_output_preserves_the_literal_tag() -> Result<()> {
+    // Default (YAML) output has tag syntax, unlike JSON, so a tag is
+    // re-emitted verbatim rather than dropped — matching real `yq`
+    // v4.53.3, checked directly against each case below. JSON output for
+    // the same inputs still drops the tag (#224); this is that dropped
+    // information being representable again in the format that can hold it.
+    for (name, input, expected) in [
+        ("value, unquoted", "a: !!str 1\n", "a: !!str 1"),
+        ("value, quoted", "a: !!int \"5\"\n", "a: !!int \"5\""),
+        ("value, custom tag", "a: !custom v\n", "a: !custom v"),
+        ("key, same line", "!!str key: value\n", "!!str key: value"),
+        (
+            "key, nested",
+            "outer:\n  !!str key: value\n",
+            "outer:\n  !!str key: value",
+        ),
+    ] {
+        let (output, exit_code) = run_yq_stdin(".", input, &[])?;
+        assert_eq!(exit_code, 0, "{name}: expected clean success");
+        assert_eq!(output.trim(), expected, "{name}");
+    }
+    Ok(())
+}
+
+// The following `test_yaml_tag_gate_gap_*` tests were the #664 audit's output:
+// they used to pin the *wrong* behavior (`exit_code == 0`, tag text silently
+// absorbed into the surrounding scalar/key) for every block-context path
+// found ungated against `check_unsupported` (`src/yaml/parser.rs`, since
+// deleted — #224 replaced it with real property consumption throughout, see
+// `parse_node_properties`/`record_key_properties`). Kept under their
+// original `_gate_gap_` names since they're still the audit's per-root-cause
+// map, now asserting each is *closed*: tag dropped from output, and
+// resolution/anchor/alias behavior all correct. See
+// `docs/compliance/yaml/limitations.md` for the historical audit (root
+// causes, file:line references, the complete gated/ungated table).
 
 #[test]
 fn test_yaml_tag_gate_gap_document_root_indented_scalar() -> Result<()> {
-    // Root cause 1: `parse_document_line`'s `check_unsupported` call
-    // (`parser.rs:4269`) runs before indentation is skipped, so it peeks the
-    // line's literal first byte — a space for any indented line — not the
-    // node's first byte. A column-0 bare scalar is rejected; the same scalar
-    // indented is not.
-    let (out, code) = run_yq_stdin(".", "!!str x\n", &["-o=json", "-I=0"])?;
-    assert_eq!(code, 1, "control (column 0) should still be rejected");
-    let _ = out;
-
-    let (out, code) = run_yq_stdin(".", "  !!str x\n", &["-o=json", "-I=0"])?;
-    assert_eq!(code, 0, "indented bare scalar: gap not yet closed");
-    assert_eq!(out.trim(), "\"!!str x\"");
+    // Root cause 1 (`parse_document_line`'s gate ran before indentation was
+    // skipped, so it only ever fired at column 0) is moot now that a tag
+    // never errors — column 0 and indented must resolve identically.
+    for (name, input) in [("column 0", "!!str x\n"), ("indented", "  !!str x\n")] {
+        let (out, code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "{name}: expected clean success");
+        assert_eq!(out.trim(), "\"x\"", "{name}");
+    }
     Ok(())
 }
 
 #[test]
 fn test_yaml_tag_gate_gap_document_start_two_documents() -> Result<()> {
     // The `J7PZ` corpus shape (`--- !!omap`). `parse_inline_document_value`
-    // (root cause 2) absorbs the tag as a complete document-root scalar, so
-    // the sequence content on the following lines starts a *second*
-    // document — one YAML input streams as two JSON documents instead of
-    // erroring.
+    // (root cause 2) used to absorb the tag as a complete document-root
+    // scalar, so the sequence content on the following lines started a
+    // *second* document — one YAML input streamed as two JSON documents.
+    // `parse_block_node`'s combined `&`/`!` arm now consumes the tag first,
+    // so `!!omap`'s deferred sequence stays this document's single value.
     let (out, code) = run_yq_stdin(".", "--- !!omap\n- a: 1\n", &["-o=json", "-I=0"])?;
-    assert_eq!(code, 0, "gap not yet closed");
-    assert_eq!(out.trim(), "\"!!omap\"\n[{\"a\":1}]");
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[{\"a\":1}]");
     Ok(())
 }
 
 #[test]
 fn test_yaml_tag_gate_gap_document_start_inline_value() -> Result<()> {
-    // Root cause 2: `parse_inline_document_value` (`parser.rs:1061-1081`)
-    // dispatches content after `---` through `parse_block_node` directly,
-    // never calling `check_unsupported` itself. Its own doc comment already
-    // names this as #224's to settle.
-    for (name, input, expected) in [
-        ("plain tag", "--- !!str x\n", "\"!!str x\""),
-        ("anchor then tag", "--- &a !!str x\n", "\"!!str x\""),
+    // Root cause 2: `parse_inline_document_value` (`parser.rs`) dispatches
+    // content after `---` through `parse_block_node` directly. Its doc
+    // comment used to name this as #224's to settle; `parse_block_node`'s
+    // combined property arm now covers it the same as every other position.
+    for (name, input) in [
+        ("plain tag", "--- !!str x\n"),
+        ("anchor then tag", "--- &a !!str x\n"),
     ] {
         let (out, code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
-        assert_eq!(code, 0, "{name}: gap not yet closed");
-        assert_eq!(out.trim(), expected, "{name}");
+        assert_eq!(code, 0, "{name}: expected clean success");
+        assert_eq!(out.trim(), "\"x\"", "{name}");
     }
     Ok(())
 }
@@ -1581,30 +1614,30 @@ fn test_yaml_tag_gate_gap_document_start_inline_value() -> Result<()> {
 #[test]
 fn test_yaml_tag_gate_gap_value_deferred_to_next_line() -> Result<()> {
     // Root causes 2/3: a value deferred to the next line eventually lands in
-    // `parse_block_node`'s scalar-dispatch arms (`4416-4441`, `4457-4490`),
-    // neither of which calls `check_unsupported`. `parse_mapping_entry`'s own
-    // gate (`2237`) only guards its *same-line* value branch, not this one
-    // (`2204-2232`).
+    // `parse_block_node`'s scalar-dispatch arms, which used to never call
+    // `check_unsupported`. `parse_mapping_entry`'s next-line branch now defers
+    // to the main loop for a `!`-prefixed line the same way it already did
+    // for `&`/`*` (its own gate only ever guarded the *same-line* branch).
     for (name, input, expected) in [
         (
             "mapping value",
             "key:\n  !!str value\n",
-            "{\"key\":\"!!str value\"}",
+            "{\"key\":\"value\"}",
         ),
-        ("sequence item", "- \n  !!str x\n", "[\"!!str x\"]"),
+        ("sequence item", "- \n  !!str x\n", "[\"x\"]"),
         (
             "compact mapping value",
             "- k:\n    !!str v\n",
-            "[{\"k\":\"!!str v\"}]",
+            "[{\"k\":\"v\"}]",
         ),
         (
             "anchor-prefixed block value",
             "a: &b\n  !!str x\n",
-            "{\"a\":\"!!str x\"}",
+            "{\"a\":\"x\"}",
         ),
     ] {
         let (out, code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
-        assert_eq!(code, 0, "{name}: gap not yet closed");
+        assert_eq!(code, 0, "{name}: expected clean success");
         assert_eq!(out.trim(), expected, "{name}");
     }
     Ok(())
@@ -1612,29 +1645,21 @@ fn test_yaml_tag_gate_gap_value_deferred_to_next_line() -> Result<()> {
 
 #[test]
 fn test_yaml_tag_gate_gap_anchor_then_tag_same_line() -> Result<()> {
-    // Root cause 4: `parse_mapping_entry` (`2237`) and
-    // `parse_compact_mapping_entry` (`1926`) each call `check_unsupported`
-    // once, *before* checking for a `&anchor`, then dispatch the
-    // post-anchor value inline with no second check. Contrast
-    // `parse_sequence_item`/flow context, which consume the anchor
-    // themselves and delegate to `parse_value`/`parse_flow_scalar` — both of
-    // which re-check independently at their own entry, so the anchor never
-    // leaves a stale check behind there (see
-    // `test_yaml_anchored_tag_in_seq_item_is_rejected` above).
+    // Root cause 4: `parse_mapping_entry` and `parse_compact_mapping_entry`
+    // each used to check `check_unsupported` once, *before* checking for a
+    // `&anchor`, then dispatch the post-anchor value inline with no second
+    // check. `parse_node_properties` now consumes both, in either order, in
+    // one call — an anchor no longer leaves a stale gate behind it.
     for (name, input, expected) in [
-        (
-            "mapping entry",
-            "key: &a !!str x\n",
-            "{\"key\":\"!!str x\"}",
-        ),
+        ("mapping entry", "key: &a !!str x\n", "{\"key\":\"x\"}"),
         (
             "compact mapping entry",
             "- k: &a !!str v\n",
-            "[{\"k\":\"!!str v\"}]",
+            "[{\"k\":\"v\"}]",
         ),
     ] {
         let (out, code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
-        assert_eq!(code, 0, "{name}: gap not yet closed");
+        assert_eq!(code, 0, "{name}: expected clean success");
         assert_eq!(out.trim(), expected, "{name}");
     }
     Ok(())
@@ -1642,25 +1667,22 @@ fn test_yaml_tag_gate_gap_anchor_then_tag_same_line() -> Result<()> {
 
 #[test]
 fn test_yaml_tag_gate_gap_explicit_value() -> Result<()> {
-    // Root cause 5: `parse_explicit_value` (`parser.rs:2582`, the `: value`
-    // half of `? key` / `: value`) has zero `check_unsupported` calls in the
-    // entire function, for its scalar arm, its anchor-then-value arm, or its
-    // compact-mapping-value arm.
+    // Root cause 5: `parse_explicit_value` (the `: value` half of `? key` /
+    // `: value`) used to have zero `check_unsupported` calls in the entire
+    // function — its scalar arm, its anchor-then-value arm, and its
+    // compact-mapping-value arm. `parse_node_properties` now runs once at
+    // entry, ahead of all three.
     for (name, input, expected) in [
-        ("plain value", "? k\n: !!str v\n", "{\"k\":\"!!str v\"}"),
-        (
-            "anchor then tag",
-            "? k\n: &a !!str v\n",
-            "{\"k\":\"!!str v\"}",
-        ),
+        ("plain value", "? k\n: !!str v\n", "{\"k\":\"v\"}"),
+        ("anchor then tag", "? k\n: &a !!str v\n", "{\"k\":\"v\"}"),
         (
             "compact mapping value, tag on its key",
             "? k\n: !!str b: c\n",
-            "{\"k\":{\"!!str b\":\"c\"}}",
+            "{\"k\":{\"b\":\"c\"}}",
         ),
     ] {
         let (out, code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
-        assert_eq!(code, 0, "{name}: gap not yet closed");
+        assert_eq!(code, 0, "{name}: expected clean success");
         assert_eq!(out.trim(), expected, "{name}");
     }
     Ok(())
@@ -1668,27 +1690,27 @@ fn test_yaml_tag_gate_gap_explicit_value() -> Result<()> {
 
 #[test]
 fn test_yaml_tag_gate_gap_key_position() -> Result<()> {
-    // Root cause 6: no block-context key parser gates the key itself —
-    // `parse_mapping_entry` and `parse_explicit_key` (`2364`, whose inline-key
-    // dispatch at `2566-2572` has no gate at all) never call
-    // `check_unsupported` on key text. The mapping-entry case is indented so
-    // root cause 1's column-0 accident doesn't incidentally catch it.
+    // Root cause 6: no block-context key parser used to gate the key itself —
+    // `parse_mapping_entry` and `parse_explicit_key` (whose inline-key
+    // dispatch had no gate at all) never called `check_unsupported` on key
+    // text. `record_key_properties` now runs before each key is parsed. The
+    // mapping-entry case is indented so root cause 1's column-0 accident
+    // isn't what makes it pass.
     //
     // A compact-mapping key reached via a sequence item (`- !!str k: v`) is
-    // *not* included here — it's already gated, because
-    // `parse_sequence_item`'s own `check_unsupported` (`1734`) runs
-    // unconditionally right after `- `, before the compact-mapping dispatch
-    // is even decided.
+    // *not* included here — it was already gated, because
+    // `parse_sequence_item`'s own gate ran unconditionally right after `- `,
+    // before the compact-mapping dispatch was even decided.
     for (name, input, expected) in [
         (
             "nested mapping key",
             "outer:\n  !!str key: value\n",
-            "{\"outer\":{\"!!str key\":\"value\"}}",
+            "{\"outer\":{\"key\":\"value\"}}",
         ),
-        ("explicit key", "? !!str k\n: v\n", "{\"!!str k\":\"v\"}"),
+        ("explicit key", "? !!str k\n: v\n", "{\"k\":\"v\"}"),
     ] {
         let (out, code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
-        assert_eq!(code, 0, "{name}: gap not yet closed");
+        assert_eq!(code, 0, "{name}: expected clean success");
         assert_eq!(out.trim(), expected, "{name}");
     }
     Ok(())


### PR DESCRIPTION
## Summary

Closes #224. Implements full YAML tag support, replacing the blanket `!` rejection with real resolution matching `yq`.

- Tags (`!!str`, `!custom`, verbatim `!<...>`) resolve instead of erroring. The 5 core-schema tags (`!!str`/`!!null`/`!!bool`/`!!int`/`!!float`) force scalar-type coercion regardless of quoting style (`!!int "5"` → `5`), matching `yq` v4.53.3 byte-for-byte (checked directly against the pinned oracle for every core-schema case).
- `check_unsupported` (whose only job was rejecting `!`) is deleted and replaced by real tag parsing wired into every node-start position — block and flow — closing all 6 root causes from #664's audit in one shared change, plus two bugs the audit couldn't have found (a flow-context multiline-after-tag bug, corpus case `EHF6`; a bare-tag-with-null-value bug that silently dropped the tag, corpus case `LE5A`).
- JSON output, default YAML output (which — unlike JSON — re-emits the tag verbatim, matching `yq`), and the `OwnedValue` conversion behind jq evaluation are all tag-aware.
- One documented, scoped-out follow-up: the lazy cursor-free half of the generic jq evaluator (shared with JSON) isn't tag-aware yet (`'.a | type'` on a tagged value), since fixing it touches ~90 call sites across 6 files. Tags on a whole collection (`!!seq [1, 2]`) aren't yet preserved in YAML output either.

**Impact**: YAML Test Suite load conformance 84.2% → 95.7% (235/279 → 267/279), parse 93.1% → 100%. The largest remaining conformance gap.

## Commits

1. `feat(yaml)` — core implementation (parser, index storage, scalar resolution, output wiring)
2. `test(yaml)` — flip the yq CLI test suite to assert resolved (not rejected/absorbed) behavior
3. `test(yaml)` — benchmark suite coverage + corpus known-failures manifest
4. `docs(yaml)` — reconcile `limitations.md` and `yaml.md` with the shipped behavior

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full workspace suite (2600+ tests) green
- [x] `cargo test --test yaml_test_suite -- --nocapture` — conformance numbers match manifest exactly
- [x] `cargo test --test yq_path_consistency_tests` — DOM and streaming output paths agree
- [x] `cargo test --test yq_golden_tests` — pinned `yq` golden fixtures unaffected
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the two CI feature-matrix clippy invocations — clean
- [x] Manual verification against real `yq` v4.53.3 for every core-schema tag combination (quoted/unquoted, anchor+tag ordering, flow/block, bare `!`)