### PR TITLE
fix(cli): resolve a bare-dash sequence item before recursing in corpus_stats

### DIFF
--- a/src/bin/succinctly/corpus_stats.rs
+++ b/src/bin/succinctly/corpus_stats.rs
@@ -373,7 +373,19 @@ fn visit_yaml(
                 if block && has_bare_dash_indicator(bytes, &child) {
                     counters.bare_dash_items += 1;
                 }
-                visit_yaml(index, bytes, child, st, counters);
+                // `child` deliberately stays unresolved for the bare-dash
+                // check above (it needs the wrapper's own position), but
+                // the recursive visit must not see the wrapper: `style()`
+                // (unlike `value()`) doesn't self-resolve, so a bare-`-`
+                // deferred flow mapping/sequence would otherwise read the
+                // `-`'s own text position instead of the deferred value's,
+                // never reporting "flow" (#849). `resolve_bare_seq_item` is
+                // private to `yaml::light`, so resolve via the public
+                // `uncons_resolved_cursor` instead of re-deriving it here.
+                let resolved = es
+                    .uncons_resolved_cursor()
+                    .map_or(child, |(resolved, _)| resolved);
+                visit_yaml(index, bytes, resolved, st, counters);
                 es = rest;
             }
             st.items_per_sequence.push(n);
@@ -1028,6 +1040,33 @@ mod tests {
         // exactly one flow collection recorded, of length == "[1, 2, 3]"
         assert_eq!(st.flow_collection_bytes.values.len(), 1);
         assert_eq!(st.flow_collection_bytes.values[0], "[1, 2, 3]".len() as u64);
+    }
+
+    #[test]
+    fn yaml_bare_dash_deferred_flow_collections_are_recorded_as_flow() {
+        // #849: a totally bare `-` sequence-item wrapper (the `-` alone on
+        // its own line, value deferred to the next line) used to make
+        // `visit_yaml`'s recursive call pass the wrapper's own cursor
+        // straight into `record_flow`, which reads `cur.style()` -- a
+        // method that (unlike `value()`) doesn't self-resolve through the
+        // wrapper, so it read the `-`'s own text position instead of the
+        // deferred value's and never reported "flow". Both a bare-dash
+        // sequence and a bare-dash mapping are covered; a same-line item
+        // (`- [7, 8]`) is included as the pre-existing, already-working
+        // control.
+        let doc = b"items:\n  -\n    [1, 2, 3]\n  -\n    {a: 1, b: 2}\n  - [7, 8]\n";
+        let mut st = YamlStats::default();
+        ingest_yaml(doc, &mut st).unwrap();
+
+        let mut lens = st.flow_collection_bytes.values.clone();
+        lens.sort_unstable();
+        let mut expected = vec![
+            "[1, 2, 3]".len() as u64,
+            "{a: 1, b: 2}".len() as u64,
+            "[7, 8]".len() as u64,
+        ];
+        expected.sort_unstable();
+        assert_eq!(lens, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `corpus_stats.rs`'s `record_flow` reads `cur.style()` on the current node being visited to decide whether to record the P5 flow-collection-bytes stat.
- `visit_yaml`'s `Sequence` arm passes its raw child cursor (from `YamlElements::uncons_cursor`) straight into its own recursive call. For a totally bare `-` sequence item (`-` alone on its own line, value deferred to the next line, e.g. `-\n  {a: 1}\n`), that cursor stays positioned at the wrapper's `-` rather than the deferred value.
- `value()` self-resolves through the wrapper (so the recursive call's own `match cur.value()` still dispatches to the correct `Mapping`/`Sequence`/`String` arm), but `style()` does not — so `record_flow`'s `cur.style()` read the wrapper's own text position instead, and never reported `"flow"` for these items, silently undercounting the stat.
- Fix: resolve through the already-public `YamlElements::uncons_resolved_cursor` before recursing. `has_bare_dash_indicator`'s own check right above it deliberately keeps using the raw, unresolved wrapper cursor (it needs the `-`'s own position) — only the cursor passed into the recursive `visit_yaml` call changes.
- `resolve_bare_seq_item` (the private method that would do this directly) isn't reachable from `corpus_stats.rs`, a separate binary-crate module — hence going through the public `uncons_resolved_cursor` wrapper instead, per the issue's own suggested fix direction.
- Internal dev-tool only — doesn't touch `yq`/`jq` query output or anything users see.

Fixes #849

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New unit test (`yaml_bare_dash_deferred_flow_collections_are_recorded_as_flow`) added directly in `corpus_stats.rs`'s own test module; confirmed it fails against unmodified `main` (only the inline control item was recorded; both bare-dash items were silently missing) and passes with this fix
- [x] Manually ran `dev bench corpus-stats` against a small test corpus containing both inline and bare-dash-deferred flow collections — flow-collection count went from 2 (inline only) to 4 (inline + bare-dash) after the fix
- [x] Existing `corpus_stats_cli_tests.rs` golden test (`--check` against the committed seed corpus) still passes unchanged — the seed corpus doesn't happen to contain this shape, so no golden regeneration needed
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — no new executable lines lack coverage