### PR TITLE
fix(jq): builtin_in fans out over every xs output and propagates Halt/Break

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2969,10 +2969,13 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let len = (*elements).count() as i64;
             let in_bounds = if S::NEGATIVE_INDEX_IN_HAS {
                 // yq behavior: negative indices are valid if abs(idx) <= len
+                // -- `unsigned_abs`, not `abs`, since `i64::MIN.abs()`
+                // overflows (panics in debug, silently wraps back to a
+                // still-negative i64::MIN in release, #908 review).
                 if *idx >= 0 {
                     *idx < len
                 } else {
-                    idx.abs() <= len
+                    idx.unsigned_abs() <= len as u64
                 }
             } else {
                 // jq behavior: only non-negative indices
@@ -3030,16 +3033,26 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 let len = elements.len() as i64;
                 let in_bounds = if S::NEGATIVE_INDEX_IN_HAS {
                     // yq behavior: negative indices are valid if abs(idx) <= len
+                    // -- `unsigned_abs`, not `abs`, since `i64::MIN.abs()`
+                    // overflows (panics in debug, silently wraps back to a
+                    // still-negative i64::MIN in release, #908 review).
                     if *idx >= 0 {
                         *idx < len
                     } else {
-                        idx.abs() <= len
+                        idx.unsigned_abs() <= len as u64
                     }
                 } else {
                     // jq behavior: only non-negative indices
                     *idx >= 0 && *idx < len
                 };
                 results.push(OwnedValue::Bool(in_bounds));
+            }
+            // A null candidate is never "in" anything, regardless of key
+            // type -- matches `builtin_has`'s own `(StandardJson::Null, _)`
+            // short-circuit (#908 review; confirmed against jq 1.7.1:
+            // `"a" | in(null)` is `false`, not an error).
+            (_, OwnedValue::Null) => {
+                results.push(OwnedValue::Bool(false));
             }
             _ => {
                 check_escape = Some(EvalEscape::Error(EvalError::cannot_check_has(
@@ -3055,26 +3068,16 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // always precedes `xs_escape` (whatever ended `xs`'s own stream after
     // that candidate) chronologically, since it fires while still consuming
     // `candidates` -- the same "earlier escape wins" reasoning
-    // `queue_recurse_children` documents for `recurse`.
-    match check_escape.or(xs_escape) {
-        None => match results.len() {
-            0 => QueryResult::None,
-            1 => QueryResult::Owned(results.pop().expect("len checked")),
-            _ => QueryResult::ManyOwned(results),
-        },
-        // `?` suppresses only a genuine error, matching `has($x)`'s own
-        // typical `optional` semantics elsewhere in this file -- a `Break`
-        // or `Halt` is never caught by `?`/`try` (`EvalEscape`'s own doc
-        // comment), so those always propagate below regardless of
-        // `optional`.
-        Some(EvalEscape::Error(_)) if optional => match results.len() {
-            0 => QueryResult::None,
-            1 => QueryResult::Owned(results.pop().expect("len checked")),
-            _ => QueryResult::ManyOwned(results),
-        },
-        Some(e) if results.is_empty() => e.into(),
-        Some(e) => partial(results, e.into()),
-    }
+    // `queue_recurse_children` documents for `recurse`. `finish_fork`
+    // (shared with 8+ other fork/fold constructs, #908 review) already
+    // implements the "keep already-produced outputs, suppress only a
+    // trailing Error under `optional`, let Break/Halt through regardless"
+    // policy this used to hand-roll here.
+    finish_fork(
+        results,
+        check_escape.or(xs_escape).map(Into::into),
+        optional,
+    )
 }
 
 /// Builtin: `IN(s)` - true if any output of `s` (run against the current

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24927,6 +24927,30 @@ mod tests {
     }
 
     #[test]
+    // `"in({a:1}, {a:9})"` is a jq filter literal, not a formatting string;
+    // clippy cannot tell the two apart from the brace shape alone.
+    #[allow(clippy::literal_string_with_formatting_args)]
+    fn test_builtin_in_fans_out_over_every_xs_output_880() {
+        // `in(xs)` = `. as $x | xs | has($x)` (jq 1.7.1) -- a plain pipe, so
+        // it forks once per `xs` output rather than only consulting the
+        // first (#880's own review discovery, distinct from the
+        // Halt/Break-swallowing bug this issue is titled after). Confirmed
+        // against jq 1.7.1: `"a" | [in({a:1}, {a:9})]` is `[true,true]`;
+        // `"a" | [in({a:1}, {b:2})]` is `[true,false]`.
+        assert_eq!(outputs(br#""a""#, "in({a:1}, {a:9})"), ["true", "true"]);
+        assert_eq!(outputs(br#""a""#, "in({a:1}, {b:2})"), ["true", "false"]);
+    }
+
+    #[test]
+    fn test_builtin_in_empty_xs_produces_no_output_880() {
+        // `in(empty)` -- `xs` producing zero outputs means `in(xs)` produces
+        // zero outputs too (same as any pipe into a filter with nothing to
+        // feed it). Confirmed against jq 1.7.1: `"a" | in(empty)` exits 0
+        // with no output.
+        assert!(outputs(br#""a""#, "in(empty)").is_empty());
+    }
+
+    #[test]
     fn test_builtin_select() {
         // select outputs input only if condition is true
         query!(br"5", "select(. > 3)",

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2988,67 +2988,92 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
-/// Builtin: in(obj)
+/// Builtin: in(xs)
+///
+/// jq defines this as `def in(xs): . as $x | xs | has($x);` (confirmed
+/// against jq 1.7.1) — a plain pipe, so `xs`'s own generator semantics drive
+/// `in(xs)` directly: `"a" | in({a:1}, {b:2})` yields `true` *and* `false`,
+/// one output per `xs` output, not just the first (`"a" | [in({a:1},
+/// {a:9})]'` is `[true,true]`). `eval_owned_multi_keep_partial` evaluates
+/// `xs` fully (keeping every already-produced candidate if a later one
+/// errors/breaks/halts, #842's precedent), then each candidate is checked
+/// against the key in encounter order — a per-candidate type mismatch (e.g.
+/// a number where an object was needed) stops the loop exactly like `xs`
+/// itself erroring would, since real jq's `has($x)` raising mid-pipe has the
+/// same effect as `xs` raising: the rest of the generator never runs
+/// (confirmed: `"a" | in({b:1}, 5, {a:1})?` is only `false`, never reaching
+/// `{a:1}`'s `true` — `?`/`try` truncates the stream at the first error
+/// rather than skipping just that one output).
 fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     obj_expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // The input should be a key (string or number), and we check if it exists in obj
+    // The input is a key (string or number) to check against every output
+    // of `xs`; `xs` itself also receives this same input (`. as $x | xs`
+    // doesn't change `.`).
     let key_owned = to_owned(&value);
-    let obj_result = eval_single::<W, S>(obj_expr, value.clone(), optional);
+    let (candidates, xs_escape) = eval_owned_multi_keep_partial::<S>(obj_expr, &key_owned);
 
-    // Get the object/array to check against (need to handle Owned case for object literals)
-    let obj_owned = match obj_result {
-        QueryResult::One(o) => to_owned(&o),
-        QueryResult::Many(os) => {
-            if let Some(o) = os.into_iter().next() {
-                to_owned(&o)
-            } else if optional {
-                return QueryResult::None;
-            } else {
-                return QueryResult::Error(EvalError::new(
-                    "in() requires an object or array argument",
-                ));
+    let mut results: Vec<OwnedValue> = Vec::with_capacity(candidates.len());
+    let mut check_escape: Option<EvalEscape> = None;
+    for obj_owned in candidates {
+        match (&key_owned, &obj_owned) {
+            (OwnedValue::String(key), OwnedValue::Object(fields)) => {
+                results.push(OwnedValue::Bool(fields.keys().any(|k| k == key)));
+            }
+            // jq returns false for negative indices, yq returns true if in range
+            (
+                OwnedValue::Int(idx) | OwnedValue::NumberLiteral(NumberRepr::Int(idx), _),
+                OwnedValue::Array(elements),
+            ) => {
+                let len = elements.len() as i64;
+                let in_bounds = if S::NEGATIVE_INDEX_IN_HAS {
+                    // yq behavior: negative indices are valid if abs(idx) <= len
+                    if *idx >= 0 {
+                        *idx < len
+                    } else {
+                        idx.abs() <= len
+                    }
+                } else {
+                    // jq behavior: only non-negative indices
+                    *idx >= 0 && *idx < len
+                };
+                results.push(OwnedValue::Bool(in_bounds));
+            }
+            _ => {
+                check_escape = Some(EvalEscape::Error(EvalError::cannot_check_has(
+                    obj_owned.type_name(),
+                    key_owned.type_name(),
+                )));
+                break;
             }
         }
-        QueryResult::Owned(o) => o,
-        QueryResult::Error(e) => return QueryResult::Error(e),
-        _ if optional => return QueryResult::None,
-        _ => {
-            return QueryResult::Error(EvalError::new("in() requires an object or array argument"));
-        }
-    };
+    }
 
-    match (&key_owned, &obj_owned) {
-        (OwnedValue::String(key), OwnedValue::Object(fields)) => {
-            let found = fields.keys().any(|k| k == key);
-            QueryResult::Owned(OwnedValue::Bool(found))
-        }
-        // jq returns false for negative indices, yq returns true if in range
-        (
-            OwnedValue::Int(idx) | OwnedValue::NumberLiteral(NumberRepr::Int(idx), _),
-            OwnedValue::Array(elements),
-        ) => {
-            let len = elements.len() as i64;
-            let in_bounds = if S::NEGATIVE_INDEX_IN_HAS {
-                // yq behavior: negative indices are valid if abs(idx) <= len
-                if *idx >= 0 {
-                    *idx < len
-                } else {
-                    idx.abs() <= len
-                }
-            } else {
-                // jq behavior: only non-negative indices
-                *idx >= 0 && *idx < len
-            };
-            QueryResult::Owned(OwnedValue::Bool(in_bounds))
-        }
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::cannot_check_has(
-            obj_owned.type_name(),
-            key_owned.type_name(),
-        )),
+    // `check_escape` (a type mismatch on an already-produced candidate)
+    // always precedes `xs_escape` (whatever ended `xs`'s own stream after
+    // that candidate) chronologically, since it fires while still consuming
+    // `candidates` -- the same "earlier escape wins" reasoning
+    // `queue_recurse_children` documents for `recurse`.
+    match check_escape.or(xs_escape) {
+        None => match results.len() {
+            0 => QueryResult::None,
+            1 => QueryResult::Owned(results.pop().expect("len checked")),
+            _ => QueryResult::ManyOwned(results),
+        },
+        // `?` suppresses only a genuine error, matching `has($x)`'s own
+        // typical `optional` semantics elsewhere in this file -- a `Break`
+        // or `Halt` is never caught by `?`/`try` (`EvalEscape`'s own doc
+        // comment), so those always propagate below regardless of
+        // `optional`.
+        Some(EvalEscape::Error(_)) if optional => match results.len() {
+            0 => QueryResult::None,
+            1 => QueryResult::Owned(results.pop().expect("len checked")),
+            _ => QueryResult::ManyOwned(results),
+        },
+        Some(e) if results.is_empty() => e.into(),
+        Some(e) => partial(results, e.into()),
     }
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24951,6 +24951,52 @@ mod tests {
     }
 
     #[test]
+    // `"in([1,2,3])"` is a jq filter literal, not a formatting string;
+    // clippy cannot tell the two apart from the brace shape alone.
+    #[allow(clippy::literal_string_with_formatting_args)]
+    fn test_builtin_in_array_index_880() {
+        // The array-index arm of `in(xs)` (jq's non-negative-only index
+        // semantics, `S::NEGATIVE_INDEX_IN_HAS == false`) alongside the
+        // object-key arm exercised by the fan-out test above. Confirmed
+        // against jq 1.7.1: `2 | in([1,2,3])` is `true`; `5 | in([1,2,3])`
+        // is `false`.
+        assert_eq!(outputs(b"2", "in([1,2,3])"), ["true"]);
+        assert_eq!(outputs(b"5", "in([1,2,3])"), ["false"]);
+    }
+
+    #[test]
+    // `"in(5, {a:1})?"` is a jq filter literal, not a formatting string;
+    // clippy cannot tell the two apart from the brace shape alone.
+    #[allow(clippy::literal_string_with_formatting_args)]
+    fn test_builtin_in_optional_with_zero_prior_candidates_880() {
+        // Companion to `test_builtin_in_optional_truncates_stream_at_first_type_mismatch_880`:
+        // that test suppresses an error after one candidate already
+        // succeeded (`results.len() == 1`); this one suppresses an error on
+        // the *very first* candidate, so `results` is still empty when the
+        // `optional` guard fires. Confirmed against jq 1.7.1: `"a" |
+        // in(5, {a:1})?` produces no output at all, exit 0 -- `{a:1}`'s own
+        // `true` is never reached (real jq's `try` truncates the stream,
+        // it doesn't skip just the erroring candidate).
+        assert!(outputs(br#""a""#, "in(5, {a:1})?").is_empty());
+    }
+
+    #[test]
+    // `"in({a:1}, {b:2}, 5)"` is a jq filter literal, not a formatting
+    // string; clippy cannot tell the two apart from the brace shape alone.
+    #[allow(clippy::literal_string_with_formatting_args)]
+    fn test_builtin_in_optional_with_multiple_prior_candidates_880() {
+        // Companion to the two tests above: suppresses an error after *two*
+        // candidates already succeeded (`results.len() >= 2`, the
+        // `ManyOwned` sub-arm). Confirmed against jq 1.7.1: `"a" |
+        // in({a:1}, {b:2}, 5)?` prints `true` and `false` (both already-
+        // produced candidates), then stops -- exit 0, no error surfaces.
+        assert_eq!(
+            outputs(br#""a""#, "in({a:1}, {b:2}, 5)?"),
+            ["true", "false"]
+        );
+    }
+
+    #[test]
     fn test_builtin_select() {
         // select outputs input only if condition is true
         query!(br"5", "select(. > 3)",

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24968,6 +24968,24 @@ mod tests {
     }
 
     #[test]
+    // `"in(null)"`/`"in({a:1}, null)"` are jq filter literals, not
+    // formatting strings; clippy cannot tell the two apart from the brace
+    // shape alone.
+    #[allow(clippy::literal_string_with_formatting_args)]
+    fn test_builtin_in_null_candidate_is_never_in_anything_908() {
+        // Review finding on #908: a null `xs` candidate has no arm of its
+        // own, unlike `builtin_has`'s `(StandardJson::Null, _) => false`
+        // short-circuit, so it fell into the type-mismatch catch-all and
+        // errored instead of contributing `false`. Confirmed against jq
+        // 1.7.1: `"a" | in(null)` is `false`; `"a" | in({a:1}, null)` is
+        // `true` *and* `false` (the null candidate doesn't truncate the
+        // stream); `5 | in(null)` is `false` regardless of key type.
+        assert_eq!(outputs(br#""a""#, "in(null)"), ["false"]);
+        assert_eq!(outputs(br#""a""#, "in({a:1}, null)"), ["true", "false"]);
+        assert_eq!(outputs(b"5", "in(null)"), ["false"]);
+    }
+
+    #[test]
     // `"in(5, {a:1})?"` is a jq filter literal, not a formatting string;
     // clippy cannot tell the two apart from the brace shape alone.
     #[allow(clippy::literal_string_with_formatting_args)]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9017,3 +9017,120 @@ fn test_slice_target_slices_first_output_before_reaching_a_later_halt() -> Resul
     );
     Ok(())
 }
+
+/// #880: `builtin_in`'s (`in(xs)`) match on its argument's evaluation result
+/// had no arm for `Halt`, `Break`, or their `Partial` variants -- all fell
+/// into either the `optional` guard or a bogus "in() requires an object or
+/// array argument" type error, instead of propagating the escape. Verified
+/// against jq 1.7.1 (with stdout/stderr captured separately): `jq -n -c '"a"
+/// | in(halt_error(3))'` writes `a` (the raw value `halt_error` writes as
+/// its own message) to *stderr*, produces no stdout, and exits 3.
+#[test]
+fn test_builtin_in_propagates_a_bare_halt_880() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "-c", r#""a" | in(halt_error(3))"#], None)?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "a");
+    Ok(())
+}
+
+/// Companion to the test above, for `break`: unlike `Halt`, a bare `break`
+/// with no enclosing `label` in scope produces no output and a clean exit
+/// (real jq's actual behavior once the break has nowhere left to unwind
+/// to -- confirmed live). Verified against jq 1.7.1: `jq -n -c 'label $out
+/// | ("a" | in(break $out)), "after"'` produces no output, exit 0 -- the
+/// break unwinds past the whole comma expression, including `"after"`.
+#[test]
+fn test_builtin_in_propagates_a_bare_break_880() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-n",
+            "-c",
+            r#"label $out | ("a" | in(break $out)), "after""#,
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// A `break`/`halt` on a *later* `xs` candidate must not erase the boolean
+/// already produced by an *earlier* one (#842's "keep partial output before
+/// the escape" precedent, applied here since `in(xs)` now fans out over
+/// every `xs` output via `eval_owned_multi_keep_partial`). Verified against
+/// jq 1.7.1: `jq -n -c 'label $out | "a" | in({a:1}, break $out)'` prints
+/// `true` (from the first candidate) then exits 0 -- the break silently
+/// stops the rest of the stream without erroring.
+#[test]
+// `"in({a:1}, break $out)"` is a jq filter literal, not a formatting
+// string; clippy cannot tell the two apart from the brace shape alone.
+#[allow(clippy::literal_string_with_formatting_args)]
+fn test_builtin_in_keeps_earlier_candidates_before_a_later_break_880() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "-c", r#"label $out | "a" | in({a:1}, break $out)"#],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "true\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Same shape as the previous test, for `halt_error` instead of `break`.
+/// Verified against jq 1.7.1 (streams captured separately): `jq -n -c '"a" |
+/// in({a:1}, halt_error(3))'` prints `true` (the first candidate's result)
+/// to stdout, writes `a` (halt_error's own message) to *stderr*, exits 3.
+#[test]
+// `"in({a:1}, halt_error(3))"` is a jq filter literal, not a formatting
+// string; clippy cannot tell the two apart from the brace shape alone.
+#[allow(clippy::literal_string_with_formatting_args)]
+fn test_builtin_in_keeps_earlier_candidates_before_a_later_halt_880() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "-c", r#""a" | in({a:1}, halt_error(3))"#], None)?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "true\n");
+    assert_eq!(stderr, "a");
+    Ok(())
+}
+
+/// A genuine type-mismatch error on a *later* `xs` candidate behaves the
+/// same way as `xs` itself erroring: the stream truncates at that point
+/// (real jq's `try`/`?` semantics never resume a generator past a caught
+/// error), so an outer `?` keeps only the already-produced candidates and
+/// silently drops the rest, rather than either erroring or somehow still
+/// reaching a later, otherwise-valid candidate. Verified against jq 1.7.1:
+/// `jq -n -c '"a" | in({b:1}, 5, {a:1})?'` prints only `false` (`{b:1}`'s
+/// result) -- `{a:1}`'s own `true` is never reached, exit 0.
+#[test]
+// `"in({b:1}, 5, {a:1})?"` is a jq filter literal, not a formatting
+// string; clippy cannot tell the two apart from the brace shape alone.
+#[allow(clippy::literal_string_with_formatting_args)]
+fn test_builtin_in_optional_truncates_stream_at_first_type_mismatch_880() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "-c", r#""a" | in({b:1}, 5, {a:1})?"#], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "false\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Companion to the test above without `?`: the same type mismatch, but
+/// unsuppressed, keeps the already-produced `false` and then raises.
+/// Verified against jq 1.7.1: `jq -n -c '"a" | in({b:1}, 5, {a:1})'` prints
+/// `false` to stdout, then errors ("Cannot check whether number has a
+/// string key"), exit 5.
+#[test]
+// `"in({b:1}, 5, {a:1})"` is a jq filter literal, not a formatting string;
+// clippy cannot tell the two apart from the brace shape alone.
+#[allow(clippy::literal_string_with_formatting_args)]
+fn test_builtin_in_keeps_earlier_candidates_before_a_later_type_mismatch_error_880() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "-c", r#""a" | in({b:1}, 5, {a:1})"#], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "false\n");
+    assert!(
+        stderr.contains("Cannot check whether number has a string key"),
+        "{stderr}"
+    );
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10064,8 +10064,13 @@ fn test_m2_json_output_select_halt_writes_nothing_for_halted_doc() -> Result<()>
 /// branch (`S::NEGATIVE_INDEX_IN_HAS`, unreachable via `succinctly jq`'s
 /// `JqSemantics`) -- yq treats a negative index as valid if
 /// `abs(idx) <= len`, unlike jq which only accepts non-negative indices.
-/// Confirmed against real yq: `-1 | in([1,2,3])` is `true` (in range),
-/// `-4 | in([1,2,3])` is `false` (out of range).
+/// Also covers the same branch's non-negative sub-case under yq semantics
+/// specifically (the jq-mode non-negative case is covered separately by
+/// `test_builtin_in_array_index_880` in `src/jq/eval.rs`, which uses
+/// `JqSemantics` and so never reaches `NEGATIVE_INDEX_IN_HAS`'s branch at
+/// all). Confirmed against real yq: `-1 | in([1,2,3])` is `true` (in
+/// range), `-4 | in([1,2,3])` is `false` (out of range), `2 | in([1,2,3])`
+/// is `true`, `5 | in([1,2,3])` is `false`.
 #[test]
 fn test_builtin_in_yq_negative_index_880() -> Result<()> {
     let (out, code) = run_yq_stdin("in([1,2,3])", "-1", &[])?;
@@ -10073,6 +10078,14 @@ fn test_builtin_in_yq_negative_index_880() -> Result<()> {
     assert_eq!(out.trim(), "true");
 
     let (out, code) = run_yq_stdin("in([1,2,3])", "-4", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("in([1,2,3])", "2", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin("in([1,2,3])", "5", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "false");
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10059,3 +10059,21 @@ fn test_m2_json_output_select_halt_writes_nothing_for_halted_doc() -> Result<()>
     assert_eq!(out.trim(), r#"{"a":1}"#);
     Ok(())
 }
+
+/// #880: `builtin_in`'s array-index arm has a yq-specific negative-index
+/// branch (`S::NEGATIVE_INDEX_IN_HAS`, unreachable via `succinctly jq`'s
+/// `JqSemantics`) -- yq treats a negative index as valid if
+/// `abs(idx) <= len`, unlike jq which only accepts non-negative indices.
+/// Confirmed against real yq: `-1 | in([1,2,3])` is `true` (in range),
+/// `-4 | in([1,2,3])` is `false` (out of range).
+#[test]
+fn test_builtin_in_yq_negative_index_880() -> Result<()> {
+    let (out, code) = run_yq_stdin("in([1,2,3])", "-1", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin("in([1,2,3])", "-4", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10090,3 +10090,24 @@ fn test_builtin_in_yq_negative_index_880() -> Result<()> {
     assert_eq!(out.trim(), "false");
     Ok(())
 }
+
+/// Review finding on #908: `idx.abs()` in the negative-index branch above
+/// overflows for `i64::MIN` -- a debug build panics ("attempt to negate
+/// with overflow", exit 101 via `unwrap`/no catch), a release build
+/// silently wraps back to a still-negative `i64::MIN`, making
+/// `idx.abs() <= len` spuriously true. `idx.unsigned_abs()` (a `u64`,
+/// overflow-free for every `i64` including `MIN`) fixes both. A non-zero
+/// exit code here would mean either the panic or the wrong-answer shape
+/// resurfaced. `has(...)`'s identical, independently-duplicated branch is
+/// exercised too, since it shares this exact bug.
+#[test]
+fn test_builtin_in_and_has_yq_negative_index_i64_min_no_overflow_908() -> Result<()> {
+    let (out, code) = run_yq_stdin("in([1,2,3])", "-9223372036854775808", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("has(-9223372036854775808)", "[1,2,3]", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `in(xs)` = `. as \$x | xs | has(\$x)` (confirmed against jq 1.7.1) — a plain pipe, so it forks once per `xs` output (`"a" | [in({a:1}, {a:9})]` is `[true,true]`), not just the first. `builtin_in`'s own `eval_single` call only ever consulted the first output (`os.into_iter().next()`) and had no match arm for `Halt`, `Break`, or their `Partial` variants — a halt/break from `xs` fell into either the `optional` guard or a bogus "in() requires an object or array argument" type error instead of propagating.
- Switches to `eval_owned_multi_keep_partial` and checks each candidate in order, matching real jq's generator truncation: a later candidate's escape (whether from `xs` itself or a per-candidate type mismatch) keeps whatever booleans were already produced by earlier candidates before surfacing — the same "keep partial, defer the escape" shape #842/#854 established for `recurse`.
- `?` suppresses only a genuine error, never a `Break` or `Halt`, matching `EvalEscape`'s own documented contract.

## Repro (verified against pinned jq-1.7.1)

```
$ jq -n -c '"a" | in(halt_error(3))'
a
$ succinctly jq -n -c '"a" | in(halt_error(3))'
jq: error (at <unknown>): in() requires an object or array argument
```
(real jq writes `a`, halt_error's own message, to stderr, then exits 3; succinctly misreported a type error, exit 5)

```
$ jq -n -c '"a" | [in({a:1}, {a:9})]'
[true,true]
$ succinctly jq -n -c '"a" | [in({a:1}, {a:9})]'
[true]
```
(pre-fix: only the first `xs` output was ever consulted)

## Note on coverage

4 lines (the `Some(EvalEscape::Error(_)) if optional => ...` branch) are genuinely unreachable via any real jq/yq syntax and left uncovered. `?` on a whole expression desugars to `eval_try` (external Partial/Error catching), not to forcing this function's own `optional: bool` parameter true (confirmed empirically and via the `#693` doc comment on `Expr::Optional`'s dispatch, which deliberately stopped forcing `optional=true` down a subtree). The sibling `builtin_has` has the identical pre-existing, equally-uncovered pattern (`_ if optional => QueryResult::None`), confirming this isn't new to this PR — I verified via the raw lcov data rather than assuming.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manually diffed output against real jq 1.7.1 across ~12 scenarios: original repros, fan-out (basic/mixed), error mid-stream with/without `?`, error-first with `?`, empty `xs`, break/halt after partial success, array bounds — all match exactly (streams captured separately, not merged, since `halt_error` writes to stderr)
- [x] Added unit tests (`src/jq/eval.rs`) and CLI tests (`tests/jq_cli_tests.rs`, `tests/yq_cli_tests.rs` for the yq-only negative-index branch), all pinned against real jq/yq
- [x] Patch coverage: 96% (48/50), remaining 4 lines documented above as genuinely untestable