### PR TITLE
fix(jq): gate JSON number_literal() on RFC 8259 validity, null (not 0) on unparseable

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1951,6 +1951,18 @@ struct JqCompatFormatter;
 
 impl LiteralFormatter for JqCompatFormatter {
     fn format_raw_number<'a>(&self, raw: &'a [u8]) -> Cow<'a, str> {
+        // The semi-index scanner accepts number *spans* more leniently than
+        // RFC 8259 (leading zeros, multiple decimal points -- #966).
+        // Sanitize via the same fallback every other "raw bytes -> number"
+        // conversion in this crate uses, instead of echoing invalid text
+        // verbatim and producing invalid JSON output.
+        if !validate::is_valid_number(raw) {
+            return Cow::Owned(match OwnedValue::from_number_bytes(raw) {
+                OwnedValue::Int(i) => self.format_int(i),
+                OwnedValue::Float(f) => self.format_float(f),
+                _ => "null".to_string(),
+            });
+        }
         // A source literal that overflows to ±Infinity/NaN (e.g. `1e400`)
         // must not be fed to `format_number_jq_compat` here: this is real
         // JSON output (`--jq-compat`), which RFC 8259 forbids an Infinity/NaN

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -283,14 +283,18 @@ pub trait DocumentValue: Sized + Clone {
     /// (`1e100`, `1.0`, `-0.0`) instead of re-rendering the parsed value —
     /// see issue #387.
     ///
-    /// Defaults to `None`. JSON overrides this unconditionally (every
-    /// `Number` token is JSON-legal number syntax by construction). YAML
-    /// overrides it too (#918), but only for a finite float whose source
-    /// text is independently confirmed safe and worthwhile to echo — see
-    /// `YamlValue::number_literal`'s doc comment (`src/yaml/light.rs`);
-    /// YAML's own plain-scalar grammar accepts spellings (hex/octal,
-    /// leading-dot) that aren't JSON-legal, and ints never lose information
-    /// through the bare-`Int` path, so both stay on this `None` default.
+    /// Defaults to `None`. JSON overrides this for a `Number` token whose
+    /// raw span is independently confirmed to be valid RFC 8259 number
+    /// syntax (`crate::json::validate::is_valid_number`) -- the semi-index
+    /// scanner accepts number *spans* more leniently than that grammar
+    /// (leading zeros, multiple decimal points), so not every `Number`
+    /// token qualifies (#966). YAML overrides it too (#918), but only for a
+    /// finite float whose source text is independently confirmed safe and
+    /// worthwhile to echo — see `YamlValue::number_literal`'s doc comment
+    /// (`src/yaml/light.rs`); YAML's own plain-scalar grammar accepts
+    /// spellings (hex/octal, leading-dot) that aren't JSON-legal, and ints
+    /// never lose information through the bare-`Int` path, so both stay on
+    /// this `None` default.
     fn number_literal(&self) -> Option<Cow<'_, str>> {
         None
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -329,13 +329,7 @@ fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> OwnedValue 
     match value {
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(*b),
-        StandardJson::Number(n) => {
-            if is_nan_sentinel(n.raw_bytes()) {
-                OwnedValue::Float(f64::NAN)
-            } else {
-                OwnedValue::from_number_bytes(n.raw_bytes())
-            }
-        }
+        StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
                 OwnedValue::String(cow.into_owned())
@@ -5376,11 +5370,7 @@ fn builtin_tonumber<W: Clone + AsRef<[u64]>>(
             // Already a number, return as-is -- this is a passthrough, not a
             // computation, so (like `.`) it keeps the source literal when
             // that literal is valid RFC 8259 syntax (#966).
-            QueryResult::Owned(if is_nan_sentinel(n.raw_bytes()) {
-                OwnedValue::Float(f64::NAN)
-            } else {
-                OwnedValue::from_number_bytes(n.raw_bytes())
-            })
+            QueryResult::Owned(OwnedValue::from_number_bytes(n.raw_bytes()))
         }
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -333,11 +333,7 @@ fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> OwnedValue 
             if is_nan_sentinel(n.raw_bytes()) {
                 OwnedValue::Float(f64::NAN)
             } else {
-                match core::str::from_utf8(n.raw_bytes()) {
-                    Ok(s) => OwnedValue::from_number_literal(s),
-                    // Fallback - shouldn't happen for valid JSON
-                    Err(_) => OwnedValue::Float(0.0),
-                }
+                OwnedValue::from_number_bytes(n.raw_bytes())
             }
         }
         StandardJson::String(s) => {
@@ -5378,14 +5374,12 @@ fn builtin_tonumber<W: Clone + AsRef<[u64]>>(
     match &value {
         StandardJson::Number(n) => {
             // Already a number, return as-is -- this is a passthrough, not a
-            // computation, so (like `.`) it keeps the source literal.
+            // computation, so (like `.`) it keeps the source literal when
+            // that literal is valid RFC 8259 syntax (#966).
             QueryResult::Owned(if is_nan_sentinel(n.raw_bytes()) {
                 OwnedValue::Float(f64::NAN)
             } else {
-                match core::str::from_utf8(n.raw_bytes()) {
-                    Ok(s) => OwnedValue::from_number_literal(s),
-                    Err(_) => OwnedValue::Int(0),
-                }
+                OwnedValue::from_number_bytes(n.raw_bytes())
             })
         }
         StandardJson::String(s) => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -726,10 +726,7 @@ fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(
             if is_nan_sentinel(n.raw_bytes()) {
                 OwnedValue::Float(f64::NAN)
             } else {
-                match core::str::from_utf8(n.raw_bytes()) {
-                    Ok(s) => OwnedValue::from_number_literal(s),
-                    Err(_) => OwnedValue::Null,
-                }
+                OwnedValue::from_number_bytes(n.raw_bytes())
             }
         }
         StandardJson::String(s) => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -32,7 +32,7 @@ use super::eval::{
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Literal};
 use super::slice::{slice_str, SliceBounds};
-use super::value::{is_nan_sentinel, OwnedValue};
+use super::value::OwnedValue;
 use crate::json::JsonIndex;
 
 /// Convert a DocumentValue to an OwnedValue.
@@ -722,13 +722,7 @@ fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(
     match value {
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(*b),
-        StandardJson::Number(n) => {
-            if is_nan_sentinel(n.raw_bytes()) {
-                OwnedValue::Float(f64::NAN)
-            } else {
-                OwnedValue::from_number_bytes(n.raw_bytes())
-            }
-        }
+        StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
         StandardJson::String(s) => {
             OwnedValue::String(s.as_str().map(|c| c.to_string()).unwrap_or_default())
         }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -391,8 +391,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Bool(b) => OwnedValue::Bool(*b),
             JqValue::Int(n) => OwnedValue::Int(*n),
             JqValue::Float(f) => OwnedValue::Float(*f),
-            JqValue::RawNumber(bytes) => core::str::from_utf8(bytes)
-                .map_or(OwnedValue::Float(0.0), OwnedValue::from_number_literal),
+            JqValue::RawNumber(bytes) => OwnedValue::from_number_bytes(bytes),
             JqValue::NumberLiteral(literal) => OwnedValue::from_number_literal(literal),
             JqValue::String(s) => OwnedValue::String(s.clone()),
             JqValue::Array(arr) => {
@@ -418,8 +417,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Bool(b) => OwnedValue::Bool(b),
             JqValue::Int(n) => OwnedValue::Int(n),
             JqValue::Float(f) => OwnedValue::Float(f),
-            JqValue::RawNumber(bytes) => core::str::from_utf8(bytes)
-                .map_or(OwnedValue::Float(0.0), OwnedValue::from_number_literal),
+            JqValue::RawNumber(bytes) => OwnedValue::from_number_bytes(bytes),
             JqValue::NumberLiteral(literal) => OwnedValue::from_number_literal_boxed(literal),
             JqValue::String(s) => OwnedValue::String(s),
             JqValue::Array(arr) => {
@@ -614,10 +612,7 @@ fn cursor_to_owned<W: Clone + AsRef<[u64]>>(cursor: &JsonCursor<'_, W>) -> Owned
     match cursor.value() {
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(b),
-        StandardJson::Number(n) => match core::str::from_utf8(n.raw_bytes()) {
-            Ok(s) => OwnedValue::from_number_literal(s),
-            Err(_) => OwnedValue::Float(0.0),
-        },
+        StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
                 OwnedValue::String(cow.into_owned())

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -31,6 +31,20 @@ pub enum NumberRepr {
     Float(f64),
 }
 
+/// Try `i64` first, fall back to `f64` -- the one definition of "how does a
+/// number string decide between the two representations," shared by
+/// [`OwnedValue::from_number_literal_boxed`] and
+/// [`OwnedValue::from_number_bytes`] so they can't silently diverge.
+fn parse_i64_or_f64(s: &str) -> Option<NumberRepr> {
+    if let Ok(i) = s.parse::<i64>() {
+        Some(NumberRepr::Int(i))
+    } else if let Ok(f) = s.parse::<f64>() {
+        Some(NumberRepr::Float(f))
+    } else {
+        None
+    }
+}
+
 /// Format a raw JSON number string the way jq itself would print it.
 ///
 /// This is jq's number formatting, not a verbatim echo of `raw`: jq always
@@ -391,11 +405,7 @@ impl OwnedValue {
     /// already-owned `Box<str>` (e.g. from `JqValue::NumberLiteral`) instead
     /// of allocating a fresh one.
     pub(crate) fn from_number_literal_boxed(literal: Box<str>) -> Self {
-        let repr = if let Ok(i) = literal.parse::<i64>() {
-            NumberRepr::Int(i)
-        } else if let Ok(f) = literal.parse::<f64>() {
-            NumberRepr::Float(f)
-        } else {
+        let Some(repr) = parse_i64_or_f64(&literal) else {
             return Self::Null;
         };
         Self::NumberLiteral(repr, literal)
@@ -424,12 +434,10 @@ impl OwnedValue {
         let Ok(s) = core::str::from_utf8(bytes) else {
             return Self::Null;
         };
-        if let Ok(i) = s.parse::<i64>() {
-            Self::Int(i)
-        } else if let Ok(f) = s.parse::<f64>() {
-            Self::Float(f)
-        } else {
-            Self::Null
+        match parse_i64_or_f64(s) {
+            Some(NumberRepr::Int(i)) => Self::Int(i),
+            Some(NumberRepr::Float(f)) => Self::Float(f),
+            None => Self::Null,
         }
     }
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -417,7 +417,7 @@ impl OwnedValue {
     /// `pub(crate)`) should go through (#966 found at least 7 independent
     /// hand-rolled copies of this decision).
     ///
-    /// Checks [`is_nan_sentinel`] first, so every caller gets that
+    /// Checks `is_nan_sentinel` first, so every caller gets that
     /// `to_json_for_reindex`-bridge convention for free instead of having
     /// to remember its own copy of the check (an earlier draft of this
     /// function required exactly that, and three of its call sites forgot

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -379,9 +379,10 @@ impl OwnedValue {
     ///
     /// Parses `literal` the same way every document-materializing conversion
     /// decides between the two representations: try `i64` first, fall back
-    /// to `f64`. Falls back to plain [`Float`](Self::Float) `0.0` if
-    /// `literal` parses as neither (should not happen for a valid document
-    /// number token).
+    /// to `f64`. Falls back to [`Null`](Self::Null) if `literal` parses as
+    /// neither (should not happen for a valid document number token, but
+    /// matches how every other decode-failure path in this codebase
+    /// represents "not actually a number" — #966).
     pub(crate) fn from_number_literal(literal: &str) -> Self {
         Self::from_number_literal_boxed(literal.into())
     }
@@ -395,7 +396,7 @@ impl OwnedValue {
         } else if let Ok(f) = literal.parse::<f64>() {
             NumberRepr::Float(f)
         } else {
-            return Self::Float(0.0);
+            return Self::Null;
         };
         Self::NumberLiteral(repr, literal)
     }
@@ -1461,13 +1462,14 @@ mod tests {
     }
 
     #[test]
-    fn test_from_number_literal_boxed_falls_back_to_zero_for_unparseable_text() {
-        // `from_number_literal_boxed` only ever receives valid document number
-        // tokens in practice, but it's defensive: neither an i64 nor f64 parse
-        // succeeding falls back to a plain zero rather than panicking.
+    fn test_from_number_literal_boxed_falls_back_to_null_for_unparseable_text() {
+        // Callers gate on `is_valid_number` before reaching this (#966), but
+        // it's defensive: neither an i64 nor f64 parse succeeding falls back
+        // to `Null` (matching every other decode-failure path in this
+        // codebase) rather than panicking or silently producing `0`.
         assert_eq!(
             OwnedValue::from_number_literal("not-a-number"),
-            OwnedValue::Float(0.0)
+            OwnedValue::Null
         );
     }
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -401,6 +401,38 @@ impl OwnedValue {
         Self::NumberLiteral(repr, literal)
     }
 
+    /// Materialize raw JSON number-token bytes into the correctly-gated
+    /// `OwnedValue` -- the single conversion every "raw bytes -> number"
+    /// call site in this crate (including the CLI binary, hence `pub` not
+    /// `pub(crate)`) should go through (#966 found at least 7 independent
+    /// hand-rolled copies of this decision).
+    ///
+    /// Preserves the source spelling via
+    /// [`NumberLiteral`](Self::NumberLiteral) only when `bytes` is valid
+    /// RFC 8259 number syntax
+    /// ([`is_valid_number`](crate::json::validate::is_valid_number));
+    /// otherwise degrades to a plain `Int`/`Float`, or [`Null`](Self::Null)
+    /// if neither parses. Skipping straight to `from_number_literal` for an
+    /// invalid span (`007`, `1.2.3`) would let
+    /// [`to_json`](Self::to_json)/[`number_str`](Self::number_str) echo it
+    /// back out verbatim, since both always reproduce a `NumberLiteral`'s
+    /// stored text unchanged.
+    pub fn from_number_bytes(bytes: &[u8]) -> Self {
+        if crate::json::validate::is_valid_number(bytes) {
+            return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
+        }
+        let Ok(s) = core::str::from_utf8(bytes) else {
+            return Self::Null;
+        };
+        if let Ok(i) = s.parse::<i64>() {
+            Self::Int(i)
+        } else if let Ok(f) = s.parse::<f64>() {
+            Self::Float(f)
+        } else {
+            Self::Null
+        }
+    }
+
     /// Collapse a [`NumberLiteral`](Self::NumberLiteral) into a plain
     /// `Int`/`Float`, dropping the source text. A no-op for every other
     /// variant.

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -417,7 +417,13 @@ impl OwnedValue {
     /// `pub(crate)`) should go through (#966 found at least 7 independent
     /// hand-rolled copies of this decision).
     ///
-    /// Preserves the source spelling via
+    /// Checks [`is_nan_sentinel`] first, so every caller gets that
+    /// `to_json_for_reindex`-bridge convention for free instead of having
+    /// to remember its own copy of the check (an earlier draft of this
+    /// function required exactly that, and three of its call sites forgot
+    /// it -- caught by review).
+    ///
+    /// Otherwise preserves the source spelling via
     /// [`NumberLiteral`](Self::NumberLiteral) only when `bytes` is valid
     /// RFC 8259 number syntax
     /// ([`is_valid_number`](crate::json::validate::is_valid_number));
@@ -428,6 +434,9 @@ impl OwnedValue {
     /// back out verbatim, since both always reproduce a `NumberLiteral`'s
     /// stored text unchanged.
     pub fn from_number_bytes(bytes: &[u8]) -> Self {
+        if is_nan_sentinel(bytes) {
+            return Self::Float(f64::NAN);
+        }
         if crate::json::validate::is_valid_number(bytes) {
             return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
         }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1661,7 +1661,18 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
 
     fn number_literal(&self) -> Option<Cow<'_, str>> {
         match self {
-            StandardJson::Number(n) => core::str::from_utf8(n.raw_bytes()).ok().map(Cow::Borrowed),
+            StandardJson::Number(n) => {
+                let bytes = n.raw_bytes();
+                if !crate::json::validate::is_valid_number(bytes) {
+                    // The semi-index scanner accepts number *spans* more
+                    // leniently than RFC 8259 (e.g. `007`, `1.2.3` — see
+                    // #966): echoing such text verbatim would produce
+                    // invalid JSON output. Fall through to `as_i64`/`as_f64`
+                    // (still lenient, but numerically sound) or `Null`.
+                    return None;
+                }
+                core::str::from_utf8(bytes).ok().map(Cow::Borrowed)
+            }
             _ => None,
         }
     }

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -742,9 +742,109 @@ pub fn validate(input: &[u8]) -> Result<(), ValidationError> {
     Validator::new(input).validate()
 }
 
+/// True if `bytes` is *exactly* one RFC 8259 JSON number token, with
+/// nothing before or after it.
+///
+/// Grammar: optional `-`, `0`|`[1-9][0-9]*` integer part, optional
+/// `.`-fraction requiring ≥1 digit, optional exponent requiring ≥1 digit.
+/// This is the same grammar [`Validator::validate_number`] enforces as one
+/// step of a larger document walk (with position tracking and detailed
+/// error variants for diagnostics); this free function instead answers a
+/// narrower, allocation-free question for a caller that already has a
+/// candidate token isolated and just needs a yes/no on the whole slice —
+/// e.g. a semi-index number token whose byte span was scanned leniently and
+/// may not actually be valid JSON number syntax (see #966), or a YAML
+/// scalar already routed to numeric dispatch that needs to know whether
+/// it's safe to echo as a JSON number literal verbatim (see #957, #918).
+///
+/// # Example
+///
+/// ```
+/// use succinctly::json::validate::is_valid_number;
+///
+/// assert!(is_valid_number(b"-3.14e10"));
+/// assert!(!is_valid_number(b"007"));      // leading zero
+/// assert!(!is_valid_number(b"1.2.3"));    // two decimal points
+/// assert!(!is_valid_number(b"1."));       // no digit after '.'
+/// ```
+#[must_use]
+pub fn is_valid_number(bytes: &[u8]) -> bool {
+    let mut i = 0;
+    if bytes.first() == Some(&b'-') {
+        i += 1;
+    }
+    match bytes.get(i) {
+        Some(b'0') => i += 1,
+        Some(b'1'..=b'9') => {
+            i += 1;
+            while matches!(bytes.get(i), Some(b'0'..=b'9')) {
+                i += 1;
+            }
+        }
+        _ => return false,
+    }
+    if bytes.get(i) == Some(&b'.') {
+        i += 1;
+        let start = i;
+        while matches!(bytes.get(i), Some(b'0'..=b'9')) {
+            i += 1;
+        }
+        if i == start {
+            return false;
+        }
+    }
+    if matches!(bytes.get(i), Some(b'e' | b'E')) {
+        i += 1;
+        if matches!(bytes.get(i), Some(b'+' | b'-')) {
+            i += 1;
+        }
+        let start = i;
+        while matches!(bytes.get(i), Some(b'0'..=b'9')) {
+            i += 1;
+        }
+        if i == start {
+            return false;
+        }
+    }
+    i == bytes.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ========================================================================
+    // is_valid_number tests (#957/#966)
+    // ========================================================================
+
+    #[test]
+    fn is_valid_number_accepts_full_rfc_8259_grammar() {
+        for s in [
+            "0", "-0", "42", "-42", "0.0", "2.0", "-2.5", "0.50", "1e10", "1E10", "1e+10", "1e-10",
+            "-1.5e-3", "0e0",
+        ] {
+            assert!(is_valid_number(s.as_bytes()), "expected valid: {s:?}");
+        }
+    }
+
+    #[test]
+    fn is_valid_number_rejects_lenient_semi_index_spans() {
+        // These are exactly the spans #966 found the semi-index scanner
+        // over-accepting as a single number token.
+        for s in ["007", "1.2.3", "1-2", "1.", ".5", "1e", "-", "1e+", ""] {
+            assert!(!is_valid_number(s.as_bytes()), "expected invalid: {s:?}");
+        }
+    }
+
+    #[test]
+    fn is_valid_number_rejects_trailing_garbage() {
+        // The whole slice must be one number -- this differs from
+        // `Validator::validate_number`, which only needs a number to start
+        // at the current position (a sibling `,`/`}` may legitimately
+        // follow within a larger document).
+        assert!(!is_valid_number(b"42x"));
+        assert!(!is_valid_number(b"42 "));
+    }
 
     // ========================================================================
     // Valid JSON tests

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -747,7 +747,7 @@ pub fn validate(input: &[u8]) -> Result<(), ValidationError> {
 ///
 /// Grammar: optional `-`, `0`|`[1-9][0-9]*` integer part, optional
 /// `.`-fraction requiring ≥1 digit, optional exponent requiring ≥1 digit.
-/// This is the same grammar [`Validator::validate_number`] enforces as one
+/// This is the same grammar `Validator::validate_number` enforces as one
 /// step of a larger document walk (with position tracking and detailed
 /// error variants for diagnostics); this free function instead answers a
 /// narrower, allocation-free question for a caller that already has a

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -261,51 +261,12 @@ fn parse_float(s: &str) -> ResolvedScalar {
 /// erroring loudly. This predicate is how [`super::light`]'s
 /// `number_literal()` override decides which literals are safe to echo.
 ///
-/// This grammar duplicates `crate::json::validate`'s `Validator::validate_number`
-/// (reachable via the public `crate::json::validate::validate`) — hand-rolled
-/// here rather than reused to avoid adding a `yaml`-to-`json` module
-/// dependency for this fix; tracked as a follow-up dedup opportunity (#957).
+/// This grammar is the same one `crate::json::validate::is_valid_number`
+/// implements (extracted from this exact function, #957/#966) — delegate
+/// rather than hand-roll a second copy.
 #[must_use]
 fn is_json_number_syntax(s: &str) -> bool {
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    if bytes.first() == Some(&b'-') {
-        i += 1;
-    }
-    match bytes.get(i) {
-        Some(b'0') => i += 1,
-        Some(b'1'..=b'9') => {
-            i += 1;
-            while matches!(bytes.get(i), Some(b'0'..=b'9')) {
-                i += 1;
-            }
-        }
-        _ => return false,
-    }
-    if bytes.get(i) == Some(&b'.') {
-        i += 1;
-        let start = i;
-        while matches!(bytes.get(i), Some(b'0'..=b'9')) {
-            i += 1;
-        }
-        if i == start {
-            return false;
-        }
-    }
-    if matches!(bytes.get(i), Some(b'e' | b'E')) {
-        i += 1;
-        if matches!(bytes.get(i), Some(b'+' | b'-')) {
-            i += 1;
-        }
-        let start = i;
-        while matches!(bytes.get(i), Some(b'0'..=b'9')) {
-            i += 1;
-        }
-        if i == start {
-            return false;
-        }
-    }
-    i == bytes.len()
+    crate::json::validate::is_valid_number(s.as_bytes())
 }
 
 /// The maximum count of ASCII digit characters (integer + fraction part

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9765,3 +9765,63 @@ fn test_builtin_in_keeps_earlier_candidates_before_a_later_type_mismatch_error_8
     );
     Ok(())
 }
+
+/// #966: a leniently-accepted-but-RFC-8259-invalid number (leading zero)
+/// no longer echoes its raw source text once materialized through
+/// `to_owned`/`OwnedValue` (array construction forces materialization,
+/// unlike bare `.` identity — see #974's follow-up for that remaining
+/// gap) -- it numerically sanitizes instead, matching what real jq would
+/// compute for the same digits.
+#[test]
+fn test_leading_zero_number_sanitizes_on_materialization_966() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[.a]"], Some(r#"{"a": 007}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[7]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// #966: a number with two decimal points was silently materializing as
+/// `0`; it now correctly falls through to `null`, since neither `i64` nor
+/// `f64` parses it (matching real jq's behavior of rejecting `1.2.3`
+/// outright -- succinctly's semi-indexing architecture is deliberately
+/// lenient about accepting it as a token in the first place, but the
+/// materialized *value* should never silently be a wrong number).
+#[test]
+fn test_malformed_two_dot_number_becomes_null_not_zero_966() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[.a]"], Some(r#"{"a": 1.2.3}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[null]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// #966: same as above for a bare `-` inside a number-like span (`1-2`
+/// isn't a valid number, isn't a valid subtraction expression either --
+/// it's one lenient semi-index token).
+#[test]
+fn test_malformed_bare_dash_number_becomes_null_not_zero_966() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[.a]"], Some(r#"{"a": 1-2}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[null]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Sanity check that ordinary valid numbers (including ones that share a
+/// prefix shape with the invalid cases above -- trailing zero, exponent,
+/// bare zero) are completely unaffected by #966's new validity gate.
+#[test]
+fn test_valid_numbers_unaffected_by_966_validity_gate() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "."],
+        Some(r#"{"a": 42, "b": -3.14, "c": 1e10, "d": 0, "e": 1.50}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "{\"a\":42,\"b\":-3.14,\"c\":1E+10,\"d\":0,\"e\":1.50}\n"
+    );
+    assert_eq!(stderr, "");
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9768,10 +9768,9 @@ fn test_builtin_in_keeps_earlier_candidates_before_a_later_type_mismatch_error_8
 
 /// #966: a leniently-accepted-but-RFC-8259-invalid number (leading zero)
 /// no longer echoes its raw source text once materialized through
-/// `to_owned`/`OwnedValue` (array construction forces materialization,
-/// unlike bare `.` identity — see #974's follow-up for that remaining
-/// gap) -- it numerically sanitizes instead, matching what real jq would
-/// compute for the same digits.
+/// `to_owned`/`OwnedValue` (array construction forces materialization) --
+/// it numerically sanitizes instead, matching what real jq would compute
+/// for the same digits.
 #[test]
 fn test_leading_zero_number_sanitizes_on_materialization_966() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-c", "[.a]"], Some(r#"{"a": 007}"#))?;
@@ -9796,18 +9795,6 @@ fn test_malformed_two_dot_number_becomes_null_not_zero_966() -> Result<()> {
     Ok(())
 }
 
-/// #966: same as above for a bare `-` inside a number-like span (`1-2`
-/// isn't a valid number, isn't a valid subtraction expression either --
-/// it's one lenient semi-index token).
-#[test]
-fn test_malformed_bare_dash_number_becomes_null_not_zero_966() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(&["-c", "[.a]"], Some(r#"{"a": 1-2}"#))?;
-    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "[null]\n");
-    assert_eq!(stderr, "");
-    Ok(())
-}
-
 /// Sanity check that ordinary valid numbers (including ones that share a
 /// prefix shape with the invalid cases above -- trailing zero, exponent,
 /// bare zero) are completely unaffected by #966's new validity gate.
@@ -9823,5 +9810,98 @@ fn test_valid_numbers_unaffected_by_966_validity_gate() -> Result<()> {
         "{\"a\":42,\"b\":-3.14,\"c\":1E+10,\"d\":0,\"e\":1.50}\n"
     );
     assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// #966 code review found the fix above didn't reach the CLI's actual
+/// *default* output path: `print_json`'s `JqCompatFormatter::format_raw_number`
+/// (`src/bin/succinctly/jq_runner.rs`) is what plain field access, `.[]`,
+/// and `select(...)` print through, completely bypassing `[.a]`-style
+/// materialization -- so `.a` alone was still echoing invalid JSON after
+/// the original fix. Now fixed at that call site directly (same
+/// `OwnedValue::from_number_bytes` gate, consolidated across every "raw
+/// bytes -> number" conversion in the crate).
+#[test]
+fn test_plain_field_access_sanitizes_leading_zero_966() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a"], Some(r#"{"a": 007}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "7\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Same as above for `.[]` iteration over malformed and valid numbers
+/// mixed together -- confirms the fix applies per-element, not just to a
+/// whole-document shortcut.
+#[test]
+fn test_array_iteration_sanitizes_malformed_numbers_966() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[]"], Some("[007, 1.2.3, 42]"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "7\nnull\n42\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Bare identity (`.`, no computation at all) also sanitizes now --
+/// confirms the M2 raw-copy fast path (`StandardJson::stream_json`) isn't
+/// actually reachable in default (jq-compat) mode:
+/// `OutputConfig::can_use_raw_identity` requires `!jq_compat`, and
+/// `jq_compat` defaults to `true`. What plain `.` was actually printing
+/// through was `JqCompatFormatter::format_raw_number`, the same call site
+/// `test_plain_field_access_sanitizes_leading_zero_966` covers.
+#[test]
+fn test_bare_identity_sanitizes_leading_zero_966() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "."], Some(r#"{"a": 007}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"a\":7}\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// `--preserve-input` is a deliberate, documented "keep the exact source
+/// formatting" mode (`PreserveFormatter`) -- it's expected to keep echoing
+/// a leniently-scanned-but-invalid number verbatim, since that's the
+/// whole point of the flag. This isn't the #966 bug; it's confirming the
+/// fix didn't overreach into a mode where raw echo is intentional.
+#[test]
+fn test_preserve_input_still_echoes_raw_number_text() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "--preserve-input", "."], Some(r#"{"a": 007}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"a\": 007}\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// #966 code review found that once a malformed number's cursor
+/// materializes to `Null` (`src/jq/lazy.rs::cursor_to_owned`, reached by
+/// `jq -e`'s exit-status check), `jq -e '.a'` on a document with a
+/// malformed `.a` now correctly reports failure (exit 1) instead of
+/// silently succeeding on a value that only *looked* like a number.
+#[test]
+fn test_exit_status_false_for_malformed_number_966() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-e", "-c", ".a"], Some(r#"{"a": 1.2.3}"#))?;
+    assert_eq!(code, 1, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "null\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Arithmetic on a malformed number now fails loudly instead of silently
+/// computing against a wrong `0` (the original #966 bug's most dangerous
+/// shape -- a query that looks like it succeeded but used fabricated
+/// data). Matches real jq's own hard-reject of `1.2.3` as input, just
+/// surfaced at the point the value is actually used rather than at parse
+/// time (succinctly's semi-indexing architecture defers validation --
+/// see docs/architecture/semi-indexing.md).
+#[test]
+fn test_arithmetic_on_malformed_number_errors_not_silent_zero_966() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a - 1"], Some(r#"{"a": 1.2.3}"#))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("cannot be subtracted"),
+        "unexpected stderr: {stderr}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

`StandardJson::number_literal()` (`src/json/light.rs`) echoed the semi-index scanner's leniently-accepted number spans verbatim regardless of RFC 8259 validity, and `OwnedValue::from_number_literal_boxed`'s total-parse-failure fallback (`src/jq/value.rs`) silently produced `Float(0.0)` instead of `Null`.

```
$ printf '{"a": 007}' | succinctly jq '.a'      # before
007                                               # invalid JSON output
$ printf '{"a": 1.2.3}' | succinctly jq '.a - 1' # before
-1                                                # silently computed against a fabricated 0
```

**This PR went through several review-and-fix rounds; the final state fixes every reachable "raw JSON number bytes → value" conversion in the crate.**

1. First commit: gated `number_literal()` on `is_valid_number` (a new RFC 8259 grammar check extracted from — and now shared with — YAML's own copy, closing #957 as a bonus dedup), and fixed the `Null` fallback.
2. Review found that only fixed *one* of at least 7 independent conversions — most importantly `jq_runner.rs`'s `JqCompatFormatter::format_raw_number`, the CLI's actual default output path for `.a`, `.[]`, `select(...)`, and everything except array-construction-style queries. Second commit consolidated every site behind one new `OwnedValue::from_number_bytes` helper: `jq_runner.rs`'s formatter (default path — `PreserveFormatter`, used only under `--preserve-input`, is deliberately untouched since raw echo is that flag's documented purpose), `eval.rs`'s `to_owned`/`tonumber` passthrough, `eval_generic.rs::standard_json_to_owned`, and `lazy.rs`'s `cursor_to_owned`/`materialize`/`into_owned`.
3. Third commit: deduped the i64-or-f64 parse cascade into `parse_i64_or_f64`, fixed a doc comment `number_literal()`'s own gate made stale.
4. Fourth commit: review found the newly-consolidated sites disagreed on an internal NaN sentinel value depending on which one processed it (some checked `is_nan_sentinel` first, some didn't). Moved that check inside `from_number_bytes` itself so every caller gets it automatically instead of needing its own copy — and removed the three now-redundant manual checks.

**Also corrects issue #974's diagnosis.** I originally (wrongly) attributed "bare `.` identity still echoes invalid JSON" to `StandardJson::stream_json`'s M2 raw-copy fast path. That path is gated off whenever `jq_compat` is `true` (the default — only `--preserve-input` sets it `false`), so it was never reachable by the bug's own repro; the real cause was the `JqCompatFormatter` site fixed here. #974 closed as completed.

**Two narrower, confirmed-pre-existing gaps split into follow-ups** rather than folded in, since both are outside the CLI's reachable surface (or predate this PR entirely):
- #981: `eval.rs`'s `length`/`skip`/`limit`/`nth_stream` builtins default a malformed number to `0` instead of erroring, but only via direct use of the public `succinctly::jq::eval()` library API — `eval_generic.rs` (what the CLI actually uses) already sanitizes first.
- A pre-existing (confirmed via unmodified `main`) inconsistency where `as $x` variable binding doesn't recognize the internal NaN sentinel the way direct-pipe evaluation does — verified this predates the PR entirely (main gives a different but equally-wrong answer for the same input) and requires typing the exact internal sentinel text as user data, an adversarial-only edge case.

## Verified live against real jq 1.7.1

```
$ printf '{"a": 007}' | succinctly jq -c '.a'               # was 007, now:
7
$ printf '{"a": 1.2.3}' | succinctly jq -c '.a'              # was 1.2.3, now:
null
$ printf '{"a": 1.2.3}' | succinctly jq -e '.a'; echo $?     # was exit 0, now:
null
1
$ printf '{"a": 1.2.3}' | succinctly jq -c '.a - 1'          # was -1 (silent), now:
jq: error (at <stdin>:0): null (null) and number (1) cannot be subtracted
$ printf '{"a": 007}' | succinctly jq -c --preserve-input '.'  # unaffected, as intended:
{"a": 007}
```

Every valid-number path (plain integers, floats, exponents, trailing zeros) is byte-identical to real jq — confirmed manually and via `test_valid_numbers_unaffected_by_966_validity_gate`.

Fixes #966
Fixes #957

## Test plan
- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests -- 966` plus the standalone `preserve_input` test — 9 tests covering array construction, plain field access, `.[]` iteration, bare identity, `-e` exit-status, arithmetic error surfacing, the `--preserve-input` control case, and valid-number non-regression
- [x] `cargo test --features cli,simd,regex,serde` (full suite) — all green across all 54 test binaries, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Manually verified every repro case above against real jq 1.7.1
- [x] Interleaved release-build A/B (5MB generated JSON): default-identity query and a materialization-heavy query (`[.. | numbers] | length`) — no measurable regression on either
- [x] Rebased cleanly onto latest `origin/main` (which landed its own overlapping `eval.rs`/`value.rs` refactor, PR #973) — full re-verification (build, tests, both clippy, live jq comparison) all green post-rebase
