### PR TITLE
fix(jq): test/match/capture unpack a bare array pattern as [pattern, flags] (#943)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -24,14 +24,14 @@ For jq *feature* coverage rather than error wording, see
 
 ## Summary
 
-Measured against jq-1.7.1 over the 212 probes in
+Measured against jq-1.7.1 over the 219 probes in
 [`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv), through
 **both** evaluators — the full one (`src/jq/eval.rs`) and the generic one
 (`src/jq/eval_generic.rs`, which the CLI uses):
 
 | Dimension                                    | Result               | Meaning                                            |
 |----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **212/212 = 100.0%** | Byte-identical to jq                               |
+| **Message text** (both evaluators, verbatim) | **219/219 = 100.0%** | Byte-identical to jq                               |
 | **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
 | **Behaviour / parser gaps**                  | **0**                | succinctly does not raise the error at all         |
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28651,6 +28651,93 @@ mod tests {
 
     #[cfg(feature = "regex")]
     #[test]
+    fn test_regex_bare_array_pattern_unpacks_as_regex_flags_943() {
+        // #943: test/match/capture's *bare* form (no flags argument at
+        // all) additionally accepts a non-empty array pattern, unpacking
+        // it as [pattern, flags, ...ignored] -- undocumented but real jq
+        // behavior. sub/gsub/scan/split/splits do NOT do this (a plain
+        // non-string-pattern error, verified separately below), and an
+        // array pattern combined with an explicit flags argument doesn't
+        // unpack either -- the two ways of supplying flags don't combine.
+        // Every case verified live against jq 1.7.1.
+
+        // Successful unpacking: 2-element [string, string].
+        for filter in [
+            r#"test(["a", "i"])"#,
+            r#"match(["a", "i"])"#,
+            r#"capture(["(?<x>a)", "i"])"#,
+        ] {
+            query!(br#""abc""#, filter,
+                QueryResult::Owned(_) | QueryResult::ManyOwned(_) => {}
+            );
+        }
+
+        // 1-element array: pattern only, missing flags slot behaves like
+        // an explicit `null` flags (still succeeds).
+        query!(br#""abc""#, r#"test(["a"])"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b);
+            }
+        );
+
+        // Extra elements past index 1 are silently ignored, not an error.
+        query!(br#""abc""#, r#"test(["a", "i", "extra", "junk"])"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b);
+            }
+        );
+
+        // A genuinely empty array has no element 0 to unpack, so it falls
+        // through to the plain non-string-pattern check on the array
+        // itself -- the *bare*-form wording (no value preview), since
+        // unpacking never happened.
+        for filter in [r"test([])", r"match([])", r"capture([])"] {
+            query!(br#""abc""#, filter,
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "array not a string or array", "filter: {filter}");
+                }
+            );
+        }
+
+        // Once unpacked, a bad pattern or flags value uses the *flagged*-
+        // form wording (is_not_a_string, with a value preview) even
+        // though this is syntactically the bare 1-arg call -- confirmed
+        // live even for a 1-element array with no explicit flags slot:
+        // `test([1])` -> "number (1) is not a string", not `test(1)`'s
+        // own "number not a string or array".
+        for filter in ["test([1])", "test([1, 2])", "test([\"a\", 2])"] {
+            query!(br#""abc""#, filter,
+                QueryResult::Error(e) => {
+                    assert!(e.message.ends_with("is not a string"), "filter: {filter}: {}", e.message);
+                }
+            );
+        }
+
+        // An explicit flags argument suppresses unpacking entirely --
+        // the array is just an ordinary bad pattern value then, using
+        // the (already-established, #937) flagged-form wording.
+        query!(br#""abc""#, r#"test(["a", "i"]; "x")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "array ([\"a\",\"i\"]) is not a string");
+            }
+        );
+
+        // sub/gsub/scan/split/splits do not unpack array patterns at all.
+        for filter in [
+            r#"sub(["a", "i"]; "b")"#,
+            r#"gsub(["a", "i"]; "b")"#,
+            r#"scan(["a", "i"])"#,
+        ] {
+            query!(br#""abc""#, filter,
+                QueryResult::Error(e) => {
+                    assert!(e.message.starts_with("array ("), "filter: {filter}: {}", e.message);
+                }
+            );
+        }
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
     fn test_regex_lookahead_unsupported() {
         // #703: jq's oniguruma backend supports lookahead (`(?=...)`), but
         // succinctly's `regex` crate does not implement lookaround at all —

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6778,6 +6778,10 @@ enum RegexArgFamily {
     /// (`flags_expr: None`) pattern error uses `not_string_or_array`,
     /// switching to `is_not_a_string` once a flags argument is present
     /// (#937), regardless of what the flags expression evaluates to.
+    /// Exception (#943): a bare-form call whose pattern is a non-empty
+    /// array unpacks it as `[pattern, flags, ...ignored]` instead, and
+    /// then *also* uses `is_not_a_string` for a bad unpacked element,
+    /// even though no flags argument was ever written at the call site.
     TestMatchCapture,
     /// `sub`: forces pattern before flags (the reverse — and unchanged
     /// from what this codebase already did before #942, since only the
@@ -28661,16 +28665,36 @@ mod tests {
         // unpack either -- the two ways of supplying flags don't combine.
         // Every case verified live against jq 1.7.1.
 
-        // Successful unpacking: 2-element [string, string].
-        for filter in [
-            r#"test(["a", "i"])"#,
-            r#"match(["a", "i"])"#,
-            r#"capture(["(?<x>a)", "i"])"#,
-        ] {
-            query!(br#""abc""#, filter,
-                QueryResult::Owned(_) | QueryResult::ManyOwned(_) => {}
-            );
-        }
+        // Successful unpacking: 2-element [string, string], content
+        // verified against the equivalent 2-arg form's own known output.
+        query!(br#""abc""#, r#"test(["a", "i"])"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b);
+            }
+        );
+        query!(br#""abc""#, r#"match(["a", "i"])"#,
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.get("string"), Some(&OwnedValue::String("a".to_string())));
+                assert_eq!(obj.get("offset"), Some(&OwnedValue::Int(0)));
+            }
+        );
+        query!(br#""abc""#, r#"capture(["(?<x>a)", "i"])"#,
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.get("x"), Some(&OwnedValue::String("a".to_string())));
+            }
+        );
+
+        // The unpacked flags slot reaches the same "g" (global) handling a
+        // real flags argument would -- multiple matches, not just one.
+        query!(br#""aaa""#, r#"match(["a", "g"])"#,
+            QueryResult::ManyOwned(matches) => {
+                assert_eq!(matches.len(), 3);
+                for m in &matches {
+                    let OwnedValue::Object(obj) = m else { panic!("expected object, got {m:?}") };
+                    assert_eq!(obj.get("string"), Some(&OwnedValue::String("a".to_string())));
+                }
+            }
+        );
 
         // 1-element array: pattern only, missing flags slot behaves like
         // an explicit `null` flags (still succeeds).

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6855,9 +6855,37 @@ fn eval_regex_pattern_and_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     };
 
+    // #943: `test`/`match`/`capture`'s *bare* form (no `flags_expr` at all)
+    // additionally unpacks a non-empty array pattern as `[pattern, flags,
+    // ...ignored]` — undocumented but real jq behavior, confirmed live:
+    // `test(["a","i"])` behaves exactly like `test("a";"i")`, extra
+    // elements past index 1 are silently ignored (`test(["a","i","x"])`
+    // still succeeds), and a 1-element array supplies `null` flags
+    // (`test(["a"])` succeeds with no flags). Only a genuinely *empty*
+    // array (no element 0 to unpack) skips this and falls through to the
+    // plain non-string-pattern check below, using the array's own type
+    // name. Does not apply to `sub` (confirmed live: `sub(["a","i"];"b")`
+    // is a plain non-string-pattern error, no unpacking) or when
+    // `flags_expr` is itself present (`test(["a","i"]; "x")` is likewise
+    // a plain error — the two ways of supplying flags don't combine).
+    let (raw_pattern, raw_flags, array_unpacked) = match (family, flags_expr, raw_pattern) {
+        (RegexArgFamily::TestMatchCapture, None, OwnedValue::Array(items)) if !items.is_empty() => {
+            let mut items = items.into_iter();
+            let pattern = items.next().expect("checked non-empty above");
+            let flags = items.next();
+            (pattern, flags, true)
+        }
+        (_, _, raw_pattern) => (raw_pattern, raw_flags, false),
+    };
+
+    // Once an array pattern has been unpacked, both the pattern and flags
+    // slots use the same wording an explicit 2-arg call would — confirmed
+    // live even for a 1-element array with no explicit flags slot at all:
+    // `test([1])` -> "number (1) is not a string", not the bare "not a
+    // string or array" `test(1)` alone would give.
     let pattern = match raw_pattern {
         OwnedValue::String(s) => s,
-        v if flags_expr.is_some() || matches!(family, RegexArgFamily::Sub) => {
+        v if array_unpacked || flags_expr.is_some() || matches!(family, RegexArgFamily::Sub) => {
             return Err(QueryResult::Error(EvalError::is_not_a_string(&v)));
         }
         v => {

--- a/tests/data/jq-error-messages.tsv
+++ b/tests/data/jq-error-messages.tsv
@@ -164,6 +164,13 @@ splits_flags_non_string	splits("a"; 1)	"abc"	string ("g") and number (1) cannot 
 test_arg_non_string_flagged	test(1; "")	"abc"	number (1) is not a string
 match_arg_non_string_flagged	match(1; "")	"abc"	number (1) is not a string
 capture_arg_non_string_flagged	capture(1; "")	"abc"	number (1) is not a string
+test_array_pattern_empty	test([])	"abc"	array not a string or array
+match_array_pattern_empty	match([])	"abc"	array not a string or array
+capture_array_pattern_empty	capture([])	"abc"	array not a string or array
+test_array_pattern_bad_element	test([1])	"abc"	number (1) is not a string
+match_array_pattern_bad_element	match([1])	"abc"	number (1) is not a string
+capture_array_pattern_bad_element	capture([1])	"abc"	number (1) is not a string
+test_array_pattern_bad_flags	test(["a", 2])	"abc"	number (2) is not a string
 has_string_on_number	has("a")	1	Cannot check whether number has a string key
 has_string_on_array	has("a")	[1]	Cannot check whether array has a string key
 has_number_on_object	has(1)	{"a":1}	Cannot check whether object has a number key

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -256,6 +256,20 @@ test_arg_non_string_flagged	test(1; "")	"abc"
 match_arg_non_string_flagged	match(1; "")	"abc"
 capture_arg_non_string_flagged	capture(1; "")	"abc"
 
+# test/match/capture's *bare* form additionally unpacks a non-empty array
+# pattern as [pattern, flags, ...ignored] (#943, undocumented real jq
+# behavior). A genuinely empty array has no element 0 to unpack, so it
+# falls through to the plain bare-form wording using the array's own type
+# name; once unpacking succeeds, a bad element uses the flagged-form
+# wording instead, even for a 1-element array with no explicit flags slot.
+test_array_pattern_empty	test([])	"abc"
+match_array_pattern_empty	match([])	"abc"
+capture_array_pattern_empty	capture([])	"abc"
+test_array_pattern_bad_element	test([1])	"abc"
+match_array_pattern_bad_element	match([1])	"abc"
+capture_array_pattern_bad_element	capture([1])	"abc"
+test_array_pattern_bad_flags	test(["a", 2])	"abc"
+
 # ── Cannot check whether <t> has a <k> key ───────────────────────────────────
 has_string_on_number	has("a")	1
 has_string_on_array	has("a")	[1]

--- a/tests/jq_error_message_tests.rs
+++ b/tests/jq_error_message_tests.rs
@@ -36,7 +36,15 @@ const KNOWN_DIVERGENCES: &str = include_str!("data/jq-error-known-divergences.tx
 /// `test_arg_non_string` needs no entry here — but that fallback doesn't
 /// support a flags argument at all, so `test_flags_non_string` (and, by the
 /// same reasoning, `test`'s *flagged* pattern-error probe,
-/// `test_arg_non_string_flagged`) still does.
+/// `test_arg_non_string_flagged`) still does. Same for #943's array-pattern
+/// unpacking: the non-regex fallback doesn't implement it at all, so any
+/// probe that depends on unpacking actually happening (`test`'s own
+/// `_array_pattern_bad_element`/`_array_pattern_bad_flags`, plus all of
+/// `match`/`capture`'s array probes, which need `regex` unconditionally
+/// regardless of unpacking) needs gating — except `test_array_pattern_empty`,
+/// which coincidentally matches on both configs, since an empty array never
+/// unpacks either way and both paths fall back to the same plain
+/// non-string-pattern check on the array itself.
 #[cfg(feature = "regex")]
 const FEATURE_GATED: &[&str] = &[];
 #[cfg(not(feature = "regex"))]
@@ -65,6 +73,12 @@ const FEATURE_GATED: &[&str] = &[
     "test_arg_non_string_flagged",
     "match_arg_non_string_flagged",
     "capture_arg_non_string_flagged",
+    "test_array_pattern_bad_element",
+    "test_array_pattern_bad_flags",
+    "match_array_pattern_empty",
+    "match_array_pattern_bad_element",
+    "capture_array_pattern_empty",
+    "capture_array_pattern_bad_element",
     // #930: these use `scan(...)` purely as a vehicle to reach a non-finite
     // value's `describe()` preview - `keys`/`.[]` would also work without
     // `regex`, but route the value through `to_json_for_reindex` first,


### PR DESCRIPTION
## Summary

jq's *bare* `test`/`match`/`capture` form (no explicit flags argument) additionally accepts an array pattern, unpacking it as `[pattern, flags, ...ignored]` before evaluating it — an undocumented but real jq behavior, confirmed live against jq 1.7.1.

The actual unpacking rule is broader than issue #943's own suggested "2-element array, both strings" check:

- A **non-empty** array unpacks regardless of length — a 1-element array leaves the flags slot absent (behaves like `null`), a 3+-element array silently ignores anything past index 1.
- A genuinely **empty** array has no element 0 to unpack, so it falls through to the plain bare-form wording, using the array's own type (`array not a string or array`).
- Once unpacking happens, a bad pattern or flags element reports the *flagged*-form wording (`is_not_a_string`, with a value preview) even though this is syntactically a 1-arg call — `test([1])` → `"number (1) is not a string"`, not `test(1)`'s own `"number not a string or array"`.
- An **explicit flags argument** (the 2-arg call form) suppresses unpacking entirely — the array pattern is then just an ordinary bad pattern value.
- `sub`/`gsub`/`scan`/`split`/`splits` never unpack array patterns — this is unique to `test`/`match`/`capture`.

`sub`'s family keeps its own pattern-first evaluation order, unchanged.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New test `test_regex_bare_array_pattern_unpacks_as_regex_flags_943` covers every case verified live against jq 1.7.1
- [x] Oracle probe corpus extended (212 → 219) and regenerated from pinned jq 1.7.1 via `./scripts/sync-jq-error-messages.sh`
- [x] Local patch coverage: 100% of new lines in `src/jq/eval.rs`

Fixes #943