### PR TITLE
fix(jq): reject an unrecognized regex flag instead of ignoring it

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7510,8 +7510,17 @@ fn builtin_scan_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
     };
 
+    // `scan` always operates in jq's "global" mode (it finds every match, the
+    // way `gsub` always replaces every match) — jq's own bootstrap prepends
+    // `g` to the flags string before validation for exactly that reason.
+    // `g` is a no-op for `build_regex`'s own compiled-pattern behavior, so
+    // this only affects the wording of an invalid-flags error, matching
+    // jq's own message: confirmed live, `scan("a"; "z")` reports "gz is not
+    // a valid modifier string", not "z is not a valid modifier string".
+    let global_flags = format!("g{}", flags.unwrap_or(""));
+
     // Build regex
-    let re = match build_regex(&pattern, flags) {
+    let re = match build_regex(&pattern, Some(&global_flags)) {
         Ok(r) => r,
         Err(_e) if optional => return QueryResult::None,
         Err(e) => return e.into(),
@@ -7582,8 +7591,13 @@ fn builtin_split_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
     };
 
+    // `split` always operates in jq's "global" mode — see `builtin_scan_with_flags`'s
+    // identical comment on why `g` is prepended before validation (confirmed
+    // live: `split("a"; "z")` reports "gz is not a valid modifier string").
+    let global_flags = format!("g{flags}");
+
     // Build regex
-    let re = match build_regex(&pattern, Some(&flags)) {
+    let re = match build_regex(&pattern, Some(&global_flags)) {
         Ok(r) => r,
         Err(_e) if optional => return QueryResult::None,
         Err(e) => return e.into(),
@@ -7646,8 +7660,14 @@ fn builtin_splits_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
     };
 
+    // `splits` always operates in jq's "global" mode — see
+    // `builtin_scan_with_flags`'s identical comment on why `g` is prepended
+    // before validation (confirmed live: `splits("a"; "z")` reports "gz is
+    // not a valid modifier string").
+    let global_flags = format!("g{}", flags.unwrap_or(""));
+
     // Build regex
-    let re = match build_regex(&pattern, flags) {
+    let re = match build_regex(&pattern, Some(&global_flags)) {
         Ok(r) => r,
         Err(_e) if optional => return QueryResult::None,
         Err(e) => return e.into(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27358,6 +27358,53 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "regex")]
+    #[test]
+    fn test_scan_split_splits_prepend_g_before_validating_flags_730() {
+        // scan/split/splits always operate in jq's "global" mode (they find
+        // or split on every match), and jq's own bootstrap prepends `g` to
+        // the flags string before validation for exactly that reason -- `g`
+        // has no effect on `build_regex`'s compiled pattern, so this only
+        // changes the wording of an invalid-flags error. Verified live
+        // against jq 1.7.1: `scan("a"; "z")` reports "gz is not a valid
+        // modifier string", not "z is not a valid modifier string" -- and
+        // the same holds for split/splits. Found during #730's own review:
+        // the first version of this fix passed the raw flags straight to
+        // `build_regex` at these three sites, producing the wrong message.
+        for (filter, expected) in [
+            (r#"scan("a"; "z")"#, "gz is not a valid modifier string"),
+            (r#"scan("a"; "iz")"#, "giz is not a valid modifier string"),
+            (r#"split("a"; "z")"#, "gz is not a valid modifier string"),
+            (r#"split("a"; "iz")"#, "giz is not a valid modifier string"),
+            (r#"splits("a"; "z")"#, "gz is not a valid modifier string"),
+            (r#"splits("a"; "iz")"#, "giz is not a valid modifier string"),
+        ] {
+            query!(br#""abc""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, expected, "filter: {filter}");
+                }
+            );
+        }
+
+        // Valid flags must still work correctly at all three sites (the `g`
+        // prefix must not leak into compiled-pattern behavior or output).
+        query!(br#""ABC""#, r#"[scan("a"; "i")]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs, vec![OwnedValue::String("A".to_string())]);
+            }
+        );
+        query!(br#""a1b2""#, r#"split("[0-9]"; "")"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs.len(), 3);
+            }
+        );
+        query!(br#""a1b2""#, r#"[splits("[0-9]"; "")]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs.len(), 3);
+            }
+        );
+    }
+
     // =========================================================================
     // Phase 8 Tests: Variables and Advanced Control Flow
     // =========================================================================

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6545,7 +6545,22 @@ fn build_regex(pattern: &str, flags: Option<&str>) -> Result<JqRegex, EvalError>
                 // to the same effect as m.
                 'p' => dot_matches_newline = true,
                 'g' => {} // global - handled at call site
-                _ => {}
+                // Recognized by real jq but not yet implemented here (#730):
+                // `n` (suppress empty matches) and `l` (POSIX leftmost-longest)
+                // are accepted as valid flag characters, silently without
+                // effect, rather than raising the error below.
+                'n' | 'l' => {}
+                _ => {
+                    // Real jq's own wording, and its own choice: the message
+                    // names the whole flags string, not just the offending
+                    // character — confirmed live, both `test("abc";"zq")`
+                    // and `test("abc";"iz")` (one valid flag, one invalid)
+                    // report "zq"/"iz is not a valid modifier string", never
+                    // singling out which character was the problem.
+                    return Err(EvalError::new(format!(
+                        "{flags} is not a valid modifier string"
+                    )));
+                }
             }
         }
         let mut prefix = String::from("(?");

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27306,6 +27306,38 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "regex")]
+    #[test]
+    fn test_regex_unknown_flags_rejected_730() {
+        // #730: an unrecognized flag character must raise jq's own error
+        // rather than silently doing nothing. Verified against jq 1.7.1:
+        // the message names the *whole* flags string, not just the
+        // offending character, and is identical whether the bad character
+        // stands alone or sits next to a genuinely valid one.
+        for (flags, expected) in [
+            ("z", "z is not a valid modifier string"),
+            ("zq", "zq is not a valid modifier string"),
+            ("iz", "iz is not a valid modifier string"),
+        ] {
+            query!(br#""abc""#, &format!(r#"test("abc"; "{flags}")"#),
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, expected, "flags: {flags:?}");
+                }
+            );
+        }
+
+        // `n` (suppress empty matches) and `l` (POSIX leftmost-longest) are
+        // real jq flag characters, just not yet functionally implemented
+        // here (#730) - they must not be rejected as unknown.
+        for flags in ["n", "l", "p"] {
+            query!(br#""abc""#, &format!(r#"test("abc"; "{flags}")"#),
+                QueryResult::Owned(OwnedValue::Bool(b)) => {
+                    assert!(b, "flags: {flags:?}");
+                }
+            );
+        }
+    }
+
     // =========================================================================
     // Phase 8 Tests: Variables and Advanced Control Flow
     // =========================================================================

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -120,10 +120,8 @@
 # mere gaps. Each below is filed as its own issue with the verified
 # jq-vs-succinctly repro already in the issue body.
 #
-# regex_sub_g_global_replace (#728) has since been fixed and dropped, leaving 1:
-# sub(re; replacement; "g") now dispatches to the same global_captures/
-# stitch_replacements path gsub already used, instead of ignoring the "g" flag.
-regex_test_z_unknown_flag      regex-flags   unknown flag characters are silently accepted, not rejected — #730
+# regex_sub_g_global_replace (#728) and regex_test_z_unknown_flag (#730) have
+# since been fixed and dropped.
 
 # Seeded by #716's date/time oracle-coverage sweep: the builtins had unit
 # tests checking self-consistency but zero cross-checks against real jq.


### PR DESCRIPTION
## Summary

`build_regex`'s flags loop silently accepted any character outside the recognized set (`g i x s m n l p`), falling into a no-op catch-all arm. Real jq validates the flags string and raises `<flags> is not a valid modifier string` for anything it doesn't recognize.

```
$ echo '"abc"' | jq 'test("abc";"z")'
jq: error (at <stdin>:1): z is not a valid modifier string
$ echo '"abc"' | succinctly jq 'test("abc";"z")'
true    # should be a "not a valid modifier string" error
```

Confirmed the error message names the **whole flags string**, not just the offending character, and is identical whether the bad character stands alone or sits next to a genuinely valid one:

```
$ echo '"abc"' | jq 'test("abc";"zq")'
jq: error (at <stdin>:1): zq is not a valid modifier string
$ echo '"abc"' | jq 'test("abc";"iz")'
jq: error (at <stdin>:1): iz is not a valid modifier string
```

## Scope note

This is a partial fix for #730, which bundles three sub-problems of very different complexity:

1. **Unknown-flag validation** — this PR. Clean, isolated, matches jq's exact wording.
2. **`l` (POSIX leftmost-longest)** — not implemented. Rust's `regex` crate doesn't support this directly; needs its own investigation into what's achievable.
3. **`n` (suppress empty matches)** — not implemented, and per #730's own text, depends on #729 (confirmed closed) landing cleanly-testable ground first.

`n`/`l`/`p` are still accepted as valid flag characters (matching real jq's grammar) — this PR only rejects characters real jq itself rejects, and doesn't attempt to implement `n`/`l`'s actual semantics. Left #730 open rather than closing it, since it isn't fully resolved; commented there with this scoping so the remaining `n`/`l` work is easy to pick up separately.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Diffed output against pinned real `jq` for single/multiple/mixed invalid flags, and confirmed `n`/`l`/`p`/`i`/`g` still work as before
- [x] Un-pinned `regex_test_z_unknown_flag` from `tests/data/jq-golden-known-failures.txt` (filed alongside #728 from #703's regex-flag coverage sweep) — golden conformance now covers this case
- [x] Added `test_regex_unknown_flags_rejected_730` pinning the exact repro shapes plus `n`/`l`/`p` acceptance