### PR TITLE
fix(yaml): tolerate an inconsistently-indented compact-mapping continuation

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1722,12 +1722,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         }
     }
 
-    /// Whether `indent` falls in the "gap" between an open compact mapping's
-    /// own recorded indent and its enclosing sequence item's virtual indent
-    /// — e.g. `-   a: hello\n  b: 2\n`, where the compact mapping opened by
-    /// `a` sits at indent 4 (the real column of `a`) but `b`'s line is
-    /// indented only 2, strictly between that and the item's own virtual
-    /// indent 1.
+    /// Whether `indent` falls anywhere from an open compact mapping's own
+    /// recorded indent down through its enclosing sequence item's virtual
+    /// indent (inclusive on both ends) — e.g. `-   a: hello\n  b: 2\n`, where
+    /// the compact mapping opened by `a` sits at indent 4 (the real column
+    /// of `a`) but `b`'s line is indented only 2, between that and the
+    /// item's own virtual indent 1.
     ///
     /// Real yq rejects this input outright as inconsistently indented, but
     /// the plain indent comparison `close_deeper_indents`/`parse_mapping_entry`
@@ -1735,18 +1735,37 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// opening a second, untagged mapping as a sibling directly under the
     /// same `SequenceItem` — which structurally expects only one value
     /// child, so every field after the first inconsistent line is silently
-    /// dropped by the JSON serializer (#885). Deliberately narrow, mirroring
-    /// `close_deeper_indents_for_sequence_item`'s own caution: only a
-    /// `Mapping` frame directly on top of a `SequenceItem` frame — the exact
-    /// shape `parse_compact_mapping_entry` creates — not mapping-under-mapping
-    /// nesting, where the same out-of-range indent is genuinely ambiguous
-    /// between two different enclosing scopes.
+    /// dropped by the JSON serializer (#885).
+    ///
+    /// The lower bound is inclusive (`>=`, not `>`) because the ordinary,
+    /// single-space-after-dash case (the common real-world shape, not just
+    /// this file's extra-spaced headline repro) lands exactly *at* the
+    /// item's own virtual indent — `close_deeper_indents` never closes a
+    /// frame at an indent equal to its own recorded value elsewhere in this
+    /// file either (`current_indent > new_indent` gates every close), so
+    /// treating equality as "still inside" here is consistent with that,
+    /// not a special case invented for this function.
+    ///
+    /// Deliberately narrow to a `Mapping` frame directly on top of a
+    /// `SequenceItem` frame: in that shape there's exactly one possible
+    /// enclosing scope for the line to belong to, which is what makes this
+    /// tolerance unambiguous. Two known, deliberately out-of-scope siblings
+    /// of this same failure shape, not yet fixed:
+    /// - A `-` continuation landing in the same gap (#900) — unlike a
+    ///   `key: value` line, a bare item has no obvious "add it to the open
+    ///   mapping" interpretation.
+    /// - Mapping-under-mapping nesting (#901) — needs its own correctness
+    ///   argument for whether the same reasoning still holds when the frame
+    ///   below isn't a `SequenceItem` (and thus not guaranteed to be the
+    ///   line's only possible enclosing scope) before extending this check
+    ///   to it.
     fn compact_mapping_gap_reaches(&self, indent: usize) -> bool {
         let len = self.indent_stack.len();
         len >= 2
             && self.type_stack[len - 1] == NodeType::Mapping
             && self.type_stack[len - 2] == NodeType::SequenceItem
-            && self.sequence_frame_reaches(len - 1, indent)
+            && indent >= self.indent_stack[len - 2]
+            && indent <= self.indent_stack[len - 1]
     }
 
     /// Normalize `indent` to the open compact mapping's own recorded indent
@@ -2178,6 +2197,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     fn parse_mapping_entry(&mut self, indent: usize) -> Result<(), YamlError> {
         let _entry_start = self.pos;
 
+        // Normalize an inconsistently-indented continuation of an open
+        // compact mapping to the mapping's own indent, so the
+        // close/need-new-mapping decision below adds an entry to it instead
+        // of closing it (#885).
+        let indent = self.resolve_compact_mapping_gap_indent(indent);
+
         // First close any containers that are deeper than our indent level.
         // This ensures we return to the appropriate context before deciding
         // whether to open a new mapping or add to an existing one.
@@ -2518,6 +2543,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Parse an explicit key (`? key`).
     /// The key can be any value: scalar, sequence, or mapping.
     fn parse_explicit_key(&mut self, indent: usize) -> Result<(), YamlError> {
+        // Same gap-tolerant normalization as parse_mapping_entry (#885):
+        // this function has the identical close/need-new-mapping shape.
+        let indent = self.resolve_compact_mapping_gap_indent(indent);
+
         // Close any deeper containers
         self.close_deeper_indents(indent);
 
@@ -2740,6 +2769,11 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
     /// Parse an explicit value (`: value` after explicit key).
     fn parse_explicit_value(&mut self, indent: usize) -> Result<(), YamlError> {
+        // Same gap-tolerant normalization as parse_mapping_entry (#885): an
+        // inconsistently-indented `:` must not close the pending key's own
+        // compact mapping out from under it.
+        let indent = self.resolve_compact_mapping_gap_indent(indent);
+
         // Close deeper structures, but keep the mapping at this indent open
         self.close_deeper_indents(indent + 1);
 
@@ -4841,13 +4875,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // Look ahead to see if this is a `key:` pattern
                 if self.node_properties_prefix_mapping_entry() {
                     // Let parse_mapping_entry handle the property, including
-                    // its own `close_deeper_indents` — using the
-                    // gap-tolerant indent (#885) rather than closing
-                    // unconditionally up front, which would otherwise
-                    // already have closed an open compact mapping this
-                    // line's indent still belongs to before this arm ever
-                    // got to decide.
-                    let indent = self.resolve_compact_mapping_gap_indent(indent);
+                    // its own close_deeper_indents — moved here (rather than
+                    // closing unconditionally up front) so a #885 gap-tolerant
+                    // indent normalization inside parse_mapping_entry isn't
+                    // preempted by an unconditional close running first.
                     self.parse_mapping_entry(indent)?;
                 } else {
                     self.close_deeper_indents(indent);
@@ -4905,8 +4936,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // Check if this is `*alias : value` pattern (alias as mapping key)
                 if self.looks_like_mapping_entry() {
                     // Alias is a key - let parse_mapping_entry handle it
-                    // (gap-tolerant indent, #885 — see the `&`/`!` arm above)
-                    let indent = self.resolve_compact_mapping_gap_indent(indent);
                     self.parse_mapping_entry(indent)?;
                 } else {
                     // Standalone alias value
@@ -4918,8 +4947,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // Check if this looks like a mapping entry (has `: ` on this line)
                 // This handles both quoted keys ("foo": bar) and unquoted keys (foo: bar)
                 if self.looks_like_mapping_entry() {
-                    // Gap-tolerant indent, #885 — see the `&`/`!` arm above.
-                    let indent = self.resolve_compact_mapping_gap_indent(indent);
                     self.parse_mapping_entry(indent)?;
                 } else {
                     // Scalar value - either bare document scalar or value in a container

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1722,6 +1722,47 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         }
     }
 
+    /// Whether `indent` falls in the "gap" between an open compact mapping's
+    /// own recorded indent and its enclosing sequence item's virtual indent
+    /// — e.g. `-   a: hello\n  b: 2\n`, where the compact mapping opened by
+    /// `a` sits at indent 4 (the real column of `a`) but `b`'s line is
+    /// indented only 2, strictly between that and the item's own virtual
+    /// indent 1.
+    ///
+    /// Real yq rejects this input outright as inconsistently indented, but
+    /// the plain indent comparison `close_deeper_indents`/`parse_mapping_entry`
+    /// would otherwise apply treats it as *closing* the compact mapping and
+    /// opening a second, untagged mapping as a sibling directly under the
+    /// same `SequenceItem` — which structurally expects only one value
+    /// child, so every field after the first inconsistent line is silently
+    /// dropped by the JSON serializer (#885). Deliberately narrow, mirroring
+    /// `close_deeper_indents_for_sequence_item`'s own caution: only a
+    /// `Mapping` frame directly on top of a `SequenceItem` frame — the exact
+    /// shape `parse_compact_mapping_entry` creates — not mapping-under-mapping
+    /// nesting, where the same out-of-range indent is genuinely ambiguous
+    /// between two different enclosing scopes.
+    fn compact_mapping_gap_reaches(&self, indent: usize) -> bool {
+        let len = self.indent_stack.len();
+        len >= 2
+            && self.type_stack[len - 1] == NodeType::Mapping
+            && self.type_stack[len - 2] == NodeType::SequenceItem
+            && self.sequence_frame_reaches(len - 1, indent)
+    }
+
+    /// Normalize `indent` to the open compact mapping's own recorded indent
+    /// when [`Self::compact_mapping_gap_reaches`] holds, so
+    /// `parse_mapping_entry` adds an entry to that mapping instead of
+    /// closing it — the same normalization `parse_sequence_item_inner`
+    /// already does for an out-dented sequence continuation (#485). A no-op
+    /// otherwise.
+    fn resolve_compact_mapping_gap_indent(&self, indent: usize) -> usize {
+        if self.compact_mapping_gap_reaches(indent) {
+            *self.indent_stack.last().unwrap()
+        } else {
+            indent
+        }
+    }
+
     /// Close a sequence that was the value of a previous mapping entry.
     ///
     /// When we're about to add a new entry to a mapping at indent N, and the top
@@ -4796,13 +4837,20 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // parse_explicit_key, and parse_explicit_value eventually
                 // lands here, so fixing property consumption in this one arm
                 // closes most of #664's audit at once (#224).
-                self.close_deeper_indents(indent);
-
+                //
                 // Look ahead to see if this is a `key:` pattern
                 if self.node_properties_prefix_mapping_entry() {
-                    // Let parse_mapping_entry handle the property
+                    // Let parse_mapping_entry handle the property, including
+                    // its own `close_deeper_indents` — using the
+                    // gap-tolerant indent (#885) rather than closing
+                    // unconditionally up front, which would otherwise
+                    // already have closed an open compact mapping this
+                    // line's indent still belongs to before this arm ever
+                    // got to decide.
+                    let indent = self.resolve_compact_mapping_gap_indent(indent);
                     self.parse_mapping_entry(indent)?;
                 } else {
+                    self.close_deeper_indents(indent);
                     // Consume any leading `&anchor` and/or `!tag`, in either
                     // order, for non-mapping-key cases
                     self.parse_node_properties()?;
@@ -4857,6 +4905,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // Check if this is `*alias : value` pattern (alias as mapping key)
                 if self.looks_like_mapping_entry() {
                     // Alias is a key - let parse_mapping_entry handle it
+                    // (gap-tolerant indent, #885 — see the `&`/`!` arm above)
+                    let indent = self.resolve_compact_mapping_gap_indent(indent);
                     self.parse_mapping_entry(indent)?;
                 } else {
                     // Standalone alias value
@@ -4868,6 +4918,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // Check if this looks like a mapping entry (has `: ` on this line)
                 // This handles both quoted keys ("foo": bar) and unquoted keys (foo: bar)
                 if self.looks_like_mapping_entry() {
+                    // Gap-tolerant indent, #885 — see the `&`/`!` arm above.
+                    let indent = self.resolve_compact_mapping_gap_indent(indent);
                     self.parse_mapping_entry(indent)?;
                 } else {
                     // Scalar value - either bare document scalar or value in a container

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5933,6 +5933,99 @@ fn test_correctly_aligned_sequence_is_unaffected_by_out_dent_handling() -> Resul
     Ok(())
 }
 
+// ============================================================================
+// Inconsistent compact-mapping continuation indent (#885)
+// ============================================================================
+// The mapping-shaped analog of #485 above: a continuation line indented
+// strictly between a compact mapping's own indent and its enclosing sequence
+// item's virtual indent is invalid YAML (`yq` v4.53.3 rejects it outright),
+// but before this fix, the plain indent comparison `close_deeper_indents`
+// applies closed the compact mapping and reopened a second, orphaned mapping
+// as a sibling directly under the same sequence item — which structurally
+// expects only one value child, so the JSON serializer silently dropped
+// every field after the first inconsistent line. Same "parse the obvious
+// extension" policy #485 (and #325 before it) already established for this
+// class of problem.
+
+#[test]
+fn test_inconsistent_compact_mapping_indent_headline_repro() -> Result<()> {
+    // yq v4.53.3: `Error: bad file '-': yaml: while parsing a block
+    // collection ...: did not find expected '-' indicator`.
+    let (output, exit_code) = run_yq_stdin(".", "-   a: hello\n  b: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":"hello","b":2}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_inconsistent_compact_mapping_indent_does_not_lose_later_fields() -> Result<()> {
+    // Every field after the first inconsistent line must survive, not just
+    // the first one.
+    let (output, exit_code) =
+        run_yq_stdin(".", "-   a: 1\n  b: 2\n  c: 3\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":1,"b":2,"c":3}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_inconsistent_compact_mapping_indent_does_not_leak_into_next_item() -> Result<()> {
+    // A properly-dashed sibling item after the inconsistent one must still
+    // be recognized as its own item, not folded into the first.
+    let (output, exit_code) =
+        run_yq_stdin(".", "-   a: 1\n  b: 2\n-   x: 9\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":1,"b":2},{"x":9}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_indent_genuinely_below_the_item_stays_a_separate_top_level_entry() -> Result<()> {
+    // Regression guard: an indent at or below the sequence item's own column
+    // (not merely below the compact mapping's) is a real sibling at the
+    // document root, not a gap this fix should swallow — `sequence_frame_reaches`
+    // must still reject it.
+    let (output, exit_code) = run_yq_stdin(".", "-   a: hello\nb: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":"hello"},{"b":2}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_inconsistent_compact_mapping_indent_with_anchor_prefixed_key() -> Result<()> {
+    // The `&`/`!` dispatch arm has its own `close_deeper_indents` call and
+    // needed the same gap-tolerant indent as the plain-key arm.
+    let (output, exit_code) = run_yq_stdin(".", "-   &anc k: v\n  b: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"k":"v","b":2}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_inconsistent_compact_mapping_indent_with_tag_prefixed_key() -> Result<()> {
+    let (output, exit_code) =
+        run_yq_stdin(".", "-   !!str k: v\n  b: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"k":"v","b":2}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_inconsistent_compact_mapping_indent_with_alias_key() -> Result<()> {
+    // The `*` (alias-as-key) dispatch arm.
+    let (output, exit_code) = run_yq_stdin(
+        ".",
+        "x: &k1 hello\nlist:\n-   *k1: v\n  b: 2\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        output.trim(),
+        r#"{"x":"hello","list":[{"hello":"v","b":2}]}"#
+    );
+    Ok(())
+}
+
 #[test]
 fn test_flow_dash_without_whitespace_is_still_a_scalar() -> Result<()> {
     // A `-` not followed by whitespace is a legitimate plain scalar in flow

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5981,13 +5981,44 @@ fn test_inconsistent_compact_mapping_indent_does_not_leak_into_next_item() -> Re
 
 #[test]
 fn test_indent_genuinely_below_the_item_stays_a_separate_top_level_entry() -> Result<()> {
-    // Regression guard: an indent at or below the sequence item's own column
-    // (not merely below the compact mapping's) is a real sibling at the
-    // document root, not a gap this fix should swallow — `sequence_frame_reaches`
-    // must still reject it.
+    // Regression guard: an indent at or below the sequence item's own dash
+    // column (strictly below the compact mapping's *and* the item's own
+    // virtual indent) must not be swallowed into the mapping by
+    // `compact_mapping_gap_reaches`. Real `yq` v4.53.3 rejects this input
+    // too (`did not find expected '-' indicator`) — same as every other
+    // case in this file — succinctly's own two-item output here comes from
+    // a separate, pre-existing "parse the obvious extension" heuristic
+    // (an indent-0 mapping line becoming a new top-level sequence item),
+    // not evidence this shape is any more spec-legitimate than the others.
     let (output, exit_code) = run_yq_stdin(".", "-   a: hello\nb: 2\n", &["-o", "json", "-I0"])?;
     assert_eq!(exit_code, 0);
     assert_eq!(output.trim(), r#"[{"a":"hello"},{"b":2}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_inconsistent_compact_mapping_indent_single_space_continuation() -> Result<()> {
+    // The most common real-world shape: single space after the dash (not
+    // this file's extra-spaced headline repro), with the continuation
+    // indented exactly at the sequence item's own virtual indent — the
+    // inclusive lower bound `compact_mapping_gap_reaches` needs (`indent >=`,
+    // not `indent >`) for this to be recognized as still belonging to the
+    // mapping rather than silently dropped.
+    let (output, exit_code) = run_yq_stdin(".", "- a: 1\n b: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":1,"b":2}]"#);
+    Ok(())
+}
+
+#[test]
+fn test_inconsistent_compact_mapping_indent_with_explicit_key() -> Result<()> {
+    // `parse_explicit_key`/`parse_explicit_value` (the `?`/`:` dispatch
+    // arms) carry the identical close_deeper_indents/need_new_mapping
+    // shape `parse_mapping_entry` does, and needed the same fix.
+    let (output, exit_code) =
+        run_yq_stdin(".", "-   a: hello\n  ? b\n  : 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"[{"a":"hello","b":2}]"#);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes #885 — a continuation line indented strictly between an open compact
mapping's own recorded indent and its enclosing sequence item's virtual
indent is invalid YAML (real yq v4.53.3 rejects it outright), but the plain
indent comparison `close_deeper_indents`/`parse_mapping_entry` applies was
treating it as *closing* the compact mapping and opening a second, orphaned
mapping as a sibling directly under the same `SequenceItem` — which
structurally expects only one value child, so the JSON serializer silently
dropped every field after the first inconsistent line:

```
$ printf -- '-   a: hello\n  b: 2\n' | yq . -o json -I0
Error: bad file '-': yaml: while parsing a block collection ...: did not find expected '-' indicator
$ printf -- '-   a: hello\n  b: 2\n' | succinctly yq . -o json -I0    # before this fix
[{"a":"hello"}]     # b: 2 silently vanishes, exit 0
$ printf -- '-   a: hello\n  b: 2\n' | succinctly yq . -o json -I0    # after this fix
[{"a":"hello","b":2}]
```

This is the mapping-shaped analog of #485 (an out-dented block-sequence
continuation), which this repo already resolved the same way: tolerate the
"obvious extension" (the same policy #325 established for `a: - x`) rather
than silently corrupting the structure, even though real yq treats the
input as a hard error.

## Review found and fixed two real gaps in the first draft

- **The gap boundary excluded the single most common real-world shape.**
  The original check reused `sequence_frame_reaches`'s strict `>` lower
  bound (correct for its own #485 use), which excluded a continuation
  indented *exactly* at the sequence item's own virtual indent — i.e. the
  ordinary single-space-after-dash case, not just this PR's extra-spaced
  headline repro:
  ```
  $ printf -- '- a: 1\n b: 2\n' | succinctly yq -o json -I0 '.'   # before the boundary fix
  [{"a":1}]     # "b" still silently dropped
  ```
  `compact_mapping_gap_reaches` now uses an inclusive range instead, with a
  regression test (`test_inconsistent_compact_mapping_indent_single_space_continuation`)
  pinning this exact shape.
- **`parse_explicit_key`/`parse_explicit_value` (the `?`/`:` dispatch arms)
  carried an unfixed instance of the identical bug** — same
  `close_deeper_indents`/`need_new_mapping` shape as `parse_mapping_entry`,
  just not covered by the first draft's 3 call sites. Now fixed the same way.

Also moved the gap-tolerant normalization from 5 external call sites into
the 3 target functions themselves (`parse_mapping_entry`/
`parse_explicit_key`/`parse_explicit_value`), so a future caller can't
forget it, and corrected two comments the review flagged as inaccurate: a
test comment that implied a regression-guard input was more spec-legitimate
than the gap cases (real yq rejects it identically), and a doc comment that
called mapping-under-mapping nesting "genuinely ambiguous" when it's
actually just a separate, real instance of the same bug (see follow-ups
below).

## Deliberately out of scope (filed as follow-ups)

- **#900** — a `-` (sequence-item) continuation landing in the same gap
  still drops content; unlike the `key: value` shapes this PR fixes, a bare
  `-` line has no equally obvious "add it to the open mapping"
  interpretation, so it needs its own design pass rather than reusing this
  PR's mechanical fix.
- **#901** — mapping-under-mapping nesting has the identical failure
  signature (`a:\n    b: 1\n  c: 2\n` → `c` silently dropped), pre-existing
  on `main`. `compact_mapping_gap_reaches` is deliberately scoped to a
  `Mapping` frame directly on top of a `SequenceItem` frame specifically,
  because that shape guarantees exactly one possible enclosing scope for
  the line to belong to — generalizing to mapping-under-mapping needs its
  own correctness argument first.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green across
      multiple runs, before and after each rebase; one `jq_cli_tests`
      contention flake — this machine's known concurrent-session pattern,
      unrelated file, passed 459/459 in isolated re-run)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Manually diffed every changed shape against the pinned real `yq`
      oracle (v4.53.3) directly
- [x] Independent code review (standard effort, 5 parallel finder angles)
      run twice — first pass found the two real gaps above, both fixed and
      re-reviewed via direct verification against the built binary
- [x] Rebased on latest `main` twice (post PR #889, then post PR #892),
      re-verified clean both times
- [x] `cargo llvm-cov` patch coverage: 100% on `src/yaml/parser.rs`