### PR TITLE
fix(jq): limit/nth/skip's negative-count handling matches real jq

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5456,19 +5456,36 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate n
+    // Evaluate n. jq 1.8's own `def skip($n; expr): if $n > 0 then ...
+    // elif $n == 0 then expr else error("skip doesn't support negative
+    // count") end` -- a genuinely negative count silently became index 0
+    // (skipping nothing) here instead of erroring (#983; `null` already
+    // fell through to the catch-all below and erred, just with different
+    // message text).
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match n_result {
         QueryResult::One(v) => {
             if let StandardJson::Number(num) = v {
-                num.as_i64().unwrap_or(0) as usize
+                let f = num.as_f64().unwrap_or(0.0);
+                if f < 0.0 {
+                    return QueryResult::Error(EvalError::new(
+                        "skip doesn't support negative count",
+                    ));
+                }
+                num.as_i64().map_or(f as usize, |i| i as usize)
             } else {
                 return QueryResult::Error(EvalError::type_error("number", type_name(&v)));
             }
         }
         QueryResult::Owned(
             ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)),
-        ) => owned.as_f64().unwrap_or(0.0) as usize,
+        ) => {
+            let f = owned.as_f64().unwrap_or(0.0);
+            if f < 0.0 {
+                return QueryResult::Error(EvalError::new("skip doesn't support negative count"));
+            }
+            f as usize
+        }
         QueryResult::Error(e) => return QueryResult::Error(e),
         _ => return QueryResult::Error(EvalError::type_error("number", "null")),
     };
@@ -13436,11 +13453,27 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate n
+    // Evaluate n. Mirrors jq's own `def limit($n; exp): if $n > 0 then
+    // ... elif $n == 0 then empty else exp end` -- a negative count (or
+    // `null`, which jq's total ordering places below every number, taking
+    // the same branch a negative count would) means "no limit at all",
+    // not an error (#983; verified against jq 1.7.1: `limit(-1; 1,2,3)`
+    // and `limit(null; 1,2,3)` both pass every value through unchanged).
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match result_to_owned(n_result) {
         Ok(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _)) if i >= 0 => {
             i as usize
+        }
+        // A negative count (or `null`, which jq's total ordering places
+        // below every number, taking the same branch a negative count
+        // would) means "no limit at all" per jq's own `def limit`, not an
+        // error -- verified against jq 1.7.1 (#983).
+        Ok(
+            OwnedValue::Int(_)
+            | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
+            | OwnedValue::Null,
+        ) => {
+            return eval_single::<W, S>(expr, value, optional);
         }
         Ok(_) => {
             return QueryResult::Error(EvalError::new("limit requires non-negative integer"));
@@ -19813,19 +19846,36 @@ fn builtin_nth_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate n
+    // Evaluate n. jq's own `def nth($n; g): if $n < 0 then error("nth
+    // doesn't support negative indices") else ...` -- `null` already falls
+    // into the `_` catch-all below and errors (different message text, but
+    // the same jq-required outcome); a genuinely negative number silently
+    // became index 0 here instead of erroring (#983; verified against jq
+    // 1.7.1's own two-arg `nth`).
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match n_result {
         QueryResult::One(v) => {
             if let StandardJson::Number(num) = v {
-                num.as_i64().unwrap_or(0) as usize
+                let f = num.as_f64().unwrap_or(0.0);
+                if f < 0.0 {
+                    return QueryResult::Error(EvalError::new(
+                        "nth doesn't support negative indices",
+                    ));
+                }
+                num.as_i64().map_or(f as usize, |i| i as usize)
             } else {
                 return QueryResult::Error(EvalError::type_error("number", type_name(&v)));
             }
         }
         QueryResult::Owned(
             ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)),
-        ) => owned.as_f64().unwrap_or(0.0) as usize,
+        ) => {
+            let f = owned.as_f64().unwrap_or(0.0);
+            if f < 0.0 {
+                return QueryResult::Error(EvalError::new("nth doesn't support negative indices"));
+            }
+            f as usize
+        }
         QueryResult::Error(e) => return QueryResult::Error(e),
         // A halt while evaluating `n` must propagate, not be misreported as
         // a type error (#791).
@@ -30106,17 +30156,24 @@ mod tests {
             );
         }
 
-        // reduce/foreach: `limit(-1; 1)` errors unconditionally, propagating
+        // reduce/foreach: `error("x")` errors unconditionally, propagating
         // as a genuine `Error`/`Partial(_, Control::Error(_))` from
         // `eval_reduce`/`eval_foreach`'s own INIT/SOURCE/fork-loop sites —
         // caught directly by `isvalid`'s match without needing any
         // optional-forcing.
+        //
+        // (Originally used `limit(-1;1)` as the guaranteed-to-error vehicle
+        // expression here; #983 corrected `limit`'s negative-count handling
+        // to match jq's own semantics -- unlimited passthrough, not an
+        // error -- which stopped it erroring at all, so it no longer fits
+        // this fixture's purpose. Swapped for `error("x")`, which still
+        // exercises the exact same isvalid/reduce/foreach code paths.)
         for expr in [
-            "isvalid(reduce (1,2) as $x (0; limit(-1;1)))",
-            "isvalid(reduce (1,2) as $x (limit(-1;1); .+$x))",
-            "isvalid(reduce (1,2) as $x ((1,limit(-1;1)); .+$x))",
-            "isvalid(foreach limit(-1;1) as $x (0; .+$x))",
-            "isvalid(foreach (1,2) as $x (limit(-1;1); .+$x))",
+            "isvalid(reduce (1,2) as $x (0; error(\"x\")))",
+            "isvalid(reduce (1,2) as $x (error(\"x\"); .+$x))",
+            "isvalid(reduce (1,2) as $x ((1,error(\"x\")); .+$x))",
+            "isvalid(foreach error(\"x\") as $x (0; .+$x))",
+            "isvalid(foreach (1,2) as $x (error(\"x\"); .+$x))",
         ] {
             query!(br"1", expr,
                 QueryResult::Owned(OwnedValue::Bool(false)) => {}

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10888,6 +10888,16 @@ fn resolve_limit<'a, S: EvalSemantics>(
         OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
             i as usize
         }
+        // Same jq-matched "no limit at all" branch as `eval_limit` (#983):
+        // a negative count, `null`, or a bool (jq's total ordering places
+        // all three below every positive number) means unlimited
+        // passthrough, not an error.
+        OwnedValue::Int(_)
+        | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
+        | OwnedValue::Null
+        | OwnedValue::Bool(_) => {
+            return resolve_node::<S>(expr, value, trackable);
+        }
         _ => {
             return Err((
                 Vec::new(),
@@ -13464,15 +13474,26 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _)) if i >= 0 => {
             i as usize
         }
-        // A negative count (or `null`, which jq's total ordering places
-        // below every number, taking the same branch a negative count
-        // would) means "no limit at all" per jq's own `def limit`, not an
-        // error -- verified against jq 1.7.1 (#983).
+        // A negative int, `null`, or a bool -- jq's total ordering places
+        // all three below every positive number, so each takes the same
+        // "no limit at all" branch of jq's own `def limit`, not an error
+        // -- verified against jq 1.7.1 (#983).
         Ok(
             OwnedValue::Int(_)
             | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
-            | OwnedValue::Null,
+            | OwnedValue::Null
+            | OwnedValue::Bool(_),
         ) => {
+            return eval_single::<W, S>(expr, value, optional);
+        }
+        // Same for a negative float. A *positive* non-integer float (e.g.
+        // `1.9`) is a separate, pre-existing gap (jq's own fractional
+        // foreach-decrement loop bounds it to 2 outputs; succinctly errors
+        // instead) left untouched here -- out of #983's scope, which is
+        // specifically the negative/null/bool "no limit" branch.
+        Ok(OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _))
+            if f < 0.0 =>
+        {
             return eval_single::<W, S>(expr, value, optional);
         }
         Ok(_) => {
@@ -19701,7 +19722,11 @@ fn builtin_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate n
+    // Evaluate n. Same "no limit at all" branch as `eval_limit` for a
+    // negative count/null/bool (#983) -- this function is parser-
+    // unreachable today (see #981's investigation), but kept consistent
+    // so a future routing change can't silently reintroduce the bug this
+    // issue fixed in the live implementation.
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match n_result {
         QueryResult::One(v) => {
@@ -19711,8 +19736,11 @@ fn builtin_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 return QueryResult::Error(EvalError::type_error("number", type_name(&v)));
             }
         }
-        QueryResult::Owned(OwnedValue::Int(i)) => i as usize,
-        QueryResult::Owned(OwnedValue::Float(f)) => f as usize,
+        QueryResult::Owned(OwnedValue::Int(i)) if i >= 0 => i as usize,
+        QueryResult::Owned(OwnedValue::Float(f)) if f >= 0.0 => f as usize,
+        QueryResult::Owned(
+            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::Null | OwnedValue::Bool(_),
+        ) => return eval_single::<W, S>(expr, value, optional),
         QueryResult::Error(e) => return QueryResult::Error(e),
         _ => return QueryResult::Error(EvalError::type_error("number", "null")),
     };

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10015,3 +10015,67 @@ fn test_skip_positive_and_zero_count_unaffected_983() -> Result<()> {
     assert_eq!(stdout, "[1,2,3]\n");
     Ok(())
 }
+
+/// #983 review: `limit`'s path-context resolver (`resolve_limit`, reached
+/// when `limit` appears inside a path/update expression like `|=`) shares
+/// `eval_limit`'s n-conversion rule but wasn't updated by the initial fix
+/// -- confirmed live against real jq 1.7.1, which gives unlimited
+/// passthrough here too.
+#[test]
+fn test_resolve_limit_negative_count_is_unlimited_not_error_983() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "(limit(-1; .a, .b) |= 99)"],
+        Some(r#"{"a": 1, "b": 2}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"a\":99,\"b\":99}\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// #983 review: `limit`'s fix only matched `Int`/`NumberLiteral(Int)`;
+/// a negative *float* count fell through to the same error a negative
+/// int used to hit. jq's own comparison is type-generic, so a negative
+/// float takes the identical "no limit" branch -- verified against real
+/// jq 1.7.1.
+#[test]
+fn test_limit_negative_float_count_is_unlimited_not_error_983() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "[limit(-1.5; 1,2,3)]"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,2,3]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// #983 review: a bool count argument (`true`/`false`) orders below every
+/// number in jq's total ordering, same as `null` -- verified against real
+/// jq 1.7.1, both give unlimited passthrough.
+#[test]
+fn test_limit_bool_count_is_unlimited_not_error_983() -> Result<()> {
+    for lit in ["true", "false"] {
+        let (stdout, stderr, code) =
+            run_jq_full(&["-cn", &format!("[limit({lit}; 1,2,3)]")], None)?;
+        assert_eq!(code, 0, "{lit}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, "[1,2,3]\n", "{lit}");
+        assert_eq!(stderr, "");
+    }
+    Ok(())
+}
+
+/// A *positive* non-integer float count is a separate, pre-existing gap
+/// (real jq bounds `limit(1.9; ...)` to 2 outputs via its fractional
+/// foreach-decrement loop; succinctly errors) deliberately left untouched
+/// by #983, which is scoped to the negative/null/bool "no limit" branch
+/// specifically. Pinned here so a future change doesn't accidentally
+/// widen #983's fix to also swallow this case silently.
+#[test]
+fn test_limit_positive_float_count_still_errors_983() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "[limit(1.9; 1,2,3)]"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("limit requires non-negative integer"),
+        "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9905,3 +9905,113 @@ fn test_arithmetic_on_malformed_number_errors_not_silent_zero_966() -> Result<()
     );
     Ok(())
 }
+
+/// #983: `limit`'s own jq definition (`if $n > 0 then ... elif $n == 0
+/// then empty else exp end`) treats a negative count as "no limit at
+/// all", not an error -- verified against real jq 1.7.1. succinctly used
+/// to error instead.
+#[test]
+fn test_limit_negative_count_is_unlimited_not_error_983() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "[limit(-1; 1,2,3)]"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,2,3]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Same as above for a `null` count, which jq's total ordering places
+/// below every number -- same branch a negative count takes.
+#[test]
+fn test_limit_null_count_is_unlimited_not_error_983() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "[limit(null; 1,2,3)]"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,2,3]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// Sanity check that ordinary positive/zero counts are unaffected by
+/// #983's fix.
+#[test]
+fn test_limit_positive_and_zero_count_unaffected_983() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-cn", "[limit(2; 1,2,3)]"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[1,2]\n");
+
+    let (stdout, _, code) = run_jq_full(&["-cn", "[limit(0; 1,2,3)]"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[]\n");
+    Ok(())
+}
+
+/// #983: two-arg `nth`'s own jq definition errors on a negative index
+/// (jq's total ordering makes `null < 0` true too, so both take the same
+/// branch) -- verified against real jq 1.7.1 (`nth/2` predates 1.8).
+/// succinctly used to silently substitute index 0 instead.
+#[test]
+fn test_nth_negative_index_errors_not_silent_zero_983() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "[1,2,3] | nth(-1; .[])"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("nth doesn't support negative indices"),
+        "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// Same as above but with the index sourced from the input document
+/// rather than a literal, exercising `builtin_nth_stream`'s other
+/// number-extraction branch (`StandardJson::Number` vs `OwnedValue`).
+#[test]
+fn test_nth_negative_index_from_document_errors_983() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "nth(.n; .arr[])"],
+        Some(r#"{"n": -1, "arr": [1,2,3]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("nth doesn't support negative indices"),
+        "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// Sanity check that an ordinary non-negative index is unaffected.
+#[test]
+fn test_nth_non_negative_index_unaffected_983() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-cn", "[1,2,3] | nth(1; .[])"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "2\n");
+    Ok(())
+}
+
+/// #983: jq 1.8's own `skip` definition errors on a negative count
+/// (`skip` doesn't exist in the pinned 1.7.1 oracle, but its definition
+/// is unambiguous: `else error("skip doesn't support negative count")`).
+/// succinctly used to silently return the unskipped stream instead.
+#[test]
+fn test_skip_negative_count_errors_not_silent_pass_through_983() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "[skip(-1; 1,2,3)]"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("skip doesn't support negative count"),
+        "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// Sanity check that ordinary positive/zero counts are unaffected.
+#[test]
+fn test_skip_positive_and_zero_count_unaffected_983() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-cn", "[skip(1; 1,2,3)]"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[2,3]\n");
+
+    let (stdout, _, code) = run_jq_full(&["-cn", "[skip(0; 1,2,3)]"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[1,2,3]\n");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`limit`, `nth`, and `skip` each have their own jq definition governing a negative (or `null`) count argument via an explicit `if/elif/else` branch — not a uniform "must be a non-negative number" check. succinctly's active implementations diverged from all three:

```
$ echo '[1,2,3]' | jq -c '[limit(-1; .[])]'        # real jq: unlimited passthrough
[1,2,3]
$ echo '[1,2,3]' | succinctly jq -c '[limit(-1; .[])]'   # before: errored instead
jq: error (at <stdin>:1): limit requires non-negative integer

$ echo '[1,2,3]' | jq -c 'nth(-1; .[])'             # real jq: errors
jq: error (at <stdin>:1): nth doesn't support negative indices
$ echo '[1,2,3]' | succinctly jq -c 'nth(-1; .[])'  # before: silently returned index 0
1

$ echo '[1,2,3]' | succinctly jq -c '[skip(-1; .[])]'  # before: silently returned the unskipped stream
[1,2,3]
```

- `limit($n; exp)`: jq's own `if $n > 0 then ... elif $n == 0 then empty else exp end` — negative/null means *unlimited passthrough*. Fixed `eval_limit` to match.
- `nth($n; g)`: jq's own `if $n < 0 then error("nth doesn't support negative indices") else ...` — jq's total ordering makes `null < 0` true too, so both take this branch. `builtin_nth_stream` (the actually-active implementation — `Expr::NthExpr`/`eval_nth_expr` is parser-unreachable, the *opposite* shadowing direction from `limit`) silently substituted index 0 instead, because Rust's `f64 as usize` cast saturates negative values to 0 rather than erroring.
- `skip($n; expr)`: jq 1.8's `else error("skip doesn't support negative count")` (this builtin postdates the pinned 1.7.1 oracle, but its definition is unambiguous — verified against jq 1.8.1's own `builtin.jq` source). `builtin_skip` silently returned the unskipped stream instead.

This was found while investigating a different, mis-scoped issue (#981, closed) — that issue targeted `builtin_length`/`builtin_skip`/`builtin_limit`/`builtin_nth_stream`'s "malformed number span" handling, but turned out to be based on a false premise for 3 of those 4 (the codebase's own test comments document that `builtin_length`/`builtin_limit` share unreachability with `Expr::Limit`/`eval_limit` shadowing, or vice versa for `nth`). Investigating which functions are *actually* parser-reachable surfaced this real, distinct, unrelated bug instead.

## Review round — 3 more gaps closed

Code review found the first commit's fix was incomplete:
- **`resolve_limit`** — `limit`'s path/assignment-context resolver (e.g. `limit(-1; .a, .b) |= 99`) shares `eval_limit`'s n-conversion rule but wasn't updated. Confirmed live against real jq. Fixed.
- **Negative `Float`** — `eval_limit`'s fix only matched `Int`/`NumberLiteral(Int)`; `limit(-1.5; ...)` still errored. jq's comparison is type-generic, so a negative float takes the identical branch. Fixed, with a test pinning that a *positive* non-integer float (`limit(1.9; ...)`) is a **separate, pre-existing, deliberately untouched** gap — jq bounds it via a fractional foreach-decrement loop succinctly doesn't implement; that's out of this issue's scope.
- **`Bool`** — `true`/`false` order below every number in jq's total ordering, same as `null`. `limit(true; ...)` diverged the same way. Fixed.
- Also updated `builtin_limit` (confirmed parser-unreachable — see #981's investigation) for consistency, so a future parser-routing change can't silently reintroduce this bug in the live path.

## Also fixes a test fixture

`test_isvalid_reaches_every_builtins_own_optional_guard` (#881) used `limit(-1;1)` purely as a convenient "guaranteed to error" vehicle expression for unrelated `isvalid`/`reduce`/`foreach` coverage. This PR correctly makes that expression *succeed* (unlimited passthrough), so the fixture is swapped for `error("x")`, which exercises the identical code paths the test actually cares about.

Fixes #983

## Test plan
- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests -- 983` — 12 tests covering negative/null/bool/float count for `limit` (both direct and path-context via `resolve_limit`), negative count for `nth` (literal and document-sourced), negative count for `skip`, the positive-float non-regression pin, and non-negative sanity checks for all three
- [x] `cargo test --features cli,simd,regex,serde` (full suite) — all green across all 54 test binaries (one transient, confirmed-flaky `test_gsub_propagates_halt_in_replacement_argument` failure reproduced during the first pass as pre-existing test-suite-under-load flakiness — passes reliably in isolation and on every clean re-run since)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Manually verified every repro case above against real jq 1.7.1 (limit, nth, resolve_limit); jq 1.8.1's own `builtin.jq` source consulted for skip since it postdates the pinned oracle
