### PR TITLE
fix(yaml): preserve integer-valued float scalars through YAML parsing

### DIFF
--- a/docs/compliance/yaml/1.2.md
+++ b/docs/compliance/yaml/1.2.md
@@ -333,7 +333,6 @@ yq v4.53.3 with `-o=json`):
 | `-0x2A` (signed hex)   | `"-0x2A"`      | Error          | 1.2 core forbids signs on based ints       |
 | `0xFFFFFFFFFFFFFFFF`   | string         | Error          | Overflows `i64`; yq errors on JSON output  |
 | `-0`                   | `0`            | `-0.0`         | go-yaml quirk (signed-zero float)          |
-| `18.0` (compact `-I=0`)| `18`           | `18.0`         | Float formatting, tracked in #169          |
 
 The `Error` rows are yq resolving a scalar as `!!int`/`!!float` and then failing to
 serialize it (`strconv` rejects the source text) — byte-parity there is impossible, so

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -283,10 +283,14 @@ pub trait DocumentValue: Sized + Clone {
     /// (`1e100`, `1.0`, `-0.0`) instead of re-rendering the parsed value —
     /// see issue #387.
     ///
-    /// Defaults to `None`: only JSON overrides this today. YAML numbers are
-    /// resolved plain scalars (hex/octal/underscore forms `yq` may or may not
-    /// echo back verbatim), which is a separate judgment call this default
-    /// deliberately leaves alone.
+    /// Defaults to `None`. JSON overrides this unconditionally (every
+    /// `Number` token is JSON-legal number syntax by construction). YAML
+    /// overrides it too (#918), but only for a finite float whose source
+    /// text is independently confirmed safe and worthwhile to echo — see
+    /// `YamlValue::number_literal`'s doc comment (`src/yaml/light.rs`);
+    /// YAML's own plain-scalar grammar accepts spellings (hex/octal,
+    /// leading-dot) that aren't JSON-legal, and ints never lose information
+    /// through the bare-`Int` path, so both stay on this `None` default.
     fn number_literal(&self) -> Option<Cow<'_, str>> {
         None
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -131,7 +131,21 @@ fn tagged_scalar_to_owned<V: DocumentValue>(tag: &str, value: &V) -> Option<Owne
         crate::yaml::ResolvedScalar::Null => OwnedValue::Null,
         crate::yaml::ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
         crate::yaml::ResolvedScalar::Int(n) => OwnedValue::Int(n),
-        crate::yaml::ResolvedScalar::Float(f) => OwnedValue::Float(f),
+        // Mirrors YamlValue::number_literal (src/yaml/light.rs) for the
+        // same reason: an explicit `!!float` tag converges on this same
+        // materialization step as a plain float scalar, so it needs the
+        // same source-text preservation for a whole-number float like
+        // `!!float 2.0` (#918) - `is_preservable_float_literal` also
+        // correctly excludes `!!float`'s int-widening case (`!!float 5`,
+        // `!!float 0x2A`, neither containing a literal `.`), which have no
+        // meaningful float-spelled text to preserve.
+        crate::yaml::ResolvedScalar::Float(f) => {
+            if crate::yaml::is_preservable_float_literal(&text) {
+                OwnedValue::from_number_literal(&text)
+            } else {
+                OwnedValue::Float(f)
+            }
+        }
         crate::yaml::ResolvedScalar::Str => OwnedValue::String(text.into_owned()),
     })
 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -649,11 +649,15 @@ impl OwnedValue {
             // to this exact `f64` - reusing it here (instead of the generic
             // sentinel) lets `describe()`'s preview show the real source
             // text (#930) instead of a disconnected "1e999"/"-1e999"
-            // placeholder (#939). `NumberLiteral` currently only ever comes
-            // from JSON parsing (`document.rs`'s `number_literal()` default
-            // returns `None`, and only `json/light.rs` overrides it - YAML
-            // has no override, so its `.inf`/`-.inf`/`.nan` always become a
-            // plain `Float`, handled by the arm above, never this one), so
+            // placeholder (#939). This arm only ever sees a JSON-sourced
+            // literal: JSON's `number_literal()` override (`json/light.rs`)
+            // is unconditional, so its overflow literals reach here
+            // directly, but YAML's own override (`yaml/light.rs`, #918)
+            // deliberately excludes non-finite values (`.inf`/`-.inf`/
+            // `.nan` never pass `is_preservable_float_literal`'s
+            // JSON-syntax check, since none of those spellings start with a
+            // digit or `-digit`) - a YAML `.inf`/`.nan` still becomes a
+            // plain `Float`, handled by the arm above, never this one - so
             // no further shape-checking is needed for correctness.
             //
             // The length cap *is* needed regardless of shape: the literal

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -25,7 +25,8 @@ use std::string::ToString;
 use super::index::YamlIndex;
 use super::line_break::{is_line_break, line_break_len, line_break_len_before};
 use super::scalar::{
-    could_be_null_or_bool, is_json_number_syntax, resolve_plain, resolve_tagged, ResolvedScalar,
+    could_be_null_or_bool, is_preservable_float_literal, resolve_plain, resolve_tagged,
+    ResolvedScalar,
 };
 use super::{starts_inline_seq_entry, starts_seq_entry};
 use crate::util::simd::escape::find_json_escape;
@@ -5760,24 +5761,24 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     }
 
     /// Unlike JSON's own override, this only fires for a plain *float*
-    /// scalar that both resolves to a finite value and is independently
-    /// confirmed JSON-number-syntax-safe by [`is_json_number_syntax`] - a
-    /// YAML document has no separate "number token" grammar the way JSON
-    /// does (`as_i64`/`as_f64` above do the same `resolve_plain` dispatch),
-    /// so this can't unconditionally hand back raw bytes the way JSON's
-    /// does. `Int` is deliberately excluded entirely: `resolve_plain`'s own
-    /// doc comment already warns that its numeric variants' source text
-    /// "cannot be re-parsed... emitters must use the carried value" (hex
-    /// `0x2A`, octal `0o52`), and plain decimal ints never lose information
-    /// through `as_i64`'s bare-`Int` path anyway, so there's no bug here to
-    /// fix by echoing their text. A finite `Float`'s raw text can still be
-    /// YAML-legal but JSON-illegal (leading `.`/`+`, a leading zero before
-    /// more digits) - `is_json_number_syntax` is what caught this: an
-    /// earlier version of this override fired for every finite float
-    /// unconditionally, which broke `tag` on a bare `.5` (see that
-    /// function's doc comment for the full mechanism). Non-finite floats
-    /// and anything JSON-unsafe fall through to `as_f64` below instead,
-    /// unchanged from before this override existed.
+    /// scalar whose raw text [`is_preservable_float_literal`] confirms is
+    /// both safe and worthwhile to echo - a YAML document has no separate
+    /// "number token" grammar the way JSON does (`as_i64`/`as_f64` above do
+    /// the same `resolve_plain` dispatch), so this can't unconditionally
+    /// hand back raw bytes the way JSON's does. `Int` is deliberately
+    /// excluded entirely: `resolve_plain`'s own doc comment already warns
+    /// that its numeric variants' source text "cannot be re-parsed...
+    /// emitters must use the carried value" (hex `0x2A`, octal `0o52`), and
+    /// plain decimal ints never lose information through `as_i64`'s
+    /// bare-`Int` path anyway, so there's no bug here to fix by echoing
+    /// their text. See [`is_preservable_float_literal`]'s doc comment for
+    /// why a `Float` needs more than just finiteness gating: an earlier
+    /// version of this override fired for every finite float unconditionally,
+    /// which broke `tag` on a bare `.5` (invalid JSON number syntax) and
+    /// silently overstated precision on an `i64`-overflow integer that only
+    /// resolves to `Float` as a fallback. Anything that predicate rejects
+    /// falls through to `as_f64` below instead, unchanged from before this
+    /// override existed.
     ///
     /// Without this override, `to_owned`'s short-circuiting chain
     /// (`number_literal` -> `as_i64` -> `as_f64`) skips straight to
@@ -5794,9 +5795,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
             YamlValue::String(s) if s.is_unquoted() => {
                 let str_val = s.as_str().ok()?;
                 match resolve_plain(&str_val) {
-                    ResolvedScalar::Float(f)
-                        if f.is_finite() && is_json_number_syntax(&str_val) =>
-                    {
+                    ResolvedScalar::Float(_) if is_preservable_float_literal(&str_val) => {
                         Some(str_val)
                     }
                     _ => None,

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5761,7 +5761,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     }
 
     /// Unlike JSON's own override, this only fires for a plain *float*
-    /// scalar whose raw text [`is_preservable_float_literal`] confirms is
+    /// scalar whose raw text `is_preservable_float_literal` confirms is
     /// both safe and worthwhile to echo - a YAML document has no separate
     /// "number token" grammar the way JSON does (`as_i64`/`as_f64` above do
     /// the same `resolve_plain` dispatch), so this can't unconditionally
@@ -5771,7 +5771,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     /// emitters must use the carried value" (hex `0x2A`, octal `0o52`), and
     /// plain decimal ints never lose information through `as_i64`'s
     /// bare-`Int` path anyway, so there's no bug here to fix by echoing
-    /// their text. See [`is_preservable_float_literal`]'s doc comment for
+    /// their text. See `is_preservable_float_literal`'s doc comment for
     /// why a `Float` needs more than just finiteness gating: an earlier
     /// version of this override fired for every finite float unconditionally,
     /// which broke `tag` on a bare `.5` (invalid JSON number syntax) and

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -24,7 +24,9 @@ use std::string::ToString;
 
 use super::index::YamlIndex;
 use super::line_break::{is_line_break, line_break_len, line_break_len_before};
-use super::scalar::{could_be_null_or_bool, resolve_plain, resolve_tagged, ResolvedScalar};
+use super::scalar::{
+    could_be_null_or_bool, is_json_number_syntax, resolve_plain, resolve_tagged, ResolvedScalar,
+};
 use super::{starts_inline_seq_entry, starts_seq_entry};
 use crate::util::simd::escape::find_json_escape;
 
@@ -5753,6 +5755,61 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
                 }
             }
             YamlValue::Alias { target, .. } => target.and_then(|t| t.value().as_f64()),
+            _ => None,
+        }
+    }
+
+    /// Unlike JSON's own override, this only fires for a plain *float*
+    /// scalar that both resolves to a finite value and is independently
+    /// confirmed JSON-number-syntax-safe by [`is_json_number_syntax`] - a
+    /// YAML document has no separate "number token" grammar the way JSON
+    /// does (`as_i64`/`as_f64` above do the same `resolve_plain` dispatch),
+    /// so this can't unconditionally hand back raw bytes the way JSON's
+    /// does. `Int` is deliberately excluded entirely: `resolve_plain`'s own
+    /// doc comment already warns that its numeric variants' source text
+    /// "cannot be re-parsed... emitters must use the carried value" (hex
+    /// `0x2A`, octal `0o52`), and plain decimal ints never lose information
+    /// through `as_i64`'s bare-`Int` path anyway, so there's no bug here to
+    /// fix by echoing their text. A finite `Float`'s raw text can still be
+    /// YAML-legal but JSON-illegal (leading `.`/`+`, a leading zero before
+    /// more digits) - `is_json_number_syntax` is what caught this: an
+    /// earlier version of this override fired for every finite float
+    /// unconditionally, which broke `tag` on a bare `.5` (see that
+    /// function's doc comment for the full mechanism). Non-finite floats
+    /// and anything JSON-unsafe fall through to `as_f64` below instead,
+    /// unchanged from before this override existed.
+    ///
+    /// Without this override, `to_owned`'s short-circuiting chain
+    /// (`number_literal` -> `as_i64` -> `as_f64`) skips straight to
+    /// `as_f64` for every YAML float, producing a bare `OwnedValue::Float`
+    /// instead of a source-text-preserving `NumberLiteral` - `OwnedValue`'s
+    /// own float-to-text formatting then re-derives text from the bare
+    /// `f64` via `Display`, which drops the decimal point on a whole
+    /// number (`2.0_f64.to_string() == "2"`), silently turning an
+    /// integer-valued float scalar like `2.0` into an indistinguishable-
+    /// from-`2` value the moment it's displayed, reindexed, or compared by
+    /// text (#918).
+    fn number_literal(&self) -> Option<Cow<'_, str>> {
+        match self {
+            YamlValue::String(s) if s.is_unquoted() => {
+                let str_val = s.as_str().ok()?;
+                match resolve_plain(&str_val) {
+                    ResolvedScalar::Float(f)
+                        if f.is_finite() && is_json_number_syntax(&str_val) =>
+                    {
+                        Some(str_val)
+                    }
+                    _ => None,
+                }
+            }
+            // `t.value()` is a temporary, so (as `as_str`'s alias arm above
+            // also has to) any borrowed `Cow` it hands back must be owned
+            // before the closure returns.
+            YamlValue::Alias { target, .. } => target.and_then(|t| {
+                t.value()
+                    .number_literal()
+                    .map(|cow| Cow::Owned(cow.into_owned()))
+            }),
             _ => None,
         }
     }

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -279,6 +279,7 @@ pub use light::{
     YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
+pub(crate) use scalar::is_preservable_float_literal;
 pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};
 
 #[cfg(test)]

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -220,8 +220,13 @@ fn parse_float(s: &str) -> ResolvedScalar {
 /// `!!null` for a scalar that plainly has a `!!float` tag) rather than
 /// erroring loudly. This predicate is how [`super::light`]'s
 /// `number_literal()` override decides which literals are safe to echo.
+///
+/// This grammar duplicates `crate::json::validate`'s `Validator::validate_number`
+/// (reachable via the public `crate::json::validate::validate`) — hand-rolled
+/// here rather than reused to avoid adding a `yaml`-to-`json` module
+/// dependency for this fix; tracked as a follow-up dedup opportunity (#957).
 #[must_use]
-pub(super) fn is_json_number_syntax(s: &str) -> bool {
+fn is_json_number_syntax(s: &str) -> bool {
     let bytes = s.as_bytes();
     let mut i = 0;
     if bytes.first() == Some(&b'-') {
@@ -261,6 +266,53 @@ pub(super) fn is_json_number_syntax(s: &str) -> bool {
         }
     }
     i == bytes.len()
+}
+
+/// The maximum count of ASCII digit characters (integer + fraction part
+/// combined) [`is_preservable_float_literal`] allows through. 17 significant
+/// decimal digits is the documented bound beyond which distinct `f64`
+/// values can round to the same printed digits (and, symmetrically, below
+/// which every `f64` round-trips uniquely) — more digits than that means
+/// the source text already carries more precision than the `f64` it parsed
+/// to actually holds, so echoing it back verbatim would silently overstate
+/// precision the parse step already discarded.
+const MAX_PRESERVABLE_FLOAT_DIGITS: usize = 17;
+
+/// True if `s` is safe *and worthwhile* to preserve verbatim as a
+/// document-sourced float's `NumberLiteral` text — used by both YAML's
+/// [`super::light`] `number_literal()` override (a plain scalar) and its
+/// `!!float`-tag resolution path (an explicitly-tagged one), so the two
+/// don't drift into re-answering this question differently.
+///
+/// Requires, beyond [`is_json_number_syntax`]:
+/// - **A literal `.`.** A bare digit run only resolves to
+///   [`Float`](ResolvedScalar::Float) when it overflows `i64`
+///   (`parse_int_or_float`'s fallback) — that's not a value someone spelled
+///   as a float, it's an integer too big for `i64`, and echoing its raw
+///   digits back verbatim would silently claim more precision than the
+///   `f64` it parsed to can actually hold (the same concern the digit-count
+///   cap below targets, just via a different trigger).
+/// - **No exponent.** `format_number_jq_compat` — the formatter this text
+///   eventually flows through — re-normalizes exponent notation into a
+///   different spelling (uppercase `E`, forced sign, no `e0` elimination)
+///   rather than preserving it, so there is nothing gained by echoing
+///   exponent text through that path; it gets overwritten anyway. This also
+///   sidesteps that formatter's separate, pre-existing loss of `-0.0`'s
+///   sign on the exponent branch, which the source-text-echo path can't
+///   reach without an exponent in play.
+/// - **At most [`MAX_PRESERVABLE_FLOAT_DIGITS`] significant digits.**
+///
+/// Deliberately conservative: legal YAML core-schema spellings that don't
+/// meet this bar (`+2.0`, a trailing-dot `1.`) fall through to the
+/// pre-existing `as_f64` path unchanged rather than being force-fit here,
+/// leaving the #918 symptom open for that narrower spelling class — see
+/// the issue tracker for the follow-up.
+#[must_use]
+pub(crate) fn is_preservable_float_literal(s: &str) -> bool {
+    s.contains('.')
+        && !s.contains(['e', 'E'])
+        && s.bytes().filter(u8::is_ascii_digit).count() <= MAX_PRESERVABLE_FLOAT_DIGITS
+        && is_json_number_syntax(s)
 }
 
 /// Force-resolves a scalar's value under an explicit YAML tag.

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -202,6 +202,67 @@ fn parse_float(s: &str) -> ResolvedScalar {
     }
 }
 
+/// True if `s` is valid JSON number syntax (RFC 8259) end to end: optional
+/// leading `-`, then `0` or a non-zero-led digit run, optional `.`-fraction
+/// (at least one digit), optional exponent (at least one digit).
+///
+/// This module's own numeric [`ResolvedScalar`] variants "carry the parsed
+/// value... emitters must use the carried value, never echo the source
+/// text" (see the type's doc comment) precisely because YAML's core-schema
+/// number grammar is looser than JSON's: a leading-dot float (`.5`), a
+/// leading `+` (`+.5`), or a leading zero followed by more digits (`007.5`)
+/// all resolve here but are not valid JSON number text, and hex/octal ints
+/// (`0x2A`) obviously aren't either. A caller that ignores that warning and
+/// hands such text to something expecting JSON syntax — as
+/// `OwnedValue::NumberLiteral`'s downstream reindexing bridge does — gets a
+/// value silently misclassified as a parse error instead of a number
+/// (confirmed via the `tag` builtin, which maps that error node to
+/// `!!null` for a scalar that plainly has a `!!float` tag) rather than
+/// erroring loudly. This predicate is how [`super::light`]'s
+/// `number_literal()` override decides which literals are safe to echo.
+#[must_use]
+pub(super) fn is_json_number_syntax(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    if bytes.first() == Some(&b'-') {
+        i += 1;
+    }
+    match bytes.get(i) {
+        Some(b'0') => i += 1,
+        Some(b'1'..=b'9') => {
+            i += 1;
+            while matches!(bytes.get(i), Some(b'0'..=b'9')) {
+                i += 1;
+            }
+        }
+        _ => return false,
+    }
+    if bytes.get(i) == Some(&b'.') {
+        i += 1;
+        let start = i;
+        while matches!(bytes.get(i), Some(b'0'..=b'9')) {
+            i += 1;
+        }
+        if i == start {
+            return false;
+        }
+    }
+    if matches!(bytes.get(i), Some(b'e' | b'E')) {
+        i += 1;
+        if matches!(bytes.get(i), Some(b'+' | b'-')) {
+            i += 1;
+        }
+        let start = i;
+        while matches!(bytes.get(i), Some(b'0'..=b'9')) {
+            i += 1;
+        }
+        if i == start {
+            return false;
+        }
+    }
+    i == bytes.len()
+}
+
 /// Force-resolves a scalar's value under an explicit YAML tag.
 ///
 /// Handles the 5 core-schema tags (`!!str`, `!!null`, `!!bool`, `!!int`,

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -634,4 +634,76 @@ mod tests {
             assert_eq!(resolve_tagged("1", tag), None, "tag: {tag}");
         }
     }
+
+    #[test]
+    fn json_number_syntax_accepts_full_rfc_8259_grammar() {
+        // Its own doc comment claims full RFC 8259 support, including the
+        // exponent form - `is_preservable_float_literal` (its only current
+        // caller) never actually routes exponent text through it, since it
+        // rejects those upstream for an unrelated reason (`format_number_
+        // jq_compat` doesn't preserve YAML's exponent spelling), so this
+        // exercises the claim directly rather than through that caller.
+        for s in [
+            "0", "-0", "42", "-42", "0.0", "2.0", "-2.5", "0.50", "1e10", "1E10", "1e+10", "1e-10",
+            "-1.5e-3", "0e0",
+        ] {
+            assert!(is_json_number_syntax(s), "expected valid: {s:?}");
+        }
+    }
+
+    #[test]
+    fn json_number_syntax_rejects_yaml_legal_json_illegal_spellings() {
+        for s in [
+            "",      // empty
+            "-",     // sign with no digits
+            ".5",    // leading dot
+            "+2.0",  // leading plus
+            "007",   // leading zero, more digits
+            "007.5", // leading zero, more digits, with fraction
+            "1.",    // trailing dot, no fraction digit
+            "2.5e",  // exponent marker, no digits
+            "2.5e+", // exponent sign, no digits
+            "0x2A",  // hex
+            "1e",    // bare exponent marker
+            "1.2.3", // trailing garbage
+            "1 ",    // trailing whitespace
+        ] {
+            assert!(!is_json_number_syntax(s), "expected invalid: {s:?}");
+        }
+    }
+
+    #[test]
+    fn preservable_float_literal_requires_a_dot_and_rejects_exponents() {
+        // The core #918 case: a plain decimal float with a literal `.`.
+        for s in ["2.0", "-2.0", "0.5", "3.140", "0.0"] {
+            assert!(
+                is_preservable_float_literal(s),
+                "expected preservable: {s:?}"
+            );
+        }
+        // No dot at all - either a plain int, or (per #953) an i64-overflow
+        // integer that only resolves to Float as a fallback; echoing its
+        // digits verbatim would overstate the f64's actual precision.
+        for s in ["2", "-2", "99999999999999999999"] {
+            assert!(!is_preservable_float_literal(s), "expected rejected: {s:?}");
+        }
+        // Exponent form - format_number_jq_compat doesn't preserve this
+        // spelling, so there's nothing to gain by echoing it (see #918's
+        // eval_generic.rs comment for the -0.0 sign-loss this also avoids).
+        for s in ["2e2", "-0e10", "1.5e-3"] {
+            assert!(!is_preservable_float_literal(s), "expected rejected: {s:?}");
+        }
+        // JSON-unsafe spellings, deliberately out of scope (#954).
+        for s in [".5", "+2.0", "1."] {
+            assert!(!is_preservable_float_literal(s), "expected rejected: {s:?}");
+        }
+    }
+
+    #[test]
+    fn preservable_float_literal_rejects_beyond_the_digit_cap() {
+        let just_over = "1.".to_string() + &"1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS);
+        assert!(!is_preservable_float_literal(&just_over));
+        let at_cap = "1.".to_string() + &"1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS - 1);
+        assert!(is_preservable_float_literal(&at_cap));
+    }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10409,9 +10409,13 @@ fn test_builtin_in_yq_positive_float_index_never_matches_909() -> Result<()> {
 /// `as_i64` and produced a bare, source-text-discarding value; the marker
 /// itself survived (`. + 1` gave `2`, not an error), but by the time it
 /// reached a whole number it silently became indistinguishable from a
-/// genuine `OwnedValue::Int`. Real yq keeps `2.0`'s Float-ness live all the
-/// way to `in([1,2,3])`'s array-key check, unlike a genuine `Int(2)`
-/// in-bounds match.
+/// genuine `OwnedValue::Int`, matching a plain `Int(2)` in-bounds index
+/// where it shouldn't. `in(...)` is a succinctly/jq-language extension --
+/// real `yq`'s own filter language has no equivalent syntax to compare
+/// against directly (`yq 'in([1,2,3])'` is a lexer error there) -- so this
+/// pins succinctly's own internal consistency (a `2.0`-valued Float must
+/// never match a positive-integer array index, same as #909's `2.5`/`1.5`
+/// cases immediately above), not a byte-for-byte oracle comparison.
 #[test]
 fn test_builtin_in_yq_integer_valued_float_yaml_input_never_matches_918() -> Result<()> {
     let (out, code) = run_yq_stdin("in([1,2,3])", "2.0", &[])?;
@@ -10438,6 +10442,35 @@ fn test_materialized_yaml_float_literal_fidelity_918() -> Result<()> {
     let (out, code) = run_yq_stdin("[.]", ".5", &["-o", "json", "-I", "0"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[0.5]");
+    Ok(())
+}
+
+/// #918 companion: an *explicitly*-tagged `!!float 2.0` converges on the
+/// same materialization step (`to_owned_cursor`'s `tagged_scalar_to_owned`,
+/// `src/jq/eval_generic.rs`) as a plain scalar, but through a separate code
+/// path that has to gate on `is_preservable_float_literal` independently --
+/// review of the initial version of this fix found that path still bypassed
+/// `number_literal()` entirely, reproducing the original #918 symptom for
+/// `!!float 2.0` even after the plain-scalar case was fixed. Pinned here
+/// against the pinned yq oracle (both give `[2.0]`).
+#[test]
+fn test_materialized_yaml_explicit_float_tag_literal_fidelity_918() -> Result<()> {
+    let (out, code) = run_yq_stdin("[.]", "!!float 2.0", &["-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2.0]");
+    Ok(())
+}
+
+/// #918 companion: `number_literal()`'s `YamlValue::Alias` arm delegates to
+/// the aliased target (mirroring the pre-existing `as_str` alias arm), so an
+/// integer-valued float reached only through an anchor/alias needs the same
+/// literal-preservation fix as a direct scalar. Pinned against the pinned yq
+/// oracle.
+#[test]
+fn test_materialized_yaml_aliased_float_literal_fidelity_918() -> Result<()> {
+    let (out, code) = run_yq_stdin("[.b]", "a: &x 2.0\nb: *x\n", &["-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2.0]");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5143,12 +5143,15 @@ fn test_yaml_special_floats_to_json_are_null() -> Result<()> {
 
 /// #939: fixed `keys`/`.[]`-style previews of a document-sourced overflow
 /// *number* literal (`123e400`) to reuse the literal's own text instead of
-/// `OwnedValue::to_json_for_reindex`'s generic `1e999` sentinel. YAML's
-/// `.inf`/`-.inf` special tokens never construct `OwnedValue::NumberLiteral`
-/// at all (only JSON's own parsing path does - see `to_json_for_reindex`'s
-/// doc comment), so they take the unrelated, unmodified `OwnedValue::Float`
-/// arm regardless of this fix; pinning here that the sentinel text they've
-/// always used stays unchanged.
+/// `OwnedValue::to_json_for_reindex`'s generic `1e999` sentinel.
+///
+/// #918 later gave YAML floats their own `number_literal()` override too
+/// (previously only JSON had one), but it deliberately excludes non-finite
+/// values: `.inf`/`-.inf`'s YAML spelling isn't valid JSON number syntax,
+/// so unlike a finite YAML float (`2.0`), they still fall through to the
+/// unrelated, unmodified `OwnedValue::Float` arm and never construct an
+/// `OwnedValue::NumberLiteral`. Pinning here that the sentinel text they've
+/// always used stays unchanged by either fix.
 #[test]
 fn test_yaml_special_float_keys_preview_is_unaffected_by_939() -> Result<()> {
     let (output, exit_code) = run_yq_stdin("try keys catch .", ".inf\n", &[])?;
@@ -10376,14 +10379,12 @@ fn test_builtin_in_yq_negative_float_index_909() -> Result<()> {
 /// `has(2.0)` and `has(1.5)` are both `false` on a 3-element array, unlike
 /// jq's truncate-then-bounds-check).
 ///
-/// Uses `2.5`/`1.5`, not `2.0`, as the YAML *input* value -- an
-/// integer-valued float scalar like `2.0` gets normalized to a genuine
-/// `OwnedValue::Int` during YAML parsing itself (confirmed via direct
-/// inspection; a separate, pre-existing characteristic of this codebase's
-/// YAML-to-OwnedValue conversion, unrelated to this fix -- filed
-/// separately). `2.5`/`1.5` have a real fractional part and are preserved
-/// as `Float` all the way through, which is what this test needs to
-/// exercise the array-key arm's Float-rejection path.
+/// Uses `2.5`/`1.5` for most cases -- `has(2.0)`'s `2.0` is a literal
+/// written directly in the filter, not YAML input, so it was never in
+/// scope for #918 either way (only document-sourced numbers go through
+/// YAML's own scalar resolution). `2.5`/`1.5` have a real fractional part
+/// and were always preserved as `Float` regardless of #918, exercising the
+/// array-key arm's Float-rejection path either way.
 #[test]
 fn test_builtin_in_yq_positive_float_index_never_matches_909() -> Result<()> {
     let (out, code) = run_yq_stdin("in([1,2,3])", "2.5", &[])?;
@@ -10397,6 +10398,64 @@ fn test_builtin_in_yq_positive_float_index_never_matches_909() -> Result<()> {
     let (out, code) = run_yq_stdin("has(2.0)", "[1,2,3]", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "false");
+    Ok(())
+}
+
+/// #918: an integer-valued YAML *input* scalar (`2.0`, as opposed to
+/// `has(2.0)` above's filter-embedded literal) used to lose its
+/// `NumberRepr::Float` marker during YAML-to-`OwnedValue` conversion
+/// entirely -- YAML's `DocumentValue` impl had no `number_literal()`
+/// override (unlike JSON's), so it always fell through to `as_f64`/
+/// `as_i64` and produced a bare, source-text-discarding value; the marker
+/// itself survived (`. + 1` gave `2`, not an error), but by the time it
+/// reached a whole number it silently became indistinguishable from a
+/// genuine `OwnedValue::Int`. Real yq keeps `2.0`'s Float-ness live all the
+/// way to `in([1,2,3])`'s array-key check, unlike a genuine `Int(2)`
+/// in-bounds match.
+#[test]
+fn test_builtin_in_yq_integer_valued_float_yaml_input_never_matches_918() -> Result<()> {
+    let (out, code) = run_yq_stdin("in([1,2,3])", "2.0", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}
+
+/// #918 companion: `[.]` forces the scalar through `to_owned` (unlike a
+/// bare `.` identity query, which streams source bytes straight through
+/// without ever materializing an `OwnedValue` and so was never affected by
+/// this bug either way). Pinned against real yq live: an integer-valued
+/// float keeps its decimal point (`[2.0]`), matching the `number_literal()`
+/// fix, while a leading-dot float normalizes to a leading zero (`[0.5]`)
+/// once materialized -- real yq does the same, confirming that excluding
+/// leading-dot text from `number_literal()` (see its doc comment) isn't
+/// just a defensive JSON-safety measure but the actually-correct output.
+#[test]
+fn test_materialized_yaml_float_literal_fidelity_918() -> Result<()> {
+    let (out, code) = run_yq_stdin("[.]", "2.0", &["-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2.0]");
+
+    let (out, code) = run_yq_stdin("[.]", ".5", &["-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[0.5]");
+    Ok(())
+}
+
+/// #918 follow-on fix: an earlier version of `number_literal()`'s override
+/// fired for *every* finite YAML float unconditionally, including
+/// JSON-unsafe spellings like a bare leading-dot `.5`. That broke `tag`
+/// (which has no native cursor-aware implementation and falls back to
+/// serializing the value to JSON text and re-parsing it -- see
+/// `is_json_number_syntax`'s doc comment for the full mechanism): the raw
+/// literal `.5` isn't valid JSON number syntax, so the reparse silently
+/// misclassified it as a parse error, and `tag` mapped that to `!!null`
+/// instead of the correct `!!float`. Pinned here against the pinned yq
+/// oracle (both agree).
+#[test]
+fn test_tag_yq_leading_dot_float_is_not_confused_for_null_918() -> Result<()> {
+    let (out, code) = run_yq_stdin("tag", ".5", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "!!float");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- YAML's `DocumentValue` impl had no `number_literal()` override (unlike JSON's), so any YAML float scalar always fell through to `as_f64`, producing a bare `OwnedValue::Float` whose `Display`-based formatting drops the decimal point on a whole number (`2.0` becomes indistinguishable from a genuine `2` once materialized, e.g. via `has()`/`in()`).
- The new override only fires for a **finite** float whose literal text is independently confirmed to be valid JSON number syntax (`is_json_number_syntax`, added in `src/yaml/scalar.rs`): YAML's plain-scalar grammar accepts spellings JSON's doesn't (leading-dot `.5`, hex/octal `0x2A`/`0o52`), and echoing those into the internal JSON-reindex bridge used by builtins like `tag` (which has no native cursor-aware implementation) silently misclassified them as parse errors instead of numbers — discovered live via the `scalar_tag_resolution` golden fixture regressing.
- `Int` is excluded entirely: `resolve_plain`'s own doc comment already warns its numeric variants' source text "cannot be re-parsed... emitters must use the carried value" (hex/octal), and plain decimal ints never lose information through the existing `as_i64` path, so there's no bug there to fix.
- All finite-float behavior verified live against the pinned `yq` oracle (v4.53.3), including confirming real yq *also* normalizes a leading-dot float (`.5` → `0.5`) once forced through materialization — validating that excluding it from literal-preservation isn't just a defensive JSON-safety measure but the actually-correct output.

Fixes #918

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 53 binaries, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New regression tests: integer-valued float never matches via `in()`/`has()` (#918), materialized float literal fidelity through `[.]` (`2.0`→`[2.0]`, `.5`→`[0.5]`), `tag` on a leading-dot float (`!!float`, not `!!null`)
- [x] Updated stale #909 test comment now that #918 is fixed
- [x] `yq_golden_conformance` (`scalar_tag_resolution` fixture) passes