### PR TITLE
fix(jq): yq has()/in() negative-index and type-mismatch semantics gaps

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2990,6 +2990,13 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(OwnedValue::Bool(in_bounds))
         }
         _ if optional => QueryResult::None,
+        // Real yq (mikefarah/yq, confirmed live against the pinned v4.53.3,
+        // #917) never raises a type-mismatch error for `has()` at all --
+        // `.a | has("x")` on an array, `has(0)` on an object, and `has(...)`
+        // on a bare scalar are all `false`, not an error. jq keeps erroring
+        // here (`Cannot check whether <container> has a <key> key`, which
+        // is correct and unaffected).
+        _ if S::NEGATIVE_INDEX_IN_HAS => QueryResult::Owned(OwnedValue::Bool(false)),
         _ => QueryResult::Error(EvalError::cannot_check_has(
             type_name(&value),
             key_owned.type_name(),
@@ -3013,6 +3020,17 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// (confirmed: `"a" | in({b:1}, 5, {a:1})?` is only `false`, never reaching
 /// `{a:1}`'s `true` — `?`/`try` truncates the stream at the first error
 /// rather than skipping just that one output).
+///
+/// **yq-mode caveat (#917):** `in(xs)` as a jq-style function-call filter is
+/// a succinctly-only convenience in yq mode, not a real-yq-compatible
+/// construct — real yq (mikefarah/yq, confirmed live against the pinned
+/// v4.53.3) has no `in(...)` syntax at all; every invocation tried
+/// (`.a | in([1,2,3])`, `yq -n 'in([1,2,3])'`) hits a lexer error
+/// (`invalid input text "in([1,2,3])"`). So "confirmed against real yq" for
+/// this builtin's yq-mode *value* semantics means checked via jq's own
+/// desugared `. as $x | xs | has($x)` form and `has()`'s independently
+/// verified real-yq behavior — never via `in(...)` call syntax itself,
+/// which has no oracle to check against.
 fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     obj_expr: &Expr,
     value: StandardJson<'a, W>,
@@ -3059,6 +3077,12 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // short-circuit (#908 review; confirmed against jq 1.7.1:
             // `"a" | in(null)` is `false`, not an error).
             (_, OwnedValue::Null) => {
+                results.push(OwnedValue::Bool(false));
+            }
+            // Real yq never raises a type-mismatch error here either --
+            // see `builtin_has`'s matching arm (#917) for the
+            // real-yq-verified rationale. jq keeps erroring.
+            _ if S::NEGATIVE_INDEX_IN_HAS => {
                 results.push(OwnedValue::Bool(false));
             }
             _ => {
@@ -7959,19 +7983,22 @@ fn numeric_key_to_array_index<S: EvalSemantics>(key: &OwnedValue) -> Option<i64>
 /// bounds for an array of length `len`, per `S`'s negative-index policy?
 /// Shared by `builtin_has`/`builtin_in`'s array-key arms (#909 review: their
 /// own copies of this check had already drifted once, in #908's
-/// `i64::MIN`-overflow fix, before this PR re-duplicated it a second time
+/// `i64::MIN`-overflow fix, before that PR re-duplicated it a second time
 /// widening both to accept Float/NaN keys).
+///
+/// yq's own rule (real mikefarah/yq, confirmed live against the pinned
+/// v4.53.3, #917) is simpler than it first looks: *any* negative integer is
+/// unconditionally `true`, regardless of magnitude or the array's own
+/// length -- `.a | has(-1)`, `has(-1000000)`, and `has(-9223372036854775808)`
+/// are all `true` on a 3-element array, and even `has(-1)` on an *empty*
+/// array is `true`. This repo's own earlier documentation ("negative
+/// indices are valid if abs(idx) <= len") was itself wrong, not just this
+/// function's implementation of it -- #880/#908's own tests asserting the
+/// bounded version were written without checking the real binary.
 fn index_in_array_bounds<S: EvalSemantics>(idx: i64, len: i64) -> bool {
     if S::NEGATIVE_INDEX_IN_HAS {
-        // yq behavior: negative indices are valid if abs(idx) <= len --
-        // `unsigned_abs`, not `abs`, since `i64::MIN.abs()` overflows
-        // (panics in debug, silently wraps back to a still-negative
-        // i64::MIN in release, #908 review).
-        if idx >= 0 {
-            idx < len
-        } else {
-            idx.unsigned_abs() <= len as u64
-        }
+        // yq behavior: any negative index is valid, unconditionally.
+        idx < 0 || idx < len
     } else {
         // jq behavior: only non-negative indices
         idx >= 0 && idx < len

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -49,7 +49,17 @@ pub trait EvalSemantics: Copy + Default {
     const OVERFLOW_WRAPS: bool;
     /// If true, division by zero returns infinity (yq). If false, returns error (jq).
     const DIV_BY_ZERO_IS_INFINITY: bool;
-    /// If true, has(-1) on arrays checks if abs(idx) <= len (yq). If false, only non-negative (jq).
+    /// If true (yq), `has()`/`in()`'s array-index arm accepts *any* negative
+    /// index unconditionally (magnitude doesn't matter, confirmed live
+    /// against real yq v4.53.3, #917 -- an earlier, narrower `abs(idx) <=
+    /// len` rule documented here was itself wrong, not just its
+    /// implementation), and their catch-all type-mismatch arm answers
+    /// `false` instead of erroring. If false (jq), only non-negative
+    /// indices are ever in bounds and a type mismatch still raises
+    /// `cannot_check_has`. These are two distinct policies bundled under
+    /// one const because real yq happens to relax both together; see
+    /// `has_type_mismatch_is_permissive` for the second policy accessed
+    /// under its own name.
     const NEGATIVE_INDEX_IN_HAS: bool;
     /// If true, `%` truncates float operands to integers (jq). If false, float modulo (yq).
     const MOD_TRUNCATES_FLOATS: bool;
@@ -78,7 +88,7 @@ pub trait EvalSemantics: Copy + Default {
 ///
 /// - Integer overflow converts to float
 /// - Division by zero returns error
-/// - has(-1) on arrays returns false
+/// - has(-1) on arrays returns false; has()/in() on a type mismatch errors
 #[derive(Debug, Clone, Copy, Default)]
 pub struct JqSemantics;
 
@@ -97,7 +107,9 @@ impl EvalSemantics for JqSemantics {
 ///
 /// - Integer overflow wraps
 /// - Division by zero returns infinity
-/// - has(-1) on arrays returns true (if abs(idx) <= len)
+/// - has(-1) on arrays returns true unconditionally (any negative index,
+///   regardless of magnitude); has()/in() on a type mismatch answers
+///   `false` instead of erroring
 #[derive(Debug, Clone, Copy, Default)]
 pub struct YqSemantics;
 
@@ -2989,14 +3001,22 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             };
             QueryResult::Owned(OwnedValue::Bool(in_bounds))
         }
-        _ if optional => QueryResult::None,
         // Real yq (mikefarah/yq, confirmed live against the pinned v4.53.3,
         // #917) never raises a type-mismatch error for `has()` at all --
         // `.a | has("x")` on an array, `has(0)` on an object, and `has(...)`
-        // on a bare scalar are all `false`, not an error. jq keeps erroring
-        // here (`Cannot check whether <container> has a <key> key`, which
-        // is correct and unaffected).
-        _ if S::NEGATIVE_INDEX_IN_HAS => QueryResult::Owned(OwnedValue::Bool(false)),
+        // on a bare scalar are all `false`, not an error. This has to come
+        // *before* the `optional` arm below: yq's `has()` never errors here
+        // regardless of `?`, so `isvalid(has("x"))` on an array (which
+        // forces `optional=true` unconditionally, see `builtin_isvalid`)
+        // must still report the expression as valid, not `None`/`false` as
+        // if it *would* have errored without `?` -- an earlier version of
+        // this arm sat after the `optional` check and made `isvalid` return
+        // `false` for a `has()` call yq itself never fails on (#917 review,
+        // caught via `isvalid(has("x"))` on `[1,2,3]` returning `false`
+        // instead of `true`). jq keeps erroring here (`Cannot check whether
+        // <container> has a <key> key`, which is correct and unaffected).
+        _ if has_type_mismatch_is_permissive::<S>() => QueryResult::Owned(OwnedValue::Bool(false)),
+        _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_check_has(
             type_name(&value),
             key_owned.type_name(),
@@ -3013,13 +3033,18 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// {a:9})]'` is `[true,true]`). `eval_owned_multi_keep_partial` evaluates
 /// `xs` fully (keeping every already-produced candidate if a later one
 /// errors/breaks/halts, #842's precedent), then each candidate is checked
-/// against the key in encounter order — a per-candidate type mismatch (e.g.
-/// a number where an object was needed) stops the loop exactly like `xs`
-/// itself erroring would, since real jq's `has($x)` raising mid-pipe has the
-/// same effect as `xs` raising: the rest of the generator never runs
-/// (confirmed: `"a" | in({b:1}, 5, {a:1})?` is only `false`, never reaching
-/// `{a:1}`'s `true` — `?`/`try` truncates the stream at the first error
-/// rather than skipping just that one output).
+/// against the key in encounter order. In jq mode, a per-candidate type
+/// mismatch (e.g. a number where an object was needed) stops the loop
+/// exactly like `xs` itself erroring would, since real jq's `has($x)`
+/// raising mid-pipe has the same effect as `xs` raising: the rest of the
+/// generator never runs (confirmed: `"a" | in({b:1}, 5, {a:1})?` is only
+/// `false`, never reaching `{a:1}`'s `true` — `?`/`try` truncates the
+/// stream at the first error rather than skipping just that one output).
+/// In yq mode this does *not* apply (#917): a type mismatch is never an
+/// error there, so the loop treats it as `false` and keeps going --
+/// `"a" | [in({b:1}, 5, {a:1})]` in yq mode is `[false, false, true]`,
+/// reaching `{a:1}`'s `true` past the mismatched `5`, unlike jq's
+/// early-truncating behavior above.
 ///
 /// **yq-mode caveat (#917):** `in(xs)` as a jq-style function-call filter is
 /// a succinctly-only convenience in yq mode, not a real-yq-compatible
@@ -3082,7 +3107,7 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // Real yq never raises a type-mismatch error here either --
             // see `builtin_has`'s matching arm (#917) for the
             // real-yq-verified rationale. jq keeps erroring.
-            _ if S::NEGATIVE_INDEX_IN_HAS => {
+            _ if has_type_mismatch_is_permissive::<S>() => {
                 results.push(OwnedValue::Bool(false));
             }
             _ => {
@@ -7997,12 +8022,35 @@ fn numeric_key_to_array_index<S: EvalSemantics>(key: &OwnedValue) -> Option<i64>
 /// bounded version were written without checking the real binary.
 fn index_in_array_bounds<S: EvalSemantics>(idx: i64, len: i64) -> bool {
     if S::NEGATIVE_INDEX_IN_HAS {
-        // yq behavior: any negative index is valid, unconditionally.
-        idx < 0 || idx < len
+        // yq behavior: any negative index is valid, unconditionally; a
+        // non-negative index still obeys the ordinary bound. `len` (an
+        // element count) is always >= 0 at both call sites, so `idx < len`
+        // alone already implies "any negative index passes" without a
+        // separate `idx < 0` disjunct -- `idx < 0 || idx < len` would be
+        // logically equivalent but reads as if the two arms independently
+        // do work, when only this one comparison is actually load-bearing.
+        idx < len
     } else {
         // jq behavior: only non-negative indices
         idx >= 0 && idx < len
     }
+}
+
+/// Does a `has()`/`in()` type mismatch (a key/container shape neither
+/// preceding match arm handles, e.g. a string key on an array) answer
+/// `false` instead of raising `cannot_check_has`? Real yq (mikefarah/yq,
+/// confirmed live against the pinned v4.53.3, #917) is fully permissive
+/// here; jq keeps erroring. Named and extracted separately from
+/// `S::NEGATIVE_INDEX_IN_HAS` itself -- even though it currently tracks the
+/// same const, this is a distinct policy (type-mismatch handling, not
+/// negative-index bounds) that real yq merely happens to relax alongside
+/// the other. Shared by `builtin_has` and `builtin_in`'s catch-all arms so
+/// the two can't silently drift the way `index_in_array_bounds`'s own
+/// bounds-check logic already did twice before its own extraction (see
+/// that function's doc comment, and CLAUDE.md's "Duplicated predicates
+/// diverge silently" insight from #106).
+fn has_type_mismatch_is_permissive<S: EvalSemantics>() -> bool {
+    S::NEGATIVE_INDEX_IN_HAS
 }
 
 /// Apply one resolved key to one target value.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10063,14 +10063,19 @@ fn test_m2_json_output_select_halt_writes_nothing_for_halted_doc() -> Result<()>
 /// #880/#917: `builtin_in`'s array-index arm has a yq-specific
 /// negative-index branch (`S::NEGATIVE_INDEX_IN_HAS`, unreachable via
 /// `succinctly jq`'s `JqSemantics`). #917's review corrected the rule this
-/// pins: real yq (confirmed live against the pinned v4.53.3) accepts *any*
-/// negative index unconditionally, regardless of magnitude vs. the array's
-/// own length -- #880's own version of this test asserted the bounded
-/// `abs(idx) <= len` rule this repo's docs used to (incorrectly) claim,
-/// written without checking the real binary. Confirmed: `-1 | in([1,2,3])`
-/// and `-4 | in([1,2,3])` (magnitude 4 > len 3) are both `true`;
-/// `2 | in([1,2,3])` is `true`; `5 | in([1,2,3])` is `false` (jq-shared,
-/// non-negative-only bound still applies on the positive side).
+/// pins: real yq accepts *any* negative index unconditionally, regardless
+/// of magnitude vs. the array's own length -- #880's own version of this
+/// test asserted the bounded `abs(idx) <= len` rule this repo's docs used
+/// to (incorrectly) claim, written without checking the real binary. Real
+/// yq itself has no `in(...)` call syntax at all (`builtin_in`'s own doc
+/// comment has the real-yq-verified detail), so the values below are
+/// checked via `succinctly yq`'s own binary, not real yq directly -- the
+/// oracle-verified claim is the *value* semantics (via `has($x)`'s
+/// desugared form, confirmed live against the pinned v4.53.3), not this
+/// `in(...)` invocation syntax. `-1 | in([1,2,3])` and `-4 | in([1,2,3])`
+/// (magnitude 4 > len 3) are both `true`; `2 | in([1,2,3])` is `true`;
+/// `5 | in([1,2,3])` is `false` (jq-shared, non-negative-only bound still
+/// applies on the positive side).
 #[test]
 fn test_builtin_in_yq_negative_index_880() -> Result<()> {
     let (out, code) = run_yq_stdin("in([1,2,3])", "-1", &[])?;
@@ -10095,11 +10100,12 @@ fn test_builtin_in_yq_negative_index_880() -> Result<()> {
 /// overflowed for `i64::MIN` -- a debug build panicked ("attempt to negate
 /// with overflow", exit 101), a release build silently wrapped back to a
 /// still-negative `i64::MIN`. #917 replaced the whole bounded-magnitude
-/// check with an unconditional `idx < 0` test (any negative index is
-/// simply always in range in real yq), which sidesteps the overflow
-/// concern entirely rather than needing `unsigned_abs()` to guard it --
-/// pinning that `i64::MIN` still doesn't panic and now correctly answers
-/// `true` (not `false`), matching every other negative magnitude.
+/// check with a plain `idx < len` comparison (any negative index is simply
+/// always in range in real yq, since `len` is never negative), which
+/// sidesteps the overflow concern entirely rather than needing
+/// `unsigned_abs()` to guard it -- pinning that `i64::MIN` still doesn't
+/// panic and now correctly answers `true` (not `false`), matching every
+/// other negative magnitude.
 #[test]
 fn test_builtin_in_and_has_yq_negative_index_i64_min_no_overflow_908() -> Result<()> {
     let (out, code) = run_yq_stdin("in([1,2,3])", "-9223372036854775808", &[])?;
@@ -10204,5 +10210,32 @@ fn test_builtin_in_yq_type_mismatch_never_errors_917() -> Result<()> {
     let (out, code) = run_yq_stdin("in(42)", r#""x""#, &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "false");
+    Ok(())
+}
+
+/// Review finding on #917: `builtin_has`'s "yq never errors on a type
+/// mismatch" arm originally sat *after* the pre-existing `_ if optional`
+/// arm, so it was unreachable whenever `optional` was true --
+/// `isvalid(EXPR)` forces `optional=true` unconditionally for its inner
+/// expression (`builtin_isvalid`), so `isvalid(has("x"))` on `[1,2,3]`
+/// returned `false` (as if `has("x")` *would* error without the forced
+/// `?`) instead of `true` (yq's `has()` never errors here at all, so the
+/// expression is valid). Fixed by moving the permissive arm before the
+/// `optional` check. `in()`'s equivalent per-candidate arm never had this
+/// bug (it doesn't have a separate `optional`-gated arm in its loop), pinned
+/// here too so the two stay symmetric.
+#[test]
+fn test_isvalid_has_yq_type_mismatch_is_valid_917() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#"isvalid(has("x"))"#, "[1,2,3]", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin("isvalid(has(0))", "{a: 1}", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin(r"isvalid(in(5))", r#""x""#, &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10060,17 +10060,17 @@ fn test_m2_json_output_select_halt_writes_nothing_for_halted_doc() -> Result<()>
     Ok(())
 }
 
-/// #880: `builtin_in`'s array-index arm has a yq-specific negative-index
-/// branch (`S::NEGATIVE_INDEX_IN_HAS`, unreachable via `succinctly jq`'s
-/// `JqSemantics`) -- yq treats a negative index as valid if
-/// `abs(idx) <= len`, unlike jq which only accepts non-negative indices.
-/// Also covers the same branch's non-negative sub-case under yq semantics
-/// specifically (the jq-mode non-negative case is covered separately by
-/// `test_builtin_in_array_index_880` in `src/jq/eval.rs`, which uses
-/// `JqSemantics` and so never reaches `NEGATIVE_INDEX_IN_HAS`'s branch at
-/// all). Confirmed against real yq: `-1 | in([1,2,3])` is `true` (in
-/// range), `-4 | in([1,2,3])` is `false` (out of range), `2 | in([1,2,3])`
-/// is `true`, `5 | in([1,2,3])` is `false`.
+/// #880/#917: `builtin_in`'s array-index arm has a yq-specific
+/// negative-index branch (`S::NEGATIVE_INDEX_IN_HAS`, unreachable via
+/// `succinctly jq`'s `JqSemantics`). #917's review corrected the rule this
+/// pins: real yq (confirmed live against the pinned v4.53.3) accepts *any*
+/// negative index unconditionally, regardless of magnitude vs. the array's
+/// own length -- #880's own version of this test asserted the bounded
+/// `abs(idx) <= len` rule this repo's docs used to (incorrectly) claim,
+/// written without checking the real binary. Confirmed: `-1 | in([1,2,3])`
+/// and `-4 | in([1,2,3])` (magnitude 4 > len 3) are both `true`;
+/// `2 | in([1,2,3])` is `true`; `5 | in([1,2,3])` is `false` (jq-shared,
+/// non-negative-only bound still applies on the positive side).
 #[test]
 fn test_builtin_in_yq_negative_index_880() -> Result<()> {
     let (out, code) = run_yq_stdin("in([1,2,3])", "-1", &[])?;
@@ -10079,7 +10079,7 @@ fn test_builtin_in_yq_negative_index_880() -> Result<()> {
 
     let (out, code) = run_yq_stdin("in([1,2,3])", "-4", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "false");
+    assert_eq!(out.trim(), "true");
 
     let (out, code) = run_yq_stdin("in([1,2,3])", "2", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
@@ -10092,23 +10092,23 @@ fn test_builtin_in_yq_negative_index_880() -> Result<()> {
 }
 
 /// Review finding on #908: `idx.abs()` in the negative-index branch above
-/// overflows for `i64::MIN` -- a debug build panics ("attempt to negate
-/// with overflow", exit 101 via `unwrap`/no catch), a release build
-/// silently wraps back to a still-negative `i64::MIN`, making
-/// `idx.abs() <= len` spuriously true. `idx.unsigned_abs()` (a `u64`,
-/// overflow-free for every `i64` including `MIN`) fixes both. A non-zero
-/// exit code here would mean either the panic or the wrong-answer shape
-/// resurfaced. `has(...)`'s identical, independently-duplicated branch is
-/// exercised too, since it shares this exact bug.
+/// overflowed for `i64::MIN` -- a debug build panicked ("attempt to negate
+/// with overflow", exit 101), a release build silently wrapped back to a
+/// still-negative `i64::MIN`. #917 replaced the whole bounded-magnitude
+/// check with an unconditional `idx < 0` test (any negative index is
+/// simply always in range in real yq), which sidesteps the overflow
+/// concern entirely rather than needing `unsigned_abs()` to guard it --
+/// pinning that `i64::MIN` still doesn't panic and now correctly answers
+/// `true` (not `false`), matching every other negative magnitude.
 #[test]
 fn test_builtin_in_and_has_yq_negative_index_i64_min_no_overflow_908() -> Result<()> {
     let (out, code) = run_yq_stdin("in([1,2,3])", "-9223372036854775808", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "false");
+    assert_eq!(out.trim(), "true");
 
     let (out, code) = run_yq_stdin("has(-9223372036854775808)", "[1,2,3]", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "false");
+    assert_eq!(out.trim(), "true");
     Ok(())
 }
 
@@ -10156,6 +10156,52 @@ fn test_builtin_in_yq_positive_float_index_never_matches_909() -> Result<()> {
     assert_eq!(out.trim(), "false");
 
     let (out, code) = run_yq_stdin("has(2.0)", "[1,2,3]", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}
+
+/// #917: real yq (confirmed live against the pinned v4.53.3) never raises a
+/// type-mismatch error for `has()` -- a string key on an array, a numeric
+/// key on an object, and any key at all on a bare scalar are all `false`,
+/// never `Cannot check whether <container> has a <key> key`. jq mode is
+/// unaffected by this fix and keeps erroring on the identical inputs --
+/// see `test_builtin_in_keeps_earlier_candidates_before_a_later_type_mismatch_error_880`
+/// in tests/jq_cli_tests.rs for that (pre-existing) coverage.
+#[test]
+fn test_builtin_has_yq_type_mismatch_never_errors_917() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#"has("x")"#, "[1,2,3]", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("has(0)", "{a: 1, b: 2}", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin(r#"has("x")"#, "42", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("has(0)", "42", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}
+
+/// Companion to the above for `in(xs)`, using the same real-yq-verified
+/// type-mismatch cases (`in()`'s own definition routes through the same
+/// per-candidate match arm as `has()`, #917).
+#[test]
+fn test_builtin_in_yq_type_mismatch_never_errors_917() -> Result<()> {
+    let (out, code) = run_yq_stdin("in([1,2,3])", r#""x""#, &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("in({a: 1, b: 2})", "0", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("in(42)", r#""x""#, &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "false");
     Ok(())


### PR DESCRIPTION
## Summary

Fixes three real-yq divergences in yq-mode `has()`/`in()`, all found and verified live against the pinned yq v4.53.3 oracle during #909's review:

1. **Negative-index bounds**: real yq accepts *any* negative integer key unconditionally, regardless of magnitude vs. the array's own length. This repo's own prior documented rule (`abs(idx) <= len`) was itself wrong, not just the implementation — `index_in_array_bounds`'s yq branch is now an unconditional `idx < 0 || idx < len`.
2. **Type-mismatch never errors**: real yq's `has()`/`in()` never raise a type-mismatch error — a string key on an array, a numeric key on an object, or `has()` on a bare scalar all answer `false`. jq mode is unaffected and keeps raising `cannot_check_has` (matches real jq).
3. **`in()` isn't real-yq syntax**: real yq's grammar has no `in(...)` construct at all (every invocation hits a lexer error). Documented this as a succinctly-only jq-compatibility convenience in yq mode via a doc comment on `builtin_in`, rather than changing behavior — there's no real-yq oracle for the call syntax itself, only for the desugared `has($x)` semantics it's built on.

Two pre-existing tests asserted the old, incorrect bounded negative-index rule — updated to the corrected, verified behavior. Added new coverage for the type-mismatch-never-errors fix in yq mode.

Fixes #917

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures; 5 unrelated transient failures from concurrent-build file-lock contention confirmed spurious via isolated re-run)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manually re-verified all corrected behaviors against real yq v4.53.3 and real jq 1.7.1