### PR TITLE
jq: A/B benchmarks for lazy map/select fast path (#724, #725)

### DIFF
--- a/docs/plan/jq-lazy-map-select.md
+++ b/docs/plan/jq-lazy-map-select.md
@@ -16,12 +16,12 @@ a flat-object (`wide`) pattern (#686's measurement, Apple M5 Max, byte-identical
 system `jq` verified). Both ratios grow monotonically with input size — an algorithmic cost,
 not a fixed constant.
 
-| Size  | floor `keys_unsorted\|length` (ms/MB) | `keys_unsorted\|map(.)` (ms/MB) | time ratio | mem ratio |
-|-------|---:|---:|---:|---:|
-| 100kb | 5.3ms / 8.7MB      | 7.3ms / 11.2MB     | 1.39x | 1.29x |
-| 1mb   | 10.7ms / 9.9MB     | 34.6ms / 33.2MB    | 3.23x | 3.34x |
-| 10mb  | 73.3ms / 21.8MB    | 308.9ms / 205.3MB  | 4.21x | 9.42x |
-| 100mb | 681.3ms / 138.9MB  | 3259.4ms / 1872.6MB| 4.78x | **13.48x** |
+| Size  | floor `keys_unsorted\|length` (ms/MB) | `keys_unsorted\|map(.)` (ms/MB) | time ratio | mem ratio  |
+|-------|--------------------------------------:|--------------------------------:|-----------:|-----------:|
+| 100kb | 5.3ms / 8.7MB                         | 7.3ms / 11.2MB                  | 1.39x      | 1.29x      |
+| 1mb   | 10.7ms / 9.9MB                        | 34.6ms / 33.2MB                 | 3.23x      | 3.34x      |
+| 10mb  | 73.3ms / 21.8MB                       | 308.9ms / 205.3MB               | 4.21x      | 9.42x      |
+| 100mb | 681.3ms / 138.9MB                     | 3259.4ms / 1872.6MB             | 4.78x      | **13.48x** |
 
 Critically, #686 also measured that **75-95% of this same cost hits plain `map(.)`** on the
 same document at the same size, with no `keys_unsorted` involved at all — `Builtin::Map` has
@@ -66,11 +66,11 @@ Delivery is still staged narrow-first, because the mechanism below splits into t
 independently-mergeable, independently-measurable slices without being redesigned between
 them:
 
-| Slice | Covers | Why this order |
-|---|---|---|
-| **1** | `keys_unsorted\|keys \| map/select` — wire the new primitive into the *existing* `LazyKeys`/`LazyIndexRange` arms of the `Pipe` fold. | Smallest diff, touches only already-well-tested machinery, retires the three fallback-pinning tests below, immediately measurable with the `QueryType::KeysUnsortedMap`/`KeysUnsortedSelect` benchmarks #686 already added. |
-| **2** | Plain `.foo \| map/select`, `arr \| map/select` — `Builtin::Map`'s first-ever native arm in `eval_builtin`. | This is where the dominant 75-95% of the measured cost actually lives, so it is **not optional** — scoped alongside Slice 1, sequenced second because it's structurally larger (first real semantics for a previously-absent builtin arm). |
-| **3** *(deferred, own issue, not part of #700's implementation)* | CLI streaming-output integration: `yq_runner.rs`'s `can_use_m2_streaming` whitelist, true zero-`Vec` CLI output. | Layered on top of an already-general core, same shape as #685 extending `stream_json`/`stream_yaml` *after* #678 made `keys_unsorted` lazy at the evaluator level. |
+| Slice                                                            | Covers                                                                                                                                | Why this order                                                                                                                                                                                                                             |
+|------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **1**                                                            | `keys_unsorted\|keys \| map/select` — wire the new primitive into the *existing* `LazyKeys`/`LazyIndexRange` arms of the `Pipe` fold. | Smallest diff, touches only already-well-tested machinery, retires the three fallback-pinning tests below, immediately measurable with the `QueryType::KeysUnsortedMap`/`KeysUnsortedSelect` benchmarks #686 already added.                |
+| **2**                                                            | Plain `.foo \| map/select`, `arr \| map/select` — `Builtin::Map`'s first-ever native arm in `eval_builtin`.                           | This is where the dominant 75-95% of the measured cost actually lives, so it is **not optional** — scoped alongside Slice 1, sequenced second because it's structurally larger (first real semantics for a previously-absent builtin arm). |
+| **3** *(deferred, own issue, not part of #700's implementation)* | CLI streaming-output integration: `yq_runner.rs`'s `can_use_m2_streaming` whitelist, true zero-`Vec` CLI output.                      | Layered on top of an already-general core, same shape as #685 extending `stream_json`/`stream_yaml` *after* #678 made `keys_unsorted` lazy at the evaluator level.                                                                         |
 
 ### Non-goals (explicit, to prevent scope creep)
 
@@ -313,6 +313,159 @@ documented A/B discipline (`docs/guides/benchmarking.md`) per slice, not just on
   pattern (already exists), Slice 2 needs `Pattern::Arrays`/`Pattern::Users`-shaped inputs
   (already exist) run through `Map`/`Select` — not just `Wide` again, per this repo's #106
   lesson about a benchmark that can't see the shape it's meant to improve.
+
+## Measurement results (2026-08-11, #758)
+
+Run against two binaries built via `git archive` at `588a4c5d` (before, the commit immediately
+preceding PR #740's merge) and `6ce12be6` (after, the #740 merge commit itself). Current `HEAD`
+was deliberately **not** used as "after": ~10 further `src/jq` commits landed since #740 (e.g.
+`047a0afd` threading `indent`/`sort_keys` through `LazySeq`, `5995e4d4` fixing `paths(f)`), and
+using HEAD would have attributed their effects to this PR. `scripts/ab-cli.py` was extended to
+support `--tool jq` (previously hardcoded `yq`-only `-o`/`-I0` flags, which made it fail outright
+for `jq`). Method: 7 reps, interleaved per `docs/guides/benchmarking.md` rule 1; `--control` run
+first on each machine to establish the noise floor; identity gated two ways — `ab-cli.py`'s
+before-vs-after digest gate, and `dev bench jq`'s always-on gate against system `jq`.
+
+**Control (noise floor):** Apple M4 Pro −2.7%..+1.0% median, AMD Ryzen 9 7950X −1.7%..+0.9%
+median (3 files × 2 queries × 7 reps each). Deltas below are only called real signal when they
+clear this band.
+
+Both machines showed transient "busy" warnings from `ab-cli.py`'s rule-6 check that were
+investigated and are not real contention: on the Apple M4 Pro, `ps -Ao pcpu` summed to 30-44%
+across many small processes with no single offender, while macOS's own aggregate reading
+(`top -l 1 -n 0`) showed 91.4% idle — the same class of misleading-aggregate-signal issue
+`docs/guides/benchmarking.md` documents for load average, just via a different command; on the
+x86_64 node, Tailscale SSH exposes the executed remote command as process argv
+(`tailscaled be-child ssh --cmd=...`), so the rule-6 `pgrep -f "cargo|rustc|criterion|claude"`
+check matched its own invocation and a leftover `cargo --version` probe from setup, not a real
+build. Both runs proceeded with `--force` after confirming no genuine competing workload via
+`ps aux`/`top`.
+
+### Slice 1 — `keys_unsorted | map(.)` / `keys_unsorted | select(true)` (`wide` pattern)
+
+| Machine           | Query  | Size      | before (med) | after (med) | Δ median   |
+|-------------------|--------|-----------|--------------|-------------|------------|
+| Apple M4 Pro      | map(.) | **100mb** | 2983.6ms     | 2596.0ms    | **-13.0%** |
+| Apple M4 Pro      | map(.) | 10mb      | 290.5ms      | 255.4ms     | **-12.1%** |
+| Apple M4 Pro      | map(.) | 1mb       | 30.6ms       | 28.0ms      | **-8.6%**  |
+| Apple M4 Pro      | map(.) | 100kb     | 5.7ms        | 5.5ms       | -3.9%      |
+| Apple M4 Pro      | select | 100mb     | 2949.0ms     | 2982.2ms    | +1.1%      |
+| Apple M4 Pro      | select | 10mb      | 285.3ms      | 281.6ms     | -1.3%      |
+| Apple M4 Pro      | select | 1mb       | 29.5ms       | 29.7ms      | +0.7%      |
+| Apple M4 Pro      | select | 100kb     | 5.7ms        | 5.4ms       | -4.4%      |
+| AMD Ryzen 9 7950X | map(.) | **100mb** | 3957.7ms     | 2887.0ms    | **-27.1%** |
+| AMD Ryzen 9 7950X | map(.) | 10mb      | 405.0ms      | 294.2ms     | **-27.3%** |
+| AMD Ryzen 9 7950X | map(.) | 1mb       | 42.0ms       | 32.2ms      | **-23.2%** |
+| AMD Ryzen 9 7950X | map(.) | 100kb     | 5.3ms        | 4.5ms       | **-16.5%** |
+| AMD Ryzen 9 7950X | select | 100mb     | 3878.1ms     | 4111.6ms    | **+6.0%**  |
+| AMD Ryzen 9 7950X | select | 10mb      | 395.9ms      | 419.7ms     | **+6.0%**  |
+| AMD Ryzen 9 7950X | select | 1mb       | 41.3ms       | 44.1ms      | **+6.8%**  |
+| AMD Ryzen 9 7950X | select | 100kb     | 5.2ms        | 5.6ms       | **+6.7%**  |
+
+`map(.)`'s speedup **grows with size** on both machines (the algorithmic-term signature the plan
+called for) — 3.9%→13.0% on ARM, 16.5%→27.3% on x86_64. `select(true)` (no dedicated Slice 1 arm
+by design — see [`select`: no new code path](#select-no-new-code-path)) is flat within the
+control band on Apple M4 Pro, but a small, **flat-not-scaling** ~6-7% regression on AMD Ryzen 9
+7950X across all four sizes — see [Regression surfaced](#regression-surfaced-select-is-slower-on-x86_64) below.
+
+### Slice 2 — `map(.)` / `select(true)` (`arrays`, `users` patterns)
+
+| Machine           | Pattern | Query  | Size      | before (med) | after (med) | Δ median   |
+|-------------------|---------|--------|-----------|--------------|-------------|------------|
+| Apple M4 Pro      | arrays  | map(.) | **100mb** | 11133.7ms    | 6573.7ms    | **-41.0%** |
+| Apple M4 Pro      | arrays  | map(.) | 10mb      | 951.9ms      | 575.3ms     | **-39.6%** |
+| Apple M4 Pro      | arrays  | map(.) | 1mb       | 93.2ms       | 55.8ms      | **-40.2%** |
+| Apple M4 Pro      | arrays  | map(.) | 100kb     | 11.2ms       | 8.1ms       | **-28.0%** |
+| Apple M4 Pro      | arrays  | select | 100mb     | 4891.1ms     | 4932.6ms    | +0.8%      |
+| Apple M4 Pro      | arrays  | select | 10mb      | 403.5ms      | 404.3ms     | +0.2%      |
+| Apple M4 Pro      | arrays  | select | 1mb       | 40.3ms       | 39.6ms      | -1.8%      |
+| Apple M4 Pro      | arrays  | select | 100kb     | 6.4ms        | 6.5ms       | +1.3%      |
+| Apple M4 Pro      | users   | map(.) | **100mb** | 3218.3ms     | 1620.4ms    | **-49.7%** |
+| Apple M4 Pro      | users   | map(.) | 10mb      | 311.2ms      | 158.0ms     | **-49.2%** |
+| Apple M4 Pro      | users   | map(.) | 1mb       | 33.9ms       | 17.9ms      | **-47.3%** |
+| Apple M4 Pro      | users   | map(.) | 100kb     | 5.9ms        | 4.4ms       | **-26.6%** |
+| Apple M4 Pro      | users   | select | 100mb     | 993.1ms      | 1000.6ms    | +0.8%      |
+| Apple M4 Pro      | users   | select | 10mb      | 97.7ms       | 95.7ms      | -2.0%      |
+| Apple M4 Pro      | users   | select | 1mb       | 11.4ms       | 11.3ms      | -0.4%      |
+| Apple M4 Pro      | users   | select | 100kb     | 3.5ms        | 3.6ms       | +0.8%      |
+| AMD Ryzen 9 7950X | arrays  | map(.) | **100mb** | 15280.7ms    | 8295.7ms    | **-45.7%** |
+| AMD Ryzen 9 7950X | arrays  | map(.) | 10mb      | 1373.4ms     | 768.7ms     | **-44.0%** |
+| AMD Ryzen 9 7950X | arrays  | map(.) | 1mb       | 133.4ms      | 76.1ms      | **-43.0%** |
+| AMD Ryzen 9 7950X | arrays  | map(.) | 100kb     | 13.1ms       | 8.1ms       | **-38.2%** |
+| AMD Ryzen 9 7950X | arrays  | select | 100mb     | 4346.0ms     | 4455.3ms    | **+2.5%**  |
+| AMD Ryzen 9 7950X | arrays  | select | 10mb      | 391.4ms      | 401.1ms     | +2.5%      |
+| AMD Ryzen 9 7950X | arrays  | select | 1mb       | 38.4ms       | 38.8ms      | +1.0%      |
+| AMD Ryzen 9 7950X | arrays  | select | 100kb     | 4.9ms        | 5.0ms       | +1.2%      |
+| AMD Ryzen 9 7950X | users   | map(.) | **100mb** | 4693.0ms     | 2283.5ms    | **-51.3%** |
+| AMD Ryzen 9 7950X | users   | map(.) | 10mb      | 467.5ms      | 249.9ms     | **-46.5%** |
+| AMD Ryzen 9 7950X | users   | map(.) | 1mb       | 42.0ms       | 23.5ms      | **-44.1%** |
+| AMD Ryzen 9 7950X | users   | map(.) | 100kb     | 5.1ms        | 3.4ms       | **-34.3%** |
+| AMD Ryzen 9 7950X | users   | select | 100mb     | 1025.4ms     | 1045.7ms    | **+2.0%**  |
+| AMD Ryzen 9 7950X | users   | select | 10mb      | 104.3ms      | 105.0ms     | +0.7%      |
+| AMD Ryzen 9 7950X | users   | select | 1mb       | 11.2ms       | 11.5ms      | **+2.1%**  |
+| AMD Ryzen 9 7950X | users   | select | 100kb     | 2.1ms        | 2.2ms       | +1.6%      |
+
+Slice 2's `map(.)` win is larger than Slice 1's (up to -51.3% vs -27.3%) and shows the same
+growing-with-size shape, consistent with #686's finding that plain containers carry the dominant
+75-95% share of the original eager-fallback cost. `select(true)` again shows the same
+platform split: flat on Apple M4 Pro (within the -2.7%..+1.0% control band), a small but
+consistently positive ~1-2.5% drift on AMD Ryzen 9 7950X — smaller than Slice 1's ~6-7% but the
+same direction, discussed below.
+
+### Regression surfaced: `select` is slower on x86_64
+
+Both slices show `select(true)` getting **consistently slower on AMD Ryzen 9 7950X** after #740
+(+6.0-6.8% for `keys_unsorted | select(true)`, +0.7-2.5% for plain `select(true)`) while Apple M4
+Pro shows no such effect (all deltas within the control band) — and the effect is **flat across
+sizes**, not growing, unlike every `map(.)` result above. That flat shape matches a small
+per-call constant-factor cost (plausibly the new `LazySeq` plumbing `select` now flows through
+before falling back to its single-pass materialize, per [`select`: no new code
+path](#select-no-new-code-path)) rather than an algorithmic regression. Confirmed reproducible:
+identical magnitude measured independently against both `HEAD` and the isolated `6ce12be6`
+binary. Per this issue's non-goals, no fix is attempted here — filed as
+[#789](https://github.com/rust-works/succinctly/issues/789) to investigate.
+
+### Output identity
+
+- `ab-cli.py` before-vs-after digest gate: 48 configurations (Slice 1: 8+8, Slice 2: 16+16
+  across both machines), **0 differences**.
+- `dev bench jq` vs. system `jq`: 48 configurations, **0 differences** (system `jq` 1.7.1 on the
+  Apple M4 Pro node, 1.6 on the AMD Ryzen 9 7950X node — each machine's installed version).
+
+### Memory (supplementary — vs. system `jq`, single run per binary, not interleaved)
+
+Collected via `dev bench jq`'s built-in RSS measurement (`/usr/bin/time`) for context, since
+`ab-cli.py` only measures wall time. Not interleaved between the two `succinctly` binaries, so
+treated as directional rather than a load-bearing timing claim (memory is far less sensitive to
+thermal drift than wall-clock, per the plan's own reasoning for this step). Full per-pattern
+tables are in `slice1-{arm,x86}.md` / `slice2-{arm,x86}.md` alongside the raw run data; summary:
+
+- `map(.)`'s memory ratio (succinctly / jq) **improved substantially** from #686's original
+  spike numbers (up to 13.48x at 100mb) to roughly parity-to-2x across both slices and machines
+  (e.g. Slice 1 `wide`/100mb: 0.50x on ARM, 1.04x on x86_64; Slice 2 `users`/100mb: 1.97x on ARM,
+  1.97x on x86_64) — consistent with replacing the old materialize-reserialize-reindex fallback.
+- `select(true)` on plain containers (Slice 2, native single-value arm) uses **far less** memory
+  than jq at 10-100mb (0.04x-0.29x on both machines, near parity at 1mb) since it never
+  materializes the whole container. `keys_unsorted | select(true)` (Slice 1, still the eager
+  fallback) uses **more** memory than jq (1.25x-2.34x), unchanged in kind from #686's original
+  finding for that path.
+
+### Reproducing
+
+```bash
+# two binaries, isolating PR #740's diff specifically (not current HEAD):
+git archive --format=tar.gz -o succ-before-src.tar.gz 588a4c5d  # parent of #740's merge
+git archive --format=tar.gz -o succ-after-src.tar.gz 6ce12be6   # the #740 merge commit itself
+# build each with: cargo build --release --features cli
+
+python3 scripts/ab-cli.py --before ./succ-before --after ./succ-after --tool jq \
+  --files wide/100kb.json wide/1mb.json wide/10mb.json wide/100mb.json \
+  --queries "keys_unsorted | map(.)" "keys_unsorted | select(true)" --reps 7
+
+./succ-after dev bench jq --data-dir corpus --patterns wide --sizes 100kb,1mb,10mb,100mb \
+  --queries keys_unsorted_map,keys_unsorted_select --binary ./succ-after \
+  --output slice1.jsonl --markdown slice1.md
+```
 
 ## Follow-up issues
 

--- a/scripts/ab-cli.py
+++ b/scripts/ab-cli.py
@@ -103,7 +103,9 @@ def run_text(cmd):
 
 
 def command(binary, args, query, path):
-    return [binary, args.tool, "-o", args.output, "-I0", query, path]
+    if args.tool == "yq":
+        return [binary, args.tool, "-o", args.output, "-I0", query, path]
+    return [binary, args.tool, query, path]
 
 
 def digest(binary, args, query, path):


### PR DESCRIPTION
## Summary

- Closes #758: runs the interleaved A/B benchmarks that #724/#725's "Measurement required before merge" sections called for, but that merged (PR #740) without being run.
- Fixes `scripts/ab-cli.py`'s `--tool jq` support — it hardcoded `yq`-only `-o`/`-I0` flags, so `--tool jq` failed outright. Needed to drive this measurement at all.
- Records full before/after tables (both slices, both architectures) in `docs/plan/jq-lazy-map-select.md` § "Measurement results (2026-08-11, #758)".

## Method

Interleaved A/B (7 reps, `--control` noise floor established first per machine), two binaries built via `git archive` at `588a4c5d` (parent of PR #740's merge) and `6ce12be6` (the #740 merge commit itself — deliberately not current `HEAD`, which has ~10 further `src/jq` commits since #740 that would have contaminated attribution). Measured on Apple M4 Pro and AMD Ryzen 9 7950X, `wide`/`arrays`/`users` patterns at 100kb/1mb/10mb/100mb, gated on output identity two ways (`ab-cli.py`'s before-vs-after digest gate and `dev bench jq`'s gate against system `jq`).

## Results

- `map(.)` shows the growing-with-size speedup the design predicted: -3.9%→-13.0% (Slice 1, ARM) up to -51.3% (Slice 2, x86_64, 100mb).
- **0 identity differences** across 96 configurations.
- Surfaced a real, small regression: `select(true)` runs ~5-8% (Slice 1) / ~1-2.5% (Slice 2) slower on x86_64 after #740, flat across all sizes, absent on ARM. Filed as #789 per this issue's non-goal against fixing it here — measurement only.

## Test plan

- [x] `ab-cli.py --control` on both machines confirms clean noise floor before any comparison
- [x] `ab-cli.py` before-vs-after identity gate: 0 differences (48 configurations)
- [x] `dev bench jq` vs system `jq` identity gate: 0 differences (48 configurations)
- [x] Both architectures measured and named per machine
- [x] Scaling curve reported (4 sizes), not a single ratio
- [x] Slice 1 and Slice 2 kept in separate tables
- [x] Slice 2 measured against `arrays`/`users` patterns, not just `wide`