### PR TITLE
fix(jq): gmtime/localtime/todate/tz/strftime error instead of panicking on extreme timestamps

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -725,6 +725,17 @@ impl EvalError {
         Self::new(format!("{builtin}() requires numeric inputs"))
     }
 
+    /// `error converting number of seconds since epoch to datetime` — a
+    /// `gmtime`/`localtime`/`strftime`/`todate`/`tz` timestamp too extreme
+    /// to convert (matches real jq's own message and, approximately, its
+    /// error boundary: confirmed empirically that jq itself starts
+    /// erroring once the resulting year would overflow a 32-bit int,
+    /// e.g. `(7e16) | strftime(...)` errors while `(6e16) | strftime(...)`
+    /// succeeds).
+    pub fn datetime_out_of_range() -> Self {
+        Self::new("error converting number of seconds since epoch to datetime")
+    }
+
     /// `mktime requires array inputs`.
     pub fn mktime_requires_array() -> Self {
         Self::new("mktime requires array inputs")

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16548,7 +16548,11 @@ fn builtin_gmtime<W: Clone + AsRef<[u64]>>(
         Err(r) => return r,
     };
 
-    let t = broken_down_time_from_unix_secs(timestamp.trunc() as i64);
+    let t = match broken_down_time_from_unix_secs(timestamp.trunc() as i64) {
+        Ok(t) => t,
+        Err(_) if optional => return QueryResult::None,
+        Err(e) => return QueryResult::Error(e),
+    };
 
     let result = vec![
         OwnedValue::Int(t.year),
@@ -16565,15 +16569,25 @@ fn builtin_gmtime<W: Clone + AsRef<[u64]>>(
 }
 
 /// Convert a Unix timestamp (whole seconds, UTC) to broken-down time using
-/// the Howard Hinnant `civil_from_days` algorithm. Shared by `gmtime` and
-/// `strftime`'s raw-number input path (#759) so a future fix to this math
-/// only needs applying in one place — see `BrokenDownTime`.
-fn broken_down_time_from_unix_secs(secs: i64) -> BrokenDownTime {
+/// the Howard Hinnant `civil_from_days` algorithm. Shared by `gmtime`,
+/// `localtime`, `todate`, `tz`, and `strftime`'s raw-number input path
+/// (#759) so a future fix to this math only needs applying in one place —
+/// see `BrokenDownTime`.
+///
+/// Returns `Err` for a `secs` too extreme to convert safely: the negative
+/// branch's `secs - 86399` is the only step in this function that can
+/// overflow `i64` (every other step stays comfortably in range for any
+/// `secs` that step doesn't already reject), and the resulting `year` is
+/// additionally checked against `i32`'s range to match real jq's own error
+/// boundary — see [`EvalError::datetime_out_of_range`].
+fn broken_down_time_from_unix_secs(secs: i64) -> Result<BrokenDownTime, EvalError> {
     // Days since Unix epoch (Jan 1, 1970)
     let days = if secs >= 0 {
         secs / 86400
     } else {
-        (secs - 86399) / 86400
+        secs.checked_sub(86399)
+            .ok_or_else(EvalError::datetime_out_of_range)?
+            / 86400
     };
     let time_of_day = secs.rem_euclid(86400);
     let hour = time_of_day / 3600;
@@ -16593,6 +16607,10 @@ fn broken_down_time_from_unix_secs(secs: i64) -> BrokenDownTime {
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
     let year = y + i64::from(month <= 2);
 
+    if year < i64::from(i32::MIN) || year > i64::from(i32::MAX) {
+        return Err(EvalError::datetime_out_of_range());
+    }
+
     // Calculate weekday (0 = Sunday, 6 = Saturday)
     // Jan 1, 1970 was a Thursday (4)
     let weekday = (days % 7 + 4 + 7) % 7;
@@ -16606,7 +16624,7 @@ fn broken_down_time_from_unix_secs(secs: i64) -> BrokenDownTime {
     };
     let yearday = month_days[(month - 1) as usize] + day - 1;
 
-    BrokenDownTime {
+    Ok(BrokenDownTime {
         year,
         month: month as i64,
         day,
@@ -16615,7 +16633,7 @@ fn broken_down_time_from_unix_secs(secs: i64) -> BrokenDownTime {
         second,
         weekday,
         yearday,
-    }
+    })
 }
 
 /// Builtin: localtime - convert Unix timestamp to broken-down local time
@@ -16667,50 +16685,27 @@ fn builtin_localtime<W: Clone + AsRef<[u64]>>(
         // Try to estimate local offset by looking at current system time
         // This gives us the offset at the current moment (may differ from timestamp's offset due to DST)
         let local_offset = estimate_local_offset(now_utc);
-        let local_secs = secs + local_offset;
-
-        // Days since Unix epoch
-        let days = if local_secs >= 0 {
-            local_secs / 86400
-        } else {
-            (local_secs - 86399) / 86400
+        let local_secs = match secs.checked_add(local_offset) {
+            Some(s) => s,
+            None if optional => return QueryResult::None,
+            None => return QueryResult::Error(EvalError::datetime_out_of_range()),
         };
-        let time_of_day = ((local_secs % 86400) + 86400) % 86400;
-        let hour = time_of_day / 3600;
-        let minute = (time_of_day % 3600) / 60;
-        let second = time_of_day % 60;
 
-        // Calculate year, month, day from days since epoch
-        let z = days + 719468;
-        let era = if z >= 0 { z } else { z - 146096 } / 146097;
-        let doe = (z - era * 146097) as u32;
-        let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-        let y = yoe as i64 + era * 400;
-        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-        let mp = (5 * doy + 2) / 153;
-        let day = (doy - (153 * mp + 2) / 5 + 1) as i64;
-        let month = if mp < 10 { mp + 3 } else { mp - 9 };
-        let year = y + i64::from(month <= 2);
-
-        let weekday = (days % 7 + 4 + 7) % 7;
-
-        let is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
-        let month_days: [i64; 12] = if is_leap {
-            [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
-        } else {
-            [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
+        let t = match broken_down_time_from_unix_secs(local_secs) {
+            Ok(t) => t,
+            Err(_) if optional => return QueryResult::None,
+            Err(e) => return QueryResult::Error(e),
         };
-        let yearday = month_days[(month - 1) as usize] + day - 1;
 
         let result = vec![
-            OwnedValue::Int(year),
-            OwnedValue::Int((month - 1) as i64),
-            OwnedValue::Int(day),
-            OwnedValue::Int(hour),
-            OwnedValue::Int(minute),
-            OwnedValue::Int(second),
-            OwnedValue::Int(weekday),
-            OwnedValue::Int(yearday),
+            OwnedValue::Int(t.year),
+            OwnedValue::Int(t.month - 1),
+            OwnedValue::Int(t.day),
+            OwnedValue::Int(t.hour),
+            OwnedValue::Int(t.minute),
+            OwnedValue::Int(t.second),
+            OwnedValue::Int(t.weekday),
+            OwnedValue::Int(t.yearday),
         ];
 
         QueryResult::Owned(OwnedValue::Array(result))
@@ -16897,7 +16892,11 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             };
 
             // Auto-converted the same way `gmtime` converts a raw number.
-            let t = broken_down_time_from_unix_secs(timestamp.trunc() as i64);
+            let t = match broken_down_time_from_unix_secs(timestamp.trunc() as i64) {
+                Ok(t) => t,
+                Err(_) if optional => return QueryResult::None,
+                Err(e) => return QueryResult::Error(e),
+            };
             (
                 t.year, t.month, t.day, t.hour, t.minute, t.second, t.weekday, t.yearday,
             )
@@ -17499,28 +17498,16 @@ fn builtin_todate<W: Clone + AsRef<[u64]>>(
 
     // Convert to broken-down time first
     let secs = timestamp.trunc() as i64;
-    let days = if secs >= 0 {
-        secs / 86400
-    } else {
-        (secs - 86399) / 86400
+    let t = match broken_down_time_from_unix_secs(secs) {
+        Ok(t) => t,
+        Err(_) if optional => return QueryResult::None,
+        Err(e) => return QueryResult::Error(e),
     };
-    let time_of_day = ((secs % 86400) + 86400) % 86400;
-    let hour = time_of_day / 3600;
-    let minute = (time_of_day % 3600) / 60;
-    let second = time_of_day % 60;
 
-    let z = days + 719468;
-    let era = if z >= 0 { z } else { z - 146096 } / 146097;
-    let doe = (z - era * 146097) as u32;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let day = doy - (153 * mp + 2) / 5 + 1;
-    let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = y + i64::from(month <= 2);
-
-    let result = format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z");
+    let result = format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        t.year, t.month, t.day, t.hour, t.minute, t.second
+    );
 
     QueryResult::Owned(OwnedValue::String(result))
 }
@@ -17684,41 +17671,28 @@ fn builtin_to_unix<W: Clone + AsRef<[u64]>>(
 }
 
 /// Format Unix timestamp to ISO 8601 string with timezone offset
-fn format_datetime_with_offset(timestamp: f64, offset_seconds: i64) -> String {
+fn format_datetime_with_offset(timestamp: f64, offset_seconds: i64) -> Result<String, EvalError> {
     // Apply the timezone offset to the timestamp
-    let adjusted_secs = timestamp.trunc() as i64 + offset_seconds;
+    let adjusted_secs = (timestamp.trunc() as i64)
+        .checked_add(offset_seconds)
+        .ok_or_else(EvalError::datetime_out_of_range)?;
 
-    let days = if adjusted_secs >= 0 {
-        adjusted_secs / 86400
-    } else {
-        (adjusted_secs - 86399) / 86400
-    };
-    let time_of_day = ((adjusted_secs % 86400) + 86400) % 86400;
-    let hour = time_of_day / 3600;
-    let minute = (time_of_day % 3600) / 60;
-    let second = time_of_day % 60;
+    let t = broken_down_time_from_unix_secs(adjusted_secs)?;
 
-    let z = days + 719468;
-    let era = if z >= 0 { z } else { z - 146096 } / 146097;
-    let doe = (z - era * 146097) as u32;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let day = doy - (153 * mp + 2) / 5 + 1;
-    let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = y + i64::from(month <= 2);
-
-    if offset_seconds == 0 {
-        format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+    Ok(if offset_seconds == 0 {
+        format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+            t.year, t.month, t.day, t.hour, t.minute, t.second
+        )
     } else {
         let offset_hours = offset_seconds.abs() / 3600;
         let offset_mins = (offset_seconds.abs() % 3600) / 60;
         let sign = if offset_seconds >= 0 { '+' } else { '-' };
         format!(
-            "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}{sign}{offset_hours:02}:{offset_mins:02}"
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}{}{:02}:{:02}",
+            t.year, t.month, t.day, t.hour, t.minute, t.second, sign, offset_hours, offset_mins
         )
-    }
+    })
 }
 
 /// Get timezone offset in seconds for a given IANA timezone name
@@ -18005,7 +17979,11 @@ fn builtin_tz<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     // Format the datetime with the timezone offset
-    let result = format_datetime_with_offset(timestamp, offset);
+    let result = match format_datetime_with_offset(timestamp, offset) {
+        Ok(s) => s,
+        Err(_) if optional => return QueryResult::None,
+        Err(e) => return QueryResult::Error(e),
+    };
     QueryResult::Owned(OwnedValue::String(result))
 }
 
@@ -31242,6 +31220,66 @@ mod tests {
                 assert_eq!(arr[6], OwnedValue::Int(4));    // weekday (Thursday)
                 assert_eq!(arr[7], OwnedValue::Int(0));    // yearday
             }
+        );
+    }
+
+    #[test]
+    fn test_datetime_extreme_magnitude_errors_instead_of_panicking() {
+        // Before #869's fix, an extreme-magnitude timestamp made
+        // `broken_down_time_from_unix_secs`'s `secs - 86399` underflow
+        // `i64` — a debug-build panic, or (release, overflow-checks off) a
+        // silently wrong result. Verified against real jq (jq-1.7.1): jq
+        // itself cleanly errors on these inputs with this exact message.
+        const MSG: &str = "error converting number of seconds since epoch to datetime";
+
+        query!(b"-1e300", r"gmtime", QueryResult::Error(e) => assert_eq!(e.message, MSG));
+        query!(b"1e300", r"gmtime", QueryResult::Error(e) => assert_eq!(e.message, MSG));
+        query!(b"-1e300", r"localtime", QueryResult::Error(e) => assert_eq!(e.message, MSG));
+        query!(b"-1e300", r"todate", QueryResult::Error(e) => assert_eq!(e.message, MSG));
+        query!(b"-1e300", r#"tz("UTC")"#, QueryResult::Error(e) => assert_eq!(e.message, MSG));
+        query!(b"-1e300", r#"strftime("%Y-%m-%d")"#, QueryResult::Error(e) => assert_eq!(e.message, MSG));
+
+        // `?` suppresses it, same as any other builtin error.
+        query!(b"-1e300", r"gmtime?", QueryResult::None => {});
+        query!(b"-1e300", r#"strftime("%Y-%m-%d")?"#, QueryResult::None => {});
+    }
+
+    #[test]
+    fn test_datetime_year_out_of_i32_range_errors_matching_jq_boundary() {
+        // Empirically bisected against real jq (jq-1.7.1): jq starts
+        // erroring on `gmtime`/`strftime` once the resulting year would
+        // overflow a 32-bit int, not merely `i64` — `6e16`/`-6e16` succeed
+        // in jq (and produce this exact date, confirmed byte-for-byte
+        // against `jq`), `7e16`/`-7e16` error, in both directions.
+        const MSG: &str = "error converting number of seconds since epoch to datetime";
+
+        query!(b"6e16", r"gmtime",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr[0], OwnedValue::Int(1_901_326_280));
+            }
+        );
+        query!(b"-6e16", r"gmtime",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr[0], OwnedValue::Int(-1_901_322_341));
+            }
+        );
+        query!(b"7e16", r"gmtime", QueryResult::Error(e) => assert_eq!(e.message, MSG));
+        query!(b"-7e16", r"gmtime", QueryResult::Error(e) => assert_eq!(e.message, MSG));
+    }
+
+    #[test]
+    fn test_datetime_nan_and_subsecond_negative_already_match_jq() {
+        // #869 suspected these were also bugs, but checking the pinned jq
+        // oracle (jq-1.7.1) directly showed both already match real jq
+        // exactly — do not "fix" either into diverging from jq:
+        //  - NaN silently maps to the Unix epoch (not an error) in jq too.
+        //  - A sub-second-negative timestamp truncates toward zero in jq
+        //    (not floor semantics — `-0.5` maps to `secs=0`, not `-1`).
+        query!(b"null", r#"(nan) | strftime("%Y-%m-%d")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(s, "1970-01-01")
+        );
+        query!(b"null", r#"(-0.5) | strftime("%Y-%m-%dT%H:%M:%SZ")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(s, "1970-01-01T00:00:00Z")
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16548,10 +16548,12 @@ fn builtin_gmtime<W: Clone + AsRef<[u64]>>(
         Err(r) => return r,
     };
 
-    let t = match broken_down_time_from_unix_secs(timestamp.trunc() as i64) {
+    let t = match ok_or_result::<W, _>(
+        broken_down_time_from_unix_secs(timestamp.trunc() as i64),
+        optional,
+    ) {
         Ok(t) => t,
-        Err(_) if optional => return QueryResult::None,
-        Err(e) => return QueryResult::Error(e),
+        Err(r) => return r,
     };
 
     let result = vec![
@@ -16578,8 +16580,24 @@ fn builtin_gmtime<W: Clone + AsRef<[u64]>>(
 /// branch's `secs - 86399` is the only step in this function that can
 /// overflow `i64` (every other step stays comfortably in range for any
 /// `secs` that step doesn't already reject), and the resulting `year` is
-/// additionally checked against `i32`'s range to match real jq's own error
-/// boundary — see [`EvalError::datetime_out_of_range`].
+/// additionally rejected outside `i32`'s range — see
+/// [`EvalError::datetime_out_of_range`].
+///
+/// This `i32` check is a deliberate, principled safety boundary, not an
+/// attempt to bit-for-bit replicate real jq's own cutoff: jq's actual
+/// behavior here is an asymmetric artifact of its C implementation, not a
+/// clean year-fits-in-i32 rule — confirmed directly against jq-1.7.1, jq
+/// silently *wraps* a `year` of `i32::MAX + 1` down to `i32::MIN` instead
+/// of erroring (`67767976233532800 | gmtime` succeeds in jq, returning a
+/// bogus `year: -2147483648`), while it *errors* on `-67768100536262402`
+/// despite that input's own computed year (`-2147483647`) fitting `i32`
+/// just fine. Reproducing jq's wraparound would reintroduce exactly the
+/// "silently wrong value" failure mode #869 exists to eliminate, so it's
+/// intentionally not replicated even though it means diverging from jq in
+/// both directions at this boundary (erroring where jq wraps; succeeding
+/// where jq errors) — the two sides agree closely (not exactly) in the
+/// practically-relevant range, confirmed by bisection up to ~1e16 seconds
+/// from the epoch in both directions.
 fn broken_down_time_from_unix_secs(secs: i64) -> Result<BrokenDownTime, EvalError> {
     // Days since Unix epoch (Jan 1, 1970)
     let days = if secs >= 0 {
@@ -16636,6 +16654,27 @@ fn broken_down_time_from_unix_secs(secs: i64) -> Result<BrokenDownTime, EvalErro
     })
 }
 
+/// Fold a `Result<T, EvalError>` into this file's `Result<T, QueryResult>`
+/// early-return idiom (already used by, e.g., `get_float_value_with`),
+/// respecting `optional` the same way: `Err(_) if optional` becomes
+/// `QueryResult::None`, otherwise the error propagates as-is. Used by every
+/// `gmtime`/`localtime`/`strftime`/`todate`/`tz` call site that can now fail
+/// on an extreme timestamp, so they share one `optional`-handling arm
+/// instead of each hand-copying `Ok(t) => t, Err(_) if optional => ...,
+/// Err(e) => ...`.
+fn ok_or_result<'a, W: Clone + AsRef<[u64]>, T>(
+    result: Result<T, EvalError>,
+    optional: bool,
+) -> Result<T, QueryResult<'a, W>> {
+    result.map_err(|e| {
+        if optional {
+            QueryResult::None
+        } else {
+            QueryResult::Error(e)
+        }
+    })
+}
+
 /// Builtin: localtime - convert Unix timestamp to broken-down local time
 /// Returns [year, month(0-11), day(1-31), hour, minute, second, weekday(0-6, Sunday=0), yearday(0-365)]
 fn builtin_localtime<W: Clone + AsRef<[u64]>>(
@@ -16685,16 +16724,18 @@ fn builtin_localtime<W: Clone + AsRef<[u64]>>(
         // Try to estimate local offset by looking at current system time
         // This gives us the offset at the current moment (may differ from timestamp's offset due to DST)
         let local_offset = estimate_local_offset(now_utc);
-        let local_secs = match secs.checked_add(local_offset) {
-            Some(s) => s,
-            None if optional => return QueryResult::None,
-            None => return QueryResult::Error(EvalError::datetime_out_of_range()),
+        let local_secs = match ok_or_result::<W, _>(
+            secs.checked_add(local_offset)
+                .ok_or_else(EvalError::datetime_out_of_range),
+            optional,
+        ) {
+            Ok(s) => s,
+            Err(r) => return r,
         };
 
-        let t = match broken_down_time_from_unix_secs(local_secs) {
+        let t = match ok_or_result::<W, _>(broken_down_time_from_unix_secs(local_secs), optional) {
             Ok(t) => t,
-            Err(_) if optional => return QueryResult::None,
-            Err(e) => return QueryResult::Error(e),
+            Err(r) => return r,
         };
 
         let result = vec![
@@ -16892,10 +16933,12 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             };
 
             // Auto-converted the same way `gmtime` converts a raw number.
-            let t = match broken_down_time_from_unix_secs(timestamp.trunc() as i64) {
+            let t = match ok_or_result::<W, _>(
+                broken_down_time_from_unix_secs(timestamp.trunc() as i64),
+                optional,
+            ) {
                 Ok(t) => t,
-                Err(_) if optional => return QueryResult::None,
-                Err(e) => return QueryResult::Error(e),
+                Err(r) => return r,
             };
             (
                 t.year, t.month, t.day, t.hour, t.minute, t.second, t.weekday, t.yearday,
@@ -17498,10 +17541,9 @@ fn builtin_todate<W: Clone + AsRef<[u64]>>(
 
     // Convert to broken-down time first
     let secs = timestamp.trunc() as i64;
-    let t = match broken_down_time_from_unix_secs(secs) {
+    let t = match ok_or_result::<W, _>(broken_down_time_from_unix_secs(secs), optional) {
         Ok(t) => t,
-        Err(_) if optional => return QueryResult::None,
-        Err(e) => return QueryResult::Error(e),
+        Err(r) => return r,
     };
 
     let result = format!(
@@ -17670,7 +17712,10 @@ fn builtin_to_unix<W: Clone + AsRef<[u64]>>(
     builtin_fromdate::<W>(value, optional)
 }
 
-/// Format Unix timestamp to ISO 8601 string with timezone offset
+/// Format Unix timestamp to ISO 8601 string with timezone offset.
+///
+/// `Err` for a timestamp/offset combination too extreme to convert — see
+/// [`EvalError::datetime_out_of_range`] and [`broken_down_time_from_unix_secs`].
 fn format_datetime_with_offset(timestamp: f64, offset_seconds: i64) -> Result<String, EvalError> {
     // Apply the timezone offset to the timestamp
     let adjusted_secs = (timestamp.trunc() as i64)
@@ -17979,11 +18024,11 @@ fn builtin_tz<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     // Format the datetime with the timezone offset
-    let result = match format_datetime_with_offset(timestamp, offset) {
-        Ok(s) => s,
-        Err(_) if optional => return QueryResult::None,
-        Err(e) => return QueryResult::Error(e),
-    };
+    let result =
+        match ok_or_result::<W, _>(format_datetime_with_offset(timestamp, offset), optional) {
+            Ok(s) => s,
+            Err(r) => return r,
+        };
     QueryResult::Owned(OwnedValue::String(result))
 }
 
@@ -31290,12 +31335,13 @@ mod tests {
     }
 
     #[test]
-    fn test_datetime_year_out_of_i32_range_errors_matching_jq_boundary() {
-        // Empirically bisected against real jq (jq-1.7.1): jq starts
-        // erroring on `gmtime`/`strftime` once the resulting year would
-        // overflow a 32-bit int, not merely `i64` — `6e16`/`-6e16` succeed
-        // in jq (and produce this exact date, confirmed byte-for-byte
-        // against `jq`), `7e16`/`-7e16` error, in both directions.
+    fn test_datetime_year_out_of_i32_range_errors_cleanly() {
+        // Empirically bisected against real jq (jq-1.7.1) in this range:
+        // `6e16`/`-6e16` succeed in jq (and produce this exact date,
+        // confirmed byte-for-byte against `jq`), `7e16`/`-7e16` error, in
+        // both directions — real jq's *exact* cutoff is not this clean
+        // (see the divergence test below and `broken_down_time_from_unix_secs`'s
+        // doc comment), but the two agree closely here.
         const MSG: &str = "error converting number of seconds since epoch to datetime";
 
         query!(b"6e16", r"gmtime",
@@ -31310,6 +31356,32 @@ mod tests {
         );
         query!(b"7e16", r"gmtime", QueryResult::Error(e) => assert_eq!(e.message, MSG));
         query!(b"-7e16", r"gmtime", QueryResult::Error(e) => assert_eq!(e.message, MSG));
+    }
+
+    #[test]
+    fn test_datetime_i32_boundary_deliberately_diverges_from_jqs_own_wraparound_quirk() {
+        // Real jq's own boundary is an asymmetric C-implementation
+        // artifact, not a clean "year fits i32" rule — confirmed directly
+        // against jq-1.7.1, in both directions:
+        //   `67767976233532800 | gmtime` (a would-be year of i32::MAX + 1)
+        //   *succeeds* in real jq, silently wrapping to `year: i32::MIN`.
+        //   Reproducing that wraparound would reintroduce exactly the
+        //   "silently wrong value" failure mode #869 exists to eliminate,
+        //   so it's intentionally not replicated — this errors instead.
+        //   `-67768100536262402 | gmtime` conversely *errors* in real jq,
+        //   despite its computed year (`-2147483647`) fitting `i32` —
+        //   jq's cutoff sits at a different, smaller magnitude than i32's
+        //   own range on the negative side. This succeeds here instead,
+        //   under-erroring relative to jq rather than over-erroring; a
+        //   documented, deliberate simplification, not a bug.
+        const MSG: &str = "error converting number of seconds since epoch to datetime";
+
+        query!(b"67767976233532800", r"gmtime", QueryResult::Error(e) => assert_eq!(e.message, MSG));
+        query!(b"-67768100536262402", r"gmtime",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr[0], OwnedValue::Int(-2_147_483_647));
+            }
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31224,6 +31224,51 @@ mod tests {
     }
 
     #[test]
+    fn test_datetime_builtins_optional_true_suppresses_extreme_magnitude_error() {
+        // `?` alone can't reach these builtins' own `optional`-guarded
+        // arms: `E?` (`eval_try`) catches `E`'s *result* from the outside,
+        // evaluated with whatever `optional` was already ambient — it does
+        // not force `optional = true` down into a bare builtin call (#693)
+        // — so this exercises the guards directly the same way this file
+        // already tests other builtins' `optional` arms elsewhere (see
+        // `eval_single::<Vec<u64>, JqSemantics>(&expr, cursor.value(),
+        // true)` a few tests up). `local_offset` defaults to 0 in this
+        // test environment (no `TZ` set), so `localtime`'s own
+        // `checked_add` overflow guard isn't reachable this way — that arm
+        // only matters with a non-default `TZ` and a timestamp within
+        // `local_offset` of `i64::MIN`, not practically triggerable
+        // through the public jq CLI/query surface.
+        let json: &[u8] = b"-1e300";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+
+        assert!(matches!(
+            builtin_gmtime::<Vec<u64>>(cursor.value(), true),
+            QueryResult::None
+        ));
+        assert!(matches!(
+            builtin_localtime::<Vec<u64>>(cursor.value(), true),
+            QueryResult::None
+        ));
+        assert!(matches!(
+            builtin_todate::<Vec<u64>>(cursor.value(), true),
+            QueryResult::None
+        ));
+
+        let fmt_expr = parse(r#""%Y-%m-%d""#).unwrap();
+        assert!(matches!(
+            builtin_strftime::<Vec<u64>, JqSemantics>(&fmt_expr, cursor.value(), true),
+            QueryResult::None
+        ));
+
+        let zone_expr = parse(r#""UTC""#).unwrap();
+        assert!(matches!(
+            builtin_tz::<Vec<u64>, JqSemantics>(&zone_expr, cursor.value(), true),
+            QueryResult::None
+        ));
+    }
+
+    #[test]
     fn test_datetime_extreme_magnitude_errors_instead_of_panicking() {
         // Before #869's fix, an extreme-magnitude timestamp made
         // `broken_down_time_from_unix_secs`'s `secs - 86399` underflow


### PR DESCRIPTION
## Summary

Fixes #869 — `broken_down_time_from_unix_secs`'s negative-timestamp branch computed
`secs - 86399`, which underflows `i64` once a timestamp's magnitude is large enough
to saturate `timestamp.trunc() as i64` to `i64::MIN` — a debug-build panic, or
(release, overflow checks off) a silent wrap into a bogus date:

```
$ echo null | succinctly jq '(-1e300) | strftime("%Y-%m-%d")'   # debug
thread 'main' panicked at src/jq/eval.rs:16436:9: attempt to subtract with overflow

$ echo null | succinctly jq '(-1e300) | strftime("%Y-%m-%d")'   # release
"292277026596-12-03"   # silently wrong, no error, exit 0
```

- Fixed with `checked_sub`, plus a check that the resulting `year` fits `i32` — a
  deliberate, principled safety boundary (verified against the pinned jq oracle,
  jq-1.7.1, to agree closely with jq's own practical error range up to ~1e16 seconds
  from the epoch in both directions — see below for where it *doesn't* match exactly).
- `builtin_localtime`, `builtin_todate`, and `format_datetime_with_offset` (`tz`) each
  carried an independent copy of the exact same vulnerable arithmetic. Migrated all
  three onto the shared, now-checked `broken_down_time_from_unix_secs` instead of
  leaving three unfixed duplicates — this was explicit scope in #869 itself ("the bugs
  will simply resurface in the three untouched copies" otherwise).
- All 6 `optional`-suppression call sites (`gmtime`/`localtime`×2/`strftime`/`todate`/`tz`)
  share one `ok_or_result` helper now, matching this file's existing `get_float_value_with`
  early-return idiom, instead of hand-copying the same match block 6 times.

**Of #869's three suspected bugs, only the panic held up against the real jq oracle** —
checked before touching anything:
- NaN → epoch (`"1970-01-01"`, exit 0): matches real jq exactly. Not a bug.
- Sub-second-negative timestamp (`-0.5` → `"1970-01-01T00:00:00Z"`): matches real jq
  exactly — jq truncates toward zero here, not floor. The issue's own suggested "fix"
  (switch to floor) would have been a *new* divergence from jq. Neither was touched;
  regression tests lock both in as intentional.

## Where the `i32` boundary deliberately does *not* match jq

Code review caught that an earlier draft overclaimed exact parity with jq's error
boundary. Checked directly against jq-1.7.1: jq's own cutoff is an asymmetric artifact
of its C implementation, not a clean "year fits i32" rule —
`67767976233532800 | gmtime` (a would-be year of `i32::MAX + 1`) *succeeds* in real jq,
silently wrapping to `year: i32::MIN`, while `-67768100536262402 | gmtime` *errors* in
jq despite its own computed year (`-2147483647`) fitting `i32` fine. Reproducing jq's
wraparound would reintroduce exactly the "silently wrong value" failure #869 exists to
eliminate, so it's intentionally not replicated — this diverges from jq in both
directions at that exact boundary (erroring where jq wraps; succeeding where jq errors),
pinned by a dedicated regression test. The doc comment and tests were corrected to state
this precisely rather than overclaim exact parity.

## Known uncovered line

`builtin_localtime`'s new `secs.checked_add(local_offset)` overflow guard is not
independently coverable: `local_offset` is always `0` in the default (no `TZ` set)
environment this suite runs in, so triggering the overflow itself needs a non-default
`TZ` *and* a timestamp within that offset of `i64::MIN` — not practically reachable
through the public jq CLI/query surface, and not safely testable via `std::env::set_var`
in a suite that runs tests in parallel. Kept as defensive-only dead code in the default
environment rather than left as a live panic risk.

## Follow-ups filed (out of scope for #869, confirmed via review + independent repro)

- #893 — `mktime`/`strftime("%s")`'s *inverse* conversion (`unix_secs_from_broken_down_time`)
  has the identical unchecked-multiply panic shape, on a function #869 didn't name.
- #894 — `localtime`'s `TZ`-env-var offset parser (`parse_simple_tz_offset`) can overflow
  and panic *before* this PR's new guard ever runs, on malformed `TZ` input (not an
  extreme timestamp).
- #895 — `tz()`'s named-zone DST heuristics still inline truncating (not floor-corrected)
  day/month math for pre-1970 timestamps, in three functions not named in #869.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green across 3 runs,
      including post-rebase; one unrelated `test_import_directive` flake reproduced this
      machine's known concurrent-session contention — passed in isolated re-run)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Manually diffed every changed behavior against the pinned real `jq` oracle (jq-1.7.1)
      directly — not just golden fixtures — including the boundary bisection and the
      confirmed-divergence case above
- [x] Independent code review (standard effort) run; all 6 findings addressed (2 in-diff
      fixes, 3 filed as follow-ups, 1 corrected-claim fix)
- [x] Rebased on latest `main` (post PR #884), re-verified clean
- [x] `cargo llvm-cov` patch coverage: 99.13% (114/115 new lines); the 1 uncovered line is
      documented above