### PR TITLE
fix(jq): bare splits(re) streams one output per substring

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27392,6 +27392,50 @@ mod tests {
 
     #[cfg(feature = "regex")]
     #[test]
+    fn test_regex_scan_bare_form_honors_capture_groups_915() {
+        // #915: bare `scan(re)` used to duplicate `scan(re; flags)`'s logic
+        // instead of delegating, and the duplicate never checked
+        // `capture_count` — so a pattern with capture groups returned the
+        // whole match (group 0) instead of the array of captured groups.
+        // Verified live against jq 1.7.1: `scan("(a)(b)")` on `"ab"` is
+        // `["a","b"]`, matching what `scan(re; "")` already produced here.
+        query!(br#""ab""#, r#"scan("(a)(b)")"#,
+            QueryResult::ManyOwned(matches) => {
+                assert_eq!(matches.len(), 1);
+                assert_eq!(
+                    matches[0],
+                    OwnedValue::Array(vec![
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("b".to_string()),
+                    ])
+                );
+            }
+        );
+
+        // Two matches of a capture-grouped pattern.
+        query!(br#""a1b2""#, r#"scan("([a-z])([0-9])")"#,
+            QueryResult::ManyOwned(matches) => {
+                assert_eq!(matches.len(), 2);
+                assert_eq!(
+                    matches[0],
+                    OwnedValue::Array(vec![
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("1".to_string()),
+                    ])
+                );
+                assert_eq!(
+                    matches[1],
+                    OwnedValue::Array(vec![
+                        OwnedValue::String("b".to_string()),
+                        OwnedValue::String("2".to_string()),
+                    ])
+                );
+            }
+        );
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
     fn test_regex_splits() {
         // `splits(re)` streams one output per substring — like real jq, and
         // like `splits(re; flags)` already did before #906's fix made the

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7123,46 +7123,22 @@ fn builtin_scan<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: splits(re) - split by regex
+///
+/// jq defines this as `splits($re; null)` — delegate to the flags-aware
+/// implementation directly rather than duplicating its (streaming) split
+/// logic here. The former standalone body returned a single
+/// `QueryResult::Owned(Array(parts))` instead of streaming one output per
+/// substring the way `splits(re; flags)` and real jq both do (#906):
+/// `[splits("[0-9]")]` on `"a1b2"` read back as `[["a","b",""]]` (one
+/// nested array) instead of `["a","b",""]` (three streamed strings
+/// collected).
 #[cfg(feature = "regex")]
 fn builtin_splits<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern
-    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "pattern")),
-        Err(e) => return e.into(),
-    };
-
-    // Get the input string
-    let input = match &value {
-        StandardJson::String(s) => match s.as_str() {
-            Ok(cow) => cow.into_owned(),
-            Err(_) if optional => return QueryResult::None,
-            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
-        },
-        _ if optional => return QueryResult::None,
-        _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
-    };
-
-    // Build regex
-    let re = match build_regex(&pattern, None) {
-        Ok(r) => r,
-        Err(_e) if optional => return QueryResult::None,
-        Err(e) => return e.into(),
-    };
-
-    // Split by regex
-    let matches = global_captures(&re, &input);
-    let parts: Vec<OwnedValue> = stitch_split(&input, &matches)
-        .into_iter()
-        .map(OwnedValue::String)
-        .collect();
-
-    QueryResult::Owned(OwnedValue::Array(parts))
+    builtin_splits_with_flags::<W, S>(re_expr, None, value, optional)
 }
 
 /// Builtin: sub(re; replacement) - replace first match
@@ -27445,8 +27421,12 @@ mod tests {
     #[cfg(feature = "regex")]
     #[test]
     fn test_regex_splits() {
+        // `splits(re)` streams one output per substring — like real jq, and
+        // like `splits(re; flags)` already did before #906's fix made the
+        // bare form (this one) match instead of wrongly collapsing to a
+        // single array-valued output.
         query!(br#""a1b2c3d""#, r#"splits("[0-9]")"#,
-            QueryResult::Owned(OwnedValue::Array(parts)) => {
+            QueryResult::ManyOwned(parts) => {
                 assert_eq!(parts.len(), 4);
                 assert_eq!(parts[0], OwnedValue::String("a".to_string()));
                 assert_eq!(parts[1], OwnedValue::String("b".to_string()));

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7077,49 +7077,21 @@ fn stitch_replacements_evaluated<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
 /// Builtin: scan(re) - find all matches
 #[cfg(feature = "regex")]
+/// jq defines this as `scan($re; null)` — delegate to the flags-aware
+/// implementation directly rather than duplicating its match-collection
+/// logic here. The former standalone body always took `caps.get(0)` (the
+/// whole match), never branching on `capture_count` the way
+/// `builtin_scan_with_flags` does, so a pattern with capture groups
+/// silently returned the wrong shape (#915): `scan("(a)(b)")` on `"ab"`
+/// read back as `"ab"` instead of `["a","b"]` — `scan("(a)(b)"; null)` and
+/// real jq both already produced the correct array. Same duplication
+/// shape #906 found and fixed for `splits`.
 fn builtin_scan<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern
-    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "pattern")),
-        Err(e) => return e.into(),
-    };
-
-    // Get the input string
-    let input = match &value {
-        StandardJson::String(s) => match s.as_str() {
-            Ok(cow) => cow.into_owned(),
-            Err(_) if optional => return QueryResult::None,
-            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
-        },
-        _ if optional => return QueryResult::None,
-        _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
-    };
-
-    // Build regex
-    let re = match build_regex(&pattern, None) {
-        Ok(r) => r,
-        Err(_e) if optional => return QueryResult::None,
-        Err(e) => return e.into(),
-    };
-
-    // Find all matches
-    let matches: Vec<OwnedValue> = global_captures(&re, &input)
-        .iter()
-        .map(|caps| {
-            let m = caps
-                .get(0)
-                .expect("capture group 0 is always present on a match");
-            OwnedValue::String(m.as_str().to_string())
-        })
-        .collect();
-
-    QueryResult::ManyOwned(matches)
+    builtin_scan_with_flags::<W, S>(re_expr, None, value, optional)
 }
 
 /// Builtin: splits(re) - split by regex


### PR DESCRIPTION
## Summary

`builtin_splits` (the bare `splits(re)` form, no flags argument) had its own standalone implementation that collected every substring into a single `QueryResult::Owned(Array(...))` instead of streaming, unlike its `splits(re; flags)` sibling (`builtin_splits_with_flags`), which correctly returns `QueryResult::ManyOwned` — one output per substring, matching real jq's `def splits($re): splits($re; null);` definition.

```
$ echo '"a1b2"' | jq -c '[splits("[0-9]")]'
["a","b",""]
$ echo '"a1b2"' | succinctly jq -c '[splits("[0-9]")]'
[["a","b",""]]
```

Delegate to `builtin_splits_with_flags` with `flags: None` instead of duplicating the split logic — matching the same pattern `builtin_sub` already uses for its own bare/flagged pair (`sub(re;str)` delegates to `sub_with_flags(...,None,...)`).

Found while fixing #730 (regex flag validation) — confirmed identical on `main` before that fix, unrelated to it.

**Update:** a second round of review on this PR's own diff surfaced a matching bug in `builtin_scan` (bare `scan(re)`), which ignored capture groups entirely (`caps.get(0)` regardless of `capture_count`). Filed as #915 and fixed here the same way — delegate to `builtin_scan_with_flags(..., None, ...)`. #915 also notes `test(re)` has the same duplication risk (unconfirmed as a live bug) and stays open for that.

Fixes #906

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Diffed output against pinned real `jq` for `[splits(re)]`, bare streamed `splits(re)`, `splits(re; flags)` (unaffected), and `?`-optional behavior
- [x] Diffed output against pinned real `jq` for `[scan(re)]` with and without capture groups, confirming array-of-groups vs bare-string dispatch matches `scan(re; flags)`
- [x] Fixed the two existing unit tests (`test_regex_splits`, and added `test_regex_scan_bare_form_honors_capture_groups_915`) that were pinning the wrong behavior / missing coverage
- [x] Rebased onto latest `main` post-#911 merge; build/test/clippy re-verified clean after rebase
