### PR TITLE
docs: add ADR-0017 on YAML presentation-metadata side-trees

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -24,25 +24,26 @@ by Michael Nygard.
 
 ## Inventory
 
-| ADR                     | Status      | Date       | Title                                                    |
-|-------------------------|-------------|------------|-----------------------------------------------------------|
-| [ADR-0000](adr-0000.md) | ✅ Accepted | 2026-07-12 | Use Architecture Decision Records                        |
-| [ADR-0001](adr-0001.md) | ✅ Accepted | 2026-07-12 | Semi-Indexing over DOM Parsing                           |
-| [ADR-0002](adr-0002.md) | ✅ Accepted | 2026-07-12 | Table-Driven PFSM as the Portable JSON Parser            |
-| [ADR-0003](adr-0003.md) | ✅ Accepted | 2026-07-12 | Oracle Parser for YAML                                   |
-| [ADR-0004](adr-0004.md) | ✅ Accepted | 2026-07-12 | Reject Software Prefetching for Large YAML Files (P2.6)  |
-| [ADR-0005](adr-0005.md) | ✅ Accepted | 2026-07-12 | Reject SIMD Threshold Tuning (P2.8)                      |
-| [ADR-0006](adr-0006.md) | ✅ Accepted | 2026-07-12 | Reject Branchless Character Classification (P3)          |
-| [ADR-0007](adr-0007.md) | ✅ Accepted | 2026-07-12 | Reject the Flow-Collection SIMD Fast Path (P5)           |
-| [ADR-0008](adr-0008.md) | ✅ Accepted | 2026-07-12 | Reject BMI2 Quote-Indexing for YAML (P6)                 |
-| [ADR-0009](adr-0009.md) | ✅ Accepted | 2026-07-12 | Reject a Parse-Time Newline Index (P7)                   |
-| [ADR-0010](adr-0010.md) | ✅ Accepted | 2026-07-12 | Reject AVX-512 SIMD Variants (P8)                        |
-| [ADR-0011](adr-0011.md) | ✅ Accepted | 2026-07-15 | Custom Succinct Structures over Existing Rust Crates     |
-| [ADR-0012](adr-0012.md) | ✅ Accepted | 2026-07-25 | Elias-Fano Line Index over a Dense Bitmap                |
-| [ADR-0013](adr-0013.md) | ✅ Accepted | 2026-07-25 | Reject the SIMD Chunk-Scanner JSON Validator (#130)      |
-| [ADR-0014](adr-0014.md) | ✅ Accepted | 2026-08-03 | Reject Consolidating This Crate's Rank Implementations   |
-| [ADR-0015](adr-0015.md) | ✅ Accepted | 2026-08-05 | Keep BitVec, RankDirectory, and SelectIndex As-Is        |
-| [ADR-0016](adr-0016.md) | ✅ Accepted | 2026-08-08 | Reject SIMD Escape Scanning for jq Format Functions      |
+| ADR                     | Status     | Date       | Title                                                         |
+|-------------------------|------------|------------|---------------------------------------------------------------|
+| [ADR-0000](adr-0000.md) | ✅ Accepted | 2026-07-12 | Use Architecture Decision Records                             |
+| [ADR-0001](adr-0001.md) | ✅ Accepted | 2026-07-12 | Semi-Indexing over DOM Parsing                                |
+| [ADR-0002](adr-0002.md) | ✅ Accepted | 2026-07-12 | Table-Driven PFSM as the Portable JSON Parser                 |
+| [ADR-0003](adr-0003.md) | ✅ Accepted | 2026-07-12 | Oracle Parser for YAML                                        |
+| [ADR-0004](adr-0004.md) | ✅ Accepted | 2026-07-12 | Reject Software Prefetching for Large YAML Files (P2.6)       |
+| [ADR-0005](adr-0005.md) | ✅ Accepted | 2026-07-12 | Reject SIMD Threshold Tuning (P2.8)                           |
+| [ADR-0006](adr-0006.md) | ✅ Accepted | 2026-07-12 | Reject Branchless Character Classification (P3)               |
+| [ADR-0007](adr-0007.md) | ✅ Accepted | 2026-07-12 | Reject the Flow-Collection SIMD Fast Path (P5)                |
+| [ADR-0008](adr-0008.md) | ✅ Accepted | 2026-07-12 | Reject BMI2 Quote-Indexing for YAML (P6)                      |
+| [ADR-0009](adr-0009.md) | ✅ Accepted | 2026-07-12 | Reject a Parse-Time Newline Index (P7)                        |
+| [ADR-0010](adr-0010.md) | ✅ Accepted | 2026-07-12 | Reject AVX-512 SIMD Variants (P8)                             |
+| [ADR-0011](adr-0011.md) | ✅ Accepted | 2026-07-15 | Custom Succinct Structures over Existing Rust Crates          |
+| [ADR-0012](adr-0012.md) | ✅ Accepted | 2026-07-25 | Elias-Fano Line Index over a Dense Bitmap                     |
+| [ADR-0013](adr-0013.md) | ✅ Accepted | 2026-07-25 | Reject the SIMD Chunk-Scanner JSON Validator (#130)           |
+| [ADR-0014](adr-0014.md) | ✅ Accepted | 2026-08-03 | Reject Consolidating This Crate's Rank Implementations        |
+| [ADR-0015](adr-0015.md) | ✅ Accepted | 2026-08-05 | Keep BitVec, RankDirectory, and SelectIndex As-Is             |
+| [ADR-0016](adr-0016.md) | ✅ Accepted | 2026-08-08 | Reject SIMD Escape Scanning for jq Format Functions           |
+| [ADR-0017](adr-0017.md) | ✅ Accepted | 2026-08-11 | Presentation-Metadata Side-Trees over a Mutable YAML Document |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0017.md
+++ b/docs/adrs/adr-0017.md
@@ -1,0 +1,197 @@
+# ADR-0017: Presentation-Metadata Side-Trees over a Mutable YAML Document
+
+## Status
+
+✅ Accepted
+
+## Context
+
+`succinctly yq` silently discards YAML presentation metadata — flow/block container
+style, scalar quote style, trailing comments, and anchor/alias syntax — on every query
+that constructs or mutates a value rather than just navigating to one. This is tracked
+as a cluster of issues, all traced to the same chokepoint:
+
+- [#739](https://github.com/rust-works/succinctly/issues/739) — assignment/`del()`/
+  object-array construction drop quote and flow/block style on every node, touched or not.
+- [#752](https://github.com/rust-works/succinctly/issues/752) — the same shape of loss
+  for trailing comments (#710's follow-up).
+- [#763](https://github.com/rust-works/succinctly/issues/763) /
+  [#786](https://github.com/rust-works/succinctly/issues/786) — `&anchor`/`*alias`
+  syntax is flattened into independently duplicated values once a query leaves the
+  cursor-preserving path. `#763`'s identity-query repro is already fixed on `main`;
+  its assignment repro (`.a = 99` losing `&x`/`*x`) still reproduces, as does `#786`'s
+  `select(true)` repro — verified against this branch and pinned real `yq` v4.53.3
+  (2026-08-11).
+
+**Root cause.** `OwnedValue` ([src/jq/value.rs](../../src/jq/value.rs)) is a
+JSON-shaped enum (`Null`/`Bool`/`Int`/`Float`/`String`/`Array`/`Object`) shared verbatim
+with the JSON evaluator, with no field for YAML-only metadata. That alone would be a
+narrow gap, but the actual chokepoint is one level deeper: any expression outside a
+short cursor-native allowlist (`can_use_m2_streaming` in
+[yq_runner.rs](../../src/bin/succinctly/yq_runner.rs) — identity, field/index
+navigation, iteration, `first`/`last`, `keys_unsorted`) is evaluated by converting the
+whole document to **JSON text** and rebuilding a fresh `JsonIndex` from it
+(`eval_generic.rs`'s `eval_single` catch-all arm, duplicated as `eval_on_owned` in
+the same file), then handing off to `eval.rs`'s JSON-only
+evaluator (`eval_assign`/`update_path`/`set_path`, all hardcoded to
+`StandardJson<'a, W>`). JSON text has no representation for single- vs. double-quote or
+flow-vs-block, so metadata is discarded twice: once at the `OwnedValue` conversion,
+again at the text round-trip. Object/array construction (`Expr::Object`/`Expr::Array`)
+and every assignment-family expression (`Expr::Assign`/`Expr::Update`) go through this
+exact path — confirmed by direct inspection; neither has a native arm in
+`eval_generic.rs`'s dispatch.
+
+**A working precedent already exists for half of this.**
+[#707](https://github.com/rust-works/succinctly/issues/707) fixed container flow-style
+loss on the pure-navigation path by having `YamlCursor::stream_yaml_value`
+(`light.rs`'s `style()` method) consult the node's own style instead of only the ambient
+indent — a ~170-line, low-risk, well-tested change, entirely local to `light.rs`.
+[#710](https://github.com/rust-works/succinctly/issues/710) went further: it introduced
+`CommentTree` ([eval_generic.rs](../../src/jq/eval_generic.rs)), a shape-parallel
+side-tree mirroring `OwnedValue`'s own shape, built once via `to_owned_with_comments`
+from a live cursor and threaded alongside `OwnedValue` through `emit_yaml_value`
+in `yq_runner.rs`. Its own doc comment states the reasoning this ADR generalizes:
+*"`OwnedValue` itself carries no metadata — extending its enum would ripple through
+every match site in both the JSON and YAML evaluators for a feature only the YAML write
+path needs."* The gap: `to_owned_with_comments` is only ever called for
+`GenericResult::OneCursor`/`ManyCursor` in `evaluate_yaml_cursor`
+(also in [yq_runner.rs](../../src/bin/succinctly/yq_runner.rs)) — results that still carry a
+live cursor. Object/array construction and assignment never produce those variants, so
+they never populate the tree; #739 and #752 are that same blind spot, for style instead
+of comments.
+
+**More scaffolding exists than the individual issues assume.** The `DocumentCursor`
+trait ([document.rs](../../src/jq/document.rs)) already exposes `.style()`,
+`.anchor()`, and `.line_comment_raw()` as trait methods (default no-ops, overridden by
+`YamlCursor`) — added by `fc869e3c` to back the `style`/`anchor`/`line_comment` jq
+*builtins* (read-only accessors a query can call, e.g. `.foo | style`). That is a
+different feature from write-path preservation, but the trait-level plumbing this
+decision needs is already in place and already exercised. Separately, `eval.rs`'s
+`resolve_dynamic_indexes` ([eval.rs](../../src/jq/eval.rs)) already computes and
+returns the exact concrete path(s) (`Vec<Expr>`) an assignment writes to, and
+`yq_runner.rs` already tracks alias identity across a write
+(`collect_alias_groups`/`walk_alias_groups`, both in
+[yq_runner.rs](../../src/bin/succinctly/yq_runner.rs); `sync_aliased_paths` in
+[eval.rs](../../src/jq/eval.rs), built for issue #711) —
+both are directly reusable inputs for the mechanism below.
+
+**Out of scope.** `OwnedValue::Object`'s `IndexMap<String, Self>` cannot represent
+duplicate mapping keys at all ([#796](https://github.com/rust-works/succinctly/issues/796),
+confirmed reproducing on `select(true)`) — a representational limit that predates this
+decision and is unaffected by it either way.
+[#747](https://github.com/rust-works/succinctly/issues/747) (explicit YAML tags ignored
+by the plain, cursor-less `to_owned`) is a related but separate bug in a function this
+decision does not change.
+
+## Decision
+
+We will preserve YAML presentation metadata through mutating queries with two additive,
+side-channel mechanisms — not by adding fields to `OwnedValue`, and not by introducing a
+mutable YAML document representation.
+
+**1. Generalize `CommentTree` into a per-node presentation side-tree** (style + trailing
+comment per node, mirroring `OwnedValue`'s shape exactly as it does today), and extend
+where it gets built and consulted in two ways beyond #710's original scope:
+
+- *Object/array construction* (`{...}`, `[...]`): give `Expr::Object`/`Expr::Array` a
+  native arm in `eval_generic.rs`'s dispatch, evaluating each field/element via the
+  existing recursive `eval_single` instead of bridging through the JSON round-trip.
+  Where a field/element resolves to a live cursor (the common `{a, b}`/`[.a, .b]`
+  shapes), convert it with the metadata-aware `to_owned_with_comments`-style function
+  instead of plain `to_owned`. This needs no changes to `eval.rs` at all, and follows the
+  same rationale this file already uses for `Expr::IndexExpr`/`Expr::SliceExpr`
+  (handled natively "because the fallback... serialises and re-indexes the whole
+  document per evaluation").
+- *Path mutation* (`=`, `|=`, `+=`, `del()`, ...): at the `eval_generic.rs` bridge, build
+  the metadata tree from the pristine value *before* the JSON round-trip (alongside the
+  existing `to_owned(&value)` call), and hold onto it across the round-trip in the same
+  Rust call frame — it does not need to survive being serialized to JSON, only the
+  `OwnedValue` does. For expressions with a path shape (`Expr::Assign`/`Expr::Update`/
+  path-taking builtins), call `resolve_dynamic_indexes` on the pristine value directly
+  from this bridge to get the touched path(s), and invalidate (drop to default) only the
+  metadata-tree node(s) at those paths. Every untouched sibling's entry is left exactly
+  as built — O(depth of the write), not an O(document) diff, and no change to
+  `eval_assign`/`update_path`/`set_path`'s existing, heavily-tested `OwnedValue`
+  mutation logic.
+
+Anything with no such correspondence to source structure (arithmetic, `map(f)`, string
+interpolation, most builtins) legitimately has no source style to preserve; it keeps
+falling back to today's heuristic default, which is correct — real `yq` has to invent
+formatting for genuinely new values too.
+
+**2. Treat anchor/alias *syntax* preservation as a distinct mechanism**, extending the
+existing alias-group tracking (`collect_alias_groups`/`sync_aliased_paths`, built for
+#711 to keep alias *values* in sync after a write) to also drive `&anchor`/`*alias`
+re-emission at output time. This is deliberately not folded into the per-node side-tree
+above: a side-tree shaped like `OwnedValue` has no notion of *cross-tree identity* (two
+positions being the same source node), only per-node data — exactly the distinction
+between "what does this node look like" (style/comments) and "is this node the same
+node as that one" (anchors). `OwnedValue` already clones every alias target
+independently with no shared identity, so this needs the alias-group machinery, not an
+extension of the metadata tree.
+
+## Consequences
+
+**Positive:**
+
+- One designed mechanism serves #739, #752, and (via the alias-group extension) lays
+  the groundwork for #763's and #786's remaining halves, instead of three independent,
+  near-identical side-tree threadings through the same chokepoint.
+- Zero changes to `OwnedValue`'s shape or the JSON evaluator: the JSON-only code paths
+  (`eval.rs`, `StandardJson`) are untouched, eliminating the scope-creep risk #739's
+  own write-up raised against adding fields to `OwnedValue` directly.
+- Touched-path invalidation reuses `resolve_dynamic_indexes`'s existing output rather
+  than a fresh document-wide diff, keeping the fix's cost proportional to what the query
+  actually writes.
+- Consistent with, and validated by, #707's already-shipped instance of the same idea
+  (consult live per-node metadata instead of losing it) and #710's already-shipped
+  `CommentTree` machinery.
+
+**Negative / trade-offs:**
+
+- Two related mechanisms (side-tree for style/comments, alias-group extension for
+  anchors) rather than one, because they solve structurally different problems
+  (per-node data vs. cross-tree identity). Implementers need to keep that boundary
+  clear rather than trying to unify them.
+- The object/array-construction native arm and the path-mutation touched-path
+  invalidation are both real, if scoped, changes to `eval_generic.rs`'s dispatch and the
+  `eval_generic.rs`/`yq_runner.rs` boundary — not a one-file patch like #707 was.
+- Does not address `OwnedValue::Object`'s duplicate-key collapse (#796) or the
+  cursor-less `to_owned`'s tag blindness (#747); both remain open, separately-scoped
+  bugs after this decision lands.
+- Real `yq`'s own comment/style preservation under structural edits (`del`+reconstruct,
+  `map`) has known rough edges upstream; per #752's own suggested fix shape, each
+  concrete query shape this mechanism claims to fix should be verified against the
+  pinned real `yq` binary rather than assumed, before being called complete.
+
+**Neutral:**
+
+- Anything genuinely computed (arithmetic results, `map(f)` output, string
+  interpolation) keeps today's style-less/comment-less default output — unchanged
+  behavior, not a regression, since there is no source node for such a value to inherit
+  from.
+
+## Alternatives considered and rejected
+
+- **Add style/comment/anchor fields directly to `OwnedValue`** (#739's original "Option
+  1"). Rejected: `OwnedValue` is shared verbatim with the JSON evaluator, so every match
+  arm across both evaluators gains dead weight for a feature only YAML needs — the exact
+  concern `CommentTree`'s own doc comment already raised and avoided for comments.
+  Worse, the value still gets discarded at the JSON-text round-trip bridge regardless of
+  what fields the enum carries, since JSON text itself cannot represent YAML style —
+  fields on `OwnedValue` alone would not even fix the bug.
+- **A mutable in-place YAML document tree**, closer to how `mikefarah/yq`/go-yaml edit
+  documents (#739's original "Option 2"). Rejected: conflicts with
+  [ADR-0001](adr-0001.md)'s foundational choice of an immutable, byte-backed semi-index
+  with no mutable tree representation anywhere in the codebase. Building one only for
+  the mutation path means maintaining two parallel document representations
+  indefinitely — a much larger, permanent surface than extending a side-tree mechanism
+  already proven low-risk by #707 and #710.
+- **A full document-wide structural diff** between the pristine and post-mutation
+  `OwnedValue` to reconcile the metadata tree, instead of touched-path invalidation.
+  Rejected as the default: `resolve_dynamic_indexes` already names the written path(s)
+  precisely, making an O(document) equality walk unnecessary work for the common case.
+  Not ruled out permanently — a small set of expression shapes (e.g. `del()` on a
+  computed path) may still need a narrow diff-based fallback where the touched path
+  can't be resolved statically; that is an implementation detail for the issues that
+  pick this up, not a reason to default to diffing everywhere.


### PR DESCRIPTION
## Summary
- Adds [ADR-0017](docs/adrs/adr-0017.md), recording the architecture decision for the #739/#752/#763/#786 cluster (YAML style, comments, and anchor/alias syntax silently dropped by any mutating `yq` query): generalize #710's `CommentTree` side-tree pattern and #707's per-node style consultation, rather than adding style/comment/anchor fields to `OwnedValue` (would leak into the shared JSON evaluator and still be discarded at the JSON-text round-trip) or building a mutable YAML document tree (conflicts with ADR-0001's immutable semi-index foundation).
- Updates `docs/adrs/README.md`'s inventory table with the new entry.
- No production code changes — this is a design record only. Implementation is tracked separately against the linked issues.

## Test plan
- [x] Verified every repro cited in the ADR's Context section against both this branch and pinned real `yq` v4.53.3 (built `cargo build --release --features cli` and ran each command by hand).
- [x] Verified every `file:line` citation in the ADR against current source (all resolve to the described function/type).
- [x] Verified every internal Markdown link resolves to a real file.
- [x] Confirmed the inventory table's column alignment is self-consistent.
- N/A — no code paths changed, so no `cargo test`/`clippy` run required.