### PR TITLE
fix(jq): isempty propagates a bare uncaught error instead of answering true

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18827,7 +18827,19 @@ fn builtin_isempty<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::None => true,
         QueryResult::Many(ref v) if v.is_empty() => true,
         QueryResult::ManyOwned(ref v) if v.is_empty() => true,
-        QueryResult::Error(_) => true, // Errors count as empty
+        // A bare, uncaught error must propagate, not be answered as `true`
+        // (#882) - real jq's `isempty` has no `try`/`catch` around its
+        // argument, so `isempty(error("x"))` genuinely fails (exit 5) rather
+        // than reporting the argument as "empty". Same asymmetry as `Halt`/
+        // `Break` below, and for the same reason: a `Partial`'s error always
+        // has a non-empty prefix (`g` already produced an output before
+        // erroring), and real jq's laziness means `g`'s second output is
+        // never requested once the first already answered `isempty`'s own
+        // internal `break $out` - confirmed via oracle, `isempty(1,
+        // error("x"))` answers `false` in real jq 1.7.1, same as
+        // `isempty(1, halt_error(3))`/`isempty(1, break $out)` below - so
+        // the wildcard arm correctly still answers `false` for that shape.
+        QueryResult::Error(e) => return QueryResult::Error(e),
         // A halt with zero prior outputs must propagate rather than answer
         // `false` — but a `Partial`'s halt always has a non-empty prefix (see
         // `partial`), meaning `g` already produced an output before halting,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18831,14 +18831,10 @@ fn builtin_isempty<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // (#882) - real jq's `isempty` has no `try`/`catch` around its
         // argument, so `isempty(error("x"))` genuinely fails (exit 5) rather
         // than reporting the argument as "empty". Same asymmetry as `Halt`/
-        // `Break` below, and for the same reason: a `Partial`'s error always
-        // has a non-empty prefix (`g` already produced an output before
-        // erroring), and real jq's laziness means `g`'s second output is
-        // never requested once the first already answered `isempty`'s own
-        // internal `break $out` - confirmed via oracle, `isempty(1,
-        // error("x"))` answers `false` in real jq 1.7.1, same as
-        // `isempty(1, halt_error(3))`/`isempty(1, break $out)` below - so
-        // the wildcard arm correctly still answers `false` for that shape.
+        // `Break` below, and the same laziness reason (see the `Break` arm's
+        // comment): confirmed via oracle, `isempty(1, error("x"))` answers
+        // `false` in real jq 1.7.1, so `Partial(_, Control::Error(_))`
+        // correctly stays on the wildcard arm below.
         QueryResult::Error(e) => return QueryResult::Error(e),
         // A halt with zero prior outputs must propagate rather than answer
         // `false` — but a `Partial`'s halt always has a non-empty prefix (see

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3049,6 +3049,7 @@ fn test_isempty_propagates_bare_error_instead_of_answering_true() -> Result<()> 
     let (stdout, stderr, code) = run_jq_full(&["-n", "isempty(error(\"x\")), \"after\""], None)?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
+    assert!(stderr.contains("jq: error"), "{stderr}");
     assert!(stderr.contains('x'), "{stderr}");
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3038,6 +3038,38 @@ fn test_isempty_break_after_partial_output_does_not_propagate() -> Result<()> {
     Ok(())
 }
 
+/// `builtin_isempty`'s bare `QueryResult::Error(_)` arm used to answer
+/// `true` unconditionally ("errors count as empty"), swallowing a genuine
+/// uncaught error instead of propagating it (#882). Real jq's `isempty` has
+/// no `try`/`catch` around its argument, so an uncaught error must fail the
+/// whole evaluation. Verified against jq 1.7.1: `jq -n
+/// 'isempty(error("x"))'` exits 5 with no output.
+#[test]
+fn test_isempty_propagates_bare_error_instead_of_answering_true() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "isempty(error(\"x\")), \"after\""], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('x'), "{stderr}");
+    Ok(())
+}
+
+/// The asymmetric counterpart, mirroring `test_isempty_break_after_partial_output_does_not_propagate`:
+/// an error surfacing *after* `g` already produced an output must NOT
+/// propagate, for the same laziness reason - real jq's `isempty` never
+/// requests `g`'s second output once the first already answered its own
+/// internal `break $out`. Verified against jq 1.7.1: `isempty(1,
+/// error("x"))` answers `false` then prints `"after"`, exiting 0. This must
+/// keep passing after the bare-error fix; a mechanical "propagate every
+/// Error/Partial(_, Error)" fix would have broken this case.
+#[test]
+fn test_isempty_error_after_partial_output_does_not_propagate() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "isempty(1, error(\"x\")), \"after\""], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "false\n\"after\"\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
 #[test]
 fn test_setpath_propagates_halt_in_path_argument() -> Result<()> {
     // `builtin_setpath`'s path-array argument used to misreport a halt as


### PR DESCRIPTION
## Summary

- `builtin_isempty`'s bare `QueryResult::Error(_)` arm unconditionally answered `true` ("errors count as empty"), swallowing a genuine uncaught error instead of propagating it.
- Real jq's `isempty` has no `try`/`catch` around its argument, so `isempty(error("x"))` genuinely fails (exit 5) rather than reporting the argument as "empty".
- Fixes #882.

Deliberately asymmetric with the function's existing `Halt`/`Break` handling: only the *bare* `Error` propagates. `Partial(_, Control::Error(_))` (an error surfacing after `g` already produced a value) stays on the wildcard's `false` answer, for the same laziness reason `isempty`'s `Halt`/`Break` arms already document — real jq never requests `g`'s second output once the first already answered `isempty`'s own internal `break $out`.

## Test plan

- [x] `cargo build --features cli` succeeds
- [x] `cargo test --features cli,simd,regex,serde` — full workspace suite green (0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Both shapes (bare error, error-after-partial-output) verified against the pinned jq 1.7.1 oracle directly, plus `isempty(...)?` under an outer `?` confirmed to still match real jq
- [x] `omni-dev coverage diff` — 100% patch coverage (1/1 new line)
- [x] 2 new regression tests added in `tests/jq_cli_tests.rs`, mirroring the existing `Halt`/`Break` tests in the same file