### PR TITLE
fix(jq): resolve explicit YAML tags in the generic evaluator

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -111,6 +111,16 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         None
     }
 
+    /// Get the explicit YAML tag at this node, if any (e.g. `"!!str"`).
+    ///
+    /// Returns `None` when the node has no explicit tag, and for formats
+    /// without a tag concept (JSON). Only YAML cursors override this —
+    /// tag lookup is keyed by byte position, which only a cursor carries;
+    /// a bare [`DocumentValue`] has already lost it (#747).
+    fn explicit_tag(&self) -> Option<&str> {
+        None
+    }
+
     /// Get the YAML style indicator for this node (e.g. `"flow"`, `"double"`).
     ///
     /// Returns `""` (no explicit style) by default; only YAML cursors

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5220,6 +5220,40 @@ mod tests {
         );
     }
 
+    /// #903 review round: `Builtin::Shuffle`'s array branch now materializes
+    /// via `collect_cursors`/`to_owned_cursor` instead of
+    /// `collect_values`/`to_owned`, the same fix as `to_entries`/`reverse`/
+    /// `pivot`. An in-process unit test (rather than a CLI subprocess test,
+    /// like the sibling cases in `tests/yq_cli_tests.rs`) because
+    /// `cargo-llvm-cov`'s workspace report doesn't reliably attribute
+    /// coverage back through `Command::new(env!("CARGO_BIN_EXE_succinctly"))`
+    /// for this arm specifically, despite the CLI binary demonstrably taking
+    /// it when run directly. Order isn't checked (`shuffle` permutes), only
+    /// that every element still carries its own resolved type.
+    #[test]
+    fn test_yaml_shuffle_resolves_explicit_tag_903() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a:\n  - !!str 1\n  - !!str 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let cursor = index.root(yaml);
+        let mapping_cursor = cursor
+            .first_child()
+            .expect("YAML document should have content");
+        let value = mapping_cursor.value();
+
+        let result = eval(&crate::jq::parse(".a | shuffle").unwrap(), value);
+        match result.into_owned().unwrap() {
+            OwnedValue::Array(items) => {
+                assert_eq!(items.len(), 2);
+                for item in &items {
+                    assert_eq!(item.type_name(), "string", "{item:?}");
+                }
+            }
+            other => panic!("expected array, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_yaml_generic_field_access() {
         use crate::yaml::YamlIndex;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5120,6 +5120,55 @@ mod tests {
         }
     }
 
+    /// #747: mirrors `test_json_multi_stage_pipe_first_stage_bare_many_lazy_index_range_684`'s
+    /// shape — `select(true,true)` on a cursor-less top-level `eval()` call
+    /// produces a bare `GenericResult::Many` (`Builtin::Select`'s `pass_n`
+    /// closure, `(n, None)` arm), whose per-item re-evaluation in the pipe
+    /// stage's `Many(vs)` arm goes through `to_owned_cursor` when the
+    /// per-item result comes back as `OneCursor` (`.a`, single field) or
+    /// `ManyCursor` (`.[]`, all fields) — exercising the exact two sub-arms
+    /// `to_owned_cursor` replaced `to_owned(&c.value())` in. Each duplicated
+    /// per-item cursor must still resolve its own explicit tag correctly,
+    /// not just the top-level query's own cursor.
+    #[test]
+    fn test_yaml_multi_stage_pipe_bare_many_per_item_cursor_resolves_tag_747() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: !!str 1\nb: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let cursor = index.root(yaml);
+        let mapping_cursor = cursor
+            .first_child()
+            .expect("YAML document should have content");
+        let value = mapping_cursor.value();
+
+        let single_field = eval(
+            &crate::jq::parse("select(true,true) | .a | type").unwrap(),
+            value.clone(),
+        );
+        assert_eq!(
+            single_field.collect_owned(),
+            vec![
+                OwnedValue::String("string".to_string()),
+                OwnedValue::String("string".to_string()),
+            ]
+        );
+
+        let iterate_fields = eval(
+            &crate::jq::parse("select(true,true) | .[] | type").unwrap(),
+            value,
+        );
+        assert_eq!(
+            iterate_fields.collect_owned(),
+            vec![
+                OwnedValue::String("string".to_string()),
+                OwnedValue::String("number".to_string()),
+                OwnedValue::String("string".to_string()),
+                OwnedValue::String("number".to_string()),
+            ]
+        );
+    }
+
     #[test]
     fn test_yaml_generic_field_access() {
         use crate::yaml::YamlIndex;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -79,6 +79,93 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
     }
 }
 
+/// Convert a `DocumentCursor`'s value to an `OwnedValue`, resolving an
+/// explicit YAML tag along the way (e.g. `!!str 1` materializes as the
+/// string `"1"`, not the number `1` — issue #747).
+///
+/// A bare [`DocumentValue`] has already lost its tag by the time it reaches
+/// [`to_owned`] — tag lookup is keyed by byte position, which only a cursor
+/// carries ([`DocumentCursor::explicit_tag`]). Mirrors `to_owned`'s
+/// container-first structure, recursing via cursors
+/// (`field.value_cursor`/`elems.uncons_cursor`, as in
+/// [`to_owned_with_comments`]) so the tag check reaches every scalar, not
+/// just the top-level one. Call sites that already hold a cursor (rather
+/// than a bare value) should use this instead of `to_owned(&cursor.value())`.
+pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
+    let value = cursor.value();
+    if let Some(fields) = value.as_object() {
+        let mut map = IndexMap::new();
+        let mut f = fields;
+        while let Some((field, rest)) = f.uncons() {
+            if let Some(key) = field.key_str() {
+                map.insert(key.into_owned(), to_owned_cursor(&field.value_cursor));
+            }
+            f = rest;
+        }
+        OwnedValue::Object(map)
+    } else if let Some(elements) = value.as_array() {
+        let mut items = Vec::new();
+        let mut elems = elements;
+        while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
+            items.push(to_owned_cursor(&elem_cursor));
+            elems = rest;
+        }
+        OwnedValue::Array(items)
+    } else {
+        cursor
+            .explicit_tag()
+            .and_then(|tag| tagged_scalar_to_owned(tag, &value))
+            .unwrap_or_else(|| to_owned(&value))
+    }
+}
+
+/// Resolve a scalar's explicit YAML tag (`!!str`, `!!int`, ...) against its
+/// raw source text, or `None` if the value isn't a scalar with text (a
+/// container, already excluded by [`to_owned_cursor`]'s caller) or the tag
+/// doesn't apply to this text (e.g. `!!int` on `"abc"` — [`resolve_tagged`]
+/// itself decides applicability).
+fn tagged_scalar_to_owned<V: DocumentValue>(tag: &str, value: &V) -> Option<OwnedValue> {
+    let text = value.as_str()?;
+    let resolved = crate::yaml::resolve_tagged(&text, tag)?;
+    Some(match resolved {
+        crate::yaml::ResolvedScalar::Null => OwnedValue::Null,
+        crate::yaml::ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
+        crate::yaml::ResolvedScalar::Int(n) => OwnedValue::Int(n),
+        crate::yaml::ResolvedScalar::Float(f) => OwnedValue::Float(f),
+        crate::yaml::ResolvedScalar::Str => OwnedValue::String(text.into_owned()),
+    })
+}
+
+/// Materialize `value`, preferring the cursor-aware, tag-resolving
+/// [`to_owned_cursor`] when a cursor is available (issue #747) and falling
+/// back to the cursor-less [`to_owned`] otherwise — e.g. a computed value
+/// with no navigated position (see [`DocumentCursor::line`]'s "not
+/// available" contract, which the same computed-vs-navigated distinction
+/// applies to). Since `cursor.value()` and a separately-threaded `value`
+/// always describe the same node on every call site in this module, `value`
+/// itself is only needed for the `None` fallback.
+fn to_owned_with_cursor<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> OwnedValue {
+    match cursor {
+        Some(c) => to_owned_cursor(&c),
+        None => to_owned(value),
+    }
+}
+
+/// The jq `type` name for `value` at `cursor`, resolving an explicit YAML
+/// tag first (e.g. `!!str 1` is `"string"`, not `"number"` — issue #747)
+/// and falling back to [`DocumentValue::type_name`] otherwise. Mirrors
+/// [`tagged_scalar_to_owned`]'s tag lookup, but only needs
+/// [`crate::yaml::ResolvedScalar::type_name`], not the resolved value
+/// itself.
+fn tagged_type_name<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> &'static str {
+    cursor
+        .and_then(|c| {
+            c.explicit_tag()
+                .and_then(|tag| tagged_scalar_to_owned(tag, value))
+        })
+        .map_or_else(|| value.type_name(), |owned| owned.type_name())
+}
+
 /// A shape-parallel tree of per-node presentation metadata.
 ///
 /// Trailing same-line comments (issue #710) and YAML style (issue #739;
@@ -545,7 +632,7 @@ impl<V: DocumentValue> LazySeq<V> {
         let mut out = Vec::new();
         for item in self {
             match item {
-                Ok(LazyElem::Cursor(c)) => out.push(to_owned(&c.value())),
+                Ok(LazyElem::Cursor(c)) => out.push(to_owned_cursor(&c)),
                 Ok(LazyElem::Owned(o)) => out.push(o),
                 Err(control) => return Err(control),
             }
@@ -772,9 +859,9 @@ fn push_generic_owned_values<V: DocumentValue>(
 ) -> Option<Control> {
     match result.materialize_lazy() {
         GenericResult::One(v) => out.push(to_owned(&v)),
-        GenericResult::OneCursor(c) => out.push(to_owned(&c.value())),
+        GenericResult::OneCursor(c) => out.push(to_owned_cursor(&c)),
         GenericResult::Many(vs) => out.extend(vs.iter().map(to_owned)),
-        GenericResult::ManyCursor(cs) => out.extend(cs.iter().map(|c| to_owned(&c.value()))),
+        GenericResult::ManyCursor(cs) => out.extend(cs.iter().map(to_owned_cursor)),
         GenericResult::None => {}
         GenericResult::Owned(v) => out.push(v),
         GenericResult::ManyOwned(vs) => out.extend(vs),
@@ -804,10 +891,10 @@ fn push_generic_truthiness<V: DocumentValue>(
 ) -> Option<Control> {
     match result {
         GenericResult::One(v) => out.push(to_owned(&v).is_truthy()),
-        GenericResult::OneCursor(c) => out.push(to_owned(&c.value()).is_truthy()),
+        GenericResult::OneCursor(c) => out.push(to_owned_cursor(&c).is_truthy()),
         GenericResult::Many(vs) => out.extend(vs.iter().map(|v| to_owned(v).is_truthy())),
         GenericResult::ManyCursor(cs) => {
-            out.extend(cs.iter().map(|c| to_owned(&c.value()).is_truthy()));
+            out.extend(cs.iter().map(|c| to_owned_cursor(c).is_truthy()));
         }
         // A lazy keys array, materialized or not, sorted or not, is
         // array-shaped and therefore always truthy in jq (only `null`/
@@ -861,10 +948,10 @@ fn flatten_generic_results<V: DocumentValue>(
     for r in items {
         match r.materialize_lazy() {
             GenericResult::One(v) => results.push(to_owned(&v)),
-            GenericResult::OneCursor(c) => results.push(to_owned(&c.value())),
+            GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c)),
             GenericResult::Many(rs) => results.extend(rs.iter().map(to_owned)),
             GenericResult::ManyCursor(cs) => {
-                results.extend(cs.iter().map(|c| to_owned(&c.value())));
+                results.extend(cs.iter().map(to_owned_cursor));
             }
             GenericResult::None => {}
             GenericResult::Owned(o) => results.push(o),
@@ -1059,11 +1146,11 @@ impl<V: DocumentValue> GenericResult<V> {
     pub fn into_owned(self) -> Option<OwnedValue> {
         match self.materialize_lazy() {
             Self::One(v) => Some(to_owned(&v)),
-            Self::OneCursor(c) => Some(to_owned(&c.value())),
+            Self::OneCursor(c) => Some(to_owned_cursor(&c)),
             Self::Many(vs) => Some(OwnedValue::Array(vs.iter().map(to_owned).collect())),
-            Self::ManyCursor(cs) => Some(OwnedValue::Array(
-                cs.iter().map(|c| to_owned(&c.value())).collect(),
-            )),
+            Self::ManyCursor(cs) => {
+                Some(OwnedValue::Array(cs.iter().map(to_owned_cursor).collect()))
+            }
             Self::None => None,
             Self::Error(_) => None,
             Self::Owned(o) => Some(o),
@@ -1086,9 +1173,9 @@ impl<V: DocumentValue> GenericResult<V> {
     pub fn collect_owned(self) -> Vec<OwnedValue> {
         match self.materialize_lazy() {
             Self::One(v) => vec![to_owned(&v)],
-            Self::OneCursor(c) => vec![to_owned(&c.value())],
+            Self::OneCursor(c) => vec![to_owned_cursor(&c)],
             Self::Many(vs) => vs.iter().map(to_owned).collect(),
-            Self::ManyCursor(cs) => cs.iter().map(|c| to_owned(&c.value())).collect(),
+            Self::ManyCursor(cs) => cs.iter().map(to_owned_cursor).collect(),
             Self::None => vec![],
             Self::Error(_) => vec![],
             Self::Owned(o) => vec![o],
@@ -1691,7 +1778,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_iterate(&to_owned(&value)))
+                GenericResult::Error(EvalError::cannot_iterate(&to_owned_with_cursor(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -1776,7 +1865,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // letting a later stage fall through `eval_builtin`'s per-builtin
             // fallback in isolation, which has no path to give it (#554).
             if exprs.iter().any(needs_path_context) {
-                let owned = to_owned(&value);
+                let owned = to_owned_with_cursor(&value, cursor);
                 return eval_on_owned::<S, _>(&Expr::Pipe(exprs.clone()), owned, optional);
             }
 
@@ -1817,12 +1906,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         for v in vs {
                             match eval_single::<S, _>(expr, v, optional, None).materialize_lazy() {
                                 GenericResult::One(r) => results.push(to_owned(&r)),
-                                GenericResult::OneCursor(c) => results.push(to_owned(&c.value())),
+                                GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c)),
                                 GenericResult::Many(rs) => {
                                     results.extend(rs.iter().map(to_owned));
                                 }
                                 GenericResult::ManyCursor(cs) => {
-                                    results.extend(cs.iter().map(|c| to_owned(&c.value())));
+                                    results.extend(cs.iter().map(to_owned_cursor));
                                 }
                                 GenericResult::None => {}
                                 // The outputs already piped through no longer
@@ -2225,7 +2314,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                                     items
                                         .into_iter()
                                         .map(|item| match item {
-                                            LazyElem::Cursor(c) => to_owned(&c.value()),
+                                            LazyElem::Cursor(c) => to_owned_cursor(&c),
                                             LazyElem::Owned(o) => o,
                                         })
                                         .collect(),
@@ -2314,7 +2403,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // Formats are pure functions of the value, so evaluate them here rather
         // than falling through to the catch-all, which would serialize the
         // value to JSON and rebuild a `JsonIndex` for every one (#124).
-        Expr::Format(format_type) => format_result(format_type, &to_owned(&value), optional),
+        Expr::Format(format_type) => {
+            format_result(format_type, &to_owned_with_cursor(&value, cursor), optional)
+        }
 
         Expr::Builtin(builtin) => eval_builtin::<S, _>(builtin, value, optional, cursor),
 
@@ -2373,7 +2464,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // Fall back to the full evaluator for complex expressions
         _ => {
             // Convert to OwnedValue, then to JSON, then evaluate with full evaluator
-            let owned = to_owned(&value);
+            let owned = to_owned_with_cursor(&value, cursor);
             let json_str = owned.to_json_for_reindex();
             let json_bytes = json_str.as_bytes();
             let index = JsonIndex::build(json_bytes);
@@ -2721,7 +2812,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             match index_one_generic::<V>(t.clone(), k, optional) {
                 GenericResult::OneCursor(c) => {
                     if any_owned {
-                        owned.push(to_owned(&c.value()));
+                        owned.push(to_owned_cursor(&c));
                     } else {
                         cursors.push(c);
                     }
@@ -2729,7 +2820,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Owned(v) => {
                     if !any_owned {
                         any_owned = true;
-                        owned = cursors.iter().map(|c| to_owned(&c.value())).collect();
+                        owned = cursors.iter().map(to_owned_cursor).collect();
                         cursors.clear();
                     }
                     owned.push(v);
@@ -2742,7 +2833,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                     let out = if any_owned {
                         owned
                     } else {
-                        cursors.iter().map(|c| to_owned(&c.value())).collect()
+                        cursors.iter().map(to_owned_cursor).collect()
                     };
                     return partial_generic(out, Control::Error(e));
                 }
@@ -2766,7 +2857,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         let out = if any_owned {
             owned
         } else {
-            cursors.iter().map(|c| to_owned(&c.value())).collect()
+            cursors.iter().map(to_owned_cursor).collect()
         };
         return partial_generic(out, Control::Halt(code));
     }
@@ -3055,7 +3146,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // dispatch path starts forcing `optional = true` here.
                 Some(control) => {
                     let prefix: Vec<OwnedValue> = match cursor {
-                        Some(c) => core::iter::repeat_with(|| to_owned(&c.value()))
+                        Some(c) => core::iter::repeat_with(|| to_owned_cursor(&c))
                             .take(truthy_count)
                             .collect(),
                         None => core::iter::repeat_with(|| to_owned(&value))
@@ -3085,7 +3176,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_iterate(&to_owned(&value)))
+                GenericResult::Error(EvalError::cannot_iterate(&to_owned_with_cursor(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -3208,7 +3301,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         }
 
         Builtin::Type => {
-            let type_name = value.type_name();
+            let type_name = tagged_type_name(&value, cursor);
             GenericResult::Owned(OwnedValue::String(type_name.to_string()))
         }
 
@@ -3232,7 +3325,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_length(&to_owned(&value)))
+                GenericResult::Error(EvalError::has_no_length(&to_owned_with_cursor(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -3258,7 +3353,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_keys(&to_owned(&value)))
+                GenericResult::Error(EvalError::has_no_keys(&to_owned_with_cursor(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -3279,7 +3376,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_keys(&to_owned(&value)))
+                GenericResult::Error(EvalError::has_no_keys(&to_owned_with_cursor(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -3333,7 +3432,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // evaluates it at the ambient `optional` (normally `false`)
                 // and lets the outer `Expr::Optional`/`eval_try`-style catch
                 // convert the resulting `Error` to `None` once instead.
-                GenericResult::Error(EvalError::has_no_keys(&to_owned(&value)))
+                GenericResult::Error(EvalError::has_no_keys(&to_owned_with_cursor(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -3439,7 +3540,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Empty => GenericResult::None,
 
         Builtin::ToString => {
-            let owned = to_owned(&value);
+            let owned = to_owned_with_cursor(&value, cursor);
             let s = match &owned {
                 OwnedValue::Null => "null".to_string(),
                 OwnedValue::Bool(b) => b.to_string(),
@@ -3470,7 +3571,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_parse_as_number(&to_owned(&value)))
+                GenericResult::Error(EvalError::cannot_parse_as_number(&to_owned_with_cursor(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -3599,7 +3702,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         // For other builtins, fall back to full evaluator via JSON
         _ => {
-            let owned = to_owned(&value);
+            let owned = to_owned_with_cursor(&value, cursor);
             eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
         }
     }
@@ -6175,7 +6278,7 @@ mod tests {
                     // `select(...)`), so a match here is `OneCursor`, not
                     // `One` — see the `Builtin::Select` cursor-forwarding
                     // fix in `eval_builtin`.
-                    GenericResult::OneCursor(c) => results.push(to_owned(&c.value())),
+                    GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c)),
                     GenericResult::Owned(o) => results.push(o),
                     GenericResult::None => {} // Filtered out
                     _ => {}

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5230,6 +5230,14 @@ mod tests {
     /// for this arm specifically, despite the CLI binary demonstrably taking
     /// it when run directly. Order isn't checked (`shuffle` permutes), only
     /// that every element still carries its own resolved type.
+    ///
+    /// `#[cfg(feature = "cli")]`: `Builtin::Shuffle`'s array-materializing
+    /// arm this test exercises only exists under that feature (see its own
+    /// `#[cfg(feature = "cli")]` a few hundred lines up) — CI's plain
+    /// `cargo test --verbose` leg (no `cli`) hits the sibling
+    /// `#[cfg(not(feature = "cli"))]` error arm instead, which isn't what
+    /// this test is for.
+    #[cfg(feature = "cli")]
     #[test]
     fn test_yaml_shuffle_resolves_explicit_tag_903() {
         use crate::yaml::YamlIndex;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -79,7 +79,7 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
     }
 }
 
-/// Convert a `DocumentCursor`'s value to an `OwnedValue`, resolving an
+/// Converts a `DocumentCursor`'s value to an `OwnedValue`, resolving an
 /// explicit YAML tag along the way (e.g. `!!str 1` materializes as the
 /// string `"1"`, not the number `1` — issue #747).
 ///
@@ -119,7 +119,7 @@ pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
     }
 }
 
-/// Resolve a scalar's explicit YAML tag (`!!str`, `!!int`, ...) against its
+/// Resolves a scalar's explicit YAML tag (`!!str`, `!!int`, ...) against its
 /// raw source text, or `None` if the value isn't a scalar with text (a
 /// container, already excluded by [`to_owned_cursor`]'s caller) or the tag
 /// doesn't apply to this text (e.g. `!!int` on `"abc"` — [`resolve_tagged`]
@@ -136,7 +136,7 @@ fn tagged_scalar_to_owned<V: DocumentValue>(tag: &str, value: &V) -> Option<Owne
     })
 }
 
-/// Materialize `value`, preferring the cursor-aware, tag-resolving
+/// Materializes `value`, preferring the cursor-aware, tag-resolving
 /// [`to_owned_cursor`] when a cursor is available (issue #747) and falling
 /// back to the cursor-less [`to_owned`] otherwise — e.g. a computed value
 /// with no navigated position (see [`DocumentCursor::line`]'s "not
@@ -160,10 +160,17 @@ fn to_owned_with_cursor<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) 
 fn tagged_type_name<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> &'static str {
     cursor
         .and_then(|c| {
-            c.explicit_tag()
-                .and_then(|tag| tagged_scalar_to_owned(tag, value))
+            // Not `c.explicit_tag().and_then(...)` chained outside this
+            // closure: `c` is a local `V::Cursor` moved in by `and_then`,
+            // so a `&str` returned through `&c` (an elided-lifetime `&self`
+            // method) can't outlive this closure even though the
+            // underlying text can — resolve it to an owned `ResolvedScalar`
+            // before returning, same as `to_owned_cursor`'s scalar arm.
+            let tag = c.explicit_tag()?;
+            let text = value.as_str()?;
+            crate::yaml::resolve_tagged(&text, tag)
         })
-        .map_or_else(|| value.type_name(), |owned| owned.type_name())
+        .map_or_else(|| value.type_name(), crate::yaml::ResolvedScalar::type_name)
 }
 
 /// A shape-parallel tree of per-node presentation metadata.
@@ -384,6 +391,22 @@ fn to_owned_key_shape<V: DocumentValue>(value: &V) -> OwnedValue {
         OwnedValue::Object(IndexMap::new())
     } else {
         to_owned(value)
+    }
+}
+
+/// Cursor-carrying sibling of [`to_owned_key_shape`] (#903 review): a
+/// computed-index key or slice bound reached via `OneCursor`/`ManyCursor`
+/// still needs its scalar resolved through `to_owned_cursor` rather than the
+/// bare `to_owned`, or an explicit tag on the key/bound expression itself
+/// (`.a[.k]` where `.k` is `!!str 1`) is silently ignored.
+fn to_owned_key_shape_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
+    let value = cursor.value();
+    if value.is_array() {
+        OwnedValue::Array(Vec::new())
+    } else if value.is_object() {
+        OwnedValue::Object(IndexMap::new())
+    } else {
+        to_owned_cursor(cursor)
     }
 }
 
@@ -1696,7 +1719,10 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_index_with_field(value.type_name(), name))
+                GenericResult::Error(EvalError::cannot_index_with_field(
+                    tagged_type_name(&value, cursor),
+                    name,
+                ))
             }
         }
 
@@ -1733,7 +1759,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // convert the resulting `Error` to `None` once, same
                 // externally-observable result via a different path.
                 GenericResult::Error(EvalError::cannot_index_with_type(
-                    value.type_name(),
+                    tagged_type_name(&value, cursor),
                     "number",
                 ))
             }
@@ -2715,11 +2741,9 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             vs
         }
         GenericResult::One(v) => vec![to_owned_key_shape(&v)],
-        GenericResult::OneCursor(c) => vec![to_owned_key_shape(&c.value())],
+        GenericResult::OneCursor(c) => vec![to_owned_key_shape_cursor(&c)],
         GenericResult::Many(vs) => vs.iter().map(to_owned_key_shape).collect(),
-        GenericResult::ManyCursor(cs) => {
-            cs.iter().map(|c| to_owned_key_shape(&c.value())).collect()
-        }
+        GenericResult::ManyCursor(cs) => cs.iter().map(to_owned_key_shape_cursor).collect(),
         other => other.collect_owned(),
     };
     if keys.is_empty() {
@@ -3008,11 +3032,9 @@ fn eval_slice_bound<S: EvalSemantics, V: DocumentValue>(
         GenericResult::None => return Ok(Vec::new()),
         GenericResult::Partial(_, control) => return Err(control),
         GenericResult::One(v) => vec![to_owned_key_shape(&v)],
-        GenericResult::OneCursor(c) => vec![to_owned_key_shape(&c.value())],
+        GenericResult::OneCursor(c) => vec![to_owned_key_shape_cursor(&c)],
         GenericResult::Many(vs) => vs.iter().map(to_owned_key_shape).collect(),
-        GenericResult::ManyCursor(cs) => {
-            cs.iter().map(|c| to_owned_key_shape(&c.value())).collect()
-        }
+        GenericResult::ManyCursor(cs) => cs.iter().map(to_owned_key_shape_cursor).collect(),
         other => other.collect_owned(),
     };
     raw.iter()
@@ -3190,15 +3212,18 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 use rand_chacha::ChaCha8Rng;
 
                 if let Some(elements) = value.as_array() {
-                    let mut values: Vec<OwnedValue> =
-                        elements.collect_values().iter().map(to_owned).collect();
+                    let mut values: Vec<OwnedValue> = elements
+                        .collect_cursors()
+                        .iter()
+                        .map(to_owned_cursor)
+                        .collect();
                     let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
                     values.shuffle(&mut rng);
                     GenericResult::Owned(OwnedValue::Array(values))
                 } else {
                     GenericResult::Error(EvalError::new(format!(
                         "shuffle requires array, got {}",
-                        value.type_name()
+                        tagged_type_name(&value, cursor)
                     )))
                 }
             }
@@ -3212,8 +3237,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::Pivot => {
             if let Some(elements) = value.as_array() {
-                let items: Vec<OwnedValue> =
-                    elements.collect_values().iter().map(to_owned).collect();
+                let items: Vec<OwnedValue> = elements
+                    .collect_cursors()
+                    .iter()
+                    .map(to_owned_cursor)
+                    .collect();
                 if items.is_empty() {
                     return GenericResult::Owned(OwnedValue::Array(vec![]));
                 }
@@ -3288,7 +3316,10 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::type_error("array", value.type_name()))
+                GenericResult::Error(EvalError::type_error(
+                    "array",
+                    tagged_type_name(&value, cursor),
+                ))
             }
         }
 
@@ -3401,13 +3432,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::ToEntries => {
             if let Some(elements) = value.as_array() {
                 let entries: Vec<OwnedValue> = elements
-                    .collect_values()
+                    .collect_cursors()
                     .into_iter()
                     .enumerate()
-                    .map(|(i, elem)| {
+                    .map(|(i, elem_cursor)| {
                         let mut entry = IndexMap::new();
                         entry.insert("key".to_string(), OwnedValue::Int(i as i64));
-                        entry.insert("value".to_string(), to_owned(&elem));
+                        entry.insert("value".to_string(), to_owned_cursor(&elem_cursor));
                         OwnedValue::Object(entry)
                     })
                     .collect();
@@ -3419,7 +3450,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     if let Some(key) = field.key_str() {
                         let mut entry = IndexMap::new();
                         entry.insert("key".to_string(), OwnedValue::String(key.into_owned()));
-                        entry.insert("value".to_string(), to_owned(&field.value));
+                        entry.insert("value".to_string(), to_owned_cursor(&field.value_cursor));
                         entries.push(OwnedValue::Object(entry));
                     }
                     f = rest;
@@ -3438,17 +3469,37 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             }
         }
 
-        Builtin::IsNull => GenericResult::Owned(OwnedValue::Bool(value.is_null())),
+        // The `is*` family reads through `tagged_type_name` rather than
+        // `DocumentValue::is_null`/`is_bool`/`is_number`/`is_string`
+        // directly: those default to shape-only checks with no tag lookup
+        // (same gap `Type` had before #747), and — for YAML specifically —
+        // `is_number`/`is_string` can both independently answer `true` for
+        // an untagged plain scalar (`as_str()` always succeeds on a
+        // `YamlValue::String` node, whatever its resolved type), which
+        // `type_name()`'s single-answer match doesn't have.
+        Builtin::IsNull => {
+            GenericResult::Owned(OwnedValue::Bool(tagged_type_name(&value, cursor) == "null"))
+        }
 
-        Builtin::IsBoolean => GenericResult::Owned(OwnedValue::Bool(value.is_bool())),
+        Builtin::IsBoolean => GenericResult::Owned(OwnedValue::Bool(
+            tagged_type_name(&value, cursor) == "boolean",
+        )),
 
-        Builtin::IsNumber => GenericResult::Owned(OwnedValue::Bool(value.is_number())),
+        Builtin::IsNumber => GenericResult::Owned(OwnedValue::Bool(
+            tagged_type_name(&value, cursor) == "number",
+        )),
 
-        Builtin::IsString => GenericResult::Owned(OwnedValue::Bool(value.is_string())),
+        Builtin::IsString => GenericResult::Owned(OwnedValue::Bool(
+            tagged_type_name(&value, cursor) == "string",
+        )),
 
-        Builtin::IsArray => GenericResult::Owned(OwnedValue::Bool(value.is_array())),
+        Builtin::IsArray => GenericResult::Owned(OwnedValue::Bool(
+            tagged_type_name(&value, cursor) == "array",
+        )),
 
-        Builtin::IsObject => GenericResult::Owned(OwnedValue::Bool(value.is_object())),
+        Builtin::IsObject => GenericResult::Owned(OwnedValue::Bool(
+            tagged_type_name(&value, cursor) == "object",
+        )),
 
         Builtin::Iterables => {
             // Returns input if iterable, empty otherwise
@@ -3481,7 +3532,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::None
             } else {
                 GenericResult::Error(EvalError::cannot_index_with_type(
-                    value.type_name(),
+                    tagged_type_name(&value, cursor),
                     "number",
                 ))
             }
@@ -3501,7 +3552,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::None
             } else {
                 GenericResult::Error(EvalError::cannot_index_with_type(
-                    value.type_name(),
+                    tagged_type_name(&value, cursor),
                     "number",
                 ))
             }
@@ -3521,17 +3572,17 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Reverse => {
             if let Some(elements) = value.as_array() {
                 let values: Vec<OwnedValue> = elements
-                    .collect_values()
+                    .collect_cursors()
                     .iter()
                     .rev()
-                    .map(to_owned)
+                    .map(to_owned_cursor)
                     .collect();
                 GenericResult::Owned(OwnedValue::Array(values))
             } else if optional {
                 GenericResult::None
             } else {
                 GenericResult::Error(EvalError::cannot_index_with_type(
-                    value.type_name(),
+                    tagged_type_name(&value, cursor),
                     "number",
                 ))
             }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2177,8 +2177,27 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// See [`Self::anchor`]'s doc comment: deliberately does not resolve a
     /// bare `-` sequence-item wrapper itself, for the same hot-path
     /// performance reason.
+    ///
+    /// Dereferences through an alias to the anchor definition's own tag
+    /// (`x: &a !!str 1` / `y: *a` — `.y`'s cursor has no tag at its own
+    /// `bp_pos`, since a YAML alias node cannot itself carry a tag; the tag
+    /// lives on the anchor it points to). Mirrors every other alias-transparent
+    /// accessor on this type (`as_bool`/`as_i64`/`as_f64`/`as_object`/
+    /// `as_array`/`type_name` below, and `stream_json_value`'s `Alias` arm) —
+    /// `explicit_tag` was the one left out (#903 review).
     #[inline]
     pub fn explicit_tag(&self) -> Option<&str> {
+        if let YamlValue::Alias { target, .. } = self.value() {
+            // Not `target.and_then(|t| t.explicit_tag())`: `t` is a local
+            // `YamlCursor` moved into the closure, so a call through `&t`
+            // ties the returned `&str` to that closure-local borrow even
+            // though the string data itself lives for `'a`. Read through
+            // `t.index` (a `Copy` `&'a YamlIndex<W>`) directly instead, so
+            // the elided lifetime resolves to `'a`, matching every other
+            // `Alias` arm in this file that recurses via the cursor itself
+            // rather than a getter call on it.
+            return target.and_then(|t| t.index.get_tag(t.bp_pos));
+        }
         self.index.get_tag(self.bp_pos)
     }
 
@@ -5649,15 +5668,20 @@ impl<'a, W: AsRef<[u64]>> YamlValue<'a, W> {
 // FORMER KNOWN LIMITATION (#224, fixed by #747): the typed getters below
 // (`is_null`, `as_bool`, `as_i64`, `as_f64`, `type_name`) are still not
 // tag-aware themselves — a bare `YamlValue` has no `bp_pos` to look an
-// explicit tag up with, only a `YamlCursor` does (`explicit_tag()`) — but
-// every caller that can reach an explicit tag now checks it first via a
-// cursor before ever falling through to these getters:
-// `crate::jq::eval_generic::to_owned_cursor` (backing `select`, `==`,
-// arithmetic, and other cursor-materializing paths) and
-// `crate::jq::eval_generic::tagged_type_name` (backing `type` specifically,
-// which doesn't materialize a value at all). So
-// `echo 'a: !!str 1' | succinctly yq '.a | type'` now correctly says
+// explicit tag up with, only a `YamlCursor` does (`explicit_tag()`). Every
+// caller that already holds a cursor at the point it navigates to a node
+// now checks the tag first, via `crate::jq::eval_generic::to_owned_cursor`
+// (`select`, `==`, arithmetic, `is*`, `to_entries`, `reverse`/`shuffle`/
+// `pivot`, and other cursor-materializing paths) or
+// `crate::jq::eval_generic::tagged_type_name` (`type` and every
+// type-mismatch error message, none of which materialize a value at all).
+// So `echo 'a: !!str 1' | succinctly yq '.a | type'` now correctly says
 // `"string"`, matching `succinctly yq '.'`'s JSON output for the same input.
+// Two gaps remain, deliberately out of scope for #747/#903: `to_owned`
+// itself (used wherever a cursor genuinely isn't available, e.g. a computed
+// value or an already-cursor-less ambient `.`) and
+// `to_owned_with_comments`'s scalar leaf (the `#710`/`#739` comment-tree
+// write path, a separate mechanism from the read-side fix here).
 impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     type Cursor = YamlCursor<'a, W>;
     type Fields = YamlFields<'a, W>;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5524,6 +5524,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn explicit_tag(&self) -> Option<&str> {
+        YamlCursor::explicit_tag(self)
+    }
+
+    #[inline]
     fn style(&self) -> &'static str {
         YamlCursor::style(self)
     }
@@ -5641,22 +5646,18 @@ impl<'a, W: AsRef<[u64]>> YamlValue<'a, W> {
     }
 }
 
-// KNOWN LIMITATION (#224, tracked as #747): the typed getters below
-// (`is_null`, `as_bool`, `as_i64`, `as_f64`, `type_name`) are not tag-aware,
-// unlike every JSON output path (`write_json_to`/`stream_json_value`) and the
-// CLI's `yaml_to_owned_value`. A bare `YamlValue` has no `bp_pos` to look an
-// explicit tag up with — only a `YamlCursor` does (`explicit_tag()`) — and
-// `crate::jq::eval_generic::to_owned`, the generic evaluator's lazy
-// materializer backing `select`, `==`, arithmetic, and `type` on the
-// cursor-evaluator path, calls these directly on a `DocumentValue` with no
-// cursor in scope. So `echo 'a: !!str 1' | succinctly yq '.a | type'` says
-// `"number"`, not `"string"` — while `succinctly yq '.'`'s JSON output for
-// the same input is correct. Fixing this needs either threading a cursor
-// through `to_owned`'s recursion (it can: `DocumentField::value_cursor` and
-// `DocumentElements::uncons_cursor` already exist) or embedding the tag in
-// `YamlValue::String` itself, which fans out to ~90 pattern-match sites
-// across 6 files. Scoped out of #224 as a follow-up rather than risking an
-// under-tested change to a evaluator shared with JSON this late.
+// FORMER KNOWN LIMITATION (#224, fixed by #747): the typed getters below
+// (`is_null`, `as_bool`, `as_i64`, `as_f64`, `type_name`) are still not
+// tag-aware themselves — a bare `YamlValue` has no `bp_pos` to look an
+// explicit tag up with, only a `YamlCursor` does (`explicit_tag()`) — but
+// every caller that can reach an explicit tag now checks it first via a
+// cursor before ever falling through to these getters:
+// `crate::jq::eval_generic::to_owned_cursor` (backing `select`, `==`,
+// arithmetic, and other cursor-materializing paths) and
+// `crate::jq::eval_generic::tagged_type_name` (backing `type` specifically,
+// which doesn't materialize a value at all). So
+// `echo 'a: !!str 1' | succinctly yq '.a | type'` now correctly says
+// `"string"`, matching `succinctly yq '.'`'s JSON output for the same input.
 impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     type Cursor = YamlCursor<'a, W>;
     type Fields = YamlFields<'a, W>;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2766,6 +2766,163 @@ fn test_yaml_explicit_tag_resolves_when_nested_747() -> Result<()> {
     Ok(())
 }
 
+/// #903 review round: a YAML alias occurrence has no `bp_pos` tag of its
+/// own — a valid alias node (`*anchor`) can't carry a tag in the source —
+/// so `YamlCursor::explicit_tag()` must dereference through
+/// `YamlValue::Alias`'s `target` to the anchor definition's tag, the same
+/// way every other alias-transparent accessor on `YamlValue` already does
+/// (`as_bool`/`as_i64`/`as_f64`/`as_object`/`as_array`/`type_name`).
+/// Without that dereference, `.y`'s tag silently vanished even though the
+/// direct `.x` access (and `-o=json`'s cursor-streaming output) already
+/// resolved it correctly.
+#[test]
+fn test_yaml_explicit_tag_resolves_through_alias_903() -> Result<()> {
+    let input = "x: &a !!str 1\ny: *a\n";
+
+    let (types, code) = run_yq_stdin("[.x, .y] | map(type)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(types.trim(), r#"["string","string"]"#);
+
+    let (eq, code) = run_yq_stdin(r#".y == "1""#, input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(eq.trim(), "true");
+
+    let (add, code) = run_yq_stdin(".y + 1", "x: &a !!int \"5\"\ny: *a\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(add.trim(), "6");
+
+    Ok(())
+}
+
+/// #903 review round: `Expr::Field`/`Expr::Index`'s type-mismatch error
+/// messages, and `Builtin::First`/`Last`/`Reverse`/`Pivot`/`Shuffle`'s
+/// non-array-input error messages, all had `cursor` in scope but still read
+/// the raw, untagged `value.type_name()` — so the error text could name a
+/// different type than `.a | type` (fixed earlier in #747) reports for the
+/// exact same node. Now routed through `tagged_type_name` like `type`
+/// itself.
+#[test]
+fn test_yaml_explicit_tag_error_messages_agree_with_type_903() -> Result<()> {
+    let input = "a: !!str 1\n";
+
+    let (_, err, code) = run_yq_stdin_with_stderr(".a.foo", input, &[])?;
+    assert_eq!(code, 1);
+    assert!(err.contains("Cannot index string with"), "{err}");
+
+    let (_, err, code) = run_yq_stdin_with_stderr(".a | last", input, &[])?;
+    assert_eq!(code, 1);
+    assert!(err.contains("Cannot index string with"), "{err}");
+
+    let (_, err, code) = run_yq_stdin_with_stderr(".a | reverse", input, &[])?;
+    assert_eq!(code, 1);
+    assert!(err.contains("Cannot index string with"), "{err}");
+
+    let (_, err, code) = run_yq_stdin_with_stderr(".a | pivot", input, &[])?;
+    assert_eq!(code, 1);
+    assert!(err.contains("expected array, got string"), "{err}");
+
+    let (_, err, code) = run_yq_stdin_with_stderr(".a | shuffle", input, &[])?;
+    assert_eq!(code, 1);
+    assert!(err.contains("shuffle requires array, got string"), "{err}");
+
+    Ok(())
+}
+
+/// #903 review round: `to_entries`, `reverse`, `pivot`, and `shuffle` each
+/// materialize their elements via a bare `to_owned`/`collect_values` instead
+/// of the cursor-carrying `to_owned_cursor`/`collect_cursors`, silently
+/// dropping an explicit tag on any element they touch — the exact #747
+/// defect, left unfixed in these four builtins specifically. `shuffle`'s
+/// element order is random, so it's checked via `type` over every element
+/// rather than positionally.
+#[test]
+fn test_yaml_explicit_tag_resolves_in_to_entries_reverse_pivot_shuffle_903() -> Result<()> {
+    let (entries, code) =
+        run_yq_stdin(". | to_entries", "a: !!str 1\nb: 2\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        entries.trim(),
+        r#"[{"key":"a","value":"1"},{"key":"b","value":2}]"#
+    );
+
+    let (reversed, code) = run_yq_stdin(
+        ".a | reverse",
+        "a:\n  - !!str 1\n  - 2\n",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(reversed.trim(), r#"[2,"1"]"#);
+
+    let (pivoted, code) = run_yq_stdin(
+        ".a | pivot",
+        "a:\n  - [!!str 1, 2]\n  - [3, 4]\n",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(pivoted.trim(), r#"[["1",3],[2,4]]"#);
+
+    let (shuffled_types, code) = run_yq_stdin(
+        "[.a | shuffle | .[] | type]",
+        "a:\n  - !!str 1\n  - !!str 2\n",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(shuffled_types.trim(), r#"["string","string"]"#);
+
+    Ok(())
+}
+
+/// #903 review round: the `is*` family (`isnull`/`isboolean`/`isnumber`/
+/// `isstring`/`isarray`/`isobject`) called `DocumentValue::is_null`/
+/// `is_bool`/etc. directly — the exact same tag-blind gap `type` had before
+/// #747 — plus a second, tag-independent bug the fix incidentally closes for
+/// these call sites: `is_number`/`is_string`'s *default* implementations can
+/// both answer `true` for the same untagged plain YAML scalar (`as_str()`
+/// always succeeds on a `YamlValue::String` node regardless of its resolved
+/// type), which `type_name()`'s single-answer match doesn't have. Routing
+/// through `tagged_type_name` fixes both at once.
+#[test]
+fn test_yaml_is_builtins_resolve_tags_and_agree_with_type_903() -> Result<()> {
+    for (query, input, expected) in [
+        ("isboolean", "a: !!bool \"yes\"\n", "true"),
+        ("isnull", "a: !!null anything\n", "true"),
+        ("isstring", "a: !!str 1\n", "true"),
+        ("isnumber", "a: !!str 1\n", "false"),
+        // Untagged plain number: isnumber true, isstring false (not both).
+        ("isnumber", "a: 1\n", "true"),
+        ("isstring", "a: 1\n", "false"),
+        ("isarray", "a: [1, 2]\n", "true"),
+        ("isobject", "a: {x: 1}\n", "true"),
+    ] {
+        let (out, code) = run_yq_stdin(&format!(".a | {query}"), input, &[])?;
+        assert_eq!(code, 0, "{query} on {input:?}: expected clean success");
+        assert_eq!(out.trim(), expected, "{query} on {input:?}");
+    }
+    Ok(())
+}
+
+/// #903 review round: `to_owned_key_shape` (backing computed-index keys and
+/// slice bounds) took a bare `&V` with no cursor, so a tagged key/bound
+/// expression resolved as its untagged plain-scalar type instead —
+/// `to_owned_key_shape_cursor` is the cursor-carrying sibling that closes
+/// this the same way `to_owned_cursor` closes it for `to_owned`.
+#[test]
+fn test_yaml_explicit_tag_resolves_in_computed_key_and_slice_bound_903() -> Result<()> {
+    let (matched, code) = run_yq_stdin(".a[.k]", "k: !!str 1\na:\n  \"1\": matched\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(matched.trim(), "matched");
+
+    let (sliced, code) = run_yq_stdin(
+        ".arr[.k:3]",
+        "k: !!int \"1\"\narr: [10, 20, 30, 40]\n",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(sliced.trim(), "[20,30]");
+
+    Ok(())
+}
+
 // The following `test_yaml_tag_gate_gap_*` tests were the #664 audit's output:
 // they used to pin the *wrong* behavior (`exit_code == 0`, tag text silently
 // absorbed into the surrounding scalar/key) for every block-context path

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2715,6 +2715,24 @@ fn test_yaml_explicit_tag_eq_and_arithmetic_resolve_747() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(add.trim(), "6");
 
+    // `tagged_scalar_to_owned`'s Null/Bool/Float arms: `type`'s own tests
+    // (`test_yaml_explicit_tag_type_resolves_747`) exercise these tags only
+    // through `tagged_type_name`, which resolves straight to
+    // `ResolvedScalar::type_name()` without ever materializing an
+    // `OwnedValue` — so an `==` comparison (which does materialize, via
+    // `to_owned_cursor`) is needed to reach these three arms at all.
+    let (eq_null, code) = run_yq_stdin(".a == null", "a: !!null anything\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(eq_null.trim(), "true");
+
+    let (eq_bool, code) = run_yq_stdin(".a == true", "a: !!bool \"yes\"\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(eq_bool.trim(), "true");
+
+    let (eq_float, code) = run_yq_stdin(".a == 5.0", "a: !!float \"5\"\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(eq_float.trim(), "true");
+
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2667,6 +2667,105 @@ fn test_yaml_default_output_preserves_the_literal_tag() -> Result<()> {
     Ok(())
 }
 
+/// #747: `type`/`==`/arithmetic/`select` on the cursor-evaluator path
+/// (`eval_generic.rs`) previously ignored an explicit YAML tag, because
+/// their shared materializer (`to_owned`) only ever saw a bare
+/// `DocumentValue`, which has no `bp_pos` to look the tag up with — only a
+/// `YamlCursor` does. `succinctly yq '.'`'s JSON/YAML output was already
+/// correct (it streams straight from a cursor, never through `to_owned`),
+/// so this is the divergence the issue reported: `.` said `"1"` but
+/// `.a | type` still said `"number"`. `type` doesn't call `to_owned` at all
+/// (it reads `DocumentValue::type_name()` directly), so it needed its own
+/// fix (`tagged_type_name`) rather than inheriting `to_owned_cursor`'s.
+#[test]
+fn test_yaml_explicit_tag_type_resolves_747() -> Result<()> {
+    for (name, input, expected) in [
+        ("str tag forces string", "a: !!str 1\n", "string"),
+        ("int tag forces number", "a: !!int \"5\"\n", "number"),
+        ("float tag forces number", "a: !!float \"5\"\n", "number"),
+        ("bool tag forces boolean", "a: !!bool \"yes\"\n", "boolean"),
+        ("null tag forces null", "a: !!null anything\n", "null"),
+        // A non-core-schema tag doesn't force anything — falls through to
+        // ordinary plain-scalar resolution, same as `resolve_tagged`'s
+        // `None` contract elsewhere in this file (#224).
+        ("custom tag is untouched", "a: !custom 1\n", "number"),
+    ] {
+        let (output, exit_code) = run_yq_stdin(".a | type", input, &[])?;
+        assert_eq!(exit_code, 0, "{name}: expected clean success");
+        assert_eq!(output.trim(), expected, "{name}");
+    }
+    Ok(())
+}
+
+/// #747: sibling of [`test_yaml_explicit_tag_type_resolves_747`] for `==`
+/// and arithmetic, which go through `to_owned_cursor` (via `eval_single`'s
+/// `OneCursor`/`ManyCursor` `GenericResult` arms) rather than `type`'s own
+/// direct fix.
+#[test]
+fn test_yaml_explicit_tag_eq_and_arithmetic_resolve_747() -> Result<()> {
+    let (eq_str, code) = run_yq_stdin(r#".a == "1""#, "a: !!str 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(eq_str.trim(), "true");
+
+    let (eq_num, code) = run_yq_stdin(".a == 1", "a: !!str 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(eq_num.trim(), "false");
+
+    let (add, code) = run_yq_stdin(".a + 1", "a: !!int \"5\"\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(add.trim(), "6");
+
+    Ok(())
+}
+
+/// #747: `select`'s cursor-forwarding arm (`eval_builtin`'s `Builtin::
+/// Select`, #378) republishes the incoming cursor on a truthy condition
+/// rather than a plain value — the condition itself is evaluated through the
+/// same `eval_single` recursion as the tests above, so a tagged condition
+/// resolves correctly, and (since select is a passthrough) the untouched
+/// original value keeps its own tag on output.
+#[test]
+fn test_yaml_explicit_tag_select_condition_resolves_747() -> Result<()> {
+    let (output, exit_code) = run_yq_stdin(
+        r#"select(.a | type == "string")"#,
+        "a: !!str 1\nb: 2\n",
+        &[],
+    )?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "a: !!str 1\nb: 2");
+
+    let (empty, exit_code) = run_yq_stdin(
+        r#"select(.a | type == "number")"#,
+        "a: !!str 1\nb: 2\n",
+        &[],
+    )?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(empty.trim(), "");
+
+    Ok(())
+}
+
+/// #747: an explicit tag nested inside a sequence/mapping must resolve too —
+/// `to_owned_cursor` has to recurse via `field.value_cursor`/
+/// `elems.uncons_cursor` (mirroring `to_owned_with_comments`'s existing
+/// cursor-threading pattern) rather than plain `to_owned`'s cursor-less
+/// `field.value`/`elems.uncons`, or only the top-level node's tag would ever
+/// be seen.
+#[test]
+fn test_yaml_explicit_tag_resolves_when_nested_747() -> Result<()> {
+    let input = "a:\n  - !!str 1\n  - !!int \"2\"\nb:\n  c: !!str 3\n";
+
+    let (seq_types, code) = run_yq_stdin("[.a[] | type]", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(seq_types.trim(), r#"["string","number"]"#);
+
+    let (obj_type, code) = run_yq_stdin(".b.c | type", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(obj_type.trim(), "string");
+
+    Ok(())
+}
+
 // The following `test_yaml_tag_gate_gap_*` tests were the #664 audit's output:
 // they used to pin the *wrong* behavior (`exit_code == 0`, tag text silently
 // absorbed into the surrounding scalar/key) for every block-context path


### PR DESCRIPTION
## Summary

- `to_owned`, the generic cursor-evaluator's materializer backing `type`, `==`, arithmetic, and `select`, only ever saw a bare `DocumentValue` — never a cursor — so it had no way to look up an explicit YAML tag (`!!str`, `!!int`, `!!bool`, `!!float`, `!!null`). That lookup is keyed by byte position, which only a `YamlCursor` carries. JSON/YAML output was already correct (`stream_json`/`stream_yaml` stream straight from a cursor), so `succinctly yq '.'` on `a: !!str 1` correctly said `{"a": "1"}` while `.a | type` still said `"number"`.
- Adds `DocumentCursor::explicit_tag` (default `None`; `YamlCursor` overrides it, delegating to the pre-existing inherent `YamlCursor::explicit_tag`), a new `to_owned_cursor` that mirrors `to_owned`'s container-first structure but recurses via cursors (`field.value_cursor`/`elems.uncons_cursor`, the same pattern `to_owned_with_comments` already established) and checks the tag on each scalar, and `tagged_type_name` for `type` specifically (it reads `DocumentValue::type_name()` directly and never goes through `to_owned` at all, so it needed its own fix).
- Every call site in `eval_generic.rs` that already holds a cursor now routes through `to_owned_cursor`/`to_owned_with_cursor` instead of the bare, tag-blind `to_owned`.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full workspace suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Verified against the pinned real `yq` oracle (v4.53.3) for identity/`==`/arithmetic output; `type`'s own output format is succinctly's own deliberate jq-style choice (already diverges from mikefarah `yq`'s `!!str`-style `type`, pre-existing and unrelated to this fix), verified instead against the issue's own stated expected values and internal consistency with untagged equivalents
- [x] New CLI tests in `tests/yq_cli_tests.rs` covering `type`/`==`/arithmetic/`select`/nested-tag resolution
- [x] New unit test in `eval_generic.rs` for the one reachable-but-obscure shape CLI queries can't easily hit directly (a bare `GenericResult::Many` fan-out from `select`'s cursor-less `pass_n` arm, whose per-item re-evaluation lands back on `OneCursor`/`ManyCursor`)
- [x] 100% patch coverage on all touched source lines (`cargo llvm-cov` + diff cross-reference)

Fixes #747