### PR TITLE
fix(cli): stop yq --color from collapsing duplicate mapping keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `column`) resolve against the extracted YAML block's own coordinates,
   not the original file.
 
+- **`yq -C`/`--color` still collapsed duplicate mapping keys** (#748), the
+  gap #733's own commit message flagged as a follow-up: `can_stream_pretty`
+  (`yq_runner.rs`) excluded `use_color`, so any identity/navigation query
+  under `-C` fell through to the `OwnedValue::Object`/`IndexMap` DOM path and
+  lost all but the last occurrence of a repeated key — `yq -C '.'` on
+  `a: 1\na: 2` printed only `a: 2` (with color).
+
+  Unlike #733, this didn't need the cursor/lazy streamers taught anything
+  new: `colorize_yaml`/`output::colorize_json` are pure text-level
+  re-lexers over an already fully-rendered string, unrelated to *how* that
+  string was produced. Fixed by buffering the still-duplicate-key-safe
+  cursor-streamed output into a `String` (a new `ColorSink` enum implementing
+  `core::fmt::Write`, alongside `stream_maybe_colored`) and running the
+  buffer through the existing colorizers unmodified, instead of threading a
+  color parameter through the ~49 `core::fmt::Write`-generic functions
+  `IndentSpec`/`sort_keys` were threaded through for #733 — six independent
+  recursive writers with no shared "write a key"/"write punctuation"
+  primitive to hang color onto, plus `ColorScheme` living in the `std`-only
+  binary crate while the streamers live in the `no_std` library crate, made
+  that shape of fix considerably more invasive here.
+
+  `can_stream_pretty` itself is unchanged and still excludes color for
+  `--slurp`'s and `--inplace`'s fast paths, which don't get the new
+  buffer-and-colorize plumbing — an explicit, narrower scope limit than
+  #733 left, not a silent gap (`--inplace` already forces color off on its
+  own DOM branch regardless, so `-i -C` only loses duplicate keys in the
+  file it writes, not color itself).
+
+  Side effect: compact output (`-I0`) already took the fast path regardless
+  of color (predating this fix), so `-C -I0` silently produced uncolored
+  output; the buffer-and-colorize decision keys only on `use_color`, so
+  compact mode is now colorized too.
+
 - **`gmtime`, `mktime`, and `strptime` raised the right exit code but the
   wrong message on bad input** (#761): `gmtime`/`localtime` on a non-number
   reported the generic `"math function requires number"` (shared with

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -47,6 +47,51 @@ impl<W: Write> core::fmt::Write for FmtWriter<W> {
     }
 }
 
+/// Either a direct passthrough to the real output writer, or an in-memory
+/// buffer collecting output to be colorized afterward. `colorize_yaml`/
+/// `output::colorize_json` are pure text-level re-lexers over an already
+/// fully-rendered string, so buffering the duplicate-key-safe cursor
+/// streamer's output and running it through them unmodified reuses that
+/// existing coloring code without teaching the streamers anything about
+/// ANSI codes (#748).
+enum ColorSink<'a, W: Write> {
+    Buffered(String),
+    Direct(FmtWriter<&'a mut W>),
+}
+
+impl<W: Write> core::fmt::Write for ColorSink<'_, W> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        match self {
+            ColorSink::Buffered(buf) => buf.write_str(s),
+            ColorSink::Direct(w) => w.write_str(s),
+        }
+    }
+}
+
+/// Streams through `render` directly when `use_color` is false. When true,
+/// renders into a buffer instead (still via the duplicate-key-safe cursor
+/// streamer passed in as `render`), then runs the buffer through `colorize`
+/// before writing the colorized result (#748).
+fn stream_maybe_colored<W: Write, T>(
+    writer: &mut W,
+    use_color: bool,
+    colorize: impl FnOnce(&str) -> String,
+    render: impl FnOnce(&mut ColorSink<'_, W>) -> Result<T, core::fmt::Error>,
+) -> anyhow::Result<T> {
+    if use_color {
+        let mut sink = ColorSink::Buffered(String::new());
+        let value = render(&mut sink).map_err(|_| anyhow::anyhow!("Write error"))?;
+        let ColorSink::Buffered(buf) = sink else {
+            unreachable!("stream_maybe_colored always constructs ColorSink::Buffered here")
+        };
+        write!(writer, "{}", colorize(&buf))?;
+        Ok(value)
+    } else {
+        let mut sink = ColorSink::Direct(FmtWriter(writer));
+        render(&mut sink).map_err(|_| anyhow::anyhow!("Write error"))
+    }
+}
+
 /// Evaluation context for passing variables to the jq evaluator.
 #[derive(Debug, Default)]
 pub struct EvalContext {
@@ -1897,12 +1942,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // Supports both JSON and YAML output formats.
     let is_identity = matches!(program.expr, Expr::Identity);
     let is_m2_streamable = can_use_m2_streaming(&program.expr);
-    // Color and pretty_print aren't implemented by the cursor streamers, so
-    // they still fall back to the DOM path, unchanged, rather than silently
-    // ignoring the flag the way compact mode already does today. `sort_keys`
-    // and `tab` (#733) are now implemented directly by the cursor/lazy
-    // streamers — see `IndentSpec` and the `sort_keys` parameter threaded
-    // through `DocumentCursor::stream_json`/`stream_yaml` and `GenericResult::
+    // pretty_print isn't implemented by the cursor streamers, so it still
+    // falls back to the DOM path, unchanged, rather than silently ignoring
+    // the flag the way compact mode already does today. `sort_keys` and
+    // `tab` (#733) are implemented directly by the cursor/lazy streamers —
+    // see `IndentSpec` and the `sort_keys` parameter threaded through
+    // `DocumentCursor::stream_json`/`stream_yaml` and `GenericResult::
     // stream_json`/`stream_yaml` — so routing them through the DOM would
     // needlessly reintroduce #442's duplicate-mapping-key collapse
     // (`OwnedValue::Object`'s `IndexMap` cannot represent duplicate keys).
@@ -1910,9 +1955,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // the default (style preservation doesn't exist yet — #707); routing it
     // through DOM now gives it a single seam to implement real
     // style-clearing against once #707 lands (#705).
+    //
+    // `can_stream_pretty` still excludes color: it also gates `--slurp`'s
+    // and `--inplace`'s fast paths below, neither of which has the
+    // buffer-and-colorize plumbing `stream_maybe_colored` adds for the
+    // plain stdout path. `can_stream_pretty_or_colored` is the same
+    // condition minus that exclusion, used only by `can_json_fast_path`/
+    // `can_yaml_fast_path`: color, when requested, is handled by
+    // `stream_maybe_colored` buffering the (still duplicate-key-safe)
+    // cursor-streamed output and running it through the existing
+    // `colorize_yaml`/`colorize_json` post-processors, rather than falling
+    // back to the DOM/IndexMap path that would collapse duplicate mapping
+    // keys (#442, #748).
     let can_stream_pretty = !output_config.use_color && !args.pretty_print;
+    let can_stream_pretty_or_colored = !args.pretty_print;
     let can_json_fast_path = is_m2_streamable
-        && (output_config.compact || (can_stream_pretty && !args.ascii_output))
+        && (output_config.compact || (can_stream_pretty_or_colored && !args.ascii_output))
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
         && !args.raw_input
@@ -1923,7 +1981,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && !args.eval_all
         && context.named.is_empty();
     let can_yaml_fast_path = is_m2_streamable
-        && (output_config.compact || can_stream_pretty)
+        && (output_config.compact || can_stream_pretty_or_colored)
         && output_config.output_format == OutputFormat::Yaml
         && !args.null_input
         && !args.raw_input
@@ -1966,8 +2024,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // `is_m2_streamable` set), since a non-trivial filter over the slurped
     // array needs real evaluation. `-o json --slurp` still uses the slow
     // DOM path below — an explicit, documented scope limit rather than a
-    // silent gap, matching color already being excluded from the gates
-    // above.
+    // silent gap. Also still excludes color (`can_stream_pretty`, not
+    // `can_stream_pretty_or_colored`) — buffer-and-colorize support (#748)
+    // wasn't added to `stream_yaml_sequence`, so `--slurp --color` stays on
+    // the DOM path, unchanged.
     let can_slurp_fast_path = is_identity
         && can_stream_pretty
         && output_config.output_format == OutputFormat::Yaml
@@ -2024,9 +2084,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // redisplayed as itself - its own trailing comment,
                         // if any, must be kept (#710).
                         emit_yaml_doc_separator($writer, $doc_streamed, true)?;
-                        $cursor
-                            .stream_yaml_as_document(&mut FmtWriter($writer), yaml_indent, sort_keys)
-                            .map_err(|_| anyhow::anyhow!("Write error"))?;
+                        stream_maybe_colored($writer, output_config.use_color, colorize_yaml, |out| {
+                            $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys)
+                        })?;
                         writeln!($writer)?;
                         // Streaming skips evaluation, so inspect the document
                         // value directly to keep `-e` falsy tracking (#178).
@@ -2043,11 +2103,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             && !matches!(&result, GenericResult::ManyCursor(cs) if cs.is_empty())
                             && !matches!(&result, GenericResult::ManyOwned(vs) if vs.is_empty());
                         emit_yaml_doc_separator($writer, $doc_streamed, will_output)?;
-                        let stats = result
-                            .stream_yaml(&mut FmtWriter($writer), yaml_indent, sort_keys, |w| {
-                                w.write_str("\n")
-                            })
-                            .map_err(|_| anyhow::anyhow!("Write error"))?;
+                        let stats =
+                            stream_maybe_colored($writer, output_config.use_color, colorize_yaml, |out| {
+                                result.stream_yaml(out, yaml_indent, sort_keys, |w| w.write_str("\n"))
+                            })?;
                         any_truthy |= stats.any_truthy;
                         // Streaming never writes a diagnostic to stdout; it hands
                         // the error back here so it reaches stderr and fails the run (#355).
@@ -2059,9 +2118,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // M2 path: JSON output streaming
                     if is_identity {
                         // P9 path: stream directly without evaluation
-                        $cursor
-                            .stream_json(&mut FmtWriter($writer), json_indent, sort_keys)
-                            .map_err(|_| anyhow::anyhow!("Write error"))?;
+                        stream_maybe_colored(
+                            $writer,
+                            output_config.use_color,
+                            |s| output::colorize_json(s, &ColorScheme::default()),
+                            |out| $cursor.stream_json(out, json_indent, sort_keys),
+                        )?;
                         writeln!($writer)?;
                         // Streaming skips evaluation, so inspect the document
                         // value directly to keep `-e` falsy tracking (#178).
@@ -2071,11 +2133,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     } else {
                         // M2 path: evaluate and stream results
                         let result = eval_with_cursor_using::<YqSemantics, _>(&program.expr, $cursor);
-                        let stats = result
-                            .stream_json(&mut FmtWriter($writer), json_indent, sort_keys, |w| {
-                                w.write_str("\n")
-                            })
-                            .map_err(|_| anyhow::anyhow!("Write error"))?;
+                        let stats = stream_maybe_colored(
+                            $writer,
+                            output_config.use_color,
+                            |s| output::colorize_json(s, &ColorScheme::default()),
+                            |out| result.stream_json(out, json_indent, sort_keys, |w| w.write_str("\n")),
+                        )?;
                         any_truthy |= stats.any_truthy;
                         // Streaming never writes a diagnostic to stdout; it hands
                         // the error back here so it reaches stderr and fails the run (#355).
@@ -2134,19 +2197,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         if is_identity {
                             // P9 path for identity on single doc
                             if can_yaml_fast_path {
-                                root.stream_yaml_document(
-                                    &mut FmtWriter(&mut writer),
-                                    yaml_indent,
-                                    sort_keys,
-                                )
-                                .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                stream_maybe_colored(
+                                    &mut writer,
+                                    output_config.use_color,
+                                    colorize_yaml,
+                                    |out| root.stream_yaml_document(out, yaml_indent, sort_keys),
+                                )?;
                             } else {
-                                root.stream_json_document(
-                                    &mut FmtWriter(&mut writer),
-                                    json_indent,
-                                    sort_keys,
-                                )
-                                .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                stream_maybe_colored(
+                                    &mut writer,
+                                    output_config.use_color,
+                                    |s| output::colorize_json(s, &ColorScheme::default()),
+                                    |out| root.stream_json_document(out, json_indent, sort_keys),
+                                )?;
                             }
                             writeln!(writer)?;
                             // `root` is the virtual document sequence; falsiness
@@ -2214,19 +2277,23 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             if is_identity {
                                 // P9 path for identity on single doc
                                 if can_yaml_fast_path {
-                                    root.stream_yaml_document(
-                                        &mut FmtWriter(&mut writer),
-                                        yaml_indent,
-                                        sort_keys,
-                                    )
-                                    .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                    stream_maybe_colored(
+                                        &mut writer,
+                                        output_config.use_color,
+                                        colorize_yaml,
+                                        |out| {
+                                            root.stream_yaml_document(out, yaml_indent, sort_keys)
+                                        },
+                                    )?;
                                 } else {
-                                    root.stream_json_document(
-                                        &mut FmtWriter(&mut writer),
-                                        json_indent,
-                                        sort_keys,
-                                    )
-                                    .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                    stream_maybe_colored(
+                                        &mut writer,
+                                        output_config.use_color,
+                                        |s| output::colorize_json(s, &ColorScheme::default()),
+                                        |out| {
+                                            root.stream_json_document(out, json_indent, sort_keys)
+                                        },
+                                    )?;
                                 }
                                 writeln!(writer)?;
                                 // `root` is the virtual document sequence; falsiness

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3562,6 +3562,95 @@ fn test_colorized_yaml_output_sequence_dash() -> Result<()> {
     Ok(())
 }
 
+/// #748: `-C`/`--color` excluded identity/navigation queries from the M2
+/// cursor-streaming fast path (`can_stream_pretty` in `yq_runner.rs`),
+/// forcing them through the `OwnedValue` DOM (`IndexMap`-backed), which
+/// silently collapsed duplicate keys — the same bug class #442 fixed for the
+/// unadorned fast path and #733 fixed for `-S`/`--tab`. Unlike #733, color
+/// doesn't need the streamers taught anything new: `colorize_yaml`/
+/// `colorize_json` are pure text-level re-lexers, so the fix buffers the
+/// still-duplicate-key-safe cursor-streamed output and colorizes the buffer,
+/// reusing the existing colorizers unmodified.
+#[test]
+fn test_duplicate_mapping_key_survives_color_yaml_output() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["-C"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[36ma\u{1b}[0m: 1\n\u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
+    );
+
+    Ok(())
+}
+
+/// Same as [`test_duplicate_mapping_key_survives_color_yaml_output`], for
+/// `-o json`.
+#[test]
+fn test_duplicate_mapping_key_survives_color_json_output() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["-C", "-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[1;39m{\u{1b}[0m\n  \u{1b}[1;34m\"a\"\u{1b}[0m: \u{1b}[0;39m1\u{1b}[0m,\n  \u{1b}[1;34m\"a\"\u{1b}[0m: \u{1b}[0;39m2\u{1b}[0m\n\u{1b}[1;39m}\u{1b}[0m\n"
+    );
+
+    Ok(())
+}
+
+/// Compact output (`-I0`) already took the fast path regardless of color
+/// (`can_json_fast_path`/`can_yaml_fast_path`'s `output_config.compact ||`
+/// short-circuit predates #748), which meant `-C -I0` silently produced
+/// uncolored output — a separate quirk from the duplicate-key collapse this
+/// issue is about, but resolved as a side effect since #748's fix keys the
+/// buffer-and-colorize decision only on `use_color`, not on which condition
+/// let the fast path through. Guards both the color and duplicate-key fixes
+/// together in compact mode, YAML and JSON.
+#[test]
+fn test_duplicate_mapping_key_survives_color_compact() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["-C", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[36ma\u{1b}[0m: 1\n\u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
+    );
+
+    let (json, code) = run_yq_stdin(".", yaml, &["-C", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        json,
+        "\u{1b}[1;39m{\u{1b}[0m\u{1b}[1;34m\"a\"\u{1b}[0m:\u{1b}[0;39m1\u{1b}[0m,\u{1b}[1;34m\"a\"\u{1b}[0m:\u{1b}[0;39m2\u{1b}[0m\u{1b}[1;39m}\u{1b}[0m\n"
+    );
+
+    Ok(())
+}
+
+/// `stream_maybe_colored` (#748) buffers a whole `stream_yaml`/`stream_json`
+/// call's output — which, for an iterating query, can be several
+/// concatenated top-level documents, not just one — before handing it to
+/// `colorize_yaml`/`colorize_json`. Neither colorizer is exercised on
+/// multi-document buffers anywhere else (the DOM path colorizes one value
+/// per call), so this guards that the re-lexers still track state correctly
+/// across a document boundary instead of only ever seeing a single value.
+#[test]
+fn test_color_output_survives_iteration_with_duplicate_keys() -> Result<()> {
+    let yaml = "- a: 1\n  a: 2\n- b: 3\n";
+
+    let (output, code) = run_yq_stdin(".[]", yaml, &["-C"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[36ma\u{1b}[0m: 1\n\u{1b}[36ma\u{1b}[0m: 2\n\u{1b}[36mb\u{1b}[0m: 3\n\u{1b}[0m"
+    );
+
+    Ok(())
+}
+
 // ============================================================================
 // Special float values (NaN / Infinity)
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3669,6 +3669,46 @@ fn test_color_output_survives_iteration_with_duplicate_keys_json() -> Result<()>
     Ok(())
 }
 
+/// `--slurp --color` intentionally still routes through the `OwnedValue`/
+/// `IndexMap` DOM path — `can_slurp_fast_path` only checks `can_stream_pretty`,
+/// not `can_stream_pretty_or_colored`, since `stream_yaml_sequence` never got
+/// `stream_maybe_colored` support (a documented scope limit, not a silent
+/// gap — #748). That means `--slurp -C` still collapses duplicate mapping
+/// keys within each slurped document, unlike plain `--slurp` (see
+/// [`test_duplicate_mapping_key_survives_slurp`]). Exercises `output_value`'s
+/// `config.use_color` YAML branch, which #748's M2-fast-path color fix made
+/// unreachable from every other angle.
+#[test]
+fn test_slurp_color_output_yaml() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["--slurp", "-C"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[33m-\u{1b}[0m\n  \u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
+    );
+
+    Ok(())
+}
+
+/// Same as [`test_slurp_color_output_yaml`], for `-o json`: exercises
+/// `output_value`'s `config.use_color` JSON branch, the `--slurp` DOM-path
+/// counterpart to [`test_slurp_color_output_yaml`].
+#[test]
+fn test_slurp_color_output_json() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["--slurp", "-C", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[1;39m[\u{1b}[0m\u{1b}[1;39m{\u{1b}[0m\u{1b}[1;34m\"a\"\u{1b}[0m:\u{1b}[0;39m2\u{1b}[0m\u{1b}[1;39m}\u{1b}[0m\u{1b}[1;39m]\u{1b}[0m\n"
+    );
+
+    Ok(())
+}
+
 // ============================================================================
 // Special float values (NaN / Infinity)
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3651,6 +3651,24 @@ fn test_color_output_survives_iteration_with_duplicate_keys() -> Result<()> {
     Ok(())
 }
 
+/// Same as [`test_color_output_survives_iteration_with_duplicate_keys`], for
+/// `-o json`: the `stream_maybe_colored` call in the non-identity JSON
+/// branch of `stream_cursor!` (`result.stream_json`, used for anything other
+/// than plain `.`) is otherwise only exercised by identity queries.
+#[test]
+fn test_color_output_survives_iteration_with_duplicate_keys_json() -> Result<()> {
+    let yaml = "- a: 1\n  a: 2\n- b: 3\n";
+
+    let (output, code) = run_yq_stdin(".[]", yaml, &["-C", "-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[1;39m{\u{1b}[0m\n  \u{1b}[1;34m\"a\"\u{1b}[0m: \u{1b}[0;39m1\u{1b}[0m,\n  \u{1b}[1;34m\"a\"\u{1b}[0m: \u{1b}[0;39m2\u{1b}[0m\n\u{1b}[1;39m}\u{1b}[0m\n\u{1b}[1;39m{\u{1b}[0m\n  \u{1b}[1;34m\"b\"\u{1b}[0m: \u{1b}[0;39m3\u{1b}[0m\n\u{1b}[1;39m}\u{1b}[0m\n"
+    );
+
+    Ok(())
+}
+
 // ============================================================================
 // Special float values (NaN / Infinity)
 // ============================================================================


### PR DESCRIPTION
## Summary

- `yq -C`/`--color` excluded `use_color` from the M2 cursor-streaming fast path (`can_stream_pretty` in `yq_runner.rs`), so any query combined with `--color` fell through to the `OwnedValue`/`IndexMap` DOM path, which cannot represent duplicate mapping keys — the same bug class #442 fixed for the default path and #733 fixed for `-S`/`--tab`. #733's own commit flagged this exact gap as a follow-up; this closes it.
- Unlike #733, color doesn't need the cursor/lazy streamers taught anything new: `colorize_yaml`/`output::colorize_json` are pure text-level re-lexers over an already-rendered string. Adds a `ColorSink` enum + `stream_maybe_colored` helper that buffers the still-duplicate-key-safe cursor-streamed output into a `String` and runs it through the existing colorizers unmodified, instead of threading a color parameter through the ~49 `core::fmt::Write`-generic streaming functions #733's `IndentSpec`/`sort_keys` went through.
- `--slurp --color` and `--inplace --color` keep routing through the DOM path unchanged — a documented scope limit, not a silent gap.
- Side effect: `-C -I0` (compact + color), which silently dropped color before this fix, is now colorized too, since the buffer-and-colorize decision keys only on `use_color`.

Fixes #748

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli` — full suite, 0 failures (2222+ tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Manual repro: `printf 'a: 1\na: 2\n' | succinctly yq -C '.'` now prints both `a: 1` and `a: 2`, each colorized
- [x] New tests in `tests/yq_cli_tests.rs` covering YAML/JSON pretty output, compact mode, and multi-value iteration with duplicate keys under `-C`