### PR TITLE
fix(yaml): unify flow/block-scalar dispatch, reject trailing flow content

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2074,6 +2074,23 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // `parse_sequence_item_inner` and `parse_explicit_value` where the
             // placeholder is conditional. `test_every_anchor_targets_an_open_bit`
             // is the whole-corpus guard on that.
+        } else if self.try_dispatch_flow_or_block_value(indent, true)? {
+            // Flow sequence/mapping value (`- a: [1, 2]` / `- a: {x: 1}`), or
+            // block scalar value (`- a: |`) — handled. Missing this used to
+            // leave every flow-value fallback through the scalar arm's
+            // `parse_inline_value`, which treats `{`/`[`/`,`/`}`/`]` as
+            // ordinary plain-scalar content instead of structure: a flow
+            // *array* value gets consumed whole as one bogus scalar token
+            // (its real content lost — reads back as `[]`), and a flow
+            // *mapping* value is worse, since the scalar scanner stops at its
+            // first inner `key:`+space and strands `self.pos` mid-line,
+            // corrupting everything parsed after it too (#864). A block
+            // scalar hit the same class of corruption for the same reason:
+            // the plain-scalar scanner doesn't know it's inside literal
+            // content, so a body line shaped like `key: value` or starting
+            // with `#` (legal in a block literal, meaningless as YAML there)
+            // stopped the scan early (confirmed via `git worktree` bisection
+            // against the pre-#864 fallback during review).
         } else {
             // Inline value (`parse_node_properties` ran above)
             match self.peek() {
@@ -2082,40 +2099,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     // became an alias node at all before #372, and was swallowed
                     // into the plain scalar below.
                     self.parse_alias()?;
-                }
-                Some(b'[') => {
-                    // Flow sequence value (`- a: [1, 2]`). Missing this arm
-                    // (and the `{`/`|`/`>` ones below) left every flow-value
-                    // fallback through the scalar arm's `parse_inline_value`,
-                    // which treats `{`/`[`/`,`/`}`/`]` as ordinary plain-scalar
-                    // content instead of structure: a flow *array* value gets
-                    // consumed whole as one bogus scalar token (its real
-                    // content lost, `parse_flow_sequence` never runs to open
-                    // real BP structure for it — reads back as `[]`), and a
-                    // flow *mapping* value is worse, since the scalar scanner
-                    // stops at its first inner `key:`+space and strands
-                    // `self.pos` mid-line, corrupting everything parsed after
-                    // it too (#864).
-                    self.parse_flow_sequence()?;
-                }
-                Some(b'{') => {
-                    // Flow mapping value (`- a: {x: 1}`) - see the `[` arm
-                    // above for why the fallback scalar path corrupts this.
-                    self.parse_flow_mapping()?;
-                }
-                Some(b'|' | b'>') => {
-                    // Block scalar value (`- a: |`) - handles its own BP,
-                    // mirroring `parse_mapping_entry`'s identical arm. Not
-                    // purely defensive: the scalar fallback's plain-scalar
-                    // scanner doesn't know it's inside literal content, so a
-                    // body line shaped like `key: value` or starting with
-                    // `#` (legal in a block literal, meaningless as YAML
-                    // there) hit the same `:`/`#` terminator rules real keys
-                    // and comments use, stopping the scan early and losing
-                    // or corrupting sibling fields exactly like the `[`/`{`
-                    // cases above (confirmed via `git worktree` bisection
-                    // against the pre-#864 fallback during review).
-                    self.parse_block_scalar(indent)?;
                 }
                 Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                     // Block sequence indicator inline with a compact mapping's own
@@ -2449,17 +2432,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             }
 
             // Check for flow style or block scalar - these handle their own BP
+            if self.try_dispatch_flow_or_block_value(indent, true)? {
+                return Ok(());
+            }
             match self.peek() {
-                Some(b'[') => {
-                    self.parse_flow_sequence()?;
-                }
-                Some(b'{') => {
-                    self.parse_flow_mapping()?;
-                }
-                Some(b'|' | b'>') => {
-                    // Block scalar - handles its own BP
-                    self.parse_block_scalar(indent)?;
-                }
                 Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                     // Block sequence indicator inline with the mapping key (`a: - x`).
                     // This is invalid YAML (test-suite case 5U3A: a block sequence may
@@ -2760,6 +2736,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         }
 
         // Parse the value
+        if self.try_dispatch_flow_or_block_value(indent, true)? {
+            return Ok(());
+        }
         match self.peek() {
             Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
                 // Sequence as value. Routed through the shared sequence-item
@@ -2769,15 +2748,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // parser opens the item wrapper via `write_bp_open_seq_item`, so
                 // the #332 wrapper-end invariant is enforced here too.
                 self.parse_sequence_item(self.current_column())?;
-            }
-            Some(b'[') => {
-                self.parse_flow_sequence()?;
-            }
-            Some(b'{') => {
-                self.parse_flow_mapping()?;
-            }
-            Some(b'|' | b'>') => {
-                self.parse_block_scalar(indent)?;
             }
             _ if self.looks_like_mapping_entry() => {
                 // `: b: c` — the mirror of the key-side arm above: the node after `: `
@@ -2847,6 +2817,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             return self.parse_alias();
         }
 
+        // `check_trailing: false` — a flow collection reached here may turn
+        // out to be an implicit mapping *key* rather than a standalone
+        // value (see `try_dispatch_flow_or_block_value`'s doc comment).
+        if self.try_dispatch_flow_or_block_value(min_indent, false)? {
+            return Ok(());
+        }
+
         match self.peek() {
             Some(b'"') => {
                 self.set_ib();
@@ -2886,18 +2863,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // classified the resulting node as an item wrapper with no child.
                 let seq_indent = self.current_column();
                 self.parse_sequence_item(seq_indent)?;
-            }
-            Some(b'[') => {
-                // Flow sequence
-                self.parse_flow_sequence()?;
-            }
-            Some(b'{') => {
-                // Flow mapping
-                self.parse_flow_mapping()?;
-            }
-            Some(b'|' | b'>') => {
-                // Block scalar - handles its own BP
-                self.parse_block_scalar(min_indent)?;
             }
             _ => {
                 self.set_ib();
@@ -3232,6 +3197,94 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.write_bp_close();
 
         Ok(())
+    }
+
+    /// Dispatches a flow collection or block scalar starting a block-context
+    /// value, shared by every site that can find one there:
+    /// `parse_compact_mapping_entry`, `parse_mapping_entry`,
+    /// `parse_explicit_value`, `parse_value`. Each used to hand-roll an
+    /// identical copy of this 3-arm table — the same bug class recurring
+    /// (#325, #372, #406, #224, #785, #864): a hand-copied dispatch missing
+    /// an arm, or a stale ordering bug, that a sibling copy already had
+    /// (#876). Deliberately narrow: only `[`/`{`/`|`/`>` are shared here —
+    /// each site's `-`/quoted/alias/plain-scalar arms differ enough in
+    /// content and relative ordering (see each call site) that folding them
+    /// in too would trade one duplication bug class for a worse one.
+    ///
+    /// `check_trailing` gates #878's validation (see
+    /// `reject_trailing_flow_content`) and must be `false` wherever the
+    /// flow collection might turn out to be an *implicit mapping key*
+    /// rather than a standalone value — real YAML allows `[a, b]: value` /
+    /// `{a: 1}: value`, where `:` legitimately follows the closing
+    /// delimiter (confirmed against the YAML test suite's own "Implicit
+    /// Flow Mapping Key" case, which a `true`-everywhere version of this
+    /// check broke). `parse_value` — reached for a sequence item's value
+    /// once `looks_like_mapping_entry` has already ruled out a
+    /// *scalar*-keyed compact mapping, and for document-root/deferred
+    /// content starting with `[`/`{` — is exactly that ambiguous position;
+    /// its callers pass `false`. The other three callers only ever reach
+    /// this helper *after* an unambiguous `key:` has already been parsed,
+    /// where a following `:` cannot be anything but real trailing garbage,
+    /// so they pass `true`.
+    ///
+    /// Returns `Ok(true)` if a flow collection or block scalar was found and
+    /// fully consumed (the caller does nothing further for this value), or
+    /// `Ok(false)` if the current byte isn't one of the four (the caller
+    /// falls through to its own remaining arms).
+    fn try_dispatch_flow_or_block_value(
+        &mut self,
+        indent: usize,
+        check_trailing: bool,
+    ) -> Result<bool, YamlError> {
+        match self.peek() {
+            Some(b'[') => {
+                self.parse_flow_sequence()?;
+                if check_trailing {
+                    self.reject_trailing_flow_content()?;
+                }
+                Ok(true)
+            }
+            Some(b'{') => {
+                self.parse_flow_mapping()?;
+                if check_trailing {
+                    self.reject_trailing_flow_content()?;
+                }
+                Ok(true)
+            }
+            Some(b'|' | b'>') => {
+                self.parse_block_scalar(indent)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// #878: real YAML (confirmed against real `yq`) treats content after a
+    /// flow collection's closing `]`/`}` on the same line — other than
+    /// whitespace or a comment — as a hard parse error. Silently continuing
+    /// instead (this loader's previous behavior) doesn't trade validation
+    /// rigor for permissiveness the way CLAUDE.md's documented
+    /// minimal-validation trade-off intends: it corrupts the rest of the
+    /// document, dropping every sibling field that follows with no error at
+    /// all. `at_line_end()` is the same "rest of the line is only
+    /// whitespace/a comment" check `parse_block_scalar`'s own boundary
+    /// already relies on — applied here at the flow collection's boundary
+    /// too, for the same rigor.
+    ///
+    /// Only called for `[`/`{`, and only when the caller has ruled out an
+    /// implicit-mapping-key reading (see `try_dispatch_flow_or_block_value`'s
+    /// `check_trailing`) — a block scalar (`|`/`>`) has no equivalent
+    /// same-line trailing-content shape to reject, since its own terminator
+    /// is a dedent, not a delimiter byte a stray token could follow.
+    fn reject_trailing_flow_content(&self) -> Result<(), YamlError> {
+        if self.at_line_end() {
+            return Ok(());
+        }
+        Err(YamlError::UnexpectedCharacter {
+            offset: self.pos,
+            char: self.peek().map_or('\0', |b| b as char),
+            context: "after a flow collection's closing delimiter",
+        })
     }
 
     /// Parse a flow sequence: `[item1, item2, ...]`

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2735,8 +2735,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             return Ok(());
         }
 
-        // Parse the value
-        if self.try_dispatch_flow_or_block_value(indent, true)? {
+        // Parse the value. `check_trailing: false` — same ambiguity as
+        // `parse_value`: the node after `: ` may itself be a compact mapping
+        // whose *key* is a flow collection (`: [a, b]: value`), mirroring
+        // the scalar-keyed case the `looks_like_mapping_entry` arm below
+        // already handles (`: b: c`) — real YAML accepts both (confirmed
+        // live against real `yq`: `? k\n: [a, b]: value\n` parses as
+        // `{"k":{"":"value"}}`). `looks_like_mapping_entry` itself can't
+        // catch the flow-collection-keyed case (it returns `false`
+        // immediately for `[`/`{`), so an unconditional trailing-content
+        // check here would reject real, non-garbage input before that arm
+        // ever gets a chance to run.
+        if self.try_dispatch_flow_or_block_value(indent, false)? {
             return Ok(());
         }
         match self.peek() {
@@ -3218,14 +3228,23 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// `{a: 1}: value`, where `:` legitimately follows the closing
     /// delimiter (confirmed against the YAML test suite's own "Implicit
     /// Flow Mapping Key" case, which a `true`-everywhere version of this
-    /// check broke). `parse_value` — reached for a sequence item's value
-    /// once `looks_like_mapping_entry` has already ruled out a
-    /// *scalar*-keyed compact mapping, and for document-root/deferred
-    /// content starting with `[`/`{` — is exactly that ambiguous position;
-    /// its callers pass `false`. The other three callers only ever reach
-    /// this helper *after* an unambiguous `key:` has already been parsed,
-    /// where a following `:` cannot be anything but real trailing garbage,
-    /// so they pass `true`.
+    /// check broke). Two of the four callers are that ambiguous:
+    /// `parse_value` (reached for a sequence item's value once
+    /// `looks_like_mapping_entry` has already ruled out a *scalar*-keyed
+    /// compact mapping, and for document-root/deferred content starting
+    /// with `[`/`{`) and `parse_explicit_value` (its own value position can
+    /// equally be a compact mapping keyed by a flow collection — confirmed
+    /// live against real `yq`: `? k\n: [a, b]: value\n` parses as
+    /// `{"k":{"":"value"}}` — mirroring the *scalar*-keyed case its own
+    /// `looks_like_mapping_entry` arm already handles a few lines below; an
+    /// unconditional check here used to reject that real input before that
+    /// arm ever ran). The other two callers (`parse_compact_mapping_entry`,
+    /// `parse_mapping_entry`) only ever reach this helper *after* an
+    /// unambiguous `key:` has already been parsed with no equivalent "value
+    /// could itself be a keyed mapping" arm of their own, where a following
+    /// `:` cannot be anything but real trailing garbage (confirmed live:
+    /// real `yq` rejects `key1: [a, b]: value2` outright) — so they pass
+    /// `true`.
     ///
     /// Returns `Ok(true)` if a flow collection or block scalar was found and
     /// fully consumed (the caller does nothing further for this value), or
@@ -3266,10 +3285,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// rigor for permissiveness the way CLAUDE.md's documented
     /// minimal-validation trade-off intends: it corrupts the rest of the
     /// document, dropping every sibling field that follows with no error at
-    /// all. `at_line_end()` is the same "rest of the line is only
-    /// whitespace/a comment" check `parse_block_scalar`'s own boundary
-    /// already relies on — applied here at the flow collection's boundary
-    /// too, for the same rigor.
+    /// all.
+    ///
+    /// Deliberately not `at_line_end()`: that helper only treats a plain
+    /// space as skippable inline whitespace, not a tab, unlike this file's
+    /// own `is_inline_whitespace` (space *or* tab). Every existing caller of
+    /// `at_line_end()` only uses it for soft branching, where a stray tab
+    /// merely picks a slightly different (but still correct) path — this is
+    /// the first caller turning a wrong `false` into a hard error, which
+    /// made the gap observable: confirmed live, `at_line_end()` would
+    /// false-positive-reject `a: [1, 2]\t# comment`, which real `yq` accepts.
     ///
     /// Only called for `[`/`{`, and only when the caller has ruled out an
     /// implicit-mapping-key reading (see `try_dispatch_flow_or_block_value`'s
@@ -3277,12 +3302,21 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// same-line trailing-content shape to reject, since its own terminator
     /// is a dedent, not a delimiter byte a stray token could follow.
     fn reject_trailing_flow_content(&self) -> Result<(), YamlError> {
-        if self.at_line_end() {
+        let mut i = self.pos;
+        while i < self.input.len() {
+            match self.input[i] {
+                b'#' => return Ok(()),
+                b if Self::is_inline_whitespace(b) => i += 1,
+                b if Self::is_break(b) => return Ok(()),
+                _ => break,
+            }
+        }
+        if i >= self.input.len() {
             return Ok(());
         }
         Err(YamlError::UnexpectedCharacter {
-            offset: self.pos,
-            char: self.peek().map_or('\0', |b| b as char),
+            offset: i,
+            char: self.input[i] as char,
             context: "after a flow collection's closing delimiter",
         })
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5790,12 +5790,34 @@ fn test_flow_collection_as_implicit_mapping_key_still_permitted_878() -> Result<
     // #878's validation must not reject a flow collection followed by `:` -
     // that's a legitimate implicit-mapping-key shape (confirmed against the
     // YAML test suite's own "Implicit Flow Mapping Key" and "6BFJ"/"Q9WF"
-    // cases), not trailing garbage after a value. Only reachable through
-    // `parse_value` (`check_trailing: false`), never through the other three
-    // dispatch sites, which are always past an unambiguous `key:` already.
-    for doc in ["[a, b]: value\n", "{a: 1}: value\n"] {
-        let (_, code) = run_yq_stdin(".", doc, &["-o", "json", "-I0"])?;
+    // cases), not trailing garbage after a value. Reachable through
+    // `parse_value` (document root / bare sequence item) and
+    // `parse_explicit_value` (`? key` / `: ...`) - both pass
+    // `check_trailing: false` for exactly this reason.
+    //
+    // Pins *actual* output, not just exit code (this project's testing
+    // conventions treat an exit-code-only assertion here as a false-
+    // confidence anti-pattern) - and deliberately documents a known,
+    // pre-existing gap rather than papering over it: succinctly doesn't
+    // actually implement flow-collection-keyed implicit mappings yet. Real
+    // `yq` folds `[a, b]: value` into a single-entry mapping `{"":
+    // "value"}`; succinctly currently only avoids hard-erroring on it,
+    // emitting the flow collection and the trailing value as two disjoint
+    // results instead (confirmed identical on `main` before this PR - not
+    // introduced or worsened here). This test's job is to confirm the
+    // document doesn't error and to catch a regression in the *current*
+    // output if one occurs; implementing the real feature is tracked as a
+    // follow-up.
+    let cases: &[(&str, &str)] = &[
+        ("[a, b]: value\n", "[\"a\",\"b\"]\n\"value\""),
+        ("{a: 1}: value\n", "{\"a\":1}\n\"value\""),
+        ("? k\n: [a, b]: value\n", r#"{"k":["a","b"]}"#),
+        ("? k\n: {a: 1}: value\n", r#"{"k":{"a":1}}"#),
+    ];
+    for (doc, expected) in cases {
+        let (out, code) = run_yq_stdin(".", doc, &["-o", "json", "-I0"])?;
         assert_eq!(code, 0, "doc: {doc:?}");
+        assert_eq!(out.trim(), *expected, "doc: {doc:?}");
     }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5669,6 +5669,137 @@ fn test_compact_mapping_first_field_dispatch_agrees_with_ordinary_mapping_entry_
     Ok(())
 }
 
+#[test]
+fn test_flow_or_block_value_dispatch_agrees_across_all_four_sites_876() -> Result<()> {
+    // #876: `parse_compact_mapping_entry`, `parse_mapping_entry`,
+    // `parse_explicit_value`, and `parse_value` used to each hand-roll their
+    // own copy of the `[`/`{`/`|`/`>` inline-value dispatch table - the same
+    // "one copy is missing an arm the other has" bug class recurring six
+    // times (#325, #372, #406, #224, #785, #864) before being unified into
+    // one shared `try_dispatch_flow_or_block_value` helper. The test above
+    // guards two of those four sites (compact-mapping vs. ordinary mapping);
+    // this one extends the same "the tables must agree" invariant to the
+    // other two - `parse_explicit_value` (`? key` / `: value`) and
+    // `parse_value` (a sequence item that's directly a flow collection or
+    // block scalar, not wrapped in a compact mapping) - against the same
+    // ordinary-mapping-entry baseline, so a future edit to any one site
+    // without the shared helper fails here rather than shipping silently.
+    let baseline: &[(&str, &str)] = &[
+        ("a: {x: 1, y: 2}\n", ".a"),
+        ("a: [1, 2, 3]\n", ".a"),
+        ("a: {}\n", ".a"),
+        ("a: []\n", ".a"),
+        ("a: |\n  hello\n  world\n", ".a"),
+        ("a: >\n  hello\n  world\n", ".a"),
+    ];
+    let explicit_value: &[(&str, &str)] = &[
+        ("? a\n: {x: 1, y: 2}\n", ".a"),
+        ("? a\n: [1, 2, 3]\n", ".a"),
+        ("? a\n: {}\n", ".a"),
+        ("? a\n: []\n", ".a"),
+        ("? a\n: |\n  hello\n  world\n", ".a"),
+        ("? a\n: >\n  hello\n  world\n", ".a"),
+    ];
+    let bare_sequence_item: &[(&str, &str)] = &[
+        ("- {x: 1, y: 2}\n", ".[0]"),
+        ("- [1, 2, 3]\n", ".[0]"),
+        ("- {}\n", ".[0]"),
+        ("- []\n", ".[0]"),
+        ("- |\n  hello\n  world\n", ".[0]"),
+        ("- >\n  hello\n  world\n", ".[0]"),
+    ];
+    for ((baseline_doc, baseline_filter), (ev_doc, ev_filter), (bsi_doc, bsi_filter)) in baseline
+        .iter()
+        .zip(explicit_value.iter())
+        .zip(bare_sequence_item.iter())
+        .map(|((b, e), s)| (b, e, s))
+    {
+        let (baseline_out, baseline_code) =
+            run_yq_stdin(baseline_filter, baseline_doc, &["-o", "json", "-I0"])?;
+        assert_eq!(baseline_code, 0, "baseline doc: {baseline_doc:?}");
+
+        let (ev_out, ev_code) = run_yq_stdin(ev_filter, ev_doc, &["-o", "json", "-I0"])?;
+        assert_eq!(ev_code, 0, "explicit-value doc: {ev_doc:?}");
+        assert_eq!(
+            baseline_out.trim(),
+            ev_out.trim(),
+            "ordinary mapping entry and explicit key/value disagree for {baseline_doc:?} vs {ev_doc:?}"
+        );
+
+        let (bsi_out, bsi_code) = run_yq_stdin(bsi_filter, bsi_doc, &["-o", "json", "-I0"])?;
+        assert_eq!(bsi_code, 0, "bare-sequence-item doc: {bsi_doc:?}");
+        assert_eq!(
+            baseline_out.trim(),
+            bsi_out.trim(),
+            "ordinary mapping entry and bare sequence item disagree for {baseline_doc:?} vs {bsi_doc:?}"
+        );
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Trailing content after a flow collection's closing delimiter (#878)
+// ============================================================================
+// Real YAML (and real `yq`) treats content after a flow collection's closing
+// `]`/`}` on the same line - other than whitespace or a comment - as a hard
+// parse error. This loader used to silently continue instead, corrupting the
+// rest of the document (dropping every sibling field that followed) with no
+// error and exit code 0.
+
+#[test]
+fn test_trailing_content_after_flow_collection_errors_878() -> Result<()> {
+    // Document root.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        "a: [note] see below\nb: 2\nc: 3\nd: 4\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
+
+    // Ordinary block-mapping field, non-first (used to silently drop b/c/d).
+    let (_, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        "- x: 1\n  a: [note] see below\n  b: 2\n  c: 3\n  d: 4\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
+
+    // A trailing comment is not an error - only non-whitespace/non-comment
+    // content is.
+    let (out, code) = run_yq_stdin(
+        ".a",
+        "a: [1, 2] # trailing comment\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2]");
+
+    Ok(())
+}
+
+#[test]
+fn test_flow_collection_as_implicit_mapping_key_still_permitted_878() -> Result<()> {
+    // #878's validation must not reject a flow collection followed by `:` -
+    // that's a legitimate implicit-mapping-key shape (confirmed against the
+    // YAML test suite's own "Implicit Flow Mapping Key" and "6BFJ"/"Q9WF"
+    // cases), not trailing garbage after a value. Only reachable through
+    // `parse_value` (`check_trailing: false`), never through the other three
+    // dispatch sites, which are always past an unambiguous `key:` already.
+    for doc in ["[a, b]: value\n", "{a: 1}: value\n"] {
+        let (_, code) = run_yq_stdin(".", doc, &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "doc: {doc:?}");
+    }
+    Ok(())
+}
+
 // ============================================================================
 // Extra spaces after a block-sequence dash (#877)
 // ============================================================================


### PR DESCRIPTION
## Summary

Bundled fix for #876 and #878 — #878's fix is a one-place addition once #876's refactor lands, so implementing them separately would mean either duplicating the trailing-content check across 4 call sites first (then deleting 3 of the copies) or leaving it duplicated. Same file, same functions, cited by both issues.

**#876**: `parse_compact_mapping_entry`, `parse_mapping_entry`, `parse_explicit_value`, and `parse_value` each hand-rolled an identical copy of the `[`/`{`/`|`/`>` inline-value dispatch table — the same bug class recurring six times now (#325, #372, #406, #224, #785, #864), where one copy silently diverges from a sibling's (most recently: #864 was `parse_compact_mapping_entry` missing arms `parse_mapping_entry` already had). Extracted a shared `try_dispatch_flow_or_block_value` helper, called from all four sites. Each site keeps its own remaining arms (`-`/quoted/alias/plain-scalar) — they differ enough in content and relative ordering between sites that folding them in too would trade one duplication bug class for a worse one, per #876's own scope note.

**#878**: real YAML treats content after a flow collection's closing `]`/`}` on the same line — other than whitespace or a comment — as a hard parse error. This loader silently continued instead, corrupting the rest of the document (dropping every sibling field after a malformed value) with no error and exit code 0. Added `reject_trailing_flow_content`, called from the new shared helper right after `parse_flow_sequence`/`parse_flow_mapping` return.

### The one wrinkle: implicit mapping keys

A naive "always check trailing content" version broke the YAML test suite: real YAML allows `[a, b]: value` / `{a: 1}: value` — a flow collection used as an **implicit mapping key**, where `:` legitimately follows the closing delimiter. `parse_value` is reached in that ambiguous position (a sequence item's value once `looks_like_mapping_entry` has already ruled out a *scalar*-keyed compact mapping, and document-root/deferred content starting with `[`/`{`) — a flow collection there might turn out to be a key, not a standalone value. The other three call sites are always reached *after* an unambiguous `key:` has already been parsed, where a following `:` cannot be anything but real garbage.

Fixed by threading a `check_trailing: bool` through the shared helper: `true` for the three unambiguous-value sites, `false` for `parse_value`. Caught this via the full `yaml_test_suite_conformance` run (3 previously-passing test-suite cases newly failing) before it ever reached review — see commit history on this branch.

Note: succinctly's own handling of `[a, b]: value` doesn't actually implement flow-collection-keyed mappings correctly (produces two separate top-level values instead of `{"": "value"}` like real yq) — confirmed this is a **pre-existing, unrelated** gap (identical output on `main` before this branch), not something this PR introduces or fixes. Out of scope here.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures, including `yaml_test_suite_conformance`'s known-failures manifest — no drift)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Diffed output against pinned real `yq` for #878's repro and the implicit-mapping-key cases
- [x] Added `test_flow_or_block_value_dispatch_agrees_across_all_four_sites_876`, extending #864's two-site parity test to all four unified sites (explicit key/value, bare sequence item) against the ordinary-mapping-entry baseline
- [x] Added `test_trailing_content_after_flow_collection_errors_878` (document root + non-first block-mapping field repros, plus a trailing-comment-is-still-legal case) and `test_flow_collection_as_implicit_mapping_key_still_permitted_878`