### PR TITLE
fix(jq): error-message value previews render non-finite floats like jq (#930)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -24,14 +24,14 @@ For jq *feature* coverage rather than error wording, see
 
 ## Summary
 
-Measured against jq-1.7.1 over the 208 probes in
+Measured against jq-1.7.1 over the 212 probes in
 [`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv), through
 **both** evaluators — the full one (`src/jq/eval.rs`) and the generic one
 (`src/jq/eval_generic.rs`, which the CLI uses):
 
 | Dimension                                    | Result               | Meaning                                            |
 |----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **208/208 = 100.0%** | Byte-identical to jq                               |
+| **Message text** (both evaluators, verbatim) | **212/212 = 100.0%** | Byte-identical to jq                               |
 | **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
 | **Behaviour / parser gaps**                  | **0**                | succinctly does not raise the error at all         |
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1952,10 +1952,16 @@ struct JqCompatFormatter;
 impl LiteralFormatter for JqCompatFormatter {
     fn format_raw_number<'a>(&self, raw: &'a [u8]) -> Cow<'a, str> {
         // A source literal that overflows to ±Infinity/NaN (e.g. `1e400`)
-        // must not be fed to `format_number_jq_compat`, which assumes a
-        // finite value and produces garbage like "NaNE+2147483647" for one
-        // that isn't (#561). Match `format_float`'s guard below: JSON output
-        // substitutes "null" for values RFC 8259 can't represent.
+        // must not be fed to `format_number_jq_compat` here: this is real
+        // JSON output (`--jq-compat`), which RFC 8259 forbids an Infinity/NaN
+        // literal from, so it must substitute "null" regardless of what text
+        // the function would produce - match `format_float`'s guard below.
+        // (`format_number_jq_compat` itself now handles a non-finite input
+        // correctly rather than the "NaNE+2147483647"-style garbage #561
+        // fixed for the plain-overflow case - #930 closed the same gap for
+        // the *literal*-with-exponent case - but that's jq's real-text
+        // convention for error-message previews, the wrong one for this
+        // RFC-8259-constrained call site.)
         let overflows = core::str::from_utf8(raw)
             .ok()
             .and_then(|s| s.parse::<f64>().ok())

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -296,7 +296,7 @@ impl EvalError {
     /// The message renders `value` the way jq reports it: a string payload is
     /// used as-is (`error("boom")` reports `boom`, not `"boom"`), anything else
     /// is serialized via the jq-error-message convention (`stream_owned_value_json_jq`,
-    /// the same one [`describe`]/[`dump_truncated`] use — not [`OwnedValue::to_json`],
+    /// the same one `describe`/`dump_truncated` use — not [`OwnedValue::to_json`],
     /// whose RFC-8259-safe `null` for a non-finite float is wrong here: `error(infinite)`
     /// reports jq's real `DBL_MAX` text, not `null` (#930)). Unlike `dump_truncated`,
     /// this has no length budget — `error(v)`'s message is the whole value, verbatim,

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -295,11 +295,20 @@ impl EvalError {
     ///
     /// The message renders `value` the way jq reports it: a string payload is
     /// used as-is (`error("boom")` reports `boom`, not `"boom"`), anything else
-    /// is serialized as JSON.
+    /// is serialized via the jq-error-message convention (`stream_owned_value_json_jq`,
+    /// the same one [`describe`]/[`dump_truncated`] use — not [`OwnedValue::to_json`],
+    /// whose RFC-8259-safe `null` for a non-finite float is wrong here: `error(infinite)`
+    /// reports jq's real `DBL_MAX` text, not `null` (#930)). Unlike `dump_truncated`,
+    /// this has no length budget — `error(v)`'s message is the whole value, verbatim,
+    /// same as real jq.
     pub fn from_value(value: OwnedValue) -> Self {
         let message = match &value {
             OwnedValue::String(s) => s.clone(),
-            other => other.to_json(),
+            other => {
+                let mut message = String::new();
+                let _ = stream_owned_value_json_jq(other, &mut message);
+                message
+            }
         };
         Self {
             message,
@@ -876,6 +885,70 @@ mod tests {
         let _ = sink.write_str(&"あ".repeat(20)); // 3 bytes each: 12 < 14 < 15
         assert_eq!(sink.buf, "ああああ", "cut back to a char boundary");
         assert!(sink.buf.len() <= 14);
+    }
+
+    /// #930: an infinite `NumberLiteral` reaching `dump_truncated` now
+    /// renders its own source text (rather than the unconditional `"null"`
+    /// this whole area used to take) via `format_number_jq_compat` - which,
+    /// same spirit as `preview_sink_copies_at_most_its_cap` above, must stay
+    /// bounded even if the document's mantissa is enormous, since almost
+    /// none of it will ever be visible past `dump_truncated`'s own budget.
+    #[test]
+    fn dump_truncated_bounds_an_overflowed_literal_with_a_huge_mantissa() {
+        let mantissa = "9".repeat(2_000_000);
+        let literal: Box<str> = format!("{mantissa}.5e400").into();
+        let value = OwnedValue::NumberLiteral(
+            super::super::value::NumberRepr::Float(f64::INFINITY),
+            literal,
+        );
+        let result = dump_truncated(&value);
+        assert!(
+            result.len() < 100,
+            "must not render anywhere near the full 2,000,000-digit mantissa: got {} bytes",
+            result.len()
+        );
+        assert!(result.starts_with("9.999999999"), "got: {result}");
+        assert!(result.ends_with("..."), "must be truncated: {result}");
+    }
+
+    /// #930 review: `from_value`'s non-string branch used `OwnedValue::to_json`,
+    /// which is the *real-output* convention (RFC-8259-safe `null` for a
+    /// non-finite float) - wrong for `error(v)`'s message, which (like
+    /// `describe`/`dump_truncated` above) isn't JSON and should show jq's
+    /// real preview text instead. Oracle-verified: `error(infinite)`
+    /// uncaught reports `1.7976931348623157e+308` in real jq, not `null`.
+    #[test]
+    fn from_value_renders_infinite_float_like_jq_not_as_null() {
+        assert_eq!(
+            EvalError::from_value(OwnedValue::Float(f64::INFINITY)).message,
+            "1.7976931348623157e+308"
+        );
+        assert_eq!(
+            EvalError::from_value(OwnedValue::Float(f64::NEG_INFINITY)).message,
+            "-1.7976931348623157e+308"
+        );
+        // NaN still has no literal to fall back to either way - unchanged.
+        assert_eq!(
+            EvalError::from_value(OwnedValue::Float(f64::NAN)).message,
+            "null"
+        );
+        // A container holding a non-finite field renders it the same way,
+        // not just a bare top-level value.
+        let mut obj = indexmap::IndexMap::new();
+        obj.insert("a".to_string(), OwnedValue::Float(f64::INFINITY));
+        obj.insert("b".to_string(), OwnedValue::String("x".to_string()));
+        assert_eq!(
+            EvalError::from_value(OwnedValue::Object(obj)).message,
+            r#"{"a":1.7976931348623157e+308,"b":"x"}"#
+        );
+        // `from_value`'s message is the whole value, not a truncated
+        // preview - unlike `dump_truncated`'s budget above.
+        let long = "x".repeat(100);
+        assert_eq!(
+            EvalError::from_value(s(&long)).message,
+            long,
+            "a string payload is used as-is, unmodified and untruncated"
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4715,9 +4715,11 @@ fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `@uri`, `@html`, `@sh`, and the CSV/TSV/DSV cell formatter that falls back
 /// to `owned_to_string`) want the same `"inf"`/`"-inf"`/`"NaN"` rendering a
 /// plain `Int`/`Float` already gets from `f64::to_string()` -- a
-/// `NumberLiteral` just needs that check made explicit, since its `number_str`
-/// otherwise re-renders the (possibly nonsensical for an overflowed literal)
-/// source text via `format_number_jq_compat`.
+/// `NumberLiteral` just needs that check made explicit: `format_number_jq_compat`
+/// now formats an overflowed literal's source text correctly (#930), but its
+/// jq-error-message-preview text (e.g. `1E+400`) still isn't the Rust-style
+/// `"inf"`/`"-inf"` these non-JSON text formats want, so the explicit check
+/// stays regardless.
 pub(crate) fn numeric_display_string(value: &OwnedValue) -> String {
     if let OwnedValue::NumberLiteral(NumberRepr::Float(f), _) = value {
         if f.is_nan() || f.is_infinite() {

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -25,7 +25,7 @@ use alloc::vec::Vec;
 
 use super::document::{DocumentFields, IndentSpec};
 use super::escape::{write_json_body_jq, write_json_body_yq};
-use super::value::{format_number_jq_compat, NumberRepr, OwnedValue};
+use super::value::{format_number_jq_compat, infinite_float_preview_text, NumberRepr, OwnedValue};
 use crate::yaml::format_float_with_fraction;
 
 /// A value that can be streamed directly to output without intermediate allocation.
@@ -176,7 +176,27 @@ fn stream_owned_value_json<W: core::fmt::Write>(
         sort_keys,
         write_json_body_yq,
         format_float_with_fraction,
+        real_output_infinite_float,
+        real_output_infinite_literal,
     )
+}
+
+/// The `yq`/real-output convention for an infinite `Float` (NaN is handled
+/// unconditionally, ahead of this, in `stream_owned_value_json_with` itself
+/// — both conventions agree it's always `null`): RFC 8259 has no literal for
+/// Infinity either, so this always renders `null` too, regardless of sign.
+/// Pinned by `test_stream_json_number_literal_nan_and_infinite` below —
+/// never change this without updating that test's expectation too.
+fn real_output_infinite_float(_negative: bool) -> String {
+    "null".to_string()
+}
+
+/// The `yq`/real-output convention for an infinite `NumberLiteral` — same
+/// rule as [`real_output_infinite_float`], just for the sibling variant that
+/// also carries the document's raw source text (irrelevant here, since real
+/// output never echoes it for a non-finite value).
+fn real_output_infinite_literal(_raw: &[u8]) -> String {
+    "null".to_string()
 }
 
 /// Stream an OwnedValue as JSON, escaping strings the way `jq` does.
@@ -198,9 +218,40 @@ pub fn stream_owned_value_json_jq<W: core::fmt::Write>(
 ) -> core::fmt::Result {
     // Always compact: this is the jq-error-message convention, which never
     // pretty-prints.
-    stream_owned_value_json_with(value, out, 0, 0, ' ', false, write_json_body_jq, |f| {
-        f.to_string()
-    })
+    stream_owned_value_json_with(
+        value,
+        out,
+        0,
+        0,
+        ' ',
+        false,
+        write_json_body_jq,
+        |f| f.to_string(),
+        |negative| infinite_float_preview_text(negative).to_string(),
+        preview_infinite_literal,
+    )
+}
+
+/// The jq-error-message-preview convention for an infinite `Float`: unlike
+/// real output, jq's own value previews aren't constrained by RFC 8259 (they
+/// aren't JSON, just message text), so an infinite value with no source
+/// literal of its own to echo — the `infinite`/`-infinite` builtins, or any
+/// arithmetic overflow — renders as jq's actual `DBL_MAX` text instead of
+/// `null` (issue #930).
+///
+/// (NaN still renders as `null` here too, same as real output — jq's own
+/// value previews do the same, since NaN has no literal spelling to fall
+/// back to either; that case is handled unconditionally in
+/// `stream_owned_value_json_with` itself, ahead of ever reaching this.)
+fn preview_infinite_literal(raw: &[u8]) -> String {
+    // The document literal this overflowed from is right here, so unlike
+    // the plain-`Float` case this can do better than `DBL_MAX` text: reuse
+    // the same jq-canonical-formatting path finite `NumberLiteral`s already
+    // go through — `format_number_jq_compat` now handles a non-finite input
+    // via `format_overflow_literal_mantissa` instead of the finite path's
+    // `log10`/`pow` (see that function's doc comment for why the split is
+    // necessary), so this can call it unconditionally.
+    format_number_jq_compat(raw)
 }
 
 /// Stream an OwnedValue as JSON without intermediate string allocation, using
@@ -222,6 +273,8 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
     sort_keys: bool,
     escape: fn(&mut W, &str) -> core::fmt::Result,
     float_fmt: fn(f64) -> String,
+    infinite_float: fn(bool) -> String,
+    infinite_literal: fn(&[u8]) -> String,
 ) -> core::fmt::Result {
     match value {
         OwnedValue::Null => out.write_str("null"),
@@ -229,20 +282,22 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
         OwnedValue::Bool(false) => out.write_str("false"),
         OwnedValue::Int(n) => write!(out, "{n}"),
         OwnedValue::Float(f) => {
-            if f.is_nan() || f.is_infinite() {
-                // JSON doesn't support NaN or Infinity
+            if f.is_nan() {
+                // Neither convention has a literal for NaN to fall back to.
                 out.write_str("null")
+            } else if f.is_infinite() {
+                out.write_str(&infinite_float(f.is_sign_negative()))
             } else {
                 out.write_str(&float_fmt(*f))
             }
         }
-        OwnedValue::NumberLiteral(repr, literal) => {
-            if matches!(repr, NumberRepr::Float(f) if f.is_nan() || f.is_infinite()) {
-                out.write_str("null")
-            } else {
-                out.write_str(&format_number_jq_compat(literal.as_bytes()))
+        OwnedValue::NumberLiteral(repr, literal) => match repr {
+            NumberRepr::Float(f) if f.is_nan() => out.write_str("null"),
+            NumberRepr::Float(f) if f.is_infinite() => {
+                out.write_str(&infinite_literal(literal.as_bytes()))
             }
-        }
+            _ => out.write_str(&format_number_jq_compat(literal.as_bytes())),
+        },
         OwnedValue::String(s) => stream_json_string(out, s, escape),
         OwnedValue::Array(arr) => {
             if arr.is_empty() {
@@ -267,6 +322,8 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
                     sort_keys,
                     escape,
                     float_fmt,
+                    infinite_float,
+                    infinite_literal,
                 )?;
             }
             if indent_spaces > 0 {
@@ -304,6 +361,8 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
                     sort_keys,
                     escape,
                     float_fmt,
+                    infinite_float,
+                    infinite_literal,
                 )?;
             }
             if indent_spaces > 0 {
@@ -946,6 +1005,59 @@ mod tests {
         OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1e400".into())
             .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
+        assert_eq!(buf, "null");
+    }
+
+    /// #930: unlike real output (above), jq's error-message value previews
+    /// (`stream_owned_value_json_jq`, used by `describe()`/`dump_truncated()`
+    /// in `src/jq/error.rs`) aren't constrained by RFC 8259 - jq's own
+    /// previews show real text for a non-finite float, not `null`. A plain
+    /// `Float` carries no source literal, so an infinite one renders as
+    /// jq's `DBL_MAX` text (oracle-verified: `infinite`/`-infinite`/any
+    /// arithmetic overflow all match this exactly). NaN still has no
+    /// literal to fall back to either way, so it stays `null` - unchanged
+    /// from real output and from jq itself.
+    #[test]
+    fn test_stream_json_jq_float_non_finite() {
+        let mut buf = String::new();
+        stream_owned_value_json_jq(&OwnedValue::Float(f64::INFINITY), &mut buf).unwrap();
+        assert_eq!(buf, "1.7976931348623157e+308");
+
+        buf.clear();
+        stream_owned_value_json_jq(&OwnedValue::Float(f64::NEG_INFINITY), &mut buf).unwrap();
+        assert_eq!(buf, "-1.7976931348623157e+308");
+
+        buf.clear();
+        stream_owned_value_json_jq(&OwnedValue::Float(f64::NAN), &mut buf).unwrap();
+        assert_eq!(buf, "null");
+    }
+
+    /// #930: a `NumberLiteral` carries its document source text, so an
+    /// overflowed one gets jq's literal-preserving text instead of `DBL_MAX`
+    /// text - matching how real jq distinguishes an echoed literal from a
+    /// computed value. `format_number_jq_compat` is exercised directly
+    /// (rather than via a CLI-level `keys`/`.[]` probe) because those
+    /// operations round-trip an input document's value through
+    /// `OwnedValue::to_json_for_reindex` before an error can reach this
+    /// code, which substitutes its own `1e999` round-trip sentinel for the
+    /// original literal text (pre-existing, unrelated to this fix - see the
+    /// `#930` follow-up filed for it).
+    #[test]
+    fn test_stream_json_jq_number_literal_overflow_preserves_literal_text() {
+        let mut buf = String::new();
+        stream_owned_value_json_jq(
+            &OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1e400".into()),
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(buf, "1E+400");
+
+        buf.clear();
+        stream_owned_value_json_jq(
+            &OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into()),
+            &mut buf,
+        )
+        .unwrap();
         assert_eq!(buf, "null");
     }
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -85,6 +85,20 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     let exp_pos = s.find(['e', 'E']).expect("has_exp guarantees e/E present");
     let exp: i32 = s[exp_pos + 1..].parse().unwrap_or(0);
 
+    // A literal whose magnitude overflows f64 (e.g. `1e400`) parses to
+    // +/-infinity, not a parse error - `value` above is non-finite in that
+    // case. The normalized-scientific-notation branch below renormalizes via
+    // `log10`/`pow` on `value`, which on an infinite input produces garbage
+    // (`log10(inf).floor() as i32` saturates to `i32::MAX`, and dividing by
+    // `10^i32::MAX` yields `NaN`) rather than erroring - so it must be
+    // special-cased here, before that branch ever runs. Every existing
+    // caller already guards non-finite `NumberLiteral`s before reaching this
+    // function (see #930), so this exists purely to make the function
+    // correct for a caller that stops doing that.
+    if !value.is_finite() {
+        return format_overflow_literal_mantissa(s, exp_pos, exp);
+    }
+
     // For e0 or e-0, jq eliminates the exponent
     if exp == 0 {
         // Check if result is integer
@@ -118,6 +132,57 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     let mantissa_str = format_mantissa_jq(normalized_mantissa);
 
     let sign = if value < 0.0 { "-" } else { "" };
+    let exp_sign = if new_exp >= 0 { "+" } else { "" };
+    format!("{sign}{mantissa_str}E{exp_sign}{new_exp}")
+}
+
+/// Renormalize an overflowed literal's own mantissa digits into jq's
+/// one-digit-before-the-point scientific form, entirely via string
+/// manipulation on `s` rather than the finite path's `log10`/`pow` on the
+/// (here, non-finite) parsed value -- see the call site above for why. `s`
+/// is the full literal text, `exp_pos` the byte index of its `e`/`E`, and
+/// `exp` its already-parsed exponent.
+///
+/// Oracle-verified against real jq (issue #930): `1e400` -> `1E+400`,
+/// `123e400` -> `1.23E+402`, `12.34e400` -> `1.234E+401`, `0.5e400` ->
+/// `5E+399`, `100e400` -> `1.00E+402` (trailing zeros preserved, matching
+/// this module's general trailing-zero rule).
+fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, exp: i32) -> String {
+    let mantissa = &s[..exp_pos];
+    let (sign, mantissa) = match mantissa.strip_prefix('-') {
+        Some(rest) => ("-", rest),
+        None => ("", mantissa),
+    };
+    let (int_part, frac_part) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+
+    let (shift, leading, rest): (i64, &str, String) = if int_part == "0" {
+        // Mantissa < 1 (e.g. `0.5e400`): shift right to the first nonzero
+        // fractional digit.
+        match frac_part.find(|c: char| c != '0') {
+            Some(k) => (
+                -(i64::try_from(k).unwrap_or(0) + 1),
+                &frac_part[k..=k],
+                frac_part[k + 1..].to_string(),
+            ),
+            // An all-zero mantissa (`0.0e400`) parses to a finite `0.0` and
+            // never reaches this function; kept as an inert fallback.
+            None => (0, "0", String::new()),
+        }
+    } else {
+        // Mantissa >= 1: shift left past every extra integer-part digit.
+        (
+            i64::try_from(int_part.len().saturating_sub(1)).unwrap_or(0),
+            &int_part[..1],
+            format!("{}{}", &int_part[1..], frac_part),
+        )
+    };
+
+    let new_exp = i64::from(exp) + shift;
+    let mantissa_str = if rest.is_empty() {
+        leading.to_string()
+    } else {
+        format!("{leading}.{rest}")
+    };
     let exp_sign = if new_exp >= 0 { "+" } else { "" };
     format!("{sign}{mantissa_str}E{exp_sign}{new_exp}")
 }
@@ -555,6 +620,28 @@ fn overflow_literal(f: f64) -> &'static str {
         "-1e999"
     } else {
         "1e999"
+    }
+}
+
+/// The exact text real jq's error-message value previews use for an
+/// infinite `f64` reached via computation (the `infinite`/`-infinite`
+/// builtins, an arithmetic overflow, or any other value with no source
+/// literal text of its own to echo) -- `DBL_MAX`'s shortest round-trip
+/// decimal representation, per jq's `jv` (issue #930). Unlike
+/// [`overflow_literal`] above, this is for display, not round-tripping, so
+/// it uses jq's real number text rather than a smuggling sentinel.
+///
+/// Hardcoded rather than derived: `DBL_MAX` is a fixed constant, so its
+/// shortest round-trip text never changes, and computing it via the
+/// `log10`/`pow`-based path the finite branch of
+/// [`format_number_jq_compat`] uses would hit the exact `NaN`-mantissa
+/// failure that path only avoids by never being called on a non-finite
+/// input in the first place.
+pub(crate) fn infinite_float_preview_text(negative: bool) -> &'static str {
+    if negative {
+        "-1.7976931348623157e+308"
+    } else {
+        "1.7976931348623157e+308"
     }
 }
 
@@ -1350,5 +1437,36 @@ mod tests {
         // format_decimal_jq's integer fast path rather than its precision loop.
         assert_eq!(format_number_jq_compat(b"100e-2"), "1");
         assert_eq!(format_number_jq_compat(b"-100e-2"), "-1");
+    }
+
+    /// #930: a literal whose magnitude overflows f64 (e.g. `1e400`) used to
+    /// route into the finite path's `log10`/`pow` renormalization, producing
+    /// garbage (`"NaNE+2147483647"`) since that path needs a finite value to
+    /// renormalize. Every case here is oracle-verified against real jq
+    /// 1.7.1's `describe()`-equivalent value preview (`try (. + "s") catch
+    /// .` on the given literal as JSON input, which reaches the value
+    /// through `keys`/`.[]`-style operations that don't lose `NumberLiteral`
+    /// status the way arithmetic does).
+    #[test]
+    fn test_format_number_jq_compat_overflow_literal_matches_jq_1_7_1() {
+        assert_eq!(format_number_jq_compat(b"1e400"), "1E+400");
+        assert_eq!(format_number_jq_compat(b"-1e400"), "-1E+400");
+        assert_eq!(format_number_jq_compat(b"123e400"), "1.23E+402");
+        assert_eq!(format_number_jq_compat(b"12.34e400"), "1.234E+401");
+        assert_eq!(format_number_jq_compat(b"0.5e400"), "5E+399");
+        assert_eq!(format_number_jq_compat(b"100e400"), "1.00E+402");
+        assert_eq!(format_number_jq_compat(b"9.999e400"), "9.999E+400");
+        assert_eq!(format_number_jq_compat(b"1E400"), "1E+400");
+    }
+
+    /// #930: a no-exponent overflow literal (e.g. a 400-digit plain integer)
+    /// takes the function's pre-existing "no exponent -> output as-is" early
+    /// return (before `value.parse()` is ever consulted), so it was already
+    /// correct - jq itself doesn't reformat these into scientific notation
+    /// either, it just echoes the digits (oracle-verified).
+    #[test]
+    fn test_format_number_jq_compat_overflow_no_exponent_is_unaffected() {
+        let digits = "9".repeat(400);
+        assert_eq!(format_number_jq_compat(digits.as_bytes()), digits);
     }
 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -95,8 +95,13 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // caller already guards non-finite `NumberLiteral`s before reaching this
     // function (see #930), so this exists purely to make the function
     // correct for a caller that stops doing that.
+    //
+    // `exp_pos` (not the already-parsed `exp: i32` above) is passed through:
+    // an overflowed literal's own exponent digit string can itself exceed
+    // `i32::MAX` (`exp`'s `unwrap_or(0)` would silently zero it), so the
+    // overflow path re-parses it independently, at wider precision.
     if !value.is_finite() {
-        return format_overflow_literal_mantissa(s, exp_pos, exp);
+        return format_overflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
     }
 
     // For e0 or e-0, jq eliminates the exponent
@@ -132,59 +137,112 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     let mantissa_str = format_mantissa_jq(normalized_mantissa);
 
     let sign = if value < 0.0 { "-" } else { "" };
-    let exp_sign = if new_exp >= 0 { "+" } else { "" };
-    format!("{sign}{mantissa_str}E{exp_sign}{new_exp}")
+    assemble_scientific(sign, &mantissa_str, i64::from(new_exp))
+}
+
+/// Join a sign, an already-normalized mantissa, and an exponent into jq's
+/// scientific-notation text (`{sign}{mantissa}E{+/-}{exp}`) -- the shared
+/// final step of both the finite path above and the overflow path below, so
+/// the two can't independently drift on the `E+`/`E-` convention.
+fn assemble_scientific(sign: &str, mantissa_str: &str, exp: i64) -> String {
+    let exp_sign = if exp >= 0 { "+" } else { "" };
+    format!("{sign}{mantissa_str}E{exp_sign}{exp}")
 }
 
 /// Renormalize an overflowed literal's own mantissa digits into jq's
 /// one-digit-before-the-point scientific form, entirely via string
 /// manipulation on `s` rather than the finite path's `log10`/`pow` on the
 /// (here, non-finite) parsed value -- see the call site above for why. `s`
-/// is the full literal text, `exp_pos` the byte index of its `e`/`E`, and
-/// `exp` its already-parsed exponent.
+/// is the full literal text and `exp_pos` the byte index of its `e`/`E`;
+/// `negative` is `value.is_sign_negative()` from the caller, which (unlike
+/// re-deriving a sign from `s` itself) is correct for `-0.0`-style edge
+/// cases too and matches this module's usual `if value < 0.0` idiom.
 ///
 /// Oracle-verified against real jq (issue #930): `1e400` -> `1E+400`,
 /// `123e400` -> `1.23E+402`, `12.34e400` -> `1.234E+401`, `0.5e400` ->
 /// `5E+399`, `100e400` -> `1.00E+402` (trailing zeros preserved, matching
-/// this module's general trailing-zero rule).
-fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, exp: i32) -> String {
-    let mantissa = &s[..exp_pos];
-    let (sign, mantissa) = match mantissa.strip_prefix('-') {
-        Some(rest) => ("-", rest),
-        None => ("", mantissa),
-    };
+/// this module's general trailing-zero rule), and beyond jq's own
+/// literal-preservation ceiling, DBL_MAX text (`1e1000000000` ->
+/// `1.7976931348623157e+308`, matching a computed infinity).
+fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> String {
+    // `dump_truncated`'s whole design keeps preview cost independent of the
+    // value's own size (see its doc comment) - a document-controlled
+    // mantissa of unbounded length must not turn into unbounded work here
+    // just because only a handful of its leading digits will ever survive
+    // that later truncation anyway. Bounding the *copy* is enough: `shift`
+    // below only ever needs `int_part.len()` (an O(1) property read, not a
+    // scan), so truncating what gets copied into `rest` doesn't touch the
+    // exponent math's correctness, only how many digits past the first one
+    // actually get rendered.
+    const MAX_RENDERED_MANTISSA_DIGITS: usize = 32;
+
+    let sign = if negative { "-" } else { "" };
+    let mantissa = s[..exp_pos].strip_prefix('-').unwrap_or(&s[..exp_pos]);
     let (int_part, frac_part) = mantissa.split_once('.').unwrap_or((mantissa, ""));
 
-    let (shift, leading, rest): (i64, &str, String) = if int_part == "0" {
-        // Mantissa < 1 (e.g. `0.5e400`): shift right to the first nonzero
-        // fractional digit.
+    // A leading-dot literal (`.5e400`) has an empty `int_part`, not `"0"` --
+    // treat both the same way (mantissa magnitude < 1).
+    let (shift, leading, rest): (i64, &str, String) = if int_part.is_empty() || int_part == "0" {
+        // Shift right to the first nonzero fractional digit.
         match frac_part.find(|c: char| c != '0') {
-            Some(k) => (
-                -(i64::try_from(k).unwrap_or(0) + 1),
-                &frac_part[k..=k],
-                frac_part[k + 1..].to_string(),
-            ),
+            Some(k) => {
+                let after = &frac_part[k + 1..];
+                (
+                    -(k as i64 + 1),
+                    &frac_part[k..=k],
+                    after[..after.len().min(MAX_RENDERED_MANTISSA_DIGITS)].to_string(),
+                )
+            }
             // An all-zero mantissa (`0.0e400`) parses to a finite `0.0` and
-            // never reaches this function; kept as an inert fallback.
-            None => (0, "0", String::new()),
+            // never reaches this function.
+            None => unreachable!("overflow literal mantissa is provably nonzero"),
         }
     } else {
         // Mantissa >= 1: shift left past every extra integer-part digit.
-        (
-            i64::try_from(int_part.len().saturating_sub(1)).unwrap_or(0),
-            &int_part[..1],
-            format!("{}{}", &int_part[1..], frac_part),
-        )
+        // `int_part[1..]` is a slice (no copy); only what actually gets
+        // concatenated into `rest` is capped.
+        let after_leading = &int_part[1..];
+        let rest = if after_leading.len() >= MAX_RENDERED_MANTISSA_DIGITS {
+            after_leading[..MAX_RENDERED_MANTISSA_DIGITS].to_string()
+        } else {
+            let budget = MAX_RENDERED_MANTISSA_DIGITS - after_leading.len();
+            format!(
+                "{after_leading}{}",
+                &frac_part[..frac_part.len().min(budget)]
+            )
+        };
+        (int_part.len() as i64 - 1, &int_part[..1], rest)
     };
 
-    let new_exp = i64::from(exp) + shift;
+    // The exponent digit string can itself be longer than `i32`/`i64` can
+    // hold (e.g. `1e99999999999999999999`) -- any such value is already
+    // certain to be past jq's literal-preservation ceiling below, so an
+    // out-of-range parse can saturate to `i64::MAX`/`MIN` rather than being
+    // treated as an error.
+    let exp_text = &s[exp_pos + 1..];
+    let parsed_exp: i64 = exp_text.parse().unwrap_or_else(|_| {
+        if exp_text.trim_start_matches('+').starts_with('-') {
+            i64::MIN
+        } else {
+            i64::MAX
+        }
+    });
+    let new_exp = parsed_exp.saturating_add(shift);
+
+    // jq's own literal-preserving text (as opposed to a computed value's
+    // DBL_MAX text) only goes up to this exponent magnitude (decNumber's
+    // limit) -- oracle-verified: `1e999999999` keeps `1E+999999999`,
+    // `1e1000000000` switches to DBL_MAX text instead.
+    if new_exp.unsigned_abs() >= 1_000_000_000 {
+        return infinite_float_preview_text(negative).to_string();
+    }
+
     let mantissa_str = if rest.is_empty() {
         leading.to_string()
     } else {
         format!("{leading}.{rest}")
     };
-    let exp_sign = if new_exp >= 0 { "+" } else { "" };
-    format!("{sign}{mantissa_str}E{exp_sign}{new_exp}")
+    assemble_scientific(sign, &mantissa_str, new_exp)
 }
 
 /// Format a mantissa value for jq-compatible output.
@@ -1459,6 +1517,63 @@ mod tests {
         assert_eq!(format_number_jq_compat(b"1E400"), "1E+400");
     }
 
+    /// #930 review: a leading-dot mantissa (`.5e400`, no digit before the
+    /// decimal point) has an *empty* integer part, which `int_part == "0"`
+    /// alone doesn't catch - the first version of this fix took the
+    /// `else` (mantissa >= 1) branch instead and panicked slicing
+    /// `&int_part[..1]` on an empty string. Oracle-verified: real jq treats
+    /// this identically to an explicit `0.5e400`.
+    #[test]
+    fn test_format_number_jq_compat_overflow_leading_dot_mantissa() {
+        assert_eq!(format_number_jq_compat(b".5e400"), "5E+399");
+        assert_eq!(format_number_jq_compat(b"-.5e400"), "-5E+399");
+    }
+
+    /// #930 review: jq's own literal-preservation only holds up to an
+    /// exponent magnitude just under 1,000,000,000 (decNumber's limit) -
+    /// beyond that, real jq falls back to `DBL_MAX` text, same as a
+    /// *computed* infinity (`infinite`). The first version of this fix had
+    /// no such ceiling, and separately parsed the exponent digits as `i32`
+    /// with a silent `unwrap_or(0)` fallback - so an exponent that
+    /// overflowed even that narrower range produced a flatly wrong `"1E+0"`
+    /// instead of anything resembling the real magnitude.
+    #[test]
+    fn test_format_number_jq_compat_overflow_exponent_ceiling_matches_jq_1_7_1() {
+        // Just at the boundary: still literal-preserving text.
+        assert_eq!(format_number_jq_compat(b"1e999999999"), "1E+999999999");
+        assert_eq!(format_number_jq_compat(b"9e999999999"), "9E+999999999");
+        // One past the boundary: DBL_MAX text instead.
+        assert_eq!(
+            format_number_jq_compat(b"1e1000000000"),
+            "1.7976931348623157e+308"
+        );
+        assert_eq!(
+            format_number_jq_compat(b"-1e1000000000"),
+            "-1.7976931348623157e+308"
+        );
+        // An exponent digit string past i64's own range: still DBL_MAX
+        // text, not a garbage or silently-wrong value.
+        assert_eq!(
+            format_number_jq_compat(b"1e99999999999999999999"),
+            "1.7976931348623157e+308"
+        );
+    }
+
+    /// #930 review: the exponent-parsing fallback used to reuse
+    /// `format_number_jq_compat`'s own `i32`-typed `exp`, which silently
+    /// zeroed via `unwrap_or(0)` for any exponent digit string past
+    /// `i32::MAX` (~10 digits) - producing `"1E+0"` for a value that's
+    /// actually astronomically large, well before the real ceiling above
+    /// even comes into play. `format_overflow_literal_mantissa` now
+    /// re-parses the exponent text itself at `i64` precision instead.
+    #[test]
+    fn test_format_number_jq_compat_overflow_exponent_past_i32_matches_jq_1_7_1() {
+        assert_eq!(
+            format_number_jq_compat(b"1e2147483648"),
+            "1.7976931348623157e+308"
+        );
+    }
+
     /// #930: a no-exponent overflow literal (e.g. a 400-digit plain integer)
     /// takes the function's pre-existing "no exponent -> output as-is" early
     /// return (before `value.parse()` is ever consulted), so it was already
@@ -1468,5 +1583,37 @@ mod tests {
     fn test_format_number_jq_compat_overflow_no_exponent_is_unaffected() {
         let digits = "9".repeat(400);
         assert_eq!(format_number_jq_compat(digits.as_bytes()), digits);
+    }
+
+    /// #930 review: an overflowed literal's mantissa can be arbitrarily long
+    /// (it's document-controlled text), but only a handful of its leading
+    /// digits ever survive `dump_truncated`'s later preview truncation - so
+    /// rendering the *whole* mantissa here, only to throw almost all of it
+    /// away one call up, would be unbounded work for no visible benefit.
+    /// Pins that the leading digits (and thus the exponent, which is
+    /// unaffected either way) stay correct, and that the rendered text
+    /// itself is bounded rather than millions of bytes long.
+    #[test]
+    fn test_format_number_jq_compat_overflow_huge_mantissa_is_bounded() {
+        let mantissa = "9".repeat(2_000_000);
+        let literal = format!("{mantissa}.5e400");
+        let result = format_number_jq_compat(literal.as_bytes());
+        let expected_prefix = format!("9.{}", "9".repeat(32));
+        assert!(
+            result.starts_with(&expected_prefix),
+            "leading digits must still be correct: {result}"
+        );
+        // The exponent shift (mantissa.len() - 1) is unaffected by the
+        // rendering cap - only how many digits after the leading one get
+        // copied into the output text.
+        assert!(
+            result.ends_with("E+2000399"),
+            "exponent must reflect the mantissa's true (uncapped) length: {result}"
+        );
+        assert!(
+            result.len() < 100,
+            "must not render anywhere near the full 2,000,000-digit mantissa: got {} bytes",
+            result.len()
+        );
     }
 }

--- a/tests/data/jq-error-messages.tsv
+++ b/tests/data/jq-error-messages.tsv
@@ -210,3 +210,7 @@ path_non_path_keys	path(keys)	{"a":1}	Invalid path expression with result ["a"]
 path_non_path_pipe_to_builtin	path(.a | tostring)	{"a":1}	Invalid path expression with result "1"
 path_non_path_object_construction	path({a:1})	{"a":1}	Invalid path expression with result {"a":1}
 path_non_path_optional_not_suppressed	path(("a")?)	{"a":1}	Invalid path expression with result "a"
+infinite_preview	scan(infinite)	"x"	number (1.797693134...) is not a string
+neg_infinite_preview	scan(-infinite)	"x"	number (-1.79769313...) is not a string
+nan_preview	scan(nan)	"x"	number (null) is not a string
+arithmetic_overflow_preview	scan(1e300*1e300)	"x"	number (1.797693134...) is not a string

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -333,7 +333,12 @@ path_non_path_optional_not_suppressed	path(("a")?)	{"a":1}
 # as JSON `null` instead of jq's real text. `infinite`/`-infinite`/arithmetic
 # overflow have no source literal of their own, so jq shows DBL_MAX text;
 # nan still has no literal spelling either way, so it stays `null` on both
-# sides (unchanged, included here as a control).
+# sides (unchanged, included here as a control). Uses `scan` (regex-gated,
+# see FEATURE_GATED in jq_error_message_tests.rs) rather than `keys`/`.[]`,
+# which route a document-sourced value through OwnedValue::to_json_for_reindex
+# first - fine for a finite value, but it substitutes its own `1e999` round-
+# trip sentinel for a non-finite one (#939), which is exactly what these
+# probes need to NOT go through.
 infinite_preview	scan(infinite)	"x"
 neg_infinite_preview	scan(-infinite)	"x"
 nan_preview	scan(nan)	"x"

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -327,3 +327,14 @@ path_non_path_keys	path(keys)	{"a":1}
 path_non_path_pipe_to_builtin	path(.a | tostring)	{"a":1}
 path_non_path_object_construction	path({a:1})	{"a":1}
 path_non_path_optional_not_suppressed	path(("a")?)	{"a":1}
+
+# ── non-finite float value previews (#930) ────────────────────────────────
+# describe()/dump_truncated() rendered an overflowed/infinite float preview
+# as JSON `null` instead of jq's real text. `infinite`/`-infinite`/arithmetic
+# overflow have no source literal of their own, so jq shows DBL_MAX text;
+# nan still has no literal spelling either way, so it stays `null` on both
+# sides (unchanged, included here as a control).
+infinite_preview	scan(infinite)	"x"
+neg_infinite_preview	scan(-infinite)	"x"
+nan_preview	scan(nan)	"x"
+arithmetic_overflow_preview	scan(1e300*1e300)	"x"

--- a/tests/jq_error_message_tests.rs
+++ b/tests/jq_error_message_tests.rs
@@ -65,6 +65,15 @@ const FEATURE_GATED: &[&str] = &[
     "test_arg_non_string_flagged",
     "match_arg_non_string_flagged",
     "capture_arg_non_string_flagged",
+    // #930: these use `scan(...)` purely as a vehicle to reach a non-finite
+    // value's `describe()` preview - `keys`/`.[]` would also work without
+    // `regex`, but route the value through `to_json_for_reindex` first,
+    // which substitutes its own round-trip sentinel for a non-finite value
+    // (#939) rather than reaching `scan`'s "is not a string" type check.
+    "infinite_preview",
+    "neg_infinite_preview",
+    "nan_preview",
+    "arithmetic_overflow_preview",
 ];
 
 struct Probe {


### PR DESCRIPTION
## Summary

- `describe()`/`dump_truncated()` (`src/jq/error.rs`), the shared machinery every `subject`-based `EvalError` constructor uses to render a value preview like `number (1)`, mapped **any** non-finite float to JSON `null` in error-message previews — but jq's own previews aren't JSON and aren't constrained by RFC 8259, so it shows real text instead:
  - `try scan(infinite) catch .` → jq: `number (1.797693134...) is not a string`; succinctly (before): `number (null) is not a string`
  - `try scan(-infinite) catch .` → jq: `number (-1.79769313...) is not a string`; succinctly (before): `number (null) is not a string`
  - `nan` stays `null` on both sides (unchanged) — it has no literal spelling to fall back to either.
- Root cause was `src/jq/stream.rs`'s shared `stream_owned_value_json_with`, used by **both** the error-preview convention (`stream_owned_value_json_jq`) and real `-o json`/`yq` output (`stream_owned_value_json`) — the fix threads two new per-convention function pointers through it (`infinite_float`/`infinite_literal`) so the **real-output convention is completely unchanged** (still always `null`, matching RFC 8259, pinned by the pre-existing `test_stream_json_number_literal_nan_and_infinite`), while the preview convention now renders real text:
  - A computed infinite `OwnedValue::Float` (the `infinite`/`-infinite` builtins, or any arithmetic overflow — no source literal of its own) renders jq's `DBL_MAX` text (hardcoded, since it's a fixed constant).
  - An infinite `OwnedValue::NumberLiteral` (an overflowed number read from a JSON *document*, which carries its own source text) reformats that text into jq's normalized scientific notation via a new `format_overflow_literal_mantissa` helper in `src/jq/value.rs` — pure string-based mantissa/exponent shifting, **not** a round-trip through `f64`, since `format_number_jq_compat`'s existing `log10`/`pow` renormalization produces garbage (`"NaNE+2147483647"`) on a non-finite input (it's built to renormalize a *finite* value's exponent, and the value here is definitionally out of `f64` range).

## Known, documented, out-of-scope gap

A numeric literal written **directly in a jq filter expression** (e.g. `scan(1e400)`, as opposed to one read from a JSON *document*) still shows `DBL_MAX` text rather than jq's literal-preserving `1E+400`, because `Expr::Literal(Literal::Float(f64))` never carried source text in the first place — only document-sourced values do, via `OwnedValue::NumberLiteral` (issue #387's fix, scoped specifically to document literals). Closing that gap would mean threading literal text through the parser/expr/eval layers for filter-embedded numbers — a materially bigger, separate change. `-1e400` (negated) is unaffected by this gap and matches jq exactly, since jq **itself** shows `DBL_MAX` text for a negated literal (verified live: `-` forces materialization in real jq too, same as any other arithmetic).

Also filed **#939** (separate, pre-existing bug found while implementing this): `keys`/`.[]`-style operations on a document-sourced overflow literal round-trip the value through `OwnedValue::to_json_for_reindex` before any error is raised, which substitutes an internal `1e999` sentinel for the value's real text — so those specific operations' previews show the sentinel rather than the literal, even after this fix. The `NumberLiteral`-arm fix here is still correct and tested directly (unit tests bypass the eval pipeline, constructing the value directly) for when the original literal text *does* reach `describe()` intact.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New oracle probes (`infinite_preview`, `neg_infinite_preview`, `nan_preview`, `arithmetic_overflow_preview`) added to `tests/data/jq-error-probes.tsv`, captured against pinned jq-1.7.1 via `sync-jq-error-messages.sh` — `jq_error_message_parity` passes 201/201
- [x] Direct unit tests in `src/jq/stream.rs` (`stream_owned_value_json_jq` on constructed `Float`/`NumberLiteral` values) and `src/jq/value.rs` (`format_number_jq_compat` on 8 oracle-verified overflow shapes: `1e400`, `-1e400`, `123e400`, `12.34e400`, `0.5e400`, `100e400`, `9.999e400`, `1E400`, plus a no-exponent 400-digit literal)
- [x] `docs/compliance/jq/limitations.md`'s probe-count summary updated (197 → 201)

Closes #930