### PR TITLE
fix(cli): preserve YAML style and comments across path-mutation writes (#739)

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -773,25 +773,27 @@ fn walk_alias_groups<W: AsRef<[u64]> + Clone>(
 /// the YAML documents this rewrites are config-file-sized, not
 /// data-file-sized.
 ///
-/// **Known gap** (untested/unfiled - narrow enough not to warrant a
-/// precursor spike, but real): a *wholesale-replaced* `Array`/`Object`'s
-/// new elements/fields should get fresh (empty) metadata regardless of
-/// position/key, since they're new nodes real `yq`'s node-mutation model
-/// never touches - `.a = [4, 5, 6]` on `a: ['x', 'y', 'z']` should drop
-/// every element's quote style, and real `yq` does. But this function has
-/// no way to tell "recursing into an untouched sibling subtree" apart from
-/// "recursing into a wholesale-replaced subtree that happens to share
+/// **Known gap, filed as #870**: this function matches a child to
+/// its pristine counterpart purely by key/index, so any write that
+/// reshuffles an `Array`'s or `Object`'s *positions* - not just a
+/// wholesale replacement like `.a = [4, 5, 6]` on `a: ['x', 'y', 'z']`,
+/// but an everyday `.arr = ["new"] + .arr` prepend or a `del()` that
+/// shifts later indices down - misattributes old elements' style/comments
+/// to whichever new element now sits at the same key/index, instead of
+/// giving every element under the write fresh (empty) metadata the way
+/// real `yq`'s node-mutation model does (confirmed against the pinned
+/// binary: prepending to `arr:\n  - "x"\n  - y` should drop the new
+/// element's style entirely and leave `"x"`'s own quotes exactly where
+/// they were; this function instead lets the new element inherit `"x"`'s
+/// old quote style and leaves `"x"` unquoted). This function has no way
+/// to tell "recursing into an untouched sibling subtree" apart from
+/// "recursing into a reshuffled subtree that happens to share
 /// positions/keys with the old one" - both look identical from a pure
-/// before/after value diff, only a path-based approach (the
-/// `resolve_dynamic_indexes` alternative above) could distinguish them. So
-/// a child at a matching key/index keeps its own metadata even under a
-/// wholesale replacement, over-preserving style/comments there instead of
-/// resetting them (confirmed against real `yq`: `.a = {"x": "p"}` on
-/// `a: {x: 'old'}` should print `a: {x: p}`, prints `a: {x: 'p'}` here).
-/// Purely cosmetic (no data loss, no incorrect values, still strictly
+/// before/after value diff; only a path-based approach (the
+/// `resolve_dynamic_indexes` alternative above) could distinguish them.
+/// Purely cosmetic (no data loss, no incorrect *values*, still strictly
 /// better than every write losing all style/comments unconditionally,
-/// which was the pre-#739 baseline) - left as a documented limitation
-/// rather than filed as a tracked issue, since it's this narrow.
+/// which was the pre-#739 baseline).
 fn reconcile_presentation(
     pristine_value: &OwnedValue,
     pristine_tree: &CommentTree,
@@ -813,10 +815,18 @@ fn reconcile_presentation(
                 // line, not its value, so it survives regardless of
                 // whether the value under it changed - only a removed key
                 // (not iterated here, since this loop is over `r_fields`)
-                // drops it.
+                // drops it. The "deferred value materialized as nothing"
+                // flag, though, is re-derived from `r_v`, not copied from
+                // pristine: a write that gives the key a real value must
+                // not carry over a stale "absent" flag, or
+                // `key_comment_if_value_absent`'s own consumer
+                // (`emit_yaml_value`'s block-mapping arm) renders only the
+                // key and comment, silently dropping the write's value
+                // entirely (found in review).
                 if let CommentTree::Object(_, _, _, pristine_key_comments) = pristine_tree {
-                    if let Some(kc) = pristine_key_comments.get(k) {
-                        key_comments.insert(k.clone(), kc.clone());
+                    if let Some((kc, _)) = pristine_key_comments.get(k) {
+                        let value_absent = matches!(r_v, OwnedValue::Null);
+                        key_comments.insert(k.clone(), (kc.clone(), value_absent));
                     }
                 }
             }
@@ -1743,9 +1753,14 @@ fn can_single_quote(s: &str) -> bool {
 /// `CommentTree`'s own doc comment) falls back to the plain heuristic
 /// unchanged.
 fn yaml_quote_string_with_style(s: &str, style: &str) -> String {
-    if s.is_empty() {
-        return "''".to_string();
-    }
+    // No empty-string special case needed here (unlike `yaml_quote_string`
+    // below): every arm already renders `""` correctly on its own -
+    // `yaml_double_quote_escaped`/`yaml_single_quote_escaped` produce
+    // `""`/`''` for an empty `s`, and the `_` fallback defers to
+    // `yaml_quote_string`, which has its own empty-string case. A
+    // short-circuit here that always returned `''` regardless of `style`
+    // used to flip an untouched double-quoted empty string to single-quote
+    // style on a sibling write (found in review).
     match style {
         "single" if can_single_quote(s) => yaml_single_quote_escaped(s),
         "double" => yaml_double_quote_escaped(s),

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -468,6 +468,7 @@ fn evaluate_yaml_direct_filtered(
     doc_filter: Option<(usize, usize)>,
     sink: &mut ErrorSink,
     need_comments: bool,
+    strip_style: bool,
 ) -> Result<(Vec<Vec<ResultWithComments>>, usize)> {
     let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
     let root = index.root(bytes);
@@ -485,7 +486,8 @@ fn evaluate_yaml_direct_filtered(
                 };
 
                 if should_eval {
-                    let results = evaluate_yaml_cursor(cursor, expr, sink, need_comments)?;
+                    let results =
+                        evaluate_yaml_cursor(cursor, expr, sink, need_comments, strip_style)?;
                     // Only include documents that have results (select may filter them out)
                     if !results.is_empty() {
                         doc_results.push(results);
@@ -516,7 +518,13 @@ fn evaluate_yaml_direct_filtered(
 
             if should_eval {
                 if let Some(content_cursor) = root.first_child() {
-                    let results = evaluate_yaml_cursor(content_cursor, expr, sink, need_comments)?;
+                    let results = evaluate_yaml_cursor(
+                        content_cursor,
+                        expr,
+                        sink,
+                        need_comments,
+                        strip_style,
+                    )?;
                     Ok((vec![results], 1))
                 } else {
                     // Empty document
@@ -740,6 +748,106 @@ fn walk_alias_groups<W: AsRef<[u64]> + Clone>(
     }
 }
 
+/// Reconcile a pristine (pre-write) presentation tree against a post-write
+/// value (issue #739, ADR-0017's mechanism 1, applied to path-mutation
+/// queries: `=`, `|=`, `+=`, `del()`, ...).
+///
+/// Verified against the pinned real `yq` binary: a node keeps its own
+/// comment and style across a write as long as the write leaves it the
+/// same *kind* (`Object`/`Array`/scalar) — regardless of whether its
+/// *value* actually changed. `.b = 2` on `b: 1 # keep` still prints
+/// `b: 2 # keep`; `.a = "new"` on `a: 'old'` still prints `a: 'new'`
+/// (single-quote style survives even though the string content didn't).
+/// Real `yq`'s in-place node-mutation model (go-yaml) explains why: `Set`
+/// overwrites the existing `Node.Value` but never touches that node's own
+/// `Style`/`LineComment`. Only a kind change (scalar becomes a container or
+/// vice versa) discards them, since there's no such node to keep - matching
+/// `.a = {"x": 1}` on `a: 'old'` dropping the quote style entirely (real
+/// `yq`: `a:\n  x: 1`).
+///
+/// Walks `pristine_value`/`result_value` in lockstep rather than computing
+/// which path(s) an expression's AST touches (`resolve_dynamic_indexes` in
+/// `eval.rs`) and invalidating just those - this is exact for every
+/// mutation shape uniformly (a single assign, a chained pipe of several, a
+/// computed-key write, a `del()`) with no per-expression-shape logic, and
+/// the YAML documents this rewrites are config-file-sized, not
+/// data-file-sized.
+///
+/// **Known gap** (untested/unfiled - narrow enough not to warrant a
+/// precursor spike, but real): a *wholesale-replaced* `Array`/`Object`'s
+/// new elements/fields should get fresh (empty) metadata regardless of
+/// position/key, since they're new nodes real `yq`'s node-mutation model
+/// never touches - `.a = [4, 5, 6]` on `a: ['x', 'y', 'z']` should drop
+/// every element's quote style, and real `yq` does. But this function has
+/// no way to tell "recursing into an untouched sibling subtree" apart from
+/// "recursing into a wholesale-replaced subtree that happens to share
+/// positions/keys with the old one" - both look identical from a pure
+/// before/after value diff, only a path-based approach (the
+/// `resolve_dynamic_indexes` alternative above) could distinguish them. So
+/// a child at a matching key/index keeps its own metadata even under a
+/// wholesale replacement, over-preserving style/comments there instead of
+/// resetting them (confirmed against real `yq`: `.a = {"x": "p"}` on
+/// `a: {x: 'old'}` should print `a: {x: p}`, prints `a: {x: 'p'}` here).
+/// Purely cosmetic (no data loss, no incorrect values, still strictly
+/// better than every write losing all style/comments unconditionally,
+/// which was the pre-#739 baseline) - left as a documented limitation
+/// rather than filed as a tracked issue, since it's this narrow.
+fn reconcile_presentation(
+    pristine_value: &OwnedValue,
+    pristine_tree: &CommentTree,
+    result_value: &OwnedValue,
+) -> CommentTree {
+    match (pristine_value, result_value) {
+        (OwnedValue::Object(p_fields), OwnedValue::Object(r_fields)) => {
+            let own_comment = pristine_tree.own().map(str::to_string);
+            let own_style = pristine_tree.style();
+            let mut fields = IndexMap::new();
+            let mut key_comments = IndexMap::new();
+            for (k, r_v) in r_fields {
+                let child = match p_fields.get(k) {
+                    Some(p_v) => reconcile_presentation(p_v, pristine_tree.field(k), r_v),
+                    None => CommentTree::empty(),
+                };
+                fields.insert(k.clone(), child);
+                // A key's own trailing comment (#765) belongs to the key's
+                // line, not its value, so it survives regardless of
+                // whether the value under it changed - only a removed key
+                // (not iterated here, since this loop is over `r_fields`)
+                // drops it.
+                if let CommentTree::Object(_, _, _, pristine_key_comments) = pristine_tree {
+                    if let Some(kc) = pristine_key_comments.get(k) {
+                        key_comments.insert(k.clone(), kc.clone());
+                    }
+                }
+            }
+            CommentTree::Object(own_comment, own_style, fields, key_comments)
+        }
+        (OwnedValue::Array(p_items), OwnedValue::Array(r_items)) => {
+            let own_comment = pristine_tree.own().map(str::to_string);
+            let own_style = pristine_tree.style();
+            let items = r_items
+                .iter()
+                .enumerate()
+                .map(|(i, r_v)| match p_items.get(i) {
+                    Some(p_v) => reconcile_presentation(p_v, pristine_tree.at_index(i), r_v),
+                    None => CommentTree::empty(),
+                })
+                .collect();
+            CommentTree::Array(own_comment, own_style, items)
+        }
+        // A kind change (container <-> scalar, or Object <-> Array) is a
+        // fresh node with no presentation memory of its own.
+        (OwnedValue::Object(_) | OwnedValue::Array(_), _)
+        | (_, OwnedValue::Object(_) | OwnedValue::Array(_)) => CommentTree::empty(),
+        // Both scalars, any variant/value: same node, only its value
+        // changed - its own comment and style survive.
+        _ => CommentTree::Leaf(
+            pristine_tree.own().map(str::to_string),
+            pristine_tree.style(),
+        ),
+    }
+}
+
 /// Evaluate `split_expr` against `result` with `$index` bound to
 /// `output_index`, expect exactly one string back, and write `result`
 /// (serialized through `output_config`, color forced off, matching
@@ -845,15 +953,21 @@ fn write_split_result(
 /// Evaluate a jq expression directly on a YAML cursor.
 ///
 /// This uses the generic evaluator to preserve position metadata (line/column).
-/// Each result carries its parallel [`CommentTree`] (issue #710) — real for
-/// `OneCursor`/`ManyCursor` (still-live cursor), [`CommentTree::empty`]
-/// everywhere else (an already-materialized/computed value, comment-less by
-/// construction — see [`CommentTree`]'s own doc comment for why).
+/// Each result carries its parallel [`CommentTree`] (issue #710/#739) —
+/// real for `OneCursor`/`ManyCursor` (still-live cursor); for every other
+/// result (an already-materialized/computed value with no cursor of its
+/// own) it's [`reconcile_presentation`]'s output against the pristine
+/// document when `expr` is a shape-preserving write
+/// ([`is_alias_sensitive_assign`]) and the caller wants comments at all
+/// (`need_comments`), or [`CommentTree::empty`] otherwise — see
+/// [`CommentTree`]'s own doc comment for why a cursor-less value can't
+/// generally carry metadata.
 fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     cursor: YamlCursor<'_, W>,
     expr: &Expr,
     sink: &mut ErrorSink,
     need_comments: bool,
+    strip_style: bool,
 ) -> Result<Vec<ResultWithComments>> {
     // Snapshot alias-sync context from the pristine document *before*
     // evaluation, only when it could possibly matter (#711): an
@@ -863,8 +977,30 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     let alias_sync_ctx = (is_alias_sensitive_assign(expr) && cursor.index().has_aliases())
         .then(|| (to_owned(&cursor.value()), collect_alias_groups(cursor)));
 
+    // Snapshot the pristine presentation tree *before* evaluation too
+    // (#739, ADR-0017): same shape-preserving-write gate as `alias_sync_ctx`
+    // above (no aliases required here - a write-family expression against
+    // any YAML document can lose style/comments, not just an aliased one),
+    // and only when the caller can use the result at all (`need_comments`).
+    // `no_comments` below reconciles this against each result document once
+    // evaluation finishes.
+    let presentation_sync_ctx = (need_comments && is_alias_sensitive_assign(expr))
+        .then(|| to_owned_with_comments(&cursor.value(), Some(&cursor)));
+
     let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
-    let no_comments = |v| (v, CommentTree::empty());
+    // A value with no live cursor of its own (an assignment/`del()`
+    // result, a computed value, ...) has no comment/style to read directly
+    // - but if it came from a shape-preserving write, `presentation_sync_ctx`
+    // lets it recover whatever the write didn't touch instead of falling
+    // back to genuinely empty (#739).
+    let no_comments = |v: OwnedValue| {
+        let comments = presentation_sync_ctx
+            .as_ref()
+            .map_or_else(CommentTree::empty, |(pristine, tree)| {
+                reconcile_presentation(pristine, tree, &v)
+            });
+        (v, comments)
+    };
     // `to_owned_with_comments` builds a full parallel `IndexMap`/`Vec` tree
     // alongside the `OwnedValue` one, just to carry comment text - wasted
     // work when the caller can't use it (`-o json`'s output never reads
@@ -982,7 +1118,60 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         }
     }
 
+    // A bare top-level/navigated scalar result drops all its own styling,
+    // matching real `yq` (#852) - unlike a scalar nested inside a mapping/
+    // sequence, which keeps it (`a: "x"` stays quoted when output as part
+    // of the whole document; a standalone `.a` result doesn't). Both
+    // `to_owned_with_comments` and `reconcile_presentation` above capture/
+    // preserve style uniformly for every node including the root, so this
+    // needs its own always-on, top-level-only pass, independent of
+    // `need_comments`/`is_alias_sensitive_assign` — real `yq` does this
+    // unconditionally, not just for shape-preserving writes.
+    if let Ok(docs) = &mut docs {
+        for (value, comments) in docs.iter_mut() {
+            if !matches!(value, OwnedValue::Object(_) | OwnedValue::Array(_)) {
+                *comments = CommentTree::Leaf(comments.own().map(str::to_string), "");
+            }
+        }
+    }
+
+    // `-P`/`--pretty-print` (#705) forces block/plain style regardless of
+    // source — a real style-clearing step, not just "there's no style data
+    // to clear" like before #739's style tracking existed. Comments stay
+    // (`-P` only ever claimed to affect style), so this only touches the
+    // style slot of every node, not the tree shape.
+    if strip_style {
+        if let Ok(docs) = &mut docs {
+            for (_value, comments) in docs.iter_mut() {
+                *comments = strip_presentation_style(comments);
+            }
+        }
+    }
+
     docs
+}
+
+/// Recursively clear every node's style (issue #705's `-P` gate) while
+/// keeping its comments and tree shape untouched — see the `strip_style`
+/// call in [`evaluate_yaml_cursor`].
+fn strip_presentation_style(tree: &CommentTree) -> CommentTree {
+    match tree {
+        CommentTree::Leaf(c, _) => CommentTree::Leaf(c.clone(), ""),
+        CommentTree::Array(c, _, items) => CommentTree::Array(
+            c.clone(),
+            "",
+            items.iter().map(strip_presentation_style).collect(),
+        ),
+        CommentTree::Object(c, _, fields, key_comments) => CommentTree::Object(
+            c.clone(),
+            "",
+            fields
+                .iter()
+                .map(|(k, v)| (k.clone(), strip_presentation_style(v)))
+                .collect(),
+            key_comments.clone(),
+        ),
+    }
 }
 
 /// Convert a StandardJson value to an OwnedValue.
@@ -1107,12 +1296,24 @@ fn output_value<W: Write>(
         // own trailing comment from output on both identity and `select`,
         // even though `line_comment` still returns it — real `yq`'s own
         // quirk, not a succinctly gap, so replicated here rather than
-        // "fixed" into a new divergence. Appended as a standalone comment
-        // line (not glued onto `body`'s last line), so it isn't
-        // indistinguishable from the last child's own comment when `body`
-        // is multi-line block content (#793).
+        // "fixed" into a new divergence.
+        //
+        // A flow-styled root (`comments.style() == "flow"`, #739) glues the
+        // comment onto `body`'s one and only line instead
+        // (`[1, 2, 3] # trailing`, matching real `yq` exactly) - there's no
+        // nested child on that same line to collide with. A block-rendered
+        // root instead appends it as a standalone comment line, or it would
+        // be indistinguishable from the last child's own comment on
+        // `body`'s last line (#793) - `append_own_comment_line`'s own doc
+        // comment already flagged this as the reason it couldn't match real
+        // `yq`'s flow-preserving output, before `CommentTree` carried style
+        // data to tell the two cases apart.
         let output = if matches!(value, OwnedValue::Array(_) | OwnedValue::Object(_)) {
-            append_own_comment_line(body, comments.own(), "")
+            if is_flow_safe(value, comments) {
+                format!("{body}{}", trailing_comment_suffix(comments))
+            } else {
+                append_own_comment_line(body, comments.own(), "")
+            }
         } else {
             body
         };
@@ -1163,6 +1364,30 @@ fn output_value<W: Write>(
     write_terminator(writer, config)?;
 
     Ok(())
+}
+
+/// Whether `value`/`comments` should render in YAML flow style (`[...]`/
+/// `{...}`, issue #739) — `comments.style() == "flow"`, unless a child
+/// (array element or object field) has its own trailing comment.
+///
+/// A `#` comment runs to end of line, so a flow collection has nowhere to
+/// put one before its last item without breaking onto another line anyway
+/// (real `yq` does this with a synthetic trailing comma:
+/// `[1, 2, # child\n]`). Falling back to block style — already
+/// comment-safe, since every comment gets its own line there — is simpler
+/// and more general than replicating that exact placement, at the cost of
+/// not matching real `yq`'s output byte-for-byte in this one narrow case
+/// (a comment on a non-final flow element); losing the comment entirely
+/// would be worse.
+fn is_flow_safe(value: &OwnedValue, comments: &CommentTree) -> bool {
+    if comments.style() != "flow" {
+        return false;
+    }
+    match value {
+        OwnedValue::Array(items) => !(0..items.len()).any(|i| comments.at_index(i).own().is_some()),
+        OwnedValue::Object(fields) => !fields.keys().any(|k| comments.field(k).own().is_some()),
+        _ => true,
+    }
 }
 
 /// Format a node's own trailing comment (issue #710) as `" # text"`, or
@@ -1245,11 +1470,11 @@ fn emit_yaml_value(
                 value.number_str().expect("numeric variant").into_owned()
             }
         }
-        OwnedValue::String(s) => yaml_quote_string(s),
+        OwnedValue::String(s) => yaml_quote_string_with_style(s, comments.style()),
         OwnedValue::Array(arr) => {
             if arr.is_empty() {
                 "[]".to_string()
-            } else if in_flow {
+            } else if in_flow || is_flow_safe(value, comments) {
                 // Flow style for nested in flow context
                 let items: Vec<_> = arr
                     .iter()
@@ -1264,8 +1489,10 @@ fn emit_yaml_value(
                     .enumerate()
                     .map(|(i, v)| {
                         let elem_comments = comments.at_index(i);
-                        if matches!(v, OwnedValue::Object(o) if !o.is_empty())
-                            || matches!(v, OwnedValue::Array(a) if !a.is_empty())
+                        let elem_is_flow = is_flow_safe(v, elem_comments);
+                        if !elem_is_flow
+                            && (matches!(v, OwnedValue::Object(o) if !o.is_empty())
+                                || matches!(v, OwnedValue::Array(a) if !a.is_empty()))
                         {
                             // A non-empty mapping/sequence element renders
                             // in real yq's "compact" form: `- ` shares its
@@ -1318,7 +1545,7 @@ fn emit_yaml_value(
         OwnedValue::Object(obj) => {
             if obj.is_empty() {
                 "{}".to_string()
-            } else if in_flow {
+            } else if in_flow || is_flow_safe(value, comments) {
                 // Flow style for nested in flow context
                 let entries: Vec<_> = obj
                     .iter()
@@ -1346,9 +1573,13 @@ fn emit_yaml_value(
                         let field_comments = comments.field(k);
                         let comment_suffix = trailing_comment_suffix(field_comments);
                         let val_indent = format!("{indent}{}", config.indent_str);
-                        // Check if value needs to be on next line
-                        if matches!(v, OwnedValue::Object(m) if !m.is_empty())
-                            || matches!(v, OwnedValue::Array(a) if !a.is_empty())
+                        // Check if value needs to be on next line - a
+                        // flow-styled container stays on the key's own line
+                        // instead, the same as a scalar (#739).
+                        let field_is_flow = is_flow_safe(v, field_comments);
+                        if !field_is_flow
+                            && (matches!(v, OwnedValue::Object(m) if !m.is_empty())
+                                || matches!(v, OwnedValue::Array(a) if !a.is_empty()))
                         {
                             // A comment trailing the key's own line, when the
                             // value is deferred to the next line, belongs to
@@ -1441,26 +1672,84 @@ fn yaml_quote_string(s: &str) -> String {
         || s.ends_with(' ');
 
     if needs_quoting {
-        // Use double quotes with escaping
-        let mut result = String::with_capacity(s.len() + 2);
-        result.push('"');
-        for c in s.chars() {
-            match c {
-                '"' => result.push_str("\\\""),
-                '\\' => result.push_str("\\\\"),
-                '\n' => result.push_str("\\n"),
-                '\r' => result.push_str("\\r"),
-                '\t' => result.push_str("\\t"),
-                c if c.is_ascii_control() => {
-                    result.push_str(&format!("\\x{:02x}", c as u32));
-                }
-                _ => result.push(c),
-            }
-        }
-        result.push('"');
-        result
+        yaml_double_quote_escaped(s)
     } else {
         s.to_string()
+    }
+}
+
+/// Double-quote `s`, escaping as needed — the actual quoting mechanics
+/// [`yaml_quote_string`]'s heuristic falls back to whenever it decides
+/// quoting is required, factored out so [`yaml_quote_string_with_style`]
+/// can also reach it directly to *force* double-quote style regardless of
+/// whether the heuristic alone would have required it (#739).
+fn yaml_double_quote_escaped(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() + 2);
+    result.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => result.push_str("\\\""),
+            '\\' => result.push_str("\\\\"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            c if c.is_ascii_control() => {
+                result.push_str(&format!("\\x{:02x}", c as u32));
+            }
+            _ => result.push(c),
+        }
+    }
+    result.push('"');
+    result
+}
+
+/// Single-quote `s`, doubling embedded single quotes per YAML's escaping
+/// rule. Only meaningful when [`can_single_quote`] agrees this is safe (a
+/// single-quoted flow scalar has no escape sequence for control
+/// characters).
+fn yaml_single_quote_escaped(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() + 2);
+    result.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            result.push_str("''");
+        } else {
+            result.push(c);
+        }
+    }
+    result.push('\'');
+    result
+}
+
+/// Whether `s` can round-trip through single-quote style at all — a
+/// single-quoted YAML scalar has no escape syntax for control characters
+/// (no `\n`, `\t`, ...), unlike double-quoted.
+fn can_single_quote(s: &str) -> bool {
+    !s.chars().any(|c| c.is_ascii_control())
+}
+
+/// Quote a YAML string the way [`yaml_quote_string`] does, except honoring
+/// a known original style (`"single"`/`"double"`, from [`CommentTree`]'s
+/// per-node style — see [`CommentTree::style`]) when there is one and it's
+/// safe to reproduce, instead of always falling back to the plain-or-
+/// double-quote heuristic. This is what makes an untouched sibling of a
+/// write keep its original quote style rather than losing it entirely —
+/// `yaml_quote_string`'s heuristic alone only adds quotes where structurally
+/// *required*, which is not the same as matching what the source actually
+/// wrote (#739's `'single'` repro needs quotes at all, not just safe ones).
+///
+/// Any other style (`""`, `"flow"`, `"literal"`, `"folded"` — the last two
+/// are block-scalar styles this DOM writer doesn't reproduce; see
+/// `CommentTree`'s own doc comment) falls back to the plain heuristic
+/// unchanged.
+fn yaml_quote_string_with_style(s: &str, style: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    match style {
+        "single" if can_single_quote(s) => yaml_single_quote_escaped(s),
+        "double" => yaml_double_quote_escaped(s),
+        _ => yaml_quote_string(s),
     }
 }
 
@@ -2716,6 +3005,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             doc_filter,
                             &mut sink,
                             need_comments,
+                            args.pretty_print,
                         )?;
                         global_doc_index += num_docs;
                         for results in doc_results {
@@ -3287,6 +3577,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         doc_filter,
                         &mut sink,
                         need_comments,
+                        args.pretty_print,
                     )?;
                     global_doc_index += num_docs;
                     all_results.push(doc_results);
@@ -3525,12 +3816,14 @@ mod tests {
         let mut obj_comments = IndexMap::new();
         obj_comments.insert(
             "k".to_string(),
-            CommentTree::Leaf(Some("# k trailing".to_string())),
+            CommentTree::Leaf(Some("# k trailing".to_string()), ""),
         );
         let comments = CommentTree::Array(
             None,
+            "",
             vec![CommentTree::Object(
                 Some("# obj trailing".to_string()),
+                "",
                 obj_comments,
                 IndexMap::new(),
             )],
@@ -3733,9 +4026,15 @@ mod tests {
     /// Like [`eval_yaml`], but keeps each result's parallel `CommentTree`
     /// (issue #710) instead of discarding it.
     fn eval_yaml_with_comments(bytes: &[u8], expr: &Expr) -> Vec<ResultWithComments> {
-        let (groups, _) =
-            evaluate_yaml_direct_filtered(bytes, expr, None, &mut ErrorSink::default(), true)
-                .unwrap();
+        let (groups, _) = evaluate_yaml_direct_filtered(
+            bytes,
+            expr,
+            None,
+            &mut ErrorSink::default(),
+            true,
+            false,
+        )
+        .unwrap();
         groups.into_iter().flatten().collect()
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -79,8 +79,12 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
     }
 }
 
-/// A shape-parallel tree of trailing same-line comments (issue #710), built
-/// alongside an `OwnedValue` by [`to_owned_with_comments`].
+/// A shape-parallel tree of per-node presentation metadata.
+///
+/// Trailing same-line comments (issue #710) and YAML style (issue #739;
+/// `""` for block/plain, `"flow"`/`"double"`/`"single"`/`"literal"`/
+/// `"folded"` per [`DocumentCursor::style`]) — built alongside an
+/// `OwnedValue` by [`to_owned_with_comments`].
 ///
 /// `OwnedValue` itself carries no metadata — extending its enum would ripple
 /// through every match site in both the JSON and YAML evaluators for a
@@ -91,51 +95,64 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
 /// `evaluate_yaml_cursor`, the only place that calls
 /// `to_owned_with_comments`). It is a distinct mechanism from
 /// `YamlCursor::stream_yaml_value`/`stream_yaml_as_document` in
-/// `light.rs`, which stream comments straight from a *live cursor* via
-/// `write_line_comment` and never go through `CommentTree` at all —
-/// `stream_owned_value_yaml` in `stream.rs` streams plain `OwnedValue`
-/// (no cursor, no comment data) and isn't part of either mechanism.
-/// A query that reshapes the tree (`map`, `del`, array construction, ...)
-/// simply has no `to_owned_with_comments` call in its chain, so comments are
-/// dropped there exactly as they are today — not a new regression, and out
-/// of scope for this issue (see the issue's own scope note).
+/// `light.rs`, which stream comments/style straight from a *live cursor*
+/// and never go through `CommentTree` at all — `stream_owned_value_yaml` in
+/// `stream.rs` streams plain `OwnedValue` (no cursor, no metadata) and
+/// isn't part of either mechanism.
+/// A query that reshapes the tree (`map`, object/array construction, ...)
+/// simply has no `to_owned_with_comments` call in its chain, so metadata is
+/// dropped there exactly as they are today — out of scope for this issue,
+/// tracked separately (see the issue's own scope note). A query that
+/// rewrites specific paths (`=`, `|=`, `del()`, ...) instead gets a
+/// reconciled tree from `evaluate_yaml_cursor`'s `reconcile_presentation`,
+/// which pairs the pristine (pre-write) tree with the post-write value and
+/// keeps metadata for every node whose value the write didn't touch.
 #[derive(Debug, Clone)]
 pub enum CommentTree {
     /// A scalar (or any node with no comment-bearing children): this node's
-    /// own trailing comment, if any.
-    Leaf(Option<String>),
+    /// own trailing comment, if any, and its style.
+    Leaf(Option<String>, &'static str),
     /// An array: this node's own trailing comment (e.g. `a: [1,2] # c`,
-    /// which trails the whole array, not an element), plus one subtree per
-    /// element in order.
-    Array(Option<String>, Vec<Self>),
-    /// An object: this node's own trailing comment, one subtree per field
-    /// (keyed the same as the parallel `OwnedValue::Object`), plus one
-    /// key-scoped comment per field for a comment trailing the *key's* own
-    /// line when its value is deferred to a following line (issue #765,
-    /// e.g. `a: # comment\n  b: 1`) - distinct from the field's value
-    /// subtree's own comment, which `.a | line_comment` etc. read instead.
-    /// The `bool` alongside each comment is whether the deferred value
-    /// materialized as nothing at all (a sibling key follows, or EOF) -
-    /// see [`Self::key_comment_if_value_absent`].
+    /// which trails the whole array, not an element) and style, plus one
+    /// subtree per element in order.
+    Array(Option<String>, &'static str, Vec<Self>),
+    /// An object: this node's own trailing comment and style, one subtree
+    /// per field (keyed the same as the parallel `OwnedValue::Object`),
+    /// plus one key-scoped comment per field for a comment trailing the
+    /// *key's* own line when its value is deferred to a following line
+    /// (issue #765, e.g. `a: # comment\n  b: 1`) - distinct from the
+    /// field's value subtree's own comment, which `.a | line_comment` etc.
+    /// read instead. The `bool` alongside each comment is whether the
+    /// deferred value materialized as nothing at all (a sibling key
+    /// follows, or EOF) - see [`Self::key_comment_if_value_absent`].
     Object(
         Option<String>,
+        &'static str,
         IndexMap<String, Self>,
         IndexMap<String, (String, bool)>,
     ),
 }
 
 impl CommentTree {
-    /// The empty tree: no comment at this node, and (for containers) no
-    /// children — used where a caller has no cursor at all (comment-less by
-    /// construction, e.g. a computed value).
+    /// The empty tree: no comment or style at this node, and (for
+    /// containers) no children — used where a caller has no cursor at all
+    /// (metadata-less by construction, e.g. a computed value).
     pub const fn empty() -> Self {
-        Self::Leaf(None)
+        Self::Leaf(None, "")
     }
 
     /// This node's own trailing comment, if any.
     pub fn own(&self) -> Option<&str> {
         match self {
-            Self::Leaf(c) | Self::Array(c, _) | Self::Object(c, _, _) => c.as_deref(),
+            Self::Leaf(c, _) | Self::Array(c, _, _) | Self::Object(c, _, _, _) => c.as_deref(),
+        }
+    }
+
+    /// This node's own YAML style (`""`, `"flow"`, `"double"`, `"single"`,
+    /// `"literal"`, or `"folded"` — see [`DocumentCursor::style`]).
+    pub fn style(&self) -> &'static str {
+        match self {
+            Self::Leaf(_, s) | Self::Array(_, s, _) | Self::Object(_, s, _, _) => s,
         }
     }
 
@@ -143,7 +160,7 @@ impl CommentTree {
     /// `Array` or the index is out of range.
     pub fn at_index(&self, i: usize) -> &Self {
         match self {
-            Self::Array(_, items) => items.get(i).unwrap_or(&EMPTY_COMMENT_TREE),
+            Self::Array(_, _, items) => items.get(i).unwrap_or(&EMPTY_COMMENT_TREE),
             _ => &EMPTY_COMMENT_TREE,
         }
     }
@@ -152,7 +169,7 @@ impl CommentTree {
     /// `Object` or has no such key.
     pub fn field(&self, key: &str) -> &Self {
         match self {
-            Self::Object(_, fields, _) => fields.get(key).unwrap_or(&EMPTY_COMMENT_TREE),
+            Self::Object(_, _, fields, _) => fields.get(key).unwrap_or(&EMPTY_COMMENT_TREE),
             _ => &EMPTY_COMMENT_TREE,
         }
     }
@@ -164,7 +181,7 @@ impl CommentTree {
     /// trailing comment (issue #710).
     pub fn key_comment(&self, key: &str) -> Option<&str> {
         match self {
-            Self::Object(_, _, key_comments) => key_comments.get(key).map(|(c, _)| c.as_str()),
+            Self::Object(_, _, _, key_comments) => key_comments.get(key).map(|(c, _)| c.as_str()),
             _ => None,
         }
     }
@@ -181,7 +198,7 @@ impl CommentTree {
     /// the key, a different, unhandled case).
     pub fn key_comment_if_value_absent(&self, key: &str) -> Option<&str> {
         match self {
-            Self::Object(_, _, key_comments) => key_comments
+            Self::Object(_, _, _, key_comments) => key_comments
                 .get(key)
                 .filter(|(_, absent)| *absent)
                 .map(|(c, _)| c.as_str()),
@@ -194,7 +211,7 @@ impl CommentTree {
 /// can't be borrowed as `'static` from inside a generic method call
 /// argument like `Option::unwrap_or`) — used by [`CommentTree::at_index`]/
 /// [`CommentTree::field`] wherever there's no comment data to return.
-static EMPTY_COMMENT_TREE: CommentTree = CommentTree::Leaf(None);
+static EMPTY_COMMENT_TREE: CommentTree = CommentTree::Leaf(None, "");
 
 /// Convert a `DocumentValue` to an `OwnedValue` alongside a parallel [`CommentTree`].
 ///
@@ -208,6 +225,7 @@ pub fn to_owned_with_comments<V: DocumentValue>(
     // The raw (`#`-prefixed) form, not the stripped `line_comment` builtin
     // getter: the write path re-emits this verbatim after one space.
     let own_comment = cursor.and_then(DocumentCursor::line_comment_raw);
+    let own_style = cursor.map_or("", DocumentCursor::style);
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut comment_map = IndexMap::new();
@@ -241,7 +259,7 @@ pub fn to_owned_with_comments<V: DocumentValue>(
         }
         (
             OwnedValue::Object(map),
-            CommentTree::Object(own_comment, comment_map, key_comment_map),
+            CommentTree::Object(own_comment, own_style, comment_map, key_comment_map),
         )
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -258,10 +276,10 @@ pub fn to_owned_with_comments<V: DocumentValue>(
         }
         (
             OwnedValue::Array(items),
-            CommentTree::Array(own_comment, comment_items),
+            CommentTree::Array(own_comment, own_style, comment_items),
         )
     } else {
-        (to_owned(value), CommentTree::Leaf(own_comment))
+        (to_owned(value), CommentTree::Leaf(own_comment, own_style))
     }
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -694,6 +694,47 @@ fn test_assign_preserves_untouched_empty_string_double_quote_style_739() -> Resu
     Ok(())
 }
 
+/// #739: a brand-new field (no pristine counterpart at that key) gets
+/// fresh, empty metadata in `reconcile_presentation`'s `Object` arm,
+/// while its untouched sibling keeps its own style.
+#[test]
+fn test_assign_adds_a_new_field_with_no_pristine_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".c = 3", "a: 'single'\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 'single'\nb: 1\nc: 3\n");
+    Ok(())
+}
+
+/// #739: an untouched double-quoted sibling containing every character
+/// `yaml_double_quote_escaped` escapes must round-trip through the
+/// style-forced "double" path, not just the default heuristic path.
+#[test]
+fn test_assign_preserves_double_quote_escaping_on_untouched_sibling_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".b = 2",
+        "a: \"line1\\nline2\\ttab\\\\back\\\"quote\"\nb: 1\n",
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "a: \"line1\\nline2\\ttab\\\\back\\\"quote\"\nb: 2\n"
+    );
+    Ok(())
+}
+
+/// #852, exercised through a write this time: a write followed by
+/// navigating to a scalar result must still drop that scalar's own
+/// styling at the top level, even though the DOM path now tracks style
+/// data for writes (#739).
+#[test]
+fn test_write_then_navigate_to_scalar_still_drops_root_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a = 5 | .a", "a: 'single'\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "5\n");
+    Ok(())
+}
+
 #[test]
 fn test_duplicate_mapping_key_is_last_wins() -> Result<()> {
     // YAML 1.2 / yq: a mapping with a duplicate key resolves `.key` to the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -591,6 +591,80 @@ fn test_field_navigation_preserves_flow_style() -> Result<()> {
     Ok(())
 }
 
+/// #739 (ADR-0017): a write to one field must not reformat an unrelated,
+/// untouched sibling — the issue's own repro. Every case verified against
+/// the pinned real `yq` binary.
+#[test]
+fn test_assign_preserves_untouched_sibling_single_quote_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".b = 2", "a: 'single'\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 'single'\nb: 2\n");
+    Ok(())
+}
+
+#[test]
+fn test_assign_preserves_untouched_sibling_double_quote_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".b = 2", "a: \"double\"\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: \"double\"\nb: 2\n");
+    Ok(())
+}
+
+#[test]
+fn test_assign_preserves_untouched_sibling_flow_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".b = 2", "a: {x: 1, y: 2}\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: {x: 1, y: 2}\nb: 2\n");
+    Ok(())
+}
+
+#[test]
+fn test_del_preserves_untouched_sibling_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin("del(.c)", "a: 'single'\nb: 1\nc: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 'single'\nb: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_compound_assign_preserves_untouched_sibling_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".b += 1", "a: 'single'\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 'single'\nb: 2\n");
+    Ok(())
+}
+
+/// #739: a *written* scalar field keeps its own quote style too, as long
+/// as the new value is still a scalar (real `yq`'s in-place node-mutation
+/// model updates the value but never touches the node's own style) — not
+/// just untouched siblings. A kind change (scalar to container) does drop
+/// it, since there's no such node to keep.
+#[test]
+fn test_assign_new_string_value_keeps_written_fields_own_quote_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a = \"new\"", "a: 'single'\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 'new'\n");
+    Ok(())
+}
+
+#[test]
+fn test_assign_kind_change_drops_the_written_fields_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a = {\"x\": 1}", "a: 'single'\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a:\n  x: 1\n");
+    Ok(())
+}
+
+/// #739/#705: `-P` still forces block/plain style unconditionally, even
+/// though the DOM path now tracks real style data for writes too.
+#[test]
+fn test_pretty_print_still_forces_block_style_on_a_write_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".b = 2", "a: {x: 1, y: 2}\nb: 1\n", &["-P"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a:\n  x: 1\n  y: 2\nb: 2\n");
+    Ok(())
+}
+
 #[test]
 fn test_duplicate_mapping_key_is_last_wins() -> Result<()> {
     // YAML 1.2 / yq: a mapping with a duplicate key resolves `.key` to the
@@ -1667,7 +1741,9 @@ fn test_split_doc_with_objects() -> Result<()> {
     let input = "[{name: alice}, {name: bob}]";
     let (output, exit_code) = run_yq_stdin(".[] | split_doc", input, &[])?;
     assert_eq!(exit_code, 0);
-    assert_eq!(output, "name: alice\n---\nname: bob\n");
+    // Each object keeps its flow style (#739) - verified against the
+    // pinned real `yq` binary.
+    assert_eq!(output, "{name: alice}\n---\n{name: bob}\n");
     Ok(())
 }
 
@@ -1727,8 +1803,9 @@ fn test_split_doc_nested_arrays() -> Result<()> {
     let input = "[[1, 2], [3, 4]]";
     let (output, exit_code) = run_yq_stdin(".[] | split_doc", input, &[])?;
     assert_eq!(exit_code, 0);
-    // Each sub-array is output as a YAML sequence
-    assert_eq!(output, "- 1\n- 2\n---\n- 3\n- 4\n");
+    // Each sub-array is output as a YAML sequence, keeping its flow style
+    // (#739) - verified against the pinned real `yq` binary.
+    assert_eq!(output, "[1, 2]\n---\n[3, 4]\n");
     Ok(())
 }
 
@@ -6215,12 +6292,18 @@ fn test_keys_unsorted_yaml_dom_fallback_matches_lazy_685() -> Result<()> {
 /// It's now wired into `can_stream_pretty` (`yq_runner.rs`), forcing the DOM
 /// fallback exactly like `--sort-keys` above (`test_keys_unsorted_yaml_dom_fallback_matches_lazy_685`).
 ///
-/// #707 (flow-style preservation) has since landed on the M2 cursor-streaming
-/// path only — the DOM fallback path `-P` forces was never touched by it and
-/// still renders unconditionally block-style. So for flow-style input, `-P`
-/// now diverges from the default (which preserves the input's flow style)
-/// and produces real block-style pretty-printing, matching real yq's `-P`
-/// semantics.
+/// #707 (flow-style preservation) landed on the M2 cursor-streaming path
+/// only; the DOM fallback path `-P` forces had no style tracking at all
+/// back then, so it always rendered block-style regardless of `-P`. #739
+/// later gave the DOM path real style tracking too (`CommentTree`'s style
+/// field, `evaluate_yaml_cursor`'s `reconcile_presentation`) — real `yq`'s
+/// own doc says `-P` is "shorthand for `... style = \"\"`", i.e. a genuine
+/// clear, not just "there's nothing to clear" — so `evaluate_yaml_cursor`'s
+/// `strip_style` parameter now does that explicitly
+/// (`strip_presentation_style`) whenever `args.pretty_print` is set. The
+/// observable result is unchanged (block-style output either way); only
+/// the reason changed, from "no style data exists here" to "style data
+/// exists and `-P` clears it."
 #[test]
 fn test_pretty_print_flag_forces_block_style_705() -> Result<()> {
     let input = "a: [1, 2, 3]\nb: {c: 1, d: 2}\n";
@@ -6549,23 +6632,24 @@ fn test_line_comment_builtin_empty_when_absent_710() -> Result<()> {
     Ok(())
 }
 
-/// Known gap, not a silent regression: assignment (`=`, `|=`, ...) isn't
-/// natively handled by the cursor-aware evaluator, so it falls through a
-/// JSON-round-trip fallback (`eval_generic.rs`'s catch-all) that discards
-/// cursor/comment data for the *entire* document - not just the assigned
-/// field. `.b = 5` here never touches `a`, yet `a`'s comment is still gone.
-/// Fixing this needs comment-aware assignment logic, not just write-path
-/// wiring; tracked as a follow-up rather than solved here so the gap is
-/// pinned and visible instead of an undocumented surprise.
+/// #739 (was a documented gap, #710): assignment (`=`, `|=`, ...) used to
+/// fall through a JSON-round-trip fallback (`eval_generic.rs`'s catch-all)
+/// that discarded cursor/comment data for the *entire* document - not just
+/// the assigned field. `evaluate_yaml_cursor`'s `reconcile_presentation`
+/// now recovers it: an untouched sibling keeps its comment (`.b = 5` here
+/// never touches `a`), and - verified against the pinned real `yq` binary -
+/// even the *written* field's own comment survives a same-kind value
+/// change (`.a = 5` still keeps `a`'s comment; only a kind change, e.g.
+/// scalar to object, would drop it).
 #[test]
-fn test_assignment_does_not_yet_preserve_comments_710() -> Result<()> {
+fn test_assignment_preserves_comments_739() -> Result<()> {
     let (out, code) = run_yq_stdin(".a = 5", "a: 1 # keep this\nb: 2\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out, "a: 5\nb: 2\n");
+    assert_eq!(out, "a: 5 # keep this\nb: 2\n");
 
     let (out, code) = run_yq_stdin(".b = 5", "a: 1 # keep this\nb: 2\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out, "a: 1\nb: 5\n");
+    assert_eq!(out, "a: 1 # keep this\nb: 5\n");
     Ok(())
 }
 
@@ -6725,7 +6809,14 @@ fn test_iterated_containers_keep_own_comments_793a() -> Result<()> {
 // widened which queries can), a container's own trailing comment used to be
 // concatenated directly onto its last child's rendered line with no
 // separator - indistinguishable from that child's own comment. Fixed by
-// giving the container's own comment a standalone comment line instead.
+// giving the container's own comment a standalone comment line instead,
+// for block-rendered output. #739 later taught this same DOM path to
+// preserve a container's own flow-vs-block style (previously always
+// forced to block, unconditionally, regardless of source): both of these
+// inputs use flow syntax (`[1, 2, 3]`), so the container now renders on
+// one line and its own comment glues onto that line instead - unambiguous
+// since there's no separate "last child's line" to collide with. Both
+// outputs verified against the pinned real `yq` binary.
 // `--arg x y` is used as the M2-blocking flag throughout (rather than the
 // original issue's `select(...)`, which #796 now routes through M2 and so
 // no longer reaches this code at all for these shapes).
@@ -6738,7 +6829,7 @@ fn test_dom_path_container_comment_gets_own_line_not_glued_to_last_child_793b() 
         &["--arg", "x", "y"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(out, "- 1\n- 2\n- 3\n# trailing\n");
+    assert_eq!(out, "[1, 2, 3] # trailing\n");
     Ok(())
 }
 
@@ -6750,12 +6841,20 @@ fn test_dom_path_root_container_comment_gets_own_line_793b() -> Result<()> {
         &["--arg", "x", "y"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(out, "items:\n  - 1\n  - 2\n  - 3\n  # container comment\n");
+    assert_eq!(out, "items: [1, 2, 3] # container comment\n");
     Ok(())
 }
 
 /// A child's own comment and the container's own comment must both survive,
 /// as two distinct comments - not silently concatenated onto one line.
+///
+/// The source is flow syntax (`[1, 2 ...]`), but a `#` comment runs to end
+/// of line and this one trails a non-final element, so there's nowhere for
+/// it to go on one line without breaking flow's grammar; `is_flow_safe`
+/// (#739) falls back to block rendering rather than lose the comment
+/// (real `yq` instead keeps flow with a synthetic trailing comma before
+/// the line break - a narrower fidelity gap this PR accepts, see
+/// `is_flow_safe`'s own doc comment).
 #[test]
 fn test_dom_path_container_and_child_comments_stay_distinct_793b() -> Result<()> {
     let (out, code) = run_yq_stdin(
@@ -7235,9 +7334,12 @@ fn test_front_matter_process_reattaches_body_verbatim() -> Result<()> {
         &["--front-matter", "process"],
     )?;
     assert_eq!(code, 0);
+    // `tags: [a, b]` keeps its flow style (#739) even though `.title` is
+    // the field actually written - verified against the pinned real `yq`
+    // binary.
     assert_eq!(
         output,
-        "---\ntitle: New\ntags:\n  - a\n  - b\n---\n# Body\n\nSome text.\n"
+        "---\ntitle: New\ntags: [a, b]\n---\n# Body\n\nSome text.\n"
     );
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -665,6 +665,35 @@ fn test_pretty_print_still_forces_block_style_on_a_write_739() -> Result<()> {
     Ok(())
 }
 
+/// #739 review finding: `reconcile_presentation` used to copy a key's
+/// stale "deferred value materialized as nothing" flag (#765) forward
+/// from the pristine document verbatim, even once a write gave that key a
+/// real value — `key_comment_if_value_absent`'s consumer in
+/// `emit_yaml_value` then rendered only the key and its comment, silently
+/// dropping the written value entirely.
+#[test]
+fn test_assign_to_a_key_with_a_deferred_value_comment_keeps_the_written_value_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".version = \"1.0.0\"",
+        "version: # TODO fill in\nauthor: me\n",
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "version: 1.0.0 # TODO fill in\nauthor: me\n");
+    Ok(())
+}
+
+/// #739 review finding: an untouched double-quoted *empty* string sibling
+/// used to always flip to single-quote style (`yaml_quote_string_with_style`'s
+/// empty-string short-circuit ran before consulting `style` at all).
+#[test]
+fn test_assign_preserves_untouched_empty_string_double_quote_style_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".b = 2", "a: \"\"\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: \"\"\nb: 2\n");
+    Ok(())
+}
+
 #[test]
 fn test_duplicate_mapping_key_is_last_wins() -> Result<()> {
     // YAML 1.2 / yq: a mapping with a duplicate key resolves `.key` to the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -723,6 +723,27 @@ fn test_assign_preserves_double_quote_escaping_on_untouched_sibling_739() -> Res
     Ok(())
 }
 
+/// #739: `yaml_double_quote_escaped`'s carriage-return and generic
+/// ascii-control-character arms specifically (`\n`/`\t` are covered by
+/// the sibling test above).
+#[test]
+fn test_assign_preserves_double_quote_escaping_of_carriage_return_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".b = 2", "a: \"cr\\rhere\"\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: \"cr\\rhere\"\nb: 2\n");
+    Ok(())
+}
+
+/// #739: `yaml_single_quote_escaped` doubles an embedded single quote per
+/// YAML's own escaping rule.
+#[test]
+fn test_assign_preserves_single_quote_escaping_of_embedded_quote_739() -> Result<()> {
+    let (output, code) = run_yq_stdin(".b = 2", "a: 'it''s'\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 'it''s'\nb: 2\n");
+    Ok(())
+}
+
 /// #852, exercised through a write this time: a write followed by
 /// navigating to a scalar result must still drop that scalar's own
 /// styling at the top level, even though the DOM path now tracks style


### PR DESCRIPTION
## Summary

- Implements ADR-0017's mechanism 1 (presentation-metadata side-tree),
  scoped to path-mutation queries: `succinctly yq` no longer discards
  YAML style (quote/flow style) and trailing comments for the *entire*
  document on any query that writes through the OwnedValue DOM path
  (`=`, `|=`, `+=`, `del()`, ...) — previously every node, touched or
  not, lost all presentation metadata on such a query.
- Widens `CommentTree` (#710's comment-only side-tree, `src/jq/eval_generic.rs`)
  to also carry each node's style, and adds `reconcile_presentation` in
  `evaluate_yaml_cursor` (`src/bin/succinctly/yq_runner.rs`): a node keeps
  its own comment/style as long as a write leaves it the same *kind*
  (scalar/Array/Object) — matching real `yq`'s in-place node-mutation
  model, verified against the pinned binary case by case (see the
  function's own doc comment for the empirical rule and a documented,
  narrow known gap in wholesale-container-replacement).
- `-P`/`--prettyPrint` (#705) now explicitly clears style
  (`strip_presentation_style`) instead of relying on there being none to
  clear.
- A bare top-level/navigated scalar result still drops its own styling
  (#852) even though the DOM path tracks it now — this fix would
  otherwise have reintroduced that gap on a second code path.
- `emit_yaml_value` gained flow-style rendering (quote style via
  `yaml_quote_string_with_style`, container flow-vs-block via
  `is_flow_safe`) and a "does a flow collection need to fall back to
  block to avoid losing a mid-collection comment" safety check, since a
  YAML `#` comment can't appear before more content on the same line.

Deliberately **not** in scope (split to follow-ups, see below): object/array
*construction* (`{...}`, `[...]`) still drops style/comments for every
field — a structurally different problem that needs new plumbing, not
just this PR's reconciliation approach.

## Follow-ups filed

- #864 (**High**, pre-existing on `main`, found via oracle-diff
  verification while testing this PR): a compact block-sequence item's
  first field silently loses a flow-collection value's content and can
  corrupt sibling parsing. Unrelated to this PR's own changes.
- #865 (**Medium**): object/array construction's own style/comment
  preservation — ADR-0017's other half, needs a native `eval_generic.rs`
  dispatch arm with its own recursive metadata-threading helper, not a
  `GenericResult` widening (that would ripple through 619 match sites
  including the plain-JSON evaluator).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full workspace suite, 2397+ lib tests / all integration suites green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New tests added for the issue's own repro (untouched sibling quote/flow style), `del()`, compound assign, the touched node's own style/comment surviving a same-kind change, and `-P` still forcing block style — every new assertion verified against the pinned real `yq` binary
- [x] Several pre-existing tests forced the DOM path (`--arg`, `--front-matter`, `--split-exp`) specifically to pin the old "always loses everything" behavior; updated to the corrected, oracle-verified output
- [x] `omni-dev coverage diff` reviewed for patch coverage