### PR TITLE
fix(jq): resolve_recurse emits a null child's own path before pruning it

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10630,6 +10630,25 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // still `O(path length)` per node, `O(d²)` total; #701, unfixed here.
         outputs.push((prefix.clone(), current.clone()));
 
+        // A null node ends its own line of descent here, unlike the value
+        // evaluator since #490 -- but (#856) it's still emitted above like
+        // every other popped node first; only the *recursion into it* is
+        // skipped, bounding path-prefix growth against a non-terminating
+        // `f` without dropping the null child's own path the way an early
+        // `continue` before crediting it would. Gating here (once popped,
+        // in its correct DFS position) rather than at collection time keeps
+        // sibling ordering correct: a null child collected alongside a
+        // non-null sibling must still wait for its turn on `stack`, so it
+        // can't jump ahead of an earlier sibling's own subtree. Confirmed
+        // against jq 1.7.1: `{"a":null,"b":{"x":1}} | path(recurse(if
+        // (.==null) then empty elif type=="object" then .[] else empty
+        // end))` streams `[]`, `["a"]`, `["b"]`, `["b","x"]` in that order
+        // -- the null leaf between the root and `b`'s own subtree, not
+        // after it.
+        if matches!(current.as_ref(), OwnedValue::Null) {
+            continue;
+        }
+
         // An `f` error aborts the whole traversal — see the doc comment
         // above (#636) — but only after whatever candidate children
         // `resolve_node` already resolved before hitting that error get
@@ -10653,13 +10672,10 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // entry is even reached.
         let mut next: Vec<PathBranch<'a>> = Vec::new();
         for (child_components, child_value) in children {
-            // A null child ends that line of descent here, unlike the value
-            // evaluator since #490. See the note above on why this function
-            // keeps the guard: it bounds path-prefix growth, not just count.
-            if matches!(child_value.as_ref(), OwnedValue::Null) {
-                continue;
-            }
-
+            // A null child is queued onto `next`/`stack` like any other --
+            // the null-recursion bound is enforced once popped, above, not
+            // here (#856), so it still gets its own turn through `cond`
+            // (if present) and its correct place in DFS order.
             let mut path = prefix.clone();
             path.extend(child_components);
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10572,19 +10572,24 @@ fn queue_recurse_children<T>(
 /// `["a"]` before erroring, not just `[]`).
 ///
 /// One divergence remains, deliberately: this function still does not
-/// stack a null child, where the value evaluator does. `f` is arbitrary
-/// and nothing says it makes progress: `recurse(.a?)` over `{"a":null}`
-/// reads `null` from `null` forever (confirmed hanging in real jq too —
-/// this is jq's actual semantics, not a bug). The value evaluator's stack
+/// recurse *past* a null node, where the value evaluator does. `f` is
+/// arbitrary and nothing says it makes progress: `recurse(.a?)` over
+/// `{"a":null}` reads `null` from `null` forever (confirmed hanging in
+/// real jq too — this is jq's actual semantics, not a bug). A null node
+/// itself is still stacked and popped like any other (#856: it's emitted,
+/// and `f`/`cond` are still evaluated on it and its own candidate
+/// children, so an error/side effect either raises still propagates) —
+/// only *its children* are never queued for their own further recursion,
+/// which is what actually bounds the growth: the value evaluator's stack
 /// holds bare `OwnedValue`s, so `MAX_ITEMS` bounds it in O(`MAX_ITEMS`)
-/// total. This function's stack holds `(path, value)` pairs, so the same
-/// non-terminating `f` would run to `MAX_ITEMS` with a prefix one
+/// total, while this function's stack holds `(path, value)` pairs, so the
+/// same non-terminating `f` would run to `MAX_ITEMS` with a prefix one
 /// component longer each round — quadratic, and measured at 9 GB for an
 /// 18-byte document before this guard existed. So the two evaluators can
-/// now disagree on this one adversarial shape (path-tracking prunes the
-/// null and stops; value evaluation runs to `MAX_ITEMS`) — both already
-/// deviate from unbounded true-jq semantics via their own `MAX_ITEMS`, so
-/// this is a narrower gap, not a new class of one.
+/// now disagree on this one adversarial shape (path-tracking prunes one
+/// node past the null and stops; value evaluation runs to `MAX_ITEMS`) —
+/// both already deviate from unbounded true-jq semantics via their own
+/// `MAX_ITEMS`, so this is a narrower gap, not a new class of one.
 ///
 /// `current.clone()`/`child_value.clone()` below are `Cow::clone()`, not a
 /// deep copy: cheap (a pointer copy) whenever the value in hand is still
@@ -10661,44 +10666,54 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // one popped, and its whole subtree completes before the second
         // entry is even reached.
         let mut next: Vec<PathBranch<'a>> = Vec::new();
-        // A null node's own line of descent ends here (see the doc comment
-        // above for why): the children `f` just produced from it are
-        // discarded rather than queued for further recursion, bounding
-        // path-prefix growth instead of relying on natural termination the
-        // way the value evaluator does. Its own path was already credited
-        // by the unconditional `outputs.push` above (#856); only recursion
-        // *into* it is skipped. Gating here -- once popped, in its correct
-        // DFS position -- rather than when the *caller* collected it as a
-        // child keeps sibling order correct: a null child queued alongside
-        // a non-null sibling still waits its own turn on `stack`, so it
-        // can't jump ahead of an earlier sibling's own subtree (confirmed
-        // against jq 1.7.1 with two siblings, one null and one with its
-        // own descendants).
-        if !is_null_current {
-            for (child_components, child_value) in children {
-                let mut path = prefix.clone();
-                path.extend(child_components);
+        for (child_components, child_value) in children {
+            let mut path = prefix.clone();
+            path.extend(child_components);
 
-                match cond {
-                    None => next.push((path, child_value)),
-                    Some(cond) => {
-                        // `cond` gates the child, not `current`, and forks once
-                        // per truthy output — see the doc comment above (#627).
-                        // A `cond` error aborts immediately too (#636), same as
-                        // `f`'s error above — this arm's own prefix-loss
-                        // (`next`'s already-cond-approved entries built so far
-                        // this node) is pre-existing and out of scope for #842,
-                        // which is specifically about `f`'s fan-out.
-                        match eval_owned_multi::<S>(cond, &child_value) {
-                            Ok(cond_outputs) => {
+            match cond {
+                None => {
+                    // A null node's own line of descent ends here (see the
+                    // doc comment above for why): its own path was already
+                    // credited by the unconditional `outputs.push` above
+                    // (#856), so only queueing this child for further
+                    // recursion is skipped, not anything with a side
+                    // effect to lose. Gating here -- once popped, in its
+                    // correct DFS position -- rather than when the
+                    // *caller* collected it as a child keeps sibling order
+                    // correct: a null child queued alongside a non-null
+                    // sibling still waits its own turn on `stack`, so it
+                    // can't jump ahead of an earlier sibling's own subtree.
+                    if !is_null_current {
+                        next.push((path, child_value));
+                    }
+                }
+                Some(cond) => {
+                    // `cond` gates the child, not `current`, and forks once
+                    // per truthy output — see the doc comment above (#627).
+                    // A `cond` error aborts immediately too (#636), same as
+                    // `f`'s error above — this arm's own prefix-loss
+                    // (`next`'s already-cond-approved entries built so far
+                    // this node) is pre-existing and out of scope for #842,
+                    // which is specifically about `f`'s fan-out.
+                    //
+                    // Evaluated unconditionally, even when `current` is
+                    // null: like `f` above, `cond`'s own error/side effect
+                    // on a candidate child must still propagate, matching
+                    // real jq's `select(cond)` semantics (#856 review) --
+                    // only whether an *accepted* child gets queued for
+                    // further recursion is bounded by `is_null_current`,
+                    // not whether `cond` runs on it at all.
+                    match eval_owned_multi::<S>(cond, &child_value) {
+                        Ok(cond_outputs) => {
+                            if !is_null_current {
                                 for c in &cond_outputs {
                                     if c.is_truthy() {
                                         next.push((path.clone(), child_value.clone()));
                                     }
                                 }
                             }
-                            Err(e) => return Err((outputs, e)),
                         }
+                        Err(e) => return Err((outputs, e)),
                     }
                 }
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10630,24 +10630,7 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // still `O(path length)` per node, `O(d²)` total; #701, unfixed here.
         outputs.push((prefix.clone(), current.clone()));
 
-        // A null node ends its own line of descent here, unlike the value
-        // evaluator since #490 -- but (#856) it's still emitted above like
-        // every other popped node first; only the *recursion into it* is
-        // skipped, bounding path-prefix growth against a non-terminating
-        // `f` without dropping the null child's own path the way an early
-        // `continue` before crediting it would. Gating here (once popped,
-        // in its correct DFS position) rather than at collection time keeps
-        // sibling ordering correct: a null child collected alongside a
-        // non-null sibling must still wait for its turn on `stack`, so it
-        // can't jump ahead of an earlier sibling's own subtree. Confirmed
-        // against jq 1.7.1: `{"a":null,"b":{"x":1}} | path(recurse(if
-        // (.==null) then empty elif type=="object" then .[] else empty
-        // end))` streams `[]`, `["a"]`, `["b"]`, `["b","x"]` in that order
-        // -- the null leaf between the root and `b`'s own subtree, not
-        // after it.
-        if matches!(current.as_ref(), OwnedValue::Null) {
-            continue;
-        }
+        let is_null_current = matches!(current.as_ref(), OwnedValue::Null);
 
         // An `f` error aborts the whole traversal — see the doc comment
         // above (#636) — but only after whatever candidate children
@@ -10661,6 +10644,13 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // above already guarantees it's `true` on entry, so this is just
         // avoiding a second, separately-maintained "always trackable here"
         // claim inside the loop.
+        //
+        // `f` is evaluated here unconditionally, even when `current` is
+        // null: real jq applies `f` to every node `recurse` visits (see
+        // the doc comment above), so an `f` that errors on null (e.g.
+        // `.[]`) must still abort the whole call like any other `f` error
+        // -- only the *children* `f` produces from a null node are
+        // discarded below, not the call itself (#856 review).
         let (children, deferred_error) = match resolve_against_cow::<S>(f, current, trackable) {
             Ok(children) => (children, None),
             Err((partial_children, e)) => (partial_children, Some(e)),
@@ -10671,33 +10661,44 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // one popped, and its whole subtree completes before the second
         // entry is even reached.
         let mut next: Vec<PathBranch<'a>> = Vec::new();
-        for (child_components, child_value) in children {
-            // A null child is queued onto `next`/`stack` like any other --
-            // the null-recursion bound is enforced once popped, above, not
-            // here (#856), so it still gets its own turn through `cond`
-            // (if present) and its correct place in DFS order.
-            let mut path = prefix.clone();
-            path.extend(child_components);
+        // A null node's own line of descent ends here (see the doc comment
+        // above for why): the children `f` just produced from it are
+        // discarded rather than queued for further recursion, bounding
+        // path-prefix growth instead of relying on natural termination the
+        // way the value evaluator does. Its own path was already credited
+        // by the unconditional `outputs.push` above (#856); only recursion
+        // *into* it is skipped. Gating here -- once popped, in its correct
+        // DFS position -- rather than when the *caller* collected it as a
+        // child keeps sibling order correct: a null child queued alongside
+        // a non-null sibling still waits its own turn on `stack`, so it
+        // can't jump ahead of an earlier sibling's own subtree (confirmed
+        // against jq 1.7.1 with two siblings, one null and one with its
+        // own descendants).
+        if !is_null_current {
+            for (child_components, child_value) in children {
+                let mut path = prefix.clone();
+                path.extend(child_components);
 
-            match cond {
-                None => next.push((path, child_value)),
-                Some(cond) => {
-                    // `cond` gates the child, not `current`, and forks once
-                    // per truthy output — see the doc comment above (#627).
-                    // A `cond` error aborts immediately too (#636), same as
-                    // `f`'s error above — this arm's own prefix-loss
-                    // (`next`'s already-cond-approved entries built so far
-                    // this node) is pre-existing and out of scope for #842,
-                    // which is specifically about `f`'s fan-out.
-                    match eval_owned_multi::<S>(cond, &child_value) {
-                        Ok(cond_outputs) => {
-                            for c in &cond_outputs {
-                                if c.is_truthy() {
-                                    next.push((path.clone(), child_value.clone()));
+                match cond {
+                    None => next.push((path, child_value)),
+                    Some(cond) => {
+                        // `cond` gates the child, not `current`, and forks once
+                        // per truthy output — see the doc comment above (#627).
+                        // A `cond` error aborts immediately too (#636), same as
+                        // `f`'s error above — this arm's own prefix-loss
+                        // (`next`'s already-cond-approved entries built so far
+                        // this node) is pre-existing and out of scope for #842,
+                        // which is specifically about `f`'s fan-out.
+                        match eval_owned_multi::<S>(cond, &child_value) {
+                            Ok(cond_outputs) => {
+                                for c in &cond_outputs {
+                                    if c.is_truthy() {
+                                        next.push((path.clone(), child_value.clone()));
+                                    }
                                 }
                             }
+                            Err(e) => return Err((outputs, e)),
                         }
-                        Err(e) => return Err((outputs, e)),
                     }
                 }
             }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7326,6 +7326,49 @@ fn test_resolve_recurse_null_child_still_evaluates_f_and_propagates_its_error() 
     Ok(())
 }
 
+/// Second review-driven regression guard: an earlier version of the fix
+/// above evaluated `f` unconditionally on a null `current` (correctly
+/// propagating its error) but left `cond`'s evaluation nested inside the
+/// same `is_null_current` gate as the "queue for further recursion"
+/// decision -- so `cond`'s own error on a candidate child produced from an
+/// already-null `current` was still silently swallowed. This is a
+/// pre-existing gap (confirmed identical on `main` before #856 for the
+/// null-root case specifically, since a non-root value could never reach
+/// `current` while null before this fix), but #856's own restructuring
+/// widened its reach from "root only" to "any null node encountered
+/// during traversal" -- so it's fixed here rather than deferred. Verified
+/// against jq 1.7.1: `null | path(recurse(.a; error("boom")))` streams
+/// `[]` (the root's own path) then raises "boom" and exits 5.
+#[test]
+fn test_resolve_recurse_null_root_still_evaluates_cond_and_propagates_its_error() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "null | path(recurse(.a; error(\"boom\")))"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+    assert_eq!(stderr, "jq: error (at <unknown>): boom\n");
+    Ok(())
+}
+
+/// Companion to the test above, for the *widened* reach specifically: a
+/// null value reached partway through the traversal (not the root) must
+/// also still evaluate `cond` on its own candidate children. Verified
+/// against jq 1.7.1: `{"a":null} | path(recurse(.a; error("boom")))`
+/// streams `[]` (the root's own path) then raises "boom" and exits 5 --
+/// the null child `"a"` is reached, `f`(`.a`) is evaluated on it, and
+/// `cond`'s error on that result aborts the call, all before any further
+/// descent.
+#[test]
+fn test_resolve_recurse_null_child_still_evaluates_cond_and_propagates_its_error() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(recurse(.a; error(\"boom\")))"],
+        Some(r#"{"a":null}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+    assert_eq!(stderr, "jq: error (at <stdin>:0): boom\n");
+    Ok(())
+}
+
 #[test]
 fn test_recurse_f_keeps_own_partial_fanout_subtree_before_error_842() -> Result<()> {
     // A deeper #842 repro: the successfully-produced child (`.child`)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7208,6 +7208,80 @@ fn test_resolve_recurse_keeps_f_partial_fanout_before_error_842() -> Result<()> 
     Ok(())
 }
 
+/// #856: `resolve_recurse`'s null-child guard (`if matches!(child_value...,
+/// OwnedValue::Null) { continue; }` in its main loop) stopped recursion
+/// *into* a null child, as documented -- but the bare `continue` also
+/// discarded the null child's own path entirely, rather than still
+/// emitting it as a leaf the way `builtin_recurse_f`/`builtin_recurse_cond`
+/// (value position) correctly do. Verified against jq 1.7.1:
+/// `{"a":null} | path(recurse(if . == {"a":null} then .a else empty
+/// end))` prints `[]` (root) *and* `["a"]` (the null child, emitted as a
+/// leaf since its own recursion into `f` produces nothing further).
+#[test]
+fn test_resolve_recurse_emits_null_childs_own_path() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path(recurse(if . == {"a":null} then .a else empty end))"#,
+        ],
+        Some(r#"{"a":null}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n[\"a\"]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Companion to the test above: a null child emitted as a leaf must not
+/// jump ahead of an *earlier* sibling's own subtree just because it has no
+/// descendants of its own. `resolve_recurse` gates the null-recursion bound
+/// at the point a node is popped from its DFS stack (the same point every
+/// other node is emitted), not at child-collection time, specifically so a
+/// null child queued alongside a non-null sibling still waits its correct
+/// turn. Verified against jq 1.7.1: `{"a":null,"b":{"x":1,"y":2}} |
+/// path(recurse(if (.==null) then empty elif (type=="object") then .[]
+/// else empty end))` streams `[]`, `["a"]`, `["b"]`, `["b","x"]`,
+/// `["b","y"]` in that order -- the null leaf right after the root, before
+/// `b`'s own subtree, not interleaved with or after it.
+#[test]
+fn test_resolve_recurse_null_child_does_not_disturb_sibling_order() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path(recurse(if (.==null) then empty elif (type=="object") then .[] else empty end))"#,
+        ],
+        Some(r#"{"a":null,"b":{"x":1,"y":2}}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[]\n[\"a\"]\n[\"b\"]\n[\"b\",\"x\"]\n[\"b\",\"y\"]\n"
+    );
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Companion to the two tests above, for `recurse(f; cond)`: `cond` still
+/// gates whether a null child is emitted *at all* -- the null-recursion
+/// bound only decides whether a null child that already passed `cond`
+/// gets recursed into further, not whether `cond` itself applies to it.
+/// Verified against jq 1.7.1: `{"a":null} | path(recurse(.a;
+/// type=="object"))` prints only `[]` (root) and exits 0 -- the null
+/// child never appears, since `type=="object"` rejects it before it would
+/// ever be emitted (real jq's `paths(node_filter)` = `path(recurse|select(
+/// node_filter))`, and a `select`-rejected child is never even reached).
+#[test]
+fn test_resolve_recurse_cond_still_gates_null_child_emission() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(recurse(.a; type=="object"))"#],
+        Some(r#"{"a":null}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
 #[test]
 fn test_recurse_f_keeps_own_partial_fanout_subtree_before_error_842() -> Result<()> {
     // A deeper #842 repro: the successfully-produced child (`.child`)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7282,6 +7282,50 @@ fn test_resolve_recurse_cond_still_gates_null_child_emission() -> Result<()> {
     Ok(())
 }
 
+/// Review-driven regression guard for the fix above: bounding recursion
+/// *into* a null node must not also skip *evaluating* `f` on it -- real
+/// jq's `recurse` always applies `f` to every node it visits, root
+/// included, so an `f` that errors on a null node (e.g. `.[]`, "Cannot
+/// iterate over null") must still abort the whole call, exactly like an
+/// `f` error on any other node. An earlier version of this fix skipped
+/// `resolve_against_cow` entirely whenever the popped node was null,
+/// silently swallowing that error instead of propagating it -- for the
+/// DFS-seed (root) value specifically, since a null root is seeded
+/// directly onto the stack without going through the per-child collection
+/// loop at all. Verified against jq 1.7.1: `null | path(recurse(.[]))`
+/// raises "Cannot iterate over null (null)" and exits 5, printing `[]`
+/// (the root's own path) first.
+#[test]
+fn test_resolve_recurse_null_root_still_evaluates_f_and_propagates_its_error() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "null | path(recurse(.[]))"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+    assert_eq!(
+        stderr,
+        "jq: error (at <unknown>): Cannot iterate over null (null)\n"
+    );
+    Ok(())
+}
+
+/// Same regression guard as above, but for a null *child* rather than the
+/// root: `f` must still be evaluated on a null child that was correctly
+/// queued and emitted (per the fix's primary #856 repro), not just on a
+/// null root. Verified against jq 1.7.1: `{"a":null} |
+/// path(recurse(.[]))` streams `[]` then `["a"]` before raising "Cannot
+/// iterate over null (null)" and exiting 5 -- the error surfaces only
+/// once the traversal actually reaches the null child, not before.
+#[test]
+fn test_resolve_recurse_null_child_still_evaluates_f_and_propagates_its_error() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "path(recurse(.[]))"], Some(r#"{"a":null}"#))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n[\"a\"]\n");
+    assert_eq!(
+        stderr,
+        "jq: error (at <stdin>:0): Cannot iterate over null (null)\n"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_recurse_f_keeps_own_partial_fanout_subtree_before_error_842() -> Result<()> {
     // A deeper #842 repro: the successfully-produced child (`.child`)


### PR DESCRIPTION
## Summary

- `resolve_recurse`'s null-child guard (`src/jq/eval.rs`) is documented as stopping recursion *into* a null child (bounding path-prefix growth against a non-terminating `f`, e.g. `recurse(.a?)` over `{"a":null}`). But the bare `continue` in the per-child collection loop discarded the null child's own path entirely, rather than still emitting it as a leaf the way the value-position evaluator (`builtin_recurse_f`/`builtin_recurse_cond`) correctly does.
- **Commit 1**: move the null check from child-collection time to stack-pop time — the same point every other node is already unconditionally emitted. Gating at pop-time (rather than collection-time) also keeps DFS sibling ordering correct: a null child queued alongside a non-null sibling still waits its turn on the stack instead of jumping ahead of that sibling's own subtree.
- **Commit 2** (review-driven): commit 1 skipped calling `resolve_against_cow` (which evaluates `f`) entirely whenever the popped node was null — which also skipped *evaluating* `f` on it, silently swallowing any error `f` would raise there. Genuine regression from `main` for the DFS root specifically (`null | path(recurse(.[]))` errors on `main`, matching real jq, but silently succeeded after commit 1). Corrected by evaluating `f` unconditionally and only discarding the *children* it produces when the current node is null.
- **Commit 3** (review-driven, a second pass): commit 2 evaluated `f` unconditionally but left `cond`'s evaluation (in the `recurse(f; cond)` form) nested inside the same `is_null_current` gate as the "queue for further recursion" decision — so `cond`'s own error/side-effect on a candidate child produced from an already-null current was still silently swallowed. This turned out to be a *pre-existing* gap (confirmed identical on `main`, before any of these commits, for the null-*root* case specifically — a non-root value could never reach `current` while null before commit 1 existed), but commit 1's restructuring widened its reach from "root only" to "any null node encountered during traversal." Fixed by evaluating `cond` unconditionally too, the same way `f` now is; only whether an *accepted* child gets queued for further recursion is gated on `is_null_current`.
- Verified against real jq 1.7.1 for every case across all three commits: the issue's own repro, DFS sibling ordering, `cond` rejecting a null child outright, plain `recurse` on null-containing input, `f` erroring on a null root/child, `cond` erroring on a candidate produced from a null root *and* from a null non-root child, and confirmed the guard's original non-termination bound still holds in every shape tried.
- Rebased cleanly onto latest `main` (10 commits, unrelated files) with no conflicts; re-verified against real jq post-rebase.

Fixes #856

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green; one unrelated pre-existing flake from concurrent-session file-lock contention confirmed to pass in isolation and on re-run)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against pinned real `jq` 1.7.1 directly for every case across all three commits — all match exactly, including exit codes and stderr text
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — 100% patch coverage (9/9 new lines covered, post-rebase)
- [x] Two rounds of independent multi-agent code review (10 finder angles each); both substantive findings verified with a built binary against real jq and fixed in commits 2 and 3