### PR TITLE
jq: add @base32/@base32d format functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **jq `@base32`/`@base32d` format functions** (#719): RFC 4648 base32
+  encoding/decoding, alongside the existing `@base64`/`@base64d`. Output
+  matches jq 1.6+ and the RFC's own test vectors (`"f"` → `"MY======"`,
+  `"foobar"` → `"MZXW6YTBOI======"`, etc.). Fixed a latent parser bug found
+  along the way: `parse_format_string`'s format-name scanner hardcoded `'6'`
+  and `'4'` as the only digits allowed in a format identifier (to admit
+  `base64`), so `@base32` truncated to `@base` before this fix — generalized
+  to `is_ascii_alphanumeric()`.
+
 - **jq `@csv`/`@tsv`/`@dsv`/`@sh` allocation overhead investigated: no
   measurable end-to-end effect** (#647, follow-up to #124's real win for
   `@uri`/`@html`): a byte-scanning rewrite of the four format functions was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,8 @@ The jq implementation supports format functions for converting values to strings
 | **@urid**    | `@urid`             | URI percent decoding                              | `hello world`       |
 | **@base64**  | `@base64`           | Base64 encoding                                   | `aGVsbG8=`          |
 | **@base64d** | `@base64d`          | Base64 decoding                                   | `hello`             |
+| **@base32**  | `@base32`           | Base32 encoding (RFC 4648)                        | `NBSWY3DP`          |
+| **@base32d** | `@base32d`          | Base32 decoding (RFC 4648)                        | `hello`             |
 | **@html**    | `@html`             | HTML entity escaping                              | `&lt;script&gt;`    |
 | **@sh**      | `@sh`               | Shell quoting                                     | `'hello world'`     |
 | **@yaml**    | `@yaml`             | YAML flow-style encoding (yq)                     | `{a: 1, b: 2}`      |

--- a/docs/reference/jq-evaluator.md
+++ b/docs/reference/jq-evaluator.md
@@ -59,7 +59,7 @@ The implementation covers a substantial subset of jq:
 - **Assignment**: `=`, `|=`, `+=`, `-=`, `*=`, `/=`, `%=`, `//=`, `del()`
 - **Control flow**: `if-then-else-end`, `try-catch`, pipes (`|`), comma (multiple outputs)
 - **Builtins**: `length`, `keys`, `values`, `has()`, `in()`, `map()`, `select()`, `empty`, `range()`, `limit()`, `first()`, `last()`, `type`, `tostring`, `tonumber`, `ascii_downcase`, `ascii_upcase`, `split()`, `join()`, `test()`, `match()`, `capture()`, `gsub()`, `sub()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `contains()`, `inside()`, `indices()`, `sort_by()`, `group_by()`, `unique_by()`, `min_by()`, `max_by()`, `flatten`, `transpose`, `to_entries`, `from_entries`, `with_entries`, `paths`, `getpath`, `setpath`, `delpaths`, `leaf_paths`, `env`, `input`, `inputs`, `debug`, `halt`, `halt_error`, `def-;` (function definitions), `label-break`, `foreach`, `reduce`, `$__loc__`, `@format` strings
-- **Format functions**: `@csv`, `@tsv`, `@dsv(delim)`, `@json`, `@text`, `@uri`, `@base64`, `@base64d`, `@html`, `@sh`, `@yaml`, `@props`
+- **Format functions**: `@csv`, `@tsv`, `@dsv(delim)`, `@json`, `@text`, `@uri`, `@base64`, `@base64d`, `@base32`, `@base32d`, `@html`, `@sh`, `@yaml`, `@props`
 - **Position navigation** (succinctly extension): `at_offset(n)`, `at_position(line; col)`
 
 ## Depends On

--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -128,6 +128,7 @@ The implementation covers ~95% of jq functionality and is production-ready.
 - [x] `@csv` / `@tsv` - Delimited formats
 - [x] `@dsv(delimiter)` - Custom delimiter; string fields always quoted (like `@csv`)
 - [x] `@base64` / `@base64d`
+- [x] `@base32` / `@base32d` - RFC 4648
 - [x] `@uri` / `@urid` - Percent encoding / decoding
 - [x] `@html` - HTML entity escaping
 - [x] `@sh` - Shell quoting

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4001,6 +4001,8 @@ pub(crate) fn format_owned(
         FormatType::Dsv(delimiter) => format_dsv(owned, delimiter, optional),
         FormatType::Base64 => format_base64(owned, optional),
         FormatType::Base64d => format_base64d(owned, optional),
+        FormatType::Base32 => format_base32(owned, optional),
+        FormatType::Base32d => format_base32d(owned, optional),
         FormatType::Html => format_html(owned, optional),
         FormatType::Sh => format_sh(owned, optional),
         FormatType::Urid => format_urid(owned, optional),
@@ -4267,6 +4269,110 @@ fn format_base64d(value: &OwnedValue, optional: bool) -> Result<String, EvalErro
             }
 
             String::from_utf8(result).map_err(|_| EvalError::new("invalid UTF-8 in decoded base64"))
+        }
+        _ if optional => Ok(String::new()),
+        _ => Err(EvalError::type_error("string", value.type_name())),
+    }
+}
+
+/// @base32 - Base32 encode (RFC 4648)
+fn format_base32(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
+    match value {
+        OwnedValue::String(s) => {
+            const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+            let bytes = s.as_bytes();
+            let mut result = String::new();
+
+            for chunk in bytes.chunks(5) {
+                let mut buf = [0u8; 5];
+                buf[..chunk.len()].copy_from_slice(chunk);
+                let quintet = (buf[0] as u64) << 32
+                    | (buf[1] as u64) << 24
+                    | (buf[2] as u64) << 16
+                    | (buf[3] as u64) << 8
+                    | (buf[4] as u64);
+
+                // RFC 4648 §6: how many of the 8 output characters carry real
+                // data (the rest are `=` padding) depends on the input chunk
+                // length, since 5 bytes (40 bits) split evenly into 8x 5-bit
+                // groups but shorter chunks don't.
+                let char_count = match chunk.len() {
+                    1 => 2,
+                    2 => 4,
+                    3 => 5,
+                    4 => 7,
+                    5 => 8,
+                    _ => unreachable!("chunks(5) yields at most 5 bytes"),
+                };
+
+                for i in 0..8 {
+                    if i < char_count {
+                        let shift = 35 - i * 5;
+                        let index = ((quintet >> shift) & 0x1F) as usize;
+                        result.push(ALPHABET[index] as char);
+                    } else {
+                        result.push('=');
+                    }
+                }
+            }
+
+            Ok(result)
+        }
+        _ if optional => Ok(String::new()),
+        _ => Err(EvalError::type_error("string", value.type_name())),
+    }
+}
+
+/// @base32d - Base32 decode (RFC 4648)
+fn format_base32d(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
+    match value {
+        OwnedValue::String(s) => {
+            fn decode_char(c: u8) -> Option<u8> {
+                match c {
+                    b'A'..=b'Z' => Some(c - b'A'),
+                    b'2'..=b'7' => Some(c - b'2' + 26),
+                    b'=' => Some(0), // Padding
+                    _ => None,
+                }
+            }
+
+            let s = s.replace(|c: char| c.is_whitespace(), "");
+            let bytes: Vec<u8> = s.bytes().collect();
+            let mut result = Vec::new();
+
+            for chunk in bytes.chunks(8) {
+                if chunk.len() < 8 {
+                    break;
+                }
+
+                let mut quintet: u64 = 0;
+                for &b in chunk {
+                    let v = decode_char(b).ok_or_else(|| EvalError::new("invalid base32"))?;
+                    quintet = (quintet << 5) | (v as u64);
+                }
+
+                let data_chars = chunk.iter().filter(|&&b| b != b'=').count();
+                let n_out = match data_chars {
+                    2 => 1,
+                    4 => 2,
+                    5 => 3,
+                    7 => 4,
+                    8 => 5,
+                    _ => return Err(EvalError::new("invalid base32 padding")),
+                };
+
+                let out_bytes = [
+                    ((quintet >> 32) & 0xFF) as u8,
+                    ((quintet >> 24) & 0xFF) as u8,
+                    ((quintet >> 16) & 0xFF) as u8,
+                    ((quintet >> 8) & 0xFF) as u8,
+                    (quintet & 0xFF) as u8,
+                ];
+
+                result.extend_from_slice(&out_bytes[..n_out]);
+            }
+
+            String::from_utf8(result).map_err(|_| EvalError::new("invalid UTF-8 in decoded base32"))
         }
         _ if optional => Ok(String::new()),
         _ => Err(EvalError::type_error("string", value.type_name())),
@@ -22204,6 +22310,24 @@ mod tests {
     }
 
     #[test]
+    fn test_format_base32() {
+        query!(br#""hello""#, "@base32",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "NBSWY3DP");
+            }
+        );
+    }
+
+    #[test]
+    fn test_format_base32d() {
+        query!(br#""NBSWY3DP""#, "@base32d",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "hello");
+            }
+        );
+    }
+
+    #[test]
     fn test_format_html() {
         query!(br#""<script>alert('xss')</script>""#, "@html",
             QueryResult::Owned(OwnedValue::String(s)) => {
@@ -23625,6 +23749,8 @@ mod tests {
             r#"isvalid(@dsv("|"))"#,
             "isvalid(@base64)",
             "isvalid(@base64d)",
+            "isvalid(@base32)",
+            "isvalid(@base32d)",
         ] {
             query!(br"1", expr,
                 QueryResult::Owned(OwnedValue::Bool(true)) => {}

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -473,6 +473,10 @@ pub enum FormatType {
     Base64,
     /// @base64d - base64 decode
     Base64d,
+    /// @base32 - base32 encode (RFC 4648)
+    Base32,
+    /// @base32d - base32 decode (RFC 4648)
+    Base32d,
     /// @html - HTML entity escape
     Html,
     /// @sh - shell quote

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1802,6 +1802,8 @@ impl<'a> Parser<'a> {
             }
             "base64" => FormatType::Base64,
             "base64d" => FormatType::Base64d,
+            "base32" => FormatType::Base32,
+            "base32d" => FormatType::Base32d,
             "html" => FormatType::Html,
             "sh" => FormatType::Sh,
             "urid" => FormatType::Urid,

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1767,12 +1767,9 @@ impl<'a> Parser<'a> {
     fn parse_format_string(&mut self) -> Result<Expr, ParseError> {
         self.expect('@')?;
 
-        // Parse the format name
+        // Parse the format name (an alphanumeric identifier, e.g. `base64`)
         let format_start = self.pos;
-        while self
-            .peek()
-            .is_some_and(|c| c.is_ascii_alphabetic() || c == '6' || c == '4')
-        {
+        while self.peek().is_some_and(|c| c.is_ascii_alphanumeric()) {
             self.next();
         }
 

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -194,10 +194,11 @@ fn test_parity_formats_array_inputs() {
 /// Formats that only accept strings.
 #[test]
 fn test_parity_formats_string_only() {
-    for filter in ["@base64", "@base64d", "@urid"] {
+    for filter in ["@base64", "@base64d", "@base32", "@base32d", "@urid"] {
         for json in [
             br#""hello""#.as_slice(),
             br#""aGVsbG8=""#,
+            br#""NBSWY3DP""#,
             br#""%C3%A9""#,
             br#""a%2Fb%20c""#,
             br#""100%""#,
@@ -218,6 +219,7 @@ fn test_parity_formats_type_errors() {
         (b"42", "@csv"),
         (b"42", "@tsv"),
         (b"42", "@base64"),
+        (b"42", "@base32"),
         (b"42", "@urid"),
         (br#""notanarray""#, "@csv"),
     ] {
@@ -351,6 +353,8 @@ fn test_formats_optional_owned_type_error_parity_124() {
         (b"null", r#"(1+1 | @dsv("|"))?"#),
         (b"null", "(1+1 | @base64)?"),
         (b"null", "(1+1 | @base64d)?"),
+        (b"null", "(1+1 | @base32)?"),
+        (b"null", "(1+1 | @base32d)?"),
         (b"null", "(1+1 | @urid)?"),
     ] {
         assert_eq!(

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -1350,6 +1350,30 @@ fn test_base64_encode() {
 }
 
 // =============================================================================
+// Compatibility tests - @base32d edge cases
+// =============================================================================
+
+#[test]
+fn test_base32_roundtrip() {
+    // jq: "hello" | @base32 | @base32d => "hello"
+    query!(br#""hello""#, "@base32 | @base32d",
+        QueryResult::Owned(OwnedValue::String(s)) => {
+            assert_eq!(s, "hello");
+        }
+    );
+}
+
+#[test]
+fn test_base32_encode() {
+    // jq: "hello" | @base32 => "NBSWY3DP"
+    query!(br#""hello""#, "@base32",
+        QueryResult::Owned(OwnedValue::String(s)) => {
+            assert_eq!(s, "NBSWY3DP");
+        }
+    );
+}
+
+// =============================================================================
 // Compatibility tests - Comparison edge cases
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- Adds `@base32`/`@base32d` jq format functions (RFC 4648, `=`-padded), closing the gap against jq's standard format builtins.
- Fixes a latent parser bug found along the way: `parse_format_string`'s format-name scanner hardcoded `'6'`/`'4'` as the only digits allowed in a format identifier (just enough to admit `base64`), so `@base32` silently truncated to `@base` before the fix.
- Updates CLAUDE.md, docs/reference/jq-language.md, docs/reference/jq-evaluator.md, and CHANGELOG.md.

Closes #719

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --workspace` (all 54 test binaries pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manually verified encode/decode against all six official RFC 4648 test vectors (`""`, `"f"`, `"fo"`, `"foo"`, `"foob"`, `"fooba"`, `"foobar"`) via the built CLI
- [x] Manually verified `isvalid(@base32)`/`isvalid(@base32d)` and `?`-suppression on non-string input