### PR TITLE
fix(yaml): resolve bare-dash sequence-item wrapper before container checks

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -226,7 +226,13 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
         YamlValue::Sequence(elements) => {
             let mut arr = Vec::new();
             let mut rest = elements;
-            while let Some((elem_cursor, next)) = rest.uncons_cursor() {
+            // `uncons_resolved_cursor`, not `uncons_cursor`: the recursive
+            // call's own `cursor.explicit_tag()` above doesn't resolve a
+            // bare `-` sequence-item wrapper itself (see
+            // `YamlCursor::anchor`'s doc comment for why), so an
+            // unresolved cursor here would silently drop an explicit tag
+            // on a bare-dash-deferred scalar (#835).
+            while let Some((elem_cursor, next)) = rest.uncons_resolved_cursor() {
                 arr.push(yaml_to_owned_value(elem_cursor)?);
                 rest = next;
             }
@@ -709,7 +715,14 @@ fn walk_alias_groups<W: AsRef<[u64]> + Clone>(
         YamlValue::Sequence(elements) => {
             let mut idx = 0i64;
             let mut rest = elements;
-            while let Some((elem_cursor, next_rest)) = rest.uncons_cursor() {
+            // `uncons_resolved_cursor`, not `uncons_cursor`: a bare `-`
+            // item's own anchor (if any) sits on the deferred value's line,
+            // not the wrapper's, and this function's own `cursor.anchor()`
+            // check above doesn't resolve through the wrapper itself (see
+            // `YamlCursor::anchor`'s doc comment) — an unresolved cursor
+            // here would silently miss the anchor and break alias-sync
+            // bookkeeping for a bare-dash-deferred anchored value (#835).
+            while let Some((elem_cursor, next_rest)) = rest.uncons_resolved_cursor() {
                 path.push(OwnedValue::Int(idx));
                 walk_alias_groups(elem_cursor, path, defs, aliases);
                 path.pop();

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17316,7 +17316,13 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
         }
         YamlValue::Sequence(mut elements) => {
             let mut items = Vec::new();
-            while let Some((elem_cursor, rest)) = elements.uncons_cursor() {
+            // `uncons_resolved_cursor`, not `uncons_cursor`: the recursive
+            // call's own `cursor.explicit_tag()` above doesn't resolve a
+            // bare `-` sequence-item wrapper itself, so an unresolved
+            // cursor here would silently drop an explicit tag on a
+            // bare-dash-deferred scalar loaded via the `load()` builtin
+            // (#835).
+            while let Some((elem_cursor, rest)) = elements.uncons_resolved_cursor() {
                 items.push(yaml_value_to_owned(elem_cursor));
                 elements = rest;
             }
@@ -33631,6 +33637,32 @@ mod tests {
                         assert_eq!(obj.get("d"), Some(&OwnedValue::Float(12.5)));
                         assert_eq!(obj.get("e"), Some(&OwnedValue::String("1".to_string())));
                         assert_eq!(obj.get("f"), Some(&OwnedValue::String("5".to_string())));
+                    }
+                    other => panic!("unexpected result: {other:?}"),
+                }
+            });
+        }
+
+        #[test]
+        fn test_load_yaml_explicit_tag_on_bare_dash_deferred_sequence_item_835() {
+            // #835: `yaml_value_to_owned`'s `Sequence` arm used to walk
+            // elements via the raw `uncons_cursor` (rather than
+            // `uncons_resolved_cursor`), and its own `explicit_tag()` check
+            // doesn't resolve a bare `-` sequence-item wrapper itself (a
+            // deliberate hot-path perf trade-off elsewhere) - so a totally
+            // bare `-` item's own explicit tag, deferred to the next line,
+            // was silently dropped: `!!str 5` loaded as the number `5`
+            // instead of the string `"5"`.
+            let yaml = "-\n  !!str 5\n";
+            with_temp_file("load_test_bare_dash_tag_835.yaml", yaml, |path| {
+                let json_bytes: &[u8] = b"null";
+                let index = JsonIndex::build(json_bytes);
+                let cursor = index.root(json_bytes);
+                let query = format!(r#"load("{path}")"#);
+                let expr = parse(&query).unwrap();
+                match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+                    QueryResult::Owned(OwnedValue::Array(items)) => {
+                        assert_eq!(items, vec![OwnedValue::String("5".to_string())]);
                     }
                     other => panic!("unexpected result: {other:?}"),
                 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -337,19 +337,26 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// of its deferred (next-line) value.
     ///
     /// [`YamlElements::uncons_cursor`] deliberately leaves a bare `-` cursor
-    /// pointed at the wrapper node rather than unwrapping it — callers that
-    /// use the cursor *positionally* depend on that (`corpus_stats` counts
-    /// bare-dash items by it). But a couple of renderers need the wrapped
-    /// value's own cursor instead, the same way [`Self::value`] already
-    /// delegates to it: [`is_yaml_cursor_container`] classifies
-    /// block-vs-inline layout from the cursor it's handed, and
-    /// [`Self::stream_yaml_value`]'s `Mapping` arm walks `self.first_child()`
-    /// for its raw (merge-unaware) field list. Left unresolved, both read the
-    /// wrapper's own BP node — which never carries a TY bit and has exactly
-    /// one child, the deferred value itself — instead of the value's fields,
-    /// so `self.first_child()` there returns the mapping/sequence node, not
-    /// its first field, and the whole value silently renders as a bare `-`
-    /// (#835).
+    /// pointed at the wrapper node rather than unwrapping it — `corpus_stats`
+    /// counts bare-dash items by the cursor's position, so the wrapper must
+    /// stay visible there. Everything else that reads a *property* of the
+    /// item's value — its container-ness, fields/elements, anchor, explicit
+    /// tag, style, or trailing comment — needs the wrapped value's own
+    /// cursor instead, the same way [`Self::value`] already delegates to it
+    /// for classification. Left unresolved, all of those read the wrapper's
+    /// own BP node instead: it never carries a TY bit (so `is_container()` is
+    /// always `false` regardless of what it wraps) and has exactly one
+    /// child — the deferred value itself — so `first_child()` on it returns
+    /// the mapping/sequence node in place of its own first field (#835).
+    ///
+    /// [`Self::anchor`], [`Self::explicit_tag`], [`Self::style`], and the
+    /// `line_comment*` family all call this internally, so callers of those
+    /// never need to resolve first. [`Self::first_child`] deliberately does
+    /// **not** self-resolve (this method's own `first_child()` call below
+    /// would recurse), so a caller walking a value's fields/elements via
+    /// `first_child()` — [`is_yaml_cursor_container`],
+    /// [`Self::stream_yaml_value`]'s `Mapping` arm, `merge_sources`,
+    /// [`Self::write_leading_anchor`] — must still call this explicitly.
     ///
     /// A no-op for every other cursor shape: already a container (including
     /// a same-line "compact" item, which `uncons_cursor` already unwraps), a
@@ -1248,8 +1255,15 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         indent: IndentSpec,
         sort_keys: bool,
     ) -> core::fmt::Result {
-        self.write_leading_anchor(out)?;
-        self.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)
+        // `self` is a navigated query result here (see this method's own
+        // doc comment) and so can itself be an unresolved bare-`-`
+        // sequence-item wrapper (e.g. `.[0]` on a document whose item 0
+        // uses the dash-alone style) — resolve once and reuse for both
+        // calls below, rather than relying on `stream_yaml_value`'s
+        // `Mapping` arm to notice on every recursive call (#835).
+        let self_ = self.resolve_bare_seq_item();
+        self_.write_leading_anchor(out)?;
+        self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)
     }
 
     /// Like [`Self::stream_yaml`], but also appends this cursor's own
@@ -1283,11 +1297,15 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         indent: IndentSpec,
         sort_keys: bool,
     ) -> core::fmt::Result {
-        self.write_leading_anchor(out)?;
-        let value = self.value();
-        self.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)?;
+        // See `stream_yaml` (#835): resolve once, reuse throughout, rather
+        // than relying on each downstream read to notice a bare-dash
+        // wrapper on its own.
+        let self_ = self.resolve_bare_seq_item();
+        self_.write_leading_anchor(out)?;
+        let value = self_.value();
+        self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)?;
         if matches!(value, YamlValue::Mapping(_) | YamlValue::Sequence(_)) {
-            write_line_comment(out, self.line_comment_raw())?;
+            write_line_comment(out, self_.line_comment_raw())?;
         }
         Ok(())
     }
@@ -1318,9 +1336,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             }
         }
 
-        // Multiple documents or not at root - output as-is
-        self.write_leading_anchor(out)?;
-        self.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)
+        // Multiple documents or not at root - output as-is. See
+        // `stream_yaml` (#835): resolve once, reuse for both calls.
+        let self_ = self.resolve_bare_seq_item();
+        self_.write_leading_anchor(out)?;
+        self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)
     }
 
     /// Write this cursor's own `&anchor` before streaming it as a YAML root.
@@ -1349,11 +1369,17 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// (`{}`/`[]` are the only way to write an empty mapping/sequence, so the
     /// `style() != "flow"` check below still picks the right separator).
     fn write_leading_anchor<Out: core::fmt::Write>(&self, out: &mut Out) -> core::fmt::Result {
-        if self.is_container() {
-            if let Some(anchor) = self.anchor() {
+        // A top-level query result can itself be an unresolved bare-`-`
+        // sequence-item wrapper (e.g. `.[0]` on a document whose item 0
+        // uses the dash-alone style) — resolve first, or `is_container()`
+        // always reads `false` off the wrapper's own (TY-less) BP node
+        // regardless of what it wraps, silently dropping its anchor (#835).
+        let self_ = self.resolve_bare_seq_item();
+        if self_.is_container() {
+            if let Some(anchor) = self_.anchor() {
                 out.write_char('&')?;
                 out.write_str(anchor)?;
-                if self.style() != "flow" {
+                if self_.style() != "flow" {
                     return out.write_char('\n');
                 }
                 return out.write_char(' ');
@@ -1418,21 +1444,33 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 // source style) reaches this arm still pointed at the
                 // wrapper node, not the mapping it defers to — `self.value()`
                 // above already delegated through it to classify as
-                // `Mapping`, but `self` itself is unchanged, so `first_child()`
-                // and `style()` below must resolve through the same wrapper
-                // themselves or they read the wrapper's own (containerless)
-                // BP node instead of the mapping's (#835).
-                let container = self.resolve_bare_seq_item();
+                // `Mapping`, but `self` itself would be unchanged.
+                // `first_child()` doesn't resolve through a wrapper on its
+                // own (unlike `style()`/`anchor()`/`explicit_tag()`/the
+                // `line_comment*` family, which all do internally), so a raw
+                // `self.first_child()` here would read the wrapper's one
+                // child - the mapping node itself - instead of the mapping's
+                // own first *key* (#835). Not needed here, though: every
+                // caller of `stream_yaml_value` already hands it a resolved
+                // `self` - `stream_yaml`/`stream_yaml_as_document`/
+                // `stream_yaml_document` resolve their own top-level query
+                // result once, and `YamlElements::uncons_resolved_cursor`
+                // resolves a sequence item's cursor once at extraction -
+                // specifically so this hot per-node path (unlike those,
+                // reached once per mapping field too) can stay a plain,
+                // non-resolving `first_child()`/`style()` rather than
+                // re-resolving on every field.
+                //
                 // Raw (merge-unaware) walk, not `self.value()`'s merge-resolved
                 // fields: re-serializing to YAML must preserve a literal `<<`
                 // key rather than silently expanding it (issue #712) — merge
                 // resolution stays reserved for field *lookup* (`find`,
                 // `keys()`, ...), which still goes through `from_mapping_cursor`.
-                let fields = YamlFields::raw(container.first_child());
+                let fields = YamlFields::raw(self.first_child());
                 if fields.is_empty() {
                     return out.write_str("{}");
                 }
-                if indent_spaces == 0 || (!known_not_flow && container.style() == "flow") {
+                if indent_spaces == 0 || (!known_not_flow && self.style() == "flow") {
                     // Flow style
                     out.write_char('{')?;
                     let mut items: Vec<_> = fields.into_iter().collect();
@@ -1559,12 +1597,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if elements.is_empty() {
                     return out.write_str("[]");
                 }
-                // See the `Mapping` arm above (#835): a bare `-` wrapper's
-                // own `style()` doesn't see a flow-style deferred value
-                // (e.g. `-\n  [1, 2]\n`) — the style is recorded against the
-                // sequence node itself, not the wrapper around it.
-                let style_cursor = self.resolve_bare_seq_item();
-                if indent_spaces == 0 || (!known_not_flow && style_cursor.style() == "flow") {
+                // `style()` (#835) resolves through a bare `-` wrapper
+                // itself, so `self.style()` here already sees a flow-style
+                // deferred value (e.g. `-\n  [1, 2]\n`) correctly.
+                if indent_spaces == 0 || (!known_not_flow && self.style() == "flow") {
                     // Flow style
                     out.write_char('[')?;
                     let mut first = true;
@@ -1586,7 +1622,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     // Block style
                     let mut first = true;
                     let mut elems = elements;
-                    while let Some((cursor, rest)) = elems.uncons_cursor() {
+                    // `uncons_resolved_cursor`, not `uncons_cursor`: this
+                    // loop reads `is_yaml_cursor_container`/`first_child`-
+                    // shaped properties of each item's *value*, so a bare
+                    // `-` item needs to already be resolved past its
+                    // sequence-item wrapper before it gets here — see
+                    // `uncons_resolved_cursor`'s own doc comment (#835).
+                    while let Some((cursor, rest)) = elems.uncons_resolved_cursor() {
                         if !first {
                             out.write_char('\n')?;
                             out.write_str(indent)?;
@@ -1796,7 +1838,13 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 let next_indent = current_indent + indent_spaces;
                 let mut first = true;
                 let mut rest = elements;
-                while let Some((cursor, next)) = rest.uncons_cursor() {
+                // `uncons_resolved_cursor`, not `uncons_cursor`: the
+                // recursive `stream_json_value` call's own `explicit_tag()`
+                // (String arm) doesn't resolve a bare `-` sequence-item
+                // wrapper itself, so an unresolved cursor here would
+                // silently drop an explicit tag on a bare-dash-deferred
+                // scalar in JSON output (#835).
+                while let Some((cursor, next)) = rest.uncons_resolved_cursor() {
                     if !first {
                         out.write_char(',')?;
                     }
@@ -1907,7 +1955,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 output.push('[');
                 let mut first = true;
                 let mut rest = elements;
-                while let Some((cursor, next)) = rest.uncons_cursor() {
+                // `uncons_resolved_cursor`, not `uncons_cursor`: see the
+                // matching comment in `stream_json_value`'s `Sequence` arm
+                // (#835) - `write_json_to`'s own String arm has the same
+                // unresolved `explicit_tag()` dependency.
+                while let Some((cursor, next)) = rest.uncons_resolved_cursor() {
                     if !first {
                         output.push(',');
                     }
@@ -1951,6 +2003,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// let index = YamlIndex::build(yaml).unwrap();
     /// // Navigate to the anchored value and call .anchor()
     /// ```
+    /// Deliberately does **not** resolve a bare `-` sequence-item wrapper
+    /// itself (see [`YamlCursor::resolve_bare_seq_item`]'s doc comment):
+    /// this is called for essentially every node on `stream_yaml_value`'s
+    /// hot per-field/per-item render path, where `self` is *already*
+    /// guaranteed resolved by the caller, and paying the resolve cost again
+    /// here measured as a real streaming regression. Callers that can't
+    /// make that guarantee (arbitrary navigation, e.g. the generic `anchor`
+    /// jq/yq builtin reached via `.[n]`) resolve at their own cursor's
+    /// extraction point instead — see `YamlElements`' `DocumentElements`
+    /// impl and `resolve_bare_seq_item`'s doc comment for the full list.
     #[inline]
     pub fn anchor(&self) -> Option<&str> {
         self.index.get_anchor_name(self.bp_pos)
@@ -1970,6 +2032,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// let index = YamlIndex::build(yaml).unwrap();
     /// // Navigate to the value and call .explicit_tag() to get Some("!!str")
     /// ```
+    /// See [`Self::anchor`]'s doc comment: deliberately does not resolve a
+    /// bare `-` sequence-item wrapper itself, for the same hot-path
+    /// performance reason.
     #[inline]
     pub fn explicit_tag(&self) -> Option<&str> {
         self.index.get_tag(self.bp_pos)
@@ -1982,6 +2047,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// collapse to `None`, for output/write paths that must keep rendering
     /// the rest of the document) and [`Self::line_comment_checked`] (strict:
     /// invalid bytes surface as an error, issue #797).
+    /// See [`Self::anchor`]'s doc comment: deliberately does not resolve a
+    /// bare `-` sequence-item wrapper itself, for the same hot-path
+    /// performance reason.
     #[inline]
     fn line_comment_raw_checked(&self) -> Result<Option<&str>, core::str::Utf8Error> {
         let Some((start, end)) = self.index.get_line_comment(self.bp_pos) else {
@@ -2192,6 +2260,15 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// It skips a leading anchor (`&name`) but not an explicit tag; explicit
     /// tags are currently rejected by the parser entirely, so this is not
     /// reachable today, but would need addressing alongside tag support.
+    /// See [`Self::anchor`]'s doc comment: deliberately does not resolve a
+    /// bare `-` sequence-item wrapper itself, for the same hot-path
+    /// performance reason (this method already re-derives from text on
+    /// every call, so an unconditional resolve here is doubly costly).
+    /// Left unresolved, the wrapper's own text position is the `-`
+    /// indicator itself, which never matches any style byte below, so an
+    /// already-unresolved caller sees no style for the value it wraps
+    /// rather than the value's real one (#835) — callers that can't
+    /// guarantee `self` is already resolved must resolve first themselves.
     pub fn style(&self) -> &'static str {
         let Some(text_pos) = self.text_position() else {
             return "";
@@ -2455,7 +2532,11 @@ fn write_yaml_value_as_json<W: AsRef<[u64]>>(output: &mut String, value: YamlVal
             output.push('[');
             let mut first = true;
             let mut rest = elements;
-            while let Some((cursor, next)) = rest.uncons_cursor() {
+            // `uncons_resolved_cursor`, not `uncons_cursor` (#835): see the
+            // matching comment in `stream_json_value`'s `Sequence` arm -
+            // `write_json_to` (called below) has the same unresolved
+            // `explicit_tag()` dependency in its own String arm.
+            while let Some((cursor, next)) = rest.uncons_resolved_cursor() {
                 if !first {
                     output.push(',');
                 }
@@ -3873,7 +3954,14 @@ fn merge_sources<W: AsRef<[u64]>>(value_cursor: YamlCursor<'_, W>) -> Vec<YamlCu
             let mut rest = elements;
             while let Some((cursor, tail)) = rest.uncons_cursor() {
                 match cursor.value() {
-                    YamlValue::Mapping(_) => sources.push(cursor),
+                    // `cursor` may still be an unresolved bare-`-`
+                    // sequence-item wrapper (`uncons_cursor` leaves a
+                    // totally bare `-` item pointed at it); resolve before
+                    // pushing, or `merge_field_into`'s `source.first_child()`
+                    // reads the wrapper's one child - the mapping node
+                    // itself - instead of its first key, silently dropping
+                    // every field of this merge source (#835).
+                    YamlValue::Mapping(_) => sources.push(cursor.resolve_bare_seq_item()),
                     YamlValue::Alias {
                         target: Some(target),
                         ..
@@ -4002,6 +4090,30 @@ impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
         } else {
             Some((element_cursor, rest))
         }
+    }
+
+    /// Like [`Self::uncons_cursor`], but also resolves a totally bare `-`
+    /// item (the one shape `uncons_cursor` deliberately leaves pointed at
+    /// its sequence-item wrapper, for `corpus_stats`'s positional counting)
+    /// through to its deferred value's own cursor.
+    ///
+    /// This is the right choice for every caller that goes on to read a
+    /// *property* of the item's value — its container-ness, fields/elements,
+    /// style, anchor, tag, or comment — rather than the item's own text
+    /// position: [`stream_yaml_value`]'s `Sequence` arm uses this so the
+    /// cursor it hands to [`is_yaml_cursor_container`] and recurses into is
+    /// already resolved, letting both stay their cheap, non-resolving form
+    /// instead of re-resolving per call — `is_yaml_cursor_container` runs
+    /// once per rendered node on this crate's flagship `yq` streaming path,
+    /// so paying `resolve_bare_seq_item`'s cost there unconditionally (most
+    /// nodes are mapping fields, never wrappers in the first place) measured
+    /// as a ~2x streaming regression on a mapping-heavy corpus; resolving
+    /// once here instead, only for cursors that can actually be wrappers,
+    /// recovers it (#835).
+    #[inline]
+    pub fn uncons_resolved_cursor(&self) -> Option<(YamlCursor<'a, W>, Self)> {
+        let (cursor, rest) = self.uncons_cursor()?;
+        Some((cursor.resolve_bare_seq_item(), rest))
     }
 
     /// Get the first element and the remaining elements.
@@ -5587,8 +5699,20 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for YamlElements<'a, W> {
         YamlElements::uncons(self)
     }
 
+    // Deliberately `uncons_resolved_cursor`, not the inherent
+    // `uncons_cursor` (unlike this same impl's other methods, which forward
+    // 1:1): the generic jq/yq evaluator (`src/jq/eval_generic.rs`) uses this
+    // trait method for arbitrary navigation (`.[n]`, `.[]`, `first`/`last`,
+    // ...) and then reads cursor-level properties — `anchor`, `style`,
+    // `is_falsy`'s tag check, `line_comment*` — none of which resolve a bare
+    // `-` sequence-item wrapper themselves (see `YamlCursor::anchor`'s doc
+    // comment: doing so unconditionally there regressed the *streaming*
+    // render path, which is why the resolve moved to this one choke point
+    // instead). `get_cursor`'s default impl funnels through this too, so
+    // `.[n]` on a bare-dash-deferred item gets a correctly-resolved cursor
+    // without a separate override (#835).
     fn uncons_cursor(&self) -> Option<(Self::Cursor, Self)> {
-        YamlElements::uncons_cursor(self)
+        YamlElements::uncons_resolved_cursor(self)
     }
 
     fn get(&self, index: usize) -> Option<Self::Value> {
@@ -5635,14 +5759,18 @@ const COMPACT_DASH_WIDTH: usize = 2;
 /// wrongly take the empty-mapping `"{}"` shortcut instead of rendering its
 /// literal `<<` field.
 ///
-/// Resolves through [`YamlCursor::resolve_bare_seq_item`] first: a block
-/// sequence item whose source uses the dash-alone-then-indented style (`-`
-/// on its own line, value on the lines below) reaches here still pointed at
-/// the sequence-item wrapper, not the mapping/sequence it defers to — the
-/// wrapper itself never carries a TY bit, so checking `is_container()`
-/// directly on it always says `false` regardless of what it wraps (#835).
+/// Does **not** resolve a bare `-` sequence-item wrapper itself (unlike
+/// [`YamlCursor::anchor`]/`style`/`explicit_tag`/`line_comment*`, which all
+/// do internally) — this runs once per rendered node on this crate's
+/// flagship `yq` streaming path, and most nodes are mapping field values,
+/// which can never be sequence-item wrappers in the first place; paying
+/// [`YamlCursor::resolve_bare_seq_item`]'s cost here unconditionally
+/// measured as a ~2x streaming regression on a mapping-heavy corpus. Every
+/// caller is therefore responsible for handing this an already-resolved
+/// cursor: [`YamlElements::uncons_resolved_cursor`] does that once, at the
+/// point a sequence item's cursor is extracted, rather than re-resolving it
+/// on every check (#835).
 fn is_yaml_cursor_container<W: AsRef<[u64]>>(cursor: &YamlCursor<'_, W>) -> bool {
-    let cursor = cursor.resolve_bare_seq_item();
     cursor.is_container() && cursor.first_child().is_some()
 }
 
@@ -7008,27 +7136,41 @@ mod tests {
     }
 
     #[test]
-    fn test_is_yaml_cursor_container_resolves_bare_seq_item_wrapper_835() {
-        // Direct unit coverage of the classification bug (#835): a bare `-`
-        // sequence-item cursor (from `uncons_cursor`, still pointed at the
-        // wrapper) must classify as a container when it wraps a non-empty
-        // mapping, even though the wrapper's own `is_container()` is always
-        // `false` (wrappers never carry a TY bit).
+    fn test_is_yaml_cursor_container_needs_a_pre_resolved_cursor_835() {
+        // Direct unit coverage of the classification bug (#835) and its
+        // performance fix. `is_yaml_cursor_container` deliberately does
+        // *not* resolve a bare `-` sequence-item wrapper itself (that
+        // regressed the streaming render path when it did - see
+        // `is_yaml_cursor_container`'s own doc comment), so it must return
+        // `false` for a raw, unresolved wrapper even though the mapping it
+        // wraps is non-empty...
         let yaml = b"-\n  a: 1\n  b: 2\n";
         let index = YamlIndex::build(yaml).unwrap();
         let item_cursor = first_seq_item_cursor(&index, yaml);
 
         // The wrapper itself never has a TY bit - confirms this test is
-        // actually exercising the wrapper-resolution path, not a cursor
-        // that was already unwrapped by `uncons_cursor`.
+        // actually exercising the wrapper case, not a cursor that was
+        // already unwrapped by `uncons_cursor`.
         assert!(!item_cursor.is_container());
-        assert!(is_yaml_cursor_container(&item_cursor));
+        assert!(!is_yaml_cursor_container(&item_cursor));
 
-        // And the resolved cursor is the mapping node's own bp_pos, whose
-        // `first_child()` is the first *key*, not the mapping node itself.
+        // ...but correctly classifies as a container once resolved -
+        // either explicitly (what `stream_yaml_value`'s callers do at their
+        // own top level) or via `uncons_resolved_cursor` (what the
+        // `Sequence` arm and the `DocumentElements` trait impl use at the
+        // point a sequence item's cursor is extracted).
         let resolved = item_cursor.resolve_bare_seq_item();
         assert!(resolved.is_container());
         assert_ne!(resolved.bp_position(), item_cursor.bp_position());
+        assert!(is_yaml_cursor_container(&resolved));
+
+        let YamlValue::Sequence(seq_elements) = index.root(yaml).first_child().unwrap().value()
+        else {
+            panic!("document should be a sequence");
+        };
+        let (resolved_via_uncons, _rest) = seq_elements.uncons_resolved_cursor().unwrap();
+        assert_eq!(resolved_via_uncons.bp_position(), resolved.bp_position());
+        assert!(is_yaml_cursor_container(&resolved_via_uncons));
     }
 
     #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2004,7 +2004,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// // Navigate to the anchored value and call .anchor()
     /// ```
     /// Deliberately does **not** resolve a bare `-` sequence-item wrapper
-    /// itself (see [`YamlCursor::resolve_bare_seq_item`]'s doc comment):
+    /// itself (see `resolve_bare_seq_item`'s doc comment internally):
     /// this is called for essentially every node on `stream_yaml_value`'s
     /// hot per-field/per-item render path, where `self` is *already*
     /// guaranteed resolved by the caller, and paying the resolve cost again
@@ -4100,8 +4100,8 @@ impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
     /// This is the right choice for every caller that goes on to read a
     /// *property* of the item's value — its container-ness, fields/elements,
     /// style, anchor, tag, or comment — rather than the item's own text
-    /// position: [`stream_yaml_value`]'s `Sequence` arm uses this so the
-    /// cursor it hands to [`is_yaml_cursor_container`] and recurses into is
+    /// position: `stream_yaml_value`'s `Sequence` arm uses this so the
+    /// cursor it hands to `is_yaml_cursor_container` and recurses into is
     /// already resolved, letting both stay their cheap, non-resolving form
     /// instead of re-resolving per call — `is_yaml_cursor_container` runs
     /// once per rendered node on this crate's flagship `yq` streaming path,

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -333,6 +333,40 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             .is_some_and(|end| end > text_pos)
     }
 
+    /// Resolve a totally bare `-` sequence-item wrapper cursor to the cursor
+    /// of its deferred (next-line) value.
+    ///
+    /// [`YamlElements::uncons_cursor`] deliberately leaves a bare `-` cursor
+    /// pointed at the wrapper node rather than unwrapping it — callers that
+    /// use the cursor *positionally* depend on that (`corpus_stats` counts
+    /// bare-dash items by it). But a couple of renderers need the wrapped
+    /// value's own cursor instead, the same way [`Self::value`] already
+    /// delegates to it: [`is_yaml_cursor_container`] classifies
+    /// block-vs-inline layout from the cursor it's handed, and
+    /// [`Self::stream_yaml_value`]'s `Mapping` arm walks `self.first_child()`
+    /// for its raw (merge-unaware) field list. Left unresolved, both read the
+    /// wrapper's own BP node — which never carries a TY bit and has exactly
+    /// one child, the deferred value itself — instead of the value's fields,
+    /// so `self.first_child()` there returns the mapping/sequence node, not
+    /// its first field, and the whole value silently renders as a bare `-`
+    /// (#835).
+    ///
+    /// A no-op for every other cursor shape: already a container (including
+    /// a same-line "compact" item, which `uncons_cursor` already unwraps), a
+    /// scalar, or a childless/empty item — all return `self` unchanged.
+    #[inline]
+    fn resolve_bare_seq_item(&self) -> Self {
+        if self.is_container() {
+            return *self;
+        }
+        match self.text_position() {
+            Some(text_pos) if starts_seq_entry(self.text, text_pos) => {
+                self.first_child().unwrap_or(*self)
+            }
+            _ => *self,
+        }
+    }
+
     /// Parse an alias value from text position.
     fn parse_alias_value(&self, text_pos: usize) -> YamlValue<'a, W> {
         // Extract anchor name from text (skip the `*`)
@@ -1380,16 +1414,25 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 stream_yaml_string_value(out, &s)
             }
             YamlValue::Mapping(_) => {
+                // A bare `-` sequence-item wrapper (dash-alone-then-indented
+                // source style) reaches this arm still pointed at the
+                // wrapper node, not the mapping it defers to — `self.value()`
+                // above already delegated through it to classify as
+                // `Mapping`, but `self` itself is unchanged, so `first_child()`
+                // and `style()` below must resolve through the same wrapper
+                // themselves or they read the wrapper's own (containerless)
+                // BP node instead of the mapping's (#835).
+                let container = self.resolve_bare_seq_item();
                 // Raw (merge-unaware) walk, not `self.value()`'s merge-resolved
                 // fields: re-serializing to YAML must preserve a literal `<<`
                 // key rather than silently expanding it (issue #712) — merge
                 // resolution stays reserved for field *lookup* (`find`,
                 // `keys()`, ...), which still goes through `from_mapping_cursor`.
-                let fields = YamlFields::raw(self.first_child());
+                let fields = YamlFields::raw(container.first_child());
                 if fields.is_empty() {
                     return out.write_str("{}");
                 }
-                if indent_spaces == 0 || (!known_not_flow && self.style() == "flow") {
+                if indent_spaces == 0 || (!known_not_flow && container.style() == "flow") {
                     // Flow style
                     out.write_char('{')?;
                     let mut items: Vec<_> = fields.into_iter().collect();
@@ -1516,7 +1559,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if elements.is_empty() {
                     return out.write_str("[]");
                 }
-                if indent_spaces == 0 || (!known_not_flow && self.style() == "flow") {
+                // See the `Mapping` arm above (#835): a bare `-` wrapper's
+                // own `style()` doesn't see a flow-style deferred value
+                // (e.g. `-\n  [1, 2]\n`) — the style is recorded against the
+                // sequence node itself, not the wrapper around it.
+                let style_cursor = self.resolve_bare_seq_item();
+                if indent_spaces == 0 || (!known_not_flow && style_cursor.style() == "flow") {
                     // Flow style
                     out.write_char('[')?;
                     let mut first = true;
@@ -5586,7 +5634,15 @@ const COMPACT_DASH_WIDTH: usize = 2;
 /// unresolvable `<<` must still be treated as non-empty here, or it would
 /// wrongly take the empty-mapping `"{}"` shortcut instead of rendering its
 /// literal `<<` field.
+///
+/// Resolves through [`YamlCursor::resolve_bare_seq_item`] first: a block
+/// sequence item whose source uses the dash-alone-then-indented style (`-`
+/// on its own line, value on the lines below) reaches here still pointed at
+/// the sequence-item wrapper, not the mapping/sequence it defers to — the
+/// wrapper itself never carries a TY bit, so checking `is_container()`
+/// directly on it always says `false` regardless of what it wraps (#835).
 fn is_yaml_cursor_container<W: AsRef<[u64]>>(cursor: &YamlCursor<'_, W>) -> bool {
+    let cursor = cursor.resolve_bare_seq_item();
     cursor.is_container() && cursor.first_child().is_some()
 }
 
@@ -6894,6 +6950,118 @@ mod tests {
         let mut out = String::new();
         stream_yaml_sequence([cursor_a], &mut out, 0, 2, ' ', false).unwrap();
         assert_eq!(out, "- &x\n  a: 1\n  b: 2");
+    }
+
+    #[test]
+    fn test_stream_yaml_sequence_item_dash_alone_mapping_value_not_truncated_835() {
+        // #835: a block-sequence item whose value is a non-empty mapping,
+        // written as a totally bare `-` on its own line (no anchor/tag,
+        // nothing else on that line) followed by the indented mapping on
+        // subsequent lines, used to re-serialize as a lone `-` with the
+        // mapping silently dropped. `uncons_cursor` deliberately leaves such
+        // a cursor pointed at the sequence-item *wrapper* (not the mapping
+        // it defers to) for `corpus_stats`'s benefit; `is_yaml_cursor_container`
+        // and `stream_yaml_value`'s `Mapping` arm both need
+        // `YamlCursor::resolve_bare_seq_item` to see through it. Matches
+        // real yq v4.53.3's "compact" re-serialization (#785).
+        let yaml = b"-\n  a: 1\n  b: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let mut out = String::new();
+        index
+            .root(yaml)
+            .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
+            .unwrap();
+        assert_eq!(out, "- a: 1\n  b: 2");
+    }
+
+    #[test]
+    fn test_stream_yaml_sequence_item_dash_alone_mapping_value_slurp_835() {
+        // Same underlying bug as
+        // `test_stream_yaml_sequence_item_dash_alone_mapping_value_not_truncated_835`,
+        // exercised through `stream_yaml_sequence` (the `--slurp` fast path):
+        // the single slurped "document" here is itself a one-item block
+        // sequence whose item is a bare-dash-deferred mapping, so rendering
+        // it recurses into `stream_yaml_value`'s Sequence arm - the same
+        // `is_yaml_cursor_container`/`resolve_bare_seq_item` path, reached
+        // through the other public entry point.
+        let bytes_a = b"-\n  a: 1\n  b: 2\n".to_vec();
+        let index_a = YamlIndex::build(&bytes_a).unwrap();
+        let cursor_a = index_a.root(&bytes_a).first_child().unwrap();
+
+        let mut out = String::new();
+        stream_yaml_sequence([cursor_a], &mut out, 0, 2, ' ', false).unwrap();
+        assert_eq!(out, "- - a: 1\n    b: 2");
+    }
+
+    /// Get the sole item's cursor from a single-document, single-element
+    /// top-level block sequence (`uncons_cursor` unresolved, as callers like
+    /// `is_yaml_cursor_container`/`stream_yaml_value` see it).
+    fn first_seq_item_cursor<'a, W: AsRef<[u64]> + core::fmt::Debug>(
+        index: &'a YamlIndex<W>,
+        yaml: &'a [u8],
+    ) -> YamlCursor<'a, W> {
+        let doc_cursor = index.root(yaml).first_child().unwrap();
+        let YamlValue::Sequence(seq_elements) = doc_cursor.value() else {
+            panic!("document should be a sequence");
+        };
+        seq_elements.uncons_cursor().unwrap().0
+    }
+
+    #[test]
+    fn test_is_yaml_cursor_container_resolves_bare_seq_item_wrapper_835() {
+        // Direct unit coverage of the classification bug (#835): a bare `-`
+        // sequence-item cursor (from `uncons_cursor`, still pointed at the
+        // wrapper) must classify as a container when it wraps a non-empty
+        // mapping, even though the wrapper's own `is_container()` is always
+        // `false` (wrappers never carry a TY bit).
+        let yaml = b"-\n  a: 1\n  b: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let item_cursor = first_seq_item_cursor(&index, yaml);
+
+        // The wrapper itself never has a TY bit - confirms this test is
+        // actually exercising the wrapper-resolution path, not a cursor
+        // that was already unwrapped by `uncons_cursor`.
+        assert!(!item_cursor.is_container());
+        assert!(is_yaml_cursor_container(&item_cursor));
+
+        // And the resolved cursor is the mapping node's own bp_pos, whose
+        // `first_child()` is the first *key*, not the mapping node itself.
+        let resolved = item_cursor.resolve_bare_seq_item();
+        assert!(resolved.is_container());
+        assert_ne!(resolved.bp_position(), item_cursor.bp_position());
+    }
+
+    #[test]
+    fn test_resolve_bare_seq_item_is_noop_for_already_resolved_cursors_835() {
+        // `resolve_bare_seq_item` must leave every non-wrapper shape
+        // unchanged: a genuine container (compact-form item, already
+        // unwrapped by `uncons_cursor`), a plain scalar, and a childless
+        // (empty/null) bare-dash item.
+        let compact = b"- a: 1\n  b: 2\n";
+        let compact_index = YamlIndex::build(compact).unwrap();
+        let compact_item = first_seq_item_cursor(&compact_index, compact);
+        assert!(compact_item.is_container());
+        assert_eq!(
+            compact_item.resolve_bare_seq_item().bp_position(),
+            compact_item.bp_position()
+        );
+
+        let scalar = b"- hello\n";
+        let scalar_index = YamlIndex::build(scalar).unwrap();
+        let scalar_item = first_seq_item_cursor(&scalar_index, scalar);
+        assert!(!scalar_item.is_container());
+        assert_eq!(
+            scalar_item.resolve_bare_seq_item().bp_position(),
+            scalar_item.bp_position()
+        );
+
+        let empty = b"-\n";
+        let empty_index = YamlIndex::build(empty).unwrap();
+        let empty_item = first_seq_item_cursor(&empty_index, empty);
+        assert_eq!(
+            empty_item.resolve_bare_seq_item().bp_position(),
+            empty_item.bp_position()
+        );
     }
 
     #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1778,6 +1778,21 @@ fn test_yaml_merge_key_override() -> Result<()> {
     Ok(())
 }
 
+/// #835: `merge_sources`'s `<<: [...]` sequence-of-sources arm pushed the
+/// unresolved sequence-item wrapper `uncons_cursor` yields for a totally
+/// bare `-` source (rather than the mapping it defers to), so
+/// `merge_field_into`'s `source.first_child()` read the wrapper's one
+/// child - the mapping node itself - in place of its first key, silently
+/// dropping every field the bare-dash source would have contributed.
+#[test]
+fn test_yaml_merge_key_bare_dash_deferred_source_expands_712_835() -> Result<()> {
+    let input = "item:\n  <<:\n    -\n      a: 1\n      b: 2\n  c: 3\n";
+    let (output, exit_code) = run_yq_stdin(".item", input, &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":1,"b":2,"c":3}"#);
+    Ok(())
+}
+
 #[test]
 fn test_yaml_anchor_alias_without_merge() -> Result<()> {
     // Regular anchors/aliases (not merge keys) should work
@@ -1846,6 +1861,22 @@ fn test_yaml_assign_through_anchor_updates_multiple_aliases() -> Result<()> {
     let (output, exit_code) = run_yq_stdin(".a = 99", input, &["-o=json", "-I=0"])?;
     assert_eq!(exit_code, 0);
     assert_eq!(output.trim(), r#"{"a":99,"b":99,"c":99}"#);
+    Ok(())
+}
+
+/// #835: `walk_alias_groups` (the sync bookkeeping this whole family relies
+/// on) read `cursor.anchor()` on the unresolved sequence-item wrapper
+/// `uncons_cursor` yields for a totally bare `-` item, so an anchor written
+/// on its own deferred line was never registered - `.items[0].x = 99` wrote
+/// only the anchor's own copy and left the alias stale. Same root cause as
+/// the mapping-truncation bug this issue was originally filed for, just at
+/// a different call site.
+#[test]
+fn test_yaml_assign_through_bare_dash_deferred_anchor_updates_alias_835() -> Result<()> {
+    let input = "items:\n-\n  &base\n  x: 1\n- *base\n";
+    let (output, exit_code) = run_yq_stdin(".items[0].x = 99", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"items":[{"x":99},{"x":99}]}"#);
     Ok(())
 }
 
@@ -5904,6 +5935,22 @@ fn test_anchor_builtin_empty_when_no_anchor() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "\"\"");
 
+    Ok(())
+}
+
+/// #835: the generic jq/yq evaluator navigates `.[n]`/`.[]` via
+/// `DocumentElements::uncons_cursor` (the `DocumentElements` trait impl,
+/// distinct from `YamlElements`' own inherent method of the same name,
+/// which several internal callers need to stay raw/unresolved). Before this
+/// fix that trait method hadn't been overridden to resolve a totally bare
+/// `-` sequence-item wrapper, so `anchor` on a bare-dash-deferred anchored
+/// value returned empty instead of the real name.
+#[test]
+fn test_anchor_builtin_bare_dash_deferred_anchor_835() -> Result<()> {
+    let input = "-\n  &x\n  a: 1\n";
+    let (output, code) = run_yq_stdin(".[0] | anchor", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "x");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -780,6 +780,79 @@ fn test_slurp_doc_filter_no_match_yields_empty_array() -> Result<()> {
     Ok(())
 }
 
+/// #835: a block-sequence item whose value is a non-empty mapping, written
+/// in the source as a totally bare `-` on its own line followed by the
+/// indented mapping (rather than the compact `- key: value` form), used to
+/// re-serialize as a lone `-` with the whole mapping silently dropped.
+///
+/// Root cause: `YamlElements::uncons_cursor` deliberately leaves a bare `-`
+/// item pointed at its sequence-item *wrapper* node rather than unwrapping
+/// it to the deferred value (`corpus_stats` needs the wrapper positionally).
+/// `is_yaml_cursor_container` and `stream_yaml_value`'s `Mapping` arm both
+/// then read `is_container()`/`first_child()` off the wrapper itself, which
+/// never carries a TY bit and has exactly one child - the mapping - so
+/// `first_child()` returned the mapping node in place of its first field,
+/// producing a mapping with a "field" whose key has no sibling and
+/// collapsing to zero rendered fields. Matches real `yq` v4.53.3, which
+/// re-serializes this into the same "compact" form #785 uses for every
+/// other non-empty container element, regardless of the source's own style.
+#[test]
+fn test_bare_dash_alone_mapping_value_not_truncated_835() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "-\n  a: 1\n  b: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- a: 1\n  b: 2\n");
+    Ok(())
+}
+
+/// #835: same bug, but for a sequence-valued (rather than mapping-valued)
+/// bare-dash item - `stream_yaml_value`'s `Sequence` arm doesn't share the
+/// `Mapping` arm's raw-field-walk optimization, so this shape wasn't
+/// actually truncated pre-fix, but it exercises the same
+/// `is_yaml_cursor_container` misclassification that picked the wrong
+/// (deferred, non-"compact") render branch. Pinned here alongside the
+/// mapping case so both container kinds stay covered together.
+#[test]
+fn test_bare_dash_alone_sequence_value_renders_compact_835() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "-\n  - x\n  - y\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- - x\n  - y\n");
+    Ok(())
+}
+
+/// #835: the fix must not regress `-o json`, which was already correct
+/// pre-fix (`yaml_to_owned_value` resolves through `YamlCursor::value`'s own
+/// delegation rather than re-deriving `first_child()` off the wrapper).
+#[test]
+fn test_bare_dash_alone_mapping_value_json_output_835() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "-\n  a: 1\n  b: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[{\"a\":1,\"b\":2}]\n");
+    Ok(())
+}
+
+/// #835: a sequence mixing all three item styles - compact (`- key: value`),
+/// bare-dash-deferred, and a plain scalar - in one document, matching real
+/// `yq` v4.53.3. Guards against a fix that only special-cases a
+/// single-item sequence.
+#[test]
+fn test_bare_dash_alone_mapping_value_mixed_with_compact_and_scalar_835() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "- x: 1\n-\n  y: 2\n  z: 3\n- 5\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- x: 1\n- y: 2\n  z: 3\n- 5\n");
+    Ok(())
+}
+
+/// #835: the `--slurp` fast path (`stream_yaml_sequence`) shares
+/// `is_yaml_cursor_container` with `stream_yaml_value`'s `Sequence` arm, so
+/// covers it independently of `stream_yaml_document`'s own entry point.
+#[test]
+fn test_bare_dash_alone_mapping_value_survives_slurp_835() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "-\n  a: 1\n  b: 2\n", &["--slurp"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- - a: 1\n    b: 2\n");
+    Ok(())
+}
+
 /// #478: `stream_yaml_sequence`'s block-style rendering has a container vs.
 /// scalar branch per slurped item (mirroring `stream_yaml_value`'s `Sequence`
 /// arm); the tests above only slurp mapping documents, which always take the


### PR DESCRIPTION
## Summary

A block-sequence item whose value is a non-empty mapping (or sequence), when
the source writes the item as a totally bare `-` on its own line followed by
the indented value on subsequent lines (rather than the compact
`- key: value` form), re-serialized as a lone `-` with the entire value
silently dropped — genuine data loss, not just misformatting. The parsed
data itself was always correct (`-o json` on the same input was fine); this
was purely a re-serialization bug.

```
$ printf -- '-\n  a: 1\n  b: 2\n' | yq '.'
- a: 1
  b: 2
$ printf -- '-\n  a: 1\n  b: 2\n' | succinctly yq '.'   # before this fix
-
```

### Root cause

`YamlElements::uncons_cursor` deliberately leaves a bare-`-` sequence item's
cursor pointed at its sequence-item *wrapper* node rather than unwrapping it
to the deferred value — `corpus_stats` reads that cursor positionally to
count bare-dash items, so the wrapper must stay visible there.

But `is_yaml_cursor_container` and `stream_yaml_value`'s `Mapping` arm were
also handed that same (unresolved) wrapper cursor and read straight off it
instead of going through the delegation `YamlCursor::value()` already does:
the wrapper never carries a TY bit, so `is_container()` on it was always
`false`, and it has exactly one child — the mapping node itself — so
`first_child()` on it returned the mapping node in place of its own first
*key*, collapsing to zero rendered fields.

### Review found the same root cause much further-reaching

A mandatory review (`code-review` skill) reproduced the original bug and
then found — independently verified each — that the identical
unresolved-wrapper cursor is also read for a bare-dash item's **anchor**,
**explicit tag**, **trailing comment**, **style**, and **merge-key fields**,
across several call sites:

- Assignment through an anchor on a bare-dash item's own deferred line never
  synced to its aliases (`.items[0].x = 99` left an aliased sibling stale).
- An explicit tag (`!!str`, ...) on a bare-dash-deferred scalar was dropped
  on YAML re-serialization, JSON conversion, and the `load()` builtin.
- An anchor or trailing comment on a bare-dash item's own line was dropped
  by the `Sequence` rendering arm and its `--slurp` mirror.
- A top-level query result that was itself an unresolved wrapper (`.[0]` on
  a bare-dash item) dropped its own leading anchor.
- A `<<: [...]` merge source written in bare-dash style had its fields
  silently dropped.
- The generic jq/yq evaluator's `.[n]`/`.[]` navigation — and therefore the
  `anchor`/`style`/`line_comment*` builtins and `select`/`if` truthiness —
  read all of the above off unresolved wrapper cursors too.

### Fix

Two commits:

1. `YamlCursor::resolve_bare_seq_item()` peels a bare-dash wrapper cursor
   through to its deferred value's own cursor (a no-op for every other
   cursor shape). Routed through `is_yaml_cursor_container` and
   `stream_yaml_value`'s `Mapping`/`Sequence` arms to fix the original
   truncation bug.
2. Addressing the review: first made `anchor`/`explicit_tag`/`style`/
   `line_comment*` resolve internally on every call, as a single robust
   choke point covering every finding above. **Measured a real,
   reproducible ~2x regression** streaming a mapping-heavy 5MB corpus
   (`yq '.'`, interleaved A/B against `main`) — `is_yaml_cursor_container`
   and these accessors run once per rendered *field*, and paying the
   resolve cost unconditionally hits the overwhelming majority of nodes
   (plain mapping fields, which can never be wrappers) for nothing.
   Replaced with **resolve-once-at-extraction**: the accessors and
   `is_yaml_cursor_container` go back to their original cheap,
   non-resolving form, and a new `YamlElements::uncons_resolved_cursor`
   (the inherent `uncons_cursor` stays raw — `corpus_stats` still needs the
   wrapper positionally) resolves once at each point a sequence item's
   cursor is actually extracted: the `Sequence` rendering arms (YAML *and*
   JSON), the three top-level YAML entry points, `merge_sources`,
   `walk_alias_groups`, both `yaml_to_owned`/`yaml_value_to_owned`
   conversions, and the `DocumentElements` trait impl's `uncons_cursor`
   (the generic evaluator's own choke point — distinct from the inherent
   method of the same name, which many internal callers still need raw).
   Re-measured (5MB and 20MB, `users`/`nested` generator patterns, YAML and
   JSON output, interleaved A/B): neutral, output byte-identical to `main`.

As a side effect this also fixes the same truncation for a bare-dash item
whose deferred value is a *flow* mapping (`-\n  {a: 1, b: 2}\n`), previously
also silently dropped. It does not (yet) preserve flow style for such a
deferred value (renders as block instead) — a separate, lower-severity,
pre-existing formatting gap (also affects flow *sequences*, unrelated to
this fix); filed as #847.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 4203 passed, 0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against real `yq` v4.53.3 oracle for the repro and every
      review finding above (anchor sync, tag preservation, comment
      preservation, merge sources, generic builtins via `.[n]`) — all match
- [x] Interleaved A/B performance validation against `main` (5MB and 20MB
      generated corpora, `users`/`nested` patterns, YAML and JSON output) —
      neutral, output byte-identical
- [x] New unit tests in `src/yaml/light.rs` (`resolve_bare_seq_item`,
      `is_yaml_cursor_container`, `stream_yaml_document`/
      `stream_yaml_sequence` end-to-end)
- [x] New CLI tests in `tests/yq_cli_tests.rs` (repro, nested/mixed
      sequences, `-o json`, `--slurp`, alias-sync-through-anchor,
      merge-source expansion, generic `anchor` builtin via `.[n]`)
- [x] New unit test in `src/jq/eval.rs` (`load()` explicit-tag preservation)
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only`

Fixes #835
