### PR TITLE
fix(yaml): compact-render mapping/sequence values inside block sequence items

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1493,6 +1493,49 @@ fn yaml_quote_key(s: &str) -> String {
     }
 }
 
+/// Whether a compact block-sequence item's remaining source (the text
+/// right after `- `, as returned by `Chars::as_str()` at that point) opens
+/// with a mapping key rather than a scalar value — i.e. whether an
+/// unquoted `:` appears before the line ends.
+///
+/// `colorize_yaml`'s state machine colors a token *as it's written*, one
+/// `char` at a time, with no ability to go back and re-color something it
+/// already emitted — so at the position right after `- `, it has to decide
+/// up front whether what follows is a key (color it) or a value (don't),
+/// and the only way to tell is to look ahead. Before #785, `- ` was always
+/// followed by either a scalar value or a newline (a container value's
+/// mapping always started on its own line), so this ambiguity never arose.
+/// A nested compact marker (`- - 1`) recurses naturally: the caller
+/// re-invokes this same lookahead for the *inner* `-` too, so a mapping
+/// arbitrarily many `- ` markers deep (`- - a: 1`) still finds its `:` and
+/// colors `a`, while a purely scalar nested sequence (`- - 1\n  - 2`) does
+/// not color the inner marker - real, but narrow and, like the rest of
+/// this colorizer, not oracle-matched against real yq's own (differently
+/// coded) `-C` output, so left as a known residual gap rather than chased
+/// further (#785).
+fn compact_item_opens_with_key(rest_of_line: &str) -> bool {
+    let mut quote: Option<char> = None;
+    let mut chars = rest_of_line.chars();
+    while let Some(c) = chars.next() {
+        match quote {
+            Some(q) => {
+                if c == '\\' {
+                    chars.next(); // Skip the escaped character.
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                '\n' => return false,
+                '"' | '\'' => quote = Some(c),
+                ':' => return true,
+                _ => {}
+            },
+        }
+    }
+    false
+}
+
 /// Colorize YAML output (basic ANSI colors).
 fn colorize_yaml(yaml: &str) -> String {
     let mut result = String::with_capacity(yaml.len() * 2);
@@ -1501,7 +1544,8 @@ fn colorize_yaml(yaml: &str) -> String {
     let mut at_key_start = true;
     let mut in_key = false;
 
-    for c in yaml.chars() {
+    let mut chars = yaml.chars();
+    while let Some(c) = chars.next() {
         if escape_next {
             result.push(c);
             escape_next = false;
@@ -1528,7 +1572,15 @@ fn colorize_yaml(yaml: &str) -> String {
                 at_key_start = false;
             }
             ':' if !in_string => {
-                result.push_str("\x1b[0m");
+                // Only close a color span that's actually open (`in_key`)
+                // - otherwise this `:` belongs to a value that was never
+                // colored (e.g. a quoted-key's colon after the closing
+                // quote already reset color, or a `:` inside an uncolored
+                // token), and unconditionally emitting a reset here would
+                // write an orphaned `\x1b[0m` with no matching open.
+                if in_key {
+                    result.push_str("\x1b[0m");
+                }
                 result.push(c);
                 in_key = false;
                 at_key_start = false;
@@ -1542,7 +1594,12 @@ fn colorize_yaml(yaml: &str) -> String {
                 result.push_str("\x1b[33m"); // Yellow for list markers
                 result.push(c);
                 result.push_str("\x1b[0m");
-                at_key_start = false;
+                // A real-yq "compact" block-sequence item (`- key: value`,
+                // #785) puts its mapping's first key directly after `- `
+                // on the same line, instead of on a fresh line (which
+                // already re-triggers `at_key_start` via the `\n` arm
+                // above) - see `compact_item_opens_with_key`'s doc comment.
+                at_key_start = compact_item_opens_with_key(chars.as_str());
             }
             _ if at_key_start && !c.is_whitespace() && !in_string => {
                 result.push_str("\x1b[36m"); // Cyan for keys

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1083,7 +1083,7 @@ fn output_value<W: Write>(
     // For YAML output format (default)
     if config.output_format == OutputFormat::Yaml {
         // For YAML, scalars are printed without quotes by default (like -r in yq)
-        let body = emit_yaml_value(value, comments, config, 0, false);
+        let body = emit_yaml_value(value, comments, config, "", false);
         // Every non-root node's own trailing comment is appended by its
         // *parent* during `emit_yaml_value`'s recursion (see its Array/Object
         // arms), but the root has no parent call site to do that for it —
@@ -1183,11 +1183,23 @@ fn append_own_comment_line(body: String, own_comment: Option<&str>, indent: &str
 /// comment from the parallel `comments` tree (issue #710). Flow-style
 /// (`in_flow`) contexts never append one — flow items are comma-joined on
 /// one line, so there's no meaningful "trailing" position between them.
+///
+/// `indent` is the exact indent *string* to prepend to this value's own
+/// top-level line(s) — not a `depth: usize` repetition count. A block
+/// sequence item whose value is a non-empty mapping/sequence renders in
+/// real yq's "compact" form (`- ` shares its line with the value's first
+/// field/element, and the rest of the value's own content aligns under
+/// that first line's content rather than under a full `config.indent_str`
+/// step further — see the `Array` arm below), so a plain `depth *
+/// config.indent_str` formula can't express every line's indent; passing
+/// the literal string lets a compact caller hand down `indent` plus a
+/// fixed 2-character offset instead of a whole extra `config.indent_str`
+/// step (#785).
 fn emit_yaml_value(
     value: &OwnedValue,
     comments: &CommentTree,
     config: &OutputConfig,
-    depth: usize,
+    indent: &str,
     in_flow: bool,
 ) -> String {
     match value {
@@ -1229,34 +1241,59 @@ fn emit_yaml_value(
                 let items: Vec<_> = arr
                     .iter()
                     .enumerate()
-                    .map(|(i, v)| emit_yaml_value(v, comments.at_index(i), config, depth, true))
+                    .map(|(i, v)| emit_yaml_value(v, comments.at_index(i), config, indent, true))
                     .collect();
                 format!("[{}]", items.join(", "))
             } else {
                 // Block style sequence
-                let indent = config.indent_str.repeat(depth);
                 let items: Vec<_> = arr
                     .iter()
                     .enumerate()
                     .map(|(i, v)| {
                         let elem_comments = comments.at_index(i);
-                        let item = emit_yaml_value(v, elem_comments, config, depth + 1, false);
-                        // Check if it's a multi-line value (mapping or sequence)
-                        if matches!(v, OwnedValue::Object(_) | OwnedValue::Array(_))
-                            && !item.starts_with('[')
-                            && !item.starts_with('{')
+                        if matches!(v, OwnedValue::Object(o) if !o.is_empty())
+                            || matches!(v, OwnedValue::Array(a) if !a.is_empty())
                         {
-                            // Multi-line value - emit nested content which
-                            // handles its own indentation. The element's own
-                            // comment goes on its own line rather than
-                            // glued onto its last grandchild's line (#793).
-                            let item = append_own_comment_line(
-                                item,
+                            // A non-empty mapping/sequence element renders
+                            // in real yq's "compact" form: `- ` shares its
+                            // line with the value's own first field/
+                            // element, and the rest of the value's own
+                            // content aligns under that first line's
+                            // content (`indent` plus the 2-character width
+                            // of `- `), not under `indent` plus a full
+                            // `config.indent_str` step like an ordinary
+                            // nested block (#785).
+                            //
+                            // `emit_yaml_value` derives every line's own
+                            // indent purely from the `indent` string it's
+                            // handed, so rendering the element at
+                            // `compact_indent` and then stripping that
+                            // exact prefix from just the start of the
+                            // result (leaving every subsequent line's own
+                            // copy of the prefix untouched) reproduces the
+                            // "no separate indent for the first line"
+                            // effect `stream_yaml_value`'s cursor-based
+                            // sibling gets for free from its per-field/
+                            // per-element loop only indenting 2nd+ items.
+                            let compact_indent = format!("{indent}  ");
+                            let rendered =
+                                emit_yaml_value(v, elem_comments, config, &compact_indent, false);
+                            // The element's own comment goes on its own
+                            // line rather than glued onto its last
+                            // grandchild's line (#793).
+                            let rendered = append_own_comment_line(
+                                rendered,
                                 elem_comments.own(),
-                                &config.indent_str.repeat(depth + 1),
+                                &compact_indent,
                             );
-                            format!("{indent}-\n{item}")
+                            let first_line = rendered
+                                .strip_prefix(compact_indent.as_str())
+                                .unwrap_or(&rendered);
+                            format!("{indent}- {first_line}")
                         } else {
+                            let val_indent = format!("{indent}{}", config.indent_str);
+                            let item =
+                                emit_yaml_value(v, elem_comments, config, &val_indent, false);
                             let comment_suffix = trailing_comment_suffix(elem_comments);
                             format!("{indent}- {item}{comment_suffix}")
                         }
@@ -1274,14 +1311,13 @@ fn emit_yaml_value(
                     .iter()
                     .map(|(k, v)| {
                         let key = yaml_quote_key(k);
-                        let val = emit_yaml_value(v, comments.field(k), config, depth, true);
+                        let val = emit_yaml_value(v, comments.field(k), config, indent, true);
                         format!("{key}: {val}")
                     })
                     .collect();
                 format!("{{{}}}", entries.join(", "))
             } else {
                 // Block style mapping
-                let indent = config.indent_str.repeat(depth);
                 let entries: Vec<_> = if config.sort_keys {
                     let mut sorted: Vec<_> = obj.iter().collect();
                     sorted.sort_by(|a, b| a.0.cmp(b.0));
@@ -1296,6 +1332,7 @@ fn emit_yaml_value(
                         let key = yaml_quote_key(k);
                         let field_comments = comments.field(k);
                         let comment_suffix = trailing_comment_suffix(field_comments);
+                        let val_indent = format!("{indent}{}", config.indent_str);
                         // Check if value needs to be on next line
                         if matches!(v, OwnedValue::Object(m) if !m.is_empty())
                             || matches!(v, OwnedValue::Array(a) if !a.is_empty())
@@ -1306,16 +1343,15 @@ fn emit_yaml_value(
                             let key_comment_suffix = comments
                                 .key_comment(k)
                                 .map_or_else(String::new, |c| format!(" {c}"));
-                            // For nested containers, emit at depth+1 which
-                            // handles its own indentation. The value's own
-                            // comment goes on its own line rather than
-                            // glued onto its last grandchild's line (#793).
-                            let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
-                            let val = append_own_comment_line(
-                                val,
-                                field_comments.own(),
-                                &config.indent_str.repeat(depth + 1),
-                            );
+                            // For nested containers, emit one `config.indent_str`
+                            // step deeper, which handles its own indentation.
+                            // The value's own comment goes on its own line
+                            // rather than glued onto its last grandchild's
+                            // line (#793).
+                            let val =
+                                emit_yaml_value(v, field_comments, config, &val_indent, false);
+                            let val =
+                                append_own_comment_line(val, field_comments.own(), &val_indent);
                             format!("{indent}{key}:{key_comment_suffix}\n{val}")
                         } else if let Some(kc) = comments.key_comment_if_value_absent(k) {
                             // The deferred value materialized as nothing at
@@ -1323,7 +1359,8 @@ fn emit_yaml_value(
                             // no value token, matching real yq (#765).
                             format!("{indent}{key}: {kc}")
                         } else {
-                            let val = emit_yaml_value(v, field_comments, config, depth + 1, false);
+                            let val =
+                                emit_yaml_value(v, field_comments, config, &val_indent, false);
                             // The value's own comment takes priority; fall
                             // back to the key's own comment when the value
                             // has none - covers an explicit key's trailing
@@ -3369,20 +3406,20 @@ mod tests {
 
         let nan = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into());
         assert_eq!(
-            emit_yaml_value(&nan, &CommentTree::empty(), &config, 0, false),
+            emit_yaml_value(&nan, &CommentTree::empty(), &config, "", false),
             ".nan"
         );
 
         let pos_inf = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1e400".into());
         assert_eq!(
-            emit_yaml_value(&pos_inf, &CommentTree::empty(), &config, 0, false),
+            emit_yaml_value(&pos_inf, &CommentTree::empty(), &config, "", false),
             ".inf"
         );
 
         let neg_inf =
             OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-1e400".into());
         assert_eq!(
-            emit_yaml_value(&neg_inf, &CommentTree::empty(), &config, 0, false),
+            emit_yaml_value(&neg_inf, &CommentTree::empty(), &config, "", false),
             "-.inf"
         );
     }
@@ -3432,7 +3469,7 @@ mod tests {
         // Flow style renders compactly and drops every trailing comment,
         // whether on the nested object or its field - unlike block style.
         assert_eq!(
-            emit_yaml_value(&value, &comments, &config, 0, true),
+            emit_yaml_value(&value, &comments, &config, "", true),
             "[{k: 1}]"
         );
     }

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -127,7 +127,7 @@ impl StreamableValue for OwnedValue {
         indent: IndentSpec,
         sort_keys: bool,
     ) -> core::fmt::Result {
-        stream_owned_value_yaml(self, out, 0, indent.width, indent.unit, sort_keys)
+        stream_owned_value_yaml(self, out, "", indent.width, indent.unit, sort_keys)
     }
 
     fn is_falsy(&self) -> bool {
@@ -360,17 +360,39 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
 // YAML Streaming
 // ============================================================================
 
+/// The literal character width of a block-sequence item's `- ` prefix
+/// (dash + one ASCII space) - always exactly 2 literal ASCII bytes,
+/// independent of the configured `indent_spaces`/`unit` (`-I`/`--tab`).
+/// Mirrors `crate::yaml::light`'s identically-named/valued constant (a
+/// separate local copy, not shared: the two live in different crate
+/// modules with no existing shared indent-primitives module, and the
+/// value is definitionally fixed - `"- "` - not something that could
+/// drift independently). See `stream_owned_value_yaml`'s `Array` arm
+/// (#785).
+const COMPACT_DASH_WIDTH: usize = 2;
+
 /// Stream an OwnedValue as YAML without intermediate string allocation.
 ///
-/// - `current_indent`: Current indentation level (number of `unit` characters)
-/// - `indent_spaces`: `unit` characters per indentation level (0 for flow style)
+/// - `indent`: the exact indent *string* to write at the start of this
+///   value's own subsequent block-style lines (not a `usize` repetition
+///   count) - needed because a real-yq "compact" block-sequence item's
+///   continuation offset ([`COMPACT_DASH_WIDTH`] literal ASCII spaces) and
+///   an ordinary `unit`-based nesting step have to interleave in the exact
+///   chronological order they were nested, which a
+///   `(current_indent: usize, extra_spaces: usize)` pair collapses into a
+///   fixed unit-then-extra order regardless of which happened first
+///   (#785) - mirrors `crate::yaml::light::stream_yaml_value`'s identical
+///   fix and its `deeper_yaml_indent`/`compact_yaml_indent` helpers (this
+///   module's `deeper_indent`/`compact_indent` below).
+/// - `indent_spaces`: `unit` characters per *ordinary* (non-compact)
+///   indentation level (0 for flow style)
 /// - `unit`: the character repeated `indent_spaces` times per level (`' '`
 ///   normally, `'\t'` for `--tab`)
 /// - `sort_keys`: sort object keys before writing (`-S`/`--sort-keys`)
 fn stream_owned_value_yaml<W: core::fmt::Write>(
     value: &OwnedValue,
     out: &mut W,
-    current_indent: usize,
+    indent: &str,
     indent_spaces: usize,
     unit: char,
     sort_keys: bool,
@@ -414,7 +436,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                     if i > 0 {
                         out.write_str(", ")?;
                     }
-                    stream_owned_value_yaml(elem, out, 0, 0, unit, sort_keys)?;
+                    stream_owned_value_yaml(elem, out, "", 0, unit, sort_keys)?;
                 }
                 out.write_char(']')
             } else {
@@ -422,28 +444,36 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                 for (i, elem) in arr.iter().enumerate() {
                     if i > 0 {
                         out.write_char('\n')?;
-                        write_indent(out, current_indent, unit)?;
+                        out.write_str(indent)?;
                     }
                     out.write_str("- ")?;
-                    // For nested containers, put on next line with extra indent
+                    // A non-empty container element renders in real yq's
+                    // "compact" form (#785): sharing `- `'s own line with
+                    // its first field/element rather than deferring to a
+                    // fully-indented line of its own. No leading indent is
+                    // written before recursing - this loop only writes one
+                    // for the 2nd+ *element* of `arr` above, mirroring the
+                    // same "no separate indent for the recursion's own
+                    // first line" trick `light.rs`'s cursor-based
+                    // renderers use.
                     if matches!(elem, OwnedValue::Array(_) | OwnedValue::Object(_))
                         && !is_empty_container(elem)
                     {
-                        out.write_char('\n')?;
-                        write_indent(out, current_indent + indent_spaces, unit)?;
+                        let child_indent = compact_indent(indent);
                         stream_owned_value_yaml(
                             elem,
                             out,
-                            current_indent + indent_spaces,
+                            &child_indent,
                             indent_spaces,
                             unit,
                             sort_keys,
                         )?;
                     } else {
+                        let child_indent = deeper_indent(indent, indent_spaces, unit);
                         stream_owned_value_yaml(
                             elem,
                             out,
-                            current_indent + indent_spaces,
+                            &child_indent,
                             indent_spaces,
                             unit,
                             sort_keys,
@@ -470,7 +500,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                     }
                     stream_yaml_string(out, key)?;
                     out.write_str(": ")?;
-                    stream_owned_value_yaml(val, out, 0, 0, unit, sort_keys)?;
+                    stream_owned_value_yaml(val, out, "", 0, unit, sort_keys)?;
                 }
                 out.write_char('}')
             } else {
@@ -478,7 +508,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                 for (i, (key, val)) in entries.into_iter().enumerate() {
                     if i > 0 {
                         out.write_char('\n')?;
-                        write_indent(out, current_indent, unit)?;
+                        out.write_str(indent)?;
                     }
                     stream_yaml_string(out, key)?;
                     out.write_str(":")?;
@@ -487,21 +517,23 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                         && !is_empty_container(val)
                     {
                         out.write_char('\n')?;
-                        write_indent(out, current_indent + indent_spaces, unit)?;
+                        let child_indent = deeper_indent(indent, indent_spaces, unit);
+                        out.write_str(&child_indent)?;
                         stream_owned_value_yaml(
                             val,
                             out,
-                            current_indent + indent_spaces,
+                            &child_indent,
                             indent_spaces,
                             unit,
                             sort_keys,
                         )?;
                     } else {
                         out.write_char(' ')?;
+                        let child_indent = deeper_indent(indent, indent_spaces, unit);
                         stream_owned_value_yaml(
                             val,
                             out,
-                            current_indent + indent_spaces,
+                            &child_indent,
                             indent_spaces,
                             unit,
                             sort_keys,
@@ -524,12 +556,41 @@ fn is_empty_container(value: &OwnedValue) -> bool {
 }
 
 /// Write `width` copies of `unit` as indentation (`unit` is `' '` for
-/// space-indented output, `'\t'` for `--tab`).
+/// space-indented output, `'\t'` for `--tab`). JSON-only:
+/// `stream_owned_value_yaml` builds its own indent *strings* instead (see
+/// `deeper_indent`) - see its doc comment for why (#785).
 fn write_indent<W: core::fmt::Write>(out: &mut W, width: usize, unit: char) -> core::fmt::Result {
     for _ in 0..width {
         out.write_char(unit)?;
     }
     Ok(())
+}
+
+/// Build a new YAML block-style indent string one level deeper than
+/// `indent`: `indent_spaces` more copies of `unit` appended. The ordinary
+/// (non-compact) nesting step for `stream_owned_value_yaml` (#785) - see
+/// `compact_indent` for the other kind of step. Mirrors
+/// `crate::yaml::light::deeper_yaml_indent`.
+fn deeper_indent(indent: &str, indent_spaces: usize, unit: char) -> String {
+    let mut next = String::with_capacity(indent.len() + indent_spaces);
+    next.push_str(indent);
+    for _ in 0..indent_spaces {
+        next.push(unit);
+    }
+    next
+}
+
+/// Build a new YAML block-style indent string for a real-yq "compact"
+/// block-sequence item's continuation lines: [`COMPACT_DASH_WIDTH`] more
+/// literal ASCII spaces appended to `indent`, regardless of `unit` (#785).
+/// Mirrors `crate::yaml::light::compact_yaml_indent`.
+fn compact_indent(indent: &str) -> String {
+    let mut next = String::with_capacity(indent.len() + COMPACT_DASH_WIDTH);
+    next.push_str(indent);
+    for _ in 0..COMPACT_DASH_WIDTH {
+        next.push(' ');
+    }
+    next
 }
 
 /// Stream a string as YAML with smart quoting.
@@ -1024,9 +1085,9 @@ mod tests {
 
     #[test]
     fn test_stream_yaml_array_block_style_nested_container() {
-        // Covers the "nested containers get their own indented line" branch,
-        // distinct from the plain-scalar-element branch `test_stream_array`-
-        // style tests already exercise.
+        // Covers the "nested containers render in real yq's compact form"
+        // branch (#785), distinct from the plain-scalar-element branch
+        // `test_stream_array`-style tests already exercise.
         let mut buf = String::new();
         OwnedValue::Array(vec![
             OwnedValue::Array(vec![OwnedValue::Int(1)]),
@@ -1034,7 +1095,7 @@ mod tests {
         ])
         .stream_yaml(&mut buf, IndentSpec::spaces(2), false)
         .unwrap();
-        assert_eq!(buf, "- \n  - 1\n- 2");
+        assert_eq!(buf, "- - 1\n- 2");
     }
 
     #[test]

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1068,6 +1068,68 @@ mod tests {
         assert_eq!(field_key_line_comment_raw(yaml, "a"), None);
     }
 
+    /// Helper: like [`field_key_line_comment_raw`], but for a field of the
+    /// mapping that is itself the value of a block-sequence item's *first*
+    /// element - the only mapping entry parsed by `parse_compact_mapping_entry`
+    /// rather than `parse_mapping_entry` (issue #785).
+    fn seq_item_field_key_line_comment_raw(yaml: &[u8], key: &str) -> Option<String> {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Sequence(items) = doc_cursor.value() else {
+            panic!("expected a sequence document");
+        };
+        let (item_cursor, _) = items.uncons_cursor().expect("at least one item");
+        let YamlValue::Mapping(fields) = item_cursor.value() else {
+            panic!(
+                "expected item to be a mapping, got {:?}",
+                item_cursor.value()
+            );
+        };
+        for field in fields {
+            if let YamlValue::String(k) = field.key() {
+                if k.raw_bytes() == key.as_bytes() {
+                    return field
+                        .key_cursor()
+                        .line_comment_raw()
+                        .map(alloc::string::ToString::to_string);
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_key_line_comment_captured_for_seq_item_first_field_785() {
+        // The compact block-sequence form (`- key: value`, the item's
+        // first field sharing the dash's own line) parses that first
+        // field through a different function than an ordinary mapping
+        // entry (`parse_compact_mapping_entry` vs `parse_mapping_entry`) -
+        // a #765 regression this pins directly (issue #785).
+        let yaml = b"- a: # comment on key\n    b: 1\n";
+        assert_eq!(
+            seq_item_field_key_line_comment_raw(yaml, "a").as_deref(),
+            Some("# comment on key")
+        );
+    }
+
+    #[test]
+    fn test_key_line_comment_captured_for_seq_item_second_field_785() {
+        // A non-first field of the same mapping already went through
+        // `parse_mapping_entry` before #785 - included as a control case
+        // confirming the first-field fix doesn't disturb it.
+        let yaml = b"- x: 1\n  a: # comment on key\n    b: 2\n";
+        assert_eq!(
+            seq_item_field_key_line_comment_raw(yaml, "a").as_deref(),
+            Some("# comment on key")
+        );
+    }
+
     #[test]
     fn test_key_line_comment_not_captured_for_same_line_value_765() {
         // A comment trailing a same-line value belongs to the value (#710),

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1520,27 +1520,51 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             write_yaml_indent(out, current_indent, unit)?;
                         }
                         first = false;
-                        // Check if value needs newline. A container value
-                        // gets a bare `-` (no trailing space) followed by its
-                        // own indented line — matching real yq and the
-                        // DOM/pretty-printer, and avoiding a stray trailing
-                        // space before the newline.
+                        // A non-empty, non-flow mapping/sequence value
+                        // renders in real yq's "compact" form: `- ` shares
+                        // its line with the value's own first field/element,
+                        // and the rest of the value's own content aligns
+                        // under that first line's content — i.e. at
+                        // `current_indent + COMPACT_DASH_WIDTH` (the literal
+                        // width of `- `), not `current_indent +
+                        // indent_spaces`, which can differ under `-I`/`-tab`
+                        // (#785). `stream_yaml_value`'s own Mapping/Sequence
+                        // loops already skip the leading indent for their
+                        // first field/element (only 2nd+ get
+                        // `write_yaml_indent`), so simply writing `- ` here
+                        // and recursing with the new baseline is enough —
+                        // no separate "compact" rendering path needed.
+                        //
+                        // An anchor written directly on the item's own line
+                        // (`- &x\n  ...`) occupies that slot instead, so the
+                        // value stays deferred to its own line in that case,
+                        // matching real yq. (An anchor sharing the first
+                        // key's own line, e.g. `- &x a: 1`, isn't captured
+                        // by `cursor.anchor()` here at all — a separate,
+                        // pre-existing gap, out of scope for #785.)
                         if is_yaml_cursor_container(&cursor) && cursor.style() != "flow" {
-                            out.write_char('-')?;
                             if let Some(anchor) = cursor.anchor() {
-                                out.write_char(' ')?;
-                                out.write_char('&')?;
+                                out.write_str("- &")?;
                                 out.write_str(anchor)?;
+                                out.write_char('\n')?;
+                                write_yaml_indent(out, current_indent + indent_spaces, unit)?;
+                                cursor.stream_yaml_value(
+                                    out,
+                                    current_indent + indent_spaces,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                )?;
+                            } else {
+                                out.write_str("- ")?;
+                                cursor.stream_yaml_value(
+                                    out,
+                                    current_indent + COMPACT_DASH_WIDTH,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                )?;
                             }
-                            out.write_char('\n')?;
-                            write_yaml_indent(out, current_indent + indent_spaces, unit)?;
-                            cursor.stream_yaml_value(
-                                out,
-                                current_indent + indent_spaces,
-                                indent_spaces,
-                                unit,
-                                sort_keys,
-                            )?;
                             write_line_comment(out, cursor.line_comment_raw())?;
                         } else {
                             out.write_str("- ")?;
@@ -5499,6 +5523,17 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for YamlElements<'a, W> {
 // YAML Streaming Helpers
 // ============================================================================
 
+/// The literal character width of a block-sequence item's `- ` prefix
+/// (dash + one ASCII space) — always exactly 2, independent of the
+/// configured `indent_spaces`/`unit` (`-I`/`--tab`). Real yq's "compact"
+/// form for a sequence item whose value is a non-empty mapping/sequence
+/// aligns the value's own continuation lines under this width, not under
+/// `indent_spaces` (verified against `yq` v4.53.3 with `-I1` through
+/// `-I6`: the alignment never moves, only the sequence item's *own*
+/// indent does). See `stream_yaml_value`'s `Sequence` block-style arm and
+/// `stream_yaml_sequence` (#785).
+const COMPACT_DASH_WIDTH: usize = 2;
+
 /// Check if a cursor points to a non-empty container.
 ///
 /// Uses `is_container()` + `first_child()` directly rather than `cursor.value()`:
@@ -5694,22 +5729,35 @@ where
                 write_yaml_indent(out, current_indent, unit)?;
             }
             first = false;
-            if is_yaml_cursor_container(&cursor) {
-                out.write_char('-')?;
+            // Mirrors `stream_yaml_value`'s `Sequence` block-style arm
+            // exactly, including its `#785` compact-form handling (see the
+            // comment there) — this doc comment already promised that
+            // parity, but the `style() != "flow"` guard had been missing
+            // here, so a flow-style item would wrongly take the block
+            // branch instead of staying inline.
+            if is_yaml_cursor_container(&cursor) && cursor.style() != "flow" {
                 if let Some(anchor) = cursor.anchor() {
-                    out.write_char(' ')?;
-                    out.write_char('&')?;
+                    out.write_str("- &")?;
                     out.write_str(anchor)?;
+                    out.write_char('\n')?;
+                    write_yaml_indent(out, current_indent + indent_spaces, unit)?;
+                    cursor.stream_yaml_value(
+                        out,
+                        current_indent + indent_spaces,
+                        indent_spaces,
+                        unit,
+                        sort_keys,
+                    )?;
+                } else {
+                    out.write_str("- ")?;
+                    cursor.stream_yaml_value(
+                        out,
+                        current_indent + COMPACT_DASH_WIDTH,
+                        indent_spaces,
+                        unit,
+                        sort_keys,
+                    )?;
                 }
-                out.write_char('\n')?;
-                write_yaml_indent(out, current_indent + indent_spaces, unit)?;
-                cursor.stream_yaml_value(
-                    out,
-                    current_indent + indent_spaces,
-                    indent_spaces,
-                    unit,
-                    sort_keys,
-                )?;
             } else {
                 out.write_str("- ")?;
                 if let Some(anchor) = cursor.anchor() {
@@ -6700,7 +6748,11 @@ mod tests {
 
         let mut out = String::new();
         stream_yaml_sequence([cursor_a, cursor_b], &mut out, 0, 2, ' ', false).unwrap();
-        assert_eq!(out, "-\n  a: 1\n- 2");
+        // The mapping element renders in real yq's "compact" form (#785):
+        // `- ` shares its line with the mapping's own first (and only)
+        // field, rather than a bare `-` deferring the whole mapping to an
+        // indented line of its own.
+        assert_eq!(out, "- a: 1\n- 2");
     }
 
     #[test]
@@ -6717,7 +6769,10 @@ mod tests {
             .root(yaml)
             .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
             .unwrap();
-        assert_eq!(out, "-\n  a: 1\n-\n  b: 2");
+        // Each mapping element renders in real yq's "compact" form (#785):
+        // `- ` shares its line with the mapping's own first field, rather
+        // than a bare `-` deferring the whole mapping to an indented line.
+        assert_eq!(out, "- a: 1\n- b: 2");
     }
 
     #[test]
@@ -10851,11 +10906,14 @@ mod tests {
 
         let mut out = String::new();
         stream_yaml_sequence([cursor_a, cursor_b], &mut out, 0, 2, ' ', false).unwrap();
-        // `stream_yaml_sequence`'s block branch always puts a mapping item on
-        // its own line (unlike `stream_yaml_value`'s Sequence arm, it doesn't
-        // gate on `.style() != "flow"` — pre-existing, unrelated to #712);
-        // the anchor/alias preservation itself is what's under test here.
-        assert_eq!(out, "-\n  a: &x 1\n  c: *x\n-\n  b: &y 2\n  d: *y");
+        // Each mapping item renders in real yq's "compact" form (#785): `- `
+        // shares its line with the mapping's own first field, rather than a
+        // bare `-` deferring the whole mapping to an indented line - now
+        // mirroring `stream_yaml_value`'s Sequence arm exactly, including its
+        // `.style() != "flow"` gate (a pre-existing parity gap this also
+        // closed). The anchor/alias preservation itself is what's under test
+        // here.
+        assert_eq!(out, "- a: &x 1\n  c: *x\n- b: &y 2\n  d: *y");
     }
 
     // =========================================================================

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1215,7 +1215,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         sort_keys: bool,
     ) -> core::fmt::Result {
         self.write_leading_anchor(out)?;
-        self.stream_yaml_value(out, 0, indent.width, indent.unit, sort_keys)
+        self.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)
     }
 
     /// Like [`Self::stream_yaml`], but also appends this cursor's own
@@ -1251,7 +1251,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     ) -> core::fmt::Result {
         self.write_leading_anchor(out)?;
         let value = self.value();
-        self.stream_yaml_value(out, 0, indent.width, indent.unit, sort_keys)?;
+        self.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)?;
         if matches!(value, YamlValue::Mapping(_) | YamlValue::Sequence(_)) {
             write_line_comment(out, self.line_comment_raw())?;
         }
@@ -1286,7 +1286,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
 
         // Multiple documents or not at root - output as-is
         self.write_leading_anchor(out)?;
-        self.stream_yaml_value(out, 0, indent.width, indent.unit, sort_keys)
+        self.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)
     }
 
     /// Write this cursor's own `&anchor` before streaming it as a YAML root.
@@ -1330,20 +1330,40 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
 
     /// Internal: stream this cursor's value as YAML.
     ///
-    /// - `unit`: the character repeated `indent_spaces` times per level
-    ///   (`' '` normally, `'\t'` for `--tab`).
+    /// - `indent`: the exact indent *string* to write at the start of this
+    ///   value's own subsequent block-style lines (not a `usize`
+    ///   repetition count) — needed because a real-yq "compact"
+    ///   block-sequence item's continuation offset ([`COMPACT_DASH_WIDTH`]
+    ///   literal ASCII spaces) and an ordinary `unit`-based nesting step
+    ///   have to interleave in the exact chronological order they were
+    ///   nested (#785); see [`deeper_yaml_indent`]/[`compact_yaml_indent`],
+    ///   which build the two kinds of "one level deeper" string this
+    ///   recurses with.
+    /// - `unit`: the character repeated `indent_spaces` times per
+    ///   *ordinary* (non-compact) indentation level (`' '` normally, `'\t'`
+    ///   for `--tab`).
     /// - `sort_keys`: sort each mapping's fields before writing (`-S`).
     ///   `YamlField` is `Copy`, so materializing a mapping's fields into a
     ///   `Vec` is cheap — cursor structs only, no value data — and is done
     ///   unconditionally so the sorted and unsorted cases share one loop
     ///   body; the `Vec` is only actually sorted when `-S` is requested.
+    /// - `known_not_flow`: `true` when the caller already resolved
+    ///   `self.style() != "flow"` for this exact cursor (the #785
+    ///   compact-rendering gate in the `Sequence` arm below and in
+    ///   `stream_yaml_sequence` both do), letting this call skip
+    ///   re-deriving it — `style()` walks `text_position()`
+    ///   (`bp_to_text_pos`) plus a byte scan, not free work to repeat
+    ///   twice per element on this crate's flagship streaming path.
+    ///   `false` everywhere else, which re-derives it as before.
+    #[allow(clippy::too_many_arguments)] // STYLE-0004: every param is threaded through this function's own recursion; a struct would hide the 1:1 relationship each has to a specific rendering decision
     fn stream_yaml_value<Out: core::fmt::Write>(
         &self,
         out: &mut Out,
-        current_indent: usize,
+        indent: &str,
         indent_spaces: usize,
         unit: char,
         sort_keys: bool,
+        known_not_flow: bool,
     ) -> core::fmt::Result {
         match self.value() {
             YamlValue::Null => out.write_str("null"),
@@ -1369,7 +1389,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if fields.is_empty() {
                     return out.write_str("{}");
                 }
-                if indent_spaces == 0 || self.style() == "flow" {
+                if indent_spaces == 0 || (!known_not_flow && self.style() == "flow") {
                     // Flow style
                     out.write_char('{')?;
                     let mut items: Vec<_> = fields.into_iter().collect();
@@ -1392,7 +1412,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         if i == last_index {
                             let value_cursor = field.value_cursor();
                             let comment = value_cursor.line_comment_raw();
-                            write_flow_last_item_comment(out, comment, current_indent, unit)?;
+                            write_flow_last_item_comment(out, comment, indent)?;
                         }
                     }
                     out.write_char('}')
@@ -1411,7 +1431,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     for field in items {
                         if !first {
                             out.write_char('\n')?;
-                            write_yaml_indent(out, current_indent, unit)?;
+                            out.write_str(indent)?;
                         }
                         first = false;
                         write_yaml_field_key(out, field)?;
@@ -1432,13 +1452,15 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 out.write_str(anchor)?;
                             }
                             out.write_char('\n')?;
-                            write_yaml_indent(out, current_indent + indent_spaces, unit)?;
+                            let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
+                            out.write_str(&child_indent)?;
                             value.stream_yaml_value(
                                 out,
-                                current_indent + indent_spaces,
+                                &child_indent,
                                 indent_spaces,
                                 unit,
                                 sort_keys,
+                                true,
                             )?;
                             write_line_comment(out, value.line_comment_raw())?;
                         } else if let Some(kc) = field
@@ -1458,12 +1480,14 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 out.write_str(anchor)?;
                                 out.write_char(' ')?;
                             }
+                            let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
                             value.stream_yaml_value(
                                 out,
-                                current_indent + indent_spaces,
+                                &child_indent,
                                 indent_spaces,
                                 unit,
                                 sort_keys,
+                                false,
                             )?;
                             // The value's own comment takes priority; fall
                             // back to the key's own comment when the value
@@ -1492,7 +1516,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if elements.is_empty() {
                     return out.write_str("[]");
                 }
-                if indent_spaces == 0 || self.style() == "flow" {
+                if indent_spaces == 0 || (!known_not_flow && self.style() == "flow") {
                     // Flow style
                     out.write_char('[')?;
                     let mut first = true;
@@ -1505,7 +1529,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         write_yaml_child_inline(out, cursor, unit, sort_keys)?;
                         if rest.is_empty() {
                             let comment = cursor.line_comment_raw();
-                            write_flow_last_item_comment(out, comment, current_indent, unit)?;
+                            write_flow_last_item_comment(out, comment, indent)?;
                         }
                         elems = rest;
                     }
@@ -1517,23 +1541,25 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     while let Some((cursor, rest)) = elems.uncons_cursor() {
                         if !first {
                             out.write_char('\n')?;
-                            write_yaml_indent(out, current_indent, unit)?;
+                            out.write_str(indent)?;
                         }
                         first = false;
                         // A non-empty, non-flow mapping/sequence value
                         // renders in real yq's "compact" form: `- ` shares
                         // its line with the value's own first field/element,
                         // and the rest of the value's own content aligns
-                        // under that first line's content — i.e. at
-                        // `current_indent + COMPACT_DASH_WIDTH` (the literal
-                        // width of `- `), not `current_indent +
-                        // indent_spaces`, which can differ under `-I`/`-tab`
-                        // (#785). `stream_yaml_value`'s own Mapping/Sequence
-                        // loops already skip the leading indent for their
-                        // first field/element (only 2nd+ get
-                        // `write_yaml_indent`), so simply writing `- ` here
-                        // and recursing with the new baseline is enough —
-                        // no separate "compact" rendering path needed.
+                        // under that first line's content — i.e.
+                        // `compact_yaml_indent(indent)`, [`COMPACT_DASH_WIDTH`]
+                        // more literal ASCII spaces than the current level
+                        // already has (never `deeper_yaml_indent`'s
+                        // `unit`-based step, which can differ under
+                        // `-I`/`--tab`) (#785). `stream_yaml_value`'s own
+                        // Mapping/Sequence loops already skip the leading
+                        // indent for their first field/element (only 2nd+
+                        // write `indent` before their own content), so
+                        // simply writing `- ` here and recursing with the
+                        // new indent string is enough — no separate
+                        // "compact" rendering path needed.
                         //
                         // An anchor written directly on the item's own line
                         // (`- &x\n  ...`) occupies that slot instead, so the
@@ -1542,27 +1568,32 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         // key's own line, e.g. `- &x a: 1`, isn't captured
                         // by `cursor.anchor()` here at all — a separate,
                         // pre-existing gap, out of scope for #785.)
-                        if is_yaml_cursor_container(&cursor) && cursor.style() != "flow" {
+                        let style = cursor.style();
+                        if is_yaml_cursor_container(&cursor) && style != "flow" {
                             if let Some(anchor) = cursor.anchor() {
                                 out.write_str("- &")?;
                                 out.write_str(anchor)?;
                                 out.write_char('\n')?;
-                                write_yaml_indent(out, current_indent + indent_spaces, unit)?;
+                                let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
+                                out.write_str(&child_indent)?;
                                 cursor.stream_yaml_value(
                                     out,
-                                    current_indent + indent_spaces,
+                                    &child_indent,
                                     indent_spaces,
                                     unit,
                                     sort_keys,
+                                    true,
                                 )?;
                             } else {
                                 out.write_str("- ")?;
+                                let child_indent = compact_yaml_indent(indent);
                                 cursor.stream_yaml_value(
                                     out,
-                                    current_indent + COMPACT_DASH_WIDTH,
+                                    &child_indent,
                                     indent_spaces,
                                     unit,
                                     sort_keys,
+                                    true,
                                 )?;
                             }
                             write_line_comment(out, cursor.line_comment_raw())?;
@@ -1573,12 +1604,14 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 out.write_str(anchor)?;
                                 out.write_char(' ')?;
                             }
+                            let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
                             cursor.stream_yaml_value(
                                 out,
-                                current_indent + indent_spaces,
+                                &child_indent,
                                 indent_spaces,
                                 unit,
                                 sort_keys,
+                                false,
                             )?;
                             write_line_comment(out, cursor.line_comment_raw())?;
                         }
@@ -5524,14 +5557,21 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for YamlElements<'a, W> {
 // ============================================================================
 
 /// The literal character width of a block-sequence item's `- ` prefix
-/// (dash + one ASCII space) — always exactly 2, independent of the
-/// configured `indent_spaces`/`unit` (`-I`/`--tab`). Real yq's "compact"
-/// form for a sequence item whose value is a non-empty mapping/sequence
-/// aligns the value's own continuation lines under this width, not under
-/// `indent_spaces` (verified against `yq` v4.53.3 with `-I1` through
-/// `-I6`: the alignment never moves, only the sequence item's *own*
-/// indent does). See `stream_yaml_value`'s `Sequence` block-style arm and
-/// `stream_yaml_sequence` (#785).
+/// (dash + one ASCII space) — always exactly 2 literal ASCII bytes,
+/// independent of the configured `indent_spaces`/`unit` (`-I`/`--tab`).
+/// Real yq's "compact" form for a sequence item whose value is a
+/// non-empty mapping/sequence aligns the value's own continuation lines
+/// under this width, not under `indent_spaces` (verified against `yq`
+/// v4.53.3 with `-I1` through `-I6`: the alignment never moves, only the
+/// sequence item's *own* indent does).
+///
+/// This offset is always written as literal `' '` characters directly —
+/// never fed through [`write_yaml_indent`]'s `unit`-repetition — because
+/// `- ` itself is always literal ASCII regardless of `unit`; under
+/// `--tab` (`unit == '\t'`), multiplying this width by `unit` would
+/// literally double-tab the continuation instead of producing a 2-column
+/// visual offset. See `stream_yaml_value`'s `Sequence` block-style arm
+/// and `stream_yaml_sequence`'s `extra_spaces` parameter (#785).
 const COMPACT_DASH_WIDTH: usize = 2;
 
 /// Check if a cursor points to a non-empty container.
@@ -5573,7 +5613,14 @@ fn is_deferred_value_absent<W: AsRef<[u64]>>(value: &YamlCursor<'_, W>) -> bool 
 }
 
 /// Write `width` copies of `unit` as indentation (`unit` is `' '` for
-/// space-indented output, `'\t'` for `--tab`).
+/// space-indented output, `'\t'` for `--tab`). JSON-only: `stream_yaml_value`
+/// and `stream_yaml_sequence` build their own indent *strings* instead (see
+/// [`deeper_yaml_indent`]) since a real-yq "compact" block-sequence item's
+/// continuation offset can't always be expressed as a pure repetition count
+/// once a normal `unit`-based nesting step follows a compact one - the two
+/// have to interleave in the exact chronological order they were nested,
+/// which a `(width: usize, extra: usize)` pair collapses into a fixed
+/// unit-then-extra order regardless of which happened first (#785).
 fn write_yaml_indent<Out: core::fmt::Write>(
     out: &mut Out,
     width: usize,
@@ -5583,6 +5630,33 @@ fn write_yaml_indent<Out: core::fmt::Write>(
         out.write_char(unit)?;
     }
     Ok(())
+}
+
+/// Build a new YAML block-style indent string one level deeper than
+/// `indent`: `indent_spaces` more copies of `unit` appended. The ordinary
+/// (non-compact) nesting step for `stream_yaml_value`/`stream_yaml_sequence`
+/// (#785) - see [`compact_yaml_indent`] for the other kind of step.
+fn deeper_yaml_indent(indent: &str, indent_spaces: usize, unit: char) -> String {
+    let mut next = String::with_capacity(indent.len() + indent_spaces);
+    next.push_str(indent);
+    for _ in 0..indent_spaces {
+        next.push(unit);
+    }
+    next
+}
+
+/// Build a new YAML block-style indent string for a real-yq "compact"
+/// block-sequence item's continuation lines: [`COMPACT_DASH_WIDTH`] more
+/// literal ASCII spaces appended to `indent`, regardless of `unit` - `- `
+/// is always exactly that many literal bytes wide, independent of the
+/// configured indent character (#785).
+fn compact_yaml_indent(indent: &str) -> String {
+    let mut next = String::with_capacity(indent.len() + COMPACT_DASH_WIDTH);
+    next.push_str(indent);
+    for _ in 0..COMPACT_DASH_WIDTH {
+        next.push(' ');
+    }
+    next
 }
 
 /// Write a mapping field's key.
@@ -5625,7 +5699,7 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
         out.write_str(anchor)?;
         out.write_char(' ')?;
     }
-    value.stream_yaml_value(out, 0, 0, unit, sort_keys)
+    value.stream_yaml_value(out, "", 0, unit, sort_keys, false)
 }
 
 /// Write a trailing same-line comment after a value, if present (issue
@@ -5666,14 +5740,13 @@ fn write_line_comment<Out: core::fmt::Write>(
 fn write_flow_last_item_comment<Out: core::fmt::Write>(
     out: &mut Out,
     comment: Option<&str>,
-    current_indent: usize,
-    unit: char,
+    indent: &str,
 ) -> core::fmt::Result {
     if let Some(c) = comment {
         out.write_char(' ')?;
         out.write_str(c)?;
         out.write_char('\n')?;
-        write_yaml_indent(out, current_indent, unit)?;
+        out.write_str(indent)?;
     }
     Ok(())
 }
@@ -5689,8 +5762,9 @@ fn write_flow_last_item_comment<Out: core::fmt::Write>(
 ///
 /// Mirrors the `Sequence` block/flow-style rendering in `stream_yaml_value`
 /// exactly (same container-vs-scalar branching, same empty-sequence `"[]"`
-/// shortcut) so multi-document slurped output matches single-document M2
-/// streaming byte-for-byte.
+/// shortcut, same `#785` compact-form handling and per-item trailing-
+/// comment write) so multi-document slurped output matches single-document
+/// M2 streaming byte-for-byte.
 pub fn stream_yaml_sequence<'a, W, I, Out>(
     cursors: I,
     out: &mut Out,
@@ -5731,33 +5805,43 @@ where
             first = false;
             // Mirrors `stream_yaml_value`'s `Sequence` block-style arm
             // exactly, including its `#785` compact-form handling (see the
-            // comment there) — this doc comment already promised that
-            // parity, but the `style() != "flow"` guard had been missing
-            // here, so a flow-style item would wrongly take the block
-            // branch instead of staying inline.
-            if is_yaml_cursor_container(&cursor) && cursor.style() != "flow" {
+            // comment there). This function is never itself called
+            // recursively (it's only ever the outermost entry point - the
+            // `--slurp` array itself), so `current_indent` has no inherited
+            // compact "extra spaces" baggage of its own yet - converting it
+            // to a plain `unit`-repeated string here before handing off to
+            // `stream_yaml_value` (which *is* recursive and needs the
+            // general string form) is exact, not an approximation.
+            let style = cursor.style();
+            if is_yaml_cursor_container(&cursor) && style != "flow" {
                 if let Some(anchor) = cursor.anchor() {
                     out.write_str("- &")?;
                     out.write_str(anchor)?;
                     out.write_char('\n')?;
-                    write_yaml_indent(out, current_indent + indent_spaces, unit)?;
+                    let child_indent = deeper_yaml_indent("", current_indent + indent_spaces, unit);
+                    out.write_str(&child_indent)?;
                     cursor.stream_yaml_value(
                         out,
-                        current_indent + indent_spaces,
+                        &child_indent,
                         indent_spaces,
                         unit,
                         sort_keys,
+                        true,
                     )?;
                 } else {
                     out.write_str("- ")?;
+                    let own_indent = deeper_yaml_indent("", current_indent, unit);
+                    let child_indent = compact_yaml_indent(&own_indent);
                     cursor.stream_yaml_value(
                         out,
-                        current_indent + COMPACT_DASH_WIDTH,
+                        &child_indent,
                         indent_spaces,
                         unit,
                         sort_keys,
+                        true,
                     )?;
                 }
+                write_line_comment(out, cursor.line_comment_raw())?;
             } else {
                 out.write_str("- ")?;
                 if let Some(anchor) = cursor.anchor() {
@@ -5765,13 +5849,16 @@ where
                     out.write_str(anchor)?;
                     out.write_char(' ')?;
                 }
+                let child_indent = deeper_yaml_indent("", current_indent + indent_spaces, unit);
                 cursor.stream_yaml_value(
                     out,
-                    current_indent + indent_spaces,
+                    &child_indent,
                     indent_spaces,
                     unit,
                     sort_keys,
+                    false,
                 )?;
+                write_line_comment(out, cursor.line_comment_raw())?;
             }
         }
         Ok(())

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6776,6 +6776,40 @@ mod tests {
     }
 
     #[test]
+    fn test_stream_yaml_sequence_item_anchor_stays_deferred_785() {
+        // An anchor written on the item's own line (`- &x\n  ...`) occupies
+        // the compact slot `stream_yaml_value`'s Sequence arm otherwise
+        // gives to the value's first field/element, so the mapping stays
+        // deferred to its own indented line rather than going compact -
+        // matching real yq (verified against v4.53.3). Covers the
+        // `cursor.anchor()` branch `stream_yaml_value`'s Sequence arm added
+        // for #785.
+        let yaml = b"- &x\n  a: 1\n  b: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
+        assert_eq!(out, "- &x\n  a: 1\n  b: 2");
+    }
+
+    #[test]
+    fn test_stream_yaml_sequence_item_anchor_stays_deferred_slurp_785() {
+        // Same as `test_stream_yaml_sequence_item_anchor_stays_deferred_785`,
+        // exercised through `stream_yaml_sequence` (the `--slurp` fast
+        // path) instead of `stream_yaml_value`'s Sequence arm - covers the
+        // equivalent `cursor.anchor()` branch added there for parity.
+        let bytes_a = b"&x\n  a: 1\n  b: 2\n".to_vec();
+        let index_a = YamlIndex::build(&bytes_a).unwrap();
+        let cursor_a = index_a.root(&bytes_a).first_child().unwrap();
+
+        let mut out = String::new();
+        stream_yaml_sequence([cursor_a], &mut out, 0, 2, ' ', false).unwrap();
+        assert_eq!(out, "- &x\n  a: 1\n  b: 2");
+    }
+
+    #[test]
     fn test_stream_yaml_flow_mapping_sorts_keys_with_nonstring_key() {
         // `-S` with `IndentSpec::COMPACT` (forces flow style regardless of
         // source style, since `indent.width == 0`) and a non-string key,

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2020,7 +2020,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Parse value
         if self.at_line_end() {
-            // Value is on next line or implicit null
+            // Value is on next line or implicit null. Capture a trailing
+            // comment on the key's own line first (issue #765) -
+            // `self.last_open_bp_pos` still holds the key node's bp_pos here
+            // since no value node has been opened yet (nothing opens a BP
+            // node between the key's own close above and this point). This
+            // mirrors `parse_mapping_entry`'s identical capture just below
+            // - missing here left a block-sequence item's *first* field
+            // (the only mapping entry parsed by this function rather than
+            // `parse_mapping_entry`) silently dropping its own key comment
+            // (#785).
+            self.maybe_capture_line_comment(self.last_open_bp_pos);
             self.skip_to_eol();
 
             // Look ahead to determine if this is a null value or a nested structure

--- a/tests/snapshots/cli_characterization_tests__yq_config_identity.snap
+++ b/tests/snapshots/cli_characterization_tests__yq_config_identity.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/cli_characterization_tests.rs
+assertion_line: 159
 expression: "run(&[\"yq\", \".\"], YAML_CONFIG)?"
 ---
 apiVersion: v1
@@ -8,9 +9,7 @@ metadata:
   name: demo
 spec:
   containers:
-    -
-      name: web
+    - name: web
       image: nginx
-    -
-      name: sidecar
+    - name: sidecar
       image: envoy

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -972,6 +972,100 @@ fn test_duplicate_mapping_key_survives_sort_keys_and_tab() -> Result<()> {
     Ok(())
 }
 
+/// #785's compact-rendering fix has to align a block-sequence item's
+/// mapping/sequence value under `- `'s own literal 2-byte width, which
+/// can't be expressed as a repetition count of `unit` once `unit != ' '`
+/// (`--tab`) - real yq itself has no `--tab` flag at all to serve as an
+/// oracle here (`Error: unknown flag: --tab` against v4.53.3), so the bar
+/// this pins is self-consistency: the identity/M2 streaming path
+/// (`YamlCursor::stream_yaml_value`) and the DOM path (`emit_yaml_value`,
+/// forced via `map(.)`) must byte-match each other under `--tab`, not just
+/// each look individually plausible. A first version of this fix fed the
+/// alignment offset through the same `unit`-repetition helper as ordinary
+/// indentation, which under `--tab` wrote literal tab characters instead
+/// of the fixed-width literal-space offset `- ` itself always needs,
+/// producing two different (and differently wrong) outputs from the two
+/// paths for the same input.
+#[test]
+fn test_compact_seq_item_tab_self_consistent_785() -> Result<()> {
+    let yaml = "- a: 1\n  b: 2\n";
+
+    let (streamed, code) = run_yq_stdin(".", yaml, &["--tab"])?;
+    assert_eq!(code, 0);
+
+    let (dom, code) = run_yq_stdin("map(.)", yaml, &["--tab"])?;
+    assert_eq!(code, 0);
+
+    assert_eq!(streamed, dom);
+    // No outer indent level applies at the top level, so the only
+    // alignment in play here is the fixed 2-literal-ASCII-space compact
+    // offset itself - never tab characters, matching `- `'s own always-
+    // ASCII width.
+    assert_eq!(streamed, "- a: 1\n  b: 2\n");
+
+    Ok(())
+}
+
+/// Same self-consistency bar, but with a genuine outer `--tab` indent
+/// level *and* the compact offset both in play, and in the order that
+/// actually exposed the bug this pins: the compact transition happens
+/// *first* (the top-level array's own single element renders compactly,
+/// since it's a non-empty mapping), and only *then* does an ordinary
+/// `unit`-based nesting step follow (that mapping's `items` field defers
+/// its own array value to a new, further-indented line). A `(current_indent:
+/// usize, extra_spaces: usize)` representation collapses to a fixed
+/// unit-then-extra order regardless of which happened first, so it got
+/// this specific compact-then-normal ordering backwards even after the
+/// first `--tab` fix (`extra_spaces` always written after `current_indent`'s
+/// `unit` repeats, when here the literal-space compact offset actually
+/// came *before* the later tab step, chronologically) - only visible once
+/// a normal indent step follows a compact one under a non-space `unit`,
+/// which the top-level, no-further-nesting cases above don't exercise.
+/// The wrapper array element (rather than a bare top-level mapping) is
+/// required for the `map(.)` DOM-forcing query below to preserve
+/// structure: real jq's `map(f)` is `[.[] | f]`, and `.[]` on a bare
+/// object iterates its *values* (restructuring `{items: [...]}` into
+/// `[[...]]`), not its entries - wrapping in an array first makes `map(.)`
+/// a true per-element identity instead.
+#[test]
+fn test_compact_seq_item_tab_self_consistent_compact_then_normal_785() -> Result<()> {
+    let yaml = "- items:\n    - a: 1\n      b: 2\n";
+
+    let (streamed, code) = run_yq_stdin(".", yaml, &["--tab"])?;
+    assert_eq!(code, 0);
+
+    let (dom, code) = run_yq_stdin("map(.)", yaml, &["--tab"])?;
+    assert_eq!(code, 0);
+
+    assert_eq!(streamed, dom);
+    assert_eq!(streamed, "- items:\n  \t- a: 1\n  \t  b: 2\n");
+
+    Ok(())
+}
+
+/// Same self-consistency bar as [`test_compact_seq_item_tab_self_consistent_785`],
+/// for nested compact items (`- - 1\n  - 2\n`) - confirms the `--tab`
+/// alignment offset accumulates correctly across more than one compact
+/// transition, not just the first. No outer indent level applies at the
+/// top level, so - same as the single-level case - the only alignment in
+/// play is two lots of the fixed 2-literal-ASCII-space compact offset,
+/// never tab characters.
+#[test]
+fn test_compact_seq_item_tab_self_consistent_nested_785() -> Result<()> {
+    let yaml = "- - 1\n  - 2\n";
+
+    let (streamed, code) = run_yq_stdin(".", yaml, &["--tab"])?;
+    assert_eq!(code, 0);
+
+    let (dom, code) = run_yq_stdin("map(.)", yaml, &["--tab"])?;
+    assert_eq!(code, 0);
+
+    assert_eq!(streamed, dom);
+    assert_eq!(streamed, "- - 1\n  - 2\n");
+
+    Ok(())
+}
+
 /// `--tab`'s fix (#733) widened `can_stream_pretty`, which also covers
 /// `keys_unsorted` (part of `can_use_m2_streaming`) — not a duplicate-key
 /// case (keys_unsorted returns an array of key names, so nothing to
@@ -3722,20 +3816,18 @@ fn test_slurp_color_output_yaml() -> Result<()> {
     assert_eq!(code, 0);
     // Renders in real yq's "compact" form (#785): `- ` shares its line
     // with the mapping's own first field. `colorize_yaml` is a simple
-    // single-pass, no-lookahead text colorizer (its own scheme, not
-    // oracle-matched against real yq's `-C`, which uses entirely
-    // different codes/colors) whose `at_key_start` flag was never
-    // previously reachable directly after a list marker - compact form is
-    // the first shape that puts a key there instead of a value or a
-    // newline. It currently clears the flag on the marker, so this first
-    // "a" misses its cyan key coloring (`a: 1` colored, first field
-    // colored the marker's color and the rest uncolored) - a cosmetic
-    // self-consistency gap in the colorizer, not a data/structure bug
-    // (see #785's PR description for the filed follow-up), left as-is
-    // here rather than in scope for this fix.
+    // single-pass text colorizer (its own scheme, not oracle-matched
+    // against real yq's `-C`, which uses entirely different codes/colors)
+    // whose `at_key_start` flag was never previously reachable directly
+    // after a list marker - compact form is the first shape that puts a
+    // key there instead of a value or a newline. It now peeks ahead
+    // (`compact_item_opens_with_key`) to tell a compact key from a bare
+    // scalar value in that position before deciding whether to color it,
+    // so this first "a" gets its cyan key coloring too, matching every
+    // other key in the document.
     assert_eq!(
         output,
-        "\u{1b}[33m-\u{1b}[0m a\u{1b}[0m: 1\n  \u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
+        "\u{1b}[33m-\u{1b}[0m \u{1b}[36ma\u{1b}[0m: 1\n  \u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
     );
 
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -683,7 +683,9 @@ fn test_duplicate_mapping_key_to_entries_preserves_both() -> Result<()> {
     let (output, code) = run_yq_stdin("to_entries", yaml, &[])?;
 
     assert_eq!(code, 0);
-    assert_eq!(output, "-\n  key: a\n  value: 1\n-\n  key: a\n  value: 2\n");
+    // Each element renders in real yq's "compact" form (#785): `- ` shares
+    // its line with the mapping's own first field.
+    assert_eq!(output, "- key: a\n  value: 1\n- key: a\n  value: 2\n");
     Ok(())
 }
 
@@ -712,11 +714,13 @@ fn test_duplicate_mapping_key_survives_slurp() -> Result<()> {
 
     let (pretty, code) = run_yq_stdin(".", yaml, &["--slurp"])?;
     assert_eq!(code, 0);
-    assert_eq!(pretty, "-\n  a: 1\n  a: 2\n");
+    // Renders in real yq's "compact" form (#785): `- ` shares its line
+    // with the mapping's own first field.
+    assert_eq!(pretty, "- a: 1\n  a: 2\n");
 
     let (compact, code) = run_yq_stdin(".", yaml, &["--slurp", "-I0"])?;
     assert_eq!(code, 0);
-    assert_eq!(compact, "-\n  a: 1\n  a: 2\n");
+    assert_eq!(compact, "- a: 1\n  a: 2\n");
 
     Ok(())
 }
@@ -742,7 +746,9 @@ fn test_duplicate_mapping_key_survives_slurp_multiple_sources() -> Result<()> {
     let stdout = String::from_utf8(output.stdout)?;
 
     assert!(output.status.success());
-    assert_eq!(stdout, "-\n  a: 1\n  a: 2\n-\n  b: 3\n");
+    // Renders in real yq's "compact" form (#785): `- ` shares its line
+    // with the mapping's own first field.
+    assert_eq!(stdout, "- a: 1\n  a: 2\n- b: 3\n");
     Ok(())
 }
 
@@ -755,7 +761,9 @@ fn test_duplicate_mapping_key_survives_slurp_multiple_sources() -> Result<()> {
 fn test_slurp_exit_status_fast_path() -> Result<()> {
     let (output, code) = run_yq_stdin(".", "a: 1\n", &["--slurp", "-e"])?;
     assert_eq!(code, 0);
-    assert_eq!(output, "-\n  a: 1\n");
+    // Renders in real yq's "compact" form (#785): `- ` shares its line
+    // with the mapping's own first field.
+    assert_eq!(output, "- a: 1\n");
     Ok(())
 }
 
@@ -3712,9 +3720,22 @@ fn test_slurp_color_output_yaml() -> Result<()> {
 
     let (output, code) = run_yq_stdin(".", yaml, &["--slurp", "-C"])?;
     assert_eq!(code, 0);
+    // Renders in real yq's "compact" form (#785): `- ` shares its line
+    // with the mapping's own first field. `colorize_yaml` is a simple
+    // single-pass, no-lookahead text colorizer (its own scheme, not
+    // oracle-matched against real yq's `-C`, which uses entirely
+    // different codes/colors) whose `at_key_start` flag was never
+    // previously reachable directly after a list marker - compact form is
+    // the first shape that puts a key there instead of a value or a
+    // newline. It currently clears the flag on the marker, so this first
+    // "a" misses its cyan key coloring (`a: 1` colored, first field
+    // colored the marker's color and the rest uncolored) - a cosmetic
+    // self-consistency gap in the colorizer, not a data/structure bug
+    // (see #785's PR description for the filed follow-up), left as-is
+    // here rather than in scope for this fix.
     assert_eq!(
         output,
-        "\u{1b}[33m-\u{1b}[0m\n  \u{1b}[36ma\u{1b}[0m: 1\n  \u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
+        "\u{1b}[33m-\u{1b}[0m a\u{1b}[0m: 1\n  \u{1b}[36ma\u{1b}[0m: 2\u{1b}[0m\n"
     );
 
     Ok(())
@@ -7479,7 +7500,9 @@ fn test_eval_all_file_index_in_map() -> Result<()> {
         &["--eval-all"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout, "-\n  a: 1\n  name: first\n");
+    // Renders in real yq's "compact" form (#785): `- ` shares its line
+    // with the mapping's own first field.
+    assert_eq!(stdout, "- a: 1\n  name: first\n");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3833,6 +3833,47 @@ fn test_slurp_color_output_yaml() -> Result<()> {
     Ok(())
 }
 
+/// `compact_item_opens_with_key`'s quote-aware lookahead must skip a `:`
+/// that's inside a quoted compact-form key, not treat it as the
+/// key-indicating colon - and must still resolve `at_key_start` correctly
+/// once the quote closes and the *real* key-ending `:` follows. The
+/// quoted key itself renders green either way (`colorize_yaml`'s `"`/`'`
+/// arm colors it unconditionally, independent of `at_key_start`), so this
+/// doesn't change what's visible - it pins the lookahead's own quote
+/// entry/exit and in-quote-skip behavior directly, which no other test
+/// exercises.
+#[test]
+fn test_color_compact_quoted_key_with_colon_785() -> Result<()> {
+    let yaml = "- \"x: y\": 1\n  b: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["-C"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[33m-\u{1b}[0m \u{1b}[32m\"x: y\"\u{1b}[0m: 1\n  \u{1b}[36mb\u{1b}[0m: 2\u{1b}[0m\n"
+    );
+
+    Ok(())
+}
+
+/// Same as [`test_slurp_color_compact_quoted_key_with_colon_785`], for an
+/// escaped quote inside the compact-form quoted key - pins the lookahead's
+/// escape-skip branch (`if c == '\\' { chars.next(); }`), which the
+/// unescaped case above doesn't reach.
+#[test]
+fn test_color_compact_quoted_key_with_escaped_quote_785() -> Result<()> {
+    let yaml = "- \"a\\\"b: c\": 1\n  d: 2\n";
+
+    let (output, code) = run_yq_stdin(".", yaml, &["-C"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[33m-\u{1b}[0m \u{1b}[32m\"a\\\"b: c\"\u{1b}[0m: 1\n  \u{1b}[36md\u{1b}[0m: 2\u{1b}[0m\n"
+    );
+
+    Ok(())
+}
+
 /// Unlike [`test_slurp_color_output_yaml`], `-o json --slurp` stays on the
 /// `OwnedValue`/`IndexMap` DOM path regardless of `-C` — `can_slurp_fast_path`
 /// requires YAML output, so `-o json --slurp` is unaffected by #809's fix and


### PR DESCRIPTION
## Summary

A block sequence item whose value is a non-empty mapping or sequence always re-serialized as a bare `-` on its own line, followed by the value fully indented on the next line, instead of real yq's "compact" form (`- key: value`, with subsequent fields/elements aligned under the first line's content). Fires on very common shapes — a list of records (Kubernetes manifests, CI/CD configs), and any nested-sequence-in-sequence-item.

```
$ printf -- '- a: 1\n  b: 2\n' | yq '.'
- a: 1
  b: 2
$ printf -- '- a: 1\n  b: 2\n' | succinctly yq '.'   # before this PR
-
  a: 1
  b: 2
```

Also fixed a compounding bug this issue's own report flagged: because the shape routed through different rendering code, #765's key-scoped comment preservation didn't apply, and the comment was dropped outright rather than just reformatted. Root-caused this to a genuine **parser** bug (not just a rendering gap): `parse_compact_mapping_entry` — used only for a block-sequence item's first field — never got #765's `maybe_capture_line_comment` call that its sibling `parse_mapping_entry` has, so the comment was never captured in the first place.

- **Streaming path**: `YamlCursor::stream_yaml_value`'s Sequence block-style arm (`src/yaml/light.rs`)
- **`--slurp` fast path**: `stream_yaml_sequence` (`src/yaml/light.rs`) — a third affected call site beyond the two named in the issue, found during investigation; also picked up a missing `.style() != "flow"` guard its own doc comment already promised but never had
- **DOM path**: `emit_yaml_value`'s `Array` arm (`src/bin/succinctly/yq_runner.rs`) — refactored from `depth: usize` to an explicit `indent: &str` parameter, since the compact continuation's `+2`-literal-character offset can't be expressed as a repetition count once `indent_str`'s own width can differ (`-I4`, `--tab`)
- **Parser**: `parse_compact_mapping_entry` (`src/yaml/parser.rs`) — one-line fix mirroring #765's existing capture in `parse_mapping_entry`

The compact continuation's alignment is always `+2` literal characters (the width of `- `), **never** `+ indent_spaces` — verified against real `yq` v4.53.3 across `-I1` through `-I6`: nested block indentation scales with `-I`, but compact alignment never moves.

An anchor written on the item's own line (`- &x\n  ...`) still occupies the compact slot and keeps the value deferred, matching real yq — `cursor.anchor()` only returns `Some` for that source shape; an anchor sharing the first key's own line (`- &x a: 1`) isn't captured by the cursor at all, a separate pre-existing gap.

## Follow-ups filed (out of scope for this PR)

- #835 (High) — `is_container()` returns `false` for a sequence item's mapping value when the source uses dash-alone-then-indented style, causing the *value to be dropped entirely* on re-serialization (not just misformatted). Confirmed pre-existing on unmodified `main`, unrelated to and unaffected by this fix.
- #836 (Medium) — block scalar (`|`/`>`) style is lost on re-serialization via the streaming/cursor path (distinct root cause from #739, which is `OwnedValue`-specific). Confirmed pre-existing on `main`.
- #837 (Low) — `yq -C`'s simplified, non-oracled colorizer doesn't color a compact item's first key (cosmetic only, newly *reachable* by this fix but not caused by it).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 2356+ lib tests plus all integration suites green; one `jq_cli_tests` flake reproduced the known concurrent-cargo-contention pattern and passed clean in isolation)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against pinned real `yq` v4.53.3 (matches `tests/data/yq-golden/YQ_VERSION`) for: basic compact mapping, list-of-records, comment-on-key, compact sequence-in-sequence-item, `-I4`/`-I6`, anchor-stays-deferred, plain scalar items (unaffected), flow-style items (unaffected) — on both the identity/streaming path and the DOM path (forced via `-C`, ANSI-stripped for structural comparison)
- [x] `./scripts/sync-yq-golden.sh --check` — no drift (no golden fixture asserts YAML-format output)
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — 89.81% patch coverage; remaining gaps are a test-helper's defensive `panic!` branches (matching an existing sibling helper's established pattern), one diff-context artifact pointing at an unrelated pre-existing test, and `?`-operator error-propagation branches on `core::fmt::Write` calls that succeed unconditionally for a `String` sink
- [x] Updated 3 `light.rs` unit tests, 6 `yq_cli_tests.rs` integration tests, and 1 insta snapshot that pinned the old buggy output; added 4 new regression tests (2 for the parser comment-capture fix, 2 for the anchor-stays-deferred branches)

Fixes #785