### PR TITLE
fix(jq): fix paths(node_filter) fan-out collapse in builtin_paths_filter

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14457,85 +14457,79 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // and `select(f)` is `if f then . else empty end` -- `if` forks
                 // over every output `f` produces, so a multi-output node_filter
                 // must be checked per-output, not collapsed into one value
-                // first. `eval_owned_multi` (not `eval_owned_expr`, which
-                // collapses 2+ outputs into one always-truthy `OwnedValue::Array`
-                // before any truthiness check ever runs) preserves that
-                // cardinality, and each truthy output re-adds this path -- once
-                // per truthy output, not once per matching node. Confirmed
-                // against jq 1.7.1: `{"a":1,"b":{"c":2}} | [paths(false,false)]`
-                // is `[]` (the bug this fixes), and `[paths(true,true)]`
-                // duplicates every path, `[["a"],["a"],["b"],["b"],["b","c"],
-                // ["b","c"]]` -- not each path once (#773).
-                match eval_owned_multi::<S>(filter, &val_at_path) {
-                    Ok(outputs) => {
-                        for out in &outputs {
+                // first. Confirmed against jq 1.7.1:
+                // `{"a":1,"b":{"c":2}} | [paths(false,false)]` is `[]`, and
+                // `[paths(true,true)]` duplicates every path, `[["a"],["a"],
+                // ["b"],["b"],["b","c"],["b","c"]]` -- not each path once
+                // (#773).
+                //
+                // This calls `eval_owned_input` directly rather than the
+                // shared `eval_owned_multi` helper (used by ~19 other
+                // callers). `eval_owned_multi`'s contract collapses a
+                // `Partial` -- one or more outputs followed by an
+                // error/break/halt -- straight to `Err`, discarding the
+                // outputs already produced; that is the correct, deliberate
+                // behavior for those other callers (#694) and must not
+                // change. But `paths(node_filter)` needs different, local
+                // handling here: confirmed against jq 1.7.1 that a node's
+                // own truthy output(s) produced before an escape in the
+                // *same* node_filter fan-out are still kept, e.g.
+                // `[1,"x",2] | paths(if type=="string" then (true,
+                // error("bad")) else true end)` streams `[0]`, `[1]`, then
+                // raises (not just `[0]`) -- so the prefix is credited
+                // below before the escape is handled, instead of being
+                // dropped along with it. Once credited, the escape itself
+                // still follows the existing policy: `halt` propagates
+                // out of the whole builtin (#791, nothing may catch it),
+                // while an ordinary error/break is swallowed and the loop
+                // moves to the next node -- a pre-existing, documented
+                // divergence from real jq (which aborts the entire
+                // `paths(...)` call on an uncaught error/break) that this
+                // fix does not change.
+                match eval_owned_input::<Vec<u64>, S>(filter, &val_at_path, false) {
+                    QueryResult::Halt(code) => {
+                        return partial(filtered_paths, Control::Halt(code));
+                    }
+                    // Bare escape, nothing produced before it -- swallow and
+                    // move to the next node (pre-existing policy). Unlike
+                    // the old `eval_owned_expr`-based code this replaced,
+                    // `Break` is directly reachable here (matched on the
+                    // raw `QueryResult`, not funneled through `EvalEscape`),
+                    // but it is still swallowed rather than propagated to
+                    // an outer `label`: `val_at_path` is re-indexed into an
+                    // isolated synthetic document and evaluated on its own
+                    // (`eval_owned_input`/`eval_single`), so a `label`
+                    // lexically enclosing the original `paths(...)` call
+                    // site is not part of the AST being evaluated here --
+                    // a `break` naming it can never resolve no matter which
+                    // `QueryResult` variant carries it. Real propagation
+                    // would need `filter` resolved through `resolve_node`'s
+                    // own machinery instead (as #824 did for its sites);
+                    // tracked separately for every remaining
+                    // `eval_owned_expr`-shaped call site, `paths(node_filter)`
+                    // included, under #833 -- out of scope for this fix.
+                    QueryResult::Error(_) | QueryResult::Break(_) => {}
+                    QueryResult::Partial(vs, control) => {
+                        for out in &vs {
+                            if out.is_truthy() {
+                                filtered_paths.push(path.clone());
+                            }
+                        }
+                        if let Control::Halt(code) = control {
+                            return partial(filtered_paths, Control::Halt(code));
+                        }
+                        // Error/Break: the prefix above is already
+                        // credited; swallow the escape itself and move on
+                        // (same #833-tracked limitation as the bare-escape
+                        // arm above).
+                    }
+                    other => {
+                        for out in other.collect_owned() {
                             if out.is_truthy() {
                                 filtered_paths.push(path.clone());
                             }
                         }
                     }
-                    // Every other error here is pre-existing, silently
-                    // swallowed behavior this fix does not change (`Ok(..)`
-                    // above), but a halt must never be silently ignored
-                    // (#791): `paths(halt_error(3))` has to actually halt,
-                    // not just skip the node as if the filter were falsy.
-                    // Paths already matched before this node must still be
-                    // reported (#400/#494), matching real jq's lazy
-                    // streaming of paths(node_filter). `eval_owned_multi`
-                    // itself intercepts a mid-stream error/break exactly
-                    // like a bare one (see its doc comment) rather than
-                    // keeping the outputs already produced before it, so a
-                    // node_filter that fans out into a truthy output
-                    // followed by an ordinary error still drops the whole
-                    // node -- consistent with the pre-existing "swallow the
-                    // whole node on error" policy this fix does not change.
-                    Err(EvalEscape::Halt(code)) => {
-                        return partial(filtered_paths, Control::Halt(code));
-                    }
-                    // The `Break` half of this pattern is structurally dead
-                    // code today: `eval_owned_expr` (unlike `resolve_node`'s
-                    // own `eval_owned_multi`-based sites, which #824 fixed)
-                    // always collapses a `Control::Break` into a *synthetic*
-                    // `EvalEscape::Error("break $label not in label")`
-                    // internally before returning, so this call can never
-                    // actually produce `Err(EvalEscape::Break(_))`.
-                    //
-                    // That does NOT mean `paths(node_filter)` is safe from
-                    // #824's bug class, though — a `break` in `filter` still
-                    // reaches here, just disguised as that synthetic `Error`,
-                    // and the `Error(_)` half right below swallows it
-                    // silently (grouped with every other pre-existing,
-                    // already-accepted error-swallowing case here) instead of
-                    // unwinding to its label. Confirmed live: `label $out |
-                    // [paths(if .==2 then break $out else true end)]` on
-                    // `{"a":1,"b":{"c":2}}` prints `[["a"],["b"]]` here,
-                    // where real jq prints nothing at all (the break cancels
-                    // the whole `[...]` construction). `builtin_paths_filter`
-                    // does not resolve `filter` through `resolve_node` at
-                    // all, so it never got any part of #824's fix — this is
-                    // the same pre-existing gap #833 already tracks for
-                    // `eval_owned_expr`'s other call sites, not a regression
-                    // from this PR. Left as a plain comment rather than
-                    // `todo!()`/`unreachable!()`: the observable bug is
-                    // already live via `Error(_)` regardless of what happens
-                    // to the dead `Break(_)` sub-pattern, so a panic here
-                    // would not catch #833 landing — it would just crash a
-                    // call that already silently mishandles this case.
-                    //
-                    // FLAG FOR #833: once `eval_owned_expr` is changed to
-                    // propagate a real `Break` instead of synthesizing this
-                    // error, the `Break(_)` half of this pattern stops being
-                    // dead code and starts silently swallowing breaks
-                    // directly (same wrong observable result, new
-                    // mechanism) unless this arm is revisited then to decide
-                    // what `paths(node_filter)` should actually do with one
-                    // — most likely propagate it the way `resolve_node`'s
-                    // own arms do post-#824, not fold it into "just skip
-                    // this node." Re-confirmed independently by multiple
-                    // review passes during #824 (see PR #834's discussion)
-                    // as a real, easy-to-miss follow-on risk, not a
-                    // hypothetical one.
-                    Err(EvalEscape::Error(_) | EvalEscape::Break(_)) => {}
                 }
             }
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14463,74 +14463,81 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // ["b"],["b"],["b","c"],["b","c"]]` -- not each path once
                 // (#773).
                 //
-                // This calls `eval_owned_input` directly rather than the
-                // shared `eval_owned_multi` helper (used by ~19 other
-                // callers). `eval_owned_multi`'s contract collapses a
-                // `Partial` -- one or more outputs followed by an
-                // error/break/halt -- straight to `Err`, discarding the
-                // outputs already produced; that is the correct, deliberate
-                // behavior for those other callers (#694) and must not
-                // change. But `paths(node_filter)` needs different, local
-                // handling here: confirmed against jq 1.7.1 that a node's
-                // own truthy output(s) produced before an escape in the
-                // *same* node_filter fan-out are still kept, e.g.
-                // `[1,"x",2] | paths(if type=="string" then (true,
-                // error("bad")) else true end)` streams `[0]`, `[1]`, then
-                // raises (not just `[0]`) -- so the prefix is credited
-                // below before the escape is handled, instead of being
-                // dropped along with it. Once credited, the escape itself
-                // still follows the existing policy: `halt` propagates
-                // out of the whole builtin (#791, nothing may catch it),
-                // while an ordinary error/break is swallowed and the loop
-                // moves to the next node -- a pre-existing, documented
-                // divergence from real jq (which aborts the entire
-                // `paths(...)` call on an uncaught error/break) that this
-                // fix does not change.
-                match eval_owned_input::<Vec<u64>, S>(filter, &val_at_path, false) {
-                    QueryResult::Halt(code) => {
-                        return partial(filtered_paths, Control::Halt(code));
-                    }
-                    // Bare escape, nothing produced before it -- swallow and
-                    // move to the next node (pre-existing policy). Unlike
-                    // the old `eval_owned_expr`-based code this replaced,
-                    // `Break` is directly reachable here (matched on the
-                    // raw `QueryResult`, not funneled through `EvalEscape`),
-                    // but it is still swallowed rather than propagated to
-                    // an outer `label`: `val_at_path` is re-indexed into an
-                    // isolated synthetic document and evaluated on its own
-                    // (`eval_owned_input`/`eval_single`), so a `label`
-                    // lexically enclosing the original `paths(...)` call
-                    // site is not part of the AST being evaluated here --
-                    // a `break` naming it can never resolve no matter which
-                    // `QueryResult` variant carries it. Real propagation
-                    // would need `filter` resolved through `resolve_node`'s
-                    // own machinery instead (as #824 did for its sites);
-                    // tracked separately for every remaining
-                    // `eval_owned_expr`-shaped call site, `paths(node_filter)`
-                    // included, under #833 -- out of scope for this fix.
-                    QueryResult::Error(_) | QueryResult::Break(_) => {}
-                    QueryResult::Partial(vs, control) => {
-                        for out in &vs {
-                            if out.is_truthy() {
-                                filtered_paths.push(path.clone());
+                // `paths(node_filter)`'s own definition is `select(node_filter)`'s
+                // fan-out (`path(recurse|select(node_filter))`), and
+                // `push_truthiness` is the exact helper this codebase
+                // already uses for that fan-out shape (it backs `eval_if`/
+                // `builtin_select` via `eval_fanout`) -- collect one
+                // truthiness bit per output instead of collapsing them
+                // (matching `eval_owned_expr_fork`'s "keep every output"
+                // idiom that `reduce`/`foreach`/`while`/`until` build on,
+                // not the shared `eval_owned_multi` helper used by ~19
+                // *other* callers, whose contract collapses a `Partial`
+                // straight to `Err` and discards the outputs already
+                // produced -- correct there, #694, wrong here). A node's
+                // own truthy output(s) produced before an error/break/halt
+                // in the *same* node_filter fan-out must still be kept and
+                // counted once each. Confirmed against jq 1.7.1: `[1,"x",2]
+                // | paths(if type=="string" then (true, error("bad")) else
+                // true end)` streams `[0]`, `[1]`, then raises -- not just
+                // `[0]`.
+                //
+                // Once credited, `halt` propagates out of the whole builtin
+                // (#791, nothing may catch it); an ordinary error/break is
+                // swallowed and the loop moves to the next node instead --
+                // a pre-existing, documented divergence from real jq (which
+                // aborts the entire `paths(...)` call on an uncaught
+                // error/break, filed as a follow-up gap, #850) that this
+                // fix does not change. `break` specifically can never
+                // resolve to an outer `label` here regardless:
+                // `val_at_path` is re-indexed into an isolated synthetic
+                // document and evaluated on its own, so a `label` lexically
+                // enclosing the original `paths(...)` call is not part of
+                // the AST being evaluated. Real propagation would need
+                // `filter` resolved through `resolve_node`'s own machinery
+                // instead (as #824 did for its sites); tracked separately
+                // for every remaining `eval_owned_expr`-shaped call site,
+                // `paths(node_filter)` included, under #833.
+                //
+                // `optional` (this builtin's own parameter, not a
+                // hardcoded `false`) must reach this per-node evaluation
+                // too: `isvalid(EXPR)` forces `optional=true` all the way
+                // down (`builtin_isvalid`, not the `?`/`try` path, which
+                // never forces it here per #693) so that an internal
+                // optional-guarded operation like `.foo` on a scalar
+                // yields empty instead of erroring. Confirmed against jq
+                // 1.7.1-equivalent semantics and this codebase's own pre-
+                // #773 code: `{"a":1,"b":2} | isvalid(paths(.foo, true))`
+                // is `true` (`.foo` errors on the scalar node but is
+                // swallowed by the forced `optional`, so the trailing
+                // `true` output still fires for every node) -- hardcoding
+                // `false` here instead breaks that to `false`.
+                let mut truthiness = Vec::new();
+                let control = push_truthiness(
+                    eval_owned_input::<Vec<u64>, S>(filter, &val_at_path, optional),
+                    &mut truthiness,
+                );
+                // Move `path` into its last truthy push instead of cloning
+                // every time -- keeps the common single-truthy-output case
+                // as allocation-free as the pre-#773 code's single `push`.
+                let mut remaining = truthiness.iter().filter(|&&t| t).count();
+                if remaining > 0 {
+                    for &truthy in &truthiness {
+                        if truthy {
+                            remaining -= 1;
+                            if remaining == 0 {
+                                filtered_paths.push(path);
+                                break;
                             }
-                        }
-                        if let Control::Halt(code) = control {
-                            return partial(filtered_paths, Control::Halt(code));
-                        }
-                        // Error/Break: the prefix above is already
-                        // credited; swallow the escape itself and move on
-                        // (same #833-tracked limitation as the bare-escape
-                        // arm above).
-                    }
-                    other => {
-                        for out in other.collect_owned() {
-                            if out.is_truthy() {
-                                filtered_paths.push(path.clone());
-                            }
+                            filtered_paths.push(path.clone());
                         }
                     }
                 }
+                if let Some(Control::Halt(code)) = control {
+                    return partial(filtered_paths, Control::Halt(code));
+                }
+                // Error/Break: the prefix above is already credited;
+                // swallow the escape itself and move to the next node.
             }
         }
     }
@@ -27169,6 +27176,26 @@ mod tests {
                 QueryResult::Owned(OwnedValue::Bool(false)) => {}
             );
         }
+    }
+
+    /// #773 follow-up regression: `builtin_paths_filter`'s per-node
+    /// `node_filter` evaluation must receive `isvalid`'s forced
+    /// `optional = true` the same way every other builtin covered by
+    /// `test_isvalid_reaches_every_builtins_own_optional_guard` above does,
+    /// not a hardcoded `false`. `.foo` on a scalar node errors; with
+    /// `optional` correctly threaded, that error is swallowed (empty), so
+    /// `(.foo, true)` still emits `true` for every node and `paths(...)`
+    /// comes back non-empty -- `isvalid` reports `true`. A hardcoded
+    /// `false` here instead lets `.foo`'s error abort the whole per-node
+    /// comma, `paths(...)` comes back empty, and `isvalid` wrongly reports
+    /// `false`. Confirmed this matches the pre-#773 code's own behavior
+    /// (which forwarded `optional` correctly) by building that commit
+    /// directly.
+    #[test]
+    fn test_isvalid_reaches_paths_filters_own_optional_guard() {
+        query!(br#"{"a":1,"b":2}"#, r"isvalid(paths(.foo, true))",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
     }
 
     // =========================================================================

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14453,25 +14453,42 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         if let OwnedValue::Array(path_arr) = &path {
             // Get the value at this path
             if let Some(val_at_path) = get_value_at_path(&owned, path_arr) {
-                // jq's `paths(node_filter)` is `path(recurse|select(node_filter))`:
-                // the path is kept whenever node_filter's result is truthy, not only
-                // when it's the literal boolean `true`. This matters for filters like
-                // `scalars`/`numbers`/`values` that yield the value itself rather than
-                // a boolean.
-                match eval_owned_expr::<S>(filter, &val_at_path, optional) {
-                    Ok(result) => {
-                        if result.is_truthy() {
-                            filtered_paths.push(path);
+                // jq's `paths(node_filter)` is `path(recurse|select(node_filter))`,
+                // and `select(f)` is `if f then . else empty end` -- `if` forks
+                // over every output `f` produces, so a multi-output node_filter
+                // must be checked per-output, not collapsed into one value
+                // first. `eval_owned_multi` (not `eval_owned_expr`, which
+                // collapses 2+ outputs into one always-truthy `OwnedValue::Array`
+                // before any truthiness check ever runs) preserves that
+                // cardinality, and each truthy output re-adds this path -- once
+                // per truthy output, not once per matching node. Confirmed
+                // against jq 1.7.1: `{"a":1,"b":{"c":2}} | [paths(false,false)]`
+                // is `[]` (the bug this fixes), and `[paths(true,true)]`
+                // duplicates every path, `[["a"],["a"],["b"],["b"],["b","c"],
+                // ["b","c"]]` -- not each path once (#773).
+                match eval_owned_multi::<S>(filter, &val_at_path) {
+                    Ok(outputs) => {
+                        for out in &outputs {
+                            if out.is_truthy() {
+                                filtered_paths.push(path.clone());
+                            }
                         }
                     }
                     // Every other error here is pre-existing, silently
-                    // swallowed behavior this fix does not change (`if let
-                    // Ok(..)` above), but a halt must never be silently
-                    // ignored (#791): `paths(halt_error(3))` has to actually
-                    // halt, not just skip the node as if the filter were
-                    // falsy. Paths already matched before this node must
-                    // still be reported (#400/#494), matching real jq's
-                    // lazy streaming of paths(node_filter).
+                    // swallowed behavior this fix does not change (`Ok(..)`
+                    // above), but a halt must never be silently ignored
+                    // (#791): `paths(halt_error(3))` has to actually halt,
+                    // not just skip the node as if the filter were falsy.
+                    // Paths already matched before this node must still be
+                    // reported (#400/#494), matching real jq's lazy
+                    // streaming of paths(node_filter). `eval_owned_multi`
+                    // itself intercepts a mid-stream error/break exactly
+                    // like a bare one (see its doc comment) rather than
+                    // keeping the outputs already produced before it, so a
+                    // node_filter that fans out into a truthy output
+                    // followed by an ordinary error still drops the whole
+                    // node -- consistent with the pre-existing "swallow the
+                    // whole node on error" policy this fix does not change.
                     Err(EvalEscape::Halt(code)) => {
                         return partial(filtered_paths, Control::Halt(code));
                     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14517,20 +14517,9 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     eval_owned_input::<Vec<u64>, S>(filter, &val_at_path, optional),
                     &mut truthiness,
                 );
-                // Move `path` into its last truthy push instead of cloning
-                // every time -- keeps the common single-truthy-output case
-                // as allocation-free as the pre-#773 code's single `push`.
-                let mut remaining = truthiness.iter().filter(|&&t| t).count();
-                if remaining > 0 {
-                    for &truthy in &truthiness {
-                        if truthy {
-                            remaining -= 1;
-                            if remaining == 0 {
-                                filtered_paths.push(path);
-                                break;
-                            }
-                            filtered_paths.push(path.clone());
-                        }
+                for &truthy in &truthiness {
+                    if truthy {
+                        filtered_paths.push(path.clone());
                     }
                 }
                 if let Some(Control::Halt(code)) = control {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7334,6 +7334,83 @@ fn test_paths_filter_still_swallows_ordinary_per_path_error() -> Result<()> {
     Ok(())
 }
 
+/// #773: `builtin_paths_filter` used to evaluate `node_filter` per path via
+/// `eval_owned_expr`, which collapses a multi-output result into a single
+/// `OwnedValue::Array` when it produces 2+ outputs. A non-empty array is
+/// always truthy in jq, so a `node_filter` with two falsy outputs (`false,
+/// false`) was wrapped into the truthy array `[false,false]` *before* the
+/// truthiness check ever ran, silently keeping every path. Verified against
+/// real jq 1.7.1: `{"a":1,"b":{"c":2}} | [paths(false,false)]` is `[]`.
+#[test]
+fn test_paths_filter_all_falsy_multi_output_keeps_nothing() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[paths(false,false)]"],
+        Some(r#"{"a":1,"b":{"c":2}}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Companion to the all-falsy test above, pinning the other half of #773's
+/// fix: the fan-out direction. jq's `paths(node_filter)` is
+/// `path(recurse|select(node_filter))`, and `select(f)` is literally
+/// `if f then . else empty end` in jq's own builtin.jq — `if` forks over
+/// every output its condition produces. So a multi-output `node_filter`
+/// with 2+ *truthy* outputs must duplicate the path once per truthy
+/// output, not keep it once regardless of how many outputs were truthy.
+/// Verified against real jq 1.7.1:
+/// `{"a":1,"b":{"c":2}} | [paths(true,true)]` is
+/// `[["a"],["a"],["b"],["b"],["b","c"],["b","c"]]` — every path duplicated,
+/// not deduplicated to one occurrence each.
+#[test]
+fn test_paths_filter_multi_truthy_output_duplicates_each_path() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[paths(true,true)]"],
+        Some(r#"{"a":1,"b":{"c":2}}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[[\"a\"],[\"a\"],[\"b\"],[\"b\"],[\"b\",\"c\"],[\"b\",\"c\"]]\n"
+    );
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// A single-truthy-output `node_filter` (the common case) must not
+/// duplicate — this is the control proving the fan-out fix above didn't
+/// overcorrect into always duplicating. Verified against real jq 1.7.1:
+/// `{"a":1,"b":{"c":2}} | [paths(true)]` is `[["a"],["b"],["b","c"]]`.
+#[test]
+fn test_paths_filter_single_truthy_output_does_not_duplicate() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[paths(true)]"], Some(r#"{"a":1,"b":{"c":2}}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[[\"a\"],[\"b\"],[\"b\",\"c\"]]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Mixed truthy/falsy outputs (`true,false`) keep the path exactly once
+/// (one truthy output out of two), distinguishing this from both the
+/// all-falsy (#773's original repro) and all-truthy (duplicate) cases
+/// above. Verified against real jq 1.7.1:
+/// `{"a":1,"b":{"c":2}} | [paths(true,false)]` is
+/// `[["a"],["b"],["b","c"]]`.
+#[test]
+fn test_paths_filter_mixed_truthy_falsy_keeps_path_once() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[paths(true,false)]"],
+        Some(r#"{"a":1,"b":{"c":2}}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[[\"a\"],[\"b\"],[\"b\",\"c\"]]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
 /// Distinct from `test_setpath_propagates_halt_in_path_argument` above,
 /// which hits `builtin_setpath`'s bare `QueryResult::Halt` arm (the path
 /// argument halts with zero prior output): this hits the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7411,6 +7411,83 @@ fn test_paths_filter_mixed_truthy_falsy_keeps_path_once() -> Result<()> {
     Ok(())
 }
 
+/// #773 follow-up (review of the original fix, commit 047133e2): once
+/// `builtin_paths_filter` switched to `eval_owned_multi` to preserve
+/// fan-out cardinality, a *different* regression appeared -- a node whose
+/// `node_filter` fans out into a truthy output followed by an ordinary
+/// `error` had its truthy output silently dropped too, where the pre-fix
+/// code (via `eval_owned_expr`'s single-value collapse) happened to keep
+/// it. Confirmed against real jq 1.7.1: `[1,"x",2] | paths(if
+/// type=="string" then (true, error("bad")) else true end)` streams `[0]`
+/// then `[1]` before raising -- the truthy output preceding the error is
+/// not discarded. succinctly's own pre-existing (and intentionally
+/// jq-divergent, see `test_paths_filter_still_swallows_ordinary_per_path_error`
+/// above) policy is to swallow an ordinary per-node error and continue to
+/// the next node rather than aborting the whole `paths` call, so the
+/// expected succinctly output here also includes `[2]`.
+#[test]
+fn test_paths_filter_keeps_truthy_prefix_before_ordinary_error() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"paths(if type=="string" then (true, error("bad")) else true end)"#,
+        ],
+        Some(r#"[1,"x",2]"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0]\n[1]\n[2]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Same regression as the ordinary-error test above, but for `halt_error`:
+/// a truthy output preceding a `halt` within one node's fan-out must still
+/// be reported before the whole builtin halts (halt itself must still
+/// propagate out unconditionally, #791 -- only the *dropped prefix* was
+/// the bug). Confirmed against real jq 1.7.1: `[1,"x",2] | paths(if
+/// type=="string" then (true, halt_error(3)) else true end)` streams
+/// `[0]` then `[1]` to stdout before exiting 3.
+#[test]
+fn test_paths_filter_keeps_truthy_prefix_before_halt() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"paths(if type=="string" then (true, halt_error(3)) else true end)"#,
+        ],
+        Some(r#"[1,"x",2]"#),
+    )?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0]\n[1]\n");
+    Ok(())
+}
+
+/// Same regression again, but for `break`: a truthy output preceding a
+/// `break $label` within one node's fan-out must still be reported. Unlike
+/// real jq (whose closures resolve a label lexically enclosing the
+/// `paths(...)` call, so `break` there aborts the whole computation
+/// cleanly), succinctly's per-node filter evaluation re-indexes the value
+/// into an isolated synthetic document (`eval_owned_input`) that cannot
+/// resolve a label from the caller's outer scope -- the label lookup fails
+/// and is treated as an ordinary error (same swallow-and-continue policy
+/// as the plain-error test above), a pre-existing, unrelated limitation
+/// this fix does not change. What this test pins is narrower: the truthy
+/// prefix produced before that failed `break` must still be kept, not
+/// dropped along with it.
+#[test]
+fn test_paths_filter_keeps_truthy_prefix_before_break() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | paths(if type=="string" then (true, break $out) else true end)"#,
+        ],
+        Some(r#"[1,"x",2]"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0]\n[1]\n[2]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
 /// Distinct from `test_setpath_propagates_halt_in_path_argument` above,
 /// which hits `builtin_setpath`'s bare `QueryResult::Halt` arm (the path
 /// argument halts with zero prior output): this hits the


### PR DESCRIPTION
## Summary

`builtin_paths_filter` (`src/jq/eval.rs`) evaluated each candidate path's
`node_filter` result via `eval_owned_expr`, which collapses a multi-output
result into a single `OwnedValue::Array` whenever `node_filter` produces
2+ outputs, *before* the truthiness check ever runs. A non-empty array is
always truthy in jq, so a `node_filter` whose outputs were all falsy
(e.g. `paths(false,false)`) got wrapped as `[false,false]` and kept every
path, when real jq keeps none.

This is the same "collapse via `eval_owned_expr` then check `.is_truthy()`"
bug shape already fixed at other call sites by #570/#627/#628, using the
cardinality-preserving sibling `eval_owned_multi`/`eval_owned_expr_fork`
built by #570 for exactly this purpose. `builtin_paths_filter` was a
remaining un-migrated site.

**Semantic question resolved against real jq 1.7.1** (per the issue's own
open question): once each output is checked individually, does a
multi-output `node_filter` with 2+ truthy outputs keep the path once, or
duplicate it once per truthy output? jq's own `builtin.jq` defines
`paths(node_filter)` as `path(recurse|select(node_filter))`, and
`select(f)` is literally `if f then . else empty end` — `if` forks once
per output its condition produces. Confirmed live:

```
$ echo '{"a":1,"b":{"c":2}}' | jq -c '[paths(true,true)]'
[["a"],["a"],["b"],["b"],["b","c"],["b","c"]]
```

So the fix duplicates the path once per truthy output, matching
`resolve_node`'s existing `Select` arm (fixed by #628), not "any-truthy
keeps it once."

## Fix

Replaced the per-path `eval_owned_expr` call with `eval_owned_multi`,
which preserves every output `node_filter` produces instead of collapsing
them. Each truthy output re-adds the path. Halt propagation and the
pre-existing (intentionally jq-divergent, already tested) "swallow the
whole node on an ordinary per-node error" policy are both preserved
unchanged.

## Repro

```
$ echo '{"a":1,"b":{"c":2}}' | jq -c '[paths(false,false)]'
[]
$ echo '{"a":1,"b":{"c":2}}' | succinctly jq -c '[paths(false,false)]'
[]          # was: [["a"],["b"],["b","c"]] before this fix
```

Fixes #773

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against the pinned real `jq` (jq-1.7.1) across a broad sweep of `paths(node_filter)` shapes (all-falsy, all-truthy, mixed, `scalars`, comparisons) on several input shapes — no divergence
- [x] Added 4 regression tests: all-falsy (original repro), all-truthy (fan-out duplication), single-truthy (no over-duplication control), mixed (keeps-once control) — all oracle-verified against real jq 1.7.1
- [x] `cargo llvm-cov` + `omni-dev coverage diff`: 100% patch coverage (6/6 new lines)