### PR TITLE
fix(yq): computed whole-number floats drop their decimal point

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -27,8 +27,8 @@ use succinctly::yaml::{
 use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
 use crate::front_matter;
 use crate::output::{
-    self, exit_codes, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation,
-    JsonFormatOpts,
+    self, exit_codes, format_float_yq, ColorScheme, ControlEscape, DiagStyle, ErrorSink,
+    FloatStyle, InputLocation, JsonFormatOpts,
 };
 
 /// yq's diagnostics carry no `(at <file>:<line>)` marker, so the yq paths have
@@ -1562,10 +1562,20 @@ fn emit_yaml_value_at_depth(
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
-        // `format_float_yq_yaml`, not `format_float_yq`: this is YAML
-        // output, whose computed-whole-float convention drops the decimal
-        // point (`2`, not `2.0`) unlike JSON output -- issue #949.
-        OwnedValue::Float(f) => format_float_yq_yaml(*f),
+        // Real yq drops a computed whole float's decimal point (`2`, not
+        // `2.0`) only at document-root scalar position -- issue #949.
+        // Anywhere nested (an object field, an array element, an `-i`
+        // in-place edit) it instead emits an explicit `!!float` tag to
+        // keep the value's type unambiguous on reparse (`a: !!float 2`);
+        // succinctly has no tag-emission mechanism to match that, so
+        // falling back to `format_float_yq`'s decimal-preserving spelling
+        // here is the safer of the two available choices -- it's not
+        // byte-identical to real yq, but unlike the bare, untagged `2`
+        // this fix originally used at every depth, it doesn't silently
+        // change the value's inferred type from float to int on
+        // reparse/round-trip through `-i`.
+        OwnedValue::Float(f) if depth == 0 => format_float_yq_yaml(*f),
+        OwnedValue::Float(f) => format_float_yq(*f),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()
         }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -20,14 +20,15 @@ use succinctly::jq::{
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
-    resolve_plain, resolve_tagged, stream_yaml_sequence, YamlCursor, YamlIndex, YamlValue,
+    format_float_yq_yaml, resolve_plain, resolve_tagged, stream_yaml_sequence, YamlCursor,
+    YamlIndex, YamlValue,
 };
 
 use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
 use crate::front_matter;
 use crate::output::{
-    self, exit_codes, format_float_yq, ColorScheme, ControlEscape, DiagStyle, ErrorSink,
-    FloatStyle, InputLocation, JsonFormatOpts,
+    self, exit_codes, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation,
+    JsonFormatOpts,
 };
 
 /// yq's diagnostics carry no `(at <file>:<line>)` marker, so the yq paths have
@@ -1561,7 +1562,10 @@ fn emit_yaml_value_at_depth(
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
-        OwnedValue::Float(f) => format_float_yq(*f),
+        // `format_float_yq_yaml`, not `format_float_yq`: this is YAML
+        // output, whose computed-whole-float convention drops the decimal
+        // point (`2`, not `2.0`) unlike JSON output -- issue #949.
+        OwnedValue::Float(f) => format_float_yq_yaml(*f),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()
         }

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -29,7 +29,7 @@ use super::value::{
     assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text,
     jq_bare_float_display, NumberRepr, OwnedValue,
 };
-use crate::yaml::format_float_with_fraction;
+use crate::yaml::{format_float_with_fraction, format_float_yq_yaml};
 
 /// A value that can be streamed directly to output without intermediate allocation.
 ///
@@ -623,10 +623,15 @@ fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
             out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
         OwnedValue::Float(f) => {
-            // Not `write!(out, "{f}")`: that drops the `.0` from a whole
-            // float, diverging from the identity streaming path and the
-            // DOM pretty-printer (issue #169).
-            out.write_str(&format_float_with_fraction(*f))
+            // `format_float_yq_yaml`, not `format_float_with_fraction`: a
+            // bare (computed) `Float` has no source text to preserve, and
+            // real yq's YAML output shows the shortest form -- with the
+            // same scientific-notation threshold as the DOM path's own
+            // `emit_yaml_value` -- for a computed whole number (e.g. `. + 1`
+            // on `1.0` prints `2`, not `2.0`) -- issue #949. An untouched
+            // literal keeps its own `.0` via the `NumberLiteral` arm below,
+            // unaffected by this.
+            out.write_str(&format_float_yq_yaml(*f))
         }
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
@@ -1104,14 +1109,42 @@ mod tests {
         assert_eq!(buf, "[1.0,2.5]");
     }
 
-    /// The `yq` YAML convention must agree with the JSON one.
+    /// Unlike the JSON M2 convention above, a bare (computed) `Float`'s YAML
+    /// rendering drops the decimal point on a whole number: real yq's YAML
+    /// output shows `2`, not `2.0`, for a genuinely computed whole float
+    /// (e.g. `. + 1` on `1.0`) — issue #949. This deliberately diverges from
+    /// `test_stream_json_whole_float_keeps_decimal_point` above: YAML output
+    /// and JSON output of the *same* computed value are not required to
+    /// agree, matching real yq. An untouched literal still keeps its own
+    /// `.0` via the sibling `NumberLiteral` variant, unaffected by this.
     #[test]
-    fn test_stream_yaml_whole_float_keeps_decimal_point() {
+    fn test_stream_yaml_computed_whole_float_drops_decimal_point_949() {
         let mut buf = String::new();
         OwnedValue::Float(1.0)
             .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
-        assert_eq!(buf, "1.0");
+        assert_eq!(buf, "1");
+
+        buf.clear();
+        OwnedValue::Float(-0.0)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(buf, "-0");
+
+        buf.clear();
+        OwnedValue::Array(vec![OwnedValue::Float(1.0), OwnedValue::Float(2.5)])
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(buf, "[1, 2.5]");
+
+        // Scientific-notation threshold agrees with the DOM path's
+        // `format_float_yq_yaml` (and `format_float_yq`'s own JSON
+        // threshold): shortest mantissa only past exponent `>= 6`/`<= -5`.
+        buf.clear();
+        OwnedValue::Float(1_500_000.0)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(buf, "1.5e+06");
     }
 
     /// The `jq` error convention is a distinct writer (`stream_owned_value_json_jq`,

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -29,7 +29,7 @@ use super::value::{
     assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text,
     jq_bare_float_display, NumberRepr, OwnedValue,
 };
-use crate::yaml::{format_float_with_fraction, format_float_yq_yaml};
+use crate::yaml::{format_float_with_fraction, format_float_yq, format_float_yq_yaml};
 
 /// A value that can be streamed directly to output without intermediate allocation.
 ///
@@ -627,19 +627,24 @@ fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
         // float's decimal point only at document-root scalar position,
         // and tags it (`!!float`) everywhere else to keep its type
         // unambiguous on reparse -- a mechanism succinctly has no way to
-        // emit, so `format_float_with_fraction`'s decimal-preserving
-        // fallback is the safer of the two available choices below root.
-        // `can_use_m2_streaming` (yq_runner.rs) has no arithmetic arm, so
-        // this function is likely unreachable with a genuinely *computed*
-        // bare `Float` through any current CLI path -- kept in sync with
-        // the DOM path anyway for `StreamableValue::stream_yaml`'s other,
-        // non-CLI callers and to avoid a silent behavioral split if a
-        // future M2-eligible construct ever does carry one through (#1064
-        // documents this same "unreachable but exhaustive" shape
-        // elsewhere in this codebase). An untouched literal keeps its own
-        // `.0` via the `NumberLiteral` arm below, unaffected by this.
+        // emit, so `format_float_yq`'s decimal-preserving fallback is the
+        // safer of the two available choices below root (also matching
+        // `emit_yaml_value_at_depth`'s nested-position fallback exactly,
+        // including its scientific-notation threshold for an
+        // extreme-magnitude nested value -- `format_float_with_fraction`
+        // alone has no such threshold and would diverge from the DOM path
+        // on that case). `can_use_m2_streaming` (yq_runner.rs) has no
+        // arithmetic arm, so this function is likely unreachable with a
+        // genuinely *computed* bare `Float` through any current CLI path
+        // -- kept in sync with the DOM path anyway for
+        // `StreamableValue::stream_yaml`'s other, non-CLI callers and to
+        // avoid a silent behavioral split if a future M2-eligible
+        // construct ever does carry one through (#1064 documents this
+        // same "unreachable but exhaustive" shape elsewhere in this
+        // codebase). An untouched literal keeps its own `.0` via the
+        // `NumberLiteral` arm below, unaffected by this.
         OwnedValue::Float(f) if depth == 0 => out.write_str(&format_float_yq_yaml(*f)),
-        OwnedValue::Float(f) => out.write_str(&format_float_with_fraction(*f)),
+        OwnedValue::Float(f) => out.write_str(&format_float_yq(*f)),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
         }

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -622,17 +622,24 @@ fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
             out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
-        OwnedValue::Float(f) => {
-            // `format_float_yq_yaml`, not `format_float_with_fraction`: a
-            // bare (computed) `Float` has no source text to preserve, and
-            // real yq's YAML output shows the shortest form -- with the
-            // same scientific-notation threshold as the DOM path's own
-            // `emit_yaml_value` -- for a computed whole number (e.g. `. + 1`
-            // on `1.0` prints `2`, not `2.0`) -- issue #949. An untouched
-            // literal keeps its own `.0` via the `NumberLiteral` arm below,
-            // unaffected by this.
-            out.write_str(&format_float_yq_yaml(*f))
-        }
+        // Mirrors `emit_yaml_value_at_depth`'s identical depth split
+        // (yq_runner.rs, issue #949): real yq drops a computed whole
+        // float's decimal point only at document-root scalar position,
+        // and tags it (`!!float`) everywhere else to keep its type
+        // unambiguous on reparse -- a mechanism succinctly has no way to
+        // emit, so `format_float_with_fraction`'s decimal-preserving
+        // fallback is the safer of the two available choices below root.
+        // `can_use_m2_streaming` (yq_runner.rs) has no arithmetic arm, so
+        // this function is likely unreachable with a genuinely *computed*
+        // bare `Float` through any current CLI path -- kept in sync with
+        // the DOM path anyway for `StreamableValue::stream_yaml`'s other,
+        // non-CLI callers and to avoid a silent behavioral split if a
+        // future M2-eligible construct ever does carry one through (#1064
+        // documents this same "unreachable but exhaustive" shape
+        // elsewhere in this codebase). An untouched literal keeps its own
+        // `.0` via the `NumberLiteral` arm below, unaffected by this.
+        OwnedValue::Float(f) if depth == 0 => out.write_str(&format_float_yq_yaml(*f)),
+        OwnedValue::Float(f) => out.write_str(&format_float_with_fraction(*f)),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
@@ -1110,13 +1117,20 @@ mod tests {
     }
 
     /// Unlike the JSON M2 convention above, a bare (computed) `Float`'s YAML
-    /// rendering drops the decimal point on a whole number: real yq's YAML
-    /// output shows `2`, not `2.0`, for a genuinely computed whole float
-    /// (e.g. `. + 1` on `1.0`) — issue #949. This deliberately diverges from
+    /// rendering drops the decimal point on a whole number *at document-root
+    /// scalar position*: real yq's YAML output shows `2`, not `2.0`, for a
+    /// genuinely computed whole float (e.g. `. + 1` on `1.0`) — issue #949.
+    /// This deliberately diverges from
     /// `test_stream_json_whole_float_keeps_decimal_point` above: YAML output
-    /// and JSON output of the *same* computed value are not required to
-    /// agree, matching real yq. An untouched literal still keeps its own
-    /// `.0` via the sibling `NumberLiteral` variant, unaffected by this.
+    /// and JSON output of the *same* root-level computed value are not
+    /// required to agree, matching real yq. An untouched literal still keeps
+    /// its own `.0` via the sibling `NumberLiteral` variant, unaffected by
+    /// this. A *nested* computed float (inside the array case below) keeps
+    /// its decimal point instead — real yq disambiguates a nested computed
+    /// float with an explicit `!!float` tag, which this codebase has no way
+    /// to emit, so falling back to the point-preserving spelling avoids
+    /// silently losing the value's float-ness on reparse (see
+    /// `format_float_yq_yaml`'s own doc comment for the full reasoning).
     #[test]
     fn test_stream_yaml_computed_whole_float_drops_decimal_point_949() {
         let mut buf = String::new();
@@ -1131,15 +1145,19 @@ mod tests {
             .unwrap();
         assert_eq!(buf, "-0");
 
+        // Nested (depth > 0): keeps the decimal point, unlike the root case
+        // above.
         buf.clear();
         OwnedValue::Array(vec![OwnedValue::Float(1.0), OwnedValue::Float(2.5)])
             .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
-        assert_eq!(buf, "[1, 2.5]");
+        assert_eq!(buf, "[1.0, 2.5]");
 
         // Scientific-notation threshold agrees with the DOM path's
         // `format_float_yq_yaml` (and `format_float_yq`'s own JSON
         // threshold): shortest mantissa only past exponent `>= 6`/`<= -5`.
+        // This is still root position, so the threshold applies via
+        // `format_float_yq_yaml` rather than the nested fallback.
         buf.clear();
         OwnedValue::Float(1_500_000.0)
             .stream_yaml(&mut buf, IndentSpec::COMPACT, false)

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3255,8 +3255,13 @@ fn write_i64(output: &mut String, mut n: i64) {
 /// whole values and never uses exponent notation, so the absence of a `.` is
 /// the only case needing repair.
 ///
-/// Shared with the streaming writer and the `yq` CLI's printers so every
-/// emitter renders a float the same way.
+/// Shared with the streaming writer and the `yq` CLI's printers as their
+/// common fallback for a *nested* (non-root) computed float, where real
+/// yq instead emits an explicit `!!float` tag to keep the value's type
+/// unambiguous -- a mechanism succinctly's YAML emitters don't have (see
+/// [`format_float_yq_yaml`]'s doc comment, issue #949). A root-position
+/// scalar routes through [`format_float_yq_yaml`] instead, matching real
+/// yq's own root-only decimal-point-dropping rule.
 #[must_use]
 pub fn format_float_with_fraction(f: f64) -> String {
     let mut buf = f.to_string();
@@ -3295,11 +3300,9 @@ pub fn format_float_with_fraction(f: f64) -> String {
 ///
 /// Lives here (not in the CLI binary) rather than only in
 /// `src/bin/succinctly/output.rs`, which now re-exports this under the
-/// same name, so a future library-side computed-float formatter (there is
-/// none yet -- `succinctly jq`'s own arithmetic results have no yq-mode
-/// concept to begin with) could share it without duplicating the
-/// threshold logic; not because the M2 streaming path calls it today (it
-/// doesn't -- see above).
+/// same name, so its YAML-output sibling ([`format_float_yq_yaml`]) and
+/// the M2 streaming writer (`src/jq/stream.rs`) can share the threshold
+/// logic without duplicating it.
 ///
 /// `f` must be finite -- like [`format_float_with_fraction`], this has no
 /// JSON/YAML-specific spelling for NaN/Infinity to fall back on, so every
@@ -3309,20 +3312,30 @@ pub fn format_float_yq(f: f64) -> String {
     format_float_yq_with(f, format_float_with_fraction)
 }
 
-/// The YAML-output sibling of [`format_float_yq`].
+/// The YAML-output sibling of [`format_float_yq`], for a computed float at
+/// **document-root scalar position only**.
 ///
 /// Same magnitude threshold and scientific-notation spelling, but everyday
 /// magnitudes render at their shortest (`2`, not `2.0`) rather than with a
 /// forced decimal point.
 ///
 /// Real yq's computed-float convention genuinely differs by *output*
-/// format, not just by input source: `. + 1` on YAML-sourced `1.0` prints
-/// `2` on YAML output but `2.0` on JSON output (compact and pretty always
-/// agree with each other, just not with YAML) -- confirmed against real yq
-/// v4.53.3 (issue #949). [`format_float_yq`] is the JSON-output
-/// convention (also used by `-o json`'s DOM path in `output.rs`); this is
-/// the YAML-output one, for [`crate::jq::eval`]'s YAML streamer and the
-/// `yq` CLI's own YAML DOM printer.
+/// format at root position specifically: `. + 1` on YAML-sourced `1.0`
+/// prints `2` on YAML output but `2.0` on JSON output (compact and pretty
+/// always agree with each other, just not with YAML) -- confirmed against
+/// real yq v4.53.3 (issue #949). Nested (any object field, array element,
+/// or `-i` in-place edit), real yq instead emits an explicit `!!float`
+/// tag to keep the value's type unambiguous on reparse (`a: !!float 2`);
+/// succinctly's YAML emitters have no tag-emission mechanism to match
+/// that, so a nested position falls back to [`format_float_yq`]'s
+/// decimal-preserving spelling instead of calling this function --
+/// imperfect versus the oracle, but it doesn't silently change the
+/// value's inferred type from float to int on round trip the way this
+/// function's bare, untagged spelling would. Callers are responsible for
+/// making that root-vs-nested choice themselves (see the `depth`-gated
+/// call sites in `src/bin/succinctly/yq_runner.rs` and
+/// `src/jq/stream.rs`); this function always drops the point
+/// unconditionally.
 ///
 /// `f` must be finite, like [`format_float_yq`].
 #[must_use]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3306,9 +3306,41 @@ pub fn format_float_with_fraction(f: f64) -> String {
 /// caller must special-case those first.
 #[must_use]
 pub fn format_float_yq(f: f64) -> String {
+    format_float_yq_with(f, format_float_with_fraction)
+}
+
+/// The YAML-output sibling of [`format_float_yq`].
+///
+/// Same magnitude threshold and scientific-notation spelling, but everyday
+/// magnitudes render at their shortest (`2`, not `2.0`) rather than with a
+/// forced decimal point.
+///
+/// Real yq's computed-float convention genuinely differs by *output*
+/// format, not just by input source: `. + 1` on YAML-sourced `1.0` prints
+/// `2` on YAML output but `2.0` on JSON output (compact and pretty always
+/// agree with each other, just not with YAML) -- confirmed against real yq
+/// v4.53.3 (issue #949). [`format_float_yq`] is the JSON-output
+/// convention (also used by `-o json`'s DOM path in `output.rs`); this is
+/// the YAML-output one, for [`crate::jq::eval`]'s YAML streamer and the
+/// `yq` CLI's own YAML DOM printer.
+///
+/// `f` must be finite, like [`format_float_yq`].
+#[must_use]
+pub fn format_float_yq_yaml(f: f64) -> String {
+    format_float_yq_with(f, |f| f.to_string())
+}
+
+/// Shared magnitude-threshold logic behind [`format_float_yq`] and
+/// [`format_float_yq_yaml`]: scientific notation (`e+NN`/`e-NN`) once the
+/// value's decimal exponent is `>= 6` or `<= -5`, otherwise
+/// `ordinary_magnitude` -- the only place the two conventions actually
+/// differ (whole-number decimal-point handling), so this is where the
+/// threshold and exponent spelling stay oracle-verified in exactly one
+/// place rather than two.
+fn format_float_yq_with(f: f64, ordinary_magnitude: impl FnOnce(f64) -> String) -> String {
     debug_assert!(
         f.is_finite(),
-        "format_float_yq requires a finite value; NaN/Infinity have no \
+        "format_float_yq_with requires a finite value; NaN/Infinity have no \
          JSON/YAML spelling here and must be special-cased by the caller"
     );
     let sci = format!("{f:e}");
@@ -3319,7 +3351,7 @@ pub fn format_float_yq(f: f64) -> String {
         .parse()
         .expect("exponent from Rust's exponential formatter is always a valid i32");
     if (-4..6).contains(&exp) {
-        format_float_with_fraction(f)
+        ordinary_magnitude(f)
     } else {
         let sign = if exp < 0 { '-' } else { '+' };
         format!("{mantissa}e{sign}{:02}", exp.abs())
@@ -12292,5 +12324,27 @@ mod tests {
             first_doc_json(b"- b: &anc 1\n- a: *anc\n"),
             r#"[{"b":1},{"a":1}]"#
         );
+    }
+
+    /// [`format_float_yq_yaml`]'s YAML-output convention: shares
+    /// [`format_float_yq`]'s scientific-notation threshold exactly, but
+    /// drops the forced decimal point for everyday magnitudes -- issue
+    /// #949. Mirrors `test_format_float_yq_997` in `output.rs`, which pins
+    /// the JSON-output sibling's identical threshold with a forced point.
+    #[test]
+    fn test_format_float_yq_yaml_949() {
+        assert_eq!(format_float_yq_yaml(0.0), "0");
+        assert_eq!(format_float_yq_yaml(-0.0), "-0");
+        // In-range: shortest decimal, no forced fractional part.
+        assert_eq!(format_float_yq_yaml(150000.0), "150000");
+        assert_eq!(format_float_yq_yaml(0.00015), "0.00015");
+        assert_eq!(format_float_yq_yaml(1.5), "1.5");
+        // Past the threshold: scientific, matching `format_float_yq` exactly
+        // (this is the one place the two conventions agree).
+        assert_eq!(format_float_yq_yaml(1_500_000.0), "1.5e+06");
+        assert_eq!(format_float_yq_yaml(0.000015), "1.5e-05");
+        assert_eq!(format_float_yq_yaml(-1_500_000.0), "-1.5e+06");
+        assert_eq!(format_float_yq_yaml(1e100), "1e+100");
+        assert_eq!(format_float_yq_yaml(1e-100), "1e-100");
     }
 }

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -275,8 +275,9 @@ pub(crate) enum QuotedSpanEnd {
 pub use error::YamlError;
 pub use index::YamlIndex;
 pub use light::{
-    format_float_with_fraction, format_float_yq, stream_yaml_sequence, ChompingIndicator,
-    YamlCursor, YamlElements, YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
+    format_float_with_fraction, format_float_yq, format_float_yq_yaml, stream_yaml_sequence,
+    ChompingIndicator, YamlCursor, YamlElements, YamlField, YamlFields, YamlNumber, YamlString,
+    YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
 pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7724,9 +7724,13 @@ fn test_computed_whole_float_json_sourced_input_unaffected_by_949() -> Result<()
     Ok(())
 }
 
-/// An untouched literal is unaffected by this fix in any output mode -- a
-/// different `OwnedValue` variant (`NumberLiteral`) with its own,
-/// unrelated rendering path.
+/// An untouched literal is unaffected by this fix in any output mode.
+/// Bare `.` (identity) here takes the cursor-based P9/M2 streaming path,
+/// echoing the source text straight from `YamlCursor` without ever
+/// constructing an `OwnedValue` at all; a *navigated* literal (e.g. `.a`)
+/// would instead reach `OwnedValue::NumberLiteral`, a different variant
+/// with its own, equally unrelated rendering path -- either way, neither
+/// goes through the bare-`Float` arms this fix changes.
 #[test]
 fn test_literal_whole_float_unaffected_by_949_fix() -> Result<()> {
     for extra_args in [&[][..], &["-o=json", "-I=0"], &["-o=json"]] {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7675,9 +7675,18 @@ fn test_jq_mode_computed_float_formatting_unaffected_by_997() -> Result<()> {
 // magnitude case #997 didn't touch: unlike JSON output (which keeps a
 // computed whole float's decimal point regardless of compact/pretty --
 // `test_compact_and_pretty_agree_on_whole_floats` above), YAML output of
-// the *same* computed value drops it -- `. + 1` on `1.0` prints `2` in
-// YAML output but `2.0` in JSON output. Each expectation was measured
-// directly against the pinned `yq` v4.53.3 binary.
+// the *same* computed value drops it -- but **only at document-root
+// scalar position**. Real yq v4.53.3 disambiguates a nested computed
+// float with an explicit `!!float` tag instead (`a: !!float 2`);
+// succinctly has no tag-emission mechanism to match that, so a nested
+// computed float here keeps its pre-existing decimal-point-preserving
+// spelling (`a: 2.0`) rather than dropping the point *without* a tag,
+// which would silently reparse as an int and lose the value's type --
+// worse than the pre-#949 status quo, not just non-byte-identical to the
+// oracle. Each root-scalar expectation was measured directly against the
+// pinned `yq` v4.53.3 binary; the nested-position fallback is
+// succinctly's own choice among its two imperfect options, not itself an
+// oracle-matched spelling (see `test_computed_whole_float_nested_yaml_output_keeps_type_949`).
 // =============================================================================
 
 #[test]
@@ -7728,17 +7737,58 @@ fn test_literal_whole_float_unaffected_by_949_fix() -> Result<()> {
     Ok(())
 }
 
-/// The M2 YAML streaming path (`stream_owned_value_yaml` in
-/// `src/jq/stream.rs`) has its own, separate `Float` arm from the DOM path
-/// (`emit_yaml_value`) fixed above -- reachable via `first`/`last`
-/// wrapping a computation, the same M2-classification path #997 fixed for
-/// the scientific-notation case. Confirms both writers agree.
+/// The critical regression this fix's first draft shipped (caught by code
+/// review, not by real yq's own byte-for-byte spelling): applying the
+/// root-only decimal-point drop at *every* nesting depth turned a
+/// type-preserving-if-imperfect output (`a: 2.0`, reparses as `!!float`)
+/// into a type-losing one (`a: 2`, reparses as `!!int`) for the much more
+/// common real-world shape of incrementing a float field in place. Real
+/// yq itself never drops the point here -- it tags instead (`a: !!float
+/// 2`) -- so `a: 2.0` is the closer of succinctly's two available
+/// spellings; `a: 2` would be closer in byte count but wrong in type,
+/// which is the worse defect for a data-format round trip.
 #[test]
-fn test_computed_whole_float_via_first_last_yaml_output_949() -> Result<()> {
-    for (filter, want) in [("first(.a + 1)", "2"), ("last(.a + 1)", "2")] {
-        let (out, code) = run_yq_stdin(filter, "a: 1.0\n", &[])?;
+fn test_computed_whole_float_nested_yaml_output_keeps_type_949() -> Result<()> {
+    for (filter, yaml) in [
+        (".a += 1", "a: 1.0\n"),
+        (".a |= . + 1", "a: 1.0\n"),
+        (".a *= 2", "a: 1.0\n"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, yaml, &[])?;
         assert_eq!(code, 0, "for {filter:?}");
-        assert_eq!(out.trim(), want, "for {filter:?}");
+        assert_eq!(out.trim(), "a: 2.0", "for {filter:?}");
+
+        // Round-trip: re-parsing the emitted YAML must still resolve to
+        // `!!float`, not `!!int` -- the actual invariant this test
+        // protects, independent of the exact decimal spelling chosen.
+        let (tag, tag_code) = run_yq_stdin(".a | tag", &out, &[])?;
+        assert_eq!(tag_code, 0, "for {filter:?}");
+        assert_eq!(tag.trim(), "!!float", "for {filter:?}");
+    }
+
+    let (out, code) = run_yq_stdin("map(. + 1)", "- 1.0\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "- 2.0");
+
+    Ok(())
+}
+
+/// `-i`/`--inplace` must stay type-idempotent: repeatedly incrementing a
+/// float field must never degrade it to an int-looking value, which would
+/// silently change downstream `tag`/`type` results after just one edit.
+#[test]
+fn test_computed_whole_float_inplace_stays_float_typed_949() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    writeln!(file, "a: 1.0")?;
+    let path = file.path().to_path_buf();
+
+    for want in ["a: 2.0", "a: 3.0"] {
+        let status = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .args(["yq", "-i", ".a += 1"])
+            .arg(&path)
+            .status()?;
+        assert!(status.success());
+        assert_eq!(std::fs::read_to_string(&path)?.trim(), want);
     }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7667,6 +7667,82 @@ fn test_jq_mode_computed_float_formatting_unaffected_by_997() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// Computed whole-float YAML output — #949
+//
+// #997 (above) fixed the *scientific-notation threshold* for a computed
+// float, in both JSON and YAML output. This is a narrower, ordinary-
+// magnitude case #997 didn't touch: unlike JSON output (which keeps a
+// computed whole float's decimal point regardless of compact/pretty --
+// `test_compact_and_pretty_agree_on_whole_floats` above), YAML output of
+// the *same* computed value drops it -- `. + 1` on `1.0` prints `2` in
+// YAML output but `2.0` in JSON output. Each expectation was measured
+// directly against the pinned `yq` v4.53.3 binary.
+// =============================================================================
+
+#[test]
+fn test_computed_whole_float_yaml_output_drops_decimal_point_949() -> Result<()> {
+    let (out, code) = run_yq_stdin(". + 1", "1.0\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+    Ok(())
+}
+
+#[test]
+fn test_computed_whole_float_json_output_keeps_decimal_point_949() -> Result<()> {
+    let (compact, compact_code) = run_yq_stdin(". + 1", "1.0\n", &["-o=json", "-I=0"])?;
+    let (pretty, pretty_code) = run_yq_stdin(". + 1", "1.0\n", &["-o=json"])?;
+    assert_eq!(compact_code, 0);
+    assert_eq!(pretty_code, 0);
+    assert_eq!(compact.trim(), "2.0");
+    assert_eq!(pretty.trim(), "2.0");
+    Ok(())
+}
+
+/// JSON-sourced input never preserves the decimal point at all (#978,
+/// already fixed on `main`) -- confirmed unaffected by this fix in either
+/// output format.
+#[test]
+fn test_computed_whole_float_json_sourced_input_unaffected_by_949() -> Result<()> {
+    for extra_args in [
+        &["--input-format=json"][..],
+        &["--input-format=json", "-o=json"][..],
+    ] {
+        let (out, code) = run_yq_stdin(". + 1", "1.0\n", extra_args)?;
+        assert_eq!(code, 0, "for {extra_args:?}");
+        assert_eq!(out.trim(), "2", "for {extra_args:?}");
+    }
+    Ok(())
+}
+
+/// An untouched literal is unaffected by this fix in any output mode -- a
+/// different `OwnedValue` variant (`NumberLiteral`) with its own,
+/// unrelated rendering path.
+#[test]
+fn test_literal_whole_float_unaffected_by_949_fix() -> Result<()> {
+    for extra_args in [&[][..], &["-o=json", "-I=0"], &["-o=json"]] {
+        let (out, code) = run_yq_stdin(".", "1.0\n", extra_args)?;
+        assert_eq!(code, 0, "for {extra_args:?}");
+        assert_eq!(out.trim(), "1.0", "for {extra_args:?}");
+    }
+    Ok(())
+}
+
+/// The M2 YAML streaming path (`stream_owned_value_yaml` in
+/// `src/jq/stream.rs`) has its own, separate `Float` arm from the DOM path
+/// (`emit_yaml_value`) fixed above -- reachable via `first`/`last`
+/// wrapping a computation, the same M2-classification path #997 fixed for
+/// the scientific-notation case. Confirms both writers agree.
+#[test]
+fn test_computed_whole_float_via_first_last_yaml_output_949() -> Result<()> {
+    for (filter, want) in [("first(.a + 1)", "2"), ("last(.a + 1)", "2")] {
+        let (out, code) = run_yq_stdin(filter, "a: 1.0\n", &[])?;
+        assert_eq!(code, 0, "for {filter:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    Ok(())
+}
+
 #[test]
 fn test_dash_not_followed_by_space_is_still_a_scalar() -> Result<()> {
     // Guard against over-matching: negative numbers and `-`-prefixed plain


### PR DESCRIPTION
## Summary

This branch was originally opened against an earlier `main`. While it sat blocked (a stuck test process on this machine held it up for over a day), independent work landed on `main` that fixed most of what this PR originally set out to do:

- #978 fixed JSON-sourced input never preserving decimal-point spelling (exactly what I'd filed as a follow-up — closed as a duplicate).
- #997 fixed the computed-float scientific-notation threshold, in both JSON and YAML output, *including* the `first(f)`/`last(f)` M2-streaming-classification gap (exactly what I'd filed as the other follow-up — also closed as a duplicate).

This PR is now a from-scratch rewrite against current `main`, scoped to the one remaining gap.

## The remaining bug

Real yq v4.53.3's computed-float convention differs by *output* format **at document-root scalar position specifically**:

```
$ echo '1.0' | yq '. + 1'          # YAML output, root
2
$ echo '1.0' | yq -o json '. + 1'  # JSON output (compact agrees)
2.0
```

`emit_yaml_value` (`yq_runner.rs`) and `stream_owned_value_yaml_at_depth` (`src/jq/stream.rs`) both called `format_float_yq`/`format_float_with_fraction` for a bare `Float`, which always keep the decimal point — correct for JSON output (already fixed by #997), but wrong for YAML at root.

## First draft had a regression (caught by code review)

My first pass at this dropped the decimal point at **every** nesting depth, not just root. Real yq only drops it at root — nested (an object field, array element, or `-i` in-place edit), real yq instead emits an explicit `!!float` tag to keep the value's type unambiguous (`a: !!float 2`). succinctly has no tag-emission mechanism, so applying the drop everywhere silently turned a merely-cosmetic mismatch (`a: 2.0`, still reparses as `!!float`) into a real type-losing regression (`a: 2`, reparses as `!!int`) — and made `-i` non-idempotent w.r.t. type (repeated `+= 1` runs would degrade a float field to an int).

Fixed by gating both writers on `depth == 0`: root gets the new shortest-form `format_float_yq_yaml`; anything nested falls back to the pre-existing decimal-preserving convention (`format_float_yq`, so both writers agree exactly, including on the scientific-notation threshold for an extreme-magnitude nested value). Not byte-identical to real yq's tagged spelling for the nested case, but it doesn't regress the value's type the way the untagged spelling would. Filed #1090 for the deeper fix (real `!!float` tag emission) as separate, larger follow-up work.

## Full confirmed matrix (root scalar; each row checked against pinned yq v4.53.3)

| Input | Value | YAML out | JSON out (compact/pretty, always agree) |
|---|---|---|---|
| YAML | computed | `2` | `2.0` |
| YAML | literal | `1.0` | `1.0` |
| JSON | computed | `2` | `2` |
| JSON | literal | `1` | `1` |

Nested computed values (`.a += 1`, `map(. + 1)`, `-i` edits) keep their decimal point in YAML output either way, verified via round-trip `tag` staying `!!float`.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the second CI feature-matrix invocation (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`)
- [x] `cargo fmt --check`
- [x] Regression tests in `tests/yq_cli_tests.rs` (`_949` suffix) cover the root-scalar matrix, the nested/`-i` round-trip type invariant (verified these fail without the depth gate), and confirm literal preservation is unaffected
- [x] Unit test for `format_float_yq_yaml` itself (`src/yaml/light.rs`)
- [x] Updated `src/jq/stream.rs`'s pre-existing whole-float test to assert the corrected (depth-aware) behavior

Also filed #1086 for an unrelated, pre-existing test-suite issue noticed along the way (a full `cargo test` run once silently corrupted a tracked repo-root fixture, `1.yml` — reverted before committing, not touched by this PR), and #1090 for the `!!float` tag-emission gap noted above.

Fixes #949
