### PR TITLE
fix(jq): report jq's real wording for a non-string regex flags argument

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -24,14 +24,14 @@ For jq *feature* coverage rather than error wording, see
 
 ## Summary
 
-Measured against jq-1.7.1 over the 197 probes in
+Measured against jq-1.7.1 over the 205 probes in
 [`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv), through
 **both** evaluators — the full one (`src/jq/eval.rs`) and the generic one
 (`src/jq/eval_generic.rs`, which the CLI uses):
 
 | Dimension                                    | Result               | Meaning                                            |
 |----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **197/197 = 100.0%** | Byte-identical to jq                               |
+| **Message text** (both evaluators, verbatim) | **205/205 = 100.0%** | Byte-identical to jq                               |
 | **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
 | **Behaviour / parser gaps**                  | **0**                | succinctly does not raise the error at all         |
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6779,21 +6779,26 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern
+    // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
+    // flags-eval block below — `optional` is never forced `true` reaching a
+    // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
 
-    // Get the flags, now that the pattern is known valid
+    // Get the flags, now that the pattern is known valid. No `Ok(_) if
+    // optional` guard here: `optional` is only ever forced `true` for the
+    // *final* step of `.[EXPR]?`/`.[S:E]?` (see `Expr::Optional`'s dispatch
+    // in `eval_single`, #693) — a nested `Call` like this one never sees it,
+    // so a bare `?` suppresses this error via the ancestor `eval_try`'s
+    // catch, not locally. Confirmed dead: 0 coverage hits pre- and post-#928.
     let flags = match flags_expr {
         None => None,
         Some(fe) => match result_to_owned(eval_single::<W, S>(fe, value.clone(), optional)) {
             Ok(OwnedValue::String(s)) => Some(s),
             Ok(OwnedValue::Null) => Some(String::new()),
-            Ok(_) if optional => return QueryResult::None,
             Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
             Err(e) => return e.into(),
         },
@@ -7340,21 +7345,26 @@ fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern
+    // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
+    // flags-eval block below — `optional` is never forced `true` reaching a
+    // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
 
-    // Get the flags, now that the pattern is known valid
+    // Get the flags, now that the pattern is known valid. No `Ok(_) if
+    // optional` guard here: `optional` is only ever forced `true` for the
+    // *final* step of `.[EXPR]?`/`.[S:E]?` (see `Expr::Optional`'s dispatch
+    // in `eval_single`, #693) — a nested `Call` like this one never sees it,
+    // so a bare `?` suppresses this error via the ancestor `eval_try`'s
+    // catch, not locally. Confirmed dead: 0 coverage hits pre- and post-#928.
     let flags = match flags_expr {
         None => None,
         Some(fe) => match result_to_owned(eval_single::<W, S>(fe, value.clone(), optional)) {
             Ok(OwnedValue::String(s)) => Some(s),
             Ok(OwnedValue::Null) => Some(String::new()),
-            Ok(_) if optional => return QueryResult::None,
             Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
             Err(e) => return e.into(),
         },
@@ -7416,21 +7426,26 @@ fn builtin_capture_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern
+    // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
+    // flags-eval block below — `optional` is never forced `true` reaching a
+    // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
 
-    // Get the flags, now that the pattern is known valid
+    // Get the flags, now that the pattern is known valid. No `Ok(_) if
+    // optional` guard here: `optional` is only ever forced `true` for the
+    // *final* step of `.[EXPR]?`/`.[S:E]?` (see `Expr::Optional`'s dispatch
+    // in `eval_single`, #693) — a nested `Call` like this one never sees it,
+    // so a bare `?` suppresses this error via the ancestor `eval_try`'s
+    // catch, not locally. Confirmed dead: 0 coverage hits pre- and post-#928.
     let flags = match flags_expr {
         None => None,
         Some(fe) => match result_to_owned(eval_single::<W, S>(fe, value.clone(), optional)) {
             Ok(OwnedValue::String(s)) => Some(s),
             Ok(OwnedValue::Null) => Some(String::new()),
-            Ok(_) if optional => return QueryResult::None,
             Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
             Err(e) => return e.into(),
         },
@@ -7514,21 +7529,26 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern
+    // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
+    // flags-eval block below — `optional` is never forced `true` reaching a
+    // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
         Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 
-    // Get the flags, now that the pattern is known valid
+    // Get the flags, now that the pattern is known valid. No `Ok(_) if
+    // optional` guard here: `optional` is only ever forced `true` for the
+    // *final* step of `.[EXPR]?`/`.[S:E]?` (see `Expr::Optional`'s dispatch
+    // in `eval_single`, #693) — a nested `Call` like this one never sees it,
+    // so a bare `?` suppresses this error via the ancestor `eval_try`'s
+    // catch, not locally. Confirmed dead: 0 coverage hits pre- and post-#928.
     let flags = match flags_expr {
         None => None,
         Some(fe) => match result_to_owned(eval_single::<W, S>(fe, value.clone(), optional)) {
             Ok(OwnedValue::String(s)) => Some(s),
             Ok(OwnedValue::Null) => Some(String::new()),
-            Ok(_) if optional => return QueryResult::None,
             Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
             Err(e) => return e.into(),
         },
@@ -7678,10 +7698,11 @@ fn builtin_gsub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let global_flags = format!("{}g", flags.unwrap_or(""));
 
-    // Get the pattern
+    // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
+    // flags-eval block in `builtin_match`/`builtin_test_with_flags`/etc. —
+    // `optional` is never forced `true` reaching a nested `Call` like this.
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
         Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
@@ -28100,14 +28121,20 @@ mod tests {
         }
 
         // ? still suppresses a non-string flags value, for every builtin
-        // whose flags-eval arm this PR touched (not just gsub — each has
-        // its own `Ok(_) if optional` guard, which needs its own coverage).
+        // whose flags-eval this PR touched (not just gsub). The suppression
+        // happens one level up, in the ancestor `eval_try` that a bare `?`
+        // installs (#693) — these builtins' own flags/pattern-eval match
+        // arms have no local `optional`-guarded case to take instead (see
+        // the "No `Ok(_) if optional` guard" comments in `builtin_match`
+        // and `builtin_gsub_with_flags`), so this is pinning the
+        // end-to-end behavior, not a specific branch.
         for filter in [
             r#"[match("a"; 1)?]"#,
             r#"[capture("(?<a>a)"; 1)?]"#,
             r#"[sub("a"; "b"; 1)?]"#,
             r#"[test("a"; 1)?]"#,
             r#"[gsub("a"; "b"; 1)?]"#,
+            r#"[gsub(1; "b"; "i")?]"#,
         ] {
             query!(br#""x""#, filter,
                 QueryResult::Owned(OwnedValue::Array(vs)) => {
@@ -28120,15 +28147,6 @@ mod tests {
         query!(br#""abc""#, r#"scan("a"; null)"#,
             QueryResult::ManyOwned(matches) => {
                 assert_eq!(matches.len(), 1);
-            }
-        );
-
-        // gsub's own pattern-eval arm (added by this PR — see
-        // builtin_gsub_with_flags) also needs its `?`-suppression covered
-        // separately from the flags-eval arm above.
-        query!(br#""x""#, r#"[gsub(1; "b"; "i")?]"#,
-            QueryResult::Owned(OwnedValue::Array(vs)) => {
-                assert!(vs.is_empty());
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6769,10 +6769,13 @@ fn builtin_test_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: match(re) or match(re; flags) - return match object
+///
+/// Evaluates `re_expr` before `flags_expr` — see `builtin_test_with_flags`'s
+/// doc comment for why this order matters (#928).
 #[cfg(feature = "regex")]
 fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
-    flags: Option<&str>,
+    flags_expr: Option<&Expr>,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
@@ -6783,6 +6786,19 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
+
+    // Get the flags, now that the pattern is known valid
+    let flags = match flags_expr {
+        None => None,
+        Some(fe) => match result_to_owned(eval_single::<W, S>(fe, value.clone(), optional)) {
+            Ok(OwnedValue::String(s)) => Some(s),
+            Ok(OwnedValue::Null) => Some(String::new()),
+            Ok(_) if optional => return QueryResult::None,
+            Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
+            Err(e) => return e.into(),
+        },
+    };
+    let flags = flags.as_deref();
 
     // Get the input string
     let input = match &value {
@@ -7304,23 +7320,23 @@ fn builtin_test_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate the flags expression
-    let flags = match result_to_owned(eval_single::<W, S>(flags_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(OwnedValue::Null) => String::new(),
-        Ok(_) if optional => return QueryResult::None,
-        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
-        Err(e) => return e.into(),
-    };
-
-    builtin_test_with_flags::<W, S>(re_expr, Some(&flags), value, optional)
+    builtin_test_with_flags::<W, S>(re_expr, Some(flags_expr), value, optional)
 }
 
 /// Builtin: test(re) or test(re; flags) - test if string matches the regex
+///
+/// Evaluates `re_expr` before `flags_expr` — jq validates the pattern
+/// argument first, so when both are invalid it's the pattern's error that
+/// surfaces (confirmed live: `test(1;2)` -> `"number (1) is not a string"`,
+/// naming the pattern, not the flags). A pre-#928 version of this evaluated
+/// flags first, which — now that the flags-argument error uses real jq
+/// wording instead of a placeholder — would have silently blamed the wrong
+/// operand, or skipped a side-effecting pattern expression's `error()`
+/// entirely (`sub(error("P");"b";2)` must raise `"P"`, not the flags error).
 #[cfg(feature = "regex")]
 fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
-    flags: Option<&str>,
+    flags_expr: Option<&Expr>,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
@@ -7331,6 +7347,19 @@ fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
+
+    // Get the flags, now that the pattern is known valid
+    let flags = match flags_expr {
+        None => None,
+        Some(fe) => match result_to_owned(eval_single::<W, S>(fe, value.clone(), optional)) {
+            Ok(OwnedValue::String(s)) => Some(s),
+            Ok(OwnedValue::Null) => Some(String::new()),
+            Ok(_) if optional => return QueryResult::None,
+            Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
+            Err(e) => return e.into(),
+        },
+    };
+    let flags = flags.as_deref();
 
     // Get the input string
     let input = match &value {
@@ -7362,16 +7391,7 @@ fn builtin_match_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate the flags expression
-    let flags = match result_to_owned(eval_single::<W, S>(flags_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(OwnedValue::Null) => String::new(),
-        Ok(_) if optional => return QueryResult::None,
-        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
-        Err(e) => return e.into(),
-    };
-
-    builtin_match::<W, S>(re_expr, Some(&flags), value, optional)
+    builtin_match::<W, S>(re_expr, Some(flags_expr), value, optional)
 }
 
 /// Builtin: capture(re; flags) - capture with flags expression
@@ -7382,23 +7402,17 @@ fn builtin_capture_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate the flags expression
-    let flags = match result_to_owned(eval_single::<W, S>(flags_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(OwnedValue::Null) => String::new(),
-        Ok(_) if optional => return QueryResult::None,
-        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
-        Err(e) => return e.into(),
-    };
-
-    builtin_capture_with_flags::<W, S>(re_expr, Some(&flags), value, optional)
+    builtin_capture_with_flags::<W, S>(re_expr, Some(flags_expr), value, optional)
 }
 
 /// Builtin: capture(re) or capture(re; flags) - capture named groups
+///
+/// Evaluates `re_expr` before `flags_expr` — see `builtin_test_with_flags`'s
+/// doc comment for why this order matters (#928).
 #[cfg(feature = "regex")]
 fn builtin_capture_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
-    flags: Option<&str>,
+    flags_expr: Option<&Expr>,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
@@ -7409,6 +7423,19 @@ fn builtin_capture_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
+
+    // Get the flags, now that the pattern is known valid
+    let flags = match flags_expr {
+        None => None,
+        Some(fe) => match result_to_owned(eval_single::<W, S>(fe, value.clone(), optional)) {
+            Ok(OwnedValue::String(s)) => Some(s),
+            Ok(OwnedValue::Null) => Some(String::new()),
+            Ok(_) if optional => return QueryResult::None,
+            Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
+            Err(e) => return e.into(),
+        },
+    };
+    let flags = flags.as_deref();
 
     // Get the input string
     let input = match &value {
@@ -7472,24 +7499,18 @@ fn builtin_sub_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate the flags expression
-    let flags = match result_to_owned(eval_single::<W, S>(flags_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(OwnedValue::Null) => String::new(),
-        Ok(_) if optional => return QueryResult::None,
-        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
-        Err(e) => return e.into(),
-    };
-
-    builtin_sub_with_flags::<W, S>(re_expr, replacement_expr, Some(&flags), value, optional)
+    builtin_sub_with_flags::<W, S>(re_expr, replacement_expr, Some(flags_expr), value, optional)
 }
 
 /// Builtin: sub(re; replacement) or sub(re; replacement; flags) - replace first match
+///
+/// Evaluates `re_expr` before `flags_expr` — see `builtin_test_with_flags`'s
+/// doc comment for why this order matters (#928).
 #[cfg(feature = "regex")]
 fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
     replacement_expr: &Expr,
-    flags: Option<&str>,
+    flags_expr: Option<&Expr>,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
@@ -7501,6 +7522,43 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(e) => return e.into(),
     };
 
+    // Get the flags, now that the pattern is known valid
+    let flags = match flags_expr {
+        None => None,
+        Some(fe) => match result_to_owned(eval_single::<W, S>(fe, value.clone(), optional)) {
+            Ok(OwnedValue::String(s)) => Some(s),
+            Ok(OwnedValue::Null) => Some(String::new()),
+            Ok(_) if optional => return QueryResult::None,
+            Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
+            Err(e) => return e.into(),
+        },
+    };
+
+    sub_with_resolved_pattern::<W, S>(
+        &pattern,
+        replacement_expr,
+        flags.as_deref(),
+        value,
+        optional,
+    )
+}
+
+/// The rest of `sub`/`gsub`'s work once the pattern string and flags string
+/// are both already resolved — input fetch, regex build, and the single-vs-
+/// global replace logic. Split out so `builtin_gsub_with_flags` (whose
+/// flags value is a synthesized `flags + "g"` string, not a user
+/// expression, and whose own flags-before-pattern evaluation order already
+/// matches jq's — see its own doc comment) can reuse this without going
+/// through `builtin_sub_with_flags`'s pattern-first evaluation, which only
+/// applies when `flags_expr` is a real, independently-evaluated argument.
+#[cfg(feature = "regex")]
+fn sub_with_resolved_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    pattern: &str,
+    replacement_expr: &Expr,
+    flags: Option<&str>,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
     // Get the input string
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
@@ -7513,7 +7571,7 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     // Build regex
-    let re = match build_regex(&pattern, flags) {
+    let re = match build_regex(pattern, flags) {
         Ok(r) => r,
         Err(_e) if optional => return QueryResult::None,
         Err(e) => return e.into(),
@@ -7595,14 +7653,21 @@ fn builtin_gsub_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Builtin: gsub(re; replacement) or gsub(re; replacement; flags) - replace all matches
 ///
 /// jq defines this as `sub($re; str; flags + "g")` — delegate straight into
-/// `builtin_sub_with_flags` instead of duplicating its pattern/input/
+/// `sub_with_resolved_pattern` instead of duplicating its pattern/input/
 /// regex-build boilerplate a second time. `'g'` is a no-op in
 /// `build_regex`'s own flag parser (it only ever affects
-/// `builtin_sub_with_flags`'s choice between its single-match and
+/// `sub_with_resolved_pattern`'s choice between its single-match and
 /// `stitch_replacements_evaluated` global-match arms, never the compiled
 /// pattern itself), so forcing it into `flags` here reliably selects the
 /// global arm — i.e. gsub's unconditional "replace every match" behavior —
 /// the same way an explicit `"g"` flag does for `sub`.
+///
+/// Deliberately does *not* route through `builtin_sub_with_flags`'s
+/// pattern-first evaluation order: `flags` here is a `builtin_gsub_flags`-
+/// synthesized `flags + "g"` string, not an independent user expression, and
+/// jq's own flags-before-pattern order for gsub (confirmed live:
+/// `gsub(1;"b";2)` blames the flags, not the pattern) already matches what
+/// evaluating flags in the caller and pattern here produces.
 #[cfg(feature = "regex")]
 fn builtin_gsub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
@@ -7612,8 +7677,17 @@ fn builtin_gsub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     let global_flags = format!("{}g", flags.unwrap_or(""));
-    builtin_sub_with_flags::<W, S>(
-        re_expr,
+
+    // Get the pattern
+    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
+        Ok(OwnedValue::String(s)) => s,
+        Ok(_) if optional => return QueryResult::None,
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
+        Err(e) => return e.into(),
+    };
+
+    sub_with_resolved_pattern::<W, S>(
+        &pattern,
         replacement_expr,
         Some(&global_flags),
         value,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28115,6 +28115,60 @@ mod tests {
 
     #[cfg(feature = "regex")]
     #[test]
+    fn test_regex_test_match_capture_sub_evaluate_pattern_before_flags_928() {
+        // #928 (review follow-up): test/match/capture/sub must evaluate the
+        // *pattern* argument before the *flags* argument, matching jq. A
+        // pre-fix version evaluated flags first, which — once the flags
+        // error stopped being an obviously-bogus placeholder and started
+        // looking like real jq wording (see #926) — silently blamed the
+        // wrong operand when both arguments were invalid, and skipped a
+        // side-effecting pattern expression's error() entirely. Every case
+        // verified live against jq 1.7.1. gsub/scan/split/splits are
+        // deliberately excluded: jq's own internal order for those already
+        // evaluates flags first (confirmed live), so no reordering was
+        // needed or made there.
+        // test/match/capture's pattern-check has no value preview
+        // ("<type> not a string or array" — a separate, pre-existing
+        // wording gap unrelated to evaluation order, tracked in #937), so
+        // the strongest same-shape check here is simply that it's *this*
+        // sentence (the pattern-argument one) that wins, not the flags-
+        // argument "is not a string" sentence #928 just added.
+        for filter in ["test(1; 2)", "match(1; 2)", "capture(1; 2)"] {
+            query!(br#""abc""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(
+                        e.message, "number not a string or array",
+                        "filter: {filter}"
+                    );
+                }
+            );
+        }
+
+        // sub's pattern-check already carries a value preview (#926), so
+        // this one *does* confirm the pattern's own value (1) wins over the
+        // flags' value (2).
+        query!(br#""abc""#, r#"sub(1; "b"; 2)"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (1) is not a string");
+            }
+        );
+
+        // A side-effecting pattern expression's error() must propagate,
+        // not get silently skipped in favor of the flags check.
+        query!(br#""abc""#, r#"sub(error("PATTERN_ERR"); "b"; 2)"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "PATTERN_ERR");
+            }
+        );
+        query!(br#""abc""#, r#"test(error("PATTERN_ERR"); error("FLAGS_ERR"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "PATTERN_ERR");
+            }
+        );
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
     fn test_regex_lookahead_unsupported() {
         // #703: jq's oniguruma backend supports lookahead (`(?=...)`), but
         // succinctly's `regex` crate does not implement lookaround at all —

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7309,7 +7309,7 @@ fn builtin_test_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::String(s)) => s,
         Ok(OwnedValue::Null) => String::new(),
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "flags")),
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 
@@ -7367,7 +7367,7 @@ fn builtin_match_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::String(s)) => s,
         Ok(OwnedValue::Null) => String::new(),
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "flags")),
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 
@@ -7387,7 +7387,7 @@ fn builtin_capture_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::String(s)) => s,
         Ok(OwnedValue::Null) => String::new(),
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "flags")),
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 
@@ -7477,7 +7477,7 @@ fn builtin_sub_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::String(s)) => s,
         Ok(OwnedValue::Null) => String::new(),
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "flags")),
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Err(e) => return e.into(),
     };
 
@@ -7574,7 +7574,18 @@ fn builtin_gsub_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::String(s)) => s,
         Ok(OwnedValue::Null) => String::new(),
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "flags")),
+        // jq builds this internally as `flags + "g"` (appending the global
+        // flag), so a non-string flags value hits jq's own `+` operator
+        // type check first — "<v> and \"g\" cannot be added", not a
+        // string-type error. Verified live: gsub(re;str;1) on any input ->
+        // "number (1) and string (\"g\") cannot be added".
+        Ok(v) => {
+            return QueryResult::Error(EvalError::binary_op(
+                &v,
+                &OwnedValue::String("g".to_string()),
+                BinOp::Add,
+            ))
+        }
         Err(e) => return e.into(),
     };
 
@@ -7623,7 +7634,18 @@ fn builtin_scan_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::String(s)) => s,
         Ok(OwnedValue::Null) => String::new(),
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "flags")),
+        // jq builds this internally as `"g" + flags` (prepending the
+        // global flag, unlike gsub's append) — see #730's g-prepend-vs-
+        // append finding. A non-string flags value hits jq's own `+`
+        // operator type check first, with "g" on the left. Verified live:
+        // scan(re;1) -> "string (\"g\") and number (1) cannot be added".
+        Ok(v) => {
+            return QueryResult::Error(EvalError::binary_op(
+                &OwnedValue::String("g".to_string()),
+                &v,
+                BinOp::Add,
+            ))
+        }
         Err(e) => return e.into(),
     };
 
@@ -7715,7 +7737,15 @@ fn builtin_split_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::String(s)) => s,
         Ok(OwnedValue::Null) => String::new(),
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "flags")),
+        // Same "g" + flags concatenation as scan/splits — verified live:
+        // split(re;1) -> "string (\"g\") and number (1) cannot be added".
+        Ok(v) => {
+            return QueryResult::Error(EvalError::binary_op(
+                &OwnedValue::String("g".to_string()),
+                &v,
+                BinOp::Add,
+            ))
+        }
         Err(e) => return e.into(),
     };
 
@@ -7773,7 +7803,15 @@ fn builtin_splits_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::String(s)) => s,
         Ok(OwnedValue::Null) => String::new(),
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "flags")),
+        // Same "g" + flags concatenation as scan/split — verified live:
+        // splits(re;1) -> "string (\"g\") and number (1) cannot be added".
+        Ok(v) => {
+            return QueryResult::Error(EvalError::binary_op(
+                &OwnedValue::String("g".to_string()),
+                &v,
+                BinOp::Add,
+            ))
+        }
         Err(e) => return e.into(),
     };
 
@@ -28013,10 +28051,12 @@ mod tests {
             }
         );
 
-        // Non-string, non-null flags must still error.
+        // Non-string, non-null flags must still error — #928: jq's real
+        // wording here ("<v> is not a string"), not the old placeholder
+        // "expected string, got flags" this loosely matched before.
         query!(br#""abc""#, r#"test("a"; 5)"#,
             QueryResult::Error(e) => {
-                assert!(e.to_string().contains("flags"));
+                assert_eq!(e.message, "number (5) is not a string");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28099,16 +28099,36 @@ mod tests {
             );
         }
 
-        // ? still suppresses a non-string flags value, and null is still
-        // treated as no flags (untouched by this fix).
-        query!(br#""x""#, r#"[gsub("a"; "b"; 1)?]"#,
-            QueryResult::Owned(OwnedValue::Array(vs)) => {
-                assert!(vs.is_empty());
-            }
-        );
+        // ? still suppresses a non-string flags value, for every builtin
+        // whose flags-eval arm this PR touched (not just gsub — each has
+        // its own `Ok(_) if optional` guard, which needs its own coverage).
+        for filter in [
+            r#"[match("a"; 1)?]"#,
+            r#"[capture("(?<a>a)"; 1)?]"#,
+            r#"[sub("a"; "b"; 1)?]"#,
+            r#"[test("a"; 1)?]"#,
+            r#"[gsub("a"; "b"; 1)?]"#,
+        ] {
+            query!(br#""x""#, filter,
+                QueryResult::Owned(OwnedValue::Array(vs)) => {
+                    assert!(vs.is_empty(), "filter: {filter}");
+                }
+            );
+        }
+
+        // null is still treated as no flags (untouched by this fix).
         query!(br#""abc""#, r#"scan("a"; null)"#,
             QueryResult::ManyOwned(matches) => {
                 assert_eq!(matches.len(), 1);
+            }
+        );
+
+        // gsub's own pattern-eval arm (added by this PR — see
+        // builtin_gsub_with_flags) also needs its `?`-suppression covered
+        // separately from the flags-eval arm above.
+        query!(br#""x""#, r#"[gsub(1; "b"; "i")?]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert!(vs.is_empty());
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27985,6 +27985,62 @@ mod tests {
 
     #[cfg(feature = "regex")]
     #[test]
+    fn test_regex_non_string_flags_wording_matches_jq_per_family_928() {
+        // #928: the *flags* argument (not the pattern) splits into the same
+        // two families as #926's pattern-argument fix, plus a third
+        // wording scan/gsub/split/splits share: jq builds their internal
+        // global-flag string via concatenation (flags + "g" or "g" +
+        // flags) *before* type-checking, so a non-string flags value hits
+        // jq's own `+` operator error instead of a string-type error.
+        // Every case verified live against jq 1.7.1.
+
+        // test/match/capture/sub: same "is not a string" wording as the
+        // pattern argument.
+        for filter in [r#"test("a"; 1)"#, r#"sub("a"; "b"; 1)"#] {
+            query!(br#""x""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "number (1) is not a string", "filter: {filter}");
+                }
+            );
+        }
+
+        // gsub: flags + "g" (append) — flags value on the left, matching
+        // #730's append-vs-prepend split for valid flags strings.
+        query!(br#""x""#, r#"gsub("a"; "b"; 1)"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (1) and string (\"g\") cannot be added");
+            }
+        );
+
+        // scan/split/splits: "g" + flags (prepend) — "g" on the left.
+        for filter in [r#"scan("a"; 1)"#, r#"split("a"; 1)"#, r#"splits("a"; 1)"#] {
+            query!(br#""x""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(
+                        e.message,
+                        "string (\"g\") and number (1) cannot be added",
+                        "filter: {filter}"
+                    );
+                }
+            );
+        }
+
+        // ? still suppresses a non-string flags value, and null is still
+        // treated as no flags (untouched by this fix).
+        query!(br#""x""#, r#"[gsub("a"; "b"; 1)?]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert!(vs.is_empty());
+            }
+        );
+        query!(br#""abc""#, r#"scan("a"; null)"#,
+            QueryResult::ManyOwned(matches) => {
+                assert_eq!(matches.len(), 1);
+            }
+        );
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
     fn test_regex_lookahead_unsupported() {
         // #703: jq's oniguruma backend supports lookahead (`(?=...)`), but
         // succinctly's `regex` crate does not implement lookaround at all —

--- a/tests/data/jq-error-messages.tsv
+++ b/tests/data/jq-error-messages.tsv
@@ -153,6 +153,14 @@ gsub_arg_non_string	gsub(1; "x")	"abc"	number (1) is not a string
 sub_arg_non_string	sub(1; "x")	"abc"	number (1) is not a string
 splits_arg_non_string	splits(1)	"abc"	number (1) is not a string
 split_regex_arg_non_string	split(1; "x")	"abc"	number (1) is not a string
+test_flags_non_string	test("a"; 1)	"abc"	number (1) is not a string
+match_flags_non_string	match("a"; 1)	"abc"	number (1) is not a string
+capture_flags_non_string	capture("(?<a>a)"; 1)	"abc"	number (1) is not a string
+sub_flags_non_string	sub("a"; "b"; 1)	"abc"	number (1) is not a string
+gsub_flags_non_string	gsub("a"; "b"; 1)	"abc"	number (1) and string ("g") cannot be added
+scan_flags_non_string	scan("a"; 1)	"abc"	string ("g") and number (1) cannot be added
+split_flags_non_string	split("a"; 1)	"abc"	string ("g") and number (1) cannot be added
+splits_flags_non_string	splits("a"; 1)	"abc"	string ("g") and number (1) cannot be added
 has_string_on_number	has("a")	1	Cannot check whether number has a string key
 has_string_on_array	has("a")	[1]	Cannot check whether array has a string key
 has_number_on_object	has(1)	{"a":1}	Cannot check whether object has a number key

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -229,6 +229,22 @@ splits_arg_non_string	splits(1)	"abc"
 # own "split input and separator must be strings" sentence instead.
 split_regex_arg_non_string	split(1; "x")	"abc"
 
+# The *flags* argument (not the pattern) to these same builtins (#928).
+# test/match/capture/sub share the pattern-argument's own "<v> is not a
+# string" wording. gsub/scan/split/splits instead hit an arithmetic error,
+# because jq builds the internal global-flag string via concatenation
+# (`flags + "g"` or `"g" + flags`) before ever checking the flags argument's
+# type — operand order flips per builtin, matching the g-append-vs-prepend
+# split #730 already found for *valid* flags strings.
+test_flags_non_string	test("a"; 1)	"abc"
+match_flags_non_string	match("a"; 1)	"abc"
+capture_flags_non_string	capture("(?<a>a)"; 1)	"abc"
+sub_flags_non_string	sub("a"; "b"; 1)	"abc"
+gsub_flags_non_string	gsub("a"; "b"; 1)	"abc"
+scan_flags_non_string	scan("a"; 1)	"abc"
+split_flags_non_string	split("a"; 1)	"abc"
+splits_flags_non_string	splits("a"; 1)	"abc"
+
 # ── Cannot check whether <t> has a <k> key ───────────────────────────────────
 has_string_on_number	has("a")	1
 has_string_on_array	has("a")	[1]

--- a/tests/jq_error_message_tests.rs
+++ b/tests/jq_error_message_tests.rs
@@ -31,8 +31,10 @@ const KNOWN_DIVERGENCES: &str = include_str!("data/jq-error-known-divergences.tx
 /// Probes whose jq message depends on an optional feature being compiled in.
 /// Without `regex`, `match`/`capture`/`scan`/`splits`/`sub`/`gsub` fail with
 /// "regex feature not enabled" before they can reach the type check the probe
-/// is about. `test` has a non-regex substring-match fallback that reproduces
-/// jq's wording on both build configs, so it needs no entry here.
+/// is about. `test`'s bare/pattern-argument form has a non-regex substring-
+/// match fallback that reproduces jq's wording on both build configs, so
+/// `test_arg_non_string` needs no entry here — but that fallback doesn't
+/// support a flags argument at all, so `test_flags_non_string` still does.
 #[cfg(feature = "regex")]
 const FEATURE_GATED: &[&str] = &[];
 #[cfg(not(feature = "regex"))]
@@ -50,6 +52,14 @@ const FEATURE_GATED: &[&str] = &[
     "sub_arg_non_string",
     "splits_arg_non_string",
     "split_regex_arg_non_string",
+    "test_flags_non_string",
+    "match_flags_non_string",
+    "capture_flags_non_string",
+    "sub_flags_non_string",
+    "gsub_flags_non_string",
+    "scan_flags_non_string",
+    "split_flags_non_string",
+    "splits_flags_non_string",
 ];
 
 struct Probe {


### PR DESCRIPTION
## Summary

Split from #926: the flags argument to `test`/`match`/`capture`/`sub`/`gsub`/`scan`/`split`/`splits` used the same placeholder `EvalError::type_error("string", "flags")` the pattern argument did, producing `"expected string, got flags"` instead of jq's real wording.

Unlike the pattern argument, this splits into **two** families rather than one:

- `test`/`match`/`capture`/`sub`: `EvalError::is_not_a_string` (the constructor #926 added) — same wording as the pattern argument.
- `gsub`/`scan`/`split`/`splits`: a **third** wording entirely. jq builds these builtins' internal global-flag string via concatenation (`flags + "g"` for `gsub`, `"g" + flags` for `scan`/`split`/`splits` — the same append-vs-prepend split #730 found for *valid* flags strings) **before** ever checking the flags argument's type, so a non-string value hits jq's own `+` operator type check instead: `"<a> and <b> cannot be added"`, via the already-existing `EvalError::binary_op`. Operand order flips per builtin, matching which side of the concatenation the flags value sits on.

```
$ echo '"a"' | jq -c 'try test("a"; 1) catch .'
"number (1) is not a string"
$ echo '"a"' | jq -c 'try gsub("a";"b";1) catch .'
"number (1) and string (\"g\") cannot be added"
$ echo '"a"' | jq -c 'try scan("a";1) catch .'
"string (\"g\") and number (1) cannot be added"
```

Every wording and operand order verified live against jq 1.7.1 for all 8 call sites, including object/array flags values, `?`-suppression, and `null`-flags (unaffected, already worked).

**Update:** review found a real, higher-severity bug in the same functions: `test`/`match`/`capture`/`sub` evaluated the flags argument *before* the pattern argument, but jq validates pattern first. Once the flags error stopped being an obviously-bogus placeholder, this silently blamed the wrong operand when both arguments were invalid, and skipped a side-effecting pattern expression's `error()` entirely. Fixed by evaluating pattern first, flags second, in all four (`gsub`/`scan`/`split`/`splits` deliberately left unchanged — their own flags-before-pattern order already matches jq's for type mismatches). Filed **#937** (pre-existing, unrelated wording gap the reorder made visible: `test`/`match`/`capture`'s pattern error doesn't switch wording based on flags-argument presence) and **#938** (gsub/scan/split/splits still lose a pattern-argument `error()` to a flags-argument one — a narrower, differently-shaped bug needing a different fix) as follow-ups.

Extended `tests/data/jq-error-probes.tsv` with 8 new probes (one per builtin), regenerated the message table, added all 8 to the `FEATURE_GATED` allowlist (learned from #927: without `regex`, every one of these fails `"regex feature not enabled"` before reaching the type check — including `test`'s flags form specifically, since its non-regex substring-match fallback has no flags support at all, unlike its pattern-argument case, which stays un-gated). Bumped `docs/compliance/jq/limitations.md`'s asserted probe count (197 → 205). Also fixed one pre-existing test's weak assertion (`e.to_string().contains("flags")`) that happened to still pass with the wrong placeholder message — now asserts the exact corrected wording.

Fixes #928

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo test --features cli,regex --test jq_error_message_tests` and `cargo test --test jq_error_message_tests` (205/205 probes match jq, both with and without `regex`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Diffed output against pinned real `jq` for all 8 builtins (bare and object/array flags values), `?`-suppression, and `null`-flags
- [x] Added `test_regex_non_string_flags_wording_matches_jq_per_family_928` covering all of the above

