### PR TITLE
fix(jq): keep recurse(f)'s own partial fan-out before a later error

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10416,9 +10416,19 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         queue_recurse_children(&mut stack, next, deferred_error, &mut pending_error);
     }
 
-    match pending_error {
-        Some(e) => Err((outputs, e)),
-        None => Ok(outputs),
+    // A `pending_error` only surfaces once `stack` drains naturally — if
+    // `MAX_ITEMS` cut the loop short instead (`stack` still non-empty), this
+    // matches the pre-existing MAX_ITEMS convention everywhere else in this
+    // file (silent truncation, no error) rather than surfacing an error
+    // whose presence would otherwise depend on where the arbitrary cap
+    // happened to land relative to it (#842 review).
+    if stack.is_empty() {
+        match pending_error {
+            Some(e) => Err((outputs, e)),
+            None => Ok(outputs),
+        }
+    } else {
+        Ok(outputs)
     }
 }
 
@@ -12762,8 +12772,13 @@ fn builtin_recurse_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         queue_recurse_children(&mut stack, children, deferred_error, &mut pending_error);
     }
 
-    if let Some(e) = pending_error {
-        return partial(outputs, e.into());
+    // See `resolve_recurse`'s matching check for the full rationale (#842
+    // review): a `pending_error` only surfaces once `stack` drains
+    // naturally, not when `MAX_ITEMS` cuts the loop short instead.
+    if stack.is_empty() {
+        if let Some(e) = pending_error {
+            return partial(outputs, e.into());
+        }
     }
 
     if outputs.is_empty() {
@@ -12859,8 +12874,13 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         queue_recurse_children(&mut stack, next, deferred_error, &mut pending_error);
     }
 
-    if let Some(e) = pending_error {
-        return partial(outputs, e.into());
+    // See `resolve_recurse`'s matching check for the full rationale (#842
+    // review): a `pending_error` only surfaces once `stack` drains
+    // naturally, not when `MAX_ITEMS` cuts the loop short instead.
+    if stack.is_empty() {
+        if let Some(e) = pending_error {
+            return partial(outputs, e.into());
+        }
     }
 
     if outputs.is_empty() {
@@ -34264,6 +34284,35 @@ mod tests {
                 r#"{"child":"leaf","leafflag":true}"#,
                 r#""leaf""#,
             ]
+        );
+    }
+
+    #[test]
+    fn test_recurse_f_max_items_truncation_suppresses_a_pending_error_842() {
+        // Review of #842's fix: a `pending_error` deferred past `MAX_ITEMS`
+        // items must not surface just because of where the (internal,
+        // non-jq-semantic) 10000-item safety cap happened to land relative
+        // to it — that would make two structurally identical large fan-outs
+        // (this one, vs. the same shape with no trailing error at all)
+        // diverge on whether an error appears, purely as an accident of the
+        // cap. `builtin_recurse_f` already silently truncates at
+        // `MAX_ITEMS` with no error for a non-erroring fan-out (unrelated
+        // to #842, pre-existing convention); this pins that a *deferred*
+        // error is suppressed the same way once the cap truncates the
+        // drain, rather than resurfacing as `QueryResult::Partial`.
+        let large_doc = format!(
+            r#"{{"items":[{}],"bad":5}}"#,
+            (0..15000)
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        query!(
+            large_doc.as_bytes(),
+            r#"recurse(if type=="object" then (.items[], .bad[0]) else empty end)"#,
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs.len(), 10000);
+            }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9412,6 +9412,27 @@ fn push_path_components(out: &mut Vec<Expr>, expr: &Expr) {
 /// first (#694): an error/break mid-stream aborts the whole expression here,
 /// it does not silently degrade into "however many outputs came before it."
 ///
+/// A `break $label` aborts this expression exactly like `Error` — whatever a
+/// resolve-node caller was accumulating before this sub-expression is a
+/// separate concern it already handles via its own `PathResolveResult`
+/// prefix, not something this helper tries to preserve. Propagated as
+/// [`EvalEscape::Break`] rather than collapsed into a synthetic "break
+/// $label not in label" `Error`, so a `label` sitting outside the caller
+/// (e.g. across a `path(...)` call boundary) still catches it instead of
+/// seeing a bogus error (#824). A halt must abort this expression exactly
+/// like `Error`/`Break` rather than falling into `collect_owned()`'s "no
+/// outputs" treatment — that would make `del(.[(halt_error(3))])` or a
+/// computed key `.[(halt)]` a silent no-op instead of halting (#791). It
+/// travels as [`EvalEscape::Halt`], its own variant, so no caller can catch
+/// or suppress it as if it were an error. Both apply to a `Partial`'s
+/// trailing control too, same as a bare occurrence (#824).
+///
+/// A thin adapter over [`eval_owned_multi_keep_partial`] that discards
+/// whatever prefix `expr` already produced before the escape — the right
+/// contract for every caller except `recurse`'s own children evaluation
+/// (`builtin_recurse_f`/`builtin_recurse_cond`/`resolve_recurse`), which
+/// call `eval_owned_multi_keep_partial` directly instead (#842).
+///
 /// The one caller that must NOT use this — `update_path`'s `Expr::Identity`
 /// arm, i.e. `|=`'s own update-filter evaluation — uses
 /// [`eval_owned_multi_first`] instead; see that function's doc comment for
@@ -9420,33 +9441,7 @@ fn eval_owned_multi<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
 ) -> Result<Vec<OwnedValue>, EvalEscape> {
-    match eval_owned_input::<Vec<u64>, S>(expr, input, false) {
-        QueryResult::Error(e) => Err(e.into()),
-        // A `break $label` aborts this expression exactly like `Error`
-        // above — whatever a resolve-node caller was accumulating before
-        // this sub-expression is a separate concern it already handles via
-        // its own `PathResolveResult` prefix, not something this helper
-        // tries to preserve. Propagated as [`EvalEscape::Break`] rather than
-        // collapsed into a synthetic "break $label not in label" `Error`, so
-        // a `label` sitting outside the caller (e.g. across a `path(...)`
-        // call boundary) still catches it instead of seeing a bogus error
-        // (#824).
-        QueryResult::Break(label) => Err(EvalEscape::Break(label)),
-        // A halt must abort this expression exactly like `Error`/`Break`
-        // above rather than falling into `collect_owned()`'s "no outputs"
-        // treatment below — that would make `del(.[(halt_error(3))])` or a
-        // computed key `.[(halt)]` a silent no-op instead of halting (#791).
-        // It travels as [`EvalEscape::Halt`], its own variant, so no caller
-        // can catch or suppress it as if it were an error.
-        QueryResult::Halt(code) => Err(EvalEscape::Halt(code)),
-        QueryResult::Partial(_, Control::Error(e)) => Err(e.into()),
-        // Same reasoning as the bare `Break` arm above: the prefix this
-        // particular sub-stream produced before breaking is not this
-        // helper's to keep (#824).
-        QueryResult::Partial(_, Control::Break(label)) => Err(EvalEscape::Break(label)),
-        QueryResult::Partial(_, Control::Halt(code)) => Err(EvalEscape::Halt(code)),
-        other => Ok(other.collect_owned()),
-    }
+    eval_owned_multi_keep_partial::<S>(expr, input).map_err(|(_prefix, e)| e)
 }
 
 /// Like [`eval_owned_multi`], but keeps `collect_owned`'s old "just give me
@@ -9499,9 +9494,14 @@ fn eval_owned_multi_first<S: EvalSemantics>(
 /// `eval_owned_multi`'s all-or-nothing contract is correct for its other
 /// callers (see its own doc comment), so this is a separate function rather
 /// than a change to that one's behavior. The only correct callers are
-/// `recurse`'s own children-evaluation step
-/// (`builtin_recurse_f`/`builtin_recurse_cond`/`resolve_recurse`): `f`'s
-/// *own* fan-out is a generator like any other comma expression, and jq's
+/// `recurse`'s own children-evaluation step, value position
+/// (`builtin_recurse_f`/`builtin_recurse_cond`, both evaluate `f` through
+/// this function directly). The path-position sibling, `resolve_recurse`,
+/// needs the same fix but resolves `f` through `resolve_node`/
+/// `resolve_against_cow` instead — a structurally different call whose
+/// `PathResolveResult` already threads a prefix through its own `Err`, so
+/// it applies the equivalent fix without calling this function. `f`'s *own*
+/// fan-out is a generator like any other comma expression, and jq's
 /// backtracking generator semantics mean a later output of that same call
 /// erroring does not retroactively un-emit an earlier one it already
 /// produced (#842). Confirmed against jq 1.7.1:
@@ -9509,20 +9509,20 @@ fn eval_owned_multi_first<S: EvalSemantics>(
 /// `{"a":1,"b":2}` prints the root *and* `1` (the `.a` branch, produced
 /// before `.b[0]` fails) before erroring — succinctly used to print only the
 /// root.
+///
+/// Built on [`push_owned_values`] (the same "keep every value, surface the
+/// terminal escape separately" primitive [`eval_binary_fanout`] already
+/// uses) rather than a second hand-rolled match over `QueryResult`, so
+/// there is exactly one implementation of that shape in this file.
 fn eval_owned_multi_keep_partial<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
 ) -> Result<Vec<OwnedValue>, (Vec<OwnedValue>, EvalEscape)> {
-    match eval_owned_input::<Vec<u64>, S>(expr, input, false) {
-        QueryResult::Error(e) => Err((Vec::new(), e.into())),
-        QueryResult::Break(label) => Err((Vec::new(), EvalEscape::Break(label))),
-        QueryResult::Halt(code) => Err((Vec::new(), EvalEscape::Halt(code))),
-        QueryResult::Partial(prefix, Control::Error(e)) => Err((prefix, e.into())),
-        QueryResult::Partial(prefix, Control::Break(label)) => {
-            Err((prefix, EvalEscape::Break(label)))
-        }
-        QueryResult::Partial(prefix, Control::Halt(code)) => Err((prefix, EvalEscape::Halt(code))),
-        other => Ok(other.collect_owned()),
+    let result = eval_owned_input::<Vec<u64>, S>(expr, input, false);
+    let mut out = Vec::new();
+    match push_owned_values(result, &mut out) {
+        Some(control) => Err((out, control.into())),
+        None => Ok(out),
     }
 }
 
@@ -10237,6 +10237,35 @@ fn resolve_catch<'a, S: EvalSemantics>(
     Ok(out)
 }
 
+/// Shared "defer the escape, queue what's left" step for `recurse`'s three
+/// stack-driven implementations (`resolve_recurse`,
+/// `builtin_recurse_f`/`builtin_recurse_cond`) (#842).
+///
+/// `next` is this node's already-`cond`-gated (where applicable) children —
+/// from a fully-successful `f` call, or from whatever `f` itself produced
+/// before ending in an error/break/halt. Called every iteration regardless
+/// of which case it was: on success `deferred_error` is `None` and this is
+/// just the ordinary "push `next` reversed" step; on an escape, `stack` is
+/// cleared first (nothing already queued may run once an escape is pending
+/// — jq's error/break/halt aborts the *entire* remaining traversal, not
+/// just the current node) before `next` replaces it, and `pending_error` is
+/// set so the caller raises it once `next`'s own subtree(s) have fully
+/// drained — which may itself overwrite `pending_error` with a *later*
+/// call's own escape, correctly superseding this one (it happens first,
+/// chronologically, in jq's real generator order).
+fn queue_recurse_children<T>(
+    stack: &mut Vec<T>,
+    next: Vec<T>,
+    deferred_error: Option<EvalEscape>,
+    pending_error: &mut Option<EvalEscape>,
+) {
+    if let Some(e) = deferred_error {
+        stack.clear();
+        *pending_error = Some(e);
+    }
+    stack.extend(next.into_iter().rev());
+}
+
 /// Fan `recurse(f)` / `recurse(f; cond)` out into one branch per visited
 /// node, depth-first. Uses the same explicit stack
 /// `builtin_recurse_f`/`builtin_recurse_cond` do — including the
@@ -10320,12 +10349,8 @@ fn resolve_recurse<'a, S: EvalSemantics>(
 ) -> PathResolveResult<'a> {
     let mut outputs: Vec<PathBranch<'a>> = Vec::new();
     let mut stack: Vec<PathBranch<'a>> = vec![(Vec::new(), Cow::Borrowed(value))];
-    // See `builtin_recurse_f`'s matching field for the full rationale
-    // (#842): set once `f` itself ends in an error/break/halt, so whatever
-    // it already produced at that node — rebased onto the absolute path and
-    // `cond`-gated exactly like a fully-successful call's children — still
-    // gets drained fully before the escape is raised, rather than being
-    // dropped.
+    // Set by `queue_recurse_children` once `f` itself ends in an
+    // error/break/halt — see that function's doc comment (#842).
     let mut pending_error: Option<EvalEscape> = None;
     const MAX_ITEMS: usize = 10000;
 
@@ -10388,13 +10413,7 @@ fn resolve_recurse<'a, S: EvalSemantics>(
             }
         }
 
-        if let Some(e) = deferred_error {
-            stack.clear();
-            stack.extend(next.into_iter().rev());
-            pending_error = Some(e);
-        } else {
-            stack.extend(next.into_iter().rev());
-        }
+        queue_recurse_children(&mut stack, next, deferred_error, &mut pending_error);
     }
 
     match pending_error {
@@ -12715,16 +12734,8 @@ fn builtin_recurse_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let mut outputs: Vec<OwnedValue> = Vec::new();
     let mut stack: Vec<OwnedValue> = vec![to_owned(&value)];
-    // Set once `f`'s own evaluation at some node ends in an error/break/halt
-    // (the `Err` arm below): whatever `f` already produced before that
-    // point still needs the same recursive treatment a fully-successful
-    // call's children would get, since jq's generator semantics mean an
-    // earlier output of a fanned-out `f` call is not retroactively
-    // un-emitted by a later sibling's error (#842). So it replaces `stack`
-    // — nothing queued before this point may run once an escape is pending,
-    // same reasoning as the plain error case below — and draining
-    // continues instead of returning immediately; the deferred escape is
-    // only raised once the stack it now owns is fully drained.
+    // Set by `queue_recurse_children` once `f`'s own evaluation at some node
+    // ends in an error/break/halt — see that function's doc comment (#842).
     let mut pending_error: Option<EvalEscape> = None;
     const MAX_ITEMS: usize = 10000;
 
@@ -12744,14 +12755,11 @@ fn builtin_recurse_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // recursive treatment (#842); `eval_owned_multi_keep_partial` keeps
         // that prefix instead of `eval_owned_multi`'s all-or-nothing
         // contract, which is right for its other callers but not this one.
-        match eval_owned_multi_keep_partial::<S>(f, &current) {
-            Ok(children) => stack.extend(children.into_iter().rev()),
-            Err((prefix, e)) => {
-                stack.clear();
-                stack.extend(prefix.into_iter().rev());
-                pending_error = Some(e);
-            }
-        }
+        let (children, deferred_error) = match eval_owned_multi_keep_partial::<S>(f, &current) {
+            Ok(children) => (children, None),
+            Err((prefix, e)) => (prefix, Some(e)),
+        };
+        queue_recurse_children(&mut stack, children, deferred_error, &mut pending_error);
     }
 
     if let Some(e) = pending_error {
@@ -12802,10 +12810,8 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let mut outputs: Vec<OwnedValue> = Vec::new();
     let mut stack: Vec<OwnedValue> = vec![to_owned(&value)];
-    // See `builtin_recurse_f`'s matching field for the full rationale
-    // (#842): set when `f` itself ends in an error/break/halt, so its own
-    // already-produced (and `cond`-gated) children still get drained fully
-    // before the escape is raised, rather than being dropped.
+    // Set by `queue_recurse_children` once `f` itself ends in an
+    // error/break/halt — see that function's doc comment (#842).
     let mut pending_error: Option<EvalEscape> = None;
     const MAX_ITEMS: usize = 10000;
 
@@ -12850,13 +12856,7 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
 
-        if let Some(e) = deferred_error {
-            stack.clear();
-            stack.extend(next.into_iter().rev());
-            pending_error = Some(e);
-        } else {
-            stack.extend(next.into_iter().rev());
-        }
+        queue_recurse_children(&mut stack, next, deferred_error, &mut pending_error);
     }
 
     if let Some(e) = pending_error {
@@ -34130,7 +34130,9 @@ mod tests {
         // Issue #694's second repro. Confirmed against real jq 1.7.1: errors
         // with "boom" -- before this fix, succinctly silently continued the
         // traversal to `[null,1]`, contradicting `builtin_recurse`'s own
-        // doc comment ("An error aborts immediately", #636).
+        // doc comment ("An error aborts the whole traversal", #636 — reworded
+        // by #842, which added the nuance that `f`'s own partial fan-out is
+        // drained before the error is actually raised).
         query!(
             b"null",
             r#"[recurse(if . == null then (foreach (1,2) as $x (0; .+$x, error("boom"))) else empty end)]"#,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34317,6 +34317,29 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_recurse_max_items_truncation_suppresses_a_pending_error_842() {
+        // Path-position sibling of the previous test: `resolve_recurse`'s
+        // own `stack.is_empty()` check (its `else` branch, hit only when
+        // `MAX_ITEMS` truncates the drain before a `pending_error` would
+        // otherwise surface) needs the same coverage as
+        // `builtin_recurse_f`'s.
+        let large_doc = format!(
+            r#"{{"items":[{}],"bad":5}}"#,
+            (0..15000)
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        query!(
+            large_doc.as_bytes(),
+            r#"path(recurse(if type=="object" then (.items[], .bad[0]) else empty end))"#,
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs.len(), 10000);
+            }
+        );
+    }
+
+    #[test]
     fn test_update_assign_ignores_trailing_error_after_first_output_694() {
         // The one call site that must NOT be "fixed" by #694: jq's `_modify`
         // (backing `|=`) only ever observes the update filter's first

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9493,6 +9493,39 @@ fn eval_owned_multi_first<S: EvalSemantics>(
     }
 }
 
+/// Like [`eval_owned_multi`], but keeps whatever prefix `expr` already
+/// produced before an error/break/halt escaped, instead of discarding it.
+///
+/// `eval_owned_multi`'s all-or-nothing contract is correct for its other
+/// callers (see its own doc comment), so this is a separate function rather
+/// than a change to that one's behavior. The only correct callers are
+/// `recurse`'s own children-evaluation step
+/// (`builtin_recurse_f`/`builtin_recurse_cond`/`resolve_recurse`): `f`'s
+/// *own* fan-out is a generator like any other comma expression, and jq's
+/// backtracking generator semantics mean a later output of that same call
+/// erroring does not retroactively un-emit an earlier one it already
+/// produced (#842). Confirmed against jq 1.7.1:
+/// `recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end)` on
+/// `{"a":1,"b":2}` prints the root *and* `1` (the `.a` branch, produced
+/// before `.b[0]` fails) before erroring — succinctly used to print only the
+/// root.
+fn eval_owned_multi_keep_partial<S: EvalSemantics>(
+    expr: &Expr,
+    input: &OwnedValue,
+) -> Result<Vec<OwnedValue>, (Vec<OwnedValue>, EvalEscape)> {
+    match eval_owned_input::<Vec<u64>, S>(expr, input, false) {
+        QueryResult::Error(e) => Err((Vec::new(), e.into())),
+        QueryResult::Break(label) => Err((Vec::new(), EvalEscape::Break(label))),
+        QueryResult::Halt(code) => Err((Vec::new(), EvalEscape::Halt(code))),
+        QueryResult::Partial(prefix, Control::Error(e)) => Err((prefix, e.into())),
+        QueryResult::Partial(prefix, Control::Break(label)) => {
+            Err((prefix, EvalEscape::Break(label)))
+        }
+        QueryResult::Partial(prefix, Control::Halt(code)) => Err((prefix, EvalEscape::Halt(code))),
+        other => Ok(other.collect_owned()),
+    }
+}
+
 /// Turn a resolved key value into the static path component it denotes.
 ///
 /// NaN is the one numeric key with no component: reading `.[nan]` is null, but
@@ -10240,11 +10273,20 @@ fn resolve_catch<'a, S: EvalSemantics>(
 /// output pushes its own copy of `(path, child_value)` into `next`, in the
 /// order `cond`'s outputs were produced.
 ///
-/// An error raised while evaluating `f` or `cond` aborts immediately —
-/// nothing in jq's own definition above catches one — returning whatever
-/// branches were already committed to `outputs`, mirroring `resolve_node`'s
-/// own `Comma` arm (#636; matches `builtin_recurse_f`/`builtin_recurse_cond`,
-/// fixed the same way).
+/// An error raised while evaluating `f` or `cond` aborts the whole
+/// traversal — nothing in jq's own definition above catches one — returning
+/// whatever branches were already committed to `outputs`, mirroring
+/// `resolve_node`'s own `Comma` arm (#636; matches
+/// `builtin_recurse_f`/`builtin_recurse_cond`, fixed the same way). `cond`'s
+/// error still aborts *immediately*, mid-node. `f`'s does not: `f`'s own
+/// fan-out at the current node is a generator like any other comma
+/// expression, so whatever it already produced before erroring still gets
+/// its own full `cond`-gated recursive descent — rebased onto `current`'s
+/// absolute path, the same way a fully-successful `f` call's children
+/// already are — before the deferred error is finally raised (#842;
+/// confirmed against jq 1.7.1: `path(recurse(if . == {"a":1,"b":2} then
+/// (.a, .b[0]) else empty end))` on `{"a":1,"b":2}` prints `[]` *and*
+/// `["a"]` before erroring, not just `[]`).
 ///
 /// One divergence remains, deliberately: this function still does not
 /// stack a null child, where the value evaluator does. `f` is arbitrary
@@ -10278,6 +10320,13 @@ fn resolve_recurse<'a, S: EvalSemantics>(
 ) -> PathResolveResult<'a> {
     let mut outputs: Vec<PathBranch<'a>> = Vec::new();
     let mut stack: Vec<PathBranch<'a>> = vec![(Vec::new(), Cow::Borrowed(value))];
+    // See `builtin_recurse_f`'s matching field for the full rationale
+    // (#842): set once `f` itself ends in an error/break/halt, so whatever
+    // it already produced at that node — rebased onto the absolute path and
+    // `cond`-gated exactly like a fully-successful call's children — still
+    // gets drained fully before the escape is raised, rather than being
+    // dropped.
+    let mut pending_error: Option<EvalEscape> = None;
     const MAX_ITEMS: usize = 10000;
 
     while !stack.is_empty() && outputs.len() < MAX_ITEMS {
@@ -10286,18 +10335,17 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // still `O(path length)` per node, `O(d²)` total; #701, unfixed here.
         outputs.push((prefix.clone(), current.clone()));
 
-        // An `f` error aborts immediately rather than pruning `current`'s
-        // children — see the doc comment above (#636). The candidate
-        // children `resolve_node` may have already resolved before hitting
-        // that error are dropped rather than stacked, matching
-        // `eval_owned_multi`'s all-or-nothing contract for
-        // `builtin_recurse_f`/`builtin_recurse_cond`. Goes through
+        // An `f` error aborts the whole traversal — see the doc comment
+        // above (#636) — but only after whatever candidate children
+        // `resolve_node` already resolved before hitting that error get
+        // their own full recursive treatment (#842), deferred below exactly
+        // like `builtin_recurse_f`/`builtin_recurse_cond`. Goes through
         // `resolve_against_cow`, not `resolve_node` directly, because
         // `current` may itself be a `Cow::Owned` value from an earlier
         // step — see that function's doc comment (#668).
-        let children = match resolve_against_cow::<S>(f, current) {
-            Ok(children) => children,
-            Err((_prefix, e)) => return Err((outputs, e)),
+        let (children, deferred_error) = match resolve_against_cow::<S>(f, current) {
+            Ok(children) => (children, None),
+            Err((partial_children, e)) => (partial_children, Some(e)),
         };
 
         // Collected in encounter order, then pushed onto `stack` reversed
@@ -10322,7 +10370,10 @@ fn resolve_recurse<'a, S: EvalSemantics>(
                     // `cond` gates the child, not `current`, and forks once
                     // per truthy output — see the doc comment above (#627).
                     // A `cond` error aborts immediately too (#636), same as
-                    // `f`'s error above.
+                    // `f`'s error above — this arm's own prefix-loss
+                    // (`next`'s already-cond-approved entries built so far
+                    // this node) is pre-existing and out of scope for #842,
+                    // which is specifically about `f`'s fan-out.
                     match eval_owned_multi::<S>(cond, &child_value) {
                         Ok(cond_outputs) => {
                             for c in &cond_outputs {
@@ -10336,10 +10387,20 @@ fn resolve_recurse<'a, S: EvalSemantics>(
                 }
             }
         }
-        stack.extend(next.into_iter().rev());
+
+        if let Some(e) = deferred_error {
+            stack.clear();
+            stack.extend(next.into_iter().rev());
+            pending_error = Some(e);
+        } else {
+            stack.extend(next.into_iter().rev());
+        }
     }
 
-    Ok(outputs)
+    match pending_error {
+        Some(e) => Err((outputs, e)),
+        None => Ok(outputs),
+    }
 }
 
 /// Does `builtin` (one of `values`/`nulls`/`booleans`/.../`scalars`) keep
@@ -12654,6 +12715,17 @@ fn builtin_recurse_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let mut outputs: Vec<OwnedValue> = Vec::new();
     let mut stack: Vec<OwnedValue> = vec![to_owned(&value)];
+    // Set once `f`'s own evaluation at some node ends in an error/break/halt
+    // (the `Err` arm below): whatever `f` already produced before that
+    // point still needs the same recursive treatment a fully-successful
+    // call's children would get, since jq's generator semantics mean an
+    // earlier output of a fanned-out `f` call is not retroactively
+    // un-emitted by a later sibling's error (#842). So it replaces `stack`
+    // — nothing queued before this point may run once an escape is pending,
+    // same reasoning as the plain error case below — and draining
+    // continues instead of returning immediately; the deferred escape is
+    // only raised once the stack it now owns is fully drained.
+    let mut pending_error: Option<EvalEscape> = None;
     const MAX_ITEMS: usize = 10000;
 
     while !stack.is_empty() && outputs.len() < MAX_ITEMS {
@@ -12666,14 +12738,24 @@ fn builtin_recurse_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // (#490). Pushed reversed so the first child stays on top and its
         // whole subtree completes before the next sibling is reached
         // (#635) — see `resolve_recurse`'s doc comment for the general
-        // shape this mirrors. An error aborts immediately, same as jq's
-        // `def r: ., (f | r); r;` (#636) — the values already output no
-        // longer vanish, via the same `partial()` helper #495 uses for
-        // `repeat`/`while`.
-        match eval_owned_multi::<S>(f, &current) {
+        // shape this mirrors. An error aborts the whole traversal, same as
+        // jq's `def r: ., (f | r); r;` (#636) — but not until whatever `f`
+        // itself already produced at this node has had its own full
+        // recursive treatment (#842); `eval_owned_multi_keep_partial` keeps
+        // that prefix instead of `eval_owned_multi`'s all-or-nothing
+        // contract, which is right for its other callers but not this one.
+        match eval_owned_multi_keep_partial::<S>(f, &current) {
             Ok(children) => stack.extend(children.into_iter().rev()),
-            Err(e) => return partial(outputs, e.into()),
+            Err((prefix, e)) => {
+                stack.clear();
+                stack.extend(prefix.into_iter().rev());
+                pending_error = Some(e);
+            }
         }
+    }
+
+    if let Some(e) = pending_error {
+        return partial(outputs, e.into());
     }
 
     if outputs.is_empty() {
@@ -12720,6 +12802,11 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let mut outputs: Vec<OwnedValue> = Vec::new();
     let mut stack: Vec<OwnedValue> = vec![to_owned(&value)];
+    // See `builtin_recurse_f`'s matching field for the full rationale
+    // (#842): set when `f` itself ends in an error/break/halt, so its own
+    // already-produced (and `cond`-gated) children still get drained fully
+    // before the escape is raised, rather than being dropped.
+    let mut pending_error: Option<EvalEscape> = None;
     const MAX_ITEMS: usize = 10000;
 
     while !stack.is_empty() && outputs.len() < MAX_ITEMS {
@@ -12729,12 +12816,15 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Every output of `f` becomes exactly one candidate child, in order —
         // a null output is a real value (not "no child"), and an array output
         // is visited as one node (not spliced into its elements) (#490). An
-        // `f` error aborts immediately rather than pruning `current`'s
-        // children, matching jq's `def r: ., (f | select(cond) | r); r;`,
-        // where nothing catches an error from `f` (#636).
-        let children = match eval_owned_multi::<S>(f, &current) {
-            Ok(children) => children,
-            Err(e) => return partial(outputs, e.into()),
+        // `f` error aborts the whole traversal, matching jq's `def r: .,
+        // (f | select(cond) | r); r;`, where nothing catches an error from
+        // `f` (#636) — but only after whatever `f` already produced at this
+        // node (kept via `eval_owned_multi_keep_partial`, #842) has had its
+        // own full `cond`-gated recursive treatment, deferred below exactly
+        // like `builtin_recurse_f`.
+        let (children, deferred_error) = match eval_owned_multi_keep_partial::<S>(f, &current) {
+            Ok(children) => (children, None),
+            Err((prefix, e)) => (prefix, Some(e)),
         };
 
         // Collected in encounter order, then pushed onto `stack` reversed —
@@ -12745,7 +12835,10 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // `cond` gates the child, not `current` (see doc comment above).
             // A `cond` error aborts immediately too — same jq definition,
             // same reasoning as `f`'s error above (#636) — rather than
-            // pruning just this child the way a falsy `cond` does.
+            // pruning just this child the way a falsy `cond` does. This
+            // arm's own prefix-loss (`next`'s already-cond-approved entries
+            // built so far this node) is pre-existing and out of scope for
+            // #842, which is specifically about `f`'s fan-out.
             let cond_outputs = match eval_owned_multi::<S>(cond, &child) {
                 Ok(cond_outputs) => cond_outputs,
                 Err(e) => return partial(outputs, e.into()),
@@ -12756,7 +12849,18 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
             }
         }
-        stack.extend(next.into_iter().rev());
+
+        if let Some(e) = deferred_error {
+            stack.clear();
+            stack.extend(next.into_iter().rev());
+            pending_error = Some(e);
+        } else {
+            stack.extend(next.into_iter().rev());
+        }
+    }
+
+    if let Some(e) = pending_error {
+        return partial(outputs, e.into());
     }
 
     if outputs.is_empty() {
@@ -34033,6 +34137,131 @@ mod tests {
             QueryResult::Error(e) | QueryResult::Partial(_, Control::Error(e)) => {
                 assert_eq!(e.message, "boom");
             }
+        );
+    }
+
+    #[test]
+    fn test_recurse_f_keeps_own_partial_fanout_before_error_842() {
+        // Issue #842's primary repro (value position, streamed — not
+        // collected into `[...]`, which is atomic in both jq and succinctly
+        // and not part of this bug). Confirmed against real jq 1.7.1:
+        // `echo '{"a":1,"b":2}' | jq -c 'recurse(if . == {"a":1,"b":2} then
+        // (.a, .b[0]) else empty end)'` prints the root *and* `1` (the `.a`
+        // branch of `f`'s fan-out, produced before `.b[0]` errors) before
+        // erroring. Before this fix, succinctly printed only the root,
+        // dropping `1`.
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                r#"recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end)"#
+            ),
+            vec![r#"{"a":1,"b":2}"#, "1"]
+        );
+        query!(
+            br#"{"a":1,"b":2}"#,
+            r#"recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end)"#,
+            QueryResult::Partial(prefix, Control::Error(e)) => {
+                assert_eq!(
+                    prefix.iter().map(OwnedValue::to_json).collect::<Vec<_>>(),
+                    vec![r#"{"a":1,"b":2}"#.to_string(), "1".to_string()]
+                );
+                assert!(e.message.contains("Cannot index number with number"));
+            }
+        );
+    }
+
+    #[test]
+    fn test_recurse_f_keeps_own_partial_fanout_subtree_before_error_842() {
+        // A deeper repro of #842: the successfully-produced child (`.child`)
+        // itself has further children under recursion, so this checks that
+        // the *entire* subtree reached from `f`'s own partial fan-out is
+        // visited before the error, not just the bare partial value.
+        // Confirmed against real jq 1.7.1:
+        // `echo '{"child":{"child":"leaf","leafflag":true},"bad":3}' | jq -c
+        // 'recurse(if (.|type)=="object" then (.child, .bad[0]) else empty
+        // end)'` prints the root, `{"child":"leaf","leafflag":true}`,
+        // `"leaf"`, and `null` (in that order) before erroring.
+        assert_eq!(
+            outputs(
+                br#"{"child":{"child":"leaf","leafflag":true},"bad":3}"#,
+                r#"recurse(if (.|type)=="object" then (.child, .bad[0]) else empty end)"#
+            ),
+            vec![
+                r#"{"child":{"child":"leaf","leafflag":true},"bad":3}"#,
+                r#"{"child":"leaf","leafflag":true}"#,
+                r#""leaf""#,
+                "null",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_recurse_cond_keeps_f_partial_fanout_before_error_842() {
+        // `builtin_recurse_cond`'s `f`-evaluation arm has the same #842 bug
+        // as `builtin_recurse_f` — kept in parity per this function's own
+        // doc comment. `cond` here is always `true` so it never itself
+        // gates or errors; only `f`'s own fan-out is under test.
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                r#"recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end; true)"#
+            ),
+            vec![r#"{"a":1,"b":2}"#, "1"]
+        );
+    }
+
+    #[test]
+    fn test_resolve_recurse_keeps_f_partial_fanout_before_error_842() {
+        // Issue #842's path-position repro (`resolve_recurse`, no `cond`).
+        // Confirmed against real jq 1.7.1:
+        // `echo '{"a":1,"b":2}' | jq -c 'path(recurse(if . ==
+        // {"a":1,"b":2} then (.a, .b[0]) else empty end))'` prints `[]`
+        // *and* `["a"]` before erroring. Before this fix, succinctly
+        // printed only `[]`, dropping `["a"]`.
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                r#"path(recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end))"#
+            ),
+            vec!["[]", r#"["a"]"#]
+        );
+    }
+
+    #[test]
+    fn test_resolve_recurse_cond_keeps_f_partial_fanout_before_error_842() {
+        // Same as the previous test, but with `cond` present (always `true`,
+        // so it never itself gates or errors) — exercises `resolve_recurse`'s
+        // `Some(cond)` arm through the same deferred-error path.
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                r#"path(recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end; true))"#
+            ),
+            vec!["[]", r#"["a"]"#]
+        );
+    }
+
+    #[test]
+    fn test_recurse_f_keeps_own_partial_fanout_before_break_842() {
+        // The same #842 fix applies uniformly to `break`, not just `error`
+        // (`eval_owned_multi_keep_partial` keeps the prefix for all three
+        // `Control` variants). Confirmed against real jq 1.7.1:
+        // `echo '{"child":{"child":"leaf","leafflag":true},"bad":3}' | jq -c
+        // 'label $out | recurse(if (.|type)=="object" then (.child, (if
+        // .bad then break $out else empty end)) else empty end)'` prints
+        // the root, `{"child":"leaf","leafflag":true}`, and `"leaf"`, then
+        // exits 0 (no error) — the break unwinds to the label with the
+        // prefix already emitted.
+        assert_eq!(
+            outputs(
+                br#"{"child":{"child":"leaf","leafflag":true},"bad":3}"#,
+                r#"label $out | recurse(if (.|type)=="object" then (.child, (if .bad then break $out else empty end)) else empty end)"#
+            ),
+            vec![
+                r#"{"child":{"child":"leaf","leafflag":true},"bad":3}"#,
+                r#"{"child":"leaf","leafflag":true}"#,
+                r#""leaf""#,
+            ]
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7097,6 +7097,89 @@ fn test_recurse_cond_propagates_halt_from_f() -> Result<()> {
 }
 
 #[test]
+fn test_recurse_f_keeps_own_partial_fanout_before_error_842() -> Result<()> {
+    // Issue #842's primary repro (value position). `f`'s own fan-out
+    // (`.a, .b[0]`) is a generator like any other comma expression: a
+    // later output of that same call erroring must not retroactively
+    // un-emit an earlier one it already produced. Before this fix,
+    // `resolve_recurse`/`builtin_recurse_f` dropped `f`'s own partial
+    // fan-out on error, matching neither jq's semantics nor the codebase's
+    // existing "never un-emit an already-produced output" rule (#530,
+    // #636, #694, #824). Verified against jq 1.7.1:
+    // `echo '{"a":1,"b":2}' | jq -c 'recurse(if . == {"a":1,"b":2} then
+    // (.a, .b[0]) else empty end)'` prints `{"a":1,"b":2}` and `1` to
+    // stdout before erroring, and exits 5.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end)"#,
+        ],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"a\":1,\"b\":2}\n1\n");
+    assert!(
+        stderr.contains("Cannot index number with number"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_resolve_recurse_keeps_f_partial_fanout_before_error_842() -> Result<()> {
+    // Issue #842's secondary repro (path position, `resolve_recurse`).
+    // Same underlying bug as the value-position test above, in the
+    // path-tracking evaluator `path(...)` uses. Verified against jq 1.7.1:
+    // `echo '{"a":1,"b":2}' | jq -c 'path(recurse(if . == {"a":1,"b":2}
+    // then (.a, .b[0]) else empty end))'` prints `[]` and `["a"]` to
+    // stdout before erroring, and exits 5.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path(recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end))"#,
+        ],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n[\"a\"]\n");
+    assert!(
+        stderr.contains("Cannot index number with number"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_recurse_f_keeps_own_partial_fanout_subtree_before_error_842() -> Result<()> {
+    // A deeper #842 repro: the successfully-produced child (`.child`)
+    // itself has further children under recursion, so the *entire*
+    // subtree reached from `f`'s own partial fan-out must be visited
+    // before the error — not just the bare partial value. Verified
+    // against jq 1.7.1: `echo
+    // '{"child":{"child":"leaf","leafflag":true},"bad":3}' | jq -c
+    // 'recurse(if (.|type)=="object" then (.child, .bad[0]) else empty
+    // end)'` prints the root, `{"child":"leaf","leafflag":true}`,
+    // `"leaf"`, and `null` (in that order) before erroring, and exits 5.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"recurse(if (.|type)=="object" then (.child, .bad[0]) else empty end)"#,
+        ],
+        Some(r#"{"child":{"child":"leaf","leafflag":true},"bad":3}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "{\"child\":{\"child\":\"leaf\",\"leafflag\":true},\"bad\":3}\n{\"child\":\"leaf\",\"leafflag\":true}\n\"leaf\"\nnull\n"
+    );
+    assert!(
+        stderr.contains("Cannot index number with number"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_walk_propagates_halt_from_f() -> Result<()> {
     // `builtin_walk`'s `Err(e) => e.into()` arm: `walk_impl` applies `f` to
     // the (already child-processed) value via `eval_owned_expr`, and a halt


### PR DESCRIPTION
## Summary

`recurse(f)`/`recurse(f; cond)` dropped `f`'s own partial fan-out output
when a *later* output of that same `f` call errored (or broke/halted), in
both the value-position evaluator (`builtin_recurse_f`/`builtin_recurse_cond`)
and the path-position evaluator (`resolve_recurse`), `src/jq/eval.rs`.

Confirmed against real jq 1.7.1: `f`'s fan-out is a generator like any other
comma expression, so real jq streams every output `f` already produced at a
node — and that value's own recursive subtree — before the error that stops
the whole traversal propagates. succinctly instead discarded that node's own
partial `f` output entirely.

```
$ echo '{"a":1,"b":2}' | jq -c 'recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end)'
jq: error (at <stdin>:1): Cannot index number with number
{"a":1,"b":2}
1
$ echo '{"a":1,"b":2}' | succinctly jq -c 'recurse(if . == {"a":1,"b":2} then (.a, .b[0]) else empty end)'
jq: error (at <stdin>:1): Cannot index number with number
{"a":1,"b":2}     # (before this fix — dropped the `1`)
```

Both repros in the issue (value position and `path(recurse(...))`) now
match real jq exactly.

### Root cause and fix

`resolve_recurse`/`builtin_recurse_f`/`builtin_recurse_cond` treated `f`'s
own multi-output evaluation as all-or-nothing via `eval_owned_multi`'s
`Partial(_, Control::Error(e)) => Err(e.into())` arm, which is the *correct*
contract for every other caller of that shared helper (~15 call sites) but
wrong for `recurse`'s own children-evaluation step.

Rather than changing `eval_owned_multi`'s shared contract (used by ~15 other
call sites — this repo has been burned before by a shared-function change
with unintended blast radius, issue #682), this adds
`eval_owned_multi_keep_partial`: a new, recurse-scoped sibling that preserves
the prefix instead of discarding it. `eval_owned_multi` itself is untouched.

Empirically, real jq's behavior is more subtle than "just fold the partial
prefix into outputs": a successfully-produced child from `f`'s own fan-out
gets its *entire* recursive subtree visited (not just the bare value) before
the deferred error propagates. Confirmed live:

```
$ echo '{"child":{"child":"leaf","leafflag":true},"bad":3}' | jq -c \
    'recurse(if (.|type)=="object" then (.child, .bad[0]) else empty end)'
jq: error (at <stdin>:1): Cannot index number with number
{"child":{"child":"leaf","leafflag":true},"bad":3}
{"child":"leaf","leafflag":true}
"leaf"
null
```

Both evaluators now use a `pending_error` that, once set, replaces the outer
stack (nothing queued before that point may run once an escape is pending —
jq's error/break/halt aborts the *entire* remaining traversal, not just the
current node) and keeps draining until the stack empties, deferring the
raise until then. The same treatment applies uniformly to `error`, `break`,
and `halt` (verified against jq 1.7.1 for all three).

### Scope

- `cond`'s own error-handling arm (in both evaluators) is left untouched —
  it's a structurally similar but separate, unreported class of bug (an
  eager per-node batch over `cond`-checked children that can itself drop an
  already-approved prefix on a *later* `cond` error), and #842 is
  specifically about `f`'s own fan-out. Noted inline at both sites for a
  future issue if it's worth filing separately.
- `eval_owned_multi`/`resolve_against_cow`'s existing contracts for their
  other ~15 call sites are unchanged.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against pinned real `jq` 1.7.1 directly for: the issue's
      two repros, a deeper nested-subtree case, a `break` case, and a `halt`
      case — all match
- [x] New unit tests in `src/jq/eval.rs` (`*_842`): value position, path
      position, `cond` present, nested subtree, `break`
- [x] New CLI/golden tests in `tests/jq_cli_tests.rs` (`*_842`) mirroring the
      issue's repros end-to-end through the CLI binary

Fixes #842