### PR TITLE
fix(yaml): preserve a mapping key's trailing comment when its value is deferred (#765)

### DIFF
--- a/docs/plan/yq-remaining.md
+++ b/docs/plan/yq-remaining.md
@@ -23,14 +23,14 @@ See [yq Language Reference](../reference/yq-language.md) for implemented feature
 | Flag                   | Description                              |
 |------------------------|------------------------------------------|
 | `--explode-anchors`    | Expand anchor/alias references inline    |
-| `--preserve-comments`  | Preserve comments in YAML output — partial (#710): always-on for trailing same-line comments on cursor-preserving paths (identity, navigation, filters, sort-keys); not yet for assignment |
+| `--preserve-comments`  | Preserve comments in YAML output — partial (#710, #765): always-on for trailing same-line comments (value-scoped and key-scoped) on cursor-preserving paths (identity, navigation, filters, sort-keys); not yet for assignment |
 
 ## YAML Features (Low Priority)
 
 | Feature          | Description                              | Notes                    |
 |------------------|------------------------------------------|--------------------------|
 | Merge keys       | `<<: *alias` syntax                      | Complex semantics        |
-| Comment storage  | Store and query trailing same-line comments | Implemented (#710) — `bp_to_line_comment` in the YAML semi-index, `line_comment` builtin. Standalone `head_comment`/`foot_comment` and assignment-path preservation remain open |
+| Comment storage  | Store and query trailing same-line comments | Implemented (#710) — `bp_to_line_comment` in the YAML semi-index, `line_comment` builtin. Key-scoped comments on a deferred value's key line also preserved on identity/output (#765), but not exposed via any getter (matches real `yq`). Standalone `head_comment`/`foot_comment` and assignment-path preservation remain open |
 
 ## Date Arithmetic (Low Priority)
 

--- a/docs/plan/yq.md
+++ b/docs/plan/yq.md
@@ -145,11 +145,18 @@ flag needed or planned) — but only on paths that keep a live YAML cursor
 (identity, field/index navigation, filters like `select`, `-S`/sort-keys).
 A comment trailing a mapping *key*'s own line, when its value is deferred to
 a following line (`a: # comment\n  b: 1`), is preserved the same way (#765)
-— it's key-scoped, not value-scoped, so it stays invisible to `line_comment`
-and friends, matching real `yq`. Assignment (`=`, `|=`, ...) and other
-value-constructing expressions fall through a JSON-round-trip evaluator path
-that has no comment data to carry; see the `comments` row below and the
-tracking issue for the follow-up.
+for the two shapes the deferred value can resolve to that real `yq` itself
+preserves: a nested mapping/sequence, or nothing at all (a sibling key
+follows at the same or lower indent, or EOF — `a: # comment\nb: 2`). It's
+key-scoped, not value-scoped, so it stays invisible to `line_comment` and
+friends, matching real `yq`. A third shape — a folded plain-scalar
+continuation (`a: # comment\n  hello` → real `yq` emits `a: hello #
+comment`, comment *after* the value) — is not handled; succinctly still
+drops the comment there, since real `yq` positions it differently from the
+other two shapes. Assignment (`=`, `|=`, ...) and other value-constructing
+expressions fall through a JSON-round-trip evaluator path that has no
+comment data to carry; see the `comments` row below and the tracking issue
+for the follow-up.
 
 ---
 

--- a/docs/plan/yq.md
+++ b/docs/plan/yq.md
@@ -143,9 +143,13 @@ succinctly yq '.spec.containers[]' deployment.yaml service.yaml
 captured and preserved through output, always-on (no `--preserve-comments`
 flag needed or planned) — but only on paths that keep a live YAML cursor
 (identity, field/index navigation, filters like `select`, `-S`/sort-keys).
-Assignment (`=`, `|=`, ...) and other value-constructing expressions fall
-through a JSON-round-trip evaluator path that has no comment data to carry;
-see the `comments` row below and the tracking issue for the follow-up.
+A comment trailing a mapping *key*'s own line, when its value is deferred to
+a following line (`a: # comment\n  b: 1`), is preserved the same way (#765)
+— it's key-scoped, not value-scoped, so it stays invisible to `line_comment`
+and friends, matching real `yq`. Assignment (`=`, `|=`, ...) and other
+value-constructing expressions fall through a JSON-round-trip evaluator path
+that has no comment data to carry; see the `comments` row below and the
+tracking issue for the follow-up.
 
 ---
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -994,6 +994,11 @@ fn emit_yaml_value(
                             // For nested containers, emit at depth+1 which handles its own indentation
                             let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
                             format!("{indent}{key}:{key_comment_suffix}\n{val}{comment_suffix}")
+                        } else if let Some(kc) = comments.key_comment_if_value_absent(k) {
+                            // The deferred value materialized as nothing at
+                            // all - the key's own comment stands alone with
+                            // no value token, matching real yq (#765).
+                            format!("{indent}{key}: {kc}")
                         } else {
                             let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
                             format!("{indent}{key}: {val}{comment_suffix}")

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -985,9 +985,15 @@ fn emit_yaml_value(
                         if matches!(v, OwnedValue::Object(m) if !m.is_empty())
                             || matches!(v, OwnedValue::Array(a) if !a.is_empty())
                         {
+                            // A comment trailing the key's own line, when the
+                            // value is deferred to the next line, belongs to
+                            // the key, not the value (#765).
+                            let key_comment_suffix = comments
+                                .key_comment(k)
+                                .map_or_else(String::new, |c| format!(" {c}"));
                             // For nested containers, emit at depth+1 which handles its own indentation
                             let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
-                            format!("{indent}{key}:\n{val}{comment_suffix}")
+                            format!("{indent}{key}:{key_comment_suffix}\n{val}{comment_suffix}")
                         } else {
                             let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
                             format!("{indent}{key}: {val}{comment_suffix}")
@@ -2543,6 +2549,7 @@ mod tests {
             vec![CommentTree::Object(
                 Some("# obj trailing".to_string()),
                 obj_comments,
+                IndexMap::new(),
             )],
         );
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -114,10 +114,13 @@ pub enum CommentTree {
     /// line when its value is deferred to a following line (issue #765,
     /// e.g. `a: # comment\n  b: 1`) - distinct from the field's value
     /// subtree's own comment, which `.a | line_comment` etc. read instead.
+    /// The `bool` alongside each comment is whether the deferred value
+    /// materialized as nothing at all (a sibling key follows, or EOF) -
+    /// see [`Self::key_comment_if_value_absent`].
     Object(
         Option<String>,
         IndexMap<String, Self>,
-        IndexMap<String, String>,
+        IndexMap<String, (String, bool)>,
     ),
 }
 
@@ -161,7 +164,27 @@ impl CommentTree {
     /// trailing comment (issue #710).
     pub fn key_comment(&self, key: &str) -> Option<&str> {
         match self {
-            Self::Object(_, _, key_comments) => key_comments.get(key).map(String::as_str),
+            Self::Object(_, _, key_comments) => key_comments.get(key).map(|(c, _)| c.as_str()),
+            _ => None,
+        }
+    }
+
+    /// The same key-scoped comment as [`Self::key_comment`], but only when
+    /// the deferred value itself materialized as nothing at all (issue
+    /// #765) - a sibling key follows at the same or lower indent, or EOF.
+    ///
+    /// `None` both when there's no key comment at all, and when there is
+    /// one but the deferred value has real content of its own (a
+    /// container - use `key_comment` plus the value's own rendering there
+    /// instead - or a folded scalar continuation like `a: # c\n  null`,
+    /// which real `yq` places the comment after rather than right after
+    /// the key, a different, unhandled case).
+    pub fn key_comment_if_value_absent(&self, key: &str) -> Option<&str> {
+        match self {
+            Self::Object(_, _, key_comments) => key_comments
+                .get(key)
+                .filter(|(_, absent)| *absent)
+                .map(|(c, _)| c.as_str()),
             _ => None,
         }
     }
@@ -199,8 +222,19 @@ pub fn to_owned_with_comments<V: DocumentValue>(
                 // A comment trailing the key's own line, when the value is
                 // deferred to a following line (issue #765) - distinct from
                 // `c`'s own comment above, which belongs to the value.
+                // Recorded alongside whether the deferred value
+                // materialized as nothing at all (a sibling key follows, or
+                // EOF): a folded scalar continuation that merely *reads* as
+                // null (`a: # c\n  null`) is a different, unhandled case
+                // where real yq places the comment after the folded value
+                // instead of right after the key, which `v`/`is_null()`
+                // alone can't tell apart from true absence - both collapse
+                // through the same semantic check `to_owned` uses - so this
+                // also checks the raw text is empty, not just null-ish.
                 if let Some(kc) = field.key_cursor.line_comment_raw() {
-                    key_comment_map.insert(key, kc);
+                    let value_absent = field.value.is_null()
+                        && field.value.as_str().map_or(true, |s| s.is_empty());
+                    key_comment_map.insert(key, (kc, value_absent));
                 }
             }
             f = rest;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -108,9 +108,17 @@ pub enum CommentTree {
     /// which trails the whole array, not an element), plus one subtree per
     /// element in order.
     Array(Option<String>, Vec<Self>),
-    /// An object: this node's own trailing comment, plus one subtree per
-    /// field, keyed the same as the parallel `OwnedValue::Object`.
-    Object(Option<String>, IndexMap<String, Self>),
+    /// An object: this node's own trailing comment, one subtree per field
+    /// (keyed the same as the parallel `OwnedValue::Object`), plus one
+    /// key-scoped comment per field for a comment trailing the *key's* own
+    /// line when its value is deferred to a following line (issue #765,
+    /// e.g. `a: # comment\n  b: 1`) - distinct from the field's value
+    /// subtree's own comment, which `.a | line_comment` etc. read instead.
+    Object(
+        Option<String>,
+        IndexMap<String, Self>,
+        IndexMap<String, String>,
+    ),
 }
 
 impl CommentTree {
@@ -124,7 +132,7 @@ impl CommentTree {
     /// This node's own trailing comment, if any.
     pub fn own(&self) -> Option<&str> {
         match self {
-            Self::Leaf(c) | Self::Array(c, _) | Self::Object(c, _) => c.as_deref(),
+            Self::Leaf(c) | Self::Array(c, _) | Self::Object(c, _, _) => c.as_deref(),
         }
     }
 
@@ -141,8 +149,20 @@ impl CommentTree {
     /// `Object` or has no such key.
     pub fn field(&self, key: &str) -> &Self {
         match self {
-            Self::Object(_, fields) => fields.get(key).unwrap_or(&EMPTY_COMMENT_TREE),
+            Self::Object(_, fields, _) => fields.get(key).unwrap_or(&EMPTY_COMMENT_TREE),
             _ => &EMPTY_COMMENT_TREE,
+        }
+    }
+
+    /// A comment trailing object field `key`'s own *key* line, when its
+    /// value is deferred to a following line (issue #765) - or `None` if
+    /// this isn't an `Object`, has no such key, or the key has no such
+    /// comment. Distinct from `field(key).own()`, which is the value's own
+    /// trailing comment (issue #710).
+    pub fn key_comment(&self, key: &str) -> Option<&str> {
+        match self {
+            Self::Object(_, _, key_comments) => key_comments.get(key).map(String::as_str),
+            _ => None,
         }
     }
 }
@@ -168,19 +188,26 @@ pub fn to_owned_with_comments<V: DocumentValue>(
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut comment_map = IndexMap::new();
+        let mut key_comment_map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
             if let Some(key) = field.key_str() {
                 let key = key.into_owned();
                 let (v, c) = to_owned_with_comments(&field.value, Some(&field.value_cursor));
                 map.insert(key.clone(), v);
-                comment_map.insert(key, c);
+                comment_map.insert(key.clone(), c);
+                // A comment trailing the key's own line, when the value is
+                // deferred to a following line (issue #765) - distinct from
+                // `c`'s own comment above, which belongs to the value.
+                if let Some(kc) = field.key_cursor.line_comment_raw() {
+                    key_comment_map.insert(key, kc);
+                }
             }
             f = rest;
         }
         (
             OwnedValue::Object(map),
-            CommentTree::Object(own_comment, comment_map),
+            CommentTree::Object(own_comment, comment_map, key_comment_map),
         )
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -945,6 +945,78 @@ mod tests {
     }
 
     // ------------------------------------------------------------------------
+    // Key-scoped trailing line comment capture (#765)
+    // ------------------------------------------------------------------------
+
+    /// Helper: the twin of [`field_line_comment_raw`], reading the *key*
+    /// cursor's line comment instead of the value cursor's.
+    fn field_key_line_comment_raw(yaml: &[u8], key: &str) -> Option<String> {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Mapping(fields) = doc_cursor.value() else {
+            panic!("expected a mapping document");
+        };
+        for field in fields {
+            if let YamlValue::String(k) = field.key() {
+                if k.raw_bytes() == key.as_bytes() {
+                    return field
+                        .key_cursor()
+                        .line_comment_raw()
+                        .map(alloc::string::ToString::to_string);
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_key_line_comment_captured_when_value_deferred_to_nested_mapping_765() {
+        let yaml = b"a: # comment on key\n  b: 1\n";
+        assert_eq!(
+            field_key_line_comment_raw(yaml, "a").as_deref(),
+            Some("# comment on key")
+        );
+        // The value cursor (what `.a | line_comment` navigates to) must NOT
+        // see it - it's scoped to the key, matching real yq's getters.
+        assert_eq!(field_line_comment_raw(yaml, "a"), None);
+    }
+
+    #[test]
+    fn test_key_line_comment_captured_when_value_deferred_to_nested_sequence_765() {
+        let yaml = b"a: # comment on key\n  - 1\n  - 2\n";
+        assert_eq!(
+            field_key_line_comment_raw(yaml, "a").as_deref(),
+            Some("# comment on key")
+        );
+        assert_eq!(field_line_comment_raw(yaml, "a"), None);
+    }
+
+    #[test]
+    fn test_key_line_comment_none_when_absent_765() {
+        let yaml = b"a:\n  b: 1\n";
+        assert_eq!(field_key_line_comment_raw(yaml, "a"), None);
+    }
+
+    #[test]
+    fn test_key_line_comment_not_captured_for_same_line_value_765() {
+        // A comment trailing a same-line value belongs to the value (#710),
+        // not the key - the new #765 capture point is only reached when the
+        // value is deferred to a following line.
+        let yaml = b"a: 1 # keep this\nb: 2\n";
+        assert_eq!(field_key_line_comment_raw(yaml, "a"), None);
+        assert_eq!(
+            field_line_comment_raw(yaml, "a").as_deref(),
+            Some("# keep this")
+        );
+    }
+
+    // ------------------------------------------------------------------------
     // Anchor targeting (#328)
     // ------------------------------------------------------------------------
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1441,6 +1441,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     sort_keys,
                                 )?;
                                 write_line_comment(out, value.line_comment_raw())?;
+                            } else if let Some(kc) = field
+                                .key_cursor()
+                                .line_comment_raw()
+                                .filter(|_| is_deferred_value_absent(&value))
+                            {
+                                // The deferred value materialized as nothing
+                                // at all - the key's own comment stands
+                                // alone with no value token, matching real
+                                // yq (#765).
+                                write_line_comment(out, Some(kc))?;
                             } else {
                                 out.write_char(' ')?;
                                 if let Some(anchor) = value.anchor() {
@@ -1492,6 +1502,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     sort_keys,
                                 )?;
                                 write_line_comment(out, value.line_comment_raw())?;
+                            } else if let Some(kc) = field
+                                .key_cursor()
+                                .line_comment_raw()
+                                .filter(|_| is_deferred_value_absent(&value))
+                            {
+                                // The deferred value materialized as nothing
+                                // at all - the key's own comment stands
+                                // alone with no value token, matching real
+                                // yq (#765).
+                                write_line_comment(out, Some(kc))?;
                             } else {
                                 out.write_char(' ')?;
                                 if let Some(anchor) = value.anchor() {
@@ -5516,6 +5536,28 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for YamlElements<'a, W> {
 /// literal `<<` field.
 fn is_yaml_cursor_container<W: AsRef<[u64]>>(cursor: &YamlCursor<'_, W>) -> bool {
     cursor.is_container() && cursor.first_child().is_some()
+}
+
+/// Whether a mapping field's value cursor is a deferred value that
+/// materialized as nothing at all - a sibling key follows at the same or
+/// lower indent, or EOF (issue #765).
+///
+/// Deliberately checks the resolved value's *text*, not general semantic
+/// nullness - a folded scalar continuation that merely *reads* as null
+/// (`a: # c\n  null`) is semantically null too, but real `yq` places its
+/// comment after the folded value instead of right after the key, a
+/// different, unhandled case this must not swallow. Also deliberately does
+/// not use `YamlCursor::raw_bytes()`: for exactly this deferred-and-absent
+/// shape, the value's recorded text position aliases onto whatever follows
+/// in the source (e.g. the next sibling key's own text), so `raw_bytes()`
+/// reads that unrelated text instead of reporting emptiness. `value()`'s
+/// `String`/`Null` classification does not have that problem.
+fn is_deferred_value_absent<W: AsRef<[u64]>>(value: &YamlCursor<'_, W>) -> bool {
+    match value.value() {
+        YamlValue::Null => true,
+        YamlValue::String(s) => s.is_unquoted() && s.as_str().map_or(true, |t| t.is_empty()),
+        _ => false,
+    }
 }
 
 /// Write `width` copies of `unit` as indentation (`unit` is `' '` for

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1419,6 +1419,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             out.write_char(':')?;
                             let value = field.value_cursor();
                             if is_yaml_cursor_container(&value) && value.style() != "flow" {
+                                // A comment trailing the key's own line, when
+                                // the value is deferred to the next line,
+                                // belongs to the key, not the value (#765).
+                                write_line_comment(out, field.key_cursor().line_comment_raw())?;
                                 // The anchor (if any) belongs on the same
                                 // line as the key, before the newline that
                                 // starts the container's own contents.
@@ -1466,6 +1470,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // Check if value needs newline
                             let value = field.value_cursor();
                             if is_yaml_cursor_container(&value) && value.style() != "flow" {
+                                // A comment trailing the key's own line, when
+                                // the value is deferred to the next line,
+                                // belongs to the key, not the value (#765).
+                                write_line_comment(out, field.key_cursor().line_comment_raw())?;
                                 // The anchor (if any) belongs on the same
                                 // line as the key, before the newline that
                                 // starts the container's own contents.

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2198,7 +2198,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.write_bp_close();
                 return Ok(());
             }
-            // Value is on next line - check what kind of value
+            // Value is on next line - check what kind of value. Capture a
+            // trailing comment on the key's own line first (issue #765) -
+            // `self.last_open_bp_pos` still holds the key node's bp_pos here
+            // since no value node has been opened yet (nothing opens a BP
+            // node between the key's own close above and this point).
+            self.maybe_capture_line_comment(self.last_open_bp_pos);
             self.skip_to_eol();
 
             // Look ahead to see what the next content line looks like

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5497,3 +5497,86 @@ fn test_line_comment_builtin_through_param_substitution_710() -> Result<()> {
     assert_eq!(out, "1\n\"\"\n");
     Ok(())
 }
+
+// Key-scoped trailing line comment preservation (#765), a follow-up to
+// #710: a comment trailing a mapping *key*'s own line, when the value is
+// deferred to a following line (nested mapping/sequence), belongs to the
+// key, not the value - #710's `line_comments`/`CommentTree` machinery was
+// entirely value-node-scoped and dropped it silently. Every expected string
+// here was verified byte-for-byte against the pinned real `yq` binary
+// before being pinned, same as the #710 block above.
+
+/// The issue's own repro: a key-trailing comment, value deferred to a
+/// nested mapping.
+#[test]
+fn test_key_comment_preserved_with_nested_mapping_value_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: # comment on key\n  b: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: # comment on key\n  b: 1\n");
+    Ok(())
+}
+
+/// Same shape, but the deferred value is a nested sequence rather than a
+/// nested mapping.
+#[test]
+fn test_key_comment_preserved_with_nested_sequence_value_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: # comment on key\n  - 1\n  - 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: # comment on key\n  - 1\n  - 2\n");
+    Ok(())
+}
+
+/// Real `yq` doesn't expose this comment through any getter - it only
+/// survives via full-tree re-serialization (see the issue's own
+/// investigation). `line_comment` on the value (`.a`) or a descendant
+/// (`.a.b`) must stay blank; this is the non-goal the issue explicitly
+/// pins down. (`head_comment`/`foot_comment` aren't implemented by
+/// succinctly at all - `Error: undefined function` - so there's nothing
+/// to pin for them here.)
+#[test]
+fn test_key_comment_not_exposed_via_line_comment_getter_765() -> Result<()> {
+    let input = "a: # comment on key\n  b: 1\n";
+
+    let (out, code) = run_yq_stdin(".a | line_comment", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "''\n");
+
+    let (out, code) = run_yq_stdin(".a.b | line_comment", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "''\n");
+
+    Ok(())
+}
+
+/// A cursor-preserving filter (the DOM/`CommentTree` path, not bare
+/// identity's M2 streaming path) must also place the key's comment right
+/// after `key:`, not just plain `.`.
+#[test]
+fn test_key_comment_preserved_via_select_dom_path_765() -> Result<()> {
+    let (out, code) = run_yq_stdin("select(true)", "a: # comment on key\n  b: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: # comment on key\n  b: 1\n");
+    Ok(())
+}
+
+/// `-S`/`--sort-keys` reorders siblings but must still resolve the key
+/// comment by field name, same as #710's value-comment equivalent
+/// (`test_sort_keys_preserves_comments_710`).
+#[test]
+fn test_key_comment_preserved_with_sort_keys_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "z: 9\na: # comment on key\n  b: 1\n", &["-S"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: # comment on key\n  b: 1\nz: 9\n");
+    Ok(())
+}
+
+/// Regression guard: a comment trailing a same-line (not deferred) value
+/// keeps belonging to the value (#710), not the key - the new #765 capture
+/// point is only reached when the value is deferred to a following line.
+#[test]
+fn test_key_comment_not_captured_for_same_line_value_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: 1 # keep this\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: 1 # keep this\nb: 2\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5580,3 +5580,63 @@ fn test_key_comment_not_captured_for_same_line_value_765() -> Result<()> {
     assert_eq!(out, "a: 1 # keep this\nb: 2\n");
     Ok(())
 }
+
+// A key's deferred value can also resolve to nothing at all - the "next
+// line" turns out to be a sibling key (at the same or a lower indent) or
+// EOF, rather than the nested mapping/sequence the cases above cover. Real
+// yq keeps the key's comment with no value token in every one of these
+// shapes too; succinctly's first #765 pass only wired up the non-empty
+// container case, silently dropping the comment here just like before the
+// fix (verified byte-for-byte against the pinned real `yq` binary, same as
+// every other block in this file).
+
+/// A sibling key immediately follows at the same indent - `a`'s deferred
+/// value is null.
+#[test]
+fn test_key_comment_preserved_with_null_value_sibling_same_indent_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: # comment on key\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: # comment on key\nb: 2\n");
+    Ok(())
+}
+
+/// Same shape, but nested: the sibling that ends `a`'s deferred value sits
+/// at a lower indent than `a` itself.
+#[test]
+fn test_key_comment_preserved_with_null_value_sibling_lower_indent_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "x:\n  a: # comment on key\ny: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "x:\n  a: # comment on key\ny: 2\n");
+    Ok(())
+}
+
+/// The deferred key is the last thing in the document - EOF ends it,
+/// leaving a null value.
+#[test]
+fn test_key_comment_preserved_with_null_value_at_eof_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: # comment on key\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: # comment on key\n");
+    Ok(())
+}
+
+/// The DOM/`CommentTree` path (`select`, not bare identity's M2 streaming
+/// path) must also keep the comment for a null deferred value.
+#[test]
+fn test_key_comment_preserved_with_null_value_via_select_dom_path_765() -> Result<()> {
+    let (out, code) = run_yq_stdin("select(true)", "a: # comment on key\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: # comment on key\nb: 2\n");
+    Ok(())
+}
+
+/// `-S`/`--sort-keys` must resolve a null-valued key's comment by field
+/// name too, same as `test_key_comment_preserved_with_sort_keys_765` above
+/// for the non-empty-container case.
+#[test]
+fn test_key_comment_preserved_with_null_value_and_sort_keys_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "z: 9\na: # comment on key\nb: 2\n", &["-S"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: # comment on key\nb: 2\nz: 9\n");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- A `#` comment trailing a mapping key's own line was silently dropped from `yq` output whenever the key's value was deferred to a following line (nested mapping/sequence), e.g. `a: # comment\n  b: 1`. Real `yq` preserves it; succinctly did not.
- Follow-up to #710 (trailing same-line comment preservation), whose `line_comments`/`CommentTree` machinery was entirely value-node-scoped. The key already gets its own BP node/cursor distinct from its value, so this reuses that existing infrastructure rather than adding a new key-scoped data structure — a key's bp_pos can never collide with any value's, and jq/yq navigation (`.a`) always lands on a value cursor, so `.a | line_comment` stays blank for free, matching real `yq`'s own getters (verified in the issue's own investigation).
- Fixes both `yq` output paths: the M2 cursor-streaming path (bare identity, `-S`) and the DOM/`CommentTree` path (`select`, other cursor-preserving filters).

Split into 5 commits for review: parser capture + unit tests, the two write-path fixes, CLI round-trip tests, and a docs note.

## Test plan

- [x] `cargo build --features cli`; manually verified the issue's repro round-trips unchanged
- [x] `cargo test --features cli,regex,serde` (full suite, no regressions)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the SIMD-feature clippy invocation (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`)
- [x] `cargo fmt --check`
- [x] Every new/changed expected output in `tests/yq_cli_tests.rs` was checked byte-for-byte against the pinned real `yq` v4.53.3 binary before being hardcoded, following the existing `_710` block's convention

Fixes #765