### PR TITLE
jq: lazy map fast path for keys_unsorted/keys (Slice 1 of #700)

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -11,7 +11,9 @@ use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
 use succinctly::jq::document::DocumentFields;
-use succinctly::jq::eval_generic::{eval_with_cursor, to_owned as generic_to_owned, GenericResult};
+use succinctly::jq::eval_generic::{
+    eval_with_cursor, materialize_atomic, to_owned as generic_to_owned, GenericResult, LazyElem,
+};
 use succinctly::jq::{self, format_number_jq_compat, Expr, JqValue, OwnedValue, Program};
 use succinctly::json::light::{JsonCursor, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
@@ -1613,6 +1615,21 @@ fn evaluate_input(
         GenericResult::LazyIndexRange(len) => Ok(vec![OwnedValue::Array(
             (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
         )]),
+        // `keys_unsorted | map(f)` (#724) reaches this runner boundary as a
+        // not-yet-materialized `LazySeq` the same way `LazyKeys`/
+        // `LazyIndexRange` above do — one forward pass here, same
+        // sink-reporting shape as the `Error`/`Break` arms below.
+        GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+            Ok(o) => Ok(vec![o]),
+            Err(jq::Control::Error(e)) => {
+                sink.report(DiagStyle::Jq, &e, at);
+                Ok(vec![])
+            }
+            Err(jq::Control::Break(label)) => {
+                sink.report_break(DiagStyle::Jq, &label, at);
+                Ok(vec![])
+            }
+        },
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);
@@ -1700,6 +1717,30 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
         // `keys_unsorted` (#684): `write_json`/`print_json` write the
         // `[0,1,...,len-1]` digits directly, no `Vec<OwnedValue::Int>`.
         GenericResult::LazyIndexRange(len) => vec![JqValue::LazyIndexRange(len)],
+        // `keys_unsorted | map(f)` (#724): one forward pass, wrapping each
+        // element as a lazy `JqValue::Cursor` where possible (matching
+        // `standard_json_to_jq_value`'s own "Phase 1 Lazy" shell-eager/
+        // leaf-lazy pattern below) — `JqValue::Array`'s existing
+        // `write_json` already streams each element without further
+        // change, so no new `JqValue` variant is needed for this.
+        GenericResult::LazySeq(seq) => {
+            let mut items = Vec::new();
+            for item in seq {
+                match item {
+                    Ok(LazyElem::Cursor(c)) => items.push(JqValue::Cursor(c)),
+                    Ok(LazyElem::Owned(o)) => items.push(JqValue::from_owned(o)),
+                    Err(jq::Control::Error(e)) => {
+                        sink.report(DiagStyle::Jq, &e, at);
+                        return vec![];
+                    }
+                    Err(jq::Control::Break(label)) => {
+                        sink.report_break(DiagStyle::Jq, &label, at);
+                        return vec![];
+                    }
+                }
+            }
+            vec![JqValue::Array(items)]
+        }
         GenericResult::None => vec![],
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Jq, &e, at);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -11,7 +11,9 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{DocumentCursor, DocumentFields, IndentSpec};
-use succinctly::jq::eval_generic::{eval_with_cursor_using, to_owned, GenericResult};
+use succinctly::jq::eval_generic::{
+    eval_with_cursor_using, materialize_atomic, to_owned, GenericResult,
+};
 use succinctly::jq::{
     self, sync_aliased_paths, Builtin, Expr, OwnedValue, QueryResult, YqSemantics,
 };
@@ -562,6 +564,21 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         GenericResult::LazyIndexRange(len) => Ok(vec![OwnedValue::Array(
             (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
         )]),
+        // `keys_unsorted | map(f)` (#724) reaches this DOM-path boundary as
+        // a not-yet-materialized `LazySeq` the same way `LazyKeys`/
+        // `LazyIndexRange` above do — one forward pass here, same
+        // sink-reporting shape as the `Error`/`Break` arms below.
+        GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+            Ok(o) => Ok(vec![o]),
+            Err(jq::Control::Error(e)) => {
+                sink.report(DiagStyle::Yq, &e, &no_location());
+                Ok(vec![])
+            }
+            Err(jq::Control::Break(label)) => {
+                sink.report_break(DiagStyle::Yq, &label, &no_location());
+                Ok(vec![])
+            }
+        },
         GenericResult::None => Ok(vec![]),
         GenericResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23,6 +23,24 @@ use indexmap::IndexMap;
 
 use super::slice::{self, SliceBounds};
 
+/// Runtime tag identifying which concrete [`EvalSemantics`] impl produced a
+/// deferred closure.
+///
+/// Used by `eval_generic::Instruction` (#724): `Instruction` can't carry a
+/// generic `S` parameter without rippling one onto `GenericResult<V>` itself
+/// (see the design doc, `docs/plan/jq-lazy-map-select.md`), so this is how a
+/// `LazySeq`'s queued `map(f)` gets re-dispatched to the right concrete
+/// `eval_single::<S,_>` from contexts where `S` has already been erased
+/// (`GenericResult`'s inherent methods, none of which are generic over `S`).
+/// Exactly two variants because exactly two `EvalSemantics` impls exist
+/// (grep-verified) — a third impl must extend both this enum and every match
+/// on it in `eval_generic.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvalTag {
+    Jq,
+    Yq,
+}
+
 /// Trait for evaluation semantics - determines behavior for edge cases.
 ///
 /// jq and yq (mikefarah/yq) have different behaviors for some operations.
@@ -37,6 +55,9 @@ pub trait EvalSemantics: Copy + Default {
     const NEGATIVE_INDEX_IN_HAS: bool;
     /// If true, `%` truncates float operands to integers (jq). If false, float modulo (yq).
     const MOD_TRUNCATES_FLOATS: bool;
+
+    /// See [`EvalTag`].
+    fn tag() -> EvalTag;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -52,6 +73,10 @@ impl EvalSemantics for JqSemantics {
     const DIV_BY_ZERO_IS_INFINITY: bool = false;
     const NEGATIVE_INDEX_IN_HAS: bool = false;
     const MOD_TRUNCATES_FLOATS: bool = true;
+
+    fn tag() -> EvalTag {
+        EvalTag::Jq
+    }
 }
 
 /// yq-compatible evaluation semantics.
@@ -67,6 +92,10 @@ impl EvalSemantics for YqSemantics {
     const DIV_BY_ZERO_IS_INFINITY: bool = true;
     const NEGATIVE_INDEX_IN_HAS: bool = true;
     const MOD_TRUNCATES_FLOATS: bool = false;
+
+    fn tag() -> EvalTag {
+        EvalTag::Yq
+    }
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -23,8 +23,8 @@ use super::document::{
 use super::eval::{
     compare_values, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
     needs_path_context, numeric_display_string, numeric_key_to_index, owned_bound_to_i64,
-    slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics, JqSemantics,
-    QueryResult,
+    slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag, JqSemantics,
+    QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Literal};
 use super::slice::{slice_str, SliceBounds};
@@ -272,6 +272,17 @@ fn push_generic_truthiness<V: DocumentValue>(
         // Same reasoning as `LazyKeys` above — the array-index-range result
         // of `keys`/`keys_unsorted` on an array is always truthy.
         GenericResult::LazyIndexRange(_) => out.push(true),
+        // Unlike `LazyKeys`/`LazyIndexRange` above, a `LazySeq` embeds a
+        // user `map(f)` that can genuinely error (#724) — e.g.
+        // `select(keys_unsorted | map(error("x")))` must propagate that
+        // error, not silently treat any array-shaped result as truthy. So
+        // this arm can't skip evaluation, only skip *inspecting the
+        // result* once evaluation succeeds (array-shaped is still always
+        // truthy).
+        GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+            Ok(_) => out.push(true),
+            Err(control) => return Some(control),
+        },
         GenericResult::None => {}
         GenericResult::Owned(v) => out.push(v.is_truthy()),
         GenericResult::ManyOwned(vs) => out.extend(vs.iter().map(OwnedValue::is_truthy)),
@@ -314,6 +325,14 @@ fn flatten_generic_results<V: DocumentValue>(items: Vec<GenericResult<V>>) -> Ve
             GenericResult::Error(_) | GenericResult::Break(_) | GenericResult::Partial(..) => {
                 unreachable!("Error/Break/Partial already routed to an early return above")
             }
+            // Both callers (the `Many`/`ManyCursor` Pipe-fold per-element
+            // loops) resolve a per-element `LazySeq` via `materialize_atomic`
+            // — and route its error, if any, to the same early return the
+            // `Error`/`Break`/`Partial` arm above documents — before ever
+            // pushing into the batch this function walks (#724).
+            GenericResult::LazySeq(_) => {
+                unreachable!("LazySeq already resolved by the caller above")
+            }
         }
     }
     results
@@ -344,6 +363,9 @@ fn eval_on_many_owned<S: EvalSemantics, V: DocumentValue>(
             GenericResult::LazyIndexRange(_) => {
                 unreachable!("eval_on_owned never returns LazyIndexRange")
             }
+            GenericResult::LazySeq(_) => {
+                unreachable!("eval_on_owned never returns LazySeq")
+            }
             GenericResult::None => {}
             // The outputs already produced no longer vanish (#400, #494).
             GenericResult::Error(e) => return partial_generic(results, Control::Error(e)),
@@ -361,6 +383,237 @@ fn eval_on_many_owned<S: EvalSemantics, V: DocumentValue>(
     } else {
         GenericResult::ManyOwned(results)
     }
+}
+
+/// One pending element of a [`LazySeq`]: still a live pointer into the
+/// source document, or a value an earlier `map` stage computed that no
+/// longer corresponds to one node in the source.
+#[derive(Debug, Clone)]
+pub enum LazyElem<V: DocumentValue> {
+    Cursor(V::Cursor),
+    Owned(OwnedValue),
+}
+
+/// The four possible starting points for a [`LazySeq`] (#700/#724). `Keys`/
+/// `IndexRange` are Slice 1's (#724) construction sites — the `Pipe` fold's
+/// `LazyKeys`/`LazyIndexRange` arms below. `Elements`/`Values` are Slice 2's
+/// (#725, `eval_builtin`'s future `Builtin::Map` arm on bare arrays/objects)
+/// — defined now per #700's staged-but-general design, not constructed by
+/// any production code path until #725 lands.
+#[derive(Debug, Clone)]
+enum LazySource<V: DocumentValue> {
+    #[allow(dead_code)]
+    // STYLE-0005: constructed by #725 (Slice 2, eval_builtin's Builtin::Map arm on bare arrays)
+    Elements(V::Elements),
+    #[allow(dead_code)]
+    // STYLE-0005: constructed by #725 (Slice 2, eval_builtin's Builtin::Map arm on bare objects)
+    Values(V::Fields),
+    Keys(V::Fields),
+    IndexRange {
+        next: usize,
+        len: usize,
+    },
+}
+
+impl<V: DocumentValue> LazySource<V> {
+    /// Pull one element and store "the rest" back into `self`. No
+    /// backward-moving method exists anywhere on `DocumentFields`/
+    /// `DocumentElements`, so this can never rewind (see the design doc's
+    /// "format-access asymmetry" section — YAML has no cheap random access).
+    fn advance(&mut self) -> Option<LazyElem<V>> {
+        match self {
+            Self::Elements(elements) => {
+                let (cursor, rest) = elements.uncons_cursor()?;
+                *elements = rest;
+                Some(LazyElem::Cursor(cursor))
+            }
+            Self::Values(fields) => {
+                let (field, rest) = fields.uncons()?;
+                *fields = rest;
+                Some(LazyElem::Cursor(field.value_cursor))
+            }
+            Self::Keys(fields) => {
+                let (field, rest) = fields.uncons()?;
+                *fields = rest;
+                Some(LazyElem::Cursor(field.key_cursor))
+            }
+            Self::IndexRange { next, len } => {
+                if *next >= *len {
+                    return None;
+                }
+                let i = *next;
+                *next += 1;
+                Some(LazyElem::Owned(OwnedValue::Int(i as i64)))
+            }
+        }
+    }
+}
+
+/// One deferred stage of a [`LazySeq`]. Only ever `Map` — `f` is always
+/// exactly the argument expression from the `map(f)` call that pushed it,
+/// never a synthesized `Builtin::Select`; composing `select` into a chain
+/// this way is reserved for future elementwise `.[] | select(g)` work (see
+/// the design doc's "select: no new code path" section) and is out of
+/// Slice 1's scope. `tag` records which concrete `EvalSemantics` impl built
+/// this instruction, since `Instruction` carries no generic parameter (doing
+/// so would ripple a lifetime/type parameter onto `GenericResult<V>` itself
+/// — see the design doc for why that was rejected).
+#[derive(Debug, Clone)]
+struct Instruction {
+    f: Box<Expr>,
+    tag: EvalTag,
+}
+
+/// A composed, not-yet-materialized `map` chain (#700/#724).
+///
+/// `source` never rewinds — consumed cons cells are simply gone.
+/// `instructions` grows by one entry per composed `map` stage, so an
+/// arbitrary-length `map(f) | map(g) | ...` chain is one value, not one type
+/// per depth. `pending` buffers only the current source element's own
+/// fan-out (0..N outputs from `,`/`empty` inside one stage), never an
+/// earlier or later element.
+#[derive(Clone)]
+pub struct LazySeq<V: DocumentValue> {
+    source: LazySource<V>,
+    instructions: Vec<Instruction>,
+    pending: Vec<LazyElem<V>>,
+}
+
+// Manual, not derived: `#[derive(Debug)]` would require `V::Cursor`/
+// `V::Fields`/`V::Elements: Debug` as an *unconditional* bound on this impl
+// (derive doesn't thread a nested generic field's own conditional Debug
+// bounds — e.g. `LazySource<V>: Debug` — up through this struct's impl), and
+// `DocumentValue`/`DocumentFields`/`DocumentElements`/`DocumentCursor` don't
+// require `Debug` on those associated types. Reporting shape only (variant/
+// lengths) keeps this impl unconditional on `V: DocumentValue` alone, which
+// is what `GenericResult<V>`'s own `#[derive(Debug)]` needs to hold for its
+// `LazySeq(LazySeq<V>)` variant.
+impl<V: DocumentValue> core::fmt::Debug for LazySeq<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LazySeq")
+            .field(
+                "source",
+                &match &self.source {
+                    LazySource::Elements(_) => "Elements(..)",
+                    LazySource::Values(_) => "Values(..)",
+                    LazySource::Keys(_) => "Keys(..)",
+                    LazySource::IndexRange { .. } => "IndexRange(..)",
+                },
+            )
+            .field("instructions_len", &self.instructions.len())
+            .field("pending_len", &self.pending.len())
+            .finish()
+    }
+}
+
+impl<V: DocumentValue> LazySeq<V> {
+    fn new(source: LazySource<V>) -> Self {
+        Self {
+            source,
+            instructions: Vec::new(),
+            pending: Vec::new(),
+        }
+    }
+
+    /// Append one more composed `map` stage. Builder-style so `Pipe`-fold
+    /// call sites read as `LazySeq::new(...).push_map(f, tag)`.
+    fn push_map(mut self, f: Box<Expr>, tag: EvalTag) -> Self {
+        self.instructions.push(Instruction { f, tag });
+        self
+    }
+}
+
+/// Evaluate one instruction's deferred `f` against one element, dispatching
+/// to the concrete `EvalSemantics` its `EvalTag` names (exactly two arms —
+/// exactly two `EvalSemantics` impls exist, see [`EvalTag`]).
+fn eval_instruction<V: DocumentValue>(elem: LazyElem<V>, instr: &Instruction) -> GenericResult<V> {
+    match (elem, instr.tag) {
+        (LazyElem::Cursor(c), EvalTag::Jq) => {
+            eval_single::<JqSemantics, V>(&instr.f, c.value(), false, Some(c))
+        }
+        (LazyElem::Cursor(c), EvalTag::Yq) => {
+            eval_single::<YqSemantics, V>(&instr.f, c.value(), false, Some(c))
+        }
+        (LazyElem::Owned(o), EvalTag::Jq) => eval_on_owned::<JqSemantics, V>(&instr.f, o, false),
+        (LazyElem::Owned(o), EvalTag::Yq) => eval_on_owned::<YqSemantics, V>(&instr.f, o, false),
+    }
+}
+
+/// Normalize one instruction's `GenericResult` into 0..N buffered items —
+/// fan-out via `,`, drop via `empty`/`None`. A mid-element `Error`/`Break`/
+/// `Partial` is a hard `Err`, discarding *its own* partial output: this
+/// mirrors `eval::map_over`'s atomicity (`map(f)` is `[.[] | f]`, an atomic
+/// array construction in jq — a mid-map error never yields a partial array),
+/// not this file's usual `partial_generic`-based preserve-the-prefix
+/// convention used everywhere else a stream is folded.
+fn into_lazy_items<V: DocumentValue>(
+    result: GenericResult<V>,
+) -> Result<Vec<LazyElem<V>>, Control> {
+    match result {
+        GenericResult::One(v) => Ok(vec![LazyElem::Owned(to_owned(&v))]),
+        GenericResult::OneCursor(c) => Ok(vec![LazyElem::Cursor(c)]),
+        GenericResult::Many(vs) => Ok(vs.iter().map(|v| LazyElem::Owned(to_owned(v))).collect()),
+        GenericResult::ManyCursor(cs) => Ok(cs.into_iter().map(LazyElem::Cursor).collect()),
+        GenericResult::LazyKeys { fields, sorted } => Ok(vec![LazyElem::Owned(
+            materialize_lazy_keys::<V>(&fields, sorted),
+        )]),
+        GenericResult::LazyIndexRange(len) => {
+            Ok(vec![LazyElem::Owned(materialize_lazy_index_range(len))])
+        }
+        GenericResult::LazySeq(seq) => materialize_atomic(seq).map(|o| vec![LazyElem::Owned(o)]),
+        GenericResult::None => Ok(vec![]),
+        GenericResult::Owned(o) => Ok(vec![LazyElem::Owned(o)]),
+        GenericResult::ManyOwned(os) => Ok(os.into_iter().map(LazyElem::Owned).collect()),
+        GenericResult::Error(e) => Err(Control::Error(e)),
+        GenericResult::Break(label) => Err(Control::Break(label)),
+        GenericResult::Partial(_, control) => Err(control),
+    }
+}
+
+impl<V: DocumentValue> Iterator for LazySeq<V> {
+    type Item = Result<LazyElem<V>, Control>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(elem) = self.pending.pop() {
+                return Some(Ok(elem));
+            }
+            let elem = self.source.advance()?;
+            let mut current = vec![elem];
+            for instr in &self.instructions {
+                let mut next_items = Vec::with_capacity(current.len());
+                for e in current {
+                    match into_lazy_items(eval_instruction(e, instr)) {
+                        Ok(items) => next_items.extend(items),
+                        Err(control) => return Some(Err(control)),
+                    }
+                }
+                current = next_items;
+            }
+            // `pending.pop()` is LIFO; reverse once so it yields in the
+            // document order `current` was built in.
+            current.reverse();
+            self.pending = current;
+        }
+    }
+}
+
+/// Fully evaluate a `LazySeq` in one forward pass.
+///
+/// Mirrors `eval::map_over`'s atomicity: a mid-stream error/break discards
+/// every element already produced (`results` is simply dropped), unlike
+/// this file's usual `Partial`-preserving convention (`partial_generic`) —
+/// `map(f)` is `[.[] | f]`, and jq's array construction is atomic.
+pub fn materialize_atomic<V: DocumentValue>(seq: LazySeq<V>) -> Result<OwnedValue, Control> {
+    let mut results = Vec::new();
+    for item in seq {
+        match item {
+            Ok(LazyElem::Cursor(c)) => results.push(to_owned(&c.value())),
+            Ok(LazyElem::Owned(o)) => results.push(o),
+            Err(control) => return Err(control),
+        }
+    }
+    Ok(OwnedValue::Array(results))
 }
 
 /// Result of evaluating a generic jq expression.
@@ -399,6 +652,11 @@ pub enum GenericResult<V: DocumentValue> {
     /// `keys`/`keys_unsorted` did.
     LazyIndexRange(usize),
 
+    /// A composed, not-yet-materialized `map` chain over `LazyKeys`/
+    /// `LazyIndexRange` (#700/#724 Slice 1; #725 Slice 2 extends the
+    /// construction sites to plain arrays/objects). See [`LazySeq`].
+    LazySeq(LazySeq<V>),
+
     /// No result (optional that was missing).
     None,
 
@@ -431,6 +689,10 @@ impl<V: DocumentValue> GenericResult<V> {
             )),
             Self::LazyKeys { fields, sorted } => Some(materialize_lazy_keys::<V>(&fields, sorted)),
             Self::LazyIndexRange(len) => Some(materialize_lazy_index_range(len)),
+            // Matches the `Error`/`Break`/`Partial` "not representable"
+            // answer below: an errored `map` has no value to give back
+            // (#724).
+            Self::LazySeq(seq) => materialize_atomic(seq).ok(),
             Self::None => None,
             Self::Error(_) => None,
             Self::Owned(o) => Some(o),
@@ -454,6 +716,11 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::ManyCursor(cs) => cs.iter().map(|c| to_owned(&c.value())).collect(),
             Self::LazyKeys { fields, sorted } => vec![materialize_lazy_keys::<V>(&fields, sorted)],
             Self::LazyIndexRange(len) => vec![materialize_lazy_index_range(len)],
+            // Same "`Error` collects to `vec![]`" convention as this
+            // method's own `Error` arm below — safe here because every
+            // direct caller of `.collect_owned()` already treats an error
+            // result as "nothing to collect" (#724).
+            Self::LazySeq(seq) => materialize_atomic(seq).map_or_else(|_| vec![], |o| vec![o]),
             Self::None => vec![],
             Self::Error(_) => vec![],
             Self::Owned(o) => vec![o],
@@ -558,6 +825,30 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.count = 1;
                 stats.last_was_falsy = false;
                 stats.any_truthy = true;
+            }
+            // Cloned (not consumed by-value) since `stream_json` takes
+            // `&self` — cheap, `LazySeq` is small owned data (a
+            // `V::Fields`/two `usize`s, a short `Vec<Instruction>`), not a
+            // document copy (#724).
+            Self::LazySeq(seq) => {
+                match crate::jq::stream::stream_lazy_seq_json(seq.clone(), out, indent, sort_keys)?
+                {
+                    Ok(()) => {
+                        on_value(out)?;
+                        stats.count = 1;
+                        stats.last_was_falsy = false; // array, always truthy
+                        stats.any_truthy = true;
+                    }
+                    Err(control) => {
+                        stats.error = Some(match control {
+                            Control::Error(e) => stream_error(&e),
+                            Control::Break(label) => StreamError {
+                                message: format!("break ${label} not in label"),
+                                not_a_string: false,
+                            },
+                        });
+                    }
+                }
             }
             Self::ManyCursor(cs) => {
                 for c in cs {
@@ -706,6 +997,27 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.count = 1;
                 stats.last_was_falsy = false;
                 stats.any_truthy = true;
+            }
+            // Mirrors `stream_json`'s `LazySeq` arm above (#724).
+            Self::LazySeq(seq) => {
+                match crate::jq::stream::stream_lazy_seq_yaml(seq.clone(), out, indent, sort_keys)?
+                {
+                    Ok(()) => {
+                        on_value(out)?;
+                        stats.count = 1;
+                        stats.last_was_falsy = false;
+                        stats.any_truthy = true;
+                    }
+                    Err(control) => {
+                        stats.error = Some(match control {
+                            Control::Error(e) => stream_error(&e),
+                            Control::Break(label) => StreamError {
+                                message: format!("break ${label} not in label"),
+                                not_a_string: false,
+                            },
+                        });
+                    }
+                }
             }
             Self::None => {
                 // No output
@@ -1092,6 +1404,24 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                 GenericResult::LazyIndexRange(len) => {
                                     results.push(materialize_lazy_index_range(len));
                                 }
+                                // A per-element `LazySeq` (e.g. one stage
+                                // producing `(keys_unsorted | map(f))` per
+                                // element of an outer `Many`) resolves here,
+                                // same early-return-on-error shape as the
+                                // `Error`/`Break`/`Partial` arms right below
+                                // (#724) — this loop inlines its own
+                                // flattening instead of calling
+                                // `flatten_generic_results`, so it needs this
+                                // fix independently of that function's own.
+                                GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+                                    Ok(o) => results.push(o),
+                                    Err(Control::Error(e)) => {
+                                        return partial_generic(results, Control::Error(e));
+                                    }
+                                    Err(Control::Break(label)) => {
+                                        return partial_generic(results, Control::Break(label));
+                                    }
+                                },
                                 GenericResult::None => {}
                                 // The outputs already piped through no longer
                                 // vanish (#400, #494).
@@ -1155,6 +1485,29 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                     prefix.extend(vs);
                                     return partial_generic(prefix, control);
                                 }
+                                // `other =>` below is a genuine wildcard, so
+                                // this needs its own explicit arm ahead of
+                                // it (#724) — without it, a per-element
+                                // `LazySeq` would silently reach
+                                // `flatten_generic_results`, which treats it
+                                // as unreachable (see that function's own
+                                // doc comment: every batch it walks must
+                                // already be `LazySeq`-free).
+                                GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+                                    Ok(o) => per_element.push(GenericResult::Owned(o)),
+                                    Err(Control::Error(e)) => {
+                                        return partial_generic(
+                                            flatten_generic_results(per_element),
+                                            Control::Error(e),
+                                        );
+                                    }
+                                    Err(Control::Break(label)) => {
+                                        return partial_generic(
+                                            flatten_generic_results(per_element),
+                                            Control::Break(label),
+                                        );
+                                    }
+                                },
                                 other => per_element.push(other),
                             }
                         }
@@ -1204,6 +1557,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         Expr::Builtin(Builtin::Length) => {
                             GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
                         }
+                        // #724: same `!sorted` guard as `.[]`/`first`/`last`
+                        // below — sorted `keys` still needs a full decode
+                        // (and sort) before anything but `length`, so it
+                        // falls through to the shared fallback arm.
+                        Expr::Builtin(Builtin::Map(f)) if !sorted => GenericResult::LazySeq(
+                            LazySeq::new(LazySource::Keys(fields)).push_map(f.clone(), S::tag()),
+                        ),
                         // Document order is a valid answer only for
                         // `keys_unsorted`. `keys` needs lexicographic order
                         // for these and falls through to the shared
@@ -1295,6 +1655,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         Expr::Builtin(Builtin::Length) => {
                             GenericResult::Owned(OwnedValue::Int(len as i64))
                         }
+                        // #724: no `sorted` flag exists here — an index
+                        // range is always already sorted, same as every
+                        // other arm in this match.
+                        Expr::Builtin(Builtin::Map(f)) => GenericResult::LazySeq(
+                            LazySeq::new(LazySource::IndexRange { next: 0, len })
+                                .push_map(f.clone(), S::tag()),
+                        ),
                         Expr::Iterate => {
                             if len == 0 {
                                 GenericResult::None
@@ -1341,6 +1708,149 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         _ => {
                             eval_on_owned::<S, _>(expr, materialize_lazy_index_range(len), optional)
                         }
+                    },
+                    // The composability engine (#700/#724): pushing one more
+                    // instruction stays the *same* variant, so an
+                    // arbitrary-length `map(f) | map(g) | ...` chain is one
+                    // value, not one type per depth. Every arm below except
+                    // `Builtin::Map` itself must still visit *every* source
+                    // element (never stop early): `map(f)` in real jq is
+                    // `[.[] | f]`, an eager array construction with no
+                    // short-circuit, so e.g. `.[0]` after a `map(f)` whose
+                    // `f` errors on a *later* element must still error, even
+                    // though only the first element was ultimately wanted.
+                    // The saving these arms deliver is skipping the
+                    // `OwnedValue::Array` + JSON-reserialize +
+                    // `JsonIndex`-rebuild + full-evaluator-reentry round trip
+                    // the `_` fallback below pays — not skipping evaluation
+                    // of `f`, which jq's own semantics never allow skipping.
+                    GenericResult::LazySeq(seq) => match unwrap_paren(expr) {
+                        Expr::Builtin(Builtin::Map(f)) => {
+                            GenericResult::LazySeq(seq.push_map(f.clone(), S::tag()))
+                        }
+                        // Single forward pass, count-and-discard.
+                        Expr::Builtin(Builtin::Length) => {
+                            let mut count: i64 = 0;
+                            for item in seq {
+                                match item {
+                                    Ok(_) => count += 1,
+                                    Err(Control::Error(e)) => return GenericResult::Error(e),
+                                    Err(Control::Break(label)) => {
+                                        return GenericResult::Break(label)
+                                    }
+                                }
+                            }
+                            GenericResult::Owned(OwnedValue::Int(count))
+                        }
+                        // Single forward pass; upgrades to `ManyOwned` the
+                        // moment a non-cursor element appears, same idiom
+                        // `eval_index_expr` already uses for cursor/owned
+                        // mixing. No `Partial` on error (atomicity, see the
+                        // arm's own doc comment above): a mid-map error
+                        // discards every element already collected here.
+                        Expr::Iterate => {
+                            let mut cursors: Vec<V::Cursor> = Vec::new();
+                            let mut owned: Vec<OwnedValue> = Vec::new();
+                            let mut any_owned = false;
+                            for item in seq {
+                                match item {
+                                    Ok(LazyElem::Cursor(c)) => {
+                                        if any_owned {
+                                            owned.push(to_owned(&c.value()));
+                                        } else {
+                                            cursors.push(c);
+                                        }
+                                    }
+                                    Ok(LazyElem::Owned(o)) => {
+                                        if !any_owned {
+                                            any_owned = true;
+                                            owned = core::mem::take(&mut cursors)
+                                                .into_iter()
+                                                .map(|c| to_owned(&c.value()))
+                                                .collect();
+                                        }
+                                        owned.push(o);
+                                    }
+                                    Err(Control::Error(e)) => return GenericResult::Error(e),
+                                    Err(Control::Break(label)) => {
+                                        return GenericResult::Break(label)
+                                    }
+                                }
+                            }
+                            if any_owned {
+                                if owned.is_empty() {
+                                    GenericResult::None
+                                } else {
+                                    GenericResult::ManyOwned(owned)
+                                }
+                            } else if cursors.is_empty() {
+                                GenericResult::None
+                            } else {
+                                GenericResult::ManyCursor(cursors)
+                            }
+                        }
+                        // Bare `first`/`.[0]` == `.[0]` indexing semantics,
+                        // NOT the generator-short-circuit `first(g)` form
+                        // (that's `eval_first_or_last_generic`, a separate,
+                        // unrelated 1-arg call). Must still drain every
+                        // element to detect a later error — the saving is
+                        // O(1) retained state (`Option<LazyElem>`), not an
+                        // early stop.
+                        Expr::Builtin(Builtin::First) | Expr::Index(0) => {
+                            let mut first: Option<LazyElem<V>> = None;
+                            for item in seq {
+                                match item {
+                                    Ok(elem) => {
+                                        if first.is_none() {
+                                            first = Some(elem);
+                                        }
+                                    }
+                                    Err(Control::Error(e)) => return GenericResult::Error(e),
+                                    Err(Control::Break(label)) => {
+                                        return GenericResult::Break(label)
+                                    }
+                                }
+                            }
+                            match first {
+                                Some(LazyElem::Cursor(c)) => GenericResult::OneCursor(c),
+                                Some(LazyElem::Owned(o)) => GenericResult::Owned(o),
+                                None => GenericResult::Owned(OwnedValue::Null),
+                            }
+                        }
+                        // Bare `last` == `.[-1]`. Deviates from treating
+                        // `last` as part of the materializing fallback
+                        // below: it's exactly as cheap as `Length` above
+                        // (one pass, O(1) retained state), and
+                        // `LazyKeys`/`LazyIndexRange` already fast-path it —
+                        // bucketing it with the fallback here would be an
+                        // unjustified regression relative to its own
+                        // siblings.
+                        Expr::Builtin(Builtin::Last) => {
+                            let mut last: Option<LazyElem<V>> = None;
+                            for item in seq {
+                                match item {
+                                    Ok(elem) => last = Some(elem),
+                                    Err(Control::Error(e)) => return GenericResult::Error(e),
+                                    Err(Control::Break(label)) => {
+                                        return GenericResult::Break(label)
+                                    }
+                                }
+                            }
+                            match last {
+                                Some(LazyElem::Cursor(c)) => GenericResult::OneCursor(c),
+                                Some(LazyElem::Owned(o)) => GenericResult::Owned(o),
+                                None => GenericResult::Owned(OwnedValue::Null),
+                            }
+                        }
+                        // Whole-value `select` (no new code path — see the
+                        // design doc), nonzero `.[n]`, comparisons: one
+                        // forward pass, then continue exactly like
+                        // `LazyKeys`/`LazyIndexRange`'s own fallback arms.
+                        _ => match materialize_atomic(seq) {
+                            Ok(owned) => eval_on_owned::<S, _>(expr, owned, optional),
+                            Err(Control::Error(e)) => GenericResult::Error(e),
+                            Err(Control::Break(label)) => GenericResult::Break(label),
+                        },
                     },
                     GenericResult::None => GenericResult::None,
                     GenericResult::Error(e) => return GenericResult::Error(e),
@@ -1403,6 +1913,20 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                     materialize_lazy_keys::<V>(&fields, sorted)
                 }
                 GenericResult::LazyIndexRange(len) => materialize_lazy_index_range(len),
+                // Mirrors the `Error` arm's `optional`-aware handling right
+                // above (#724) — a `LazySeq`'s error is the same kind of
+                // "operand failed" outcome, just discovered a pass later.
+                GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+                    Ok(o) => o,
+                    Err(Control::Error(e)) => {
+                        return if optional {
+                            GenericResult::None
+                        } else {
+                            GenericResult::Error(e)
+                        }
+                    }
+                    Err(Control::Break(label)) => return GenericResult::Break(label),
+                },
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -1448,6 +1972,18 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                     materialize_lazy_keys::<V>(&fields, sorted)
                 }
                 GenericResult::LazyIndexRange(len) => materialize_lazy_index_range(len),
+                // Mirrors the left-operand arm above.
+                GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+                    Ok(o) => o,
+                    Err(Control::Error(e)) => {
+                        return if optional {
+                            GenericResult::None
+                        } else {
+                            GenericResult::Error(e)
+                        }
+                    }
+                    Err(Control::Break(label)) => return GenericResult::Break(label),
+                },
                 GenericResult::Error(e) => {
                     return if optional {
                         GenericResult::None
@@ -1593,6 +2129,13 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::LazyKeys { fields, sorted }
             }
             GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
+            // Same forwarding, same reasoning: `inner` here is the 1-arg
+            // `first(EXPR)`/`last(EXPR)` form, which produces exactly one
+            // output (the not-yet-materialized `map` chain itself) — unlike
+            // the bare `first`/`.[0]`/`last` handled in the `Pipe` fold's
+            // own `LazySeq` arm, nothing here extracts an *array element*,
+            // so there's no error-visibility hazard to guard against (#724).
+            GenericResult::LazySeq(seq) => GenericResult::LazySeq(seq),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1625,6 +2168,8 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::LazyKeys { fields, sorted }
             }
             GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
+            // Same forwarding as the `want_last` branch above.
+            GenericResult::LazySeq(seq) => GenericResult::LazySeq(seq),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
@@ -1728,6 +2273,17 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         GenericResult::ManyCursor(cs) => {
             cs.iter().map(|c| to_owned_key_shape(&c.value())).collect()
         }
+        // `other =>` below is a genuine wildcard, so this needs its own
+        // explicit arm ahead of it (#724): folding a `LazySeq` into
+        // `other.collect_owned()` would silently swallow a `map` error into
+        // `keys.is_empty() -> return None`, contradicting the explicit
+        // `Error`/`Partial(Error)` handling a few lines above in this same
+        // match.
+        GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+            Ok(o) => vec![o],
+            Err(Control::Error(e)) => return GenericResult::Error(e),
+            Err(Control::Break(label)) => return GenericResult::Break(label),
+        },
         other => other.collect_owned(),
     };
     if keys.is_empty() {
@@ -1756,6 +2312,31 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         | GenericResult::LazyKeys { .. }
         | GenericResult::LazyIndexRange(_)) => {
             let targets = owned.collect_owned();
+            let mut out = Vec::with_capacity(keys.len() * targets.len());
+            for k in &keys {
+                for t in &targets {
+                    match index_owned_by_key(t, k, optional) {
+                        Ok(Some(v)) => out.push(v),
+                        Ok(None) => {}
+                        Err(e) => return GenericResult::Error(e),
+                    }
+                }
+            }
+            return match out.len() {
+                1 => GenericResult::Owned(out.pop().expect("len checked")),
+                _ => GenericResult::ManyOwned(out),
+            };
+        }
+        // Not folded into the OR-pattern above: that arm's `.collect_owned()`
+        // silently drops an error (`vec![]`), which is safe only because
+        // every variant currently grouped there is structurally infallible
+        // to materialize — a `LazySeq`'s `map` genuinely can fail (#724).
+        GenericResult::LazySeq(seq) => {
+            let targets = match materialize_atomic(seq) {
+                Ok(o) => vec![o],
+                Err(Control::Error(e)) => return GenericResult::Error(e),
+                Err(Control::Break(label)) => return GenericResult::Break(label),
+            };
             let mut out = Vec::with_capacity(keys.len() * targets.len());
             for k in &keys {
                 for t in &targets {
@@ -1872,6 +2453,16 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         | GenericResult::ManyOwned(_)
         | GenericResult::LazyKeys { .. }
         | GenericResult::LazyIndexRange(_)) => Targets::Owned(owned.collect_owned()),
+        // Not folded into the OR-pattern above: that arm's `.collect_owned()`
+        // silently drops an error, safe only because every variant grouped
+        // there is structurally infallible to materialize — a `LazySeq`'s
+        // `map` genuinely can fail (#724, mirrors `eval_index_expr`'s
+        // equivalent fix).
+        GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+            Ok(o) => Targets::Owned(vec![o]),
+            Err(Control::Error(e)) => return GenericResult::Error(e),
+            Err(Control::Break(label)) => return GenericResult::Break(label),
+        },
     };
 
     // Start outer, end middle, target inner. The result is always owned:
@@ -1938,6 +2529,13 @@ fn eval_slice_bound<S: EvalSemantics, V: DocumentValue>(
         GenericResult::ManyCursor(cs) => {
             cs.iter().map(|c| to_owned_key_shape(&c.value())).collect()
         }
+        // `other =>` below is a genuine wildcard, so this needs its own
+        // explicit arm ahead of it (#724): folding a `LazySeq` into
+        // `other.collect_owned()` would silently coerce a `map` error into
+        // an empty bound (`Ok(Vec::new())`-shaped), instead of the
+        // `Err(Control::Error(...))` the explicit arms above already model
+        // for every other failure mode in this same match.
+        GenericResult::LazySeq(seq) => vec![materialize_atomic(seq)?],
         other => other.collect_owned(),
     };
     raw.iter()

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -276,11 +276,12 @@ fn push_generic_truthiness<V: DocumentValue>(
         // user `map(f)` that can genuinely error (#724) — e.g.
         // `select(keys_unsorted | map(error("x")))` must propagate that
         // error, not silently treat any array-shaped result as truthy. So
-        // this arm can't skip evaluation, only skip *inspecting the
+        // this arm can't skip evaluation, only skip *materializing the
         // result* once evaluation succeeds (array-shaped is still always
-        // truthy).
-        GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
-            Ok(_) => out.push(true),
+        // truthy) — `drain_for_error` runs every element's `map(f)` but
+        // never collects the output, unlike `materialize_atomic`.
+        GenericResult::LazySeq(seq) => match drain_for_error(seq) {
+            Ok(()) => out.push(true),
             Err(control) => return Some(control),
         },
         GenericResult::None => {}
@@ -614,6 +615,23 @@ pub fn materialize_atomic<V: DocumentValue>(seq: LazySeq<V>) -> Result<OwnedValu
         }
     }
     Ok(OwnedValue::Array(results))
+}
+
+/// Drive a `LazySeq` to completion without materializing any element, only
+/// surfacing a mid-stream error/break.
+///
+/// For consumers that only need to know *whether* evaluation succeeded, not
+/// the resulting array — e.g. [`push_generic_truthiness`], where an
+/// array-shaped result is always truthy in jq regardless of its contents.
+/// Every element's `map(f)` still runs (that's unavoidable — it's the only
+/// way to know whether a later element errors), but skips
+/// `materialize_atomic`'s per-`Cursor`-element `to_owned()` deep clone and
+/// its `Vec<OwnedValue>` accumulation, which the caller would only discard.
+fn drain_for_error<V: DocumentValue>(seq: LazySeq<V>) -> Result<(), Control> {
+    for item in seq {
+        item?;
+    }
+    Ok(())
 }
 
 /// Result of evaluating a generic jq expression.
@@ -3721,6 +3739,38 @@ mod tests {
                 OwnedValue::String("c".to_string()),
             ])
         );
+    }
+
+    /// `select(keys_unsorted | map(f))` -- unlike the plain-`select` case
+    /// above, the *condition* here is a `LazySeq`, so it goes through
+    /// `push_generic_truthiness`'s `LazySeq` arm (#724 fix: `drain_for_error`
+    /// instead of `materialize_atomic`, so a truthy array-shaped condition no
+    /// longer gets deep-cloned into a throwaway `Vec<OwnedValue>` just to
+    /// answer "is this truthy"). Covers both sides: a non-erroring `map`
+    /// leaves the original value untouched (array-shaped is always truthy),
+    /// and a mid-map error must still surface through the boolean condition,
+    /// not get silently swallowed by an "array is always truthy" shortcut.
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_select_condition() {
+        let json = br#"{"b": 1, "a": 2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("select(keys_unsorted | map(.))").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Object(IndexMap::from_iter([
+                ("b".to_string(), OwnedValue::Int(1)),
+                ("a".to_string(), OwnedValue::Int(2)),
+            ]))
+        );
+
+        let expr = crate::jq::parse(
+            r#"select(keys_unsorted | map(if . == "b" then error("boom") else . end))"#,
+        )
+        .unwrap();
+        assert!(eval(&expr, value).is_error());
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3884,6 +3884,99 @@ mod tests {
         );
     }
 
+    /// `stream_lazy_seq_json`/`_yaml` (#724) must indent a mapped element's
+    /// own nested containers relative to the element's true depth (one level
+    /// inside the array), not nominal depth 0 -- verified by requiring the
+    /// lazy `LazySeq` streaming path to byte-match the eager `OwnedValue`
+    /// streaming path for the exact same query, rather than a hand-computed
+    /// expected string.
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_stream_json_nested_indent() {
+        use crate::jq::stream::StreamableValue;
+
+        let json = br#"{"b": 1, "a": 2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse(r"keys_unsorted | map({x: ., y: [1, 2]})").unwrap();
+
+        let lazy = eval(&expr, value.clone());
+        assert!(matches!(lazy, GenericResult::LazySeq(_)));
+        let mut lazy_buf = String::new();
+        lazy.stream_json(&mut lazy_buf, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+
+        let eager = eval(&expr, value).into_owned().unwrap();
+        let mut eager_buf = String::new();
+        eager
+            .stream_json(&mut eager_buf, IndentSpec::spaces(2), false)
+            .unwrap();
+
+        assert_eq!(lazy_buf, eager_buf);
+        // Pin the actual shape too, so a future change to *both* paths in
+        // the same wrong way can't cancel out.
+        assert_eq!(
+            lazy_buf,
+            "[\n  {\n    \"x\": \"b\",\n    \"y\": [\n      1,\n      2\n    ]\n  },\n  {\n    \"x\": \"a\",\n    \"y\": [\n      1,\n      2\n    ]\n  }\n]"
+        );
+    }
+
+    /// YAML counterpart of the JSON indent test above -- also exercises the
+    /// block-style "nested container gets its own line after `- `"
+    /// convention (`stream_owned_value_yaml`'s `Array` arm), which
+    /// `stream_lazy_seq_yaml` previously skipped entirely.
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_stream_yaml_nested_indent() {
+        use crate::jq::stream::StreamableValue;
+
+        let json = br#"{"b": 1, "a": 2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse(r"keys_unsorted | map({x: ., y: [1, 2]})").unwrap();
+
+        let lazy = eval(&expr, value.clone());
+        assert!(matches!(lazy, GenericResult::LazySeq(_)));
+        let mut lazy_buf = String::new();
+        lazy.stream_yaml(&mut lazy_buf, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+
+        let eager = eval(&expr, value).into_owned().unwrap();
+        let mut eager_buf = String::new();
+        eager
+            .stream_yaml(&mut eager_buf, IndentSpec::spaces(2), false)
+            .unwrap();
+
+        assert_eq!(lazy_buf, eager_buf);
+        assert_eq!(
+            lazy_buf,
+            "- \n  x: b\n  y:\n    - 1\n    - 2\n- \n  x: a\n  y:\n    - 1\n    - 2"
+        );
+    }
+
+    /// `stream_lazy_seq_yaml`'s block-style branch previously had no `i ==
+    /// 0` short circuit (unlike its own flow-style branch just above it and
+    /// the sibling `stream_lazy_keys_yaml`), so an empty `LazySeq` wrote
+    /// nothing instead of `[]` (#724).
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_stream_yaml_empty_block() {
+        let json = br"{}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | map(.)").unwrap();
+        let lazy = eval(&expr, value);
+        assert!(matches!(lazy, GenericResult::LazySeq(_)));
+
+        let mut block_yaml = String::new();
+        lazy.stream_yaml(&mut block_yaml, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(block_yaml, "[]");
+    }
+
     #[test]
     fn test_generic_keys_unsorted_lazy_large_object() {
         // No allocation-count assertion here (that's covered by the A/B

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3674,17 +3674,20 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_keys_unsorted_fallback_map_select() {
-        // `map`/`select` have no native lazy path -- `eval_generic.rs` has
-        // no native `Builtin::Map` arm at all (see the `Pipe` dispatch's
-        // `LazyKeys` arm doc comment) -- so these must still materialize
-        // correctly via the fallback.
+    fn test_generic_keys_unsorted_lazy_map_select() {
+        // #724: `keys_unsorted | map(f)` now stays lazy (`GenericResult::
+        // LazySeq`) instead of falling back to the eager `to_owned` +
+        // reserialize + reindex + re-evaluate round trip.
         let json = br#"{"b": 1, "a": 2, "c": 3}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
 
         let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase)").unwrap();
+        assert!(
+            matches!(eval(&expr, value.clone()), GenericResult::LazySeq(_)),
+            "keys_unsorted | map(f) should stay lazy, not fall back"
+        );
         assert_eq!(
             eval(&expr, value.clone()).into_owned().unwrap(),
             OwnedValue::Array(vec![
@@ -3694,6 +3697,11 @@ mod tests {
             ])
         );
 
+        // No `map` here, so this doesn't exercise `LazySeq` -- `select`
+        // itself still has no new lazy code path (see the design doc's
+        // "select: no new code path" section) and reaches `Builtin::
+        // Select`'s native arm only via `LazyKeys`'s own pre-existing
+        // materializing fallback.
         let expr = crate::jq::parse("keys_unsorted | select(length == 3)").unwrap();
         assert_eq!(
             eval(&expr, value).into_owned().unwrap(),
@@ -3701,6 +3709,141 @@ mod tests {
                 OwnedValue::String("b".to_string()),
                 OwnedValue::String("a".to_string()),
                 OwnedValue::String("c".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_chain() {
+        // #724: `keys_unsorted | map(f) | map(g)` composes onto the *same*
+        // `LazySeq` (`instructions.len() == 2`), not a materializing fallback
+        // after the first `map`.
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase) | map(. + \"!\")").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("B!".to_string()),
+                OwnedValue::String("A!".to_string()),
+                OwnedValue::String("C!".to_string()),
+            ])
+        );
+
+        // The chain #724 exists for: `map(f) | select(g)` stays lazy through
+        // the `map` stage, only materializing (once, in one forward pass)
+        // when `select` is reached.
+        let expr =
+            crate::jq::parse("keys_unsorted | map(ascii_upcase) | select(length == 3)").unwrap();
+        assert!(matches!(
+            eval(
+                &crate::jq::parse("keys_unsorted | map(ascii_upcase)").unwrap(),
+                value.clone()
+            ),
+            GenericResult::LazySeq(_)
+        ));
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("B".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("C".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_atomicity() {
+        // #724 / design doc risk #2: a mid-map error discards the whole
+        // array, matching `eval::map_over`'s atomicity -- not a `Partial`
+        // with the successfully-mapped prefix. `"c"` is *last* in document
+        // order (`b, a, c`), so this only fails correctly if every element
+        // is actually visited -- an implementation that stopped early after
+        // the first success/error would miss it. `| length` forces
+        // materialization through the `LazySeq` composability arm's own
+        // `Length` fast path, which must still propagate the error as a
+        // bare `GenericResult::Error`, not silently answer with a count.
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse(
+            r#"keys_unsorted | map(if . == "c" then error("boom") else . end) | length"#,
+        )
+        .unwrap();
+        assert!(eval(&expr, value).is_error());
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_first_index_error_visibility() {
+        // #724 correctness fix (see the plan's "Decisions and corrections"
+        // #3): bare `first`/`.[0]` after a `map(f)` must still surface an
+        // error from a *later* element -- `map(f)` is an eager, atomic array
+        // construction in real jq (`[.[] | f]`), so a fast path that
+        // literally stopped after the first successful pull would wrongly
+        // return `"a"` here instead of propagating the `"b"`-triggered error.
+        let json = br#"{"a": 1, "b": 2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse(
+            r#"keys_unsorted | map(if . == "b" then error("x") else . end) | .[0]"#,
+        )
+        .unwrap();
+        assert!(eval(&expr, value.clone()).is_error());
+
+        let expr = crate::jq::parse(
+            r#"keys_unsorted | map(if . == "b" then error("x") else . end) | first"#,
+        )
+        .unwrap();
+        assert!(eval(&expr, value).is_error());
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_index_boundary() {
+        // Design doc risk #3: `.[0]` gets a lazy fast path; nonzero `.[n]`
+        // still falls back to materializing (documented scope, not a bug) --
+        // both must stay correct.
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase) | .[0]").unwrap();
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap(),
+            OwnedValue::String("B".to_string())
+        );
+
+        let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase) | .[2]").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::String("C".to_string())
+        );
+    }
+
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_yq_semantics() {
+        // #724: `EvalTag::Yq` is genuinely exercised, not just defined.
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase)").unwrap();
+        assert_eq!(
+            eval_using::<YqSemantics, _>(&expr, value)
+                .into_owned()
+                .unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("B".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("C".to_string()),
             ])
         );
     }
@@ -3838,6 +3981,11 @@ mod tests {
 
     #[test]
     fn test_generic_keys_sorted_fallback_map_select() {
+        // Unlike `keys_unsorted`, sorted `keys | map/select` is an explicit
+        // non-goal of #724 (sorting requires seeing every key before
+        // emitting the first one -- a different complexity class, not a
+        // narrower version of `keys_unsorted`'s problem) -- so this stays on
+        // the eager materializing fallback indefinitely, unchanged by #724.
         let json = br#"{"b": 1, "a": 2, "c": 3}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
@@ -4032,15 +4180,20 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_array_keys_unsorted_fallback_map_select() {
-        // `map`/`select` have no native lazy path here either -- must still
-        // materialize correctly via the fallback.
+    fn test_generic_array_keys_unsorted_lazy_map_select() {
+        // #724: the `LazyIndexRange` counterpart of
+        // `test_generic_keys_unsorted_lazy_map_select` -- array
+        // `keys_unsorted | map(f)` also stays lazy now.
         let json = br#"["x","y","z"]"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
 
         let expr = crate::jq::parse("keys_unsorted | map(. * 10)").unwrap();
+        assert!(
+            matches!(eval(&expr, value.clone()), GenericResult::LazySeq(_)),
+            "array keys_unsorted | map(f) should stay lazy, not fall back"
+        );
         assert_eq!(
             eval(&expr, value.clone()).into_owned().unwrap(),
             OwnedValue::Array(vec![
@@ -4050,6 +4203,7 @@ mod tests {
             ])
         );
 
+        // No `map` here -- unaffected by #724, same as the object case above.
         let expr = crate::jq::parse("keys_unsorted | select(length == 3)").unwrap();
         assert_eq!(
             eval(&expr, value).into_owned().unwrap(),
@@ -4677,6 +4831,52 @@ mod tests {
         assert_eq!(
             eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
             OwnedValue::String("c".to_string())
+        );
+    }
+
+    #[test]
+    fn test_yaml_keys_unsorted_lazy_map_select() {
+        // #724: `LazySeq` is generic over `V: DocumentValue`, so this must
+        // hold under `YamlFields`'s `Clone`-not-`Copy` cons-list walk, not
+        // just JSON's `Copy` one (the design doc's whole "format-access
+        // asymmetry" section exists because of this distinction — a
+        // JSON-only suite could pass while silently relying on `Copy`-cheap
+        // re-cloning that's wrong/expensive for YAML).
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"b: 1\na: 2\nc: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase)").unwrap();
+        assert!(
+            matches!(
+                eval_with_cursor(&expr, doc_cursor),
+                GenericResult::LazySeq(_)
+            ),
+            "YAML keys_unsorted | map(f) should stay lazy, not fall back"
+        );
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("B".to_string()),
+                OwnedValue::String("A".to_string()),
+                OwnedValue::String("C".to_string()),
+            ])
+        );
+
+        // `instructions.len() == 2` under YAML's `Clone`-not-`Copy` fields.
+        let expr = crate::jq::parse("keys_unsorted | map(ascii_upcase) | map(. + \"!\")").unwrap();
+        assert_eq!(
+            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("B!".to_string()),
+                OwnedValue::String("A!".to_string()),
+                OwnedValue::String("C!".to_string()),
+            ])
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1322,6 +1322,16 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // stopping (#693).
         Expr::Optional(inner) => match eval_single::<S, _>(inner, value, optional, cursor) {
             GenericResult::Error(_) | GenericResult::Break(_) => GenericResult::None,
+            // A `LazySeq` is deferred, so the `Error`/`Break` arm above
+            // never sees it — `map`'s error (if any) only appears once the
+            // chain is actually drained. `?` is itself an error boundary, so
+            // it must force that drain here to know whether to catch
+            // anything; mirrors this same arm's eager Error/Break handling
+            // immediately above (#724).
+            GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
+                Ok(o) => GenericResult::Owned(o),
+                Err(Control::Error(_) | Control::Break(_)) => GenericResult::None,
+            },
             // `prefix` is never empty here: `partial_generic` (and
             // `eval::partial`, its mirror) already collapse an empty prefix
             // to the bare `Error`/`Break` variant above before a `Partial`
@@ -3776,6 +3786,32 @@ mod tests {
         )
         .unwrap();
         assert!(eval(&expr, value).is_error());
+    }
+
+    /// #724 fix: `(keys_unsorted | map(f))?` must catch an error raised
+    /// inside the deferred `map(f)` chain. Before the fix, `Expr::Optional`
+    /// matched the *immediate* `GenericResult` of `inner` to decide whether
+    /// to catch anything -- but for a `LazySeq`-producing pipe that
+    /// immediate result is the deferred sequence itself, not yet drained, so
+    /// it fell through the catch-all `other => other` arm unevaluated and
+    /// the error only surfaced later when something else finally drained
+    /// it, past where `?` could still catch it.
+    #[test]
+    fn test_generic_keys_unsorted_lazy_map_try_catches_error() {
+        let json = br#"{"b": 1, "a": 2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let expr = crate::jq::parse(
+            r#"(keys_unsorted | map(if . == "b" then error("boom") else . end))?"#,
+        )
+        .unwrap();
+        let result = eval(&expr, value);
+        assert!(
+            matches!(result, GenericResult::None),
+            "expected `?` to catch the map error and yield no output, got {result:?}"
+        );
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -599,6 +599,37 @@ impl<V: DocumentValue> Iterator for LazySeq<V> {
     }
 }
 
+/// Convert a `Control` signal into the `GenericResult` variant that reports
+/// it — the shared tail of every `LazySeq`/`materialize_atomic` drain site
+/// in this file (#724), previously hand-duplicated as a two-arm
+/// `Err(Control::Error(e)) => return GenericResult::Error(e), Err(Control::
+/// Break(label)) => return GenericResult::Break(label)` at each site. Not
+/// for sites that need `optional`-aware Error handling — see
+/// [`control_into_generic_optional`] for those.
+fn control_into_generic<V: DocumentValue>(control: Control) -> GenericResult<V> {
+    match control {
+        Control::Error(e) => GenericResult::Error(e),
+        Control::Break(label) => GenericResult::Break(label),
+    }
+}
+
+/// [`control_into_generic`]'s counterpart for the handful of sites (`Expr::
+/// Compare`'s operand materialization) where an ambient `optional` should
+/// swallow an `Error` into `GenericResult::None` — mirroring how every other
+/// `GenericResult::Error` arm at those same sites already treats `optional`.
+/// `Break` is never `optional`-gated anywhere in this file, so this always
+/// propagates it unconditionally, same as the non-`optional` variant above.
+fn control_into_generic_optional<V: DocumentValue>(
+    control: Control,
+    optional: bool,
+) -> GenericResult<V> {
+    match control {
+        Control::Error(_) if optional => GenericResult::None,
+        Control::Error(e) => GenericResult::Error(e),
+        Control::Break(label) => GenericResult::Break(label),
+    }
+}
+
 /// Fully evaluate a `LazySeq` in one forward pass.
 ///
 /// Mirrors `eval::map_over`'s atomicity: a mid-stream error/break discards
@@ -1762,10 +1793,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                             for item in seq {
                                 match item {
                                     Ok(_) => count += 1,
-                                    Err(Control::Error(e)) => return GenericResult::Error(e),
-                                    Err(Control::Break(label)) => {
-                                        return GenericResult::Break(label)
-                                    }
+                                    Err(control) => return control_into_generic(control),
                                 }
                             }
                             GenericResult::Owned(OwnedValue::Int(count))
@@ -1799,10 +1827,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                         }
                                         owned.push(o);
                                     }
-                                    Err(Control::Error(e)) => return GenericResult::Error(e),
-                                    Err(Control::Break(label)) => {
-                                        return GenericResult::Break(label)
-                                    }
+                                    Err(control) => return control_into_generic(control),
                                 }
                             }
                             if any_owned {
@@ -1833,10 +1858,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                             first = Some(elem);
                                         }
                                     }
-                                    Err(Control::Error(e)) => return GenericResult::Error(e),
-                                    Err(Control::Break(label)) => {
-                                        return GenericResult::Break(label)
-                                    }
+                                    Err(control) => return control_into_generic(control),
                                 }
                             }
                             match first {
@@ -1858,10 +1880,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                             for item in seq {
                                 match item {
                                     Ok(elem) => last = Some(elem),
-                                    Err(Control::Error(e)) => return GenericResult::Error(e),
-                                    Err(Control::Break(label)) => {
-                                        return GenericResult::Break(label)
-                                    }
+                                    Err(control) => return control_into_generic(control),
                                 }
                             }
                             match last {
@@ -1876,8 +1895,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         // `LazyKeys`/`LazyIndexRange`'s own fallback arms.
                         _ => match materialize_atomic(seq) {
                             Ok(owned) => eval_on_owned::<S, _>(expr, owned, optional),
-                            Err(Control::Error(e)) => GenericResult::Error(e),
-                            Err(Control::Break(label)) => GenericResult::Break(label),
+                            Err(control) => control_into_generic(control),
                         },
                     },
                     GenericResult::None => GenericResult::None,
@@ -1946,14 +1964,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // "operand failed" outcome, just discovered a pass later.
                 GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
                     Ok(o) => o,
-                    Err(Control::Error(e)) => {
-                        return if optional {
-                            GenericResult::None
-                        } else {
-                            GenericResult::Error(e)
-                        }
-                    }
-                    Err(Control::Break(label)) => return GenericResult::Break(label),
+                    Err(control) => return control_into_generic_optional(control, optional),
                 },
                 GenericResult::Error(e) => {
                     return if optional {
@@ -2003,14 +2014,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // Mirrors the left-operand arm above.
                 GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
                     Ok(o) => o,
-                    Err(Control::Error(e)) => {
-                        return if optional {
-                            GenericResult::None
-                        } else {
-                            GenericResult::Error(e)
-                        }
-                    }
-                    Err(Control::Break(label)) => return GenericResult::Break(label),
+                    Err(control) => return control_into_generic_optional(control, optional),
                 },
                 GenericResult::Error(e) => {
                     return if optional {
@@ -2309,8 +2313,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         // match.
         GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
             Ok(o) => vec![o],
-            Err(Control::Error(e)) => return GenericResult::Error(e),
-            Err(Control::Break(label)) => return GenericResult::Break(label),
+            Err(control) => return control_into_generic(control),
         },
         other => other.collect_owned(),
     };
@@ -2362,8 +2365,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         GenericResult::LazySeq(seq) => {
             let targets = match materialize_atomic(seq) {
                 Ok(o) => vec![o],
-                Err(Control::Error(e)) => return GenericResult::Error(e),
-                Err(Control::Break(label)) => return GenericResult::Break(label),
+                Err(control) => return control_into_generic(control),
             };
             let mut out = Vec::with_capacity(keys.len() * targets.len());
             for k in &keys {
@@ -2488,8 +2490,7 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         // equivalent fix).
         GenericResult::LazySeq(seq) => match materialize_atomic(seq) {
             Ok(o) => Targets::Owned(vec![o]),
-            Err(Control::Error(e)) => return GenericResult::Error(e),
-            Err(Control::Break(label)) => return GenericResult::Break(label),
+            Err(control) => return control_into_generic(control),
         },
     };
 

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -83,7 +83,7 @@ mod value;
 
 pub use error::{BinOp, Control, EvalError};
 pub use eval::{
-    eval, eval_lenient, substitute_vars, sync_aliased_paths, EvalSemantics, JqSemantics,
+    eval, eval_lenient, substitute_vars, sync_aliased_paths, EvalSemantics, EvalTag, JqSemantics,
     QueryResult, YqSemantics,
 };
 pub use expr::{

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -384,9 +384,16 @@ pub fn stream_lazy_seq_json<V: DocumentValue>(
                     buf.write_char('\n')?;
                     write_indent(&mut buf, indent.width, indent.unit)?;
                 }
-                match elem {
-                    LazyElem::Cursor(c) => c.stream_json(&mut buf, indent, sort_keys)?,
-                    LazyElem::Owned(o) => o.stream_json(&mut buf, indent, sort_keys)?,
+                if indent.width == 0 {
+                    stream_lazy_elem_json(&elem, &mut buf, indent, sort_keys)?;
+                } else {
+                    // The element sits one level inside this array (depth
+                    // `indent.width`), but `stream_json` always renders
+                    // starting at nominal depth 0 — render into a scratch
+                    // buffer, then shift it into place (#724).
+                    let mut scratch = String::new();
+                    stream_lazy_elem_json(&elem, &mut scratch, indent, sort_keys)?;
+                    append_reindented(&mut buf, indent.width, indent.unit, &scratch);
                 }
                 i += 1;
             }
@@ -582,6 +589,80 @@ fn write_indent<W: core::fmt::Write>(out: &mut W, width: usize, unit: char) -> c
     Ok(())
 }
 
+/// Append `rendered` — already rendered starting at nominal indent 0, e.g.
+/// via `StreamableValue::stream_json`/`stream_yaml`, which always start
+/// there and have no `current_indent` parameter to override it — to `buf`,
+/// shifting every line but the first right by `indent_spaces`.
+///
+/// This produces exactly what rendering the same value with `current_indent
+/// = indent_spaces` from the start would have (the internal `Array`/`Object`
+/// recursion above only ever writes an indent prefix for lines *after* the
+/// first — the first line's own prefix is always the caller's
+/// responsibility, one level up), without needing a `current_indent`-aware
+/// entry point on `StreamableValue`/`DocumentCursor`. Used by
+/// `stream_lazy_seq_json`/`_yaml` (#724) to correctly indent a `LazySeq`
+/// element's own nested containers one level inside the array.
+fn append_reindented(buf: &mut String, width: usize, unit: char, rendered: &str) {
+    let mut lines = rendered.split('\n');
+    if let Some(first) = lines.next() {
+        buf.push_str(first);
+    }
+    for line in lines {
+        buf.push('\n');
+        for _ in 0..width {
+            buf.push(unit);
+        }
+        buf.push_str(line);
+    }
+}
+
+/// Stream one `LazySeq` element as JSON, dispatching on whether it's still a
+/// live cursor into the source document or an owned value a stage computed.
+fn stream_lazy_elem_json<V: DocumentValue, W: core::fmt::Write>(
+    elem: &LazyElem<V>,
+    out: &mut W,
+    indent: IndentSpec,
+    sort_keys: bool,
+) -> core::fmt::Result {
+    match elem {
+        LazyElem::Cursor(c) => c.stream_json(out, indent, sort_keys),
+        LazyElem::Owned(o) => o.stream_json(out, indent, sort_keys),
+    }
+}
+
+/// The YAML counterpart of `stream_lazy_elem_json` above.
+fn stream_lazy_elem_yaml<V: DocumentValue, W: core::fmt::Write>(
+    elem: &LazyElem<V>,
+    out: &mut W,
+    indent: IndentSpec,
+    sort_keys: bool,
+) -> core::fmt::Result {
+    match elem {
+        LazyElem::Cursor(c) => c.stream_yaml(out, indent, sort_keys),
+        LazyElem::Owned(o) => o.stream_yaml(out, indent, sort_keys),
+    }
+}
+
+/// Whether a `LazySeq` element should get its own indented line in YAML
+/// block style, mirroring `stream_owned_value_yaml`'s `Array`/`Object` arms'
+/// "nested containers go on the next line" convention (empty containers
+/// render as the one-line `[]`/`{}`, so they stay inline like scalars).
+///
+/// Source elements from `keys_unsorted`/array `keys_unsorted` are always
+/// scalar key/index cursors (see `stream_lazy_keys_yaml`'s own doc comment),
+/// but a composed `map(f)` stage can produce or forward a cursor into an
+/// arbitrary, possibly-container part of the document (e.g. `map($doc.foo)`
+/// closing over an unrelated cursor) — so this can't assume `Cursor` is
+/// always scalar just because today's only production `LazySource`s are.
+fn lazy_elem_is_nonempty_container<V: DocumentValue>(elem: &LazyElem<V>) -> bool {
+    match elem {
+        LazyElem::Cursor(c) => c.is_container() && c.first_child().is_some(),
+        LazyElem::Owned(o) => {
+            matches!(o, OwnedValue::Array(_) | OwnedValue::Object(_)) && !is_empty_container(o)
+        }
+    }
+}
+
 /// Stream a string as YAML with smart quoting.
 ///
 /// Uses double quotes if the string contains special characters,
@@ -667,10 +748,7 @@ pub fn stream_lazy_seq_yaml<V: DocumentValue>(
                     if i > 0 {
                         buf.write_str(", ")?;
                     }
-                    match elem {
-                        LazyElem::Cursor(c) => c.stream_yaml(&mut buf, indent, sort_keys)?,
-                        LazyElem::Owned(o) => o.stream_yaml(&mut buf, indent, sort_keys)?,
-                    }
+                    stream_lazy_elem_yaml(&elem, &mut buf, indent, sort_keys)?;
                     i += 1;
                 }
                 Err(control) => return Ok(Err(control)),
@@ -691,16 +769,34 @@ pub fn stream_lazy_seq_yaml<V: DocumentValue>(
                         buf.write_char('\n')?;
                     }
                     buf.write_str("- ")?;
-                    match elem {
-                        LazyElem::Cursor(c) => c.stream_yaml(&mut buf, indent, sort_keys)?,
-                        LazyElem::Owned(o) => o.stream_yaml(&mut buf, indent, sort_keys)?,
+                    // Mirrors `stream_owned_value_yaml`'s `Array` arm: a
+                    // nested non-empty container goes on its own indented
+                    // line, everything else stays inline after `- `.
+                    let own_line = lazy_elem_is_nonempty_container(&elem);
+                    // The element sits one level inside this array (depth
+                    // `indent.width`), but `stream_yaml` always renders
+                    // starting at nominal depth 0 — render into a scratch
+                    // buffer, then shift it into place (#724).
+                    let mut scratch = String::new();
+                    stream_lazy_elem_yaml(&elem, &mut scratch, indent, sort_keys)?;
+                    if own_line {
+                        buf.write_char('\n')?;
+                        write_indent(&mut buf, indent.width, indent.unit)?;
                     }
+                    append_reindented(&mut buf, indent.width, indent.unit, &scratch);
                     i += 1;
                 }
                 Err(control) => return Ok(Err(control)),
             }
         }
-        out.write_str(&buf)?;
+        // Unlike flow style above, an empty block-style array previously
+        // fell through to `out.write_str(&buf)` with `buf` still empty,
+        // writing nothing instead of `[]` (#724).
+        if i == 0 {
+            out.write_str("[]")?;
+        } else {
+            out.write_str(&buf)?;
+        }
     }
     Ok(Ok(()))
 }

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -22,9 +22,12 @@
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::fmt::Write as _;
 
-use super::document::{DocumentFields, IndentSpec};
+use super::document::{DocumentCursor, DocumentFields, DocumentValue, IndentSpec};
+use super::error::Control;
 use super::escape::{write_json_body_jq, write_json_body_yq};
+use super::eval_generic::{LazyElem, LazySeq};
 use super::value::{format_number_jq_compat, NumberRepr, OwnedValue};
 use crate::yaml::format_float_with_fraction;
 
@@ -345,6 +348,64 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
     out.write_char(']')
 }
 
+/// Stream a [`LazySeq`]'s (#724) composed `map` chain as a JSON array in one
+/// forward pass, without ever materializing an `OwnedValue` tree, rebuilding
+/// a `JsonIndex`, or re-entering the full evaluator.
+///
+/// Unlike `stream_lazy_keys_json` above, this genuinely can fail (`f` is
+/// arbitrary user code) — and `map(f)` is atomic in jq (see
+/// `eval_generic::materialize_atomic`'s own doc comment): a mid-stream error
+/// must not leave a truncated-but-valid `[...]` on `out`, since real jq never
+/// emits a partial array for a failed `map`. `core::fmt::Write` has no
+/// rewind, so this renders into a local buffer first and only transfers it to
+/// `out` once the whole array is confirmed good — still one forward pass over
+/// the document, still no tree, just not zero-buffer (that combination is
+/// impossible while staying atomicity-correct). On failure `out` is left
+/// completely untouched, mirroring `GenericResult::stream_json`'s existing
+/// `Error`/`Break` arms (nothing goes to `out`, the caller reports via
+/// `StreamStats::error`) rather than its `Partial` arm's "stream a prefix,
+/// then report" UX, which is for independent top-level `,`-outputs, not one
+/// array's atomic construction.
+pub fn stream_lazy_seq_json<V: DocumentValue>(
+    seq: LazySeq<V>,
+    out: &mut impl core::fmt::Write,
+    indent: IndentSpec,
+    sort_keys: bool,
+) -> Result<Result<(), Control>, core::fmt::Error> {
+    let mut buf = String::new();
+    let mut i = 0usize;
+    for item in seq {
+        match item {
+            Ok(elem) => {
+                if i > 0 {
+                    buf.write_char(',')?;
+                }
+                if indent.width > 0 {
+                    buf.write_char('\n')?;
+                    write_indent(&mut buf, indent.width, indent.unit)?;
+                }
+                match elem {
+                    LazyElem::Cursor(c) => c.stream_json(&mut buf, indent, sort_keys)?,
+                    LazyElem::Owned(o) => o.stream_json(&mut buf, indent, sort_keys)?,
+                }
+                i += 1;
+            }
+            Err(control) => return Ok(Err(control)), // `out` untouched
+        }
+    }
+    if i == 0 {
+        out.write_str("[]")?;
+    } else {
+        out.write_char('[')?;
+        out.write_str(&buf)?;
+        if indent.width > 0 {
+            out.write_char('\n')?;
+        }
+        out.write_char(']')?;
+    }
+    Ok(Ok(()))
+}
+
 // ============================================================================
 // YAML Streaming
 // ============================================================================
@@ -586,6 +647,62 @@ pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
         }
         Ok(())
     }
+}
+
+/// The YAML counterpart of `stream_lazy_seq_json` above — same atomicity
+/// constraint (buffer locally, transfer to `out` only on full success), same
+/// flow/block split as `stream_lazy_keys_yaml`.
+pub fn stream_lazy_seq_yaml<V: DocumentValue>(
+    seq: LazySeq<V>,
+    out: &mut impl core::fmt::Write,
+    indent: IndentSpec,
+    sort_keys: bool,
+) -> Result<Result<(), Control>, core::fmt::Error> {
+    let mut buf = String::new();
+    let mut i = 0usize;
+    if indent.width == 0 {
+        for item in seq {
+            match item {
+                Ok(elem) => {
+                    if i > 0 {
+                        buf.write_str(", ")?;
+                    }
+                    match elem {
+                        LazyElem::Cursor(c) => c.stream_yaml(&mut buf, indent, sort_keys)?,
+                        LazyElem::Owned(o) => o.stream_yaml(&mut buf, indent, sort_keys)?,
+                    }
+                    i += 1;
+                }
+                Err(control) => return Ok(Err(control)),
+            }
+        }
+        if i == 0 {
+            out.write_str("[]")?;
+        } else {
+            out.write_char('[')?;
+            out.write_str(&buf)?;
+            out.write_char(']')?;
+        }
+    } else {
+        for item in seq {
+            match item {
+                Ok(elem) => {
+                    if i > 0 {
+                        buf.write_char('\n')?;
+                    }
+                    buf.write_str("- ")?;
+                    match elem {
+                        LazyElem::Cursor(c) => c.stream_yaml(&mut buf, indent, sort_keys)?,
+                        LazyElem::Owned(o) => o.stream_yaml(&mut buf, indent, sort_keys)?,
+                    }
+                    i += 1;
+                }
+                Err(control) => return Ok(Err(control)),
+            }
+        }
+        out.write_str(&buf)?;
+    }
+    Ok(Ok(()))
 }
 
 /// Check if a string needs quoting in YAML.


### PR DESCRIPTION
## Summary

Slice 1 of #700's design (`docs/plan/jq-lazy-map-select.md`): wires a new `GenericResult::LazySeq` primitive into the existing `LazyKeys`/`LazyIndexRange` fast path in `eval_generic.rs`'s `Pipe` fold, so `keys_unsorted|keys | map(f)/select(g)` (and chains like `keys_unsorted | map(f) | select(g)`) stay lazy instead of falling back to the full `to_owned` → reserialize → reindex → re-evaluate round trip (#686 measured that fallback at 4.6-4.8x time / up to 13.5x memory at 100MB).

- `EvalTag`/`EvalSemantics::tag()` (`src/jq/eval.rs`) let a deferred `map(f)` re-dispatch to the concrete `JqSemantics`/`YqSemantics` that built it from contexts where the generic evaluator's `S` type parameter has already been erased (e.g. `GenericResult`'s inherent `stream_json`/`into_owned`).
- `LazyElem`/`LazySource`/`Instruction`/`LazySeq` + the new `GenericResult::LazySeq` variant (`src/jq/eval_generic.rs`), wired into the `LazyKeys`/`LazyIndexRange` `Pipe`-fold arms via a new `Builtin::Map` case each (same `!sorted` guard the existing `.[]`/`first`/`last` arms use), plus a composability arm so `map(f) | map(g) | ...` composes onto the same `LazySeq` — one value, not one type per depth.
- `select` gets no new code path (`Builtin::Select` is untouched) — composed after a `map`, it reaches its native arm only via `LazySeq`'s own single-forward-pass materializing fallback, never the four-pass round trip.
- Every element's `map(f)` is still evaluated even for `first`/`.[0]`: jq's `map(f)` is `[.[] | f]`, an eager, non-short-circuiting array construction, so a later element's error must still surface even when only the first element is wanted. `materialize_atomic` mirrors `eval::map_over`'s atomicity (a mid-map error discards the whole array, never a partial prefix) — including through the new `stream_lazy_seq_json`/`_yaml` (`src/jq/stream.rs`), which buffer locally and write nothing to `out` on failure, since a partial array is never valid jq output for a failed `map`.
- `LazySource::Elements`/`Values` (plain-container `map`, the dominant cost share per #686) are defined now but constructed only by #725 (Slice 2), per `docs/STYLE_GUIDE.md`'s STYLE-0005.
- Retired the three fallback-pinning tests, replaced with tests asserting the lazy path is taken, plus new coverage for chains, atomicity, the `first`/`.[0]` error-visibility fix, YAML (`YamlFields`'s `Clone`-not-`Copy` cons-list), yq semantics, and the `.[0]`/`.[2]` fast-path boundary.

### Post-review fixes

A review pass found 6 issues in the initial implementation, fixed in 4 follow-up commits (all with new regression tests, full suite + all 3 CI clippy feature-set legs green after each):

- `Expr::Optional` (`?`/`try`) didn't catch an error raised inside a deferred `map(f)` chain — it matched the immediate `GenericResult`, but a `LazySeq` comes back unevaluated, so `(keys_unsorted | map(f))?` let the error escape instead of yielding empty.
- `stream_lazy_seq_json`/`_yaml` rendered a mapped element's own nested containers at the wrong depth, and the YAML block-style path wrote nothing instead of `[]` for an empty sequence.
- `push_generic_truthiness`'s `LazySeq` arm fully materialized the array (deep-cloning every element) just to check truthiness — an array is always truthy, so only error detection was needed (`drain_for_error`).
- ~10 duplicated `Err(Control::Error)/Err(Control::Break)` match arms collapsed into shared `control_into_generic`/`control_into_generic_optional` helpers.

One review finding was deliberately **not** fixed here: `yq_runner.rs`'s `can_use_m2_streaming` still doesn't admit `Builtin::Map`, so the new `stream_lazy_seq_json`/`_yaml` functions aren't yet reachable from the `syq`/yq CLI. That's explicitly out of scope for this issue (see "Non-goals" above and Slice 3 in the design doc), not a bug.

## Measurement

Interleaved A/B, `wide` pattern, 100kb-100mb, output byte-identical to system `jq -c` at every size (gated: 0 differences across all configurations on both platforms).

**Apple ARM (M-series):**

| Query | 100kb | 1mb | 10mb | 100mb |
|---|---|---|---|---|
| `keys_unsorted \| map(.)` | 1.13x | 1.38x | 1.45x | 1.40x |
| `keys_unsorted \| select(true)` | 0.96x | 0.98x | 0.98x | 0.97x |
| `keys_unsorted \| map(.) \| select(true)` | 1.03x | 1.07x | 1.09x | 1.11x |

**x86_64 (AMD Ryzen 9 7950X, Zen 4):**

| Query | 100kb | 1mb | 10mb | 100mb |
|---|---|---|---|---|
| `keys_unsorted \| map(.)` | 1.44x | 1.72x | 1.79x | 1.74x |
| `keys_unsorted \| select(true)` | 0.98x | 1.01x | 1.00x | 1.00x |
| `keys_unsorted \| map(.) \| select(true)` | 1.24x | 1.26x | 1.19x | 1.23x |

`map` shows a real, growing win on both platforms — notably larger on x86_64 (up to 1.79x) than ARM (up to 1.45x). Bare `select` (no `map`) is correctly unaffected on both — it has no new code path in this slice. `map | select` lands in between, since `select` still materializes once via `LazySeq`'s fallback. This slice is not expected to move plain `Map`/`Select` (that's #725); it didn't.

x86_64 run included a `--control` pass first (before-binary vs. a copy of itself) to establish this machine's noise floor: median -0.08%, range -5.2%..+1.5% across the same 12 configurations — every real result above is well outside that range in a consistent direction, so this isn't noise.

## Test plan

- [x] `cargo test` (default features, and `cli,simd,regex,serde`) — full suite green
- [x] `cargo clippy --all-targets -- -D warnings` for all three CI feature combinations (including `broadword-yaml`)
- [x] Output identity vs system `jq` (byte-identical)
- [x] x86_64/Zen 4 A/B leg
