### PR TITLE
fix(jq): bare test(re) delegates to test(re; flags) instead of duplicating

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27320,6 +27320,47 @@ mod tests {
 
     #[cfg(feature = "regex")]
     #[test]
+    fn test_regex_bare_test_delegates_to_flagged_923() {
+        // #923: bare test(re) now delegates to builtin_test_with_flags
+        // instead of duplicating pattern/input fetch and regex build.
+        // Every case verified live against jq 1.7.1.
+
+        // Ordinary match/non-match, unaffected by the delegation.
+        query!(br#""abc""#, r#"test("abc")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b);
+            }
+        );
+        query!(br#""ABC""#, r#"test("abc")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(!b, "bare test() must stay case-sensitive (no flags)");
+            }
+        );
+
+        // Non-string pattern and non-string input error the same way as
+        // the flagged form (both route through the same shared checks now).
+        query!(br#""abc""#, r#"try test(5) catch "ERR""#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "ERR");
+            }
+        );
+        query!(b"5", r#"try test("abc") catch "ERR""#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "ERR");
+            }
+        );
+
+        // `?` suppresses a bad pattern with no output, matching
+        // test(re;flags)'s existing optional behavior.
+        query!(br#""abc""#, r#"[test("(")?]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert!(vs.is_empty());
+            }
+        );
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
     fn test_regex_flags_s_m_p() {
         // The #727 repro: jq's `s` (single-line mode) leaves dot NOT
         // matching newline.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6705,39 +6705,19 @@ fn build_regex(pattern: &str, flags: Option<&str>) -> Result<JqRegex, EvalError>
 }
 
 /// Builtin: test(re) - test if string matches the regex
+///
+/// jq defines this as `def test($re): test($re; null);` — delegate to the
+/// flags-aware implementation directly rather than duplicating its
+/// pattern/input fetch and regex build (#923), matching the established
+/// local convention `builtin_sub`/`builtin_gsub`/`builtin_splits`/
+/// `builtin_scan` already use post-#906/#913.
 #[cfg(feature = "regex")]
 fn builtin_test_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate the pattern
-    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
-        Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
-        Err(e) => return e.into(),
-    };
-
-    // Get the input string
-    let input = match &value {
-        StandardJson::String(s) => match s.as_str() {
-            Ok(cow) => cow.into_owned(),
-            Err(_) if optional => return QueryResult::None,
-            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
-        },
-        _ if optional => return QueryResult::None,
-        _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
-    };
-
-    // Build regex and test for a match
-    let re = match build_regex(&pattern, None) {
-        Ok(r) => r,
-        Err(_e) if optional => return QueryResult::None,
-        Err(e) => return e.into(),
-    };
-
-    QueryResult::Owned(OwnedValue::Bool(re.is_match(&input)))
+    builtin_test_with_flags::<W, S>(re_expr, None, value, optional)
 }
 
 /// Builtin: match(re) or match(re; flags) - return match object
@@ -7285,6 +7265,17 @@ fn builtin_test_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(e) => return e.into(),
     };
 
+    builtin_test_with_flags::<W, S>(re_expr, Some(&flags), value, optional)
+}
+
+/// Builtin: test(re) or test(re; flags) - test if string matches the regex
+#[cfg(feature = "regex")]
+fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    re_expr: &Expr,
+    flags: Option<&str>,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
     // Get the pattern
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
@@ -7305,7 +7296,7 @@ fn builtin_test_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     // Build regex with flags
-    let re = match build_regex(&pattern, Some(&flags)) {
+    let re = match build_regex(&pattern, flags) {
         Ok(r) => r,
         Err(_e) if optional => return QueryResult::None,
         Err(e) => return e.into(),


### PR DESCRIPTION
## Summary

`builtin_test_regex` (bare `test(re)`, no flags argument) had its own standalone body for pattern/input fetch and regex build, rather than delegating to `builtin_test_flags` with `flags: None` — the same duplication-instead-of-delegation anti-pattern #906/#913 fixed in `builtin_splits`/`builtin_scan`.

Unlike `scan`, this hadn't drifted into a wrong-output bug: `test()` only returns a boolean `is_match`, so there's no capture-group-shaped output to diverge on. Still a maintenance-drift risk worth closing off, since any future change to the flags-aware matching logic previously only landed in one of the two copies.

Extracted `builtin_test_with_flags` (taking `flags: Option<&str>`, matching `build_regex`'s own signature) as the shared implementation; both `builtin_test_regex` and `builtin_test_flags` are now thin wrappers around it, following the established local convention.

Fixes #923

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Diffed output against pinned real `jq` for bare `test()` (match/non-match, case-sensitivity, non-string pattern/input errors, `?`-optional on a bad pattern) and confirmed the flagged form is unaffected
- [x] Added `test_regex_bare_test_delegates_to_flagged_923` covering all of the above
