### PR TITLE
yq: add --front-matter, --split-exp, and --eval-all/file_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`yq` gains `--front-matter`, `--split-exp`, and `--eval-all`/`file_index`**
+  (#715), closing three real `yq` CLI gaps found by a systematic gap-audit:
+  - `--front-matter=extract|process` operates on YAML embedded as front
+    matter in another file (e.g. a Markdown post's `---`-fenced header):
+    `extract` evaluates the expression against just the front matter,
+    discarding the body; `process` re-emits the transformed front matter
+    followed by the original body, byte-for-byte unchanged.
+  - `--split-exp EXPR` splits output into one file per result, named by
+    evaluating `EXPR` against it (`.` is the result, `$index` its 0-based
+    output index). Deliberately long-only, unlike real yq's `-s`/
+    `--split-exp`: succinctly's `-s` is already `--slurp`.
+  - `--eval-all`/`--ea` combines every document from every file into one
+    evaluation context, exposing a new `file_index`/`fileIndex`/`fi`
+    builtin for cross-file merges (`.[] | select(file_index == 0)`).
+    Requires explicit `.[]` iteration, unlike real yq's implicit
+    node-list broadcast (`select(fileIndex == 0)` with no `.[]`) — a
+    deliberate, documented scope boundary given succinctly's evaluator has
+    one scalar value per evaluation, not a broadcasting node list.
+    Building it surfaced and fixed a pre-existing gap: `key`/
+    `document_index` (and now `file_index`) inside a `select(...)`
+    condition or a comparison (`select(key >= 1)`, `document_index == 0`)
+    previously fell back to their 0/null stub instead of resolving via
+    path context, because `needs_path_context` never recursed into
+    `Expr::Select`/`Expr::Compare`/`Expr::Arithmetic`.
+  - See [yq Language Reference](docs/reference/yq-language.md#cross-file-operations-succinctly-extension)
+    for the full `--eval-all` deviation and supported idioms.
+
 - **jq `@csv`/`@tsv`/`@dsv`/`@sh` allocation overhead investigated: no
   measurable end-to-end effect** (#647, follow-up to #124's real win for
   `@uri`/`@html`): a byte-scanning rewrite of the four format functions was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`yq --front-matter`/`--split-exp`/`--eval-all` correctness fixes found
+  reviewing #715 before merge**:
+  - `--front-matter=extract --inplace` overwrote the target file with just
+    the transformed front matter, discarding everything after the closing
+    fence — `extract` mode captures no body to reattach (only `process`
+    does). Now rejected with a clear error; use `--front-matter=process` to
+    edit in place.
+  - The path-context evaluator's shared `Partial`-result continuation
+    (`continue_rest_with_context`, reached by `Select`/`Map`/`If`/`Comma`/
+    `Try`/`Label`) skipped piping its already-produced values through the
+    rest of the pipe: `.[] | (1, error("boom")) | file_index` returned the
+    raw `1` instead of `file_index`'s resolved value, and silently dropped
+    any error the rest of the pipe would itself have raised.
+  - `--eval-all` never routed its output through the `SplitDocState` state
+    machine every other output path uses, so `--eval-all '... | split_doc'`
+    silently merged every result with zero `---` separators.
+  - `--split-exp`'s expression never received `--arg`/`--argjson`/`$ARGS`
+    substitution (only `$index` was bound per result), so a filename
+    expression referencing an `--arg` value failed as an undefined variable
+    even though the same `--arg` works for the main filter.
+  - `--front-matter`'s fence detection scanned only for `\n`, so a file with
+    classic-Mac (`\r`-only) line endings collapsed into one "line" and its
+    front matter was misreported as unterminated — the same failure class
+    #324 already fixed for the YAML parser — and a leading UTF-8 BOM
+    defeated fence detection entirely, both now fixed by routing through
+    the shared `text::line_break` rule.
+  - `apply_front_matter` silently forced `InputFormat::Yaml` even when the
+    caller explicitly passed `--input-format json`; now rejected instead.
+
+  Also documented two pre-existing behaviors, not bugs, found along the
+  way: `--slurp`/`--eval-all` output carries no comments (both combine
+  documents through the `OwnedValue` DOM, which has none to carry), and
+  `--front-matter`'s position builtins (`at_offset`/`at_position`/`line`/
+  `column`) resolve against the extracted YAML block's own coordinates,
+  not the original file.
+
 - **`gmtime`, `mktime`, and `strptime` raised the right exit code but the
   wrong message on bad input** (#761): `gmtime`/`localtime` on a non-number
   reported the generic `"math function requires number"` (shared with

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -421,7 +421,7 @@ succinctly yq '.users[]' input.yaml
 - `-P, --prettyPrint`: Pretty print, expand flow styles to block style
 - `--tab`: Use tabs for indentation
 - `-a, --ascii-output`: Output ASCII only, escaping non-ASCII as `\uXXXX`
-- `--split-exp <EXPR>`: Split output into one file per result, named by evaluating `EXPR` against it (`.` is the result, `$index` its 0-based output index); suppresses stdout. Long-only, unlike real yq's `-s`/`--split-exp` — succinctly's `-s` is already `--slurp` (#715). Incompatible with `--slurp`, `--inplace`, `--front-matter`; `--raw-input` not yet supported
+- `--split-exp <EXPR>`: Split output into one file per result, named by evaluating `EXPR` against it (`.` is the result, `$index` its 0-based output index; `--arg`/`--argjson` values and `$ARGS` are also available, same as the main filter). Suppresses stdout. Long-only, unlike real yq's `-s`/`--split-exp` — succinctly's `-s` is already `--slurp` (#715). Incompatible with `--slurp`, `--inplace`, `--front-matter`; `--raw-input` not yet supported
 
 ### Input Options
 
@@ -432,8 +432,8 @@ succinctly yq '.users[]' input.yaml
 - `--validate`: Validate YAML strictly (opt-in) before processing; reports line:column errors and bails without producing output (see [YAML Validation](#yaml-validation))
 - `-i, --inplace`: Update the file in place
 - `--doc <N>`: Select specific document by 0-based index from multi-document stream
-- `--eval-all`, `--ea`: Combine all documents from all files into one evaluation context, exposing `file_index`/`fileIndex`/`fi` for cross-file merges (e.g. `.[] | select(file_index == 0)`). Requires explicit `.[]` iteration, unlike real yq's bare `select(fileIndex == 0)` — see [yq Language Reference](../reference/yq-language.md#cross-file-operations-succinctly-extension) for the full deviation (#715). Incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, `--front-matter`
-- `--front-matter <MODE>`: Treat input as text with a `---`-fenced YAML front matter header (e.g. Markdown). `extract` evaluates only the front matter, discarding the body; `process` re-emits the transformed front matter followed by the untouched body. Incompatible with `--doc`, `--null-input`, `--raw-input`, `--eval-all`; `process` mode also requires YAML output and is incompatible with `--slurp`
+- `--eval-all`, `--ea`: Combine all documents from all files into one evaluation context, exposing `file_index`/`fileIndex`/`fi` for cross-file merges (e.g. `.[] | select(file_index == 0)`). Requires explicit `.[]` iteration, unlike real yq's bare `select(fileIndex == 0)` — see [yq Language Reference](../reference/yq-language.md#cross-file-operations-succinctly-extension) for the full deviation (#715). Combines documents through the `OwnedValue` DOM, same as `--slurp`, so output carries no comments regardless of the input. Incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, `--front-matter`
+- `--front-matter <MODE>`: Treat input as text with a `---`-fenced YAML front matter header (e.g. Markdown). `extract` evaluates only the front matter, discarding the body; `process` re-emits the transformed front matter followed by the untouched body. Incompatible with `--doc`, `--null-input`, `--raw-input`, `--eval-all`, an explicit `--input-format json` (front matter is YAML by definition); `process` mode also requires YAML output and is incompatible with `--slurp`; `extract` mode is incompatible with `--inplace` (it captures no body to reattach, so `-i` would discard everything after the closing fence). Position builtins (`at_offset`, `at_position`, `line`, `column`) resolve against the extracted YAML block's own coordinates, not the original file — a `line`/`column` reported under `--front-matter` does not match the file's line/column
 
 ### Variables
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -421,6 +421,7 @@ succinctly yq '.users[]' input.yaml
 - `-P, --prettyPrint`: Pretty print, expand flow styles to block style
 - `--tab`: Use tabs for indentation
 - `-a, --ascii-output`: Output ASCII only, escaping non-ASCII as `\uXXXX`
+- `--split-exp <EXPR>`: Split output into one file per result, named by evaluating `EXPR` against it (`.` is the result, `$index` its 0-based output index); suppresses stdout. Long-only, unlike real yq's `-s`/`--split-exp` — succinctly's `-s` is already `--slurp` (#715). Incompatible with `--slurp`, `--inplace`, `--front-matter`; `--raw-input` not yet supported
 
 ### Input Options
 
@@ -431,6 +432,8 @@ succinctly yq '.users[]' input.yaml
 - `--validate`: Validate YAML strictly (opt-in) before processing; reports line:column errors and bails without producing output (see [YAML Validation](#yaml-validation))
 - `-i, --inplace`: Update the file in place
 - `--doc <N>`: Select specific document by 0-based index from multi-document stream
+- `--eval-all`, `--ea`: Combine all documents from all files into one evaluation context, exposing `file_index`/`fileIndex`/`fi` for cross-file merges (e.g. `.[] | select(file_index == 0)`). Requires explicit `.[]` iteration, unlike real yq's bare `select(fileIndex == 0)` — see [yq Language Reference](../reference/yq-language.md#cross-file-operations-succinctly-extension) for the full deviation (#715). Incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, `--front-matter`
+- `--front-matter <MODE>`: Treat input as text with a `---`-fenced YAML front matter header (e.g. Markdown). `extract` evaluates only the front matter, discarding the body; `process` re-emits the transformed front matter followed by the untouched body. Incompatible with `--doc`, `--null-input`, `--raw-input`, `--eval-all`; `process` mode also requires YAML output and is incompatible with `--slurp`
 
 ### Variables
 
@@ -490,6 +493,16 @@ cat data.yaml | succinctly yq '.items[]'
 
 # Multi-document YAML
 succinctly yq '.' multi-doc.yaml
+
+# Combine documents across files, merge by file origin
+succinctly yq --eval-all '(.[] | select(file_index == 0)) * (.[] | select(file_index == 1))' base.yaml override.yaml
+
+# Extract/rewrite YAML front matter in a Markdown file
+succinctly yq --front-matter extract '.title' post.md
+succinctly yq --front-matter process --inplace '.tags += ["new"]' post.md
+
+# Split each array element into its own file
+succinctly yq --split-exp '.name + ".yml"' '.[]' users.yaml
 ```
 
 ### Differences from jq

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -137,7 +137,7 @@ succinctly yq --eval-all 'reduce .[] as $item ({}; . * $item)' f1.yaml f2.yaml f
 succinctly yq --eval-all '(.[] | select(file_index == 0)) * (.[] | select(file_index == 1))' f1.yaml f2.yaml
 ```
 
-**Deviation from real yq**: real yq's `eval-all` treats the combined documents as an implicit node list that most operators broadcast over, so `select(fileIndex == 0) * select(fileIndex == 1)` works with no `.[]`. succinctly's evaluator has one scalar value per evaluation instead, so `.[]` must be explicit — `.[] | select(file_index == 0)`, not the bare `select(fileIndex == 0)`. `file_index`/`key`/`document_index` resolve correctly through `.`/`.[]`/`.field` navigation, comparisons, and `select(...)`, matching what `document_index` already supports — but not inside `map(...)`, `if/then/else`, array/object literals, `any`/`all`, or user-defined functions, where they fall back to `0` (see [Known Limitations](#known-limitations)). `--eval-all` is incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, and `--front-matter`.
+**Deviation from real yq**: real yq's `eval-all` treats the combined documents as an implicit node list that most operators broadcast over, so `select(fileIndex == 0) * select(fileIndex == 1)` works with no `.[]`. succinctly's evaluator has one scalar value per evaluation instead, so `.[]` must be explicit — `.[] | select(file_index == 0)`, not the bare `select(fileIndex == 0)`. `file_index`/`key`/`document_index` resolve correctly through `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`, `if/then/else`, `try/catch`, comma, and `label`, matching what `document_index` already supports — but not inside array/object literals, `any`/`all`, or user-defined functions, where they fall back to `0` (see [Known Limitations](#known-limitations)). `--eval-all` is incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, and `--front-matter`.
 
 ### yq-Specific Operators
 
@@ -416,7 +416,7 @@ See [yq Remaining Work](../plan/yq-remaining.md) for incomplete features.
 
 1. **`line`/`column` in complex expressions** - Work best with direct cursor access; may return 0 after DOM conversion
 2. **Anchor metadata** - Available at cursor level; may be lost after complex jq operations
-3. **`file_index`/`key`/`document_index` in complex expressions** - Resolve through `.`/`.[]`/`.field` navigation, comparisons, and `select(...)`; return `0` inside `map(...)`, `if/then/else`, array/object literals, `any`/`all`, or user-defined functions
+3. **`file_index`/`key`/`document_index` in complex expressions** - Resolve through `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`, `if/then/else`, `try/catch`, comma, and `label`; return `0` inside array/object literals, `any`/`all`, or user-defined functions
 4. **`*`/`+` are not cartesian generators** - `(a, b) * (c, d)` takes only the first value of each side, unlike real jq/yq's cartesian-product combination; this bounds the `--eval-all` two-file merge idiom (`select(file_index == 0) * select(file_index == 1)`) to inputs where each file contributes exactly one matching document
 
 ---

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -112,6 +112,33 @@ succinctly yq '.items[] | split_doc' file.yaml
 # item3
 ```
 
+### Cross-File Operations (Succinctly Extension)
+
+`--eval-all`/`--ea` combines every document from every input file into one evaluation context (default `eval` mode evaluates each document independently, low memory). `file_index`/`fileIndex`/`fi` returns the 0-indexed origin file position, resolvable only within that combined context.
+
+| Function/Flag        | Description                                                      |
+|----------------------|------------------------------------------------------------------|
+| `--eval-all`, `--ea` | Combine all documents from all files into one evaluation context |
+| `file_index`         | 0-indexed origin file position (within `--eval-all`)             |
+| `fileIndex`          | Alias for `file_index` (real yq's own spelling)                  |
+| `fi`                 | Short alias for `file_index`                                     |
+
+```bash
+# Combine documents across files, count them
+succinctly yq --eval-all 'length' f1.yaml f2.yaml
+
+# Select only documents from the first file
+succinctly yq --eval-all '.[] | select(file_index == 0)' f1.yaml f2.yaml
+
+# General merge across any number of files
+succinctly yq --eval-all 'reduce .[] as $item ({}; . * $item)' f1.yaml f2.yaml f3.yaml
+
+# Merge exactly two files (correct only when each contributes one document)
+succinctly yq --eval-all '(.[] | select(file_index == 0)) * (.[] | select(file_index == 1))' f1.yaml f2.yaml
+```
+
+**Deviation from real yq**: real yq's `eval-all` treats the combined documents as an implicit node list that most operators broadcast over, so `select(fileIndex == 0) * select(fileIndex == 1)` works with no `.[]`. succinctly's evaluator has one scalar value per evaluation instead, so `.[]` must be explicit — `.[] | select(file_index == 0)`, not the bare `select(fileIndex == 0)`. `file_index`/`key`/`document_index` resolve correctly through `.`/`.[]`/`.field` navigation, comparisons, and `select(...)`, matching what `document_index` already supports — but not inside `map(...)`, `if/then/else`, array/object literals, `any`/`all`, or user-defined functions, where they fall back to `0` (see [Known Limitations](#known-limitations)). `--eval-all` is incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, and `--front-matter`.
+
 ### yq-Specific Operators
 
 | Operator      | Description                                  | Example                        |
@@ -285,25 +312,56 @@ succinctly yq 'at_position(5; 3)' config.yaml
 
 ### Input Options
 
-| Flag                  | Description                              |
-|-----------------------|------------------------------------------|
-| `-n, --null-input`    | Don't read input; use null               |
-| `-p, --input-format`  | Input format: `auto`, `yaml`, `json`     |
-| `-s, --slurp`         | Read all inputs into array               |
-| `-R, --raw-input`     | Read lines as strings instead of YAML    |
-| `--doc N`             | Select Nth document (0-indexed)          |
+| Flag                  | Description                                      |
+|-----------------------|--------------------------------------------------|
+| `-n, --null-input`    | Don't read input; use null                       |
+| `-p, --input-format`  | Input format: `auto`, `yaml`, `json`             |
+| `-s, --slurp`         | Read all inputs into array                       |
+| `-R, --raw-input`     | Read lines as strings instead of YAML            |
+| `--doc N`             | Select Nth document (0-indexed)                  |
+| `--eval-all`, `--ea`  | Combine docs/files into one eval context (below) |
+| `--front-matter MODE` | Extract/process YAML front matter (below)        |
 
 ### Output Options
 
-| Flag                  | Description                              |
-|-----------------------|------------------------------------------|
-| `-r, --unwrapScalar`  | Output raw strings without quotes        |
-| `-I, --indent N`      | Indent level (0 for compact)             |
-| `-o, --output-format` | Output format: `yaml`, `json`, `auto`    |
-| `-i, --inplace`       | Update file in place                     |
-| `-0, --nul-output`    | Use NUL separator instead of newline     |
-| `--no-doc`            | Omit document separators (`---`)         |
-| `--tab`               | Use tabs for indentation                 |
+| Flag                  | Description                                   |
+|-----------------------|-----------------------------------------------|
+| `-r, --unwrapScalar`  | Output raw strings without quotes             |
+| `-I, --indent N`      | Indent level (0 for compact)                  |
+| `-o, --output-format` | Output format: `yaml`, `json`, `auto`         |
+| `-i, --inplace`       | Update file in place                          |
+| `-0, --nul-output`    | Use NUL separator instead of newline          |
+| `--no-doc`            | Omit document separators (`---`)              |
+| `--tab`               | Use tabs for indentation                      |
+| `--split-exp EXPR`    | Split output into one file per result (below) |
+
+### `--front-matter` (Succinctly Extension)
+
+Real yq can operate on YAML embedded as front matter inside another file (e.g. Markdown with a `---`-delimited YAML header). `--front-matter extract` evaluates the expression against just the front matter and discards the trailing content; `--front-matter process` re-emits the transformed front matter (re-fenced) followed by the original trailing content, unchanged.
+
+```bash
+# Extract: read only the front matter
+succinctly yq --front-matter extract '.title' post.md
+
+# Process: rewrite the front matter in place, body untouched
+succinctly yq --front-matter process --inplace '.tags += ["new"]' post.md
+```
+
+A file without a leading `---` line errors. `--front-matter` is incompatible with `--doc`, `--null-input`, `--raw-input`, and `--eval-all`; `--front-matter=process` additionally requires YAML output and is incompatible with `--slurp` (a slurped array can't reattach a body per input file).
+
+### `--split-exp` (Succinctly Extension)
+
+Splits output into one file per result instead of printing to stdout, named by evaluating `EXPR` against that result (`.` is the result; `$index` is its zero-based output index across the whole run).
+
+```bash
+# One file per array element, named by index
+succinctly yq --split-exp '"out_" + ($index|tostring) + ".yml"' '.[]' data.yaml
+
+# Named by a field of the result itself
+succinctly yq --split-exp '.name + ".yml"' '.[]' data.yaml
+```
+
+**Deliberately long-only**, unlike real yq's `-s`/`--split-exp`: succinctly's `-s` is already `--slurp`. A non-string result errors; a duplicate filename overwrites with a warning. Incompatible with `--slurp`, `--inplace`, and `--front-matter`; `--raw-input` is not yet supported.
 
 ### Variables
 
@@ -358,6 +416,8 @@ See [yq Remaining Work](../plan/yq-remaining.md) for incomplete features.
 
 1. **`line`/`column` in complex expressions** - Work best with direct cursor access; may return 0 after DOM conversion
 2. **Anchor metadata** - Available at cursor level; may be lost after complex jq operations
+3. **`file_index`/`key`/`document_index` in complex expressions** - Resolve through `.`/`.[]`/`.field` navigation, comparisons, and `select(...)`; return `0` inside `map(...)`, `if/then/else`, array/object literals, `any`/`all`, or user-defined functions
+4. **`*`/`+` are not cartesian generators** - `(a, b) * (c, d)` takes only the first value of each side, unlike real jq/yq's cartesian-product combination; this bounds the `--eval-all` two-file merge idiom (`select(file_index == 0) * select(file_index == 1)`) to inputs where each file contributes exactly one matching document
 
 ---
 
@@ -409,12 +469,13 @@ succinctly yq '.services | to_entries[] | select(.value.image | contains("postgr
 
 ## Changelog
 
-| Date       | Change                                                   |
-|------------|----------------------------------------------------------|
-| 2026-01-20 | Initial yq implementation complete                       |
-| 2026-01-20 | Added date/time extensions: `from_unix`, `to_unix`, `tz` |
-| 2026-01-20 | Added `@yaml`, `@props` format encoders                  |
-| 2026-01-20 | Added `load(file)` operator                              |
-| 2026-01-20 | Added `split_doc` operator                               |
-| 2026-01-20 | Added multi-document support with `--doc N`              |
-| 2026-01-24 | Document created from plan/yq.md                         |
+| Date       | Change                                                                  |
+|------------|-------------------------------------------------------------------------|
+| 2026-01-20 | Initial yq implementation complete                                      |
+| 2026-01-20 | Added date/time extensions: `from_unix`, `to_unix`, `tz`                |
+| 2026-01-20 | Added `@yaml`, `@props` format encoders                                 |
+| 2026-01-20 | Added `load(file)` operator                                             |
+| 2026-01-20 | Added `split_doc` operator                                              |
+| 2026-01-20 | Added multi-document support with `--doc N`                             |
+| 2026-01-24 | Document created from plan/yq.md                                        |
+| 2026-08-10 | Added `--front-matter`, `--split-exp`, `--eval-all`/`file_index` (#715) |

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -347,11 +347,11 @@ succinctly yq --front-matter extract '.title' post.md
 succinctly yq --front-matter process --inplace '.tags += ["new"]' post.md
 ```
 
-A file without a leading `---` line errors. `--front-matter` is incompatible with `--doc`, `--null-input`, `--raw-input`, and `--eval-all`; `--front-matter=process` additionally requires YAML output and is incompatible with `--slurp` (a slurped array can't reattach a body per input file).
+A file without a leading `---` line errors. `--front-matter` is incompatible with `--doc`, `--null-input`, `--raw-input`, `--eval-all`, and an explicit `--input-format json` (front matter is YAML by definition); `--front-matter=process` additionally requires YAML output and is incompatible with `--slurp` (a slurped array can't reattach a body per input file); `--front-matter=extract` is incompatible with `--inplace` (it captures no body to reattach, so `-i` would discard everything after the closing fence). Position builtins (`at_offset`/`at_position`/`line`/`column`) resolve against the extracted YAML block's own coordinates, not the original file (see [Known Limitations](#known-limitations)).
 
 ### `--split-exp` (Succinctly Extension)
 
-Splits output into one file per result instead of printing to stdout, named by evaluating `EXPR` against that result (`.` is the result; `$index` is its zero-based output index across the whole run).
+Splits output into one file per result instead of printing to stdout, named by evaluating `EXPR` against that result (`.` is the result; `$index` is its zero-based output index across the whole run; `--arg`/`--argjson` values and `$ARGS` are also available, same as the main filter).
 
 ```bash
 # One file per array element, named by index
@@ -418,6 +418,8 @@ See [yq Remaining Work](../plan/yq-remaining.md) for incomplete features.
 2. **Anchor metadata** - Available at cursor level; may be lost after complex jq operations
 3. **`file_index`/`key`/`document_index` in complex expressions** - Resolve through `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`, `if/then/else`, `try/catch`, comma, and `label`; return `0` inside array/object literals, `any`/`all`, or user-defined functions
 4. **`*`/`+` are not cartesian generators** - `(a, b) * (c, d)` takes only the first value of each side, unlike real jq/yq's cartesian-product combination; this bounds the `--eval-all` two-file merge idiom (`select(file_index == 0) * select(file_index == 1)`) to inputs where each file contributes exactly one matching document
+5. **`--slurp`/`--eval-all` output has no comments** - both combine documents through the `OwnedValue` DOM (which carries no comment data) before evaluating, unlike the default per-document path
+6. **`--front-matter` position builtins use the extracted block's own coordinates** - `at_offset`, `at_position`, `line`, and `column` resolve against the extracted YAML slice, not the original file; a reported `line`/`column` is offset from the file's real line/column by the front-matter header's length
 
 ---
 

--- a/src/bin/succinctly/front_matter.rs
+++ b/src/bin/succinctly/front_matter.rs
@@ -6,6 +6,8 @@
 
 use std::fmt;
 
+use succinctly::text::line_break::line_break_len;
+
 /// The result of successfully splitting front matter from an input.
 #[derive(Debug)]
 pub struct FrontMatter<'a> {
@@ -46,13 +48,19 @@ impl fmt::Display for FrontMatterError {
 
 impl std::error::Error for FrontMatterError {}
 
+/// A leading UTF-8 BOM, if present, sits before the `---` fence rather than
+/// inside it -- common in Markdown files saved by Windows editors.
+const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
+
 /// Split `input` into its YAML front matter and trailing body.
 ///
 /// The input must start with a line that is exactly `---` (trailing
-/// whitespace/`\r` ignored). The front matter ends at the next line that is
-/// exactly `---` or `...` (mirroring YAML's own end-of-document marker).
-/// Everything after that line is returned as the body, unparsed.
+/// whitespace/`\r` ignored, and a leading UTF-8 BOM skipped). The front
+/// matter ends at the next line that is exactly `---` or `...` (mirroring
+/// YAML's own end-of-document marker). Everything after that line is
+/// returned as the body, unparsed.
 pub fn split_front_matter(input: &[u8]) -> Result<FrontMatter<'_>, FrontMatterError> {
+    let input = input.strip_prefix(UTF8_BOM).unwrap_or(input);
     let mut lines = LineScanner::new(input);
 
     let first = lines.next().ok_or(FrontMatterError::NoFrontMatter)?;
@@ -77,14 +85,18 @@ pub fn split_front_matter(input: &[u8]) -> Result<FrontMatter<'_>, FrontMatterEr
 /// The line-ending convention `body` uses, detected from its first line
 /// terminator. `--front-matter=process` reattaches `body` byte-for-byte, so
 /// a fence line injected right before it (the closing `---`) must match --
-/// otherwise a CRLF body ends up preceded by a bare-LF fence, producing a
+/// otherwise a CRLF body ends up preceded by a mismatched fence, producing a
 /// file with mixed line endings. Falls back to `\n` for a body with no line
 /// break to sniff (nothing to mismatch).
 pub(crate) fn body_line_ending(body: &[u8]) -> &'static [u8] {
-    match body.iter().position(|&b| b == b'\n') {
-        Some(nl) if nl > 0 && body[nl - 1] == b'\r' => b"\r\n",
-        _ => b"\n",
+    for (i, &b) in body.iter().enumerate() {
+        match line_break_len(body, i) {
+            2 => return b"\r\n",
+            1 => return if b == b'\r' { b"\r" } else { b"\n" },
+            _ => {}
+        }
     }
+    b"\n"
 }
 
 fn is_fence_line(content: &[u8]) -> bool {
@@ -131,26 +143,26 @@ impl<'a> Iterator for LineScanner<'a> {
             return None;
         }
         let start = self.pos;
-        match self.input[start..].iter().position(|&b| b == b'\n') {
-            Some(rel) => {
-                let content_end = start + rel;
-                let end = content_end + 1;
+        let mut i = start;
+        while i < self.input.len() {
+            let len = line_break_len(self.input, i);
+            if len > 0 {
+                let end = i + len;
                 self.pos = end;
-                Some(Line {
-                    content: &self.input[start..content_end],
+                return Some(Line {
+                    content: &self.input[start..i],
                     start,
                     end,
-                })
+                });
             }
-            None => {
-                self.pos = self.input.len();
-                Some(Line {
-                    content: &self.input[start..],
-                    start,
-                    end: self.input.len(),
-                })
-            }
+            i += 1;
         }
+        self.pos = self.input.len();
+        Some(Line {
+            content: &self.input[start..],
+            start,
+            end: self.input.len(),
+        })
     }
 }
 
@@ -225,6 +237,23 @@ mod tests {
     }
 
     #[test]
+    fn bare_cr_line_endings() {
+        // Classic-Mac (`\r`-only) line endings: a `\n`-only scan would run
+        // straight past every break and collapse the whole input into one
+        // "line", the same failure class #324 fixed for the YAML parser.
+        let fm = split_front_matter(b"---\rtitle: foo\r---\rBody\r").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\r");
+        assert_eq!(fm.body, b"Body\r");
+    }
+
+    #[test]
+    fn leading_utf8_bom_is_skipped() {
+        let fm = split_front_matter(b"\xEF\xBB\xBF---\ntitle: foo\n---\nBody\n").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\n");
+        assert_eq!(fm.body, b"Body\n");
+    }
+
+    #[test]
     fn multiple_yaml_lines_preserved_verbatim() {
         let fm = split_front_matter(b"---\ntitle: foo\ntags: [a, b]\n---\nBody\n").unwrap();
         assert_eq!(fm.yaml, b"title: foo\ntags: [a, b]\n");
@@ -256,6 +285,11 @@ mod tests {
     #[test]
     fn body_line_ending_detects_crlf() {
         assert_eq!(body_line_ending(b"line one\r\nline two\r\n"), b"\r\n");
+    }
+
+    #[test]
+    fn body_line_ending_detects_bare_cr() {
+        assert_eq!(body_line_ending(b"line one\rline two\r"), b"\r");
     }
 
     #[test]

--- a/src/bin/succinctly/front_matter.rs
+++ b/src/bin/succinctly/front_matter.rs
@@ -1,0 +1,237 @@
+//! Front matter extraction for `yq --front-matter=<extract|process>`.
+//!
+//! Splits an input into a leading `---`-fenced YAML block and the trailing
+//! body content, matching real yq's front-matter convention (e.g. Markdown
+//! files with a YAML header).
+
+use std::fmt;
+
+/// The result of successfully splitting front matter from an input.
+#[derive(Debug)]
+pub struct FrontMatter<'a> {
+    /// The YAML content between the opening and closing fence (exclusive).
+    pub yaml: &'a [u8],
+    /// Everything after the closing fence line; empty if the input ends
+    /// immediately after the fence.
+    pub body: &'a [u8],
+}
+
+/// Errors produced when splitting front matter out of an input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontMatterError {
+    /// The input doesn't start with a `---` fence line.
+    NoFrontMatter,
+    /// A `---` fence was found but never closed with a matching `---`/`...`.
+    UnterminatedFrontMatter,
+}
+
+impl fmt::Display for FrontMatterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoFrontMatter => {
+                write!(
+                    f,
+                    "no front matter found (input must start with a `---` line)"
+                )
+            }
+            Self::UnterminatedFrontMatter => {
+                write!(
+                    f,
+                    "unterminated front matter (missing closing `---` or `...`)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for FrontMatterError {}
+
+/// Split `input` into its YAML front matter and trailing body.
+///
+/// The input must start with a line that is exactly `---` (trailing
+/// whitespace/`\r` ignored). The front matter ends at the next line that is
+/// exactly `---` or `...` (mirroring YAML's own end-of-document marker).
+/// Everything after that line is returned as the body, unparsed.
+pub fn split_front_matter(input: &[u8]) -> Result<FrontMatter<'_>, FrontMatterError> {
+    let mut lines = LineScanner::new(input);
+
+    let first = lines.next().ok_or(FrontMatterError::NoFrontMatter)?;
+    if !is_fence_line(first.content) {
+        return Err(FrontMatterError::NoFrontMatter);
+    }
+
+    let yaml_start = first.end;
+    loop {
+        let line = lines
+            .next()
+            .ok_or(FrontMatterError::UnterminatedFrontMatter)?;
+        if is_fence_line(line.content) || is_end_marker(line.content) {
+            return Ok(FrontMatter {
+                yaml: &input[yaml_start..line.start],
+                body: &input[line.end..],
+            });
+        }
+    }
+}
+
+fn is_fence_line(content: &[u8]) -> bool {
+    trim_trailing_ws(content) == b"---"
+}
+
+fn is_end_marker(content: &[u8]) -> bool {
+    trim_trailing_ws(content) == b"..."
+}
+
+fn trim_trailing_ws(content: &[u8]) -> &[u8] {
+    let end = content
+        .iter()
+        .rposition(|b| !matches!(b, b' ' | b'\t' | b'\r'))
+        .map_or(0, |i| i + 1);
+    &content[..end]
+}
+
+struct Line<'a> {
+    /// Line content, excluding the line terminator.
+    content: &'a [u8],
+    /// Offset of `content`'s first byte.
+    start: usize,
+    /// Offset right after the line terminator (or end of input).
+    end: usize,
+}
+
+struct LineScanner<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> LineScanner<'a> {
+    fn new(input: &'a [u8]) -> Self {
+        Self { input, pos: 0 }
+    }
+}
+
+impl<'a> Iterator for LineScanner<'a> {
+    type Item = Line<'a>;
+
+    fn next(&mut self) -> Option<Line<'a>> {
+        if self.pos >= self.input.len() {
+            return None;
+        }
+        let start = self.pos;
+        match self.input[start..].iter().position(|&b| b == b'\n') {
+            Some(rel) => {
+                let content_end = start + rel;
+                let end = content_end + 1;
+                self.pos = end;
+                Some(Line {
+                    content: &self.input[start..content_end],
+                    start,
+                    end,
+                })
+            }
+            None => {
+                self.pos = self.input.len();
+                Some(Line {
+                    content: &self.input[start..],
+                    start,
+                    end: self.input.len(),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_leading_fence_errors() {
+        let err = split_front_matter(b"title: foo\nbody text\n").unwrap_err();
+        assert_eq!(err, FrontMatterError::NoFrontMatter);
+    }
+
+    #[test]
+    fn empty_input_errors() {
+        let err = split_front_matter(b"").unwrap_err();
+        assert_eq!(err, FrontMatterError::NoFrontMatter);
+    }
+
+    #[test]
+    fn basic_dash_terminator() {
+        let fm = split_front_matter(b"---\ntitle: foo\n---\n# Body\n").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\n");
+        assert_eq!(fm.body, b"# Body\n");
+    }
+
+    #[test]
+    fn dots_terminator() {
+        let fm = split_front_matter(b"---\ntitle: foo\n...\nBody text\n").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\n");
+        assert_eq!(fm.body, b"Body text\n");
+    }
+
+    #[test]
+    fn empty_body_at_eof() {
+        let fm = split_front_matter(b"---\ntitle: foo\n---\n").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\n");
+        assert_eq!(fm.body, b"");
+    }
+
+    #[test]
+    fn empty_body_at_eof_no_trailing_newline() {
+        let fm = split_front_matter(b"---\ntitle: foo\n---").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\n");
+        assert_eq!(fm.body, b"");
+    }
+
+    #[test]
+    fn empty_front_matter_block() {
+        let fm = split_front_matter(b"---\n---\nBody\n").unwrap();
+        assert_eq!(fm.yaml, b"");
+        assert_eq!(fm.body, b"Body\n");
+    }
+
+    #[test]
+    fn unterminated_errors() {
+        let err = split_front_matter(b"---\ntitle: foo\nno closing fence\n").unwrap_err();
+        assert_eq!(err, FrontMatterError::UnterminatedFrontMatter);
+    }
+
+    #[test]
+    fn opening_fence_only_no_newline_is_unterminated() {
+        let err = split_front_matter(b"---").unwrap_err();
+        assert_eq!(err, FrontMatterError::UnterminatedFrontMatter);
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        let fm = split_front_matter(b"---\r\ntitle: foo\r\n---\r\nBody\r\n").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\r\n");
+        assert_eq!(fm.body, b"Body\r\n");
+    }
+
+    #[test]
+    fn multiple_yaml_lines_preserved_verbatim() {
+        let fm = split_front_matter(b"---\ntitle: foo\ntags: [a, b]\n---\nBody\n").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\ntags: [a, b]\n");
+        assert_eq!(fm.body, b"Body\n");
+    }
+
+    #[test]
+    fn trailing_whitespace_on_fence_lines_tolerated() {
+        let fm = split_front_matter(b"---   \ntitle: foo\n---\t\nBody\n").unwrap();
+        assert_eq!(fm.yaml, b"title: foo\n");
+        assert_eq!(fm.body, b"Body\n");
+    }
+
+    #[test]
+    fn indented_dashes_are_not_fences() {
+        // YAML document markers must start at column 0; an indented `---`
+        // inside the front matter (e.g. a nested key) must not be mistaken
+        // for the closing fence.
+        let fm = split_front_matter(b"---\nkey:\n  ---\n---\nBody\n").unwrap();
+        assert_eq!(fm.yaml, b"key:\n  ---\n");
+        assert_eq!(fm.body, b"Body\n");
+    }
+}

--- a/src/bin/succinctly/front_matter.rs
+++ b/src/bin/succinctly/front_matter.rs
@@ -74,6 +74,19 @@ pub fn split_front_matter(input: &[u8]) -> Result<FrontMatter<'_>, FrontMatterEr
     }
 }
 
+/// The line-ending convention `body` uses, detected from its first line
+/// terminator. `--front-matter=process` reattaches `body` byte-for-byte, so
+/// a fence line injected right before it (the closing `---`) must match --
+/// otherwise a CRLF body ends up preceded by a bare-LF fence, producing a
+/// file with mixed line endings. Falls back to `\n` for a body with no line
+/// break to sniff (nothing to mismatch).
+pub(crate) fn body_line_ending(body: &[u8]) -> &'static [u8] {
+    match body.iter().position(|&b| b == b'\n') {
+        Some(nl) if nl > 0 && body[nl - 1] == b'\r' => b"\r\n",
+        _ => b"\n",
+    }
+}
+
 fn is_fence_line(content: &[u8]) -> bool {
     trim_trailing_ws(content) == b"---"
 }
@@ -233,5 +246,21 @@ mod tests {
         let fm = split_front_matter(b"---\nkey:\n  ---\n---\nBody\n").unwrap();
         assert_eq!(fm.yaml, b"key:\n  ---\n");
         assert_eq!(fm.body, b"Body\n");
+    }
+
+    #[test]
+    fn body_line_ending_detects_lf() {
+        assert_eq!(body_line_ending(b"line one\nline two\n"), b"\n");
+    }
+
+    #[test]
+    fn body_line_ending_detects_crlf() {
+        assert_eq!(body_line_ending(b"line one\r\nline two\r\n"), b"\r\n");
+    }
+
+    #[test]
+    fn body_line_ending_defaults_to_lf_with_no_newline() {
+        assert_eq!(body_line_ending(b"no newline here"), b"\n");
+        assert_eq!(body_line_ending(b""), b"\n");
     }
 }

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1106,8 +1106,9 @@ pub struct YqCommand {
 
     /// Split output into multiple files, one per result, named by evaluating
     /// EXPR against each result (`.` is the result; `$index` is that
-    /// result's zero-based output index across the whole run). Suppresses
-    /// normal stdout output.
+    /// result's zero-based output index across the whole run; --arg/
+    /// --argjson values and $ARGS are also available, same as the main
+    /// filter). Suppresses normal stdout output.
     ///
     /// Deliberately long-only, unlike real yq's `-s`/`--split-exp`:
     /// succinctly's `-s` is already `--slurp` (#715).

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -976,6 +976,20 @@ pub enum InputFormat {
     Json,
 }
 
+/// Front matter handling mode for `--front-matter`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum FrontMatterMode {
+    /// Evaluate the expression against only the YAML front matter, discard
+    /// the trailing body content.
+    #[value(name = "extract")]
+    Extract,
+    /// Evaluate the expression against the YAML front matter, then re-emit
+    /// the transformed front matter followed by the original trailing body,
+    /// unchanged.
+    #[value(name = "process")]
+    Process,
+}
+
 /// Command-line YAML processor (yq-compatible)
 #[derive(Debug, Parser)]
 #[command(name = "yq")]
@@ -1002,6 +1016,15 @@ pub struct YqCommand {
     #[arg(short = 's', long)]
     pub slurp: bool,
 
+    /// Combine all documents from all files into one evaluation context
+    /// (yq-compatible name: `eval-all`/`ea`), exposing `file_index`/
+    /// `fileIndex`/`fi` for cross-file merges. Unlike real yq, expressions
+    /// must use explicit `.[]` iteration (e.g. `.[] | select(file_index ==
+    /// 0)`) rather than a bare top-level `select(...)` -- see
+    /// docs/reference/yq-language.md for the full deviation (#715).
+    #[arg(long = "eval-all", alias = "ea")]
+    pub eval_all: bool,
+
     /// Validate YAML strictly (opt-in) before processing. Reports line:column
     /// errors and exits without producing output on the first violation.
     #[arg(long)]
@@ -1015,6 +1038,13 @@ pub struct YqCommand {
         default_value = "auto"
     )]
     pub input_format: InputFormat,
+
+    /// Treat input as text with a `---`-fenced YAML front matter header
+    /// (e.g. Markdown). `extract` evaluates the expression against just the
+    /// front matter and discards the body; `process` re-emits the
+    /// transformed front matter followed by the untouched body.
+    #[arg(long = "front-matter", value_name = "MODE")]
+    pub front_matter: Option<FrontMatterMode>,
 
     // === Output Options ===
     /// Output format type [yaml, json, auto] (default: yaml)
@@ -1073,6 +1103,16 @@ pub struct YqCommand {
     /// Update the file in place
     #[arg(short = 'i', long)]
     pub inplace: bool,
+
+    /// Split output into multiple files, one per result, named by evaluating
+    /// EXPR against each result (`.` is the result; `$index` is that
+    /// result's zero-based output index across the whole run). Suppresses
+    /// normal stdout output.
+    ///
+    /// Deliberately long-only, unlike real yq's `-s`/`--split-exp`:
+    /// succinctly's `-s` is already `--slurp` (#715).
+    #[arg(long = "split-exp", value_name = "EXPR")]
+    pub split_exp: Option<String>,
 
     // === Program Input ===
     /// Read filter from file instead of command line
@@ -2196,6 +2236,7 @@ mod corpus_stats;
 mod dsv_bench;
 mod dsv_generators;
 mod env_config;
+mod front_matter;
 mod generators;
 mod jq_bench;
 mod jq_locate;

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -114,6 +114,7 @@ impl core::fmt::Display for InputLocation {
 #[derive(Debug, Default)]
 pub struct ErrorSink {
     hit: bool,
+    report_count: usize,
 }
 
 impl ErrorSink {
@@ -143,11 +144,23 @@ impl ErrorSink {
             DiagStyle::Yq => eprintln!("Error: {message}"),
         }
         self.hit = true;
+        self.report_count += 1;
     }
 
     /// Whether any uncaught error was reported during the run.
     pub fn hit(&self) -> bool {
         self.hit
+    }
+
+    /// How many uncaught errors have been reported so far. Unlike `hit()`
+    /// (sticky for the whole run, once true never false again), this lets a
+    /// caller detect whether *this specific call* reported anything, by
+    /// comparing the count before and after -- `hit()` alone can't tell
+    /// "just reported" from "reported earlier, unrelated to this call" once
+    /// any prior error has already flipped it (#715 follow-up: this is what
+    /// `write_split_result` needs to avoid double-reporting).
+    pub fn report_count(&self) -> usize {
+        self.report_count
     }
 }
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -299,6 +299,56 @@ fn apply_front_matter(
     Ok((fm.yaml.to_vec(), InputFormat::Yaml, body))
 }
 
+/// The result of [`gather_input_sources`]: either the gathered sources, or
+/// an exit code from a failed `--validate` check that the caller must
+/// return immediately, mirroring [`yaml_validate_guard`]'s "bail with this
+/// code" contract at each of this function's now-single call site.
+enum GatheredSources {
+    Sources(Vec<(Vec<u8>, InputFormat, Option<Vec<u8>>)>),
+    ExitCode(i32),
+}
+
+/// Reads each input source -- stdin if `input_files` is empty, else each
+/// file in listed order -- applying `--front-matter` (a no-op unless the
+/// flag is set, via [`apply_front_matter`]) and resolving its format, then
+/// running the shared `--validate` guard. Shared by `--eval-all`,
+/// `--split-exp`, `--slurp`, and the default path, which all start from
+/// this identical stdin-or-per-file gather step; each `--front-matter`
+/// body is `None` unless `front_matter` is `Some(Process)`, same contract
+/// as `apply_front_matter`.
+fn gather_input_sources(
+    input_files: &[String],
+    input_format: InputFormat,
+    front_matter: Option<FrontMatterMode>,
+    validate: bool,
+) -> Result<GatheredSources> {
+    let mut sources = Vec::new();
+    if input_files.is_empty() {
+        let raw_bytes = read_stdin()?;
+        let resolved_format = resolve_input_format(input_format, None);
+        let (input_bytes, format, body) =
+            apply_front_matter(raw_bytes, resolved_format, front_matter, "<stdin>")?;
+        if let Some(code) = yaml_validate_guard(&input_bytes, format, validate, None) {
+            return Ok(GatheredSources::ExitCode(code));
+        }
+        sources.push((input_bytes, format, body));
+    } else {
+        for file_path in input_files {
+            let path = Path::new(file_path);
+            let raw_bytes = read_file(path)?;
+            let resolved_format = resolve_input_format(input_format, Some(path));
+            let (input_bytes, format, body) =
+                apply_front_matter(raw_bytes, resolved_format, front_matter, file_path)?;
+            if let Some(code) = yaml_validate_guard(&input_bytes, format, validate, Some(file_path))
+            {
+                return Ok(GatheredSources::ExitCode(code));
+            }
+            sources.push((input_bytes, format, body));
+        }
+    }
+    Ok(GatheredSources::Sources(sources))
+}
+
 /// Parse input bytes according to the specified format.
 fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
     match format {
@@ -2208,33 +2258,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // but tracks each document's origin file index alongside it and
         // evaluates via `eval_owned_with_file_index` instead of plain
         // `evaluate_input`, so `file_index` resolves against that side table.
-        let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
-            let input_bytes = read_stdin()?;
-            let format = resolve_input_format(args.input_format, None);
-            if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
-                return Ok(code);
-            }
-            vec![(input_bytes, format)]
-        } else {
-            let mut sources = Vec::new();
-            for file_path in &input_files {
-                let path = Path::new(file_path);
-                let input_bytes = read_file(path)?;
-                let format = resolve_input_format(args.input_format, Some(path));
-                if let Some(code) =
-                    yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
-                {
-                    return Ok(code);
-                }
-                sources.push((input_bytes, format));
-            }
-            sources
+        // `--front-matter` is rejected in combination above, so every
+        // gathered body is `None` here.
+        let input_sources = match gather_input_sources(
+            &input_files,
+            args.input_format,
+            args.front_matter,
+            args.validate,
+        )? {
+            GatheredSources::Sources(s) => s,
+            GatheredSources::ExitCode(code) => return Ok(code),
         };
 
         let mut all_docs: Vec<OwnedValue> = Vec::new();
         let mut file_origin: Vec<usize> = Vec::new();
         let mut global_doc_index: usize = 0;
-        for (file_idx, (bytes, format)) in input_sources.iter().enumerate() {
+        for (file_idx, (bytes, format, _)) in input_sources.iter().enumerate() {
             let inputs = parse_input(bytes, *format)?;
             for input in inputs {
                 let should_include = args
@@ -2305,31 +2344,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 output_index += 1;
             }
         } else {
-            let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
-                let input_bytes = read_stdin()?;
-                let format = resolve_input_format(args.input_format, None);
-                if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
-                    return Ok(code);
-                }
-                vec![(input_bytes, format)]
-            } else {
-                let mut sources = Vec::new();
-                for file_path in &input_files {
-                    let path = Path::new(file_path);
-                    let input_bytes = read_file(path)?;
-                    let format = resolve_input_format(args.input_format, Some(path));
-                    if let Some(code) =
-                        yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
-                    {
-                        return Ok(code);
-                    }
-                    sources.push((input_bytes, format));
-                }
-                sources
+            // `--front-matter` is rejected in combination above, so every
+            // gathered body is `None` here.
+            let input_sources = match gather_input_sources(
+                &input_files,
+                args.input_format,
+                args.front_matter,
+                args.validate,
+            )? {
+                GatheredSources::Sources(s) => s,
+                GatheredSources::ExitCode(code) => return Ok(code),
             };
 
             let mut global_doc_index: usize = 0;
-            for (bytes, format) in &input_sources {
+            for (bytes, format, _) in &input_sources {
                 match format {
                     InputFormat::Yaml | InputFormat::Auto => {
                         let doc_filter = args.document.map(|target| (target, global_doc_index));
@@ -2445,31 +2473,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // mode is rejected above since a slurped array can't reattach a body
         // per input file) is applied before validation, since the raw
         // file bytes (e.g. Markdown) aren't valid standalone YAML.
-        let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
-            let raw_bytes = read_stdin()?;
-            let resolved_format = resolve_input_format(args.input_format, None);
-            let (input_bytes, format, _body) =
-                apply_front_matter(raw_bytes, resolved_format, args.front_matter, "<stdin>")?;
-            if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
-                return Ok(code);
-            }
-            vec![(input_bytes, format)]
-        } else {
-            let mut sources = Vec::new();
-            for file_path in &input_files {
-                let path = Path::new(file_path);
-                let raw_bytes = read_file(path)?;
-                let resolved_format = resolve_input_format(args.input_format, Some(path));
-                let (input_bytes, format, _body) =
-                    apply_front_matter(raw_bytes, resolved_format, args.front_matter, file_path)?;
-                if let Some(code) =
-                    yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
-                {
-                    return Ok(code);
-                }
-                sources.push((input_bytes, format));
-            }
-            sources
+        let input_sources = match gather_input_sources(
+            &input_files,
+            args.input_format,
+            args.front_matter,
+            args.validate,
+        )? {
+            GatheredSources::Sources(s) => s,
+            GatheredSources::ExitCode(code) => return Ok(code),
         };
 
         if can_slurp_fast_path {
@@ -2487,7 +2498,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // `Vec` unless their backing bytes/index all outlive that `Vec`.
             let mut parsed_sources: Vec<(Vec<u8>, YamlIndex<Vec<u64>>)> =
                 Vec::with_capacity(input_sources.len());
-            for (bytes, _format) in input_sources {
+            for (bytes, _format, _) in input_sources {
                 let index = YamlIndex::build(&bytes)
                     .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
                 parsed_sources.push((bytes, index));
@@ -2549,7 +2560,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
             // Parse all inputs and collect documents
             let mut global_doc_index: usize = 0;
-            for (bytes, format) in &input_sources {
+            for (bytes, format, _) in &input_sources {
                 let inputs = parse_input(bytes, *format)?;
                 for input in inputs {
                     // Apply --doc filter if specified
@@ -2750,35 +2761,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // Collect input sources with their bytes and formats. `--front-matter`
         // is applied before validation, since the raw file bytes (e.g.
         // Markdown) aren't valid standalone YAML; `process` mode's body is
-        // stashed per-source for reattachment in the output loop below.
-        let mut front_matter_bodies: Vec<Option<Vec<u8>>> = Vec::new();
-        let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
-            let raw_bytes = read_stdin()?;
-            let resolved_format = resolve_input_format(args.input_format, None);
-            let (input_bytes, format, body) =
-                apply_front_matter(raw_bytes, resolved_format, args.front_matter, "<stdin>")?;
-            front_matter_bodies.push(body);
-            if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
-                return Ok(code);
-            }
-            vec![(input_bytes, format)]
-        } else {
-            let mut sources = Vec::new();
-            for file_path in &input_files {
-                let path = Path::new(file_path);
-                let raw_bytes = read_file(path)?;
-                let resolved_format = resolve_input_format(args.input_format, Some(path));
-                let (input_bytes, format, body) =
-                    apply_front_matter(raw_bytes, resolved_format, args.front_matter, file_path)?;
-                front_matter_bodies.push(body);
-                if let Some(code) =
-                    yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
-                {
-                    return Ok(code);
-                }
-                sources.push((input_bytes, format));
-            }
-            sources
+        // carried alongside each source for reattachment in the output loop
+        // below.
+        let input_sources = match gather_input_sources(
+            &input_files,
+            args.input_format,
+            args.front_matter,
+            args.validate,
+        )? {
+            GatheredSources::Sources(s) => s,
+            GatheredSources::ExitCode(code) => return Ok(code),
         };
 
         // Process all inputs first to collect results, then determine multi-doc status
@@ -2788,7 +2780,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // input has none, so it's paired with CommentTree::empty().
         let mut all_results: Vec<Vec<Vec<ResultWithComments>>> = Vec::new();
         let mut global_doc_index: usize = 0;
-        for (bytes, format) in &input_sources {
+        for (bytes, format, _) in &input_sources {
             match format {
                 InputFormat::Yaml | InputFormat::Auto => {
                     // Use direct YAML evaluation to preserve position metadata
@@ -2843,10 +2835,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // For regular multi-doc: add --- before each document's results
         // For --front-matter=process: each file's own leading/closing ---
         // fences wrap its transformed front matter, followed by its
-        // untouched body (see `front_matter_bodies`, collected above).
+        // untouched body (carried alongside `input_sources`, gathered above).
         let mut split_doc_state = SplitDocState::new(has_split_doc);
         for (file_idx, doc_results) in all_results.into_iter().enumerate() {
-            let front_matter_body = front_matter_bodies.get(file_idx).and_then(Option::as_ref);
+            let front_matter_body = input_sources
+                .get(file_idx)
+                .and_then(|(_, _, body)| body.as_ref());
             if front_matter_body.is_some() {
                 writeln!(writer, "---")?;
             }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1771,19 +1771,6 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     let mut program = jq::parse_program_with_mode(&filter_str, jq::ParserMode::Yq)
         .map_err(|e| anyhow::anyhow!("parse error: {e}"))?;
 
-    // Parse the --split-exp expression, if given, once up front. `$index` is
-    // bound per output result (see `write_split_result`); no other variable
-    // substitution is applied to it, deliberately -- see the flag's help text.
-    let split_expr: Option<Expr> = args
-        .split_exp
-        .as_deref()
-        .map(|s| {
-            jq::parse_program_with_mode(s, jq::ParserMode::Yq)
-                .map(|p| p.expr)
-                .map_err(|e| anyhow::anyhow!("parse error in --split-exp expression: {e}"))
-        })
-        .transpose()?;
-
     // Parse variables
     let context = parse_variables(&args)?;
 
@@ -1791,13 +1778,27 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // variable into the expression AST before evaluating, mirroring the jq
     // runner (see jq_runner.rs). Without this, filter references like `$g`
     // error as "undefined variable" even though the values were parsed (#284).
-    {
-        let args_value = build_args_var(&context);
-        let mut all_vars: Vec<(&str, &OwnedValue)> =
-            context.named.iter().map(|(k, v)| (k.as_str(), v)).collect();
-        all_vars.push(("ARGS", &args_value));
-        program.expr = jq::substitute_vars(&program.expr, all_vars);
-    }
+    let args_value = build_args_var(&context);
+    let mut all_vars: Vec<(&str, &OwnedValue)> =
+        context.named.iter().map(|(k, v)| (k.as_str(), v)).collect();
+    all_vars.push(("ARGS", &args_value));
+    program.expr = jq::substitute_vars(&program.expr, all_vars.iter().copied());
+
+    // Parse the --split-exp expression, if given, once up front, applying
+    // the same --arg/--argjson/$ARGS substitution as the main filter --
+    // otherwise a filename expression referencing `--arg`-provided values
+    // (e.g. an output directory prefix) fails as an undefined variable even
+    // though the same flag works for the main filter. `$index` is bound
+    // separately, per output result (see `write_split_result`).
+    let split_expr: Option<Expr> = args
+        .split_exp
+        .as_deref()
+        .map(|s| {
+            jq::parse_program_with_mode(s, jq::ParserMode::Yq)
+                .map(|p| jq::substitute_vars(&p.expr, all_vars.iter().copied()))
+                .map_err(|e| anyhow::anyhow!("parse error in --split-exp expression: {e}"))
+        })
+        .transpose()?;
 
     // Output configuration
     let output_config = OutputConfig::from_args(&args);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -15,7 +15,7 @@ use succinctly::jq::eval_generic::{
     eval_with_cursor_using, to_owned, to_owned_with_comments, CommentTree, GenericResult,
 };
 use succinctly::jq::{
-    self, sync_aliased_paths, Builtin, Expr, OwnedValue, QueryResult, YqSemantics,
+    self, sync_aliased_paths, Builtin, EvalError, Expr, OwnedValue, QueryResult, YqSemantics,
 };
 use succinctly::json::light::StandardJson;
 use succinctly::json::JsonIndex;
@@ -24,7 +24,8 @@ use succinctly::yaml::{
     ResolvedScalar, YamlCursor, YamlIndex, YamlValue,
 };
 
-use super::{InputFormat, OutputFormat, YqCommand};
+use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
+use crate::front_matter;
 use crate::output::{
     self, exit_codes, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation,
     JsonFormatOpts,
@@ -272,6 +273,26 @@ fn resolve_input_format(format: InputFormat, path: Option<&Path>) -> InputFormat
     }
 }
 
+/// Applies `--front-matter`, if set, to raw input bytes before format
+/// resolution and validation: the raw bytes (e.g. Markdown) aren't valid
+/// standalone YAML, so extraction must happen first. Returns
+/// `(bytes, format, body)`; `body` is `Some` only in `process` mode, where
+/// the caller must reattach it verbatim after the transformed front matter.
+fn apply_front_matter(
+    raw_bytes: Vec<u8>,
+    resolved_format: InputFormat,
+    front_matter: Option<FrontMatterMode>,
+    name: &str,
+) -> Result<(Vec<u8>, InputFormat, Option<Vec<u8>>)> {
+    let Some(mode) = front_matter else {
+        return Ok((raw_bytes, resolved_format, None));
+    };
+    let fm =
+        front_matter::split_front_matter(&raw_bytes).map_err(|e| anyhow::anyhow!("{name}: {e}"))?;
+    let body = (mode == FrontMatterMode::Process).then(|| fm.body.to_vec());
+    Ok((fm.yaml.to_vec(), InputFormat::Yaml, body))
+}
+
 /// Parse input bytes according to the specified format.
 fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
     match format {
@@ -396,32 +417,44 @@ fn evaluate_input(
     let cursor = index.root(json_bytes);
 
     let result = jq::eval::<Vec<u64>, YqSemantics>(expr, cursor);
+    Ok(query_result_to_owned_values(result, sink))
+}
 
-    // Convert result to Vec<OwnedValue>
+/// Convert a `QueryResult` into `Vec<OwnedValue>`, reporting an uncaught
+/// error/break through `sink` (evaluation continues past one, per yq's
+/// convention -- see `ErrorSink`'s own doc comment) rather than failing the
+/// whole run. Factored out of [`evaluate_input`] so `--eval-all`'s
+/// `eval_owned_with_file_index` call site (#715) shares the exact same
+/// conversion/error-reporting policy instead of a second, divergence-prone
+/// copy.
+fn query_result_to_owned_values(
+    result: QueryResult<'_, Vec<u64>>,
+    sink: &mut ErrorSink,
+) -> Vec<OwnedValue> {
     match result {
-        QueryResult::One(v) => Ok(vec![standard_json_to_owned(&v)]),
-        QueryResult::OneCursor(c) => Ok(vec![standard_json_to_owned(&c.value())]),
-        QueryResult::Many(vs) => Ok(vs.iter().map(standard_json_to_owned).collect()),
-        QueryResult::None => Ok(vec![]),
+        QueryResult::One(v) => vec![standard_json_to_owned(&v)],
+        QueryResult::OneCursor(c) => vec![standard_json_to_owned(&c.value())],
+        QueryResult::Many(vs) => vs.iter().map(standard_json_to_owned).collect(),
+        QueryResult::None => vec![],
         QueryResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());
-            Ok(vec![])
+            vec![]
         }
-        QueryResult::Owned(v) => Ok(vec![v]),
-        QueryResult::ManyOwned(vs) => Ok(vs),
+        QueryResult::Owned(v) => vec![v],
+        QueryResult::ManyOwned(vs) => vs,
         QueryResult::Break(label) => {
             sink.report_break(DiagStyle::Yq, &label, &no_location());
-            Ok(vec![])
+            vec![]
         }
         // The outputs already produced no longer vanish behind the failure
         // (#400, #494).
         QueryResult::Partial(vs, jq::Control::Error(e)) => {
             sink.report(DiagStyle::Yq, &e, &no_location());
-            Ok(vs)
+            vs
         }
         QueryResult::Partial(vs, jq::Control::Break(label)) => {
             sink.report_break(DiagStyle::Yq, &label, &no_location());
-            Ok(vs)
+            vs
         }
     }
 }
@@ -557,6 +590,82 @@ fn walk_alias_groups<W: AsRef<[u64]> + Clone>(
         }
         _ => {}
     }
+}
+
+/// Evaluate `split_expr` against `result` with `$index` bound to
+/// `output_index`, expect exactly one string back, and write `result`
+/// (serialized through `output_config`, color forced off, matching
+/// `--inplace`) to that path.
+///
+/// Non-string, empty, or multi-value split-expression results are reported
+/// through `sink` — the same "continue, exit 1 at the end" convention used
+/// for other uncaught evaluation errors in this file — rather than aborting
+/// the run outright.
+fn write_split_result(
+    result: &OwnedValue,
+    comments: &CommentTree,
+    split_expr: &Expr,
+    output_index: i64,
+    output_config: &OutputConfig,
+    written_files: &mut std::collections::HashSet<String>,
+    sink: &mut ErrorSink,
+) -> Result<()> {
+    let index_val = OwnedValue::Int(output_index);
+    let per_result_expr = jq::substitute_vars(split_expr, [("index", &index_val)]);
+
+    let sink_was_hit = sink.hit();
+    let filename_results = evaluate_input(result, &per_result_expr, sink)?;
+
+    let filename = match filename_results.as_slice() {
+        [OwnedValue::String(s)] => s.clone(),
+        // `evaluate_input` already reported the underlying error (e.g. an
+        // undefined variable, or an explicit `error(...)`) via `sink`.
+        [] if sink.hit() && !sink_was_hit => return Ok(()),
+        [] => {
+            sink.report(
+                DiagStyle::Yq,
+                &EvalError::new(format!(
+                    "--split-exp expression produced no output for result #{output_index}"
+                )),
+                &no_location(),
+            );
+            return Ok(());
+        }
+        [other] => {
+            sink.report(
+                DiagStyle::Yq,
+                &EvalError::new(format!(
+                    "--split-exp expression must evaluate to a string, got {} for result #{output_index}",
+                    other.type_name()
+                )),
+                &no_location(),
+            );
+            return Ok(());
+        }
+        many => {
+            sink.report(
+                DiagStyle::Yq,
+                &EvalError::new(format!(
+                    "--split-exp expression must evaluate to exactly one string, got {} results for result #{output_index}",
+                    many.len()
+                )),
+                &no_location(),
+            );
+            return Ok(());
+        }
+    };
+
+    if !written_files.insert(filename.clone()) {
+        eprintln!("Warning: --split-exp path '{filename}' written more than once; overwriting");
+    }
+
+    let mut buf = Vec::new();
+    let mut no_color_config = output_config.clone();
+    no_color_config.use_color = false;
+    output_value(&mut buf, result, comments, &no_color_config)?;
+
+    std::fs::write(&filename, &buf)
+        .with_context(|| format!("failed to write --split-exp output file: {filename}"))
 }
 
 /// Evaluate a jq expression directly on a YAML cursor.
@@ -1577,9 +1686,79 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         anyhow::bail!("--doc and --raw-input are incompatible");
     }
 
+    if args.front_matter.is_some() {
+        if args.document.is_some() {
+            anyhow::bail!("--front-matter and --doc are incompatible");
+        }
+        if args.null_input {
+            anyhow::bail!("--front-matter and --null-input are incompatible");
+        }
+        if args.raw_input {
+            anyhow::bail!("--front-matter and --raw-input are incompatible");
+        }
+        if args.front_matter == Some(FrontMatterMode::Process) {
+            if args.slurp {
+                anyhow::bail!("--front-matter=process and --slurp are incompatible");
+            }
+            if args.output_format == OutputFormat::Json {
+                anyhow::bail!(
+                    "--front-matter=process requires YAML output (got -o/--output-format json)"
+                );
+            }
+        }
+    }
+
+    if args.split_exp.is_some() {
+        if args.slurp {
+            anyhow::bail!("--split-exp and --slurp are incompatible");
+        }
+        if args.inplace {
+            anyhow::bail!("--split-exp and --inplace are incompatible");
+        }
+        if args.raw_input {
+            anyhow::bail!("--split-exp with --raw-input is not yet supported");
+        }
+        if args.front_matter.is_some() {
+            anyhow::bail!("--split-exp and --front-matter are incompatible");
+        }
+    }
+
+    if args.eval_all {
+        if args.slurp {
+            anyhow::bail!(
+                "--eval-all and --slurp are incompatible: both combine inputs into a single evaluation"
+            );
+        }
+        if args.inplace {
+            anyhow::bail!("--eval-all and --inplace are incompatible");
+        }
+        if args.raw_input {
+            anyhow::bail!("--eval-all and --raw-input are incompatible");
+        }
+        if args.split_exp.is_some() {
+            anyhow::bail!("--eval-all and --split-exp are incompatible");
+        }
+        if args.front_matter.is_some() {
+            anyhow::bail!("--eval-all and --front-matter are incompatible");
+        }
+    }
+
     // Parse the jq program (use Yq mode for extended identifier syntax like kebab-case)
     let mut program = jq::parse_program_with_mode(&filter_str, jq::ParserMode::Yq)
         .map_err(|e| anyhow::anyhow!("parse error: {e}"))?;
+
+    // Parse the --split-exp expression, if given, once up front. `$index` is
+    // bound per output result (see `write_split_result`); no other variable
+    // substitution is applied to it, deliberately -- see the flag's help text.
+    let split_expr: Option<Expr> = args
+        .split_exp
+        .as_deref()
+        .map(|s| {
+            jq::parse_program_with_mode(s, jq::ParserMode::Yq)
+                .map(|p| p.expr)
+                .map_err(|e| anyhow::anyhow!("parse error in --split-exp expression: {e}"))
+        })
+        .transpose()?;
 
     // Parse variables
     let context = parse_variables(&args)?;
@@ -1651,6 +1830,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && !args.raw_input
         && !args.slurp
         && !args.inplace
+        && args.front_matter.is_none()
+        && split_expr.is_none()
+        && !args.eval_all
         && context.named.is_empty();
     let can_yaml_fast_path = is_m2_streamable
         && (output_config.compact || can_stream_pretty)
@@ -1659,6 +1841,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && !args.raw_input
         && !args.slurp
         && !args.inplace
+        && args.front_matter.is_none()
+        && split_expr.is_none()
+        && !args.eval_all
         && context.named.is_empty();
     let can_fast_path = can_json_fast_path || can_yaml_fast_path;
 
@@ -1676,6 +1861,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && !args.null_input
         && !args.raw_input
         && args.inplace
+        && args.front_matter.is_none()
         && context.named.is_empty();
     let can_inplace_yaml_fast_path = is_m2_streamable
         && (output_config.compact || can_stream_pretty)
@@ -1683,6 +1869,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && !args.null_input
         && !args.raw_input
         && args.inplace
+        && args.front_matter.is_none()
         && context.named.is_empty();
     let can_inplace_fast_path = can_inplace_json_fast_path || can_inplace_yaml_fast_path;
 
@@ -1698,6 +1885,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && output_config.output_format == OutputFormat::Yaml
         && !args.null_input
         && !args.raw_input
+        && args.front_matter.is_none()
         && context.named.is_empty();
 
     // Indent width/unit for the fast path's streamers. `--tab` always means
@@ -1975,6 +2163,190 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 }
             }
         }
+    } else if args.eval_all {
+        // Handle --eval-all: combine every document from every file into one
+        // evaluation context, exposing `file_index`/`fileIndex`/`fi` (#715).
+        // Input-gathering mirrors --slurp's DOM path (all_docs collection),
+        // but tracks each document's origin file index alongside it and
+        // evaluates via `eval_owned_with_file_index` instead of plain
+        // `evaluate_input`, so `file_index` resolves against that side table.
+        let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
+            let input_bytes = read_stdin()?;
+            let format = resolve_input_format(args.input_format, None);
+            if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
+                return Ok(code);
+            }
+            vec![(input_bytes, format)]
+        } else {
+            let mut sources = Vec::new();
+            for file_path in &input_files {
+                let path = Path::new(file_path);
+                let input_bytes = read_file(path)?;
+                let format = resolve_input_format(args.input_format, Some(path));
+                if let Some(code) =
+                    yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
+                {
+                    return Ok(code);
+                }
+                sources.push((input_bytes, format));
+            }
+            sources
+        };
+
+        let mut all_docs: Vec<OwnedValue> = Vec::new();
+        let mut file_origin: Vec<usize> = Vec::new();
+        let mut global_doc_index: usize = 0;
+        for (file_idx, (bytes, format)) in input_sources.iter().enumerate() {
+            let inputs = parse_input(bytes, *format)?;
+            for input in inputs {
+                let should_include = args
+                    .document
+                    .map_or(true, |target| target == global_doc_index);
+                if should_include {
+                    all_docs.push(input);
+                    file_origin.push(file_idx);
+                }
+                global_doc_index += 1;
+            }
+        }
+
+        let combined = OwnedValue::Array(all_docs);
+        let query_result: QueryResult<'_, Vec<u64>> = jq::eval_owned_with_file_index::<
+            Vec<u64>,
+            YqSemantics,
+        >(
+            &program.expr, &combined, &file_origin
+        );
+        let results = query_result_to_owned_values(query_result, &mut sink);
+
+        for (i, result) in results.iter().enumerate() {
+            // `---` BETWEEN results (not before the first) -- deliberately
+            // different from --slurp's no-separator convention, since
+            // eval-all is explicitly a multi-document-stream feature (#715).
+            if !has_split_doc
+                && output_config.output_format == OutputFormat::Yaml
+                && !output_config.no_doc
+                && results.len() > 1
+                && i > 0
+            {
+                writeln!(writer, "---")?;
+            }
+            any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
+            output_value(&mut writer, result, &CommentTree::empty(), &output_config)?;
+        }
+    } else if let Some(split_expr) = split_expr.as_ref() {
+        // Handle --split-exp: write each result to its own file (named by
+        // evaluating `split_expr` against it, with `$index` bound to its
+        // zero-based output index) instead of stdout. `--front-matter` is
+        // rejected in combination above, so no extraction step is needed
+        // here; the input-gathering below otherwise mirrors the standard
+        // path at the bottom of this function.
+        let mut output_index: i64 = 0;
+        let mut written_split_files: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+
+        if args.null_input {
+            let results = evaluate_input(&OwnedValue::Null, &program.expr, &mut sink)?;
+            for result in &results {
+                any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
+                write_split_result(
+                    result,
+                    &CommentTree::empty(),
+                    split_expr,
+                    output_index,
+                    &output_config,
+                    &mut written_split_files,
+                    &mut sink,
+                )?;
+                output_index += 1;
+            }
+        } else {
+            let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
+                let input_bytes = read_stdin()?;
+                let format = resolve_input_format(args.input_format, None);
+                if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
+                    return Ok(code);
+                }
+                vec![(input_bytes, format)]
+            } else {
+                let mut sources = Vec::new();
+                for file_path in &input_files {
+                    let path = Path::new(file_path);
+                    let input_bytes = read_file(path)?;
+                    let format = resolve_input_format(args.input_format, Some(path));
+                    if let Some(code) =
+                        yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
+                    {
+                        return Ok(code);
+                    }
+                    sources.push((input_bytes, format));
+                }
+                sources
+            };
+
+            let mut global_doc_index: usize = 0;
+            for (bytes, format) in &input_sources {
+                match format {
+                    InputFormat::Yaml | InputFormat::Auto => {
+                        let doc_filter = args.document.map(|target| (target, global_doc_index));
+                        // Split-exp output files carry real comments when
+                        // written as YAML, same as the main output path (#710).
+                        let need_comments = output_config.output_format == OutputFormat::Yaml;
+                        let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
+                            bytes,
+                            &program.expr,
+                            doc_filter,
+                            &mut sink,
+                            need_comments,
+                        )?;
+                        global_doc_index += num_docs;
+                        for results in doc_results {
+                            for (result, comments) in &results {
+                                any_truthy |=
+                                    !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
+                                write_split_result(
+                                    result,
+                                    comments,
+                                    split_expr,
+                                    output_index,
+                                    &output_config,
+                                    &mut written_split_files,
+                                    &mut sink,
+                                )?;
+                                output_index += 1;
+                            }
+                        }
+                    }
+                    InputFormat::Json => {
+                        let inputs = parse_input(bytes, InputFormat::Json)?;
+                        for input in inputs {
+                            if let Some(target_doc) = args.document {
+                                if global_doc_index != target_doc {
+                                    global_doc_index += 1;
+                                    continue;
+                                }
+                            }
+                            let results = evaluate_input(&input, &program.expr, &mut sink)?;
+                            for result in &results {
+                                any_truthy |=
+                                    !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
+                                write_split_result(
+                                    result,
+                                    &CommentTree::empty(),
+                                    split_expr,
+                                    output_index,
+                                    &output_config,
+                                    &mut written_split_files,
+                                    &mut sink,
+                                )?;
+                                output_index += 1;
+                            }
+                            global_doc_index += 1;
+                        }
+                    }
+                }
+            }
+        }
     } else if args.null_input {
         // Handle --null-input
         let mut split_doc_state = SplitDocState::new(has_split_doc);
@@ -2025,10 +2397,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     } else if args.slurp {
         // Handle --slurp: collect all documents from all inputs into an array
 
-        // Collect input sources
+        // Collect input sources. `--front-matter` (extract only here; process
+        // mode is rejected above since a slurped array can't reattach a body
+        // per input file) is applied before validation, since the raw
+        // file bytes (e.g. Markdown) aren't valid standalone YAML.
         let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
-            let input_bytes = read_stdin()?;
-            let format = resolve_input_format(args.input_format, None);
+            let raw_bytes = read_stdin()?;
+            let resolved_format = resolve_input_format(args.input_format, None);
+            let (input_bytes, format, _body) =
+                apply_front_matter(raw_bytes, resolved_format, args.front_matter, "<stdin>")?;
             if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
                 return Ok(code);
             }
@@ -2037,8 +2414,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             let mut sources = Vec::new();
             for file_path in &input_files {
                 let path = Path::new(file_path);
-                let input_bytes = read_file(path)?;
-                let format = resolve_input_format(args.input_format, Some(path));
+                let raw_bytes = read_file(path)?;
+                let resolved_format = resolve_input_format(args.input_format, Some(path));
+                let (input_bytes, format, _body) =
+                    apply_front_matter(raw_bytes, resolved_format, args.front_matter, file_path)?;
                 if let Some(code) =
                     yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
                 {
@@ -2160,8 +2539,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         let mut global_doc_index: usize = 0;
         for file_path in &input_files {
             let path = Path::new(file_path);
-            let input_bytes = read_file(path)?;
-            let format = resolve_input_format(args.input_format, Some(path));
+            let raw_bytes = read_file(path)?;
+            let resolved_format = resolve_input_format(args.input_format, Some(path));
+            let (input_bytes, format, front_matter_body) =
+                apply_front_matter(raw_bytes, resolved_format, args.front_matter, file_path)?;
             if let Some(code) =
                 yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
             {
@@ -2261,6 +2642,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 };
                 let is_multi_doc = matching_docs > 1;
 
+                // `--front-matter=process` opens its own leading `---` fence
+                // here; the body's closing fence + body text are appended
+                // after `buf_writer` is dropped, below.
+                if front_matter_body.is_some() {
+                    writeln!(buf_writer, "---")?;
+                }
+
                 let mut split_doc_state = SplitDocState::new(has_split_doc);
                 for (local_idx, input) in inputs.iter().enumerate() {
                     let current_doc_index = global_doc_index + local_idx;
@@ -2276,6 +2664,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         && output_config.output_format == OutputFormat::Yaml
                         && !output_config.no_doc
                         && is_multi_doc
+                        && front_matter_body.is_none()
                     {
                         writeln!(buf_writer, "---")?;
                     }
@@ -2299,6 +2688,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 global_doc_index += inputs.len();
             }
 
+            if let Some(body) = &front_matter_body {
+                output_buffer.extend_from_slice(b"---\n");
+                output_buffer.extend_from_slice(body);
+            }
+
             // Write the output back to the file
             std::fs::write(path, &output_buffer)
                 .with_context(|| format!("failed to write to file: {}", path.display()))?;
@@ -2308,10 +2702,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // For YAML inputs, use direct evaluation to preserve position metadata
         // For JSON inputs, use the OwnedValue path
 
-        // Collect input sources with their bytes and formats
+        // Collect input sources with their bytes and formats. `--front-matter`
+        // is applied before validation, since the raw file bytes (e.g.
+        // Markdown) aren't valid standalone YAML; `process` mode's body is
+        // stashed per-source for reattachment in the output loop below.
+        let mut front_matter_bodies: Vec<Option<Vec<u8>>> = Vec::new();
         let input_sources: Vec<(Vec<u8>, InputFormat)> = if input_files.is_empty() {
-            let input_bytes = read_stdin()?;
-            let format = resolve_input_format(args.input_format, None);
+            let raw_bytes = read_stdin()?;
+            let resolved_format = resolve_input_format(args.input_format, None);
+            let (input_bytes, format, body) =
+                apply_front_matter(raw_bytes, resolved_format, args.front_matter, "<stdin>")?;
+            front_matter_bodies.push(body);
             if let Some(code) = yaml_validate_guard(&input_bytes, format, args.validate, None) {
                 return Ok(code);
             }
@@ -2320,8 +2721,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             let mut sources = Vec::new();
             for file_path in &input_files {
                 let path = Path::new(file_path);
-                let input_bytes = read_file(path)?;
-                let format = resolve_input_format(args.input_format, Some(path));
+                let raw_bytes = read_file(path)?;
+                let resolved_format = resolve_input_format(args.input_format, Some(path));
+                let (input_bytes, format, body) =
+                    apply_front_matter(raw_bytes, resolved_format, args.front_matter, file_path)?;
+                front_matter_bodies.push(body);
                 if let Some(code) =
                     yaml_validate_guard(&input_bytes, format, args.validate, Some(file_path))
                 {
@@ -2392,14 +2796,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // Output all results with proper separators
         // For split_doc: add --- BETWEEN each result (not before first)
         // For regular multi-doc: add --- before each document's results
+        // For --front-matter=process: each file's own leading/closing ---
+        // fences wrap its transformed front matter, followed by its
+        // untouched body (see `front_matter_bodies`, collected above).
         let mut split_doc_state = SplitDocState::new(has_split_doc);
-        for doc_results in all_results {
+        for (file_idx, doc_results) in all_results.into_iter().enumerate() {
+            let front_matter_body = front_matter_bodies.get(file_idx).and_then(Option::as_ref);
+            if front_matter_body.is_some() {
+                writeln!(writer, "---")?;
+            }
             for results in doc_results {
                 // Add document separator in YAML mode for multi-doc (before each doc's results)
                 if !has_split_doc
                     && output_config.output_format == OutputFormat::Yaml
                     && !output_config.no_doc
                     && is_multi_doc
+                    && front_matter_body.is_none()
                 {
                     writeln!(writer, "---")?;
                 }
@@ -2408,6 +2820,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
                     output_value(&mut writer, &result, &comments, &output_config)?;
                 }
+            }
+            if let Some(body) = front_matter_body {
+                writer.write_all(b"---\n")?;
+                writer.write_all(body)?;
             }
         }
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1701,6 +1701,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         if args.raw_input {
             anyhow::bail!("--front-matter and --raw-input are incompatible");
         }
+        if args.front_matter == Some(FrontMatterMode::Extract) && args.inplace {
+            // `extract` never captures a body to reattach (only `process`
+            // does, see `apply_front_matter`), so `--inplace` would
+            // overwrite the file with just the transformed front matter,
+            // silently discarding everything after the closing fence.
+            anyhow::bail!(
+                "--front-matter=extract and --inplace are incompatible (would discard the file's body); use --front-matter=process instead"
+            );
+        }
         if args.front_matter == Some(FrontMatterMode::Process) {
             if args.slurp {
                 anyhow::bail!("--front-matter=process and --slurp are incompatible");

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -278,6 +278,12 @@ fn resolve_input_format(format: InputFormat, path: Option<&Path>) -> InputFormat
 /// standalone YAML, so extraction must happen first. Returns
 /// `(bytes, format, body)`; `body` is `Some` only in `process` mode, where
 /// the caller must reattach it verbatim after the transformed front matter.
+///
+/// Once a mode is set, the returned format is always `InputFormat::Yaml`
+/// regardless of `resolved_format` -- front matter is YAML by definition,
+/// and the `run_yq` compat guard already rejects an explicit
+/// `--input-format json` paired with `--front-matter`, so this never
+/// actually overrides a caller's real preference.
 fn apply_front_matter(
     raw_bytes: Vec<u8>,
     resolved_format: InputFormat,
@@ -1700,6 +1706,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         }
         if args.raw_input {
             anyhow::bail!("--front-matter and --raw-input are incompatible");
+        }
+        if args.input_format == InputFormat::Json {
+            // Front matter is YAML by definition (the `---`-fenced header),
+            // so `apply_front_matter` always forces `InputFormat::Yaml` once
+            // a mode is set -- reject an explicit, contradictory
+            // `--input-format json` instead of silently overriding it.
+            anyhow::bail!("--front-matter and --input-format json are incompatible");
         }
         if args.front_matter == Some(FrontMatterMode::Extract) && args.inplace {
             // `extract` never captures a body to reattach (only `process`

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1700,9 +1700,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             if args.slurp {
                 anyhow::bail!("--front-matter=process and --slurp are incompatible");
             }
-            if args.output_format == OutputFormat::Json {
+            // `output_value` treats anything other than `Yaml` as JSON
+            // output (including `Auto`, which has no YAML/Markdown-file
+            // detection of its own) -- so the guard must reject everything
+            // but `Yaml`, not just the explicit `Json` variant, or `-o auto`
+            // silently slips through and wraps a JSON body in `---` fences.
+            if args.output_format != OutputFormat::Yaml {
                 anyhow::bail!(
-                    "--front-matter=process requires YAML output (got -o/--output-format json)"
+                    "--front-matter=process requires YAML output (got -o/--output-format {})",
+                    if args.output_format == OutputFormat::Json {
+                        "json"
+                    } else {
+                        "auto"
+                    }
                 );
             }
         }
@@ -2689,7 +2699,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }
 
             if let Some(body) = &front_matter_body {
-                output_buffer.extend_from_slice(b"---\n");
+                output_buffer.extend_from_slice(b"---");
+                output_buffer.extend_from_slice(front_matter::body_line_ending(body));
                 output_buffer.extend_from_slice(body);
             }
 
@@ -2822,8 +2833,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 }
             }
             if let Some(body) = front_matter_body {
-                writer.write_all(b"---\n")?;
+                let line_ending = front_matter::body_line_ending(body);
+                writer.write_all(b"---")?;
+                writer.write_all(line_ending)?;
                 writer.write_all(body)?;
+                // A body with no trailing line break would otherwise run
+                // straight into the next file's opening fence (or whatever
+                // follows), corrupting the stream -- ensure one separates
+                // them, matching this body's own line-ending convention.
+                if !body.is_empty() && !body.ends_with(b"\n") {
+                    writer.write_all(line_ending)?;
+                }
             }
         }
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2243,16 +2243,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         );
         let results = query_result_to_owned_values(query_result, &mut sink);
 
+        let mut split_doc_state = SplitDocState::new(has_split_doc);
         for (i, result) in results.iter().enumerate() {
-            // `---` BETWEEN results (not before the first) -- deliberately
-            // different from --slurp's no-separator convention, since
-            // eval-all is explicitly a multi-document-stream feature (#715).
-            if !has_split_doc
-                && output_config.output_format == OutputFormat::Yaml
+            if has_split_doc {
+                // The filter explicitly marks its outputs as separate
+                // documents (`split_doc`); route through the same state
+                // machine every other output path uses for that, or no
+                // separator is ever written here at all.
+                split_doc_state.write_separator(&mut writer, &output_config)?;
+            } else if output_config.output_format == OutputFormat::Yaml
                 && !output_config.no_doc
                 && results.len() > 1
                 && i > 0
             {
+                // `---` BETWEEN results (not before the first) -- deliberately
+                // different from --slurp's no-separator convention, since
+                // eval-all is explicitly a multi-document-stream feature (#715).
                 writeln!(writer, "---")?;
             }
             any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -613,14 +613,19 @@ fn write_split_result(
     let index_val = OwnedValue::Int(output_index);
     let per_result_expr = jq::substitute_vars(split_expr, [("index", &index_val)]);
 
-    let sink_was_hit = sink.hit();
+    let reports_before = sink.report_count();
     let filename_results = evaluate_input(result, &per_result_expr, sink)?;
 
     let filename = match filename_results.as_slice() {
         [OwnedValue::String(s)] => s.clone(),
         // `evaluate_input` already reported the underlying error (e.g. an
         // undefined variable, or an explicit `error(...)`) via `sink`.
-        [] if sink.hit() && !sink_was_hit => return Ok(()),
+        // `report_count()` (not `hit()`, which is sticky for the whole run)
+        // is what lets this tell "this call just reported" from "some
+        // earlier result already tripped the sink" -- otherwise every
+        // result after the first real error in the run double-reports here
+        // (#715 follow-up).
+        [] if sink.report_count() > reports_before => return Ok(()),
         [] => {
             sink.report(
                 DiagStyle::Yq,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11680,6 +11680,56 @@ fn eval_pipe_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     eval_pipe_with_path_context_internal::<W, S>(exprs, value, value, None, current_path, optional)
 }
 
+/// Fold one fan-out step's result into `results`, matching the project's
+/// #400/#494 guarantee: an `Error`/`Break` produced partway through a
+/// fan-out must not discard outputs already produced by earlier steps. Every
+/// fan-out loop in `eval_pipe_with_path_context_internal` (`Iterate`, `If`'s
+/// multi-valued `cond`, `Comma`, `Select`'s continuation) and
+/// `continue_rest_with_context` shares this exact accumulate-or-stop shape;
+/// this is the one place it's implemented (#715 follow-up -- six near-copies
+/// of this loop each independently collapsed `Break`/`Partial` to a bare
+/// `None`, silently dropping both the escaping control signal and any output
+/// already produced).
+///
+/// Returns `Some(result)` when the loop must stop and propagate that result
+/// immediately (an error, an escaping `break`, or a nested partial result);
+/// `None` to keep iterating.
+fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
+    results: &mut Vec<OwnedValue>,
+    step: QueryResult<'a, W>,
+) -> Option<QueryResult<'a, W>> {
+    match step.materialize_cursor() {
+        QueryResult::Owned(v) => {
+            results.push(v);
+            None
+        }
+        QueryResult::ManyOwned(vs) => {
+            results.extend(vs);
+            None
+        }
+        // `eval_fanout` (used by `Select`) returns these borrowed-cursor
+        // variants even from an all-owned-value call site -- e.g. a `select`
+        // whose condition matched nothing produces `Many(vec![])`, not
+        // `None` -- so this must convert, not treat them as unreachable.
+        QueryResult::One(v) => {
+            results.push(to_owned(&v));
+            None
+        }
+        QueryResult::Many(vs) => {
+            results.extend(vs.iter().map(to_owned));
+            None
+        }
+        QueryResult::None => None,
+        QueryResult::Error(e) => Some(partial(core::mem::take(results), Control::Error(e))),
+        QueryResult::Break(label) => Some(partial(core::mem::take(results), Control::Break(label))),
+        QueryResult::Partial(vs, control) => {
+            results.extend(vs);
+            Some(partial(core::mem::take(results), control))
+        }
+        QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
+    }
+}
+
 /// Continue evaluating `rest` for each output of an already-computed
 /// intermediate `QueryResult`, preserving `root`/`current_path` (the
 /// intermediate stage doesn't move navigational position -- e.g. a
@@ -11687,9 +11737,7 @@ fn eval_pipe_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// "at" the position it was computed from) and fanning a multi-valued
 /// result back out over `rest` the same way `Iterate` does above. Shared by
 /// `If`/`Comma`/`Try`/`Label` below to avoid re-deriving this fan-out loop
-/// at each call site. `Break`/`Partial` inputs collapse to `None` here,
-/// matching `Select`'s pre-existing fan-out policy just above (not a
-/// regression this helper introduces).
+/// at each call site.
 fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     intermediate: QueryResult<'a, W>,
     rest: &[Expr],
@@ -11698,7 +11746,11 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     current_path: &[OwnedValue],
     optional: bool,
 ) -> QueryResult<'a, W> {
-    match intermediate {
+    // `eval_fanout` (reached via `Select`) can hand back its borrowed-cursor
+    // variants (`One`/`Many`) even here, not just Owned/ManyOwned -- e.g. a
+    // `select` that matched nothing produces `Many(vec![])` -- so those
+    // convert via `to_owned` instead of being treated as unreachable.
+    match intermediate.materialize_cursor() {
         QueryResult::Owned(v) => eval_pipe_with_path_context_internal::<W, S>(
             rest,
             &v,
@@ -11707,35 +11759,54 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             current_path,
             optional,
         ),
+        QueryResult::One(v) => eval_pipe_with_path_context_internal::<W, S>(
+            rest,
+            &to_owned(&v),
+            root,
+            file_origin,
+            current_path,
+            optional,
+        ),
         QueryResult::ManyOwned(vs) => {
             let mut results = Vec::new();
             for v in vs {
-                match eval_pipe_with_path_context_internal::<W, S>(
+                let step = eval_pipe_with_path_context_internal::<W, S>(
                     rest,
                     &v,
                     root,
                     file_origin,
                     current_path,
                     optional,
-                ) {
-                    QueryResult::Owned(r) => results.push(r),
-                    QueryResult::ManyOwned(rs) => results.extend(rs),
-                    QueryResult::None => {}
-                    QueryResult::Error(e) => return QueryResult::Error(e),
-                    _ => {}
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                    return stop;
                 }
             }
-            if results.is_empty() {
-                QueryResult::None
-            } else if results.len() == 1 {
-                QueryResult::Owned(results.pop().unwrap())
-            } else {
-                QueryResult::ManyOwned(results)
+            owned_vec_to_result(results)
+        }
+        QueryResult::Many(vs) => {
+            let mut results = Vec::new();
+            for v in vs {
+                let owned_v = to_owned(&v);
+                let step = eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &owned_v,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                    return stop;
+                }
             }
+            owned_vec_to_result(results)
         }
         QueryResult::None => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),
-        _ => QueryResult::None,
+        QueryResult::Break(label) => QueryResult::Break(label),
+        QueryResult::Partial(vs, control) => partial(vs, control),
+        QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
     }
 }
 
@@ -12010,19 +12081,16 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                         if rest.is_empty() {
                             results.push(v.clone());
                         } else {
-                            match eval_pipe_with_path_context_internal::<W, S>(
+                            let step = eval_pipe_with_path_context_internal::<W, S>(
                                 rest,
                                 v,
                                 root,
                                 file_origin,
                                 &new_path,
                                 optional,
-                            ) {
-                                QueryResult::Owned(r) => results.push(r),
-                                QueryResult::ManyOwned(rs) => results.extend(rs),
-                                QueryResult::None => {}
-                                QueryResult::Error(e) => return QueryResult::Error(e),
-                                _ => {}
+                            );
+                            if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                                return stop;
                             }
                         }
                     }
@@ -12034,19 +12102,16 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                         if rest.is_empty() {
                             results.push(v.clone());
                         } else {
-                            match eval_pipe_with_path_context_internal::<W, S>(
+                            let step = eval_pipe_with_path_context_internal::<W, S>(
                                 rest,
                                 v,
                                 root,
                                 file_origin,
                                 &new_path,
                                 optional,
-                            ) {
-                                QueryResult::Owned(r) => results.push(r),
-                                QueryResult::ManyOwned(rs) => results.extend(rs),
-                                QueryResult::None => {}
-                                QueryResult::Error(e) => return QueryResult::Error(e),
-                                _ => {}
+                            );
+                            if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                                return stop;
                             }
                         }
                     }
@@ -12054,13 +12119,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_iterate(value)),
             }
-            if results.is_empty() {
-                QueryResult::None
-            } else if results.len() == 1 {
-                QueryResult::Owned(results.pop().unwrap())
-            } else {
-                QueryResult::ManyOwned(results)
-            }
+            owned_vec_to_result(results)
         }
         Expr::Paren(inner) => {
             // Parentheses don't change path, just evaluate inner
@@ -12266,50 +12325,20 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 return select_result;
             }
             // `select` doesn't navigate, so continue `rest` from `value`'s
-            // existing path/root for each surviving (truthy) output --
-            // mirrors the `Iterate` arm's accumulate-then-collapse pattern
-            // above for fanning a multi-valued result back through `rest`.
-            match select_result {
-                QueryResult::Owned(v) => eval_pipe_with_path_context_internal::<W, S>(
-                    rest,
-                    &v,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                ),
-                QueryResult::ManyOwned(vs) => {
-                    let mut results = Vec::new();
-                    for v in vs {
-                        match eval_pipe_with_path_context_internal::<W, S>(
-                            rest,
-                            &v,
-                            root,
-                            file_origin,
-                            current_path,
-                            optional,
-                        ) {
-                            QueryResult::Owned(r) => results.push(r),
-                            QueryResult::ManyOwned(rs) => results.extend(rs),
-                            QueryResult::None => {}
-                            QueryResult::Error(e) => return QueryResult::Error(e),
-                            _ => {}
-                        }
-                    }
-                    if results.is_empty() {
-                        QueryResult::None
-                    } else if results.len() == 1 {
-                        QueryResult::Owned(results.pop().unwrap())
-                    } else {
-                        QueryResult::ManyOwned(results)
-                    }
-                }
-                QueryResult::None => QueryResult::None,
-                QueryResult::Error(e) => QueryResult::Error(e),
-                // `eval_fanout` above only ever produces Owned/ManyOwned/
-                // None/Error from an Owned-only `body` closure.
-                _ => QueryResult::None,
-            }
+            // existing path/root for each surviving (truthy) output.
+            // `eval_fanout` above can produce `Partial`/`Break` (e.g. when
+            // `cond` itself fans out and errors partway through), not just
+            // Owned/ManyOwned/None/Error, so this delegates to
+            // `continue_rest_with_context` instead of re-deriving (and
+            // mis-deriving, #715 follow-up) the same fan-out loop here.
+            continue_rest_with_context::<W, S>(
+                select_result,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
         }
         Expr::Builtin(builtin) => {
             // Handle other builtins that don't need special path handling
@@ -12376,56 +12405,53 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 current_path,
                 optional,
             );
-            let branch_result = match cond_result {
-                QueryResult::Owned(v) => {
-                    let branch = if v.is_truthy() {
-                        then_branch
-                    } else {
-                        else_branch
-                    };
-                    eval_pipe_with_path_context_internal::<W, S>(
-                        core::slice::from_ref(branch),
-                        value,
-                        root,
-                        file_origin,
-                        current_path,
-                        optional,
+            // Unpack `cond_result` into its truthy/falsy values plus any
+            // trailing control (#400/#494) -- `cond` itself can produce more
+            // than one value (e.g. `if .[] then ... end`) and/or end in an
+            // error/break after producing some, and both must still drive a
+            // branch evaluation per value with the control propagated after.
+            let (cond_values, cond_control): (Vec<OwnedValue>, Option<Control>) = match cond_result
+            {
+                QueryResult::Owned(v) => (vec![v], None),
+                QueryResult::ManyOwned(vs) => (vs, None),
+                QueryResult::None => (Vec::new(), None),
+                QueryResult::Error(e) => (Vec::new(), Some(Control::Error(e))),
+                QueryResult::Break(label) => (Vec::new(), Some(Control::Break(label))),
+                QueryResult::Partial(vs, control) => (vs, Some(control)),
+                QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                    unreachable!(
+                        "eval_pipe_with_path_context_internal only ever produces \
+                         Owned/ManyOwned/None/Error/Break/Partial"
                     )
                 }
-                QueryResult::ManyOwned(vs) => {
-                    let mut results = Vec::new();
-                    for v in vs {
-                        let branch = if v.is_truthy() {
-                            then_branch
-                        } else {
-                            else_branch
-                        };
-                        match eval_pipe_with_path_context_internal::<W, S>(
-                            core::slice::from_ref(branch),
-                            value,
-                            root,
-                            file_origin,
-                            current_path,
-                            optional,
-                        ) {
-                            QueryResult::Owned(r) => results.push(r),
-                            QueryResult::ManyOwned(rs) => results.extend(rs),
-                            QueryResult::None => {}
-                            QueryResult::Error(e) => return QueryResult::Error(e),
-                            _ => {}
-                        }
-                    }
-                    if results.is_empty() {
-                        QueryResult::None
-                    } else if results.len() == 1 {
-                        QueryResult::Owned(results.pop().unwrap())
-                    } else {
-                        QueryResult::ManyOwned(results)
-                    }
+            };
+            let mut results = Vec::new();
+            let mut stopped = None;
+            for v in cond_values {
+                let branch = if v.is_truthy() {
+                    then_branch
+                } else {
+                    else_branch
+                };
+                let step = eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(branch),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                    stopped = Some(stop);
+                    break;
                 }
-                QueryResult::None => QueryResult::None,
-                QueryResult::Error(e) => QueryResult::Error(e),
-                _ => QueryResult::None,
+            }
+            let branch_result = if let Some(stop) = stopped {
+                stop
+            } else if let Some(control) = cond_control {
+                partial(results, control)
+            } else {
+                owned_vec_to_result(results)
             };
             if rest.is_empty() {
                 return branch_result;
@@ -12445,43 +12471,27 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // resolve correctly per-branch instead of falling back to the
             // stub (#715 follow-up; `needs_path_context` already recurses
             // into `Comma`, but there was no matching interpreter arm).
-            // Collapses more-than-one output into an array -- matching
-            // `eval_owned_expr_ctrl`'s existing multi-output policy for
-            // this position, since that's what the generic fallback below
-            // (which this arm replaces for path-context pipes) already
-            // delegated to; comma not fanning out to independent top-level
-            // outputs here is a separate, pre-existing limitation, left
-            // unchanged.
+            // Fans out independently and preserves output already produced
+            // before a later branch errors/breaks, matching the plain
+            // evaluator's `eval_comma` (line ~690) instead of re-deriving a
+            // different (collapse-to-array, discard-on-error) policy here.
             let mut branch_outputs = Vec::new();
-            let mut branch_error = None;
+            let mut stopped = None;
             for sub_expr in exprs {
-                match eval_pipe_with_path_context_internal::<W, S>(
+                let step = eval_pipe_with_path_context_internal::<W, S>(
                     core::slice::from_ref(sub_expr),
                     value,
                     root,
                     file_origin,
                     current_path,
                     optional,
-                ) {
-                    QueryResult::Owned(v) => branch_outputs.push(v),
-                    QueryResult::ManyOwned(vs) => branch_outputs.extend(vs),
-                    QueryResult::None => {}
-                    QueryResult::Error(e) => {
-                        branch_error = Some(e);
-                        break;
-                    }
-                    _ => {}
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut branch_outputs, step) {
+                    stopped = Some(stop);
+                    break;
                 }
             }
-            let comma_result = if let Some(e) = branch_error {
-                QueryResult::Error(e)
-            } else if branch_outputs.is_empty() {
-                QueryResult::Owned(OwnedValue::Null)
-            } else if branch_outputs.len() == 1 {
-                QueryResult::Owned(branch_outputs.pop().unwrap())
-            } else {
-                QueryResult::Owned(OwnedValue::Array(branch_outputs))
-            };
+            let comma_result = stopped.unwrap_or_else(|| owned_vec_to_result(branch_outputs));
             if rest.is_empty() {
                 return comma_result;
             }
@@ -12612,6 +12622,17 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 optional,
             )
         }
+        // `break` is a control signal, not a value -- `rest` (anything
+        // structurally following it once a flattened pipe is split at
+        // `exprs.split_first()`) never runs; the `Label` arm above is what
+        // catches this. Without this arm, `Expr::Break` fell into the
+        // generic fallback below, which unconditionally converts any
+        // `Control::Break` into a synthetic "break $label not in label"
+        // `EvalError` (`eval_owned_expr`, above) -- wrongly reporting a
+        // label miss even when a real enclosing `label` was present, just
+        // not visible to that fallback's single-expression evaluation
+        // (#715 follow-up).
+        Expr::Break(name) => QueryResult::Break(name.clone()),
         _ => {
             // For other expressions, evaluate normally and continue
             // Note: This loses path context for complex expressions
@@ -29107,9 +29128,16 @@ mod tests {
 
     #[test]
     fn test_key_survives_comma_branches() {
+        // `(key, key)` fans out to independent top-level outputs, matching
+        // plain jq's `(a, b)` comma semantics -- not a single `[key, key]`
+        // array per element (#715 follow-up: the path-context `Comma` arm
+        // used to collapse every branch's outputs into one array and
+        // silently discard anything already produced once a later branch
+        // errored; fixed to reuse the same accumulate-independently policy
+        // `eval_comma` already has).
         assert_eq!(
             outputs(b"[10,20]", ".[] | (key, key)"),
-            vec!["[0,0]", "[1,1]"]
+            vec!["0", "0", "1", "1"]
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -409,6 +409,12 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         Expr::Try { expr, catch } => {
             needs_path_context(expr) || catch.as_ref().is_some_and(|c| needs_path_context(c))
         }
+        // `label $x | ...` is otherwise inert wrt path context, but a
+        // `key`/`document_index`/`file_index` inside its body still needs
+        // the same recursion as `If`/`Try` above -- without it,
+        // `label $out | file_index` silently dropped path context (#715
+        // follow-up).
+        Expr::Label { body, .. } => needs_path_context(body),
         _ => false,
     }
 }
@@ -11674,6 +11680,65 @@ fn eval_pipe_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     eval_pipe_with_path_context_internal::<W, S>(exprs, value, value, None, current_path, optional)
 }
 
+/// Continue evaluating `rest` for each output of an already-computed
+/// intermediate `QueryResult`, preserving `root`/`current_path` (the
+/// intermediate stage doesn't move navigational position -- e.g. a
+/// comparison, an `if`/`then`/`else`, or a `try`/`catch` result is still
+/// "at" the position it was computed from) and fanning a multi-valued
+/// result back out over `rest` the same way `Iterate` does above. Shared by
+/// `If`/`Comma`/`Try`/`Label` below to avoid re-deriving this fan-out loop
+/// at each call site. `Break`/`Partial` inputs collapse to `None` here,
+/// matching `Select`'s pre-existing fan-out policy just above (not a
+/// regression this helper introduces).
+fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    intermediate: QueryResult<'a, W>,
+    rest: &[Expr],
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    optional: bool,
+) -> QueryResult<'a, W> {
+    match intermediate {
+        QueryResult::Owned(v) => eval_pipe_with_path_context_internal::<W, S>(
+            rest,
+            &v,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        ),
+        QueryResult::ManyOwned(vs) => {
+            let mut results = Vec::new();
+            for v in vs {
+                match eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &v,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ) {
+                    QueryResult::Owned(r) => results.push(r),
+                    QueryResult::ManyOwned(rs) => results.extend(rs),
+                    QueryResult::None => {}
+                    QueryResult::Error(e) => return QueryResult::Error(e),
+                    _ => {}
+                }
+            }
+            if results.is_empty() {
+                QueryResult::None
+            } else if results.len() == 1 {
+                QueryResult::Owned(results.pop().unwrap())
+            } else {
+                QueryResult::ManyOwned(results)
+            }
+        }
+        QueryResult::None => QueryResult::None,
+        QueryResult::Error(e) => QueryResult::Error(e),
+        _ => QueryResult::None,
+    }
+}
+
 /// Internal helper that also tracks the root value for parent navigation,
 /// and (for `--eval-all`, #715) an optional origin-file-index side table
 /// keyed by top-level array position, resolving `file_index`/`fileIndex`/`fi`.
@@ -12103,13 +12168,16 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             }
             match arith_result {
                 QueryResult::Owned(v) => {
-                    // Fresh computed value -- reset path/root, same as `Compare`.
+                    // Preserve root/current_path, same as `Compare` above --
+                    // arithmetic is typically a mid-pipe computation, not the
+                    // pipe's final value, so later `key`/`file_index` calls
+                    // must still resolve against the pre-arithmetic position.
                     eval_pipe_with_path_context_internal::<W, S>(
                         rest,
                         &v,
-                        &v,
+                        root,
                         file_origin,
-                        &[],
+                        current_path,
                         optional,
                     )
                 }
@@ -12153,15 +12221,20 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 return compare_result;
             }
             if let QueryResult::Owned(v) = compare_result {
-                // A comparison produces a fresh boolean, unrelated to
-                // `value`'s position -- reset path/root like the
-                // `Object`/`Array`/`Literal` arm below does.
+                // Unlike `Object`/`Array`/`Literal`, a comparison is
+                // typically a mid-pipe filter/test, not the pipe's final
+                // value -- `key`/`document_index`/`file_index` later in the
+                // same pipe must still resolve against the position the
+                // comparison was evaluated at, so `root`/`current_path` are
+                // preserved (matching the generic fallback below, and
+                // `main`'s pre-#715 behavior: `.[] | (1==1) | key` must keep
+                // returning the original index, not `null`).
                 return eval_pipe_with_path_context_internal::<W, S>(
                     rest,
                     &v,
-                    &v,
+                    root,
                     file_origin,
-                    &[],
+                    current_path,
                     optional,
                 );
             }
@@ -12281,6 +12354,263 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 Err(_) if optional => QueryResult::None,
                 Err(e) => QueryResult::Error(e),
             }
+        }
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            // Evaluate cond/then/else through the path-context evaluator
+            // too, so `if file_index == 0 then ... end` -- a natural
+            // `--eval-all` idiom -- resolves correctly instead of falling
+            // back to the 0/null stub. `needs_path_context` already
+            // recurses into `If`; this arm is what actually honors that
+            // (#715 follow-up: previously there was no explicit `If` arm
+            // here, so it fell into the generic fallback below and lost
+            // path context for anything nested in cond/then/else).
+            let cond_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(cond),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let branch_result = match cond_result {
+                QueryResult::Owned(v) => {
+                    let branch = if v.is_truthy() {
+                        then_branch
+                    } else {
+                        else_branch
+                    };
+                    eval_pipe_with_path_context_internal::<W, S>(
+                        core::slice::from_ref(branch),
+                        value,
+                        root,
+                        file_origin,
+                        current_path,
+                        optional,
+                    )
+                }
+                QueryResult::ManyOwned(vs) => {
+                    let mut results = Vec::new();
+                    for v in vs {
+                        let branch = if v.is_truthy() {
+                            then_branch
+                        } else {
+                            else_branch
+                        };
+                        match eval_pipe_with_path_context_internal::<W, S>(
+                            core::slice::from_ref(branch),
+                            value,
+                            root,
+                            file_origin,
+                            current_path,
+                            optional,
+                        ) {
+                            QueryResult::Owned(r) => results.push(r),
+                            QueryResult::ManyOwned(rs) => results.extend(rs),
+                            QueryResult::None => {}
+                            QueryResult::Error(e) => return QueryResult::Error(e),
+                            _ => {}
+                        }
+                    }
+                    if results.is_empty() {
+                        QueryResult::None
+                    } else if results.len() == 1 {
+                        QueryResult::Owned(results.pop().unwrap())
+                    } else {
+                        QueryResult::ManyOwned(results)
+                    }
+                }
+                QueryResult::None => QueryResult::None,
+                QueryResult::Error(e) => QueryResult::Error(e),
+                _ => QueryResult::None,
+            };
+            if rest.is_empty() {
+                return branch_result;
+            }
+            continue_rest_with_context::<W, S>(
+                branch_result,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        Expr::Comma(exprs) => {
+            // Evaluate every branch through the path-context evaluator too,
+            // so `key`/`document_index`/`file_index` nested in a comma
+            // resolve correctly per-branch instead of falling back to the
+            // stub (#715 follow-up; `needs_path_context` already recurses
+            // into `Comma`, but there was no matching interpreter arm).
+            // Collapses more-than-one output into an array -- matching
+            // `eval_owned_expr_ctrl`'s existing multi-output policy for
+            // this position, since that's what the generic fallback below
+            // (which this arm replaces for path-context pipes) already
+            // delegated to; comma not fanning out to independent top-level
+            // outputs here is a separate, pre-existing limitation, left
+            // unchanged.
+            let mut branch_outputs = Vec::new();
+            let mut branch_error = None;
+            for sub_expr in exprs {
+                match eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(sub_expr),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ) {
+                    QueryResult::Owned(v) => branch_outputs.push(v),
+                    QueryResult::ManyOwned(vs) => branch_outputs.extend(vs),
+                    QueryResult::None => {}
+                    QueryResult::Error(e) => {
+                        branch_error = Some(e);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            let comma_result = if let Some(e) = branch_error {
+                QueryResult::Error(e)
+            } else if branch_outputs.is_empty() {
+                QueryResult::Owned(OwnedValue::Null)
+            } else if branch_outputs.len() == 1 {
+                QueryResult::Owned(branch_outputs.pop().unwrap())
+            } else {
+                QueryResult::Owned(OwnedValue::Array(branch_outputs))
+            };
+            if rest.is_empty() {
+                return comma_result;
+            }
+            continue_rest_with_context::<W, S>(
+                comma_result,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        Expr::Try {
+            expr: try_expr,
+            catch,
+        } => {
+            // Evaluate the try body (and catch handler) through the
+            // path-context evaluator too, so `try select(file_index == 1)
+            // catch ...` -- a natural `--eval-all` idiom -- resolves
+            // correctly instead of falling back to the stub (#715
+            // follow-up). Mirrors `eval_try`'s Error/Break/Partial handling
+            // above, just routed through path context instead of
+            // `eval_single`.
+            let result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(try_expr),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let try_result = match result {
+                QueryResult::Error(e) => match catch.as_deref() {
+                    Some(catch_expr) => eval_pipe_with_path_context_internal::<W, S>(
+                        core::slice::from_ref(catch_expr),
+                        &e.payload(),
+                        root,
+                        file_origin,
+                        current_path,
+                        optional,
+                    ),
+                    None => QueryResult::None,
+                },
+                QueryResult::Break(_) => match catch.as_deref() {
+                    Some(catch_expr) => eval_pipe_with_path_context_internal::<W, S>(
+                        core::slice::from_ref(catch_expr),
+                        &OwnedValue::Null,
+                        root,
+                        file_origin,
+                        current_path,
+                        optional,
+                    ),
+                    None => QueryResult::None,
+                },
+                QueryResult::Partial(prefix, Control::Error(e)) => {
+                    let handled = match catch.as_deref() {
+                        Some(catch_expr) => eval_pipe_with_path_context_internal::<W, S>(
+                            core::slice::from_ref(catch_expr),
+                            &e.payload(),
+                            root,
+                            file_origin,
+                            current_path,
+                            optional,
+                        ),
+                        None => QueryResult::None,
+                    };
+                    prepend(prefix, handled)
+                }
+                QueryResult::Partial(prefix, Control::Break(_)) => {
+                    let handled = match catch.as_deref() {
+                        Some(catch_expr) => eval_pipe_with_path_context_internal::<W, S>(
+                            core::slice::from_ref(catch_expr),
+                            &OwnedValue::Null,
+                            root,
+                            file_origin,
+                            current_path,
+                            optional,
+                        ),
+                        None => QueryResult::None,
+                    };
+                    prepend(prefix, handled)
+                }
+                other => other,
+            };
+            if rest.is_empty() {
+                return try_result;
+            }
+            continue_rest_with_context::<W, S>(
+                try_result,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        Expr::Label { name, body } => {
+            // Evaluate the label body through the path-context evaluator
+            // too, so `label $out | ... file_index ...` -- a natural (if
+            // inert) wrapper -- resolves correctly instead of silently
+            // falling back to the 0/null stub. Paired with the
+            // `needs_path_context` fix for `Label`: one without the other
+            // still drops path context silently (#715 follow-up).
+            let result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(body),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let label_result = match result {
+                QueryResult::Break(label) if &label == name => QueryResult::None,
+                QueryResult::Partial(prefix, Control::Break(label)) if &label == name => {
+                    owned_vec_to_result(prefix)
+                }
+                other => other,
+            };
+            if rest.is_empty() {
+                return label_result;
+            }
+            continue_rest_with_context::<W, S>(
+                label_result,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
         }
         _ => {
             // For other expressions, evaluate normally and continue
@@ -28726,6 +29056,60 @@ mod tests {
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "inner");
             }
+        );
+    }
+
+    // Regression tests (#715 follow-up): `eval_pipe_with_path_context_internal`
+    // gained `Compare`/`Arithmetic`/`Select` arms for `--eval-all`'s
+    // `file_index`, but the `Compare`/`Arithmetic` arms unconditionally reset
+    // `current_path`/`root` for the rest of the pipe, breaking `key` (and
+    // `document_index`/`file_index`) in plain `jq` usage that has nothing to
+    // do with `--eval-all` -- e.g. `.[] | (1==1) | key`. Fixed by preserving
+    // path context instead, matching the pre-existing generic fallback.
+    // `If`/`Try`/`Comma`/`Label` had the same gap for a different reason: no
+    // explicit arm at all, so they fell into that same generic fallback
+    // which evaluates via the *plain* (non-path-context) evaluator, losing
+    // `key`/`file_index` for anything nested inside.
+
+    #[test]
+    fn test_key_survives_comparison_mid_pipe() {
+        assert_eq!(outputs(b"[10,20]", ".[] | (1==1) | key"), vec!["0", "1"]);
+    }
+
+    #[test]
+    fn test_key_survives_arithmetic_mid_pipe() {
+        assert_eq!(outputs(b"[10,20]", ".[] | (1+1) | key"), vec!["0", "1"]);
+    }
+
+    #[test]
+    fn test_key_survives_if_then_else_mid_pipe() {
+        assert_eq!(
+            outputs(b"[10,20]", ".[] | if true then key else null end"),
+            vec!["0", "1"]
+        );
+    }
+
+    #[test]
+    fn test_key_survives_try_catch_mid_pipe() {
+        assert_eq!(
+            outputs(b"[10,20]", ".[] | try key catch \"err\""),
+            vec!["0", "1"]
+        );
+    }
+
+    #[test]
+    fn test_key_survives_label_wrapper() {
+        assert_eq!(
+            outputs(b"[10,20]", "label $out | .[] | key"),
+            vec!["0", "1"]
+        );
+    }
+
+    #[test]
+    fn test_key_survives_comma_branches() {
+        assert_eq!(
+            outputs(b"[10,20]", ".[] | (key, key)"),
+            vec!["[0,0]", "[1,1]"]
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -367,6 +367,26 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         Expr::Builtin(Builtin::Parent) => true,
         Expr::Builtin(Builtin::ParentN(_)) => true,
         Expr::Builtin(Builtin::Key) => true,
+        // `--eval-all`'s `file_index`/`fileIndex`/`fi` (#715) needs the same
+        // path-context routing as `Key` above -- it resolves via
+        // `current_path`, not a cursor.
+        Expr::Builtin(Builtin::FileIndex) => true,
+        // Neither `Compare` nor `Select` carries path context on its own,
+        // but a `key`/`document_index`/`file_index` nested in one of their
+        // operands does -- e.g. `select(file_index == 0)`, the headline
+        // `--eval-all` idiom. Recursing here is what makes
+        // `eval_pipe`/`eval_pipe_with_path_context_internal` route the whole
+        // pipe through path-context evaluation instead of losing it (#715;
+        // this closes a pre-existing gap for `key`/`document_index` too,
+        // e.g. `.[] | select(key >= 1)` previously produced no output).
+        Expr::Compare { left, right, .. } => needs_path_context(left) || needs_path_context(right),
+        // `*`-merge (`select(file_index==0) * select(file_index==1)`) is the
+        // other headline `--eval-all` idiom (#715) -- both operands need the
+        // same recursion as `Compare` above.
+        Expr::Arithmetic { left, right, .. } => {
+            needs_path_context(left) || needs_path_context(right)
+        }
+        Expr::Builtin(Builtin::Select(cond)) => needs_path_context(cond),
         Expr::Pipe(exprs) => exprs.iter().any(needs_path_context),
         Expr::Paren(inner) => needs_path_context(inner),
         Expr::Optional(inner) => needs_path_context(inner),
@@ -1834,16 +1854,27 @@ fn eval_compare<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(e) => return QueryResult::Error(e),
     };
 
-    let result = match op {
-        CompareOp::Eq => left_val == right_val,
-        CompareOp::Ne => left_val != right_val,
-        CompareOp::Lt => compare_values(&left_val, &right_val) == core::cmp::Ordering::Less,
-        CompareOp::Le => compare_values(&left_val, &right_val) != core::cmp::Ordering::Greater,
-        CompareOp::Gt => compare_values(&left_val, &right_val) == core::cmp::Ordering::Greater,
-        CompareOp::Ge => compare_values(&left_val, &right_val) != core::cmp::Ordering::Less,
-    };
+    QueryResult::Owned(OwnedValue::Bool(apply_compare_op(
+        op, &left_val, &right_val,
+    )))
+}
 
-    QueryResult::Owned(OwnedValue::Bool(result))
+/// Apply a comparison operator to two already-evaluated values.
+///
+/// Factored out of [`eval_compare`] so the path-context evaluator's own
+/// `Expr::Compare` arm (`eval_pipe_with_path_context_internal`, #715) can
+/// reuse the exact same operator semantics rather than a second, divergence-
+/// prone copy -- see the project's own "one definition, plus a test that call
+/// sites agree" convention (already applied to `compare_values` itself).
+fn apply_compare_op(op: CompareOp, left: &OwnedValue, right: &OwnedValue) -> bool {
+    match op {
+        CompareOp::Eq => left == right,
+        CompareOp::Ne => left != right,
+        CompareOp::Lt => compare_values(left, right) == core::cmp::Ordering::Less,
+        CompareOp::Le => compare_values(left, right) != core::cmp::Ordering::Greater,
+        CompareOp::Gt => compare_values(left, right) == core::cmp::Ordering::Greater,
+        CompareOp::Ge => compare_values(left, right) != core::cmp::Ordering::Less,
+    }
 }
 
 /// Compare two values using jq ordering: null < bool < number < string < array < object.
@@ -2524,6 +2555,14 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::Column => builtin_column::<W>(),
         Builtin::DocumentIndex => builtin_document_index::<W>(),
         Builtin::LineComment => builtin_line_comment::<W>(),
+        Builtin::FileIndex => {
+            // Requires the `--eval-all` path-context evaluator to resolve to
+            // anything but 0; reached here means either outside `--eval-all`
+            // or nested in a shape that evaluator doesn't cover (#715), the
+            // same documented "0 outside supported context" contract
+            // `document_index` already has.
+            QueryResult::Owned(OwnedValue::Int(0))
+        }
         Builtin::Shuffle => builtin_shuffle::<W>(value, optional),
         Builtin::Pivot => builtin_pivot::<W>(value, optional),
         Builtin::SplitDoc => {
@@ -7522,6 +7561,41 @@ pub fn eval_lenient<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Evaluate `expr` against a combined `--eval-all` array (succinctly
+/// extension, #715).
+///
+/// Makes `file_index`/`fileIndex`/`fi` resolve via `file_origin` -- a side
+/// table mapping each top-level array position to its originating file
+/// index, built by the yq CLI driver -- wherever
+/// `eval_pipe_with_path_context_internal` can reach it: plain
+/// `.`/`.[]`/`.field` navigation, comparisons, and `select(...)` (the same
+/// capability level `key`/`document_index` already have; `map`/`if`/
+/// literals/user functions are documented out of scope, matching those
+/// builtins' own existing limits).
+///
+/// Routes through the ordinary evaluator, untouched, whenever `expr`
+/// doesn't reference `file_index`/`key`/`parent`/`path` anywhere
+/// [`needs_path_context`] can see -- the overwhelming majority of
+/// `--eval-all` filters pay zero extra cost over a normal `evaluate_input`.
+pub fn eval_owned_with_file_index<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    input: &OwnedValue,
+    file_origin: &[usize],
+) -> QueryResult<'a, W> {
+    if needs_path_context(expr) {
+        eval_pipe_with_path_context_internal::<W, S>(
+            core::slice::from_ref(expr),
+            input,
+            input,
+            Some(file_origin),
+            &[],
+            false,
+        )
+    } else {
+        eval_owned_input::<W, S>(expr, input, false)
+    }
+}
+
 // =============================================================================
 // Assignment Operators Implementation
 // =============================================================================
@@ -10144,6 +10218,7 @@ fn substitute_var_in_builtin(
         Builtin::Column => Builtin::Column,
         Builtin::DocumentIndex => Builtin::DocumentIndex,
         Builtin::LineComment => Builtin::LineComment,
+        Builtin::FileIndex => Builtin::FileIndex,
         Builtin::Shuffle => Builtin::Shuffle,
         Builtin::Pivot => Builtin::Pivot,
         Builtin::SplitDoc => Builtin::SplitDoc,
@@ -11592,15 +11667,21 @@ fn eval_pipe_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     current_path: &[OwnedValue],
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Call the internal version with root value
-    eval_pipe_with_path_context_internal::<W, S>(exprs, value, value, current_path, optional)
+    // Call the internal version with root value. `file_origin` is only ever
+    // `Some` for `--eval-all`'s combined-array evaluation, which calls
+    // `eval_pipe_with_path_context_internal` directly (see
+    // `eval_owned_with_file_index`) rather than through this wrapper.
+    eval_pipe_with_path_context_internal::<W, S>(exprs, value, value, None, current_path, optional)
 }
 
-/// Internal helper that also tracks the root value for parent navigation.
+/// Internal helper that also tracks the root value for parent navigation,
+/// and (for `--eval-all`, #715) an optional origin-file-index side table
+/// keyed by top-level array position, resolving `file_index`/`fileIndex`/`fi`.
 fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     exprs: &[Expr],
     value: &OwnedValue,
     root: &OwnedValue,
+    file_origin: Option<&[usize]>,
     current_path: &[OwnedValue],
     optional: bool,
 ) -> QueryResult<'a, W> {
@@ -11622,6 +11703,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 rest,
                 &v,
                 root,
+                file_origin,
                 current_path,
                 optional,
             );
@@ -11646,6 +11728,38 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 rest,
                 &v,
                 root,
+                file_origin,
+                current_path,
+                optional,
+            );
+        }
+    }
+
+    // Handle FileIndex - return the origin file index of the top-level
+    // element `current_path` descends from (#715). Reads `current_path[0]`
+    // (the outermost index), not `.last()` like `Key` does: `file_index`
+    // answers "which file did this whole document come from", unaffected by
+    // further navigation. Falls back to 0 outside `--eval-all` (`file_origin`
+    // is `None`) or once past the top level's index (defensive; `.first()`
+    // always exists once inside an `--eval-all` array), matching
+    // `document_index`'s existing "0 outside supported context" contract.
+    if matches!(first, Expr::Builtin(Builtin::FileIndex)) {
+        let file_idx = current_path
+            .first()
+            .and_then(OwnedValue::as_i64)
+            .and_then(|i| usize::try_from(i).ok())
+            .and_then(|i| file_origin.and_then(|origins| origins.get(i).copied()))
+            .unwrap_or(0);
+        let file_index_result = QueryResult::Owned(OwnedValue::Int(file_idx as i64));
+        if rest.is_empty() {
+            return file_index_result;
+        }
+        if let QueryResult::Owned(v) = file_index_result {
+            return eval_pipe_with_path_context_internal::<W, S>(
+                rest,
+                &v,
+                root,
+                file_origin,
                 current_path,
                 optional,
             );
@@ -11680,6 +11794,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 rest,
                 &v,
                 root,
+                file_origin,
                 &parent_path,
                 optional,
             );
@@ -11725,6 +11840,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 rest,
                 &v,
                 root,
+                file_origin,
                 &parent_path,
                 optional,
             );
@@ -11735,7 +11851,14 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     match first {
         Expr::Identity => {
             // Identity doesn't change the path
-            eval_pipe_with_path_context_internal::<W, S>(rest, value, root, current_path, optional)
+            eval_pipe_with_path_context_internal::<W, S>(
+                rest,
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
         }
         Expr::Field(name) => {
             // Extend path with field name
@@ -11749,7 +11872,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                         return QueryResult::Owned(v.clone());
                     }
                     return eval_pipe_with_path_context_internal::<W, S>(
-                        rest, v, root, &new_path, optional,
+                        rest,
+                        v,
+                        root,
+                        file_origin,
+                        &new_path,
+                        optional,
                     );
                 }
                 // jq returns null for missing fields on objects (not an error)
@@ -11784,7 +11912,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                         return QueryResult::Owned(v.clone());
                     }
                     return eval_pipe_with_path_context_internal::<W, S>(
-                        rest, v, root, &new_path, optional,
+                        rest,
+                        v,
+                        root,
+                        file_origin,
+                        &new_path,
+                        optional,
                     );
                 }
             }
@@ -11813,7 +11946,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             results.push(v.clone());
                         } else {
                             match eval_pipe_with_path_context_internal::<W, S>(
-                                rest, v, root, &new_path, optional,
+                                rest,
+                                v,
+                                root,
+                                file_origin,
+                                &new_path,
+                                optional,
                             ) {
                                 QueryResult::Owned(r) => results.push(r),
                                 QueryResult::ManyOwned(rs) => results.extend(rs),
@@ -11832,7 +11970,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             results.push(v.clone());
                         } else {
                             match eval_pipe_with_path_context_internal::<W, S>(
-                                rest, v, root, &new_path, optional,
+                                rest,
+                                v,
+                                root,
+                                file_origin,
+                                &new_path,
+                                optional,
                             ) {
                                 QueryResult::Owned(r) => results.push(r),
                                 QueryResult::ManyOwned(rs) => results.extend(rs),
@@ -11861,6 +12004,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     &[(**inner).clone()],
                     value,
                     root,
+                    file_origin,
                     current_path,
                     optional,
                 )
@@ -11871,6 +12015,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     &combined,
                     value,
                     root,
+                    file_origin,
                     current_path,
                     optional,
                 )
@@ -11883,6 +12028,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     &[(**inner).clone()],
                     value,
                     root,
+                    file_origin,
                     current_path,
                     true,
                 )
@@ -11893,6 +12039,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     &combined,
                     value,
                     root,
+                    file_origin,
                     current_path,
                     true,
                 )
@@ -11906,9 +12053,190 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 &combined,
                 value,
                 root,
+                file_origin,
                 current_path,
                 optional,
             )
+        }
+        Expr::Arithmetic { op, left, right } => {
+            // Evaluate both sides through the path-context evaluator too --
+            // without this, `select(file_index==0) * select(file_index==1)`
+            // (the other headline `--eval-all` merge idiom, #715) silently
+            // evaluates both `select`s against the 0-stub, so the
+            // `file_index==1` side always comes back empty.
+            let left_val = match result_to_owned(eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(left),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )) {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            };
+            let right_val = match result_to_owned(eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(right),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )) {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            };
+            let arith_result = match op {
+                ArithOp::Add => arith_add::<S>(left_val, right_val),
+                ArithOp::Sub => arith_sub::<S>(left_val, right_val),
+                ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, *flags),
+                ArithOp::Div => arith_div::<S>(left_val, right_val),
+                ArithOp::Mod => arith_mod::<S>(left_val, right_val),
+            };
+            let arith_result = match arith_result {
+                Ok(v) => QueryResult::Owned(v),
+                Err(_) if optional => QueryResult::None,
+                Err(e) => QueryResult::Error(e),
+            };
+            if rest.is_empty() {
+                return arith_result;
+            }
+            match arith_result {
+                QueryResult::Owned(v) => {
+                    // Fresh computed value -- reset path/root, same as `Compare`.
+                    eval_pipe_with_path_context_internal::<W, S>(
+                        rest,
+                        &v,
+                        &v,
+                        file_origin,
+                        &[],
+                        optional,
+                    )
+                }
+                QueryResult::None => QueryResult::None,
+                QueryResult::Error(e) => QueryResult::Error(e),
+                _ => unreachable!("arith_result was just constructed above as Owned/None/Error"),
+            }
+        }
+        Expr::Compare { op, left, right } => {
+            // Evaluate both sides through the path-context evaluator too, so
+            // `key`/`document_index`/`file_index` resolve correctly inside a
+            // comparison (e.g. `file_index == 0`) rather than falling back to
+            // their 0/null stubs (#715 -- this was already a latent gap for
+            // `key`/`document_index`, not something `file_index` introduces).
+            let left_val = match result_to_owned(eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(left),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )) {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            };
+            let right_val = match result_to_owned(eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(right),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )) {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            };
+            let compare_result = QueryResult::Owned(OwnedValue::Bool(apply_compare_op(
+                *op, &left_val, &right_val,
+            )));
+            if rest.is_empty() {
+                return compare_result;
+            }
+            if let QueryResult::Owned(v) = compare_result {
+                // A comparison produces a fresh boolean, unrelated to
+                // `value`'s position -- reset path/root like the
+                // `Object`/`Array`/`Literal` arm below does.
+                return eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &v,
+                    &v,
+                    file_origin,
+                    &[],
+                    optional,
+                );
+            }
+            unreachable!("QueryResult::Owned was just constructed above")
+        }
+        Expr::Builtin(Builtin::Select(cond)) => {
+            // Evaluate the condition through the path-context evaluator too,
+            // so `select(file_index == 0)` -- the headline `--eval-all` idiom
+            // -- resolves correctly instead of falling back to the 0 stub
+            // (#715; same latent gap `Compare` above closes for `key`/
+            // `document_index`). Mirrors `builtin_select`'s `eval_fanout`
+            // structure so multi-valued conditions still fan out identically.
+            let cond_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(cond),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let select_result = eval_fanout(cond_result, |truthy| {
+                if truthy {
+                    QueryResult::Owned(value.clone())
+                } else {
+                    QueryResult::None
+                }
+            });
+            if rest.is_empty() {
+                return select_result;
+            }
+            // `select` doesn't navigate, so continue `rest` from `value`'s
+            // existing path/root for each surviving (truthy) output --
+            // mirrors the `Iterate` arm's accumulate-then-collapse pattern
+            // above for fanning a multi-valued result back through `rest`.
+            match select_result {
+                QueryResult::Owned(v) => eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &v,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ),
+                QueryResult::ManyOwned(vs) => {
+                    let mut results = Vec::new();
+                    for v in vs {
+                        match eval_pipe_with_path_context_internal::<W, S>(
+                            rest,
+                            &v,
+                            root,
+                            file_origin,
+                            current_path,
+                            optional,
+                        ) {
+                            QueryResult::Owned(r) => results.push(r),
+                            QueryResult::ManyOwned(rs) => results.extend(rs),
+                            QueryResult::None => {}
+                            QueryResult::Error(e) => return QueryResult::Error(e),
+                            _ => {}
+                        }
+                    }
+                    if results.is_empty() {
+                        QueryResult::None
+                    } else if results.len() == 1 {
+                        QueryResult::Owned(results.pop().unwrap())
+                    } else {
+                        QueryResult::ManyOwned(results)
+                    }
+                }
+                QueryResult::None => QueryResult::None,
+                QueryResult::Error(e) => QueryResult::Error(e),
+                // `eval_fanout` above only ever produces Owned/ManyOwned/
+                // None/Error from an Owned-only `body` closure.
+                _ => QueryResult::None,
+            }
         }
         Expr::Builtin(builtin) => {
             // Handle other builtins that don't need special path handling
@@ -11921,6 +12249,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             rest,
                             &result,
                             root,
+                            file_origin,
                             current_path,
                             optional,
                         )
@@ -11943,6 +12272,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             rest,
                             &result,
                             &result,
+                            file_origin,
                             &[],
                             optional,
                         )
@@ -11964,6 +12294,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             rest,
                             &result,
                             root,
+                            file_origin,
                             current_path,
                             optional,
                         )
@@ -18290,6 +18621,7 @@ fn expand_func_calls_in_builtin(
         Builtin::Column => Builtin::Column,
         Builtin::DocumentIndex => Builtin::DocumentIndex,
         Builtin::LineComment => Builtin::LineComment,
+        Builtin::FileIndex => Builtin::FileIndex,
         Builtin::Shuffle => Builtin::Shuffle,
         Builtin::Pivot => Builtin::Pivot,
         Builtin::SplitDoc => Builtin::SplitDoc,
@@ -18591,6 +18923,7 @@ fn substitute_func_param_in_builtin(builtin: &Builtin, param: &str, arg: &Expr) 
         Builtin::Column => Builtin::Column,
         Builtin::DocumentIndex => Builtin::DocumentIndex,
         Builtin::LineComment => Builtin::LineComment,
+        Builtin::FileIndex => Builtin::FileIndex,
         Builtin::Shuffle => Builtin::Shuffle,
         Builtin::Pivot => Builtin::Pivot,
         Builtin::SplitDoc => Builtin::SplitDoc,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -387,6 +387,11 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
             needs_path_context(left) || needs_path_context(right)
         }
         Expr::Builtin(Builtin::Select(cond)) => needs_path_context(cond),
+        // `map(f)` needs the same recursion as `Select` above -- e.g.
+        // `map(select(file_index == 0))`, previously silently stubbed to 0
+        // for every element instead of resolving or erroring (#715
+        // follow-up).
+        Expr::Builtin(Builtin::Map(f)) => needs_path_context(f),
         Expr::Pipe(exprs) => exprs.iter().any(needs_path_context),
         Expr::Paren(inner) => needs_path_context(inner),
         Expr::Optional(inner) => needs_path_context(inner),
@@ -7574,9 +7579,10 @@ pub fn eval_lenient<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// table mapping each top-level array position to its originating file
 /// index, built by the yq CLI driver -- wherever
 /// `eval_pipe_with_path_context_internal` can reach it: plain
-/// `.`/`.[]`/`.field` navigation, comparisons, and `select(...)` (the same
-/// capability level `key`/`document_index` already have; `map`/`if`/
-/// literals/user functions are documented out of scope, matching those
+/// `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`,
+/// `if`/`then`/`else`, `try`/`catch`, comma, and `label` (the same
+/// capability level `key`/`document_index` already have; array/object
+/// literals and user-defined functions remain out of scope, matching those
 /// builtins' own existing limits).
 ///
 /// Routes through the ordinary evaluator, untouched, whenever `expr`
@@ -12333,6 +12339,65 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // mis-deriving, #715 follow-up) the same fan-out loop here.
             continue_rest_with_context::<W, S>(
                 select_result,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        Expr::Builtin(Builtin::Map(f)) => {
+            // Evaluate `map(f)` through the path-context evaluator too, so
+            // `file_index`/`key`/`document_index` inside `f` resolve
+            // correctly per-element instead of falling back to the 0/null
+            // stub (#715 follow-up) -- `map(f)` is `[.[] | f]`, mirroring
+            // `builtin_map`'s element-source handling (object values too,
+            // #422) and `eval_array_construction`'s atomicity (a mid-way
+            // error/break discards the in-progress array rather than
+            // surfacing a partial one, verified: `[1,error("x"),3]`
+            // produces no output at all).
+            let elements: Vec<(OwnedValue, OwnedValue)> = match value {
+                OwnedValue::Array(arr) => arr
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| (OwnedValue::Int(i as i64), v.clone()))
+                    .collect(),
+                OwnedValue::Object(entries) => entries
+                    .iter()
+                    .map(|(k, v)| (OwnedValue::String(k.clone()), v.clone()))
+                    .collect(),
+                _ if optional => return QueryResult::None,
+                _ => return QueryResult::Error(EvalError::cannot_iterate(value)),
+            };
+            let mut results = Vec::new();
+            let mut stopped = None;
+            for (key, elem) in elements {
+                let mut new_path = current_path.to_vec();
+                new_path.push(key);
+                let step = eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(f),
+                    &elem,
+                    root,
+                    file_origin,
+                    &new_path,
+                    optional,
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                    stopped = Some(stop);
+                    break;
+                }
+            }
+            let map_result = match stopped {
+                Some(QueryResult::Partial(_, Control::Error(e))) => QueryResult::Error(e),
+                Some(QueryResult::Partial(_, Control::Break(label))) => QueryResult::Break(label),
+                Some(other) => other,
+                None => QueryResult::Owned(OwnedValue::Array(results)),
+            };
+            if rest.is_empty() {
+                return map_result;
+            }
+            continue_rest_with_context::<W, S>(
+                map_result,
                 rest,
                 root,
                 file_origin,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11811,7 +11811,34 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::None => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),
         QueryResult::Break(label) => QueryResult::Break(label),
-        QueryResult::Partial(vs, control) => partial(vs, control),
+        // `intermediate` produced `vs` before terminating in `outer_control`
+        // (#400, #494): pipe each already-produced value through `rest`
+        // first -- mirroring `pipe_owned_prefix`'s handling of the same
+        // shape -- and only attach `outer_control` once that's done, unless
+        // piping itself fails first, in which case that failure is what's
+        // actually reached and `outer_control` never surfaces. The previous
+        // `partial(vs, control)` here skipped `rest` entirely, silently
+        // dropping its transformation and swallowing any error it would
+        // have raised (e.g. `(1, error("x")) | file_index` reported the raw
+        // `1` instead of `file_index`'s resolved value, and never reported
+        // an error for a `rest` that itself fails).
+        QueryResult::Partial(vs, outer_control) => {
+            let mut results = Vec::new();
+            for v in vs {
+                let step = eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &v,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                    return stop;
+                }
+            }
+            partial(results, outer_control)
+        }
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
     }
 }
@@ -29557,14 +29584,18 @@ mod tests {
         // `cond` itself fans out to more than one value and then errors
         // (`(true, error("boom"))`): the branch loop finishes normally for
         // every value `cond` did produce, so the trailing control has to be
-        // reapplied *after* the loop rather than short-circuiting it.
+        // reapplied *after* the loop rather than short-circuiting it. The
+        // branch's own output (`1`) must still be piped through the rest of
+        // the pipe (`| file_index`, which ignores its input and reads only
+        // `current_path`) before landing in `vs` -- so the surviving prefix
+        // is `file_index`'s resolved `0`, not the raw branch value `1`.
         match eval_all_result(
             b"[1]",
             &[0],
             r#".[] | (if (true, error("boom")) then 1 else 2 end) | file_index"#,
         ) {
             QueryResult::Partial(vs, Control::Error(e)) => {
-                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert_eq!(vs, vec![OwnedValue::Int(0)]);
                 assert_eq!(e.message, "boom");
             }
             other => panic!("expected Partial, got {other:?}"),
@@ -29573,12 +29604,49 @@ mod tests {
 
     #[test]
     fn test_comma_partial_error_propagates_through_continuation_with_path_context() {
+        // The comma's own prefix output (`1`) must be piped through the
+        // rest of the pipe (`| file_index`) before landing in `vs`, exactly
+        // like `pipe_owned_prefix` does for the plain evaluator -- so the
+        // surviving prefix is `file_index`'s resolved `0`, not the raw
+        // comma value `1`.
         match eval_all_result(b"[1]", &[0], r#".[] | (1, error("boom")) | file_index"#) {
             QueryResult::Partial(vs, Control::Error(e)) => {
-                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert_eq!(vs, vec![OwnedValue::Int(0)]);
                 assert_eq!(e.message, "boom");
             }
             other => panic!("expected Partial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_try_catch_partial_prefix_continues_pipe_with_path_context() {
+        // `try`/`catch` reaching `continue_rest_with_context` with a
+        // `Partial` intermediate (the `catch` branch's own generator fans
+        // out and then errors) must still pipe its prefix through the rest
+        // of the pipe rather than passing the raw pre-`rest` value through.
+        match eval_all_result(
+            b"[1]",
+            &[0],
+            r#".[] | (try (1, error("x")) catch (2, error("y"))) | file_index"#,
+        ) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(0), OwnedValue::Int(0)]);
+                assert_eq!(e.message, "y");
+            }
+            other => panic!("expected Partial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_label_break_partial_prefix_continues_pipe_with_path_context() {
+        // Same shape as the `try`/`catch` case above, via `label`/`break`.
+        match eval_all_result(
+            b"[1]",
+            &[0],
+            r#".[] | (label $out | (1, break $out)) | file_index"#,
+        ) {
+            QueryResult::Owned(v) => assert_eq!(v, OwnedValue::Int(0)),
+            other => panic!("expected Owned, got {other:?}"),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7575,7 +7575,7 @@ pub fn eval_lenient<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ///
 /// Routes through the ordinary evaluator, untouched, whenever `expr`
 /// doesn't reference `file_index`/`key`/`parent`/`path` anywhere
-/// [`needs_path_context`] can see -- the overwhelming majority of
+/// `needs_path_context` can see -- the overwhelming majority of
 /// `--eval-all` filters pay zero extra cost over a normal `evaluate_input`.
 pub fn eval_owned_with_file_index<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -29643,7 +29643,7 @@ mod tests {
         match eval_all_result(
             b"[1]",
             &[0],
-            r#".[] | (label $out | (1, break $out)) | file_index"#,
+            r".[] | (label $out | (1, break $out)) | file_index",
         ) {
             QueryResult::Owned(v) => assert_eq!(v, OwnedValue::Int(0)),
             other => panic!("expected Owned, got {other:?}"),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -29206,6 +29206,725 @@ mod tests {
         );
     }
 
+    // Coverage-gap regression tests (PR #770 review): `--eval-all`'s
+    // path-context plumbing (`eval_pipe_with_path_context_internal`,
+    // `accumulate_path_context_step`, `continue_rest_with_context`) grew a
+    // lot of branches for `file_index`/`Compare`/`Arithmetic`/`Select`/
+    // `Map`/`If`/`Comma`/`Try`/`Label`, most reachable only through
+    // combinations the CLI-level `--eval-all` tests above don't happen to
+    // hit (e.g. a builtin followed by *more* pipe stages, an operand that
+    // itself errors, a condition that fans out to multiple values). These
+    // exercise them directly.
+
+    /// Every output of `filter` against `json`, evaluated through
+    /// `eval_owned_with_file_index` with `file_index` resolving against
+    /// `file_origin` -- the same entry point the `--eval-all` CLI driver
+    /// uses. Mirrors `outputs`, but for the path-context evaluator; panics
+    /// on `Error`/`Break`/`Partial` since those are asserted on directly via
+    /// `eval_all_result` where expected.
+    fn eval_all_outputs(json: &[u8], file_origin: &[usize], filter: &str) -> Vec<String> {
+        match eval_all_result(json, file_origin, filter) {
+            QueryResult::Owned(v) => vec![v.to_json()],
+            QueryResult::ManyOwned(vs) => vs.iter().map(OwnedValue::to_json).collect(),
+            QueryResult::None => vec![],
+            other => panic!("expected a successful result, got {other:?}"),
+        }
+    }
+
+    /// Like `eval_all_outputs`, but returns the raw `QueryResult` so a test
+    /// can assert on `Error`/`Break`/`Partial` too. `json` is fed straight
+    /// in as `eval_owned_with_file_index`'s `input` -- i.e. it plays the
+    /// role of the already-combined `--eval-all` array the yq CLI driver
+    /// builds, with `file_origin[i]` naming array element `i`'s origin file.
+    fn eval_all_result<'a>(
+        json: &[u8],
+        file_origin: &[usize],
+        filter: &str,
+    ) -> QueryResult<'a, Vec<u64>> {
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let input = to_owned(&cursor.value());
+        let expr = parse(filter).unwrap();
+        eval_owned_with_file_index::<Vec<u64>, JqSemantics>(&expr, &input, file_origin)
+    }
+
+    #[test]
+    fn test_key_continues_pipe_after_itself() {
+        assert_eq!(
+            outputs(b"[10,20]", ".[] | key | tostring"),
+            vec![r#""0""#, r#""1""#]
+        );
+    }
+
+    #[test]
+    fn test_file_index_continues_pipe_after_itself() {
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[7, 8], ".[] | file_index | tostring"),
+            vec![r#""7""#, r#""8""#]
+        );
+    }
+
+    #[test]
+    fn test_generic_builtin_continues_pipe_with_path_context() {
+        // `tostring` (any builtin without its own dedicated path-context
+        // arm) followed by yet another stage, not just used as the pipe's
+        // final value.
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[100, 8],
+                ".[] | file_index | tostring | length"
+            ),
+            vec!["3", "1"]
+        );
+    }
+
+    #[test]
+    fn test_array_construction_continues_pipe_with_path_context() {
+        // An array literal resets path/root to the newly constructed value
+        // (it's not navigation), but must still continue the rest of the
+        // pipe rather than short-circuiting.
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[7, 8], ".[] | file_index | [., 1] | length"),
+            vec!["2", "2"]
+        );
+    }
+
+    #[test]
+    fn test_parent_continues_pipe_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                br#"[{"a":1},{"a":2}]"#,
+                &[7, 8],
+                ".[] | .a | parent | file_index"
+            ),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_parent_n_continues_pipe_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                br#"[{"a":1},{"a":2}]"#,
+                &[7, 8],
+                ".[] | .a | parent(1) | file_index"
+            ),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_identity_continues_pipe_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[7, 8], ".[] | . | file_index"),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_optional_as_final_pipe_stage_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[7, 8], ".[] | (file_index)?"),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_optional_continues_pipe_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[7, 8], ".[] | (file_index)? | tostring"),
+            vec![r#""7""#, r#""8""#]
+        );
+    }
+
+    #[test]
+    fn test_object_iterate_path_context_stops_on_error() {
+        // Same "stop early, don't discard the escaping control" contract
+        // the array-`.[]` loop above already has a test for, but for the
+        // `OwnedValue::Object` iteration branch specifically.
+        let expr = parse(r#".[] | if key == "a" then error("boom") else file_index end"#).unwrap();
+        let input = OwnedValue::Object(IndexMap::from([
+            ("a".to_string(), OwnedValue::Int(1)),
+            ("b".to_string(), OwnedValue::Int(2)),
+        ]));
+        match eval_owned_with_file_index::<Vec<u64>, JqSemantics>(&expr, &input, &[]) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_arithmetic_left_operand_error_propagates() {
+        match eval_all_result(b"[1]", &[0], r#".[] | (error("boom") + 1) | file_index"#) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_arithmetic_right_operand_error_propagates() {
+        match eval_all_result(b"[1]", &[0], r#".[] | (1 + error("boom")) | file_index"#) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_arithmetic_every_op_reachable_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(b"[10]", &[0], ".[] | (file_index - 1) | tostring"),
+            vec![r#""-1""#]
+        );
+        assert_eq!(
+            eval_all_outputs(b"[10]", &[6], ".[] | (file_index % 4) | tostring"),
+            vec![r#""2""#]
+        );
+    }
+
+    #[test]
+    fn test_arithmetic_division_error_propagates_with_path_context() {
+        match eval_all_result(b"[1]", &[0], ".[] | (1 / 0) | file_index") {
+            QueryResult::Error(_) => {}
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_arithmetic_optional_division_error_becomes_none_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(b"[1]", &[0], ".[] | (1 / 0)? | file_index"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_compare_left_operand_error_propagates() {
+        match eval_all_result(b"[1]", &[0], r#".[] | (error("boom") == 1) | file_index"#) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compare_right_operand_error_propagates() {
+        match eval_all_result(b"[1]", &[0], r#".[] | (1 == error("boom")) | file_index"#) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_over_object_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(br#"[{"a":1,"b":2}]"#, &[9], ".[] | map(file_index)"),
+            vec!["[9,9]"]
+        );
+    }
+
+    #[test]
+    fn test_map_over_non_container_errors_with_path_context() {
+        match eval_all_result(b"[5]", &[0], ".[] | map(file_index)") {
+            QueryResult::Error(_) => {}
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_over_non_container_optional_is_none_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(b"[5]", &[0], ".[] | map(file_index)?"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_map_element_partial_error_propagates_with_path_context() {
+        match eval_all_result(
+            b"[[1]]",
+            &[0],
+            r#".[] | map((1, error("boom"))) | file_index"#,
+        ) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_element_partial_break_propagates_with_path_context() {
+        match eval_all_result(b"[[1]]", &[0], ".[] | map((1, break $out)) | file_index") {
+            QueryResult::Break(label) => assert_eq!(label, "out"),
+            other => panic!("expected Break, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_continues_pipe_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(b"[[1,2]]", &[9], ".[] | map(file_index) | length"),
+            vec!["2"]
+        );
+    }
+
+    #[test]
+    fn test_if_cond_empty_produces_none_with_path_context() {
+        // `.arr[]` on an empty array produces bare `QueryResult::None`
+        // directly, so the `If` cond -- and thus the whole `if`/`then`/
+        // `else` -- does too, feeding `continue_rest_with_context`'s
+        // top-level `None` arm (rather than the "false, take else" case a
+        // non-empty falsy cond would).
+        assert_eq!(
+            eval_all_outputs(
+                br#"[{"arr":[]}]"#,
+                &[3],
+                ".[] | (if .arr[] then 1 else 2 end) | file_index"
+            ),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_if_branch_error_propagates_through_continuation_with_path_context() {
+        match eval_all_result(
+            b"[1]",
+            &[0],
+            r#".[] | (if true then error("boom") else 1 end) | file_index"#,
+        ) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_if_branch_break_propagates_through_continuation_with_path_context() {
+        match eval_all_result(
+            b"[1]",
+            &[0],
+            ".[] | (if true then break $out else 1 end) | file_index",
+        ) {
+            QueryResult::Break(label) => assert_eq!(label, "out"),
+            other => panic!("expected Break, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_if_cond_many_owned_with_path_context() {
+        // `cond` itself fans out to more than one value with no error at
+        // all (`.arr[]` over two truthy elements) -- the `ManyOwned` arm of
+        // the cond-unpacking match, sibling to the `Owned`/`None`/`Error`/
+        // `Break`/`Partial` ones the other `test_if_cond_*` tests cover.
+        assert_eq!(
+            eval_all_outputs(
+                br#"[{"arr":[1,2]}]"#,
+                &[5],
+                ".[] | (if .arr[] then 1 else 2 end) | file_index"
+            ),
+            vec!["5", "5"]
+        );
+    }
+
+    #[test]
+    fn test_if_cond_bare_error_with_path_context() {
+        // `cond` itself is a bare error (not a `Comma` that produced some
+        // output first), so the cond-unpacking match's `Error` arm builds
+        // an empty-values, `Some(Control::Error(_))` pair directly, unlike
+        // `test_if_cond_partial_error_drives_partial_branch_result_with_path_context`'s
+        // `Partial` cond result.
+        match eval_all_result(
+            b"[1]",
+            &[0],
+            r#".[] | (if error("boom") then 1 else 2 end) | file_index"#,
+        ) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_if_cond_bare_break_with_path_context() {
+        match eval_all_result(
+            b"[1]",
+            &[0],
+            ".[] | (if break $out then 1 else 2 end) | file_index",
+        ) {
+            QueryResult::Break(label) => assert_eq!(label, "out"),
+            other => panic!("expected Break, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_if_cond_partial_error_drives_partial_branch_result_with_path_context() {
+        // `cond` itself fans out to more than one value and then errors
+        // (`(true, error("boom"))`): the branch loop finishes normally for
+        // every value `cond` did produce, so the trailing control has to be
+        // reapplied *after* the loop rather than short-circuiting it.
+        match eval_all_result(
+            b"[1]",
+            &[0],
+            r#".[] | (if (true, error("boom")) then 1 else 2 end) | file_index"#,
+        ) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert_eq!(e.message, "boom");
+            }
+            other => panic!("expected Partial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_comma_partial_error_propagates_through_continuation_with_path_context() {
+        match eval_all_result(b"[1]", &[0], r#".[] | (1, error("boom")) | file_index"#) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert_eq!(e.message, "boom");
+            }
+            other => panic!("expected Partial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_select_fanout_produces_many_owned_with_path_context() {
+        // `select(.tags[])` on an element whose `.tags` has two truthy
+        // entries fans `cond` out to two truthy bits, so `select`'s own
+        // `eval_fanout` accumulates a genuine `ManyOwned` (not the
+        // single-`Owned`/empty-`Many` shapes every other `select` test in
+        // this file produces) -- routed onward through
+        // `continue_rest_with_context`'s `ManyOwned` loop since `|
+        // file_index` follows.
+        assert_eq!(
+            eval_all_outputs(
+                br#"[{"tags":["a","b"]}]"#,
+                &[9],
+                ".[] | select(.tags[]) | file_index"
+            ),
+            vec!["9", "9"]
+        );
+    }
+
+    #[test]
+    fn test_try_catches_error_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                r#".[] | try error("boom") catch file_index"#
+            ),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_try_without_catch_swallows_error_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                r#".[] | (try error("boom")) | file_index"#
+            ),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_try_catches_break_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                ".[] | try (break $out) catch file_index"
+            ),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_try_without_catch_swallows_break_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[7, 8], ".[] | (try (break $out)) | file_index"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_try_catches_partial_error_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                r#".[] | try (1, error("boom")) catch file_index"#
+            ),
+            vec!["1", "7", "1", "8"]
+        );
+    }
+
+    #[test]
+    fn test_try_without_catch_prepends_partial_error_prefix_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                r#".[] | (try (1, error("boom"))) | file_index"#
+            ),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_try_catches_partial_break_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                ".[] | try (1, break $out) catch file_index"
+            ),
+            vec!["1", "7", "1", "8"]
+        );
+    }
+
+    #[test]
+    fn test_try_without_catch_prepends_partial_break_prefix_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                ".[] | (try (1, break $out)) | file_index"
+            ),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_label_catches_its_own_bare_break_with_path_context() {
+        // The break fires on the very first element, so the enclosing
+        // `.[]` loop's fan-out aborts with zero accumulated output --
+        // `result` is a bare `Break`, not a `Partial`.
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                "label $out | .[] | if key == 0 then break $out else file_index end"
+            ),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_label_catches_partial_break_with_path_context() {
+        // The break fires on the second element, after the first already
+        // produced output -- `result` is `Partial(prefix, Break(_))`, and
+        // catching it must keep the prefix rather than discarding it.
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                "label $out | .[] | if key == 1 then break $out else file_index end"
+            ),
+            vec!["7"]
+        );
+    }
+
+    #[test]
+    fn test_label_continues_pipe_with_path_context() {
+        assert_eq!(
+            eval_all_outputs(
+                b"[10,20]",
+                &[7, 8],
+                ".[] | (label $out | file_index) | tostring"
+            ),
+            vec![r#""7""#, r#""8""#]
+        );
+    }
+
+    #[test]
+    fn test_file_index_inside_user_defined_function() {
+        // `eval_owned_with_file_index`'s own doc comment: user-defined
+        // functions are out of scope for `--eval-all` path-context
+        // resolution, the same pre-existing limit `key`/`document_index`
+        // already have -- `needs_path_context` doesn't see through a
+        // `FuncCall`, so `.[] | f` never routes through path-context
+        // evaluation and `file_index` inside `f`'s body falls back to its
+        // default (0) rather than resolving per-element. This exercises
+        // `expand_func_calls`'s `FileIndex` arm (hit while inlining `f`'s
+        // body at call time), not per-element resolution --
+        // `test_file_index_continues_pipe_after_itself` covers that.
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[3, 4], "def f: file_index; .[] | f"),
+            vec!["0", "0"]
+        );
+    }
+
+    #[test]
+    fn test_file_index_inside_parameterized_user_defined_function() {
+        // Same scope boundary as above, via `substitute_func_param`'s
+        // `FileIndex` arm instead of `expand_func_calls`'s.
+        assert_eq!(
+            eval_all_outputs(b"[10]", &[9], "def f($x): (file_index, $x); .[] | f(1)"),
+            vec!["0", "1"]
+        );
+    }
+
+    // The remaining branches in this plumbing are provably unreachable
+    // through any real filter, so they're exercised directly against the
+    // private functions instead of via a filter: `accumulate_path_context_step`'s
+    // `One` and `continue_rest_with_context`'s `One`/non-empty-`Many` exist
+    // only because `eval_fanout` (shared with plain `select`) is generic
+    // over borrowed-cursor results, but the `Select` arm's own fan-out body
+    // (`Owned`/`None` only, never `One`/`Many`) can never construct a
+    // non-empty borrowed variant.
+
+    #[test]
+    fn test_accumulate_path_context_step_handles_borrowed_one() {
+        let bytes: &[u8] = b"42";
+        let index = JsonIndex::build(bytes);
+        let cursor = index.root(bytes);
+        let sj = cursor.value();
+
+        let mut results = Vec::new();
+        let stop = accumulate_path_context_step::<Vec<u64>>(&mut results, QueryResult::One(sj));
+        assert!(stop.is_none());
+        assert_eq!(results, vec![OwnedValue::Int(42)]);
+    }
+
+    #[test]
+    fn test_continue_rest_with_context_handles_borrowed_one() {
+        let bytes: &[u8] = b"42";
+        let index = JsonIndex::build(bytes);
+        let cursor = index.root(bytes);
+        let sj = cursor.value();
+        let rest_expr = parse("tostring").unwrap();
+
+        let result = continue_rest_with_context::<Vec<u64>, JqSemantics>(
+            QueryResult::One(sj),
+            core::slice::from_ref(&rest_expr),
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        );
+        match result {
+            QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(s, "42"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_continue_rest_with_context_handles_borrowed_many() {
+        let bytes: &[u8] = br#"{"a": [1, false, 2]}"#;
+        let index = JsonIndex::build(bytes);
+        let cursor = index.root(bytes);
+        let many = match eval::<Vec<u64>, JqSemantics>(&parse(".a[] // 9").unwrap(), cursor) {
+            QueryResult::Many(vs) => vs,
+            other => panic!("expected Many, got {other:?}"),
+        };
+        assert_eq!(many.len(), 2);
+
+        let rest_expr = parse("tostring").unwrap();
+        let result = continue_rest_with_context::<Vec<u64>, JqSemantics>(
+            QueryResult::Many(many),
+            core::slice::from_ref(&rest_expr),
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        );
+        match result {
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(
+                    vs,
+                    vec![
+                        OwnedValue::String("1".to_string()),
+                        OwnedValue::String("2".to_string())
+                    ]
+                );
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_continue_rest_with_context_many_owned_loop_stops_on_error() {
+        // `(1, 2)` (a `Comma`, evaluated with no error at all) hands
+        // `continue_rest_with_context` a genuine `ManyOwned([1, 2])`
+        // intermediate; erroring on the *second* value while continuing
+        // `rest` per-element exercises the loop's early-return "stop" path
+        // rather than the case (`test_select_fanout_produces_many_owned_with_path_context`)
+        // where every element's continuation succeeds.
+        match eval_all_result(
+            b"1",
+            &[0],
+            r#"(1, 2) | if . == 2 then error("boom") else file_index end"#,
+        ) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(0)]);
+                assert_eq!(e.message, "boom");
+            }
+            other => panic!("expected Partial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_continue_rest_with_context_borrowed_many_loop_stops_on_error() {
+        // Same "stop early, keep the prefix" contract as the `ManyOwned`
+        // loop above, for the borrowed-cursor `Many` loop -- reachable
+        // only via a direct call (see the borrowed-`One`/`Many` tests
+        // above for why).
+        let bytes: &[u8] = br#"{"a": [1, 2]}"#;
+        let index = JsonIndex::build(bytes);
+        let cursor = index.root(bytes);
+        let many = match eval::<Vec<u64>, JqSemantics>(&parse(".a[]").unwrap(), cursor) {
+            QueryResult::Many(vs) => vs,
+            other => panic!("expected Many, got {other:?}"),
+        };
+        assert_eq!(many.len(), 2);
+
+        let rest_expr = parse(r#"if . == 2 then error("boom") else tostring end"#).unwrap();
+        let result = continue_rest_with_context::<Vec<u64>, JqSemantics>(
+            QueryResult::Many(many),
+            core::slice::from_ref(&rest_expr),
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        );
+        match result {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::String("1".to_string())]);
+                assert_eq!(e.message, "boom");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generic_fallback_continues_pipe_with_path_context() {
+        // `1 as $x | $x` (`Expr::As`) has no dedicated path-context arm, so
+        // it falls into the generic `_` fallback -- which must still
+        // continue the rest of the pipe (here, `file_index`) rather than
+        // treating itself as the pipe's final value.
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[7, 8], ".[] | (1 as $x | $x) | file_index"),
+            vec!["7", "8"]
+        );
+    }
+
+    #[test]
+    fn test_key_continues_pipe_after_itself_yq_semantics() {
+        // Same shape as `test_key_continues_pipe_after_itself`, but through
+        // `YqSemantics` -- the generic path-context functions are
+        // monomorphized per `EvalSemantics` impl, and the yq CLI (the only
+        // real caller of the eval-all-adjacent parts of this file) always
+        // uses `YqSemantics`, never `JqSemantics`.
+        let index = JsonIndex::build(b"[10,20]");
+        let cursor = index.root(b"[10,20]");
+        let expr = parse(".[] | key | tostring").unwrap();
+        let out: Vec<String> = eval::<Vec<u64>, YqSemantics>(&expr, cursor)
+            .collect_owned()
+            .iter()
+            .map(OwnedValue::to_json)
+            .collect();
+        assert_eq!(out, vec![r#""0""#, r#""1""#]);
+    }
+
     // Phase 12 tests: Additional builtins
 
     #[test]

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -818,6 +818,17 @@ pub enum Builtin {
     DocumentIndex,
     /// `line_comment` - return the trailing same-line comment text, or "" (yq, #710)
     LineComment,
+    /// `file_index` / `fileIndex` / `fi` - return the 0-indexed origin file
+    /// position within an `--eval-all` combined evaluation (yq/succinctly
+    /// extension, #715). Resolves via the same `current_path`-derived
+    /// mechanism as `key`, not `document_index`'s cursor mechanism, since
+    /// only that path reaches the combined-array evaluation `--eval-all`
+    /// requires. Outside `--eval-all` (or reachable through the same
+    /// supported shapes `key`/`document_index` already document — plain
+    /// navigation/`select`/comparisons, not `map`/`if`/literals/user
+    /// functions), returns 0 -- the same "0 outside supported context"
+    /// contract `document_index` already has today.
+    FileIndex,
     /// `shuffle` - randomly shuffle array elements (yq)
     Shuffle,
     /// `pivot` - transpose arrays/objects (yq)

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -84,8 +84,8 @@ mod value;
 
 pub use error::{BinOp, Control, EvalError};
 pub use eval::{
-    eval, eval_lenient, substitute_vars, sync_aliased_paths, EvalSemantics, JqSemantics,
-    QueryResult, YqSemantics,
+    eval, eval_lenient, eval_owned_with_file_index, substitute_vars, sync_aliased_paths,
+    EvalSemantics, JqSemantics, QueryResult, YqSemantics,
 };
 pub use expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MetaValue,

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2953,6 +2953,23 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::DocumentIndex));
         }
 
+        // file_index / fileIndex / fi - succinctly extension (#715): return
+        // 0-indexed origin file position within an `--eval-all` combined
+        // evaluation. `fileIndex` (camelCase) is real yq's own spelling;
+        // `file_index` mirrors this codebase's `document_index` convention.
+        if self.matches_keyword("file_index") {
+            self.consume_keyword("file_index");
+            return Ok(Some(Builtin::FileIndex));
+        }
+        if self.matches_keyword("fileIndex") {
+            self.consume_keyword("fileIndex");
+            return Ok(Some(Builtin::FileIndex));
+        }
+        if self.matches_keyword("fi") {
+            self.consume_keyword("fi");
+            return Ok(Some(Builtin::FileIndex));
+        }
+
         // shuffle - yq: randomly shuffle array elements
         if self.matches_keyword("shuffle") {
             self.consume_keyword("shuffle");

--- a/src/text/line_break.rs
+++ b/src/text/line_break.rs
@@ -39,8 +39,11 @@ pub(crate) fn is_line_break(b: u8) -> bool {
 /// Zero doubles as "not at a break", so `pos += line_break_len(text, pos)` is a
 /// safe unconditional advance only when the caller has already established that
 /// it is at one; otherwise test the width before stepping.
+///
+/// `pub`, not `pub(crate)`, so the `src/bin` binary crate can share this rule
+/// too (e.g. `front_matter.rs`'s line scanning) instead of re-deriving it.
 #[inline]
-pub(crate) fn line_break_len(text: &[u8], pos: usize) -> usize {
+pub fn line_break_len(text: &[u8], pos: usize) -> usize {
     match text.get(pos) {
         Some(b'\r') if text.get(pos + 1) == Some(&b'\n') => 2,
         Some(b'\r' | b'\n') => 1,

--- a/src/text/line_break.rs
+++ b/src/text/line_break.rs
@@ -13,8 +13,9 @@
 //! predicates diverge silently, and the next edge case would have landed in one
 //! copy and not the others. #341 collapsed them onto `yaml::line_break`; #228
 //! added a fourth consumer outside `yaml`, so the definition moved here and
-//! [`crate::yaml::line_break`] re-exports it. Callers that need a different
-//! *shape* adapt around these three functions rather than restating the rule.
+//! `yaml::line_break` (a private module, not doc-linkable from here) re-exports
+//! it. Callers that need a different *shape* adapt around these three
+//! functions rather than restating the rule.
 //!
 //! Two exceptions survive, both in YAML and both documented at their sites:
 //! `yaml::parser::Parser::skip_line_break` keeps a hand-rolled dispatch for a

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -48,7 +48,7 @@
 //! assert_eq!(err.offset, 0);
 //! ```
 
-pub(crate) mod line_break;
+pub mod line_break;
 pub mod lines;
 pub mod utf8;
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3077,6 +3077,66 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
     Ok(())
 }
 
+/// Regression tests (#715 follow-up) for the path-context evaluator's
+/// fan-out loops (`Iterate`, `If`'s multi-valued `cond`, `Comma`, `Select`):
+/// each independently collapsed an escaping `break` or `error` to a bare
+/// synthetic error / `None`, discarding output already produced by earlier
+/// iterations. Fixed by routing every loop through a shared
+/// accumulate-or-stop helper that matches the plain evaluator's `eval_comma`
+/// (#400/#494) semantics instead of re-deriving (and mis-deriving) the same
+/// logic per arm.
+#[test]
+fn test_path_context_fanout_preserves_output_before_break_or_error_715() -> Result<()> {
+    // `break` inside `if`/`then`/`else` whose `cond` needs path context
+    // (`key`) used to wrongly report "break $out not in label" even though
+    // the label genuinely enclosed it -- `Expr::Break` had no arm in the
+    // path-context evaluator and fell into a fallback that unconditionally
+    // converts `Control::Break` into a synthetic error.
+    let (stdout, _stderr, code) = run_jq_full(
+        &["label $out | .[] | if key == 1 then break $out else key end"],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(stdout, "0\n");
+    assert_eq!(code, 0);
+
+    // `Iterate` (`.[]`) used to discard output from earlier elements when a
+    // later element's path-context-dependent branch errored.
+    let (stdout, stderr, code) = run_jq_full(
+        &[".[] | if key == 2 then error(\"boom\") else key end"],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(stdout, "0\n1\n");
+    assert!(stderr.contains("boom"), "expected the error, got: {stderr}");
+    assert_eq!(code, 5);
+
+    // `Comma` used to discard an earlier branch's output on a later
+    // branch's error (and also collapsed independent branch outputs into a
+    // single array, unlike plain jq's `(a, b)`).
+    let (stdout, stderr, code) = run_jq_full(&[".[0] | (key, error(\"boom\"))"], Some("[10,20]"))?;
+    assert_eq!(stdout, "0\n");
+    assert!(stderr.contains("boom"), "expected the error, got: {stderr}");
+    assert_eq!(code, 5);
+
+    // `(key, key)` now fans out to independent top-level outputs, matching
+    // plain jq's comma semantics instead of collapsing per-element into a
+    // `[key, key]` array.
+    let (stdout, _stderr, code) = run_jq_full(&[".[] | (key, key)"], Some("[10,20]"))?;
+    assert_eq!(stdout, "0\n0\n1\n1\n");
+    assert_eq!(code, 0);
+
+    // `Select`'s continuation used to collapse a `Partial`/`Break` result to
+    // a bare `None`; it now delegates to the same shared helper.
+    let (stdout, stderr, code) = run_jq_full(
+        &[".[] | select(key == 0, error(\"boom\"))"],
+        Some("[10,20]"),
+    )?;
+    assert_eq!(stdout, "10\n");
+    assert!(stderr.contains("boom"), "expected the error, got: {stderr}");
+    assert_eq!(code, 5);
+
+    Ok(())
+}
+
 /// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
 /// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
 /// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6364,6 +6364,41 @@ fn test_eval_all_file_index_survives_label_wrapper() -> Result<()> {
     Ok(())
 }
 
+/// Regression test: same gap as `test_eval_all_file_index_in_if_then_else`,
+/// for `map(...)` -- `file_index` silently stubbed to 0 for every element
+/// instead of resolving, so `map(select(file_index == 0))` returned every
+/// document from every file instead of filtering to file 0's (#715
+/// follow-up).
+#[test]
+fn test_eval_all_file_index_in_map() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        "map(select(file_index == 0))",
+        &[f1.path(), f2.path()],
+        &["--eval-all"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "-\n  a: 1\n  name: first\n");
+    Ok(())
+}
+
+/// `map(f)` is `[.[] | f]`, so it must stay atomic on error like real array
+/// construction (`[1,error("x"),3]` produces no output at all) rather than
+/// leaking an in-progress array (#715 follow-up).
+#[test]
+fn test_eval_all_file_index_in_map_is_atomic_on_error() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, stderr, code) = run_yq_files(
+        r#"map(if file_index == 0 then error("boom") else . end)"#,
+        &[f1.path(), f2.path()],
+        &["--eval-all"],
+    )?;
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "expected the error, got: {stderr}");
+    assert_eq!(code, 1);
+    Ok(())
+}
+
 #[test]
 fn test_eval_all_file_index_outside_eval_all_is_zero() -> Result<()> {
     let (f1, _f2) = two_doc_fixtures()?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6229,6 +6229,54 @@ fn test_eval_all_file_index_select_then_field() -> Result<()> {
     Ok(())
 }
 
+/// Regression test: `needs_path_context` recurses into `Expr::If`, but
+/// `eval_pipe_with_path_context_internal` had no matching arm, so it fell
+/// into the generic (non-path-context) fallback and silently lost
+/// `file_index` for anything nested in `then`/`else` (#715 follow-up).
+#[test]
+fn test_eval_all_file_index_in_if_then_else() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        r#".[] | if file_index == 0 then "from-f1" else "from-f2" end"#,
+        &[f1.path(), f2.path()],
+        &["--eval-all"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "from-f1\n---\nfrom-f2\n");
+    Ok(())
+}
+
+/// Regression test: same gap as `test_eval_all_file_index_in_if_then_else`,
+/// for `Expr::Try` (#715 follow-up).
+#[test]
+fn test_eval_all_file_index_in_try_catch() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        r#".[] | try select(file_index == 1) catch "err""#,
+        &[f1.path(), f2.path()],
+        &["--eval-all"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "b: 2\nname: second\n");
+    Ok(())
+}
+
+/// Regression test: `label $x | ...` is otherwise inert, but wrapping a
+/// `file_index`-using pipe in one silently dropped path context on both the
+/// `needs_path_context` predicate and the interpreter side (#715 follow-up).
+#[test]
+fn test_eval_all_file_index_survives_label_wrapper() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        "label $out | .[] | file_index",
+        &[f1.path(), f2.path()],
+        &["--eval-all", "-o", "json"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0\n1");
+    Ok(())
+}
+
 #[test]
 fn test_eval_all_file_index_outside_eval_all_is_zero() -> Result<()> {
     let (f1, _f2) = two_doc_fixtures()?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5925,6 +5925,64 @@ fn test_front_matter_process_rejects_json_output() -> Result<()> {
     Ok(())
 }
 
+/// Regression test: `output_value` treats anything other than `Yaml` as
+/// JSON output (including `Auto`), but the compat guard only checked for
+/// the explicit `Json` variant -- `-o auto` slipped through and wrapped a
+/// JSON body in `---` fences (#715 follow-up).
+#[test]
+fn test_front_matter_process_rejects_auto_output() -> Result<()> {
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        FRONT_MATTER_FIXTURE,
+        &["--front-matter", "process", "-o", "auto"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("auto"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// Regression test: reattaching a body that doesn't end in a newline used
+/// to run straight into the next file's opening fence with no separator,
+/// e.g. `Body A---` -- corrupting the stream (#715 follow-up).
+#[test]
+fn test_front_matter_process_multi_file_separates_body_from_next_fence() -> Result<()> {
+    let mut file1 = NamedTempFile::new()?;
+    write!(file1, "---\ntitle: A\n---\nBody A")?; // no trailing newline
+    let mut file2 = NamedTempFile::new()?;
+    write!(file2, "---\ntitle: B\n---\nBody B\n")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["--front-matter", "process"])
+        .arg(".title = \"X\"")
+        .arg(file1.path())
+        .arg(file2.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(
+        stdout,
+        "---\ntitle: X\n---\nBody A\n---\ntitle: X\n---\nBody B\n"
+    );
+    Ok(())
+}
+
+/// Regression test: the closing `---` fence injected right before a
+/// reattached body was always LF-only, even when the body itself was CRLF
+/// -- producing a file with mixed line endings (#715 follow-up).
+#[test]
+fn test_front_matter_process_preserves_crlf_line_endings() -> Result<()> {
+    let (output, stderr, code) = run_yq_stdin_with_stderr(
+        ".title = \"X\"",
+        "---\r\ntitle: A\r\n---\r\nBody\r\ntext\r\n",
+        &["--front-matter", "process"],
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(output, "---\ntitle: X\n---\r\nBody\r\ntext\r\n");
+    Ok(())
+}
+
 #[test]
 fn test_front_matter_extract_allows_slurp_across_files() -> Result<()> {
     let mut file1 = NamedTempFile::new()?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5860,6 +5860,33 @@ fn test_front_matter_process_inplace_rewrites_file() -> Result<()> {
     Ok(())
 }
 
+/// Regression test: `extract` mode captures no body to reattach (only
+/// `process` does), so `--front-matter=extract -i` used to overwrite the
+/// file with just the transformed front matter, silently discarding
+/// everything after the closing fence (#715 follow-up).
+#[test]
+fn test_front_matter_extract_rejects_inplace() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{FRONT_MATTER_FIXTURE}")?;
+    let original = std::fs::read_to_string(input_file.path())?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["--front-matter", "extract", "-i"])
+        .arg(".title = \"New\"")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--inplace"), "stderr: {stderr}");
+
+    // The file must be left untouched, not partially overwritten.
+    let unchanged = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(unchanged, original);
+    Ok(())
+}
+
 #[test]
 fn test_front_matter_no_fence_errors() -> Result<()> {
     let (_output, _stderr, code) =

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5907,6 +5907,23 @@ fn test_front_matter_unterminated_errors() -> Result<()> {
     Ok(())
 }
 
+/// Regression test: `apply_front_matter` always forces `InputFormat::Yaml`
+/// once a mode is set (front matter is YAML by definition), but it used to
+/// do so silently even when the caller explicitly asked for
+/// `--input-format json` -- reject the contradictory combination instead
+/// (#715 follow-up).
+#[test]
+fn test_front_matter_rejects_json_input_format() -> Result<()> {
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        FRONT_MATTER_FIXTURE,
+        &["--front-matter", "extract", "--input-format", "json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--input-format"), "stderr: {stderr}");
+    Ok(())
+}
+
 #[test]
 fn test_front_matter_rejects_doc_flag() -> Result<()> {
     let (_output, stderr, code) = run_yq_stdin_with_stderr(

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6694,6 +6694,21 @@ fn test_eval_all_doc_separator_between_results() -> Result<()> {
     Ok(())
 }
 
+/// Regression test: `--eval-all` never routed through `SplitDocState` (the
+/// state machine every other output path uses to honor an explicit
+/// `split_doc` marker), so `--eval-all '... | split_doc'` silently merged
+/// every result with zero `---` separators instead of one per result
+/// (#715 follow-up).
+#[test]
+fn test_eval_all_split_doc_emits_separators() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) =
+        run_yq_files(".[] | split_doc", &[f1.path(), f2.path()], &["--eval-all"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "a: 1\nname: first\n---\nb: 2\nname: second\n");
+    Ok(())
+}
+
 #[test]
 fn test_eval_all_doc_flag_interaction() -> Result<()> {
     let mut multi = NamedTempFile::new()?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 use anyhow::Result;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 /// Helper to run yq command with input from stdin
 fn run_yq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(String, i32)> {
@@ -5783,5 +5783,597 @@ fn test_713_merge_flags_on_null_or_absent_target() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"{"a":[1,2]}"#);
 
+    Ok(())
+}
+
+// ============================================================================
+// --front-matter Tests (#715)
+// ============================================================================
+
+const FRONT_MATTER_FIXTURE: &str = "---\ntitle: My Post\ntags: [a, b]\n---\n# Body\n\nSome text.\n";
+
+#[test]
+fn test_front_matter_extract_evaluates_only_yaml() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{FRONT_MATTER_FIXTURE}")?;
+
+    let (output, code) = run_yq_file(
+        ".title",
+        input_file.path().to_str().unwrap(),
+        &["--front-matter", "extract"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "My Post");
+    assert!(!output.contains("Body"));
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_process_reattaches_body_verbatim() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{FRONT_MATTER_FIXTURE}")?;
+
+    let (output, code) = run_yq_file(
+        ".title = \"New\"",
+        input_file.path().to_str().unwrap(),
+        &["--front-matter", "process"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "---\ntitle: New\ntags:\n  - a\n  - b\n---\n# Body\n\nSome text.\n"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_process_inplace_rewrites_file() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{FRONT_MATTER_FIXTURE}")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["--front-matter", "process", "-i"])
+        .arg(".title = \"New\"")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(
+        rewritten,
+        "---\ntitle: New\ntags:\n  - a\n  - b\n---\n# Body\n\nSome text.\n"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_no_fence_errors() -> Result<()> {
+    let (_output, _stderr, code) =
+        run_yq_stdin_with_stderr(".", "just: yaml\n", &["--front-matter", "extract"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_unterminated_errors() -> Result<()> {
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        "---\ntitle: foo\nno closing fence\n",
+        &["--front-matter", "extract"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("unterminated"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_rejects_doc_flag() -> Result<()> {
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        FRONT_MATTER_FIXTURE,
+        &["--front-matter", "extract", "--doc", "0"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--doc"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_rejects_null_input() -> Result<()> {
+    let (_output, stderr, code) =
+        run_yq_stdin_with_stderr(".", "", &["--front-matter", "extract", "-n"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--null-input"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_rejects_raw_input() -> Result<()> {
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        FRONT_MATTER_FIXTURE,
+        &["--front-matter", "extract", "-R"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--raw-input"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_process_rejects_slurp() -> Result<()> {
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        FRONT_MATTER_FIXTURE,
+        &["--front-matter", "process", "-s"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--slurp"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_process_rejects_json_output() -> Result<()> {
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        FRONT_MATTER_FIXTURE,
+        &["--front-matter", "process", "-o", "json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("json"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_front_matter_extract_allows_slurp_across_files() -> Result<()> {
+    let mut file1 = NamedTempFile::new()?;
+    write!(file1, "---\ntitle: One\n---\nBody one\n")?;
+    let mut file2 = NamedTempFile::new()?;
+    write!(file2, "---\ntitle: Two\n---\nBody two\n")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["--front-matter", "extract", "-s", "-o", "json", "-I0"])
+        .arg(".")
+        .arg(file1.path())
+        .arg(file2.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout.trim(), r#"[{"title":"One"},{"title":"Two"}]"#);
+    Ok(())
+}
+
+// ============================================================================
+// --split-exp Tests (#715)
+// ============================================================================
+
+fn run_yq_split(filter: &str, input: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
+    run_yq_stdin_with_stderr(filter, input, extra_args)
+}
+
+#[test]
+fn test_split_exp_writes_one_file_per_result_by_index() -> Result<()> {
+    let dir = TempDir::new()?;
+    let pattern = format!(
+        "\"{}/out_\" + ($index|tostring) + \".yml\"",
+        dir.path().display()
+    );
+    let (stdout, _stderr, code) = run_yq_split(
+        ".[]",
+        r#"[{"name":"a"},{"name":"b"},{"name":"c"}]"#,
+        &["--split-exp", &pattern, "-p", "json"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "", "stdout must be suppressed on success");
+
+    for (i, expected) in ["a", "b", "c"].into_iter().enumerate() {
+        let content = std::fs::read_to_string(dir.path().join(format!("out_{i}.yml")))?;
+        assert_eq!(content, format!("name: {expected}\n"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_non_string_result_errors() -> Result<()> {
+    let (_stdout, stderr, code) =
+        run_yq_split(".[]", "[1, 2]", &["--split-exp", "$index", "-p", "json"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("must evaluate to a string"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_dot_is_bound_to_result() -> Result<()> {
+    let dir = TempDir::new()?;
+    let pattern = format!("\"{}/\" + .name + \".yml\"", dir.path().display());
+    let (_stdout, _stderr, code) = run_yq_split(
+        ".[]",
+        r#"[{"name":"a"},{"name":"b"}]"#,
+        &["--split-exp", &pattern, "-p", "json"],
+    )?;
+    assert_eq!(code, 0);
+
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("a.yml"))?,
+        "name: a\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("b.yml"))?,
+        "name: b\n"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_and_slurp_incompatible() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(".", "{}", &["--split-exp", "\"f.yml\"", "-s"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--slurp"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_and_inplace_incompatible() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["--split-exp", "\"f.yml\"", "-i"])
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("--inplace"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_and_raw_input_not_yet_supported() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(".", "hello", &["--split-exp", "\"f.yml\"", "-R"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("not yet supported"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_and_front_matter_incompatible() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(
+        ".",
+        "---\na: 1\n---\nbody\n",
+        &["--split-exp", "\"f.yml\"", "--front-matter", "extract"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--front-matter"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_with_null_input() -> Result<()> {
+    let dir = TempDir::new()?;
+    let pattern = format!(
+        "\"{}/f\" + ($index|tostring) + \".yml\"",
+        dir.path().display()
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["-n", "--split-exp", &pattern])
+        .arg("range(3)")
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+
+    for (i, expected) in ["0", "1", "2"].into_iter().enumerate() {
+        let content = std::fs::read_to_string(dir.path().join(format!("f{i}.yml")))?;
+        assert_eq!(content.trim(), expected);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_duplicate_filename_warns_and_overwrites() -> Result<()> {
+    let dir = TempDir::new()?;
+    let pattern = format!("\"{}/const.yml\"", dir.path().display());
+    let (_stdout, stderr, code) =
+        run_yq_split(".[]", "[1, 2]", &["--split-exp", &pattern, "-p", "json"])?;
+    assert_eq!(code, 0);
+    assert!(
+        stderr.contains("written more than once"),
+        "stderr: {stderr}"
+    );
+
+    let content = std::fs::read_to_string(dir.path().join("const.yml"))?;
+    assert_eq!(content.trim(), "2");
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_output_format_respected() -> Result<()> {
+    let dir = TempDir::new()?;
+    let pattern = format!(
+        "\"{}/j\" + ($index|tostring) + \".json\"",
+        dir.path().display()
+    );
+    let (_stdout, _stderr, code) = run_yq_split(
+        ".[]",
+        r#"[{"a":1},{"a":2}]"#,
+        &["--split-exp", &pattern, "-p", "json", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("j0.json"))?.trim(),
+        r#"{"a":1}"#
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("j1.json"))?.trim(),
+        r#"{"a":2}"#
+    );
+    Ok(())
+}
+
+/// Regression test: `.` alone is `is_m2_streamable`, so without the
+/// `split_expr.is_none()` guard on the M2 fast-path gates, `--split-exp`
+/// combined with an identity filter would silently stream straight to
+/// stdout instead of writing the split file (#715).
+#[test]
+fn test_split_exp_with_identity_filter_not_bypassed_by_m2() -> Result<()> {
+    let dir = TempDir::new()?;
+    let pattern = format!("\"{}/identity_out.yml\"", dir.path().display());
+    let (stdout, _stderr, code) = run_yq_split(".", "a: 1\n", &["--split-exp", &pattern])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "",
+        "stdout must stay empty; M2 fast path must not bypass split-exp"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("identity_out.yml"))?,
+        "a: 1\n"
+    );
+    Ok(())
+}
+
+// ============================================================================
+// --eval-all / file_index Tests (#715)
+// ============================================================================
+
+fn run_yq_files(
+    filter: &str,
+    files: &[&std::path::Path],
+    extra_args: &[&str],
+) -> Result<(String, String, i32)> {
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(extra_args)
+        .arg(filter)
+        .args(files)
+        .stdin(Stdio::null())
+        .output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    let code = output.status.code().unwrap_or(-1);
+    Ok((stdout, stderr, code))
+}
+
+fn two_doc_fixtures() -> Result<(NamedTempFile, NamedTempFile)> {
+    let mut f1 = NamedTempFile::new()?;
+    write!(f1, "a: 1\nname: first\n")?;
+    let mut f2 = NamedTempFile::new()?;
+    write!(f2, "b: 2\nname: second\n")?;
+    Ok((f1, f2))
+}
+
+#[test]
+fn test_eval_all_combines_documents_across_files() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files("length", &[f1.path(), f2.path()], &["--eval-all"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "2");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_ea_alias() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files("length", &[f1.path(), f2.path()], &["--ea"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "2");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_file_index_bare() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        ".[] | file_index",
+        &[f1.path(), f2.path()],
+        &["--eval-all", "-o", "json"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0\n1");
+    Ok(())
+}
+
+/// The headline `--eval-all` idiom -- regression test for the
+/// `needs_path_context`/`Select` runtime-arm fix (#715).
+#[test]
+fn test_eval_all_file_index_select() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        ".[] | select(file_index == 0)",
+        &[f1.path(), f2.path()],
+        &["--eval-all"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "a: 1\nname: first\n");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_file_index_select_then_field() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        ".[] | select(file_index == 0) | .name",
+        &[f1.path(), f2.path()],
+        &["--eval-all"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "first");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_file_index_outside_eval_all_is_zero() -> Result<()> {
+    let (f1, _f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files("file_index", &[f1.path()], &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_file_index_camelcase_and_short_alias() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    for keyword in ["fileIndex", "fi"] {
+        let (stdout, _stderr, code) = run_yq_files(
+            &format!(".[] | {keyword}"),
+            &[f1.path(), f2.path()],
+            &["--eval-all", "-o", "json"],
+        )?;
+        assert_eq!(code, 0, "keyword: {keyword}");
+        assert_eq!(stdout.trim(), "0\n1", "keyword: {keyword}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_reduce_merge() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        "reduce .[] as $item ({}; . * $item)",
+        &[f1.path(), f2.path()],
+        &["--eval-all", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":1,"name":"second","b":2}"#);
+    Ok(())
+}
+
+/// The approximated real-yq merge idiom -- correct only when each file
+/// contributes exactly one matching top-level document (#715). Also the
+/// regression test for the `Expr::Arithmetic` path-context runtime-arm fix:
+/// without it, both `select`s evaluate against the 0-stub and the
+/// `file_index==1` side comes back empty ("no value" error).
+#[test]
+fn test_eval_all_select_star_merge_single_doc_per_file() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(
+        "(.[] | select(file_index == 0)) * (.[] | select(file_index == 1))",
+        &[f1.path(), f2.path()],
+        &["--eval-all", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":1,"name":"second","b":2}"#);
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_doc_separator_between_results() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let (stdout, _stderr, code) = run_yq_files(".[]", &[f1.path(), f2.path()], &["--eval-all"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "a: 1\nname: first\n---\nb: 2\nname: second\n");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_doc_flag_interaction() -> Result<()> {
+    let mut multi = NamedTempFile::new()?;
+    write!(multi, "x: 1\n---\nx: 2\n")?;
+    let (stdout, _stderr, code) =
+        run_yq_files(".[] | .x", &[multi.path()], &["--eval-all", "--doc", "1"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "2");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_rejects_slurp() -> Result<()> {
+    let (f1, _f2) = two_doc_fixtures()?;
+    let (_stdout, stderr, code) = run_yq_files(".", &[f1.path()], &["--eval-all", "-s"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--slurp"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_rejects_inplace() -> Result<()> {
+    let (f1, _f2) = two_doc_fixtures()?;
+    let (_stdout, stderr, code) = run_yq_files(".", &[f1.path()], &["--eval-all", "-i"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--inplace"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_rejects_raw_input() -> Result<()> {
+    let (f1, _f2) = two_doc_fixtures()?;
+    let (_stdout, stderr, code) = run_yq_files(".", &[f1.path()], &["--eval-all", "-R"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--raw-input"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_rejects_split_exp() -> Result<()> {
+    let (f1, _f2) = two_doc_fixtures()?;
+    let (_stdout, stderr, code) = run_yq_files(
+        ".",
+        &[f1.path()],
+        &["--eval-all", "--split-exp", "\"f.yml\""],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--split-exp"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_eval_all_rejects_front_matter() -> Result<()> {
+    let (f1, _f2) = two_doc_fixtures()?;
+    let (_stdout, stderr, code) = run_yq_files(
+        ".",
+        &[f1.path()],
+        &["--eval-all", "--front-matter", "extract"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("--front-matter"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// Regression test for the `needs_path_context`/`Compare` runtime-arm fix
+/// (#715): `key` used inside `select(...)`'s condition previously produced
+/// no output at all, independent of `--eval-all`.
+#[test]
+fn test_key_inside_select_regression() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(".[] | select(key >= 1)", "[10, 20, 30]", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "20\n30");
+    Ok(())
+}
+
+/// Regression test for the same fix, via `document_index` (yq's existing
+/// builtin) inside a comparison instead of `key` inside `select`.
+#[test]
+fn test_document_index_inside_comparison_regression() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("select(document_index == 1)", "a: 1\n---\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "b: 2\n");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6128,6 +6128,37 @@ fn test_split_exp_dot_is_bound_to_result() -> Result<()> {
     Ok(())
 }
 
+/// Regression test: `--split-exp`'s expression was parsed independently of
+/// the main filter and never received `--arg`/`--argjson`/`$ARGS`
+/// substitution (only `$index` was bound), so a filename expression
+/// referencing an `--arg` value failed as an undefined variable even though
+/// the same `--arg` works fine for the main filter (#715 follow-up).
+#[test]
+fn test_split_exp_uses_arg_variable() -> Result<()> {
+    let dir = TempDir::new()?;
+    let pattern = format!("\"{}/\" + $prefix + .name + \".yml\"", dir.path().display());
+    let (_stdout, stderr, code) = run_yq_split(
+        ".[]",
+        r#"[{"name":"a"}]"#,
+        &[
+            "--arg",
+            "prefix",
+            "pre_",
+            "--split-exp",
+            &pattern,
+            "-p",
+            "json",
+        ],
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("pre_a.yml"))?,
+        "name: a\n"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_split_exp_and_slurp_incompatible() -> Result<()> {
     let (_stdout, stderr, code) = run_yq_split(".", "{}", &["--split-exp", "\"f.yml\"", "-s"])?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1991,6 +1991,18 @@ fn test_yaml_assign_then_map_through_anchor_still_excluded() -> Result<()> {
 }
 
 #[test]
+fn test_yaml_paren_wrapped_optional_assign_through_anchor_updates_alias() -> Result<()> {
+    // `(.a = 99)?` -- `Optional` wrapping `Paren` wrapping `Assign` -- must
+    // still count as alias-sensitive: `is_alias_sensitive_assign` unwraps
+    // both `Paren` and `Optional` before checking for a write underneath.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin("(.a = 99)?", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":99,"b":99}"#);
+    Ok(())
+}
+
+#[test]
 fn test_yaml_bare_select_without_assign_is_unaffected() -> Result<()> {
     // Regression guard: a pass-through stage with *no* assignment anywhere
     // in the pipe must not trigger alias-sync snapshotting at all -- there's
@@ -6004,6 +6016,27 @@ fn test_front_matter_extract_allows_slurp_across_files() -> Result<()> {
     Ok(())
 }
 
+/// A top-level `break` with no enclosing `label` reaches
+/// `query_result_to_owned_values` as a bare `QueryResult::Break`, distinct
+/// from the `Partial(_, Control::Break(_))` case an escaping break-after-
+/// some-output takes -- exercised elsewhere via `--eval-all`'s
+/// `write_split_result`, but not through the plain evaluation path.
+#[test]
+fn test_bare_break_outside_label_reports_error() -> Result<()> {
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["-n", "break $foo"])
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains("break $foo not in label"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 // ============================================================================
 // --split-exp Tests (#715)
 // ============================================================================
@@ -6227,6 +6260,165 @@ fn test_split_exp_with_identity_filter_not_bypassed_by_m2() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_split_exp_empty_result_errors() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(".", "a: 1\n", &["--split-exp", "empty"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("produced no output"), "stderr: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_many_results_errors() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(".", "a: 1\n", &["--split-exp", "$index, $index"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("exactly one string") && stderr.contains("2 results"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// Regression coverage for `write_split_result`'s own `std::fs::write`
+/// failure path (distinct from the filename-evaluation error paths above):
+/// a directory that doesn't exist makes the actual file write fail, which
+/// must surface as a normal CLI error rather than a panic, across all three
+/// input-gathering branches (`-n`/null-input, YAML, JSON).
+#[test]
+fn test_split_exp_write_failure_reports_error_null_input() -> Result<()> {
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["-n", "--split-exp", "\"/nonexistent-dir-715/out.yml\""])
+        .arg("1")
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains("failed to write --split-exp output file"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_write_failure_reports_error_yaml_input() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(
+        ".",
+        "a: 1\n",
+        &["--split-exp", "\"/nonexistent-dir-715/out.yml\""],
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("failed to write --split-exp output file"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_split_exp_write_failure_reports_error_json_input() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(
+        ".",
+        "{\"a\":1}",
+        &[
+            "--split-exp",
+            "\"/nonexistent-dir-715/out.yml\"",
+            "-p",
+            "json",
+        ],
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("failed to write --split-exp output file"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// `--split-exp` combined with `--doc`/`document` filtering for JSON input:
+/// with two JSON files and `--doc 1`, the first file's document must be
+/// skipped (not written) and only the second file's document processed.
+#[test]
+fn test_split_exp_document_filter_skips_earlier_json_files() -> Result<()> {
+    let dir = TempDir::new()?;
+    let mut file1 = NamedTempFile::new()?;
+    write!(file1, "{{\"which\":\"one\"}}")?;
+    let mut file2 = NamedTempFile::new()?;
+    write!(file2, "{{\"which\":\"two\"}}")?;
+    let pattern = format!("\"{}/out.json\"", dir.path().display());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args([
+            "--split-exp",
+            &pattern,
+            "-p",
+            "json",
+            "-o",
+            "json",
+            "-I0",
+            "--doc",
+            "1",
+        ])
+        .arg(".")
+        .arg(file1.path())
+        .arg(file2.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+
+    let content = std::fs::read_to_string(dir.path().join("out.json"))?;
+    assert_eq!(content.trim(), r#"{"which":"two"}"#);
+    Ok(())
+}
+
+/// `--split-exp` reading from stdin with `--validate` set must reject
+/// invalid YAML before ever reaching the split-write loop.
+#[test]
+fn test_split_exp_validate_rejects_invalid_yaml_from_stdin() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(
+        ".",
+        "a: b: c: d\n",
+        &["--split-exp", "\"f.yml\"", "--validate"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// Same as above, but reading from a file (exercises the file-gathering
+/// branch of `--split-exp`'s input collection rather than the stdin one).
+#[test]
+fn test_split_exp_validate_rejects_invalid_yaml_from_file() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: b: c: d")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["--split-exp", "\"f.yml\"", "--validate"])
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// A hard parse failure (as opposed to `--validate`'s opt-in strict check)
+/// from the loose YAML loader itself, e.g. tab-indentation, must still
+/// surface as a normal CLI error under `--split-exp`'s YAML branch, not a
+/// panic -- exercises `evaluate_yaml_direct_filtered`'s own `Err` path
+/// rather than `write_split_result`'s.
+#[test]
+fn test_split_exp_hard_yaml_parse_error_propagates() -> Result<()> {
+    let (_stdout, stderr, code) = run_yq_split(".", "a:\n\t- 1\n", &["--split-exp", "\"f.yml\""])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("YAML parse error"), "stderr: {stderr}");
+    Ok(())
+}
+
 // ============================================================================
 // --eval-all / file_index Tests (#715)
 // ============================================================================
@@ -6263,6 +6455,18 @@ fn test_eval_all_combines_documents_across_files() -> Result<()> {
     let (stdout, _stderr, code) = run_yq_files("length", &[f1.path(), f2.path()], &["--eval-all"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "2");
+    Ok(())
+}
+
+/// `--eval-all` reading a single document from stdin (no input files at
+/// all) is a distinct input-gathering branch from the file-list one every
+/// other `--eval-all` test above exercises.
+#[test]
+fn test_eval_all_works_from_stdin() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".", "a: 1\n", &["--eval-all", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), r#"[{"a":1}]"#);
     Ok(())
 }
 
@@ -6524,6 +6728,30 @@ fn test_eval_all_rejects_front_matter() -> Result<()> {
     )?;
     assert_ne!(code, 0);
     assert!(stderr.contains("--front-matter"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// `--eval-all` reading from stdin with `--validate` set must reject invalid
+/// YAML before combining it into the evaluation array.
+#[test]
+fn test_eval_all_validate_rejects_invalid_yaml_from_stdin() -> Result<()> {
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".", "a: b: c: d\n", &["--eval-all", "--validate"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// Same as above, but reading from files (exercises the file-gathering
+/// branch of `--eval-all`'s input collection rather than the stdin one).
+#[test]
+fn test_eval_all_validate_rejects_invalid_yaml_from_file() -> Result<()> {
+    let mut bad_file = NamedTempFile::new()?;
+    writeln!(bad_file, "a: b: c: d")?;
+    let (_stdout, stderr, code) =
+        run_yq_files(".", &[bad_file.path()], &["--eval-all", "--validate"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6152,6 +6152,35 @@ fn test_split_exp_duplicate_filename_warns_and_overwrites() -> Result<()> {
     Ok(())
 }
 
+/// Regression test: `ErrorSink::hit()` is sticky for the whole run, so
+/// comparing it before/after each call only correctly detects "this call
+/// just reported" for the very first error -- every later real error was
+/// double-reported with a spurious extra "produced no output" message
+/// (#715 follow-up). Fixed via `report_count()`, which can be compared
+/// per-call regardless of earlier hits.
+#[test]
+fn test_split_exp_reports_each_error_exactly_once() -> Result<()> {
+    let dir = TempDir::new()?;
+    let pattern = format!(
+        "if . == 1 then error(\"boom1\") elif . == 2 then error(\"boom2\") else \"{}/f3.yml\" end",
+        dir.path().display()
+    );
+    let (_stdout, stderr, code) =
+        run_yq_split(".[]", "[1, 2, 3]", &["--split-exp", &pattern, "-p", "json"])?;
+    assert_ne!(code, 0);
+    let error_lines: Vec<&str> = stderr.lines().filter(|l| l.starts_with("Error:")).collect();
+    assert_eq!(
+        error_lines,
+        vec!["Error: boom1", "Error: boom2"],
+        "stderr: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("f3.yml"))?.trim(),
+        "3"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_split_exp_output_format_respected() -> Result<()> {
     let dir = TempDir::new()?;


### PR DESCRIPTION
## Description

Closes three real `yq` CLI gaps found by a systematic gap-audit against mikefarah/yq's own test suite (#715):

1. **`--front-matter=extract|process`** — operate on YAML embedded as front matter inside another file (e.g. a Markdown post's `---`-fenced header). `extract` evaluates the expression against just the front matter and discards the trailing body; `process` re-emits the transformed front matter followed by the original body, byte-for-byte unchanged.
2. **`--split-exp EXPR`** — split output into one file per result, named by evaluating `EXPR` against it (`.` is the result, `$index` its 0-based output index). Deliberately long-only: real yq's short form is `-s`, already taken by succinctly's `--slurp`.
3. **`--eval-all`/`--ea` + `file_index`/`fileIndex`/`fi`** — combine every document from every file into one evaluation context for cross-file merges (`.[] | select(file_index == 0)`). Requires explicit `.[]` iteration, unlike real yq's implicit node-list broadcast (`select(fileIndex == 0)` with no `.[]`) — succinctly's evaluator has one scalar value per evaluation rather than a broadcasting node list, so full syntax parity would need a much larger rearchitecture than this issue warrants. Documented as a deliberate scope boundary in [docs/reference/yq-language.md](docs/reference/yq-language.md#cross-file-operations-succinctly-extension).

Building `--eval-all` surfaced and fixed a **pre-existing bug**: `key`/`document_index` inside a `select(...)` condition or a comparison (e.g. `select(key >= 1)`, `select(document_index == 0)`) previously produced no output, because `needs_path_context` never recursed into `Expr::Compare`/`Expr::Builtin(Builtin::Select(_))`/`Expr::Arithmetic`, so those shapes silently fell back to the evaluator's 0/null stub instead of resolving via path context. `file_index`'s headline idiom has the identical shape, so fixing this was required to make the feature usable at all — not optional polish.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Closes #715

## Changes Made
- New `src/bin/succinctly/front_matter.rs`: pure `--front-matter` splitter (13 unit tests)
- `src/bin/succinctly/main.rs`: `--front-matter`, `--split-exp`, `--eval-all`/`--ea` flags
- `src/bin/succinctly/yq_runner.rs`: flag validation, fast-path gate fixes, three new evaluation branches, `write_split_result`, `apply_front_matter`, shared `query_result_to_owned_values`
- `src/jq/{expr,parser,eval,mod}.rs`: new `Builtin::FileIndex`, `needs_path_context`/`eval_pipe_with_path_context_internal` extended for `Compare`/`Select`/`Arithmetic` (fixing the pre-existing `key`/`document_index` gap along the way), new `eval_owned_with_file_index` entry point
- `tests/yq_cli_tests.rs`: 40 new CLI integration tests across all three features plus the regression fix
- Docs: `docs/reference/yq-language.md`, `docs/guides/cli.md`, `CHANGELOG.md`

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested on x86_64 (arm not available in this environment)

### Test Commands
```bash
cargo test --features cli,simd,regex,serde
cargo clippy --all-targets --all-features -- -D warnings
cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
cargo fmt --check
```
All green: 2127 lib tests, full `yq_cli_tests`/`jq_cli_tests` suites, all three CI clippy invocations, no formatting diffs.

## Performance Impact
- [x] No performance impact — `eval_owned_with_file_index` checks `needs_path_context` once and falls straight through to the existing evaluator when a filter never references `file_index`/`key`/`parent`, so the overwhelming majority of filters (including all pre-existing `yq` usage) pay zero extra cost. The new `Compare`/`Select`/`Arithmetic` path-context arms are reached only when routed there in the first place.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

Scope decisions worth flagging for review:
- `--eval-all`'s two-file merge idiom (`select(file_index==0) * select(file_index==1)`) only works correctly when each file contributes exactly one matching document, since succinctly's `*`/`+` take the first value of each side rather than cartesian-combining (a separate, pre-existing, documented limitation). The general N-file merge idiom `reduce .[] as $item ({}; . * $item)` has no such limitation.
- `--eval-all`, `--split-exp`, and `--front-matter` are pairwise incompatible with each other and with `--slurp`/`--inplace`/`--raw-input` in various combinations — each rejection has a dedicated test and a clear error message rather than silently doing something unexpected.