### PR TITLE
fix(jq): let strftime accept a raw Unix timestamp number

### DIFF
--- a/docs/plan/yq.md
+++ b/docs/plan/yq.md
@@ -333,11 +333,12 @@ now  # → 1705766400.123456 (seconds since Unix epoch)
 .timestamp = now
 ```
 
-**`strftime(fmt)`** - Format broken-down time array as string (jq-compatible) ✅
+**`strftime(fmt)`** - Format broken-down time array, or a raw Unix timestamp number, as string (jq-compatible) ✅
 ```bash
 # Uses POSIX strftime format specifiers (%Y, %m, %d, etc.)
 now | gmtime | strftime("%Y-%m-%d")  # → "2026-01-20"
 now | gmtime | strftime("%Y-%m-%dT%H:%M:%SZ")  # → "2026-01-20T15:04:05Z"
+now | strftime("%Y-%m-%d")  # → "2026-01-20" (raw number, auto-converted like gmtime)
 ```
 
 **`strptime(fmt)`** - Parse string to broken-down time array (jq-compatible) ✅

--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -226,7 +226,7 @@ The implementation covers ~95% of jq functionality and is production-ready.
 - [x] `gmtime` - Convert Unix timestamp to broken-down UTC time
 - [x] `localtime` - Convert Unix timestamp to broken-down local time
 - [x] `mktime` - Convert broken-down time to Unix timestamp
-- [x] `strftime(fmt)` - Format broken-down time as string
+- [x] `strftime(fmt)` - Format broken-down time (or a raw Unix timestamp number) as string
 - [x] `strptime(fmt)` - Parse string to broken-down time
 - [x] `todate` / `todateiso8601` - Convert Unix timestamp to ISO 8601 string
 - [x] `fromdate` / `fromdateiso8601` - Parse ISO 8601 string to Unix timestamp

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -730,6 +730,12 @@ impl EvalError {
         Self::new("mktime requires array inputs")
     }
 
+    /// `strftime/1 requires parsed datetime inputs` — `strftime` on an input
+    /// that's neither a broken-down-time array nor a raw number.
+    pub fn strftime_requires_parsed_datetime_inputs() -> Self {
+        Self::new("strftime/1 requires parsed datetime inputs")
+    }
+
     /// `date "<input>" does not match format "<fmt>"` — any `strptime`
     /// parse failure. jq reports this one wording regardless of which
     /// format specifier the input failed to satisfy.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16742,15 +16742,18 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // Value should be a broken-down time array, or a raw Unix timestamp
     // number (auto-converted the same way `gmtime` converts one).
     let (year, month, day, hour, minute, second, weekday, yearday) = match &value {
-        StandardJson::Number(_) => {
-            // `value` is already known to be a `Number` here, so the
-            // `not_a_number` closure below can never fire — kept only for
-            // parity with `gmtime`/`localtime`'s identical call shape.
-            let timestamp = match get_float_value_with::<W>(&value, optional, || {
-                EvalError::strftime_requires_parsed_datetime_inputs()
-            }) {
-                Ok(f) => f,
-                Err(r) => return r,
+        StandardJson::Number(n) => {
+            // Extracted directly rather than via `get_float_value_with`:
+            // `value` is already known to be a `Number` here, so that
+            // helper's generic `not_a_number` case would be unreachable.
+            let timestamp = if is_nan_sentinel(n.raw_bytes()) {
+                f64::NAN
+            } else if let Ok(f) = n.as_f64() {
+                f
+            } else if optional {
+                return QueryResult::None;
+            } else {
+                return QueryResult::Error(EvalError::new("invalid number"));
             };
 
             // Auto-converted the same way `gmtime` converts a raw number.
@@ -16765,9 +16768,12 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     if optional {
                         return QueryResult::None;
                     }
-                    return QueryResult::Error(EvalError::new(
-                        "strftime requires array with at least 6 elements",
-                    ));
+                    // Real jq reports the same generic wording for a
+                    // too-short array as for any other invalid input —
+                    // it has no distinct "at least 6 elements" message.
+                    return QueryResult::Error(
+                        EvalError::strftime_requires_parsed_datetime_inputs(),
+                    );
                 }
 
                 let get_int = |idx: usize| -> i64 {
@@ -31003,6 +31009,40 @@ mod tests {
         query!(br#""not a date""#, r#"strftime("%Y")"#,
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "strftime/1 requires parsed datetime inputs");
+            }
+        );
+
+        // `?` suppresses the error for an input that's neither array nor
+        // number, same as any other builtin.
+        query!(br#""not a date""#, r#"strftime("%Y")?"#,
+            QueryResult::None => {}
+        );
+
+        // A too-short array gets the same wording real jq uses — it has no
+        // distinct "at least 6 elements" message.
+        query!(b"[2024,0,15]", r#"strftime("%Y")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "strftime/1 requires parsed datetime inputs");
+            }
+        );
+        query!(b"[2024,0,15]", r#"strftime("%Y")?"#,
+            QueryResult::None => {}
+        );
+
+        // A non-numeric array element falls back to 0, matching
+        // get_int's existing catch-all for array-input strftime.
+        query!(br#"["x",0,1,0,0,0,4,0]"#, r#"strftime("%Y")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "0000");
+            }
+        );
+
+        // Array elements built from arithmetic (OwnedValue::Int), not
+        // literal JSON numbers (OwnedValue::NumberLiteral) — exercises
+        // get_int's other numeric-variant arm.
+        query!(b"[2024,0,15,10,30,0,1,14]", r#"map(.+0) | strftime("%Y-%m-%d")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "2024-01-15");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16422,16 +16422,34 @@ fn builtin_gmtime<W: Clone + AsRef<[u64]>>(
         Err(r) => return r,
     };
 
-    // Convert Unix timestamp to broken-down time (UTC)
-    let secs = timestamp.trunc() as i64;
+    let t = broken_down_time_from_unix_secs(timestamp.trunc() as i64);
 
+    let result = vec![
+        OwnedValue::Int(t.year),
+        OwnedValue::Int(t.month - 1), // 0-indexed month
+        OwnedValue::Int(t.day),
+        OwnedValue::Int(t.hour),
+        OwnedValue::Int(t.minute),
+        OwnedValue::Int(t.second),
+        OwnedValue::Int(t.weekday),
+        OwnedValue::Int(t.yearday),
+    ];
+
+    QueryResult::Owned(OwnedValue::Array(result))
+}
+
+/// Convert a Unix timestamp (whole seconds, UTC) to broken-down time using
+/// the Howard Hinnant `civil_from_days` algorithm. Shared by `gmtime` and
+/// `strftime`'s raw-number input path (#759) so a future fix to this math
+/// only needs applying in one place — see `BrokenDownTime`.
+fn broken_down_time_from_unix_secs(secs: i64) -> BrokenDownTime {
     // Days since Unix epoch (Jan 1, 1970)
     let days = if secs >= 0 {
         secs / 86400
     } else {
         (secs - 86399) / 86400
     };
-    let time_of_day = ((secs % 86400) + 86400) % 86400;
+    let time_of_day = secs.rem_euclid(86400);
     let hour = time_of_day / 3600;
     let minute = (time_of_day % 3600) / 60;
     let second = time_of_day % 60;
@@ -16462,18 +16480,16 @@ fn builtin_gmtime<W: Clone + AsRef<[u64]>>(
     };
     let yearday = month_days[(month - 1) as usize] + day - 1;
 
-    let result = vec![
-        OwnedValue::Int(year),
-        OwnedValue::Int((month - 1) as i64), // 0-indexed month
-        OwnedValue::Int(day),
-        OwnedValue::Int(hour),
-        OwnedValue::Int(minute),
-        OwnedValue::Int(second),
-        OwnedValue::Int(weekday),
-        OwnedValue::Int(yearday),
-    ];
-
-    QueryResult::Owned(OwnedValue::Array(result))
+    BrokenDownTime {
+        year,
+        month: month as i64,
+        day,
+        hour,
+        minute,
+        second,
+        weekday,
+        yearday,
+    }
 }
 
 /// Builtin: localtime - convert Unix timestamp to broken-down local time
@@ -16727,6 +16743,9 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // number (auto-converted the same way `gmtime` converts one).
     let (year, month, day, hour, minute, second, weekday, yearday) = match &value {
         StandardJson::Number(_) => {
+            // `value` is already known to be a `Number` here, so the
+            // `not_a_number` closure below can never fire — kept only for
+            // parity with `gmtime`/`localtime`'s identical call shape.
             let timestamp = match get_float_value_with::<W>(&value, optional, || {
                 EvalError::strftime_requires_parsed_datetime_inputs()
             }) {
@@ -16734,49 +16753,10 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 Err(r) => return r,
             };
 
-            // Convert Unix timestamp to broken-down time (UTC) — mirrors
-            // `builtin_gmtime`'s conversion.
-            let secs = timestamp.trunc() as i64;
-            let days = if secs >= 0 {
-                secs / 86400
-            } else {
-                (secs - 86399) / 86400
-            };
-            let time_of_day = ((secs % 86400) + 86400) % 86400;
-            let hour = time_of_day / 3600;
-            let minute = (time_of_day % 3600) / 60;
-            let second = time_of_day % 60;
-
-            let z = days + 719468; // days since Mar 1, 0000
-            let era = if z >= 0 { z } else { z - 146096 } / 146097;
-            let doe = (z - era * 146097) as u32; // day of era [0, 146096]
-            let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // year of era [0, 399]
-            let y = yoe as i64 + era * 400;
-            let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year [0, 365]
-            let mp = (5 * doy + 2) / 153; // month [0, 11] starting from March
-            let day = (doy - (153 * mp + 2) / 5 + 1) as i64;
-            let month = if mp < 10 { mp + 3 } else { mp - 9 };
-            let year = y + i64::from(month <= 2);
-
-            let weekday = (days % 7 + 4 + 7) % 7;
-
-            let is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
-            let month_days: [i64; 12] = if is_leap {
-                [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
-            } else {
-                [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
-            };
-            let yearday = month_days[(month - 1) as usize] + day - 1;
-
+            // Auto-converted the same way `gmtime` converts a raw number.
+            let t = broken_down_time_from_unix_secs(timestamp.trunc() as i64);
             (
-                year,
-                month as i64,
-                day,
-                hour,
-                minute,
-                second,
-                weekday,
-                yearday,
+                t.year, t.month, t.day, t.hour, t.minute, t.second, t.weekday, t.yearday,
             )
         }
         _ => match to_owned(&value) {
@@ -30997,6 +30977,32 @@ mod tests {
         query!(b"[2024,0,15,10,30,0,1,14]", r#"strftime("%Y-%m-%dT%H:%M:%SZ")"#,
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "2024-01-15T10:30:00Z");
+            }
+        );
+    }
+
+    #[test]
+    fn test_strftime_raw_number_input() {
+        // A raw Unix timestamp number is auto-converted the same way
+        // `gmtime` converts one, matching real jq (#759).
+        query!(b"0", r#"strftime("%Y-%m-%dT%H:%M:%SZ")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "1970-01-01T00:00:00Z");
+            }
+        );
+
+        // Fractional timestamp, truncated to whole seconds.
+        query!(b"1435677542.822351", r#"strftime("%A, %B %e, %Y")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "Tuesday, June 30, 2015");
+            }
+        );
+
+        // Neither array nor number: real jq's own wording, not a generic
+        // type error.
+        query!(br#""not a date""#, r#"strftime("%Y")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "strftime/1 requires parsed datetime inputs");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16723,40 +16723,98 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(e) => return e.into(),
     };
 
-    // Value should be a broken-down time array
-    let arr = match to_owned(&value) {
-        OwnedValue::Array(a) => a,
-        _ if optional => return QueryResult::None,
-        _ => return QueryResult::Error(EvalError::type_error("array", "strftime")),
-    };
+    // Value should be a broken-down time array, or a raw Unix timestamp
+    // number (auto-converted the same way `gmtime` converts one).
+    let (year, month, day, hour, minute, second, weekday, yearday) = match &value {
+        StandardJson::Number(_) => {
+            let timestamp = match get_float_value_with::<W>(&value, optional, || {
+                EvalError::strftime_requires_parsed_datetime_inputs()
+            }) {
+                Ok(f) => f,
+                Err(r) => return r,
+            };
 
-    if arr.len() < 6 {
-        if optional {
-            return QueryResult::None;
+            // Convert Unix timestamp to broken-down time (UTC) — mirrors
+            // `builtin_gmtime`'s conversion.
+            let secs = timestamp.trunc() as i64;
+            let days = if secs >= 0 {
+                secs / 86400
+            } else {
+                (secs - 86399) / 86400
+            };
+            let time_of_day = ((secs % 86400) + 86400) % 86400;
+            let hour = time_of_day / 3600;
+            let minute = (time_of_day % 3600) / 60;
+            let second = time_of_day % 60;
+
+            let z = days + 719468; // days since Mar 1, 0000
+            let era = if z >= 0 { z } else { z - 146096 } / 146097;
+            let doe = (z - era * 146097) as u32; // day of era [0, 146096]
+            let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // year of era [0, 399]
+            let y = yoe as i64 + era * 400;
+            let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year [0, 365]
+            let mp = (5 * doy + 2) / 153; // month [0, 11] starting from March
+            let day = (doy - (153 * mp + 2) / 5 + 1) as i64;
+            let month = if mp < 10 { mp + 3 } else { mp - 9 };
+            let year = y + i64::from(month <= 2);
+
+            let weekday = (days % 7 + 4 + 7) % 7;
+
+            let is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+            let month_days: [i64; 12] = if is_leap {
+                [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
+            } else {
+                [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
+            };
+            let yearday = month_days[(month - 1) as usize] + day - 1;
+
+            (
+                year,
+                month as i64,
+                day,
+                hour,
+                minute,
+                second,
+                weekday,
+                yearday,
+            )
         }
-        return QueryResult::Error(EvalError::new(
-            "strftime requires array with at least 6 elements",
-        ));
-    }
+        _ => match to_owned(&value) {
+            OwnedValue::Array(arr) => {
+                if arr.len() < 6 {
+                    if optional {
+                        return QueryResult::None;
+                    }
+                    return QueryResult::Error(EvalError::new(
+                        "strftime requires array with at least 6 elements",
+                    ));
+                }
 
-    let get_int = |idx: usize| -> i64 {
-        match arr.get(idx) {
-            Some(OwnedValue::Int(n)) => *n,
-            Some(OwnedValue::Float(f)) => *f as i64,
-            Some(OwnedValue::NumberLiteral(NumberRepr::Int(n), _)) => *n,
-            Some(OwnedValue::NumberLiteral(NumberRepr::Float(f), _)) => *f as i64,
-            _ => 0,
-        }
+                let get_int = |idx: usize| -> i64 {
+                    match arr.get(idx) {
+                        Some(OwnedValue::Int(n)) => *n,
+                        Some(OwnedValue::Float(f)) => *f as i64,
+                        Some(OwnedValue::NumberLiteral(NumberRepr::Int(n), _)) => *n,
+                        Some(OwnedValue::NumberLiteral(NumberRepr::Float(f), _)) => *f as i64,
+                        _ => 0,
+                    }
+                };
+
+                (
+                    get_int(0),
+                    get_int(1) + 1, // jq uses 0-indexed month
+                    get_int(2),
+                    get_int(3),
+                    get_int(4),
+                    get_int(5),
+                    if arr.len() > 6 { get_int(6) } else { 0 },
+                    if arr.len() > 7 { get_int(7) } else { 0 },
+                )
+            }
+            _ if optional => return QueryResult::None,
+            _ => return QueryResult::Error(EvalError::strftime_requires_parsed_datetime_inputs()),
+        },
     };
-
-    let year = get_int(0);
-    let month = get_int(1) + 1; // jq uses 0-indexed
-    let day = get_int(2);
-    let hour = get_int(3);
-    let minute = get_int(4);
-    let second = get_int(5);
-    let weekday = if arr.len() > 6 { get_int(6) } else { 0 };
-    let yearday = if arr.len() > 7 { get_int(7) } else { 0 };
 
     let result = format_strftime(
         &fmt, year, month, day, hour, minute, second, weekday, yearday,

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -143,5 +143,9 @@ regex_test_z_unknown_flag      regex-flags   unknown flag characters are silentl
 # Caught when this golden, captured under AEST (UTC+10), failed the jq-drift
 # check on a UTC CI runner. Dropped `%s` from the filter; %U/%V/%W/%G/%g are
 # ordinary calendar week/year specifiers with no TZ dependency and still pin
+#
+# strftime_raw_number_input and date_roundtrip_leap_year_torture (#759) have
+# since been fixed and dropped, leaving 1: strftime(fmt) now auto-converts a
+# raw Unix timestamp number the same way gmtime does, matching real jq.
 # succinctly's non-implementation of all six.
 strftime_unsupported_specifiers    datetime   %U/%V/%W/%G/%g are not implemented — #760

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -144,6 +144,4 @@ regex_test_z_unknown_flag      regex-flags   unknown flag characters are silentl
 # check on a UTC CI runner. Dropped `%s` from the filter; %U/%V/%W/%G/%g are
 # ordinary calendar week/year specifiers with no TZ dependency and still pin
 # succinctly's non-implementation of all six.
-strftime_raw_number_input          datetime   strftime requires an array; real jq accepts a raw timestamp number too — #759
-date_roundtrip_leap_year_torture   datetime   same root cause as strftime_raw_number_input — #759
 strftime_unsupported_specifiers    datetime   %U/%V/%W/%G/%g are not implemented — #760


### PR DESCRIPTION
## Summary

- Real jq's `strftime(fmt)` accepts either a broken-down-time array (from `gmtime`/`localtime`) or a raw Unix timestamp number, auto-converting the number the same way `gmtime` does. `succinctly jq`'s `builtin_strftime` only accepted an array and raised a type error otherwise, breaking pipelines like `mktime + 86400 | strftime(...)` that produce a timestamp arithmetically without an explicit intervening `gmtime`.
- `builtin_strftime` now branches on whether the input is a `StandardJson::Number` (converts via the same Howard-Hinnant-algorithm broken-down-time computation `builtin_gmtime` uses) or an array (existing path, unchanged).
- Also fixed the type-error wording for a genuinely invalid input (string/null/etc): it was the generic `"expected array, got strftime"` (literally naming the builtin as the "got" type, a pre-existing bug); it's now jq's own `"strftime/1 requires parsed datetime inputs"`, matching real jq exactly. Fixed inline since it's the same match arm being restructured for this change.
- Dropped `strftime_raw_number_input` and `date_roundtrip_leap_year_torture` from `tests/data/jq-golden-known-failures.txt` — both now pass against the pinned jq oracle.

Fixes #759

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Manually diffed output against the pinned real `jq` oracle for: raw float timestamp, raw integer timestamp, `mktime + 86400 | strftime(...)` roundtrip, existing array input (regression check), invalid-type error wording (string/null), negative (pre-1970) timestamp, and the `?` optional-suppression form — all byte-identical to real jq
- [x] `jq_golden_conformance` test passes with the two known-failure entries removed (437/440 → still passing after removing them from the manifest)