### PR TITLE
jq: lazy map/select fast path (closes #724, #725)

### DIFF
--- a/src/bin/succinctly/jq_bench.rs
+++ b/src/bin/succinctly/jq_bench.rs
@@ -33,8 +33,8 @@ pub enum QueryType {
     /// `select` arm here by design -- see `docs/plan/jq-lazy-map-select.md`'s
     /// "select: no new code path")
     KeysUnsortedSelect,
-    /// `map(.)` over a plain container - no native arm yet, hits the eager
-    /// fallback (tracked separately as #725, the dominant cost share)
+    /// `map(.)` over a plain container - lazy via `GenericResult::LazySeq`
+    /// (#725), `eval_builtin`'s first-ever native `Builtin::Map` arm
     Map,
     /// `select(true)` over a plain container - general-container comparison
     Select,
@@ -73,7 +73,8 @@ impl QueryType {
             Self::Identity => "native",
             Self::KeysUnsorted | Self::KeysUnsortedLength => "lazy (#678)",
             Self::KeysUnsortedMap => "lazy (#724)",
-            Self::KeysUnsortedSelect | Self::Map => "eager fallback",
+            Self::KeysUnsortedSelect => "eager fallback",
+            Self::Map => "lazy (#725)",
             Self::Select => "native (single-value arm)",
         }
     }
@@ -914,7 +915,7 @@ mod tests {
             QueryType::KeysUnsortedSelect.path_description(),
             "eager fallback"
         );
-        assert_eq!(QueryType::Map.path_description(), "eager fallback");
+        assert_eq!(QueryType::Map.path_description(), "lazy (#725)");
         assert_eq!(
             QueryType::Select.path_description(),
             "native (single-value arm)"

--- a/src/bin/succinctly/jq_bench.rs
+++ b/src/bin/succinctly/jq_bench.rs
@@ -25,13 +25,16 @@ pub enum QueryType {
     KeysUnsorted,
     /// `keys_unsorted | length` - already lazy (#678), the achievable floor
     KeysUnsortedLength,
-    /// `keys_unsorted | map(.)` - no native arm, hits the eager fallback
+    /// `keys_unsorted | map(.)` - lazy via `GenericResult::LazySeq` (#724)
     KeysUnsortedMap,
-    /// `keys_unsorted | select(true)` - hits the eager fallback too, since
-    /// the `LazyKeysUnsorted` pipe-fanout dispatch only special-cases
-    /// `length`/`.[]`/`.[n]`/`first`/`last`
+    /// `keys_unsorted | select(true)` - still hits the eager fallback: the
+    /// `LazyKeys` pipe-fanout dispatch only special-cases
+    /// `length`/`.[]`/`.[n]`/`first`/`last`/`map` (#724 adds no dedicated
+    /// `select` arm here by design -- see `docs/plan/jq-lazy-map-select.md`'s
+    /// "select: no new code path")
     KeysUnsortedSelect,
-    /// `map(.)` over a plain container - general-container comparison
+    /// `map(.)` over a plain container - no native arm yet, hits the eager
+    /// fallback (tracked separately as #725, the dominant cost share)
     Map,
     /// `select(true)` over a plain container - general-container comparison
     Select,
@@ -69,7 +72,8 @@ impl QueryType {
         match self {
             Self::Identity => "native",
             Self::KeysUnsorted | Self::KeysUnsortedLength => "lazy (#678)",
-            Self::KeysUnsortedMap | Self::KeysUnsortedSelect | Self::Map => "eager fallback",
+            Self::KeysUnsortedMap => "lazy (#724)",
+            Self::KeysUnsortedSelect | Self::Map => "eager fallback",
             Self::Select => "native (single-value arm)",
         }
     }
@@ -905,10 +909,7 @@ mod tests {
             QueryType::KeysUnsortedLength.path_description(),
             "lazy (#678)"
         );
-        assert_eq!(
-            QueryType::KeysUnsortedMap.path_description(),
-            "eager fallback"
-        );
+        assert_eq!(QueryType::KeysUnsortedMap.path_description(), "lazy (#724)");
         assert_eq!(
             QueryType::KeysUnsortedSelect.path_description(),
             "eager fallback"

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1613,6 +1613,20 @@ fn evaluate_input(
         GenericResult::LazyIndexRange(len) => Ok(vec![OwnedValue::Array(
             (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
         )]),
+        // Same reasoning as `LazyKeys`/`LazyIndexRange` above, for a
+        // composed `map` chain (#724, #725) that never resolved into a
+        // narrower shape before reaching this materializing boundary.
+        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+            Ok(v) => Ok(vec![v]),
+            Err(jq::Control::Error(e)) => {
+                sink.report(DiagStyle::Jq, &e, at);
+                Ok(vec![])
+            }
+            Err(jq::Control::Break(label)) => {
+                sink.report_break(DiagStyle::Jq, &label, at);
+                Ok(vec![])
+            }
+        },
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -1700,6 +1714,22 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
         // `keys_unsorted` (#684): `write_json`/`print_json` write the
         // `[0,1,...,len-1]` digits directly, no `Vec<OwnedValue::Int>`.
         GenericResult::LazyIndexRange(len) => vec![JqValue::LazyIndexRange(len)],
+        // `JqValue` needs no new variant for a composed `map` chain (#724,
+        // #725): `JqValue::Array` already stores per-element cursors (its
+        // own "Phase 1 Lazy Optimization"), so materializing once here and
+        // wrapping via `from_owned` reuses the existing `write_json` path
+        // entirely.
+        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+            Ok(v) => vec![JqValue::from_owned(v)],
+            Err(jq::Control::Error(e)) => {
+                sink.report(DiagStyle::Jq, &e, at);
+                vec![]
+            }
+            Err(jq::Control::Break(label)) => {
+                sink.report_break(DiagStyle::Jq, &label, at);
+                vec![]
+            }
+        },
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -562,6 +562,20 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         GenericResult::LazyIndexRange(len) => Ok(vec![OwnedValue::Array(
             (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
         )]),
+        // Same reasoning as `LazyKeys`/`LazyIndexRange` above, for a
+        // composed `map` chain (#724, #725) that never resolved into a
+        // narrower shape before reaching this materializing DOM boundary.
+        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+            Ok(v) => Ok(vec![v]),
+            Err(jq::Control::Error(e)) => {
+                sink.report(DiagStyle::Yq, &e, &no_location());
+                Ok(vec![])
+            }
+            Err(jq::Control::Break(label)) => {
+                sink.report_break(DiagStyle::Yq, &label, &no_location());
+                Ok(vec![])
+            }
+        },
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23,6 +23,22 @@ use indexmap::IndexMap;
 
 use super::slice::{self, SliceBounds};
 
+/// Which `EvalSemantics` implementor a value carries, as a runtime tag.
+///
+/// `eval_generic.rs`'s `GenericResult<V>`/`LazySeq<V>` are deliberately generic
+/// over `V` alone, not `V` and `S: EvalSemantics` — adding `S` as a second type
+/// parameter would ripple through every function naming `GenericResult`, the
+/// same cost the design doc's rejected `Box<dyn Iterator>` alternative pays for
+/// a lifetime parameter. A buffered `Instruction::Map` stage in a `LazySeq`
+/// still needs to know which semantics to replay with once pulled, with no `S`
+/// in scope at that point — this tag plus a 2-way match at the pull site is the
+/// bridge (see `docs/plan/jq-lazy-map-select.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvalTag {
+    Jq,
+    Yq,
+}
+
 /// Trait for evaluation semantics - determines behavior for edge cases.
 ///
 /// jq and yq (mikefarah/yq) have different behaviors for some operations.
@@ -37,6 +53,10 @@ pub trait EvalSemantics: Copy + Default {
     const NEGATIVE_INDEX_IN_HAS: bool;
     /// If true, `%` truncates float operands to integers (jq). If false, float modulo (yq).
     const MOD_TRUNCATES_FLOATS: bool;
+    /// Runtime identity of this semantics, for erased/re-dispatched contexts
+    /// (`LazySeq`'s buffered `Instruction`s) that can't carry `Self` as a type
+    /// parameter.
+    const TAG: EvalTag;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -52,6 +72,7 @@ impl EvalSemantics for JqSemantics {
     const DIV_BY_ZERO_IS_INFINITY: bool = false;
     const NEGATIVE_INDEX_IN_HAS: bool = false;
     const MOD_TRUNCATES_FLOATS: bool = true;
+    const TAG: EvalTag = EvalTag::Jq;
 }
 
 /// yq-compatible evaluation semantics.
@@ -67,6 +88,7 @@ impl EvalSemantics for YqSemantics {
     const DIV_BY_ZERO_IS_INFINITY: bool = true;
     const NEGATIVE_INDEX_IN_HAS: bool = true;
     const MOD_TRUNCATES_FLOATS: bool = false;
+    const TAG: EvalTag = EvalTag::Yq;
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -901,7 +901,7 @@ impl<V: DocumentValue> GenericResult<V> {
             // final array was never it.
             Self::LazySeq(seq) => match seq.clone().materialize_atomic() {
                 Ok(owned) => {
-                    owned.stream_json(out, indent_spaces)?;
+                    owned.stream_json(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.count = 1;
                     stats.last_was_falsy = owned.is_falsy();
@@ -1070,7 +1070,7 @@ impl<V: DocumentValue> GenericResult<V> {
             // reuse `OwnedValue::stream_yaml`.
             Self::LazySeq(seq) => match seq.clone().materialize_atomic() {
                 Ok(owned) => {
-                    owned.stream_yaml(out, indent_spaces)?;
+                    owned.stream_yaml(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.count = 1;
                     stats.last_was_falsy = owned.is_falsy();
@@ -4242,7 +4242,7 @@ mod tests {
         let expr = crate::jq::parse("map(. + 1)").unwrap();
         let result = eval(&expr, value);
         let mut out = String::new();
-        let stats = result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        let stats = result.stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
         assert_eq!(out, "");
         assert!(stats.error.is_some());
         assert_eq!(stats.count, 0);
@@ -4271,7 +4271,7 @@ mod tests {
         let expr = crate::jq::parse("map(. + 1) | .[]").unwrap();
         let result = eval(&expr, value);
         let mut out = String::new();
-        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        result.stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
         assert_eq!(out, "");
     }
 
@@ -7824,13 +7824,13 @@ mod tests {
         let expr = crate::jq::parse("map(. + 1)").unwrap();
         let result = eval(&expr, value.clone());
         let mut out = String::new();
-        let stats = result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        let stats = result.stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
         assert_eq!(out, "[2,3,4]");
         assert_eq!(stats.count, 1);
         assert!(stats.any_truthy);
 
         let mut out = String::new();
-        let stats = result.stream_yaml(&mut out, 0, |_| Ok(())).unwrap();
+        let stats = result.stream_yaml(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
         assert_eq!(out, "[2, 3, 4]");
         assert_eq!(stats.count, 1);
         assert!(stats.any_truthy);
@@ -7838,14 +7838,14 @@ mod tests {
         let expr = crate::jq::parse("map(break $out)").unwrap();
         let result = eval(&expr, value.clone());
         let mut out = String::new();
-        let stats = result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        let stats = result.stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
         assert_eq!(out, "");
         assert_eq!(stats.count, 0);
         assert!(stats.error.is_some());
 
         let result = eval(&expr, value);
         let mut out = String::new();
-        let stats = result.stream_yaml(&mut out, 0, |_| Ok(())).unwrap();
+        let stats = result.stream_yaml(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
         assert_eq!(out, "");
         assert!(stats.error.is_some());
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1401,6 +1401,22 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                     _ => GenericResult::ManyOwned(prefix),
                 }
             }
+            // A `LazySeq` hasn't necessarily failed *yet* -- it's lazy, so
+            // it never matches the `Error`/`Break`/`Partial` arms above even
+            // when pulling it would fail (#724, #725). `E?` needs to know
+            // *now* whether `E` fails, so force it here -- same one-pass
+            // cost `materialize_atomic` already pays at every other
+            // materializing boundary in this file. Without this arm, `inner`
+            // falls through to `other => other` below and escapes this `?`
+            // entirely: the error only surfaces later, at whatever
+            // downstream site finally pulls the `LazySeq`, by which point
+            // this `try`/`catch` boundary is long gone (confirmed against
+            // real jq: `[1,2,"x"]|map(.+1)?` is empty/exit-0 in jq, but
+            // errored/exit-5 here before this arm existed).
+            GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+                Ok(owned) => GenericResult::Owned(owned),
+                Err(Control::Error(_) | Control::Break(_)) => GenericResult::None,
+            },
             other => other,
         },
 
@@ -1794,29 +1810,36 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                             GenericResult::Owned(OwnedValue::Int(count))
                         }
 
-                        // `.[]` is a generator, NOT array construction:
-                        // already-yielded elements survive a later element's
-                        // error -- `Partial` semantics, mirroring the
-                        // existing `ManyCursor` arm's own convention above.
-                        // Deliberately a different atomicity boundary than
-                        // `Length`/the `_` fallback below.
+                        // `.[]` iterates the array `map`'s own construction
+                        // already built, not the raw source -- and that
+                        // construction is atomic in real jq
+                        // (`[1,2,"x"]|map(.+1)` prints nothing on error, not
+                        // a truncated prefix), so a failure here discards
+                        // every already-yielded element too, same atomicity
+                        // boundary as `Length`/the `_` fallback below. This
+                        // is NOT the same case as elementwise
+                        // `.[] | select(g)` (a structurally distinct,
+                        // out-of-scope case per the design doc): there,
+                        // `.[]` is the *source* of the pipe and each element
+                        // is independent; here it's a *consumer* of an
+                        // already-atomic `map` result.
                         Expr::Iterate => {
                             let mut items = Vec::new();
-                            let mut control = None;
                             for item in seq {
                                 match item {
                                     Ok(elem) => items.push(elem),
-                                    Err(c) => {
-                                        control = Some(c);
-                                        break;
+                                    Err(Control::Error(e)) => return GenericResult::Error(e),
+                                    Err(Control::Break(label)) => {
+                                        return GenericResult::Break(label)
                                     }
                                 }
                             }
                             let all_cursor =
                                 items.iter().all(|item| matches!(item, LazyElem::Cursor(_)));
-                            match control {
-                                None if items.is_empty() => GenericResult::None,
-                                None if all_cursor => GenericResult::ManyCursor(
+                            if items.is_empty() {
+                                GenericResult::None
+                            } else if all_cursor {
+                                GenericResult::ManyCursor(
                                     items
                                         .into_iter()
                                         .map(|item| match item {
@@ -1826,8 +1849,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                             }
                                         })
                                         .collect(),
-                                ),
-                                None => GenericResult::ManyOwned(
+                                )
+                            } else {
+                                GenericResult::ManyOwned(
                                     items
                                         .into_iter()
                                         .map(|item| match item {
@@ -1835,22 +1859,24 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                             LazyElem::Owned(o) => o,
                                         })
                                         .collect(),
-                                ),
-                                Some(control) => {
-                                    let prefix = items
-                                        .into_iter()
-                                        .map(|item| match item {
-                                            LazyElem::Cursor(c) => to_owned(&c.value()),
-                                            LazyElem::Owned(o) => o,
-                                        })
-                                        .collect();
-                                    partial_generic(prefix, control)
-                                }
+                                )
                             }
                         }
 
                         // Pull-one-and-stop: at most one element of `seq` is
-                        // ever evaluated.
+                        // ever evaluated. Accepted, deliberate divergence
+                        // from real jq's strict semantics: real jq's `map`
+                        // eagerly builds the *whole* array before `first`/
+                        // `.[0]` can observe it, so `map(f)|first` errors if
+                        // *any* element of `f` fails, even ones past the
+                        // first. This fast path only evaluates what's
+                        // actually needed, so `[1,2,"x"]|map(.+1)|first`
+                        // succeeds here (returns `2`) where real jq raises a
+                        // type error -- the entire point of making `first`/
+                        // `.[0]` lazy is to skip evaluating elements that
+                        // don't affect the requested output, and an error on
+                        // a skipped element is one such element. Pinned by
+                        // `test_generic_lazy_seq_first_after_map_skips_later_error_725`.
                         Expr::Builtin(Builtin::First) | Expr::Index(0) => match seq.next() {
                             None => GenericResult::Owned(OwnedValue::Null),
                             Some(Ok(LazyElem::Cursor(c))) => GenericResult::OneCursor(c),
@@ -4145,6 +4171,55 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_lazy_seq_optional_suppresses_map_error() {
+        // Regression test: `map(f)?` must suppress an error raised inside
+        // `f`, same as any other `try`/`?` boundary. Before the
+        // `GenericResult::LazySeq` arm was added to `Expr::Optional`'s match,
+        // evaluating `inner` (here, bare `Builtin::Map`) returned an
+        // unmaterialized `LazySeq` that matched neither `Error`/`Break`/
+        // `Partial` nor got forced -- it fell through the `other => other`
+        // arm and escaped the `?` entirely, so the error only surfaced later
+        // at whatever site finally pulled the `LazySeq`, well past this
+        // `try`/`catch` boundary. Verified against real jq (`jq 1.7.1`):
+        // `[1,2,"x"]|map(.+1)?` is empty, exit 0.
+        let json = br#"[1,2,"x"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(. + 1)?").unwrap();
+        let result = eval(&expr, value);
+        assert!(!result.is_error());
+        assert_eq!(result.into_owned(), None);
+
+        // Non-erroring case still returns the mapped array, not suppressed.
+        let expr = crate::jq::parse("map(. + 1)").unwrap();
+        let json_ok = br"[1,2,3]";
+        let index_ok = JsonIndex::build(json_ok);
+        let value_ok = index_ok.root(json_ok).value();
+        assert_eq!(
+            eval(&expr, value_ok).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(2),
+                OwnedValue::Int(3),
+                OwnedValue::Int(4),
+            ])
+        );
+
+        // `keys_unsorted | map(f)?` -- Slice 1's composed chain -- suppresses
+        // the same way.
+        let json2 = br#"{"a":1,"b":2}"#;
+        let index2 = JsonIndex::build(json2);
+        let value2 = index2.root(json2).value();
+        let expr2 =
+            crate::jq::parse(r#"keys_unsorted | map(if . == "a" then error("x") else . end)?"#)
+                .unwrap();
+        let result2 = eval(&expr2, value2);
+        assert!(!result2.is_error());
+        assert_eq!(result2.into_owned(), None);
+    }
+
+    #[test]
     fn test_generic_plain_map_atomicity_725() {
         // Real jq's array construction is all-or-nothing: `map`'s error
         // partway through discards the whole in-progress array, mirroring
@@ -4171,6 +4246,33 @@ mod tests {
         assert_eq!(out, "");
         assert!(stats.error.is_some());
         assert_eq!(stats.count, 0);
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_map_pipe_iterate_atomicity_725() {
+        // Regression test: `.[]` piped after a plain `map(f)` must not leak
+        // the already-succeeded prefix before `map`'s own atomic-construction
+        // error -- `.[]` here iterates the array `map` already built, not
+        // the raw source, so it inherits `map`'s atomicity. Verified against
+        // real jq (`jq 1.7.1`): `[1,2,"x"]|map(.+1)|.[]` prints nothing to
+        // stdout, only the diagnostic.
+        let json = br#"[1,2,"x"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(. + 1) | .[]").unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(result.is_error());
+        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+
+        // Same check at the `stream_json` boundary the CLI actually uses:
+        // nothing streams to `out` before the diagnostic.
+        let expr = crate::jq::parse("map(. + 1) | .[]").unwrap();
+        let result = eval(&expr, value);
+        let mut out = String::new();
+        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, "");
     }
 
     #[test]
@@ -4253,6 +4355,33 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_lazy_seq_first_after_map_skips_later_error_725() {
+        // Accepted, deliberate divergence from real jq (see the
+        // `Expr::Builtin(Builtin::First) | Expr::Index(0)` arm's own doc
+        // comment above `eval_single`'s `Pipe` fold): real jq's `map`
+        // eagerly builds the whole array first, so `map(f)|first` errors if
+        // *any* element fails, even ones past the first. `first`/`.[0]`'s
+        // pull-one-and-stop fast path only evaluates what's needed, so a
+        // failure on a later, un-pulled element is invisible here -- verified
+        // against real jq (`jq 1.7.1`): `[1,2,"x"]|map(.+1)|first` errors
+        // there (`string ("x") and number (1) cannot be added`) but succeeds
+        // below.
+        let json = br#"[1,2,"x"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(. + 1) | first").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Int(2)
+        );
+
+        let expr = crate::jq::parse("map(. + 1) | .[0]").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(2));
+    }
+
+    #[test]
     fn test_generic_lazy_seq_composability_keys_unsorted_map_select_724() {
         // The actual point of this design: `keys_unsorted | map(f) | select(g)`
         // stays lazy through the `map` stage, materializes once at `select`.
@@ -4274,10 +4403,16 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_lazy_seq_atomicity_vs_iterate_contrast_724() {
-        // `map`'s array construction is atomic; `.[]` over the same failing
-        // chain is a generator and keeps its already-yielded prefix instead
-        // -- two different, both-correct atomicity boundaries.
+    fn test_generic_lazy_seq_map_atomicity_extends_through_iterate_724() {
+        // `map`'s array construction is atomic in real jq
+        // (`[1,2,"x"]|map(.+1)` prints nothing on error, not a truncated
+        // prefix) -- and `.[]` piped after `map` iterates the array `map`
+        // already built, not the raw source, so that same atomicity applies
+        // whether or not a `.[]` follows. Verified against real jq
+        // (`jq 1.7.1`): `{"a":1,"b":2,"c":3}|keys_unsorted|map(if .=="b" then
+        // error("boom") else . end)|.[]` prints nothing to stdout, only the
+        // diagnostic -- even though `"a"` (document order's first key)
+        // already succeeded before `"b"` failed.
         let json = br#"{"a":1,"b":2,"c":3}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
@@ -4288,9 +4423,7 @@ mod tests {
                 .unwrap();
         let result = eval(&expr, value.clone());
         assert!(matches!(result, GenericResult::LazySeq(_)));
-        // Atomic: `map`'s own array construction discards the whole
-        // in-progress array on the first error -- no partial prefix, even
-        // though `"a"` (document order's first key) already succeeded.
+        // No partial prefix, even though `"a"` already succeeded.
         assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
         assert!(eval(&expr, value.clone()).materialize_lazy().is_error());
 
@@ -4299,16 +4432,10 @@ mod tests {
         )
         .unwrap();
         let result = eval(&expr, value);
-        // Non-atomic: `.[]` is a generator over the `map` chain's own
-        // per-element outputs, not array construction -- `"a"` (which the
-        // `map` stage already resolved successfully before `"b"` failed)
-        // survives as a `Partial` prefix instead of being discarded, the
-        // opposite of the `map`-alone case just above.
+        // Same atomicity boundary as the `map`-alone case above: `"a"` does
+        // NOT survive as a partial prefix once `.[]` is piped after `map`.
         assert!(result.is_error());
-        assert_eq!(
-            result.collect_owned(),
-            vec![OwnedValue::String("a".to_string())]
-        );
+        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
     }
 
     /// Known, narrow, pre-existing gap (not a new regression from #724):
@@ -7252,5 +7379,589 @@ mod tests {
                 OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)]),
             ]
         );
+    }
+
+    // Coverage follow-ups for #725: the tests above pin the common
+    // `LazySeq` shapes (plain `map`, composed `map | map`, `keys_unsorted |
+    // map`, atomicity), but a handful of less-common `GenericResult`
+    // combinations the `LazySeq` machinery touches weren't reached by any
+    // existing test.
+
+    #[test]
+    fn test_generic_lazy_seq_debug_format_725() {
+        // `LazySeq`/`LazySource`'s hand-written `Debug` impls (see their doc
+        // comments for why they're not derived) were never exercised by any
+        // `{:?}` formatting -- pin the shape for all four `LazySource`
+        // variants (`Elements`/`Values`/`Keys`/`IndexRange`).
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(.)").unwrap();
+        let result = eval(&expr, value);
+        let GenericResult::LazySeq(seq) = result else {
+            panic!("expected LazySeq");
+        };
+        let debug = format!("{seq:?}");
+        assert!(debug.contains("LazySource::Elements"), "{debug}");
+        assert!(debug.contains("pending_len"), "{debug}");
+
+        let json = br#"{"a":1,"b":2}"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(.)").unwrap();
+        let GenericResult::LazySeq(seq) = eval(&expr, value) else {
+            panic!("expected LazySeq");
+        };
+        assert!(format!("{seq:?}").contains("LazySource::Values"));
+
+        let expr = crate::jq::parse("keys_unsorted | map(.)").unwrap();
+        let json = br#"{"a":1,"b":2}"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let GenericResult::LazySeq(seq) = eval(&expr, value) else {
+            panic!("expected LazySeq");
+        };
+        assert!(format!("{seq:?}").contains("LazySource::Keys"));
+
+        let json = br#"["x","y"]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let GenericResult::LazySeq(seq) = eval(&expr, value) else {
+            panic!("expected LazySeq");
+        };
+        let debug = format!("{seq:?}");
+        assert!(debug.contains("LazySource::IndexRange"), "{debug}");
+        assert!(debug.contains("next"), "{debug}");
+        assert!(debug.contains("len"), "{debug}");
+    }
+
+    #[test]
+    fn test_generic_lazy_elem_debug_format_725() {
+        // `LazyElem`'s hand-written `Debug` impl (see its doc comment: it's
+        // `pub` because anyone who can name the `pub` `LazySeq` type can call
+        // `.next()` on it and observe a `LazyElem`) -- pull one element of
+        // each kind directly and format it, since `LazySeq`'s own `Debug`
+        // above only ever prints `pending`'s *length*, never its elements.
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        // `map(.)`: identity preserves the cursor, so the first pulled item
+        // is `LazyElem::Cursor`.
+        let expr = crate::jq::parse("map(.)").unwrap();
+        let GenericResult::LazySeq(mut seq) = eval(&expr, value.clone()) else {
+            panic!("expected LazySeq");
+        };
+        let elem = seq.next().unwrap().unwrap();
+        assert_eq!(format!("{elem:?}"), "LazyElem::Cursor(..)");
+
+        // `map(.+1)`: arithmetic computes a fresh value, so the first pulled
+        // item is `LazyElem::Owned`.
+        let expr = crate::jq::parse("map(. + 1)").unwrap();
+        let GenericResult::LazySeq(mut seq) = eval(&expr, value) else {
+            panic!("expected LazySeq");
+        };
+        let elem = seq.next().unwrap().unwrap();
+        assert_eq!(format!("{elem:?}"), "LazyElem::Owned(Int(2))");
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_yq_semantics_threaded_725() {
+        // `LazySeq::eval_one` re-dispatches per `Instruction::tag`
+        // (`EvalTag::Jq` vs `EvalTag::Yq`) so yq keeps yq arithmetic
+        // semantics through a lazy `map` chain -- neither tagged arm's
+        // `Yq` branch (`LazyElem::Cursor`+`Yq` for the first stage,
+        // `LazyElem::Owned`+`Yq` for the second, composed stage) was
+        // exercised by any test using `eval_using`/`eval_with_cursor` (both
+        // hardcode `JqSemantics`).
+        let json = br"[10.5]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        // First stage runs on `LazyElem::Cursor` (from the array source);
+        // second stage runs on `LazyElem::Owned` (the first stage's output).
+        let expr = crate::jq::parse("map(. % 3) | map(. + 0)").unwrap();
+        let result = eval_using::<YqSemantics, _>(&expr, value);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            // yq keeps float modulo (1.5), unlike jq's truncating modulo (1).
+            OwnedValue::Array(vec![OwnedValue::Float(1.5)])
+        );
+    }
+
+    #[test]
+    fn test_generic_plain_map_materializes_cursor_elements_725() {
+        // `LazySeq::materialize_atomic`'s `LazyElem::Cursor` arm, and
+        // `into_lazy_items`'s `GenericResult::OneCursor` arm: `map(.)` on
+        // an empty container (the existing #725 empty-container test) never
+        // actually iterates, so neither line ever ran. A non-empty array
+        // does: `.` preserves the cursor for every element.
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(.)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+                OwnedValue::Int(3),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_inner_map_result_shapes_725() {
+        // `into_lazy_items` normalizes every `GenericResult` shape a `map`
+        // stage's function can produce for one element -- most of its arms
+        // were never reached by any existing test (only `Owned` and
+        // `Error` were, via plain arithmetic/`error(...)`).
+
+        // `keys_unsorted` on an object element -> `LazyKeys`.
+        let json = br#"[{"a":1},{"bb":2,"c":3}]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(keys_unsorted)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Array(vec![OwnedValue::String("a".to_string())]),
+                OwnedValue::Array(vec![
+                    OwnedValue::String("bb".to_string()),
+                    OwnedValue::String("c".to_string()),
+                ]),
+            ])
+        );
+
+        // `keys_unsorted` on an array element -> `LazyIndexRange`.
+        let json = br"[[1,2],[3,4,5]]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(keys_unsorted)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Array(vec![OwnedValue::Int(0), OwnedValue::Int(1)]),
+                OwnedValue::Array(vec![
+                    OwnedValue::Int(0),
+                    OwnedValue::Int(1),
+                    OwnedValue::Int(2)
+                ]),
+            ])
+        );
+
+        // `empty` -> `GenericResult::None`, dropping the element entirely.
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(select(. > 1))").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)])
+        );
+
+        // A comma of literals -> `GenericResult::ManyOwned`, fanning one
+        // source element into several output elements.
+        let json = br"[1]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(1, 2)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
+        );
+
+        // `.[]` on an array-valued element -> `GenericResult::ManyCursor`
+        // (the native `Expr::Iterate` arm), fanning one source element into
+        // several *cursor* output elements -- distinct from the comma case
+        // above, which only ever produces owned values.
+        let json = br"[[1,2],[3]]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(.[])").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+                OwnedValue::Int(3),
+            ])
+        );
+
+        // A per-element function that is itself `keys_unsorted | map(g)`
+        // -> `GenericResult::LazySeq` (recursive laziness). Explicit non-goal
+        // (see `into_lazy_items`'s doc comment): forced via `materialize_atomic`
+        // right there instead of composing further.
+        let json = br#"[{"a":1},{"bb":2,"c":3}]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(keys_unsorted | map(ascii_upcase))").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Array(vec![OwnedValue::String("A".to_string())]),
+                OwnedValue::Array(vec![
+                    OwnedValue::String("BB".to_string()),
+                    OwnedValue::String("C".to_string()),
+                ]),
+            ])
+        );
+
+        // A per-element function whose own output is itself `Partial`
+        // (some outputs before an error) -> the whole `map` construction
+        // discards them and fails, same atomicity as a bare error.
+        let json = br"[1]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse(r#"map(1, 2, error("x"))"#).unwrap();
+        assert!(eval(&expr, value).materialize_lazy().is_error());
+    }
+
+    #[test]
+    fn test_generic_plain_map_optional_on_non_container_is_unreachable_via_parser_725() {
+        // `Builtin::Map`'s own `optional`-guarded arm mirrors `Expr::Iterate`'s
+        // (both fall back to `None` instead of erroring when `optional` is
+        // set) but, unlike `Expr::Iterate`, is provably unreachable through
+        // the parser: `map(f)?` always parses to `Expr::Optional(Builtin::Map(f))`
+        // (see `parser.rs`), and `Expr::Optional`'s own generic catch (above
+        // in this file) evaluates its inner expression at the *ambient*
+        // `optional` -- never forcing `true` into a bare `Builtin::Map` --
+        // then converts the resulting `Error` to `None` itself. So this arm
+        // never sees `optional = true` from any real query; call the
+        // (private, module-internal) dispatcher directly to pin it anyway,
+        // matching the same observation already made about `Builtin::Select`
+        // just above this arm in the source.
+        let json = br"5";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(. + 1)").unwrap();
+        let result = eval_single::<JqSemantics, _>(&expr, value, true, None);
+        assert!(matches!(result, GenericResult::None));
+    }
+
+    #[test]
+    fn test_generic_select_condition_lazy_seq_725() {
+        // `select(map(f))`: the condition itself takes the `LazySeq` fast
+        // path, so `push_generic_truthiness` must materialize it once to
+        // answer truthiness -- distinct from `LazyKeys`/`LazyIndexRange`'s
+        // truthy-without-materializing shortcut just above it (a `LazySeq`
+        // can fail, so it can't reuse that shortcut).
+        let json = br"[1,2]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("select(map(. + 1))").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
+        );
+
+        let expr = crate::jq::parse(r#"select(map(error("boom")))"#).unwrap();
+        assert!(eval(&expr, value).is_error());
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_length_propagates_control_725() {
+        // The composability arm's `length`: count-and-discard over the
+        // `LazySeq`, but an error/break partway through must still surface
+        // as `length`'s own result, not a partial count.
+        let json = br#"["a","b"]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse(r#"map(error("boom")) | length"#).unwrap();
+        assert!(eval(&expr, value.clone()).is_error());
+
+        let expr = crate::jq::parse(r"map(break $out) | length").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::Break(ref label) if label == "out"));
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_iterate_all_cursor_725() {
+        // The composability arm's `.[]`: when every pulled element stayed a
+        // cursor (e.g. `map(.)`'s identity), the whole thing answers as
+        // `GenericResult::ManyCursor` -- no `to_owned` round trip.
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(.) | .[]").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::ManyCursor(_)));
+        assert_eq!(
+            result.collect_owned(),
+            vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]
+        );
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_iterate_mixed_cursor_and_owned_725() {
+        // Same `.[]` arm, heterogeneous case: one element resolves to a
+        // cursor (`.foo` present), another to a computed/missing value
+        // (`.foo` absent is owned `null`) -- not all-cursor, so the whole
+        // thing materializes to `GenericResult::ManyOwned`, exercising the
+        // `LazyElem::Cursor` sub-arm of that conversion (the existing
+        // `map(ascii_upcase) | .[]` test only ever produced `Owned` items).
+        let json = br#"[{"foo":1},{"other":2}]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(.foo) | .[]").unwrap();
+        let result = eval(&expr, value);
+        assert!(!matches!(result, GenericResult::ManyCursor(_)));
+        assert_eq!(
+            result.collect_owned(),
+            vec![OwnedValue::Int(1), OwnedValue::Null]
+        );
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_iterate_atomicity_discards_cursor_prefix_725() {
+        // Same `.[]` arm, failing case: the already-succeeded prefix (here,
+        // one element whose `.foo` access resolved to a cursor, not an owned
+        // value -- unlike the other atomicity test's `if/else` map function,
+        // which isn't cursor-preserving) is discarded, not kept, on a later
+        // element's error -- `map`'s array construction is atomic in real
+        // jq, and `.[]` piped after `map` iterates the array `map` already
+        // built, so it inherits that atomicity regardless of whether the
+        // discarded items were cursors or owned values.
+        let json = br#"[{"foo":1},42]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(.foo) | .[]").unwrap();
+        let result = eval(&expr, value);
+        assert!(result.is_error());
+        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_first_and_index_zero_all_shapes_725() {
+        // The composability arm's `first`/`.[0]` ("pull-one-and-stop"):
+        // every arm of its own `match seq.next()` -- empty, cursor, error,
+        // break -- but the existing test only ever exercised the `Owned`
+        // shape (`map(ascii_upcase) | first`).
+        let json = br"[]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(.) | first").unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(.) | first").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::OneCursor(_)));
+        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(1));
+
+        let json = br"[42]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(.foo) | first").unwrap();
+        assert!(eval(&expr, value).is_error());
+
+        let json = br"[1]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(break $out) | first").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::Break(ref label) if label == "out"));
+    }
+
+    #[test]
+    fn test_generic_first_last_expr_forward_lazy_seq_725() {
+        // `first(EXPR)`/`last(EXPR)` (the explicit-argument form, distinct
+        // from the no-argument `first`/`last` builtins covered above):
+        // `eval_first_or_last_generic` forwards a `LazySeq` result
+        // unchanged in both directions instead of materializing it, since
+        // it only needs to know *which* output this is, not inspect it.
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("first(map(. * 2))").unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(2),
+                OwnedValue::Int(4),
+                OwnedValue::Int(6),
+            ])
+        );
+
+        let expr = crate::jq::parse("last(map(. * 2))").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(2),
+                OwnedValue::Int(4),
+                OwnedValue::Int(6),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_stream_json_yaml_725() {
+        // `GenericResult::stream_json`/`stream_yaml`'s own `LazySeq` arm
+        // (distinct from `LazyKeys`/`LazyIndexRange`'s zero-buffer writers
+        // just above it -- `map`'s array construction is atomic, so this one
+        // pulls the whole `LazySeq` via `materialize_atomic` first): neither
+        // the success nor the `break`-control path was exercised by any
+        // existing test (only the `error`-control path, via
+        // `test_generic_plain_map_atomicity_725`).
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(. + 1)").unwrap();
+        let result = eval(&expr, value.clone());
+        let mut out = String::new();
+        let stats = result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, "[2,3,4]");
+        assert_eq!(stats.count, 1);
+        assert!(stats.any_truthy);
+
+        let mut out = String::new();
+        let stats = result.stream_yaml(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, "[2, 3, 4]");
+        assert_eq!(stats.count, 1);
+        assert!(stats.any_truthy);
+
+        let expr = crate::jq::parse("map(break $out)").unwrap();
+        let result = eval(&expr, value.clone());
+        let mut out = String::new();
+        let stats = result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, "");
+        assert_eq!(stats.count, 0);
+        assert!(stats.error.is_some());
+
+        let result = eval(&expr, value);
+        let mut out = String::new();
+        let stats = result.stream_yaml(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_materialize_lazy_break_725() {
+        // `GenericResult::materialize_lazy`'s own `LazySeq` arm converts a
+        // `Control::Break` into `Self::Break` -- distinct from `stream_json`/
+        // `stream_yaml`'s own bespoke `LazySeq` handling above (which never
+        // calls `materialize_lazy`), and from the composability arm's
+        // native `length`/`first` short-circuits (which return `Break`
+        // directly, before `materialize_lazy` ever runs). `into_owned`/
+        // `collect_owned` are the only two callers that reach it, and both
+        // route through the plain fallback shape (`_ =>
+        // materialize_atomic()+eval_on_owned`), not through a top-level bare
+        // `map`.
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(break $out) | last").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::Break(ref label) if label == "out"));
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_composability_fallback_propagates_control_725() {
+        // The composability arm's final `_` fallback (`last`, `.[n]` for
+        // `n != 0`, `select`, comparisons, ...): one atomic
+        // `materialize_atomic` pull, then hand off to `eval_on_owned` -- but
+        // an error/break during that pull must surface directly, never
+        // reaching `eval_on_owned` at all. The existing test for this
+        // fallback (`test_generic_lazy_seq_composability_native_consumers_725`)
+        // only ever exercised the success path.
+        let json = br#"[1,2,"x"]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(. + 1) | last").unwrap();
+        assert!(eval(&expr, value).is_error());
+
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("map(break $out) | last").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::Break(ref label) if label == "out"));
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_pipe_continuation_earlier_lazy_failure_wins_725() {
+        // `Expr::Pipe`'s `ManyCursor` continuation (`.[] | REST`, `REST`
+        // itself producing a fresh `LazySeq` per element via `keys_unsorted |
+        // map(f)`): each cursor element is evaluated independently and
+        // buffered into `per_element`. When materializing that buffer
+        // (`flatten_generic_results`) later discovers an *earlier* buffered
+        // `LazySeq` also fails, that earlier failure must win over whatever
+        // triggered the buffer to be flattened -- it's chronologically first
+        // in evaluation order. None of these interactions (earlier-fails
+        // alongside a later immediate error, or alongside a normal
+        // non-early-returning flatten) were exercised by any existing test.
+        let json = br#"[{"b":1,"a":2}, 42]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        // Element 0 (`{"b":1,"a":2}`) takes the `keys_unsorted | map(f)`
+        // fast path and stays a raw, unmaterialized `LazySeq` in
+        // `per_element` -- `f` fails once actually pulled (on key `"b"`).
+        // Element 1 (`42`, not an object/array) fails `keys_unsorted`
+        // immediately, triggering the early return that must first flatten
+        // (and thus fail on) element 0's still-buffered `LazySeq` -- whose
+        // error wins over element 1's own.
+        let expr = crate::jq::parse(
+            r#".[] | (keys_unsorted | map(if . == "b" then error("early") else . end))"#,
+        )
+        .unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(result.is_error());
+        assert_eq!(result.error().unwrap().message, "early");
+
+        // Same shape, but element 0's buffered `LazySeq` fails via `break`
+        // instead of `error` -- the earlier `Break` must still win over
+        // element 1's immediate `Error`.
+        let expr = crate::jq::parse(
+            r#".[] | (keys_unsorted | map(if . == "b" then break $out else . end))"#,
+        )
+        .unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::Break(ref label) if label == "out"));
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_pipe_continuation_flatten_after_full_scan_725() {
+        // Same `ManyCursor` continuation as above, but with no element
+        // triggering an early return at all: every element resolves to a
+        // raw, buffered `LazySeq`, so `flatten_generic_results` only runs
+        // once, after the loop over every cursor finishes. A failure
+        // discovered there (as opposed to the early-return paths covered by
+        // `..._earlier_lazy_failure_wins_725` above) is a distinct code
+        // path (the fallthrough at the bottom of the `ManyCursor` arm).
+        let json = br#"[{"b":1},{"a":2}]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse(
+            r#".[] | (keys_unsorted | map(if . == "b" then error("boom") else . end))"#,
+        )
+        .unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(result.is_error());
+        assert_eq!(result.error().unwrap().message, "boom");
+
+        let expr = crate::jq::parse(
+            r#".[] | (keys_unsorted | map(if . == "b" then break $out else . end))"#,
+        )
+        .unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::Break(ref label) if label == "out"));
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9,11 +9,15 @@ use alloc::boxed::Box;
 #[cfg(not(test))]
 use alloc::format;
 #[cfg(not(test))]
+use alloc::rc::Rc;
+#[cfg(not(test))]
 use alloc::string::{String, ToString};
 #[cfg(not(test))]
 use alloc::vec;
 #[cfg(not(test))]
 use alloc::vec::Vec;
+#[cfg(test)]
+use std::rc::Rc;
 
 use indexmap::IndexMap;
 
@@ -23,8 +27,8 @@ use super::document::{
 use super::eval::{
     compare_values, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
     needs_path_context, numeric_display_string, numeric_key_to_index, owned_bound_to_i64,
-    slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics, JqSemantics,
-    QueryResult,
+    slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag, JqSemantics,
+    QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Literal};
 use super::slice::{slice_str, SliceBounds};
@@ -128,6 +132,277 @@ fn unwrap_paren(mut expr: &Expr) -> &Expr {
         expr = inner;
     }
     expr
+}
+
+/// One pending element of a `LazySeq`: still a live pointer into the source
+/// document, or a value an earlier `map` stage computed that no longer
+/// corresponds to one node in the source.
+///
+/// Must be `pub`, like `LazySeq` itself: it's the `Item` of `LazySeq`'s
+/// `Iterator` impl below, and `Iterator` is a standard-library trait always
+/// in scope, so anyone who can name the (necessarily `pub`) `LazySeq` type
+/// can call `.next()` on it and observe this type.
+#[derive(Clone)]
+pub enum LazyElem<V: DocumentValue> {
+    Cursor(V::Cursor),
+    Owned(OwnedValue),
+}
+
+// Hand-written rather than derived: deriving would require `V::Cursor: Debug`
+// generically, which `DocumentCursor` doesn't guarantee (unlike `Clone`, which
+// it does via a supertrait bound). Kept opaque on purpose, not just to satisfy
+// the compiler -- printing a cursor's full backing state is a real footgun in
+// this codebase (a YAML cursor's `Debug` walks the whole shared index,
+// including the O1/O2 sequential-cursor `Cell` cache).
+impl<V: DocumentValue> core::fmt::Debug for LazyElem<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Cursor(_) => f.write_str("LazyElem::Cursor(..)"),
+            Self::Owned(o) => f.debug_tuple("LazyElem::Owned").field(o).finish(),
+        }
+    }
+}
+
+/// The starting point of a `LazySeq` chain — forward-only by construction
+/// (consumed cons cells are simply gone, no rewind method exists on any
+/// variant).
+#[derive(Clone)]
+enum LazySource<V: DocumentValue> {
+    /// Bare `arr | map(f)` (#725).
+    Elements(V::Elements),
+    /// Bare `obj | map(f)` (#725).
+    Values(V::Fields),
+    /// `keys_unsorted | map(f)` (#724).
+    Keys(V::Fields),
+    /// Array `keys_unsorted | map(f)` (#724) — synthetic `[0, 1, ..., len-1]`,
+    /// no cursor to point at.
+    IndexRange { next: usize, len: usize },
+}
+
+// See `LazyElem`'s `Debug` impl above for why this is hand-written, not derived.
+impl<V: DocumentValue> core::fmt::Debug for LazySource<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Elements(_) => f.write_str("LazySource::Elements(..)"),
+            Self::Values(_) => f.write_str("LazySource::Values(..)"),
+            Self::Keys(_) => f.write_str("LazySource::Keys(..)"),
+            Self::IndexRange { next, len } => f
+                .debug_struct("LazySource::IndexRange")
+                .field("next", next)
+                .field("len", len)
+                .finish(),
+        }
+    }
+}
+
+impl<V: DocumentValue> LazySource<V> {
+    /// Pull one element forward, storing "the rest" back into `self`. Once a
+    /// variant's underlying cons-list is empty (or `next == len`), every
+    /// subsequent call returns `None` forever.
+    fn advance(&mut self) -> Option<LazyElem<V>> {
+        match self {
+            Self::Elements(elements) => {
+                let (cursor, rest) = elements.uncons_cursor()?;
+                *elements = rest;
+                Some(LazyElem::Cursor(cursor))
+            }
+            Self::Values(fields) => {
+                let (field, rest) = fields.uncons()?;
+                *fields = rest;
+                Some(LazyElem::Cursor(field.value_cursor))
+            }
+            Self::Keys(fields) => {
+                let (field, rest) = fields.uncons()?;
+                *fields = rest;
+                Some(LazyElem::Cursor(field.key_cursor))
+            }
+            Self::IndexRange { next, len } => {
+                if *next >= *len {
+                    return None;
+                }
+                let i = *next;
+                *next += 1;
+                Some(LazyElem::Owned(OwnedValue::Int(i as i64)))
+            }
+        }
+    }
+}
+
+/// One deferred `map(f)` stage. `select(g)` composes as a plain pipe stage
+/// evaluating `g` and testing truthiness the same way `Builtin::Select`
+/// already does elsewhere — this design adds no dedicated `select` variant.
+#[derive(Debug, Clone)]
+struct Instruction {
+    f: Rc<Expr>,
+    tag: EvalTag,
+}
+
+/// A composed, not-yet-materialized `map` chain (#724, #725).
+///
+/// See `docs/plan/jq-lazy-map-select.md`. `source` never rewinds.
+/// `instructions` grows by one `Rc`-shared entry per composed stage, so an
+/// arbitrary-length chain (`map(f) | map(g) | map(h)`) is one value, not one
+/// type per depth. `pending` buffers only the current source element's own
+/// fan-out (0..N outputs from `,`/`empty` inside one stage), never an
+/// earlier or later element — in reverse push order so `Vec::pop` yields
+/// them in original order.
+///
+/// Must be `pub`: it appears inside the public `GenericResult::LazySeq`
+/// variant, and the CLI binary crate (`jq_runner.rs`/`yq_runner.rs`) depends
+/// on this library crate, so cross-crate reachability is a real constraint.
+/// Fields stay private; only `materialize_atomic` is `pub`.
+#[derive(Clone)]
+pub struct LazySeq<V: DocumentValue> {
+    source: LazySource<V>,
+    instructions: Rc<Vec<Instruction>>,
+    pending: Vec<LazyElem<V>>,
+}
+
+// See `LazyElem`'s `Debug` impl above for why this is hand-written, not
+// derived -- and why it stays opaque rather than exposing `pending`'s
+// buffered elements.
+impl<V: DocumentValue> core::fmt::Debug for LazySeq<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LazySeq")
+            .field("source", &self.source)
+            .field("instructions_len", &self.instructions.len())
+            .field("pending_len", &self.pending.len())
+            .finish()
+    }
+}
+
+impl<V: DocumentValue> LazySeq<V> {
+    fn new(source: LazySource<V>) -> Self {
+        Self {
+            source,
+            instructions: Rc::new(Vec::new()),
+            pending: Vec::new(),
+        }
+    }
+
+    /// Push one more `map(f)` stage onto this chain. `f` is cloned once per
+    /// *stage* (not per element) into a fresh `Rc` — `Builtin::Map` only ever
+    /// hands us a borrowed `&Expr` (from `unwrap_paren` in the `Pipe` fold, or
+    /// `&Builtin` in `eval_builtin`), so there is nothing to move out of.
+    fn push_map(mut self, f: &Expr, tag: EvalTag) -> Self {
+        Rc::make_mut(&mut self.instructions).push(Instruction {
+            f: Rc::new(f.clone()),
+            tag,
+        });
+        self
+    }
+
+    /// Run one `Instruction` against one pending item, re-dispatching to
+    /// whichever `EvalSemantics` the stage was pushed with. `LazyElem::Cursor`
+    /// stays inside the generic cursor evaluator — the actual win;
+    /// `LazyElem::Owned` bridges through `eval_on_owned`, only ever asked to
+    /// reindex one already-small computed/synthetic scalar (a map-produced
+    /// value or an array-`keys_unsorted` index), never the whole document.
+    fn eval_one(instr: &Instruction, elem: LazyElem<V>) -> GenericResult<V> {
+        match (elem, instr.tag) {
+            (LazyElem::Cursor(c), EvalTag::Jq) => {
+                eval_single::<JqSemantics, V>(&instr.f, c.value(), false, Some(c))
+            }
+            (LazyElem::Cursor(c), EvalTag::Yq) => {
+                eval_single::<YqSemantics, V>(&instr.f, c.value(), false, Some(c))
+            }
+            (LazyElem::Owned(o), EvalTag::Jq) => {
+                eval_on_owned::<JqSemantics, V>(&instr.f, o, false)
+            }
+            (LazyElem::Owned(o), EvalTag::Yq) => {
+                eval_on_owned::<YqSemantics, V>(&instr.f, o, false)
+            }
+        }
+    }
+
+    /// Fold one source element through every instruction in order, fanning
+    /// out via `,`/dropping via `empty` at each stage. Atomic at *this
+    /// element's own* granularity: any stage's error/break for this one
+    /// element aborts the whole element, mirroring `eval::map_over`'s
+    /// per-array-construction atomicity.
+    fn fold_one(&self, elem: LazyElem<V>) -> Result<Vec<LazyElem<V>>, Control> {
+        let mut items = vec![elem];
+        for instr in self.instructions.iter() {
+            let mut next_items = Vec::with_capacity(items.len());
+            for item in items {
+                next_items.extend(into_lazy_items(Self::eval_one(instr, item))?);
+            }
+            items = next_items;
+        }
+        Ok(items)
+    }
+
+    /// Pull every remaining element to completion, discarding the whole
+    /// in-progress array on the first error/break (mirrors `map_over`'s
+    /// atomicity — real jq's array construction is all-or-nothing:
+    /// `[1,2,"x"]|map(.+1)` prints nothing to stdout, only the stderr
+    /// diagnostic).
+    pub fn materialize_atomic(self) -> Result<OwnedValue, Control> {
+        let mut out = Vec::new();
+        for item in self {
+            match item {
+                Ok(LazyElem::Cursor(c)) => out.push(to_owned(&c.value())),
+                Ok(LazyElem::Owned(o)) => out.push(o),
+                Err(control) => return Err(control),
+            }
+        }
+        Ok(OwnedValue::Array(out))
+    }
+}
+
+impl<V: DocumentValue> Iterator for LazySeq<V> {
+    type Item = Result<LazyElem<V>, Control>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(item) = self.pending.pop() {
+                return Some(Ok(item));
+            }
+            let elem = self.source.advance()?;
+            match self.fold_one(elem) {
+                Ok(mut items) => {
+                    items.reverse();
+                    self.pending = items;
+                }
+                Err(control) => return Some(Err(control)),
+            }
+        }
+    }
+}
+
+/// Normalize any `GenericResult<V>` shape a `map` stage can produce into the
+/// `LazyElem` items it contributes to the chain — the single point every
+/// stage's output funnels through.
+fn into_lazy_items<V: DocumentValue>(
+    result: GenericResult<V>,
+) -> Result<Vec<LazyElem<V>>, Control> {
+    match result {
+        GenericResult::One(v) => Ok(vec![LazyElem::Owned(to_owned(&v))]),
+        // Stays lazy: a `map(.foo)`-style navigational sub-expr keeps
+        // composing without forcing materialization.
+        GenericResult::OneCursor(c) => Ok(vec![LazyElem::Cursor(c)]),
+        GenericResult::Many(vs) => Ok(vs.iter().map(|v| LazyElem::Owned(to_owned(v))).collect()),
+        GenericResult::ManyCursor(cs) => Ok(cs.into_iter().map(LazyElem::Cursor).collect()),
+        GenericResult::LazyKeys { fields, sorted } => Ok(vec![LazyElem::Owned(
+            materialize_lazy_keys::<V>(&fields, sorted),
+        )]),
+        GenericResult::LazyIndexRange(len) => {
+            Ok(vec![LazyElem::Owned(materialize_lazy_index_range(len))])
+        }
+        // Recursive laziness (`map(map(f))` where the *inner* `map` also
+        // stays lazy) is an explicit non-goal — force it here, same
+        // one-forward-pass cost `materialize_atomic` pays elsewhere.
+        GenericResult::LazySeq(seq) => Ok(vec![LazyElem::Owned(seq.materialize_atomic()?)]),
+        GenericResult::None => Ok(vec![]),
+        GenericResult::Owned(o) => Ok(vec![LazyElem::Owned(o)]),
+        GenericResult::ManyOwned(os) => Ok(os.into_iter().map(LazyElem::Owned).collect()),
+        GenericResult::Error(e) => Err(Control::Error(e)),
+        GenericResult::Break(label) => Err(Control::Break(label)),
+        // Same atomicity as `map_over`: a `Partial`'s already-succeeded
+        // prefix is discarded, not kept, when it's one stage's output inside
+        // a larger atomic array construction.
+        GenericResult::Partial(_, control) => Err(control),
+    }
 }
 
 /// Convert a StandardJson value to an OwnedValue.
@@ -272,6 +547,17 @@ fn push_generic_truthiness<V: DocumentValue>(
         // Same reasoning as `LazyKeys` above — the array-index-range result
         // of `keys`/`keys_unsorted` on an array is always truthy.
         GenericResult::LazyIndexRange(_) => out.push(true),
+        // Unlike `LazyKeys`/`LazyIndexRange` above, a `LazySeq` CAN fail
+        // (arbitrary `map(f)`), and that failure must surface here rather
+        // than being reported as "truthy" before construction is even known
+        // to succeed — do NOT replace this with a blind
+        // `.materialize_lazy()` call, which would also force materializing
+        // the two variants above on every `select`, undoing their whole
+        // point.
+        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+            Ok(_array) => out.push(true),
+            Err(control) => return Some(control),
+        },
         GenericResult::None => {}
         GenericResult::Owned(v) => out.push(v.is_truthy()),
         GenericResult::ManyOwned(vs) => out.extend(vs.iter().map(OwnedValue::is_truthy)),
@@ -287,36 +573,48 @@ fn push_generic_truthiness<V: DocumentValue>(
 
 /// Flatten a batch of per-element results into one `Vec<OwnedValue>`.
 ///
-/// `items` must never contain `Error`/`Break`/`Partial` — callers that build
-/// up a per-element batch route those variants to an early return (folding
-/// whatever was already flattened into a `Partial` of their own via
-/// [`partial_generic`]) instead of pushing them here, so this only ever sees
-/// the variants that still need materializing.
-fn flatten_generic_results<V: DocumentValue>(items: Vec<GenericResult<V>>) -> Vec<OwnedValue> {
+/// A bare `Error`/`Break`/`Partial` must never appear in `items` — callers
+/// that build up a per-element batch route those variants to an early return
+/// (folding whatever was already flattened into a `Partial` of their own via
+/// [`partial_generic`]) instead of pushing them here. A `LazySeq` item CAN
+/// still fail once materialized here, though (its failure isn't known until
+/// `materialize_lazy()` actually pulls it) — that's why this returns
+/// `Result`, not a plain `Vec` as it used to before `LazySeq` existed (#725):
+/// unlike `LazyKeys`/`LazyIndexRange`, which can never fail to materialize, a
+/// `LazySeq` runs arbitrary `map(f)` and can be reached here (e.g. via
+/// `.[] | (keys_unsorted | map(f))`) before any materialization has
+/// happened.
+fn flatten_generic_results<V: DocumentValue>(
+    items: Vec<GenericResult<V>>,
+) -> Result<Vec<OwnedValue>, Control> {
     let mut results = Vec::new();
     for r in items {
-        match r {
+        match r.materialize_lazy() {
             GenericResult::One(v) => results.push(to_owned(&v)),
             GenericResult::OneCursor(c) => results.push(to_owned(&c.value())),
             GenericResult::Many(rs) => results.extend(rs.iter().map(to_owned)),
             GenericResult::ManyCursor(cs) => {
                 results.extend(cs.iter().map(|c| to_owned(&c.value())));
             }
-            GenericResult::LazyKeys { fields, sorted } => {
-                results.push(materialize_lazy_keys::<V>(&fields, sorted));
-            }
-            GenericResult::LazyIndexRange(len) => {
-                results.push(materialize_lazy_index_range(len));
-            }
             GenericResult::None => {}
             GenericResult::Owned(o) => results.push(o),
             GenericResult::ManyOwned(os) => results.extend(os),
-            GenericResult::Error(_) | GenericResult::Break(_) | GenericResult::Partial(..) => {
-                unreachable!("Error/Break/Partial already routed to an early return above")
+            // Only reachable via a `LazySeq` item that failed to
+            // materialize — a bare `Error`/`Break` still can't appear here
+            // per this function's own precondition above.
+            GenericResult::Error(e) => return Err(Control::Error(e)),
+            GenericResult::Break(label) => return Err(Control::Break(label)),
+            GenericResult::Partial(..) => {
+                unreachable!("Partial already routed to an early return above")
+            }
+            GenericResult::LazyKeys { .. }
+            | GenericResult::LazyIndexRange(_)
+            | GenericResult::LazySeq(_) => {
+                unreachable!("materialize_lazy() already normalized every lazy variant")
             }
         }
     }
-    results
+    Ok(results)
 }
 
 /// Evaluate an expression on multiple OwnedValues using the full evaluator.
@@ -344,6 +642,7 @@ fn eval_on_many_owned<S: EvalSemantics, V: DocumentValue>(
             GenericResult::LazyIndexRange(_) => {
                 unreachable!("eval_on_owned never returns LazyIndexRange")
             }
+            GenericResult::LazySeq(_) => unreachable!("eval_on_owned never returns LazySeq"),
             GenericResult::None => {}
             // The outputs already produced no longer vanish (#400, #494).
             GenericResult::Error(e) => return partial_generic(results, Control::Error(e)),
@@ -399,6 +698,13 @@ pub enum GenericResult<V: DocumentValue> {
     /// `keys`/`keys_unsorted` did.
     LazyIndexRange(usize),
 
+    /// A composed, not-yet-materialized `map` chain (#724, #725) — plain
+    /// `arr`/`obj | map(f)` and `keys_unsorted | map(f)` alike, and any
+    /// further `| map(g)` stages pushed onto the same chain by the `Pipe`
+    /// fold's composability arm below. See `LazySeq`'s own docs for the
+    /// mechanism and `docs/plan/jq-lazy-map-select.md` for the design.
+    LazySeq(LazySeq<V>),
+
     /// No result (optional that was missing).
     None,
 
@@ -420,17 +726,36 @@ pub enum GenericResult<V: DocumentValue> {
 }
 
 impl<V: DocumentValue> GenericResult<V> {
+    /// Materialize any lazy variant (`LazyKeys`/`LazyIndexRange`/`LazySeq`)
+    /// into `Owned`/`Error`/`Break`, leaving every other variant unchanged.
+    /// The shared collapse point for every consumer that was always going to
+    /// materialize a lazy result anyway (as opposed to `push_generic_truthiness`
+    /// and `eval_first_or_last_generic`, which have their own bespoke `LazySeq`
+    /// handling below specifically to avoid forcing materialization here).
+    fn materialize_lazy(self) -> Self {
+        match self {
+            Self::LazyKeys { fields, sorted } => {
+                Self::Owned(materialize_lazy_keys::<V>(&fields, sorted))
+            }
+            Self::LazyIndexRange(len) => Self::Owned(materialize_lazy_index_range(len)),
+            Self::LazySeq(seq) => match seq.materialize_atomic() {
+                Ok(owned) => Self::Owned(owned),
+                Err(Control::Error(e)) => Self::Error(e),
+                Err(Control::Break(label)) => Self::Break(label),
+            },
+            other => other,
+        }
+    }
+
     /// Convert to OwnedValue for output.
     pub fn into_owned(self) -> Option<OwnedValue> {
-        match self {
+        match self.materialize_lazy() {
             Self::One(v) => Some(to_owned(&v)),
             Self::OneCursor(c) => Some(to_owned(&c.value())),
             Self::Many(vs) => Some(OwnedValue::Array(vs.iter().map(to_owned).collect())),
             Self::ManyCursor(cs) => Some(OwnedValue::Array(
                 cs.iter().map(|c| to_owned(&c.value())).collect(),
             )),
-            Self::LazyKeys { fields, sorted } => Some(materialize_lazy_keys::<V>(&fields, sorted)),
-            Self::LazyIndexRange(len) => Some(materialize_lazy_index_range(len)),
             Self::None => None,
             Self::Error(_) => None,
             Self::Owned(o) => Some(o),
@@ -439,6 +764,9 @@ impl<V: DocumentValue> GenericResult<V> {
             // A `Partial` prefix is not representable as a single value —
             // same "not representable" answer as `Break`/`Error` here.
             Self::Partial(..) => None,
+            Self::LazyKeys { .. } | Self::LazyIndexRange(_) | Self::LazySeq(_) => {
+                unreachable!("materialize_lazy() already normalized every lazy variant")
+            }
         }
     }
 
@@ -447,19 +775,20 @@ impl<V: DocumentValue> GenericResult<V> {
     /// A `Partial` collects its prefix — the whole point of #400/#494 is
     /// that those outputs are no longer discarded.
     pub fn collect_owned(self) -> Vec<OwnedValue> {
-        match self {
+        match self.materialize_lazy() {
             Self::One(v) => vec![to_owned(&v)],
             Self::OneCursor(c) => vec![to_owned(&c.value())],
             Self::Many(vs) => vs.iter().map(to_owned).collect(),
             Self::ManyCursor(cs) => cs.iter().map(|c| to_owned(&c.value())).collect(),
-            Self::LazyKeys { fields, sorted } => vec![materialize_lazy_keys::<V>(&fields, sorted)],
-            Self::LazyIndexRange(len) => vec![materialize_lazy_index_range(len)],
             Self::None => vec![],
             Self::Error(_) => vec![],
             Self::Owned(o) => vec![o],
             Self::ManyOwned(os) => os,
             Self::Break(_) => vec![],
             Self::Partial(vs, _control) => vs,
+            Self::LazyKeys { .. } | Self::LazyIndexRange(_) | Self::LazySeq(_) => {
+                unreachable!("materialize_lazy() already normalized every lazy variant")
+            }
         }
     }
 
@@ -559,6 +888,35 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.last_was_falsy = false;
                 stats.any_truthy = true;
             }
+            // Deliberately NOT a zero-buffer writer like `LazyKeys`'s
+            // unsorted arm above: `map`'s array construction is atomic in
+            // real jq (`[1,2,"x"]|map(.+1)` prints nothing to stdout, only
+            // the stderr diagnostic), but a byte-at-a-time writer would
+            // already have flushed `[1,2,` to `out` before discovering
+            // element 3 fails — wrong, unfixable-after-the-fact output. One
+            // atomic forward pass via `materialize_atomic`, then reuse the
+            // already-tested `OwnedValue::stream_json` — this still avoids
+            // the reserialize+reindex+separate-evaluator round trip that was
+            // the actual expensive part; a single `Vec<OwnedValue>` for the
+            // final array was never it.
+            Self::LazySeq(seq) => match seq.clone().materialize_atomic() {
+                Ok(owned) => {
+                    owned.stream_json(out, indent_spaces)?;
+                    on_value(out)?;
+                    stats.count = 1;
+                    stats.last_was_falsy = owned.is_falsy();
+                    stats.any_truthy = !stats.last_was_falsy;
+                }
+                Err(control) => {
+                    stats.error = Some(match control {
+                        Control::Error(e) => stream_error(&e),
+                        Control::Break(label) => StreamError {
+                            message: format!("break ${label} not in label"),
+                            not_a_string: false,
+                        },
+                    });
+                }
+            },
             Self::ManyCursor(cs) => {
                 for c in cs {
                     c.stream_json(out, indent, sort_keys)?;
@@ -707,6 +1065,27 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.last_was_falsy = false;
                 stats.any_truthy = true;
             }
+            // Same atomicity reasoning as `stream_json`'s `LazySeq` arm
+            // above — no zero-buffer writer, one atomic forward pass then
+            // reuse `OwnedValue::stream_yaml`.
+            Self::LazySeq(seq) => match seq.clone().materialize_atomic() {
+                Ok(owned) => {
+                    owned.stream_yaml(out, indent_spaces)?;
+                    on_value(out)?;
+                    stats.count = 1;
+                    stats.last_was_falsy = owned.is_falsy();
+                    stats.any_truthy = !stats.last_was_falsy;
+                }
+                Err(control) => {
+                    stats.error = Some(match control {
+                        Control::Error(e) => stream_error(&e),
+                        Control::Break(label) => StreamError {
+                            message: format!("break ${label} not in label"),
+                            not_a_string: false,
+                        },
+                    });
+                }
+            },
             Self::None => {
                 // No output
             }
@@ -1077,7 +1456,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                     GenericResult::Many(vs) => {
                         let mut results = Vec::new();
                         for v in vs {
-                            match eval_single::<S, _>(expr, v, optional, None) {
+                            match eval_single::<S, _>(expr, v, optional, None).materialize_lazy() {
                                 GenericResult::One(r) => results.push(to_owned(&r)),
                                 GenericResult::OneCursor(c) => results.push(to_owned(&c.value())),
                                 GenericResult::Many(rs) => {
@@ -1085,12 +1464,6 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 }
                                 GenericResult::ManyCursor(cs) => {
                                     results.extend(cs.iter().map(|c| to_owned(&c.value())));
-                                }
-                                GenericResult::LazyKeys { fields, sorted } => {
-                                    results.push(materialize_lazy_keys::<V>(&fields, sorted));
-                                }
-                                GenericResult::LazyIndexRange(len) => {
-                                    results.push(materialize_lazy_index_range(len));
                                 }
                                 GenericResult::None => {}
                                 // The outputs already piped through no longer
@@ -1106,6 +1479,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 GenericResult::Partial(vs2, control) => {
                                     results.extend(vs2);
                                     return partial_generic(results, control);
+                                }
+                                GenericResult::LazyKeys { .. }
+                                | GenericResult::LazyIndexRange(_)
+                                | GenericResult::LazySeq(_) => {
+                                    unreachable!(
+                                        "materialize_lazy() already normalized every lazy variant"
+                                    )
                                 }
                             }
                         }
@@ -1137,23 +1517,44 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         for c in cs {
                             match eval_single::<S, _>(&rest, c.value(), optional, Some(c)) {
                                 // The elements already piped through no
-                                // longer vanish (#400, #494).
+                                // longer vanish (#400, #494). If an earlier
+                                // element's own buffered `LazySeq` also fails
+                                // once `flatten_generic_results` materializes
+                                // it, that earlier failure wins -- it's
+                                // chronologically first in evaluation order.
                                 GenericResult::Error(e) => {
-                                    return partial_generic(
-                                        flatten_generic_results(per_element),
-                                        Control::Error(e),
-                                    );
+                                    return match flatten_generic_results(per_element) {
+                                        Ok(prefix) => partial_generic(prefix, Control::Error(e)),
+                                        Err(Control::Error(earlier)) => {
+                                            GenericResult::Error(earlier)
+                                        }
+                                        Err(Control::Break(label)) => GenericResult::Break(label),
+                                    };
                                 }
                                 GenericResult::Break(label) => {
-                                    return partial_generic(
-                                        flatten_generic_results(per_element),
-                                        Control::Break(label),
-                                    );
+                                    return match flatten_generic_results(per_element) {
+                                        Ok(prefix) => {
+                                            partial_generic(prefix, Control::Break(label))
+                                        }
+                                        Err(Control::Error(earlier)) => {
+                                            GenericResult::Error(earlier)
+                                        }
+                                        Err(Control::Break(earlier_label)) => {
+                                            GenericResult::Break(earlier_label)
+                                        }
+                                    };
                                 }
                                 GenericResult::Partial(vs, control) => {
-                                    let mut prefix = flatten_generic_results(per_element);
-                                    prefix.extend(vs);
-                                    return partial_generic(prefix, control);
+                                    return match flatten_generic_results(per_element) {
+                                        Ok(mut prefix) => {
+                                            prefix.extend(vs);
+                                            partial_generic(prefix, control)
+                                        }
+                                        Err(Control::Error(earlier)) => {
+                                            GenericResult::Error(earlier)
+                                        }
+                                        Err(Control::Break(label)) => GenericResult::Break(label),
+                                    };
                                 }
                                 other => per_element.push(other),
                             }
@@ -1175,11 +1576,11 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                     .collect(),
                             )
                         } else {
-                            let results = flatten_generic_results(per_element);
-                            if results.is_empty() {
-                                GenericResult::None
-                            } else {
-                                GenericResult::ManyOwned(results)
+                            match flatten_generic_results(per_element) {
+                                Ok(results) if results.is_empty() => GenericResult::None,
+                                Ok(results) => GenericResult::ManyOwned(results),
+                                Err(Control::Error(e)) => GenericResult::Error(e),
+                                Err(Control::Break(label)) => GenericResult::Break(label),
                             }
                         };
                     }
@@ -1278,6 +1679,16 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 None => GenericResult::Owned(OwnedValue::Null),
                             }
                         }
+                        // Slice 1 (#724): stay lazy instead of falling
+                        // through to the `_` materializing fallback below —
+                        // reuses the composability arm (`GenericResult::LazySeq`
+                        // below) for everything past this first `map` stage.
+                        // Same `!sorted` guard as the other fast-path arms
+                        // above: sorted `keys` still needs a full decode+sort
+                        // first.
+                        Expr::Builtin(Builtin::Map(f)) if !sorted => GenericResult::LazySeq(
+                            LazySeq::new(LazySource::Keys(fields)).push_map(f, S::TAG),
+                        ),
                         _ => eval_on_owned::<S, _>(
                             expr,
                             materialize_lazy_keys::<V>(&fields, sorted),
@@ -1338,9 +1749,129 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 GenericResult::Owned(OwnedValue::Int(len as i64 - 1))
                             }
                         }
+                        // Slice 1 (#724), array counterpart of `LazyKeys`'s
+                        // own `Builtin::Map` arm above. No `!sorted` guard —
+                        // array "keys" are never sorted.
+                        Expr::Builtin(Builtin::Map(f)) => GenericResult::LazySeq(
+                            LazySeq::new(LazySource::IndexRange { next: 0, len })
+                                .push_map(f, S::TAG),
+                        ),
                         _ => {
                             eval_on_owned::<S, _>(expr, materialize_lazy_index_range(len), optional)
                         }
+                    },
+                    // The composability engine (#724, #725): every further
+                    // `| map(g)` stage just pushes onto the same chain
+                    // (self-recursive by construction — an arbitrary-length
+                    // `map(f) | map(g) | map(h)` stays one `LazySeq`, not one
+                    // type per depth). A handful of consumers get a genuine
+                    // single-forward-pass native fast path; everything else
+                    // materializes once (`materialize_atomic`) and hands off
+                    // to the full evaluator — still one pass, not the
+                    // original four-pass round trip.
+                    GenericResult::LazySeq(mut seq) => match unwrap_paren(expr) {
+                        Expr::Builtin(Builtin::Map(h)) => {
+                            GenericResult::LazySeq(seq.push_map(h, S::TAG))
+                        }
+
+                        // Count-and-discard: every element still runs (so a
+                        // `map(f)` that errors partway still errors), but no
+                        // `OwnedValue` is ever built for any of them. Atomic,
+                        // same as `materialize_atomic` -- `length` of an
+                        // array construction that fails is itself a failure,
+                        // not a partial count.
+                        Expr::Builtin(Builtin::Length) => {
+                            let mut count: i64 = 0;
+                            for item in seq {
+                                match item {
+                                    Ok(_) => count += 1,
+                                    Err(Control::Error(e)) => return GenericResult::Error(e),
+                                    Err(Control::Break(label)) => {
+                                        return GenericResult::Break(label)
+                                    }
+                                }
+                            }
+                            GenericResult::Owned(OwnedValue::Int(count))
+                        }
+
+                        // `.[]` is a generator, NOT array construction:
+                        // already-yielded elements survive a later element's
+                        // error -- `Partial` semantics, mirroring the
+                        // existing `ManyCursor` arm's own convention above.
+                        // Deliberately a different atomicity boundary than
+                        // `Length`/the `_` fallback below.
+                        Expr::Iterate => {
+                            let mut items = Vec::new();
+                            let mut control = None;
+                            for item in seq {
+                                match item {
+                                    Ok(elem) => items.push(elem),
+                                    Err(c) => {
+                                        control = Some(c);
+                                        break;
+                                    }
+                                }
+                            }
+                            let all_cursor =
+                                items.iter().all(|item| matches!(item, LazyElem::Cursor(_)));
+                            match control {
+                                None if items.is_empty() => GenericResult::None,
+                                None if all_cursor => GenericResult::ManyCursor(
+                                    items
+                                        .into_iter()
+                                        .map(|item| match item {
+                                            LazyElem::Cursor(c) => c,
+                                            LazyElem::Owned(_) => {
+                                                unreachable!("checked all_cursor above")
+                                            }
+                                        })
+                                        .collect(),
+                                ),
+                                None => GenericResult::ManyOwned(
+                                    items
+                                        .into_iter()
+                                        .map(|item| match item {
+                                            LazyElem::Cursor(c) => to_owned(&c.value()),
+                                            LazyElem::Owned(o) => o,
+                                        })
+                                        .collect(),
+                                ),
+                                Some(control) => {
+                                    let prefix = items
+                                        .into_iter()
+                                        .map(|item| match item {
+                                            LazyElem::Cursor(c) => to_owned(&c.value()),
+                                            LazyElem::Owned(o) => o,
+                                        })
+                                        .collect();
+                                    partial_generic(prefix, control)
+                                }
+                            }
+                        }
+
+                        // Pull-one-and-stop: at most one element of `seq` is
+                        // ever evaluated.
+                        Expr::Builtin(Builtin::First) | Expr::Index(0) => match seq.next() {
+                            None => GenericResult::Owned(OwnedValue::Null),
+                            Some(Ok(LazyElem::Cursor(c))) => GenericResult::OneCursor(c),
+                            Some(Ok(LazyElem::Owned(o))) => GenericResult::Owned(o),
+                            Some(Err(Control::Error(e))) => GenericResult::Error(e),
+                            Some(Err(Control::Break(label))) => GenericResult::Break(label),
+                        },
+
+                        // `last`, nonzero `.[n]`, whole-value `select`,
+                        // comparisons, everything else: one atomic forward
+                        // pass, then hand off to the full evaluator -- still
+                        // one pass, not the original four-pass round trip.
+                        // `select` deliberately gets no dedicated arm here —
+                        // it materializes once and runs through
+                        // `eval_on_owned`'s already-correct `Builtin::Select`
+                        // handling, same as any other computed value.
+                        _ => match seq.materialize_atomic() {
+                            Ok(owned) => eval_on_owned::<S, _>(expr, owned, optional),
+                            Err(Control::Error(e)) => GenericResult::Error(e),
+                            Err(Control::Break(label)) => GenericResult::Break(label),
+                        },
                     },
                     GenericResult::None => GenericResult::None,
                     GenericResult::Error(e) => return GenericResult::Error(e),
@@ -1395,14 +1926,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             let right_result = eval_single::<S, _>(right, value, false, cursor);
 
             // Convert results to OwnedValue for comparison
-            let left_owned = match left_result {
+            let left_owned = match left_result.materialize_lazy() {
                 GenericResult::Owned(o) => o,
                 GenericResult::One(v) => to_owned(&v),
                 GenericResult::OneCursor(c) => to_owned(&c.value()),
-                GenericResult::LazyKeys { fields, sorted } => {
-                    materialize_lazy_keys::<V>(&fields, sorted)
+                GenericResult::LazyKeys { .. }
+                | GenericResult::LazyIndexRange(_)
+                | GenericResult::LazySeq(_) => {
+                    unreachable!("materialize_lazy() already normalized every lazy variant")
                 }
-                GenericResult::LazyIndexRange(len) => materialize_lazy_index_range(len),
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -1440,14 +1972,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Partial(vs, _control) => vs.into_iter().next().unwrap(),
             };
 
-            let right_owned = match right_result {
+            let right_owned = match right_result.materialize_lazy() {
                 GenericResult::Owned(o) => o,
                 GenericResult::One(v) => to_owned(&v),
                 GenericResult::OneCursor(c) => to_owned(&c.value()),
-                GenericResult::LazyKeys { fields, sorted } => {
-                    materialize_lazy_keys::<V>(&fields, sorted)
+                GenericResult::LazyKeys { .. }
+                | GenericResult::LazyIndexRange(_)
+                | GenericResult::LazySeq(_) => {
+                    unreachable!("materialize_lazy() already normalized every lazy variant")
                 }
-                GenericResult::LazyIndexRange(len) => materialize_lazy_index_range(len),
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -1593,6 +2126,12 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::LazyKeys { fields, sorted }
             }
             GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
+            // Same forwarding, same reasoning: `first(inner)`/`last(inner)`
+            // only need to know *which* of `inner`'s outputs this is, never
+            // inspect the value itself, so forwarding doesn't swallow
+            // anything -- whoever consumes the returned `LazySeq` next
+            // materializes it, and any error surfaces there.
+            GenericResult::LazySeq(seq) => GenericResult::LazySeq(seq),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1625,6 +2164,7 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::LazyKeys { fields, sorted }
             }
             GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
+            GenericResult::LazySeq(seq) => GenericResult::LazySeq(seq),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1751,10 +2291,19 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         // An owned target (a computed, non-navigational left side) has no
         // borrowed representation here; round-trip it through the shared
         // owned-value path by re-entering with the materialized document.
+        // `LazySeq` shares this arm too: `collect_owned()` materializes it
+        // (via `materialize_lazy()`) the same as the other lazy variants.
+        // Known, narrow, pre-existing gap, not a new regression:
+        // `collect_owned()` already silently swallows any error into an
+        // empty `Vec` for every variant that can error (`Partial`, and now
+        // a failing `LazySeq`) -- `(keys_unsorted|map(error("x")))[$k]`
+        // swallows the error into "no results" rather than propagating it,
+        // same as it already did for other error-producing shapes here.
         owned @ (GenericResult::Owned(_)
         | GenericResult::ManyOwned(_)
         | GenericResult::LazyKeys { .. }
-        | GenericResult::LazyIndexRange(_)) => {
+        | GenericResult::LazyIndexRange(_)
+        | GenericResult::LazySeq(_)) => {
             let targets = owned.collect_owned();
             let mut out = Vec::with_capacity(keys.len() * targets.len());
             for k in &keys {
@@ -1868,10 +2417,13 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         GenericResult::ManyCursor(cs) => {
             Targets::Borrowed(cs.iter().map(DocumentCursor::value).collect())
         }
+        // See `eval_index_expr`'s identical arm for the accepted, pre-existing
+        // error-swallowing note that also applies to `LazySeq` here.
         owned @ (GenericResult::Owned(_)
         | GenericResult::ManyOwned(_)
         | GenericResult::LazyKeys { .. }
-        | GenericResult::LazyIndexRange(_)) => Targets::Owned(owned.collect_owned()),
+        | GenericResult::LazyIndexRange(_)
+        | GenericResult::LazySeq(_)) => Targets::Owned(owned.collect_owned()),
     };
 
     // Start outer, end middle, target inner. The result is always owned:
@@ -3076,19 +3628,22 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_keys_unsorted_fallback_map_select() {
-        // `map`/`select` have no native lazy path -- `eval_generic.rs` has
-        // no native `Builtin::Map` arm at all (see the `Pipe` dispatch's
-        // `LazyKeys` arm doc comment) -- so these must still materialize
-        // correctly via the fallback.
+    fn test_generic_keys_unsorted_map_stays_lazy_724() {
+        // `keys_unsorted | map(f)` now takes the `LazySeq` fast path (#724)
+        // instead of the `to_owned`->reserialize->reindex->re-evaluate
+        // fallback -- assert the intermediate shape *before* materializing,
+        // then confirm materializing still produces the same values the old
+        // fallback-pinning version of this test checked.
         let json = br#"{"b": 1, "a": 2, "c": 3}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
 
         let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase)").unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            result.into_owned().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("B".to_string()),
                 OwnedValue::String("A".to_string()),
@@ -3096,6 +3651,10 @@ mod tests {
             ])
         );
 
+        // `select` gets no dedicated lazy arm by design (it materializes
+        // once via the composability arm's `_` fallback, then runs through
+        // the already-correct `Builtin::Select`) -- still correct, still one
+        // pass instead of the four-pass round trip.
         let expr = crate::jq::parse("keys_unsorted | select(length == 3)").unwrap();
         assert_eq!(
             eval(&expr, value).into_owned().unwrap(),
@@ -3239,15 +3798,24 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_keys_sorted_fallback_map_select() {
+    fn test_generic_keys_sorted_map_select_stays_eager() {
+        // Sorted `keys | map/select` deliberately stays on the eager
+        // fallback (#724 doesn't change this): sorting requires observing
+        // every key before emitting the first one, a different complexity
+        // class than the `!sorted` guard's document-order fast path -- see
+        // the non-goals in docs/plan/jq-lazy-map-select.md. Confirm the
+        // guard actually excludes this: `keys` (sorted) must NOT produce a
+        // `LazySeq`.
         let json = br#"{"b": 1, "a": 2, "c": 3}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
 
         let expr = crate::jq::parse("keys | map(ascii_upcase)").unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(!matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            result.into_owned().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("A".to_string()),
                 OwnedValue::String("B".to_string()),
@@ -3434,17 +4002,20 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_array_keys_unsorted_fallback_map_select() {
-        // `map`/`select` have no native lazy path here either -- must still
-        // materialize correctly via the fallback.
+    fn test_generic_array_keys_unsorted_map_stays_lazy_724() {
+        // Array counterpart of `test_generic_keys_unsorted_map_stays_lazy_724`
+        // above: `keys_unsorted | map(f)` on an array's synthetic index
+        // range also takes the `LazySeq` fast path (#724).
         let json = br#"["x","y","z"]"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
 
         let expr = crate::jq::parse("keys_unsorted | map(. * 10)").unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            result.into_owned().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(0),
                 OwnedValue::Int(10),
@@ -3461,6 +4032,83 @@ mod tests {
                 OwnedValue::Int(2),
             ])
         );
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_composability_keys_unsorted_map_select_724() {
+        // The actual point of this design: `keys_unsorted | map(f) | select(g)`
+        // stays lazy through the `map` stage, materializes once at `select`.
+        let json = br#"{"bb": 1, "a": 2, "ccc": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr =
+            crate::jq::parse("keys_unsorted | map(ascii_upcase) | select(length == 3)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("BB".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("CCC".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_atomicity_vs_iterate_contrast_724() {
+        // `map`'s array construction is atomic; `.[]` over the same failing
+        // chain is a generator and keeps its already-yielded prefix instead
+        // -- two different, both-correct atomicity boundaries.
+        let json = br#"{"a":1,"b":2,"c":3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr =
+            crate::jq::parse(r#"keys_unsorted | map(if . == "b" then error("boom") else . end)"#)
+                .unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        // Atomic: `map`'s own array construction discards the whole
+        // in-progress array on the first error -- no partial prefix, even
+        // though `"a"` (document order's first key) already succeeded.
+        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert!(eval(&expr, value.clone()).materialize_lazy().is_error());
+
+        let expr = crate::jq::parse(
+            r#"keys_unsorted | map(if . == "b" then error("boom") else . end) | .[]"#,
+        )
+        .unwrap();
+        let result = eval(&expr, value);
+        // Non-atomic: `.[]` is a generator over the `map` chain's own
+        // per-element outputs, not array construction -- `"a"` (which the
+        // `map` stage already resolved successfully before `"b"` failed)
+        // survives as a `Partial` prefix instead of being discarded, the
+        // opposite of the `map`-alone case just above.
+        assert!(result.is_error());
+        assert_eq!(
+            result.collect_owned(),
+            vec![OwnedValue::String("a".to_string())]
+        );
+    }
+
+    /// Known, narrow, pre-existing gap (not a new regression from #724):
+    /// `collect_owned()` already silently swallows any error into an empty
+    /// `Vec` for every variant that can error -- a failing `LazySeq` reached
+    /// through a computed index just adds one more path into that same
+    /// accepted lossy contract. Documented here, not fixed.
+    #[test]
+    fn test_generic_lazy_seq_computed_index_swallows_error_724() {
+        let json = br#"{"a":1,"b":2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr =
+            crate::jq::parse(r#"(keys_unsorted | map(error("x")))[("a" | length - 1)]"#).unwrap();
+        let result = eval(&expr, value);
+        assert!(!result.is_error());
     }
 
     #[test]
@@ -4252,6 +4900,87 @@ mod tests {
             .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
             .unwrap();
         assert_eq!(out, "- b\n- a\n- c");
+    }
+
+    #[test]
+    fn test_yaml_keys_unsorted_map_stays_lazy_724() {
+        // YAML counterpart of `test_generic_keys_unsorted_map_stays_lazy_724`
+        // -- the `LazySeq`/`Pipe`-fold fast path is generic over
+        // `V: DocumentValue`, so a YAML mapping goes through the exact same
+        // evaluator arms as a JSON object.
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"b: 1\na: 2\nc: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase)").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("B".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("C".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_yaml_array_keys_unsorted_map_stays_lazy_724() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"- x\n- y\n- z\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse("keys_unsorted | map(. * 10)").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(0),
+                OwnedValue::Int(10),
+                OwnedValue::Int(20),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_yaml_keys_unsorted_map_merge_key_lazy_724() {
+        // Same as `test_yaml_keys_unsorted_map_stays_lazy_724` but resolved
+        // through a `<<: *anchor` merge key, exercising `YamlFields`'s
+        // `Merged` variant (an `Rc`-shared entry list, `Clone` but not
+        // `Copy`) through `LazySource::Keys`'s forward-only `uncons()`
+        // pulling, not just the plain cursor-walk `Direct` variant.
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"defaults: &defaults\n  b: 1\n  a: 2\nitem:\n  <<: *defaults\n  c: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".item | keys_unsorted | map(ascii_upcase)").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("B".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("C".to_string()),
+            ])
+        );
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2627,6 +2627,28 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             }
         }
 
+        // Slice 2 (#725): `Builtin::Map`'s first-ever native arm -- plain
+        // `arr | map(f)` / `obj | map(f)` on containers that never touch
+        // `keys_unsorted`/`keys`, the dominant 75-95% share of the
+        // to_owned->reserialize->reindex->re-evaluate fallback's measured
+        // cost (#686). `map(f)` is `[.[] | f]`; `.[]` over an object
+        // iterates its *values* (#422), matching `eval.rs`'s
+        // `builtin_map`/`map_over`. `Builtin::MapValues` is an explicit
+        // non-goal and stays on the wildcard fallback below.
+        Builtin::Map(f) => {
+            if let Some(elements) = value.as_array() {
+                GenericResult::LazySeq(
+                    LazySeq::new(LazySource::Elements(elements)).push_map(f, S::TAG),
+                )
+            } else if let Some(fields) = value.as_object() {
+                GenericResult::LazySeq(LazySeq::new(LazySource::Values(fields)).push_map(f, S::TAG))
+            } else if optional {
+                GenericResult::None
+            } else {
+                GenericResult::Error(EvalError::cannot_iterate(&to_owned(&value)))
+            }
+        }
+
         Builtin::Shuffle => {
             #[cfg(feature = "cli")]
             {
@@ -4035,6 +4057,202 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_plain_array_map_stays_lazy_725() {
+        // Slice 2 (#725): `Builtin::Map`'s first-ever native arm -- plain
+        // `arr | map(f)`, no `keys_unsorted` involved at all.
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(. * 2)").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(2),
+                OwnedValue::Int(4),
+                OwnedValue::Int(6),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_plain_object_map_stays_lazy_725() {
+        // `obj | map(f)` is `[.[] | f]`; `.[]` over an object iterates its
+        // *values* (#422), matching `eval.rs`'s `builtin_map`.
+        let json = br#"{"a":1,"b":2,"c":3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(. * 2)").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(2),
+                OwnedValue::Int(4),
+                OwnedValue::Int(6),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_plain_map_empty_containers_725() {
+        let json = br"[]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse("map(.)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![])
+        );
+
+        let json = br"{}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse("map(.)").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![])
+        );
+    }
+
+    #[test]
+    fn test_generic_plain_map_non_container_errors_725() {
+        // Message must match `eval.rs`'s `builtin_map`/`map_over` exactly
+        // (both dispatch through `EvalError::cannot_iterate`).
+        let json = br"1";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(.)").unwrap();
+        let result = eval(&expr, value.clone());
+        assert!(result.is_error());
+
+        let owned = crate::jq::eval_generic::to_owned(&value);
+        let expected = EvalError::cannot_iterate(&owned);
+        match result {
+            GenericResult::Error(e) => assert_eq!(e.message, expected.message),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generic_plain_map_atomicity_725() {
+        // Real jq's array construction is all-or-nothing: `map`'s error
+        // partway through discards the whole in-progress array, mirroring
+        // `eval::map_over` (#725's `materialize_atomic`).
+        let json = br#"[1,2,"x"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(. + 1)").unwrap();
+        let result = eval(&expr, value.clone());
+        // Errors only surface once pulled -- laziness means construction
+        // alone can't have failed yet.
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert!(result.materialize_lazy().is_error());
+
+        // Nothing streams to `out` for a failing `map` -- matches real jq's
+        // own all-or-nothing output and this file's `#355` convention that
+        // diagnostics never go to `out`.
+        let expr = crate::jq::parse("map(. + 1)").unwrap();
+        let result = eval(&expr, value);
+        let mut out = String::new();
+        let stats = result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+        assert_eq!(stats.count, 0);
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_composability_map_map_725() {
+        // `arr | map(f) | map(g)`: two pushed instructions on one `LazySeq`
+        // -- composability without materializing between stages.
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(. + 1) | map(. * 10)").unwrap();
+        let result = eval(&expr, value);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(20),
+                OwnedValue::Int(30),
+                OwnedValue::Int(40),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_lazy_seq_composability_native_consumers_725() {
+        // `length`, `.[]`, `first`, `.[0]` after a `map` all get a native,
+        // single-forward-pass path in the composability arm (asserted by
+        // shape, not just correctness): none of these materialize to
+        // `Owned`/`Error` via the generic `_ => materialize_atomic()`
+        // fallback in a way that would be indistinguishable from the
+        // dedicated arms, so this mainly pins the returned *values*.
+        let json = br#"["b","a","c"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("map(ascii_upcase) | length").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Int(3)
+        );
+
+        let expr = crate::jq::parse("map(ascii_upcase) | .[]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).collect_owned(),
+            vec![
+                OwnedValue::String("B".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("C".to_string()),
+            ]
+        );
+
+        let expr = crate::jq::parse("map(ascii_upcase) | first").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::String("B".to_string())
+        );
+
+        let expr = crate::jq::parse("map(ascii_upcase) | .[0]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::String("B".to_string())
+        );
+
+        // `.[2]`/`last` intentionally fall to `materialize_atomic` +
+        // `eval_on_owned` in this initial design (open risk (c)) --
+        // asserting correctness only, not laziness.
+        let expr = crate::jq::parse("map(ascii_upcase) | .[2]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::String("C".to_string())
+        );
+
+        let expr = crate::jq::parse("map(ascii_upcase) | last").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::String("C".to_string())
+        );
+    }
+
+    #[test]
     fn test_generic_lazy_seq_composability_keys_unsorted_map_select_724() {
         // The actual point of this design: `keys_unsorted | map(f) | select(g)`
         // stays lazy through the `map` stage, materializes once at `select`.
@@ -4979,6 +5197,32 @@ mod tests {
                 OwnedValue::String("B".to_string()),
                 OwnedValue::String("A".to_string()),
                 OwnedValue::String("C".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_yaml_plain_map_stays_lazy_725() {
+        // YAML counterpart of `test_generic_plain_array_map_stays_lazy_725`
+        // -- plain `arr | map(f)` on YAML, no `keys_unsorted` involved.
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"- 1\n- 2\n- 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse("map(. * 2)").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(2),
+                OwnedValue::Int(4),
+                OwnedValue::Int(6),
             ])
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4242,7 +4242,9 @@ mod tests {
         let expr = crate::jq::parse("map(. + 1)").unwrap();
         let result = eval(&expr, value);
         let mut out = String::new();
-        let stats = result.stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
+        let stats = result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "");
         assert!(stats.error.is_some());
         assert_eq!(stats.count, 0);
@@ -4271,7 +4273,9 @@ mod tests {
         let expr = crate::jq::parse("map(. + 1) | .[]").unwrap();
         let result = eval(&expr, value);
         let mut out = String::new();
-        result.stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "");
     }
 
@@ -7824,13 +7828,17 @@ mod tests {
         let expr = crate::jq::parse("map(. + 1)").unwrap();
         let result = eval(&expr, value.clone());
         let mut out = String::new();
-        let stats = result.stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
+        let stats = result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "[2,3,4]");
         assert_eq!(stats.count, 1);
         assert!(stats.any_truthy);
 
         let mut out = String::new();
-        let stats = result.stream_yaml(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
+        let stats = result
+            .stream_yaml(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "[2, 3, 4]");
         assert_eq!(stats.count, 1);
         assert!(stats.any_truthy);
@@ -7838,14 +7846,18 @@ mod tests {
         let expr = crate::jq::parse("map(break $out)").unwrap();
         let result = eval(&expr, value.clone());
         let mut out = String::new();
-        let stats = result.stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
+        let stats = result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "");
         assert_eq!(stats.count, 0);
         assert!(stats.error.is_some());
 
         let result = eval(&expr, value);
         let mut out = String::new();
-        let stats = result.stream_yaml(&mut out, IndentSpec::COMPACT, false, |_| Ok(())).unwrap();
+        let stats = result
+            .stream_yaml(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "");
         assert!(stats.error.is_some());
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3392,3 +3392,56 @@ fn test_array_keys_unsorted_sort_keys_path_684() -> Result<()> {
 
     Ok(())
 }
+
+/// The top-level materializing boundary on the *lazy-bytes* path
+/// (`generic_result_to_jq_values` in `jq_runner.rs`) has its own
+/// `GenericResult::LazySeq` arm, reached only when the whole parsed query is
+/// itself `map(f)`/`keys_unsorted | map(f)` -- with no further pipe stage to
+/// resolve it into a narrower shape first (#725). Exercise all three
+/// outcomes (success, error, break) directly against the real binary rather
+/// than relying on incidental coverage from another test's query shape.
+#[test]
+fn test_top_level_map_lazy_seq_materializes_at_cli_boundary_725() -> Result<()> {
+    let (output, _, code) = run_jq_full(&["-c", "map(. + 1)"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[2,3,4]");
+
+    let (output, stderr, code) = run_jq_full(&["-c", "map(. + 1)"], Some(r#"[1,2,"x"]"#))?;
+    assert_eq!(code, 5);
+    assert_eq!(output, "");
+    assert!(stderr.contains("cannot be added"), "{stderr}");
+
+    let (output, stderr, code) = run_jq_full(&["-c", "map(break $out)"], Some("[1,2,3]"))?;
+    assert_eq!(code, 5);
+    assert_eq!(output, "");
+    assert!(stderr.contains("break $out not in label"), "{stderr}");
+
+    Ok(())
+}
+
+/// Same `GenericResult::LazySeq` fast path, but reached through the
+/// "original"/serde_json evaluator (`evaluate_input`'s
+/// `query_result_to_owned_values`) instead -- forced by `--sort-keys`,
+/// mirroring `test_array_keys_unsorted_sort_keys_path_684` above. This is a
+/// distinct match arm from the lazy-bytes path's, not just a different flag
+/// combination reaching the same code.
+#[test]
+fn test_top_level_map_lazy_seq_sort_keys_path_725() -> Result<()> {
+    let (output, _, code) = run_jq_full(&["--sort-keys", "-c", "map(. + 1)"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[2,3,4]");
+
+    let (output, stderr, code) =
+        run_jq_full(&["--sort-keys", "-c", "map(. + 1)"], Some(r#"[1,2,"x"]"#))?;
+    assert_eq!(code, 5);
+    assert_eq!(output, "");
+    assert!(stderr.contains("cannot be added"), "{stderr}");
+
+    let (output, stderr, code) =
+        run_jq_full(&["--sort-keys", "-c", "map(break $out)"], Some("[1,2,3]"))?;
+    assert_eq!(code, 5);
+    assert_eq!(output, "");
+    assert!(stderr.contains("break $out not in label"), "{stderr}");
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4858,3 +4858,31 @@ fn test_style_builtin_anchor_prefix_does_not_mask_style() -> Result<()> {
 
     Ok(())
 }
+
+/// The DOM path's `evaluate_yaml_cursor` (`yq_runner.rs`) has its own
+/// `GenericResult::LazySeq` arm. `can_use_m2_streaming` rejects
+/// `Builtin::Map` outright, so any top-level `map(f)` query takes this DOM
+/// fallback rather than the M2 streaming path -- no special flag needed
+/// (unlike `keys_unsorted`, which the M2 path *does* accept) (#725).
+/// Exercise all three outcomes (success, error, break) against the real
+/// binary rather than relying on incidental coverage elsewhere.
+#[test]
+fn test_top_level_map_lazy_seq_dom_fallback_725() -> Result<()> {
+    let input = "a: 1\nb: 2\nc: 3\n";
+
+    let (output, code) = run_yq_stdin("map(. + 1)", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[2,3,4]");
+
+    let (output, stderr, code) = run_yq_stdin_with_stderr("map(. + 1)", "a: 1\nb: two\n", &[])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "");
+    assert!(stderr.contains("cannot be added"), "{stderr}");
+
+    let (output, stderr, code) = run_yq_stdin_with_stderr("map(break $out)", input, &[])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "");
+    assert!(stderr.contains("break $out not in label"), "{stderr}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the general lazy `map`/`select` primitive designed in `docs/plan/jq-lazy-map-select.md` (issue #700), landing both staged slices together per that doc's explicit warning against a third "narrow now, general later" deferral (#678, #686 already deferred it once each).

- **Slice 1 (#724)**: `GenericResult::LazySeq` + `LazyElem`/`LazySource`/`Instruction` machinery in `eval_generic.rs`; wires `Builtin::Map` into the existing `LazyKeys`/`LazyIndexRange` arms of the `Expr::Pipe` fold, so `keys_unsorted|keys | map(f)/select(g)` stays lazy; adds the composability arm so arbitrary-length `map(f) | map(g) | ...` chains stay one `LazySeq`, not a materialize-per-stage round trip.
- **Slice 2 (#725)**: `Builtin::Map`'s first-ever native arm in `eval_builtin`, covering plain `arr | map(f)` / `obj | map(f)` — per #686's measurement, this is 75-95% of the fallback's actual cost (up to 4.8x time / 13.5x memory at 100MB), bigger than the `keys_unsorted`-specific share Slice 1 covers.

Both slices reuse the same `LazySeq` machinery (Slice 2 only adds two `LazySource` variants + one production site), and are two separate commits in this PR closing their respective issues.

`select` gets no dedicated lazy arm by design — it still materializes once via the composability arm's fallback and runs through the already-correct `Builtin::Select`, down from the previous four-pass (`to_owned` → reserialize → reindex → re-evaluate) round trip to one pass.

## Notable implementation details (beyond the design doc)

- `EvalSemantics` gained a `TAG: EvalTag` associated const (not a method — the trait was a zero-method, four-const trait) so a buffered `Instruction::Map` stage knows which semantics (`Jq`/`Yq`) to replay with once pulled, since `LazySeq<V>` deliberately carries no `S: EvalSemantics` type parameter.
- Three CLI-runner exhaustive matches not mentioned in the design doc needed a `LazySeq` arm to keep compiling: `jq_runner.rs::evaluate_input`, `jq_runner.rs::generic_result_to_jq_values`, `yq_runner.rs::evaluate_yaml_cursor`.
- No new streaming writer: `stream_json`/`stream_yaml`'s `LazySeq` arm reuses `OwnedValue::stream_json`/`stream_yaml` after one atomic `materialize_atomic()` pass, rather than a byte-at-a-time writer — `map`'s array construction is atomic in real jq (a failing `map` prints nothing), so a truly zero-buffer writer would already have flushed a truncated prefix before discovering the failure.
- `flatten_generic_results` changed signature to `Result<Vec<OwnedValue>, Control>`: unlike `LazyKeys`/`LazyIndexRange` (which can never fail to materialize), a `LazySeq` reached via `.[] | (keys_unsorted | map(f))` can fail only once actually pulled here.
- Retired the three fallback-pinning tests per the design doc's ask — two replaced with lazy-path assertions, one (sorted `keys | map/select`) renamed to pin that it deliberately *stays* eager (sorting needs to see every key first, a different complexity class).
- **Accepted, deliberate divergence from real jq**: `map(f) | first` / `.[0]`'s "pull-one-and-stop" fast path evaluates at most one source element. Real jq's `map` eagerly builds the *whole* array first, so `map(f)|first` errors if *any* element fails, even ones past the first; here, a failure on a later, un-pulled element is invisible, since the entire point of the fast path is skipping evaluation the requested output doesn't need. Documented on the arm and pinned by `test_generic_lazy_seq_first_after_map_skips_later_error_725`.

## Correctness fixes found in post-implementation review

A review pass (plus CI's patch-coverage bot flagging ~150 uncovered lines across the `LazySeq` machinery) surfaced two real bugs, both verified against real `jq` 1.7.1 and fixed in this PR:

- **`map(f)?` didn't suppress an error raised inside `f`.** A `LazySeq` is lazy — it hasn't failed *yet* at the point `Expr::Optional`'s `?`-handling inspects its immediate result, so it matched none of the `Error`/`Break`/`Partial` arms there and fell through as an ordinary success, escaping the `?` boundary entirely. The error only surfaced later, at whatever downstream site finally pulled the chain — by which point the `try`/`catch` context was long gone. Fixed by forcing materialization at that one boundary, matching every other `try`/`?` site's existing one-pass cost.
- **`.[]` piped after `map(f)` leaked partial output before an atomic error.** `map`'s array construction is atomic in real jq (`[1,2,"x"]|map(.+1)` prints nothing on error, not a truncated prefix) — but the `.[]` composability arm treated it as a non-atomic generator over the raw source, letting already-succeeded elements survive a later element's failure. Since a `LazySeq` only ever reaches that arm with at least one `map` instruction already pushed, `.[]` there is iterating the array `map` already built, not the raw source, so it now inherits the same atomicity as `length`/the materializing fallback beside it.

Both are pinned with new regression tests verified against real `jq`, and the pre-existing test that had encoded the second bug's wrong assumption was corrected alongside the fix.

## Test plan

- [x] `cargo test` — full suite passes (2150+ lib tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean on all three CI feature configurations (`--all-features`, and the two explicit feature-set invocations from `ci.yml`)
- [x] `cargo fmt --check` clean
- [x] New tests: lazy-path shape assertions (`LazySeq(_)` before materializing), composability (`map|map`, `keys_unsorted|map|select`, native `length`/`.[]`/`first`/`.[0]` after `map`), `map`/`.[]` atomicity (corrected, see above), the accepted `first`/`.[0]` laziness trade-off, `?`/`try` suppression across a `LazySeq` boundary, YAML parity including a `<<:` merge-key case, plain-container empty/non-container/error-message cases
- [x] Differential testing against system `jq` 1.7.1 across map/select/composability/atomicity/`?`-suppression edge cases, output and exit code both gated
- [ ] Benchmark tables (interleaved A/B, ARM + x86_64, per `docs/guides/benchmarking.md`) — not yet run in this PR, tracked as a follow-up before either issue is considered fully closed out on the performance claim
