### PR TITLE
test(cli): pin flow-style preservation under a bare-dash-deferred value (#847)

### DIFF
--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1057,6 +1057,29 @@ fn test_bare_dash_alone_flow_mapping_value_preserves_flow_style_847() -> Result<
     Ok(())
 }
 
+/// #847: the `--slurp` fast path (`stream_yaml_sequence`) is a separate code
+/// path from `stream_yaml_document`'s `Sequence` arm exercised by the tests
+/// above - mirrors the #835 slurp test's rationale for the same reason.
+/// Matches real `yq` v4.53.3 (`eval-all '[.]' -`).
+#[test]
+fn test_bare_dash_alone_flow_sequence_value_preserves_flow_style_survives_slurp_847() -> Result<()>
+{
+    let (output, code) = run_yq_stdin(".", "-\n  [1, 2]\n", &["--slurp"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- - [1, 2]\n");
+    Ok(())
+}
+
+/// #847: same as above, for a flow-style *mapping* value under `--slurp`.
+/// Matches real `yq` v4.53.3.
+#[test]
+fn test_bare_dash_alone_flow_mapping_value_preserves_flow_style_survives_slurp_847() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "-\n  {a: 1, b: 2}\n", &["--slurp"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- - {a: 1, b: 2}\n");
+    Ok(())
+}
+
 /// #478: `stream_yaml_sequence`'s block-style rendering has a container vs.
 /// scalar branch per slurped item (mirroring `stream_yaml_value`'s `Sequence`
 /// arm); the tests above only slurp mapping documents, which always take the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1033,6 +1033,30 @@ fn test_bare_dash_alone_mapping_value_survives_slurp_835() -> Result<()> {
     Ok(())
 }
 
+/// #847: a block-sequence item whose value is a *flow*-style sequence,
+/// written as a bare `-` on its own line followed by the indented flow
+/// value on the next line, must preserve the source's flow style rather
+/// than re-serializing in block style. Distinct from the #835 tests above,
+/// which all use block-style sources for the deferred value. Matches real
+/// `yq` v4.53.3.
+#[test]
+fn test_bare_dash_alone_flow_sequence_value_preserves_flow_style_847() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "-\n  [1, 2]\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- [1, 2]\n");
+    Ok(())
+}
+
+/// #847: same as above, for a flow-style *mapping* value. Matches real `yq`
+/// v4.53.3.
+#[test]
+fn test_bare_dash_alone_flow_mapping_value_preserves_flow_style_847() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "-\n  {a: 1, b: 2}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- {a: 1, b: 2}\n");
+    Ok(())
+}
+
 /// #478: `stream_yaml_sequence`'s block-style rendering has a container vs.
 /// scalar branch per slurped item (mirroring `stream_yaml_value`'s `Sequence`
 /// arm); the tests above only slurp mapping documents, which always take the


### PR DESCRIPTION
## Summary

- #847 describes a block-sequence item whose value is a *flow*-style mapping/sequence, written as a bare `-` on its own line followed by the indented flow value on the next line, allegedly re-serializing in block style instead of preserving flow style.
- Verified directly against real `yq` v4.53.3: both repro cases already match on current `main` — this is already fixed (likely a side effect of #835's `resolve_bare_seq_item` fix, which routes the `style()` lookup through the resolved value cursor rather than the wrapper).
- The existing #835 regression tests (`test_bare_dash_alone_mapping_value_not_truncated_835`, `test_bare_dash_alone_sequence_value_renders_compact_835`, etc.) only cover **block-style** sources for the deferred value — none exercise the flow-style case #847 actually describes, so this real fix had no regression coverage.
- Adds two tests pinning the correct flow-style output for both container kinds and closes the issue.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output directly against pinned real `yq` v4.53.3 for both repro cases before writing the tests
- [x] `omni-dev git commit message lint`

Closes #847