### PR TITLE
docs(jq): document sub/gsub zero-output replacement as accepted divergence

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -352,6 +352,39 @@ the one sentence left in `eval_object_construction`, because reaching jq's answe
 means generating a stream, not renaming an error. The sentence stays succinctly's until
 #354 is built.
 
+`sub`/`gsub`'s replacement filter emitting zero or 2+ outputs for one match is a third,
+unrelated group — [#840](https://github.com/rust-works/succinctly/issues/840). jq's
+`sub`/`gsub` are defined via a `reduce` over each regex match that threads the
+replacement filter's own output stream through the fold, and the exact resulting
+semantics are inconsistent enough (see the two zero-output rows below) that reproducing
+them exactly would mean re-deriving jq's `builtin.jq` `reduce` structure verbatim rather
+than patching `eval_sub_replacement`'s current one-output-per-match assumption:
+
+| Filter                                                             | Input           | jq                                    | succinctly                     |
+|--------------------------------------------------------------------|-----------------|---------------------------------------|--------------------------------|
+| `sub("a"; empty)`                                                  | `"cab"`         | `"cab"` (unchanged)                   | `error("no value")`            |
+| `gsub("(?<x>[aeiou])"; if .x=="e" then empty else "["+.x+"]" end)` | `"hello world"` | `"ll[o] w[o]rld"`                     | `error("empty result")`        |
+| `sub("(?<x>[aeiou])"; (.x, .x+"!"))`                               | `"hello world"` | `"hello world"` then `"he!llo world"` | `"hello world"` (first output) |
+
+The two zero-output rows alone show jq's actual rule isn't a simple, safely-portable one:
+a *single*-match `sub` with an empty replacement leaves the input completely untouched
+(row 1), but a *multi*-match `gsub` where only one match's replacement is empty drops
+that match's own text *and* the gap immediately before it, while other empty matches
+elsewhere in the same string behave the same way independently (row 2 — verified
+separately: swap which vowel maps to `empty` and the *other* match's own preceding gap
+disappears instead, not a fixed position). The 2+-output row (row 3) is a real, if
+partial, jq feature: full support means forking the whole `sub`/`gsub` call across every
+combination the multi-valued matches produce (confirmed empirically:
+`gsub("(?<x>[aeiou])"; (.x, .x+"!"))` — three vowel matches, not just one — still only
+forks into 2 outputs total, applying the *n*-th replacement candidate uniformly to every
+match rather than a 2³ cartesian product). Succinctly's current stopgap (`eval_owned_input`
++ "take the first output", added same-day as #826 itself, in `src/jq/eval.rs`'s
+`eval_sub_replacement`) reaches jq's *first* output for the 2+-output shape but not the
+rest, and errors outright rather than guessing at the zero-output shape's real rule.
+Real-world replacement filters are overwhelmingly single-output (the shape #826 fixed),
+so this is left as a deliberate, documented divergence rather than chased for a
+rarely-hit, non-obviously-specified shape.
+
 `setpath` is the same operation without the syntax, and after #359 it does follow jq —
 `[1,2] | setpath([5]; 9)` is `[1,2,null,null,null,9]`, and `null | setpath(["a"]; 1)` is
 `{"a":1}`. The two used to disagree with each other in-tree; [#486](https://github.com/rust-works/succinctly/issues/486)

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -352,38 +352,35 @@ the one sentence left in `eval_object_construction`, because reaching jq's answe
 means generating a stream, not renaming an error. The sentence stays succinctly's until
 #354 is built.
 
-`sub`/`gsub`'s replacement filter emitting zero or 2+ outputs for one match is a third,
-unrelated group — [#840](https://github.com/rust-works/succinctly/issues/840). jq's
-`sub`/`gsub` are defined via a `reduce` over each regex match that threads the
-replacement filter's own output stream through the fold, and the exact resulting
-semantics are inconsistent enough (see the two zero-output rows below) that reproducing
-them exactly would mean re-deriving jq's `builtin.jq` `reduce` structure verbatim rather
-than patching `eval_sub_replacement`'s current one-output-per-match assumption:
+`sub`/`gsub`'s replacement filter emitting 2+ outputs for one match remains a genuine,
+narrower divergence — [#840](https://github.com/rust-works/succinctly/issues/840). jq
+forks the whole `sub`/`gsub` call across every combination the multi-valued matches
+produce:
 
-| Filter                                                             | Input           | jq                                    | succinctly                     |
-|--------------------------------------------------------------------|-----------------|---------------------------------------|--------------------------------|
-| `sub("a"; empty)`                                                  | `"cab"`         | `"cab"` (unchanged)                   | `error("no value")`            |
-| `gsub("(?<x>[aeiou])"; if .x=="e" then empty else "["+.x+"]" end)` | `"hello world"` | `"ll[o] w[o]rld"`                     | `error("empty result")`        |
-| `sub("(?<x>[aeiou])"; (.x, .x+"!"))`                               | `"hello world"` | `"hello world"` then `"he!llo world"` | `"hello world"` (first output) |
+| Filter                               | Input           | jq                                    | succinctly                     |
+|--------------------------------------|-----------------|---------------------------------------|--------------------------------|
+| `sub("(?<x>[aeiou])"; (.x, .x+"!"))` | `"hello world"` | `"hello world"` then `"he!llo world"` | `"hello world"` (first output) |
 
-The two zero-output rows alone show jq's actual rule isn't a simple, safely-portable one:
-a *single*-match `sub` with an empty replacement leaves the input completely untouched
-(row 1), but a *multi*-match `gsub` where only one match's replacement is empty drops
-that match's own text *and* the gap immediately before it, while other empty matches
-elsewhere in the same string behave the same way independently (row 2 — verified
-separately: swap which vowel maps to `empty` and the *other* match's own preceding gap
-disappears instead, not a fixed position). The 2+-output row (row 3) is a real, if
-partial, jq feature: full support means forking the whole `sub`/`gsub` call across every
-combination the multi-valued matches produce (confirmed empirically:
+This is a real, if partial, jq feature (confirmed empirically:
 `gsub("(?<x>[aeiou])"; (.x, .x+"!"))` — three vowel matches, not just one — still only
 forks into 2 outputs total, applying the *n*-th replacement candidate uniformly to every
-match rather than a 2³ cartesian product). Succinctly's current stopgap (`eval_owned_input`
-+ "take the first output", added same-day as #826 itself, in `src/jq/eval.rs`'s
-`eval_sub_replacement`) reaches jq's *first* output for the 2+-output shape but not the
-rest, and errors outright rather than guessing at the zero-output shape's real rule.
+match rather than a 2³ cartesian product). Succinctly's current stopgap
+(`eval_owned_input` + "take the first output", added same-day as #826 itself, in
+`src/jq/eval.rs`'s `eval_sub_replacement`) reaches jq's *first* output but not the rest.
 Real-world replacement filters are overwhelmingly single-output (the shape #826 fixed),
 so this is left as a deliberate, documented divergence rather than chased for a
-rarely-hit, non-obviously-specified shape.
+rarely-hit shape whose full fix means re-deriving jq's `builtin.jq` `reduce` structure
+verbatim.
+
+#840 also covers a *zero*-output replacement filter (`sub("a"; empty)`), which turned out
+**not** to need this treatment: re-deriving jq's own `reduce`-based definition (and
+verifying empirically, jq 1.7.1) showed a simple, fully portable rule — if *every* match
+in the call has an empty replacement, the whole input is returned unchanged; otherwise
+each empty match drops its own text *and* its own immediately-preceding gap, while every
+non-empty match is processed normally. `eval_sub_replacement`,
+`stitch_replacements_evaluated`, and `builtin_sub_with_flags` implement this rule
+directly rather than erroring — see those functions' doc comments in `src/jq/eval.rs` for
+the mechanism.
 
 `setpath` is the same operation without the syntax, and after #359 it does follow jq —
 `[1,2] | setpath([5]; 9)` is `[1,2,null,null,null,9]`, and `null | setpath(["a"]; 1)` is

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7340,10 +7340,12 @@ fn eval_sub_replacement<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> Result<Option<String>, QueryResult<'a, W>> {
     let captures = capture_object(re, caps);
+    // `eval_owned_input` never returns a bare `QueryResult::Many` -- its own
+    // body converts every borrowed `Many` to `ManyOwned` before returning --
+    // so only `None`/`ManyOwned([])` need checking here, not `Many([])`.
     let materialized =
         eval_owned_input::<W, S>(replacement_expr, &captures, optional).materialize_cursor();
     let stream_is_empty = matches!(&materialized, QueryResult::None)
-        || matches!(&materialized, QueryResult::Many(vs) if vs.is_empty())
         || matches!(&materialized, QueryResult::ManyOwned(vs) if vs.is_empty());
     if stream_is_empty {
         return Ok(None);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7319,33 +7319,37 @@ fn stitch_split(input: &str, matches: &[regex::Captures]) -> Vec<String> {
 /// lands.
 ///
 /// A replacement filter that produces *zero* outputs for a match (`sub("a";
-/// empty)`) is the other unimplemented shape (#840) — `result_to_owned`
-/// raises a plain "no value"/"empty result" error for it here rather than
-/// attempting jq's own rule, because jq's actual rule turned out (verified
-/// empirically, not assumed) to be genuinely inconsistent between a
-/// single-match `sub` (leaves the input completely unchanged) and a
-/// multi-match `gsub` where only some matches are empty (drops each empty
-/// match's own preceding gap along with it) — not a simple, safely-portable
-/// "delete the match" rule. See
-/// `docs/compliance/jq/limitations.md`'s "Where succinctly errors and jq
-/// does not" section for the full empirical writeup and why this is left as
-/// a documented divergence alongside the multi-output case above rather
-/// than guessed at.
+/// empty)`) returns `Ok(None)` here rather than erroring (#840) — jq's own
+/// rule for this shape, re-derived from jq's embedded `builtin.jq` and
+/// verified empirically (jq 1.7.1) across single/multi-match and
+/// adjacent/non-adjacent-gap cases, is: **if every match in the call
+/// produces a zero-output replacement, the whole input is returned
+/// unchanged**; otherwise each zero-output match drops its own text *and*
+/// its own preceding gap, while every non-empty match is processed
+/// normally. The first half of that rule (single-match `sub`, or a `gsub`
+/// where every match is empty) is a trivial "all empty" case; the caller
+/// (`stitch_replacements_evaluated`, or `builtin_sub_with_flags`'s
+/// non-global arm) is what actually implements it, since only the caller
+/// sees every match in the call — this function reports a single match's
+/// outcome, not the whole call's.
 #[cfg(feature = "regex")]
 fn eval_sub_replacement<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     replacement_expr: &Expr,
     re: &JqRegex,
     caps: &regex::Captures,
     optional: bool,
-) -> Result<String, QueryResult<'a, W>> {
+) -> Result<Option<String>, QueryResult<'a, W>> {
     let captures = capture_object(re, caps);
-    let result = result_to_owned(eval_owned_input::<W, S>(
-        replacement_expr,
-        &captures,
-        optional,
-    ));
-    match result {
-        Ok(OwnedValue::String(s)) => Ok(s),
+    let materialized =
+        eval_owned_input::<W, S>(replacement_expr, &captures, optional).materialize_cursor();
+    let stream_is_empty = matches!(&materialized, QueryResult::None)
+        || matches!(&materialized, QueryResult::Many(vs) if vs.is_empty())
+        || matches!(&materialized, QueryResult::ManyOwned(vs) if vs.is_empty());
+    if stream_is_empty {
+        return Ok(None);
+    }
+    match result_to_owned(materialized) {
+        Ok(OwnedValue::String(s)) => Ok(Some(s)),
         Ok(_) if optional => Err(QueryResult::None),
         Ok(_) => Err(QueryResult::Error(EvalError::type_error(
             "string",
@@ -7361,6 +7365,11 @@ fn eval_sub_replacement<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `Regex::replace_all`, but driven by a match list computed ourselves — see
 /// `stitch_split`'s doc comment for why — and by a real per-match jq
 /// evaluation rather than a static template string.
+///
+/// Implements jq's all-matches-empty rule (#840, see `eval_sub_replacement`):
+/// every match's replacement is evaluated first, and if every one of them
+/// produced zero outputs, `input` is returned completely unchanged rather
+/// than with every match individually deleted.
 #[cfg(feature = "regex")]
 fn stitch_replacements_evaluated<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     replacement_expr: &Expr,
@@ -7369,15 +7378,32 @@ fn stitch_replacements_evaluated<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     matches: &[regex::Captures],
     optional: bool,
 ) -> Result<String, QueryResult<'a, W>> {
+    let mut replacements = Vec::with_capacity(matches.len());
+    for caps in matches {
+        replacements.push(eval_sub_replacement::<W, S>(
+            replacement_expr,
+            re,
+            caps,
+            optional,
+        )?);
+    }
+    if replacements.iter().all(Option::is_none) {
+        return Ok(input.to_string());
+    }
+
     let mut out = String::with_capacity(input.len());
     let mut last_end = 0;
-    for caps in matches {
+    for (caps, replacement) in matches.iter().zip(replacements) {
         let m = caps
             .get(0)
             .expect("capture group 0 is always present on a match");
-        let replacement = eval_sub_replacement::<W, S>(replacement_expr, re, caps, optional)?;
-        out.push_str(&input[last_end..m.start()]);
-        out.push_str(&replacement);
+        // A zero-output match drops both its own text and its own preceding
+        // gap (jq 1.7.1, verified) -- distinct from the all-empty case
+        // above, which is handled before this loop runs.
+        if let Some(replacement) = replacement {
+            out.push_str(&input[last_end..m.start()]);
+            out.push_str(&replacement);
+        }
         last_end = m.end();
     }
     out.push_str(&input[last_end..]);
@@ -7728,14 +7754,23 @@ fn sub_with_resolved_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 .expect("capture group 0 is always present on a match");
             let replacement =
                 match eval_sub_replacement::<W, S>(replacement_expr, &re, &caps, optional) {
-                    Ok(s) => s,
+                    Ok(r) => r,
                     Err(qr) => return qr,
                 };
-            let mut out = String::with_capacity(input.len());
-            out.push_str(&input[..m.start()]);
-            out.push_str(&replacement);
-            out.push_str(&input[m.end()..]);
-            QueryResult::Owned(OwnedValue::String(out))
+            match replacement {
+                Some(replacement) => {
+                    let mut out = String::with_capacity(input.len());
+                    out.push_str(&input[..m.start()]);
+                    out.push_str(&replacement);
+                    out.push_str(&input[m.end()..]);
+                    QueryResult::Owned(OwnedValue::String(out))
+                }
+                // The single-match specialization of the all-matches-empty
+                // rule `stitch_replacements_evaluated` implements for gsub
+                // (#840): a zero-output replacement on the one match `sub`
+                // ever considers leaves the input unchanged.
+                None => QueryResult::Owned(OwnedValue::String(input)),
+            }
         }
         None => QueryResult::Owned(OwnedValue::String(input)),
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7317,6 +7317,20 @@ fn stitch_split(input: &str, matches: &[regex::Captures]) -> Vec<String> {
 /// once via `result_to_owned(eval_single(...))`. Non-fatal, if not fully
 /// jq-correct, is the stopgap this function commits to until the follow-up
 /// lands.
+///
+/// A replacement filter that produces *zero* outputs for a match (`sub("a";
+/// empty)`) is the other unimplemented shape (#840) — `result_to_owned`
+/// raises a plain "no value"/"empty result" error for it here rather than
+/// attempting jq's own rule, because jq's actual rule turned out (verified
+/// empirically, not assumed) to be genuinely inconsistent between a
+/// single-match `sub` (leaves the input completely unchanged) and a
+/// multi-match `gsub` where only some matches are empty (drops each empty
+/// match's own preceding gap along with it) — not a simple, safely-portable
+/// "delete the match" rule. See
+/// `docs/compliance/jq/limitations.md`'s "Where succinctly errors and jq
+/// does not" section for the full empirical writeup and why this is left as
+/// a documented divergence alongside the multi-output case above rather
+/// than guessed at.
 #[cfg(feature = "regex")]
 fn eval_sub_replacement<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     replacement_expr: &Expr,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5976,6 +5976,50 @@ fn test_gsub_replacement_multi_value_takes_first_value() -> Result<()> {
     Ok(())
 }
 
+/// `eval_sub_replacement`'s zero-output shape (#840), the sibling gap to the
+/// multi-value stopgap above -- untested until now. A replacement filter
+/// that emits `empty` for the (single) match is not a type mismatch, so it
+/// does not go through the `type_error("string", "replacement")` arm at
+/// all; it hits `result_to_owned`'s own "no value" error for an empty
+/// stream instead, one layer up. Verified against jq 1.7.1: `jq -c
+/// 'sub("a"; empty)'` on `"cab"` prints `"cab"` *unchanged*, exit 0 --
+/// jq's actual rule for this shape is not a simple "delete the match" one,
+/// confirmed inconsistent with the multi-match `gsub` case documented in
+/// docs/compliance/jq/limitations.md's "Where succinctly errors and jq
+/// does not" section, which is why this stays a documented divergence
+/// rather than a guessed-at fix.
+#[test]
+fn test_sub_replacement_empty_output_errors() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"sub("a"; empty)"#], Some(r#""cab""#))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("no value"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// `gsub` counterpart: one match (of several) whose replacement filter
+/// emits `empty`, the shape #840's own repro used. Verified against jq
+/// 1.7.1: `jq -c 'gsub("(?<x>[aeiou])"; if .x=="e" then empty else
+/// "["+.x+"]" end)'` on `"hello world"` prints `"ll[o] w[o]rld"` -- the
+/// gap before the empty-replaced match (`"h"`) vanishes along with the
+/// match itself, not just that match's own contribution, which is the
+/// "genuinely surprising" behavior the compliance doc's #840 entry
+/// declines to reproduce.
+#[test]
+fn test_gsub_replacement_empty_output_errors() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"gsub("(?<x>[aeiou])"; if .x=="e" then empty else "["+.x+"]" end)"#,
+        ],
+        Some(r#""hello world""#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("empty result"), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// `builtin_gsub_flags`'s flags-argument arm (`gsub(re; replacement; flags)`,
 /// the 3-arg form) -- same shape as `builtin_sub_flags`'s flags arm, but a
 /// distinct function/site in the source. Verified against jq 1.7.1:

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5977,36 +5977,45 @@ fn test_gsub_replacement_multi_value_takes_first_value() -> Result<()> {
 }
 
 /// `eval_sub_replacement`'s zero-output shape (#840), the sibling gap to the
-/// multi-value stopgap above -- untested until now. A replacement filter
-/// that emits `empty` for the (single) match is not a type mismatch, so it
-/// does not go through the `type_error("string", "replacement")` arm at
-/// all; it hits `result_to_owned`'s own "no value" error for an empty
-/// stream instead, one layer up. Verified against jq 1.7.1: `jq -c
-/// 'sub("a"; empty)'` on `"cab"` prints `"cab"` *unchanged*, exit 0 --
-/// jq's actual rule for this shape is not a simple "delete the match" one,
-/// confirmed inconsistent with the multi-match `gsub` case documented in
-/// docs/compliance/jq/limitations.md's "Where succinctly errors and jq
-/// does not" section, which is why this stays a documented divergence
-/// rather than a guessed-at fix.
+/// multi-value stopgap above -- untested until now, and (unlike that
+/// stopgap) now fully implemented rather than left as a divergence.
+/// `stitch_replacements_evaluated`/`builtin_sub_with_flags` re-derive jq's
+/// own rule for a replacement filter that produces zero outputs: if *every*
+/// match's replacement is empty, the whole input comes back unchanged; a
+/// single-match `sub` is the trivial case of that rule (one match is
+/// trivially "every match"). Verified against jq 1.7.1: `jq -c 'sub("a";
+/// empty)'` on `"cab"` prints `"cab"` unchanged, exit 0.
 #[test]
-fn test_sub_replacement_empty_output_errors() -> Result<()> {
+fn test_sub_replacement_all_matches_empty_leaves_input_unchanged() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-c", r#"sub("a"; empty)"#], Some(r#""cab""#))?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "");
-    assert!(stderr.contains("no value"), "stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "\"cab\"\n");
     Ok(())
 }
 
-/// `gsub` counterpart: one match (of several) whose replacement filter
-/// emits `empty`, the shape #840's own repro used. Verified against jq
-/// 1.7.1: `jq -c 'gsub("(?<x>[aeiou])"; if .x=="e" then empty else
-/// "["+.x+"]" end)'` on `"hello world"` prints `"ll[o] w[o]rld"` -- the
-/// gap before the empty-replaced match (`"h"`) vanishes along with the
-/// match itself, not just that match's own contribution, which is the
-/// "genuinely surprising" behavior the compliance doc's #840 entry
-/// declines to reproduce.
+/// `gsub` counterpart to the test above, with 3 matches (not 1) all empty --
+/// the case that actually distinguishes "every match is empty" from
+/// "delete every empty match", since a naive per-match deletion would give
+/// `""`, not `"banana"`. Verified against jq 1.7.1: `jq -c 'gsub("a";
+/// empty)'` on `"banana"` prints `"banana"` unchanged, exit 0.
 #[test]
-fn test_gsub_replacement_empty_output_errors() -> Result<()> {
+fn test_gsub_replacement_all_matches_empty_leaves_input_unchanged() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"gsub("a"; empty)"#], Some(r#""banana""#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "\"banana\"\n");
+    Ok(())
+}
+
+/// `gsub` with a *mix* of empty and non-empty replacements, the shape
+/// #840's own repro used -- distinct from the two "every match empty" tests
+/// above, whose all-input-unchanged rule only applies when there is no
+/// non-empty replacement anywhere in the call. Verified against jq 1.7.1:
+/// `jq -c 'gsub("(?<x>[aeiou])"; if .x=="e" then empty else "["+.x+"]"
+/// end)'` on `"hello world"` prints `"ll[o] w[o]rld"` -- the empty match's
+/// own preceding gap (`"h"`) is dropped along with the match itself, while
+/// the two non-empty matches (both `"o"`) are processed normally.
+#[test]
+fn test_gsub_replacement_mixed_empty_and_nonempty_drops_only_empty_matches_own_gap() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
@@ -6014,9 +6023,31 @@ fn test_gsub_replacement_empty_output_errors() -> Result<()> {
         ],
         Some(r#""hello world""#),
     )?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "");
-    assert!(stderr.contains("empty result"), "stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "\"ll[o] w[o]rld\"\n");
+    Ok(())
+}
+
+/// Regression guard for the exact gap-tracking rule: with *non-adjacent*
+/// empty matches (real text sitting between two empty matches, not just
+/// between an empty and a non-empty one), each empty match still only drops
+/// its own immediately-preceding gap -- the gap belongs to whichever match
+/// follows it, whether or not that match happens to be a survivor.
+/// Verified against jq 1.7.1: `jq -c 'gsub("(?<x>[ac])"; if .x=="c" then
+/// "["+.x+"]" else empty end)'` on `"xaYaZc"` prints `"Z[c]"` -- `"x"`
+/// (before the first empty `a`) and `"Y"` (before the second empty `a`) are
+/// both dropped, but `"Z"` (before the surviving `c`) is kept.
+#[test]
+fn test_gsub_replacement_non_adjacent_empty_matches_each_drop_only_their_own_gap() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"gsub("(?<x>[ac])"; if .x=="c" then "["+.x+"]" else empty end)"#,
+        ],
+        Some(r#""xaYaZc""#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "\"Z[c]\"\n");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Implements jq's actual rule for a `sub`/`gsub` replacement filter that produces **zero** outputs for a match (`sub("a"; empty)`), rather than documenting it as an unreproducible divergence. Re-deriving jq's own `reduce`-based `sub`/`gsub` definition, and verifying empirically against jq 1.7.1 across single/multi-match and adjacent/non-adjacent-gap cases (surfaced during this PR's own code-review), showed the rule is simple and fully portable: if **every** match in the call has an empty replacement, the whole input is returned unchanged; otherwise each empty match drops its own text and its own preceding gap, while non-empty matches are processed normally.
- `eval_sub_replacement` now reports `Option<String>` (empty stream vs. a real value) instead of erroring; `stitch_replacements_evaluated` (gsub / `sub(...;...;"g")`) and `builtin_sub_with_flags`'s single-match arm implement the all-empty check.
- Documents the one remaining, genuine divergence for this issue: a replacement filter producing **2+** outputs for one match still takes succinctly's first-output stopgap rather than jq's full cartesian fork across every combination — that one really does require re-deriving jq's `reduce` structure verbatim for a rarely-hit shape, so it stays documented rather than implemented.
- Also corrects #840's own stale repro text: the multi-output case it originally cited (`expected string, got replacement`) was already fixed same-day as #826, prior to this investigation.

Fixes #840

## Test plan
- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests` — 473/473 passed
- [x] `cargo test --features cli,simd,regex,serde` (full suite, run in isolation) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Doc-drift tests (`jq_error_message_tests`) confirm the revised limitations.md table parses correctly
- [x] New tests verified against real jq 1.7.1: single-match unchanged, multi-match all-empty unchanged, mixed empty/non-empty, non-adjacent-gap regression guard