### PR TITLE
fix(jq): correct s/m/p regex flag mapping to match jq's oniguruma semantics

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6054,17 +6054,38 @@ fn build_regex(pattern: &str, flags: Option<&str>) -> Result<regex::Regex, EvalE
 
     // Apply flags
     if let Some(flags) = flags {
-        let mut prefix = String::from("(?");
+        let mut case_insensitive = false;
+        let mut extended = false;
+        let mut dot_matches_newline = false; // jq's `m`/`p` -> Rust regex's `s`
         for c in flags.chars() {
             match c {
-                'i' => prefix.push('i'), // case insensitive
-                'x' => prefix.push('x'), // extended mode (ignore whitespace)
-                's' => prefix.push('s'), // single-line mode (. matches newline)
-                'm' => prefix.push('m'), // multi-line mode
-                'g' => {}                // global - handled at call site
-                'p' => {}                // PCRE mode - not fully supported
+                'i' => case_insensitive = true, // case insensitive
+                'x' => extended = true,         // extended mode (ignore whitespace)
+                // jq's `s` (oniguruma ONIG_OPTION_SINGLELINE) only affects
+                // ^/$ anchoring, which is already the default under jq's
+                // Perl-style syntax (and Rust regex's un-flagged default) —
+                // no native flag needed.
+                's' => {}
+                // jq's `m` (oniguruma ONIG_OPTION_MULTILINE) means dot
+                // matches newline ("dotall" in Perl/PCRE terms) — Rust
+                // regex's native `s` flag.
+                'm' => dot_matches_newline = true,
+                // `p` enables both s and m; s is a no-op here, so p reduces
+                // to the same effect as m.
+                'p' => dot_matches_newline = true,
+                'g' => {} // global - handled at call site
                 _ => {}
             }
+        }
+        let mut prefix = String::from("(?");
+        if case_insensitive {
+            prefix.push('i');
+        }
+        if extended {
+            prefix.push('x');
+        }
+        if dot_matches_newline {
+            prefix.push('s');
         }
         if prefix.len() > 2 {
             prefix.push(')');
@@ -24263,6 +24284,32 @@ mod tests {
         query!(br#""abc""#, r#"test("[0-9]+")"#,
             QueryResult::Owned(OwnedValue::Bool(b)) => {
                 assert!(!b);
+            }
+        );
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
+    fn test_regex_flags_s_m_p() {
+        // The #727 repro: jq's `s` (single-line mode) leaves dot NOT
+        // matching newline.
+        query!(br#""a\nb""#, r#"test("a.b";"s")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(!b);
+            }
+        );
+
+        // jq's `m` (multi-line mode) makes dot match newline.
+        query!(br#""a\nb""#, r#"test("a.b";"m")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b);
+            }
+        );
+
+        // jq's `p` enables both s and m; dot still matches newline.
+        query!(br#""a\nb""#, r#"test("a.b";"p")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b);
             }
         );
     }

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -119,9 +119,6 @@
 # tests against the pinned jq oracle surfaced four distinct bugs rather than
 # mere gaps. Each below is filed as its own issue with the verified
 # jq-vs-succinctly repro already in the issue body.
-regex_test_s_single_line_dot   regex-flags   jq's s/m/p flags are inverted vs succinctly's — #727
-regex_test_m_multiline_dot     regex-flags   jq's s/m/p flags are inverted vs succinctly's — #727
-regex_test_p_both_modes        regex-flags   jq's s/m/p flags are inverted vs succinctly's — #727
 regex_sub_g_global_replace     regex-flags   sub(...;...;"g") never does a global replace — #728
 regex_match_g_streams          regex-flags   match(...;"g") returns one array, not a stream — #729
 regex_match_g_zero_width       regex-flags   match(...;"g") doesn't stream and misses the trailing zero-width match — #729


### PR DESCRIPTION
## Summary

- jq's `s`/`m`/`p` regex flags were passed straight through to Rust regex's own native `s`/`m` inline flags, which mean the opposite pairing: jq's `s` (anchor-only, oniguruma `ONIG_OPTION_SINGLELINE`) landed on Rust's dotall flag, jq's `m` (dot matches newline) landed on Rust's per-line-anchor flag, and `p` was a complete no-op.
- `build_regex` now maps jq's `s` to nothing (verified to already be the default under jq's Perl-style syntax) and `m`/`p` to Rust regex's native `s` (dotall).
- Added a unit test (`test_regex_flags_s_m_p`) and unpinned the 3 golden known-failures this fixes (`regex_test_s_single_line_dot`, `regex_test_m_multiline_dot`, `regex_test_p_both_modes`).
- While verifying jq's default anchor behavior empirically, found a separate, unrelated divergence (jq's `$`/`^` get a Perl-style trailing-newline exception even with no flags) — filed as #799, explicitly out of scope here.

Fixes #727

## Test plan

- [x] `cargo test --features cli,regex jq_golden_conformance` — passes, manifest matches actual failures (harness would fail loudly if the fix were wrong)
- [x] `cargo test --features cli,regex test_regex --lib` — all 10 regex unit tests pass, including the new one
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `./scripts/sync-jq-golden.sh --check` — no golden drift (412 goldens up to date)
- [x] Manually re-verified the issue's exact repro against the built binary: `test("a.b";"s")` → `false`, `test("a.b";"m")` → `true`, `test("a.b";"p")` → `true` (all match real jq)