### PR TITLE
fix(yaml): preserve trailing YAML line comments through yq (#710)

### DIFF
--- a/docs/plan/yq-remaining.md
+++ b/docs/plan/yq-remaining.md
@@ -23,14 +23,14 @@ See [yq Language Reference](../reference/yq-language.md) for implemented feature
 | Flag                   | Description                              |
 |------------------------|------------------------------------------|
 | `--explode-anchors`    | Expand anchor/alias references inline    |
-| `--preserve-comments`  | Preserve comments in YAML output         |
+| `--preserve-comments`  | Preserve comments in YAML output — partial (#710): always-on for trailing same-line comments on cursor-preserving paths (identity, navigation, filters, sort-keys); not yet for assignment |
 
 ## YAML Features (Low Priority)
 
 | Feature          | Description                              | Notes                    |
 |------------------|------------------------------------------|--------------------------|
 | Merge keys       | `<<: *alias` syntax                      | Complex semantics        |
-| Comment storage  | Store and query comments                 | Requires index changes   |
+| Comment storage  | Store and query trailing same-line comments | Implemented (#710) — `bp_to_line_comment` in the YAML semi-index, `line_comment` builtin. Standalone `head_comment`/`foot_comment` and assignment-path preservation remain open |
 
 ## Date Arithmetic (Low Priority)
 

--- a/docs/plan/yq.md
+++ b/docs/plan/yq.md
@@ -89,7 +89,7 @@ succinctly yq '.spec.containers[]' deployment.yaml service.yaml
 |------|-------------|--------|
 | `--output-format yaml` | Output format: `json` (default), `yaml` | ✅ |
 | `--no-doc` | Omit document separators (`---`) | ✅ |
-| `--preserve-comments` | Preserve comments in YAML output | ❌ Not planned |
+| `--preserve-comments` | Preserve comments in YAML output | 🟡 Partial, always-on (#710) — no flag; see notes below |
 | `--explode-anchors` | Expand anchor/alias references | ❌ Not planned |
 | `--doc N` | Select Nth document from multi-doc stream (0-indexed) | ✅ |
 | `--all-documents` | Process all documents | ✅ Default behavior |
@@ -137,8 +137,15 @@ succinctly yq '.spec.containers[]' deployment.yaml service.yaml
 
 **Not Implemented** (low priority):
 - [ ] `--explode-anchors` flag
-- [ ] `--preserve-comments` flag
 - [ ] Merge keys (`<<: *alias`)
+
+**Partial** (#710): trailing same-line comments (`a: 1 # comment`) are
+captured and preserved through output, always-on (no `--preserve-comments`
+flag needed or planned) — but only on paths that keep a live YAML cursor
+(identity, field/index navigation, filters like `select`, `-S`/sort-keys).
+Assignment (`=`, `|=`, ...) and other value-constructing expressions fall
+through a JSON-round-trip evaluator path that has no comment data to carry;
+see the `comments` row below and the tracking issue for the follow-up.
 
 ---
 
@@ -179,13 +186,15 @@ succinctly yq '.spec.containers[]' deployment.yaml service.yaml
 - [x] `style` - Return scalar/collection style (double, single, literal, folded, flow, or empty)
 - [x] `kind` - Return node kind (scalar, seq, map, alias)
 - [x] `key` - Return current key when iterating (string for objects, int for arrays)
+- [x] `line_comment` - Return trailing same-line comment text, or `""` (#710)
 
 **Not Implemented** (low priority):
 
 | Operator | Description | Status |
 |----------|-------------|--------|
 | `has_anchor` | Check if node has anchor | ❌ (use `anchor != ""`) |
-| `comments` | Get associated comments | ❌ (not stored in index) |
+| `head_comment` / `foot_comment` | Get standalone-line comments before/after a node | ❌ (deferred, #710 scoped to trailing line comments only) |
+| `comments` (get/set forms beyond `line_comment`) | Full comment API parity with real `yq` | ❌ (deferred) |
 
 ---
 
@@ -693,6 +702,13 @@ This plan depends on the YAML parser implementation phases defined in [parsing/y
 
 3. **Comment handling**: How to expose comments in queries?
    - *Decision*: Deferred - implement on user demand
+   - *Update (#710)*: Implemented for trailing same-line comments — capture
+     in the semi-index, a `line_comment` getter builtin, and preservation
+     through output, always-on by default (matching real `yq`, no flag).
+     Scoped to paths that keep a live cursor (identity, navigation, filters,
+     sort-keys); assignment and other value-constructing expressions are a
+     tracked follow-up. `head_comment`/`foot_comment` (standalone-line
+     comments) remain deferred.
 
 4. **Schema validation**: Should yq validate against YAML schemas?
    - *Decision*: Out of scope (separate tool concern)

--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -228,6 +228,7 @@ The implementation covers ~95% of jq functionality and is production-ready.
 - [x] `line` - return 1-based line number of current node
 - [x] `column` - return 1-based column number of current node
 - [x] `document_index` / `di` - return 0-indexed document position in multi-doc stream
+- [x] `line_comment` - return trailing same-line comment text (e.g. `"keep this"` for `a: 1 # keep this`), or `""` if absent (#710)
 - [x] `shuffle` - randomly shuffle array elements
 - [x] `pivot` - transpose arrays/objects
 - [x] `split_doc` - mark outputs as separate YAML documents
@@ -244,6 +245,21 @@ The implementation covers ~95% of jq functionality and is production-ready.
 - `cursor.kind()` → `&'static str` - structural kind ("scalar", "seq", "map", "alias")
 - `cursor.line()` → `usize` - 1-based line number
 - `cursor.column()` → `usize` - 1-based column number
+- `cursor.line_comment()` → `Option<&str>` - trailing same-line comment, stripped of leading `#`/space (#710)
+- `cursor.line_comment_raw()` → `Option<&str>` - the same comment, `#` and all, as written to output
+
+**`line_comment` scope (#710)**: like `line`/`column`, works correctly on any
+path that keeps a live cursor — identity, field/index navigation
+(`.foo`, `.[0]`, `.[]`), `select(...)`, and other pure-navigation filters.
+Output preservation (not just the getter) shares this scope: identity,
+navigation, filters, and `-S`/`--sort-keys` all correctly keep trailing
+comments in their output. Assignment (`=`, `|=`, `+=`, ...) and other
+value-constructing expressions fall through a JSON-round-trip evaluation
+path with no comment data to carry, so comments are dropped there — for the
+whole document, not just the assigned field. This is a known gap, not
+silent data loss introduced by this feature; see the tracking issue for the
+planned follow-up. `head_comment`/`foot_comment` (standalone-line comments,
+as opposed to a trailing same-line comment) are not implemented at all.
 
 ### Module System
 - [x] `import "path" as name;` - Import module with namespace
@@ -430,3 +446,4 @@ cargo test --features cli,regex --test jq_error_message_tests
 | 2026-01-24 | Clarified YAML metadata: `alias` is cursor-level API only (not a jq builtin)|
 | 2026-01-24 | Updated coverage to 100% for most categories after comprehensive code review|
 | 2026-08-10 | Fixed `anchor`/`style` jq builtins to resolve real YAML metadata via cursor (previously hardcoded to always return `""`) (#709, ✅ complete)|
+| 2026-08-10 | Added `line_comment` yq builtin and trailing same-line comment preservation on cursor-preserving output paths (#710, ✅ partial - assignment paths not yet covered)|

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -354,7 +354,10 @@ fn evaluate_yaml_direct_filtered(
             Ok((doc_results, local_idx))
         }
         _ => {
-            // Single document - navigate to actual content
+            // Defensive fallback only, same as the inplace fast path's
+            // identical `_ =>` arm below: `root.value()` always reports the
+            // virtual document sequence (single documents included), so
+            // this arm is unreachable through any real input today.
             let should_eval = match doc_filter {
                 Some((target_doc, global_offset)) => global_offset == target_doc,
                 None => true,
@@ -549,6 +552,14 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     };
 
     // Convert GenericResult to Vec<ResultWithComments>
+    //
+    // `One`/`Many` (as opposed to `OneCursor`/`ManyCursor`) only ever arise
+    // from `eval_generic.rs`'s cursor-loss cascade, which requires an
+    // already-cursor-less value to begin with (e.g. via the cursor-less
+    // `eval()` entry point `jq`'s DOM path uses) — this function always
+    // starts `eval_with_cursor_using` from a real `cursor`, so these two
+    // arms are defensive/unreachable here today, kept for exhaustiveness
+    // over the shared `GenericResult` enum.
     let mut docs = match result {
         GenericResult::One(v) => Ok(vec![no_comments(to_owned(&v))]),
         GenericResult::OneCursor(c) => Ok(vec![owned_with_comments(&c)]),

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -323,6 +323,7 @@ fn evaluate_yaml_direct_filtered(
     expr: &Expr,
     doc_filter: Option<(usize, usize)>,
     sink: &mut ErrorSink,
+    need_comments: bool,
 ) -> Result<(Vec<Vec<ResultWithComments>>, usize)> {
     let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
     let root = index.root(bytes);
@@ -340,7 +341,7 @@ fn evaluate_yaml_direct_filtered(
                 };
 
                 if should_eval {
-                    let results = evaluate_yaml_cursor(cursor, expr, sink)?;
+                    let results = evaluate_yaml_cursor(cursor, expr, sink, need_comments)?;
                     // Only include documents that have results (select may filter them out)
                     if !results.is_empty() {
                         doc_results.push(results);
@@ -361,7 +362,7 @@ fn evaluate_yaml_direct_filtered(
 
             if should_eval {
                 if let Some(content_cursor) = root.first_child() {
-                    let results = evaluate_yaml_cursor(content_cursor, expr, sink)?;
+                    let results = evaluate_yaml_cursor(content_cursor, expr, sink, need_comments)?;
                     Ok((vec![results], 1))
                 } else {
                     // Empty document
@@ -523,6 +524,7 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     cursor: YamlCursor<'_, W>,
     expr: &Expr,
     sink: &mut ErrorSink,
+    need_comments: bool,
 ) -> Result<Vec<ResultWithComments>> {
     // Snapshot alias-sync context from the pristine document *before*
     // evaluation, only when it could possibly matter (#711): an
@@ -534,16 +536,24 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
 
     let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
     let no_comments = |v| (v, CommentTree::empty());
+    // `to_owned_with_comments` builds a full parallel `IndexMap`/`Vec` tree
+    // alongside the `OwnedValue` one, just to carry comment text - wasted
+    // work when the caller can't use it (`-o json`'s output never reads
+    // `CommentTree` at all; see `output_value`'s JSON branch) (#710).
+    let owned_with_comments = |c: &YamlCursor<'_, W>| {
+        if need_comments {
+            to_owned_with_comments(&c.value(), Some(c))
+        } else {
+            no_comments(to_owned(&c.value()))
+        }
+    };
 
     // Convert GenericResult to Vec<ResultWithComments>
     let mut docs = match result {
         GenericResult::One(v) => Ok(vec![no_comments(to_owned(&v))]),
-        GenericResult::OneCursor(c) => Ok(vec![to_owned_with_comments(&c.value(), Some(&c))]),
+        GenericResult::OneCursor(c) => Ok(vec![owned_with_comments(&c)]),
         GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).map(no_comments).collect()),
-        GenericResult::ManyCursor(cs) => Ok(cs
-            .iter()
-            .map(|c| to_owned_with_comments(&c.value(), Some(c)))
-            .collect()),
+        GenericResult::ManyCursor(cs) => Ok(cs.iter().map(owned_with_comments).collect()),
         // This is the DOM/slow path (`evaluate_yaml_direct_filtered`'s
         // fallback), reached only when `can_use_m2_streaming` rejects the
         // expression or a flag (`--sort-keys`, color, `--tab`, `--slurp`,
@@ -2268,8 +2278,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // Filter at evaluation time to avoid evaluating (and printing errors for)
                     // documents that don't match the --doc filter
                     let doc_filter = args.document.map(|target| (target, global_doc_index));
-                    let (doc_results, num_docs) =
-                        evaluate_yaml_direct_filtered(bytes, &program.expr, doc_filter, &mut sink)?;
+                    // JSON output never reads `CommentTree` (see
+                    // `output_value`'s JSON branch), so don't build one (#710).
+                    let need_comments = output_config.output_format == OutputFormat::Yaml;
+                    let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
+                        bytes,
+                        &program.expr,
+                        doc_filter,
+                        &mut sink,
+                        need_comments,
+                    )?;
                     global_doc_index += num_docs;
                     all_results.push(doc_results);
                 }
@@ -2620,7 +2638,8 @@ mod tests {
     /// (issue #710) instead of discarding it.
     fn eval_yaml_with_comments(bytes: &[u8], expr: &Expr) -> Vec<ResultWithComments> {
         let (groups, _) =
-            evaluate_yaml_direct_filtered(bytes, expr, None, &mut ErrorSink::default()).unwrap();
+            evaluate_yaml_direct_filtered(bytes, expr, None, &mut ErrorSink::default(), true)
+                .unwrap();
         groups.into_iter().flatten().collect()
     }
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -11,7 +11,9 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{DocumentCursor, DocumentFields, IndentSpec};
-use succinctly::jq::eval_generic::{eval_with_cursor_using, to_owned, GenericResult};
+use succinctly::jq::eval_generic::{
+    eval_with_cursor_using, to_owned, to_owned_with_comments, CommentTree, GenericResult,
+};
 use succinctly::jq::{
     self, sync_aliased_paths, Builtin, Expr, OwnedValue, QueryResult, YqSemantics,
 };
@@ -304,6 +306,9 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
     }
 }
 
+/// A single jq result value paired with its parallel [`CommentTree`] (issue #710).
+type ResultWithComments = (OwnedValue, CommentTree);
+
 /// Evaluate YAML input directly using the generic evaluator with per-document processing.
 ///
 /// This processes YAML documents directly without intermediate OwnedValue conversion,
@@ -318,7 +323,7 @@ fn evaluate_yaml_direct_filtered(
     expr: &Expr,
     doc_filter: Option<(usize, usize)>,
     sink: &mut ErrorSink,
-) -> Result<(Vec<Vec<OwnedValue>>, usize)> {
+) -> Result<(Vec<Vec<ResultWithComments>>, usize)> {
     let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
     let root = index.root(bytes);
 
@@ -510,11 +515,15 @@ fn walk_alias_groups<W: AsRef<[u64]> + Clone>(
 /// Evaluate a jq expression directly on a YAML cursor.
 ///
 /// This uses the generic evaluator to preserve position metadata (line/column).
+/// Each result carries its parallel [`CommentTree`] (issue #710) — real for
+/// `OneCursor`/`ManyCursor` (still-live cursor), [`CommentTree::empty`]
+/// everywhere else (an already-materialized/computed value, comment-less by
+/// construction — see [`CommentTree`]'s own doc comment for why).
 fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     cursor: YamlCursor<'_, W>,
     expr: &Expr,
     sink: &mut ErrorSink,
-) -> Result<Vec<OwnedValue>> {
+) -> Result<Vec<ResultWithComments>> {
     // Snapshot alias-sync context from the pristine document *before*
     // evaluation, only when it could possibly matter (#711): an
     // assignment-family expression against a document that actually has
@@ -524,13 +533,17 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         .then(|| (to_owned(&cursor.value()), collect_alias_groups(cursor)));
 
     let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
+    let no_comments = |v| (v, CommentTree::empty());
 
-    // Convert GenericResult to Vec<OwnedValue>
+    // Convert GenericResult to Vec<ResultWithComments>
     let mut docs = match result {
-        GenericResult::One(v) => Ok(vec![to_owned(&v)]),
-        GenericResult::OneCursor(c) => Ok(vec![to_owned(&c.value())]),
-        GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).collect()),
-        GenericResult::ManyCursor(cs) => Ok(cs.iter().map(|c| to_owned(&c.value())).collect()),
+        GenericResult::One(v) => Ok(vec![no_comments(to_owned(&v))]),
+        GenericResult::OneCursor(c) => Ok(vec![to_owned_with_comments(&c.value(), Some(&c))]),
+        GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).map(no_comments).collect()),
+        GenericResult::ManyCursor(cs) => Ok(cs
+            .iter()
+            .map(|c| to_owned_with_comments(&c.value(), Some(c)))
+            .collect()),
         // This is the DOM/slow path (`evaluate_yaml_direct_filtered`'s
         // fallback), reached only when `can_use_m2_streaming` rejects the
         // expression or a flag (`--sort-keys`, color, `--tab`, `--slurp`,
@@ -553,20 +566,20 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
             if sorted {
                 keys.sort();
             }
-            Ok(vec![OwnedValue::Array(
+            Ok(vec![no_comments(OwnedValue::Array(
                 keys.into_iter().map(OwnedValue::String).collect(),
-            )])
+            ))])
         }
         // Same reasoning as `LazyKeys` above, for array `keys`/
         // `keys_unsorted` (#684).
-        GenericResult::LazyIndexRange(len) => Ok(vec![OwnedValue::Array(
+        GenericResult::LazyIndexRange(len) => Ok(vec![no_comments(OwnedValue::Array(
             (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
-        )]),
+        ))]),
         // Same reasoning as `LazyKeys`/`LazyIndexRange` above, for a
         // composed `map` chain (#724, #725) that never resolved into a
         // narrower shape before reaching this materializing DOM boundary.
         GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
-            Ok(v) => Ok(vec![v]),
+            Ok(v) => Ok(vec![no_comments(v)]),
             Err(jq::Control::Error(e)) => {
                 sink.report(DiagStyle::Yq, &e, &no_location());
                 Ok(vec![])
@@ -581,8 +594,8 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
             sink.report(DiagStyle::Yq, &e, &no_location());
             Ok(vec![])
         }
-        GenericResult::Owned(v) => Ok(vec![v]),
-        GenericResult::ManyOwned(vs) => Ok(vs),
+        GenericResult::Owned(v) => Ok(vec![no_comments(v)]),
+        GenericResult::ManyOwned(vs) => Ok(vs.into_iter().map(no_comments).collect()),
         GenericResult::Break(label) => {
             sink.report_break(DiagStyle::Yq, &label, &no_location());
             Ok(vec![])
@@ -591,18 +604,18 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         // (#400, #494).
         GenericResult::Partial(vs, jq::Control::Error(e)) => {
             sink.report(DiagStyle::Yq, &e, &no_location());
-            Ok(vs)
+            Ok(vs.into_iter().map(no_comments).collect())
         }
         GenericResult::Partial(vs, jq::Control::Break(label)) => {
             sink.report_break(DiagStyle::Yq, &label, &no_location());
-            Ok(vs)
+            Ok(vs.into_iter().map(no_comments).collect())
         }
     };
 
     if let Some((pristine, groups)) = &alias_sync_ctx {
         if let Ok(docs) = &mut docs {
-            for doc in docs.iter_mut() {
-                sync_aliased_paths(doc, pristine, groups);
+            for (value, _comments) in docs.iter_mut() {
+                sync_aliased_paths(value, pristine, groups);
             }
         }
     }
@@ -699,8 +712,16 @@ fn write_terminator<W: Write>(writer: &mut W, config: &OutputConfig) -> Result<(
     Ok(())
 }
 
-/// Format and output a value.
-fn output_value<W: Write>(writer: &mut W, value: &OwnedValue, config: &OutputConfig) -> Result<()> {
+/// Format and output a value, threading `comments` through to `emit_yaml_value`
+/// (issue #710). Callers with no cursor-derived comment data (JSON input,
+/// `--null-input`, `--raw-input`, `--slurp`, `--inplace`'s slow path) pass
+/// `&CommentTree::empty()`.
+fn output_value<W: Write>(
+    writer: &mut W,
+    value: &OwnedValue,
+    comments: &CommentTree,
+    config: &OutputConfig,
+) -> Result<()> {
     // Handle raw output for scalars
     if config.raw_output {
         if let OwnedValue::String(s) = value {
@@ -713,7 +734,14 @@ fn output_value<W: Write>(writer: &mut W, value: &OwnedValue, config: &OutputCon
     // For YAML output format (default)
     if config.output_format == OutputFormat::Yaml {
         // For YAML, scalars are printed without quotes by default (like -r in yq)
-        let output = emit_yaml_value(value, config, 0, false);
+        let body = emit_yaml_value(value, comments, config, 0, false);
+        // Every non-root node's own trailing comment is appended by its
+        // *parent* during `emit_yaml_value`'s recursion (see its Array/Object
+        // arms), but the root has no parent call site to do that for it —
+        // append it here instead, or a comment trailing the jq result's own
+        // top-level node (e.g. `42 # trailing`) is silently dropped (#710).
+        let root_comment_suffix = comments.own().map_or_else(String::new, |c| format!(" {c}"));
+        let output = format!("{body}{root_comment_suffix}");
         if config.use_color {
             write!(writer, "{}", colorize_yaml(&output))?;
         } else {
@@ -763,9 +791,13 @@ fn output_value<W: Write>(writer: &mut W, value: &OwnedValue, config: &OutputCon
     Ok(())
 }
 
-/// Emit a YAML value as a string.
+/// Emit a YAML value as a string, appending each node's trailing same-line
+/// comment from the parallel `comments` tree (issue #710). Flow-style
+/// (`in_flow`) contexts never append one — flow items are comma-joined on
+/// one line, so there's no meaningful "trailing" position between them.
 fn emit_yaml_value(
     value: &OwnedValue,
+    comments: &CommentTree,
     config: &OutputConfig,
     depth: usize,
     in_flow: bool,
@@ -808,7 +840,8 @@ fn emit_yaml_value(
                 // Flow style for nested in flow context
                 let items: Vec<_> = arr
                     .iter()
-                    .map(|v| emit_yaml_value(v, config, depth, true))
+                    .enumerate()
+                    .map(|(i, v)| emit_yaml_value(v, comments.at_index(i), config, depth, true))
                     .collect();
                 format!("[{}]", items.join(", "))
             } else {
@@ -816,17 +849,22 @@ fn emit_yaml_value(
                 let indent = config.indent_str.repeat(depth);
                 let items: Vec<_> = arr
                     .iter()
-                    .map(|v| {
-                        let item = emit_yaml_value(v, config, depth + 1, false);
+                    .enumerate()
+                    .map(|(i, v)| {
+                        let elem_comments = comments.at_index(i);
+                        let item = emit_yaml_value(v, elem_comments, config, depth + 1, false);
+                        let comment_suffix = elem_comments
+                            .own()
+                            .map_or_else(String::new, |c| format!(" {c}"));
                         // Check if it's a multi-line value (mapping or sequence)
                         if matches!(v, OwnedValue::Object(_) | OwnedValue::Array(_))
                             && !item.starts_with('[')
                             && !item.starts_with('{')
                         {
                             // Multi-line value - emit nested content which handles its own indentation
-                            format!("{indent}-\n{item}")
+                            format!("{indent}-\n{item}{comment_suffix}")
                         } else {
-                            format!("{indent}- {item}")
+                            format!("{indent}- {item}{comment_suffix}")
                         }
                     })
                     .collect();
@@ -842,7 +880,7 @@ fn emit_yaml_value(
                     .iter()
                     .map(|(k, v)| {
                         let key = yaml_quote_key(k);
-                        let val = emit_yaml_value(v, config, depth, true);
+                        let val = emit_yaml_value(v, comments.field(k), config, depth, true);
                         format!("{key}: {val}")
                     })
                     .collect();
@@ -862,16 +900,20 @@ fn emit_yaml_value(
                     .iter()
                     .map(|(k, v)| {
                         let key = yaml_quote_key(k);
+                        let field_comments = comments.field(k);
+                        let comment_suffix = field_comments
+                            .own()
+                            .map_or_else(String::new, |c| format!(" {c}"));
                         // Check if value needs to be on next line
                         if matches!(v, OwnedValue::Object(m) if !m.is_empty())
                             || matches!(v, OwnedValue::Array(a) if !a.is_empty())
                         {
                             // For nested containers, emit at depth+1 which handles its own indentation
-                            let val = emit_yaml_value(v, config, depth + 1, false);
-                            format!("{indent}{key}:\n{val}")
+                            let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
+                            format!("{indent}{key}:\n{val}{comment_suffix}")
                         } else {
-                            let val = emit_yaml_value(v, config, depth + 1, false);
-                            format!("{indent}{key}: {val}")
+                            let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
+                            format!("{indent}{key}: {val}{comment_suffix}")
                         }
                     })
                     .collect();
@@ -1848,7 +1890,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         for result in results {
             split_doc_state.write_separator(&mut writer, &output_config)?;
             any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-            output_value(&mut writer, &result, &output_config)?;
+            output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
         }
     } else if args.raw_input {
         // Handle --raw-input: read each line as a string instead of parsing as YAML
@@ -1874,7 +1916,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             for result in results {
                 split_doc_state.write_separator(&mut writer, &output_config)?;
                 any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                output_value(&mut writer, &result, &output_config)?;
+                output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
             }
         } else {
             // Without --slurp, process each line independently
@@ -1884,7 +1926,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 for result in results {
                     split_doc_state.write_separator(&mut writer, &output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                    output_value(&mut writer, &result, &output_config)?;
+                    output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
                 }
             }
         }
@@ -2014,7 +2056,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             for result in results {
                 split_doc_state.write_separator(&mut writer, &output_config)?;
                 any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                output_value(&mut writer, &result, &output_config)?;
+                output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
             }
         }
     } else if args.inplace {
@@ -2153,7 +2195,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         split_doc_state.write_separator(&mut buf_writer, &no_color_config)?;
                         any_truthy |=
                             !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                        output_value(&mut buf_writer, &result, &no_color_config)?;
+                        output_value(
+                            &mut buf_writer,
+                            &result,
+                            &CommentTree::empty(),
+                            &no_color_config,
+                        )?;
                     }
                 }
                 buf_writer.flush()?;
@@ -2195,8 +2242,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
         // Process all inputs first to collect results, then determine multi-doc status
         // This avoids double-parsing YAML for document counting
-        // Each entry in all_results is a Vec of document results from one file
-        let mut all_results: Vec<Vec<Vec<OwnedValue>>> = Vec::new();
+        // Each entry in all_results is a Vec of document results from one file.
+        // Each result carries its parallel CommentTree (issue #710); JSON
+        // input has none, so it's paired with CommentTree::empty().
+        let mut all_results: Vec<Vec<Vec<ResultWithComments>>> = Vec::new();
         let mut global_doc_index: usize = 0;
         for (bytes, format) in &input_sources {
             match format {
@@ -2223,7 +2272,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             }
                         }
                         let results = evaluate_input(&input, &program.expr, &mut sink)?;
-                        json_results.push(results);
+                        json_results.push(
+                            results
+                                .into_iter()
+                                .map(|v| (v, CommentTree::empty()))
+                                .collect::<Vec<_>>(),
+                        );
                         global_doc_index += 1;
                     }
                     all_results.push(json_results);
@@ -2249,10 +2303,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 {
                     writeln!(writer, "---")?;
                 }
-                for result in results {
+                for (result, comments) in results {
                     split_doc_state.write_separator(&mut writer, &output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                    output_value(&mut writer, &result, &output_config)?;
+                    output_value(&mut writer, &result, &comments, &output_config)?;
                 }
             }
         }
@@ -2343,14 +2397,23 @@ mod tests {
         };
 
         let nan = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into());
-        assert_eq!(emit_yaml_value(&nan, &config, 0, false), ".nan");
+        assert_eq!(
+            emit_yaml_value(&nan, &CommentTree::empty(), &config, 0, false),
+            ".nan"
+        );
 
         let pos_inf = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1e400".into());
-        assert_eq!(emit_yaml_value(&pos_inf, &config, 0, false), ".inf");
+        assert_eq!(
+            emit_yaml_value(&pos_inf, &CommentTree::empty(), &config, 0, false),
+            ".inf"
+        );
 
         let neg_inf =
             OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-1e400".into());
-        assert_eq!(emit_yaml_value(&neg_inf, &config, 0, false), "-.inf");
+        assert_eq!(
+            emit_yaml_value(&neg_inf, &CommentTree::empty(), &config, 0, false),
+            "-.inf"
+        );
     }
 
     #[test]
@@ -2533,6 +2596,15 @@ mod tests {
 
     /// Evaluate YAML through the production path and flatten per-document groups.
     fn eval_yaml(bytes: &[u8], expr: &Expr) -> Vec<OwnedValue> {
+        eval_yaml_with_comments(bytes, expr)
+            .into_iter()
+            .map(|(v, _)| v)
+            .collect()
+    }
+
+    /// Like [`eval_yaml`], but keeps each result's parallel `CommentTree`
+    /// (issue #710) instead of discarding it.
+    fn eval_yaml_with_comments(bytes: &[u8], expr: &Expr) -> Vec<ResultWithComments> {
         let (groups, _) =
             evaluate_yaml_direct_filtered(bytes, expr, None, &mut ErrorSink::default()).unwrap();
         groups.into_iter().flatten().collect()

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -757,7 +757,7 @@ fn output_value<W: Write>(
         // quirk, not a succinctly gap, so replicated here rather than
         // "fixed" into a new divergence.
         let root_comment_suffix = if matches!(value, OwnedValue::Array(_) | OwnedValue::Object(_)) {
-            comments.own().map_or_else(String::new, |c| format!(" {c}"))
+            trailing_comment_suffix(comments)
         } else {
             String::new()
         };
@@ -809,6 +809,13 @@ fn output_value<W: Write>(
     write_terminator(writer, config)?;
 
     Ok(())
+}
+
+/// Format a node's own trailing comment (issue #710) as `" # text"`, or
+/// `""` if it has none — the single point of change for the separator
+/// convention shared by every `emit_yaml_value` call site that appends one.
+fn trailing_comment_suffix(comments: &CommentTree) -> String {
+    comments.own().map_or_else(String::new, |c| format!(" {c}"))
 }
 
 /// Emit a YAML value as a string, appending each node's trailing same-line
@@ -873,9 +880,7 @@ fn emit_yaml_value(
                     .map(|(i, v)| {
                         let elem_comments = comments.at_index(i);
                         let item = emit_yaml_value(v, elem_comments, config, depth + 1, false);
-                        let comment_suffix = elem_comments
-                            .own()
-                            .map_or_else(String::new, |c| format!(" {c}"));
+                        let comment_suffix = trailing_comment_suffix(elem_comments);
                         // Check if it's a multi-line value (mapping or sequence)
                         if matches!(v, OwnedValue::Object(_) | OwnedValue::Array(_))
                             && !item.starts_with('[')
@@ -921,9 +926,7 @@ fn emit_yaml_value(
                     .map(|(k, v)| {
                         let key = yaml_quote_key(k);
                         let field_comments = comments.field(k);
-                        let comment_suffix = field_comments
-                            .own()
-                            .map_or_else(String::new, |c| format!(" {c}"));
+                        let comment_suffix = trailing_comment_suffix(field_comments);
                         // Check if value needs to be on next line
                         if matches!(v, OwnedValue::Object(m) if !m.is_empty())
                             || matches!(v, OwnedValue::Array(a) if !a.is_empty())

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -739,8 +739,18 @@ fn output_value<W: Write>(
         // *parent* during `emit_yaml_value`'s recursion (see its Array/Object
         // arms), but the root has no parent call site to do that for it —
         // append it here instead, or a comment trailing the jq result's own
-        // top-level node (e.g. `42 # trailing`) is silently dropped (#710).
-        let root_comment_suffix = comments.own().map_or_else(String::new, |c| format!(" {c}"));
+        // top-level node (e.g. `[1, 2, 3] # trailing`) is silently dropped
+        // (#710). Scalars are excluded: verified against the pinned real
+        // `yq` binary, a bare scalar document (`42 # trailing`) drops its
+        // own trailing comment from output on both identity and `select`,
+        // even though `line_comment` still returns it — real `yq`'s own
+        // quirk, not a succinctly gap, so replicated here rather than
+        // "fixed" into a new divergence.
+        let root_comment_suffix = if matches!(value, OwnedValue::Array(_) | OwnedValue::Object(_)) {
+            comments.own().map_or_else(String::new, |c| format!(" {c}"))
+        } else {
+            String::new()
+        };
         let output = format!("{body}{root_comment_suffix}");
         if config.use_color {
             write!(writer, "{}", colorize_yaml(&output))?;
@@ -1654,10 +1664,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 if $is_yaml {
                     // M2 YAML path: YAML output streaming
                     if is_identity {
-                        // P9 path: stream directly without evaluation
+                        // P9 path: stream directly without evaluation.
+                        // `stream_yaml_as_document` (not `stream_yaml`) since
+                        // `$cursor` here is the whole document being
+                        // redisplayed as itself - its own trailing comment,
+                        // if any, must be kept (#710).
                         emit_yaml_doc_separator($writer, $doc_streamed, true)?;
                         $cursor
-                            .stream_yaml(&mut FmtWriter($writer), yaml_indent, sort_keys)
+                            .stream_yaml_as_document(&mut FmtWriter($writer), yaml_indent, sort_keys)
                             .map_err(|_| anyhow::anyhow!("Write error"))?;
                         writeln!($writer)?;
                         // Streaming skips evaluation, so inspect the document

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2462,6 +2462,55 @@ mod tests {
         );
     }
 
+    /// `in_flow: true` is never reached through any CLI-observable path
+    /// today (`output_value`'s only call site always starts at `false`, and
+    /// nothing downstream re-enters flow style) - `can_use_m2_streaming`'s
+    /// doc comment notes there's no `--flow`-style output flag yet. Call the
+    /// private helper directly, mirroring the NaN/Infinity test above, to
+    /// pin the flow-style Array/Object arms' comment threading (#710):
+    /// `comments.at_index`/`comments.field` must recurse correctly even
+    /// though flow style never appends a trailing comment of its own (see
+    /// `emit_yaml_value`'s own doc comment for why).
+    #[test]
+    fn test_emit_yaml_value_flow_style_threads_comments_without_appending_them() {
+        let config = OutputConfig {
+            output_format: OutputFormat::Yaml,
+            compact: true,
+            raw_output: false,
+            join_output: false,
+            nul_output: false,
+            ascii_output: false,
+            sort_keys: false,
+            no_doc: false,
+            indent_str: String::new(),
+            use_color: false,
+        };
+
+        let mut obj = IndexMap::new();
+        obj.insert("k".to_string(), OwnedValue::Int(1));
+        let value = OwnedValue::Array(vec![OwnedValue::Object(obj)]);
+
+        let mut obj_comments = IndexMap::new();
+        obj_comments.insert(
+            "k".to_string(),
+            CommentTree::Leaf(Some("# k trailing".to_string())),
+        );
+        let comments = CommentTree::Array(
+            None,
+            vec![CommentTree::Object(
+                Some("# obj trailing".to_string()),
+                obj_comments,
+            )],
+        );
+
+        // Flow style renders compactly and drops every trailing comment,
+        // whether on the nested object or its field - unlike block style.
+        assert_eq!(
+            emit_yaml_value(&value, &comments, &config, 0, true),
+            "[{k: 1}]"
+        );
+    }
+
     #[test]
     fn test_yaml_to_owned_value_bool() {
         let yaml = b"active: true";

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -119,6 +119,34 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         ""
     }
 
+    /// Get this node's trailing same-line comment text, with the leading
+    /// `#`/space stripped (the `line_comment` jq builtin, issue #710).
+    ///
+    /// Returns `None` if this node has no trailing comment, or for formats
+    /// without comments at all (e.g. JSON) — the "not available" contract
+    /// mirrors [`line`](Self::line)/[`column`](Self::column): the builtin
+    /// itself maps `None` to `""`, matching real `yq`.
+    ///
+    /// Owned rather than borrowed: a trait method's `&self` elides to a
+    /// lifetime scoped to the borrow at the call site, which for a `Copy`
+    /// cursor obtained from e.g. `Option<V::Cursor>::and_then` can be
+    /// shorter than the cursor's own internal `'a` — too short to hand back
+    /// a `&str` slice of the source text. Comments are rare enough per
+    /// document that the allocation only on actual read is not a concern.
+    fn line_comment(&self) -> Option<String> {
+        None
+    }
+
+    /// Get this node's trailing same-line comment, `#` and all, exactly as
+    /// it appears in the source (issue #710) — used by the write path
+    /// ([`crate::jq::eval_generic::to_owned_with_comments`]) to re-emit it
+    /// verbatim. See [`line_comment`](Self::line_comment) for the stripped
+    /// getter form the jq builtin uses; the two intentionally differ (this
+    /// one keeps the `#`, that one usually doesn't).
+    fn line_comment_raw(&self) -> Option<String> {
+        None
+    }
+
     /// Create a cursor at the specified byte offset (0-indexed).
     ///
     /// Returns None if:

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2352,6 +2352,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::Line => builtin_line::<W>(),
         Builtin::Column => builtin_column::<W>(),
         Builtin::DocumentIndex => builtin_document_index::<W>(),
+        Builtin::LineComment => builtin_line_comment::<W>(),
         Builtin::Shuffle => builtin_shuffle::<W>(value, optional),
         Builtin::Pivot => builtin_pivot::<W>(value, optional),
         Builtin::SplitDoc => {
@@ -9971,6 +9972,7 @@ fn substitute_var_in_builtin(
         Builtin::Line => Builtin::Line,
         Builtin::Column => Builtin::Column,
         Builtin::DocumentIndex => Builtin::DocumentIndex,
+        Builtin::LineComment => Builtin::LineComment,
         Builtin::Shuffle => Builtin::Shuffle,
         Builtin::Pivot => Builtin::Pivot,
         Builtin::SplitDoc => Builtin::SplitDoc,
@@ -15450,6 +15452,7 @@ fn builtin_builtins<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
         "key/0",
         "line/0",
         "column/0",
+        "line_comment/0",
         "parent/0",
         "parent/1",
     ];
@@ -16927,6 +16930,15 @@ fn builtin_document_index<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
     QueryResult::Owned(OwnedValue::Int(0))
 }
 
+/// `line_comment` - returns the trailing same-line comment text, or `""` (yq, #710)
+///
+/// See [`builtin_line`]: same reason, same evaluator, same permanent `""`
+/// (matching real `yq`'s empty-string default, verified empirically — not
+/// `null`).
+fn builtin_line_comment<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
+    QueryResult::Owned(OwnedValue::String(String::new()))
+}
+
 /// `shuffle` - randomly shuffle array elements (yq)
 /// Uses non-cryptographic RNG for performance.
 #[cfg(feature = "cli")]
@@ -18079,6 +18091,7 @@ fn expand_func_calls_in_builtin(
         Builtin::Line => Builtin::Line,
         Builtin::Column => Builtin::Column,
         Builtin::DocumentIndex => Builtin::DocumentIndex,
+        Builtin::LineComment => Builtin::LineComment,
         Builtin::Shuffle => Builtin::Shuffle,
         Builtin::Pivot => Builtin::Pivot,
         Builtin::SplitDoc => Builtin::SplitDoc,
@@ -18379,6 +18392,7 @@ fn substitute_func_param_in_builtin(builtin: &Builtin, param: &str, arg: &Expr) 
         Builtin::Line => Builtin::Line,
         Builtin::Column => Builtin::Column,
         Builtin::DocumentIndex => Builtin::DocumentIndex,
+        Builtin::LineComment => Builtin::LineComment,
         Builtin::Shuffle => Builtin::Shuffle,
         Builtin::Pivot => Builtin::Pivot,
         Builtin::SplitDoc => Builtin::SplitDoc,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -79,6 +79,125 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
     }
 }
 
+/// A shape-parallel tree of trailing same-line comments (issue #710), built
+/// alongside an `OwnedValue` by [`to_owned_with_comments`].
+///
+/// `OwnedValue` itself carries no metadata — extending its enum would ripple
+/// through every match site in both the JSON and YAML evaluators for a
+/// feature only the YAML write path needs. This tree is a separate,
+/// additive structure consulted only by the DOM/owned YAML writers
+/// (`emit_yaml_value` in `yq_runner.rs`, `stream_owned_value_yaml` in
+/// `stream.rs`), and only at the two call sites that still have a live
+/// cursor when they materialize (`yq_runner.rs`'s `evaluate_yaml_cursor`).
+/// A query that reshapes the tree (`map`, `del`, array construction, ...)
+/// simply has no `to_owned_with_comments` call in its chain, so comments are
+/// dropped there exactly as they are today — not a new regression, and out
+/// of scope for this issue (see the issue's own scope note).
+#[derive(Debug, Clone)]
+pub enum CommentTree {
+    /// A scalar (or any node with no comment-bearing children): this node's
+    /// own trailing comment, if any.
+    Leaf(Option<String>),
+    /// An array: this node's own trailing comment (e.g. `a: [1,2] # c`,
+    /// which trails the whole array, not an element), plus one subtree per
+    /// element in order.
+    Array(Option<String>, Vec<Self>),
+    /// An object: this node's own trailing comment, plus one subtree per
+    /// field, keyed the same as the parallel `OwnedValue::Object`.
+    Object(Option<String>, IndexMap<String, Self>),
+}
+
+impl CommentTree {
+    /// The empty tree: no comment at this node, and (for containers) no
+    /// children — used where a caller has no cursor at all (comment-less by
+    /// construction, e.g. a computed value).
+    pub const fn empty() -> Self {
+        Self::Leaf(None)
+    }
+
+    /// This node's own trailing comment, if any.
+    pub fn own(&self) -> Option<&str> {
+        match self {
+            Self::Leaf(c) | Self::Array(c, _) | Self::Object(c, _) => c.as_deref(),
+        }
+    }
+
+    /// The subtree for array index `i`, or the empty tree if this isn't an
+    /// `Array` or the index is out of range.
+    pub fn at_index(&self, i: usize) -> &Self {
+        match self {
+            Self::Array(_, items) => items.get(i).unwrap_or(&EMPTY_COMMENT_TREE),
+            _ => &EMPTY_COMMENT_TREE,
+        }
+    }
+
+    /// The subtree for object key `key`, or the empty tree if this isn't an
+    /// `Object` or has no such key.
+    pub fn field(&self, key: &str) -> &Self {
+        match self {
+            Self::Object(_, fields) => fields.get(key).unwrap_or(&EMPTY_COMMENT_TREE),
+            _ => &EMPTY_COMMENT_TREE,
+        }
+    }
+}
+
+/// The empty tree, as a genuine `'static` place (not a local `const`, which
+/// can't be borrowed as `'static` from inside a generic method call
+/// argument like `Option::unwrap_or`) — used by [`CommentTree::at_index`]/
+/// [`CommentTree::field`] wherever there's no comment data to return.
+static EMPTY_COMMENT_TREE: CommentTree = CommentTree::Leaf(None);
+
+/// Convert a `DocumentValue` to an `OwnedValue` alongside a parallel [`CommentTree`].
+///
+/// Uses a live cursor to read each node's trailing comment (issue #710).
+/// See [`to_owned`] for the value-only conversion this mirrors and
+/// delegates scalar handling to.
+pub fn to_owned_with_comments<V: DocumentValue>(
+    value: &V,
+    cursor: Option<&V::Cursor>,
+) -> (OwnedValue, CommentTree) {
+    // The raw (`#`-prefixed) form, not the stripped `line_comment` builtin
+    // getter: the write path re-emits this verbatim after one space.
+    let own_comment = cursor.and_then(DocumentCursor::line_comment_raw);
+    if let Some(fields) = value.as_object() {
+        let mut map = IndexMap::new();
+        let mut comment_map = IndexMap::new();
+        let mut f = fields;
+        while let Some((field, rest)) = f.uncons() {
+            if let Some(key) = field.key_str() {
+                let key = key.into_owned();
+                let (v, c) = to_owned_with_comments(&field.value, Some(&field.value_cursor));
+                map.insert(key.clone(), v);
+                comment_map.insert(key, c);
+            }
+            f = rest;
+        }
+        (
+            OwnedValue::Object(map),
+            CommentTree::Object(own_comment, comment_map),
+        )
+    } else if let Some(elements) = value.as_array() {
+        let mut items = Vec::new();
+        let mut comment_items = Vec::new();
+        // Iterate by cursor (`uncons_cursor`, not `uncons`, which yields
+        // values only) so each element's own comment is reachable.
+        let mut elems = elements;
+        while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
+            let elem_value = elem_cursor.value();
+            let (v, c) = to_owned_with_comments(&elem_value, Some(&elem_cursor));
+            items.push(v);
+            comment_items.push(c);
+            elems = rest;
+        }
+        (
+            OwnedValue::Array(items),
+            CommentTree::Array(own_comment, comment_items),
+        )
+    } else {
+        (to_owned(value), CommentTree::Leaf(own_comment))
+    }
+}
+
 /// Materialize a key/slice-bound candidate just enough to classify it.
 ///
 /// Mirrors `eval::to_owned_key_shape` (#626/#670): `index_one_generic`'s
@@ -2597,6 +2716,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             GenericResult::Owned(OwnedValue::String(style.to_string()))
         }
 
+        Builtin::LineComment => {
+            let comment = cursor.and_then(|c| c.line_comment()).unwrap_or_default();
+            GenericResult::Owned(OwnedValue::String(comment))
+        }
+
         Builtin::Select(cond) => {
             // Evaluate condition with cursor context preserved.
             // This is critical for select(di == N) to work correctly.
@@ -4953,6 +5077,106 @@ mod tests {
 
         // Without cursor, line returns 0
         assert_eq!(owned, OwnedValue::Int(0));
+    }
+
+    // Tests for `line_comment` (#710): a getter for a node's trailing
+    // same-line comment. Unlike `line`/`column`, the "not available"
+    // default is `""`, matching real `yq` (verified empirically), not `0`.
+
+    #[test]
+    fn test_yaml_line_comment_builtin_with_cursor() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: 1 # keep this\nb: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".a | line_comment").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String("keep this".to_string())
+        );
+    }
+
+    #[test]
+    fn test_yaml_line_comment_builtin_no_comment() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: 1\nb: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".a | line_comment").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String(String::new())
+        );
+    }
+
+    #[test]
+    fn test_yaml_line_comment_builtin_no_space_after_hash_keeps_hash() {
+        use crate::yaml::YamlIndex;
+
+        // No space after '#' means nothing to strip - the whole thing,
+        // '#' included, is the comment text (verified against real yq).
+        let yaml = b"a: 1 #keep this\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".a | line_comment").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String("#keep this".to_string())
+        );
+    }
+
+    #[test]
+    fn test_yaml_line_comment_without_cursor() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: 1 # keep this\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let cursor = index.root(yaml);
+        let mapping_cursor = cursor
+            .first_child()
+            .expect("YAML document should have content");
+        let value = mapping_cursor.value();
+
+        // Using eval (not eval_with_cursor) loses position metadata, so
+        // line_comment falls back to "" even though the source has one.
+        let result = eval(&Expr::Builtin(Builtin::LineComment), value);
+        let owned = result.into_owned().unwrap();
+        assert_eq!(owned, OwnedValue::String(String::new()));
+    }
+
+    #[test]
+    fn test_json_line_comment_is_always_empty() {
+        // JSON has no comments; the DocumentCursor default (None) applies
+        // unconditionally regardless of cursor presence.
+        let json = b"{\"a\": 1}";
+        let index = crate::json::JsonIndex::build(json);
+        let cursor = index.root(json);
+        let field_cursor = cursor
+            .first_child()
+            .expect("JSON object should have a field");
+
+        let result = eval_with_cursor(&Expr::Builtin(Builtin::LineComment), field_cursor);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::String(String::new())
+        );
     }
 
     // Regression tests for #532: `line`/`column` returned 0 for anything

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -85,10 +85,16 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
 /// `OwnedValue` itself carries no metadata — extending its enum would ripple
 /// through every match site in both the JSON and YAML evaluators for a
 /// feature only the YAML write path needs. This tree is a separate,
-/// additive structure consulted only by the DOM/owned YAML writers
-/// (`emit_yaml_value` in `yq_runner.rs`, `stream_owned_value_yaml` in
-/// `stream.rs`), and only at the two call sites that still have a live
-/// cursor when they materialize (`yq_runner.rs`'s `evaluate_yaml_cursor`).
+/// additive structure consulted only by `emit_yaml_value` in
+/// `yq_runner.rs`, the DOM writer used once a query's `GenericResult` has
+/// been materialized to `OwnedValue` (`yq_runner.rs`'s
+/// `evaluate_yaml_cursor`, the only place that calls
+/// `to_owned_with_comments`). It is a distinct mechanism from
+/// `YamlCursor::stream_yaml_value`/`stream_yaml_as_document` in
+/// `light.rs`, which stream comments straight from a *live cursor* via
+/// `write_line_comment` and never go through `CommentTree` at all —
+/// `stream_owned_value_yaml` in `stream.rs` streams plain `OwnedValue`
+/// (no cursor, no comment data) and isn't part of either mechanism.
 /// A query that reshapes the tree (`map`, `del`, array construction, ...)
 /// simply has no `to_owned_with_comments` call in its chain, so comments are
 /// dropped there exactly as they are today — not a new regression, and out

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5185,6 +5185,29 @@ mod tests {
         );
     }
 
+    /// `to_owned_with_comments` reads the raw (`#`-and-all) form via
+    /// [`DocumentCursor::line_comment_raw`] (issue #710), not the stripped
+    /// `line_comment` builtin getter the test above exercises. JSON never
+    /// overrides `line_comment_raw` (only `YamlCursor` does), so this is the
+    /// only route that reaches the trait's default `None` implementation for
+    /// that method - unlike `line_comment`, which the plain `jq` `line_comment`
+    /// builtin already exercises on JSON above.
+    #[test]
+    fn test_json_to_owned_with_comments_uses_line_comment_raw_default() {
+        let json = b"{\"a\": 1}";
+        let index = crate::json::JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let (owned, comments) = to_owned_with_comments(&value, Some(&cursor));
+        assert_eq!(
+            owned,
+            OwnedValue::Object(IndexMap::from([("a".to_string(), OwnedValue::Int(1))]))
+        );
+        assert_eq!(comments.own(), None);
+        assert_eq!(comments.field("a").own(), None);
+    }
+
     // Regression tests for #532: `line`/`column` returned 0 for anything
     // downstream of `.foo`/`.[]`/`select(...)`, because those Expr/Builtin
     // arms received a cursor but never forwarded it — only a bare `line`

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -816,6 +816,8 @@ pub enum Builtin {
     Column,
     /// `document_index` / `di` - return the 0-indexed document position in multi-doc stream (yq)
     DocumentIndex,
+    /// `line_comment` - return the trailing same-line comment text, or "" (yq, #710)
+    LineComment,
     /// `shuffle` - randomly shuffle array elements (yq)
     Shuffle,
     /// `pivot` - transpose arrays/objects (yq)

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2916,6 +2916,12 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Column));
         }
 
+        // line_comment - yq: return trailing same-line comment text, or "" (#710)
+        if self.matches_keyword("line_comment") {
+            self.consume_keyword("line_comment");
+            return Ok(Some(Builtin::LineComment));
+        }
+
         // document_index / di - yq: return 0-indexed document position in multi-doc stream
         if self.matches_keyword("document_index") {
             self.consume_keyword("document_index");

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -912,6 +912,16 @@ mod tests {
     }
 
     #[test]
+    fn test_line_comment_field_not_found_returns_none() {
+        // Every other case above queries a key that's actually present, so
+        // `field_line_comment_raw`'s loop always returns from inside the
+        // `for` — this is the only test that lets it run out of fields and
+        // fall through to the `None` after the loop.
+        let yaml = b"a: 1 # keep this\n";
+        assert_eq!(field_line_comment_raw(yaml, "nonexistent"), None);
+    }
+
+    #[test]
     fn test_line_comment_on_sequence_items() {
         let yaml = b"a:\n  - 1 # first\n  - 2 # second\n";
         let index = YamlIndex::build(yaml).expect("valid YAML");

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -72,6 +72,9 @@ pub struct YamlIndex<W = Vec<u64>> {
     /// resolves to a tag by reference the way an alias resolves to an
     /// anchor, so this is a single side table, not three (#224).
     tags: BTreeMap<usize, String>,
+    /// Trailing same-line comments: BP position of the owning node → `(start, end)`
+    /// byte range of the raw `#...` comment text (issue #710).
+    line_comments: BTreeMap<usize, (u32, u32)>,
     /// Line starts for line/column lookup (built lazily on first use).
     /// Only needed by `to_line_column()` and `to_offset()` (used by the
     /// `yq-locate` CLI and the `at_position` jq builtin).
@@ -136,6 +139,7 @@ impl YamlIndex<Vec<u64>> {
             bp_to_anchor,
             aliases: semi.aliases,
             tags: semi.tags,
+            line_comments: semi.line_comments,
             lines: OnceCell::new(),
         };
         index.validate_alias_acyclicity()?;
@@ -189,6 +193,10 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             bp_to_anchor,
             aliases,
             tags,
+            // `from_parts` predates line-comment tracking and has no caller
+            // in this codebase today; a future caller that needs it can be
+            // given an explicit parameter then.
+            line_comments: BTreeMap::new(),
             lines: OnceCell::new(),
         }
     }
@@ -477,6 +485,19 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     #[inline]
     pub fn get_tag(&self, bp_pos: usize) -> Option<&str> {
         self.tags.get(&bp_pos).map(alloc::string::String::as_str)
+    }
+
+    /// Get the raw trailing-comment byte range for a BP position, if the
+    /// node at that position has a same-line comment (issue #710).
+    ///
+    /// The range starts at `#` and runs to end of line, exclusive of the
+    /// line break — the caller slices it out of the original source text
+    /// and strips the leading `#`/space at the point of use, mirroring how
+    /// [`YamlCursor::style`](super::light::YamlCursor::style) reads from
+    /// already-retained text rather than a stored string.
+    #[inline]
+    pub fn get_line_comment(&self, bp_pos: usize) -> Option<(u32, u32)> {
+        self.line_comments.get(&bp_pos).copied()
     }
 
     /// Resolve an alias at the given BP position to a cursor pointing to
@@ -795,6 +816,122 @@ mod tests {
         let yaml = b"- item1\n- item2";
         let index = YamlIndex::build(yaml);
         assert!(index.is_ok());
+    }
+
+    // ------------------------------------------------------------------------
+    // Trailing line comment capture (#710)
+    // ------------------------------------------------------------------------
+
+    /// Helper: build an index, navigate to `.<key>`'s value cursor via the
+    /// virtual-document-root -> mapping -> field path every YAML document
+    /// shares, and return its raw `#`-prefixed line comment (if any).
+    fn field_line_comment_raw(yaml: &[u8], key: &str) -> Option<String> {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Mapping(fields) = doc_cursor.value() else {
+            panic!("expected a mapping document");
+        };
+        for field in fields {
+            if let YamlValue::String(k) = field.key() {
+                if k.raw_bytes() == key.as_bytes() {
+                    return field
+                        .value_cursor()
+                        .line_comment_raw()
+                        .map(alloc::string::ToString::to_string);
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_line_comment_captured_on_plain_scalar() {
+        let yaml = b"a: 1 # keep this\nb: 2\n";
+        assert_eq!(
+            field_line_comment_raw(yaml, "a").as_deref(),
+            Some("# keep this")
+        );
+        assert_eq!(field_line_comment_raw(yaml, "b"), None);
+    }
+
+    #[test]
+    fn test_line_comment_captured_on_quoted_scalar() {
+        let yaml = b"a: \"hello\" # quoted\n";
+        assert_eq!(
+            field_line_comment_raw(yaml, "a").as_deref(),
+            Some("# quoted")
+        );
+    }
+
+    #[test]
+    fn test_line_comment_captured_on_flow_collection_close() {
+        let yaml = b"a: [1, 2, 3] # flow comment\n";
+        assert_eq!(
+            field_line_comment_raw(yaml, "a").as_deref(),
+            Some("# flow comment")
+        );
+    }
+
+    #[test]
+    fn test_line_comment_captured_on_flow_mapping_close() {
+        let yaml = b"a: {b: 1} # flow mapping comment\n";
+        assert_eq!(
+            field_line_comment_raw(yaml, "a").as_deref(),
+            Some("# flow mapping comment")
+        );
+    }
+
+    #[test]
+    fn test_line_comment_captured_on_block_scalar_header() {
+        let yaml = b"a: | # header comment\n  line one\n  line two\n";
+        assert_eq!(
+            field_line_comment_raw(yaml, "a").as_deref(),
+            Some("# header comment")
+        );
+    }
+
+    #[test]
+    fn test_line_comment_not_preceded_by_space_is_not_a_comment() {
+        // '#' immediately after non-whitespace content is part of the scalar,
+        // not a comment start (pre-existing rule, #437/#410).
+        let yaml = b"a: 1#notacomment\n";
+        assert_eq!(field_line_comment_raw(yaml, "a"), None);
+    }
+
+    #[test]
+    fn test_line_comment_no_comment_returns_none() {
+        let yaml = b"a: 1\nb: 2\n";
+        assert_eq!(field_line_comment_raw(yaml, "a"), None);
+        assert_eq!(field_line_comment_raw(yaml, "b"), None);
+    }
+
+    #[test]
+    fn test_line_comment_on_sequence_items() {
+        let yaml = b"a:\n  - 1 # first\n  - 2 # second\n";
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        use crate::yaml::light::YamlValue;
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Mapping(fields) = doc_cursor.value() else {
+            panic!("expected a mapping document");
+        };
+        let (field, _) = fields.uncons().expect("field 'a'");
+        let YamlValue::Sequence(elements) = field.value_cursor().value() else {
+            panic!("expected a sequence value");
+        };
+        let (first, rest) = elements.uncons_cursor().expect("first element");
+        assert_eq!(first.line_comment_raw(), Some("# first"));
+        let (second, _) = rest.uncons_cursor().expect("second element");
+        assert_eq!(second.line_comment_raw(), Some("# second"));
     }
 
     // ------------------------------------------------------------------------

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1218,6 +1218,46 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         self.stream_yaml_value(out, 0, indent.width, indent.unit, sort_keys)
     }
 
+    /// Like [`Self::stream_yaml`], but also appends this cursor's own
+    /// trailing comment (#710) - for callers displaying this cursor's value
+    /// as an entire document (identity), as opposed to a bare navigated
+    /// result. `stream_yaml_value`'s Mapping/Sequence arms already append
+    /// each *child's* own comment as they recurse, but nothing does that for
+    /// the outermost value, since every recursive call goes straight to the
+    /// private `stream_yaml_value` rather than back through a public entry
+    /// point.
+    ///
+    /// This must stay separate from `stream_yaml` rather than folded into
+    /// it: real `yq` keeps a comment when redisplaying the whole document
+    /// unmodified, but drops it when the very same node is extracted alone
+    /// via field/index navigation (`.a` on `a: 1 # keep this` outputs a bare
+    /// `1`, no comment - verified against the pinned real `yq` binary).
+    /// `stream_yaml` is also what `GenericResult::stream_yaml`'s
+    /// `OneCursor`/`ManyCursor` arms use for exactly those navigated
+    /// results, so it must keep the bare (no-comment) behavior.
+    ///
+    /// Scalar/null/alias document roots are excluded even here: verified
+    /// against the pinned real `yq` binary, a bare scalar document
+    /// (`42 # trailing`) drops its own trailing comment from output, even
+    /// though `line_comment` still returns it - real `yq`'s own quirk, not a
+    /// succinctly gap, so replicated rather than "fixed" into a new
+    /// divergence. Only `Mapping`/`Sequence` roots (e.g. `[1, 2, 3] # c`)
+    /// keep it.
+    pub fn stream_yaml_as_document<Out: core::fmt::Write>(
+        &self,
+        out: &mut Out,
+        indent: IndentSpec,
+        sort_keys: bool,
+    ) -> core::fmt::Result {
+        self.write_leading_anchor(out)?;
+        let value = self.value();
+        self.stream_yaml_value(out, 0, indent.width, indent.unit, sort_keys)?;
+        if matches!(value, YamlValue::Mapping(_) | YamlValue::Sequence(_)) {
+            write_line_comment(out, self.line_comment_raw())?;
+        }
+        Ok(())
+    }
+
     /// Stream YAML, unwrapping single documents (matches yq behavior).
     ///
     /// If the root is a single-document array `[doc]`, outputs just `doc` as YAML.
@@ -1232,15 +1272,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             if let YamlValue::Sequence(elements) = self.value() {
                 if let Some((cursor, rest)) = elements.uncons_cursor() {
                     if rest.is_empty() {
-                        // Single document - output it directly without array wrapper
-                        cursor.write_leading_anchor(out)?;
-                        return cursor.stream_yaml_value(
-                            out,
-                            0,
-                            indent.width,
-                            indent.unit,
-                            sort_keys,
-                        );
+                        // Single document - output it directly without array
+                        // wrapper. `stream_yaml_as_document` (not
+                        // `stream_yaml`/`stream_yaml_value`) so the
+                        // document's own trailing comment, if any, is
+                        // included too (#710); it writes the leading anchor
+                        // itself, matching `stream_yaml`.
+                        return cursor.stream_yaml_as_document(out, indent, sort_keys);
                     }
                 }
             }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1392,6 +1392,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     unit,
                                     sort_keys,
                                 )?;
+                                write_line_comment(out, value.line_comment_raw())?;
                             } else {
                                 out.write_char(' ')?;
                                 if let Some(anchor) = value.anchor() {
@@ -1406,6 +1407,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     unit,
                                     sort_keys,
                                 )?;
+                                write_line_comment(out, value.line_comment_raw())?;
                             }
                         }
                     } else {
@@ -1437,6 +1439,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     unit,
                                     sort_keys,
                                 )?;
+                                write_line_comment(out, value.line_comment_raw())?;
                             } else {
                                 out.write_char(' ')?;
                                 if let Some(anchor) = value.anchor() {
@@ -1451,6 +1454,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     unit,
                                     sort_keys,
                                 )?;
+                                write_line_comment(out, value.line_comment_raw())?;
                             }
                         }
                     }
@@ -1506,6 +1510,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 unit,
                                 sort_keys,
                             )?;
+                            write_line_comment(out, cursor.line_comment_raw())?;
                         } else {
                             out.write_str("- ")?;
                             if let Some(anchor) = cursor.anchor() {
@@ -1520,6 +1525,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 unit,
                                 sort_keys,
                             )?;
+                            write_line_comment(out, cursor.line_comment_raw())?;
                         }
                         elems = rest;
                     }
@@ -1859,6 +1865,39 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     #[inline]
     pub fn explicit_tag(&self) -> Option<&str> {
         self.index.get_tag(self.bp_pos)
+    }
+
+    /// Get the raw trailing same-line comment for this node, `#` and all,
+    /// exactly as it appears in the source (issue #710).
+    ///
+    /// Returns `None` if this node has no trailing comment. Used by the
+    /// write path, which re-emits the bytes verbatim after a single
+    /// normalized space (matching real `yq`'s output, verified empirically:
+    /// the gap before `#` is normalized to one space, but everything from
+    /// `#` onward — including internal/trailing whitespace — is preserved
+    /// as-is). See [`Self::line_comment`] for the stripped getter form.
+    #[inline]
+    pub fn line_comment_raw(&self) -> Option<&str> {
+        let (start, end) = self.index.get_line_comment(self.bp_pos)?;
+        core::str::from_utf8(&self.text[start as usize..end as usize]).ok()
+    }
+
+    /// Get this node's trailing same-line comment text (the `line_comment`
+    /// jq builtin, issue #710), with the leading `#` and at most one
+    /// following space stripped — matching real `yq`: `# keep this` →
+    /// `"keep this"`, but `#keep this` (no space after `#`) → `"#keep this"`
+    /// unchanged, since there's nothing to strip.
+    ///
+    /// Returns `None` if this node has no trailing comment; the builtin
+    /// itself maps that to `""`, matching real `yq`.
+    #[inline]
+    pub fn line_comment(&self) -> Option<&str> {
+        let raw = self.line_comment_raw()?;
+        // `raw` always starts with '#'. Only strip it (plus one following
+        // space) when a space actually follows — otherwise the '#' is part
+        // of the text with nothing to strip, e.g. `#keep this` stays
+        // `"#keep this"` unchanged (verified against real `yq`).
+        Some(raw.strip_prefix("# ").unwrap_or(raw))
     }
 
     /// Get the anchor name that this alias references.
@@ -5094,6 +5133,16 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn line_comment(&self) -> Option<String> {
+        YamlCursor::line_comment(self).map(ToString::to_string)
+    }
+
+    #[inline]
+    fn line_comment_raw(&self) -> Option<String> {
+        YamlCursor::line_comment_raw(self).map(ToString::to_string)
+    }
+
+    #[inline]
     fn cursor_at_offset(&self, offset: usize) -> Option<Self> {
         YamlCursor::cursor_at_offset(self, offset)
     }
@@ -5468,6 +5517,27 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
         out.write_char(' ')?;
     }
     value.stream_yaml_value(out, 0, 0, unit, sort_keys)
+}
+
+/// Write a trailing same-line comment after a value, if present (issue
+/// #710). `comment` is the raw text as returned by
+/// [`YamlCursor::line_comment_raw`] — starting with `#`, un-stripped — and
+/// is written verbatim after a single normalized space, matching real
+/// `yq`'s output (empirically verified: the gap before `#` is always
+/// exactly one space regardless of the source's original spacing, but
+/// everything from `#` onward, including internal/trailing whitespace, is
+/// preserved as-is).
+fn write_line_comment<Out: core::fmt::Write>(
+    out: &mut Out,
+    comment: Option<&str>,
+) -> core::fmt::Result {
+    match comment {
+        Some(c) => {
+            out.write_char(' ')?;
+            out.write_str(c)
+        }
+        None => Ok(()),
+    }
 }
 
 /// Stream independent document cursors as a single YAML sequence (block or

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -464,7 +464,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     #[inline]
     fn maybe_capture_line_comment(&mut self, owner_bp_pos: usize) {
         let mut p = self.pos;
-        while p < self.input.len() && matches!(self.input[p], b' ' | b'\t') {
+        while p < self.input.len() && Self::is_inline_whitespace(self.input[p]) {
             p += 1;
         }
         if p < self.input.len() && self.input[p] == b'#' {
@@ -597,6 +597,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         }
     }
 
+    /// A space or tab - YAML's "inline whitespace", separation within a
+    /// line rather than between them. Shared by [`Self::skip_inline_whitespace`]
+    /// (which consumes it) and [`Self::maybe_capture_line_comment`] (which
+    /// only peeks past it, since its caller still needs to consume the run
+    /// itself).
+    #[inline]
+    fn is_inline_whitespace(b: u8) -> bool {
+        matches!(b, b' ' | b'\t')
+    }
+
     /// Width in bytes of the line break at `pos`, under this parser's `HAS_CR`
     /// specialization: [`line_break_len`] when a `\r` may be present, and
     /// otherwise the one-byte LF answer it collapses to.
@@ -680,11 +690,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Skip whitespace on the current line (spaces and tabs, not newlines).
     #[inline]
     fn skip_inline_whitespace(&mut self) {
-        while self.pos < self.input.len() {
-            match self.input[self.pos] {
-                b' ' | b'\t' => self.pos += 1,
-                _ => break,
-            }
+        while self.pos < self.input.len() && Self::is_inline_whitespace(self.input[self.pos]) {
+            self.pos += 1;
         }
     }
 

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -115,6 +115,12 @@ pub struct SemiIndex {
     pub aliases: BTreeMap<usize, usize>,
     /// Explicit source tags: BP position → raw tag text (see [`YamlIndex::get_tag`](super::index::YamlIndex::get_tag))
     pub tags: BTreeMap<usize, String>,
+    /// Trailing same-line comments: BP position of the node the comment trails →
+    /// `(start, end)` byte range of the raw comment text, starting at `#` and
+    /// running to end of line (exclusive of the line break, inclusive of any
+    /// trailing whitespace). Only line comments (issue #710) — standalone
+    /// head/foot comments are not captured.
+    pub line_comments: BTreeMap<usize, (u32, u32)>,
 }
 
 /// Maximum nesting depth for recursively-parsed constructs (flow collections
@@ -172,6 +178,10 @@ struct Parser<'a, const HAS_CR: bool> {
     aliases: BTreeMap<usize, usize>,
     /// Explicit source tags collected during parsing: bp_pos → raw tag text
     tags: BTreeMap<usize, String>,
+    /// Trailing same-line comments collected during parsing: bp_pos of the
+    /// owning node → `(start, end)` byte range of the raw `#...` comment text.
+    /// See [`SemiIndex::line_comments`].
+    line_comments: BTreeMap<usize, (u32, u32)>,
 
     // Document tracking
     /// Whether we're currently inside a document
@@ -216,6 +226,17 @@ struct Parser<'a, const HAS_CR: bool> {
     /// Asserted in [`Self::write_bp_open_seq_item`].
     #[cfg(debug_assertions)]
     last_recorded_end: usize,
+
+    /// The raw BP bit position ([`Self::bp_pos`] before increment) most
+    /// recently assigned by [`Self::write_bp_open_at`].
+    ///
+    /// `bp_to_text_end.len() - 1` is *not* this value in general — it counts
+    /// opens only, while `bp_pos` counts opens and closes together, so the
+    /// two diverge by the number of closes that happened before this node's
+    /// own open. [`Self::set_bp_text_end`]'s trailing-comment capture
+    /// (#710) needs the real bit position, since that's what every
+    /// `YamlCursor` method (`self.bp_pos`) keys its lookups on.
+    last_open_bp_pos: usize,
 }
 
 impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
@@ -254,6 +275,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             anchors: BTreeMap::new(),
             aliases: BTreeMap::new(),
             tags: BTreeMap::new(),
+            line_comments: BTreeMap::new(),
             in_document: false,
             document_start_bp_pos: 0,
             pending_explicit_key: None,
@@ -262,6 +284,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             wrapper_slots: Vec::with_capacity(estimated_opens),
             #[cfg(debug_assertions)]
             last_recorded_end: 0,
+            last_open_bp_pos: 0,
         }
     }
 
@@ -331,6 +354,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             self.bp_words.push(0);
         }
         self.bp_words[word_idx] |= 1u64 << bit_idx;
+        self.last_open_bp_pos = self.bp_pos;
         // Record the text position for this BP open
         self.bp_to_text.push(text_pos as u32);
         // Placeholder for end position (will be set by set_bp_text_end for scalars)
@@ -398,6 +422,41 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         #[cfg(debug_assertions)]
         {
             self.last_recorded_end = end_pos;
+        }
+        // The node whose end was just recorded is the one that owns a
+        // trailing same-line comment, if `self.pos` (left wherever scanning
+        // for this value stopped) has nothing but inline whitespace before
+        // a `#`. Every scalar-parsing call site invokes `set_bp_text_end`
+        // immediately after its own scan loop returns, with no intervening
+        // advance, so `self.pos` still reflects exactly where that scan
+        // stopped (#710).
+        let owner_bp_pos = self.last_open_bp_pos;
+        self.maybe_capture_line_comment(owner_bp_pos);
+    }
+
+    /// Capture a trailing same-line comment for `owner_bp_pos`, if `self.pos`
+    /// is separated from a `#` only by inline whitespace (spaces/tabs) on the
+    /// current line. Does not consume any input — callers still run their own
+    /// `skip_to_eol`/`skip_newlines` afterward to actually advance past it.
+    ///
+    /// Uses `entry().or_insert()` rather than unconditional `insert()` so a
+    /// node captured explicitly at a more specific point (e.g. a block
+    /// scalar's header-line comment, captured before its content is parsed)
+    /// is never clobbered by a later, spurious call for the same bp_pos.
+    #[inline]
+    fn maybe_capture_line_comment(&mut self, owner_bp_pos: usize) {
+        let mut p = self.pos;
+        while p < self.input.len() && matches!(self.input[p], b' ' | b'\t') {
+            p += 1;
+        }
+        if p < self.input.len() && self.input[p] == b'#' {
+            let start = p;
+            while p < self.input.len() && !Self::is_break(self.input[p]) {
+                p += 1;
+            }
+            self.line_comments
+                .entry(owner_bp_pos)
+                .or_insert((start as u32, p as u32));
         }
     }
 
@@ -3101,6 +3160,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.set_ib();
 
         // Open sequence container
+        let container_bp_pos = self.bp_pos;
         self.write_bp_open();
         self.write_ty(true); // 1 = sequence
 
@@ -3181,6 +3241,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             self.advance();
         }
 
+        // A trailing comment right after `]` belongs to this sequence as a
+        // whole (#710), e.g. `a: [1, 2, 3] # comment`.
+        self.maybe_capture_line_comment(container_bp_pos);
+
         // Close sequence
         self.write_bp_close();
 
@@ -3200,6 +3264,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.set_ib();
 
         // Open mapping container
+        let container_bp_pos = self.bp_pos;
         self.write_bp_open();
         self.write_ty(false); // 0 = mapping
 
@@ -3313,6 +3378,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             self.set_ib();
             self.advance();
         }
+
+        // A trailing comment right after `}` belongs to this mapping as a
+        // whole (#710), e.g. `a: {b: 1} # comment`.
+        self.maybe_capture_line_comment(container_bp_pos);
 
         // Close mapping
         self.write_bp_close();
@@ -3905,7 +3974,11 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Parse the header
         let header = self.parse_block_scalar_header()?;
 
-        // Skip to end of indicator line (may have trailing comment)
+        // Skip to end of indicator line, capturing a trailing comment as this
+        // block scalar's own line comment first (#710) — `self.last_open_bp_pos`
+        // is still this node's bp_pos here since no content/children are
+        // parsed yet.
+        self.maybe_capture_line_comment(self.last_open_bp_pos);
         self.skip_to_eol();
         self.skip_line_break();
 
@@ -4297,6 +4370,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             anchors: core::mem::take(&mut self.anchors),
             aliases: core::mem::take(&mut self.aliases),
             tags: core::mem::take(&mut self.tags),
+            line_comments: core::mem::take(&mut self.line_comments),
         })
     }
 

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -408,6 +408,33 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// their leading `[`, `{` or `*`. So don't call this after them.
     #[inline]
     fn set_bp_text_end(&mut self, end_pos: usize) {
+        self.set_bp_text_end_position(end_pos);
+        // The node whose end was just recorded is the one that owns a
+        // trailing same-line comment, if `self.pos` (left wherever scanning
+        // for this value stopped) has nothing but inline whitespace before
+        // a `#`. Every scalar-parsing call site invokes `set_bp_text_end`
+        // immediately after its own scan loop returns, with no intervening
+        // advance, so `self.pos` still reflects exactly where that scan
+        // stopped (#710).
+        let owner_bp_pos = self.last_open_bp_pos;
+        self.maybe_capture_line_comment(owner_bp_pos);
+    }
+
+    /// Record `end_pos` as the text end for the node currently open, without
+    /// attempting trailing-comment capture (#710). Block scalars call this
+    /// directly: their own trailing comment, if any, was already captured
+    /// explicitly on the header line (`| # text`) before content was
+    /// consumed, and by the time content parsing finishes `self.pos` sits at
+    /// the start of a following line — possibly several blank lines, or a
+    /// comment line belonging to the next sibling, past the block region
+    /// (`consume_block_scalar_content`/`detect_block_content_indent` both
+    /// advance `self.pos` past it). `set_bp_text_end`'s same-line capture
+    /// would misattribute that unrelated following comment to this block
+    /// scalar; skipping it here is always safe since `self.pos` is at column
+    /// 0 of a fresh line, never mid-line, so there is no legitimate
+    /// same-line comment left to find.
+    #[inline]
+    fn set_bp_text_end_position(&mut self, end_pos: usize) {
         #[cfg(debug_assertions)]
         debug_assert!(
             self.wrapper_slots.last() != Some(&true),
@@ -423,15 +450,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         {
             self.last_recorded_end = end_pos;
         }
-        // The node whose end was just recorded is the one that owns a
-        // trailing same-line comment, if `self.pos` (left wherever scanning
-        // for this value stopped) has nothing but inline whitespace before
-        // a `#`. Every scalar-parsing call site invokes `set_bp_text_end`
-        // immediately after its own scan loop returns, with no intervening
-        // advance, so `self.pos` still reflects exactly where that scan
-        // stopped (#710).
-        let owner_bp_pos = self.last_open_bp_pos;
-        self.maybe_capture_line_comment(owner_bp_pos);
     }
 
     /// Capture a trailing same-line comment for `owner_bp_pos`, if `self.pos`
@@ -3990,8 +4008,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             match self.detect_block_content_indent(base_indent) {
                 Some(indent) => indent,
                 None => {
-                    // Empty block scalar
-                    self.set_bp_text_end(self.pos);
+                    // Empty block scalar. `self.pos` sits at the start of the
+                    // line following the header (see `detect_block_content_indent`),
+                    // so a `#` there belongs to a following comment/sibling
+                    // line, not this scalar — use the no-capture variant
+                    // (#710, see `set_bp_text_end_position`'s doc comment).
+                    self.set_bp_text_end_position(self.pos);
                     self.write_bp_close();
                     return Ok(());
                 }
@@ -4001,8 +4023,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Consume content lines
         let content_end = self.consume_block_scalar_content(content_indent, header.chomping);
 
-        // Close the block scalar node
-        self.set_bp_text_end(content_end);
+        // Close the block scalar node. `self.pos` has been advanced past the
+        // block region (potentially past blank lines or a following
+        // sibling's comment line) by `consume_block_scalar_content`, so use
+        // the no-capture variant — the block's own trailing comment, if any,
+        // was already captured on the header line above (#710, see
+        // `set_bp_text_end_position`'s doc comment).
+        self.set_bp_text_end_position(content_end);
         self.write_bp_close();
 
         Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5212,3 +5212,43 @@ fn test_assignment_does_not_yet_preserve_comments_710() -> Result<()> {
     assert_eq!(out, "a: 1\nb: 5\n");
     Ok(())
 }
+
+/// A standalone comment on the line right after a block scalar's content
+/// belongs to whatever follows it, not to the block scalar - it must not be
+/// misattributed to `a`. `set_bp_text_end`'s generic same-line capture used
+/// `self.pos`, which by the time block-scalar content parsing finishes has
+/// already advanced past the block region (see
+/// `set_bp_text_end_position`'s doc comment); this stole `b`'s comment and
+/// attached it to `a`. Real `yq` drops this comment entirely (it's not a
+/// same-line trailing comment for anything in this document, and
+/// `head_comment` isn't implemented), so this pins the correct "drop, don't
+/// steal" behavior rather than replicating misattribution.
+#[test]
+fn test_block_scalar_does_not_steal_following_comment_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: |\n  line one\n# comment for b\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: \"line one\\n\"\nb: 2\n");
+    Ok(())
+}
+
+/// Same misattribution risk for an empty block scalar (no content lines at
+/// all): `detect_block_content_indent` also leaves `self.pos` at the start
+/// of the following line before returning `None`.
+#[test]
+fn test_empty_block_scalar_does_not_steal_following_comment_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: |\n# comment for b\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: \"\"\nb: 2\n");
+    Ok(())
+}
+
+/// The block scalar's own trailing comment on the header line itself
+/// (`| # text`, captured explicitly before content parsing) must still work
+/// after splitting `set_bp_text_end` into capture/no-capture variants.
+#[test]
+fn test_block_scalar_header_comment_still_preserved_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a | line_comment", "a: | # keep this\n  line one\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "keep this");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5349,3 +5349,18 @@ fn test_json_output_unaffected_by_comment_tree_skip_710() -> Result<()> {
     assert_eq!(out, "{\n  \"a\": 1,\n  \"b\": 2\n}\n");
     Ok(())
 }
+
+/// A named variable (`--arg`) forces every document through
+/// `evaluate_yaml_cursor`'s DOM-ish fallback (`can_yaml_fast_path` requires
+/// `context.named.is_empty()`), same as a non-M2-streamable expression.
+/// `keys_unsorted` on a top-level array still resolves to
+/// `GenericResult::LazyIndexRange` there (#684) even though nothing forced
+/// materialization for its own sake - this pins that fallback arm produces
+/// the same `[0, 1, ..., len-1]` a plain `syq keys` would.
+#[test]
+fn test_keys_unsorted_lazy_index_range_via_dom_fallback_710() -> Result<()> {
+    let (out, code) = run_yq_stdin("keys_unsorted", "- a\n- b\n- c\n", &["--arg", "x", "y"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- 0\n- 1\n- 2\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5077,3 +5077,138 @@ fn test_top_level_map_lazy_seq_dom_fallback_725() -> Result<()> {
 
     Ok(())
 }
+
+// Trailing line comment preservation (#710). Every expected string here was
+// verified byte-for-byte against the pinned real `yq` binary
+// (tests/data/yq-golden/YQ_VERSION) before being pinned.
+
+/// Identity on a document with a trailing comment must keep it verbatim,
+/// with the gap before `#` normalized to one space (matching real `yq`,
+/// which does the same regardless of the source's original spacing).
+#[test]
+fn test_identity_preserves_line_comment_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: 1 # keep this\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: 1 # keep this\nb: 2\n");
+    Ok(())
+}
+
+/// A scalar extracted alone (not as part of its parent mapping) does not
+/// carry its former sibling comment - it belongs to the mapping entry, not
+/// the bare value. Matches real `yq`.
+#[test]
+fn test_field_navigation_drops_the_comment_like_real_yq_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a", "a: 1 # keep this\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "1");
+    Ok(())
+}
+
+#[test]
+fn test_sequence_item_comments_preserved_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "items:\n  - 1 # first\n  - 2 # second\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "items:\n  - 1 # first\n  - 2 # second\n");
+    Ok(())
+}
+
+#[test]
+fn test_nested_mapping_comment_preserved_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a:\n  b: 1 # nested\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a:\n  b: 1 # nested\n");
+    Ok(())
+}
+
+/// A comment trailing a whole flow collection (not between its elements)
+/// attaches to the field that owns it, same as a scalar value would.
+#[test]
+fn test_flow_collection_trailing_comment_preserved_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: [1, 2, 3] # flow comment\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: [1, 2, 3] # flow comment\n");
+    Ok(())
+}
+
+#[test]
+fn test_quoted_scalar_comment_preserved_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: \"hello\" # quoted\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: \"hello\" # quoted\n");
+    Ok(())
+}
+
+/// A cursor-preserving filter (stays on the P9/DOM path via a live cursor,
+/// not a JSON round-trip) keeps comments too, not just bare identity.
+#[test]
+fn test_select_true_preserves_comments_710() -> Result<()> {
+    let (out, code) = run_yq_stdin("select(true)", "a: 1 # keep this\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: 1 # keep this\nb: 2\n");
+    Ok(())
+}
+
+/// `-S`/`--sort-keys` forces the DOM output path but doesn't rebuild the
+/// underlying `IndexMap`, just its display order - comments still resolve
+/// by field name.
+#[test]
+fn test_sort_keys_preserves_comments_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "b: 2\na: 1 # keep this\n", &["-S"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: 1 # keep this\nb: 2\n");
+    Ok(())
+}
+
+/// `line_comment` getter: strips `# ` (hash + one space) when present.
+#[test]
+fn test_line_comment_builtin_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a | line_comment", "a: 1 # keep this\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "keep this");
+    Ok(())
+}
+
+/// No space after `#` - nothing to strip, matching real `yq`'s value. The
+/// result is quoted (`"#keep this"`) because an unquoted string starting
+/// with `#` would itself look like a comment in the re-parsed YAML.
+#[test]
+fn test_line_comment_builtin_no_space_after_hash_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a | line_comment", "a: 1 #keep this\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "\"#keep this\"");
+    Ok(())
+}
+
+/// No comment at all - the getter returns `""`, not `null` (matches real
+/// `yq`'s value, verified empirically - this is not the same default as
+/// `line`/`column`, which return `0`). Output is `''` rather than a blank
+/// line because succinctly quotes empty-string scalars by default, unlike
+/// real `yq` - a pre-existing, unrelated discrepancy (`yq '""'` shows the
+/// same gap on unmodified `main`), not something this feature introduces.
+#[test]
+fn test_line_comment_builtin_empty_when_absent_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a | line_comment", "a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "''\n");
+    Ok(())
+}
+
+/// Known gap, not a silent regression: assignment (`=`, `|=`, ...) isn't
+/// natively handled by the cursor-aware evaluator, so it falls through a
+/// JSON-round-trip fallback (`eval_generic.rs`'s catch-all) that discards
+/// cursor/comment data for the *entire* document - not just the assigned
+/// field. `.b = 5` here never touches `a`, yet `a`'s comment is still gone.
+/// Fixing this needs comment-aware assignment logic, not just write-path
+/// wiring; tracked as a follow-up rather than solved here so the gap is
+/// pinned and visible instead of an undocumented surprise.
+#[test]
+fn test_assignment_does_not_yet_preserve_comments_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a = 5", "a: 1 # keep this\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: 5\nb: 2\n");
+
+    let (out, code) = run_yq_stdin(".b = 5", "a: 1 # keep this\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: 1\nb: 5\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5364,3 +5364,50 @@ fn test_keys_unsorted_lazy_index_range_via_dom_fallback_710() -> Result<()> {
     assert_eq!(out, "- 0\n- 1\n- 2\n");
     Ok(())
 }
+
+/// `--input-format json` (`-p json`) routes evaluation through
+/// `evaluate_input`/`jq::eval` - the plain, cursor-generic-free evaluator in
+/// `eval.rs`, distinct from `eval_generic.rs`'s `Builtin::LineComment` arm
+/// the earlier `line_comment` tests in this file exercise via the normal
+/// YAML M2 path. `builtin_line_comment` there is a permanent `""` regardless
+/// of cursor, matching `builtin_line`/`builtin_column`'s same contract.
+#[test]
+fn test_line_comment_builtin_via_json_input_dom_path_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a | line_comment", "{\"a\": 1}", &["-p", "json"])?;
+    assert_eq!(code, 0);
+    // Default output stays YAML (`-p` only sets the *input* format), so an
+    // empty string renders as YAML's `''`, not JSON's `""`.
+    assert_eq!(out, "''\n");
+    Ok(())
+}
+
+/// Same DOM path as above, but with `line_comment` reached only after
+/// `def`-expansion substitutes a zero-arg function's body into the call
+/// site - exercises `expand_func_calls_in_builtin`'s `Builtin::LineComment`
+/// passthrough arm, which `eval.rs`'s plain evaluator (unlike
+/// `eval_generic.rs`, which has no `def` AST-rewriting of its own) uses to
+/// inline every `def` before evaluation.
+#[test]
+fn test_line_comment_builtin_through_def_expansion_710() -> Result<()> {
+    let (out, code) = run_yq_stdin("def f: line_comment; .a | f", "{\"a\": 1}", &["-p", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "''\n");
+    Ok(())
+}
+
+/// A parameterized `def` forces the call site's argument to be substituted
+/// into the function body via `substitute_func_param_in_builtin` - which,
+/// like `expand_func_calls_in_builtin` above, walks every `Builtin` node in
+/// the body (including a `line_comment` that doesn't reference the param at
+/// all) and must pass `Builtin::LineComment` through unchanged.
+#[test]
+fn test_line_comment_builtin_through_param_substitution_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "def f($x): $x, line_comment; f(.a)",
+        "{\"a\": 1}",
+        &["-p", "json", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "1\n\"\"\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5337,3 +5337,15 @@ fn test_multi_doc_root_scalar_comment_dropped_matches_real_yq_710() -> Result<()
     assert_eq!(out, "42\n---\nfoo: bar\n");
     Ok(())
 }
+
+/// `-o json` never reads `CommentTree` (JSON has no comment syntax), so
+/// `evaluate_yaml_cursor` skips building one for JSON output (#710
+/// follow-up efficiency fix) - this just pins that the skip doesn't change
+/// JSON output correctness for a document that does have comments.
+#[test]
+fn test_json_output_unaffected_by_comment_tree_skip_710() -> Result<()> {
+    let (out, code) = run_yq_stdin("select(true)", "a: 1 # keep this\nb: 2\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{\n  \"a\": 1,\n  \"b\": 2\n}\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5252,3 +5252,88 @@ fn test_block_scalar_header_comment_still_preserved_710() -> Result<()> {
     assert_eq!(out.trim(), "keep this");
     Ok(())
 }
+
+// Root-node trailing comments (#710 follow-up). Every expected string here
+// was verified byte-for-byte against the pinned real `yq` binary. Real `yq`
+// has a quirk worth pinning explicitly: a comment trailing a *scalar*
+// document root is dropped from output (though still readable via
+// `line_comment`), but a comment trailing an *array/object* document root is
+// kept - this is replicated exactly, not "improved into" a new divergence.
+
+/// A comment trailing the whole document's own array/object root (not a
+/// child field) was previously dropped everywhere - `emit_yaml_value`'s
+/// scalar/root arms only ever append a *child's* comment, appended by the
+/// child's parent during recursion; nothing appended the outermost value's
+/// own comment. Matches real `yq`, which keeps this for container roots.
+#[test]
+fn test_root_array_comment_preserved_on_identity_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "[1, 2, 3] # trailing\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[1, 2, 3] # trailing\n");
+    Ok(())
+}
+
+#[test]
+fn test_root_object_comment_preserved_on_identity_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "{a: 1} # trailing\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: 1} # trailing\n");
+    Ok(())
+}
+
+/// Same fix, but through the DOM/`select` path (`output_value` in
+/// `yq_runner.rs`) rather than the M2/P9 streaming path exercised by plain
+/// identity above.
+#[test]
+fn test_root_array_comment_preserved_on_select_710() -> Result<()> {
+    let (out, code) = run_yq_stdin("select(true)", "{a: 1} # trailing\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim_end(), "a: 1 # trailing");
+    Ok(())
+}
+
+/// A comment trailing a *scalar* document root is a known real-`yq` quirk
+/// (verified empirically): it's dropped from output on both identity and
+/// `select`, unlike an array/object root. `line_comment` still returns it
+/// (the data isn't lost internally, just not re-emitted) - pinning this
+/// exact behavior rather than "fixing" it into a new divergence from real
+/// `yq`.
+#[test]
+fn test_root_scalar_comment_dropped_on_identity_matches_real_yq_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "42 # trailing\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "42");
+
+    let (out, code) = run_yq_stdin("select(true)", "42 # trailing\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "42");
+
+    let (out, code) = run_yq_stdin(". | line_comment", "42 # trailing\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "trailing");
+    Ok(())
+}
+
+/// Field/index navigation extracts a bare value and must NOT gain the
+/// parent-context comment, even where the M2 path shares its streaming
+/// entry point with plain identity - `stream_yaml_as_document` (identity
+/// only) vs. `stream_yaml` (bare navigated results) must stay distinct.
+/// Matches real `yq`: `.a` on `a: 1 # keep this` outputs bare `1`.
+#[test]
+fn test_field_navigation_still_drops_comment_after_root_fix_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a", "a: 1 # keep this\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "1");
+    Ok(())
+}
+
+/// A comment trailing the first document's scalar root in a multi-document
+/// stream is dropped by real `yq` too (verified empirically) - not a
+/// regression to "fix" here.
+#[test]
+fn test_multi_doc_root_scalar_comment_dropped_matches_real_yq_710() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "42 # trailing\n---\nfoo: bar\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "42\n---\nfoo: bar\n");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds trailing same-line YAML comment (`a: 1 # keep this`) capture to the semi-index, a `line_comment` getter builtin, and always-on output preservation — closes the "no builtin to read a comment back, and comments silently dropped from every output" gap in #710.
- Preservation works on paths that keep a live YAML cursor: identity (`.`), field/index navigation (`.a`, `.[0]`, `.[]`), cursor-preserving filters (`select(...)`), and `-S`/`--sort-keys`. All verified byte-for-byte against the pinned real `yq` binary.
- **Known gap, not silently shipped**: assignment operators (`=`, `|=`, `+=`, ...) still drop comments — for the *entire* document, not just the assigned field — because `Expr::Assign` falls through a JSON-round-trip evaluator path that has no cursor/comment data to carry. This is a materially bigger change (comment-aware assignment logic, not write-path wiring) and is tracked separately in #752 rather than attempted here.
- **Known gap, not silently shipped**: a same-line comment on a mapping key whose value is deferred to the next line (`a: # comment\n  b: 1`) isn't exposed by `line_comment` at all — verified this actually matches real `yq` (it doesn't expose it via any getter either, only via a full-document re-marshal), but succinctly's output currently drops it where real `yq` keeps it. Needs a second, key-owned comment map distinct from this PR's value-owned one; tracked separately in #765.
- `head_comment`/`foot_comment` (standalone-line comments, as opposed to a trailing same-line comment) remain out of scope per the original issue's own scope note.

## Post-review fixes

A code review after the initial implementation found two correctness bugs, one efficiency gap, and a few cleanups, all now fixed on this branch:

- **Block scalars were stealing a following sibling's comment**, not just dropping it. `a: |\n  line one\n# comment for b\nb: 2` attached `# comment for b` to `a` instead of leaving it alone — `self.pos` had already advanced past the whole block region by the time the generic same-line capture ran. Worse than a drop: silent misattribution, corrupting output on an unrelated node. Fixed by splitting the capture logic so block scalars record their end position without re-triggering it (their own trailing comment, if any, is already captured explicitly on the header line).
- **A comment trailing the whole document's array/object root was dropped.** Every node's own comment was appended by its *parent* during recursion, but nothing did that for the outermost value — `[1, 2, 3] # trailing` lost the comment on identity, `select`, and other cursor-preserving queries, contradicting this PR's own documented scope. Fixed in both the DOM path and the M2/P9 streaming path (a new `stream_yaml_as_document`, kept distinct from `stream_yaml` since the latter is shared with bare field/index navigation results, which must *not* gain a comment they didn't have — matches real `yq`'s own quirk of dropping this specifically for *scalar* roots, verified empirically and replicated rather than "improved" into a new divergence).
- **`-o json` was building a `CommentTree` it never reads.** `evaluate_yaml_cursor` now only builds one when output is YAML.
- A doc comment on `CommentTree` named a consumer (`stream_owned_value_yaml`) that doesn't actually consult it; corrected to name the real second mechanism (`YamlCursor::stream_yaml_value`/`stream_yaml_as_document`, which stream comments from a live cursor and bypass `CommentTree` entirely).
- Two small dedups: a shared `trailing_comment_suffix` helper (was duplicated 3x in `emit_yaml_value`), and a shared `is_inline_whitespace` predicate (was reimplemented locally in `maybe_capture_line_comment` instead of reusing `skip_inline_whitespace`'s).

All fixes verified byte-for-byte against the pinned real `yq` binary and covered by new regression tests in `tests/yq_cli_tests.rs`.

## Design

- **Capture**: `bp_to_line_comment: BTreeMap<usize, (u32, u32)>` added to `SemiIndex`/`YamlIndex`, storing only a raw byte-range (not an owned string) since source text is already retained — cheaper than the existing `anchors` side table. Hooked into the existing `set_bp_text_end` (fires after every scalar's end position is recorded, covering plain/quoted scalars uniformly) plus explicit sites for flow-collection-close and block-scalar-header trailing comments. `set_bp_text_end` is now split into a capture variant and a `set_bp_text_end_position` no-capture variant used by block scalars (see Post-review fixes above).
- **Cursor/trait**: `YamlCursor::line_comment()`/`line_comment_raw()` (stripped vs. raw-with-`#` forms), `DocumentCursor::line_comment()`/`line_comment_raw()` trait defaults (`None`), following the existing `line()`/`column()` template rather than the broken `anchor`/`style` fallthrough pattern `eval_generic.rs` had for those.
- **Builtin**: `Builtin::LineComment`, wired through the parser keyword, native `eval_generic.rs` dispatch arm, and the four compile-enforced exhaustive matches in `eval.rs` plus the `builtins/0` name list.
- **Write path**: P9 cursor streaming (`YamlCursor::stream_yaml_value`/`stream_yaml_as_document`) emits the raw comment inline. The DOM path (`emit_yaml_value` in `yq_runner.rs`) threads a new shape-parallel `CommentTree` (`eval_generic.rs`), built by `to_owned_with_comments` only at the two DOM-boundary call sites that still have a live cursor, and only when the output format can use it (JSON output skips it — see Post-review fixes) — additive, not a signature change to the existing `to_owned` (which has ~200 unrelated internal call sites).

## Format details (verified empirically against the pinned `yq` binary, not assumed)

- `line_comment` getter strips `# ` (hash + one space) when present; `#text` with no space after `#` is returned unchanged, `#` included.
- No comment → `""`, not `null` (differs from `line`/`column`'s `0` default).
- On write, the gap before `#` is normalized to exactly one space regardless of the source's original spacing; everything from `#` onward (including internal/trailing whitespace) is preserved verbatim.
- A comment trailing a *scalar* document root is dropped from output (though still readable via `line_comment`), while an array/object root keeps it — a real `yq` quirk, replicated exactly rather than "fixed" into a new divergence. Multi-document streams drop a scalar root's comment the same way real `yq` does.

## Test plan

- [x] `cargo test` — full suite, 2500+ tests, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the two additional CI feature-set clippy invocations — clean
- [x] New unit tests: parser/index capture across plain/quoted/flow scalar/flow-collection-close/block-scalar-header (`src/yaml/index.rs`), `line_comment` builtin with/without cursor + JSON no-op (`src/jq/eval_generic.rs`)
- [x] New CLI tests (`tests/yq_cli_tests.rs`, 22 cases) covering identity/navigation/select/sort-keys preservation, the builtin's exact stripping/default rules, an explicit known-gap test pinning assignment's current (unchanged) behavior, block-scalar misattribution, root-node array/object preservation (DOM + streaming), the scalar-root/multi-doc quirks matching real `yq`, and JSON output correctness with the `CommentTree` build skipped
- [x] Manual verification of the issue's own repros against the release binary
- [x] `./scripts/build.sh` (check + clippy + release build, both crates)
- [x] Full CI green on this branch (all platforms/toolchains, coverage, golden-drift checks)

Addresses #710 (not closing — assignment preservation is tracked separately in #752, and key-owned deferred-value comments in #765; the issue title 'comments silently dropped from all output' is not yet fully true for those two cases).
