### PR TITLE
refactor(jq): collapse path-resolver escape-handling into one path_result helper

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10128,7 +10128,11 @@ fn eval_owned_multi_first<S: EvalSemantics>(
 /// same child), and `resolve_leaf`'s non-primitive fallback, also path
 /// position (#861 — the same all-or-nothing pitfall reaching
 /// `path(...)`-wrapped expressions whose argument isn't one of the
-/// specially-tracked navigation primitives). `resolve_recurse`'s own
+/// specially-tracked navigation primitives). Also `resolve_node`'s own
+/// `Select`/`If` arms (their `cond`), its `GetPath` arm (its `arg`), and
+/// `resolve_index_expr` (its `key`) — the same argument-can-itself-be-a-
+/// generator shape #842/#854 fixed for `recurse`, independently live at
+/// these 4 unrelated call sites too (#896). `resolve_recurse`'s own
 /// `f`-evaluation step is the one exception: it resolves `f` through
 /// `resolve_node`/`resolve_against_cow` instead — a structurally different
 /// call whose `PathResolveResult` already threads a prefix through its own
@@ -10240,6 +10244,24 @@ type PathBranch<'a> = (Vec<Expr>, Cow<'a, OwnedValue>);
 /// treats this exactly like a plain `Err`, matching jq's atomic write-side
 /// semantics (confirmed live: `(.a, 1) = 5` produces no output at all).
 type PathResolveResult<'a> = Result<Vec<PathBranch<'a>>, (Vec<PathBranch<'a>>, EvalEscape)>;
+
+/// Combine an already-resolved branch prefix with an optional trailing
+/// escape into this resolver's `PathResolveResult` shape.
+///
+/// Every "keep-partial" call site below ends by matching a
+/// `(prefix, Option<EvalEscape>)` pair the exact same way — `Some(e) =>
+/// Err((prefix, e)), None => Ok(prefix)` — hand-written independently at
+/// each one. Collapsing that into a single call removes the chance of a
+/// stray unmatched arm or an escape variable going unread at a *new* call
+/// site by omission, the way two of #896's own review-round bugs did
+/// (#962).
+#[inline]
+fn path_result(branches: Vec<PathBranch<'_>>, escape: Option<EvalEscape>) -> PathResolveResult<'_> {
+    match escape {
+        Some(e) => Err((branches, e)),
+        None => Ok(branches),
+    }
+}
 
 /// Resolve one path node against one value, yielding a branch per output.
 ///
@@ -10541,10 +10563,7 @@ fn resolve_node<'a, S: EvalSemantics>(
                 .filter(OwnedValue::is_truthy)
                 .map(|_| (Vec::new(), Cow::Borrowed(value)))
                 .collect();
-            match escape {
-                Some(e) => Err((branches, e)),
-                None => Ok(branches),
-            }
+            path_result(branches, escape)
         }
         Expr::Builtin(
             builtin @ (Builtin::Values
@@ -10615,10 +10634,7 @@ fn resolve_node<'a, S: EvalSemantics>(
                     }
                 }
             }
-            match escape {
-                Some(e) => Err((out, e)),
-                None => Ok(out),
-            }
+            path_result(out, escape)
         }
 
         // `a // b`: resolve `a`, keep only its truthy branches — jq's `//`
@@ -10825,10 +10841,7 @@ fn resolve_node<'a, S: EvalSemantics>(
                     components.push(component);
                 }
                 let branch = (components, current);
-                return match escape {
-                    Some(e) => Err((vec![branch], e)),
-                    None => Ok(vec![branch]),
-                };
+                return path_result(vec![branch], escape);
             }
             if let Some(e) = escape {
                 return Err((Vec::new(), e));
@@ -11011,13 +11024,6 @@ fn resolve_leaf<'a, S: EvalSemantics>(
     if let Some(EvalEscape::Halt(code)) = &trailing {
         return Err((Vec::new(), EvalEscape::Halt(*code)));
     }
-    // No output prunes the branch — unless there never would have been one
-    // because evaluating `expr` itself broke/errored (Halt excluded, handled
-    // above) before producing anything.
-    let empty_case = |trailing: Option<EvalEscape>| match trailing {
-        Some(escape) => Err((Vec::new(), escape)),
-        None => Ok(Vec::new()),
-    };
     if trackable
         && matches!(
             expr,
@@ -11027,7 +11033,10 @@ fn resolve_leaf<'a, S: EvalSemantics>(
         let mut components = Vec::new();
         push_path_components(&mut components, expr);
         return match values.len() {
-            0 => empty_case(trailing),
+            // No output prunes the branch — unless there never would have
+            // been one because evaluating `expr` itself broke/errored (Halt
+            // excluded, handled above) before producing anything.
+            0 => path_result(Vec::new(), trailing),
             1 => Ok(vec![(
                 components,
                 Cow::Owned(values.pop().expect("len checked")),
@@ -11045,7 +11054,7 @@ fn resolve_leaf<'a, S: EvalSemantics>(
         };
     }
     match values.len() {
-        0 => empty_case(trailing),
+        0 => path_result(Vec::new(), trailing),
         // Real jq's `path(...)` checks each output as it streams: the first
         // non-path-shaped value raises "Invalid path expression" immediately,
         // before a later output of the same expression is ever produced —
@@ -11525,10 +11534,7 @@ fn resolve_recurse<'a, S: EvalSemantics>(
     // whose presence would otherwise depend on where the arbitrary cap
     // happened to land relative to it (#842 review).
     if stack.is_empty() {
-        match pending_error {
-            Some(e) => Err((outputs, e)),
-            None => Ok(outputs),
-        }
+        path_result(outputs, pending_error)
     } else {
         Ok(outputs)
     }
@@ -11614,10 +11620,7 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
     // prefix, same as every other bare-escape site in this file.
     let (keys, key_escape) = eval_owned_multi_keep_partial::<S>(key, value);
     if keys.is_empty() {
-        return match key_escape {
-            Some(e) => Err((Vec::new(), e)),
-            None => Ok(Vec::new()),
-        };
+        return path_result(Vec::new(), key_escape);
     }
     // #843: `target` is a no-op read of the untracked value itself, so the
     // key computed above is the first real navigation attempted against it
@@ -11726,10 +11729,7 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
     // `target_escape` first: see the comment on `target_branches`'s own
     // computation above for why jq's evaluation order surfaces it ahead of
     // `key_escape`.
-    match target_escape.or(key_escape) {
-        Some(e) => Err((out, e)),
-        None => Ok(out),
-    }
+    path_result(out, target_escape.or(key_escape))
 }
 
 /// Resolve `E[S:T]` in path context, with or without a trailing `?`.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10122,7 +10122,10 @@ fn eval_owned_multi_first<S: EvalSemantics>(
 /// than a change to that one's behavior. Direct callers today: `recurse`'s
 /// own children-evaluation step in value position (`builtin_recurse_f`/
 /// `builtin_recurse_cond`, both evaluate `f` through this function
-/// directly), `resolve_recurse`'s own `cond`-evaluation step in path
+/// directly), `builtin_in`'s own `xs`-evaluation step (also value
+/// position — the candidates to check `.` against can themselves be a
+/// multi-output generator with the same shape), `resolve_recurse`'s own
+/// `cond`-evaluation step in path
 /// position (#854 — `cond` can itself be a multi-output generator whose own
 /// later output errors after an earlier one already fired truthy for the
 /// same child), and `resolve_leaf`'s non-primitive fallback, also path
@@ -10251,11 +10254,18 @@ type PathResolveResult<'a> = Result<Vec<PathBranch<'a>>, (Vec<PathBranch<'a>>, E
 /// Every "keep-partial" call site below ends by matching a
 /// `(prefix, Option<EvalEscape>)` pair the exact same way — `Some(e) =>
 /// Err((prefix, e)), None => Ok(prefix)` — hand-written independently at
-/// each one. Collapsing that into a single call removes the chance of a
-/// stray unmatched arm or an escape variable going unread at a *new* call
-/// site by omission, the way two of #896's own review-round bugs did
-/// (#962).
-#[inline]
+/// each one. Collapsing that into a single call removes exactly one class
+/// of mistake: an incorrectly hand-copied `Some`/`None` arm at a site that
+/// reaches this combine step at all (#962). It is not a general guard
+/// against every prefix-loss bug in this area — #896's own review round
+/// found two related-but-distinct bugs neither of which this helper would
+/// have caught, since neither reached a `Some`/`None` match to get wrong: a
+/// bare `?` on a `PathResolveResult` discarding its prefix outright
+/// (`resolve_index_expr`'s `target_branches`, before that review's fix), and
+/// a fallthrough path that skipped checking an escape at all before
+/// delegating elsewhere (`GetPath`'s multi-output case, same review). A
+/// third instance of the bare-`?` kind, in `resolve_slice_expr`, is fixed
+/// alongside this helper's introduction — see that function's own comment.
 fn path_result(branches: Vec<PathBranch<'_>>, escape: Option<EvalEscape>) -> PathResolveResult<'_> {
     match escape {
         Some(e) => Err((branches, e)),
@@ -11054,6 +11064,11 @@ fn resolve_leaf<'a, S: EvalSemantics>(
         };
     }
     match values.len() {
+        // No output prunes the branch — unless there never would have been
+        // one because evaluating `expr` itself broke/errored (Halt excluded,
+        // handled above) before producing anything. Same rule as the
+        // `trackable`-primitive branch above, for the general non-primitive
+        // case this arm covers.
         0 => path_result(Vec::new(), trailing),
         // Real jq's `path(...)` checks each output as it streams: the first
         // non-path-shaped value raises "Invalid path expression" immediately,
@@ -11778,7 +11793,23 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
             .into(),
         ));
     }
-    let target_branches = resolve_node::<S>(target, value, trackable)?;
+    // Keeps `target`'s own partial prefix, not just discarding it via `?`,
+    // the same fix #896's review applied to `resolve_index_expr`'s sibling
+    // target-resolution step (found independently live here too — #973
+    // review): `target` can itself be one of #896's keep-partial sites
+    // (`select`, `if`, `getpath`, a computed index), so its own `Err` can
+    // carry a non-empty prefix that still needs slicing by `starts`/`ends`
+    // rather than being returned unsliced. Only reachable with a genuinely
+    // dynamic bound — a *literal* `[N:M]` desugars to a static `Pipe`
+    // (`resolve_seq`'s own fast path) at parse time and never reaches this
+    // function at all; see #977 for that separate gap. Confirmed against jq
+    // 1.7.1: `path((select(true, error("t")))[(0+1):2])` on `[10,20,30]`
+    // prints `[{"start":1,"end":2}]` (the already-produced `select` branch,
+    // sliced) before raising `t`.
+    let (target_branches, target_escape) = match resolve_node::<S>(target, value, trackable) {
+        Ok(branches) => (branches, None),
+        Err((prefix, e)) => (prefix, Some(e)),
+    };
     // #843: `resolve_index_expr`'s sibling `getpath`-laundering check —
     // `target` can also resolve successfully with `trackable: false`
     // through `Builtin::GetPath`'s deliberate exemption, which doesn't
@@ -11821,7 +11852,7 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
             }
         }
     }
-    Ok(out)
+    path_result(out, target_escape)
 }
 
 /// Evaluate one slice bound (`start` or `end`) in path context.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7867,6 +7867,29 @@ fn test_resolve_node_getpath_multi_output_surfaces_real_error_not_a_fabricated_o
     Ok(())
 }
 
+/// #973 review round: `resolve_slice_expr`'s `target_branches =
+/// resolve_node::<S>(target, value, trackable)?` had the same bare-`?`
+/// bug #896's review already found and fixed in `resolve_index_expr`'s
+/// sibling target-resolution step — reachable only with a *dynamic* slice
+/// bound (`(0+1)`, not a literal), since a literal bound desugars into a
+/// static `Pipe` at parse time and never reaches this function at all
+/// (that literal-bound gap is a separate, unrelated bug in `resolve_seq`,
+/// filed as #977). Verified against jq 1.7.1: `echo '[10,20,30]' | jq -c
+/// 'path((select(true, error("t")))[(0+1):2])'` prints
+/// `[{"start":1,"end":2}]` (the already-produced `select` branch, sliced)
+/// before raising `t`.
+#[test]
+fn test_resolve_slice_expr_keeps_target_partial_fanout_before_its_own_error_973() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path((select(true, error("t")))[(0+1):2])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":1,\"end\":2}]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+    Ok(())
+}
+
 #[test]
 fn test_walk_propagates_halt_from_f() -> Result<()> {
     // `walk_impl` applies `f` via `eval_owned_expr_fork` at every level


### PR DESCRIPTION
## Summary

- #962 item 2: the `Some(e) => Err((prefix, e)), None => Ok(prefix)` idiom was hand-rolled independently at 7 `PathResolveResult`-returning call sites in `src/jq/eval.rs` (`resolve_node`'s `Select`/`If`/`GetPath` arms, `resolve_index_expr`'s two return points, `resolve_leaf`'s `empty_case` closure, `resolve_recurse`'s `pending_error` match) — 4 of them added by #896. Collapsed into one `path_result(branches, escape) -> PathResolveResult` helper, placed right next to the `PathResolveResult` type alias it wraps.
- #962 item 3: `eval_owned_multi_keep_partial`'s doc comment listed its "direct callers today" but hadn't been updated for #896's 4 new callers (`Select`/`If`'s `cond`, `GetPath`'s `arg`, `resolve_index_expr`'s `key`). Updated.
- #962 item 1 (a real but wider-blast-radius bug: `first`/`limit` don't truncate the keep-partial resolvers lazily, so a trailing error after the nth output still surfaces) is **out of scope here** — filed separately as #972, since it also affects pre-existing `recurse` behavior, not just #896's 4 sites, and needs its own lazy-truncation design rather than a per-site patch.

This is a pure refactor — every touched arm's control flow is unchanged. Verified by spot-checking each of the 6 previously-`#896`/`#854`/`#861`-covered repros against both this branch and real jq 1.7.1 (identical output/exit codes before and after), and confirmed via `omni-dev coverage diff` that all 13 changed lines are already covered by the existing test suite (no new test needed, since no new behavior was introduced).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Spot-checked every touched arm's output against real jq 1.7.1 (select/if/computed-index/getpath partial-fanout cases, recurse cond partial, resolve_leaf non-primitive fallback, resolve_index_expr target-prefix case) — all identical before/after
- [x] `omni-dev coverage diff`: 100% patch coverage (13/13 new lines), consistent with this being a pure refactor of already-tested code

Fixes #962