### PR TITLE
refactor(jq): deduplicate civil-date-math and DST-preamble copies

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17721,6 +17721,20 @@ fn parse_simple_tz_offset(tz: &str) -> Option<i64> {
     Some(offset_secs)
 }
 
+/// Bump a broken-down-time array's 0-indexed month (jq's convention) to the
+/// 1-indexed month this file's date math uses, checked against an
+/// adversarial `i64::MAX` array element (#893's panic class) — shared by
+/// `builtin_mktime` and `builtin_strftime`'s array branch, which previously
+/// each spelled the same "+1, checked" step in a different shape (a
+/// `Result`-returning `.and_then()` chain in one, a bare `Option`-returning
+/// `.checked_add(1)` in the other) for no reason tied to genuine complexity
+/// (#912).
+fn checked_month_index(month: i64) -> Result<i64, EvalError> {
+    month
+        .checked_add(1)
+        .ok_or_else(EvalError::broken_down_time_out_of_range)
+}
+
 /// Builtin: mktime - convert broken-down time to Unix timestamp
 fn builtin_mktime<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
@@ -17759,10 +17773,7 @@ fn builtin_mktime<W: Clone + AsRef<[u64]>>(
         Err(_) if optional => return QueryResult::None,
         Err(e) => return e.into(),
     };
-    let month = match get_int(1).and_then(|m| {
-        m.checked_add(1)
-            .ok_or_else(EvalError::broken_down_time_out_of_range)
-    }) {
+    let month = match get_int(1).and_then(checked_month_index) {
         Ok(m) => m, // jq uses 0-indexed months
         Err(_) if optional => return QueryResult::None,
         Err(e) => return e.into(),
@@ -17797,17 +17808,69 @@ fn builtin_mktime<W: Clone + AsRef<[u64]>>(
     QueryResult::Owned(OwnedValue::Float(timestamp as f64))
 }
 
+/// Days since the Unix epoch for a civil `(year, month 1-12, day)` date, via
+/// the Howard Hinnant `days_from_civil` algorithm — the shared core of
+/// [`unix_secs_from_broken_down_time`] (which extends this with
+/// hour/minute/second), `parse_strptime`, and `parse_iso8601` (which use the
+/// day count alone to derive a weekday). One definition instead of the
+/// three/four hand-duplicated copies #893's fix originally left in place
+/// (#912): a change to this math previously had to be applied in every copy
+/// to stay correct.
+///
+/// Returns `Err` for any `year`/`month`/`day` combination whose arithmetic
+/// would overflow `i64` (#893) — every step uses `checked_*` instead of the
+/// original's plain operators, since a user-controlled broken-down-time
+/// array can set any of these fields to an arbitrary integer. Each
+/// multi-step accumulation (`doy`, `doe`) is flattened into its own
+/// intermediate `let`, rather than burying a `?` mid-expression inside a
+/// parenthesized sub-group and continuing to chain outside it, so every step
+/// is auditable against the original unchecked formula on its own line
+/// (#912).
+fn checked_days_from_civil(year: i64, month: i64, day: i64) -> Result<i64, EvalError> {
+    let overflow = EvalError::broken_down_time_out_of_range;
+
+    let y = year
+        .checked_sub(i64::from(month <= 2))
+        .ok_or_else(overflow)?;
+    let era = if y >= 0 {
+        y / 400
+    } else {
+        y.checked_sub(399).ok_or_else(overflow)? / 400
+    };
+    let era_400 = era.checked_mul(400).ok_or_else(overflow)?;
+    let yoe = y.checked_sub(era_400).ok_or_else(overflow)?; // year of era [0, 399]
+
+    let m = if month > 2 { month - 3 } else { month + 9 };
+    let doy_base = 153i64
+        .checked_mul(m)
+        .and_then(|v| v.checked_add(2))
+        .ok_or_else(overflow)?
+        / 5;
+    let doy = doy_base
+        .checked_add(day)
+        .and_then(|v| v.checked_sub(1))
+        .ok_or_else(overflow)?; // day of year [0, 365]
+
+    let yoe_365 = yoe.checked_mul(365).ok_or_else(overflow)?;
+    let doe_partial = yoe_365.checked_add(yoe / 4).ok_or_else(overflow)?;
+    let doe_partial = doe_partial.checked_sub(yoe / 100).ok_or_else(overflow)?;
+    let doe = doe_partial.checked_add(doy).ok_or_else(overflow)?; // day of era [0, 146096]
+
+    let era_146097 = era.checked_mul(146097).ok_or_else(overflow)?;
+    let days_since_epoch = era_146097.checked_add(doe).ok_or_else(overflow)?;
+    days_since_epoch.checked_sub(719468).ok_or_else(overflow) // days since Unix epoch
+}
+
 /// Convert broken-down time (UTC) to a Unix timestamp — the inverse of
-/// [`broken_down_time_from_unix_secs`], using the inverse of the Howard
-/// Hinnant `civil_from_days` algorithm. Shared by `mktime` and `strftime`'s
+/// [`broken_down_time_from_unix_secs`]. Shared by `mktime` and `strftime`'s
 /// `%s` specifier (#760) so a future fix to this math only needs applying
 /// in one place.
 ///
 /// Returns `Err` for any `year`/`month`/`day`/`hour`/`minute`/`second`
 /// combination whose arithmetic would overflow `i64` (#893 — a
 /// user-controlled `mktime`/`strftime` broken-down-time array can set any of
-/// these to an arbitrary integer, not just `year`). Every step here now uses
-/// `checked_*` instead of the original's plain operators, mirroring
+/// these to an arbitrary integer, not just `year`). Every step here uses
+/// `checked_*` instead of a plain operator, mirroring
 /// [`broken_down_time_from_unix_secs`]'s own `checked_sub` guard on its one
 /// overflow-prone step, applied everywhere in this direction since every
 /// field independently risks the same panic (verified: extreme `year`,
@@ -17823,49 +17886,14 @@ fn unix_secs_from_broken_down_time(
 ) -> Result<i64, EvalError> {
     let overflow = EvalError::broken_down_time_out_of_range;
 
-    let y = year
-        .checked_sub(i64::from(month <= 2))
-        .ok_or_else(overflow)?;
-    let era = if y >= 0 {
-        y / 400
-    } else {
-        y.checked_sub(399).ok_or_else(overflow)? / 400
-    };
-    let era_400 = era.checked_mul(400).ok_or_else(overflow)?;
-    let yoe = y.checked_sub(era_400).ok_or_else(overflow)?; // year of era [0, 399]
-
-    let m = if month > 2 { month - 3 } else { month + 9 };
-    let doy = (153i64
-        .checked_mul(m)
-        .and_then(|v| v.checked_add(2))
-        .ok_or_else(overflow)?
-        / 5)
-    .checked_add(day)
-    .and_then(|v| v.checked_sub(1))
-    .ok_or_else(overflow)?; // day of year [0, 365]
-
-    let doe = yoe
-        .checked_mul(365)
-        .and_then(|v| v.checked_add(yoe / 4))
-        .and_then(|v| v.checked_sub(yoe / 100))
-        .and_then(|v| v.checked_add(doy))
-        .ok_or_else(overflow)?; // day of era [0, 146096]
-
-    let era_146097 = era.checked_mul(146097).ok_or_else(overflow)?;
-    let days = era_146097
-        .checked_add(doe)
-        .and_then(|v| v.checked_sub(719468))
-        .ok_or_else(overflow)?; // days since Unix epoch
-
+    let days = checked_days_from_civil(year, month, day)?;
     let days_secs = days.checked_mul(86400).ok_or_else(overflow)?;
     let hour_secs = hour.checked_mul(3600).ok_or_else(overflow)?;
     let minute_secs = minute.checked_mul(60).ok_or_else(overflow)?;
 
-    days_secs
-        .checked_add(hour_secs)
-        .and_then(|v| v.checked_add(minute_secs))
-        .and_then(|v| v.checked_add(second))
-        .ok_or_else(overflow)
+    let secs = days_secs.checked_add(hour_secs).ok_or_else(overflow)?;
+    let secs = secs.checked_add(minute_secs).ok_or_else(overflow)?;
+    secs.checked_add(second).ok_or_else(overflow)
 }
 
 /// Builtin: strftime(fmt) - format broken-down time as string
@@ -17941,15 +17969,15 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     }
                 };
 
-                // `+ 1` (jq's 0-indexed month -> this function's 1-indexed
-                // month) overflows for an adversarial `i64::MAX` array
-                // element (#893's panic class, reachable here independently
-                // of `%s`/`unix_secs_from_broken_down_time`: every format
-                // path eagerly computes `month`, not just `%s`).
-                let month = match get_int(1).checked_add(1) {
-                    Some(m) => m,
-                    None if optional => return QueryResult::None,
-                    None => return QueryResult::Error(EvalError::broken_down_time_out_of_range()),
+                // `checked_month_index` (jq's 0-indexed month -> this
+                // function's 1-indexed month) overflows for an adversarial
+                // `i64::MAX` array element (#893's panic class, reachable
+                // here independently of `%s`/`unix_secs_from_broken_down_time`:
+                // every format path eagerly computes `month`, not just `%s`).
+                let month = match checked_month_index(get_int(1)) {
+                    Ok(m) => m,
+                    Err(_) if optional => return QueryResult::None,
+                    Err(e) => return QueryResult::Error(e),
                 };
 
                 (
@@ -18487,18 +18515,10 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
         }
     }
 
-    // Calculate weekday if not explicitly set
-    // Using Zeller's congruence or similar
-    let y = year - i64::from(month <= 2);
-    let era = if y >= 0 { y } else { y - 399 } / 400;
-    let yoe = (y - era * 400) as u32;
-    let m = month as u32;
-    let d = day as u32;
-    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146097 + doe as i64 - 719468;
-
-    // Calculate weekday from days
+    // Calculate weekday from days-since-epoch, via the same checked
+    // days-from-civil math `mktime`/`strftime`'s %s specifier use (#912)
+    // instead of a hand-duplicated, unchecked copy of the same formula.
+    let days = checked_days_from_civil(year, month, day).map_err(|e| e.to_string())?;
     weekday = (days % 7 + 4 + 7) % 7;
 
     // Calculate yearday
@@ -18692,17 +18712,12 @@ fn parse_iso8601(input: &str) -> Result<f64, String> {
             (0, 0, 0, 0)
         };
 
-    // Convert to Unix timestamp
-    let y = year - i64::from(month <= 2);
-    let era = if y >= 0 { y } else { y - 399 } / 400;
-    let yoe = (y - era * 400) as u32;
-    let m = month as u32;
-    let d = day as u32;
-    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146097 + doe as i64 - 719468;
-
-    let timestamp = days * 86400 + hour * 3600 + minute * 60 + second + tz_offset;
+    // Convert to Unix timestamp, reusing the same checked days-from-civil
+    // math `mktime`/`strftime`'s %s specifier use (#912) instead of a 4th
+    // hand-duplicated, unchecked copy of the same formula.
+    let base = unix_secs_from_broken_down_time(year, month, day, hour, minute, second)
+        .map_err(|e| e.to_string())?;
+    let timestamp = base + tz_offset;
 
     Ok(timestamp as f64)
 }
@@ -18939,68 +18954,66 @@ fn parse_numeric_offset(s: &str) -> Option<i64> {
     None
 }
 
-/// Simplified DST check for US Eastern timezone
-/// DST starts 2nd Sunday of March, ends 1st Sunday of November (since 2007)
-///
-/// Derives month/day via the shared, floor-corrected
+/// `(month, day)` for a timestamp, via the shared, floor-corrected
 /// [`broken_down_time_from_unix_secs`] rather than re-deriving the civil
 /// date inline (#895): the inline version this replaced truncated
 /// `secs / 86400` toward zero instead of flooring, giving the wrong
 /// month/day — and thus the wrong DST answer near a transition boundary —
-/// for any pre-1970 timestamp. `Err` (a timestamp too extreme to convert)
-/// falls back to `false`, consistent with this function's own "simplified
-/// subset" scope and the catch-all `_ => false` arm below.
-fn is_dst_us_eastern(timestamp: f64) -> bool {
+/// for any pre-1970 timestamp. `None` for a timestamp too extreme to
+/// convert; every `is_dst_*` caller falls back to `false` for that case,
+/// consistent with each function's own "simplified subset" scope. Shared by
+/// [`is_dst_us_eastern`], [`is_dst_europe`], and [`is_dst_australia`], which
+/// previously each duplicated this same two-line preamble verbatim (#912).
+fn dst_month_day(timestamp: f64) -> Option<(i64, i64)> {
     let secs = timestamp.trunc() as i64;
-    let Ok(t) = broken_down_time_from_unix_secs(secs) else {
+    let t = broken_down_time_from_unix_secs(secs).ok()?;
+    Some((t.month, t.day))
+}
+
+/// Simplified DST check for US Eastern timezone
+/// DST starts 2nd Sunday of March, ends 1st Sunday of November (since 2007)
+fn is_dst_us_eastern(timestamp: f64) -> bool {
+    let Some((month, day)) = dst_month_day(timestamp) else {
         return false;
     };
 
     // Approximate DST: March 8-14 to November 1-7 (simplified)
     // More accurate would check actual Sunday dates
-    match t.month {
-        3 => t.day >= 8, // After ~2nd week of March
-        4..=10 => true,  // April through October
-        11 => t.day < 7, // First week of November
-        _ => false,      // December through February
+    match month {
+        3 => day >= 8,  // After ~2nd week of March
+        4..=10 => true, // April through October
+        11 => day < 7,  // First week of November
+        _ => false,     // December through February
     }
 }
 
 /// Simplified DST check for European timezones
 /// DST starts last Sunday of March, ends last Sunday of October
-///
-/// See [`is_dst_us_eastern`]'s doc comment for why this derives month/day
-/// via [`broken_down_time_from_unix_secs`] rather than inline (#895).
 fn is_dst_europe(timestamp: f64) -> bool {
-    let secs = timestamp.trunc() as i64;
-    let Ok(t) = broken_down_time_from_unix_secs(secs) else {
+    let Some((month, day)) = dst_month_day(timestamp) else {
         return false;
     };
 
-    match t.month {
-        3 => t.day >= 25, // Last week of March
-        4..=9 => true,    // April through September
-        10 => t.day < 25, // Before last week of October
+    match month {
+        3 => day >= 25, // Last week of March
+        4..=9 => true,  // April through September
+        10 => day < 25, // Before last week of October
         _ => false,
     }
 }
 
 /// Simplified DST check for Australian Eastern timezones
 /// DST starts first Sunday of October, ends first Sunday of April
-///
-/// See [`is_dst_us_eastern`]'s doc comment for why this derives month/day
-/// via [`broken_down_time_from_unix_secs`] rather than inline (#895).
 fn is_dst_australia(timestamp: f64) -> bool {
-    let secs = timestamp.trunc() as i64;
-    let Ok(t) = broken_down_time_from_unix_secs(secs) else {
+    let Some((month, day)) = dst_month_day(timestamp) else {
         return false;
     };
 
     // Australian DST is opposite to Northern Hemisphere
-    match t.month {
-        10 => t.day >= 7,            // After first Sunday of October
+    match month {
+        10 => day >= 7,              // After first Sunday of October
         11 | 12 | 1 | 2 | 3 => true, // November through March
-        4 => t.day < 7,              // Before first Sunday of April
+        4 => day < 7,                // Before first Sunday of April
         _ => false,
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -33567,6 +33567,11 @@ mod tests {
         // reaches that function.
         query!(b"null", r#"[2020,9223372036854775807,1,0,0,0,0,0] | strftime("%Y")"#,
             QueryResult::Error(e) => assert_eq!(e.message, MSG));
+        // `?` suppresses the array branch's own month-overflow error too
+        // (distinct site from the `%s`-via-unix_secs_from_broken_down_time
+        // case above — both now share `checked_month_index`, #912).
+        query!(b"null", r#"[2020,9223372036854775807,1,0,0,0,0,0] | strftime("%Y")?"#,
+            QueryResult::None => {});
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17541,13 +17541,7 @@ fn broken_down_time_from_unix_secs(secs: i64) -> Result<BrokenDownTime, EvalErro
     let weekday = (days % 7 + 4 + 7) % 7;
 
     // Calculate day of year (0-365, 0 = Jan 1)
-    let is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
-    let month_days: [i64; 12] = if is_leap {
-        [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
-    } else {
-        [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
-    };
-    let yearday = month_days[(month - 1) as usize] + day - 1;
+    let yearday = yearday_for_civil(year, i64::from(month), day);
 
     Ok(BrokenDownTime {
         year,
@@ -17811,11 +17805,13 @@ fn builtin_mktime<W: Clone + AsRef<[u64]>>(
 /// Days since the Unix epoch for a civil `(year, month 1-12, day)` date, via
 /// the Howard Hinnant `days_from_civil` algorithm — the shared core of
 /// [`unix_secs_from_broken_down_time`] (which extends this with
-/// hour/minute/second), `parse_strptime`, and `parse_iso8601` (which use the
-/// day count alone to derive a weekday). One definition instead of the
-/// three/four hand-duplicated copies #893's fix originally left in place
-/// (#912): a change to this math previously had to be applied in every copy
-/// to stay correct.
+/// hour/minute/second) and `parse_strptime` (which uses the day count alone
+/// to derive a weekday). `parse_iso8601` reuses
+/// [`unix_secs_from_broken_down_time`] directly rather than calling this
+/// function itself, since it needs the full seconds conversion, not just
+/// the day count. One definition instead of the three/four hand-duplicated
+/// copies #893's fix originally left in place (#912): a change to this math
+/// previously had to be applied in every copy to stay correct.
 ///
 /// Returns `Err` for any `year`/`month`/`day` combination whose arithmetic
 /// would overflow `i64` (#893) — every step uses `checked_*` instead of the
@@ -17852,13 +17848,32 @@ fn checked_days_from_civil(year: i64, month: i64, day: i64) -> Result<i64, EvalE
         .ok_or_else(overflow)?; // day of year [0, 365]
 
     let yoe_365 = yoe.checked_mul(365).ok_or_else(overflow)?;
-    let doe_partial = yoe_365.checked_add(yoe / 4).ok_or_else(overflow)?;
-    let doe_partial = doe_partial.checked_sub(yoe / 100).ok_or_else(overflow)?;
-    let doe = doe_partial.checked_add(doy).ok_or_else(overflow)?; // day of era [0, 146096]
+    let yoe_365_plus_leap = yoe_365.checked_add(yoe / 4).ok_or_else(overflow)?;
+    let doe_before_doy = yoe_365_plus_leap
+        .checked_sub(yoe / 100)
+        .ok_or_else(overflow)?;
+    let doe = doe_before_doy.checked_add(doy).ok_or_else(overflow)?; // day of era [0, 146096]
 
     let era_146097 = era.checked_mul(146097).ok_or_else(overflow)?;
     let days_since_epoch = era_146097.checked_add(doe).ok_or_else(overflow)?;
     days_since_epoch.checked_sub(719468).ok_or_else(overflow) // days since Unix epoch
+}
+
+/// Day of year (0-365, Jan 1 = 0) for a civil `(year, month 1-12, day)`
+/// date, via a leap-year check and a cumulative month-length table —
+/// shared by [`broken_down_time_from_unix_secs`] and `parse_strptime`,
+/// which each duplicated this exact leap-year rule and table verbatim
+/// (#912): a future leap-year fix (there is none currently known, but the
+/// duplication itself was the risk) would otherwise have had no reason to
+/// touch both copies to stay correct.
+fn yearday_for_civil(year: i64, month: i64, day: i64) -> i64 {
+    let is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+    let month_days: [i64; 12] = if is_leap {
+        [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
+    } else {
+        [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
+    };
+    month_days[(month - 1) as usize] + day - 1
 }
 
 /// Convert broken-down time (UTC) to a Unix timestamp — the inverse of
@@ -17891,9 +17906,11 @@ fn unix_secs_from_broken_down_time(
     let hour_secs = hour.checked_mul(3600).ok_or_else(overflow)?;
     let minute_secs = minute.checked_mul(60).ok_or_else(overflow)?;
 
-    let secs = days_secs.checked_add(hour_secs).ok_or_else(overflow)?;
-    let secs = secs.checked_add(minute_secs).ok_or_else(overflow)?;
-    secs.checked_add(second).ok_or_else(overflow)
+    let days_and_hour_secs = days_secs.checked_add(hour_secs).ok_or_else(overflow)?;
+    let secs_before_second = days_and_hour_secs
+        .checked_add(minute_secs)
+        .ok_or_else(overflow)?;
+    secs_before_second.checked_add(second).ok_or_else(overflow)
 }
 
 /// Builtin: strftime(fmt) - format broken-down time as string
@@ -18521,14 +18538,9 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
     let days = checked_days_from_civil(year, month, day).map_err(|e| e.to_string())?;
     weekday = (days % 7 + 4 + 7) % 7;
 
-    // Calculate yearday
-    let is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
-    let month_days: [i64; 12] = if is_leap {
-        [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335]
-    } else {
-        [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
-    };
-    let yearday = month_days[(month - 1) as usize] + day - 1;
+    // Calculate day of year, via the same leap-year table
+    // broken_down_time_from_unix_secs uses (#912).
+    let yearday = yearday_for_civil(year, month, day);
 
     Ok(BrokenDownTime {
         year,


### PR DESCRIPTION
## Summary

Follow-up from #911's own review round (#912). None of the 5 items in the issue are live bugs — all are maintainability/consistency cleanups with **no behavior change** (verified byte-identical output against both real jq and this branch's pre-refactor build across `mktime`/`strftime`/`strptime`/`fromdateiso8601`/`tz`, including a pre-1970 date exercising the flooring-sensitive DST math).

- **Item 1**: Extracted `checked_days_from_civil(year, month, day) -> days-since-epoch` as the shared core of `unix_secs_from_broken_down_time`, `parse_strptime`, and `parse_iso8601`, which each hand-duplicated the same Howard Hinnant days-from-civil formula — two of them (`parse_strptime`/`parse_iso8601`) still unchecked, latently reintroducing #893's exact panic class in code that was already fixed once elsewhere in this file. `parse_iso8601` goes further and reuses `unix_secs_from_broken_down_time` directly (it needs the full seconds conversion, not just the day count), eliminating its own duplicated hour/minute/second combination too. Code review additionally found `parse_strptime`'s adjacent **yearday** computation (the leap-year check + cumulative month-days table) left as a still-duplicated verbatim copy against `broken_down_time_from_unix_secs`'s own copy — extracted as `yearday_for_civil(year, month, day)` and shared by both.
- **Item 2**: Extracted `checked_month_index(month)` for the "+1, checked" 0-indexed→1-indexed month bump `builtin_mktime` and `builtin_strftime`'s array branch each spelled in a different shape (a `Result`-returning `.and_then()` chain vs. a bare `Option`-returning `.checked_add(1)`) for no reason tied to genuine complexity.
- **Item 3**: Extracted `dst_month_day(timestamp)` for the two-line `broken_down_time_from_unix_secs` preamble `is_dst_us_eastern`/`is_dst_europe`/`is_dst_australia` each copy-pasted verbatim.
- **Item 4**: Consistency pass on `checked_days_from_civil`/`unix_secs_from_broken_down_time` — every step is now its own flat `let x = ...ok_or_else(overflow)?;` statement rather than mixing that shape with multi-step `.and_then()` chains for equivalent-complexity steps; the `doy` computation in particular no longer buries a `?` mid-expression inside a parenthesized sub-group while continuing to chain outside it. Shadowed intermediates with unclear names (`doe_partial` reused for two different values, `secs` reused twice) renamed to distinct, self-describing names.
- **Item 5** (is_dst_* computing the full 8-field broken-down time to use 2 fields) is left as-is per the issue's own explicit "not worth a targeted fix on its own" scope note.

Code review also caught a genuine, **pre-existing** panic in `parse_strptime` (unrelated to this refactor, reproduces identically on unmodified `main`): an out-of-range month (`00` or `13+` from `%m`) indexes `month_days[(month-1) as usize]` with no bounds check. Left unfixed here since this PR is scoped to pure refactor / no behavior change; filed as #968.

Fixes #912

## Test plan
- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,simd,regex,serde --lib -- mktime strftime strptime iso8601 dst datetime` — all pass
- [x] `cargo test --features cli,simd,regex,serde` (full suite, run in isolation) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Manually cross-checked `mktime`/`strftime`/`strptime`/`fromdateiso8601` against real jq 1.7.1, and `tz()` (a succinctly-only extension) against this branch's own pre-refactor build — byte-identical in every case, including a pre-1970 date and a DST-transition-boundary timestamp
- [x] Re-verified post-rebase onto latest `origin/main` (which landed #907's own overlapping dedup PR touching 300 lines of the same file) — clean rebase, full re-build + spot checks + full test suite + both clippy invocations all green
