### PR TITLE
fix(yaml): derive compact-mapping indent from the real dash column

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1911,13 +1911,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // The sequence item contains a mapping.
             //
             // The key's real column, not a hardcoded `indent + 2` - `- `
-            // (dash + whitespace) is already skipped by this point, same as
-            // the nested-sequence arm above uses `self.current_column()`
-            // rather than assuming a fixed offset. A fixed `indent + 2`
-            // assumed exactly one space after the dash: with more than one
-            // (`-   a: hello`), every entry after the compact mapping's
-            // first field folded into that first field's own value instead
-            // of being recognized as its own entry (#877).
+            // (dash + whitespace) is already skipped by this point, so
+            // `self.current_column()` is exact regardless of spacing. A
+            // fixed `indent + 2` assumed exactly one space after the dash:
+            // with more than one (`-   a: hello`), every entry after the
+            // compact mapping's first field folded into that first field's
+            // own value instead of being recognized as its own entry (#877).
             let compact_indent = self.current_column();
             self.parse_compact_mapping_entry(compact_indent)?;
             // Don't close anything - mapping and item will be closed by
@@ -2627,7 +2626,14 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 if !self.at_line_end() {
                     // Parse item value
                     if self.looks_like_mapping_entry() {
-                        self.parse_compact_mapping_entry(indent + 3)?;
+                        // The key's real column, not a hardcoded `indent + 3`
+                        // - `- ` is already skipped above, so `self.pos` sits
+                        // at the key. `indent + 3` was wrong even for the
+                        // ordinary single-space case (`? - a: 1`): `?` + ` `
+                        // + `-` + ` ` is 4 columns, not 3, so every field
+                        // after the compact mapping's first silently landed
+                        // at the wrong indent (#877 follow-up).
+                        self.parse_compact_mapping_entry(self.current_column())?;
                     } else {
                         self.parse_value(indent + 2)?;
                     }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1909,9 +1909,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // Check for compact mapping: `- key: value`
             // This is a mapping entry directly as the sequence item value
             // The sequence item contains a mapping.
-            // Use indent + 2 so that entries at actual indent >= indent+2 are
-            // considered part of this mapping.
-            let compact_indent = indent + 2;
+            //
+            // The key's real column, not a hardcoded `indent + 2` - `- `
+            // (dash + whitespace) is already skipped by this point, same as
+            // the nested-sequence arm above uses `self.current_column()`
+            // rather than assuming a fixed offset. A fixed `indent + 2`
+            // assumed exactly one space after the dash: with more than one
+            // (`-   a: hello`), every entry after the compact mapping's
+            // first field folded into that first field's own value instead
+            // of being recognized as its own entry (#877).
+            let compact_indent = self.current_column();
             self.parse_compact_mapping_entry(compact_indent)?;
             // Don't close anything - mapping and item will be closed by
             // close_deeper_indents when we see content at lower indent.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5641,6 +5641,72 @@ fn test_compact_mapping_first_field_dispatch_agrees_with_ordinary_mapping_entry_
 }
 
 // ============================================================================
+// Extra spaces after a block-sequence dash (#877)
+// ============================================================================
+// `parse_sequence_item`'s compact-mapping dispatch used to hardcode
+// `compact_indent = indent + 2`, assuming exactly one space between `-` and
+// a compact item's first key. With more than one space, every field after
+// the first folded into the first field's own scalar value instead of being
+// recognized as its own entry - `-   a: hello` / `    b: 2` (three spaces
+// after the dash) read back as `{"a":"hello b"}` (`b` concatenated as text
+// onto `a`'s value, `2` lost entirely).
+
+#[test]
+fn test_compact_mapping_extra_spaces_after_dash_877() -> Result<()> {
+    let (output, exit_code) =
+        run_yq_stdin(".", "-   a: hello\n    b: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":"hello","b":2}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_compact_mapping_extra_spaces_after_dash_multi_field_877() -> Result<()> {
+    let (output, exit_code) = run_yq_stdin(
+        ".",
+        "-     a: 1\n      b: 2\n      c: 3\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":1,"b":2,"c":3}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_compact_mapping_extra_spaces_after_dash_with_flow_first_field_877() -> Result<()> {
+    // Interacts with #864's fix: the compact-mapping indent this dispatches
+    // through is the same one #877 fixes, so a flow-collection first field
+    // (routed through the #864 arms) must also land at the correct column
+    // when the dash has extra spaces.
+    let (output, exit_code) =
+        run_yq_stdin(".", "-   a: {x: 1}\n    b: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":{"x":1},"b":2}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_compact_mapping_extra_spaces_after_dash_multiple_items_877() -> Result<()> {
+    let (output, exit_code) = run_yq_stdin(
+        ".",
+        "-   a: 1\n    b: 2\n-   a: 3\n    b: 4\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":1,"b":2},{"a":3,"b":4}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_compact_mapping_single_space_after_dash_still_works_877() -> Result<()> {
+    // Control: the ordinary single-space case must remain unaffected.
+    let (output, exit_code) = run_yq_stdin(".", "- a: hello\n  b: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":"hello","b":2}]"#);
+    Ok(())
+}
+
+// ============================================================================
 // Out-dented block sequence continuation (#485)
 // ============================================================================
 // A continuation `-` indented strictly between a sequence's own indent and

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3610,6 +3610,35 @@ fn test_yaml_explicit_non_scalar_key_headline_repro() -> Result<()> {
 }
 
 #[test]
+fn test_yaml_explicit_key_sequence_item_compact_mapping_second_field_877() -> Result<()> {
+    // A different shape from the headline repro above: the key sequence's
+    // first item is itself a compact mapping (`? - a: 1`, not `? - a`). This
+    // arm hardcoded `indent + 3` for the compact mapping's own indent - wrong
+    // even for ordinary single-space spacing (`?` + ` ` + `-` + ` ` is 4
+    // columns, not 3) - so the second field silently landed at the wrong
+    // indent and the `: value` line was swallowed into it instead of closing
+    // the entry. A single-field compact mapping here never exercised the bug
+    // (nothing to land at the wrong indent), which is why it takes a second
+    // field to distinguish this from #877's own primary repro.
+    let input = "? - a: 1\n    b: 2\n: value\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"":"value"}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_explicit_key_sequence_item_compact_mapping_extra_spaces_877() -> Result<()> {
+    // Combines the two #877 shapes: extra spaces after the nested `-`, on
+    // top of the explicit-key wrapper.
+    let input = "? -   a: 1\n      b: 2\n: value\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"":"value"}"#);
+    Ok(())
+}
+
+#[test]
 fn test_yaml_explicit_non_scalar_key_keeps_its_siblings() -> Result<()> {
     // Entries before and after the explicit entry are unaffected.
     let input = "x: 1\n? - a\n  - b\n: value\ny: 2\n";
@@ -5652,57 +5681,32 @@ fn test_compact_mapping_first_field_dispatch_agrees_with_ordinary_mapping_entry_
 // onto `a`'s value, `2` lost entirely).
 
 #[test]
-fn test_compact_mapping_extra_spaces_after_dash_877() -> Result<()> {
-    let (output, exit_code) =
-        run_yq_stdin(".", "-   a: hello\n    b: 2\n", &["-o", "json", "-I0"])?;
-    assert_eq!(exit_code, 0);
-    assert_eq!(output.trim(), r#"[{"a":"hello","b":2}]"#);
-    Ok(())
-}
-
-#[test]
-fn test_compact_mapping_extra_spaces_after_dash_multi_field_877() -> Result<()> {
-    let (output, exit_code) = run_yq_stdin(
-        ".",
-        "-     a: 1\n      b: 2\n      c: 3\n",
-        &["-o", "json", "-I0"],
-    )?;
-    assert_eq!(exit_code, 0);
-    assert_eq!(output.trim(), r#"[{"a":1,"b":2,"c":3}]"#);
-    Ok(())
-}
-
-#[test]
-fn test_compact_mapping_extra_spaces_after_dash_with_flow_first_field_877() -> Result<()> {
-    // Interacts with #864's fix: the compact-mapping indent this dispatches
-    // through is the same one #877 fixes, so a flow-collection first field
-    // (routed through the #864 arms) must also land at the correct column
-    // when the dash has extra spaces.
-    let (output, exit_code) =
-        run_yq_stdin(".", "-   a: {x: 1}\n    b: 2\n", &["-o", "json", "-I0"])?;
-    assert_eq!(exit_code, 0);
-    assert_eq!(output.trim(), r#"[{"a":{"x":1},"b":2}]"#);
-    Ok(())
-}
-
-#[test]
-fn test_compact_mapping_extra_spaces_after_dash_multiple_items_877() -> Result<()> {
-    let (output, exit_code) = run_yq_stdin(
-        ".",
-        "-   a: 1\n    b: 2\n-   a: 3\n    b: 4\n",
-        &["-o", "json", "-I0"],
-    )?;
-    assert_eq!(exit_code, 0);
-    assert_eq!(output.trim(), r#"[{"a":1,"b":2},{"a":3,"b":4}]"#);
-    Ok(())
-}
-
-#[test]
-fn test_compact_mapping_single_space_after_dash_still_works_877() -> Result<()> {
-    // Control: the ordinary single-space case must remain unaffected.
-    let (output, exit_code) = run_yq_stdin(".", "- a: hello\n  b: 2\n", &["-o", "json", "-I0"])?;
-    assert_eq!(exit_code, 0);
-    assert_eq!(output.trim(), r#"[{"a":"hello","b":2}]"#);
+fn test_compact_mapping_dash_spacing_877() -> Result<()> {
+    let cases: &[(&str, &str)] = &[
+        // Extra spaces, the headline repro.
+        ("-   a: hello\n    b: 2\n", r#"[{"a":"hello","b":2}]"#),
+        // Extra spaces, three fields.
+        (
+            "-     a: 1\n      b: 2\n      c: 3\n",
+            r#"[{"a":1,"b":2,"c":3}]"#,
+        ),
+        // Extra spaces + a flow-collection first field: interacts with
+        // #864's fix, since the compact-mapping indent this dispatches
+        // through is the same one #877 fixes.
+        ("-   a: {x: 1}\n    b: 2\n", r#"[{"a":{"x":1},"b":2}]"#),
+        // Extra spaces, multiple compact items in one sequence.
+        (
+            "-   a: 1\n    b: 2\n-   a: 3\n    b: 4\n",
+            r#"[{"a":1,"b":2},{"a":3,"b":4}]"#,
+        ),
+        // Control: the ordinary single-space case must remain unaffected.
+        ("- a: hello\n  b: 2\n", r#"[{"a":"hello","b":2}]"#),
+    ];
+    for (input, expected) in cases {
+        let (output, exit_code) = run_yq_stdin(".", input, &["-o", "json", "-I0"])?;
+        assert_eq!(exit_code, 0, "input: {input:?}");
+        assert_eq!(output.trim(), *expected, "input: {input:?}");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `parse_sequence_item`'s compact-mapping dispatch hardcoded `compact_indent = indent + 2`, assuming exactly one space between `-` and a compact item's first key.
- With more than one space, every field after the first folded into the first field's own scalar value instead of being recognized as its own entry: `-   a: hello\n    b: 2\n` read back as `{"a":"hello b"}` (`b` concatenated as text onto `a`'s value, `2` lost entirely).
- Fixes #877.

Uses `self.current_column()` instead, mirroring the nested-sequence arm three lines above it (`- - item`): `- ` is already skipped by this point, so the cursor's real column is the key's real column regardless of spacing — a strict generalization of the single-space case, not a behavior change for it.

**Expanded during code review**: an independent reviewer found the identical hardcoded-offset bug in `parse_explicit_key`'s "sequence as key" arm (`? - key: value`) — `indent + 3`, which was wrong even for the ordinary single-space case. Fixed the same way, with its own regression tests.

One more related, narrower finding was confirmed but is **out of scope** — filed as a follow-up: #885, a continuation line with genuinely *inconsistent* indentation (which real `yq` already rejects as malformed) now silently drops a field instead of erroring, where it previously survived by coincidence. Doesn't affect any well-formed input; extensively verified separately.

## Test plan

- [x] `cargo build --features cli` succeeds
- [x] `cargo test --features cli,simd,regex,serde` — full workspace suite green (0 failures), re-verified after every expansion
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Every behavioral claim diffed against the pinned `yq` v4.53.3 oracle directly (extra spaces with single/multiple fields, interaction with #864's flow-first-field fix, multiple compact items, the `? - key: value` explicit-key shape, and the single-space control case)
- [x] Confirmed via detached pre-fix worktree comparisons that both fixed shapes actually fail without their respective fix
- [x] `omni-dev coverage diff` — 100% patch coverage (2/2 new lines)
- [x] Regression tests added/consolidated in `tests/yq_cli_tests.rs`, table-driven per this file's own convention