### PR TITLE
fix(jq): match(re) produces no output on no match instead of null

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6445,10 +6445,10 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::ManyOwned(matches)
         }
     } else {
-        // Return first match or null
+        // Return first match, or no output (not `null`) when there's no match.
         match re.captures(&input) {
             Some(caps) => QueryResult::Owned(build_match_object(&re, &caps)),
-            None => QueryResult::Owned(OwnedValue::Null),
+            None => QueryResult::None,
         }
     }
 }
@@ -25133,10 +25133,27 @@ mod tests {
                 assert_eq!(obj.get("length"), Some(&OwnedValue::Int(3)));
             }
         );
+    }
 
-        // No match returns null
-        query!(br#""hello""#, r#"match("[0-9]+")"#,
-            QueryResult::Owned(OwnedValue::Null) => {}
+    // #810: match(re) produced `null` on no match, diverging from real jq's
+    // "no output" (empty stream) behavior -- the same defect class #805 fixed
+    // for capture. match(re; flags) delegates to the same implementation, so
+    // both forms are covered here (verified against pinned jq-1.7.1: all four
+    // combinations below produce zero outputs).
+    #[cfg(feature = "regex")]
+    #[test]
+    fn test_regex_match_no_match_produces_no_output() {
+        query!(br#""abc""#, r#"match("[0-9]+")"#,
+            QueryResult::None => {}
+        );
+        query!(br#""abc""#, r#"match("[0-9]+")?"#,
+            QueryResult::None => {}
+        );
+        query!(br#""abc""#, r#"match("[0-9]+"; "")"#,
+            QueryResult::None => {}
+        );
+        query!(br#""abc""#, r#"match("[0-9]+"; "")?"#,
+            QueryResult::None => {}
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2570,6 +2570,24 @@ fn test_regex_capture_flags_form_no_match_produces_no_output() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_regex_match_bare_form_no_match_produces_no_output() -> Result<()> {
+    // #810: bare match(re) printed `null` on no match; real jq prints nothing.
+    let (output, code) = run_jq_stdin(r#"match("[0-9]+")"#, r#""abc""#, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "");
+    Ok(())
+}
+
+#[test]
+fn test_regex_match_flags_form_no_match_produces_no_output() -> Result<()> {
+    // #810: match(re; flags) printed `null` on no match; real jq prints nothing.
+    let (output, code) = run_jq_stdin(r#"match("[0-9]+"; "")"#, r#""abc""#, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "");
+    Ok(())
+}
+
 // =============================================================================
 // range() float support (issue #165)
 // =============================================================================


### PR DESCRIPTION
## Summary
- `match(re)` and `match(re; flags)` (non-global) returned `null` when the regex didn't match; real jq produces no output at all (empty stream) — the same defect class as #805, which fixed the equivalent bug in `capture`.
- `builtin_match`'s non-global no-match arm now returns `QueryResult::None` instead of `QueryResult::Owned(OwnedValue::Null)`. `match(re; flags)` already delegates into `builtin_match`, so this one change fixes both forms. The already-correct global (`g` flag) no-match path is untouched.

Fixes #810

## Test plan
- [x] `test_regex_match` no-match assertion removed (it pinned the old, wrong `null` behavior)
- [x] New unit test `test_regex_match_no_match_produces_no_output` covers bare/flags × with/without `?`
- [x] New CLI tests assert empty stdout + exit 0 for both forms
- [x] `cargo test --features cli,regex --lib` — 2317 passed
- [x] `cargo test --features cli,regex --test jq_cli_tests` — 165 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Manual CLI check: `echo '"abc"' | succinctly jq -c 'match("[0-9]+")'` now prints nothing (exit 0); successful matches and the `g`-flag no-match case are unaffected