### PR TITLE
yq: fix six comment-attachment bugs found in #710 code review (#793, #794, #795, #796, #797)

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1534,6 +1534,17 @@ fn can_use_m2_streaming(expr: &Expr) -> bool {
         Expr::Builtin(Builtin::FirstStream(_) | Builtin::LastStream(_)) => true,
         Expr::IndexExpr { .. } => true,
 
+        // `select(...)` never changes position - a truthy output is always
+        // the input node unchanged - and `eval_generic.rs`'s own
+        // `Builtin::Select` arm already forwards the incoming cursor as-is
+        // (`OneCursor`/`ManyCursor`) rather than rebuilding a value. Routing
+        // it here rather than through `evaluate_yaml_cursor`'s unconditional
+        // `to_owned()` DOM path is what keeps duplicate mapping keys (and
+        // their comments) intact, matching `FirstExpr`/`LastExpr` above
+        // (#631) and `-S`/`--tab` (#733) - `select()` had the same latent
+        // gap (#796).
+        Expr::Builtin(Builtin::Select(_)) => true,
+
         // `keys_unsorted` on a mapping produces `GenericResult::LazyKeys { sorted: false, .. }`,
         // which `GenericResult::stream_json`/`stream_yaml` now stream directly
         // from the field cursor (#685) instead of materializing a `Vec<String>`

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1024,13 +1024,15 @@ fn output_value<W: Write>(
         // own trailing comment from output on both identity and `select`,
         // even though `line_comment` still returns it — real `yq`'s own
         // quirk, not a succinctly gap, so replicated here rather than
-        // "fixed" into a new divergence.
-        let root_comment_suffix = if matches!(value, OwnedValue::Array(_) | OwnedValue::Object(_)) {
-            trailing_comment_suffix(comments)
+        // "fixed" into a new divergence. Appended as a standalone comment
+        // line (not glued onto `body`'s last line), so it isn't
+        // indistinguishable from the last child's own comment when `body`
+        // is multi-line block content (#793).
+        let output = if matches!(value, OwnedValue::Array(_) | OwnedValue::Object(_)) {
+            append_own_comment_line(body, comments.own(), "")
         } else {
-            String::new()
+            body
         };
-        let output = format!("{body}{root_comment_suffix}");
         if config.use_color {
             write!(writer, "{}", colorize_yaml(&output))?;
         } else {
@@ -1082,9 +1084,29 @@ fn output_value<W: Write>(
 
 /// Format a node's own trailing comment (issue #710) as `" # text"`, or
 /// `""` if it has none — the single point of change for the separator
-/// convention shared by every `emit_yaml_value` call site that appends one.
+/// convention shared by every `emit_yaml_value` call site that appends one
+/// *on the same line* as the rest of the value (safe only when that value
+/// renders as a single line — a scalar, or an empty/flow-style container).
 fn trailing_comment_suffix(comments: &CommentTree) -> String {
     comments.own().map_or_else(String::new, |c| format!(" {c}"))
+}
+
+/// Append a container's own trailing comment (#710/#793) as a standalone
+/// comment line at `indent`, rather than concatenating it onto `body`'s
+/// last line the way [`trailing_comment_suffix`] does. `body` here is
+/// always genuinely multi-line block content (a non-empty, block-rendered
+/// `Array`/`Object`) — gluing the container's *own* comment onto that last
+/// line would make it indistinguishable from the last child's own trailing
+/// comment on that same line, silently merging two distinct comments into
+/// one (#793). `OwnedValue` carries no source flow/block style, so this
+/// doesn't attempt to match real `yq`'s exact output (which keeps flow
+/// style, staying on one line); it only guarantees the two comments never
+/// collide.
+fn append_own_comment_line(body: String, own_comment: Option<&str>, indent: &str) -> String {
+    match own_comment {
+        Some(c) => format!("{body}\n{indent}{c}"),
+        None => body,
+    }
 }
 
 /// Emit a YAML value as a string, appending each node's trailing same-line
@@ -1149,15 +1171,23 @@ fn emit_yaml_value(
                     .map(|(i, v)| {
                         let elem_comments = comments.at_index(i);
                         let item = emit_yaml_value(v, elem_comments, config, depth + 1, false);
-                        let comment_suffix = trailing_comment_suffix(elem_comments);
                         // Check if it's a multi-line value (mapping or sequence)
                         if matches!(v, OwnedValue::Object(_) | OwnedValue::Array(_))
                             && !item.starts_with('[')
                             && !item.starts_with('{')
                         {
-                            // Multi-line value - emit nested content which handles its own indentation
-                            format!("{indent}-\n{item}{comment_suffix}")
+                            // Multi-line value - emit nested content which
+                            // handles its own indentation. The element's own
+                            // comment goes on its own line rather than
+                            // glued onto its last grandchild's line (#793).
+                            let item = append_own_comment_line(
+                                item,
+                                elem_comments.own(),
+                                &config.indent_str.repeat(depth + 1),
+                            );
+                            format!("{indent}-\n{item}")
                         } else {
+                            let comment_suffix = trailing_comment_suffix(elem_comments);
                             format!("{indent}- {item}{comment_suffix}")
                         }
                     })
@@ -1206,9 +1236,17 @@ fn emit_yaml_value(
                             let key_comment_suffix = comments
                                 .key_comment(k)
                                 .map_or_else(String::new, |c| format!(" {c}"));
-                            // For nested containers, emit at depth+1 which handles its own indentation
+                            // For nested containers, emit at depth+1 which
+                            // handles its own indentation. The value's own
+                            // comment goes on its own line rather than
+                            // glued onto its last grandchild's line (#793).
                             let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
-                            format!("{indent}{key}:{key_comment_suffix}\n{val}{comment_suffix}")
+                            let val = append_own_comment_line(
+                                val,
+                                field_comments.own(),
+                                &config.indent_str.repeat(depth + 1),
+                            );
+                            format!("{indent}{key}:{key_comment_suffix}\n{val}")
                         } else if let Some(kc) = comments.key_comment_if_value_absent(k) {
                             // The deferred value materialized as nothing at
                             // all - the key's own comment stands alone with

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1254,6 +1254,21 @@ fn emit_yaml_value(
                             format!("{indent}{key}: {kc}")
                         } else {
                             let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
+                            // The value's own comment takes priority; fall
+                            // back to the key's own comment when the value
+                            // has none - covers an explicit key's trailing
+                            // comment (`? k # key comment\n: v\n`), which
+                            // otherwise has no write site once key and
+                            // value collapse onto one output line (#795).
+                            // A no-op for the ordinary implicit-key case
+                            // (`comment_suffix` is already non-empty then).
+                            let comment_suffix = if comment_suffix.is_empty() {
+                                comments
+                                    .key_comment(k)
+                                    .map_or_else(String::new, |c| format!(" {c}"))
+                            } else {
+                                comment_suffix
+                            };
                             format!("{indent}{key}: {val}{comment_suffix}")
                         }
                     })

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -147,6 +147,18 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         None
     }
 
+    /// Get this node's trailing same-line comment, distinguishing "no
+    /// comment" (`Ok(None)`) from "comment present but not valid UTF-8"
+    /// (`Err(_)`) — unlike [`line_comment`](Self::line_comment), which
+    /// silently collapses both to `None` (issue #797).
+    ///
+    /// Default `Ok(None)`: formats without a comment concept (JSON) never
+    /// have an invalid-UTF-8 comment to report. Only YAML cursors override
+    /// this.
+    fn line_comment_checked(&self) -> Result<Option<String>, core::str::Utf8Error> {
+        Ok(None)
+    }
+
     /// Create a cursor at the specified byte offset (0-indexed).
     ///
     /// Returns None if:

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -214,6 +214,26 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         Err(core::fmt::Error)
     }
 
+    /// Like [`stream_yaml`](Self::stream_yaml), but also appends this
+    /// cursor's own trailing comment (#710/#793) when it's a container -
+    /// for callers displaying this cursor's value as a complete result in
+    /// its own right (a navigated query result, or the whole document), as
+    /// opposed to a value nested inside a parent that already appends its
+    /// children's comments as it recurses.
+    ///
+    /// Default: delegates to `stream_yaml` unchanged. Correct for formats
+    /// without a comment concept (JSON) and as a fallback for any
+    /// `DocumentCursor` impl that doesn't override it; only YAML cursors
+    /// need to override this.
+    fn stream_yaml_as_document<W: core::fmt::Write>(
+        &self,
+        out: &mut W,
+        indent: IndentSpec,
+        sort_keys: bool,
+    ) -> core::fmt::Result {
+        self.stream_yaml(out, indent, sort_keys)
+    }
+
     /// Check if the value at this cursor is falsy (null or false).
     ///
     /// Used for `--exit-status` flag handling without requiring full materialization.

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -293,6 +293,17 @@ impl EvalError {
         Self::new(format!("Cannot use {} as object key", describe(key)))
     }
 
+    /// `invalid UTF-8 in comment`.
+    ///
+    /// Raised by the `line_comment` builtin (issue #797) when a node's
+    /// trailing comment bytes aren't valid UTF-8. Mirrors
+    /// `YamlValue::Error("invalid UTF-8 in anchor name")`'s handling of the
+    /// identical situation for anchor names, so "invalid" surfaces as an
+    /// error here too, rather than silently reading back as "no comment".
+    pub fn invalid_utf8_in_comment() -> Self {
+        Self::new("invalid UTF-8 in comment")
+    }
+
     /// `Path must be specified as an array`.
     ///
     /// Raised by the path builtins when their path argument is not an array at

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1201,8 +1201,12 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.any_truthy = !stats.last_was_falsy;
             }
             Self::OneCursor(c) => {
-                // Stream directly from cursor using DocumentCursor trait
-                c.stream_yaml(out, indent, sort_keys)?;
+                // Stream directly from cursor using DocumentCursor trait.
+                // `stream_yaml_as_document` (not the bare `stream_yaml`): a
+                // navigated container result keeps its own trailing comment
+                // just like the whole document does, unlike a navigated
+                // scalar (#793a).
+                c.stream_yaml_as_document(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = c.is_falsy();
@@ -1220,7 +1224,9 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::ManyCursor(cs) => {
                 for c in cs {
-                    c.stream_yaml(out, indent, sort_keys)?;
+                    // See `OneCursor` above: each streamed result keeps its
+                    // own trailing comment if it's a container (#793a).
+                    c.stream_yaml_as_document(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = c.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2783,10 +2783,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             GenericResult::Owned(OwnedValue::String(style.to_string()))
         }
 
-        Builtin::LineComment => {
-            let comment = cursor.and_then(|c| c.line_comment()).unwrap_or_default();
-            GenericResult::Owned(OwnedValue::String(comment))
-        }
+        Builtin::LineComment => match cursor.map(|c| c.line_comment_checked()) {
+            Some(Err(_)) => GenericResult::Error(EvalError::invalid_utf8_in_comment()),
+            Some(Ok(comment)) => {
+                GenericResult::Owned(OwnedValue::String(comment.unwrap_or_default()))
+            }
+            None => GenericResult::Owned(OwnedValue::String(String::new())),
+        },
 
         Builtin::Select(cond) => {
             // Evaluate condition with cursor context preserved.
@@ -5186,6 +5189,25 @@ mod tests {
             result.into_owned().unwrap(),
             OwnedValue::String(String::new())
         );
+    }
+
+    #[test]
+    fn test_yaml_line_comment_builtin_invalid_utf8_is_error_797() {
+        use crate::yaml::YamlIndex;
+
+        // "caf\xE9" - a comment with an invalid UTF-8 byte. Must surface as
+        // an error, not silently collapse to "" as if there were no comment
+        // at all (issue #797).
+        let yaml = b"a: 1 # caf\xE9\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let doc_cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+
+        let expr = crate::jq::parse(".a | line_comment").unwrap();
+        let result = eval_with_cursor(&expr, doc_cursor);
+        assert!(result.is_error());
     }
 
     #[test]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2099,6 +2099,21 @@ mod tests {
         assert!(!index.bp().is_empty());
     }
 
+    /// `DocumentCursor::line_comment`'s default impl (`document.rs`,
+    /// unconditionally `None`) is what every JSON cursor uses - JSON has no
+    /// comment syntax, so `JsonCursor` never overrides it. Its only
+    /// production caller (the `line_comment` jq builtin) switched to
+    /// `line_comment_checked` for YAML's #797 fix, which has its own
+    /// JSON-side default (`Ok(None)`) - this pins the older, still-public
+    /// default directly, since nothing else reaches it anymore.
+    #[test]
+    fn test_document_cursor_line_comment_default_is_none_for_json() {
+        let json = br#"{"a": 1}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        assert_eq!(DocumentCursor::line_comment(&root), None);
+    }
+
     /// `stream_json_as_yaml`'s scalar-string arm previously read
     /// `raw_bytes()` (the source JSON bytes, quotes and escapes included)
     /// instead of the decoded `as_str()` content, so a plain string value

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -904,6 +904,25 @@ mod tests {
         // Present but not valid UTF-8 - must be `Err`, not silently `Ok(None)`
         // like the tolerant `line_comment_raw` getter.
         assert!(field_line_comment_checked(b"a: 1 # caf\xE9\n", "a").is_err());
+        // A key that isn't the first field - exercises the helper's
+        // skip-and-continue loop, not just its immediate-match return.
+        assert_eq!(
+            field_line_comment_checked(b"a: 1\nb: 2 # keep this\n", "b"),
+            Ok(Some("keep this".to_string()))
+        );
+        // A key that's absent entirely - the helper's own fallback, as
+        // opposed to a present-but-commentless value (the "Absent" case
+        // above).
+        assert_eq!(field_line_comment_checked(b"a: 1\n", "z"), Ok(None));
+        // A preceding field with a non-scalar (explicit complex) key -
+        // `field.key()` returns `YamlValue::Sequence`, not `String`, so the
+        // helper's `if let YamlValue::String(k) = field.key()` pattern
+        // match itself fails and skips the field, distinct from the
+        // scalar-key-that-just-doesn't-match case above.
+        assert_eq!(
+            field_line_comment_checked(b"? [1, 2]\n: 1\na: 2 # keep this\n", "a"),
+            Ok(Some("keep this".to_string()))
+        );
     }
 
     #[test]

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -860,6 +860,52 @@ mod tests {
         assert_eq!(field_line_comment_raw(yaml, "b"), None);
     }
 
+    /// Helper: like [`field_line_comment_raw`], but via the checked getter
+    /// that distinguishes "no comment" from "comment present but not valid
+    /// UTF-8" (issue #797).
+    fn field_line_comment_checked(
+        yaml: &[u8],
+        key: &str,
+    ) -> Result<Option<String>, core::str::Utf8Error> {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Mapping(fields) = doc_cursor.value() else {
+            panic!("expected a mapping document");
+        };
+        for field in fields {
+            if let YamlValue::String(k) = field.key() {
+                if k.raw_bytes() == key.as_bytes() {
+                    return field
+                        .value_cursor()
+                        .line_comment_checked()
+                        .map(|opt| opt.map(alloc::string::ToString::to_string));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    #[test]
+    fn test_line_comment_checked_distinguishes_absent_from_invalid_utf8_797() {
+        // Absent: no comment at all.
+        assert_eq!(field_line_comment_checked(b"a: 1\nb: 2\n", "a"), Ok(None));
+        // Present and valid - stripped form, like `line_comment` (not the
+        // raw `#`-prefixed form `line_comment_raw` returns).
+        assert_eq!(
+            field_line_comment_checked(b"a: 1 # keep this\n", "a"),
+            Ok(Some("keep this".to_string()))
+        );
+        // Present but not valid UTF-8 - must be `Err`, not silently `Ok(None)`
+        // like the tolerant `line_comment_raw` getter.
+        assert!(field_line_comment_checked(b"a: 1 # caf\xE9\n", "a").is_err());
+    }
+
     #[test]
     fn test_line_comment_captured_on_quoted_scalar() {
         let yaml = b"a: \"hello\" # quoted\n";

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1845,19 +1845,37 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         self.index.get_tag(self.bp_pos)
     }
 
+    /// Get the raw byte range of this node's trailing same-line comment and
+    /// decode it as UTF-8, distinguishing "no comment" (`Ok(None)`) from
+    /// "comment present but not valid UTF-8" (`Err(_)`) — the shared
+    /// decode point for [`Self::line_comment_raw`] (tolerant: invalid bytes
+    /// collapse to `None`, for output/write paths that must keep rendering
+    /// the rest of the document) and [`Self::line_comment_checked`] (strict:
+    /// invalid bytes surface as an error, issue #797).
+    #[inline]
+    fn line_comment_raw_checked(&self) -> Result<Option<&str>, core::str::Utf8Error> {
+        let Some((start, end)) = self.index.get_line_comment(self.bp_pos) else {
+            return Ok(None);
+        };
+        core::str::from_utf8(&self.text[start as usize..end as usize]).map(Some)
+    }
+
     /// Get the raw trailing same-line comment for this node, `#` and all,
     /// exactly as it appears in the source (issue #710).
     ///
-    /// Returns `None` if this node has no trailing comment. Used by the
-    /// write path, which re-emits the bytes verbatim after a single
-    /// normalized space (matching real `yq`'s output, verified empirically:
-    /// the gap before `#` is normalized to one space, but everything from
-    /// `#` onward — including internal/trailing whitespace — is preserved
+    /// Returns `None` if this node has no trailing comment *or* if the
+    /// comment bytes aren't valid UTF-8 — this tolerant getter is for
+    /// output/write paths that must keep rendering the rest of the document
+    /// either way; use [`Self::line_comment_checked`] where "absent" and
+    /// "invalid" need to be told apart (issue #797). Used by the write
+    /// path, which re-emits the bytes verbatim after a single normalized
+    /// space (matching real `yq`'s output, verified empirically: the gap
+    /// before `#` is normalized to one space, but everything from `#`
+    /// onward — including internal/trailing whitespace — is preserved
     /// as-is). See [`Self::line_comment`] for the stripped getter form.
     #[inline]
     pub fn line_comment_raw(&self) -> Option<&str> {
-        let (start, end) = self.index.get_line_comment(self.bp_pos)?;
-        core::str::from_utf8(&self.text[start as usize..end as usize]).ok()
+        self.line_comment_raw_checked().ok().flatten()
     }
 
     /// Get this node's trailing same-line comment text (the `line_comment`
@@ -1867,7 +1885,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// unchanged, since there's nothing to strip.
     ///
     /// Returns `None` if this node has no trailing comment; the builtin
-    /// itself maps that to `""`, matching real `yq`.
+    /// itself maps that to `""`, matching real `yq`. Invalid UTF-8 also
+    /// collapses to `None` here — use [`Self::line_comment_checked`] to
+    /// tell the two apart (issue #797).
     #[inline]
     pub fn line_comment(&self) -> Option<&str> {
         let raw = self.line_comment_raw()?;
@@ -1876,6 +1896,20 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // of the text with nothing to strip, e.g. `#keep this` stays
         // `"#keep this"` unchanged (verified against real `yq`).
         Some(raw.strip_prefix("# ").unwrap_or(raw))
+    }
+
+    /// Get this node's trailing same-line comment, distinguishing "no
+    /// comment" (`Ok(None)`) from "comment present but not valid UTF-8"
+    /// (`Err(_)`) — unlike [`Self::line_comment`], which silently collapses
+    /// both to `None`, indistinguishable from each other (issue #797).
+    /// Mirrors `parse_alias_value`'s `YamlValue::Error` handling of the
+    /// identical situation for an invalid-UTF-8 anchor name.
+    #[inline]
+    pub fn line_comment_checked(&self) -> Result<Option<&str>, core::str::Utf8Error> {
+        match self.line_comment_raw_checked()? {
+            Some(raw) => Ok(Some(raw.strip_prefix("# ").unwrap_or(raw))),
+            None => Ok(None),
+        }
     }
 
     /// Get the anchor name that this alias references.
@@ -5118,6 +5152,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     #[inline]
     fn line_comment_raw(&self) -> Option<String> {
         YamlCursor::line_comment_raw(self).map(ToString::to_string)
+    }
+
+    #[inline]
+    fn line_comment_checked(&self) -> Result<Option<String>, core::str::Utf8Error> {
+        YamlCursor::line_comment_checked(self).map(|opt| opt.map(ToString::to_string))
     }
 
     #[inline]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1372,7 +1372,6 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if indent_spaces == 0 || self.style() == "flow" {
                     // Flow style
                     out.write_char('{')?;
-                    let mut first = true;
                     let mut items: Vec<_> = fields.into_iter().collect();
                     if sort_keys {
                         let mut keyed: Vec<_> = items
@@ -1382,14 +1381,22 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         keyed.sort_by(|a, b| a.0.cmp(&b.0));
                         items = keyed.into_iter().map(|(_, field)| field).collect();
                     }
-                    for field in items {
-                        if !first {
+                    let last_index = items.len() - 1;
+                    for (i, field) in items.into_iter().enumerate() {
+                        if i != 0 {
                             out.write_str(", ")?;
                         }
-                        first = false;
                         write_yaml_field_key(out, field)?;
                         out.write_str(": ")?;
                         write_yaml_child_inline(out, field.value_cursor(), unit, sort_keys)?;
+                        if i == last_index {
+                            write_flow_last_item_comment(
+                                out,
+                                field.value_cursor().line_comment_raw(),
+                                current_indent,
+                                unit,
+                            )?;
+                        }
                     }
                     out.write_char('}')
                 } else {
@@ -1482,6 +1489,14 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         }
                         first = false;
                         write_yaml_child_inline(out, cursor, unit, sort_keys)?;
+                        if rest.is_empty() {
+                            write_flow_last_item_comment(
+                                out,
+                                cursor.line_comment_raw(),
+                                current_indent,
+                                unit,
+                            )?;
+                        }
                         elems = rest;
                     }
                     out.write_char(']')
@@ -5587,6 +5602,35 @@ fn write_line_comment<Out: core::fmt::Write>(
         }
         None => Ok(()),
     }
+}
+
+/// Write the last item's own trailing comment in a flow-style sequence or
+/// mapping, if present, followed by a newline and reindent to the
+/// container's own indentation (issue #794).
+///
+/// A comment can't be followed by the closing `]`/`}` on the same line -
+/// `#` would consume the bracket into the comment text, corrupting the
+/// YAML - so unlike a comment elsewhere in a flow collection, the last
+/// item's own comment forces a line break before the close, mirroring real
+/// `yq`'s own reformatting for this shape (which also adds a trailing
+/// comma; that's not replicated here, as it's cosmetic and comma-before-
+/// comment isn't required by the grammar). Only the *last* item is handled
+/// this way - a comment on a middle item would need to avoid also
+/// swallowing the following `,` onto the same line, which no filed issue
+/// currently asks for.
+fn write_flow_last_item_comment<Out: core::fmt::Write>(
+    out: &mut Out,
+    comment: Option<&str>,
+    current_indent: usize,
+    unit: char,
+) -> core::fmt::Result {
+    if let Some(c) = comment {
+        out.write_char(' ')?;
+        out.write_str(c)?;
+        out.write_char('\n')?;
+        write_yaml_indent(out, current_indent, unit)?;
+    }
+    Ok(())
 }
 
 /// Stream independent document cursors as a single YAML sequence (block or

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5190,6 +5190,16 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn stream_yaml_as_document<Out: core::fmt::Write>(
+        &self,
+        out: &mut Out,
+        indent: IndentSpec,
+        sort_keys: bool,
+    ) -> core::fmt::Result {
+        YamlCursor::stream_yaml_as_document(self, out, indent, sort_keys)
+    }
+
+    #[inline]
     fn is_falsy(&self) -> bool {
         // A value is falsy if it's null or false
         match self.value() {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1468,7 +1468,26 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 unit,
                                 sort_keys,
                             )?;
-                            write_line_comment(out, value.line_comment_raw())?;
+                            // The value's own comment takes priority; fall
+                            // back to the key's own comment when the value
+                            // has none - covers an explicit key's trailing
+                            // comment (`? k # key comment\n: v\n`), which
+                            // the parser captures against the key's own
+                            // node but which otherwise has no write site
+                            // once key and value collapse onto one output
+                            // line (#795). A no-op for the ordinary
+                            // implicit-key case: the parser only ever
+                            // captures a same-line comment against
+                            // whichever node's text ends there last, which
+                            // for `a: v # c` is always the value, never
+                            // the key.
+                            let key_cursor = field.key_cursor();
+                            write_line_comment(
+                                out,
+                                value
+                                    .line_comment_raw()
+                                    .or_else(|| key_cursor.line_comment_raw()),
+                            )?;
                         }
                     }
                     Ok(())

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1390,12 +1390,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         out.write_str(": ")?;
                         write_yaml_child_inline(out, field.value_cursor(), unit, sort_keys)?;
                         if i == last_index {
-                            write_flow_last_item_comment(
-                                out,
-                                field.value_cursor().line_comment_raw(),
-                                current_indent,
-                                unit,
-                            )?;
+                            let value_cursor = field.value_cursor();
+                            let comment = value_cursor.line_comment_raw();
+                            write_flow_last_item_comment(out, comment, current_indent, unit)?;
                         }
                     }
                     out.write_char('}')
@@ -1482,12 +1479,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // for `a: v # c` is always the value, never
                             // the key.
                             let key_cursor = field.key_cursor();
-                            write_line_comment(
-                                out,
-                                value
-                                    .line_comment_raw()
-                                    .or_else(|| key_cursor.line_comment_raw()),
-                            )?;
+                            let comment = value
+                                .line_comment_raw()
+                                .or_else(|| key_cursor.line_comment_raw());
+                            write_line_comment(out, comment)?;
                         }
                     }
                     Ok(())
@@ -1509,12 +1504,8 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         first = false;
                         write_yaml_child_inline(out, cursor, unit, sort_keys)?;
                         if rest.is_empty() {
-                            write_flow_last_item_comment(
-                                out,
-                                cursor.line_comment_raw(),
-                                current_indent,
-                                unit,
-                            )?;
+                            let comment = cursor.line_comment_raw();
+                            write_flow_last_item_comment(out, comment, current_indent, unit)?;
                         }
                         elems = rest;
                     }
@@ -10513,6 +10504,59 @@ mod tests {
                     .stream_yaml(&mut out, IndentSpec::COMPACT, false)
                     .expect("streams");
                 assert_eq!(out, "{!!str k: v}");
+                return;
+            }
+        }
+        panic!("Could not find value");
+    }
+
+    /// Direct coverage for `DocumentCursor::stream_yaml`'s `YamlCursor`
+    /// delegation. Its only production caller (`GenericResult::stream_yaml`'s
+    /// `OneCursor`/`ManyCursor` arms, `eval_generic.rs`) switched to
+    /// `stream_yaml_as_document` for #793a (a navigated container keeps its
+    /// own trailing comment, unlike a navigated scalar) - this pins the
+    /// bare, no-own-comment contract directly (trait-qualified, same
+    /// pattern as `test_stream_yaml_flow_mapping_preserves_tagged_key`
+    /// above for the inherent method), since nothing else reaches it
+    /// anymore.
+    #[test]
+    fn test_document_cursor_stream_yaml_trait_delegation_drops_own_comment() {
+        let yaml = b"a: [1, 2, 3] # trailing\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let root = index.root(yaml);
+        if let YamlValue::Mapping(fields) = first_doc(root) {
+            if let Some(field) = fields.into_iter().next() {
+                let cursor = field.value_cursor();
+                let mut out = String::new();
+                DocumentCursor::stream_yaml(&cursor, &mut out, IndentSpec::COMPACT, false)
+                    .expect("streams");
+                assert_eq!(out, "[1, 2, 3]");
+                return;
+            }
+        }
+        panic!("Could not find value");
+    }
+
+    /// Direct coverage for the stripped `line_comment` getter (issue #710)
+    /// and its `DocumentCursor` trait delegation. Both lost their only
+    /// caller when the `line_comment` jq builtin switched to
+    /// `line_comment_checked`, which distinguishes "absent" from "invalid
+    /// UTF-8" where this getter collapses both to `None` (issue #797) -
+    /// pinned directly here since nothing in the CLI reaches either form
+    /// anymore.
+    #[test]
+    fn test_line_comment_getter_and_trait_delegation_direct() {
+        let yaml = b"a: 1 # keep this\nb: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let root = index.root(yaml);
+        if let YamlValue::Mapping(fields) = first_doc(root) {
+            if let Some(field) = fields.into_iter().next() {
+                let cursor = field.value_cursor();
+                assert_eq!(cursor.line_comment(), Some("keep this"));
+                assert_eq!(
+                    DocumentCursor::line_comment(&cursor),
+                    Some("keep this".to_string())
+                );
                 return;
             }
         }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5518,6 +5518,51 @@ fn test_flow_collection_trailing_comment_preserved_710() -> Result<()> {
     Ok(())
 }
 
+/// #794: unlike the comment-after-the-closing-bracket case just above, a
+/// comment between the *last element* and the closing bracket *on a
+/// following line* used to be silently dropped from identity output
+/// entirely (not merely reformatted differently). The parser already
+/// attributes it to the last element (verified via the DOM path, which
+/// showed it correctly before this fix - see #793's own repro); the bug was
+/// that flow-style rendering never emitted an item's own trailing comment
+/// at all. A newline before the closing bracket is required for validity -
+/// `#` would otherwise consume the bracket into the comment text - so exact
+/// formatting isn't expected to byte-match real `yq`'s own reformatting.
+#[test]
+fn test_flow_sequence_comment_before_closing_bracket_on_next_line_794() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: [1, 2, 3 # trailing\n]\n", &[])?;
+    assert_eq!(code, 0);
+    assert!(out.contains("# trailing"), "comment missing: {out:?}");
+    // Must still be valid YAML that round-trips without losing the comment.
+    let (out2, code2) = run_yq_stdin(".", &out, &[])?;
+    assert_eq!(code2, 0);
+    assert_eq!(out2, out);
+    Ok(())
+}
+
+/// Same shape, but for a flow mapping rather than a flow sequence.
+#[test]
+fn test_flow_mapping_comment_before_closing_brace_on_next_line_794() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: {b: 1, c: 2 # trailing\n}\n", &[])?;
+    assert_eq!(code, 0);
+    assert!(out.contains("# trailing"), "comment missing: {out:?}");
+    let (out2, code2) = run_yq_stdin(".", &out, &[])?;
+    assert_eq!(code2, 0);
+    assert_eq!(out2, out);
+    Ok(())
+}
+
+/// Regression guard: a *single*-element flow collection with the comment
+/// before the closing bracket on the next line hits the same "last item"
+/// code path as the multi-element cases above.
+#[test]
+fn test_flow_sequence_single_element_comment_before_closing_bracket_794() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: [1 # trailing\n]\n", &[])?;
+    assert_eq!(code, 0);
+    assert!(out.contains("# trailing"), "comment missing: {out:?}");
+    Ok(())
+}
+
 #[test]
 fn test_quoted_scalar_comment_preserved_710() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "a: \"hello\" # quoted\n", &[])?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -857,6 +857,33 @@ fn test_duplicate_mapping_key_survives_computed_index() -> Result<()> {
     Ok(())
 }
 
+/// #796: `select(...)` had the same latent bug as #631's `first`/`last`/
+/// computed-indexing - `eval_generic.rs`'s own `Builtin::Select` arm already
+/// forwarded the incoming cursor unchanged, but `can_use_m2_streaming` never
+/// had an arm for it, so `yq` always fell through to `evaluate_yaml_cursor`'s
+/// `to_owned()` DOM path and silently collapsed duplicate keys (and, since
+/// #710, the earlier key's own comment right along with it).
+#[test]
+fn test_duplicate_mapping_key_survives_select_796() -> Result<()> {
+    let yaml = "a: 1 # first\na: 2 # second\n";
+
+    let (out, code) = run_yq_stdin("select(true)", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: 1 # first\na: 2 # second\n");
+
+    // A real (non-`true`) predicate must still evaluate correctly through
+    // the new M2 path, not just pass everything through unconditionally.
+    let (filtered_out, code) = run_yq_stdin("select(.a == 2) | .a", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(filtered_out, "2\n");
+
+    let (json_out, code) = run_yq_stdin("select(true)", yaml, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(json_out, "{\"a\":1,\"a\":2}\n");
+
+    Ok(())
+}
+
 /// #733: `-S`/`--sort-keys` excluded identity/navigation queries from the M2
 /// cursor-streaming fast path, forcing them through the `OwnedValue` DOM
 /// (`IndexMap`-backed), which silently collapsed duplicate keys — the same
@@ -5642,14 +5669,23 @@ fn test_root_object_comment_preserved_on_identity_710() -> Result<()> {
     Ok(())
 }
 
-/// Same fix, but through the DOM/`select` path (`output_value` in
-/// `yq_runner.rs`) rather than the M2/P9 streaming path exercised by plain
-/// identity above.
+/// Same fix, but for `select(true)` rather than plain identity above.
+///
+/// Before #796, `select(...)` always fell through to the DOM path
+/// (`output_value`'s `root_comment_suffix` in `yq_runner.rs`), which
+/// reserializes every container to block style regardless of the source's
+/// own style - so this used to assert the reformatted `"a: 1 # trailing"`.
+/// #796 routes `select(...)` through the same cursor-native M2 path plain
+/// identity already used, which preserves the source's original flow/block
+/// style instead of always reformatting to block - so the expected output
+/// here changed to match, and now agrees with real `yq` byte-for-byte
+/// (verified against the pinned v4.53.3 binary), where the old block-style
+/// expectation did not.
 #[test]
 fn test_root_array_comment_preserved_on_select_710() -> Result<()> {
     let (out, code) = run_yq_stdin("select(true)", "{a: 1} # trailing\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim_end(), "a: 1 # trailing");
+    assert_eq!(out.trim_end(), "{a: 1} # trailing");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5977,12 +5977,14 @@ fn test_key_comment_not_exposed_via_line_comment_getter_765() -> Result<()> {
     Ok(())
 }
 
-/// A cursor-preserving filter (the DOM/`CommentTree` path, not bare
-/// identity's M2 streaming path) must also place the key's comment right
-/// after `key:`, not just plain `.`.
+/// The DOM/`CommentTree` path must also place the key's comment right
+/// after `key:`, not just plain `.` on the M2 streaming path (`--arg`
+/// forces the DOM path, since `select(...)` now routes through M2 after
+/// #796 and would no longer exercise this code for a query shape this
+/// simple - same reasoning as `test_explicit_key_comment_preserved_via_dom_path_795`).
 #[test]
-fn test_key_comment_preserved_via_select_dom_path_765() -> Result<()> {
-    let (out, code) = run_yq_stdin("select(true)", "a: # comment on key\n  b: 1\n", &[])?;
+fn test_key_comment_preserved_via_dom_path_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: # comment on key\n  b: 1\n", &["--arg", "x", "y"])?;
     assert_eq!(code, 0);
     assert_eq!(out, "a: # comment on key\n  b: 1\n");
     Ok(())
@@ -6049,11 +6051,12 @@ fn test_key_comment_preserved_with_null_value_at_eof_765() -> Result<()> {
     Ok(())
 }
 
-/// The DOM/`CommentTree` path (`select`, not bare identity's M2 streaming
-/// path) must also keep the comment for a null deferred value.
+/// The DOM/`CommentTree` path (`--arg` forces it, since `select(...)` now
+/// routes through M2 after #796 - see `test_key_comment_preserved_via_dom_path_765`
+/// above) must also keep the comment for a null deferred value.
 #[test]
-fn test_key_comment_preserved_with_null_value_via_select_dom_path_765() -> Result<()> {
-    let (out, code) = run_yq_stdin("select(true)", "a: # comment on key\nb: 2\n", &[])?;
+fn test_key_comment_preserved_with_null_value_via_dom_path_765() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: # comment on key\nb: 2\n", &["--arg", "x", "y"])?;
     assert_eq!(code, 0);
     assert_eq!(out, "a: # comment on key\nb: 2\n");
     Ok(())
@@ -6111,6 +6114,18 @@ fn test_explicit_key_comment_preserved_via_dom_path_795() -> Result<()> {
 #[test]
 fn test_implicit_key_same_line_value_comment_unaffected_by_795_fallback() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "a: v # normal\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: v # normal\n");
+    Ok(())
+}
+
+/// Same regression guard, but through the DOM/`CommentTree` path (`--arg`
+/// forces it, same as the other `_765`/`_795` DOM-path variants above) -
+/// the value's own comment must win outright on this path too, rather than
+/// falling back to a (non-existent, for this shape) key comment.
+#[test]
+fn test_implicit_key_same_line_value_comment_unaffected_by_795_fallback_dom_path() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: v # normal\n", &["--arg", "x", "y"])?;
     assert_eq!(code, 0);
     assert_eq!(out, "a: v # normal\n");
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5688,6 +5688,31 @@ fn test_field_navigation_still_drops_comment_after_root_fix_710() -> Result<()> 
     Ok(())
 }
 
+/// #793a: unlike a navigated *scalar* (dropped, see above - matches real
+/// `yq`), a navigated *container* keeps its own trailing comment, the same
+/// as when that container is the whole document's root. Before the fix,
+/// `GenericResult::stream_yaml`'s `OneCursor`/`ManyCursor` arms always used
+/// the bare (comment-less) `stream_yaml`, so `.a` alone silently dropped it
+/// even though plain `.` on the same document already kept it.
+#[test]
+fn test_navigated_container_keeps_own_comment_793a() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a", "a: [1, 2, 3] # trailing\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[1, 2, 3] # trailing\n");
+    Ok(())
+}
+
+/// Same fix, but for a multi-result stream (`.[]`) rather than a single
+/// navigated result - each streamed container result keeps its own comment
+/// independently.
+#[test]
+fn test_iterated_containers_keep_own_comments_793a() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[]", "- [1, 2] # x\n- [3, 4] # y\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[1, 2] # x\n[3, 4] # y\n");
+    Ok(())
+}
+
 /// A comment trailing the first document's scalar root in a multi-document
 /// stream is dropped by real `yq` too (verified empirically) - not a
 /// regression to "fix" here.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5749,6 +5749,54 @@ fn test_iterated_containers_keep_own_comments_793a() -> Result<()> {
     Ok(())
 }
 
+// #793b: on the DOM path (`OwnedValue` + `emit_yaml_value`, still reachable
+// via flags like `--arg` that can't use the M2 fast path even after #796
+// widened which queries can), a container's own trailing comment used to be
+// concatenated directly onto its last child's rendered line with no
+// separator - indistinguishable from that child's own comment. Fixed by
+// giving the container's own comment a standalone comment line instead.
+// `--arg x y` is used as the M2-blocking flag throughout (rather than the
+// original issue's `select(...)`, which #796 now routes through M2 and so
+// no longer reaches this code at all for these shapes).
+
+#[test]
+fn test_dom_path_container_comment_gets_own_line_not_glued_to_last_child_793b() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".a",
+        "a: [1, 2, 3] # trailing\nb: 2\n",
+        &["--arg", "x", "y"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- 1\n- 2\n- 3\n# trailing\n");
+    Ok(())
+}
+
+#[test]
+fn test_dom_path_root_container_comment_gets_own_line_793b() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".",
+        "items: [1, 2, 3] # container comment\n",
+        &["--arg", "x", "y"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "items:\n  - 1\n  - 2\n  - 3\n  # container comment\n");
+    Ok(())
+}
+
+/// A child's own comment and the container's own comment must both survive,
+/// as two distinct comments - not silently concatenated onto one line.
+#[test]
+fn test_dom_path_container_and_child_comments_stay_distinct_793b() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".",
+        "items: [1, 2 # child\n] # container\n",
+        &["--arg", "x", "y"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "items:\n  - 1\n  - 2 # child\n  # container\n");
+    Ok(())
+}
+
 /// A comment trailing the first document's scalar root in a multi-document
 /// stream is dropped by real `yq` too (verified empirically) - not a
 /// regression to "fix" here.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6071,6 +6071,52 @@ fn test_key_comment_preserved_with_null_value_and_sort_keys_765() -> Result<()> 
 }
 
 // ============================================================================
+// Explicit-key (`? k ... : v`) trailing comment (#795)
+// ============================================================================
+//
+// Distinct from #765 above: #765 covers the *implicit*-key form (`a: #
+// comment\n  b: 1`, key/value on separate lines via indentation); this is
+// the *explicit*-key form (`? k ... : v`), a different grammar production.
+// The parser already captures the key's own comment generically (any
+// scalar node close, including an explicit key) via the same side-table
+// #710 added, but no write site read it back for a same-line scalar value
+// until this fix - it was captured but never re-emitted anywhere.
+
+/// The issue's own repro: an explicit key's trailing comment, with a
+/// same-line scalar value - re-serialized to implicit single-line form,
+/// same as real `yq`.
+#[test]
+fn test_explicit_key_comment_preserved_on_identity_795() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k # key comment\n: v\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: v # key comment\n");
+    Ok(())
+}
+
+/// Same fix, but through the DOM/`CommentTree` path (`--arg` forces it,
+/// since `select(...)` now routes through the M2 path after #796 and would
+/// no longer exercise this code for a query shape this simple).
+#[test]
+fn test_explicit_key_comment_preserved_via_dom_path_795() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k # key comment\n: v\n", &["--arg", "x", "y"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: v # key comment\n");
+    Ok(())
+}
+
+/// Regression guard: an ordinary implicit key with its own same-line value
+/// comment is unaffected by the new key-comment fallback (the value's own
+/// comment always takes priority; the key's own comment is only ever
+/// present at all for the explicit-key shape above).
+#[test]
+fn test_implicit_key_same_line_value_comment_unaffected_by_795_fallback() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: v # normal\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: v # normal\n");
+    Ok(())
+}
+
+// ============================================================================
 // Merge-flag suffixes on `*`/`*=` (#713)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Six independently bisectable commits, each fixing one follow-up bug from #710's code review. #798 (head_comment/foot_comment builtins, `line_comment =` set-form, `... comments=""`) is intentionally excluded — its own issue text says it needs new parser-level standalone-comment capture design that doesn't exist yet, unlike these five/six fixes.

- **#797** — `line_comment` now raises an error on invalid UTF-8 in a comment instead of silently treating it as absent, matching the sibling anchor-name path's `YamlValue::Error` handling.
- **#793** (two commits) — a container's own trailing comment is no longer dropped on navigated fast-path results (e.g. `.a`), and is no longer glued onto its last child's line (indistinguishable from that child's own comment) on the DOM path.
- **#796** — `select(...)` now routes through the duplicate-key-safe M2 cursor path, matching the precedent set by #631/#733 for `first`/`last`/computed-indexing and `-S`/`--tab`. As a side effect this also fixed a real-`yq` divergence: the old DOM path always reformatted containers to block style regardless of source style.
- **#794** — a flow collection's comment between its last element and a closing bracket on a following line is preserved instead of silently dropped.
- **#795** — an explicit key's (`? k # comment`) trailing comment is now emitted when re-serialized to implicit single-line form, instead of being captured but never written anywhere.

## Test plan

- [x] `cargo build --features cli,regex` and `--release`
- [x] `cargo test --features cli,regex` (full suite, including `tests/yq_cli_tests.rs`, `tests/yq_golden_tests.rs` conformance against pinned real `yq` v4.53.3, and new tests for each issue)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (the non-`scalar-yaml` ARM/x86 SIMD-path clippy leg)
- [x] Manually re-verified every repro from #793–#797 against expected output