### PR TITLE
fix(cli): yq -C still collapsed duplicate keys with --slurp/--inplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output; the buffer-and-colorize decision keys only on `use_color`, so
   compact mode is now colorized too.
 
+- **`yq -C` combined with `--slurp` or `--inplace` still collapsed duplicate
+  mapping keys** (#809), the follow-up gap #748 itself flagged as scope,
+  not a silent regression: `can_slurp_fast_path`/`can_inplace_json_fast_path`/
+  `can_inplace_yaml_fast_path` still gated on the color-excluding
+  `can_stream_pretty`, so `-C` combined with either flag fell through to the
+  `OwnedValue`/`IndexMap` DOM path and lost all but the last occurrence of a
+  repeated key — `yq -C --slurp '.'` on `a: 1\na: 2` printed only `a: 2`
+  (with color), and `yq -C -i '.'` wrote only `a: 2` to the file (uncolored,
+  since `--inplace` already forced color off on that path).
+
+  Fixed by switching all three gates to the color-inclusive
+  `can_stream_pretty_or_colored` (removing the now-redundant
+  `can_stream_pretty`) and, for `--slurp`, wrapping the existing
+  `stream_yaml_sequence` call in `stream_maybe_colored` — no changes needed
+  in `stream_yaml_sequence` itself, since it was already generic over
+  `core::fmt::Write`. `-o json --slurp` is unaffected: it stays on the DOM
+  path regardless of color, a separate, pre-existing scope limit.
+
+  `--inplace`'s fast path shares its cursor-streaming code
+  (`stream_cursor!`) with the plain stdout path, which does need color, so
+  the macro now takes an explicit `$use_color` argument instead of reading
+  `output_config.use_color` directly — a same-named `output_config` shadowed
+  to `use_color: false` at the `--inplace` call site is invisible to a bare
+  reference inside the macro, since `macro_rules!` resolves such free
+  identifiers against whatever was visible when the macro was *defined*, not
+  a later local shadow at the call site. Stdout call sites pass
+  `output_config.use_color` through unchanged; `--inplace`'s two call sites
+  pass `false` explicitly.
+
+  Fixing this also closed a second, previously-unnoticed bug: compact output
+  (`-I0`) already took `--inplace`'s fast path unconditionally (`compact ||`
+  short-circuited before color was checked), and nothing forced color off on
+  that path, so `-C -I0 --inplace` wrote raw ANSI escape bytes straight into
+  the file on disk.
+
 - **`gmtime`, `mktime`, and `strptime` raised the right exit code but the
   wrong message on bad input** (#761): `gmtime`/`localtime` on a non-number
   reported the generic `"math function requires number"` (shared with

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1956,18 +1956,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // through DOM now gives it a single seam to implement real
     // style-clearing against once #707 lands (#705).
     //
-    // `can_stream_pretty` still excludes color: it also gates `--slurp`'s
-    // and `--inplace`'s fast paths below, neither of which has the
-    // buffer-and-colorize plumbing `stream_maybe_colored` adds for the
-    // plain stdout path. `can_stream_pretty_or_colored` is the same
-    // condition minus that exclusion, used only by `can_json_fast_path`/
-    // `can_yaml_fast_path`: color, when requested, is handled by
-    // `stream_maybe_colored` buffering the (still duplicate-key-safe)
-    // cursor-streamed output and running it through the existing
-    // `colorize_yaml`/`colorize_json` post-processors, rather than falling
-    // back to the DOM/IndexMap path that would collapse duplicate mapping
-    // keys (#442, #748).
-    let can_stream_pretty = !output_config.use_color && !args.pretty_print;
+    // `can_stream_pretty_or_colored` gates every M2 fast path below,
+    // stdout, `--slurp`, and `--inplace` alike: color, when requested, is
+    // handled by `stream_maybe_colored` buffering the (still
+    // duplicate-key-safe) cursor-streamed output and running it through the
+    // existing `colorize_yaml`/`colorize_json` post-processors, rather than
+    // falling back to the DOM/IndexMap path that would collapse duplicate
+    // mapping keys (#442, #748, #809).
     let can_stream_pretty_or_colored = !args.pretty_print;
     let can_json_fast_path = is_m2_streamable
         && (output_config.compact || (can_stream_pretty_or_colored && !args.ascii_output))
@@ -2000,9 +1995,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // per-file buffer (then `fs::write`), not the shared stdout `writer`
     // the block below uses — the two loops have different write targets and
     // per-file `---` separator resets, so they stay as distinct branches
-    // that happen to share the same underlying `stream_cursor!` macro.
+    // that happen to share the same underlying `stream_cursor!` macro. Color
+    // no longer excludes the fast path here (#809): the inplace write loop
+    // below passes `false` as `stream_cursor!`'s `$use_color` argument (and
+    // shadows `output_config.use_color` to `false` for its own DOM-branch
+    // writes), so `-C` reaching the fast path still never writes ANSI to
+    // disk, but no longer forces a fallback to the duplicate-key-collapsing
+    // DOM path either.
     let can_inplace_json_fast_path = is_m2_streamable
-        && (output_config.compact || (can_stream_pretty && !args.ascii_output))
+        && (output_config.compact || (can_stream_pretty_or_colored && !args.ascii_output))
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
         && !args.raw_input
@@ -2010,7 +2011,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && args.front_matter.is_none()
         && context.named.is_empty();
     let can_inplace_yaml_fast_path = is_m2_streamable
-        && (output_config.compact || can_stream_pretty)
+        && (output_config.compact || can_stream_pretty_or_colored)
         && output_config.output_format == OutputFormat::Yaml
         && !args.null_input
         && !args.raw_input
@@ -2024,12 +2025,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // `is_m2_streamable` set), since a non-trivial filter over the slurped
     // array needs real evaluation. `-o json --slurp` still uses the slow
     // DOM path below — an explicit, documented scope limit rather than a
-    // silent gap. Also still excludes color (`can_stream_pretty`, not
-    // `can_stream_pretty_or_colored`) — buffer-and-colorize support (#748)
-    // wasn't added to `stream_yaml_sequence`, so `--slurp --color` stays on
-    // the DOM path, unchanged.
+    // silent gap. Color no longer excludes this gate either (#809): the
+    // call site now wraps `stream_yaml_sequence` in `stream_maybe_colored`,
+    // same as the stdout/inplace paths.
     let can_slurp_fast_path = is_identity
-        && can_stream_pretty
+        && can_stream_pretty_or_colored
         && output_config.output_format == OutputFormat::Yaml
         && !args.null_input
         && !args.raw_input
@@ -2069,12 +2069,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // Helper macro to stream cursor results (avoiding closure borrow issues).
     // Defined here (rather than inside the `if can_fast_path` block below) so
     // both the stdout M2 path and `--inplace`'s fast path (#478) can reuse
-    // it. `$is_yaml` is threaded through explicitly rather than closing over
-    // `can_yaml_fast_path` by name, and `yaml_doc_streamed`/`any_truthy`/
-    // `sink` resolve, at each call site, to whichever same-named local is in
-    // scope there — each branch below declares its own `yaml_doc_streamed`.
+    // it. `$is_yaml`/`$use_color` are threaded through explicitly rather than
+    // closing over `can_yaml_fast_path`/`output_config.use_color` by name:
+    // both of those differ per call site (`--inplace` always forces color
+    // off, #809), and — unlike `yaml_doc_streamed`/`any_truthy`/`sink`,
+    // which each call site's enclosing block declares fresh right before
+    // invoking this macro — `output_config` already existed when this macro
+    // was *defined*, so a `let output_config = ...` shadow introduced later,
+    // at a given call site, is invisible to a bare (non-`$`) reference here:
+    // `macro_rules!` resolves such free identifiers against whatever was in
+    // scope at definition time, not at each expansion site. `$fragment:expr`
+    // parameters don't have that problem — they always evaluate in the
+    // caller's own scope — hence passing color as `$use_color:expr`.
     macro_rules! stream_cursor {
-            ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr) => {{
+            ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr) => {{
                 if $is_yaml {
                     // M2 YAML path: YAML output streaming
                     if is_identity {
@@ -2084,7 +2092,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // redisplayed as itself - its own trailing comment,
                         // if any, must be kept (#710).
                         emit_yaml_doc_separator($writer, $doc_streamed, true)?;
-                        stream_maybe_colored($writer, output_config.use_color, colorize_yaml, |out| {
+                        stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                             $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys)
                         })?;
                         writeln!($writer)?;
@@ -2104,7 +2112,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             && !matches!(&result, GenericResult::ManyOwned(vs) if vs.is_empty());
                         emit_yaml_doc_separator($writer, $doc_streamed, will_output)?;
                         let stats =
-                            stream_maybe_colored($writer, output_config.use_color, colorize_yaml, |out| {
+                            stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                                 result.stream_yaml(out, yaml_indent, sort_keys, |w| w.write_str("\n"))
                             })?;
                         any_truthy |= stats.any_truthy;
@@ -2120,7 +2128,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // P9 path: stream directly without evaluation
                         stream_maybe_colored(
                             $writer,
-                            output_config.use_color,
+                            $use_color,
                             |s| output::colorize_json(s, &ColorScheme::default()),
                             |out| $cursor.stream_json(out, json_indent, sort_keys),
                         )?;
@@ -2135,7 +2143,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         let result = eval_with_cursor_using::<YqSemantics, _>(&program.expr, $cursor);
                         let stats = stream_maybe_colored(
                             $writer,
-                            output_config.use_color,
+                            $use_color,
                             |s| output::colorize_json(s, &ColorScheme::default()),
                             |out| result.stream_json(out, json_indent, sort_keys, |w| w.write_str("\n")),
                         )?;
@@ -2181,7 +2189,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 cursor,
                                 &mut writer,
                                 can_yaml_fast_path,
-                                &mut yaml_doc_streamed
+                                &mut yaml_doc_streamed,
+                                output_config.use_color
                             );
                         }
                         global_doc_index += 1;
@@ -2224,7 +2233,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     doc_cursor,
                                     &mut writer,
                                     can_yaml_fast_path,
-                                    &mut yaml_doc_streamed
+                                    &mut yaml_doc_streamed,
+                                    output_config.use_color
                                 );
                             }
                         }
@@ -2257,7 +2267,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     cursor,
                                     &mut writer,
                                     can_yaml_fast_path,
-                                    &mut yaml_doc_streamed
+                                    &mut yaml_doc_streamed,
+                                    output_config.use_color
                                 );
                             }
                             global_doc_index += 1;
@@ -2308,7 +2319,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         doc_cursor,
                                         &mut writer,
                                         can_yaml_fast_path,
-                                        &mut yaml_doc_streamed
+                                        &mut yaml_doc_streamed,
+                                        output_config.use_color
                                     );
                                 }
                             }
@@ -2612,15 +2624,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // matching jq/yq `-e` semantics for arrays.
                 any_truthy = true;
             }
-            stream_yaml_sequence(
-                cursors.iter().copied(),
-                &mut FmtWriter(&mut writer),
-                0,
-                yaml_indent_spaces,
-                indent_unit,
-                sort_keys,
-            )
-            .map_err(|_| anyhow::anyhow!("Write error"))?;
+            // Buffer-and-colorize (#748, extended to `--slurp` by #809):
+            // `stream_yaml_sequence` is generic over `core::fmt::Write`, so
+            // it slots into `stream_maybe_colored` unmodified.
+            stream_maybe_colored(&mut writer, output_config.use_color, colorize_yaml, |out| {
+                stream_yaml_sequence(
+                    cursors.iter().copied(),
+                    out,
+                    0,
+                    yaml_indent_spaces,
+                    indent_unit,
+                    sort_keys,
+                )
+            })?;
             writeln!(writer)?;
         } else {
             let mut all_docs: Vec<OwnedValue> = Vec::new();
@@ -2673,6 +2689,23 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
             let mut output_buffer = Vec::new();
 
+            // `--inplace` never writes ANSI to disk (#809): shadow
+            // `output_config` for the rest of this file's write so the DOM
+            // branch below sees `use_color: false` regardless of `-C` (the
+            // fast-path branch instead passes `false` explicitly as
+            // `stream_cursor!`'s `$use_color` argument — a bare
+            // `output_config.use_color` reference inside that macro would
+            // resolve against the *original*, unshadowed binding, since
+            // `output_config` already existed when the macro was defined).
+            // Forcing color off here also closes a live bug: compact mode
+            // (`-I0`) already took the fast path unconditionally (the
+            // `compact ||` gate short-circuits before color is checked),
+            // and nothing forced color off on that path, so
+            // `-C -I0 --inplace` wrote raw ANSI bytes straight into the
+            // file.
+            let mut output_config = output_config.clone();
+            output_config.use_color = false;
+
             if can_inplace_fast_path {
                 // M2 streaming fast path (#478): stream cursor results
                 // directly into this file's buffer, skipping the OwnedValue
@@ -2699,7 +2732,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         cursor,
                                         &mut buf_writer,
                                         can_inplace_yaml_fast_path,
-                                        &mut yaml_doc_streamed
+                                        &mut yaml_doc_streamed,
+                                        false
                                     );
                                 }
                                 global_doc_index += 1;
@@ -2741,7 +2775,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         doc_cursor,
                                         &mut buf_writer,
                                         can_inplace_yaml_fast_path,
-                                        &mut yaml_doc_streamed
+                                        &mut yaml_doc_streamed,
+                                        false
                                     );
                                 }
                             }
@@ -2791,18 +2826,18 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         writeln!(buf_writer, "---")?;
                     }
                     let results = evaluate_input(input, &program.expr, &mut sink)?;
-                    // Write without color for inplace editing
-                    let mut no_color_config = output_config.clone();
-                    no_color_config.use_color = false;
+                    // `output_config` was already shadowed to `use_color:
+                    // false` above — reused here rather than building a
+                    // second, parallel no-color config.
                     for result in results {
-                        split_doc_state.write_separator(&mut buf_writer, &no_color_config)?;
+                        split_doc_state.write_separator(&mut buf_writer, &output_config)?;
                         any_truthy |=
                             !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
                         output_value(
                             &mut buf_writer,
                             &result,
                             &CommentTree::empty(),
-                            &no_color_config,
+                            &output_config,
                         )?;
                     }
                 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3669,15 +3669,16 @@ fn test_color_output_survives_iteration_with_duplicate_keys_json() -> Result<()>
     Ok(())
 }
 
-/// `--slurp --color` intentionally still routes through the `OwnedValue`/
-/// `IndexMap` DOM path — `can_slurp_fast_path` only checks `can_stream_pretty`,
-/// not `can_stream_pretty_or_colored`, since `stream_yaml_sequence` never got
-/// `stream_maybe_colored` support (a documented scope limit, not a silent
-/// gap — #748). That means `--slurp -C` still collapses duplicate mapping
-/// keys within each slurped document, unlike plain `--slurp` (see
-/// [`test_duplicate_mapping_key_survives_slurp`]). Exercises `output_value`'s
-/// `config.use_color` YAML branch, which #748's M2-fast-path color fix made
-/// unreachable from every other angle.
+/// #809: `--slurp -C` used to intentionally route through the `OwnedValue`/
+/// `IndexMap` DOM path — `can_slurp_fast_path` only checked
+/// `can_stream_pretty`, not `can_stream_pretty_or_colored`, since
+/// `stream_yaml_sequence` never got `stream_maybe_colored` support (a
+/// documented scope limit, not a silent gap — #748). That collapsed
+/// duplicate mapping keys within each slurped document, unlike plain
+/// `--slurp` (see [`test_duplicate_mapping_key_survives_slurp`]). Fixed by
+/// wrapping the `stream_yaml_sequence` call in `stream_maybe_colored`,
+/// mirroring the stdout path's own fix — `stream_yaml_sequence` needed no
+/// changes itself, since it's already generic over `core::fmt::Write`.
 #[test]
 fn test_slurp_color_output_yaml() -> Result<()> {
     let yaml = "a: 1\na: 2\n";
@@ -3686,15 +3687,21 @@ fn test_slurp_color_output_yaml() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(
         output,
-        "\u{1b}[33m-\u{1b}[0m\n  \u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
+        "\u{1b}[33m-\u{1b}[0m\n  \u{1b}[36ma\u{1b}[0m: 1\n  \u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
     );
 
     Ok(())
 }
 
-/// Same as [`test_slurp_color_output_yaml`], for `-o json`: exercises
-/// `output_value`'s `config.use_color` JSON branch, the `--slurp` DOM-path
-/// counterpart to [`test_slurp_color_output_yaml`].
+/// Unlike [`test_slurp_color_output_yaml`], `-o json --slurp` stays on the
+/// `OwnedValue`/`IndexMap` DOM path regardless of `-C` — `can_slurp_fast_path`
+/// requires YAML output, so `-o json --slurp` is unaffected by #809's fix and
+/// still collapses duplicate keys, exactly as it did (with or without color)
+/// before #809. This is the same pre-existing, separately-scoped `-o json
+/// --slurp` limitation the `can_slurp_fast_path` code comment documents, not
+/// a `-C`-specific gap. Exercises `output_value`'s `config.use_color` JSON
+/// branch, which #748's M2-fast-path color fix made unreachable from every
+/// other angle.
 #[test]
 fn test_slurp_color_output_json() -> Result<()> {
     let yaml = "a: 1\na: 2\n";

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3716,6 +3716,100 @@ fn test_slurp_color_output_json() -> Result<()> {
     Ok(())
 }
 
+/// #809: `-C --inplace` fell through to the `OwnedValue`/`IndexMap` DOM
+/// path for any non-compact indent (`can_inplace_yaml_fast_path` excluded
+/// color via `can_stream_pretty`), collapsing duplicate keys — mirrors
+/// [`test_duplicate_mapping_key_survives_inplace`], plus `-C`. `--inplace`
+/// still never writes ANSI to the file even once the fast path is taken:
+/// the fast-path branch passes `false` as `stream_cursor!`'s `$use_color`
+/// argument explicitly, since a bare `output_config.use_color` reference
+/// inside that macro resolves against the *original* binding from where the
+/// macro was defined, not a later same-named shadow at the call site — see
+/// the code comment above `macro_rules! stream_cursor` in `yq_runner.rs`.
+#[test]
+fn test_duplicate_mapping_key_survives_color_inplace() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\na: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-C")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "a: 1\na: 2\n");
+    assert!(
+        !rewritten.contains('\u{1b}'),
+        "inplace must never write ANSI color codes to disk"
+    );
+    Ok(())
+}
+
+/// Same as [`test_duplicate_mapping_key_survives_color_inplace`], for
+/// `-o json`.
+#[test]
+fn test_duplicate_mapping_key_survives_color_inplace_json_output() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\na: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-C")
+        .arg("-o")
+        .arg("json")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "{\n  \"a\": 1,\n  \"a\": 2\n}\n");
+    assert!(
+        !rewritten.contains('\u{1b}'),
+        "inplace must never write ANSI color codes to disk"
+    );
+    Ok(())
+}
+
+/// #809 bonus finding: compact output (`-I0`) already took `--inplace`'s
+/// fast path unconditionally, since the gate is `compact || (color-aware
+/// condition)` and `compact ||` short-circuits before color is ever
+/// checked. Before this fix, that meant `-C -I0 --inplace` wrote raw ANSI
+/// escape bytes straight into the file — worse than the non-compact case,
+/// which never colored its (collapsed) DOM-path output. Regression test:
+/// compact + color + inplace must never leak ANSI into the file.
+#[test]
+fn test_inplace_color_compact_does_not_write_ansi_to_file() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\na: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-C")
+        .arg("-I0")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "a: 1\na: 2\n");
+    assert!(
+        !rewritten.contains('\u{1b}'),
+        "inplace must never write ANSI color codes to disk"
+    );
+    Ok(())
+}
+
 // ============================================================================
 // Special float values (NaN / Infinity)
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3716,6 +3716,21 @@ fn test_slurp_color_output_json() -> Result<()> {
     Ok(())
 }
 
+/// #809 follow-up: before this fix, `--slurp -C`'s identity query was the
+/// only thing exercising `output_value`'s YAML `config.use_color` branch.
+/// Once `can_slurp_fast_path` started accepting color (this PR), that query
+/// moved onto the new fast path and stopped covering it. `--null-input` has
+/// no cursor to stream from, so it bypasses the M2 fast path entirely
+/// regardless of query shape and keeps hitting `output_value` — pinning it
+/// here so the DOM-path YAML color branch stays covered.
+#[test]
+fn test_null_input_color_output_yaml() -> Result<()> {
+    let (output, code) = run_yq_stdin("{a: 1}", "", &["-n", "-C"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "\u{1b}[36ma\u{1b}[0m: 1\u{1b}[0m\n");
+    Ok(())
+}
+
 /// #809: `-C --inplace` fell through to the `OwnedValue`/`IndexMap` DOM
 /// path for any non-compact indent (`can_inplace_yaml_fast_path` excluded
 /// color via `can_stream_pretty`), collapsing duplicate keys — mirrors


### PR DESCRIPTION
## Summary

Closes #809, the tracked follow-up to #748: `-C`/`--color` combined with `--slurp` or `--inplace` still collapsed duplicate YAML mapping keys, because `can_slurp_fast_path`/`can_inplace_json_fast_path`/`can_inplace_yaml_fast_path` still gated on the color-excluding `can_stream_pretty`, an explicit scope limit #748 itself documented rather than fixed.

- Switched all three gates to the color-inclusive `can_stream_pretty_or_colored` (the now-dead `can_stream_pretty` is removed).
- `--slurp`'s `stream_yaml_sequence` call is wrapped in `stream_maybe_colored`, the same buffer-and-colorize plumbing #748 added for the stdout path — no changes needed in `stream_yaml_sequence` itself, since it's already generic over `core::fmt::Write`.
- `--inplace`'s fast path shares its cursor-streaming code (`stream_cursor!`) with the plain stdout path, which *does* need color, so the macro now takes an explicit `$use_color` argument instead of reading `output_config.use_color` directly. A same-named `output_config` shadowed to `use_color: false` at the `--inplace` call site turned out to be invisible to a bare reference inside the macro — `macro_rules!` resolves such free identifiers against whatever was visible when the macro was *defined*, not a later local shadow at the call site (confirmed with a minimal standalone repro before relying on it). Stdout call sites pass `output_config.use_color` through unchanged; `--inplace`'s two call sites now pass `false` explicitly.

**Bonus fix found along the way:** compact output (`-I0`) already took `--inplace`'s fast path unconditionally (`compact ||` short-circuited before color was ever checked), and nothing forced color off on that path, so `-C -I0 --inplace` was writing raw ANSI escape bytes straight into the file on disk — a worse bug than the one reported. Closed by the same `$use_color`/shadow fix.

## Commits

1. `fix(cli): stop yq -C from collapsing duplicate keys with --slurp/--inplace` — the core fix, CHANGELOG entry, and the minimal test updates needed to keep the suite green.
2. `test(test): cover --inplace -C duplicate-key and ANSI-leak regressions (#809)` — new `--inplace -C` coverage (YAML + JSON) plus a dedicated regression test for the compact-mode ANSI-into-file bug, mirroring how #748's own follow-up test commits were split from its fix commit.

## Test plan

- [x] `cargo build --features cli` — clean
- [x] `cargo test --features cli --test yq_cli_tests` — 423/423 passing
- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Manually verified all repros from the issue plus the compact-mode bonus bug, before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)