### PR TITLE
test(yq): pin flow-style preservation on array-element assignment (#707)

### DIFF
--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -578,6 +578,21 @@ fn test_identity_preserves_flow_nested_under_block_mapping() -> Result<()> {
     Ok(())
 }
 
+/// #707's second repro: writing to one element of a flow-style array must
+/// not reformat the array itself to block style. The `_739` tests above
+/// cover an untouched *sibling* keeping its style, and a directly-written
+/// *scalar* keeping its own; this is the container analog of the latter --
+/// the array's own node is what's mutated (`reconcile_presentation`'s
+/// `Array` arm), not just a value inside it. Verified against real yq:
+/// `a: [1, 2, 3]` + `.a[0] = 9` -> `a: [9, 2, 3]`.
+#[test]
+fn test_assign_to_flow_array_element_preserves_the_arrays_own_flow_style_707() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a[0] = 9", "a: [1, 2, 3]\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: [9, 2, 3]\n");
+    Ok(())
+}
+
 /// #707: the fix applies to any pure-navigation query, not just the bare
 /// identity `.` P9 fast path — `.top` still routes through the same
 /// cursor-streaming `stream_yaml_value` and must preserve style too.


### PR DESCRIPTION
## Summary

- #707 reported that `succinctly yq` always re-serialized YAML as block style, even for an unmodified identity query on flow-style input, with two repros: a plain identity/navigation case and a partial-edit case (`.a[0] = 9` on a flow-style array).
- PR #744 (branch `issue-707-style-not-preserved`) already fixed this and added regression coverage for the first repro (identity/navigation preserving flow style) and the general untouched-sibling-style case (`_739` tests from the later ADR-0017 work) — but #707 itself was never closed, matching this repo's documented recurring "#767 pattern" of fixed-but-still-open issues.
- The one gap: no test covered #707's *second* repro specifically — assigning into one element of a flow-style array, where the array's own node (not just an untouched sibling) is what's mutated. Verified against real `yq` (`a: [1, 2, 3]` + `.a[0] = 9` → `a: [9, 2, 3]`) before adding the test.
- Closing #707 now that its coverage is complete.

Closes #707

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Both of #707's original repro commands, plus a quote-style preservation check, diffed directly against real `yq` — all match exactly
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — test-only diff, no new executable lines
- [x] `omni-dev git commit message lint` — clean