### PR TITLE
fix(jq): keep path() prefix when a try/catch handler itself fails

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10190,22 +10190,18 @@ fn resolve_catch<'a, S: EvalSemantics>(
     prefix: Vec<PathBranch<'a>>,
     payload: OwnedValue,
 ) -> PathResolveResult<'a> {
-    match catch {
-        None => Ok(prefix),
-        Some(catch_expr) => {
-            let mut out = prefix;
-            match resolve_against_cow::<S>(catch_expr, Cow::Owned(payload)) {
-                Ok(handled) => {
-                    out.extend(handled);
-                    Ok(out)
-                }
-                Err((handler_prefix, escape)) => {
-                    out.extend(handler_prefix);
-                    Err((out, escape))
-                }
-            }
+    let Some(catch_expr) = catch else {
+        return Ok(prefix);
+    };
+    let mut out = prefix;
+    match resolve_against_cow::<S>(catch_expr, Cow::Owned(payload)) {
+        Ok(branches) => out.extend(branches),
+        Err((branches, e)) => {
+            out.extend(branches);
+            return Err((out, e));
         }
     }
+    Ok(out)
 }
 
 /// Fan `recurse(f)` / `recurse(f; cond)` out into one branch per visited

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10173,10 +10173,18 @@ fn resolve_against_cow<'a, S: EvalSemantics>(
 /// live: `path(try (.a, .x[0]) catch empty)` on `{"a":1,"x":5}` prints
 /// `["a"]`, not nothing).
 ///
-/// If `catch_expr` itself then fails, the `?` below returns its `Err`
-/// directly, losing `prefix` rather than threading it into the returned
-/// tuple — a separate, pre-existing gap in this same arm (#832), not fixed
-/// here.
+/// If `catch_expr` itself then fails — with an ordinary error (including
+/// #530's "Invalid path expression"), a `break` targeting some outer label,
+/// or a `halt`/`halt_error` — `prefix` (and whatever partial output the
+/// handler itself already resolved before its own failure) is threaded into
+/// the returned `Err` rather than dropped, matching every other arm in this
+/// resolver (`Expr::Comma`, `Expr::As`, ...) that already keeps its
+/// accumulated prefix on the error path (#832; before this fix, all three
+/// escape kinds silently discarded `prefix` here — confirmed live:
+/// `path(try (.a, .x[0]) catch "x")` on `{"a":1,"x":5}` dropped `["a"]`
+/// before raising `"x"`'s own #530 error, and
+/// `label $out | path(try (.a, break $out) catch error("y"))` on `{"a":1}`
+/// dropped `["a"]` before raising `"y"`).
 fn resolve_catch<'a, S: EvalSemantics>(
     catch: Option<&Expr>,
     prefix: Vec<PathBranch<'a>>,
@@ -10186,8 +10194,16 @@ fn resolve_catch<'a, S: EvalSemantics>(
         None => Ok(prefix),
         Some(catch_expr) => {
             let mut out = prefix;
-            out.extend(resolve_against_cow::<S>(catch_expr, Cow::Owned(payload))?);
-            Ok(out)
+            match resolve_against_cow::<S>(catch_expr, Cow::Owned(payload)) {
+                Ok(handled) => {
+                    out.extend(handled);
+                    Ok(out)
+                }
+                Err((handler_prefix, escape)) => {
+                    out.extend(handler_prefix);
+                    Err((out, escape))
+                }
+            }
         }
     }
 }
@@ -29316,6 +29332,46 @@ mod tests {
         // means nothing is written at all — no partial prefix here.
         query!(br#"{"a":1}"#, "(.a, 1) = 5",
             QueryResult::Error(e) => assert_eq!(e.message, "Invalid path expression with result 1")
+        );
+    }
+
+    /// #832: `resolve_catch` (shared by `resolve_node`'s `Expr::Try` arm's
+    /// `Error` and `Break` cases) used a bare `?` on the catch handler's own
+    /// resolution, discarding `prefix` -- whatever the failed `try` body had
+    /// already resolved -- the instant the handler itself failed, instead of
+    /// threading it into the returned `Err` the way every sibling arm here
+    /// does (e.g. `test_path_keeps_the_prefix_before_a_later_sibling_errors`
+    /// above). Ordinary-error variant: the handler's own output (`"x"`) is
+    /// not a valid path expression (#530's gate). Verified against jq 1.7.1:
+    /// `path(try (.a, .x[0]) catch "x")` on `{"a":1,"x":5}` prints `["a"]`
+    /// (the `.a` branch, resolved before `.x[0]` failed) then raises
+    /// "Invalid path expression with result \"x\"", exit 5.
+    #[test]
+    fn test_path_try_catch_handler_error_keeps_prefix_832() {
+        query!(br#"{"a":1,"x":5}"#, r#"path(try (.a, .x[0]) catch "x")"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"["a"]"#]);
+                assert!(e.is_invalid_path_expression(), "{}", e.message);
+            }
+        );
+    }
+
+    /// #832, break variant: the same `resolve_catch` helper is reached via
+    /// the `Expr::Try` arm's `Break` case (rather than its `Error` case
+    /// above) once `catch` intercepts a `break` (#824, #562's "catch catches
+    /// break the same way it catches error" rule) -- and the handler itself
+    /// then raises an ordinary error. Verified against jq 1.7.1: `label $out
+    /// | path(try (.a, break $out) catch error("y"))` on `{"a":1}` prints
+    /// `["a"]` then raises "y", exit 5.
+    #[test]
+    fn test_path_try_catch_handler_break_keeps_prefix_832() {
+        query!(
+            br#"{"a":1}"#,
+            r#"label $out | path(try (.a, break $out) catch error("y"))"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"["a"]"#]);
+                assert_eq!(e.message, "y");
+            }
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6531,13 +6531,15 @@ fn test_try_catch_inside_a_path_call_catches_a_break_regardless_of_label_824() -
     // label it targets -- the same rule the value-position evaluator's
     // `eval_try` already applies (#562), now mirrored in path context
     // (#824). `catch empty` here (rather than a handler that is itself not
-    // a valid path expression, e.g. `catch "x"`) sidesteps a separate,
-    // pre-existing gap in this same `Expr::Try` arm -- filed as #832 --
-    // where the resolved prefix is lost if the *handler itself* then fails
-    // as a path expression (#530); that gap already exists for the
-    // ordinary-error side of this arm too (`path(try (.a, .x[0]) catch
-    // "x")` on real jq 1.7.1, confirmed live: prefix `["a"]` on stdout,
-    // "Invalid path expression..." on stderr) and is not specific to break.
+    // a valid path expression, e.g. `catch "x"`) is deliberate regardless:
+    // it isolates *this* test's break-interception claim from the catch
+    // handler's own success/failure, which is covered separately below and
+    // by the dedicated #832 regression tests
+    // (`test_path_try_catch_handler_error_keeps_prefix_832` and
+    // `test_path_try_catch_handler_halt_keeps_prefix_832`) -- #832 fixed
+    // `resolve_catch` (shared by this arm's `Error` and `Break` cases) so
+    // the resolved prefix survives even when the handler itself then fails,
+    // for all three escape kinds (error, break, halt).
     // Verified against jq 1.7.1: `path(try (.a, break $out) catch empty)`
     // on `{"a":1}` is `["a"]`, exit 0 -- the break never reaches `$out` at
     // all, catch runs before the label ever gets a chance.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6574,14 +6574,18 @@ fn test_try_catch_inside_a_path_call_catches_a_break_regardless_of_label_824() -
 
     // The catch handler itself raising a *different* error, rather than
     // failing as a path expression (#530) — the same "catch runs, and its
-    // own failure propagates" shape, through the code path shared with
-    // #832's pre-existing gap (see the doc comment above): confirmed live,
-    // real jq's `path(try (.a, break $out) catch error("y"))` on `{"a":1}`
-    // prints the prefix `["a"]` then raises "y", exit 5. succinctly instead
-    // loses the prefix here (empty stdout) while still raising "y" and
-    // exiting 5 -- the handler's own failure is reported correctly, only
-    // the earlier prefix is dropped, which is #832's gap, not a new one
-    // this fix introduces.
+    // own failure propagates" shape, through the code path #832 fixed
+    // (`resolve_catch`, shared by this arm's `Error` and `Break` cases):
+    // confirmed live, real jq's `path(try (.a, break $out) catch
+    // error("y"))` on `{"a":1}` prints the prefix `["a"]` then raises "y",
+    // exit 5. Before #832, succinctly lost the prefix here (empty stdout)
+    // while still raising "y" and exiting 5 -- the handler's own failure was
+    // reported correctly, only the earlier prefix was dropped. `resolve_catch`
+    // now threads `prefix` into the `Err` side the same way every other arm
+    // in this resolver already does, so the prefix survives regardless of
+    // which escape kind (error, break, or halt) the handler itself raises --
+    // see #832's dedicated regression tests below for the ordinary-error and
+    // halt cases.
     let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
@@ -6590,9 +6594,49 @@ fn test_try_catch_inside_a_path_call_catches_a_break_regardless_of_label_824() -
         Some(r#"{"a":1}"#),
     )?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "");
+    assert_eq!(stdout, "[\"a\"]\n");
     assert!(stderr.contains("error (at <stdin>:"), "{stderr}");
     assert!(stderr.trim_end().ends_with(": y"), "{stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_path_try_catch_handler_error_keeps_prefix_832() -> Result<()> {
+    // #832: `resolve_catch` (the helper `resolve_node`'s `Expr::Try` arm
+    // shares between its `Error` and `Break` cases) used to return the catch
+    // handler's own failure via a bare `?`, discarding whatever `prefix` the
+    // failed `try` body had already resolved. Ordinary-error variant:
+    // `catch_expr` itself is not a valid path expression (#530). Verified
+    // against jq 1.7.1: `path(try (.a, .x[0]) catch "x")` on
+    // `{"a":1,"x":5}` prints the prefix `["a"]` (the `.a` branch, resolved
+    // before `.x[0]` failed) then raises the #530 "Invalid path expression"
+    // complaint about `"x"`, exit 5.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(try (.a, .x[0]) catch "x")"#],
+        Some(r#"{"a":1,"x":5}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert!(stderr.contains("Invalid path expression"), "{stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_path_try_catch_handler_halt_keeps_prefix_832() -> Result<()> {
+    // #832, halt variant: the catch handler itself calls `halt_error`, which
+    // is never caught by `try`/`catch` (#791) and exits the whole process.
+    // `resolve_catch`'s fix is escape-kind-agnostic (it matches on the
+    // handler's `Err((prefix, escape))` generically), so this needs its own
+    // regression case distinct from the ordinary-error and break variants
+    // above/below -- confirmed independently rather than assumed from the
+    // other two. The prefix `["a"]` (resolved before `.x[0]` failed) must
+    // still reach stdout before the process halts.
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", "path(try (.a, .x[0]) catch halt_error)"],
+        Some(r#"{"a":1,"x":5}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`resolve_node`'s `Expr::Try` arm (`src/jq/eval.rs`) builds a path prefix as it resolves a `try` body, then hands off to a shared helper, `resolve_catch`, to run the `catch` handler (if any) on failure. `resolve_catch` used a bare `?` on the handler's own `resolve_against_cow` call:

```rust
let mut out = prefix;
out.extend(resolve_against_cow::<S>(catch_expr, Cow::Owned(payload))?);
Ok(out)
```

If the catch handler itself then failed — an ordinary error, a `break` targeting some outer label, or a `halt`/`halt_error` — the `?` returned that failure immediately, discarding `out` (and the `prefix` it held) entirely. Every other arm in this resolver (`Expr::Comma`, `Expr::As`, ...) already threads its accumulated prefix through the `Err` side on failure; this was the one arm that didn't.

This is a follow-up from #824's review, which found the same gap generalizes across **all three** `EvalEscape` kinds (`Error`, `Break`, `Halt`), not just the ordinary-error case the issue was originally scoped around — since `resolve_catch` is the single helper both of `Expr::Try`'s `Error`- and `Break`-catching branches call, one fix at that helper covers all three.

### Fix

`resolve_catch` now matches on `resolve_against_cow`'s result explicitly instead of using `?`:

```rust
match resolve_against_cow::<S>(catch_expr, Cow::Owned(payload)) {
    Ok(handled) => {
        out.extend(handled);
        Ok(out)
    }
    Err((handler_prefix, escape)) => {
        out.extend(handler_prefix);
        Err((out, escape))
    }
}
```

### Repro (before → after)

```
$ echo '{"a":1,"x":5}' | succinctly jq -c 'path(try (.a, .x[0]) catch "x")'
# before: (nothing on stdout) / jq: error (at <stdin>:1): Invalid path expression with result "x"
# after:  ["a"]                / jq: error (at <stdin>:1): Invalid path expression with result "x"
```
matches real jq 1.7.1 exactly (exit 5 both before and after; only the missing stdout prefix is fixed).

```
$ echo '{"a":1}' | succinctly jq -c 'label $out | path(try (.a, break $out) catch error("y"))'
# before: (nothing on stdout) / jq: error (at <stdin>:1): y
# after:  ["a"]                / jq: error (at <stdin>:1): y
```
also now matches real jq 1.7.1 exactly.

### Scope

Kept strictly local to `resolve_catch` / the path-context catch-handling code in `resolve_node`'s `Expr::Try` arm, per the issue's explicit scope note. `eval_owned_expr`/`result_to_owned`'s broader break-swallowing gap across the general builtin-argument-evaluation surface is a separate, already-filed issue (#833) — not touched here.

Fixes #832

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manually diffed output against real jq 1.7.1 for both issue repros (ordinary-error and break variants) plus a new halt variant — all three now match jq exactly
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only` — both new branches of the fix (`Ok`/`Err`) exercised by dedicated unit tests (`src/jq/eval.rs`) and CLI-level tests (`tests/jq_cli_tests.rs`) covering all three `EvalEscape` kinds (error, break, halt)
- [x] Updated a pre-existing #824 test (`test_try_catch_inside_a_path_call_catches_a_break_regardless_of_label_824`) that was asserting the old, buggy empty-stdout behavior for this exact shape

## Review notes

A multi-angle review of this diff found the fix itself correct and complete (traced through `resolve_dynamic_indexes`/`builtin_path`/`walk_path`, A/B tested against real jq 1.7.1 across nested-try, comma-composed, break-then-error, and halt-in-handler scenarios). Two review angles disagreed on whether `resolve_recurse`'s unrelated `Err((_prefix, e)) => return Err((outputs, e))` (which discards `f`'s own partial fan-out) was a bug or intentional; resolved empirically against real jq — it *is* a real divergence, but the correct fix isn't the naive one-liner first proposed (its `_prefix` is relative to the current node, not absolute like `outputs`, so appending it directly would produce corrupted paths) and it also requires keeping the value-position `builtin_recurse_f`/`builtin_recurse_cond` in parity, so it's out of scope for this narrowly-scoped PR — filed as #842 instead of folded in here.

Two more pre-existing, unrelated bugs turned up while probing for additional #832 regression-test coverage (trying to construct a "catch handler produces non-empty output before its own later failure" case) — filed as #843 and #844 rather than added as tests here, since every repro attempt for that scenario turned out to hit one of these two separate gaps instead of exercising `resolve_catch` itself:

- #842 — `recurse(f)` drops `f`'s own partial fan-out when a later `f` output errors (value + path evaluators)
- #843 — `path()`'s catch handler treats the caught error/break value as path-trackable when real jq never does
- #844 — `path()` doesn't track a variable bound outside its own argument

Applied from review: flattened `resolve_catch`'s nested match into a `let-else` + single accumulate-then-`Ok` shape matching the sibling `Comma`/`If` arms' established idiom, consistent naming (`branches`/`e`) across both match arms, and fixed a stale comment on a pre-existing #824 test that still described #832 as an open gap.
