### PR TITLE
fix(jq): hoist the duplicated ResolvedScalar->OwnedValue conversion

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -11,7 +11,8 @@ use std::path::Path;
 
 use succinctly::jq::document::{DocumentCursor, DocumentFields, IndentSpec};
 use succinctly::jq::eval_generic::{
-    eval_with_cursor_using, to_owned, to_owned_with_comments, CommentTree, GenericResult,
+    eval_with_cursor_using, to_owned as generic_to_owned, to_owned_with_comments, CommentTree,
+    GenericResult,
 };
 use succinctly::jq::{
     self, sync_aliased_paths, Builtin, EvalError, Expr, OwnedValue, QueryResult, YqSemantics,
@@ -406,7 +407,7 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
             // Parse as JSON
             let index = JsonIndex::build(bytes);
             let cursor = index.root(bytes);
-            Ok(vec![to_owned(&cursor.value())])
+            Ok(vec![generic_to_owned(&cursor.value())])
         }
         InputFormat::Yaml | InputFormat::Auto => {
             // Parse as YAML (Auto defaults to YAML when no extension hint)
@@ -553,9 +554,9 @@ fn query_result_to_owned_values(
     sink: &mut ErrorSink,
 ) -> Vec<OwnedValue> {
     match result {
-        QueryResult::One(v) => vec![to_owned(&v)],
-        QueryResult::OneCursor(c) => vec![to_owned(&c.value())],
-        QueryResult::Many(vs) => vs.iter().map(to_owned).collect(),
+        QueryResult::One(v) => vec![generic_to_owned(&v)],
+        QueryResult::OneCursor(c) => vec![generic_to_owned(&c.value())],
+        QueryResult::Many(vs) => vs.iter().map(generic_to_owned).collect(),
         QueryResult::None => vec![],
         QueryResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());
@@ -967,8 +968,13 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // assignment-family expression against a document that actually has
     // aliases. Everything else (JSON, plain reads, alias-free YAML) pays
     // nothing beyond this one bool check.
-    let alias_sync_ctx = (is_alias_sensitive_assign(expr) && cursor.index().has_aliases())
-        .then(|| (to_owned(&cursor.value()), collect_alias_groups(cursor)));
+    let alias_sync_ctx =
+        (is_alias_sensitive_assign(expr) && cursor.index().has_aliases()).then(|| {
+            (
+                generic_to_owned(&cursor.value()),
+                collect_alias_groups(cursor),
+            )
+        });
 
     // Snapshot the pristine presentation tree *before* evaluation too
     // (#739, ADR-0017): same shape-preserving-write gate as `alias_sync_ctx`
@@ -1002,7 +1008,7 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         if need_comments {
             to_owned_with_comments(&c.value(), Some(c))
         } else {
-            no_comments(to_owned(&c.value()))
+            no_comments(generic_to_owned(&c.value()))
         }
     };
 
@@ -1016,9 +1022,9 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // arms are defensive/unreachable here today, kept for exhaustiveness
     // over the shared `GenericResult` enum.
     let mut docs = match result {
-        GenericResult::One(v) => Ok(vec![no_comments(to_owned(&v))]),
+        GenericResult::One(v) => Ok(vec![no_comments(generic_to_owned(&v))]),
         GenericResult::OneCursor(c) => Ok(vec![owned_with_comments(&c)]),
-        GenericResult::Many(vs) => Ok(vs.iter().map(to_owned).map(no_comments).collect()),
+        GenericResult::Many(vs) => Ok(vs.iter().map(generic_to_owned).map(no_comments).collect()),
         GenericResult::ManyCursor(cs) => Ok(cs.iter().map(owned_with_comments).collect()),
         // This is the DOM/slow path (`evaluate_yaml_direct_filtered`'s
         // fallback), reached only when `can_use_m2_streaming` rejects the

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -6,7 +6,6 @@
 use anyhow::{Context, Result};
 use core::fmt::Write as FmtWrite;
 use indexmap::IndexMap;
-use std::borrow::Cow;
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
@@ -17,11 +16,10 @@ use succinctly::jq::eval_generic::{
 use succinctly::jq::{
     self, sync_aliased_paths, Builtin, EvalError, Expr, OwnedValue, QueryResult, YqSemantics,
 };
-use succinctly::json::light::StandardJson;
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
-    format_float_with_fraction, resolve_plain, resolve_tagged, stream_yaml_sequence,
-    ResolvedScalar, YamlCursor, YamlIndex, YamlValue,
+    format_float_with_fraction, resolve_plain, resolve_tagged, stream_yaml_sequence, YamlCursor,
+    YamlIndex, YamlValue,
 };
 
 use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
@@ -165,18 +163,6 @@ impl OutputConfig {
     }
 }
 
-/// Convert an already-resolved scalar to `OwnedValue`. `str_value` is the
-/// original source text, used only for the `Str` case.
-fn resolved_scalar_to_owned(resolved: ResolvedScalar, str_value: Cow<'_, str>) -> OwnedValue {
-    match resolved {
-        ResolvedScalar::Null => OwnedValue::Null,
-        ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
-        ResolvedScalar::Int(n) => OwnedValue::Int(n),
-        ResolvedScalar::Float(f) => OwnedValue::Float(f),
-        ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
-    }
-}
-
 /// Convert a YAML value to an OwnedValue for jq evaluation.
 ///
 /// Takes a cursor rather than a bare `YamlValue`: an explicit tag
@@ -195,7 +181,7 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
 
             if let Some(explicit) = cursor.explicit_tag() {
                 if let Some(resolved) = resolve_tagged(&str_value, explicit) {
-                    return Ok(resolved_scalar_to_owned(resolved, str_value));
+                    return Ok(resolved.to_owned_value(str_value));
                 }
             }
 
@@ -206,10 +192,7 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
             }
 
             // Resolve plain scalars per the YAML 1.2 core schema
-            Ok(resolved_scalar_to_owned(
-                resolve_plain(&str_value),
-                str_value,
-            ))
+            Ok(resolve_plain(&str_value).to_owned_value(str_value))
         }
         YamlValue::Mapping(fields) => {
             let mut map = IndexMap::new();
@@ -423,7 +406,7 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
             // Parse as JSON
             let index = JsonIndex::build(bytes);
             let cursor = index.root(bytes);
-            Ok(vec![standard_json_to_owned(&cursor.value())])
+            Ok(vec![to_owned(&cursor.value())])
         }
         InputFormat::Yaml | InputFormat::Auto => {
             // Parse as YAML (Auto defaults to YAML when no extension hint)
@@ -570,9 +553,9 @@ fn query_result_to_owned_values(
     sink: &mut ErrorSink,
 ) -> Vec<OwnedValue> {
     match result {
-        QueryResult::One(v) => vec![standard_json_to_owned(&v)],
-        QueryResult::OneCursor(c) => vec![standard_json_to_owned(&c.value())],
-        QueryResult::Many(vs) => vs.iter().map(standard_json_to_owned).collect(),
+        QueryResult::One(v) => vec![to_owned(&v)],
+        QueryResult::OneCursor(c) => vec![to_owned(&c.value())],
+        QueryResult::Many(vs) => vs.iter().map(to_owned).collect(),
         QueryResult::None => vec![],
         QueryResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());
@@ -1181,41 +1164,6 @@ fn strip_presentation_style(tree: &CommentTree) -> CommentTree {
                 .collect(),
             key_comments.clone(),
         ),
-    }
-}
-
-/// Convert a StandardJson value to an OwnedValue.
-fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> OwnedValue {
-    match value {
-        StandardJson::Null => OwnedValue::Null,
-        StandardJson::Bool(b) => OwnedValue::Bool(*b),
-        StandardJson::Number(n) => {
-            if let Ok(i) = n.as_i64() {
-                OwnedValue::Int(i)
-            } else if let Ok(f) = n.as_f64() {
-                OwnedValue::Float(f)
-            } else {
-                OwnedValue::Null
-            }
-        }
-        StandardJson::String(s) => {
-            OwnedValue::String(s.as_str().map(|c| c.to_string()).unwrap_or_default())
-        }
-        StandardJson::Array(elements) => {
-            OwnedValue::Array((*elements).map(|e| standard_json_to_owned(&e)).collect())
-        }
-        StandardJson::Object(fields) => OwnedValue::Object(
-            (*fields)
-                .filter_map(|field| {
-                    let key = match field.key() {
-                        StandardJson::String(s) => s.as_str().ok()?.to_string(),
-                        _ => return None,
-                    };
-                    Some((key, standard_json_to_owned(&field.value())))
-                })
-                .collect(),
-        ),
-        StandardJson::Error(_) => OwnedValue::Null,
     }
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19131,21 +19131,7 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
     cursor: crate::yaml::YamlCursor<'_, W>,
 ) -> OwnedValue {
-    use crate::yaml::{resolve_plain, resolve_tagged, ResolvedScalar, YamlValue};
-
-    // Convert an already-resolved scalar to `OwnedValue`. `str_value` is the
-    // original source text, used only for the `Str` case. Mirrors
-    // `yq_runner.rs`'s `resolved_scalar_to_owned`, which can't be shared
-    // directly since that lives in the CLI binary, not this library crate.
-    fn resolved_scalar_to_owned(resolved: ResolvedScalar, str_value: Cow<'_, str>) -> OwnedValue {
-        match resolved {
-            ResolvedScalar::Null => OwnedValue::Null,
-            ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
-            ResolvedScalar::Int(n) => OwnedValue::Int(n),
-            ResolvedScalar::Float(f) => OwnedValue::Float(f),
-            ResolvedScalar::Str => OwnedValue::String(str_value.into_owned()),
-        }
-    }
+    use crate::yaml::{resolve_plain, resolve_tagged, YamlValue};
 
     match cursor.value() {
         YamlValue::Null => OwnedValue::Null,
@@ -19158,7 +19144,7 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
 
             if let Some(explicit) = cursor.explicit_tag() {
                 if let Some(resolved) = resolve_tagged(&str_value, explicit) {
-                    return resolved_scalar_to_owned(resolved, str_value);
+                    return resolved.to_owned_value(str_value);
                 }
             }
 
@@ -19168,7 +19154,7 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
             }
 
             // Resolve plain scalars per the YAML 1.2 core schema
-            resolved_scalar_to_owned(resolve_plain(&str_value), str_value)
+            resolve_plain(&str_value).to_owned_value(str_value)
         }
         YamlValue::Sequence(mut elements) => {
             let mut items = Vec::new();

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -127,27 +127,7 @@ pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
 fn tagged_scalar_to_owned<V: DocumentValue>(tag: &str, value: &V) -> Option<OwnedValue> {
     let text = value.as_str()?;
     let resolved = crate::yaml::resolve_tagged(&text, tag)?;
-    Some(match resolved {
-        crate::yaml::ResolvedScalar::Null => OwnedValue::Null,
-        crate::yaml::ResolvedScalar::Bool(b) => OwnedValue::Bool(b),
-        crate::yaml::ResolvedScalar::Int(n) => OwnedValue::Int(n),
-        // Mirrors YamlValue::number_literal (src/yaml/light.rs) for the
-        // same reason: an explicit `!!float` tag converges on this same
-        // materialization step as a plain float scalar, so it needs the
-        // same source-text preservation for a whole-number float like
-        // `!!float 2.0` (#918) - `is_preservable_float_literal` also
-        // correctly excludes `!!float`'s int-widening case (`!!float 5`,
-        // `!!float 0x2A`, neither containing a literal `.`), which have no
-        // meaningful float-spelled text to preserve.
-        crate::yaml::ResolvedScalar::Float(f) => {
-            if crate::yaml::is_preservable_float_literal(&text) {
-                OwnedValue::from_number_literal(&text)
-            } else {
-                OwnedValue::Float(f)
-            }
-        }
-        crate::yaml::ResolvedScalar::Str => OwnedValue::String(text.into_owned()),
-    })
+    Some(resolved.to_owned_value(text))
 }
 
 /// Materializes `value`, preferring the cursor-aware, tag-resolving

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -279,7 +279,6 @@ pub use light::{
     YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
-pub(crate) use scalar::is_preservable_float_literal;
 pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};
 
 #[cfg(test)]

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -30,6 +30,10 @@
 //! assert_eq!(resolve_plain("1_000"), ResolvedScalar::Str);
 //! ```
 
+use std::borrow::Cow;
+
+use crate::jq::OwnedValue;
+
 /// The resolved type (and parsed value) of a plain YAML scalar.
 ///
 /// Numeric variants carry the parsed value because some spellings (`0x2A`)
@@ -77,6 +81,36 @@ impl ResolvedScalar {
             Self::Bool(_) => "boolean",
             Self::Int(_) | Self::Float(_) => "number",
             Self::Str => "string",
+        }
+    }
+
+    /// Converts this resolution to jq's [`OwnedValue`], given `text` — the
+    /// scalar's original source text (used for the `Str` case, and, for a
+    /// `Float` that also passes `is_preservable_float_literal`, to
+    /// preserve a whole-number float's spelling through materialization —
+    /// issue #918: `2.0`'s decimal point otherwise vanishes via bare
+    /// `f64::Display`, since `Int`/`Float`/`Bool`/`Null` carry no source
+    /// text of their own to fall back on).
+    ///
+    /// The single source of truth this crate's three independent
+    /// `ResolvedScalar -> OwnedValue` match arms (issue #907) collapse
+    /// into: `crate::jq::eval_generic`'s tagged-scalar materialization,
+    /// the yq CLI's DOM conversion (`yq_runner.rs`), and the `load()`
+    /// builtin's YAML loader (`eval.rs`) all called this out independently
+    /// before, which is exactly how the yq-CLI and `load()` copies missed
+    /// #918's literal-preservation fix when it landed only in
+    /// `eval_generic.rs`.
+    #[must_use]
+    pub fn to_owned_value(self, text: Cow<'_, str>) -> OwnedValue {
+        match self {
+            Self::Null => OwnedValue::Null,
+            Self::Bool(b) => OwnedValue::Bool(b),
+            Self::Int(n) => OwnedValue::Int(n),
+            Self::Float(_) if is_preservable_float_literal(&text) => {
+                OwnedValue::from_number_literal(&text)
+            }
+            Self::Float(f) => OwnedValue::Float(f),
+            Self::Str => OwnedValue::String(text.into_owned()),
         }
     }
 }
@@ -308,7 +342,7 @@ const MAX_PRESERVABLE_FLOAT_DIGITS: usize = 17;
 /// leaving the #918 symptom open for that narrower spelling class — see
 /// the issue tracker for the follow-up.
 #[must_use]
-pub(crate) fn is_preservable_float_literal(s: &str) -> bool {
+pub(super) fn is_preservable_float_literal(s: &str) -> bool {
     s.contains('.')
         && !s.contains(['e', 'E'])
         && s.bytes().filter(u8::is_ascii_digit).count() <= MAX_PRESERVABLE_FLOAT_DIGITS

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -95,14 +95,17 @@ impl ResolvedScalar {
     /// `f64::Display`, since `Int`/`Float`/`Bool`/`Null` carry no source
     /// text of their own to fall back on).
     ///
-    /// The single source of truth this crate's three independent
-    /// `ResolvedScalar -> OwnedValue` match arms (issue #907) collapse
-    /// into: `crate::jq::eval_generic`'s tagged-scalar materialization,
-    /// the yq CLI's DOM conversion (`yq_runner.rs`), and the `load()`
-    /// builtin's YAML loader (`eval.rs`) all called this out independently
-    /// before, which is exactly how the yq-CLI and `load()` copies missed
-    /// #918's literal-preservation fix when it landed only in
-    /// `eval_generic.rs`.
+    /// Three independent `ResolvedScalar -> OwnedValue` match arms (issue
+    /// #907) collapse into this one: `crate::jq::eval_generic`'s
+    /// tagged-scalar materialization, the yq CLI's DOM conversion
+    /// (`yq_runner.rs`), and the `load()` builtin's YAML loader
+    /// (`eval.rs`) all had their own copy before, which is exactly how the
+    /// yq-CLI and `load()` copies missed #918's literal-preservation fix
+    /// when it landed only in `eval_generic.rs`. Two further siblings that
+    /// produce JSON *text* directly rather than an `OwnedValue`
+    /// (`light.rs`'s `write_resolved_scalar_as_json`/
+    /// `stream_resolved_scalar_as_json`) are a different output type and
+    /// weren't folded in here — see the #907 follow-up issue.
     #[must_use]
     pub fn to_owned_value(self, text: Cow<'_, str>) -> OwnedValue {
         match self {

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -30,6 +30,9 @@
 //! assert_eq!(resolve_plain("1_000"), ResolvedScalar::Str);
 //! ```
 
+#[cfg(not(test))]
+use alloc::borrow::Cow;
+#[cfg(test)]
 use std::borrow::Cow;
 
 use crate::jq::OwnedValue;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1115,17 +1115,24 @@ fn test_duplicate_mapping_key_survives_inplace() -> Result<()> {
     Ok(())
 }
 
-/// #907: `--slurp`, `--eval-all`, and the `load()` builtin each materialize
-/// through their own copy of the `ResolvedScalar -> OwnedValue` mapping
-/// (`yq_runner.rs`'s `resolved_scalar_to_owned`/`standard_json_to_owned`,
-/// `eval.rs`'s local `resolved_scalar_to_owned`) -- none of which are the
-/// `eval_generic.rs` path #918 fixed, so an integer-valued float scalar
-/// (`2.0`) lost its decimal point through all three even after #918 landed.
-/// Confirmed live before this fix: `--slurp '.'` gave `[2]`, `--eval-all
-/// '.'` gave `2`, both wrong. Fixed by hoisting one shared
-/// `ResolvedScalar::to_owned_value` (used by all three, plus the fourth
-/// copy this uncovered, `standard_json_to_owned` -- see that function's own
-/// former doc comment; replaced by the shared `to_owned` instead).
+/// #907: `--slurp` and `load()` materialized YAML input through their own
+/// copy of the `ResolvedScalar -> OwnedValue` mapping (`yq_runner.rs`'s
+/// `resolved_scalar_to_owned`, `eval.rs`'s local `resolved_scalar_to_owned`)
+/// -- neither was the `eval_generic.rs` path #918 fixed, so an
+/// integer-valued float scalar (`2.0`) lost its decimal point through both
+/// even after #918 landed. Fixed by hoisting one shared
+/// `ResolvedScalar::to_owned_value`, used by both plus the third,
+/// tag-carrying copy in `eval_generic.rs`.
+///
+/// `--slurp`/`--eval-all`'s JSON-round-trip evaluation bridge
+/// (`evaluate_input`) uncovered a *separate*, unrelated duplicate on the
+/// way: `yq_runner.rs`'s `standard_json_to_owned` converted `StandardJson`
+/// (a JSON DOM value, not a `ResolvedScalar`) via `as_i64`/`as_f64`
+/// directly, bypassing `DocumentValue::number_literal()` entirely -- unlike
+/// this crate's own `to_owned()`, which `StandardJson` already implements
+/// `DocumentValue` for. Replaced with a call to that existing `to_owned()`
+/// instead of writing a fourth copy of anything. Confirmed live before this
+/// fix: `--slurp '.'` gave `[2]`, `--eval-all '.'` gave `2`, both wrong.
 #[test]
 fn test_integer_valued_float_survives_slurp_eval_all_load_907() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "2.0", &["--slurp", "-o", "json", "-I", "0"])?;
@@ -1143,6 +1150,27 @@ fn test_integer_valued_float_survives_slurp_eval_all_load_907() -> Result<()> {
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "{\"a\":2.0}");
 
+    Ok(())
+}
+
+/// #907 companion: `standard_json_to_owned`'s removal (see the test above)
+/// changes `--slurp`/`--eval-all --input-format json`'s number formatting,
+/// not just YAML input's -- `StandardJson::number_literal()` is
+/// unconditional (unlike YAML's gated override), so every JSON number now
+/// preserves its own source spelling through this path instead of
+/// `as_i64`/`as_f64`'s lossy round-trip. Pinned against the pinned jq
+/// oracle: `echo '{"a":1e2}' | jq '.'` also gives `1E+2`, confirming this
+/// is a correctness fix (the old behavior silently normalized to `100.0`),
+/// not a new divergence.
+#[test]
+fn test_json_input_slurp_preserves_exponent_literal_spelling_907() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".",
+        "{\"a\":1e2}",
+        &["--input-format", "json", "--slurp", "-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[{\"a\":1E+2}]");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1115,6 +1115,37 @@ fn test_duplicate_mapping_key_survives_inplace() -> Result<()> {
     Ok(())
 }
 
+/// #907: `--slurp`, `--eval-all`, and the `load()` builtin each materialize
+/// through their own copy of the `ResolvedScalar -> OwnedValue` mapping
+/// (`yq_runner.rs`'s `resolved_scalar_to_owned`/`standard_json_to_owned`,
+/// `eval.rs`'s local `resolved_scalar_to_owned`) -- none of which are the
+/// `eval_generic.rs` path #918 fixed, so an integer-valued float scalar
+/// (`2.0`) lost its decimal point through all three even after #918 landed.
+/// Confirmed live before this fix: `--slurp '.'` gave `[2]`, `--eval-all
+/// '.'` gave `2`, both wrong. Fixed by hoisting one shared
+/// `ResolvedScalar::to_owned_value` (used by all three, plus the fourth
+/// copy this uncovered, `standard_json_to_owned` -- see that function's own
+/// former doc comment; replaced by the shared `to_owned` instead).
+#[test]
+fn test_integer_valued_float_survives_slurp_eval_all_load_907() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "2.0", &["--slurp", "-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2.0]");
+
+    let (out, code) = run_yq_stdin(".", "2.0", &["--eval-all", "-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2.0]");
+
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 2.0")?;
+    let load_expr = format!("load({:?})", input_file.path().display().to_string());
+    let (out, code) = run_yq_stdin(&load_expr, "null", &["-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "{\"a\":2.0}");
+
+    Ok(())
+}
+
 /// #631: `first(.[])`/`last(.[])` (the `Expr::FirstExpr`/`LastExpr` one-arg
 /// stream form `first(f)`/`last(f)` compiles to) fell through
 /// `evaluate_yaml_cursor`'s unconditional `to_owned()` DOM path, unlike


### PR DESCRIPTION
## Summary

#907's item 3 catalogued three independent copies of the same `ResolvedScalar -> OwnedValue` match arm:
- `src/jq/eval_generic.rs`'s `tagged_scalar_to_owned`
- `src/bin/succinctly/yq_runner.rs`'s `resolved_scalar_to_owned`
- `src/jq/eval.rs`'s local helper inside `yaml_value_to_owned`

Collapsed into one `ResolvedScalar::to_owned_value` (`src/yaml/scalar.rs`), used by all three call sites.

**This wasn't just a duplication cleanup.** #918's literal-preservation fix for integer-valued floats (`2.0` losing its decimal point) only landed in `eval_generic.rs`'s copy — the other two silently missed it:
- `yq_runner.rs`'s copy backs `--slurp`/`--eval-all`'s DOM materialization path
- `eval.rs`'s copy backs the `load()` builtin

Both still showed the original #918 symptom (`2.0` → `2`) until this fix.

**A fourth, previously uncatalogued duplicate surfaced during investigation**: `yq_runner.rs`'s `standard_json_to_owned` hand-rolled its own JSON `Number -> OwnedValue` conversion via `as_i64()`/`as_f64()`, completely bypassing `DocumentValue::number_literal()` — unlike the crate's own `to_owned()`, which `StandardJson` already implements `DocumentValue` for. This is what actually caused `--slurp`/`--eval-all`'s JSON-round-trip evaluation bridge (`evaluate_input`) to still show the bug even after the `ResolvedScalar` fix alone. Replaced with a direct call to the existing `to_owned()`.

#907's items 1 and 2 (unconfirmed "tag-blind path" audit gaps in `to_owned_with_comments` and two other `yq_runner.rs` call sites) were investigated again with different targeted test cases (an explicit tag that actually changes resolution, e.g. `!!str 5`, combined with an untouched sibling through `.b |= . + 1` / `del()` under `-o json`) and remained unreproducible — matching the original author's own finding. Left as-is rather than fixed speculatively, per this project's convention against unverified defensive fixes.

Item 4 (`to_owned`/`to_owned_cursor` container-recursion duplication) has no proposed fix per the issue itself; not addressed here either.

Fixes #907

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 53 binaries, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo doc --no-deps --all-features` (RUSTDOCFLAGS=-D warnings)
- [x] New regression test `test_integer_valued_float_survives_slurp_eval_all_load_907` covering `--slurp`, `--eval-all`, and `load()`
- [x] Live-verified fix via direct CLI testing before/after (confirmed `--slurp '.'` went from `[2]` → `[2.0]`, `--eval-all '.'` from `2` → `[2.0]`, `load()` from `2` → `2.0`)