### PR TITLE
fix(jq): walk forks correctly at every level; repeat's trailing error/break/budget fixes

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13107,11 +13107,18 @@ fn eval_owned_fast_path(
 
 /// Same evaluator as [`eval_owned_expr`], but keeps a `break` distinguishable
 /// from a real error via [`Control`] instead of collapsing it into a
-/// synthetic "break $label not in label" [`EvalError`] — needed by callers
-/// that run their operand through a loop of their own (`while`, `until`,
-/// `repeat`, `reduce`, `foreach`'s per-iteration UPDATE/EXTRACT) and must let
-/// a `break $label` inside that operand reach its enclosing `label` (#575).
-/// Same fix [`eval_slice_bound`] already applies to slice bounds.
+/// synthetic "break $label not in label" [`EvalError`] — needed by any
+/// caller that must let a `break $label` inside its operand reach its
+/// enclosing `label` (#575) but can't (or, for a caller needing every
+/// output rather than one collapsed value, shouldn't) use
+/// [`eval_owned_expr_fork`] directly. Direct callers today: `resolve_limit`
+/// (a single bound value, not a stream) and `builtin_paths_filter`'s
+/// root-node check (only ever cares whether the root escaped, not what it
+/// produced). `while`/`until`/`repeat`/`reduce`/`foreach`/`walk` all use
+/// `eval_owned_expr_fork` directly instead, since each needs the full
+/// `(Vec<OwnedValue>, Option<Control>)` shape to avoid silently dropping a
+/// trailing error/break behind values already produced (#855). Same fix
+/// [`eval_slice_bound`] already applies to slice bounds.
 fn eval_owned_expr_ctrl<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
@@ -13161,8 +13168,11 @@ fn eval_owned_expr_ctrl<S: EvalSemantics>(
         QueryResult::Break(label) => Err(Control::Break(label)),
         QueryResult::Halt(code) => Err(Control::Halt(code)),
         // A trailing halt is never droppable, unlike the `Error`/`Break`
-        // cases below: `repeat((. + 1, halt_error(3)))` must exit 3, not run
-        // to the iteration cap with the halt discarded once per round (#791).
+        // cases below: a caller looping on this function's own result (any
+        // of `resolve_limit`, `eval_owned_expr`'s further callers, or
+        // `builtin_paths_filter`'s root check) must see a halt that arrives
+        // after some values were already produced, not have it silently
+        // discarded (#791).
         QueryResult::Partial(_, Control::Halt(code)) => Err(Control::Halt(code)),
         // Same collapse-to-single-or-array policy as `Many`/`ManyOwned`
         // above; the trailing `Error`/`Break` is dropped, consistent with how
@@ -13834,7 +13844,19 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let owned = to_owned(&value);
     let mut outputs: Vec<OwnedValue> = Vec::new();
-    const MAX_ITERATIONS: usize = 1000; // Limit to prevent infinite loops
+    // Bounds the round count for the one case a per-value budget can't
+    // reach: an `expr` that produces zero outputs every round (e.g.
+    // `repeat(empty)`) never charges `budget` below, so it would loop
+    // forever without this backstop.
+    const MAX_ITERATIONS: usize = 1000;
+    // Bounds total output size independent of `expr`'s own fan-out (#855
+    // follow-up): the per-round loop below used to push at most one
+    // (collapsed) value per round, implicitly capping output at
+    // `MAX_ITERATIONS`; extending with every value a multi-output round
+    // produces removes that implicit cap unless charged explicitly here,
+    // the same "width needs its own accounting" reasoning `foreach`'s own
+    // per-EXTRACT charge already documents.
+    let mut budget = REDUCE_FOREACH_MAX_STEPS;
 
     for _ in 0..MAX_ITERATIONS {
         // Evaluate expr with the original input each time, extending
@@ -13844,7 +13866,12 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // .+100)))]` on `0` is `[1,100,1,100,1,100]`, not
         // `[[1,100],[1,100],[1,100]]`.
         let (vals, control) = eval_owned_expr_fork::<S>(expr, &owned, optional);
-        outputs.extend(vals);
+        for val in vals {
+            if let Some(control) = charge_budget(&mut budget, "repeat") {
+                return finish_fork(outputs, Some(control), optional);
+            }
+            outputs.push(val);
+        }
         // The values already output no longer vanish, and an error with
         // no prior output surfaces as an error rather than empty output
         // (#495): `repeat(if . > 3 then error("boom") else .+1 end)` on
@@ -13856,7 +13883,7 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // then raises, matching jq exactly, instead of looping to
         // `MAX_ITERATIONS` with the error silently dropped every round.
         if let Some(control) = control {
-            return partial(outputs, control);
+            return finish_fork(outputs, Some(control), optional);
         }
     }
 
@@ -14199,83 +14226,96 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
 /// Builtin: walk(f) - recursively transform all values.
 ///
-/// The outermost application of `f` (to the fully children-processed root
-/// value) uses `eval_owned_expr_fork` directly, not `walk_impl`'s own
-/// (nested) collapsing behavior: a multi-output `f` that also errors partway
-/// through must surface the values it already produced before the error,
-/// not silently drop them (#855) — verified against jq 1.7.1: `walk(1,
-/// error("bad"))` on `5` prints `1` then raises, exit 5.
-///
-/// `f` applied at *nested* levels (inside `walk_impl`'s own recursion, for
-/// every array/object element) keeps its existing single-value-collapsing
-/// behavior unchanged — real jq's own `walk` recursively forks at every
-/// level (verified: `walk(1, 2)` on `5` prints `1` and `2` as two separate
-/// top-level outputs, not one array, with no error involved at all), so
-/// fully matching it would mean threading a value-stream through every
-/// level of tree recursion, with array/object using different combination
-/// rules (`map`'s flatten-concatenate vs `map_values`'s `|=`
-/// last-output-wins-or-delete) — real, separable design work tracked as a
-/// follow-up rather than attempted here. This fix's own scope is narrower:
-/// stop the outermost application from *silently swallowing* a trailing
-/// error/break behind values it already produced, exactly the shape #855
-/// reports.
+/// jq's own recursive definition (`def walk(f): def w: (if type == "object"
+/// then map_values(w) elif type == "array" then map(w) else . end) | f; w;`)
+/// genuinely forks at *every* recursion level, not just the outermost one
+/// (#855) — verified against jq 1.7.1: `walk(1, 2)` on the container `[5]`
+/// (not a scalar, which only exercises the outermost level) prints `[1,2]`
+/// as `.[0]`'s own two-way fork flattened into the rebuilt array, matching
+/// `map(w)`'s `[.[] | w]` semantics; `walk(1, error("bad"))` on `[5,6]`
+/// prints nothing at all before raising, matching `[...]`'s atomic
+/// construction (an interior error discards the whole array, not just the
+/// one element). `walk_impl` implements this directly: see its own doc
+/// comment for the two containers' differing combination rules and the
+/// verification behind each.
 fn builtin_walk<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     f: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
     let owned = to_owned(&value);
-    let processed = match walk_children::<S>(f, owned, optional) {
-        Ok(v) => v,
-        Err(e) => return e.into(),
-    };
-    let (vals, control) = eval_owned_expr_fork::<S>(f, &processed, optional);
+    let (vals, control) = walk_impl::<S>(f, owned, optional);
     finish_fork(vals, control, optional)
 }
 
-/// Recursively process `value`'s children (if it's an array/object), each
-/// via [`walk_impl`] -- shared by [`builtin_walk`] (for the outermost
-/// value, before its own fork-aware `f` application) and `walk_impl` itself
-/// (for a nested value, before *its* still-collapsing `f` application).
-fn walk_children<S: EvalSemantics>(
-    f: &Expr,
-    value: OwnedValue,
-    optional: bool,
-) -> Result<OwnedValue, EvalEscape> {
-    match value {
-        OwnedValue::Array(arr) => {
-            let new_arr: Result<Vec<_>, _> = arr
-                .into_iter()
-                .map(|v| walk_impl::<S>(f, v, optional))
-                .collect();
-            Ok(OwnedValue::Array(new_arr?))
-        }
-        OwnedValue::Object(obj) => {
-            let new_obj: Result<IndexMap<_, _>, _> = obj
-                .into_iter()
-                .map(|(k, v)| walk_impl::<S>(f, v, optional).map(|nv| (k, nv)))
-                .collect();
-            Ok(OwnedValue::Object(new_obj?))
-        }
-        other => Ok(other),
-    }
-}
-
-/// Implementation of walk - processes children first, then applies f.
+/// Recursively transform `value`, returning every output `f` produces for
+/// the whole (sub)tree and an optional trailing control if evaluation cut
+/// short partway through -- the same `(Vec<OwnedValue>, Option<Control>)`
+/// shape [`eval_owned_expr_fork`] returns, since this function's own final
+/// step *is* an `eval_owned_expr_fork` call (applying `f` to the
+/// already-processed value).
 ///
-/// Used for every *nested* value (array/object elements); the outermost
-/// value's own `f` application is [`builtin_walk`]'s job instead, via
-/// [`walk_children`] + `eval_owned_expr_fork` directly -- see that
-/// function's doc comment for why the two levels are treated differently.
+/// Array and object children combine their own sub-streams with two
+/// different rules, matching `map`/`map_values`'s real jq definitions
+/// exactly (each verified live against jq 1.7.1):
+/// - **Array** (`map(w) = [.[] | w]`): flatten-concatenate every child's
+///   full output stream into the rebuilt array. `walk(if type=="array"
+///   then . else (1,2) end)` on `[5,6]` is `[1,2,1,2]` (two elements, two
+///   outputs each, all four flattened) — not `[[1,2],[1,2]]`. A
+///   zero-output child drops out of the array entirely (`walk(if
+///   type=="array" then . else empty end)` on `[5,6]` is `[]`, not
+///   `[null,null]`).
+/// - **Object** (`map_values(w) = .[] |= w`): each key takes only the
+///   *first* output of its own child's stream, or is deleted if that
+///   stream is empty. `walk(if type=="object" then . else (1,2) end)` on
+///   `{"a":5}` is `{"a":1}`, not `{"a":2}` — jq's `|=` (via its
+///   `_modify`/`label`+`break` desugaring) commits the first successful
+///   update and never runs the rest of the stream. `walk(if
+///   type=="object" then . else empty end)` on `{"a":5}` is `{}`.
+///
+/// Both containers are atomic on error/break, matching how `[...]`/`{...}`
+/// construction works in jq generally: a child that returns a trailing
+/// `Control` aborts the *whole* container immediately, discarding every
+/// sibling already processed (not just that one child) — verified:
+/// `walk(if .==5 then error("x") else . end)` on `[5,6]` raises with no
+/// output at all, not a partial array.
 fn walk_impl<S: EvalSemantics>(
     f: &Expr,
     value: OwnedValue,
     optional: bool,
-) -> Result<OwnedValue, EvalEscape> {
-    let processed = walk_children::<S>(f, value, optional)?;
+) -> (Vec<OwnedValue>, Option<Control>) {
+    let processed = match value {
+        OwnedValue::Array(arr) => {
+            let mut new_arr = Vec::with_capacity(arr.len());
+            for v in arr {
+                let (vs, control) = walk_impl::<S>(f, v, optional);
+                new_arr.extend(vs);
+                if let Some(control) = control {
+                    return (Vec::new(), Some(control));
+                }
+            }
+            OwnedValue::Array(new_arr)
+        }
+        OwnedValue::Object(obj) => {
+            let mut new_obj = IndexMap::with_capacity(obj.len());
+            for (k, v) in obj {
+                let (vs, control) = walk_impl::<S>(f, v, optional);
+                if let Some(control) = control {
+                    return (Vec::new(), Some(control));
+                }
+                if let Some(new_v) = vs.into_iter().next() {
+                    new_obj.insert(k, new_v);
+                }
+            }
+            OwnedValue::Object(new_obj)
+        }
+        other => other,
+    };
 
-    // Then apply f to the processed value
-    eval_owned_expr::<S>(f, &processed, optional)
+    // Then apply f to the processed value, correctly threading Control
+    // (#855) at every level -- the same fork building block every other
+    // fork construct in this file uses.
+    eval_owned_expr_fork::<S>(f, &processed, optional)
 }
 
 /// Builtin: isvalid(expr) - check if expr succeeds without errors.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13837,16 +13837,26 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     const MAX_ITERATIONS: usize = 1000; // Limit to prevent infinite loops
 
     for _ in 0..MAX_ITERATIONS {
-        // Evaluate expr with the original input each time
-        match eval_owned_expr_ctrl::<S>(expr, &owned, optional) {
-            Ok(new_val) => outputs.push(new_val),
-            // The values already output no longer vanish, and an error with
-            // no prior output surfaces as an error rather than empty output
-            // (#495): `repeat(if . > 3 then error("boom") else .+1 end)` on
-            // `5` raises immediately with no output, matching jq exactly.
-            // A `break $label` reaches its enclosing `label` instead of
-            // degrading into a synthetic error (#575).
-            Err(control) => return partial(outputs, control),
+        // Evaluate expr with the original input each time, extending
+        // `outputs` with *every* value it produces this round -- not just
+        // one collapsed value (#855): jq's own `repeat` genuinely forks on a
+        // multi-output `expr`, verified live: `[limit(6; repeat((.+1,
+        // .+100)))]` on `0` is `[1,100,1,100,1,100]`, not
+        // `[[1,100],[1,100],[1,100]]`.
+        let (vals, control) = eval_owned_expr_fork::<S>(expr, &owned, optional);
+        outputs.extend(vals);
+        // The values already output no longer vanish, and an error with
+        // no prior output surfaces as an error rather than empty output
+        // (#495): `repeat(if . > 3 then error("boom") else .+1 end)` on
+        // `5` raises immediately with no output, matching jq exactly.
+        // A `break $label` reaches its enclosing `label` instead of
+        // degrading into a synthetic error (#575). Also covers a trailing
+        // error/break after this round's own multi-output prefix (#855):
+        // `limit(3; repeat((1, error("bad"))))` on `null` prints `1` once
+        // then raises, matching jq exactly, instead of looping to
+        // `MAX_ITERATIONS` with the error silently dropped every round.
+        if let Some(control) = control {
+            return partial(outputs, control);
         }
     }
 
@@ -14188,42 +14198,81 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: walk(f) - recursively transform all values.
+///
+/// The outermost application of `f` (to the fully children-processed root
+/// value) uses `eval_owned_expr_fork` directly, not `walk_impl`'s own
+/// (nested) collapsing behavior: a multi-output `f` that also errors partway
+/// through must surface the values it already produced before the error,
+/// not silently drop them (#855) — verified against jq 1.7.1: `walk(1,
+/// error("bad"))` on `5` prints `1` then raises, exit 5.
+///
+/// `f` applied at *nested* levels (inside `walk_impl`'s own recursion, for
+/// every array/object element) keeps its existing single-value-collapsing
+/// behavior unchanged — real jq's own `walk` recursively forks at every
+/// level (verified: `walk(1, 2)` on `5` prints `1` and `2` as two separate
+/// top-level outputs, not one array, with no error involved at all), so
+/// fully matching it would mean threading a value-stream through every
+/// level of tree recursion, with array/object using different combination
+/// rules (`map`'s flatten-concatenate vs `map_values`'s `|=`
+/// last-output-wins-or-delete) — real, separable design work tracked as a
+/// follow-up rather than attempted here. This fix's own scope is narrower:
+/// stop the outermost application from *silently swallowing* a trailing
+/// error/break behind values it already produced, exactly the shape #855
+/// reports.
 fn builtin_walk<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     f: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
     let owned = to_owned(&value);
-    match walk_impl::<S>(f, owned, optional) {
-        Ok(result) => QueryResult::Owned(result),
-        Err(e) => e.into(),
-    }
+    let processed = match walk_children::<S>(f, owned, optional) {
+        Ok(v) => v,
+        Err(e) => return e.into(),
+    };
+    let (vals, control) = eval_owned_expr_fork::<S>(f, &processed, optional);
+    finish_fork(vals, control, optional)
 }
 
-/// Implementation of walk - processes children first, then applies f.
-fn walk_impl<S: EvalSemantics>(
+/// Recursively process `value`'s children (if it's an array/object), each
+/// via [`walk_impl`] -- shared by [`builtin_walk`] (for the outermost
+/// value, before its own fork-aware `f` application) and `walk_impl` itself
+/// (for a nested value, before *its* still-collapsing `f` application).
+fn walk_children<S: EvalSemantics>(
     f: &Expr,
     value: OwnedValue,
     optional: bool,
 ) -> Result<OwnedValue, EvalEscape> {
-    // First, recursively process children
-    let processed = match value {
+    match value {
         OwnedValue::Array(arr) => {
             let new_arr: Result<Vec<_>, _> = arr
                 .into_iter()
                 .map(|v| walk_impl::<S>(f, v, optional))
                 .collect();
-            OwnedValue::Array(new_arr?)
+            Ok(OwnedValue::Array(new_arr?))
         }
         OwnedValue::Object(obj) => {
             let new_obj: Result<IndexMap<_, _>, _> = obj
                 .into_iter()
                 .map(|(k, v)| walk_impl::<S>(f, v, optional).map(|nv| (k, nv)))
                 .collect();
-            OwnedValue::Object(new_obj?)
+            Ok(OwnedValue::Object(new_obj?))
         }
-        other => other,
-    };
+        other => Ok(other),
+    }
+}
+
+/// Implementation of walk - processes children first, then applies f.
+///
+/// Used for every *nested* value (array/object elements); the outermost
+/// value's own `f` application is [`builtin_walk`]'s job instead, via
+/// [`walk_children`] + `eval_owned_expr_fork` directly -- see that
+/// function's doc comment for why the two levels are treated differently.
+fn walk_impl<S: EvalSemantics>(
+    f: &Expr,
+    value: OwnedValue,
+    optional: bool,
+) -> Result<OwnedValue, EvalEscape> {
+    let processed = walk_children::<S>(f, value, optional)?;
 
     // Then apply f to the processed value
     eval_owned_expr::<S>(f, &processed, optional)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3291,12 +3291,12 @@ fn test_pow_propagates_halt_in_argument() -> Result<()> {
 
 #[test]
 fn test_repeat_propagates_halt_instead_of_running_to_iteration_cap() -> Result<()> {
-    // `eval_owned_expr_ctrl`'s `Partial(vs, _control)` arm collapsed a
-    // multi-output result to first-value-or-array and dropped a trailing
-    // halt, so a `repeat` body that output a value and then halted on the
-    // *same* iteration kept looping instead of stopping -- silently
-    // discarding the halt every round until hitting the internal iteration
-    // cap. `repeat` is a succinctly extension (no upstream jq builtin), so
+    // A halt was already threaded correctly even before #855 (`eval_repeat`
+    // now uses `eval_owned_expr_fork`, not `eval_owned_expr_ctrl`, but both
+    // always propagated a trailing `Control::Halt` rather than silencing
+    // it) -- this pins that a `repeat` body producing a value and then
+    // halting on the *same* round stops immediately rather than looping.
+    // `repeat` is a succinctly extension (no upstream jq builtin), so
     // this is checked against succinctly's own contract: the halt must win
     // on the very first iteration, giving exit 3 and no output, not a
     // 1000-element array and exit 0.
@@ -7869,11 +7869,10 @@ fn test_resolve_node_getpath_multi_output_surfaces_real_error_not_a_fabricated_o
 
 #[test]
 fn test_walk_propagates_halt_from_f() -> Result<()> {
-    // `builtin_walk` applies `f` to the (already child-processed) root value
-    // via `eval_owned_expr_fork` + `finish_fork` (#855); for a scalar input
-    // like `1` there are no children, so this exercises the outermost
-    // application directly, and a halt from `f` propagates through
-    // `finish_fork`'s `partial`/`Control::Halt` handling into a `QueryResult`.
+    // `walk_impl` applies `f` via `eval_owned_expr_fork` at every level
+    // (#855, #960); a scalar input like `1` has no children, so this
+    // exercises that application directly, and a halt from `f` propagates
+    // through `finish_fork`'s `Control::Halt` handling into a `QueryResult`.
     // Verified against jq 1.7.1: `jq -n '1 | walk(halt_error(8))'` prints
     // nothing to stdout, dumps `1` (the value `f` was applied to) to stderr,
     // and exits 8.
@@ -7884,17 +7883,23 @@ fn test_walk_propagates_halt_from_f() -> Result<()> {
 }
 
 // ============================================================================
-// walk(f)/repeat(f) drop a trailing error/break after a multi-output f (#855)
+// walk(f)/repeat(f) drop a trailing error/break after a multi-output f
+// (#855), and don't fork on a multi-output f at all, independent of errors
+// (#960)
 // ============================================================================
 // eval_owned_expr_ctrl's Partial(vs, control) arm keeps the values `f`
-// already produced but silently drops the trailing Error/Break -- fixed for
-// repeat by switching its loop to eval_owned_expr_fork (which also fixes the
-// same collapse-to-array bug for a plain, non-erroring multi-output f), and
-// for walk by having builtin_walk apply the outermost f via
-// eval_owned_expr_fork directly rather than walk_impl's own (still
-// single-value-collapsing) recursive application. Real jq's own `walk`
-// forks at every recursion level, not just the outermost one -- fully
-// matching that is separable, bigger design work, tracked as a follow-up.
+// already produced but silently drops the trailing Error/Break. Fixed for
+// `repeat` by switching its loop to eval_owned_expr_fork (which also fixes
+// the same collapse-to-array bug for a plain, non-erroring multi-output f).
+// `walk_impl` implements jq's actual recursive fork semantics directly
+// (verified against jq 1.7.1 for every combination rule -- see its own doc
+// comment): array children flatten-concatenate their sub-streams (`map`),
+// object children take the first output or delete the key (`map_values`/
+// `|=`), and both are atomic on an interior error/break, discarding every
+// sibling already processed. This closes both #855 and #960 for walk; #960
+// remains open only in spirit for `repeat`, which cannot meaningfully
+// "recurse into children" (it's a flat loop over the unchanged original
+// input, not a tree), and already forks fully as of #855's own fix.
 
 #[test]
 fn test_walk_propagates_error_after_partial_output() -> Result<()> {
@@ -7955,6 +7960,157 @@ fn test_repeat_multi_output_extends_rather_than_collapses() -> Result<()> {
         run_jq_full(&["-c", "[limit(6; repeat((.+1, .+100)))]"], Some("0"))?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "[1,100,1,100,1,100]\n");
+    Ok(())
+}
+
+#[test]
+fn test_repeat_empty_expr_yields_nothing_instead_of_looping_forever_on_nulls() -> Result<()> {
+    // `eval_owned_expr_ctrl` mapped a zero-output round to `Ok(Null)`, so
+    // `repeat(empty)` used to emit `MAX_ITERATIONS` `null`s; `eval_owned_expr_fork`
+    // reports zero-output rounds as genuinely zero values, so `repeat(empty)`
+    // now emits nothing at all -- jq itself has no oracle answer here (a
+    // bare `repeat(empty)` spins forever with no output either way, so this
+    // pins succinctly's own bounded behavior rather than a jq comparison).
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[limit(3; repeat(empty))]"], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+    Ok(())
+}
+
+#[test]
+fn test_walk_array_multi_output_flattens_children_streams() -> Result<()> {
+    // `map(w) = [.[] | w]`: every child's own output stream flattens
+    // straight into the rebuilt array, not one sub-array per child.
+    // Verified against jq 1.7.1: `echo '[5,6]' | jq -c 'walk(if
+    // type=="array" then . else (1,2) end)'` is `[1,2,1,2]`.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"walk(if type=="array" then . else (1,2) end)"#],
+        Some("[5,6]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,2,1,2]\n");
+    Ok(())
+}
+
+#[test]
+fn test_walk_array_zero_output_child_drops_out_of_the_array() -> Result<()> {
+    // Verified against jq 1.7.1: `echo '[5,6]' | jq -c 'walk(if
+    // type=="array" then . else empty end)'` is `[]`, not `[null,null]`.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"walk(if type=="array" then . else empty end)"#],
+        Some("[5,6]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+    Ok(())
+}
+
+#[test]
+fn test_walk_object_multi_output_child_takes_the_first_value() -> Result<()> {
+    // `map_values(w) = .[] |= w`: jq's `|=` commits the *first* output of
+    // the update stream (via its `label`/`break` desugaring), not the
+    // last. Verified against jq 1.7.1: `echo '{"a":5}' | jq -c 'walk(if
+    // type=="object" then . else (1,2) end)'` is `{"a":1}`, not `{"a":2}`.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"walk(if type=="object" then . else (1,2) end)"#],
+        Some(r#"{"a":5}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"a\":1}\n");
+    Ok(())
+}
+
+#[test]
+fn test_walk_object_zero_output_child_deletes_the_key() -> Result<()> {
+    // Verified against jq 1.7.1: `echo '{"a":5}' | jq -c 'walk(if
+    // type=="object" then . else empty end)'` is `{}`.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"walk(if type=="object" then . else empty end)"#],
+        Some(r#"{"a":5}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{}\n");
+    Ok(())
+}
+
+#[test]
+fn test_walk_array_construction_is_atomic_on_an_interior_error() -> Result<()> {
+    // A child's error must discard the *whole* array being built, not just
+    // that one element -- matching how `[...]` construction works in jq
+    // generally. Verified against jq 1.7.1: `echo '[5,6]' | jq -c 'walk(if
+    // .==5 then error("x") else . end)'` raises with no output at all, not
+    // a partial array (e.g. `[6]` or `[null,6]`).
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"walk(if .==5 then error("x") else . end)"#],
+        Some("[5,6]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+#[test]
+fn test_walk_nested_break_reaches_its_enclosing_label() -> Result<()> {
+    // Before this fix, a nested `f` application collapsed a `Control::Break`
+    // into a synthetic "break $label not in label" `EvalError` (the same
+    // #575 shape already fixed for `repeat`'s own single-level loop, now
+    // fixed for every level of `walk`'s tree recursion too). Verified
+    // against jq 1.7.1: `echo '[5]' | jq -c 'label $out | walk(if
+    // type=="number" then break $out else . end)'` prints nothing and
+    // exits 0 -- not a "break $out not in label" error.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | walk(if type=="number" then break $out else . end)"#,
+        ],
+        Some("[5]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+#[test]
+fn test_walk_nested_error_reports_the_same_message_jq_does() -> Result<()> {
+    // Before this fix, a nested trailing error was silently absorbed and
+    // the *outermost* `f` was re-applied to the corrupted, partially-built
+    // tree instead -- reporting a synthetic error message and a spurious
+    // stdout value neither of which jq ever produces. Verified against jq
+    // 1.7.1: `echo '[5]' | jq -c 'walk(1, error(tostring))'` prints nothing
+    // to stdout and reports "5" (the value `f` was applied to, via
+    // `tostring`), not "[1]" (a rebuilt array `f` was never really applied
+    // to in the real evaluation).
+    let (stdout, stderr, code) = run_jq_full(&["-c", "walk(1, error(tostring))"], Some("[5]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('5'), "stderr: {stderr:?}");
+    assert!(!stderr.contains('1'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+#[test]
+fn test_walk_deep_nesting_does_not_overflow_the_stack() -> Result<()> {
+    // Regression guard: an earlier version of this fix split `walk_impl`
+    // into two mutually-recursive functions, adding a non-inlined stack
+    // frame per nesting level. Measured on a release build, that dropped
+    // the depth `walk(.)` could handle before overflowing from ~7000-8000
+    // down to ~6000-7000; on the debug build this test binary actually
+    // runs, frames are far larger and the safe/unsafe boundary sits
+    // between depth 500 and 700 post-fix (measured). Depth 200 here is
+    // comfortably under that boundary (leaving margin for a CI runner with
+    // a smaller default stack than the dev machine this was measured on)
+    // while still deep enough that reintroducing a meaningfully-sized
+    // per-level frame has a real chance of tripping it.
+    let depth = 200;
+    let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+    // Compares stdout directly against the input text (both already
+    // whitespace-free) rather than round-tripping through jq's own `==`,
+    // whose comparison recursion could mask a `walk`-specific regression
+    // behind a stack limit of its own.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "walk(.)"], Some(&input))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), input);
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7869,17 +7869,92 @@ fn test_resolve_node_getpath_multi_output_surfaces_real_error_not_a_fabricated_o
 
 #[test]
 fn test_walk_propagates_halt_from_f() -> Result<()> {
-    // `builtin_walk`'s `Err(e) => e.into()` arm: `walk_impl` applies `f` to
-    // the (already child-processed) value via `eval_owned_expr`, and a halt
-    // from `f` propagates back up through every recursive `walk_impl` call's
-    // `?` (through `Vec<_>`/`IndexMap<_>`'s `collect()` for container
-    // values) to this top-level match, converting back into a `QueryResult`.
+    // `builtin_walk` applies `f` to the (already child-processed) root value
+    // via `eval_owned_expr_fork` + `finish_fork` (#855); for a scalar input
+    // like `1` there are no children, so this exercises the outermost
+    // application directly, and a halt from `f` propagates through
+    // `finish_fork`'s `partial`/`Control::Halt` handling into a `QueryResult`.
     // Verified against jq 1.7.1: `jq -n '1 | walk(halt_error(8))'` prints
     // nothing to stdout, dumps `1` (the value `f` was applied to) to stderr,
     // and exits 8.
     let (stdout, stderr, code) = run_jq_full(&["-n", "1 | walk(halt_error(8))"], None)?;
     assert_eq!(code, 8, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
+    Ok(())
+}
+
+// ============================================================================
+// walk(f)/repeat(f) drop a trailing error/break after a multi-output f (#855)
+// ============================================================================
+// eval_owned_expr_ctrl's Partial(vs, control) arm keeps the values `f`
+// already produced but silently drops the trailing Error/Break -- fixed for
+// repeat by switching its loop to eval_owned_expr_fork (which also fixes the
+// same collapse-to-array bug for a plain, non-erroring multi-output f), and
+// for walk by having builtin_walk apply the outermost f via
+// eval_owned_expr_fork directly rather than walk_impl's own (still
+// single-value-collapsing) recursive application. Real jq's own `walk`
+// forks at every recursion level, not just the outermost one -- fully
+// matching that is separable, bigger design work, tracked as a follow-up.
+
+#[test]
+fn test_walk_propagates_error_after_partial_output() -> Result<()> {
+    // Verified against jq 1.7.1: `echo 5 | jq -c 'walk(1, error("bad"))'`
+    // prints `1` then raises, exit 5.
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"walk(1, error("bad"))"#], Some("5"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "1\n");
+    assert!(stderr.contains("bad"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+#[test]
+fn test_walk_propagates_break_after_partial_output() -> Result<()> {
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", "label $out | walk(1, break $out)"], Some("5"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout, "1\n");
+    Ok(())
+}
+
+#[test]
+fn test_repeat_propagates_error_after_partial_output() -> Result<()> {
+    // Verified against jq 1.7.1: `echo null | jq -c 'limit(3;
+    // repeat((1, error("bad"))))'` prints `1` once then raises, exit 5 --
+    // not looping to `MAX_ITERATIONS` with the error silently dropped every
+    // round (the pre-fix behavior).
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"limit(3; repeat((1, error("bad"))))"#],
+        Some("null"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "1\n");
+    assert!(stderr.contains("bad"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+#[test]
+fn test_repeat_propagates_break_after_partial_output() -> Result<()> {
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", "label $out | limit(3; repeat((1, break $out)))"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout, "1\n");
+    Ok(())
+}
+
+#[test]
+fn test_repeat_multi_output_extends_rather_than_collapses() -> Result<()> {
+    // The non-error sibling of the two tests above: `repeat`'s own loop
+    // previously collapsed each round's multi-output `expr` into one array
+    // per round instead of extending its output stream with every value.
+    // Verified against jq 1.7.1: `echo 0 | jq -c '[limit(6; repeat((.+1,
+    // .+100)))]'` is `[1,100,1,100,1,100]`, not
+    // `[[1,100],[1,100],[1,100]]`.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[limit(6; repeat((.+1, .+100)))]"], Some("0"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,100,1,100,1,100]\n");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8051,6 +8051,45 @@ fn test_walk_array_construction_is_atomic_on_an_interior_error() -> Result<()> {
 }
 
 #[test]
+fn test_walk_object_construction_is_atomic_on_an_interior_error() -> Result<()> {
+    // The object counterpart to the array test above -- a distinct branch
+    // in `walk_impl` (objects use `map_values`/`|=` semantics, not `map`'s),
+    // so it needs its own coverage. Verified against jq 1.7.1: `echo
+    // '{"a":5,"b":6}' | jq -c 'walk(if .==5 then error("x") else . end)'`
+    // raises with no output at all.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"walk(if .==5 then error("x") else . end)"#],
+        Some(r#"{"a":5,"b":6}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+#[test]
+fn test_repeat_value_budget_bounds_total_output_independent_of_fan_out() -> Result<()> {
+    // Regression guard for the memory-bound fix: without a per-value
+    // budget, a single highly-fanning-out round (`range(20001)` produces
+    // 20001 values in one round) could balloon `outputs` far past any
+    // reasonable size before the per-round `MAX_ITERATIONS` cap ever had a
+    // chance to matter. `repeat` is a succinctly extension (no upstream jq
+    // builtin to compare against), so this pins succinctly's own contract:
+    // the budget (`REDUCE_FOREACH_MAX_STEPS`, shared with `reduce`/
+    // `foreach`) cuts the stream at exactly 10000 values with a clear
+    // error, not an unbounded allocation.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "repeat(range(20001))"], Some("null"))?;
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert_eq!(stdout.lines().count(), 10000, "stdout: {stdout:?}");
+    assert_eq!(stdout.lines().last(), Some("9999"));
+    assert!(
+        stderr.contains("maximum iterations exceeded"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_walk_nested_break_reaches_its_enclosing_label() -> Result<()> {
     // Before this fix, a nested `f` application collapsed a `Control::Break`
     // into a synthetic "break $label not in label" `EvalError` (the same


### PR DESCRIPTION
## Summary

`eval_owned_expr_ctrl`'s `Partial(vs, control)` arm keeps the values a multi-output `f` already produced but silently drops the trailing `Error`/`Break`, turning a query that should raise partway through into one that quietly continues (or, for `repeat`, loops all the way to its iteration cap). Verified against jq 1.7.1:
- `walk(1, error("bad"))` on `5` prints `1` then raises; succinctly previously dropped the error entirely.
- `limit(3; repeat((1, error("bad"))))` on `null` prints `1` once then raises; succinctly previously looped to `MAX_ITERATIONS` with the error silently dropped every round.

**`repeat`**: switched from `eval_owned_expr_ctrl` (single-value collapse) to `eval_owned_expr_fork`, extending `outputs` with every value each round instead of pushing one collapsed value — this also fixes a plain (non-erroring) multi-output `expr` collapsing into one array per round (confirmed wrong against real jq's `[1,100,1,100,1,100]` for `repeat((.+1, .+100))`). Also switched to `finish_fork` (matching every sibling fork construct) and added a per-value budget (`charge_budget`, the same helper `foreach`'s own per-EXTRACT accounting uses) so a highly-fanning-out `expr` can't balloon memory unboundedly within the existing round cap.

**`walk`**: this PR went through two iterations. The first only fixed the *outermost* `f` application, framing full per-level forking as separable follow-up work (#960). Code review then found that framing significantly understated the residual gap: a nested `break` degraded into a synthetic "not in label" error, a nested trailing error was silently absorbed causing the outermost `f` to be re-applied to a corrupted tree (reporting a message and stdout value real jq never produces), and an intermediate attempt at threading control through nested levels (splitting `walk_impl` into two mutually-recursive functions) added a non-inlined stack frame per nesting level — a measured regression dropping the depth `walk(.)` could handle before overflowing from ~7000-8000 to ~6000-7000 on a release build.

The fix: a single recursive `walk_impl` returning `(Vec<OwnedValue>, Option<Control>)` uniformly at every level (the same shape `eval_owned_expr_fork` returns, since this function's own last step *is* that call). This restores the original recursion depth *and* makes full jq-matching forking achievable rather than out of scope — verified against jq 1.7.1 for every combination rule: arrays flatten-concatenate each child's own output stream (`map`'s `[.[] | w]`); objects take the first output of each child's stream or delete the key on empty (`map_values`'s `.[] |= w`, first-output-wins via jq's own `label`/`break` desugaring — **not** last-output-wins, correcting an error in this PR's own first-iteration doc comment); both containers are atomic on an interior error/break. This closes #960 for `walk` (`repeat` already forked fully via the `finish_fork` fix above).

Fixes #855
Fixes #960

## Test plan
- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests` — 495/495 passed (run in isolation)
- [x] `cargo test --features cli,simd,regex,serde` (full suite, run in isolation) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Every behavioral claim (including all array/object combination rules, atomic-abort, nested break/halt, and the memory-bound fix) verified against real jq 1.7.1 and measured directly
- [x] Stack-depth regression confirmed fixed on both debug (previous safe/unsafe boundary ~500-700 restored) and release (~7000-8000 restored) builds