### PR TITLE
fix(jq): let break inside path(...) reach a label outside it

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -64,8 +64,9 @@ pub enum Control {
 }
 
 /// How an owned-evaluation helper's expression stopped: a genuine error that
-/// `try`/`catch` may handle and `?` may suppress, or a `halt` that nothing may
-/// catch (#791).
+/// `try`/`catch` may handle and `?` may suppress, a `break $label` unwinding
+/// to some enclosing `label` (#824), or a `halt` that nothing may catch
+/// (#791).
 ///
 /// This is the error type of `result_to_owned`, `eval_owned_multi` and the
 /// other `eval.rs` helpers that evaluate a sub-expression to owned values. An
@@ -75,17 +76,40 @@ pub enum Control {
 /// error, and review kept finding missed sites. Carrying the two cases as
 /// distinct variants makes that mistake unrepresentable — an `EvalError` can
 /// no longer *be* a halt, so only an explicit wildcard arm can misroute one.
+/// `Break` was added later for the same reason: before #824, every consumer
+/// of this type had no choice but to fold a `Control::Break` it received into
+/// a synthetic `EvalError::new("break $label not in label")` — correct only
+/// when nothing outside actually catches it, and wrong (loud, wrongly-worded,
+/// wrongly-exit-coded) whenever a matching `label` sits further out, e.g.
+/// across a `path(...)` call boundary. Not every caller of this type has been
+/// audited to propagate `Break` correctly yet — `result_to_owned` and
+/// `eval_owned_expr` still collapse it into that same synthetic error by
+/// design, matching this type's `eval_owned_expr_ctrl`/`eval_owned_expr`
+/// split (#575's precedent: a `_ctrl`-suffixed twin that preserves
+/// [`Control`] losslessly exists at the few call sites that have been made to
+/// need it). Only `eval_owned_multi`/`eval_owned_multi_first` and
+/// `resolve_node`'s own arms (in `eval.rs`) have been updated to propagate a
+/// real `Break` so far, which is what `path()`, and the computed-key path
+/// this type also drives for `=`/`|=`/`del()`, needed. Auditing every
+/// `result_to_owned`/`eval_owned_expr` call site for the same fix is tracked
+/// separately (#833) — it is used far more broadly than path-context
+/// resolution, so it needs its own review rather than riding along here.
 ///
 /// Consumers should write `Err(EvalEscape::Error(e))` for the catchable case
 /// and let everything else flow through the `From` conversions into
-/// `QueryResult`/[`Control`], which preserve `Halt` by construction. Never
-/// write `Err(_) => …-that-discards` — that is the one remaining way to lose
-/// a halt.
+/// `QueryResult`/[`Control`], which preserve `Halt`/`Break` by construction.
+/// Never write `Err(_) => …-that-discards` — that is the one remaining way to
+/// lose a halt or a break addressed to an outer label.
 #[derive(Debug, Clone, PartialEq)]
 pub enum EvalEscape {
     /// A genuine evaluation error — catchable by `try`/`catch`, suppressible
     /// by `?`.
     Error(EvalError),
+    /// `break $label`, still looking for a `label $label` to catch it (#824).
+    /// Every consumer that has not been specifically updated to propagate
+    /// this should keep converting it to a synthetic "break $label not in
+    /// label" `Error` — see this type's own doc comment.
+    Break(String),
     /// `halt`/`halt_error(n)`: exit the whole process with this code. Must
     /// reach the CLI unconditionally; never catchable, never suppressible.
     Halt(i32),
@@ -103,10 +127,21 @@ impl From<EvalError> for Control {
     }
 }
 
+impl From<Control> for EvalEscape {
+    fn from(control: Control) -> Self {
+        match control {
+            Control::Error(e) => Self::Error(e),
+            Control::Break(label) => Self::Break(label),
+            Control::Halt(code) => Self::Halt(code),
+        }
+    }
+}
+
 impl From<EvalEscape> for Control {
     fn from(escape: EvalEscape) -> Self {
         match escape {
             EvalEscape::Error(e) => Self::Error(e),
+            EvalEscape::Break(label) => Self::Break(label),
             EvalEscape::Halt(code) => Self::Halt(code),
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -229,6 +229,7 @@ impl<W> From<EvalEscape> for QueryResult<'_, W> {
     fn from(escape: EvalEscape) -> Self {
         match escape {
             EvalEscape::Error(e) => QueryResult::Error(e),
+            EvalEscape::Break(label) => QueryResult::Break(label),
             EvalEscape::Halt(code) => QueryResult::Halt(code),
         }
     }
@@ -9518,9 +9519,16 @@ fn eval_owned_multi<S: EvalSemantics>(
 ) -> Result<Vec<OwnedValue>, EvalEscape> {
     match eval_owned_input::<Vec<u64>, S>(expr, input, false) {
         QueryResult::Error(e) => Err(e.into()),
-        QueryResult::Break(label) => {
-            Err(EvalError::new(format!("break ${label} not in label")).into())
-        }
+        // A `break $label` aborts this expression exactly like `Error`
+        // above — whatever a resolve-node caller was accumulating before
+        // this sub-expression is a separate concern it already handles via
+        // its own `PathResolveResult` prefix, not something this helper
+        // tries to preserve. Propagated as [`EvalEscape::Break`] rather than
+        // collapsed into a synthetic "break $label not in label" `Error`, so
+        // a `label` sitting outside the caller (e.g. across a `path(...)`
+        // call boundary) still catches it instead of seeing a bogus error
+        // (#824).
+        QueryResult::Break(label) => Err(EvalEscape::Break(label)),
         // A halt must abort this expression exactly like `Error`/`Break`
         // above rather than falling into `collect_owned()`'s "no outputs"
         // treatment below — that would make `del(.[(halt_error(3))])` or a
@@ -9529,9 +9537,10 @@ fn eval_owned_multi<S: EvalSemantics>(
         // can catch or suppress it as if it were an error.
         QueryResult::Halt(code) => Err(EvalEscape::Halt(code)),
         QueryResult::Partial(_, Control::Error(e)) => Err(e.into()),
-        QueryResult::Partial(_, Control::Break(label)) => {
-            Err(EvalError::new(format!("break ${label} not in label")).into())
-        }
+        // Same reasoning as the bare `Break` arm above: the prefix this
+        // particular sub-stream produced before breaking is not this
+        // helper's to keep (#824).
+        QueryResult::Partial(_, Control::Break(label)) => Err(EvalEscape::Break(label)),
         QueryResult::Partial(_, Control::Halt(code)) => Err(EvalEscape::Halt(code)),
         other => Ok(other.collect_owned()),
     }
@@ -9556,9 +9565,19 @@ fn eval_owned_multi_first<S: EvalSemantics>(
 ) -> Result<Vec<OwnedValue>, EvalEscape> {
     match eval_owned_input::<Vec<u64>, S>(expr, input, false) {
         QueryResult::Error(e) => Err(e.into()),
-        QueryResult::Break(label) => {
-            Err(EvalError::new(format!("break ${label} not in label")).into())
-        }
+        // A *bare* break — nothing produced before it — has no prefix to
+        // fall back to, so it must propagate rather than becoming a
+        // synthetic "not in label" error: `label $out | (.a |= (break
+        // $out))` with the label outside produces no output at all in real
+        // jq (the break unwinds the whole expression, including the update
+        // that never got a value to write), not a raised error (#824,
+        // mirroring the bare-`Halt` case below). A `Partial`'s
+        // trailing break, by contrast, is exactly the "just give me the
+        // prefix" case this function's doc comment already covers — the
+        // `other` arm below keeps producing the update filter's first
+        // output and silently drops the break, which is what real jq does
+        // too (confirmed live: `.a |= (2, break $out)` is `{"a":2}`).
+        QueryResult::Break(label) => Err(EvalEscape::Break(label)),
         // Unlike a `Partial`'s trailing control (kept as "just give me the
         // prefix" per this function's doc comment, since real jq's `_modify`
         // never evaluates far enough to see it), a *bare* halt has no prior
@@ -9708,6 +9727,15 @@ fn resolve_node<'a, S: EvalSemantics>(expr: &Expr, value: &'a OwnedValue) -> Pat
                 // not a path expression, not a value error raised while
                 // collecting one (confirmed live: `path(("a")?)` still
                 // raises in jq).
+                //
+                // A `break $label` is pruned the same unconditional way,
+                // regardless of which label it targets — jq's `?`/bare `try`
+                // (no `catch`) always intercepts a break passing through
+                // (confirmed live: `label $out | ((.a, break $out)?)` is `1`
+                // and exits 0, never reaching `$out`; the value-position
+                // evaluator's `eval_try` already applies the same rule, #562)
+                // — never something to re-raise like the invalid-path-
+                // expression carve-out above.
                 let branches = match resolve_node::<S>(inner, value) {
                     Ok(branches) => branches,
                     // Only a genuine collection failure prunes to the
@@ -9718,6 +9746,7 @@ fn resolve_node<'a, S: EvalSemantics>(expr: &Expr, value: &'a OwnedValue) -> Pat
                     Err((prefix, EvalEscape::Error(e))) if !e.is_invalid_path_expression() => {
                         prefix
                     }
+                    Err((prefix, EvalEscape::Break(_))) => prefix,
                     Err(escape) => return Err(escape),
                 };
                 Ok(branches
@@ -9921,47 +9950,47 @@ fn resolve_node<'a, S: EvalSemantics>(expr: &Expr, value: &'a OwnedValue) -> Pat
             Ok(branches) => Ok(branches),
             // `halt`/`halt_error(n)` is never caught by `try`/`catch`, in
             // path expressions any more than in value position (#791) —
-            // only a genuine error reaches `catch` (or the no-catch
-            // prefix-keeping fallback below); everything else propagates
-            // unchanged, as does an invalid-path-expression complaint
-            // (#530).
+            // only a genuine error or a break (below) reaches `catch`;
+            // everything else propagates unchanged, as does an
+            // invalid-path-expression complaint (#530).
             Err((prefix, EvalEscape::Error(e))) if !e.is_invalid_path_expression() => {
-                match catch {
-                    // No catch: keep whatever was already resolved before
-                    // the failure (confirmed live: `path(try (.a, .b[0]))`
-                    // prints `["a"]` and stops), same as `?`'s matching fix
-                    // above.
-                    None => Ok(prefix),
-                    // `e.payload()` is a fresh, function-local `OwnedValue`
-                    // (the error consumes itself to produce it) — it cannot
-                    // lend a reference with this function's own `'a`, so
-                    // resolution against it goes through
-                    // `resolve_against_cow`, which forces the result back to
-                    // `Cow::Owned` before it escapes. `prefix` must still be
-                    // kept ahead of the handler's own output (confirmed
-                    // live: `path(try (.a, .x[0]) catch empty)` on
-                    // `{"a":1,"x":5}` prints `["a"]`, not nothing) --
-                    // `catch`'s handler runs in addition to, not instead of,
-                    // whatever the failed `try` body already resolved.
-                    Some(catch_expr) => {
-                        let mut out = prefix;
-                        out.extend(resolve_against_cow::<S>(
-                            catch_expr,
-                            Cow::Owned(e.payload()),
-                        )?);
-                        Ok(out)
-                    }
-                }
+                resolve_catch::<S>(catch.as_deref(), prefix, e.payload())
+            }
+            // `catch` catches a `break` the same way it catches a raised
+            // error, regardless of which label it targets — jq's own rule
+            // (#562, already applied by the value-position `eval_try`),
+            // mirrored here for path context (#824): confirmed live,
+            // `label $out | path(try (.a, break $out) catch "x")` prints the
+            // prefix `["a"]` and then raises the catch handler's own
+            // `"x"` as an invalid-path-expression (#530) — the break never
+            // reaches `$out` at all. Real jq binds the handler's input to
+            // its internal break marker, which `null` stands in for here,
+            // same as `eval_try` already does.
+            Err((prefix, EvalEscape::Break(_))) => {
+                resolve_catch::<S>(catch.as_deref(), prefix, OwnedValue::Null)
             }
             Err(escape) => Err(escape),
         },
 
-        // `label $x | body`: transparent. Path-tracking has no notion of
-        // `break` to catch here — an unmatched `break` inside `body` will
-        // already surface as an ordinary `EvalError` via `eval_owned_multi`
-        // (see its doc comment), which propagates as any other resolution
-        // failure would.
-        Expr::Label { body, .. } => resolve_node::<S>(body, value),
+        // `label $x | body`: catches a `break` targeting this exact label
+        // while resolving `body`, mirroring the value-position `eval_label`'s
+        // `QueryResult::Break`/`Partial(_, Control::Break(_))` handling —
+        // keeping whatever branches already resolved before the break, same
+        // "prefix survives, only the escape is caught" rule every other arm
+        // in this resolver already follows (#824). Confirmed live:
+        // `path(label $out | (.a, break $out))` is `["a"]`, not an error, and
+        // — unlike a label sitting *outside* `path(...)`, which this same fix
+        // lets `EvalEscape::Break` reach — evaluation continues normally
+        // after `path(...)` returns rather than unwinding any further.
+        //
+        // A non-matching break (a different label, still meant for something
+        // further out) is not this arm's to catch, so it propagates
+        // unchanged along with every other escape.
+        Expr::Label { name, body } => match resolve_node::<S>(body, value) {
+            Ok(branches) => Ok(branches),
+            Err((prefix, EvalEscape::Break(label))) if label == *name => Ok(prefix),
+            Err(escape) => Err(escape),
+        },
 
         // `E as $x | body`: bind each output of `E` into `body` by
         // substitution — reusing `substitute_var`, already relied on for
@@ -9991,12 +10020,17 @@ fn resolve_node<'a, S: EvalSemantics>(expr: &Expr, value: &'a OwnedValue) -> Pat
             }
             match trailing {
                 None => Ok(out),
-                Some(Control::Error(e)) => Err((out, EvalEscape::Error(e))),
-                Some(Control::Break(label)) => Err((
-                    out,
-                    EvalEscape::Error(EvalError::new(format!("break ${label} not in label"))),
-                )),
-                Some(Control::Halt(code)) => Err((out, EvalEscape::Halt(code))),
+                // `Control::into()` (via `From<Control> for EvalEscape`)
+                // preserves every variant losslessly, `Break` included —
+                // propagated as a real `EvalEscape::Break` rather than
+                // collapsed into a synthetic "not in label" error, so a
+                // `label` outside this `as`-binding's enclosing `path(...)`
+                // call still catches it (#824) — confirmed live:
+                // `label $out | path((1, break $out) as $x | .a)` on
+                // `{"a":1}` prints `["a"]` (the `$x=1` iteration's own
+                // `body` resolution, already in `out`) and exits cleanly,
+                // never raising the bogus error this arm used to produce.
+                Some(control) => Err((out, control.into())),
             }
         }
 
@@ -10039,12 +10073,23 @@ fn resolve_node<'a, S: EvalSemantics>(expr: &Expr, value: &'a OwnedValue) -> Pat
 
 /// Resolve `n; expr`'s `n` the same way `eval_limit` does, then take that
 /// many resolved branches of `expr`.
+///
+/// Uses `eval_owned_expr_ctrl` (which preserves [`Control`] losslessly, the
+/// same #575 precedent `resolve_node`'s other arms rely on), not the
+/// `eval_owned_expr` that collapses a `break` into a synthetic "not in
+/// label" error — this call sits directly in `resolve_node`'s own domain
+/// (unlike the far more broadly-shared `eval_owned_expr` call sites #833
+/// tracks), so there is no reason to leave `limit(n; f)`'s own `n` bound
+/// carrying #824's bug after every other arm here was fixed: verified live,
+/// `label $out | path(limit(break $out; .a))` on `{"a":1}` now produces no
+/// output, exit 0, matching real jq exactly.
 fn resolve_limit<'a, S: EvalSemantics>(
     n_expr: &Expr,
     expr: &Expr,
     value: &'a OwnedValue,
 ) -> PathResolveResult<'a> {
-    let n_value = eval_owned_expr::<S>(n_expr, value, false).map_err(|e| (Vec::new(), e))?;
+    let n_value = eval_owned_expr_ctrl::<S>(n_expr, value, false)
+        .map_err(|control| (Vec::new(), control.into()))?;
     let n = match n_value {
         OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
             i as usize
@@ -10205,6 +10250,42 @@ fn resolve_against_cow<'a, S: EvalSemantics>(
                 e,
             )),
         },
+    }
+}
+
+/// Apply `Expr::Try`'s `catch` clause (if any) after `expr` failed to
+/// resolve as a path, keeping `prefix` — whatever `expr` had already
+/// resolved before the failure — ahead of the handler's own output. Shared
+/// by `resolve_node`'s `Expr::Try` arm's `Error` and `Break` cases, which
+/// differ only in what `payload` binds to: the raised error's own value for
+/// an ordinary failure, `null` for a `break` (mirroring the value-position
+/// `eval_try`'s treatment of jq's internal break marker, since #562's rule
+/// is "catch catches break the same way it catches error").
+///
+/// A no-catch `try` (or bare `?`, sugar for one) keeps just `prefix`
+/// (confirmed live: `path(try (.a, .b[0]))` prints `["a"]` and stops).
+/// With a `catch`, `catch_expr` resolves as a path expression too, and its
+/// output is appended after `prefix` — `catch`'s handler runs in addition
+/// to, not instead of, whatever the failed body already resolved (confirmed
+/// live: `path(try (.a, .x[0]) catch empty)` on `{"a":1,"x":5}` prints
+/// `["a"]`, not nothing).
+///
+/// If `catch_expr` itself then fails, the `?` below returns its `Err`
+/// directly, losing `prefix` rather than threading it into the returned
+/// tuple — a separate, pre-existing gap in this same arm (#832), not fixed
+/// here.
+fn resolve_catch<'a, S: EvalSemantics>(
+    catch: Option<&Expr>,
+    prefix: Vec<PathBranch<'a>>,
+    payload: OwnedValue,
+) -> PathResolveResult<'a> {
+    match catch {
+        None => Ok(prefix),
+        Some(catch_expr) => {
+            let mut out = prefix;
+            out.extend(resolve_against_cow::<S>(catch_expr, Cow::Owned(payload))?);
+            Ok(out)
+        }
     }
 }
 
@@ -14479,7 +14560,50 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     Err(EvalEscape::Halt(code)) => {
                         return partial(filtered_paths, Control::Halt(code));
                     }
-                    Err(EvalEscape::Error(_)) => {}
+                    // The `Break` half of this pattern is structurally dead
+                    // code today: `eval_owned_expr` (unlike `resolve_node`'s
+                    // own `eval_owned_multi`-based sites, which #824 fixed)
+                    // always collapses a `Control::Break` into a *synthetic*
+                    // `EvalEscape::Error("break $label not in label")`
+                    // internally before returning, so this call can never
+                    // actually produce `Err(EvalEscape::Break(_))`.
+                    //
+                    // That does NOT mean `paths(node_filter)` is safe from
+                    // #824's bug class, though — a `break` in `filter` still
+                    // reaches here, just disguised as that synthetic `Error`,
+                    // and the `Error(_)` half right below swallows it
+                    // silently (grouped with every other pre-existing,
+                    // already-accepted error-swallowing case here) instead of
+                    // unwinding to its label. Confirmed live: `label $out |
+                    // [paths(if .==2 then break $out else true end)]` on
+                    // `{"a":1,"b":{"c":2}}` prints `[["a"],["b"]]` here,
+                    // where real jq prints nothing at all (the break cancels
+                    // the whole `[...]` construction). `builtin_paths_filter`
+                    // does not resolve `filter` through `resolve_node` at
+                    // all, so it never got any part of #824's fix — this is
+                    // the same pre-existing gap #833 already tracks for
+                    // `eval_owned_expr`'s other call sites, not a regression
+                    // from this PR. Left as a plain comment rather than
+                    // `todo!()`/`unreachable!()`: the observable bug is
+                    // already live via `Error(_)` regardless of what happens
+                    // to the dead `Break(_)` sub-pattern, so a panic here
+                    // would not catch #833 landing — it would just crash a
+                    // call that already silently mishandles this case.
+                    //
+                    // FLAG FOR #833: once `eval_owned_expr` is changed to
+                    // propagate a real `Break` instead of synthesizing this
+                    // error, the `Break(_)` half of this pattern stops being
+                    // dead code and starts silently swallowing breaks
+                    // directly (same wrong observable result, new
+                    // mechanism) unless this arm is revisited then to decide
+                    // what `paths(node_filter)` should actually do with one
+                    // — most likely propagate it the way `resolve_node`'s
+                    // own arms do post-#824, not fold it into "just skip
+                    // this node." Re-confirmed independently by multiple
+                    // review passes during #824 (see PR #834's discussion)
+                    // as a real, easy-to-miss follow-on risk, not a
+                    // hypothetical one.
+                    Err(EvalEscape::Error(_) | EvalEscape::Break(_)) => {}
                 }
             }
         }
@@ -21061,16 +21185,16 @@ mod tests {
 
     #[test]
     fn eval_owned_multi_propagates_a_partial_break() {
-        // `1, break $foo` with no enclosing `label $foo` in scope produces
-        // `Partial([1], Control::Break("foo"))` -- same fix as the error
-        // case, folded into the same synthetic "break $label not in label"
-        // `EvalError` the bare (non-`Partial`) `Break` arm already used.
+        // `1, break $foo` produces `Partial([1], Control::Break("foo"))`.
+        // Before #824, this was folded into a synthetic "break $label not
+        // in label" `EvalError` unconditionally, which was wrong whenever a
+        // `label $foo` actually sits outside this sub-expression's caller
+        // (e.g. across a `path(...)` call boundary) -- it now surfaces as a
+        // real `EvalEscape::Break` so that caller can decide, instead of
+        // this helper deciding for it.
         let expr = parse("1, break $foo").unwrap();
         let err = eval_owned_multi::<JqSemantics>(&expr, &OwnedValue::Null).unwrap_err();
-        let EvalEscape::Error(err) = err else {
-            panic!("expected EvalEscape::Error, got {err:?}");
-        };
-        assert!(err.message.contains("break $foo not in label"));
+        assert_eq!(err, EvalEscape::Break("foo".to_string()));
     }
 
     #[test]
@@ -21088,15 +21212,30 @@ mod tests {
     fn eval_owned_multi_first_propagates_a_bare_break() {
         // `break $foo` alone (no preceding output, so no `Partial` wrapper --
         // `eval_owned_input` returns a bare `QueryResult::Break` directly)
-        // still shares its own dedicated arm with the plain
-        // `eval_owned_multi`, unlike the `Partial` case above which
-        // `eval_owned_multi_first` deliberately keeps un-fixed.
+        // has no prefix to fall back to, so — like the bare `Error`/`Halt`
+        // arms — it must propagate as a real `EvalEscape::Break` rather than
+        // a synthetic "not in label" error (#824): `label $out | (.a |=
+        // (break $out))` with the label outside produces no output at all
+        // in real jq, not a raised error. Distinct from the `Partial` case
+        // below, which `eval_owned_multi_first` deliberately keeps dropping
+        // the trailing control from (jq's `_modify` never observes it).
         let expr = parse("break $foo").unwrap();
         let err = eval_owned_multi_first::<JqSemantics>(&expr, &OwnedValue::Null).unwrap_err();
-        let EvalEscape::Error(err) = err else {
-            panic!("expected EvalEscape::Error, got {err:?}");
-        };
-        assert!(err.message.contains("break $foo not in label"));
+        assert_eq!(err, EvalEscape::Break("foo".to_string()));
+    }
+
+    #[test]
+    fn eval_owned_multi_first_drops_partial_break_keeping_prefix() {
+        // `1, break $foo` produces `Partial([1], Control::Break("foo"))`.
+        // Unlike the bare-break case above, `eval_owned_multi_first` keeps
+        // its old "just give me the prefix" policy for a `Partial` (#694):
+        // jq's `_modify` only ever observes the update filter's first
+        // output, so the trailing break must not surface here either --
+        // confirmed live, `.a |= (2, break $out)` is `{"a":2}` in real jq,
+        // not an error and not an unwind to `$out`.
+        let expr = parse("1, break $foo").unwrap();
+        let values = eval_owned_multi_first::<JqSemantics>(&expr, &OwnedValue::Null).unwrap();
+        assert_eq!(values, vec![OwnedValue::Int(1)]);
     }
 
     /// Evaluate `Identity`/`Field`/`Index` against an `OwnedValue` the way

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6328,30 +6328,186 @@ fn test_path_as_binding_propagates_error_from_partial_bind_stream() -> Result<()
 }
 
 #[test]
-fn test_path_as_binding_break_in_bind_stream_is_a_known_pre_existing_gap() -> Result<()> {
+fn test_path_as_binding_break_in_bind_stream_reaches_an_outer_label() -> Result<()> {
     // `Expr::As`'s `Some(Control::Break(label))` trailing-control arm,
     // reached when the bind source itself raises a labeled `break` after
-    // already producing an output. This documents a real, PRE-EXISTING
-    // divergence from real jq that predates #791 and isn't specific to
-    // `as`-bindings -- confirmed live that a bare, non-`as` comma reaches
-    // the exact same mismatch: `label $out | path((.a, break $out))` on
-    // `{"a":1}` also exits 5 with "break $out not in label" here, instead
-    // of real jq's exit 0 with `["a"]`. Path-context has no mechanism to
-    // let a `break` escape `resolve_node` and be caught by a `label`
-    // sitting *outside* the `path(...)` call (`PathResolveResult`'s error
-    // type, `EvalEscape`, has no `Break` variant to carry it), so every
-    // site that turns a path-context `Control::Break` into an ordinary
-    // "break $label not in label" `EvalError` -- this one and the
-    // pre-existing `eval_owned_multi` one alike -- shares this gap. Kept
-    // consistent with that existing behavior rather than fixed here; not a
-    // regression introduced by this arm. Filed as #824.
+    // already producing an output. Before #824, `resolve_node`'s error type
+    // (`EvalEscape`, threaded through `PathResolveResult`) had no way to
+    // carry a `Control::Break`, so every site that received one -- this arm
+    // and `eval_owned_multi` alike -- had no choice but to fold it into a
+    // synthetic "break $label not in label" `EvalError`, even when a
+    // `label` with that exact name was sitting right outside the
+    // `path(...)` call, fully able to catch it. `EvalEscape::Break` now
+    // carries the label through instead, so `label $out`, sitting outside
+    // this `path(...)` call, catches it cleanly: verified against jq 1.7.1,
+    // `label $out | path((1, break $out) as $x | .a)` on `{"a":1}` exits 0
+    // with `["a"]` (the `$x=1` iteration's own `body` resolution completing
+    // before the break), not an error.
     let (stdout, stderr, code) = run_jq_full(
         &["-c", "label $out | path((1, break $out) as $x | .a)"],
         Some(r#"{"a":1}"#),
     )?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "[\"a\"]\n");
-    assert!(stderr.contains("break $out not in label"), "{stderr}");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_break_across_a_path_call_boundary_reaches_an_outer_label_824() -> Result<()> {
+    // Issue #824's own first repro: a `break $label` raised inside a
+    // `path(...)` call's argument couldn't reach a `label $label` sitting
+    // *outside* that call -- it degraded into a bogus "break $out not in
+    // label" error (exit 5) instead of unwinding cleanly, even though the
+    // output already resolved before the break (`["a"]`) still reached
+    // stdout first. Verified against jq 1.7.1. The issue's second repro,
+    // through an `as`-binding's bind source, is covered by
+    // `test_path_as_binding_break_in_bind_stream_reaches_an_outer_label`
+    // above rather than duplicated here.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "label $out | path((.a, break $out))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_break_inside_a_path_call_is_caught_by_a_label_inside_it_824() -> Result<()> {
+    // The mirror image of the boundary-crossing case above: a `label`
+    // sitting *inside* `path(...)` catches its own matching `break` right
+    // there -- `path(...)` still resolves normally, and (unlike a break
+    // that escapes `path(...)` entirely) evaluation continues afterward
+    // rather than unwinding any further. Verified against jq 1.7.1:
+    // `path(label $out | (.a, break $out))` is `["a"]`, and following it
+    // with another expression in the same enclosing label still reaches
+    // that expression.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(label $out | (.a, break $out))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert_eq!(stderr, "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (path(label $out | (.a, break $out)), "after")"#,
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n\"after\"\n");
+    assert_eq!(stderr, "");
+
+    // A *non-matching* break (still meant for something further out) is not
+    // this `label`'s to catch, so it propagates past it unchanged -- here as
+    // a plain error unrelated to any break at all, exercising the same
+    // catch-all fallthrough. Verified against jq 1.7.1: `path(label $out |
+    // error("boom"))` raises "boom", exit 5 (the `label` plays no role when
+    // there's no break to catch).
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(label $out | error("boom"))"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "{stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_try_catch_inside_a_path_call_catches_a_break_regardless_of_label_824() -> Result<()> {
+    // `try`/`catch` (and bare `?`, sugar for a catch-less `try`) intercept a
+    // `break` passing through them unconditionally, regardless of which
+    // label it targets -- the same rule the value-position evaluator's
+    // `eval_try` already applies (#562), now mirrored in path context
+    // (#824). `catch empty` here (rather than a handler that is itself not
+    // a valid path expression, e.g. `catch "x"`) sidesteps a separate,
+    // pre-existing gap in this same `Expr::Try` arm -- filed as #832 --
+    // where the resolved prefix is lost if the *handler itself* then fails
+    // as a path expression (#530); that gap already exists for the
+    // ordinary-error side of this arm too (`path(try (.a, .x[0]) catch
+    // "x")` on real jq 1.7.1, confirmed live: prefix `["a"]` on stdout,
+    // "Invalid path expression..." on stderr) and is not specific to break.
+    // Verified against jq 1.7.1: `path(try (.a, break $out) catch empty)`
+    // on `{"a":1}` is `["a"]`, exit 0 -- the break never reaches `$out` at
+    // all, catch runs before the label ever gets a chance.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "label $out | path(try (.a, break $out) catch empty)"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert_eq!(stderr, "");
+
+    // Bare `?` (no catch) prunes the break the same way, keeping just the
+    // prefix: `path((.a, break $out)?)` on `{"a":1}` is `["a"]`, exit 0.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "label $out | path((.a, break $out)?)"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert_eq!(stderr, "");
+
+    // `try EXPR` with *no* `catch` clause at all (distinct from bare `?`
+    // above at the AST level, `Expr::Try { catch: None, .. }` rather than
+    // `Expr::Optional`) catches the break the same unconditional way.
+    // Verified against jq 1.7.1: `path(try (.a, break $out))` on `{"a":1}`
+    // is `["a"]`, exit 0.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "label $out | path(try (.a, break $out))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert_eq!(stderr, "");
+
+    // The catch handler itself raising a *different* error, rather than
+    // failing as a path expression (#530) — the same "catch runs, and its
+    // own failure propagates" shape, through the code path shared with
+    // #832's pre-existing gap (see the doc comment above): confirmed live,
+    // real jq's `path(try (.a, break $out) catch error("y"))` on `{"a":1}`
+    // prints the prefix `["a"]` then raises "y", exit 5. succinctly instead
+    // loses the prefix here (empty stdout) while still raising "y" and
+    // exiting 5 -- the handler's own failure is reported correctly, only
+    // the earlier prefix is dropped, which is #832's gap, not a new one
+    // this fix introduces.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | path(try (.a, break $out) catch error("y"))"#,
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("error (at <stdin>:"), "{stderr}");
+    assert!(stderr.trim_end().ends_with(": y"), "{stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_limit_n_bound_break_inside_a_path_call_reaches_an_outer_label_824() -> Result<()> {
+    // `resolve_limit`'s own `n_expr` evaluation (`limit(n; f)`'s count) sits
+    // directly in `resolve_node`'s domain, adjacent to every other arm this
+    // PR fixed, so it was switched from `eval_owned_expr` (which still
+    // collapses a break into a synthetic "not in label" error, same as
+    // #833's broader, out-of-scope call sites) to `eval_owned_expr_ctrl`
+    // (which preserves `Control` losslessly), rather than leaving this one
+    // adjacent gap unfixed. Verified against jq 1.7.1: `path(limit(break
+    // $out; .a))` on `{"a":1}` produces no output, exit 0.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "label $out | path(limit(break $out; .a))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
     Ok(())
 }
 

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -496,16 +496,21 @@ fn test_assignment_key_must_denote_a_component() {
         r#".[error("boom")] = 5"#,
         Outcome::error("boom"),
     );
-    // DIVERGENCE from jq 1.7.1: a `break` in a key is silent there, unwinding
-    // to the label and emitting nothing. The path pre-pass resolves keys with a
-    // plain `Result`, which has no way to carry a label out, so it reports the
-    // unwind rather than mapping it to "no paths" — the alternative would make
-    // `break` in a key indistinguishable from an empty key stream, which is a
-    // *successful* no-op assignment.
+    // A `break` in a key unwinds to the enclosing `label` and emits nothing,
+    // matching jq 1.7.1 exactly (#824). Before #824, the path pre-pass
+    // resolved keys through `PathResolveResult`'s `EvalEscape`, which had no
+    // way to carry a label out — every caller folded the break into a
+    // synthetic "not in label" error instead of letting `label $out` catch
+    // it. `EvalEscape::Break` now carries the label through, so this is a
+    // real, successful no-op assignment rather than an error — the same
+    // "no paths resolved" outcome an empty key stream already produces
+    // (confirmed via `label $out | .[break $out]` above, the read-side
+    // sibling of this write, which never had this gap since ordinary
+    // value-context indexing already propagated `Break` correctly).
     check(
         r#"{"a":1}"#,
         "label $out | (.[break $out] = 5)",
-        Outcome::error("break $out not in label"),
+        Outcome::values(&[]),
     );
 }
 


### PR DESCRIPTION
## Summary

A `break $label` raised inside a `path(...)` call's argument couldn't reach a `label $label` sitting *outside* that `path(...)` call — instead of unwinding cleanly like real jq, it degraded into a bogus "break $label not in label" error (stderr, exit non-zero), even though output already resolved before the break still correctly reached stdout.

Root cause: `resolve_node`'s `PathResolveResult` (`Result<Vec<PathBranch>, (Vec<PathBranch>, EvalEscape)>`) had no way to carry a `Control::Break` — `EvalEscape` only had `Error`/`Halt` variants. Every path-context site that received a `Control::Break` while resolving a sub-expression had no choice but to fold it into a synthetic error, even when a matching `label` was sitting right outside `path(...)`, fully able to catch it.

- Added `EvalEscape::Break(String)`, threaded it through `From<EvalEscape> for Control`/`QueryResult` and a new `From<Control> for EvalEscape` (mirroring the file's existing `From<Control> for ObjectEscape`).
- `eval_owned_multi`/`eval_owned_multi_first`'s `Break` arms and `Expr::As`'s trailing-control conversion now propagate a real `Break` instead of synthesizing an error. This also fixes the same gap for `=`/`|=` computed keys, which share this machinery (`.[("a", break $out)] = 5` now behaves like real jq too).
- `resolve_node`'s `Expr::Label` arm now catches a break targeting its own name, keeping the already-resolved prefix — needed for a label sitting *inside* `path(...)`, matching jq's continue-after-catch model (verified live: `path(label $out | (.a, break $out))` still resolves normally, and evaluation continues afterward).
- `resolve_node`'s `Expr::Try` and bare-`?` arms now catch a break unconditionally, mirroring the value-position evaluator's existing #562 rule that `catch`/`?` intercept a break regardless of label. Both catch-application code paths (the pre-existing `Error` case and the new `Break` case) now share one `resolve_catch` helper instead of duplicating the same ~15-line block.
- `resolve_limit`'s own `n_expr` (`limit(n; f)`'s count) sits directly in `resolve_node`'s domain, so it was switched from `eval_owned_expr` to the `Control`-preserving `eval_owned_expr_ctrl` (the same #575 precedent every other arm here relies on) rather than leaving this one adjacent gap unfixed — `path(limit(break $out; .a))` with the label outside now matches jq too.

`result_to_owned`/`eval_owned_expr` deliberately keep their existing synthetic-error behavior everywhere else — they're used far more broadly than path-context resolution (dozens of unrelated builtin-argument call sites), and propagating `Break` through them safely needs its own audit. Filed as a follow-up: #833 (also covers a `paths(node_filter)` instance of the same gap, found and confirmed live during review).

While adding coverage, also found and filed a narrower, separate pre-existing gap in the same `Expr::Try`/`resolve_catch` code: the already-resolved prefix is lost if the `catch` handler *itself* then fails (as a path expression, or with any other error/break/halt). This exists on `main` today for the ordinary-error case too (confirmed live against real jq), unrelated to `break`/labels — filed as #832, not fixed here to keep this PR scoped to #824's specific "give `Break` a way to escape at all" gap.

Fixes #824

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green — 2 pre-existing tests updated because they pinned the old buggy behavior as expected; 1 test's title/body flipped from documenting a "known pre-existing gap" to asserting the now-correct behavior)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed behavior against the pinned real `jq` (1.7.1) for every scenario touched: both of the issue's own repros, label-inside-`path(...)`, `try`/`catch` catching a break regardless of label, bare `?` pruning a break, `limit(n; f)`'s own count bound, and the computed-key `=` case — all now match jq exactly
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --json --output-path /tmp/824-cov.json` + `omni-dev coverage diff` — **100% patch coverage** (42/42 new lines)
- [x] Mandatory review (9 agents, medium effort): resolved one direct contradiction between two agents' findings via a fresh empirical repro (`builtin_paths_filter`'s `Break` arm is dead code as one agent claimed, but the same observable bug is real via a sibling `Error` arm as another agent claimed — both were right about different halves of the same picture; comment corrected to say so precisely); fixed a factually-wrong "confirmed live" claim in two doc comments; de-duplicated the `Expr::Try` catch logic; replaced a hand-written `Control`→`EvalEscape` match with a `From` impl; removed a byte-for-byte duplicate test; fixed the adjacent `resolve_limit` gap noted above; filed/updated #832 and #833 with what the review surfaced
