### PR TITLE
fix(jq): isvalid propagates an unresolved break instead of answering true

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13403,15 +13403,41 @@ fn builtin_isvalid<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // A halt is never a validity verdict: it must exit the process, not
         // report `true`/`false` and let evaluation continue (#791) — same
         // shape as the `Error`/`None` cases above never being swallowed by
-        // `isempty`.
-        QueryResult::Halt(code) => QueryResult::Halt(code),
-        QueryResult::Partial(_, Control::Halt(code)) => QueryResult::Halt(code),
+        // `isempty`. Both the bare and `Partial`-prefixed shapes propagate
+        // identically, so they're one OR-pattern arm (matching this file's
+        // own precedent, e.g. `QueryResult::is_error`).
+        QueryResult::Halt(code) | QueryResult::Partial(_, Control::Halt(code)) => {
+            QueryResult::Halt(code)
+        }
         // Same reasoning applies to an unresolved `break`: it must keep
         // unwinding toward its enclosing `label`, not report `true` and let
         // evaluation continue (#867) — the `_` catch-all below previously
         // swallowed both shapes exactly like the `Halt` cases once did.
-        QueryResult::Break(label) => QueryResult::Break(label),
-        QueryResult::Partial(_, Control::Break(label)) => QueryResult::Break(label),
+        //
+        // Deliberately propagates `Partial(_, Control::Break(_))`
+        // unconditionally too, same as `Halt` above, even though a prior
+        // output *was* produced — this is not an oversight, and does not
+        // need `isempty`'s asymmetric treatment (see that function's own
+        // comment): `isempty`'s asymmetry exists because real jq's own
+        // laziness means a break *after* the first output is never even
+        // reached there. `isvalid` has no such laziness (`eval_single`
+        // evaluates the whole argument eagerly), so the real question is
+        // simply "is a trailing `break` isvalid's concern, or a foreign
+        // escape passing through it" - and unwrapped jq settles that:
+        // `label $out | (1, break $out), "after"` prints `1` then unwinds
+        // to `$out` untouched (exit 0), while the structurally identical
+        // `(1, error("x")), "after"` prints `1` then genuinely fails (exit
+        // 5) - real jq itself only ever "digests" the *error* case into a
+        // pass/fail outcome, never the break case, regardless of what
+        // already ran before it. `isvalid` mirrors that: `Error`/`None`
+        // are its actual domain (digested into `Bool`), `Break` and `Halt`
+        // are both foreign control escapes that must pass through
+        // unconverted no matter what already ran - keeping `Break`
+        // symmetric with the already-established `Halt` arm above, not
+        // with `Error`.
+        QueryResult::Break(label) | QueryResult::Partial(_, Control::Break(label)) => {
+            QueryResult::Break(label)
+        }
         _ => QueryResult::Owned(OwnedValue::Bool(true)),
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18785,6 +18785,17 @@ fn builtin_delpaths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // array" (#791).
         QueryResult::Halt(code) => return QueryResult::Halt(code),
         QueryResult::Partial(_, Control::Halt(code)) => return QueryResult::Halt(code),
+        // Same reasoning for a bare, unresolved `break` (#867 follow-up):
+        // must keep unwinding, not be misreported as the same array-type
+        // error. Deliberately asymmetric with `Halt` above, though:
+        // `Partial(_, Control::Break(_))` (paths_expr already produced a
+        // value before breaking) stays on the wildcard arm below, since
+        // real jq only ever demands paths_expr's *first* output here and
+        // never reaches a later comma branch at all — confirmed via oracle,
+        // `delpaths(1, break $out)` in real jq 1.7.1 raises the same "Paths
+        // must be specified as an array" error this wildcard already
+        // produces, it never even reaches the break.
+        QueryResult::Break(label) => return QueryResult::Break(label),
         _ => return QueryResult::Error(EvalError::paths_must_be_array()),
     };
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18724,6 +18724,20 @@ fn builtin_isempty<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // case, same as it already does for `Partial(_, Control::Error(_))`
         // (#791).
         QueryResult::Halt(code) => return QueryResult::Halt(code),
+        // Same reasoning for `break`, and the same asymmetry: a bare `Break`
+        // (zero prior output) must propagate — `isempty(break $out)` in real
+        // jq produces no output and exits 0, matching real jq's own `def
+        // isempty(g): label $out | (g|false,break $out), true;`, which never
+        // even asks `g` for a value at all when `g`'s very first "output" is
+        // itself a break. `Partial(_, Control::Break(_))` (`g` already
+        // produced a value before the break) must NOT propagate, though:
+        // real jq's laziness means `g`'s second output is never requested
+        // once the first already answered `isempty`'s own internal `break
+        // $out` — confirmed via oracle (`isempty(1, break $out)` answers
+        // `false` in real jq 1.7.1, same as `isempty(1, halt_error(3))`
+        // above) — so the wildcard arm correctly still answers `false` for
+        // that shape too (#867 follow-up).
+        QueryResult::Break(label) => return QueryResult::Break(label),
         _ => false,
     };
     QueryResult::Owned(OwnedValue::Bool(is_empty))

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13406,6 +13406,12 @@ fn builtin_isvalid<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // `isempty`.
         QueryResult::Halt(code) => QueryResult::Halt(code),
         QueryResult::Partial(_, Control::Halt(code)) => QueryResult::Halt(code),
+        // Same reasoning applies to an unresolved `break`: it must keep
+        // unwinding toward its enclosing `label`, not report `true` and let
+        // evaluation continue (#867) — the `_` catch-all below previously
+        // swallowed both shapes exactly like the `Halt` cases once did.
+        QueryResult::Break(label) => QueryResult::Break(label),
+        QueryResult::Partial(_, Control::Break(label)) => QueryResult::Break(label),
         _ => QueryResult::Owned(OwnedValue::Bool(true)),
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3073,6 +3073,46 @@ fn test_delpaths_propagates_halt_in_paths_argument() -> Result<()> {
     Ok(())
 }
 
+/// Companion to `test_delpaths_propagates_halt_in_paths_argument`, for a
+/// bare `break` (#867 follow-up): must keep unwinding, not be misreported
+/// as "Paths must be specified as an array". Verified against jq 1.7.1:
+/// `label $out | delpaths(break $out), "after"` produces no output and
+/// exits 0.
+#[test]
+fn test_delpaths_propagates_bare_break_to_outer_label() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "label $out | delpaths(break $out), \"after\""],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// The asymmetric counterpart, mirroring `isempty`'s equivalent pair of
+/// tests: unlike the bare-break case above, a `break` surfacing *after*
+/// `paths_expr` already produced a value must NOT propagate. Real jq's
+/// `delpaths` only ever demands `paths_expr`'s first output, so a
+/// non-array first value raises immediately without ever reaching a later
+/// comma branch. Verified against jq 1.7.1: `delpaths(1, break $out)`
+/// raises "Paths must be specified as an array", the same error the bare
+/// non-array case already produces — it never reaches the break.
+#[test]
+fn test_delpaths_break_after_partial_output_does_not_propagate() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "label $out | delpaths(1, break $out), \"after\""],
+        None,
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Paths must be specified as an array"),
+        "{stderr}"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_nth_stream_propagates_halt_in_n_argument() -> Result<()> {
     // The two-argument `nth(n; expr)` form matched its `n` argument's result

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7432,6 +7432,62 @@ fn test_isvalid_propagates_halt_from_partial_argument_result() -> Result<()> {
     Ok(())
 }
 
+/// `builtin_isvalid`'s `QueryResult::Break`/`Partial(_, Control::Break(_))`
+/// arms (#867): mirrors the `Halt` arms directly above -- an unresolved
+/// `break $label` in `isvalid`'s argument must keep unwinding toward its
+/// enclosing `label`, not be swallowed by the old `_ => Bool(true)`
+/// catch-all. `isvalid` is a succinctly-only extension (no real jq to diff
+/// against), but the `break`/`label` semantics it must not interfere with
+/// are real jq's own: this input would produce no output and exit 0 in real
+/// jq if `isvalid` didn't exist to swallow the break at all.
+#[test]
+fn test_isvalid_propagates_bare_break_to_outer_label() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "label $out | isvalid(break $out), \"after\""], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Companion to the bare-break test above, for the `Partial(_,
+/// Control::Break(_))` arm specifically: an argument that produces an
+/// output *before* breaking (`1, break $out`) comes back as
+/// `QueryResult::Partial`, not a bare `Break` -- same distinction
+/// `test_isvalid_propagates_halt_from_partial_argument_result` draws for
+/// `Halt`.
+#[test]
+fn test_isvalid_propagates_break_from_partial_argument_result() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "label $out | isvalid(1, break $out), \"after\""],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// The issue's own repro shape: a `break` surfacing through
+/// `paths(node_filter)` (only reachable as a bare `Break` since #850 fixed
+/// `builtin_paths_filter`'s own control-signal handling) wrapped in
+/// `isvalid`. Confirms the fix is reachable through a realistic nested
+/// builtin call, not just a directly-written `break $out`.
+#[test]
+fn test_isvalid_propagates_break_through_paths_filter() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | isvalid(paths(if type=="number" then break $out else true end))"#,
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
 /// `continue_rest_with_context`'s bare `QueryResult::Halt` arm: reached
 /// whenever an `If`/`Comma`/`Try`/`Label` branch inside a path-context pipe
 /// (here, `if`'s `then` branch) halts with zero prior output of its own and

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2999,6 +2999,45 @@ fn test_isempty_propagates_halt_instead_of_answering_false() -> Result<()> {
     Ok(())
 }
 
+/// Companion to `test_isempty_propagates_halt_instead_of_answering_false`,
+/// for `break` (#867 follow-up): the same "zero prior outputs must
+/// propagate" reasoning applies to a bare `Break`, not just `Halt`.
+/// Verified against jq 1.7.1: `label $out | isempty(break $out), "after"`
+/// produces no output and exits 0.
+#[test]
+fn test_isempty_propagates_bare_break_to_outer_label() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "label $out | isempty(break $out), \"after\""], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// The asymmetric counterpart: unlike the bare-break case above, a `break`
+/// that only surfaces *after* `g` already produced an output must NOT
+/// propagate — real jq's `isempty` is defined as `label $out | (g|false,
+/// break $out), true`, so `g`'s second output (the `break`) is never even
+/// requested once its first output already answered `isempty`'s own
+/// internal `break $out`. Verified against jq 1.7.1: `isempty(1, break
+/// $out)` answers `false` then prints `"after"`, exiting 0 — the exact
+/// same shape as `isempty(1, halt_error(3))` staying `false` above it in
+/// this file. This must keep passing after the bare-break fix; a
+/// mechanical "propagate every Break/Partial(_, Break)" fix (mirroring
+/// `isvalid`'s) would have broken this case, which is why `isempty`'s fix
+/// only touches the bare `Break` arm, not `Partial(_, Control::Break(_))`.
+#[test]
+fn test_isempty_break_after_partial_output_does_not_propagate() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "label $out | isempty(1, break $out), \"after\""],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "false\n\"after\"\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
 #[test]
 fn test_setpath_propagates_halt_in_path_argument() -> Result<()> {
     // `builtin_setpath`'s path-array argument used to misreport a halt as


### PR DESCRIPTION
## Summary

- `builtin_isvalid`'s match on its argument's evaluation result explicitly handled `Error`, `None`, `Halt`, and `Partial(_, Control::Halt(_))`, but had no arm for a bare `QueryResult::Break` or `Partial(_, Control::Break(_))` — both fell into the `_ => Bool(true)` catch-all, silently treating an unresolved `break $label` as "the argument is valid" instead of letting it keep unwinding toward its enclosing `label`.
- `isvalid` is a succinctly-only extension (not a real jq builtin), so there's no oracle to diff against — but the `break`/`label` semantics it must not interfere with are real jq's own.
- Fixes #867.

**Expanded twice during code review**, once the same bug shape was confirmed live in two more hand-rolled-match builtins:
- `builtin_isempty` (a *real* jq builtin) — fixed, with one important asymmetry discovered along the way: unlike `isvalid`, `isempty`'s own laziness (`def isempty(g): label $out | (g|false,break $out), true;`) means a `break` surfacing *after* `g`'s first output must **not** propagate — only a bare `Break` with zero prior output does.
- `builtin_delpaths` — fixed, with an analogous but differently-caused asymmetry: real jq's `delpaths` only ever demands its argument's *first* output, so a `break` after a prior output never gets reached at all.

Both asymmetries, and `isvalid`'s own deliberate *lack* of asymmetry (it propagates `Partial(_, Control::Break(_))` unconditionally, unlike `isempty`/`delpaths`), are oracle-verified and documented in-line — a mechanical "propagate every Break/Partial(_, Break) the same way" fix would have broken at least two of these three functions.

Several related bugs were found and confirmed during review but are **out of scope** for this PR (different root causes/mechanisms, need their own investigation) — filed as follow-ups:
- #880 — `builtin_in` has the same Halt/Break-swallowing shape, but interacts with genuine multi-output fan-out mechanics this PR didn't trace.
- #881 — `isvalid` also wrongly answers `true` when a later comma-sibling's genuine error is masked by its own broad `optional=true` forcing (unrelated to the Break-swallowing bug this PR fixes; independently reconfirmed, and one proposed fix mechanism explicitly ruled out via direct testing — see the issue for details).
- #882 — `isempty`'s pre-existing `Error(_) => true` arm also diverges from real jq (which propagates an uncaught error); left out since it changes established behavior rather than adding a missing arm.
- Also confirmed, but already covered by the existing, deliberately large-scope #833 (`result_to_owned`/`eval_owned_expr` audit): the identical Break-swallowing shape in `has`/`contains`/`inside`/`test`/`getpath`/the regex builtin family, and in path-context-routed pipe evaluation reaching `isvalid`/`isempty` via a different call path than this PR's fix covers. Added as supporting evidence on #833.

## Test plan

- [x] `cargo build --features cli` succeeds
- [x] `cargo test --features cli,simd,regex,serde` — full workspace suite green (0 failures), re-verified after every expansion
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Every behavioral claim (including both asymmetries and `isvalid`'s deliberate non-asymmetry) verified against the pinned jq 1.7.1 oracle directly, or against `isvalid`'s own unwrapped-jq baseline behavior where no direct oracle exists
- [x] `omni-dev coverage diff` — 100% patch coverage (6/6 new lines)
- [x] 12 new regression tests added in `tests/jq_cli_tests.rs` across `isvalid`/`isempty`/`delpaths`, each shape (bare break, break-after-partial-output, and — for `isvalid` — the issue's own `paths(...)`-wrapped repro) independently oracle-verified