### PR TITLE
docs(jq): document leaf_paths' intentional divergence from paths(scalars)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,37 @@ echo '{"data": {"nested": {"value": 42}}}' | succinctly jq 'at_offset(9) | .nest
 - Returns error if offset/position is out of bounds or doesn't correspond to a valid node
 - Use `at_offset(n)?` or `at_position(l; c)?` for optional (returns empty on invalid position)
 
+### jq `leaf_paths` (succinctly extension)
+
+`leaf_paths` is **not a real jq builtin** — it errors with `leaf_paths/0 is
+not defined` in real jq (confirmed against jq 1.7.1 and 1.8.2). It's a
+succinctly extension modeled on the community recipe
+`def leaf_paths: paths(scalars);`, but intentionally broader: it returns
+paths to every **leaf** (childless) node in the tree, not just paths whose
+`type` is scalar.
+
+```bash
+echo '{"a": {"b": 1, "c": null}, "d": [], "e": [2, 3]}' | succinctly jq -c 'leaf_paths'
+# ["a","b"]
+# ["a","c"]
+# ["d"]
+# ["e",0]
+# ["e",1]
+```
+
+**Diverges from `paths(scalars)` on two cases:**
+- `null` counts as a leaf here; `paths(scalars)` excludes it (an accidental
+  side effect of `select()` treating a `null` yield as falsy, not a
+  deliberate design choice in jq).
+- Empty `{}`/`[]` count as leaves here; `paths(scalars)` excludes them too,
+  since their `type` is `"object"`/`"array"`, not scalar — even though they
+  have no children to recurse into either.
+
+This divergence is intentional: `leaf_paths` uses a tree-structural
+definition of "leaf" (no children), which the community recipe's
+type-based `scalars` filter doesn't fully capture. See
+[collect_leaf_paths](src/jq/eval.rs) and issue #771 for the full rationale.
+
 ## Feature Flags
 
 | Feature             | Description                               |

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12517,7 +12517,16 @@ fn get_value_at_path(value: &OwnedValue, path: &[OwnedValue]) -> Option<OwnedVal
     }
 }
 
-/// Helper to collect leaf paths (paths to scalars)
+/// Helper to collect leaf paths: paths to values with no children to recurse
+/// into. "Leaf" here is a tree-structural notion, not jq's type-based
+/// `scalars` filter — so `null` and empty `{}`/`[]` count as leaves too,
+/// since there's nothing further to descend into.
+///
+/// This is a deliberate divergence from the community recipe
+/// `def leaf_paths: paths(scalars);`, which excludes `null` (an accidental
+/// side effect of `select()`'s falsy handling, not a design choice) and
+/// empty containers (whose `type` isn't scalar even though they have no
+/// children either). See #771.
 fn collect_leaf_paths(
     value: &OwnedValue,
     current_path: &[OwnedValue],
@@ -12555,9 +12564,12 @@ fn collect_leaf_paths(
     }
 }
 
-/// Builtin: leaf_paths - paths to scalar (non-container) values
-/// Returns each path as a separate output (streaming). Diverges from jq's
-/// `paths(scalars)` idiom for `null` and empty containers — see #771.
+/// Builtin: leaf_paths - paths to every leaf (childless) node in the tree.
+/// A succinctly extension, not a real jq builtin — modeled on the community
+/// recipe `def leaf_paths: paths(scalars);` but intentionally broader: it
+/// also yields paths to `null` values and empty `{}`/`[]`, which that
+/// recipe's `scalars` filter excludes. See `collect_leaf_paths` and #771.
+/// Returns each path as a separate output (streaming).
 fn builtin_leaf_paths<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
     _optional: bool,


### PR DESCRIPTION
## Summary
- `leaf_paths` is a succinctly extension, not a real jq builtin (confirmed against jq 1.7.1/1.8.2 — both error `leaf_paths/0 is not defined`).
- It intentionally diverges from the community recipe it's modeled on, `def leaf_paths: paths(scalars);`, by treating `null` and empty `{}`/`[]` as leaves. This was previously discoverable only via test comments.
- Documents *why* the divergence is kept rather than changed: `leaf_paths` uses a tree-structural "no children" definition of leaf, whereas jq's `scalars` filter excludes `null` only as an accidental side effect of `select()`'s falsy handling, and excludes empty containers by type rather than by whether they have children.
- No behavior change — pure documentation.

Closes #771.

## Changes
- `src/jq/eval.rs`: rewrote doc comments on `collect_leaf_paths` and `builtin_leaf_paths` to explain the divergence and its rationale.
- `CLAUDE.md`: added a "jq `leaf_paths` (succinctly extension)" section with a verified example and the two divergence cases, following the existing "succinctly extension" doc pattern (e.g. position-based navigation).

## Test plan
- [x] `cargo test --lib jq::eval::tests::test_leaf_paths` — all 7 existing tests pass unmodified
- [x] `cargo fmt --check` on the touched file
- [x] Manually verified the CLAUDE.md example output against a live build (`cargo build --features cli` + `echo ... | succinctly jq -c 'leaf_paths'`)