### PR TITLE
fix(jq, yaml, json, cli): stream sort-keys and tab through the duplicate-key-safe cursor path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -997,6 +997,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   input, matching it byte-for-byte instead of merely agreeing on the
   duplicate-key count.
 
+- **`yq -S`/`--sort-keys` and `--tab` still collapsed duplicate mapping
+  keys** (#733), the last gap #442 left open: both flags were excluded from
+  `can_stream_pretty` (`yq_runner.rs`), so any identity/navigation query
+  under either flag fell through to the `OwnedValue::Object`/`IndexMap`
+  DOM path and lost all but the last occurrence of a repeated key — e.g.
+  `yq -S '.'` on `a: 1\na: 2` printed `a: 2`. Unlike #442/#478/#607/#631,
+  this wasn't a missing expression shape in `can_use_m2_streaming`; it was
+  the cursor/lazy streamers themselves not supporting sort or a non-space
+  indent unit, exactly as the code comment at the time predicted ("`tab`
+  indentation needs a string-based indent unit they don't accept yet").
+
+  Fixed by teaching the streamers both features instead of excluding the
+  flags: `DocumentCursor::stream_json`/`stream_yaml` (and every concrete
+  implementation and caller — `YamlCursor`'s mapping/sequence streamers,
+  `GenericResult::stream_json`/`stream_yaml`, `jq/stream.rs`'s
+  `OwnedValue`/lazy-keys streamers) now take an `IndentSpec { width, unit }`
+  (`unit` is `'\t'` for `--tab`, `' '` otherwise) instead of a bare space
+  count, plus a `sort_keys` flag. `YamlCursor`'s mapping arm sorts by
+  materializing that mapping's fields into a `Vec<YamlField>` (`YamlField`
+  is `Copy`, so this is cursor-only, no value data) and stable-sorting by
+  key — duplicate keys stay adjacent in original relative order rather than
+  merging, since a `Vec` sort, unlike an `IndexMap` insert, never collapses
+  equal keys. `can_stream_pretty` now only excludes color (`use_color`),
+  which has the same latent bug but is out of scope here (unreported,
+  tracked as a follow-up). Also closes a `--tab`-only correctness gap the
+  widened gate would otherwise have introduced: `keys_unsorted` is also
+  `can_use_m2_streaming`-eligible and streams through a separate helper
+  (`stream_lazy_keys_json`/`_yaml`) with its own indent-writing code, which
+  needed the same `unit` threading to avoid emitting spaces under `--tab`.
+
 - **The strict YAML validator accepted a flow-collection anchor immediately
   followed by an alias** (#452): `[&a *a]` and `{k: &a *a}` passed
   `succinctly yaml validate`, which `yq` rejects — an anchor property cannot

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
-use succinctly::jq::document::{DocumentCursor, DocumentFields};
+use succinctly::jq::document::{DocumentCursor, DocumentFields, IndentSpec};
 use succinctly::jq::eval_generic::{eval_with_cursor_using, to_owned, GenericResult};
 use succinctly::jq::{
     self, sync_aliased_paths, Builtin, Expr, OwnedValue, QueryResult, YqSemantics,
@@ -1486,11 +1486,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // Supports both JSON and YAML output formats.
     let is_identity = matches!(program.expr, Expr::Identity);
     let is_m2_streamable = can_use_m2_streaming(&program.expr);
-    // sort_keys and color aren't implemented by the cursor streamers, and
-    // tab indentation needs a string-based indent unit they don't accept
-    // yet — all three fall back to the DOM path, unchanged, rather than
-    // silently ignoring the flag the way compact mode already does today.
-    let can_stream_pretty = !args.sort_keys && !output_config.use_color && !args.tab;
+    // Color isn't implemented by the cursor streamers, so it still falls
+    // back to the DOM path, unchanged, rather than silently ignoring the
+    // flag the way compact mode already does today. `sort_keys` and `tab`
+    // (#733) are now implemented directly by the cursor/lazy streamers —
+    // see `IndentSpec` and the `sort_keys` parameter threaded through
+    // `DocumentCursor::stream_json`/`stream_yaml` and `GenericResult::
+    // stream_json`/`stream_yaml` — so routing them through the DOM would
+    // needlessly reintroduce #442's duplicate-mapping-key collapse
+    // (`OwnedValue::Object`'s `IndexMap` cannot represent duplicate keys).
+    let can_stream_pretty = !output_config.use_color;
     let can_json_fast_path = is_m2_streamable
         && (output_config.compact || (can_stream_pretty && !args.ascii_output))
         && output_config.output_format == OutputFormat::Json
@@ -1538,8 +1543,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // `is_m2_streamable` set), since a non-trivial filter over the slurped
     // array needs real evaluation. `-o json --slurp` still uses the slow
     // DOM path below — an explicit, documented scope limit rather than a
-    // silent gap, matching `sort_keys`/color/tab already being excluded
-    // from the gates above.
+    // silent gap, matching color already being excluded from the gates
+    // above.
     let can_slurp_fast_path = is_identity
         && can_stream_pretty
         && output_config.output_format == OutputFormat::Yaml
@@ -1547,20 +1552,35 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && !args.raw_input
         && context.named.is_empty();
 
-    // Indent width for the fast path's streamers. YAML's `-I0` is a special
-    // case: real `yq` treats it as "use the library default" (4 spaces),
-    // and succinctly's existing (pre-#442) compact-YAML fast path hardcodes
-    // 2 regardless of `-I` — preserved as-is here since reconciling that
-    // mismatch is a separate, out-of-scope issue. Every other value threads
-    // through directly, matching what the DOM path already produces
-    // (verified against `-I1` through `-I6`). JSON has no such quirk: `-I0`
-    // means compact/flow for both real yq and succinctly today.
-    let yaml_indent_spaces: usize = if args.indent == 0 {
+    // Indent width/unit for the fast path's streamers. `--tab` always means
+    // exactly one tab per level, ignoring `-I`'s numeric value — matching
+    // `OutputConfig::indent_str`'s DOM-path behavior above. YAML's `-I0` is
+    // otherwise a special case: real `yq` treats it as "use the library
+    // default" (4 spaces), and succinctly's existing (pre-#442) compact-YAML
+    // fast path hardcodes 2 regardless of `-I` — preserved as-is here since
+    // reconciling that mismatch is a separate, out-of-scope issue. Every
+    // other value threads through directly, matching what the DOM path
+    // already produces (verified against `-I1` through `-I6`). JSON has no
+    // such quirk: `-I0` means compact/flow for both real yq and succinctly
+    // today.
+    let indent_unit: char = if args.tab { '\t' } else { ' ' };
+    let yaml_indent_spaces: usize = if args.tab {
+        1
+    } else if args.indent == 0 {
         2
     } else {
         args.indent as usize
     };
-    let json_indent_spaces: usize = args.indent as usize;
+    let json_indent_spaces: usize = if args.tab { 1 } else { args.indent as usize };
+    let yaml_indent = IndentSpec {
+        width: yaml_indent_spaces,
+        unit: indent_unit,
+    };
+    let json_indent = IndentSpec {
+        width: json_indent_spaces,
+        unit: indent_unit,
+    };
+    let sort_keys = args.sort_keys;
 
     // Helper macro to stream cursor results (avoiding closure borrow issues).
     // Defined here (rather than inside the `if can_fast_path` block below) so
@@ -1577,7 +1597,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // P9 path: stream directly without evaluation
                         emit_yaml_doc_separator($writer, $doc_streamed, true)?;
                         $cursor
-                            .stream_yaml(&mut FmtWriter($writer), yaml_indent_spaces)
+                            .stream_yaml(&mut FmtWriter($writer), yaml_indent, sort_keys)
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
                         writeln!($writer)?;
                         // Streaming skips evaluation, so inspect the document
@@ -1596,7 +1616,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             && !matches!(&result, GenericResult::ManyOwned(vs) if vs.is_empty());
                         emit_yaml_doc_separator($writer, $doc_streamed, will_output)?;
                         let stats = result
-                            .stream_yaml(&mut FmtWriter($writer), yaml_indent_spaces, |w| {
+                            .stream_yaml(&mut FmtWriter($writer), yaml_indent, sort_keys, |w| {
                                 w.write_str("\n")
                             })
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
@@ -1612,7 +1632,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     if is_identity {
                         // P9 path: stream directly without evaluation
                         $cursor
-                            .stream_json(&mut FmtWriter($writer), json_indent_spaces)
+                            .stream_json(&mut FmtWriter($writer), json_indent, sort_keys)
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
                         writeln!($writer)?;
                         // Streaming skips evaluation, so inspect the document
@@ -1624,7 +1644,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // M2 path: evaluate and stream results
                         let result = eval_with_cursor_using::<YqSemantics, _>(&program.expr, $cursor);
                         let stats = result
-                            .stream_json(&mut FmtWriter($writer), json_indent_spaces, |w| {
+                            .stream_json(&mut FmtWriter($writer), json_indent, sort_keys, |w| {
                                 w.write_str("\n")
                             })
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
@@ -1688,13 +1708,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             if can_yaml_fast_path {
                                 root.stream_yaml_document(
                                     &mut FmtWriter(&mut writer),
-                                    yaml_indent_spaces,
+                                    yaml_indent,
+                                    sort_keys,
                                 )
                                 .map_err(|_| anyhow::anyhow!("Write error"))?;
                             } else {
                                 root.stream_json_document(
                                     &mut FmtWriter(&mut writer),
-                                    json_indent_spaces,
+                                    json_indent,
+                                    sort_keys,
                                 )
                                 .map_err(|_| anyhow::anyhow!("Write error"))?;
                             }
@@ -1766,13 +1788,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 if can_yaml_fast_path {
                                     root.stream_yaml_document(
                                         &mut FmtWriter(&mut writer),
-                                        yaml_indent_spaces,
+                                        yaml_indent,
+                                        sort_keys,
                                     )
                                     .map_err(|_| anyhow::anyhow!("Write error"))?;
                                 } else {
                                     root.stream_json_document(
                                         &mut FmtWriter(&mut writer),
-                                        json_indent_spaces,
+                                        json_indent,
+                                        sort_keys,
                                     )
                                     .map_err(|_| anyhow::anyhow!("Write error"))?;
                                 }
@@ -1940,6 +1964,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 &mut FmtWriter(&mut writer),
                 0,
                 yaml_indent_spaces,
+                indent_unit,
+                sort_keys,
             )
             .map_err(|_| anyhow::anyhow!("Write error"))?;
             writeln!(writer)?;
@@ -2038,13 +2064,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     if can_inplace_yaml_fast_path {
                                         root.stream_yaml_document(
                                             &mut FmtWriter(&mut buf_writer),
-                                            yaml_indent_spaces,
+                                            yaml_indent,
+                                            sort_keys,
                                         )
                                         .map_err(|_| anyhow::anyhow!("Write error"))?;
                                     } else {
                                         root.stream_json_document(
                                             &mut FmtWriter(&mut buf_writer),
-                                            json_indent_spaces,
+                                            json_indent,
+                                            sort_keys,
                                         )
                                         .map_err(|_| anyhow::anyhow!("Write error"))?;
                                     }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -9,6 +9,42 @@ use alloc::{borrow::Cow, string::String, vec::Vec};
 #[cfg(test)]
 use std::borrow::Cow;
 
+/// Indentation configuration for cursor/lazy streaming output.
+///
+/// `width` is the number of `unit` characters written per nesting level;
+/// `width == 0` means compact/flow style (no newlines, no indentation).
+/// `unit` is `' '` for ordinary space-indented output and `'\t'` for
+/// `--tab` — mirroring `OutputConfig::indent_str` in
+/// `src/bin/succinctly/yq_runner.rs`, which the `OwnedValue` DOM path
+/// already builds this way (`if args.tab { "\t" } else { "
+/// ".repeat(args.indent) }`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndentSpec {
+    /// Number of `unit` characters per indentation level.
+    pub width: usize,
+    /// The character repeated `width` times per level.
+    pub unit: char,
+}
+
+impl IndentSpec {
+    /// Compact/flow style: no indentation, no newlines.
+    pub const COMPACT: Self = Self {
+        width: 0,
+        unit: ' ',
+    };
+
+    /// `width` spaces per indentation level.
+    pub fn spaces(width: usize) -> Self {
+        Self { width, unit: ' ' }
+    }
+
+    /// Whether this spec requests compact/flow-style output (no newlines).
+    #[inline]
+    pub fn is_compact(&self) -> bool {
+        self.width == 0
+    }
+}
+
 /// A cursor for navigating an indexed document.
 ///
 /// Provides tree navigation operations that work in O(1) time
@@ -107,13 +143,15 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     ///
     /// This enables M2 streaming optimization where navigation query results
     /// can be written directly to output without materializing OwnedValue.
-    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
+    /// - `indent`: indentation width/unit (`IndentSpec::COMPACT` for compact)
+    /// - `sort_keys`: sort mapping/object keys before writing (`-S`/`--sort-keys`)
     ///
     /// Default implementation returns an error indicating streaming is not supported.
     fn stream_json<W: core::fmt::Write>(
         &self,
         _out: &mut W,
-        _indent_spaces: usize,
+        _indent: IndentSpec,
+        _sort_keys: bool,
     ) -> core::fmt::Result {
         Err(core::fmt::Error)
     }
@@ -121,15 +159,17 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     /// Stream this cursor's value as YAML to the output.
     ///
     /// This enables M2.5 streaming optimization for YAML output format.
-    /// - `indent_spaces`: Spaces per indentation level for block style (0
-    ///   forces flow style for the whole subtree); a node whose source used
-    ///   flow style renders as flow regardless of `indent_spaces` (#707).
+    /// - `indent`: indentation width/unit (`IndentSpec::COMPACT` forces flow
+    ///   style for the whole subtree); a node whose source used flow style
+    ///   renders as flow regardless of `indent` (#707).
+    /// - `sort_keys`: sort mapping/object keys before writing (`-S`/`--sort-keys`)
     ///
     /// Default implementation returns an error indicating streaming is not supported.
     fn stream_yaml<W: core::fmt::Write>(
         &self,
         _out: &mut W,
-        _indent_spaces: usize,
+        _indent: IndentSpec,
+        _sort_keys: bool,
     ) -> core::fmt::Result {
         Err(core::fmt::Error)
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -17,7 +17,9 @@ use alloc::vec::Vec;
 
 use indexmap::IndexMap;
 
-use super::document::{DocumentCursor, DocumentElements, DocumentFields, DocumentValue};
+use super::document::{
+    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
+};
 use super::eval::{
     compare_values, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
     needs_path_context, numeric_display_string, numeric_key_to_index, owned_bound_to_i64,
@@ -480,13 +482,15 @@ impl<V: DocumentValue> GenericResult<V> {
     ///
     /// This is the M2 streaming fast path that avoids OwnedValue materialization
     /// for cursor-based results. For owned results, uses the StreamableValue impl.
-    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
+    /// - `indent`: indentation width/unit (`IndentSpec::COMPACT` for compact)
+    /// - `sort_keys`: sort mapping/object keys before writing (`-S`/`--sort-keys`)
     ///
     /// Returns the number of values streamed and whether the last was falsy.
     pub fn stream_json<W: core::fmt::Write>(
         &self,
         out: &mut W,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
         mut on_value: impl FnMut(&mut W) -> core::fmt::Result,
     ) -> Result<crate::jq::stream::StreamStats, core::fmt::Error> {
         use crate::jq::stream::{StreamError, StreamStats, StreamableValue};
@@ -497,7 +501,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::One(v) => {
                 // Convert to owned for streaming
                 let owned = to_owned(v);
-                owned.stream_json(out, indent_spaces)?;
+                owned.stream_json(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = owned.is_falsy();
@@ -505,7 +509,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::OneCursor(c) => {
                 // Stream directly from cursor using DocumentCursor trait
-                c.stream_json(out, indent_spaces)?;
+                c.stream_json(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = c.is_falsy();
@@ -514,7 +518,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::Many(vs) => {
                 for v in vs {
                     let owned = to_owned(v);
-                    owned.stream_json(out, indent_spaces)?;
+                    owned.stream_json(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = owned.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -527,15 +531,17 @@ impl<V: DocumentValue> GenericResult<V> {
                     // every key first, so this can't stream lazily like the
                     // unsorted case below.
                     let owned = materialize_lazy_keys::<V>(fields, true);
-                    owned.stream_json(out, indent_spaces)?;
+                    owned.stream_json(out, indent, sort_keys)?;
                 } else {
                     // Genuinely lazy (#685): each key is pulled from
                     // `fields` and written straight to `out` as it's
                     // produced — no `Vec<String>` or `OwnedValue::Array` is
                     // ever built. Reachable from `yq_runner.rs`'s M2 fast
                     // path now that `can_use_m2_streaming` admits
-                    // `Builtin::KeysUnsorted`.
-                    crate::jq::stream::stream_lazy_keys_json(fields, out, indent_spaces)?;
+                    // `Builtin::KeysUnsorted`. `sort_keys` (`-S`) is a no-op
+                    // here: this is a flat array of key names, not a
+                    // mapping, so there's nothing for `-S` to reorder.
+                    crate::jq::stream::stream_lazy_keys_json(fields, out, indent)?;
                 }
                 on_value(out)?;
                 stats.count = 1;
@@ -547,7 +553,7 @@ impl<V: DocumentValue> GenericResult<V> {
             // Arrays are always truthy in jq, even `[]` (only `null`/`false`
             // are falsy), so `last_was_falsy` is unconditionally `false`.
             Self::LazyIndexRange(len) => {
-                write_index_range_json(out, *len, indent_spaces)?;
+                write_index_range_json(out, *len, indent)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = false;
@@ -555,7 +561,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::ManyCursor(cs) => {
                 for c in cs {
-                    c.stream_json(out, indent_spaces)?;
+                    c.stream_json(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = c.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -572,7 +578,7 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.error = Some(stream_error(e));
             }
             Self::Owned(o) => {
-                o.stream_json(out, indent_spaces)?;
+                o.stream_json(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = o.is_falsy();
@@ -580,7 +586,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::ManyOwned(os) => {
                 for o in os {
-                    o.stream_json(out, indent_spaces)?;
+                    o.stream_json(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = o.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -598,7 +604,7 @@ impl<V: DocumentValue> GenericResult<V> {
             // outputs already produced no longer vanish behind the failure.
             Self::Partial(os, control) => {
                 for o in os {
-                    o.stream_json(out, indent_spaces)?;
+                    o.stream_json(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = o.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -633,7 +639,8 @@ impl<V: DocumentValue> GenericResult<V> {
     pub fn stream_yaml<W: core::fmt::Write>(
         &self,
         out: &mut W,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
         mut on_value: impl FnMut(&mut W) -> core::fmt::Result,
     ) -> Result<crate::jq::stream::StreamStats, core::fmt::Error> {
         use crate::jq::stream::{StreamError, StreamStats, StreamableValue};
@@ -643,7 +650,7 @@ impl<V: DocumentValue> GenericResult<V> {
         match self {
             Self::One(v) => {
                 let owned = to_owned(v);
-                owned.stream_yaml(out, indent_spaces)?;
+                owned.stream_yaml(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = owned.is_falsy();
@@ -651,7 +658,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::OneCursor(c) => {
                 // Stream directly from cursor using DocumentCursor trait
-                c.stream_yaml(out, indent_spaces)?;
+                c.stream_yaml(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = c.is_falsy();
@@ -660,7 +667,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::Many(vs) => {
                 for v in vs {
                     let owned = to_owned(v);
-                    owned.stream_yaml(out, indent_spaces)?;
+                    owned.stream_yaml(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = owned.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -669,7 +676,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::ManyCursor(cs) => {
                 for c in cs {
-                    c.stream_yaml(out, indent_spaces)?;
+                    c.stream_yaml(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = c.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -681,11 +688,11 @@ impl<V: DocumentValue> GenericResult<V> {
                     // Fallback: materialize+sort. See `stream_json`'s
                     // `LazyKeys` arm above — same reasoning.
                     let owned = materialize_lazy_keys::<V>(fields, true);
-                    owned.stream_yaml(out, indent_spaces)?;
+                    owned.stream_yaml(out, indent, sort_keys)?;
                 } else {
                     // Genuinely lazy (#685): see `stream_json`'s
                     // `LazyKeys` arm above — same reasoning, YAML target.
-                    crate::jq::stream::stream_lazy_keys_yaml(fields, out, indent_spaces)?;
+                    crate::jq::stream::stream_lazy_keys_yaml(fields, out, indent)?;
                 }
                 on_value(out)?;
                 stats.count = 1;
@@ -694,7 +701,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             // Same allocation-free approach as `stream_json` above (#684).
             Self::LazyIndexRange(len) => {
-                write_index_range_yaml(out, *len, indent_spaces)?;
+                write_index_range_yaml(out, *len, indent)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = false;
@@ -708,7 +715,7 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.error = Some(stream_error(e));
             }
             Self::Owned(o) => {
-                o.stream_yaml(out, indent_spaces)?;
+                o.stream_yaml(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = o.is_falsy();
@@ -716,7 +723,7 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::ManyOwned(os) => {
                 for o in os {
-                    o.stream_yaml(out, indent_spaces)?;
+                    o.stream_yaml(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = o.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -733,7 +740,7 @@ impl<V: DocumentValue> GenericResult<V> {
             // streams first, then the control is reported.
             Self::Partial(os, control) => {
                 for o in os {
-                    o.stream_yaml(out, indent_spaces)?;
+                    o.stream_yaml(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = o.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -762,7 +769,7 @@ impl<V: DocumentValue> GenericResult<V> {
 fn write_index_range_json<W: core::fmt::Write>(
     out: &mut W,
     len: usize,
-    indent_spaces: usize,
+    indent: IndentSpec,
 ) -> core::fmt::Result {
     if len == 0 {
         return out.write_str("[]");
@@ -772,15 +779,15 @@ fn write_index_range_json<W: core::fmt::Write>(
         if i > 0 {
             out.write_char(',')?;
         }
-        if indent_spaces > 0 {
+        if indent.width > 0 {
             out.write_char('\n')?;
-            for _ in 0..indent_spaces {
-                out.write_char(' ')?;
+            for _ in 0..indent.width {
+                out.write_char(indent.unit)?;
             }
         }
         write!(out, "{i}")?;
     }
-    if indent_spaces > 0 {
+    if indent.width > 0 {
         out.write_char('\n')?;
     }
     out.write_char(']')
@@ -793,12 +800,12 @@ fn write_index_range_json<W: core::fmt::Write>(
 fn write_index_range_yaml<W: core::fmt::Write>(
     out: &mut W,
     len: usize,
-    indent_spaces: usize,
+    indent: IndentSpec,
 ) -> core::fmt::Result {
     if len == 0 {
         return out.write_str("[]");
     }
-    if indent_spaces == 0 {
+    if indent.is_compact() {
         out.write_char('[')?;
         for i in 0..len {
             if i > 0 {
@@ -2742,22 +2749,26 @@ mod tests {
 
         let mut compact_json = String::new();
         result
-            .stream_json(&mut compact_json, 0, |_| Ok(()))
+            .stream_json(&mut compact_json, IndentSpec::COMPACT, false, |_| Ok(()))
             .unwrap();
         assert_eq!(compact_json, "[0,1,2]");
 
         let mut indented_json = String::new();
         result
-            .stream_json(&mut indented_json, 2, |_| Ok(()))
+            .stream_json(&mut indented_json, IndentSpec::spaces(2), false, |_| Ok(()))
             .unwrap();
         assert_eq!(indented_json, "[\n  0,\n  1,\n  2\n]");
 
         let mut flow_yaml = String::new();
-        result.stream_yaml(&mut flow_yaml, 0, |_| Ok(())).unwrap();
+        result
+            .stream_yaml(&mut flow_yaml, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(flow_yaml, "[0, 1, 2]");
 
         let mut block_yaml = String::new();
-        result.stream_yaml(&mut block_yaml, 2, |_| Ok(())).unwrap();
+        result
+            .stream_yaml(&mut block_yaml, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
         assert_eq!(block_yaml, "- 0\n- 1\n- 2");
 
         let empty_json = br"[]";
@@ -2767,13 +2778,23 @@ mod tests {
 
         let mut empty_json_out = String::new();
         empty_result
-            .stream_json(&mut empty_json_out, 2, |_| Ok(()))
+            .stream_json(
+                &mut empty_json_out,
+                IndentSpec::spaces(2),
+                false,
+                |_| Ok(()),
+            )
             .unwrap();
         assert_eq!(empty_json_out, "[]");
 
         let mut empty_yaml_out = String::new();
         empty_result
-            .stream_yaml(&mut empty_yaml_out, 2, |_| Ok(()))
+            .stream_yaml(
+                &mut empty_yaml_out,
+                IndentSpec::spaces(2),
+                false,
+                |_| Ok(()),
+            )
             .unwrap();
         assert_eq!(empty_yaml_out, "[]");
     }
@@ -4174,19 +4195,27 @@ mod tests {
         ));
 
         let mut out = String::new();
-        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, r#"["b","a","c"]"#);
 
         let mut out = String::new();
-        result.stream_json(&mut out, 2, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "[\n  \"b\",\n  \"a\",\n  \"c\"\n]");
 
         let mut out = String::new();
-        result.stream_yaml(&mut out, 0, |_| Ok(())).unwrap();
+        result
+            .stream_yaml(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "[b, a, c]");
 
         let mut out = String::new();
-        result.stream_yaml(&mut out, 2, |_| Ok(())).unwrap();
+        result
+            .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "- b\n- a\n- c");
     }
 
@@ -4213,11 +4242,15 @@ mod tests {
         ));
 
         let mut out = String::new();
-        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, r#"["b","a","c"]"#);
 
         let mut out = String::new();
-        result.stream_yaml(&mut out, 2, |_| Ok(())).unwrap();
+        result
+            .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, "- b\n- a\n- c");
     }
 
@@ -4710,14 +4743,16 @@ mod tests {
         // stream_json / stream_yaml exercise every variant's match arm.
         for r in &results {
             let mut j = String::new();
-            r.stream_json(&mut j, 0, |_| Ok(())).unwrap();
+            r.stream_json(&mut j, IndentSpec::COMPACT, false, |_| Ok(()))
+                .unwrap();
             let mut y = String::new();
-            r.stream_yaml(&mut y, 2, |_| Ok(())).unwrap();
+            r.stream_yaml(&mut y, IndentSpec::spaces(2), false, |_| Ok(()))
+                .unwrap();
         }
         // Spot-check the owned and error stream output.
         let mut owned_json = String::new();
         results[2]
-            .stream_json(&mut owned_json, 0, |_| Ok(()))
+            .stream_json(&mut owned_json, IndentSpec::COMPACT, false, |_| Ok(()))
             .unwrap();
         assert_eq!(owned_json, "5");
         // An error writes nothing to `out` — `out` is stdout, and a diagnostic
@@ -4725,7 +4760,7 @@ mod tests {
         // `stats.error` instead, for the caller to print to stderr (#355).
         let mut err_json = String::new();
         let err_stats = results[5]
-            .stream_json(&mut err_json, 0, |_| Ok(()))
+            .stream_json(&mut err_json, IndentSpec::COMPACT, false, |_| Ok(()))
             .unwrap();
         assert_eq!(err_json, "", "diagnostics must never reach stdout");
         assert_eq!(
@@ -4736,7 +4771,7 @@ mod tests {
 
         let mut err_yaml = String::new();
         let err_stats = results[5]
-            .stream_yaml(&mut err_yaml, 2, |_| Ok(()))
+            .stream_yaml(&mut err_yaml, IndentSpec::spaces(2), false, |_| Ok(()))
             .unwrap();
         assert_eq!(err_yaml, "", "diagnostics must never reach stdout");
         assert_eq!(
@@ -4747,7 +4782,9 @@ mod tests {
         // Break escapes its label: an uncaught error like any other, and it too
         // stays off stdout.
         let mut brk = String::new();
-        let brk_stats = results[6].stream_json(&mut brk, 0, |_| Ok(())).unwrap();
+        let brk_stats = results[6]
+            .stream_json(&mut brk, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(brk, "");
         assert!(brk_stats
             .error
@@ -4760,7 +4797,7 @@ mod tests {
         let mut partial_json = String::new();
         let mut seen = 0usize;
         let partial_stats = results[7]
-            .stream_json(&mut partial_json, 0, |_| {
+            .stream_json(&mut partial_json, IndentSpec::COMPACT, false, |_| {
                 seen += 1;
                 Ok(())
             })
@@ -4776,7 +4813,7 @@ mod tests {
 
         let mut partial_yaml = String::new();
         let partial_stats = results[7]
-            .stream_yaml(&mut partial_yaml, 2, |w| {
+            .stream_yaml(&mut partial_yaml, IndentSpec::spaces(2), false, |w| {
                 use core::fmt::Write;
                 writeln!(w)
             })
@@ -4792,7 +4829,7 @@ mod tests {
         // diagnostic the bare `Break` arm does, after its prefix.
         let mut partial_brk = String::new();
         let brk_stats = results[8]
-            .stream_json(&mut partial_brk, 0, |_| Ok(()))
+            .stream_json(&mut partial_brk, IndentSpec::COMPACT, false, |_| Ok(()))
             .unwrap();
         assert_eq!(partial_brk, "3");
         assert!(brk_stats
@@ -4801,7 +4838,9 @@ mod tests {
             .is_some_and(|e| e.message.contains("not in label")));
         let mut partial_brk_yaml = String::new();
         let brk_stats = results[8]
-            .stream_yaml(&mut partial_brk_yaml, 2, |_| Ok(()))
+            .stream_yaml(&mut partial_brk_yaml, IndentSpec::spaces(2), false, |_| {
+                Ok(())
+            })
             .unwrap();
         assert_eq!(partial_brk_yaml, "3");
         assert!(brk_stats
@@ -4891,10 +4930,14 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_single_cursor());
         let mut j = String::new();
-        result.stream_json(&mut j, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut j, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(j, "1");
         let mut y = String::new();
-        result.stream_yaml(&mut y, 2, |_| Ok(())).unwrap();
+        result
+            .stream_yaml(&mut y, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
 
         let result2 = eval_with_cursor(&expr, index.root(json));
         assert_eq!(result2.collect_owned(), vec![OwnedValue::Int(1)]);
@@ -4913,7 +4956,9 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_single_cursor());
         let mut j = String::new();
-        assert!(result.stream_json(&mut j, 2, |_| Ok(())).is_err());
+        assert!(result
+            .stream_json(&mut j, IndentSpec::spaces(2), false, |_| Ok(()))
+            .is_err());
     }
 
     #[test]
@@ -4932,10 +4977,14 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(yaml));
         assert!(result.is_single_cursor());
         let mut j = String::new();
-        result.stream_json(&mut j, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut j, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(j, "1");
         let mut y = String::new();
-        result.stream_yaml(&mut y, 2, |_| Ok(())).unwrap();
+        result
+            .stream_yaml(&mut y, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
         assert_eq!(y, "1");
     }
 
@@ -5087,7 +5136,9 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_single_cursor());
         let mut out = String::new();
-        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, r#"{"a":1,"a":2}"#);
     }
 
@@ -5101,7 +5152,9 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_single_cursor());
         let mut out = String::new();
-        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, r#"{"b":3,"b":4}"#);
     }
 
@@ -5121,7 +5174,9 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_single_cursor());
         let mut out = String::new();
-        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, r#"{"a":1,"a":2}"#);
     }
 
@@ -5138,7 +5193,9 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_single_cursor());
         let mut out = String::new();
-        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, r#"{"b":3,"b":4}"#);
     }
 
@@ -5178,7 +5235,9 @@ mod tests {
         let first = eval_with_cursor(&crate::jq::parse("first(.)").unwrap(), index.root(json));
         assert!(first.is_single_cursor());
         let mut out = String::new();
-        first.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        first
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, r#"{"a":1,"a":2}"#);
 
         let last = eval_with_cursor(&crate::jq::parse("last(.)").unwrap(), index.root(json));
@@ -5347,7 +5406,9 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(result.is_single_cursor());
         let mut out = String::new();
-        result.stream_json(&mut out, 0, |_| Ok(())).unwrap();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
         assert_eq!(out, r#"{"a":1,"a":2}"#);
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5267,6 +5267,62 @@ mod tests {
         assert_eq!(last.collect_owned(), vec![OwnedValue::Int(1)]);
     }
 
+    // `GenericResult::stream_json`/`stream_yaml`'s `Self::One`/`Self::Many`
+    // arms (bare, cursor-less `V`) convert to `OwnedValue` via `to_owned`
+    // and stream that -- distinct from `Self::OneCursor`/`ManyCursor`'s
+    // direct cursor streaming, which is what the M2 CLI fast path actually
+    // exercises for real navigation queries. Reached the same way as
+    // `test_json_first_and_last_of_identity_without_cursor_yield_bare_one`/
+    // `..._of_multi_truthy_select_without_cursor_yield_bare_many` above: via
+    // the cursor-less `eval()` entry point.
+    #[test]
+    fn test_stream_json_and_yaml_bare_one_streams_via_owned_value() {
+        let json = br#"{"b": 1, "a": 2}"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let result = eval(&crate::jq::parse("first(.)").unwrap(), value);
+        assert!(matches!(result, GenericResult::One(_)));
+
+        let mut json_out = String::new();
+        result
+            .stream_json(&mut json_out, IndentSpec::COMPACT, true, |_| Ok(()))
+            .unwrap();
+        assert_eq!(json_out, r#"{"a":2,"b":1}"#);
+
+        let mut yaml_out = String::new();
+        result
+            .stream_yaml(&mut yaml_out, IndentSpec::COMPACT, true, |_| Ok(()))
+            .unwrap();
+        assert_eq!(yaml_out, "{a: 2, b: 1}");
+    }
+
+    #[test]
+    fn test_stream_json_and_yaml_bare_many_streams_via_owned_values() {
+        let json = br#"{"b": 1, "a": 2}"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let result = eval(&crate::jq::parse("select(true,true)").unwrap(), value);
+        assert!(matches!(result, GenericResult::Many(_)));
+
+        let mut json_out = String::new();
+        result
+            .stream_json(&mut json_out, IndentSpec::COMPACT, true, |w| {
+                core::fmt::Write::write_str(w, ";")
+            })
+            .unwrap();
+        assert_eq!(json_out, r#"{"a":2,"b":1};{"a":2,"b":1};"#);
+
+        let mut yaml_out = String::new();
+        result
+            .stream_yaml(&mut yaml_out, IndentSpec::COMPACT, true, |w| {
+                core::fmt::Write::write_str(w, ";")
+            })
+            .unwrap();
+        assert_eq!(yaml_out, "{a: 2, b: 1};{a: 2, b: 1};");
+    }
+
     #[test]
     fn test_json_first_and_last_of_single_literal_yield_owned() {
         // `eval_first_or_last_generic`'s `Owned(v) => Owned(v)` passthrough

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -21,8 +21,9 @@
 //! | `length`, complex | OwnedValue | 5-8x input |
 
 use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
-use super::document::DocumentFields;
+use super::document::{DocumentFields, IndentSpec};
 use super::escape::{write_json_body_jq, write_json_body_yq};
 use super::value::{format_number_jq_compat, NumberRepr, OwnedValue};
 use crate::yaml::format_float_with_fraction;
@@ -36,22 +37,25 @@ pub trait StreamableValue {
     /// Stream this value as JSON to the output.
     ///
     /// The output should be valid JSON without trailing newlines or separators.
-    /// For pretty-printed output, pass indent_spaces > 0. For compact output,
-    /// pass indent_spaces = 0.
+    /// `indent` selects width/unit (`IndentSpec::COMPACT` for compact output);
+    /// `sort_keys` sorts object keys before writing (`-S`/`--sort-keys`).
     fn stream_json<W: core::fmt::Write>(
         &self,
         out: &mut W,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result;
 
     /// Stream this value as YAML to the output.
     ///
-    /// The output should be valid YAML. For block style, pass indent_spaces > 0.
-    /// For flow style (compact), pass indent_spaces = 0.
+    /// The output should be valid YAML. `indent` selects width/unit
+    /// (`IndentSpec::COMPACT` for flow style); `sort_keys` sorts object keys
+    /// before writing (`-S`/`--sort-keys`).
     fn stream_yaml<W: core::fmt::Write>(
         &self,
         out: &mut W,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result;
 
     /// Check if this value is falsy (null or false).
@@ -100,17 +104,19 @@ impl StreamableValue for OwnedValue {
     fn stream_json<W: core::fmt::Write>(
         &self,
         out: &mut W,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result {
-        stream_owned_value_json(self, out, 0, indent_spaces)
+        stream_owned_value_json(self, out, 0, indent.width, indent.unit, sort_keys)
     }
 
     fn stream_yaml<W: core::fmt::Write>(
         &self,
         out: &mut W,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result {
-        stream_owned_value_yaml(self, out, 0, indent_spaces)
+        stream_owned_value_yaml(self, out, 0, indent.width, indent.unit, sort_keys)
     }
 
     fn is_falsy(&self) -> bool {
@@ -134,12 +140,16 @@ fn stream_owned_value_json<W: core::fmt::Write>(
     out: &mut W,
     current_indent: usize,
     indent_spaces: usize,
+    unit: char,
+    sort_keys: bool,
 ) -> core::fmt::Result {
     stream_owned_value_json_with(
         value,
         out,
         current_indent,
         indent_spaces,
+        unit,
+        sort_keys,
         write_json_body_yq,
         format_float_with_fraction,
     )
@@ -164,20 +174,28 @@ pub fn stream_owned_value_json_jq<W: core::fmt::Write>(
 ) -> core::fmt::Result {
     // Always compact: this is the jq-error-message convention, which never
     // pretty-prints.
-    stream_owned_value_json_with(value, out, 0, 0, write_json_body_jq, |f| f.to_string())
+    stream_owned_value_json_with(value, out, 0, 0, ' ', false, write_json_body_jq, |f| {
+        f.to_string()
+    })
 }
 
 /// Stream an OwnedValue as JSON without intermediate string allocation, using
 /// `escape` for every string body and `float_fmt` for every float — the two
 /// places the `yq`/jq-error conventions differ.
 ///
-/// - `current_indent`: Current indentation level (number of spaces)
-/// - `indent_spaces`: Spaces per indentation level (0 for compact)
+/// - `current_indent`: Current indentation level (number of `unit` characters)
+/// - `indent_spaces`: `unit` characters per indentation level (0 for compact)
+/// - `unit`: the character repeated `indent_spaces` times per level (`' '`
+///   normally, `'\t'` for `--tab`)
+/// - `sort_keys`: sort object keys before writing (`-S`/`--sort-keys`)
+#[allow(clippy::too_many_arguments)]
 fn stream_owned_value_json_with<W: core::fmt::Write>(
     value: &OwnedValue,
     out: &mut W,
     current_indent: usize,
     indent_spaces: usize,
+    unit: char,
+    sort_keys: bool,
     escape: fn(&mut W, &str) -> core::fmt::Result,
     float_fmt: fn(f64) -> String,
 ) -> core::fmt::Result {
@@ -214,20 +232,22 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
                 }
                 if indent_spaces > 0 {
                     out.write_char('\n')?;
-                    write_indent(out, next_indent)?;
+                    write_indent(out, next_indent, unit)?;
                 }
                 stream_owned_value_json_with(
                     elem,
                     out,
                     next_indent,
                     indent_spaces,
+                    unit,
+                    sort_keys,
                     escape,
                     float_fmt,
                 )?;
             }
             if indent_spaces > 0 {
                 out.write_char('\n')?;
-                write_indent(out, current_indent)?;
+                write_indent(out, current_indent, unit)?;
             }
             out.write_char(']')
         }
@@ -237,13 +257,17 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
             }
             out.write_char('{')?;
             let next_indent = current_indent + indent_spaces;
-            for (i, (key, value)) in obj.iter().enumerate() {
+            let mut entries: Vec<(&String, &OwnedValue)> = obj.iter().collect();
+            if sort_keys {
+                entries.sort_by(|a, b| a.0.cmp(b.0));
+            }
+            for (i, (key, value)) in entries.into_iter().enumerate() {
                 if i > 0 {
                     out.write_char(',')?;
                 }
                 if indent_spaces > 0 {
                     out.write_char('\n')?;
-                    write_indent(out, next_indent)?;
+                    write_indent(out, next_indent, unit)?;
                 }
                 stream_json_string(out, key, escape)?;
                 out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
@@ -252,13 +276,15 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
                     out,
                     next_indent,
                     indent_spaces,
+                    unit,
+                    sort_keys,
                     escape,
                     float_fmt,
                 )?;
             }
             if indent_spaces > 0 {
                 out.write_char('\n')?;
-                write_indent(out, current_indent)?;
+                write_indent(out, current_indent, unit)?;
             }
             out.write_char('}')
         }
@@ -288,7 +314,7 @@ fn stream_json_string<W: core::fmt::Write>(
 pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
     fields: &F,
     out: &mut W,
-    indent_spaces: usize,
+    indent: IndentSpec,
 ) -> core::fmt::Result {
     if fields.is_empty() {
         return out.write_str("[]");
@@ -304,16 +330,16 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
             if i > 0 {
                 out.write_char(',')?;
             }
-            if indent_spaces > 0 {
+            if indent.width > 0 {
                 out.write_char('\n')?;
-                write_indent(out, indent_spaces)?;
+                write_indent(out, indent.width, indent.unit)?;
             }
             stream_json_string(out, &key, write_json_body_yq)?;
             i += 1;
         }
         current = rest;
     }
-    if indent_spaces > 0 {
+    if indent.width > 0 {
         out.write_char('\n')?;
     }
     out.write_char(']')
@@ -325,13 +351,18 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
 
 /// Stream an OwnedValue as YAML without intermediate string allocation.
 ///
-/// - `current_indent`: Current indentation level (number of spaces)
-/// - `indent_spaces`: Spaces per indentation level (0 for flow style)
+/// - `current_indent`: Current indentation level (number of `unit` characters)
+/// - `indent_spaces`: `unit` characters per indentation level (0 for flow style)
+/// - `unit`: the character repeated `indent_spaces` times per level (`' '`
+///   normally, `'\t'` for `--tab`)
+/// - `sort_keys`: sort object keys before writing (`-S`/`--sort-keys`)
 fn stream_owned_value_yaml<W: core::fmt::Write>(
     value: &OwnedValue,
     out: &mut W,
     current_indent: usize,
     indent_spaces: usize,
+    unit: char,
+    sort_keys: bool,
 ) -> core::fmt::Result {
     match value {
         OwnedValue::Null => out.write_str("null"),
@@ -372,7 +403,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                     if i > 0 {
                         out.write_str(", ")?;
                     }
-                    stream_owned_value_yaml(elem, out, 0, 0)?;
+                    stream_owned_value_yaml(elem, out, 0, 0, unit, sort_keys)?;
                 }
                 out.write_char(']')
             } else {
@@ -380,7 +411,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                 for (i, elem) in arr.iter().enumerate() {
                     if i > 0 {
                         out.write_char('\n')?;
-                        write_indent(out, current_indent)?;
+                        write_indent(out, current_indent, unit)?;
                     }
                     out.write_str("- ")?;
                     // For nested containers, put on next line with extra indent
@@ -388,12 +419,14 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                         && !is_empty_container(elem)
                     {
                         out.write_char('\n')?;
-                        write_indent(out, current_indent + indent_spaces)?;
+                        write_indent(out, current_indent + indent_spaces, unit)?;
                         stream_owned_value_yaml(
                             elem,
                             out,
                             current_indent + indent_spaces,
                             indent_spaces,
+                            unit,
+                            sort_keys,
                         )?;
                     } else {
                         stream_owned_value_yaml(
@@ -401,6 +434,8 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                             out,
                             current_indent + indent_spaces,
                             indent_spaces,
+                            unit,
+                            sort_keys,
                         )?;
                     }
                 }
@@ -409,25 +444,30 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
         }
         OwnedValue::Object(obj) => {
             if obj.is_empty() {
-                out.write_str("{}")
-            } else if indent_spaces == 0 {
+                return out.write_str("{}");
+            }
+            let mut entries: Vec<(&String, &OwnedValue)> = obj.iter().collect();
+            if sort_keys {
+                entries.sort_by(|a, b| a.0.cmp(b.0));
+            }
+            if indent_spaces == 0 {
                 // Flow style
                 out.write_char('{')?;
-                for (i, (key, val)) in obj.iter().enumerate() {
+                for (i, (key, val)) in entries.into_iter().enumerate() {
                     if i > 0 {
                         out.write_str(", ")?;
                     }
                     stream_yaml_string(out, key)?;
                     out.write_str(": ")?;
-                    stream_owned_value_yaml(val, out, 0, 0)?;
+                    stream_owned_value_yaml(val, out, 0, 0, unit, sort_keys)?;
                 }
                 out.write_char('}')
             } else {
                 // Block style
-                for (i, (key, val)) in obj.iter().enumerate() {
+                for (i, (key, val)) in entries.into_iter().enumerate() {
                     if i > 0 {
                         out.write_char('\n')?;
-                        write_indent(out, current_indent)?;
+                        write_indent(out, current_indent, unit)?;
                     }
                     stream_yaml_string(out, key)?;
                     out.write_str(":")?;
@@ -436,12 +476,14 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                         && !is_empty_container(val)
                     {
                         out.write_char('\n')?;
-                        write_indent(out, current_indent + indent_spaces)?;
+                        write_indent(out, current_indent + indent_spaces, unit)?;
                         stream_owned_value_yaml(
                             val,
                             out,
                             current_indent + indent_spaces,
                             indent_spaces,
+                            unit,
+                            sort_keys,
                         )?;
                     } else {
                         out.write_char(' ')?;
@@ -450,6 +492,8 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                             out,
                             current_indent + indent_spaces,
                             indent_spaces,
+                            unit,
+                            sort_keys,
                         )?;
                     }
                 }
@@ -468,10 +512,11 @@ fn is_empty_container(value: &OwnedValue) -> bool {
     }
 }
 
-/// Write indentation spaces.
-fn write_indent<W: core::fmt::Write>(out: &mut W, spaces: usize) -> core::fmt::Result {
-    for _ in 0..spaces {
-        out.write_char(' ')?;
+/// Write `width` copies of `unit` as indentation (`unit` is `' '` for
+/// space-indented output, `'\t'` for `--tab`).
+fn write_indent<W: core::fmt::Write>(out: &mut W, width: usize, unit: char) -> core::fmt::Result {
+    for _ in 0..width {
+        out.write_char(unit)?;
     }
     Ok(())
 }
@@ -505,14 +550,14 @@ pub fn stream_yaml_string<W: core::fmt::Write>(out: &mut W, s: &str) -> core::fm
 pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
     fields: &F,
     out: &mut W,
-    indent_spaces: usize,
+    indent: IndentSpec,
 ) -> core::fmt::Result {
     if fields.is_empty() {
         return out.write_str("[]");
     }
     let mut current = fields.clone();
     let mut i = 0usize;
-    if indent_spaces == 0 {
+    if indent.is_compact() {
         // Flow style
         out.write_char('[')?;
         while let Some((field, rest)) = current.uncons() {
@@ -684,36 +729,48 @@ mod tests {
     #[test]
     fn test_stream_null() {
         let mut buf = String::new();
-        OwnedValue::Null.stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Null
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "null");
     }
 
     #[test]
     fn test_stream_bool() {
         let mut buf = String::new();
-        OwnedValue::Bool(true).stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Bool(true)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "true");
 
         buf.clear();
-        OwnedValue::Bool(false).stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Bool(false)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "false");
     }
 
     #[test]
     fn test_stream_int() {
         let mut buf = String::new();
-        OwnedValue::Int(42).stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Int(42)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "42");
 
         buf.clear();
-        OwnedValue::Int(-123).stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Int(-123)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "-123");
     }
 
     #[test]
     fn test_stream_float() {
         let mut buf = String::new();
-        OwnedValue::Float(3.125).stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Float(3.125)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "3.125");
     }
 
@@ -723,16 +780,20 @@ mod tests {
     #[test]
     fn test_stream_json_whole_float_keeps_decimal_point() {
         let mut buf = String::new();
-        OwnedValue::Float(1.0).stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Float(1.0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "1.0");
 
         buf.clear();
-        OwnedValue::Float(-0.0).stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Float(-0.0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "-0.0");
 
         buf.clear();
         OwnedValue::Array(vec![OwnedValue::Float(1.0), OwnedValue::Float(2.5)])
-            .stream_json(&mut buf, 0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "[1.0,2.5]");
     }
@@ -741,7 +802,9 @@ mod tests {
     #[test]
     fn test_stream_yaml_whole_float_keeps_decimal_point() {
         let mut buf = String::new();
-        OwnedValue::Float(1.0).stream_yaml(&mut buf, 0).unwrap();
+        OwnedValue::Float(1.0)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "1.0");
     }
 
@@ -761,7 +824,7 @@ mod tests {
     fn test_stream_json_number_literal() {
         let mut buf = String::new();
         OwnedValue::NumberLiteral(NumberRepr::Float(1.2e3), "1.2e3".into())
-            .stream_json(&mut buf, 0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "1.2E+3");
     }
@@ -773,13 +836,13 @@ mod tests {
         // non-finite Float does, not fall through to `format_number_jq_compat`.
         let mut buf = String::new();
         OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into())
-            .stream_json(&mut buf, 0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "null");
 
         buf.clear();
         OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1e400".into())
-            .stream_json(&mut buf, 0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "null");
     }
@@ -788,19 +851,19 @@ mod tests {
     fn test_stream_yaml_number_literal_nan_and_infinite() {
         let mut buf = String::new();
         OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into())
-            .stream_yaml(&mut buf, 0)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, ".nan");
 
         buf.clear();
         OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1e400".into())
-            .stream_yaml(&mut buf, 0)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, ".inf");
 
         buf.clear();
         OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-1e400".into())
-            .stream_yaml(&mut buf, 0)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "-.inf");
     }
@@ -809,7 +872,7 @@ mod tests {
     fn test_stream_string() {
         let mut buf = String::new();
         OwnedValue::String("hello".to_string())
-            .stream_json(&mut buf, 0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "\"hello\"");
     }
@@ -818,19 +881,19 @@ mod tests {
     fn test_stream_string_escaping() {
         let mut buf = String::new();
         OwnedValue::String("hello\nworld".to_string())
-            .stream_json(&mut buf, 0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "\"hello\\nworld\"");
 
         buf.clear();
         OwnedValue::String("tab\there".to_string())
-            .stream_json(&mut buf, 0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "\"tab\\there\"");
 
         buf.clear();
         OwnedValue::String("quote\"here".to_string())
-            .stream_json(&mut buf, 0)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "\"quote\\\"here\"");
     }
@@ -843,7 +906,7 @@ mod tests {
             OwnedValue::Int(2),
             OwnedValue::Int(3),
         ])
-        .stream_json(&mut buf, 0)
+        .stream_json(&mut buf, IndentSpec::COMPACT, false)
         .unwrap();
         assert_eq!(buf, "[1,2,3]");
     }
@@ -854,7 +917,9 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert("name".to_string(), OwnedValue::String("Alice".to_string()));
         map.insert("age".to_string(), OwnedValue::Int(30));
-        OwnedValue::Object(map).stream_json(&mut buf, 0).unwrap();
+        OwnedValue::Object(map)
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
         assert_eq!(buf, "{\"name\":\"Alice\",\"age\":30}");
     }
 
@@ -872,7 +937,9 @@ mod tests {
             "tags".to_string(),
             OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
         );
-        OwnedValue::Object(outer).stream_json(&mut buf, 2).unwrap();
+        OwnedValue::Object(outer)
+            .stream_json(&mut buf, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(
             buf,
             "{\n  \"user\": {\n    \"name\": \"Alice\"\n  },\n  \"tags\": [\n    1,\n    2\n  ]\n}"
@@ -904,7 +971,7 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert("a".to_string(), OwnedValue::String("boom".to_string()));
         let mut out = FailOnMarker { marker: "boom" };
-        let result = OwnedValue::Object(map).stream_json(&mut out, 2);
+        let result = OwnedValue::Object(map).stream_json(&mut out, IndentSpec::spaces(2), false);
         assert!(result.is_err());
     }
 

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -975,6 +975,94 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // The `sort_keys` (`-S`) parameter was threaded through
+    // `stream_owned_value_json_with`/`stream_owned_value_yaml` in #746, but
+    // nothing exercised its actual sort branch: the M2 CLI fast path only
+    // ever reaches these `OwnedValue` streamers via `GenericResult::Owned`/
+    // `ManyOwned`/`One`/`Many`, and no existing test carried a
+    // multi-key object through one of those with `sort_keys: true`.
+    #[test]
+    fn test_stream_json_object_sorts_keys() {
+        let mut map = IndexMap::new();
+        map.insert("b".to_string(), OwnedValue::Int(1));
+        map.insert("a".to_string(), OwnedValue::Int(2));
+        let mut buf = String::new();
+        OwnedValue::Object(map)
+            .stream_json(&mut buf, IndentSpec::COMPACT, true)
+            .unwrap();
+        assert_eq!(buf, "{\"a\":2,\"b\":1}");
+    }
+
+    #[test]
+    fn test_stream_yaml_empty_object() {
+        let mut buf = String::new();
+        OwnedValue::Object(IndexMap::new())
+            .stream_yaml(&mut buf, IndentSpec::spaces(2), false)
+            .unwrap();
+        assert_eq!(buf, "{}");
+    }
+
+    #[test]
+    fn test_stream_yaml_array_flow_style_multiple_elements() {
+        let mut buf = String::new();
+        OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(buf, "[1, 2]");
+    }
+
+    #[test]
+    fn test_stream_yaml_array_block_style_nested_container() {
+        // Covers the "nested containers get their own indented line" branch,
+        // distinct from the plain-scalar-element branch `test_stream_array`-
+        // style tests already exercise.
+        let mut buf = String::new();
+        OwnedValue::Array(vec![
+            OwnedValue::Array(vec![OwnedValue::Int(1)]),
+            OwnedValue::Int(2),
+        ])
+        .stream_yaml(&mut buf, IndentSpec::spaces(2), false)
+        .unwrap();
+        assert_eq!(buf, "- \n  - 1\n- 2");
+    }
+
+    #[test]
+    fn test_stream_yaml_object_flow_style_sorts_keys() {
+        let mut map = IndexMap::new();
+        map.insert("b".to_string(), OwnedValue::Int(1));
+        map.insert("a".to_string(), OwnedValue::Int(2));
+        let mut buf = String::new();
+        OwnedValue::Object(map.clone())
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, true)
+            .unwrap();
+        assert_eq!(buf, "{a: 2, b: 1}");
+
+        // `sort_keys: false` skips the `sort_by` call above but shares the
+        // rest of this function -- covers that branch too.
+        buf.clear();
+        OwnedValue::Object(map)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(buf, "{b: 1, a: 2}");
+    }
+
+    #[test]
+    fn test_stream_yaml_object_block_style_sorts_keys_with_nested_and_scalar_values() {
+        // Sorts "b" before "a" out of insertion order, and covers both the
+        // nested-container-gets-its-own-line branch (key "a") and the
+        // plain-scalar-value branch (key "b") in the same pass.
+        let mut map = IndexMap::new();
+        map.insert("b".to_string(), OwnedValue::Int(1));
+        let mut nested = IndexMap::new();
+        nested.insert("x".to_string(), OwnedValue::Int(9));
+        map.insert("a".to_string(), OwnedValue::Object(nested));
+        let mut buf = String::new();
+        OwnedValue::Object(map)
+            .stream_yaml(&mut buf, IndentSpec::spaces(2), true)
+            .unwrap();
+        assert_eq!(buf, "a:\n  x: 9\nb: 1");
+    }
+
     #[test]
     fn test_is_falsy() {
         assert!(OwnedValue::Null.is_falsy());

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1519,7 +1519,7 @@ pub type BorrowedJsonCursor<'a> = JsonCursor<'a, &'a [u64]>;
 // ============================================================================
 
 use crate::jq::document::{
-    DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue,
+    DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
@@ -1579,13 +1579,17 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
     fn stream_json<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        _sort_keys: bool,
     ) -> core::fmt::Result {
         // Compact only: echo the raw bytes verbatim, since they're already
         // valid JSON. Indented (pretty) JSON->JSON streaming isn't
         // implemented here — callers fall back to the DOM path (#442 only
         // extended the YAML-target and YAML-cursor-to-JSON pretty paths).
-        if indent_spaces != 0 {
+        // `sort_keys` is unused: `jq`'s own M2 gate (src/bin/succinctly/
+        // jq_runner.rs) excludes `-S` independently of this trait, so this
+        // is never reached with `sort_keys: true`.
+        if !indent.is_compact() {
             return Err(core::fmt::Error);
         }
         if let Some(bytes) = self.raw_bytes() {
@@ -1601,10 +1605,12 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
     fn stream_yaml<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        _sort_keys: bool,
     ) -> core::fmt::Result {
-        // For JSON->YAML conversion, we need to format as YAML
-        stream_json_as_yaml(out, self.value(), 0, indent_spaces)
+        // For JSON->YAML conversion, we need to format as YAML. `sort_keys`
+        // is unused for the same reason as `stream_json` above.
+        stream_json_as_yaml(out, self.value(), 0, indent.width)
     }
 
     #[inline]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1148,16 +1148,18 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     ///         self.0.write_all(s.as_bytes()).map_err(|_| core::fmt::Error)
     ///     }
     /// }
-    /// cursor.stream_json(&mut FmtWriter(&mut output), 0).unwrap();
+    /// cursor.stream_json(&mut FmtWriter(&mut output), IndentSpec::COMPACT, false).unwrap();
     /// ```
     ///
-    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
+    /// - `indent`: indentation width/unit (`IndentSpec::COMPACT` for compact)
+    /// - `sort_keys`: sort mapping keys before writing (`-S`/`--sort-keys`)
     pub fn stream_json<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result {
-        self.stream_json_value(out, 0, indent_spaces)
+        self.stream_json_value(out, 0, indent.width, indent.unit, sort_keys)
     }
 
     /// Stream YAML as JSON, unwrapping single documents (matches yq behavior).
@@ -1165,11 +1167,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// If the root is a single-document array `[doc]`, outputs just `doc` as JSON.
     /// If there are multiple documents, outputs the array `[doc1, doc2, ...]`.
     ///
-    /// - `indent_spaces`: Spaces per indentation level (0 for compact)
+    /// - `indent`: indentation width/unit (`IndentSpec::COMPACT` for compact)
+    /// - `sort_keys`: sort mapping keys before writing (`-S`/`--sort-keys`)
     pub fn stream_json_document<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result {
         // Check if this is the root document array with a single document
         if self.bp_pos == 0 {
@@ -1180,19 +1184,26 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         // wrapper. Via the cursor, not the extracted
                         // `YamlValue`: the document's own tag lives on its
                         // cursor's `bp_pos` (#224).
-                        return first_cursor.stream_json_value(out, 0, indent_spaces);
+                        return first_cursor.stream_json_value(
+                            out,
+                            0,
+                            indent.width,
+                            indent.unit,
+                            sort_keys,
+                        );
                     }
                 }
             }
         }
 
         // Multiple documents or not at root - output as-is
-        self.stream_json_value(out, 0, indent_spaces)
+        self.stream_json_value(out, 0, indent.width, indent.unit, sort_keys)
     }
 
     /// Stream this cursor's value as YAML.
     ///
-    /// - `indent_spaces`: Spaces per indentation level (0 for flow style)
+    /// - `indent`: indentation width/unit (`IndentSpec::COMPACT` for flow style)
+    /// - `sort_keys`: sort mapping keys before writing (`-S`/`--sort-keys`)
     ///
     /// This enables M2.5 streaming optimization for YAML output format,
     /// allowing navigation query results to be written directly without
@@ -1200,9 +1211,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     pub fn stream_yaml<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result {
-        self.stream_yaml_value(out, 0, indent_spaces)
+        self.stream_yaml_value(out, 0, indent.width, indent.unit, sort_keys)
     }
 
     /// Stream YAML, unwrapping single documents (matches yq behavior).
@@ -1211,7 +1223,8 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     pub fn stream_yaml_document<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result {
         // Check if this is the root document array with a single document
         if self.bp_pos == 0 {
@@ -1219,22 +1232,38 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if let Some((cursor, rest)) = elements.uncons_cursor() {
                     if rest.is_empty() {
                         // Single document - output it directly without array wrapper
-                        return cursor.stream_yaml_value(out, 0, indent_spaces);
+                        return cursor.stream_yaml_value(
+                            out,
+                            0,
+                            indent.width,
+                            indent.unit,
+                            sort_keys,
+                        );
                     }
                 }
             }
         }
 
         // Multiple documents or not at root - output as-is
-        self.stream_yaml_value(out, 0, indent_spaces)
+        self.stream_yaml_value(out, 0, indent.width, indent.unit, sort_keys)
     }
 
     /// Internal: stream this cursor's value as YAML.
+    ///
+    /// - `unit`: the character repeated `indent_spaces` times per level
+    ///   (`' '` normally, `'\t'` for `--tab`).
+    /// - `sort_keys`: sort each mapping's fields before writing (`-S`).
+    ///   `YamlField` is `Copy`, so materializing a mapping's fields into a
+    ///   `Vec` to sort them is cheap — cursor structs only, no value data —
+    ///   and this branch is only taken when `-S` is actually requested, so
+    ///   the default (unsorted) path below is untouched.
     fn stream_yaml_value<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
         current_indent: usize,
         indent_spaces: usize,
+        unit: char,
+        sort_keys: bool,
     ) -> core::fmt::Result {
         match self.value() {
             YamlValue::Null => out.write_str("null"),
@@ -1258,62 +1287,135 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     // Flow style
                     out.write_char('{')?;
                     let mut first = true;
-                    for field in fields {
-                        if !first {
-                            out.write_str(", ")?;
-                        }
-                        first = false;
-                        // Write key
-                        if let YamlValue::String(s) = field.key() {
-                            if let Some(tag) = field.key_cursor().explicit_tag() {
-                                out.write_str(tag)?;
-                                out.write_char(' ')?;
+                    if sort_keys {
+                        let mut sorted: Vec<_> = fields.into_iter().collect();
+                        sorted.sort_by(|a, b| a.key().key_string().cmp(&b.key().key_string()));
+                        for field in sorted {
+                            if !first {
+                                out.write_str(", ")?;
                             }
-                            stream_yaml_string_value(out, &s)?;
-                        } else {
-                            stream_yaml_nonstring_key(out, &field.key())?;
+                            first = false;
+                            if let YamlValue::String(s) = field.key() {
+                                if let Some(tag) = field.key_cursor().explicit_tag() {
+                                    out.write_str(tag)?;
+                                    out.write_char(' ')?;
+                                }
+                                stream_yaml_string_value(out, &s)?;
+                            } else {
+                                stream_yaml_nonstring_key(out, &field.key())?;
+                            }
+                            out.write_str(": ")?;
+                            field
+                                .value_cursor()
+                                .stream_yaml_value(out, 0, 0, unit, sort_keys)?;
                         }
-                        out.write_str(": ")?;
-                        field.value_cursor().stream_yaml_value(out, 0, 0)?;
+                    } else {
+                        for field in fields {
+                            if !first {
+                                out.write_str(", ")?;
+                            }
+                            first = false;
+                            // Write key
+                            if let YamlValue::String(s) = field.key() {
+                                if let Some(tag) = field.key_cursor().explicit_tag() {
+                                    out.write_str(tag)?;
+                                    out.write_char(' ')?;
+                                }
+                                stream_yaml_string_value(out, &s)?;
+                            } else {
+                                stream_yaml_nonstring_key(out, &field.key())?;
+                            }
+                            out.write_str(": ")?;
+                            field
+                                .value_cursor()
+                                .stream_yaml_value(out, 0, 0, unit, sort_keys)?;
+                        }
                     }
                     out.write_char('}')
                 } else {
                     // Block style
                     let mut first = true;
-                    for field in fields {
-                        if !first {
-                            out.write_char('\n')?;
-                            write_yaml_indent(out, current_indent)?;
-                        }
-                        first = false;
-                        // Write key
-                        if let YamlValue::String(s) = field.key() {
-                            if let Some(tag) = field.key_cursor().explicit_tag() {
-                                out.write_str(tag)?;
-                                out.write_char(' ')?;
+                    if sort_keys {
+                        let mut sorted: Vec<_> = fields.into_iter().collect();
+                        sorted.sort_by(|a, b| a.key().key_string().cmp(&b.key().key_string()));
+                        for field in sorted {
+                            if !first {
+                                out.write_char('\n')?;
+                                write_yaml_indent(out, current_indent, unit)?;
                             }
-                            stream_yaml_string_value(out, &s)?;
-                        } else {
-                            stream_yaml_nonstring_key(out, &field.key())?;
+                            first = false;
+                            if let YamlValue::String(s) = field.key() {
+                                if let Some(tag) = field.key_cursor().explicit_tag() {
+                                    out.write_str(tag)?;
+                                    out.write_char(' ')?;
+                                }
+                                stream_yaml_string_value(out, &s)?;
+                            } else {
+                                stream_yaml_nonstring_key(out, &field.key())?;
+                            }
+                            out.write_char(':')?;
+                            let value = field.value_cursor();
+                            if is_yaml_cursor_container(&value) && value.style() != "flow" {
+                                out.write_char('\n')?;
+                                write_yaml_indent(out, current_indent + indent_spaces, unit)?;
+                                value.stream_yaml_value(
+                                    out,
+                                    current_indent + indent_spaces,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                )?;
+                            } else {
+                                out.write_char(' ')?;
+                                value.stream_yaml_value(
+                                    out,
+                                    current_indent + indent_spaces,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                )?;
+                            }
                         }
-                        out.write_char(':')?;
-                        // Check if value needs newline
-                        let value = field.value_cursor();
-                        if is_yaml_cursor_container(&value) && value.style() != "flow" {
-                            out.write_char('\n')?;
-                            write_yaml_indent(out, current_indent + indent_spaces)?;
-                            value.stream_yaml_value(
-                                out,
-                                current_indent + indent_spaces,
-                                indent_spaces,
-                            )?;
-                        } else {
-                            out.write_char(' ')?;
-                            value.stream_yaml_value(
-                                out,
-                                current_indent + indent_spaces,
-                                indent_spaces,
-                            )?;
+                    } else {
+                        for field in fields {
+                            if !first {
+                                out.write_char('\n')?;
+                                write_yaml_indent(out, current_indent, unit)?;
+                            }
+                            first = false;
+                            // Write key
+                            if let YamlValue::String(s) = field.key() {
+                                if let Some(tag) = field.key_cursor().explicit_tag() {
+                                    out.write_str(tag)?;
+                                    out.write_char(' ')?;
+                                }
+                                stream_yaml_string_value(out, &s)?;
+                            } else {
+                                stream_yaml_nonstring_key(out, &field.key())?;
+                            }
+                            out.write_char(':')?;
+                            // Check if value needs newline
+                            let value = field.value_cursor();
+                            if is_yaml_cursor_container(&value) && value.style() != "flow" {
+                                out.write_char('\n')?;
+                                write_yaml_indent(out, current_indent + indent_spaces, unit)?;
+                                value.stream_yaml_value(
+                                    out,
+                                    current_indent + indent_spaces,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                )?;
+                            } else {
+                                out.write_char(' ')?;
+                                value.stream_yaml_value(
+                                    out,
+                                    current_indent + indent_spaces,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                )?;
+                            }
                         }
                     }
                     Ok(())
@@ -1333,7 +1435,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             out.write_str(", ")?;
                         }
                         first = false;
-                        cursor.stream_yaml_value(out, 0, 0)?;
+                        cursor.stream_yaml_value(out, 0, 0, unit, sort_keys)?;
                         elems = rest;
                     }
                     out.write_char(']')
@@ -1344,7 +1446,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     while let Some((cursor, rest)) = elems.uncons_cursor() {
                         if !first {
                             out.write_char('\n')?;
-                            write_yaml_indent(out, current_indent)?;
+                            write_yaml_indent(out, current_indent, unit)?;
                         }
                         first = false;
                         // Check if value needs newline. A container value
@@ -1355,11 +1457,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         if is_yaml_cursor_container(&cursor) && cursor.style() != "flow" {
                             out.write_char('-')?;
                             out.write_char('\n')?;
-                            write_yaml_indent(out, current_indent + indent_spaces)?;
+                            write_yaml_indent(out, current_indent + indent_spaces, unit)?;
                             cursor.stream_yaml_value(
                                 out,
                                 current_indent + indent_spaces,
                                 indent_spaces,
+                                unit,
+                                sort_keys,
                             )?;
                         } else {
                             out.write_str("- ")?;
@@ -1367,6 +1471,8 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 out,
                                 current_indent + indent_spaces,
                                 indent_spaces,
+                                unit,
+                                sort_keys,
                             )?;
                         }
                         elems = rest;
@@ -1376,7 +1482,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             }
             YamlValue::Alias { target, .. } => {
                 if let Some(target_cursor) = target {
-                    target_cursor.stream_yaml_value(out, current_indent, indent_spaces)
+                    target_cursor.stream_yaml_value(
+                        out,
+                        current_indent,
+                        indent_spaces,
+                        unit,
+                        sort_keys,
+                    )
                 } else {
                     out.write_str("null")
                 }
@@ -1388,11 +1500,18 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// Internal: stream this cursor's value as JSON.
     ///
     /// - `indent_spaces`: Spaces per indentation level (0 for compact)
+    /// - `unit`: the character repeated `indent_spaces` times per level
+    ///   (`' '` normally, `'\t'` for `--tab`).
+    /// - `sort_keys`: sort each mapping's fields before writing (`-S`). See
+    ///   `stream_yaml_value`'s doc comment for why materializing into a
+    ///   `Vec<YamlField>` to sort is cheap and only paid when requested.
     fn stream_json_value<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
         current_indent: usize,
         indent_spaces: usize,
+        unit: char,
+        sort_keys: bool,
     ) -> core::fmt::Result {
         match self.value() {
             YamlValue::Null => out.write_str("null"),
@@ -1435,42 +1554,83 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 out.write_char('{')?;
                 let next_indent = current_indent + indent_spaces;
                 let mut first = true;
-                for field in fields {
-                    if !first {
-                        out.write_char(',')?;
-                    }
-                    first = false;
-                    if indent_spaces > 0 {
-                        out.write_char('\n')?;
-                        write_yaml_indent(out, next_indent)?;
-                    }
-
-                    // Write key
-                    if let YamlValue::String(s) = field.key() {
-                        match stream_yaml_string_to_json(out, &s) {
-                            Ok(true) => {} // Written directly
-                            Ok(false) | Err(_) => {
-                                if let Ok(key_str) = s.as_str() {
-                                    stream_json_string(out, &key_str)?;
-                                } else {
-                                    out.write_str("\"\"")?;
+                if sort_keys {
+                    let mut sorted: Vec<_> = fields.into_iter().collect();
+                    sorted.sort_by(|a, b| a.key().key_string().cmp(&b.key().key_string()));
+                    for field in sorted {
+                        if !first {
+                            out.write_char(',')?;
+                        }
+                        first = false;
+                        if indent_spaces > 0 {
+                            out.write_char('\n')?;
+                            write_yaml_indent(out, next_indent, unit)?;
+                        }
+                        if let YamlValue::String(s) = field.key() {
+                            match stream_yaml_string_to_json(out, &s) {
+                                Ok(true) => {} // Written directly
+                                Ok(false) | Err(_) => {
+                                    if let Ok(key_str) = s.as_str() {
+                                        stream_json_string(out, &key_str)?;
+                                    } else {
+                                        out.write_str("\"\"")?;
+                                    }
                                 }
                             }
+                        } else {
+                            stream_json_string(out, &field.key().key_string())?;
                         }
-                    } else {
-                        // Alias/complex key (#222): resolve alias-to-scalar,
-                        // else "" — the entry is kept, never dropped
-                        stream_json_string(out, &field.key().key_string())?;
+                        out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
+                        field.value_cursor().stream_json_value(
+                            out,
+                            next_indent,
+                            indent_spaces,
+                            unit,
+                            sort_keys,
+                        )?;
                     }
+                } else {
+                    for field in fields {
+                        if !first {
+                            out.write_char(',')?;
+                        }
+                        first = false;
+                        if indent_spaces > 0 {
+                            out.write_char('\n')?;
+                            write_yaml_indent(out, next_indent, unit)?;
+                        }
 
-                    out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
-                    field
-                        .value_cursor()
-                        .stream_json_value(out, next_indent, indent_spaces)?;
+                        // Write key
+                        if let YamlValue::String(s) = field.key() {
+                            match stream_yaml_string_to_json(out, &s) {
+                                Ok(true) => {} // Written directly
+                                Ok(false) | Err(_) => {
+                                    if let Ok(key_str) = s.as_str() {
+                                        stream_json_string(out, &key_str)?;
+                                    } else {
+                                        out.write_str("\"\"")?;
+                                    }
+                                }
+                            }
+                        } else {
+                            // Alias/complex key (#222): resolve alias-to-scalar,
+                            // else "" — the entry is kept, never dropped
+                            stream_json_string(out, &field.key().key_string())?;
+                        }
+
+                        out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
+                        field.value_cursor().stream_json_value(
+                            out,
+                            next_indent,
+                            indent_spaces,
+                            unit,
+                            sort_keys,
+                        )?;
+                    }
                 }
                 if indent_spaces > 0 {
                     out.write_char('\n')?;
-                    write_yaml_indent(out, current_indent)?;
+                    write_yaml_indent(out, current_indent, unit)?;
                 }
                 out.write_char('}')
             }
@@ -1490,22 +1650,28 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     rest = next;
                     if indent_spaces > 0 {
                         out.write_char('\n')?;
-                        write_yaml_indent(out, next_indent)?;
+                        write_yaml_indent(out, next_indent, unit)?;
                     }
                     // Recurse via the cursor, not the extracted `YamlValue`:
                     // an element's own tag lives on its cursor's `bp_pos`,
                     // which a bare `YamlValue` has already lost (#224).
-                    cursor.stream_json_value(out, next_indent, indent_spaces)?;
+                    cursor.stream_json_value(out, next_indent, indent_spaces, unit, sort_keys)?;
                 }
                 if indent_spaces > 0 {
                     out.write_char('\n')?;
-                    write_yaml_indent(out, current_indent)?;
+                    write_yaml_indent(out, current_indent, unit)?;
                 }
                 out.write_char(']')
             }
             YamlValue::Alias { target, .. } => {
                 if let Some(target_cursor) = target {
-                    target_cursor.stream_json_value(out, current_indent, indent_spaces)
+                    target_cursor.stream_json_value(
+                        out,
+                        current_indent,
+                        indent_spaces,
+                        unit,
+                        sort_keys,
+                    )
                 } else {
                     out.write_str("null")
                 }
@@ -4826,7 +4992,7 @@ impl core::fmt::Display for YamlNumberError {
 // ============================================================================
 
 use crate::jq::document::{
-    DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue,
+    DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
@@ -4901,18 +5067,20 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     fn stream_json<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result {
-        YamlCursor::stream_json(self, out, indent_spaces)
+        YamlCursor::stream_json(self, out, indent, sort_keys)
     }
 
     #[inline]
     fn stream_yaml<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        indent_spaces: usize,
+        indent: IndentSpec,
+        sort_keys: bool,
     ) -> core::fmt::Result {
-        YamlCursor::stream_yaml(self, out, indent_spaces)
+        YamlCursor::stream_yaml(self, out, indent, sort_keys)
     }
 
     #[inline]
@@ -5199,10 +5367,15 @@ fn is_yaml_cursor_container<W: AsRef<[u64]>>(cursor: &YamlCursor<'_, W>) -> bool
     }
 }
 
-/// Write indentation spaces.
-fn write_yaml_indent<Out: core::fmt::Write>(out: &mut Out, spaces: usize) -> core::fmt::Result {
-    for _ in 0..spaces {
-        out.write_char(' ')?;
+/// Write `width` copies of `unit` as indentation (`unit` is `' '` for
+/// space-indented output, `'\t'` for `--tab`).
+fn write_yaml_indent<Out: core::fmt::Write>(
+    out: &mut Out,
+    width: usize,
+    unit: char,
+) -> core::fmt::Result {
+    for _ in 0..width {
+        out.write_char(unit)?;
     }
     Ok(())
 }
@@ -5225,6 +5398,8 @@ pub fn stream_yaml_sequence<'a, W, I, Out>(
     out: &mut Out,
     current_indent: usize,
     indent_spaces: usize,
+    unit: char,
+    sort_keys: bool,
 ) -> core::fmt::Result
 where
     W: AsRef<[u64]> + 'a,
@@ -5244,7 +5419,7 @@ where
                 out.write_str(", ")?;
             }
             first = false;
-            cursor.stream_yaml_value(out, 0, 0)?;
+            cursor.stream_yaml_value(out, 0, 0, unit, sort_keys)?;
         }
         out.write_char(']')
     } else {
@@ -5253,17 +5428,29 @@ where
         for cursor in iter {
             if !first {
                 out.write_char('\n')?;
-                write_yaml_indent(out, current_indent)?;
+                write_yaml_indent(out, current_indent, unit)?;
             }
             first = false;
             if is_yaml_cursor_container(&cursor) {
                 out.write_char('-')?;
                 out.write_char('\n')?;
-                write_yaml_indent(out, current_indent + indent_spaces)?;
-                cursor.stream_yaml_value(out, current_indent + indent_spaces, indent_spaces)?;
+                write_yaml_indent(out, current_indent + indent_spaces, unit)?;
+                cursor.stream_yaml_value(
+                    out,
+                    current_indent + indent_spaces,
+                    indent_spaces,
+                    unit,
+                    sort_keys,
+                )?;
             } else {
                 out.write_str("- ")?;
-                cursor.stream_yaml_value(out, current_indent + indent_spaces, indent_spaces)?;
+                cursor.stream_yaml_value(
+                    out,
+                    current_indent + indent_spaces,
+                    indent_spaces,
+                    unit,
+                    sort_keys,
+                )?;
             }
         }
         Ok(())
@@ -5746,7 +5933,10 @@ mod tests {
         let yaml = b"s: \"caf\\xe9\"\ni: +123\nf: +1.5\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_json_document(&mut out, 0).unwrap();
+        index
+            .root(yaml)
+            .stream_json_document(&mut out, IndentSpec::COMPACT, false)
+            .unwrap();
         assert!(out.contains("\"i\":123"), "got {out}");
         assert!(out.contains("\"f\":1.5"), "got {out}");
     }
@@ -5762,7 +5952,10 @@ mod tests {
         let yaml = b"s: \"next\\Nline\"\nt: \"non\\_break\"\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_json_document(&mut out, 0).unwrap();
+        index
+            .root(yaml)
+            .stream_json_document(&mut out, IndentSpec::COMPACT, false)
+            .unwrap();
         assert!(out.contains("\"s\":\"next\u{0085}line\""), "got {out}");
         assert!(out.contains("\"t\":\"non\u{00a0}break\""), "got {out}");
     }
@@ -5776,7 +5969,10 @@ mod tests {
         let yaml = b"s: \"line\\Lsep\"\nt: \"para\\Psep\"\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_json_document(&mut out, 0).unwrap();
+        index
+            .root(yaml)
+            .stream_json_document(&mut out, IndentSpec::COMPACT, false)
+            .unwrap();
         assert!(out.contains("\"s\":\"line\\u2028sep\""), "got {out}");
         assert!(out.contains("\"t\":\"para\\u2029sep\""), "got {out}");
     }
@@ -5810,7 +6006,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed, 0)
+                .stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -5830,7 +6026,8 @@ mod tests {
 
         let json = root.to_json_document();
         let mut streamed = String::new();
-        root.stream_json_document(&mut streamed, 0).unwrap();
+        root.stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
+            .unwrap();
 
         assert_eq!(json, r#"[{"a":1},{"b":2}]"#);
         assert_eq!(streamed, json);
@@ -5858,7 +6055,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed, 0)
+                .stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -5919,7 +6116,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed, 0)
+                .stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -5993,7 +6190,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed, 0)
+                .stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
                 .unwrap();
             let mut expected_json = String::new();
             write_json_string(&mut expected_json, expected);
@@ -6061,7 +6258,10 @@ mod tests {
         let yaml = multibyte_yaml();
         let index = YamlIndex::build(&yaml).unwrap();
         let mut out = String::new();
-        index.root(&yaml).stream_json_document(&mut out, 0).unwrap();
+        index
+            .root(&yaml)
+            .stream_json_document(&mut out, IndentSpec::COMPACT, false)
+            .unwrap();
         for expect in MULTIBYTE_JSON_VALUES {
             assert!(
                 out.contains(expect),
@@ -6079,7 +6279,10 @@ mod tests {
         let yaml = b"a: 1\nb: true\nc: hello\nd: 1.0\ne: .5\nf: yes\ng: null\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(
             out,
             "a: 1\nb: true\nc: hello\nd: 1.0\ne: .5\nf: yes\ng: null"
@@ -6094,7 +6297,10 @@ mod tests {
         let yaml = b"a: [1, 2, 3]\nb: {c: 1, d: 2}\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "a: [1, 2, 3]\nb: {c: 1, d: 2}");
     }
 
@@ -6105,7 +6311,10 @@ mod tests {
         let yaml = b"top:\n  a: [1, 2, 3]\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "top:\n  a: [1, 2, 3]");
     }
 
@@ -6116,7 +6325,10 @@ mod tests {
         let yaml = b"a:\n  - [1, 2]\n  - 3\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "a:\n  - [1, 2]\n  - 3");
     }
 
@@ -6127,7 +6339,10 @@ mod tests {
         let yaml = b"a:\n  b: {x: 1, y: 2}\n  c: 3\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "a:\n  b: {x: 1, y: 2}\n  c: 3");
     }
 
@@ -6138,7 +6353,10 @@ mod tests {
         let yaml = b"a: [1, 2, 3]\nb:\n  x: 1\n  y: 2\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "a: [1, 2, 3]\nb:\n  x: 1\n  y: 2");
     }
 
@@ -6150,7 +6368,10 @@ mod tests {
         let yaml = b"a: {b: [1, 2], c: {d: 3}}\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "a: {b: [1, 2], c: {d: 3}}");
     }
 
@@ -6161,7 +6382,10 @@ mod tests {
         let yaml = b"a: []\nb: {}\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "a: []\nb: {}");
     }
 
@@ -6184,7 +6408,7 @@ mod tests {
         let cursor_b = index_b.root(&bytes_b).first_child().unwrap();
 
         let mut out = String::new();
-        stream_yaml_sequence([cursor_a, cursor_b], &mut out, 0, 0).unwrap();
+        stream_yaml_sequence([cursor_a, cursor_b], &mut out, 0, 0, ' ', false).unwrap();
         assert_eq!(out, "[{a: 1}, {b: 2}]");
     }
 
@@ -6195,7 +6419,10 @@ mod tests {
         let yaml = b"a: \"1\"\nb: 'true'\nc: \"hello\"\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "a: \"1\"\nb: 'true'\nc: \"hello\"");
     }
 
@@ -6208,7 +6435,10 @@ mod tests {
         let yaml = b"a: |-\n  hello\n  world\nb: |-\n  plain\nc: |-\n  true\nd: |-\n  123\ne: |-\n  1.5e+3\nf: |-\n  12x\ng: |-\n  1.5.5\nh: |-\n  +\ni: |-\n  +x\nj: |-\n  +5x\nk: >-\n  folded here\nl: |-\n  -foo\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(
             out,
             "a: \"hello\\nworld\"\n\
@@ -6233,7 +6463,10 @@ mod tests {
         let yaml = b"t: |-\n  x \n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "t: \"x \"");
     }
 
@@ -6246,7 +6479,10 @@ mod tests {
         let yaml = b"a: one\n  two\nb: one\n\n  two\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();
-        index.root(yaml).stream_yaml_document(&mut out, 2).unwrap();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
         assert_eq!(out, "a: one two\nb: \"one\\ntwo\"");
     }
 
@@ -6749,7 +6985,8 @@ mod tests {
             );
 
             let mut streamed = String::new();
-            root.stream_json_document(&mut streamed, 0).unwrap();
+            root.stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
+                .unwrap();
             assert_eq!(
                 streamed,
                 *expected,
@@ -7116,7 +7353,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed, 0)
+                .stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -7231,7 +7468,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed, 0)
+                .stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -7335,7 +7572,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed, 0)
+                .stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -7384,7 +7621,7 @@ mod tests {
             let mut streamed = String::new();
             index
                 .root(yaml)
-                .stream_json_document(&mut streamed, 0)
+                .stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
                 .unwrap();
             let input = core::str::from_utf8(yaml).unwrap();
             assert_eq!(json, *expected, "to_json mismatch for {input:?}");
@@ -8845,7 +9082,9 @@ mod tests {
                 let cursor = field.value_cursor();
                 assert_eq!(cursor.to_json(), "\"hello\"");
                 let mut streamed = String::new();
-                cursor.stream_json(&mut streamed, 0).expect("streams");
+                cursor
+                    .stream_json(&mut streamed, IndentSpec::COMPACT, false)
+                    .expect("streams");
                 assert_eq!(streamed, "\"hello\"");
                 return;
             }
@@ -9502,7 +9741,9 @@ mod tests {
 
         let buffered = cursor.to_json();
         let mut streamed = String::new();
-        cursor.stream_json(&mut streamed, 0).expect("streams");
+        cursor
+            .stream_json(&mut streamed, IndentSpec::COMPACT, false)
+            .expect("streams");
         let what = String::from_utf8_lossy(yaml);
         assert_eq!(
             buffered, streamed,
@@ -9741,7 +9982,8 @@ mod tests {
             let index = YamlIndex::build(yaml).expect("builds");
             let root = index.root(yaml);
             let mut out = String::new();
-            root.stream_yaml_document(&mut out, 2).expect("streams");
+            root.stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+                .expect("streams");
             let what = String::from_utf8_lossy(yaml);
             assert_eq!(out, expected, "for {what}");
 
@@ -9773,7 +10015,9 @@ mod tests {
             if let Some(field) = fields.into_iter().next() {
                 let cursor = field.value_cursor();
                 let mut out = String::new();
-                cursor.stream_yaml(&mut out, 0).expect("streams");
+                cursor
+                    .stream_yaml(&mut out, IndentSpec::COMPACT, false)
+                    .expect("streams");
                 assert_eq!(out, "{!!str k: v}");
                 return;
             }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6413,6 +6413,216 @@ mod tests {
     }
 
     #[test]
+    fn test_stream_yaml_sequence_block_style_mixed_container_and_scalar() {
+        // Companion to `test_stream_yaml_sequence_flow_style` above: that one
+        // covers the flow branch, this covers block style's two element
+        // kinds (nested container vs. plain scalar) in the same pass.
+        let bytes_a = b"a: 1\n".to_vec();
+        let index_a = YamlIndex::build(&bytes_a).unwrap();
+        let bytes_b = b"2\n".to_vec();
+        let index_b = YamlIndex::build(&bytes_b).unwrap();
+
+        let cursor_a = index_a.root(&bytes_a).first_child().unwrap();
+        let cursor_b = index_b.root(&bytes_b).first_child().unwrap();
+
+        let mut out = String::new();
+        stream_yaml_sequence([cursor_a, cursor_b], &mut out, 0, 2, ' ', false).unwrap();
+        assert_eq!(out, "-\n  a: 1\n- 2");
+    }
+
+    #[test]
+    fn test_stream_yaml_multi_document_identity_streams_as_block_sequence() {
+        // #746's `sort_keys`/`IndentSpec` threading touched
+        // `stream_yaml_document`'s multi-document fallback line even though
+        // its logic didn't change; exercise it directly rather than relying
+        // on the single-document unwrap every other `stream_yaml_document`
+        // test above takes.
+        let yaml = b"a: 1\n---\nb: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
+        assert_eq!(out, "-\n  a: 1\n-\n  b: 2");
+    }
+
+    #[test]
+    fn test_stream_yaml_flow_mapping_sorts_keys_with_nonstring_key() {
+        // `-S` with `IndentSpec::COMPACT` (forces flow style regardless of
+        // source style, since `indent.width == 0`) and a non-string key,
+        // covering `stream_yaml_value`'s flow-style `sort_keys` branch end
+        // to end.
+        //
+        // A plain scalar key like `2` is *not* a non-string key here:
+        // `YamlValue` has no `Int`/`Bool` variant at all (see its doc
+        // comment) -- every scalar, key or value, resolves to `String`
+        // (the `YamlString` sub-variant only distinguishes quote style),
+        // and type resolution happens later at render time. An explicit
+        // complex key (`? {a: 1}`) is genuinely outside the `String`
+        // variant, and `key_string()`'s documented fallback for it is `""`.
+        let yaml = b"k: hello\n? {a: 1}\n: v\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::COMPACT, true)
+            .unwrap();
+        assert_eq!(out, "{\"\": v, k: hello}");
+    }
+
+    #[test]
+    fn test_stream_yaml_flow_mapping_unsorted_with_nonstring_key() {
+        // Same shape as above without `-S`: covers the flow style's
+        // unsorted-loop non-string-key branch, which the sorted-loop test
+        // above doesn't reach.
+        let yaml = b"k: hello\n? {a: 1}\n: v\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(out, "{k: hello, \"\": v}");
+    }
+
+    #[test]
+    fn test_stream_yaml_block_mapping_sorted_nested_and_nonstring_key() {
+        // `-S` on a block-style mapping with an explicit complex key (see
+        // the flow test above for why a plain scalar key doesn't exercise
+        // this) that sorts before its string-keyed sibling (`key_string()`'s
+        // `""` sorts first) and whose value is itself a nested non-empty
+        // mapping: covers the sorted block loop's non-string-key branch and
+        // its "nested container gets its own indented line" branch
+        // together.
+        let yaml = b"k: hello\n? {a: 1}\n:\n  y: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), true)
+            .unwrap();
+        assert_eq!(out, "\"\":\n  y: 3\nk: hello");
+    }
+
+    #[test]
+    fn test_stream_yaml_block_mapping_unsorted_nested_and_nonstring_key() {
+        // Same shape as above without `-S`: covers the unsorted block
+        // loop's non-string-key and nested-container branches, which the
+        // sorted-loop test above doesn't reach (it's a separate code path,
+        // not shared, since sorting needs to materialize into a `Vec` first).
+        let yaml = b"k: hello\n? {a: 1}\n:\n  y: 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
+        assert_eq!(out, "k: hello\n\"\":\n  y: 3");
+    }
+
+    #[test]
+    fn test_stream_yaml_alias_streams_as_yaml() {
+        // `test_alias_resolves_wherever_the_anchor_is_in_scope` (below)
+        // exercises `stream_json_value`'s `Alias` arm exclusively (its
+        // cases assert JSON output); this covers the same resolution
+        // through `stream_yaml_value`'s own `Alias` arm, reached only via
+        // YAML-formatted output.
+        let yaml = b"a: &x 1\nb: *x\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
+        assert_eq!(out, "a: 1\nb: 1");
+    }
+
+    #[test]
+    fn test_stream_json_pretty_sorts_keys_with_quoted_and_nonstring_keys() {
+        // `-S -o json` (pretty) on a *navigated* mapping cursor -- reached
+        // via `stream_json` (what the M2 fast path calls for `.field`/
+        // `.[0]`-style navigation results), not `stream_json_document`
+        // (identity's `.` path): that one unwraps a single document through
+        // the free function `stream_yaml_value_as_json` instead, never
+        // touching `stream_json_value`'s own copy of this sort/key logic.
+        //
+        // A quoted key ("z") exercises the direct-transcode `Ok(true)` arm;
+        // an explicit complex key (`? {a: 1}`) -- `YamlValue` has no
+        // `Int`/`Bool` variant, so a plain scalar key like `2` is still
+        // `String`, see
+        // `test_stream_yaml_flow_mapping_sorts_keys_with_nonstring_key` --
+        // exercises the non-string-key branch, together with the sorted
+        // loop's indentation.
+        let yaml = b"\"z\": 1\n? {a: 1}\n: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index.root(yaml).first_child().unwrap();
+        let mut out = String::new();
+        doc_cursor
+            .stream_json(&mut out, IndentSpec::spaces(2), true)
+            .unwrap();
+        assert_eq!(out, "{\n  \"\": 2,\n  \"z\": 1\n}");
+    }
+
+    #[test]
+    fn test_stream_json_pretty_unsorted_with_quoted_and_nonstring_keys() {
+        // Same shape as above without `-S`: covers `stream_json_value`'s
+        // *unsorted* loop indentation, quoted-key, and non-string-key
+        // branches, which the sorted-loop test above doesn't reach (it's a
+        // separate code path, not shared).
+        let yaml = b"\"z\": 1\n? {a: 1}\n: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index.root(yaml).first_child().unwrap();
+        let mut out = String::new();
+        doc_cursor
+            .stream_json(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
+        assert_eq!(out, "{\n  \"z\": 1,\n  \"\": 2\n}");
+    }
+
+    #[test]
+    fn test_stream_json_sequence_of_mappings_sorts_keys_with_quoted_and_nonstring_keys() {
+        // A mapping *nested inside a sequence* converts through the
+        // free-function `stream_yaml_value_as_json` (not the cursor-method
+        // `stream_json_value` the two tests above cover) --
+        // `stream_json_value`'s own `Sequence` arm delegates to it per
+        // element. Same key-shape coverage goal as those tests, plus a
+        // plain unquoted key ("k") that the two tests above don't need: it
+        // exercises this path's `Ok(false)`-then-`as_str`-success arm,
+        // distinct from the quoted key's direct-transcode `Ok(true)`.
+        let yaml = b"- \"z\": 1\n  k: 2\n  ? {a: 1}\n  : 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_json_document(&mut out, IndentSpec::spaces(2), true)
+            .unwrap();
+        assert_eq!(
+            out,
+            "[\n  {\n    \"\": 3,\n    \"k\": 2,\n    \"z\": 1\n  }\n]"
+        );
+    }
+
+    #[test]
+    fn test_stream_json_sequence_of_mappings_unsorted_with_nonstring_key() {
+        // Same shape as above without `-S`: covers
+        // `stream_yaml_value_as_json`'s *unsorted* loop indentation,
+        // plain-key, and non-string-key branches, which the sorted-loop
+        // test above doesn't reach (it's a separate code path, not shared).
+        let yaml = b"- \"z\": 1\n  k: 2\n  ? {a: 1}\n  : 3\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_json_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
+        assert_eq!(
+            out,
+            "[\n  {\n    \"z\": 1,\n    \"k\": 2,\n    \"\": 3\n  }\n]"
+        );
+    }
+
+    #[test]
     fn test_stream_yaml_quoted_scalars_stay_quoted() {
         // #175: quoted source scalars are genuine strings and must keep their
         // quoting style so they don't turn into numbers/booleans on re-parse.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -857,6 +857,104 @@ fn test_duplicate_mapping_key_survives_computed_index() -> Result<()> {
     Ok(())
 }
 
+/// #733: `-S`/`--sort-keys` excluded identity/navigation queries from the M2
+/// cursor-streaming fast path, forcing them through the `OwnedValue` DOM
+/// (`IndexMap`-backed), which silently collapsed duplicate keys — the same
+/// bug class #442 fixed for the unadorned fast path. Fixed by teaching the
+/// YAML mapping cursor streamer to sort fields itself (materializing into a
+/// `Vec<YamlField>`, which stays duplicate-key-safe since sorting is stable
+/// and doesn't merge same-key entries) rather than excluding `-S` from the
+/// fast path. Uses an extra out-of-order, non-duplicate key (`b`) alongside
+/// the duplicate `a` pair so the test also confirms sorting still happens.
+#[test]
+fn test_duplicate_mapping_key_survives_sort_keys() -> Result<()> {
+    let yaml = "b: 1\na: 2\na: 3\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["-S"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 2\na: 3\nb: 1\n");
+
+    Ok(())
+}
+
+/// Same as [`test_duplicate_mapping_key_survives_sort_keys`], for `-o json`.
+#[test]
+fn test_duplicate_mapping_key_survives_sort_keys_json_output() -> Result<()> {
+    let yaml = "b: 1\na: 2\na: 3\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["-S", "-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "{\n  \"a\": 2,\n  \"a\": 3,\n  \"b\": 1\n}\n");
+
+    Ok(())
+}
+
+/// #733: `--tab` excluded identity/navigation queries from the M2
+/// cursor-streaming fast path for the same reason as `-S` above (the
+/// streamers only accepted a numeric space count, not a string/char indent
+/// unit), forcing the same `IndexMap`-backed DOM collapse. Fixed by
+/// threading an indent unit character through the streamers instead of a
+/// bare space count.
+#[test]
+fn test_duplicate_mapping_key_survives_tab() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["--tab"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\na: 2\n");
+
+    Ok(())
+}
+
+/// Same as [`test_duplicate_mapping_key_survives_tab`], for `-o json` —
+/// also confirms nested indentation actually uses a literal tab character.
+#[test]
+fn test_duplicate_mapping_key_survives_tab_json_output() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["--tab", "-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "{\n\t\"a\": 1,\n\t\"a\": 2\n}\n");
+
+    Ok(())
+}
+
+/// `-S` and `--tab` combined: both flags widen the same `can_stream_pretty`
+/// gate (#733), so confirm they compose correctly rather than one silently
+/// overriding the other.
+#[test]
+fn test_duplicate_mapping_key_survives_sort_keys_and_tab() -> Result<()> {
+    let yaml = "b: 1\na: 2\na: 3\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["-S", "--tab"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 2\na: 3\nb: 1\n");
+
+    let (json, code) = run_yq_stdin(".", yaml, &["-S", "--tab", "-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(json, "{\n\t\"a\": 2,\n\t\"a\": 3,\n\t\"b\": 1\n}\n");
+
+    Ok(())
+}
+
+/// `--tab`'s fix (#733) widened `can_stream_pretty`, which also covers
+/// `keys_unsorted` (part of `can_use_m2_streaming`) — not a duplicate-key
+/// case (keys_unsorted returns an array of key names, so nothing to
+/// collapse), but its lazy streamer (`stream_lazy_keys_json`/`_yaml` in
+/// `src/jq/stream.rs`) has its own indentation helper, independent of the
+/// mapping cursor streamer's. Guards against that helper silently emitting
+/// spaces instead of tabs now that this path is reachable with `--tab`.
+#[test]
+fn test_tab_indent_keys_unsorted() -> Result<()> {
+    let yaml = "b: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin("keys_unsorted", yaml, &["--tab", "-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[\n\t\"b\",\n\t\"a\"\n]\n");
+
+    Ok(())
+}
+
 /// #478: the `--inplace` fast path is scoped to M2-streamable expressions
 /// (identity/field/index/iterate); confirm field navigation still rewrites
 /// the file correctly, not just plain identity.


### PR DESCRIPTION
## Summary

- `yq -S`/`--sort-keys` and `--tab` excluded identity/navigation queries from the M2 cursor-streaming fast path, forcing them through the `OwnedValue::Object`/`IndexMap` DOM, which cannot represent duplicate mapping keys — the same collapse #442 fixed for plain pretty output. `yq -S '.'` on `a: 1\na: 2` printed only `a: 2`.
- Fixed by teaching the cursor/lazy streamers to sort and to accept a non-space indent unit, instead of excluding those flags from the fast path — the same pattern #442/#478/#607/#631 each used to close this bug class.
- `DocumentCursor::stream_json`/`stream_yaml` (and every implementation/caller) now take an `IndentSpec { width, unit }` plus a `sort_keys` flag instead of a bare space count.
- `YamlCursor`'s mapping streamer sorts by materializing a mapping's fields into a `Vec<YamlField>` (`Copy`, cursor-only) and stable-sorting by key, so duplicate keys stay adjacent instead of merging.
- `can_stream_pretty` now only excludes color (a separate, unreported latent instance of the same bug, left for a follow-up).
- Also fixes a `--tab`-only correctness gap the widened gate would otherwise introduce for `keys_unsorted`, which streams through its own separate indent-writing helper.

Fixes #733

## Test plan

- [x] `cargo test` (full suite): 2088 unit tests, 252 `yq` CLI tests (246 existing + 6 new), golden/byte-identity fixtures — all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the two other CI clippy feature combinations (`simd`, `broadword-yaml`) — clean
- [x] `cargo fmt --check` — clean
- [x] Manual repro of the issue's exact commands (`-S`, `--tab`, both combined, YAML and JSON output) — duplicates now survive, sort order verified with an out-of-order sibling key