### PR TITLE
fix(jq): resolve anchor/style builtins via real YAML cursor metadata

### DIFF
--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -233,7 +233,7 @@ The implementation covers ~95% of jq functionality and is production-ready.
 - [x] `split_doc` - mark outputs as separate YAML documents
 - [x] `load(file)` - load external YAML/JSON file
 
-**Note on metadata builtins**: The `anchor`, `style`, `line`, and `column` builtins work best with direct cursor access. When YAML is converted to JSON for complex jq operations, some metadata may be lost. Direct YamlCursor methods (`cursor.anchor()`, `cursor.style()`, etc.) always preserve full metadata.
+**Note on metadata builtins**: The `anchor`, `style`, `line`, and `column` builtins resolve real source metadata when a cursor is available — ordinary navigation (`.foo`, `.[]`, `select(...)`, chained field/index access) on YAML input forwards the cursor and resolves real values. They return their zero value (`""` for `anchor`/`style`, `0` for `line`/`column`) whenever there's no cursor to consult: JSON input (which has no YAML anchor/style concept), or evaluation paths that materialize to `OwnedValue` before evaluating (`-n`, `--slurp`, and similar). Direct YamlCursor methods (`cursor.anchor()`, `cursor.style()`, etc.) always preserve full metadata since they operate on the cursor directly.
 
 **YamlCursor API** (for programmatic access):
 - `cursor.anchor()` → `Option<&str>` - anchor name (e.g., "myanchor" for `&myanchor value`)
@@ -395,7 +395,7 @@ cargo test --features cli,regex --test jq_error_message_tests
 | 2026-01-19 | Added parent / parent(n) for yq (✅ complete)|
 | 2026-01-19 | Added type filters: values, nulls, booleans, numbers, strings, arrays, objects, iterables, scalars (✅ complete)|
 | 2026-01-19 | Added tojson / fromjson for JSON string conversion (✅ complete)|
-| 2026-01-19 | Added YAML metadata functions: tag, anchor, style for yq (✅ partial - tag works fully, anchor/style return defaults)|
+| 2026-01-19 | Added YAML metadata functions: tag, anchor, style for yq (✅ partial - tag works fully, anchor/style returned defaults until #709)|
 | 2026-01-19 | Added kind function for yq - returns node kind: scalar, seq, map (✅ complete)|
 | 2026-01-19 | Added key function for yq - returns current key when iterating (✅ complete)|
 | 2026-01-19 | Added quoted field access `."key"` and bracket notation `.["key"]` (✅ complete)|
@@ -429,3 +429,4 @@ cargo test --features cli,regex --test jq_error_message_tests
 | 2026-01-24 | Document audit: Added `omit(keys)`, `load(file)`, `at_offset(n)`, `at_position(line; col)` to docs|
 | 2026-01-24 | Clarified YAML metadata: `alias` is cursor-level API only (not a jq builtin)|
 | 2026-01-24 | Updated coverage to 100% for most categories after comprehensive code review|
+| 2026-08-10 | Fixed `anchor`/`style` jq builtins to resolve real YAML metadata via cursor (previously hardcoded to always return `""`) (#709, ✅ complete)|

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -67,6 +67,22 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         None
     }
 
+    /// Get the YAML anchor name at this node, if any.
+    ///
+    /// Returns `None` when the node has no anchor, and for formats without
+    /// an anchor concept (JSON). Only YAML cursors override this.
+    fn anchor(&self) -> Option<&str> {
+        None
+    }
+
+    /// Get the YAML style indicator for this node (e.g. `"flow"`, `"double"`).
+    ///
+    /// Returns `""` (no explicit style) by default; only YAML cursors
+    /// override this to report block/flow/quote style from the source text.
+    fn style(&self) -> &'static str {
+        ""
+    }
+
     /// Create a cursor at the specified byte offset (0-indexed).
     ///
     /// Returns None if:

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2325,7 +2325,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // YAML metadata functions (yq)
         Builtin::Tag => builtin_tag::<W>(value),
         Builtin::Anchor => builtin_anchor::<W>(),
-        Builtin::Style => builtin_style::<W>(value),
+        Builtin::Style => builtin_style::<W>(),
         Builtin::Kind => builtin_kind::<W>(value),
         Builtin::Line => builtin_line::<W>(),
         Builtin::Column => builtin_column::<W>(),
@@ -16762,28 +16762,28 @@ fn builtin_tag<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryResu
     QueryResult::Owned(OwnedValue::String(tag.to_string()))
 }
 
-// Builtin: anchor - return anchor name if present
-// Since YAML metadata is lost during conversion to OwnedValue, this always returns empty string.
-// In a full yq implementation, this would require tracking anchor metadata through the pipeline.
+/// `anchor` - returns the YAML anchor name at the current node (yq)
+///
+/// Always `""` here: this is the "full"/`OwnedValue` evaluator (`eval` in
+/// this file), whose `eval_single` never carries a cursor at all — see
+/// [`builtin_line`]'s doc comment for why. YAML anchor names live only in
+/// the source text via [`YamlCursor::anchor`](crate::yaml::light::YamlCursor::anchor),
+/// which `src/jq/eval_generic.rs`'s cursor-carrying `Builtin::Anchor` arm
+/// (#709) reaches for real YAML input; this permanently-empty answer is
+/// also correct for JSON input, which has no anchor concept at all.
 fn builtin_anchor<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
-    // Currently YAML anchors are not preserved through the OwnedValue conversion.
-    // Return empty string to match yq behavior for values without anchors.
     QueryResult::Owned(OwnedValue::String(String::new()))
 }
 
-// Builtin: style - return scalar/collection style
-// Since YAML style metadata is lost during conversion to OwnedValue, this returns
-// reasonable defaults based on the JSON structure.
-fn builtin_style<W: Clone + AsRef<[u64]>>(value: StandardJson<'_, W>) -> QueryResult<'_, W> {
-    let style = match &value {
-        // Collections: yq returns "flow" for flow-style, empty for block-style
-        // Since we lose this info, we return empty string (block-style is more common)
-        StandardJson::Array(_) | StandardJson::Object(_) => "",
-        // Scalars: yq returns "double", "single", "literal", "folded", or empty for plain
-        // Since we lose quote info, we return empty string (plain scalar)
-        _ => "",
-    };
-    QueryResult::Owned(OwnedValue::String(style.to_string()))
+/// `style` - returns the YAML style indicator at the current node (yq)
+///
+/// Always `""` here, for the same reason as [`builtin_anchor`]: no cursor,
+/// so no access to [`YamlCursor::style`](crate::yaml::light::YamlCursor::style).
+/// `src/jq/eval_generic.rs`'s `Builtin::Style` arm (#709) resolves the real
+/// block/flow/quote style for YAML input; `""` is also correct here for
+/// JSON input, which has no style concept.
+fn builtin_style<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
+    QueryResult::Owned(OwnedValue::String(String::new()))
 }
 
 /// `kind` - returns the node kind: "scalar", "seq", or "map"
@@ -27543,8 +27543,11 @@ mod tests {
     }
 
     #[test]
-    fn test_anchor_returns_empty() {
-        // anchor always returns empty string (metadata not preserved)
+    fn test_anchor_returns_empty_for_json() {
+        // JSON has no anchor concept, so "" is correct here — this is not
+        // exercising the stub `eval.rs` used to hard-code (#709); real YAML
+        // anchor resolution is covered by
+        // `eval_generic::tests::test_yaml_anchor_builtin_with_cursor`.
         query!(br#"{"a": 1}"#, "anchor",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "");
@@ -27553,8 +27556,10 @@ mod tests {
     }
 
     #[test]
-    fn test_style_returns_empty() {
-        // style always returns empty string (metadata not preserved)
+    fn test_style_returns_empty_for_json() {
+        // JSON has no style concept, so "" is correct here — see
+        // `test_anchor_returns_empty_for_json`; real YAML style resolution
+        // is covered by `eval_generic::tests::test_yaml_style_builtin_with_cursor`.
         query!(br#""hello""#, "style",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "");

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3879,6 +3879,44 @@ mod tests {
         );
     }
 
+    // JSON has no anchor/style concept, so `JsonCursor` doesn't override
+    // `DocumentCursor::anchor`/`style` and falls through to the trait's
+    // default `None`/`""` impl (`document.rs`). The YAML tests above only
+    // exercise the *overridden* impls in `yaml/light.rs` — these cover the
+    // default itself, reached here via a real navigated cursor (not the
+    // cursor-less fallback `test_yaml_anchor_style_without_cursor` covers).
+    #[test]
+    fn test_json_anchor_builtin_default_empty() {
+        use crate::json::JsonIndex;
+
+        let json = br#"{"a": 1}"#;
+        let index = JsonIndex::build(json);
+        let doc_cursor = index.root(json);
+
+        let expr = parse(".a | anchor").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String(String::new())
+        );
+    }
+
+    #[test]
+    fn test_json_style_builtin_default_empty() {
+        use crate::json::JsonIndex;
+
+        let json = br#"{"a": [1, 2, 3]}"#;
+        let index = JsonIndex::build(json);
+        let doc_cursor = index.root(json);
+
+        let expr = parse(".a | style").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String(String::new())
+        );
+    }
+
     #[test]
     fn test_yaml_line_without_cursor() {
         use crate::yaml::YamlIndex;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1998,6 +1998,20 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             GenericResult::Owned(OwnedValue::Int(doc_index as i64))
         }
 
+        Builtin::Anchor => {
+            // `c.anchor()`'s `&str` borrows from `c`, a value local to this
+            // closure — must own it via `to_string` before it escapes.
+            let anchor = cursor
+                .and_then(|c| c.anchor().map(str::to_string))
+                .unwrap_or_default();
+            GenericResult::Owned(OwnedValue::String(anchor))
+        }
+
+        Builtin::Style => {
+            let style = cursor.map_or("", |c| c.style());
+            GenericResult::Owned(OwnedValue::String(style.to_string()))
+        }
+
         Builtin::Select(cond) => {
             // Evaluate condition with cursor context preserved.
             // This is critical for select(di == N) to work correctly.
@@ -3767,6 +3781,102 @@ mod tests {
 
         // Mapping starts at column 1
         assert_eq!(owned, OwnedValue::Int(1));
+    }
+
+    // Regression tests for #709: `anchor`/`style` had no cursor-aware arm at
+    // all in this evaluator, so they always fell through to the OwnedValue
+    // fallback (`eval_on_owned`) and lost YAML metadata even for direct,
+    // un-navigated cursor access.
+
+    #[test]
+    fn test_yaml_anchor_builtin_with_cursor() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: &x 1\nb: *x\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".a | anchor").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String("x".to_string())
+        );
+    }
+
+    #[test]
+    fn test_yaml_anchor_builtin_empty_when_absent() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: 1\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".a | anchor").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String(String::new())
+        );
+    }
+
+    #[test]
+    fn test_yaml_style_builtin_with_cursor() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: [1, 2, 3]\nb: \"quoted\"\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".a | style").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String("flow".to_string())
+        );
+
+        let expr = crate::jq::parse(".b | style").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String("double".to_string())
+        );
+    }
+
+    #[test]
+    fn test_yaml_anchor_style_without_cursor() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"&x [1, 2, 3]\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+        let value = doc_cursor.value();
+
+        // Using eval (not eval_with_cursor) loses anchor/style metadata,
+        // same as `line`/`column` above.
+        let result = eval(&Expr::Builtin(Builtin::Anchor), value.clone());
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String(String::new())
+        );
+
+        let result = eval(&Expr::Builtin(Builtin::Style), value);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String(String::new())
+        );
     }
 
     #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -4842,6 +4842,16 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn anchor(&self) -> Option<&str> {
+        YamlCursor::anchor(self)
+    }
+
+    #[inline]
+    fn style(&self) -> &'static str {
+        YamlCursor::style(self)
+    }
+
+    #[inline]
     fn cursor_at_offset(&self, offset: usize) -> Option<Self> {
         YamlCursor::cursor_at_offset(self, offset)
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4414,3 +4414,69 @@ fn test_keys_unsorted_yaml_merge_key_lazy_685() -> Result<()> {
 
     Ok(())
 }
+
+// ============================================================================
+// anchor/style builtins (#709) - previously hardcoded to always return ""
+// ============================================================================
+
+#[test]
+fn test_anchor_builtin_returns_real_anchor_name() -> Result<()> {
+    let input = "a: &x 1\nb: *x\n";
+    let (output, code) = run_yq_stdin(".a | anchor", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "x");
+
+    Ok(())
+}
+
+#[test]
+fn test_anchor_builtin_empty_when_no_anchor() -> Result<()> {
+    let input = "a: 1\n";
+    let (output, code) = run_yq_stdin(".a | anchor", input, &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "\"\"");
+
+    Ok(())
+}
+
+#[test]
+fn test_style_builtin_flow_collection() -> Result<()> {
+    let input = "a: [1, 2, 3]\n";
+    let (output, code) = run_yq_stdin(".a | style", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "flow");
+
+    Ok(())
+}
+
+#[test]
+fn test_style_builtin_scalar_quote_styles() -> Result<()> {
+    let cases = [
+        ("a: \"hi\"\n", "\"double\""),
+        ("a: 'hi'\n", "\"single\""),
+        ("a: |\n  hi\n", "\"literal\""),
+        ("a: >\n  hi\n", "\"folded\""),
+        ("a: hi\n", "\"\""),
+        ("a: {b: 1}\n", "\"flow\""),
+    ];
+
+    for (input, expected) in cases {
+        let (output, code) = run_yq_stdin(".a | style", input, &["-o=json"])?;
+        assert_eq!(code, 0, "input: {input:?}");
+        assert_eq!(output.trim(), expected, "input: {input:?}");
+    }
+
+    Ok(())
+}
+
+/// An anchored scalar's `style` must still reflect its own style, not the
+/// anchor indicator preceding it in the source text.
+#[test]
+fn test_style_builtin_anchor_prefix_does_not_mask_style() -> Result<()> {
+    let input = "a: &x \"hi\"\n";
+    let (output, code) = run_yq_stdin(".a | style", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "double");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`Builtin::Anchor`/`Builtin::Style` had no cursor-aware arm in `eval_generic.rs`, so every call fell through to the OwnedValue fallback, which hardcoded `""` regardless of input — even for direct, un-navigated YAML input. `YamlCursor::anchor()`/`style()` already worked internally but were unreachable from the CLI's `anchor`/`style` filters.

- Added `anchor()`/`style()` to the `DocumentCursor` trait (defaulting to `None`/`""`, matching JSON's lack of these concepts).
- Overrode both on `YamlCursor`'s `DocumentCursor` impl, delegating to the existing `YamlCursor::anchor()`/`style()`.
- Added `Builtin::Anchor`/`Builtin::Style` arms to `eval_generic.rs`'s cursor-carrying evaluator.
- The full/OwnedValue evaluator's `builtin_anchor`/`builtin_style` (`eval.rs`) remain permanently `""` — there's no cursor on that path, same as `line`/`column` — but their doc comments and the JSON-only pinning tests now say so explicitly instead of reading like an unfinished stub.

```
$ printf 'a: &x 1\nb: *x\n' | succinctly yq '.a | anchor'
x
$ printf 'a: [1, 2, 3]\n' | succinctly yq '.a | style'
flow
```

Fixes #709

## Commits

1. `fix(jq)` — the core fix plus inline unit tests in `eval_generic.rs`/`eval.rs`.
2. `test(cli)` — black-box `yq` CLI integration tests: the issue's repro, plus quote/block-scalar style variants (double, single, literal, folded, flow, plain) and an anchor-prefix-doesn't-mask-style case.
3. `docs(jq)` — corrected a `jq-language.md` note that understated the bug (it claimed metadata was only lost "when YAML is converted to JSON for complex jq operations"; it was actually unreachable for any input via these builtins).

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (SIMD-YAML feature set `--all-features` compiles out)
- [x] Manually verified both repro commands from the issue against expected real-`yq` output