### PR TITLE
fix(jq): recurse(f; cond) keeps cond-approved siblings before a later cond error

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -35663,6 +35663,65 @@ mod tests {
     }
 
     #[test]
+    fn test_recurse_cond_keeps_already_approved_siblings_before_cond_error_854() {
+        // #854's own bug shape, distinct from #842 above: here `f` never
+        // errors (it fans out cleanly over every array element); `cond`
+        // itself errors on a later child, after already approving an
+        // earlier one in the same batch. Confirmed against real jq 1.7.1:
+        // `echo '[1,2,3]' | jq -c 'recurse(if type=="array" then .[] else
+        // empty end; if . == 2 then error("boom") else true end)'` prints
+        // the root `[1,2,3]` *and* `1` (the first child, already
+        // `cond`-approved and fully recursed before `cond` errors on the
+        // second child) before erroring. Before this fix, succinctly
+        // printed only the root, dropping `1`.
+        assert_eq!(
+            outputs(
+                br"[1,2,3]",
+                r#"recurse(if type=="array" then .[] else empty end; if . == 2 then error("boom") else true end)"#
+            ),
+            vec!["[1,2,3]", "1"]
+        );
+    }
+
+    #[test]
+    fn test_resolve_recurse_cond_keeps_already_approved_siblings_before_cond_error_854() {
+        // Path-position counterpart of the previous test (`resolve_recurse`'s
+        // `Some(cond)` arm). Confirmed against real jq 1.7.1: `echo
+        // '[1,2,3]' | jq -c 'path(recurse(if type=="array" then .[] else
+        // empty end; if . == 2 then error("boom") else true end))'` prints
+        // `[]` *and* `[0]` before erroring.
+        assert_eq!(
+            outputs(
+                br"[1,2,3]",
+                r#"path(recurse(if type=="array" then .[] else empty end; if . == 2 then error("boom") else true end))"#
+            ),
+            vec!["[]", "[0]"]
+        );
+    }
+
+    #[test]
+    fn test_recurse_cond_error_supersedes_f_own_later_deferred_error_854() {
+        // When both `f` and `cond` would eventually error at the same node,
+        // `cond`'s error on an already-`f`-produced child must win over `f`'s
+        // own later deferred error (from #842) — real jq's generator
+        // semantics evaluate `select(cond)` on each child as `f` produces
+        // it, so a `cond` error on an earlier child always happens before
+        // `f` is ever asked to produce a later one. Confirmed against real
+        // jq 1.7.1: `echo '[1,2,3,4,5,6]' | jq -c 'recurse(if type=="array"
+        // then (if length>=4 then (.[0],.[1],.[2],error("f-boom")) else
+        // empty end) else empty end; if . == 2 then error("cond-boom") else
+        // true end)'` prints the root and `1`, then raises `cond-boom` —
+        // `f-boom` never surfaces.
+        assert_eq!(
+            outputs(
+                br"[1,2,3,4,5,6]",
+                r#"recurse(if type=="array" then (if length>=4 then (.[0],.[1],.[2],error("f-boom")) else empty end) else empty end; if . == 2 then error("cond-boom") else true end)"#
+            ),
+            vec!["[1,2,3,4,5,6]", "1"]
+        );
+    }
+
+    #[test]
     fn test_recurse_f_keeps_own_partial_fanout_before_break_842() {
         // The same #842 fix applies uniformly to `break`, not just `error`
         // (`eval_owned_multi_keep_partial` keeps the prefix for all three

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10666,6 +10666,8 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // one popped, and its whole subtree completes before the second
         // entry is even reached.
         let mut next: Vec<PathBranch<'a>> = Vec::new();
+        // Set below on a `cond` error — see the loop's `Err(e)` arm (#854).
+        let mut cond_error: Option<EvalEscape> = None;
         for (child_components, child_value) in children {
             let mut path = prefix.clone();
             path.extend(child_components);
@@ -10690,11 +10692,6 @@ fn resolve_recurse<'a, S: EvalSemantics>(
                 Some(cond) => {
                     // `cond` gates the child, not `current`, and forks once
                     // per truthy output — see the doc comment above (#627).
-                    // A `cond` error aborts immediately too (#636), same as
-                    // `f`'s error above — this arm's own prefix-loss
-                    // (`next`'s already-cond-approved entries built so far
-                    // this node) is pre-existing and out of scope for #842,
-                    // which is specifically about `f`'s fan-out.
                     //
                     // Evaluated unconditionally, even when `current` is
                     // null: like `f` above, `cond`'s own error/side effect
@@ -10713,13 +10710,36 @@ fn resolve_recurse<'a, S: EvalSemantics>(
                                 }
                             }
                         }
-                        Err(e) => return Err((outputs, e)),
+                        Err(e) => {
+                            // Same "keep what's already approved, defer the
+                            // error" treatment `f`'s own error gets above
+                            // (#842), applied to `cond`'s error too (#854):
+                            // stop considering further children at this
+                            // node, but let `next`'s already-`cond`-approved
+                            // siblings (built so far this iteration) get
+                            // their own full recursive descent before this
+                            // error is raised. `cond_error` supersedes
+                            // `deferred_error` below rather than the other
+                            // way around — real jq's generator semantics
+                            // evaluate `select(cond)` on each child as `f`
+                            // produces it, so a `cond` error on an
+                            // already-produced child always happens before
+                            // `f` would ever be asked to produce a later one
+                            // (which is what `deferred_error` represents).
+                            cond_error = Some(e);
+                            break;
+                        }
                     }
                 }
             }
         }
 
-        queue_recurse_children(&mut stack, next, deferred_error, &mut pending_error);
+        queue_recurse_children(
+            &mut stack,
+            next,
+            cond_error.or(deferred_error),
+            &mut pending_error,
+        );
     }
 
     // A `pending_error` only surfaces once `stack` drains naturally — if
@@ -13309,17 +13329,22 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // see `resolve_recurse`'s doc comment (#635) — so the first entry's
         // whole subtree completes before the next is reached.
         let mut next: Vec<OwnedValue> = Vec::new();
+        // Set below on a `cond` error — see the loop's `Err(e)` arm (#854).
+        let mut cond_error: Option<EvalEscape> = None;
         for child in children {
             // `cond` gates the child, not `current` (see doc comment above).
-            // A `cond` error aborts immediately too — same jq definition,
-            // same reasoning as `f`'s error above (#636) — rather than
-            // pruning just this child the way a falsy `cond` does. This
-            // arm's own prefix-loss (`next`'s already-cond-approved entries
-            // built so far this node) is pre-existing and out of scope for
-            // #842, which is specifically about `f`'s fan-out.
             let cond_outputs = match eval_owned_multi::<S>(cond, &child) {
                 Ok(cond_outputs) => cond_outputs,
-                Err(e) => return partial(outputs, e.into()),
+                Err(e) => {
+                    // Same "keep what's already approved, defer the error"
+                    // treatment `f`'s own error gets above (#842), applied
+                    // to `cond`'s error too (#854) — see `resolve_recurse`'s
+                    // matching arm for the full rationale, including why
+                    // `cond_error` supersedes `deferred_error` below rather
+                    // than the other way around.
+                    cond_error = Some(e);
+                    break;
+                }
             };
             for c in &cond_outputs {
                 if c.is_truthy() {
@@ -13328,7 +13353,12 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
 
-        queue_recurse_children(&mut stack, next, deferred_error, &mut pending_error);
+        queue_recurse_children(
+            &mut stack,
+            next,
+            cond_error.or(deferred_error),
+            &mut pending_error,
+        );
     }
 
     // See `resolve_recurse`'s matching check for the full rationale (#842

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7287,6 +7287,50 @@ fn test_resolve_recurse_keeps_f_partial_fanout_before_error_842() -> Result<()> 
     Ok(())
 }
 
+/// #854: `recurse(f; cond)`'s `cond`-evaluation loop dropped the
+/// already-`cond`-approved siblings of a node's children when `cond`
+/// errored on a *later* child in the same batch -- distinct from #842
+/// above (which was about `f`'s own fan-out, not `cond`'s). Verified
+/// against jq 1.7.1: `echo '[1,2,3]' | jq -c 'recurse(if type=="array"
+/// then .[] else empty end; if . == 2 then error("boom") else true
+/// end)'` prints the root `[1,2,3]` and `1` (the first child, already
+/// `cond`-approved and fully recursed before `cond` errors on the second
+/// child) to stdout, then errors and exits 5.
+#[test]
+fn test_recurse_cond_keeps_already_approved_siblings_before_cond_error_854() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"recurse(if type=="array" then .[] else empty end; if . == 2 then error("boom") else true end)"#,
+        ],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,2,3]\n1\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// Path-position counterpart of the previous test (`resolve_recurse`'s
+/// `Some(cond)` arm). Verified against jq 1.7.1: `echo '[1,2,3]' | jq -c
+/// 'path(recurse(if type=="array" then .[] else empty end; if . == 2
+/// then error("boom") else true end))'` prints `[]` and `[0]` before
+/// erroring, exit 5.
+#[test]
+fn test_resolve_recurse_cond_keeps_already_approved_siblings_before_cond_error_854() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path(recurse(if type=="array" then .[] else empty end; if . == 2 then error("boom") else true end))"#,
+        ],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n[0]\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #856: `resolve_recurse`'s null-child guard (`if matches!(child_value...,
 /// OwnedValue::Null) { continue; }` in its main loop) stopped recursion
 /// *into* a null child, as documented -- but the bare `continue` also


### PR DESCRIPTION
## Summary

- `recurse(f; cond)`'s `cond`-evaluation loop (both the value-position `builtin_recurse_cond` and the path-position `resolve_recurse`, in `src/jq/eval.rs`) dropped the already-`cond`-approved siblings of a node's children when `cond` itself errored on a *later* child in the same batch — real jq's generator semantics give each already-approved child its own full recursive descent before `cond` is ever asked about the next candidate child.
- Reuses #842's `queue_recurse_children`/`pending_error` deferred-error mechanism (already used for `f`'s own fan-out) for `cond`'s error too: on a `cond` error, the loop now stops considering further children but lets whatever already passed `cond` this batch (`next`) get its own full recursive descent before the error surfaces.
- `cond`'s error supersedes `f`'s own later deferred error (not the other way around) — verified against real jq: a `cond` error on an already-`f`-produced child always happens before `f` would ever be asked to produce a later one, in real generator order.

## Repro (verified against pinned jq-1.7.1)

```
$ echo '[1,2,3]' | jq -c 'recurse(if type=="array" then .[] else empty end; if . == 2 then error("boom") else true end)'
jq: error (at <stdin>:1): boom
[1,2,3]
1
```

Before this fix, `succinctly jq` printed only `[1,2,3]`, dropping the already-approved `1`. After the fix, output matches real jq exactly (value position and `path(...)` position both verified).

Fixes #854

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Manually diffed output against real jq 1.7.1 across several scenarios: original repro, multiple approved siblings, error on the very first child, no-error sanity check, `break` through `cond`, and the `cond`-error-vs-`f`-own-later-error priority ordering — all match exactly
- [x] Added unit tests in `src/jq/eval.rs` (value + path position, plus the priority-ordering case) and CLI-level tests in `tests/jq_cli_tests.rs` (stdout/stderr/exit-code), all pinned against real jq 1.7.1