### PR TITLE
fix(jq): scan/gsub/sub/splits report jq's real non-string-pattern wording

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -24,14 +24,14 @@ For jq *feature* coverage rather than error wording, see
 
 ## Summary
 
-Measured against jq-1.7.1 over the 196 probes in
+Measured against jq-1.7.1 over the 197 probes in
 [`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv), through
 **both** evaluators — the full one (`src/jq/eval.rs`) and the generic one
 (`src/jq/eval_generic.rs`, which the CLI uses):
 
 | Dimension                                    | Result               | Meaning                                            |
 |----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **196/196 = 100.0%** | Byte-identical to jq                               |
+| **Message text** (both evaluators, verbatim) | **197/197 = 100.0%** | Byte-identical to jq                               |
 | **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
 | **Behaviour / parser gaps**                  | **0**                | succinctly does not raise the error at all         |
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -24,14 +24,14 @@ For jq *feature* coverage rather than error wording, see
 
 ## Summary
 
-Measured against jq-1.7.1 over the 192 probes in
+Measured against jq-1.7.1 over the 196 probes in
 [`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv), through
 **both** evaluators — the full one (`src/jq/eval.rs`) and the generic one
 (`src/jq/eval_generic.rs`, which the CLI uses):
 
 | Dimension                                    | Result               | Meaning                                            |
 |----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **192/192 = 100.0%** | Byte-identical to jq                               |
+| **Message text** (both evaluators, verbatim) | **196/196 = 100.0%** | Byte-identical to jq                               |
 | **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
 | **Behaviour / parser gaps**                  | **0**                | succinctly does not raise the error at all         |
 
@@ -78,6 +78,7 @@ iterate over number` for the same condition, and `cannot parse 'a' as number` ag
 | `<v> cannot be sorted, as it is not an array`            | `cannot_be_sorted`                            |
 | `<v> cannot be matched, as it is not a string`           | `cannot_be_matched`                           |
 | `<t> not a string or array`                              | `not_string_or_array`                         |
+| `<v> is not a string`                                    | `is_not_a_string`                             |
 | `<v> cannot be parsed as a number`                       | `cannot_parse_as_number`                      |
 | `<v> only strings can be parsed`                         | `only_strings_can_be_parsed`                  |
 | `<v> only strings have UTF-8 byte length`                | `no_utf8_byte_length`                         |

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -690,6 +690,21 @@ impl EvalError {
         Self::new(format!("{type_name} not a string or array"))
     }
 
+    /// `<v> is not a string`.
+    ///
+    /// jq's wording when scan/gsub/sub/splits's *pattern* argument isn't a
+    /// string — a genuinely different sentence from `not_string_or_array`
+    /// above (test/match/capture's own pattern-type error), not just a
+    /// stylistic variant: confirmed live against jq-1.7.1, `scan(1)` and
+    /// `sub(1; "y")` both raise `number (1) is not a string` (#926), where
+    /// `test(1)` raises `number not a string or array`. jq itself uses two
+    /// different sentences for the same conceptual failure depending on
+    /// which builtin family raises it, so both constructors stay separate
+    /// rather than merging into one.
+    pub fn is_not_a_string(value: &OwnedValue) -> Self {
+        Self::subject(value, "is not a string")
+    }
+
     /// `<v> cannot be parsed as a number`.
     pub fn cannot_parse_as_number(value: &OwnedValue) -> Self {
         Self::subject(value, "cannot be parsed as a number")

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27791,6 +27791,59 @@ mod tests {
 
     #[cfg(feature = "regex")]
     #[test]
+    fn test_regex_non_string_pattern_wording_matches_jq_per_family_926() {
+        // #926: jq itself uses two different sentences for a non-string
+        // *pattern* argument depending on which builtin family raises it.
+        // test/match/capture: "<type> not a string or array" (no value
+        // preview, allows arrays too). scan/gsub/sub/splits: "<v> is not a
+        // string" (with a value preview, arrays included). Every case here
+        // is verified live against jq 1.7.1.
+        for filter in ["test(1)", "match(1)", "capture(1)"] {
+            query!(br#""x""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "number not a string or array", "filter: {filter}");
+                }
+            );
+        }
+
+        for filter in ["scan(1)", "gsub(1; \"y\")", "sub(1; \"y\")", "splits(1)"] {
+            query!(br#""x""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "number (1) is not a string", "filter: {filter}");
+                }
+            );
+        }
+
+        // The flagged siblings share the same wording as their bare form.
+        query!(br#""x""#, r#"scan(1; "i")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (1) is not a string");
+            }
+        );
+
+        // Object/array previews render the same way `describe()` renders
+        // them elsewhere in this file (truncated JSON dump).
+        query!(br#""x""#, r#"scan({"a":1})"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, r#"object ({"a":1}) is not a string"#);
+            }
+        );
+        query!(br#""x""#, r"scan([1,2])",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "array ([1,2]) is not a string");
+            }
+        );
+
+        // split(re) has its own distinct jq wording, untouched by this fix.
+        query!(br#""x""#, r"split(1)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "split input and separator must be strings");
+            }
+        );
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
     fn test_regex_lookahead_unsupported() {
         // #703: jq's oniguruma backend supports lookahead (`(?=...)`), but
         // succinctly's `regex` crate does not implement lookaround at all —

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27793,28 +27793,18 @@ mod tests {
     #[test]
     fn test_regex_non_string_pattern_wording_matches_jq_per_family_926() {
         // #926: jq itself uses two different sentences for a non-string
-        // *pattern* argument depending on which builtin family raises it.
-        // test/match/capture: "<type> not a string or array" (no value
-        // preview, allows arrays too). scan/gsub/sub/splits: "<v> is not a
-        // string" (with a value preview, arrays included). Every case here
-        // is verified live against jq 1.7.1.
-        for filter in ["test(1)", "match(1)", "capture(1)"] {
-            query!(br#""x""#, filter,
-                QueryResult::Error(e) => {
-                    assert_eq!(e.message, "number not a string or array", "filter: {filter}");
-                }
-            );
-        }
+        // *pattern* argument depending on which builtin family raises it —
+        // test/match/capture's "<type> not a string or array" (no value
+        // preview) vs. scan/gsub/sub/splits/split(re;flags)'s "<v> is not a
+        // string" (with a value preview). Both bare forms are already
+        // pinned per-builtin, against both evaluators, by the oracle-driven
+        // `jq_error_message_parity` test via `tests/data/jq-error-probes.tsv`
+        // (test_arg_non_string, scan_arg_non_string, etc.) — this test only
+        // covers what that corpus can't: a flagged sibling sharing its bare
+        // form's wording, and the object/array value-preview rendering.
+        // Verified live against jq 1.7.1.
 
-        for filter in ["scan(1)", "gsub(1; \"y\")", "sub(1; \"y\")", "splits(1)"] {
-            query!(br#""x""#, filter,
-                QueryResult::Error(e) => {
-                    assert_eq!(e.message, "number (1) is not a string", "filter: {filter}");
-                }
-            );
-        }
-
-        // The flagged siblings share the same wording as their bare form.
+        // The flagged sibling shares its bare form's wording.
         query!(br#""x""#, r#"scan(1; "i")"#,
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "number (1) is not a string");
@@ -27831,13 +27821,6 @@ mod tests {
         query!(br#""x""#, r"scan([1,2])",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "array ([1,2]) is not a string");
-            }
-        );
-
-        // split(re) has its own distinct jq wording, untouched by this fix.
-        query!(br#""x""#, r"split(1)",
-            QueryResult::Error(e) => {
-                assert_eq!(e.message, "split input and separator must be strings");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7455,7 +7455,7 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "pattern")),
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 
@@ -7600,7 +7600,7 @@ fn builtin_scan_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "pattern")),
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 
@@ -7681,7 +7681,7 @@ fn builtin_split_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "pattern")),
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 
@@ -7750,7 +7750,7 @@ fn builtin_splits_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "pattern")),
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 

--- a/tests/data/jq-error-messages.tsv
+++ b/tests/data/jq-error-messages.tsv
@@ -152,6 +152,7 @@ scan_arg_non_string	scan(1)	"abc"	number (1) is not a string
 gsub_arg_non_string	gsub(1; "x")	"abc"	number (1) is not a string
 sub_arg_non_string	sub(1; "x")	"abc"	number (1) is not a string
 splits_arg_non_string	splits(1)	"abc"	number (1) is not a string
+split_regex_arg_non_string	split(1; "x")	"abc"	number (1) is not a string
 has_string_on_number	has("a")	1	Cannot check whether number has a string key
 has_string_on_array	has("a")	[1]	Cannot check whether array has a string key
 has_number_on_object	has(1)	{"a":1}	Cannot check whether object has a number key

--- a/tests/data/jq-error-messages.tsv
+++ b/tests/data/jq-error-messages.tsv
@@ -148,6 +148,10 @@ gsub_on_number	gsub("a";"b")	1	number (1) cannot be matched, as it is not a stri
 test_arg_non_string	test(1)	"abc"	number not a string or array
 match_arg_non_string	match(1)	"abc"	number not a string or array
 capture_arg_non_string	capture(1)	"abc"	number not a string or array
+scan_arg_non_string	scan(1)	"abc"	number (1) is not a string
+gsub_arg_non_string	gsub(1; "x")	"abc"	number (1) is not a string
+sub_arg_non_string	sub(1; "x")	"abc"	number (1) is not a string
+splits_arg_non_string	splits(1)	"abc"	number (1) is not a string
 has_string_on_number	has("a")	1	Cannot check whether number has a string key
 has_string_on_array	has("a")	[1]	Cannot check whether array has a string key
 has_number_on_object	has(1)	{"a":1}	Cannot check whether object has a number key

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -223,6 +223,12 @@ gsub_arg_non_string	gsub(1; "x")	"abc"
 sub_arg_non_string	sub(1; "x")	"abc"
 splits_arg_non_string	splits(1)	"abc"
 
+# split(re; flags) (the two-arg regex form, `Builtin::SplitRegex`) shares the
+# same "<v> is not a string" wording as its scan/gsub/sub/splits siblings —
+# distinct from split(sep) just below (`split_arg_non_string`), which has its
+# own "split input and separator must be strings" sentence instead.
+split_regex_arg_non_string	split(1; "x")	"abc"
+
 # ── Cannot check whether <t> has a <k> key ───────────────────────────────────
 has_string_on_number	has("a")	1
 has_string_on_array	has("a")	[1]

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -214,6 +214,15 @@ test_arg_non_string	test(1)	"abc"
 match_arg_non_string	match(1)	"abc"
 capture_arg_non_string	capture(1)	"abc"
 
+# `<v> is not a string` — scan/gsub/sub/splits's pattern argument, a
+# different wording again from `not_string_or_array` just above even though
+# it is the same conceptual failure (#926): jq itself uses two sentences for
+# a non-string pattern depending on which builtin family raises it.
+scan_arg_non_string	scan(1)	"abc"
+gsub_arg_non_string	gsub(1; "x")	"abc"
+sub_arg_non_string	sub(1; "x")	"abc"
+splits_arg_non_string	splits(1)	"abc"
+
 # ── Cannot check whether <t> has a <k> key ───────────────────────────────────
 has_string_on_number	has("a")	1
 has_string_on_array	has("a")	[1]

--- a/tests/jq_error_message_tests.rs
+++ b/tests/jq_error_message_tests.rs
@@ -45,6 +45,11 @@ const FEATURE_GATED: &[&str] = &[
     "gsub_on_number",
     "match_arg_non_string",
     "capture_arg_non_string",
+    "scan_arg_non_string",
+    "gsub_arg_non_string",
+    "sub_arg_non_string",
+    "splits_arg_non_string",
+    "split_regex_arg_non_string",
 ];
 
 struct Probe {


### PR DESCRIPTION
## Summary

`scan`/`gsub`/`sub`/`splits` used the generic `EvalError::type_error("string", "pattern")` for a non-string pattern argument, producing `"expected string, got pattern"` — a message that doesn't even substitute the actual runtime type, and doesn't match real jq's wording at all.

```
$ echo '"x"' | jq -c 'try sub(1; "y") catch .'
"number (1) is not a string"
$ echo '"x"' | succinctly jq -c 'try sub(1; "y") catch .'
"expected string, got pattern"
```

Verified live against jq-1.7.1: jq uses **two different sentences** for a non-string pattern depending on the builtin family. `test`/`match`/`capture` report `"<type> not a string or array"` (already correct here, via `not_string_or_array`). `scan`/`gsub`/`sub`/`splits` instead report `"<v> is not a string"` (with a value preview) — added `EvalError::is_not_a_string` for this second family and switched all four call sites to it. `split(re)` has its own distinct jq wording (`"split input and separator must be strings"`) and is untouched.

Extended `tests/data/jq-error-probes.tsv` with the four missing probes — `scan`/`gsub`/`sub`/`splits`'s non-string-pattern case existed for `test`/`match`/`capture` already, but not for this family, which is the exact gap that let this wording drift go undetected — and regenerated `jq-error-messages.tsv` from the pinned jq oracle. Updated `docs/compliance/jq/limitations.md`'s asserted probe count (192 → 196), which the test suite itself asserts against.

Found by `/code-review` on #925 — three independent angles (Reuse, Altitude, Simplification) converged on the underlying duplication between `test`'s implementation and its siblings; digging into *why* it mattered (rather than just deduping) surfaced this live wording bug.

Fixes #926

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo test --features cli,regex --test jq_error_message_tests` (196/196 probes match jq, including the 4 new ones)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Diffed output against pinned real `jq` for `scan`/`gsub`/`sub`/`splits` (bare and flagged) with a number/object/array pattern, and confirmed `test`/`match`/`capture`/`split` are unaffected
- [x] Added `test_regex_non_string_pattern_wording_matches_jq_per_family_926` covering all of the above
