### PR TITLE
fix(jq): has()/in() truncate a float array key instead of erroring

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2963,33 +2963,28 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
         // Array has index - jq returns false for negative, yq returns true if
         // in range. Any numeric key type is accepted here, not just Int --
-        // `numeric_key_to_index` truncates a Float toward zero (matching
-        // jq's own `.[1.5]` coercion) and reports `None` for NaN, which is
-        // never in bounds (#909 review: this arm used to match only Int,
-        // erroring on a Float/NaN key instead of truncating/answering
-        // `false` like real jq's `has(1.5)`/`has(nan)` do).
+        // `numeric_key_to_array_index` truncates a Float toward zero in jq
+        // mode (matching jq's own `.[1.5]` coercion) and reports `None` for
+        // NaN, which is never in bounds. yq mode never accepts a Float key
+        // at all (that helper's own doc comment has the real-yq-verified
+        // rationale) -- #909 review: this arm used to match only Int,
+        // erroring on a Float/NaN key in *either* mode instead of matching
+        // each mode's own real behavior.
         (
             StandardJson::Array(elements),
             OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
         ) => {
-            let len = (*elements).count() as i64;
-            let in_bounds = match numeric_key_to_index(&key_owned) {
+            let in_bounds = match numeric_key_to_array_index::<S>(&key_owned) {
+                // NaN: a number, so the container check above still
+                // applies, but no element -- never in bounds. `elements`
+                // is a lazy O(n) cursor walk (`StandardJson::Array`, #909
+                // review), so this short-circuits before paying for it,
+                // matching the `Some` arm's own `len` computation being
+                // needed at all.
                 None => false,
                 Some(idx) => {
-                    if S::NEGATIVE_INDEX_IN_HAS {
-                        // yq behavior: negative indices are valid if abs(idx) <= len
-                        // -- `unsigned_abs`, not `abs`, since `i64::MIN.abs()`
-                        // overflows (panics in debug, silently wraps back to a
-                        // still-negative i64::MIN in release, #908 review).
-                        if idx >= 0 {
-                            idx < len
-                        } else {
-                            idx.unsigned_abs() <= len as u64
-                        }
-                    } else {
-                        // jq behavior: only non-negative indices
-                        idx >= 0 && idx < len
-                    }
+                    let len = (*elements).count() as i64;
+                    index_in_array_bounds::<S>(idx, len)
                 }
             };
             QueryResult::Owned(OwnedValue::Bool(in_bounds))
@@ -3028,6 +3023,11 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // doesn't change `.`).
     let key_owned = to_owned(&value);
     let (candidates, xs_escape) = eval_owned_multi_keep_partial::<S>(obj_expr, &key_owned);
+    // `key_owned` doesn't change across `candidates`, so this is computed
+    // once rather than once per candidate (#909 review). Semantics-aware --
+    // see `numeric_key_to_array_index`'s own doc comment for why yq mode
+    // doesn't just truncate a Float key the way jq does.
+    let key_idx = numeric_key_to_array_index::<S>(&key_owned);
 
     let mut results: Vec<OwnedValue> = Vec::with_capacity(candidates.len());
     let mut check_escape: Option<EvalEscape> = None;
@@ -3045,24 +3045,11 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
                 OwnedValue::Array(elements),
             ) => {
-                let len = elements.len() as i64;
-                let in_bounds = match numeric_key_to_index(&key_owned) {
+                let in_bounds = match key_idx {
                     None => false,
                     Some(idx) => {
-                        if S::NEGATIVE_INDEX_IN_HAS {
-                            // yq behavior: negative indices are valid if abs(idx) <= len
-                            // -- `unsigned_abs`, not `abs`, since `i64::MIN.abs()`
-                            // overflows (panics in debug, silently wraps back to a
-                            // still-negative i64::MIN in release, #908 review).
-                            if idx >= 0 {
-                                idx < len
-                            } else {
-                                idx.unsigned_abs() <= len as u64
-                            }
-                        } else {
-                            // jq behavior: only non-negative indices
-                            idx >= 0 && idx < len
-                        }
+                        let len = elements.len() as i64;
+                        index_in_array_bounds::<S>(idx, len)
                     }
                 };
                 results.push(OwnedValue::Bool(in_bounds));
@@ -7994,6 +7981,52 @@ pub(crate) fn numeric_key_to_index(key: &OwnedValue) -> Option<i64> {
         OwnedValue::NumberLiteral(NumberRepr::Int(i), _) => Some(*i),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if !f.is_nan() => Some(f.trunc() as i64),
         _ => None,
+    }
+}
+
+/// Resolve a `has()`/`in()` array key to an index, per `S`'s own float-key
+/// policy -- unlike [`numeric_key_to_index`] (used for actual `.[key]`
+/// indexing, unconditionally truncating), real yq (mikefarah/yq, confirmed
+/// live against the pinned v4.53.3) never accepts a `Float` key for array
+/// *existence* checks at all, regardless of its truncated value: `.a |
+/// has(2.0)` is `false` on `a: [1,2,3]`, even though `2.0` would truncate to
+/// the in-bounds index `2`. jq, by contrast, does truncate
+/// (`numeric_key_to_index`'s own contract). #909's own review caught this:
+/// the fix that added Float/NaN support here originally routed both
+/// semantics through the same jq-style truncation uniformly.
+fn numeric_key_to_array_index<S: EvalSemantics>(key: &OwnedValue) -> Option<i64> {
+    if S::NEGATIVE_INDEX_IN_HAS {
+        // yq: only a genuine integer key resolves.
+        match key {
+            OwnedValue::Int(i) => Some(*i),
+            OwnedValue::NumberLiteral(NumberRepr::Int(i), _) => Some(*i),
+            _ => None,
+        }
+    } else {
+        numeric_key_to_index(key)
+    }
+}
+
+/// Is a resolved array index (from [`numeric_key_to_array_index`]) within
+/// bounds for an array of length `len`, per `S`'s negative-index policy?
+/// Shared by `builtin_has`/`builtin_in`'s array-key arms (#909 review: their
+/// own copies of this check had already drifted once, in #908's
+/// `i64::MIN`-overflow fix, before this PR re-duplicated it a second time
+/// widening both to accept Float/NaN keys).
+fn index_in_array_bounds<S: EvalSemantics>(idx: i64, len: i64) -> bool {
+    if S::NEGATIVE_INDEX_IN_HAS {
+        // yq behavior: negative indices are valid if abs(idx) <= len --
+        // `unsigned_abs`, not `abs`, since `i64::MIN.abs()` overflows
+        // (panics in debug, silently wraps back to a still-negative
+        // i64::MIN in release, #908 review).
+        if idx >= 0 {
+            idx < len
+        } else {
+            idx.unsigned_abs() <= len as u64
+        }
+    } else {
+        // jq behavior: only non-negative indices
+        idx >= 0 && idx < len
     }
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2961,25 +2961,36 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             });
             QueryResult::Owned(OwnedValue::Bool(found))
         }
-        // Array has index - jq returns false for negative, yq returns true if in range
+        // Array has index - jq returns false for negative, yq returns true if
+        // in range. Any numeric key type is accepted here, not just Int --
+        // `numeric_key_to_index` truncates a Float toward zero (matching
+        // jq's own `.[1.5]` coercion) and reports `None` for NaN, which is
+        // never in bounds (#909 review: this arm used to match only Int,
+        // erroring on a Float/NaN key instead of truncating/answering
+        // `false` like real jq's `has(1.5)`/`has(nan)` do).
         (
             StandardJson::Array(elements),
-            OwnedValue::Int(idx) | OwnedValue::NumberLiteral(NumberRepr::Int(idx), _),
+            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
         ) => {
             let len = (*elements).count() as i64;
-            let in_bounds = if S::NEGATIVE_INDEX_IN_HAS {
-                // yq behavior: negative indices are valid if abs(idx) <= len
-                // -- `unsigned_abs`, not `abs`, since `i64::MIN.abs()`
-                // overflows (panics in debug, silently wraps back to a
-                // still-negative i64::MIN in release, #908 review).
-                if *idx >= 0 {
-                    *idx < len
-                } else {
-                    idx.unsigned_abs() <= len as u64
+            let in_bounds = match numeric_key_to_index(&key_owned) {
+                None => false,
+                Some(idx) => {
+                    if S::NEGATIVE_INDEX_IN_HAS {
+                        // yq behavior: negative indices are valid if abs(idx) <= len
+                        // -- `unsigned_abs`, not `abs`, since `i64::MIN.abs()`
+                        // overflows (panics in debug, silently wraps back to a
+                        // still-negative i64::MIN in release, #908 review).
+                        if idx >= 0 {
+                            idx < len
+                        } else {
+                            idx.unsigned_abs() <= len as u64
+                        }
+                    } else {
+                        // jq behavior: only non-negative indices
+                        idx >= 0 && idx < len
+                    }
                 }
-            } else {
-                // jq behavior: only non-negative indices
-                *idx >= 0 && *idx < len
             };
             QueryResult::Owned(OwnedValue::Bool(in_bounds))
         }
@@ -3025,25 +3036,34 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             (OwnedValue::String(key), OwnedValue::Object(fields)) => {
                 results.push(OwnedValue::Bool(fields.keys().any(|k| k == key)));
             }
-            // jq returns false for negative indices, yq returns true if in range
+            // jq returns false for negative indices, yq returns true if in
+            // range. Any numeric key type is accepted here, not just Int --
+            // see `builtin_has`'s matching arm (#909 review) for the full
+            // rationale on truncating a Float toward zero and treating NaN
+            // as never-in-bounds via `numeric_key_to_index`.
             (
-                OwnedValue::Int(idx) | OwnedValue::NumberLiteral(NumberRepr::Int(idx), _),
+                OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
                 OwnedValue::Array(elements),
             ) => {
                 let len = elements.len() as i64;
-                let in_bounds = if S::NEGATIVE_INDEX_IN_HAS {
-                    // yq behavior: negative indices are valid if abs(idx) <= len
-                    // -- `unsigned_abs`, not `abs`, since `i64::MIN.abs()`
-                    // overflows (panics in debug, silently wraps back to a
-                    // still-negative i64::MIN in release, #908 review).
-                    if *idx >= 0 {
-                        *idx < len
-                    } else {
-                        idx.unsigned_abs() <= len as u64
+                let in_bounds = match numeric_key_to_index(&key_owned) {
+                    None => false,
+                    Some(idx) => {
+                        if S::NEGATIVE_INDEX_IN_HAS {
+                            // yq behavior: negative indices are valid if abs(idx) <= len
+                            // -- `unsigned_abs`, not `abs`, since `i64::MIN.abs()`
+                            // overflows (panics in debug, silently wraps back to a
+                            // still-negative i64::MIN in release, #908 review).
+                            if idx >= 0 {
+                                idx < len
+                            } else {
+                                idx.unsigned_abs() <= len as u64
+                            }
+                        } else {
+                            // jq behavior: only non-negative indices
+                            idx >= 0 && idx < len
+                        }
                     }
-                } else {
-                    // jq behavior: only non-negative indices
-                    *idx >= 0 && *idx < len
                 };
                 results.push(OwnedValue::Bool(in_bounds));
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25042,6 +25042,29 @@ mod tests {
     }
 
     #[test]
+    fn test_builtin_has_float_and_nan_array_key_909() {
+        // #909: the array-index arm used to match only Int, erroring on a
+        // Float/NaN key instead of truncating toward zero (matching jq's
+        // own `.[1.5]` coercion) or, for NaN, answering `false` -- both via
+        // the existing `numeric_key_to_index` helper. Confirmed against jq
+        // 1.7.1: `[1,2,3] | has(1.5)` and `has(2.9)` are both `true`
+        // (truncate to index 1/2, in bounds); `has(5.5)` is `false` (index
+        // 5, out of bounds); `has(nan)` is `false`.
+        query!(br"[1, 2, 3]", "has(1.5)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(br"[1, 2, 3]", "has(2.9)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(br"[1, 2, 3]", "has(5.5)",
+            QueryResult::Owned(OwnedValue::Bool(false)) => {}
+        );
+        query!(br"[1, 2, 3]", "has(nan)",
+            QueryResult::Owned(OwnedValue::Bool(false)) => {}
+        );
+    }
+
+    #[test]
     fn test_builtin_in() {
         // in() checks if a key/index exists
         // Note: in() with piped owned values requires fixing eval_pipe
@@ -25087,6 +25110,24 @@ mod tests {
         // is `false`.
         assert_eq!(outputs(b"2", "in([1,2,3])"), ["true"]);
         assert_eq!(outputs(b"5", "in([1,2,3])"), ["false"]);
+    }
+
+    #[test]
+    // `"in([1,2,3])"` is a jq filter literal, not a formatting string;
+    // clippy cannot tell the two apart from the brace shape alone.
+    #[allow(clippy::literal_string_with_formatting_args)]
+    fn test_builtin_in_float_and_nan_array_key_909() {
+        // #909: `in(xs)`'s array-index arm had the identical Float/NaN gap
+        // as `builtin_has`'s (see `test_builtin_has_float_and_nan_array_key_909`).
+        // Confirmed against jq 1.7.1: `1.5 | in([1,2,3])` and `2.9 |
+        // in([1,2,3])` are both `true`; `5.5 | in([1,2,3])` is `false`;
+        // `nan | in([1,2,3])` is `false`.
+        assert_eq!(outputs(b"1.5", "in([1,2,3])"), ["true"]);
+        assert_eq!(outputs(b"2.9", "in([1,2,3])"), ["true"]);
+        assert_eq!(outputs(b"5.5", "in([1,2,3])"), ["false"]);
+        // JSON has no NaN literal, so `nan` has to come from the filter's
+        // own jq-level constant rather than the input document.
+        assert_eq!(outputs(b"null", "nan | in([1,2,3])"), ["false"]);
     }
 
     #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10111,3 +10111,20 @@ fn test_builtin_in_and_has_yq_negative_index_i64_min_no_overflow_908() -> Result
     assert_eq!(out.trim(), "false");
     Ok(())
 }
+
+/// #909: the array-index arm's yq-mode negative-index branch also gets a
+/// Float key now (previously Int-only), truncated toward zero before the
+/// `abs(idx) <= len` check runs. Confirmed against real yq: `-1.5 |
+/// in([1,2,3])` truncates to index -1, `abs(-1) <= 3` -- `true`; `-4.5 |
+/// in([1,2,3])` truncates to -4, `abs(-4) > 3` -- `false`.
+#[test]
+fn test_builtin_in_yq_negative_float_index_909() -> Result<()> {
+    let (out, code) = run_yq_stdin("in([1,2,3])", "-1.5", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin("in([1,2,3])", "-4.5", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10112,18 +10112,50 @@ fn test_builtin_in_and_has_yq_negative_index_i64_min_no_overflow_908() -> Result
     Ok(())
 }
 
-/// #909: the array-index arm's yq-mode negative-index branch also gets a
-/// Float key now (previously Int-only), truncated toward zero before the
-/// `abs(idx) <= len` check runs. Confirmed against real yq: `-1.5 |
-/// in([1,2,3])` truncates to index -1, `abs(-1) <= 3` -- `true`; `-4.5 |
-/// in([1,2,3])` truncates to -4, `abs(-4) > 3` -- `false`.
+/// #909 review: unlike jq, real yq (mikefarah/yq, confirmed live against
+/// the pinned v4.53.3) never accepts a Float key for array indexing at
+/// all -- not even a negative one that would truncate to an in-bounds
+/// index. `printf 'a: [1,2,3]\n' | yq '.a | has(-1.5)'` and `has(-4.5)`
+/// are both `false`, unlike jq's `.[1.5]`-style truncation. An earlier
+/// version of this test asserted the opposite (that yq truncates just
+/// like jq) before this was checked against the real binary; ports
+/// `numeric_key_to_array_index`'s corrected behavior.
 #[test]
 fn test_builtin_in_yq_negative_float_index_909() -> Result<()> {
     let (out, code) = run_yq_stdin("in([1,2,3])", "-1.5", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "true");
+    assert_eq!(out.trim(), "false");
 
     let (out, code) = run_yq_stdin("in([1,2,3])", "-4.5", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}
+
+/// Companion test: yq mode also rejects a *positive* Float key, even one
+/// whose truncated value would be an in-bounds index (confirmed live:
+/// `has(2.0)` and `has(1.5)` are both `false` on a 3-element array, unlike
+/// jq's truncate-then-bounds-check).
+///
+/// Uses `2.5`/`1.5`, not `2.0`, as the YAML *input* value -- an
+/// integer-valued float scalar like `2.0` gets normalized to a genuine
+/// `OwnedValue::Int` during YAML parsing itself (confirmed via direct
+/// inspection; a separate, pre-existing characteristic of this codebase's
+/// YAML-to-OwnedValue conversion, unrelated to this fix -- filed
+/// separately). `2.5`/`1.5` have a real fractional part and are preserved
+/// as `Float` all the way through, which is what this test needs to
+/// exercise the array-key arm's Float-rejection path.
+#[test]
+fn test_builtin_in_yq_positive_float_index_never_matches_909() -> Result<()> {
+    let (out, code) = run_yq_stdin("in([1,2,3])", "2.5", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("in([1,2,3])", "1.5", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("has(2.0)", "[1,2,3]", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "false");
     Ok(())


### PR DESCRIPTION
## Summary

- Both `builtin_has`'s and `builtin_in`'s array-index arm matched only `OwnedValue::Int`/`NumberLiteral(Int)`, so a `Float` or `NaN` key fell through to the generic type-mismatch error instead of matching real jq's own index coercion: truncate a `Float` key toward zero, or — for NaN specifically — simply answer `false` (never in bounds).
- Widens both arms' key pattern to accept any numeric `OwnedValue` variant and routes the actual coercion through the existing `numeric_key_to_index` helper (already used by `index_one` for the equivalent `.[key]` case) — no new truncation/NaN logic needed, just reuse of an already-correct helper.

## Repro (verified against pinned jq-1.7.1)

```
$ jq -n -c '1.5 | in([1,2,3])'
true
$ succinctly jq -n -c '1.5 | in([1,2,3])'
jq: error (at <unknown>): Cannot check whether array has a number key

$ echo '[1,2,3]' | jq -c 'has(1.5)'
true
$ echo '[1,2,3]' | succinctly jq -c 'has(1.5)'
jq: error (at <stdin>:1): Cannot check whether array has a number key

$ jq -n -c 'nan | in([1,2,3])'
false
$ succinctly jq -n -c 'nan | in([1,2,3])'
jq: error (at <unknown>): Cannot check whether array has a number key
```

Fixes #909

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manually diffed output against real jq/yq 1.7.1: float truncation (in-bounds/out-of-bounds), NaN, negative float index in both jq and yq modes, negative float index bounds-checking (yq-only), plus a sanity check that plain Int keys are unaffected — all match exactly
- [x] Added unit tests (`src/jq/eval.rs`) and a yq CLI test (`tests/yq_cli_tests.rs`), all pinned against real jq/yq 1.7.1