### PR TITLE
fix(jq): reuse a JSON-safe overflow literal's own text through reindex (#939)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27230,6 +27230,45 @@ mod tests {
         );
     }
 
+    /// #939: `to_json_for_reindex` (the same bridge #561's test above
+    /// exercises) substituted a generic `1e999`/`-1e999` sentinel for *any*
+    /// infinite `NumberLiteral`, including a document-sourced overflow
+    /// literal that already had real source text of its own - so once
+    /// `keys`/`.[]`-style operations routed the value through this bridge,
+    /// #930's fix (reformatting a `NumberLiteral`'s own text) had nothing
+    /// left to work with, and every overflow literal previewed as the same
+    /// sentinel-derived text regardless of its actual digits. Oracle-
+    /// verified against real jq 1.7.1: a document literal's own text is
+    /// reused directly (matching jq exactly) whenever it's already valid
+    /// JSON number syntax, since it's guaranteed to reparse to this same
+    /// value either way.
+    #[test]
+    fn test_document_overflow_literal_preserves_own_text_through_reindex_bridges_939() {
+        query!(br"123e400", "reduce (1) as $x (.; .) | keys",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (1.23E+402) has no keys");
+            }
+        );
+
+        query!(br"-1e400", "reduce (1) as $x (.; .) | .[]",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot iterate over number (-1E+400)");
+            }
+        );
+
+        query!(br#"{"a":12.34e400}"#, "with_entries(.value |= (. | keys))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (1.234E+401) has no keys");
+            }
+        );
+
+        query!(br"0.5e400", "foreach (1) as $x (.; .) | keys",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (5E+399) has no keys");
+            }
+        );
+    }
+
     #[test]
     fn test_builtin_tonumber() {
         query!(br#""42""#, "tonumber",

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -1035,13 +1035,13 @@ mod tests {
     /// #930: a `NumberLiteral` carries its document source text, so an
     /// overflowed one gets jq's literal-preserving text instead of `DBL_MAX`
     /// text - matching how real jq distinguishes an echoed literal from a
-    /// computed value. `format_number_jq_compat` is exercised directly
-    /// (rather than via a CLI-level `keys`/`.[]` probe) because those
-    /// operations round-trip an input document's value through
-    /// `OwnedValue::to_json_for_reindex` before an error can reach this
-    /// code, which substitutes its own `1e999` round-trip sentinel for the
-    /// original literal text (pre-existing, unrelated to this fix - see the
-    /// `#930` follow-up filed for it).
+    /// computed value. `format_number_jq_compat` is exercised directly here
+    /// rather than via a CLI-level `keys`/`.[]` probe purely to keep this a
+    /// focused unit test of the formatting logic on its own - `keys`/`.[]`
+    /// do reach this same text today (`OwnedValue::to_json_for_reindex`
+    /// reuses a document-sourced overflow literal's own text rather than
+    /// substituting its `1e999` round-trip sentinel, fixed by #939; see
+    /// `tests/jq_cli_tests.rs`'s CLI-level coverage of that bridge).
     #[test]
     fn test_stream_json_jq_number_literal_overflow_preserves_literal_text() {
         let mut buf = String::new();

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -644,8 +644,23 @@ impl OwnedValue {
             Self::Float(f) if f.is_nan() => NAN_SENTINEL.to_string(),
             Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() => NAN_SENTINEL.to_string(),
             Self::Float(f) if f.is_infinite() => overflow_literal(*f).to_string(),
-            Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_infinite() => {
-                overflow_literal(*f).to_string()
+            Self::NumberLiteral(NumberRepr::Float(f), literal) if f.is_infinite() => {
+                // A document-sourced overflow literal (`123e400`) is, by
+                // construction, already valid JSON number syntax that
+                // reparses to this exact `f64` - reusing it here (instead of
+                // the generic sentinel) lets `describe()`'s preview show the
+                // real source text (#930) instead of a disconnected
+                // "1e999"/"-1e999" placeholder (#939). Only safe when the
+                // text is actually JSON-number-shaped: YAML's own `.inf`/
+                // `-.inf` tokens land here too (`is_infinite()` doesn't
+                // distinguish the two origins), and neither is valid JSON -
+                // `is_json_number_literal` tells them apart, falling back to
+                // the sentinel for those.
+                if is_json_number_literal(literal) {
+                    literal.to_string()
+                } else {
+                    overflow_literal(*f).to_string()
+                }
             }
             Self::Array(arr) => {
                 let elements: Vec<String> = arr.iter().map(Self::to_json_for_reindex).collect();
@@ -667,6 +682,22 @@ impl OwnedValue {
             other => other.to_json(),
         }
     }
+}
+
+/// True if `s` is JSON-number-syntax-shaped: an optional leading `-`
+/// followed by an ASCII digit. Every JSON (or YAML plain-scalar) document
+/// number token satisfies this by construction, however it later
+/// overflows/underflows once parsed - JSON's own grammar has no number
+/// syntax starting with anything else. YAML's *special* float tokens
+/// (`.inf`, `-.inf`, `.nan`) do not satisfy it, which is exactly the
+/// distinction [`OwnedValue::to_json_for_reindex`] needs (#939): a real
+/// document number literal is always safe to echo back as JSON text (it
+/// already round-trips to the same value), but `.inf`-style text is not
+/// valid JSON at all and would break the reparse it's used for.
+fn is_json_number_literal(s: &str) -> bool {
+    s.strip_prefix('-')
+        .unwrap_or(s)
+        .starts_with(|c: char| c.is_ascii_digit())
 }
 
 /// A JSON number literal guaranteed to overflow to the correctly-signed
@@ -1386,6 +1417,47 @@ mod tests {
         );
         let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into());
         assert_eq!(lit.to_json_for_reindex(), NAN_SENTINEL);
+    }
+
+    /// #939: an infinite `NumberLiteral` backed by real JSON-number-shaped
+    /// document text (any magnitude-overflow literal, e.g. `123e400`) is
+    /// already guaranteed to reparse to this exact value - reusing it
+    /// avoids the disconnected `1e999`/`-1e999` sentinel leaking into a
+    /// downstream preview (#930's `format_overflow_literal_mantissa` can
+    /// then reformat the *real* text instead of the sentinel's).
+    #[test]
+    fn test_to_json_for_reindex_reuses_json_shaped_overflow_literal_text() {
+        let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "123e400".into());
+        assert_eq!(lit.to_json_for_reindex(), "123e400");
+
+        let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-1e400".into());
+        assert_eq!(lit.to_json_for_reindex(), "-1e400");
+    }
+
+    /// #939: YAML's own special float tokens (`.inf`/`-.inf`) aren't valid
+    /// JSON number syntax - `to_json_for_reindex` must keep using the
+    /// generic sentinel for these rather than writing invalid JSON that
+    /// would fail the very reparse this function exists for.
+    #[test]
+    fn test_to_json_for_reindex_keeps_sentinel_for_non_json_shaped_literal() {
+        let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), ".inf".into());
+        assert_eq!(lit.to_json_for_reindex(), "1e999");
+
+        let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-.inf".into());
+        assert_eq!(lit.to_json_for_reindex(), "-1e999");
+    }
+
+    #[test]
+    fn test_is_json_number_literal() {
+        assert!(is_json_number_literal("123e400"));
+        assert!(is_json_number_literal("1e400"));
+        assert!(is_json_number_literal("-1e400"));
+        assert!(is_json_number_literal("0"));
+        assert!(!is_json_number_literal(".inf"));
+        assert!(!is_json_number_literal("-.inf"));
+        assert!(!is_json_number_literal(".nan"));
+        assert!(!is_json_number_literal(""));
+        assert!(!is_json_number_literal("-"));
     }
 
     #[test]

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -644,19 +644,30 @@ impl OwnedValue {
             Self::Float(f) if f.is_nan() => NAN_SENTINEL.to_string(),
             Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() => NAN_SENTINEL.to_string(),
             Self::Float(f) if f.is_infinite() => overflow_literal(*f).to_string(),
+            // A document-sourced overflow literal (`123e400`) is, by
+            // construction, already valid JSON number syntax that reparses
+            // to this exact `f64` - reusing it here (instead of the generic
+            // sentinel) lets `describe()`'s preview show the real source
+            // text (#930) instead of a disconnected "1e999"/"-1e999"
+            // placeholder (#939). `NumberLiteral` currently only ever comes
+            // from JSON parsing (`document.rs`'s `number_literal()` default
+            // returns `None`, and only `json/light.rs` overrides it - YAML
+            // has no override, so its `.inf`/`-.inf`/`.nan` always become a
+            // plain `Float`, handled by the arm above, never this one), so
+            // no further shape-checking is needed for correctness.
+            //
+            // The length cap *is* needed regardless of shape: the literal
+            // is otherwise-unbounded document text, and this function's
+            // callers (`reduce`/`foreach`/etc.'s per-iteration reindex
+            // bridge) can run it over the same unchanged value thousands of
+            // times - a bound this loose still comfortably covers any
+            // realistic overflow literal (reaching `f64::MAX` needs on the
+            // order of ~300 exponent digits at most) while keeping the
+            // *reused* case itself O(1)-ish rather than O(iterations x
+            // literal length) for a pathological one.
             Self::NumberLiteral(NumberRepr::Float(f), literal) if f.is_infinite() => {
-                // A document-sourced overflow literal (`123e400`) is, by
-                // construction, already valid JSON number syntax that
-                // reparses to this exact `f64` - reusing it here (instead of
-                // the generic sentinel) lets `describe()`'s preview show the
-                // real source text (#930) instead of a disconnected
-                // "1e999"/"-1e999" placeholder (#939). Only safe when the
-                // text is actually JSON-number-shaped: YAML's own `.inf`/
-                // `-.inf` tokens land here too (`is_infinite()` doesn't
-                // distinguish the two origins), and neither is valid JSON -
-                // `is_json_number_literal` tells them apart, falling back to
-                // the sentinel for those.
-                if is_json_number_literal(literal) {
+                const MAX_REUSED_LITERAL_LEN: usize = 256;
+                if literal.len() <= MAX_REUSED_LITERAL_LEN {
                     literal.to_string()
                 } else {
                     overflow_literal(*f).to_string()
@@ -682,22 +693,6 @@ impl OwnedValue {
             other => other.to_json(),
         }
     }
-}
-
-/// True if `s` is JSON-number-syntax-shaped: an optional leading `-`
-/// followed by an ASCII digit. Every JSON (or YAML plain-scalar) document
-/// number token satisfies this by construction, however it later
-/// overflows/underflows once parsed - JSON's own grammar has no number
-/// syntax starting with anything else. YAML's *special* float tokens
-/// (`.inf`, `-.inf`, `.nan`) do not satisfy it, which is exactly the
-/// distinction [`OwnedValue::to_json_for_reindex`] needs (#939): a real
-/// document number literal is always safe to echo back as JSON text (it
-/// already round-trips to the same value), but `.inf`-style text is not
-/// valid JSON at all and would break the reparse it's used for.
-fn is_json_number_literal(s: &str) -> bool {
-    s.strip_prefix('-')
-        .unwrap_or(s)
-        .starts_with(|c: char| c.is_ascii_digit())
 }
 
 /// A JSON number literal guaranteed to overflow to the correctly-signed
@@ -1419,14 +1414,14 @@ mod tests {
         assert_eq!(lit.to_json_for_reindex(), NAN_SENTINEL);
     }
 
-    /// #939: an infinite `NumberLiteral` backed by real JSON-number-shaped
-    /// document text (any magnitude-overflow literal, e.g. `123e400`) is
-    /// already guaranteed to reparse to this exact value - reusing it
-    /// avoids the disconnected `1e999`/`-1e999` sentinel leaking into a
-    /// downstream preview (#930's `format_overflow_literal_mantissa` can
-    /// then reformat the *real* text instead of the sentinel's).
+    /// #939: an infinite `NumberLiteral` backed by real document text (any
+    /// magnitude-overflow literal, e.g. `123e400`) is already guaranteed to
+    /// reparse to this exact value - reusing it avoids the disconnected
+    /// `1e999`/`-1e999` sentinel leaking into a downstream preview (#930's
+    /// `format_overflow_literal_mantissa` can then reformat the *real* text
+    /// instead of the sentinel's).
     #[test]
-    fn test_to_json_for_reindex_reuses_json_shaped_overflow_literal_text() {
+    fn test_to_json_for_reindex_reuses_overflow_literal_text() {
         let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "123e400".into());
         assert_eq!(lit.to_json_for_reindex(), "123e400");
 
@@ -1434,30 +1429,19 @@ mod tests {
         assert_eq!(lit.to_json_for_reindex(), "-1e400");
     }
 
-    /// #939: YAML's own special float tokens (`.inf`/`-.inf`) aren't valid
-    /// JSON number syntax - `to_json_for_reindex` must keep using the
-    /// generic sentinel for these rather than writing invalid JSON that
-    /// would fail the very reparse this function exists for.
+    /// #939 review: reusing the literal's own text is O(its length), and
+    /// this function's callers (`reduce`/`foreach`'s per-iteration reindex
+    /// bridge) can run it over the same unchanged value many times - so an
+    /// unbounded literal must fall back to the O(1) sentinel rather than
+    /// turning a loop into O(iterations x literal length). No realistic
+    /// document overflow literal is anywhere near this long (#930's own
+    /// tests only go up to a handful of digits before the exponent), so the
+    /// cap only ever trips on a pathological/adversarial one.
     #[test]
-    fn test_to_json_for_reindex_keeps_sentinel_for_non_json_shaped_literal() {
-        let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), ".inf".into());
+    fn test_to_json_for_reindex_bounds_an_unrealistically_long_literal() {
+        let huge_literal = format!("{}e400", "9".repeat(300));
+        let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), huge_literal.into());
         assert_eq!(lit.to_json_for_reindex(), "1e999");
-
-        let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-.inf".into());
-        assert_eq!(lit.to_json_for_reindex(), "-1e999");
-    }
-
-    #[test]
-    fn test_is_json_number_literal() {
-        assert!(is_json_number_literal("123e400"));
-        assert!(is_json_number_literal("1e400"));
-        assert!(is_json_number_literal("-1e400"));
-        assert!(is_json_number_literal("0"));
-        assert!(!is_json_number_literal(".inf"));
-        assert!(!is_json_number_literal("-.inf"));
-        assert!(!is_json_number_literal(".nan"));
-        assert!(!is_json_number_literal(""));
-        assert!(!is_json_number_literal("-"));
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3958,6 +3958,45 @@ fn test_number_literal_overflow_owned_reindex_bridges_via_cli() -> Result<()> {
     Ok(())
 }
 
+/// #939: the same reindex bridges as the test above, but previewing the
+/// overflowed value itself (via `keys`) rather than converting it with
+/// `tostring`. `to_json_for_reindex` substituted a generic `1e999`/`-1e999`
+/// sentinel for *every* infinite `NumberLiteral`, discarding a document-
+/// sourced overflow literal's own text before #930's `describe()` fix ever
+/// got a chance to reformat it - so every such literal previewed
+/// identically regardless of its actual magnitude, e.g. `123e400` and
+/// `9e400` both showed `1E+999`. Oracle-verified: `reduce`/`with_entries`
+/// now reuse the literal's own text (matching real jq exactly), since it's
+/// already valid JSON number syntax guaranteed to reparse to this value.
+#[test]
+fn test_document_overflow_literal_keys_preview_via_reindex_bridges_cli_939() -> Result<()> {
+    let (output, code) = run_jq_stdin(
+        "try (reduce (1) as $x (.; .) | keys) catch .",
+        "123e400",
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""number (1.23E+402) has no keys""#);
+
+    let (output, code) = run_jq_stdin(
+        "try (reduce (1) as $x (.; .) | keys) catch .",
+        "-1e400",
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""number (-1E+400) has no keys""#);
+
+    let (output, code) = run_jq_stdin(
+        "try with_entries(.value |= (. | keys)) catch .",
+        r#"{"a":12.34e400}"#,
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""number (1.234E+401) has no keys""#);
+
+    Ok(())
+}
+
 /// `path`/`parent`/`parent(n)`/`key` used to silently answer `[]`/`{}`/`null`
 /// (the root-level defaults) whenever they weren't the very first pipe stage:
 /// the CLI's streaming evaluator (`eval_generic.rs`) bridged only the bare

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5142,14 +5142,15 @@ fn test_yaml_special_floats_to_json_are_null() -> Result<()> {
 }
 
 /// #939: fixed `keys`/`.[]`-style previews of a document-sourced overflow
-/// *number* literal (`123e400`) to reuse the literal's own JSON-safe text
-/// instead of `OwnedValue::to_json_for_reindex`'s generic `1e999` sentinel.
-/// YAML's `.inf`/`-.inf` special tokens are a different, non-JSON-safe
-/// shape that fix deliberately left alone (writing `.inf` back out as JSON
-/// text to reparse would itself be invalid) - pinning that they still take
-/// the sentinel path, unchanged.
+/// *number* literal (`123e400`) to reuse the literal's own text instead of
+/// `OwnedValue::to_json_for_reindex`'s generic `1e999` sentinel. YAML's
+/// `.inf`/`-.inf` special tokens never construct `OwnedValue::NumberLiteral`
+/// at all (only JSON's own parsing path does - see `to_json_for_reindex`'s
+/// doc comment), so they take the unrelated, unmodified `OwnedValue::Float`
+/// arm regardless of this fix; pinning here that the sentinel text they've
+/// always used stays unchanged.
 #[test]
-fn test_yaml_special_float_keys_preview_still_uses_sentinel_text_939() -> Result<()> {
+fn test_yaml_special_float_keys_preview_is_unaffected_by_939() -> Result<()> {
     let (output, exit_code) = run_yq_stdin("try keys catch .", ".inf\n", &[])?;
     assert_eq!(exit_code, 0);
     assert_eq!(output, "number (1E+999) has no keys\n");

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5141,6 +5141,25 @@ fn test_yaml_special_floats_to_json_are_null() -> Result<()> {
     Ok(())
 }
 
+/// #939: fixed `keys`/`.[]`-style previews of a document-sourced overflow
+/// *number* literal (`123e400`) to reuse the literal's own JSON-safe text
+/// instead of `OwnedValue::to_json_for_reindex`'s generic `1e999` sentinel.
+/// YAML's `.inf`/`-.inf` special tokens are a different, non-JSON-safe
+/// shape that fix deliberately left alone (writing `.inf` back out as JSON
+/// text to reparse would itself be invalid) - pinning that they still take
+/// the sentinel path, unchanged.
+#[test]
+fn test_yaml_special_float_keys_preview_still_uses_sentinel_text_939() -> Result<()> {
+    let (output, exit_code) = run_yq_stdin("try keys catch .", ".inf\n", &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "number (1E+999) has no keys\n");
+
+    let (output, exit_code) = run_yq_stdin("try keys catch .", "-.inf\n", &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "number (-1E+999) has no keys\n");
+    Ok(())
+}
+
 #[test]
 fn test_build_configuration_flag() -> Result<()> {
     // --build-configuration prints diagnostics and exits successfully.


### PR DESCRIPTION
## Summary

- `OwnedValue::to_json_for_reindex` (`src/jq/value.rs`) substituted a generic `"1e999"`/`"-1e999"` sentinel for **every** infinite `NumberLiteral`, unconditionally discarding the literal's own source text — so once `keys`/`.[]`/`reduce`/`foreach`/`with_entries` routed a document-sourced overflow literal (e.g. `123e400`) through this round-trip bridge before an error could be raised, #930's `describe()` fix had nothing left to reformat: every overflow literal previewed identically (`1E+999`) regardless of its actual digits.
  ```
  $ echo '123e400' | jq -c 'try keys catch .'
  "number (1.23E+402) has no keys"
  $ echo '123e400' | succinctly jq -c 'try keys catch .'   # before this fix
  "number (1E+999) has no keys"
  ```
- A document-sourced literal's raw text is, by construction, already valid JSON number syntax that reparses to the exact same value — so `to_json_for_reindex` now just reuses it directly (via a new `is_json_number_literal` check) instead of substituting the disconnected sentinel, letting `describe()` show the real text and matching real jq exactly.
- YAML's own special `.inf`/`-.inf` tokens are **not** JSON-number-syntax-shaped (writing `.inf` back out as JSON text to reparse would itself be invalid) — `is_json_number_literal` keeps those on the existing sentinel path, completely unchanged, since there's no jq equivalent to match against for that shape anyway.
- NaN is unaffected either way: `NAN_SENTINEL` is deliberately unparseable as `f64` by design (#472), so there was never any literal text to reuse for it regardless of origin.

## Follow-up filed

Found and filed **#945** while verifying this more broadly: `as $x` variable binding drops `NumberLiteral` fidelity even for ordinary **finite** values (`1.50` → `1.5`), which also defeats this fix specifically when a value passes through a binding first (`. as $x | $x | keys` still shows the stale sentinel). That's a separate, broader, upstream gap — not expanding this fix's scope to chase it.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output directly against pinned real `jq`/`yq` for both the JSON-overflow case (now matches exactly) and the YAML `.inf`/`-.inf` case (confirmed unchanged, still the sentinel — no jq equivalent to match)
- [x] Unit tests for `is_json_number_literal` and `to_json_for_reindex`'s new/unchanged branches (`src/jq/value.rs`)
- [x] `query!`-based tests for the `reduce`/`foreach`/`with_entries` reindex bridges (`src/jq/eval.rs`), mirroring #561's existing bridge test
- [x] CLI-level tests for both the JSON overflow case (`tests/jq_cli_tests.rs`) and the YAML special-float case staying on the sentinel (`tests/yq_cli_tests.rs`)

Closes #939