### PR TITLE
fix(cli): sync aliases through pipes mixing assign with pass-through stages

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -426,31 +426,74 @@ fn evaluate_input(
     }
 }
 
-/// Whether `expr`'s top-level shape is "rewrite the document at specific
-/// paths, leaving everything else identical" -- the class of expression for
-/// which comparing a path's value before and after the write is meaningful.
-/// Unwraps `Paren`/`Optional` so `(.a = 1)?` still matches, and recurses into
-/// `Pipe` so a chain of assignments like `.a = 1 | .b = 2` (the common
-/// `yq -i '... | ...'` idiom) matches when every stage does.
+/// Whether `expr` is itself an assignment-family write: `.path = value`,
+/// `|=`, a compound assign, `//=`, or `del(...)`. Unwraps `Paren`/`Optional`
+/// so `(.a = 1)?` still counts, and recurses into `Pipe` so a chain counts
+/// as soon as *any* stage writes.
 ///
-/// Used to gate the alias-sync post-process (#711): outside this class (a
-/// bare `map`, `select`, `.a, .b`, ...) the result document doesn't
-/// necessarily share the input's shape at all, so diffing "the same path" in
-/// both would be meaningless at best and could clobber it at worst. A pipe
-/// with even one non-assign stage (`.a = 1 | select(...)`) is conservatively
-/// excluded for the same reason, even though some such stages would in fact
-/// preserve paths -- that's left for a future extension, not assumed here.
-fn is_alias_sensitive_assign(expr: &Expr) -> bool {
+/// Split out from [`is_alias_sensitive_assign`] so a pipe made entirely of
+/// pass-through stages (`select(true) | debug`, no write at all) doesn't
+/// pay for alias-sync snapshotting -- only a pipe that both preserves shape
+/// *and* actually writes somewhere needs the pristine-vs-result diff.
+fn contains_assign(expr: &Expr) -> bool {
     match expr {
         Expr::Assign { .. }
         | Expr::Update { .. }
         | Expr::CompoundAssign { .. }
         | Expr::AlternativeAssign { .. }
         | Expr::Builtin(Builtin::Del(_)) => true,
-        Expr::Paren(inner) | Expr::Optional(inner) => is_alias_sensitive_assign(inner),
-        Expr::Pipe(stages) => stages.iter().all(is_alias_sensitive_assign),
+        Expr::Paren(inner) | Expr::Optional(inner) => contains_assign(inner),
+        Expr::Pipe(stages) => stages.iter().any(contains_assign),
         _ => false,
     }
+}
+
+/// Whether `expr`'s top-level shape is "rewrite the document at specific
+/// paths, leaving everything else identical" -- the class of expression for
+/// which comparing a path's value before and after the write is meaningful.
+/// Unwraps `Paren`/`Optional` so `(.a = 1)?` still matches, and recurses into
+/// `Pipe` so a chain matches when every stage does, whether the stage is a
+/// write (`.a = 1 | .b = 2`) or one of a small allow-list of pass-through
+/// stages that provably either emit the input document completely unchanged
+/// or emit nothing at all: `.` (`Identity`), `select(...)`, `empty`,
+/// `debug`/`debug(msg)`. Mixing one into an assignment pipe (`.a = 1 |
+/// select(.a > 0)`, the guard-style `yq -i` idiom from #764) still leaves
+/// "the same path means the same thing" true for every document that comes
+/// out the other end, since none of these four ever rewrite or reshape the
+/// value they pass through -- unlike `map`, `select`'s own predicate or
+/// `debug`'s own message expression never appear in the pipeline's output,
+/// only their pass/fail or side-effect result does, so `contains_assign`
+/// deliberately does not recurse into either.
+///
+/// Used to gate the alias-sync post-process (#711): outside this class (a
+/// bare `map`, `.a, .b`, ...) the result document doesn't necessarily share
+/// the input's shape at all, so diffing "the same path" in both would be
+/// meaningless at best and could clobber it at worst. A pipe with a stage
+/// outside both the write list and this pass-through allow-list is
+/// conservatively excluded for the same reason -- verifying more stages
+/// preserve paths is left for a future extension, not assumed here.
+fn is_alias_sensitive_assign(expr: &Expr) -> bool {
+    fn is_shape_preserving(expr: &Expr) -> bool {
+        match expr {
+            Expr::Assign { .. }
+            | Expr::Update { .. }
+            | Expr::CompoundAssign { .. }
+            | Expr::AlternativeAssign { .. }
+            | Expr::Identity
+            | Expr::Builtin(
+                Builtin::Del(_)
+                | Builtin::Select(_)
+                | Builtin::Empty
+                | Builtin::Debug
+                | Builtin::DebugMsg(_),
+            ) => true,
+            Expr::Paren(inner) | Expr::Optional(inner) => is_shape_preserving(inner),
+            Expr::Pipe(stages) => stages.iter().all(is_shape_preserving),
+            _ => false,
+        }
+    }
+
+    is_shape_preserving(expr) && contains_assign(expr)
 }
 
 /// Walk `cursor`'s document collecting, for every anchor with at least one

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1917,6 +1917,92 @@ fn test_yaml_empty_mapping_anchor_preserved_on_whole_document_root_712() -> Resu
 }
 
 // =============================================================================
+// Alias-sync survives a pass-through stage mixed into the pipe (#764) - the
+// #711 gate originally required *every* pipe stage to be assignment-family,
+// so `.a = 99 | select(true)` fell outside it and `.b` went stale again. `.`,
+// `select(...)`, `debug`, and `empty` never rewrite or reshape the document
+// they pass through, so mixing one into an assignment pipe is now allowed.
+// =============================================================================
+
+#[test]
+fn test_yaml_assign_then_select_true_through_anchor_updates_alias() -> Result<()> {
+    // The issue's own repro.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99 | select(true)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":99,"b":99}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_then_select_false_produces_no_output() -> Result<()> {
+    // `select(false)` drops the document entirely -- there's nothing to
+    // sync, and nothing should be printed.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99 | select(false)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_select_guard_then_assign_through_anchor_updates_alias() -> Result<()> {
+    // The guard-style idiom named in #764: a leading `select` filters, then
+    // the assignment writes.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin("select(.a > 0) | .a = 5", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":5,"b":5}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_then_debug_through_anchor_updates_alias() -> Result<()> {
+    // `debug` passes its input through unchanged (aside from the stderr
+    // side effect), so it must not block the sync either.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99 | debug", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":99,"b":99}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_then_empty_produces_no_output() -> Result<()> {
+    // `empty` drops the document -- same as `select(false)`, nothing to
+    // sync and nothing to print.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99 | empty", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_then_map_through_anchor_still_excluded() -> Result<()> {
+    // Regression guard: `map` is not on the pass-through allow-list (it can
+    // reshape the document), so a pipe mixing it with an assignment must
+    // stay excluded from alias-sync, exactly as before #764.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99 | map(.)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r"[99,1]");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_bare_select_without_assign_is_unaffected() -> Result<()> {
+    // Regression guard: a pass-through stage with *no* assignment anywhere
+    // in the pipe must not trigger alias-sync snapshotting at all -- there's
+    // nothing to diff, so the plain read behavior from before #764 holds.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin("select(true)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":1,"b":1}"#);
+    Ok(())
+}
+
+// =============================================================================
 // Anchored sequence items (#328) - an anchor on `- ` binds to the item's value
 // whatever its kind. Expectations are mikefarah/yq v4.53.3 output.
 // =============================================================================


### PR DESCRIPTION
## Summary
- `is_alias_sensitive_assign` (the #711 alias-sync gate) required every stage of a pipe to be assignment-family, so a pipe mixing a write with any other stage — `.a = 99 | select(true)`, guard-style `select(.a > 0) | .a = 5`, etc. — skipped the whole alias-sync post-process and left aliases stale, same failure mode as #711.
- Splits the gate into `contains_assign` (does the pipe write anywhere?) and a `is_shape_preserving` check that now also allows `.` (`Identity`), `select(...)`, `debug`/`debug(msg)`, and `empty` — none of these ever rewrite or reshape the document they pass through, so mixing one into an assignment pipe still leaves "the same path means the same thing" true for every document that comes out the other end.
- Gating on **both** avoids a perf regression: a bare pass-through query with no write anywhere (`yq '.'`, `yq 'select(true)'`) still skips the alias-sync snapshot entirely, same as before.
- Stages not on the allow-list (`map`, arbitrary filters, ...) remain conservatively excluded, unchanged from #711's scope.

Fixes #764.

## Test plan
- [x] Added 7 tests in `tests/yq_cli_tests.rs` covering the issue's repro, guard-style ordering, `debug`, `empty`, and two regression guards (`map` still excluded; bare `select` with no write still unaffected)
- [x] Full `yq_cli_tests.rs` suite: 286/286 passing
- [x] `cargo clippy --features cli --all-targets -- -D warnings`: clean
- [x] Manual repro verified against installed `yq` v4.53.3 (`select(true)`/`select(false)`, guard-style ordering)