### PR TITLE
fix(jq): abort paths(node_filter) on a per-node error/break instead of swallowing it

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14985,13 +14985,22 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // later filtered out of the result (`length > 0`); confirmed live:
     // `1 | [paths(error("x"))]` raises in real jq, though a scalar has no
     // non-root paths at all. The loop below only visits non-root paths, so
-    // without this, `paths(halt_error(3))` on a scalar/null/empty container
-    // never runs `filter` at all. Only the halt case is fixed here, matching
-    // the existing per-path "every other error is pre-existing, silently
-    // swallowed behavior this fix does not change" policy below, applied
-    // consistently to the root (#791).
-    if let Err(EvalEscape::Halt(code)) = eval_owned_expr::<S>(filter, &owned, optional) {
-        return QueryResult::Halt(code);
+    // without this, `paths(node_filter)` on a scalar/null/empty container
+    // never runs `filter` at all -- and (#850) even on a non-empty root, an
+    // error/break on the root itself must abort before any non-root path is
+    // produced, not just be missed. Nothing has been credited to
+    // `filtered_paths` yet at this point, so any escape here is a bare
+    // `Error`/`Break`/`Halt`, never a `Partial`. Uses `eval_owned_expr_ctrl`
+    // rather than its `eval_owned_expr` twin specifically for the `break`
+    // case: the latter collapses `Control::Break` into a synthetic "not in
+    // label" `EvalError` (see #833), which would make `label $out |
+    // [paths(break $out)]` on a scalar report a bogus error instead of
+    // unwinding to `$out`. Confirmed against jq 1.7.1: `{"a":1} |
+    // paths(if type=="object" then error("x") else true end)` raises
+    // immediately with no output (not `["a"]`), and `label $out |
+    // [paths(break $out)]` on `1` produces no output and exits 0.
+    if let Err(control) = eval_owned_expr_ctrl::<S>(filter, &owned, optional) {
+        return partial(Vec::new(), control);
     }
 
     let mut all_paths = Vec::new();

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15031,22 +15031,29 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // true end)` streams `[0]`, `[1]`, then raises -- not just
                 // `[0]`.
                 //
-                // Once credited, `halt` propagates out of the whole builtin
-                // (#791, nothing may catch it); an ordinary error/break is
-                // swallowed and the loop moves to the next node instead --
-                // a pre-existing, documented divergence from real jq (which
-                // aborts the entire `paths(...)` call on an uncaught
-                // error/break, filed as a follow-up gap, #850) that this
-                // fix does not change. `break` specifically can never
-                // resolve to an outer `label` here regardless:
-                // `val_at_path` is re-indexed into an isolated synthetic
-                // document and evaluated on its own, so a `label` lexically
-                // enclosing the original `paths(...)` call is not part of
-                // the AST being evaluated. Real propagation would need
-                // `filter` resolved through `resolve_node`'s own machinery
-                // instead (as #824 did for its sites); tracked separately
-                // for every remaining `eval_owned_expr`-shaped call site,
-                // `paths(node_filter)` included, under #833.
+                // Once credited, any control signal -- `halt` (#791), or an
+                // ordinary error/break -- aborts the whole builtin instead of
+                // being swallowed and moving on to the next node (#850).
+                // This matches real jq: `paths(node_filter)` is
+                // `path(recurse|select(node_filter))`, and an uncaught
+                // error/break inside `select`'s fan-out aborts the entire
+                // generator, not just the current node. Confirmed against jq
+                // 1.7.1: `[1,"x",2] | paths(if type=="string" then
+                // error("bad") else true end)` streams `[0]` then raises,
+                // never reaching index 2. `break $label` also now correctly
+                // unwinds to a `label` lexically enclosing the whole
+                // `paths(...)` call: unlike `result_to_owned`/`eval_owned_expr`
+                // (the helpers #833 is about), `eval_owned_input` never
+                // collapses `Control::Break` into a "not in label" error --
+                // `push_truthiness` already threads it through intact, so
+                // once this loop stops swallowing it, propagation just
+                // works. Confirmed: `label $out | paths(if type=="string"
+                // then break $out else true end)` on `[1,"x",2]` now matches
+                // real jq exactly (streams `[0]`, exit 0), including when
+                // the matching node is nested. This does not extend to
+                // `path(paths(node_filter))` -- wrapping this builtin's own
+                // output in `path(...)`'s trackable-path machinery is a
+                // separate, still-open divergence (filed as #861).
                 //
                 // `optional` (this builtin's own parameter, not a
                 // hardcoded `false`) must reach this per-node evaluation
@@ -15071,11 +15078,9 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         filtered_paths.push(path.clone());
                     }
                 }
-                if let Some(Control::Halt(code)) = control {
-                    return partial(filtered_paths, Control::Halt(code));
+                if let Some(control) = control {
+                    return partial(filtered_paths, control);
                 }
-                // Error/Break: the prefix above is already credited;
-                // swallow the escape itself and move to the next node.
             }
         }
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7392,18 +7392,16 @@ fn test_paths_filter_propagates_halt_from_non_root_path() -> Result<()> {
     Ok(())
 }
 
-/// Companion to the halt test above: proves the refactor's
-/// `Err(EvalEscape::Error(_)) => {}` arm still keeps the pre-existing (and,
-/// per its own comment, intentionally jq-divergent) policy of silently
-/// skipping a node whose filter errors ordinarily, rather than aborting
-/// the whole `paths` call -- unlike halt, this does not escape. Verified
-/// against real jq 1.7.1 that this is a genuine divergence, not something
-/// this test should expect to match: `[1,"x",2] | paths(if type=="string"
-/// then error("bad") else true end)` raises in real jq (its `paths`
-/// streams `[0]` first, then errors), while succinctly silently drops the
-/// string element's path and keeps every other match.
+/// Companion to the halt test above, now pinning #850's fix: an ordinary
+/// per-node error/break aborts the whole `paths` call instead of being
+/// swallowed and moving on to the next node -- matching real jq exactly,
+/// since `paths(node_filter)` is `path(recurse|select(node_filter))` and an
+/// uncaught error/break inside `select`'s fan-out aborts the entire
+/// generator. Verified against real jq 1.7.1: `[1,"x",2] | paths(if
+/// type=="string" then error("bad") else true end)` streams `[0]`, then
+/// raises without ever reaching index 2.
 #[test]
-fn test_paths_filter_still_swallows_ordinary_per_path_error() -> Result<()> {
+fn test_paths_filter_aborts_on_ordinary_per_path_error() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
@@ -7411,9 +7409,9 @@ fn test_paths_filter_still_swallows_ordinary_per_path_error() -> Result<()> {
         ],
         Some(r#"[1,"x",2]"#),
     )?;
-    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "[0]\n[2]\n");
-    assert_eq!(stderr, "");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0]\n");
+    assert_eq!(stderr, "jq: error (at <stdin>:0): bad\n");
     Ok(())
 }
 
@@ -7503,11 +7501,9 @@ fn test_paths_filter_mixed_truthy_falsy_keeps_path_once() -> Result<()> {
 /// it. Confirmed against real jq 1.7.1: `[1,"x",2] | paths(if
 /// type=="string" then (true, error("bad")) else true end)` streams `[0]`
 /// then `[1]` before raising -- the truthy output preceding the error is
-/// not discarded. succinctly's own pre-existing (and intentionally
-/// jq-divergent, see `test_paths_filter_still_swallows_ordinary_per_path_error`
-/// above) policy is to swallow an ordinary per-node error and continue to
-/// the next node rather than aborting the whole `paths` call, so the
-/// expected succinctly output here also includes `[2]`.
+/// not discarded. Since #850, succinctly also aborts the whole `paths`
+/// call on that same error rather than continuing to the next node, so
+/// index 2 (`[2]`) is never reached, matching real jq exactly.
 #[test]
 fn test_paths_filter_keeps_truthy_prefix_before_ordinary_error() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -7517,9 +7513,9 @@ fn test_paths_filter_keeps_truthy_prefix_before_ordinary_error() -> Result<()> {
         ],
         Some(r#"[1,"x",2]"#),
     )?;
-    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "[0]\n[1]\n[2]\n");
-    assert_eq!(stderr, "");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0]\n[1]\n");
+    assert_eq!(stderr, "jq: error (at <stdin>:0): bad\n");
     Ok(())
 }
 
@@ -7545,17 +7541,17 @@ fn test_paths_filter_keeps_truthy_prefix_before_halt() -> Result<()> {
 }
 
 /// Same regression again, but for `break`: a truthy output preceding a
-/// `break $label` within one node's fan-out must still be reported. Unlike
-/// real jq (whose closures resolve a label lexically enclosing the
-/// `paths(...)` call, so `break` there aborts the whole computation
-/// cleanly), succinctly's per-node filter evaluation re-indexes the value
-/// into an isolated synthetic document (`eval_owned_input`) that cannot
-/// resolve a label from the caller's outer scope -- the label lookup fails
-/// and is treated as an ordinary error (same swallow-and-continue policy
-/// as the plain-error test above), a pre-existing, unrelated limitation
-/// this fix does not change. What this test pins is narrower: the truthy
-/// prefix produced before that failed `break` must still be kept, not
-/// dropped along with it.
+/// `break $label` within one node's fan-out must still be reported, and
+/// (since #850) the `break` itself now correctly unwinds to a `label`
+/// lexically enclosing the whole `paths(...)` call instead of being
+/// swallowed and treated as an ordinary per-node error. Unlike
+/// `result_to_owned`/`eval_owned_expr` (see #833), `eval_owned_input` never
+/// collapses `Control::Break` into a "not in label" error, so once
+/// `builtin_paths_filter`'s loop stopped swallowing every non-halt control
+/// signal, propagation to the outer label just worked. Confirmed against
+/// real jq 1.7.1: `label $out | paths(if type=="string" then (true, break
+/// $out) else true end)` on `[1,"x",2]` streams `[0]` then `[1]` before the
+/// break unwinds, exiting 0 -- index 2 is never reached.
 #[test]
 fn test_paths_filter_keeps_truthy_prefix_before_break() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -7566,7 +7562,7 @@ fn test_paths_filter_keeps_truthy_prefix_before_break() -> Result<()> {
         Some(r#"[1,"x",2]"#),
     )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "[0]\n[1]\n[2]\n");
+    assert_eq!(stdout, "[0]\n[1]\n");
     assert_eq!(stderr, "");
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3276,6 +3276,65 @@ fn test_paths_filter_halt_on_scalar_root() -> Result<()> {
     Ok(())
 }
 
+/// Companion to the halt test above (#850): an ordinary error on the root
+/// itself must also abort the whole builtin, matching real jq. Before this
+/// fix, `builtin_paths_filter`'s root-value precheck only special-cased
+/// `Halt` -- an `Error` or `Break` from evaluating `filter` against the
+/// root fell through silently, so the root's own escape was discarded
+/// entirely rather than just missing (unlike the halt case, which at least
+/// never ran `filter` on the root at all for a scalar/empty-container
+/// input). Verified against jq 1.7.1: `1 | [paths(error("x"))]` raises
+/// immediately with no output.
+#[test]
+fn test_paths_filter_aborts_on_scalar_root_error() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "1 | [paths(error(\"x\"))]"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "jq: error (at <unknown>): x\n");
+    Ok(())
+}
+
+/// Sharper than the scalar-root case above: here the root filter's error is
+/// reached only via a `node_filter` that also matches a legitimate child
+/// path (`"a"`), so a swallowed root error wouldn't just be a missing
+/// error -- it would produce *wrong* output (`["a"]`) as if the root's own
+/// escape had never happened. Verified against jq 1.7.1: `{"a":1} |
+/// paths(if type=="object" then error("root-err") else true end)` raises
+/// immediately, never reaching the child path at all.
+#[test]
+fn test_paths_filter_root_error_aborts_before_child_paths() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"paths(if type=="object" then error("root-err") else true end)"#,
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "jq: error (at <stdin>:0): root-err\n");
+    Ok(())
+}
+
+/// Same root-level fix, but for `break`: unlike an ordinary error, a `break
+/// $label` from the root's own `node_filter` evaluation must unwind to an
+/// enclosing `label`, not surface as any kind of error. This specifically
+/// exercises why the root precheck uses `eval_owned_expr_ctrl` rather than
+/// `eval_owned_expr`: the latter collapses `Control::Break` into a
+/// synthetic "break $label not in label" `EvalError` (#833), which would
+/// make this case report a bogus error instead of unwinding cleanly.
+/// Verified against jq 1.7.1: `label $out | 1 | [paths(break $out)]`
+/// produces no output and exits 0.
+#[test]
+fn test_paths_filter_root_break_unwinds_to_outer_label() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "label $out | 1 | [paths(break $out)]"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
 #[test]
 fn test_halt_error_negative_exit_code_floors_to_zero() -> Result<()> {
     // Real jq clamps any negative `halt_error(n)` argument to exit code 0,
@@ -7394,12 +7453,10 @@ fn test_paths_filter_propagates_halt_from_non_root_path() -> Result<()> {
 
 /// Companion to the halt test above, now pinning #850's fix: an ordinary
 /// per-node error/break aborts the whole `paths` call instead of being
-/// swallowed and moving on to the next node -- matching real jq exactly,
-/// since `paths(node_filter)` is `path(recurse|select(node_filter))` and an
-/// uncaught error/break inside `select`'s fan-out aborts the entire
-/// generator. Verified against real jq 1.7.1: `[1,"x",2] | paths(if
-/// type=="string" then error("bad") else true end)` streams `[0]`, then
-/// raises without ever reaching index 2.
+/// swallowed and moving on to the next node (see `builtin_paths_filter`'s
+/// own comment for why this matches real jq). Verified against real jq
+/// 1.7.1: `[1,"x",2] | paths(if type=="string" then error("bad") else true
+/// end)` streams `[0]`, then raises without ever reaching index 2.
 #[test]
 fn test_paths_filter_aborts_on_ordinary_per_path_error() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -7502,8 +7559,9 @@ fn test_paths_filter_mixed_truthy_falsy_keeps_path_once() -> Result<()> {
 /// type=="string" then (true, error("bad")) else true end)` streams `[0]`
 /// then `[1]` before raising -- the truthy output preceding the error is
 /// not discarded. Since #850, succinctly also aborts the whole `paths`
-/// call on that same error rather than continuing to the next node, so
-/// index 2 (`[2]`) is never reached, matching real jq exactly.
+/// call on that same error rather than continuing to the next node (see
+/// `builtin_paths_filter`'s own comment), so index 2 (`[2]`) is never
+/// reached, matching real jq exactly.
 #[test]
 fn test_paths_filter_keeps_truthy_prefix_before_ordinary_error() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -7544,14 +7602,12 @@ fn test_paths_filter_keeps_truthy_prefix_before_halt() -> Result<()> {
 /// `break $label` within one node's fan-out must still be reported, and
 /// (since #850) the `break` itself now correctly unwinds to a `label`
 /// lexically enclosing the whole `paths(...)` call instead of being
-/// swallowed and treated as an ordinary per-node error. Unlike
-/// `result_to_owned`/`eval_owned_expr` (see #833), `eval_owned_input` never
-/// collapses `Control::Break` into a "not in label" error, so once
-/// `builtin_paths_filter`'s loop stopped swallowing every non-halt control
-/// signal, propagation to the outer label just worked. Confirmed against
-/// real jq 1.7.1: `label $out | paths(if type=="string" then (true, break
-/// $out) else true end)` on `[1,"x",2]` streams `[0]` then `[1]` before the
-/// break unwinds, exiting 0 -- index 2 is never reached.
+/// swallowed and treated as an ordinary per-node error (see
+/// `builtin_paths_filter`'s own comment for why this works without needing
+/// #833's broader fix). Confirmed against real jq 1.7.1: `label $out |
+/// paths(if type=="string" then (true, break $out) else true end)` on
+/// `[1,"x",2]` streams `[0]` then `[1]` before the break unwinds, exiting 0
+/// -- index 2 is never reached.
 #[test]
 fn test_paths_filter_keeps_truthy_prefix_before_break() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(


### PR DESCRIPTION
## Summary

- `builtin_paths_filter` (`src/jq/eval.rs`) evaluated `node_filter` once per node visited by `paths(node_filter)`'s traversal. When that evaluation ended in an ordinary `error(...)` or an unresolvable `break $label`, the previous policy silently swallowed the escape and skipped only that one node, continuing to evaluate every remaining node.
- Real jq's `paths(node_filter)` is `path(recurse|select(node_filter))`, and an uncaught `error`/`break` inside `select(node_filter)` aborts the *entire* `path(...)` generator, not just the current node.
- The fix: once a per-node filter evaluation's already-truthy prefix is credited, propagate *any* control signal (`Error`, `Break`, or `Halt`) as a `Partial` — not just `Halt` as before — matching real jq's abort-the-whole-call behavior exactly, including exit code and stderr text.
- As a side effect, this also fixes `break $label` correctly unwinding to a `label` lexically enclosing the whole `paths(...)` call — the old swallow-and-continue policy applied uniformly to `Error` and `Break`, so `break` was never actually failing to resolve the label (a prior code comment misattributed this to a `resolve_node`/AST-position limitation); `eval_owned_input` already threads `Control::Break` through intact via `push_truthiness`.
- **Follow-up commit (review-driven):** the same function's *root-value* precheck (evaluating `node_filter` against `.` itself, since `recurse` always visits the root first) still only special-cased `Halt` — an ordinary error/break on the root fell through silently, which is worse than a missed error when the root also matches a legitimate child path (the child's path would leak into output as if the root's escape never happened). Fixed by switching that precheck from `eval_owned_expr` to its `Control`-preserving twin `eval_owned_expr_ctrl` (the same pattern #575 already established for `while`/`until`/`repeat`/`reduce`/`foreach`), so `break` correctly unwinds to an outer `label` there too instead of being collapsed into a synthetic "not in label" error (`eval_owned_expr`'s behavior, see #833).
- Verified against real jq 1.7.1 for every case: plain error, error with a truthy prefix, break with a truthy prefix, nested-node break, root-level error (both empty and non-empty root), and root-level break — all now match jq's stdout/stderr/exit code exactly.
- While verifying, found three separate pre-existing issues, all out of scope here and filed as follow-ups:
  - #861 — `path(paths(node_filter))` (wrapping this builtin in `path(...)`'s own trackable-path machinery) still diverges from jq.
  - #867 — `isvalid(...)` swallows an unresolved `break $label` as `true` instead of letting it unwind (a dormant gap now reachable through `paths(...)` since `Break` correctly propagates out of this builtin).
  - #868 — `paths`/`paths(node_filter)` in yq mode silently drop duplicate YAML mapping keys that identity output preserves (same root-cause class as the closed #631, different call site).

Fixes #850

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 2397+ tests green; two unrelated pre-existing flakes from concurrent-session file-lock contention confirmed to pass in isolation)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against pinned real `jq` 1.7.1 directly for every changed/added test case (error, error-with-prefix, break, break-with-prefix, nested-node break, scalar-root error, object-root error before child paths, root break-to-label) — all match exactly, including exit codes and stderr text
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — 100% patch coverage (2/2 new executable lines covered)
- [x] Independent multi-agent code review (5 angles) on the first commit; the one substantive finding (root-precheck gap) verified and fixed in the second commit