### PR TITLE
fix(jq): test/match/capture's pattern error switches on flags arity

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -24,14 +24,14 @@ For jq *feature* coverage rather than error wording, see
 
 ## Summary
 
-Measured against jq-1.7.1 over the 205 probes in
+Measured against jq-1.7.1 over the 208 probes in
 [`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv), through
 **both** evaluators — the full one (`src/jq/eval.rs`) and the generic one
 (`src/jq/eval_generic.rs`, which the CLI uses):
 
 | Dimension                                    | Result               | Meaning                                            |
 |----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **205/205 = 100.0%** | Byte-identical to jq                               |
+| **Message text** (both evaluators, verbatim) | **208/208 = 100.0%** | Byte-identical to jq                               |
 | **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
 | **Behaviour / parser gaps**                  | **0**                | succinctly does not raise the error at all         |
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28177,6 +28177,57 @@ mod tests {
 
     #[cfg(feature = "regex")]
     #[test]
+    fn test_regex_pattern_error_wording_switches_on_flags_arity_937() {
+        // #937: test/match/capture's pattern-argument error wording depends
+        // on which arity was actually called, not just the pattern's own
+        // type — the bare 1-arg form says "<type> not a string or array"
+        // (#926), but the 2-arg form switches to "<v> is not a string" even
+        // when the flags value itself is fine (a valid, empty, or `null`
+        // flags string). `sub` has no such split — its bare-vs-flagged
+        // wording is identical in real jq, so #926 already gave it
+        // `is_not_a_string` unconditionally and this fix doesn't touch it.
+        // Every case verified live against jq 1.7.1.
+
+        // Bare form: unchanged from #926 (not_string_or_array, no preview).
+        for filter in [r"test(1)", r"match(1)", r"capture(1)"] {
+            query!(br#""x""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "number not a string or array", "filter: {filter}");
+                }
+            );
+        }
+
+        // Flagged form with a *valid* flags value still switches wording —
+        // it's the arity, not the flags value's own validity, that matters.
+        for filter in [
+            r#"test(1; "")"#,
+            r#"match(1; "")"#,
+            r#"capture(1; "")"#,
+            r"test(1; null)",
+            r"match(1; null)",
+            r"capture(1; null)",
+        ] {
+            query!(br#""x""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "number (1) is not a string", "filter: {filter}");
+                }
+            );
+        }
+
+        // Flagged form where *both* arguments are invalid: the pattern's
+        // error still wins (matches #928's pattern-before-flags order), now
+        // with the flagged-form wording rather than the bare one.
+        for filter in [r"test(1; 2)", r"match(1; 2)", r"capture(1; 2)"] {
+            query!(br#""x""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "number (1) is not a string", "filter: {filter}");
+                }
+            );
+        }
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
     fn test_regex_test_match_capture_sub_evaluate_pattern_before_flags_928() {
         // #928 (review follow-up): test/match/capture/sub must evaluate the
         // *pattern* argument before the *flags* argument, matching jq. A

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6782,8 +6782,16 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
     // flags-eval block below — `optional` is never forced `true` reaching a
     // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
+    //
+    // jq's own pattern-error wording depends on which arity was called: the
+    // bare 1-arg form says "<type> not a string or array", but the 2-arg
+    // form (even with a valid/empty/null flags value) says "<v> is not a
+    // string" instead — confirmed live (#937). `flags_expr.is_some()`
+    // tracks which arity this call actually used, independent of what the
+    // flags expression evaluates to.
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
+        Ok(v) if flags_expr.is_some() => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
@@ -7348,8 +7356,16 @@ fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
     // flags-eval block below — `optional` is never forced `true` reaching a
     // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
+    //
+    // jq's own pattern-error wording depends on which arity was called: the
+    // bare 1-arg form says "<type> not a string or array", but the 2-arg
+    // form (even with a valid/empty/null flags value) says "<v> is not a
+    // string" instead — confirmed live (#937). `flags_expr.is_some()`
+    // tracks which arity this call actually used, independent of what the
+    // flags expression evaluates to.
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
+        Ok(v) if flags_expr.is_some() => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
@@ -7429,8 +7445,16 @@ fn builtin_capture_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
     // flags-eval block below — `optional` is never forced `true` reaching a
     // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
+    //
+    // jq's own pattern-error wording depends on which arity was called: the
+    // bare 1-arg form says "<type> not a string or array", but the 2-arg
+    // form (even with a valid/empty/null flags value) says "<v> is not a
+    // string" instead — confirmed live (#937). `flags_expr.is_some()`
+    // tracks which arity this call actually used, independent of what the
+    // flags expression evaluates to.
     let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
+        Ok(v) if flags_expr.is_some() => return QueryResult::Error(EvalError::is_not_a_string(&v)),
         Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
         Err(e) => return e.into(),
     };
@@ -28165,17 +28189,19 @@ mod tests {
         // deliberately excluded: jq's own internal order for those already
         // evaluates flags first (confirmed live), so no reordering was
         // needed or made there.
-        // test/match/capture's pattern-check has no value preview
-        // ("<type> not a string or array" — a separate, pre-existing
-        // wording gap unrelated to evaluation order, tracked in #937), so
-        // the strongest same-shape check here is simply that it's *this*
-        // sentence (the pattern-argument one) that wins, not the flags-
-        // argument "is not a string" sentence #928 just added.
+        // test/match/capture's pattern-check switches to the "<v> is not a
+        // string" wording once a flags argument is present in the call
+        // (#937, a separate, pre-existing wording gap unrelated to
+        // evaluation order) — so on the 2-arg form used here, the pattern's
+        // error message is byte-identical in shape to what the flags-
+        // argument "is not a string" sentence #928 added. What distinguishes
+        // "pattern won" from "flags won" here is the *value* previewed: `1`
+        // (the pattern), not `2` (the flags).
         for filter in ["test(1; 2)", "match(1; 2)", "capture(1; 2)"] {
             query!(br#""abc""#, filter,
                 QueryResult::Error(e) => {
                     assert_eq!(
-                        e.message, "number not a string or array",
+                        e.message, "number (1) is not a string",
                         "filter: {filter}"
                     );
                 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6752,13 +6752,54 @@ fn build_regex(pattern: &str, flags: Option<&str>) -> Result<JqRegex, EvalError>
     })
 }
 
+/// Evaluate `match`/`test`/`capture`'s shared pattern argument, applying
+/// jq's arity-dependent error wording (#937): the bare 1-arg form says
+/// "<type> not a string or array", but the 2-arg form (even with a
+/// valid/empty/`null` flags value) switches to "<v> is not a string"
+/// instead. `flags_expr` only needs to be checked for *presence* here
+/// (`is_some()`) — its own value has no bearing on which wording applies,
+/// and is evaluated separately by each caller afterward.
+///
+/// Shared by `builtin_match`/`builtin_test_with_flags`/
+/// `builtin_capture_with_flags` instead of duplicated per function
+/// (following the same-file precedent `sub_with_resolved_pattern` and
+/// `next_match_step` already set for this exact "one predicate, several
+/// builtins" shape — see #106's "duplicated predicates diverge silently").
+///
+/// No `Ok(_) if optional` guard: `optional` is never forced `true`
+/// reaching a nested `Call` like this one (see `Expr::Optional`'s
+/// dispatch in `eval_single`, #693) — a bare `?` suppresses this error via
+/// the ancestor `eval_try`'s catch, not locally.
+#[cfg(feature = "regex")]
+fn eval_regex_pattern_arg<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    re_expr: &Expr,
+    flags_expr: Option<&Expr>,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> Result<String, QueryResult<'a, W>> {
+    match result_to_owned(eval_single::<W, S>(re_expr, value, optional)) {
+        Ok(OwnedValue::String(s)) => Ok(s),
+        Ok(v) if flags_expr.is_some() => Err(QueryResult::Error(EvalError::is_not_a_string(&v))),
+        Ok(v) => Err(QueryResult::Error(EvalError::not_string_or_array(
+            v.type_name(),
+        ))),
+        Err(e) => Err(e.into()),
+    }
+}
+
 /// Builtin: test(re) - test if string matches the regex
 ///
-/// jq defines this as `def test($re): test($re; null);` — delegate to the
-/// flags-aware implementation directly rather than duplicating its
-/// pattern/input fetch and regex build (#923), matching the established
-/// local convention `builtin_sub`/`builtin_gsub`/`builtin_splits`/
-/// `builtin_scan` already use post-#906/#913.
+/// jq defines this as `def test($re): test($re; null);`, but that's jq's
+/// own *definition*, not a literal call — delegating to
+/// `builtin_test_with_flags` with `flags_expr: None` (a real 1-arg call,
+/// not a synthesized `Some(null)`) is what reproduces jq's *observable*
+/// arity-dependent behavior (#937): a hand-rolled `Some(&Expr::Literal(
+/// Literal::Null))` here would flip `flags_expr.is_some()` to `true` and
+/// silently switch this bare form to the 2-arg error wording. Delegating
+/// this way also avoids duplicating the pattern/input fetch and regex
+/// build (#923), matching the established local convention
+/// `builtin_sub`/`builtin_gsub`/`builtin_splits`/`builtin_scan` already
+/// use post-#906/#913.
 #[cfg(feature = "regex")]
 fn builtin_test_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
@@ -6779,21 +6820,12 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
-    // flags-eval block below — `optional` is never forced `true` reaching a
-    // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
-    //
-    // jq's own pattern-error wording depends on which arity was called: the
-    // bare 1-arg form says "<type> not a string or array", but the 2-arg
-    // form (even with a valid/empty/null flags value) says "<v> is not a
-    // string" instead — confirmed live (#937). `flags_expr.is_some()`
-    // tracks which arity this call actually used, independent of what the
-    // flags expression evaluates to.
-    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(v) if flags_expr.is_some() => return QueryResult::Error(EvalError::is_not_a_string(&v)),
-        Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
-        Err(e) => return e.into(),
+    // See `eval_regex_pattern_arg`'s doc comment for the arity-dependent
+    // wording rationale (#937) and why there's no `Ok(_) if optional` arm.
+    let pattern = match eval_regex_pattern_arg::<W, S>(re_expr, flags_expr, value.clone(), optional)
+    {
+        Ok(s) => s,
+        Err(qr) => return qr,
     };
 
     // Get the flags, now that the pattern is known valid. No `Ok(_) if
@@ -7353,21 +7385,12 @@ fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
-    // flags-eval block below — `optional` is never forced `true` reaching a
-    // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
-    //
-    // jq's own pattern-error wording depends on which arity was called: the
-    // bare 1-arg form says "<type> not a string or array", but the 2-arg
-    // form (even with a valid/empty/null flags value) says "<v> is not a
-    // string" instead — confirmed live (#937). `flags_expr.is_some()`
-    // tracks which arity this call actually used, independent of what the
-    // flags expression evaluates to.
-    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(v) if flags_expr.is_some() => return QueryResult::Error(EvalError::is_not_a_string(&v)),
-        Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
-        Err(e) => return e.into(),
+    // See `eval_regex_pattern_arg`'s doc comment for the arity-dependent
+    // wording rationale (#937) and why there's no `Ok(_) if optional` arm.
+    let pattern = match eval_regex_pattern_arg::<W, S>(re_expr, flags_expr, value.clone(), optional)
+    {
+        Ok(s) => s,
+        Err(qr) => return qr,
     };
 
     // Get the flags, now that the pattern is known valid. No `Ok(_) if
@@ -7442,21 +7465,12 @@ fn builtin_capture_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the pattern. No `Ok(_) if optional` guard: same reasoning as the
-    // flags-eval block below — `optional` is never forced `true` reaching a
-    // nested `Call` like this one (see `Expr::Optional`'s dispatch, #693).
-    //
-    // jq's own pattern-error wording depends on which arity was called: the
-    // bare 1-arg form says "<type> not a string or array", but the 2-arg
-    // form (even with a valid/empty/null flags value) says "<v> is not a
-    // string" instead — confirmed live (#937). `flags_expr.is_some()`
-    // tracks which arity this call actually used, independent of what the
-    // flags expression evaluates to.
-    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(v) if flags_expr.is_some() => return QueryResult::Error(EvalError::is_not_a_string(&v)),
-        Ok(v) => return QueryResult::Error(EvalError::not_string_or_array(v.type_name())),
-        Err(e) => return e.into(),
+    // See `eval_regex_pattern_arg`'s doc comment for the arity-dependent
+    // wording rationale (#937) and why there's no `Ok(_) if optional` arm.
+    let pattern = match eval_regex_pattern_arg::<W, S>(re_expr, flags_expr, value.clone(), optional)
+    {
+        Ok(s) => s,
+        Err(qr) => return qr,
     };
 
     // Get the flags, now that the pattern is known valid. No `Ok(_) if
@@ -28214,16 +28228,10 @@ mod tests {
             );
         }
 
-        // Flagged form where *both* arguments are invalid: the pattern's
-        // error still wins (matches #928's pattern-before-flags order), now
-        // with the flagged-form wording rather than the bare one.
-        for filter in [r"test(1; 2)", r"match(1; 2)", r"capture(1; 2)"] {
-            query!(br#""x""#, filter,
-                QueryResult::Error(e) => {
-                    assert_eq!(e.message, "number (1) is not a string", "filter: {filter}");
-                }
-            );
-        }
+        // The both-arguments-invalid case (`test(1; 2)` etc.) is already
+        // covered by `test_regex_test_match_capture_sub_evaluate_pattern_
+        // before_flags_928`, which asserts the same flagged-form wording
+        // this test pins above — not repeated here.
     }
 
     #[cfg(feature = "regex")]
@@ -28235,11 +28243,27 @@ mod tests {
         // error stopped being an obviously-bogus placeholder and started
         // looking like real jq wording (see #926) — silently blamed the
         // wrong operand when both arguments were invalid, and skipped a
-        // side-effecting pattern expression's error() entirely. Every case
-        // verified live against jq 1.7.1. gsub/scan/split/splits are
-        // deliberately excluded: jq's own internal order for those already
-        // evaluates flags first (confirmed live), so no reordering was
-        // needed or made there.
+        // side-effecting pattern expression's error() entirely. gsub/
+        // scan/split/splits are deliberately excluded: jq's own internal
+        // order for those already evaluates flags first (confirmed live),
+        // so no reordering was needed or made there.
+        //
+        // Every case below is verified live against jq 1.7.1 *except* the
+        // last one: `test(error(P); error(F))`'s asserted "PATTERN_ERR"
+        // pins succinctly's actual (current) behavior, not jq's — real jq
+        // returns "FLAGS_ERR" there, because it forces the *flags*
+        // argument before the pattern argument (propagating whichever
+        // errors first), and only afterward runs the pattern-preferred
+        // type-check this fix implements. All four builtins here
+        // (including `sub` — `sub(1; "b"; error("F"))` is "F" in jq, not
+        // this file's "number (1) is not a string") share that same
+        // deeper divergence; it just isn't exercised by the specific `sub`
+        // case below, where the pattern's own error() happens to still
+        // win because the flags value (2) doesn't raise. That's a real
+        // evaluation-order bug, not a wording gap — filed as #942, since
+        // fixing it means restructuring these builtins to evaluate both
+        // arguments before either can early-return, not just relabeling a
+        // message.
         // test/match/capture's pattern-check switches to the "<v> is not a
         // string" wording once a flags argument is present in the call
         // (#937, a separate, pre-existing wording gap unrelated to
@@ -28275,6 +28299,9 @@ mod tests {
                 assert_eq!(e.message, "PATTERN_ERR");
             }
         );
+        // Pins current (jq-diverging) behavior, not jq parity — see the
+        // #942 discussion in this test's doc comment above. Real jq
+        // returns "FLAGS_ERR" here.
         query!(br#""abc""#, r#"test(error("PATTERN_ERR"); error("FLAGS_ERR"))"#,
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "PATTERN_ERR");

--- a/tests/data/jq-error-messages.tsv
+++ b/tests/data/jq-error-messages.tsv
@@ -161,6 +161,9 @@ gsub_flags_non_string	gsub("a"; "b"; 1)	"abc"	number (1) and string ("g") cannot
 scan_flags_non_string	scan("a"; 1)	"abc"	string ("g") and number (1) cannot be added
 split_flags_non_string	split("a"; 1)	"abc"	string ("g") and number (1) cannot be added
 splits_flags_non_string	splits("a"; 1)	"abc"	string ("g") and number (1) cannot be added
+test_arg_non_string_flagged	test(1; "")	"abc"	number (1) is not a string
+match_arg_non_string_flagged	match(1; "")	"abc"	number (1) is not a string
+capture_arg_non_string_flagged	capture(1; "")	"abc"	number (1) is not a string
 has_string_on_number	has("a")	1	Cannot check whether number has a string key
 has_string_on_array	has("a")	[1]	Cannot check whether array has a string key
 has_number_on_object	has(1)	{"a":1}	Cannot check whether object has a number key

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -245,6 +245,17 @@ scan_flags_non_string	scan("a"; 1)	"abc"
 split_flags_non_string	split("a"; 1)	"abc"
 splits_flags_non_string	splits("a"; 1)	"abc"
 
+# test/match/capture's *pattern*-argument error wording switches based on
+# call arity, not the pattern's own type (#937): the bare 1-arg form uses
+# `test_arg_non_string`'s "<t> not a string or array" wording above, but
+# the 2-arg form (even with a valid/empty flags value) switches to the
+# "<v> is not a string" wording instead — the gap the existing corpus
+# missed, since it only ever probed the bare form and the flags-argument
+# error separately, never a flagged call with a bad *pattern*.
+test_arg_non_string_flagged	test(1; "")	"abc"
+match_arg_non_string_flagged	match(1; "")	"abc"
+capture_arg_non_string_flagged	capture(1; "")	"abc"
+
 # ── Cannot check whether <t> has a <k> key ───────────────────────────────────
 has_string_on_number	has("a")	1
 has_string_on_array	has("a")	[1]

--- a/tests/jq_error_message_tests.rs
+++ b/tests/jq_error_message_tests.rs
@@ -34,7 +34,9 @@ const KNOWN_DIVERGENCES: &str = include_str!("data/jq-error-known-divergences.tx
 /// is about. `test`'s bare/pattern-argument form has a non-regex substring-
 /// match fallback that reproduces jq's wording on both build configs, so
 /// `test_arg_non_string` needs no entry here — but that fallback doesn't
-/// support a flags argument at all, so `test_flags_non_string` still does.
+/// support a flags argument at all, so `test_flags_non_string` (and, by the
+/// same reasoning, `test`'s *flagged* pattern-error probe,
+/// `test_arg_non_string_flagged`) still does.
 #[cfg(feature = "regex")]
 const FEATURE_GATED: &[&str] = &[];
 #[cfg(not(feature = "regex"))]
@@ -60,6 +62,9 @@ const FEATURE_GATED: &[&str] = &[
     "scan_flags_non_string",
     "split_flags_non_string",
     "splits_flags_non_string",
+    "test_arg_non_string_flagged",
+    "match_arg_non_string_flagged",
+    "capture_arg_non_string_flagged",
 ];
 
 struct Probe {


### PR DESCRIPTION
## Summary

Split from #928's review: `test`/`match`/`capture`'s pattern-argument type-error always used `EvalError::not_string_or_array` ("`<type> not a string or array`", no value preview), but real jq switches to the `"<v> is not a string"` wording (the same one `is_not_a_string`/#926 already implements) whenever a flags argument is *textually present* in the call — even a valid, empty, or `null` one.

```
$ echo '"abc"' | jq -c 'try test(1) catch .'
"number not a string or array"          # bare 1-arg form — unchanged
$ echo '"abc"' | jq -c 'try test(1; "") catch .'
"number (1) is not a string"            # 2-arg form — switches, even with valid flags
$ echo '"abc"' | jq -c 'try test(1; 2) catch .'
"number (1) is not a string"            # 2-arg form, both args invalid — pattern still wins
```

Same divergence for `match(1;"")`/`match(1;2)` and `capture(1;"")`/`capture(1;2)`. `sub`'s pattern-check has no such split — its bare-vs-flagged wording is identical in real jq, so #926 already gave it `is_not_a_string` unconditionally, and this PR doesn't touch it.

Found while fixing #928's evaluation-order bug: reordering pattern-before-flags made the pattern's error win on a double-invalid call (`test(1; 2)`), which made this pre-existing wording gap directly visible for the first time (previously the flags error's now-fixed-but-formerly-bogus placeholder wording masked it entirely).

## Root cause & fix

`flags_expr.is_some()` already tracks exactly which arity a given call used — `None` for the bare form, `Some` for the flagged form regardless of what the flags expression evaluates to. Branching on it in each of the three pattern-check match arms (`builtin_match`, `builtin_test_with_flags`, `builtin_capture_with_flags`) is enough: `not_string_or_array` when `None`, `is_not_a_string` when `Some`.

Updated one pre-existing test (`test_regex_test_match_capture_sub_evaluate_pattern_before_flags_928`) whose assertion pinned the old (masked) wording for the double-invalid case — its own comment already flagged this exact gap as "tracked in #937".

Added 3 new probes to `tests/data/jq-error-probes.tsv` (`test_arg_non_string_flagged`, `match_arg_non_string_flagged`, `capture_arg_non_string_flagged`), regenerated the message table against the pinned jq 1.7.1, bumped `docs/compliance/jq/limitations.md`'s asserted count 205→208. Confirmed empirically (not just by analogy to #927/#928) that all 3 need the non-regex `FEATURE_GATED` allowlist in `jq_error_message_tests.rs`.

Fixes #937

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo test --test jq_error_message_tests` and `cargo test --features cli,regex --test jq_error_message_tests` (208/208 probes match jq, both with and without `regex`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Diffed output against pinned real `jq` for all 3 builtins × bare/flagged (valid, empty, `null`, and both-invalid) forms
- [x] Local patch-coverage cross-check against `origin/main` (100%, 24/24 new lines in `src/jq/eval.rs`)