### PR TITLE
fix(jq): validate strptime's month/day before array-indexing them

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18555,8 +18555,8 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
     // instead of a hand-duplicated, unchecked copy of the same formula.
     // Its `i64`, checked arithmetic throughout is also what fixes #968's
     // second panic: `day == 0` needs this formula's `doy` term to go
-    // momentarily negative for March specifically, which a `u32` (the
-    // pre-#912 hand-duplicated copy's type) couldn't represent without its
+    // momentarily negative for March specifically, which the pre-#912
+    // hand-duplicated copy's `u32` type couldn't represent without its
     // subtraction underflowing.
     let days = checked_days_from_civil(year, month, day).map_err(|e| e.to_string())?;
     weekday = (days % 7 + 4 + 7) % 7;

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18532,9 +18532,32 @@ fn parse_strptime(input: &str, fmt: &str) -> Result<BrokenDownTime, String> {
         }
     }
 
+    // `%m`/`%d`/`%e`/`%D`/`%F` parse up to 2 digits with no range check of
+    // their own (`parse_digits` just accepts `00`-`99`), so an out-of-range
+    // month reaching `yearday_for_civil`'s `month_days[(month - 1) as
+    // usize]` below panics (month=0 wraps `(0 - 1) as usize` to
+    // `usize::MAX`; month=13+ is a plain out-of-bounds index) - matching
+    // real jq's own rejection of month 0 and 13+, and day > 31 (confirmed
+    // live against jq 1.7.1: `2024-01-32` errors). `checked_days_from_civil`
+    // (#912) doesn't validate this itself - it only guards against actual
+    // `i64` overflow, which an out-of-semantic-range month/day doesn't
+    // trigger - so this check is still required even after that refactor.
+    // `day`'s lower bound is never checked: it's only ever assigned from
+    // `parse_digits`, which builds its output from `is_ascii_digit()`
+    // characters alone, so it can never be negative (`day == 0` is real,
+    // jq-valid input - `2024-01-00` succeeds) (#968).
+    if !(1..=12).contains(&month) || day > 31 {
+        return Err(format!("month {month} or day {day} out of range"));
+    }
+
     // Calculate weekday from days-since-epoch, via the same checked
     // days-from-civil math `mktime`/`strftime`'s %s specifier use (#912)
     // instead of a hand-duplicated, unchecked copy of the same formula.
+    // Its `i64`, checked arithmetic throughout is also what fixes #968's
+    // second panic: `day == 0` needs this formula's `doy` term to go
+    // momentarily negative for March specifically, which a `u32` (the
+    // pre-#912 hand-duplicated copy's type) couldn't represent without its
+    // subtraction underflowing.
     let days = checked_days_from_civil(year, month, day).map_err(|e| e.to_string())?;
     weekday = (days % 7 + 4 + 7) % 7;
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8694,6 +8694,38 @@ fn test_strptime_propagates_halt_in_format_argument() -> Result<()> {
     Ok(())
 }
 
+/// #968: an out-of-range `%m` month (`00`, or `13`+) reached
+/// `month_days[(month - 1) as usize]`'s fixed 12-element array with no
+/// bounds check, panicking the process (month=0 wraps `(0 - 1) as usize`
+/// to `usize::MAX`; month=13+ is a plain out-of-bounds index) instead of
+/// reporting an ordinary parse error the way real jq does. Also covers an
+/// out-of-range `%d` day (`32`+), which can't panic (day is only used in
+/// arithmetic, never as an array index) but real jq rejects it too.
+/// Pinned against the pinned jq oracle for every case, including the
+/// (surprising, but confirmed live) fact that day `00` is accepted.
+#[test]
+fn test_strptime_out_of_range_month_or_day_errors_instead_of_panicking_968() -> Result<()> {
+    for input in ["\"2024-00-15\"", "\"2024-13-15\"", "\"2024-01-32\""] {
+        let (stdout, _, code) = run_jq_full(&["-c", r#"strptime("%Y-%m-%d")"#], Some(input))?;
+        assert_eq!(code, 5, "input: {input}, stdout: {stdout:?}");
+    }
+
+    let (stdout, _, code) =
+        run_jq_full(&["-c", r#"strptime("%Y-%m-%d")"#], Some("\"2024-01-00\""))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim(), "[2024,0,0,0,0,0,0,-1]");
+
+    let (stdout, _, code) =
+        run_jq_full(&["-c", r#"strptime("%Y-%m-%d")"#], Some("\"2024-06-15\""))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim(), "[2024,5,15,0,0,0,6,166]");
+
+    // %D (mm/dd/yy) is a separate parsing arm reaching the same panic site.
+    let (stdout, _, code) = run_jq_full(&["-c", r#"strptime("%D")"#], Some("\"13/15/24\""))?;
+    assert_eq!(code, 5, "stdout: {stdout:?}");
+    Ok(())
+}
+
 /// `builtin_combinations_n`'s `n`-argument wildcard swallowed a halt the
 /// same way `nth`'s `n` argument used to. `combinations(n)` is a real jq
 /// builtin, but real jq's own `n` is bound via `as $n` and interacts with

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8726,6 +8726,47 @@ fn test_strptime_out_of_range_month_or_day_errors_instead_of_panicking_968() -> 
     Ok(())
 }
 
+/// #968 follow-on: the first fix (validating `month`/`day` before
+/// `month_days[(month - 1) as usize]`'s array index) left a second,
+/// distinct panic reachable through the *weekday* computation two lines
+/// above that array index -- a separate Howard Hinnant `days_from_civil`
+/// formula, `u32`-typed, that assumes `day >= 1`. `day == 0` is real,
+/// jq-valid input the fix above deliberately keeps accepting (see that
+/// test), and for March specifically (the one month where the formula's
+/// leading term truncates to exactly `0`) `day == 0` made `0u32 - 1`
+/// underflow: confirmed live, `"2024-03-00"` panicked with "attempt to
+/// subtract with overflow" even after the array-index fix alone. Every
+/// other month's day-0 case was already safe (verified by sweeping all
+/// 12), which is exactly why a test that only covered January (like the
+/// one above) didn't catch it. Fixed by widening that computation's
+/// intermediate types from `u32` to `i64`, matching the pinned jq oracle
+/// for every month.
+#[test]
+fn test_strptime_day_zero_all_months_matches_march_underflow_fixed_968() -> Result<()> {
+    let expected = [
+        "[2024,0,0,0,0,0,0,-1]",
+        "[2024,1,0,0,0,0,3,30]",
+        "[2024,2,0,0,0,0,4,59]",
+        "[2024,3,0,0,0,0,0,90]",
+        "[2024,4,0,0,0,0,2,120]",
+        "[2024,5,0,0,0,0,5,151]",
+        "[2024,6,0,0,0,0,0,181]",
+        "[2024,7,0,0,0,0,3,212]",
+        "[2024,8,0,0,0,0,6,243]",
+        "[2024,9,0,0,0,0,1,273]",
+        "[2024,10,0,0,0,0,4,304]",
+        "[2024,11,0,0,0,0,6,334]",
+    ];
+    for (i, exp) in expected.iter().enumerate() {
+        let month = i + 1;
+        let input = format!("\"2024-{month:02}-00\"");
+        let (stdout, _, code) = run_jq_full(&["-c", r#"strptime("%Y-%m-%d")"#], Some(&input))?;
+        assert_eq!(code, 0, "month: {month}, stdout: {stdout:?}");
+        assert_eq!(stdout.trim(), *exp, "month: {month}");
+    }
+    Ok(())
+}
+
 /// `builtin_combinations_n`'s `n`-argument wildcard swallowed a halt the
 /// same way `nth`'s `n` argument used to. `combinations(n)` is a real jq
 /// builtin, but real jq's own `n` is bound via `as $n` and interacts with


### PR DESCRIPTION
## Summary

`parse_strptime` parsed `%m`/`%d`/`%e`/`%D`/`%F` with no range check (`parse_digits` just accepts `00`-`99`), so an out-of-range month reaching `month_days[(month - 1) as usize]` panicked the process:
- month=0: `(0 - 1) as usize` wraps to `usize::MAX`
- month=13+: a plain out-of-bounds index

Real jq rejects both as an ordinary catchable parse error instead of crashing.

## Fix

Validates `month` is `1..=12` and `day` is `0..=31` before the weekday/yearday computation, matching real jq's own boundary — confirmed live against jq 1.7.1, including the surprising but genuine acceptance of day `00` (`2024-01-00` succeeds; `2024-01-32` errors).

The caller (`builtin_strptime`) already discards `parse_strptime`'s specific error text in favor of `EvalError::strptime_no_match`'s jq-matching wording (`date "..." does not match format "..."`), so any `Err(..)` returned here produces the correct final message — no new error-formatting logic needed.

A second `month_days[(month - 1) as usize]` site exists (`broken_down_time_from_unix_secs`), but its `month` is derived algorithmically from a mathematically-bounded civil-date computation (Howard Hinnant's algorithm), never from unchecked user input — confirmed it can't produce an out-of-range value, so it needs no fix.

Fixes #968

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 53 binaries, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New regression test `test_strptime_out_of_range_month_or_day_errors_instead_of_panicking_968` covering month 0/13+, day 32+, day 00 (accepted), a valid date, and `%D`'s separate parsing arm
- [x] Live-verified every case against the pinned jq oracle (exit codes and output match exactly)