### PR TITLE
fix(jq, yaml, cli): sync assigned anchor values to their yq aliases

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -420,12 +420,17 @@ fn evaluate_input(
 /// Whether `expr`'s top-level shape is "rewrite the document at specific
 /// paths, leaving everything else identical" -- the class of expression for
 /// which comparing a path's value before and after the write is meaningful.
-/// Unwraps `Paren`/`Optional` so `(.a = 1)?` still matches.
+/// Unwraps `Paren`/`Optional` so `(.a = 1)?` still matches, and recurses into
+/// `Pipe` so a chain of assignments like `.a = 1 | .b = 2` (the common
+/// `yq -i '... | ...'` idiom) matches when every stage does.
 ///
 /// Used to gate the alias-sync post-process (#711): outside this class (a
 /// bare `map`, `select`, `.a, .b`, ...) the result document doesn't
 /// necessarily share the input's shape at all, so diffing "the same path" in
-/// both would be meaningless at best and could clobber it at worst.
+/// both would be meaningless at best and could clobber it at worst. A pipe
+/// with even one non-assign stage (`.a = 1 | select(...)`) is conservatively
+/// excluded for the same reason, even though some such stages would in fact
+/// preserve paths -- that's left for a future extension, not assumed here.
 fn is_alias_sensitive_assign(expr: &Expr) -> bool {
     match expr {
         Expr::Assign { .. }
@@ -434,6 +439,7 @@ fn is_alias_sensitive_assign(expr: &Expr) -> bool {
         | Expr::AlternativeAssign { .. }
         | Expr::Builtin(Builtin::Del(_)) => true,
         Expr::Paren(inner) | Expr::Optional(inner) => is_alias_sensitive_assign(inner),
+        Expr::Pipe(stages) => stages.iter().all(is_alias_sensitive_assign),
         _ => false,
     }
 }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -12,7 +12,9 @@ use std::path::Path;
 
 use succinctly::jq::document::{DocumentCursor, DocumentFields};
 use succinctly::jq::eval_generic::{eval_with_cursor_using, to_owned, GenericResult};
-use succinctly::jq::{self, Builtin, Expr, OwnedValue, QueryResult, YqSemantics};
+use succinctly::jq::{
+    self, sync_aliased_paths, Builtin, Expr, OwnedValue, QueryResult, YqSemantics,
+};
 use succinctly::json::light::StandardJson;
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
@@ -415,6 +417,90 @@ fn evaluate_input(
     }
 }
 
+/// Whether `expr`'s top-level shape is "rewrite the document at specific
+/// paths, leaving everything else identical" -- the class of expression for
+/// which comparing a path's value before and after the write is meaningful.
+/// Unwraps `Paren`/`Optional` so `(.a = 1)?` still matches.
+///
+/// Used to gate the alias-sync post-process (#711): outside this class (a
+/// bare `map`, `select`, `.a, .b`, ...) the result document doesn't
+/// necessarily share the input's shape at all, so diffing "the same path" in
+/// both would be meaningless at best and could clobber it at worst.
+fn is_alias_sensitive_assign(expr: &Expr) -> bool {
+    match expr {
+        Expr::Assign { .. }
+        | Expr::Update { .. }
+        | Expr::CompoundAssign { .. }
+        | Expr::AlternativeAssign { .. }
+        | Expr::Builtin(Builtin::Del(_)) => true,
+        Expr::Paren(inner) | Expr::Optional(inner) => is_alias_sensitive_assign(inner),
+        _ => false,
+    }
+}
+
+/// Walk `cursor`'s document collecting, for every anchor with at least one
+/// alias, its definition path and the path of every alias that resolves to
+/// it (#711). Paths are plain `String`/`i64` key sequences -- the same shape
+/// `sync_aliased_paths` (and jq's own `getpath`/`setpath`) use -- so they
+/// line up with coordinates in the `OwnedValue` tree `to_owned` builds from
+/// this same document.
+///
+/// Mirrors `yaml_to_owned_value`'s recursion, including its treatment of
+/// merge keys (`<<: *base`): `Mapping`'s `fields` iterator already resolves
+/// them transparently, so this walk does too, unchanged. Fixing merge-key/
+/// anchor interaction is issue #712's territory, not this one.
+fn collect_alias_groups<W: AsRef<[u64]> + Clone>(
+    cursor: YamlCursor<'_, W>,
+) -> Vec<(Vec<OwnedValue>, Vec<Vec<OwnedValue>>)> {
+    let mut defs: IndexMap<String, Vec<OwnedValue>> = IndexMap::new();
+    let mut aliases: IndexMap<String, Vec<Vec<OwnedValue>>> = IndexMap::new();
+    let mut path = Vec::new();
+    walk_alias_groups(cursor, &mut path, &mut defs, &mut aliases);
+    defs.into_iter()
+        .filter_map(|(name, def_path)| Some((def_path, aliases.swap_remove(&name)?)))
+        .collect()
+}
+
+fn walk_alias_groups<W: AsRef<[u64]> + Clone>(
+    cursor: YamlCursor<'_, W>,
+    path: &mut Vec<OwnedValue>,
+    defs: &mut IndexMap<String, Vec<OwnedValue>>,
+    aliases: &mut IndexMap<String, Vec<Vec<OwnedValue>>>,
+) {
+    // `anchor()` returns `None` for alias nodes, so an alias is never
+    // mistaken for its own definition here.
+    if let Some(name) = cursor.anchor() {
+        defs.insert(name.to_string(), path.clone());
+    }
+    match cursor.value() {
+        YamlValue::Mapping(fields) => {
+            for field in fields {
+                path.push(OwnedValue::String(field.key().key_string().into_owned()));
+                walk_alias_groups(field.value_cursor(), path, defs, aliases);
+                path.pop();
+            }
+        }
+        YamlValue::Sequence(elements) => {
+            let mut idx = 0i64;
+            let mut rest = elements;
+            while let Some((elem_cursor, next_rest)) = rest.uncons_cursor() {
+                path.push(OwnedValue::Int(idx));
+                walk_alias_groups(elem_cursor, path, defs, aliases);
+                path.pop();
+                idx += 1;
+                rest = next_rest;
+            }
+        }
+        YamlValue::Alias { anchor_name, .. } => {
+            aliases
+                .entry(anchor_name.to_string())
+                .or_default()
+                .push(path.clone());
+        }
+        _ => {}
+    }
+}
+
 /// Evaluate a jq expression directly on a YAML cursor.
 ///
 /// This uses the generic evaluator to preserve position metadata (line/column).
@@ -423,10 +509,18 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     expr: &Expr,
     sink: &mut ErrorSink,
 ) -> Result<Vec<OwnedValue>> {
+    // Snapshot alias-sync context from the pristine document *before*
+    // evaluation, only when it could possibly matter (#711): an
+    // assignment-family expression against a document that actually has
+    // aliases. Everything else (JSON, plain reads, alias-free YAML) pays
+    // nothing beyond this one bool check.
+    let alias_sync_ctx = (is_alias_sensitive_assign(expr) && cursor.index().has_aliases())
+        .then(|| (to_owned(&cursor.value()), collect_alias_groups(cursor)));
+
     let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
 
     // Convert GenericResult to Vec<OwnedValue>
-    match result {
+    let mut docs = match result {
         GenericResult::One(v) => Ok(vec![to_owned(&v)]),
         GenericResult::OneCursor(c) => Ok(vec![to_owned(&c.value())]),
         GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).collect()),
@@ -483,7 +577,17 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
             sink.report_break(DiagStyle::Yq, &label, &no_location());
             Ok(vs)
         }
+    };
+
+    if let Some((pristine, groups)) = &alias_sync_ctx {
+        if let Ok(docs) = &mut docs {
+            for doc in docs.iter_mut() {
+                sync_aliased_paths(doc, pristine, groups);
+            }
+        }
     }
+
+    docs
 }
 
 /// Convert a StandardJson value to an OwnedValue.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12550,6 +12550,47 @@ fn set_value_at_path(
     }
 }
 
+/// Propagate a write through a YAML anchor to every alias sharing it (#711).
+///
+/// YAML anchor/alias pairs are the same node in the representation graph: a
+/// write through the anchor's own path must be visible through every alias
+/// that points to it, matching real `yq`. `OwnedValue` itself has no notion
+/// of shared identity, so this is applied as a post-process instead: `groups`
+/// is a list of `(anchor_definition_path, [alias_paths...])` pairs, computed
+/// by the caller from the pre-mutation document. For each group, if the
+/// value at the definition path differs between `pristine` (before the
+/// write) and `result` (after), every alias path is overwritten with a clone
+/// of the new value.
+///
+/// A group whose definition path no longer resolves in `result` (e.g. the
+/// anchored key was deleted) is left untouched, so its aliases keep their
+/// last-resolved value -- matching how a detached graph node behaves in real
+/// yq. Likewise, a write that lands on an alias path directly rather than
+/// the anchor's own path leaves every other member of the group alone, since
+/// the anchor's own value never changed.
+pub fn sync_aliased_paths(
+    result: &mut OwnedValue,
+    pristine: &OwnedValue,
+    groups: &[(Vec<OwnedValue>, Vec<Vec<OwnedValue>>)],
+) {
+    for (def_path, alias_paths) in groups {
+        let (Some(old), Some(new)) = (
+            get_value_at_path(pristine, def_path),
+            get_value_at_path(result, def_path),
+        ) else {
+            continue;
+        };
+        if old == new {
+            continue;
+        }
+        for alias_path in alias_paths {
+            if let Ok(updated) = set_value_at_path(result.clone(), alias_path, new.clone()) {
+                *result = updated;
+            }
+        }
+    }
+}
+
 /// Builtin: setpath(path; value) - set value at path
 fn builtin_setpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -83,7 +83,8 @@ mod value;
 
 pub use error::{BinOp, Control, EvalError};
 pub use eval::{
-    eval, eval_lenient, substitute_vars, EvalSemantics, JqSemantics, QueryResult, YqSemantics,
+    eval, eval_lenient, substitute_vars, sync_aliased_paths, EvalSemantics, JqSemantics,
+    QueryResult, YqSemantics,
 };
 pub use expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MetaValue,

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -360,6 +360,15 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         self.aliases.contains_key(&bp_pos)
     }
 
+    /// Whether this document has any alias (`*name`) references at all.
+    ///
+    /// Used to skip alias-sensitive post-processing entirely for the
+    /// overwhelmingly common case of a document with no aliases (#711).
+    #[inline]
+    pub fn has_aliases(&self) -> bool {
+        !self.aliases.is_empty()
+    }
+
     /// Check if a BP position is a sequence item wrapper.
     ///
     /// Sequence items have BP open/close but no TY entry.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1602,6 +1602,31 @@ fn test_yaml_plain_alias_read_unaffected_by_assign_gating() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_yaml_pipe_chained_assigns_through_anchor_updates_alias() -> Result<()> {
+    // A chain of assignments joined by `|` -- the common `yq -i '.a = 1 |
+    // .b = 2' file` idiom -- must sync aliases too, not just a single
+    // top-level assignment. Each `|` stage here rewrites `.a` in place, so
+    // the whole chain still qualifies as alias-sensitive.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 5 | .a = 10", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":10,"b":10}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_pipe_chained_assigns_to_different_paths_through_anchor_updates_alias() -> Result<()> {
+    // The stages don't need to touch the same path -- as long as every
+    // stage is itself alias-sensitive, later stages can read the
+    // already-synced value.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99 | .c = .a + 1", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":99,"b":99,"c":100}"#);
+    Ok(())
+}
+
 // =============================================================================
 // Anchored sequence items (#328) - an anchor on `- ` binds to the item's value
 // whatever its kind. Expectations are mikefarah/yq v4.53.3 output.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1489,6 +1489,120 @@ fn test_yaml_anchor_alias_without_merge() -> Result<()> {
 }
 
 // =============================================================================
+// Assignment through an anchor propagates to aliases (#711) - real yq treats
+// an anchor/alias pair as one shared node in the representation graph, so a
+// write through the anchor must be visible through every alias. succinctly
+// deliberately does not reproduce the `&x`/`*x` syntax on output (a separate,
+// already-tracked gap, #709) -- only value propagation is in scope here, so
+// these assert on values (via `-o=json`) rather than YAML anchor syntax.
+// =============================================================================
+
+#[test]
+fn test_yaml_assign_through_anchor_updates_alias() -> Result<()> {
+    // The issue's own repro: `.a = 99` must be visible through `.b`'s alias.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":99,"b":99}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_through_alias_does_not_clobber_anchor() -> Result<()> {
+    // Writing directly to the alias detaches it -- the anchor's own value
+    // must be left alone, matching real yq.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".b = 5", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":1,"b":5}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_unrelated_key_does_not_sync_alias() -> Result<()> {
+    // Writing an unrelated key must not perturb an anchor/alias pair it
+    // never touched.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = 5", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":1,"b":1,"c":5}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_nested_field_through_anchor_updates_alias() -> Result<()> {
+    // A write nested inside the anchored subtree must propagate the whole
+    // updated subtree to every alias, not just a top-level scalar.
+    let input = "a: &x\n  p: 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a.p = 9", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":{"p":9},"b":{"p":9}}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_through_anchor_updates_multiple_aliases() -> Result<()> {
+    let input = "a: &x 1\nb: *x\nc: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":99,"b":99,"c":99}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_update_assign_through_anchor_updates_alias() -> Result<()> {
+    // `|=` goes through the same fallback path as `=` and must sync too.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a |= . + 100", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":101,"b":101}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_compound_assign_through_anchor_updates_alias() -> Result<()> {
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a += 100", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":101,"b":101}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_del_nested_field_through_anchor_updates_alias() -> Result<()> {
+    // Deleting a field inside the anchored subtree shrinks every alias's
+    // copy too -- the shared node lost a field, not just the `.a` view.
+    let input = "a: &x\n  p: 1\n  q: 2\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin("del(.a.q)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":{"p":1},"b":{"p":1}}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_del_anchor_key_leaves_alias_at_last_value() -> Result<()> {
+    // Deleting the anchor's own key removes it from the document; there's
+    // nothing left to propagate, so the alias keeps its last-resolved value
+    // -- matching how a detached graph node behaves in real yq.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin("del(.a)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"b":1}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_plain_alias_read_unaffected_by_assign_gating() -> Result<()> {
+    // Regression check: a plain read of an alias (no assignment involved)
+    // must remain unaffected by the new alias-sync gating check.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".b", input, &["-o=json"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "1");
+    Ok(())
+}
+
+// =============================================================================
 // Anchored sequence items (#328) - an anchor on `- ` binds to the item's value
 // whatever its kind. Expectations are mikefarah/yq v4.53.3 output.
 // =============================================================================


### PR DESCRIPTION
## Summary

- Assignment (`=`, `|=`, `+=`, `-=`, `*=`, `/=`, `%=`, `//=`) and `del()` materialize YAML into `OwnedValue` via the JSON-reindex fallback, which resolves each alias to an independent copy of its anchor's value — so writing through the anchor left every alias stale. Reads alone were already correct: `YamlCursor` re-resolves aliases against the live text on every access.
- Adds `YamlIndex::has_aliases()` and `jq::sync_aliased_paths()`, which diffs each anchor's subtree in the pre- and post-write `OwnedValue` trees and clones the new value over every alias path when it changed. Wired into `yq_runner`'s `evaluate_yaml_cursor`, gated on assignment-family expressions (including `del()`) against a document that actually has aliases, so every other query pays nothing beyond one bool check.
- **Scope**: value correctness only. Output stays anchor-free (`a: 99` / `b: 99`, not real yq's `a: &x 99` / `b: *x`) since no query shape emits `&x`/`*x` syntax today — that's a separate, already-tracked gap (#709).

Fixes #711

## Test plan

- [x] `cargo build --release --features cli` — clean
- [x] `cargo test --features cli,simd,regex,serde` — full suite passes (2096+ unit tests, all integration suites, doc-tests), zero failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's SIMD-path leg, per project convention) — clean
- [x] 11 new tests in `tests/yq_cli_tests.rs`: the issue's own repro, direct-alias-write non-propagation, unrelated-key no-op, nested writes through the anchored subtree, multiple aliases, `|=`/`+=`, `del()` at both a nested field and the anchor's own key, and a plain-read regression check
- [x] Manual repro: `printf 'a: &x 1\nb: *x\n' | succinctly yq '.a = 99'` → `a: 99` / `b: 99` (was `a: 99` / `b: 1`)