### PR TITLE
perf(yaml): decode sort-keys comparator key once per field, not per comparison

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1374,9 +1374,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     out.write_char('{')?;
                     let mut first = true;
                     if sort_keys {
-                        let mut sorted: Vec<_> = fields.into_iter().collect();
-                        sorted.sort_by(|a, b| a.key().key_string().cmp(&b.key().key_string()));
-                        for field in sorted {
+                        let mut sorted: Vec<_> = fields
+                            .into_iter()
+                            .map(|field| (field.key().key_string(), field))
+                            .collect();
+                        sorted.sort_by(|a, b| a.0.cmp(&b.0));
+                        for (_, field) in sorted {
                             if !first {
                                 out.write_str(", ")?;
                             }
@@ -1401,9 +1404,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     // Block style
                     let mut first = true;
                     if sort_keys {
-                        let mut sorted: Vec<_> = fields.into_iter().collect();
-                        sorted.sort_by(|a, b| a.key().key_string().cmp(&b.key().key_string()));
-                        for field in sorted {
+                        let mut sorted: Vec<_> = fields
+                            .into_iter()
+                            .map(|field| (field.key().key_string(), field))
+                            .collect();
+                        sorted.sort_by(|a, b| a.0.cmp(&b.0));
+                        for (_, field) in sorted {
                             if !first {
                                 out.write_char('\n')?;
                                 write_yaml_indent(out, current_indent, unit)?;
@@ -1639,9 +1645,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 let next_indent = current_indent + indent_spaces;
                 let mut first = true;
                 if sort_keys {
-                    let mut sorted: Vec<_> = fields.into_iter().collect();
-                    sorted.sort_by(|a, b| a.key().key_string().cmp(&b.key().key_string()));
-                    for field in sorted {
+                    let mut sorted: Vec<_> = fields
+                        .into_iter()
+                        .map(|field| (field.key().key_string(), field))
+                        .collect();
+                    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+                    for (_, field) in sorted {
                         if !first {
                             out.write_char(',')?;
                         }


### PR DESCRIPTION
## Summary
- `-S`/`--sort-keys` mapping sort at all three sites in `src/yaml/light.rs` called `key_string()` inside the `sort_by` comparator, so each key was decoded (escape-decode / byte-rescan) up to O(n log n) times for n fields instead of once.
- Applies the decorate-sort-undecorate (Schwartzian transform) fix suggested in the issue: compute each field's decoded key once, sort by that, then discard the decoration. `YamlField` is `Copy`, so decorating costs only a `Cow<str>` per field, no value data duplication.
- Fixes 3 sites (the issue listed 4; `stream_yaml_value_as_json` was removed as dead code in a later commit, so only 3 remain: flow-mapping and block-mapping arms in `stream_yaml_value`, and the object arm in `stream_json_value`).

Fixes #751

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, incl. `sort_keys` tests and all 524 yaml unit tests) — all green, output unchanged
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (covers real x86/ARM SIMD paths, since `--all-features` compiles them out via `scalar-yaml`) — clean
- [x] `cargo fmt --check` — clean