### PR TITLE
fix(jq): match jq's gmtime/mktime/strptime error wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`gmtime`, `mktime`, and `strptime` raised the right exit code but the
+  wrong message on bad input** (#761): `gmtime`/`localtime` on a non-number
+  reported the generic `"math function requires number"` (shared with
+  `floor`/`sqrt`/etc.) instead of jq's `"gmtime() requires numeric
+  inputs"`/`"localtime() requires numeric inputs"`; `mktime` on a non-array
+  reported `EvalError::type_error`'s `"expected array, got mktime"` instead
+  of jq's `"mktime requires array inputs"`; and `strptime` on a
+  non-matching format surfaced whichever low-level parser diagnostic failed
+  first (`"expected digits"`, `"expected '-'"`, ...) instead of jq's single
+  `date "<input>" does not match format "<fmt>"` for every failure mode.
+  Since #158, `catch` binds the raised value, so this wording is part of the
+  observable filter surface, not just stderr decoration. Added
+  `EvalError::datetime_requires_number`/`::mktime_requires_array`/
+  `::strptime_no_match` named constructors matching jq byte for byte,
+  and gave `get_float_value` a `get_float_value_with` sibling so
+  `gmtime`/`localtime` can supply their own message without touching the
+  other ~27 math builtins that share the generic one. Un-pins
+  `gmtime_type_error_on_string`, `mktime_type_error_on_number`, and
+  `strptime_no_match_error` from `tests/data/jq-golden-known-failures.txt`.
+
 - **`path`/`parent`/`parent(n)`/`key` (yq's path-context builtins) returned
   the root-level defaults `[]`/`{}`/`null` instead of the real answer
   whenever they appeared anywhere in a pipe other than the very first stage**

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -539,6 +539,24 @@ impl EvalError {
         ))
     }
 
+    /// `<builtin>() requires numeric inputs` — `gmtime`/`localtime` on a
+    /// non-number input.
+    pub fn datetime_requires_number(builtin: &str) -> Self {
+        Self::new(format!("{builtin}() requires numeric inputs"))
+    }
+
+    /// `mktime requires array inputs`.
+    pub fn mktime_requires_array() -> Self {
+        Self::new("mktime requires array inputs")
+    }
+
+    /// `date "<input>" does not match format "<fmt>"` — any `strptime`
+    /// parse failure. jq reports this one wording regardless of which
+    /// format specifier the input failed to satisfy.
+    pub fn strptime_no_match(input: &str, fmt: &str) -> Self {
+        Self::new(format!(r#"date "{input}" does not match format "{fmt}""#))
+    }
+
     /// `<a> and <b> <phrase>`.
     fn pair(left: &OwnedValue, right: &OwnedValue, phrase: &str) -> Self {
         Self::new(format!(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13603,7 +13603,9 @@ fn builtin_gmtime<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
     optional: bool,
 ) -> QueryResult<'_, W> {
-    let timestamp = match get_float_value::<W>(&value, optional) {
+    let timestamp = match get_float_value_with::<W>(&value, optional, || {
+        EvalError::datetime_requires_number("gmtime")
+    }) {
         Ok(f) => f,
         Err(r) => return r,
     };
@@ -13670,7 +13672,9 @@ fn builtin_localtime<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     #[cfg(feature = "std")]
     {
-        let timestamp = match get_float_value::<W>(&value, optional) {
+        let timestamp = match get_float_value_with::<W>(&value, optional, || {
+            EvalError::datetime_requires_number("localtime")
+        }) {
             Ok(f) => f,
             Err(r) => return r,
         };
@@ -13821,7 +13825,7 @@ fn builtin_mktime<W: Clone + AsRef<[u64]>>(
     let arr = match to_owned(&value) {
         OwnedValue::Array(a) => a,
         _ if optional => return QueryResult::None,
-        _ => return QueryResult::Error(EvalError::type_error("array", "mktime")),
+        _ => return QueryResult::Error(EvalError::mktime_requires_array()),
     };
 
     // Need at least 6 elements: [year, month, day, hour, minute, second]
@@ -14096,7 +14100,7 @@ fn builtin_strptime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(OwnedValue::Array(result))
         }
         Err(_) if optional => QueryResult::None,
-        Err(e) => QueryResult::Error(EvalError::new(e)),
+        Err(_) => QueryResult::Error(EvalError::strptime_no_match(&input, &fmt)),
     }
 }
 
@@ -15806,6 +15810,19 @@ fn get_float_value<'a, W: Clone + AsRef<[u64]>>(
     value: &StandardJson<'a, W>,
     optional: bool,
 ) -> Result<f64, QueryResult<'a, W>> {
+    get_float_value_with(value, optional, || {
+        EvalError::new("math function requires number")
+    })
+}
+
+/// Like [`get_float_value`], but with a caller-supplied error for the
+/// non-number case — used by `gmtime`/`localtime` to raise jq's own wording
+/// instead of the generic math-function message.
+fn get_float_value_with<'a, W: Clone + AsRef<[u64]>>(
+    value: &StandardJson<'a, W>,
+    optional: bool,
+    not_a_number: impl FnOnce() -> EvalError,
+) -> Result<f64, QueryResult<'a, W>> {
     match value {
         StandardJson::Number(n) => {
             if is_nan_sentinel(n.raw_bytes()) {
@@ -15819,9 +15836,7 @@ fn get_float_value<'a, W: Clone + AsRef<[u64]>>(
             }
         }
         _ if optional => Err(QueryResult::None),
-        _ => Err(QueryResult::Error(EvalError::new(
-            "math function requires number",
-        ))),
+        _ => Err(QueryResult::Error(not_a_number())),
     }
 }
 

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -150,6 +150,3 @@ regex_test_z_unknown_flag      regex-flags   unknown flag characters are silentl
 strftime_raw_number_input          datetime   strftime requires an array; real jq accepts a raw timestamp number too — #759
 date_roundtrip_leap_year_torture   datetime   same root cause as strftime_raw_number_input — #759
 strftime_unsupported_specifiers    datetime   %U/%V/%W/%G/%g are not implemented — #760
-gmtime_type_error_on_string        datetime   error wording diverges from jq's "gmtime() requires numeric inputs" — #761
-mktime_type_error_on_number        datetime   error wording diverges from jq's "mktime requires array inputs" — #761
-strptime_no_match_error            datetime   error wording diverges from jq's `date "..." does not match format "..."` — #761


### PR DESCRIPTION
## Summary

`gmtime`, `mktime`, and `strptime` raised errors on bad input with the
right exit code (5) but the wrong message text, because they routed
through generic helpers instead of jq's per-builtin wording:

- `gmtime`/`localtime` on a non-number reported the generic `"math
  function requires number"` (shared with `floor`/`sqrt`/etc.) instead of
  jq's `"gmtime() requires numeric inputs"`/`"localtime() requires
  numeric inputs"`.
- `mktime` on a non-array reported `EvalError::type_error`'s `"expected
  array, got mktime"` instead of jq's `"mktime requires array inputs"`.
- `strptime` on a non-matching format surfaced whichever low-level parser
  diagnostic happened to fail first (`"expected digits"`, `"expected
  '-'"`, ...) instead of jq's single `date "<input>" does not match
  format "<fmt>"` for every failure mode.

Since #158, `catch` binds the raised value, so this wording is part of
the observable filter surface, not just stderr decoration.

## Changes

- Added `EvalError::datetime_requires_number`/`::mktime_requires_array`/
  `::strptime_no_match` named constructors matching jq byte for byte.
- Gave `get_float_value` a `get_float_value_with` sibling so
  `gmtime`/`localtime` can supply their own message without touching the
  ~27 other math builtins that share the generic one.
- Un-pinned `gmtime_type_error_on_string`, `mktime_type_error_on_number`,
  and `strptime_no_match_error` from
  `tests/data/jq-golden-known-failures.txt`.
- Recorded the fix in `CHANGELOG.md`.

Fixes #761

## Test plan

- [x] `cargo test --features cli --test jq_golden_tests` — golden
      conformance and known-failures manifest both pass
- [x] `cargo test --features cli,regex,serde` — full suite green
      (2209+ lib tests, all integration suites)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manually diffed output against real `jq-1.7.1` for all four cases
      (`gmtime`, `localtime`, `mktime`, `strptime`) on both the `jq` and
      `yq` CLI paths, plus confirmed `floor`'s unrelated error message is
      unaffected