### PR TITLE
fix(jq): correct EvalError::type_error wording at 10 call sites

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -299,13 +299,13 @@ A probe is only admitted to the corpus if jq errors on it, so the corpus is blin
 opposite divergence: a filter that jq answers with a value and succinctly refuses. Those
 have to be recorded here.
 
-| Filter            | Input         | jq                          | succinctly                            |
-|-------------------|---------------|-----------------------------|---------------------------------------|
-| `.[1:2] = ["x"]`  | `null`        | `["x"]`                     | `Cannot index null with object`       |
-| `.[1:2] \|= ["x"]`| `null`        | `["x"]`                     | `Cannot index null with object`       |
-| `@uri`            | `[1,2]`       | `"%5B1%2C2%5D"`             | `expected string, got array`          |
-| `@base64`         | `5`           | `"NQ=="`                    | `expected string, got number`         |
-| `flatten("x")`    | `[1,2]`       | `[1,2]` (ignores non-integer depth) | `expected number, got non-number` |
+| Filter             | Input   | jq                                  | succinctly                        |
+|--------------------|---------|-------------------------------------|-----------------------------------|
+| `.[1:2] = ["x"]`   | `null`  | `["x"]`                             | `Cannot index null with object`   |
+| `.[1:2] \|= ["x"]` | `null`  | `["x"]`                             | `Cannot index null with object`   |
+| `@uri`             | `[1,2]` | `"%5B1%2C2%5D"`                     | `expected string, got array`      |
+| `@base64`          | `5`     | `"NQ=="`                            | `expected string, got number`     |
+| `flatten("x")`     | `[1,2]` | `[1,2]` (ignores non-integer depth) | `expected number, got non-number` |
 
 [#929](https://github.com/rust-works/succinctly/issues/929) found these while auditing
 `EvalError::type_error` wording: real jq's `@uri`/`@base64` (and every other format string

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -303,6 +303,19 @@ have to be recorded here.
 |-------------------|---------------|-----------------------------|---------------------------------------|
 | `.[1:2] = ["x"]`  | `null`        | `["x"]`                     | `Cannot index null with object`       |
 | `.[1:2] \|= ["x"]`| `null`        | `["x"]`                     | `Cannot index null with object`       |
+| `@uri`            | `[1,2]`       | `"%5B1%2C2%5D"`             | `expected string, got array`          |
+| `@base64`         | `5`           | `"NQ=="`                    | `expected string, got number`         |
+| `flatten("x")`    | `[1,2]`       | `[1,2]` (ignores non-integer depth) | `expected number, got non-number` |
+
+[#929](https://github.com/rust-works/succinctly/issues/929) found these while auditing
+`EvalError::type_error` wording: real jq's `@uri`/`@base64` (and every other format string
+except `@csv`/`@tsv`/`@sh`) auto-`tostring`s a non-string argument before formatting rather
+than refusing it outright, and `flatten`'s depth argument is silently ignored if it isn't a
+number rather than validated. `@base64d` is a related but distinct case — jq *does* still
+error on `5 | @base64d` (`string ("5") trailing base64 byte found`), just from attempting to
+base64-decode the auto-stringified `"5"` rather than refusing the number up front, so it
+isn't purely a "jq doesn't error" gap; matching it needs the same underlying
+auto-`tostring`-first change `@uri`/`@base64` do, not just a different error message.
 
 Both rows are a slice write walking a path *in place*, and the gap is the same
 auto-vivification jq performs everywhere else it writes through a path: `null` grows into

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -512,6 +512,44 @@ impl EvalError {
         Self::new(format!("Cannot iterate over {}", describe(value)))
     }
 
+    /// `strptime/1 requires string inputs and arguments` (#929).
+    ///
+    /// jq's C implementation validates `strptime`'s input *and* format
+    /// argument with a single combined check, raising this exact message
+    /// regardless of which one is the non-string offender — confirmed live
+    /// against jq 1.7.1 for all three: a non-string format on a valid
+    /// string input, a non-string input with a valid format string, and
+    /// `fromdate`/`fromdateiso8601` (defined in terms of `strptime`) on a
+    /// non-string input. (A non-string format *and* non-string input
+    /// together crashes real jq with a C assertion failure rather than
+    /// raising this message — not reproduced here; this message is
+    /// strictly better than a crash for that combination.)
+    pub fn strptime_requires_string() -> Self {
+        Self::new("strptime/1 requires string inputs and arguments")
+    }
+
+    /// `<type> (<value>) cannot be <format>-formatted, only array` (#929).
+    ///
+    /// Raised by `@csv`/`@tsv` for a non-array top-level value — confirmed
+    /// live against jq 1.7.1: `5 | @csv` is `"number (5) cannot be
+    /// csv-formatted, only array"`, `5 | @tsv` the same with `tsv`.
+    pub fn cannot_be_dsv_formatted(value: &OwnedValue, format: &str) -> Self {
+        Self::new(format!(
+            "{} cannot be {format}-formatted, only array",
+            describe(value)
+        ))
+    }
+
+    /// `<type> (<value>) can not be escaped for shell` (#929).
+    ///
+    /// Raised by `@sh` for a value that isn't a string, number, boolean,
+    /// `null`, or array of those (jq's own shell-quoting rules) — confirmed
+    /// live against jq 1.7.1: `{"a":1} | @sh` is `"object ({\"a\":1}) can
+    /// not be escaped for shell"`.
+    pub fn cannot_be_shell_escaped(value: &OwnedValue) -> Self {
+        Self::new(format!("{} can not be escaped for shell", describe(value)))
+    }
+
     /// `Invalid path expression with result <value>` (#530).
     ///
     /// Raised by `path()` when the filter it was given is not a path

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -694,6 +694,12 @@ impl EvalError {
         Self::pair(left, right, "cannot be iterated over")
     }
 
+    /// `<a> and <b> cannot be sorted, as they are not both arrays` — jq's
+    /// wording for `unique_by`/`sort_by`/`group_by` on a non-array (#929).
+    pub fn pair_cannot_be_sorted(left: &OwnedValue, right: &OwnedValue) -> Self {
+        Self::pair(left, right, "cannot be sorted, as they are not both arrays")
+    }
+
     /// `<v> has no keys`.
     pub fn has_no_keys(value: &OwnedValue) -> Self {
         Self::subject(value, "has no keys")

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3384,7 +3384,11 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(OwnedValue::Array(results))
         }
         _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::type_error("object or array", type_name(&value))),
+        // #929: real jq defines map_values(f) via `.[] |= f`'s own `.[]`,
+        // so a non-object/array input fails the same way any other bare
+        // `.[]` does. Confirmed live: `5 | map_values(.)` raises "Cannot
+        // iterate over number (5)" in jq 1.7.1.
+        _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
 }
 
@@ -3677,7 +3681,12 @@ fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(min)
         }
         _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::type_error("array", type_name(&value))),
+        // #929: real jq defines min_by(f) via `.[0] as $x | reduce ...` --
+        // the eventual failure is the same "Cannot iterate over" a bare
+        // `.[]`/`length` on a non-array/object gets, not a bespoke
+        // "expected array" wording. Confirmed live: `5 | min_by(.)` raises
+        // "Cannot iterate over number (5)" in jq 1.7.1.
+        _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
 }
 
@@ -3718,7 +3727,9 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(max)
         }
         _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::type_error("array", type_name(&value))),
+        // #929: same wording as min_by's own arm above -- confirmed live:
+        // `5 | max_by(.)` raises "Cannot iterate over number (5)" in jq 1.7.1.
+        _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
 }
 
@@ -4117,7 +4128,12 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match result_to_owned(n_result) {
         Ok(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _)) => i,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("number", "non-number")),
+        // #929: real jq defines nth(n) as `.[n]`, so a non-numeric n on an
+        // array input fails the same way any other computed-index does,
+        // naming the *value* jq embeds in the message. Confirmed live:
+        // `[1,2,3] | nth("x")` raises `Cannot index array with string "x"`
+        // in jq 1.7.1.
+        Ok(v) => return QueryResult::Error(EvalError::cannot_index(type_name(&value), &v)),
         Err(e) => return e.into(),
     };
 
@@ -4128,7 +4144,13 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             None => QueryResult::Owned(OwnedValue::Null),
         },
         _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::type_error("array", type_name(&value))),
+        // #929: same `.[n]` definition, this time for a non-array input --
+        // confirmed live: `5 | nth(1)` raises `Cannot index number with
+        // number` in jq 1.7.1.
+        _ => QueryResult::Error(EvalError::cannot_index(
+            type_name(&value),
+            &OwnedValue::Int(n),
+        )),
     }
 }
 
@@ -4342,7 +4364,10 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(OwnedValue::Array(result))
         }
         _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::type_error("array", type_name(&value))),
+        // #929: same "Cannot iterate over" wording min_by/max_by use --
+        // confirmed live: `5 | unique_by(.)` raises "Cannot iterate over
+        // number (5)" in jq 1.7.1.
+        _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
 }
 
@@ -4889,7 +4914,9 @@ fn format_csv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
             Ok(parts.join(","))
         }
         _ if optional => Ok(String::new()),
-        _ => Err(EvalError::type_error("array", value.type_name())),
+        // #929: confirmed live: `5 | @csv` raises "number (5) cannot be
+        // csv-formatted, only array" in jq 1.7.1.
+        _ => Err(EvalError::cannot_be_dsv_formatted(value, "csv")),
     }
 }
 
@@ -4912,7 +4939,9 @@ fn format_tsv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
             Ok(parts.join("\t"))
         }
         _ if optional => Ok(String::new()),
-        _ => Err(EvalError::type_error("array", value.type_name())),
+        // #929: confirmed live: `5 | @tsv` raises "number (5) cannot be
+        // tsv-formatted, only array" in jq 1.7.1.
+        _ => Err(EvalError::cannot_be_dsv_formatted(value, "tsv")),
     }
 }
 
@@ -5126,7 +5155,11 @@ fn format_sh(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
             "false".to_string()
         }),
         OwnedValue::Null => Ok("null".to_string()),
-        _ => Err(EvalError::type_error("string", value.type_name())),
+        // #929: confirmed live: `{"a":1} | @sh` raises `object ({"a":1})
+        // can not be escaped for shell` in jq 1.7.1 -- the only remaining
+        // variant here is Object, since every other one already has its
+        // own arm above.
+        _ => Err(EvalError::cannot_be_shell_escaped(value)),
     }
 }
 
@@ -18409,7 +18442,11 @@ fn builtin_strptime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let fmt = match result_to_owned(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
         Ok(OwnedValue::String(s)) => s,
         Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "strptime format")),
+        // #929: confirmed live: `"2020" | strptime(1)` raises "strptime/1
+        // requires string inputs and arguments" in jq 1.7.1 -- the same
+        // wording jq's combined input+format check uses regardless of
+        // which side is the offender (see the other arm below).
+        Ok(_) => return QueryResult::Error(EvalError::strptime_requires_string()),
         Err(e) => return e.into(),
     };
 
@@ -18421,7 +18458,9 @@ fn builtin_strptime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
         },
         _ if optional => return QueryResult::None,
-        _ => return QueryResult::Error(EvalError::type_error("string", "strptime")),
+        // #929: confirmed live: `5 | strptime("%Y")` raises "strptime/1
+        // requires string inputs and arguments" in jq 1.7.1.
+        _ => return QueryResult::Error(EvalError::strptime_requires_string()),
     };
 
     match parse_strptime(&input, &fmt) {
@@ -18807,7 +18846,11 @@ fn builtin_fromdate<W: Clone + AsRef<[u64]>>(
             Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
         },
         _ if optional => return QueryResult::None,
-        _ => return QueryResult::Error(EvalError::type_error("string", "fromdate")),
+        // #929: `fromdate` is defined in terms of `strptime` in real jq, so
+        // a non-string input hits the same combined check -- confirmed
+        // live: `5 | fromdate` raises "strptime/1 requires string inputs
+        // and arguments" in jq 1.7.1.
+        _ => return QueryResult::Error(EvalError::strptime_requires_string()),
     };
 
     // Parse ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS+HH:MM
@@ -28038,6 +28081,86 @@ mod tests {
         query!(br#""abc""#, r#"test(["a", null])"#,
             QueryResult::Owned(OwnedValue::Bool(b)) => {
                 assert!(b);
+            }
+        );
+    }
+
+    /// #929: `EvalError::type_error` is documented as reserved for sites
+    /// with no jq counterpart, but several call sites had a real jq
+    /// wording they didn't match. Confirmed against jq 1.7.1 for every
+    /// case below.
+    #[test]
+    fn test_type_error_sites_match_real_jq_wording_929() {
+        // map_values/min_by/max_by/unique_by all fail like a bare `.[]`
+        // would on a non-object/array input.
+        query!(br"5", r"map_values(.)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot iterate over number (5)");
+            }
+        );
+        query!(br"5", r"min_by(.)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot iterate over number (5)");
+            }
+        );
+        query!(br"5", r"max_by(.)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot iterate over number (5)");
+            }
+        );
+        query!(br"5", r"unique_by(.)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot iterate over number (5)");
+            }
+        );
+        // nth(n) is `.[n]` in real jq: a non-numeric n names itself as the
+        // bad key, a non-array input names the successfully-parsed n.
+        query!(br"[1,2,3]", r#"nth("x")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index array with string \"x\"");
+            }
+        );
+        query!(br"5", r"nth(1)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with number");
+            }
+        );
+        query!(br#""abc""#, r"nth(1)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index string with number");
+            }
+        );
+        // @csv/@tsv on a non-array, @sh on an object.
+        query!(br"5", r"@csv",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (5) cannot be csv-formatted, only array");
+            }
+        );
+        query!(br"5", r"@tsv",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (5) cannot be tsv-formatted, only array");
+            }
+        );
+        query!(br#"{"a":1}"#, r"@sh",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "object ({\"a\":1}) can not be escaped for shell");
+            }
+        );
+        // strptime/fromdate: real jq validates both the input and the
+        // format argument with one combined check, same message either way.
+        query!(br#""2020""#, r"strptime(1)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "strptime/1 requires string inputs and arguments");
+            }
+        );
+        query!(br"5", r#"strptime("%Y")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "strptime/1 requires string inputs and arguments");
+            }
+        );
+        query!(br"5", r"fromdate",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "strptime/1 requires string inputs and arguments");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3645,6 +3645,35 @@ fn builtin_max<W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: min_by(f)
+/// jq's `map([f])`, applied to an object's values in field order.
+///
+/// `min_by`/`max_by`/`unique_by` all compute this array unconditionally
+/// before checking whether the *input* is itself an array -- `.[]` (bare
+/// iterate) accepts an object just as readily as an array, so on an object
+/// input the computation below succeeds, and the resulting array becomes
+/// the *named operand* of the eventual two-value type error rather than a
+/// fixed placeholder. Confirmed live against jq 1.7.1:
+/// `{"a":3,"b":1} | min_by(. + 100)` raises `object ({"a":3,"b":1}) and
+/// array ([[103],[101]]) cannot be iterated over` -- the `[[103],[101]]` is
+/// exactly this function's output for that input and filter.
+fn map_bracketed_over_object_fields<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    f: &Expr,
+    fields: JsonFields<'a, W>,
+    optional: bool,
+) -> Result<Vec<OwnedValue>, QueryResult<'a, W>> {
+    let mut computed = Vec::new();
+    for field in fields {
+        match eval_array_construction::<W, S>(f, field.value(), optional) {
+            QueryResult::Owned(v) => computed.push(v),
+            QueryResult::Error(e) => return Err(QueryResult::Error(e)),
+            QueryResult::Break(label) => return Err(QueryResult::Break(label)),
+            QueryResult::Halt(code) => return Err(QueryResult::Halt(code)),
+            _ => unreachable!("eval_array_construction only returns Owned/Error/Break/Halt"),
+        }
+    }
+    Ok(computed)
+}
+
 fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     f: &Expr,
     value: StandardJson<'a, W>,
@@ -3680,10 +3709,28 @@ fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 .unwrap();
             QueryResult::Owned(min)
         }
+        // #929: see `map_bracketed_over_object_fields` -- confirmed live:
+        // `{"a":3,"b":1} | min_by(.)` raises `object ({"a":3,"b":1}) and
+        // array ([[3],[1]]) cannot be iterated over` in jq 1.7.1.
+        StandardJson::Object(fields) => {
+            let original = to_owned(&StandardJson::Object(fields));
+            let computed = match map_bracketed_over_object_fields::<W, S>(f, fields, optional) {
+                Ok(v) => v,
+                Err(result) => return result,
+            };
+            if optional {
+                QueryResult::None
+            } else {
+                QueryResult::Error(EvalError::pair_cannot_be_iterated(
+                    &original,
+                    &OwnedValue::Array(computed),
+                ))
+            }
+        }
         _ if optional => QueryResult::None,
         // #929: real jq defines min_by(f) via `.[0] as $x | reduce ...` --
         // the eventual failure is the same "Cannot iterate over" a bare
-        // `.[]`/`length` on a non-array/object gets, not a bespoke
+        // `.[]`/`length` on a non-array/non-object gets, not a bespoke
         // "expected array" wording. Confirmed live: `5 | min_by(.)` raises
         // "Cannot iterate over number (5)" in jq 1.7.1.
         _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
@@ -3726,9 +3773,29 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 .unwrap();
             QueryResult::Owned(max)
         }
+        // #929: same operand-pairing as min_by's own Object arm above --
+        // confirmed live: `{"a":3,"b":1} | max_by(.)` raises `object
+        // ({"a":3,"b":1}) and array ([[3],[1]]) cannot be iterated over` in
+        // jq 1.7.1.
+        StandardJson::Object(fields) => {
+            let original = to_owned(&StandardJson::Object(fields));
+            let computed = match map_bracketed_over_object_fields::<W, S>(f, fields, optional) {
+                Ok(v) => v,
+                Err(result) => return result,
+            };
+            if optional {
+                QueryResult::None
+            } else {
+                QueryResult::Error(EvalError::pair_cannot_be_iterated(
+                    &original,
+                    &OwnedValue::Array(computed),
+                ))
+            }
+        }
         _ if optional => QueryResult::None,
-        // #929: same wording as min_by's own arm above -- confirmed live:
-        // `5 | max_by(.)` raises "Cannot iterate over number (5)" in jq 1.7.1.
+        // #929: same wording as min_by's own scalar arm above -- confirmed
+        // live: `5 | max_by(.)` raises "Cannot iterate over number (5)" in
+        // jq 1.7.1.
         _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
 }
@@ -4119,39 +4186,22 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // jq: null | nth(0) => null
-    if matches!(value, StandardJson::Null) {
-        return QueryResult::Owned(OwnedValue::Null);
-    }
-
-    // Get the index
+    // #929: real jq defines `nth(n)` as `n as $n | .[$n]` -- `n` is
+    // evaluated against the *original* input before indexing, so it runs
+    // even when `.` is null (confirmed live: `null | nth(error("boom"))`
+    // raises "boom" in jq 1.7.1, it does not short-circuit to null), and
+    // the indexing step needs every `.[$n]` target/key combination: an
+    // object with a string key (missing key => null, not an error), a
+    // float key truncated toward zero, and null passed through for any
+    // key type valid on null. `index_one` is the generic `.[$k]` operator
+    // itself, so delegating to it gets all of this -- including its own
+    // lazy array fast path -- for free instead of re-deriving it here.
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match result_to_owned(n_result) {
-        Ok(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _)) => i,
-        // #929: real jq defines nth(n) as `.[n]`, so a non-numeric n on an
-        // array input fails the same way any other computed-index does,
-        // naming the *value* jq embeds in the message. Confirmed live:
-        // `[1,2,3] | nth("x")` raises `Cannot index array with string "x"`
-        // in jq 1.7.1.
-        Ok(v) => return QueryResult::Error(EvalError::cannot_index(type_name(&value), &v)),
+        Ok(v) => v,
         Err(e) => return e.into(),
     };
-
-    match value {
-        StandardJson::Array(elements) => match get_element_at_index::<W>(elements, n) {
-            Some(v) => QueryResult::One(v),
-            // jq: [1,2] | nth(10) => null
-            None => QueryResult::Owned(OwnedValue::Null),
-        },
-        _ if optional => QueryResult::None,
-        // #929: same `.[n]` definition, this time for a non-array input --
-        // confirmed live: `5 | nth(1)` raises `Cannot index number with
-        // number` in jq 1.7.1.
-        _ => QueryResult::Error(EvalError::cannot_index(
-            type_name(&value),
-            &OwnedValue::Int(n),
-        )),
-    }
+    index_one::<W>(value, &n, optional)
 }
 
 /// Builtin: reverse - reverse array
@@ -4363,10 +4413,30 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let result: Vec<OwnedValue> = keyed.into_iter().map(|(_, v)| v).collect();
             QueryResult::Owned(OwnedValue::Array(result))
         }
+        // #929: unique_by shares min_by/max_by's `map([f])`-pairing
+        // computation (see `map_bracketed_over_object_fields`) but a third,
+        // distinct suffix -- confirmed live: `{"a":3,"b":1} | unique_by(.)`
+        // raises `object ({"a":3,"b":1}) and array ([[3],[1]]) cannot be
+        // sorted, as they are not both arrays` in jq 1.7.1.
+        StandardJson::Object(fields) => {
+            let original = to_owned(&StandardJson::Object(fields));
+            let computed = match map_bracketed_over_object_fields::<W, S>(f, fields, optional) {
+                Ok(v) => v,
+                Err(result) => return result,
+            };
+            if optional {
+                QueryResult::None
+            } else {
+                QueryResult::Error(EvalError::pair_cannot_be_sorted(
+                    &original,
+                    &OwnedValue::Array(computed),
+                ))
+            }
+        }
         _ if optional => QueryResult::None,
-        // #929: same "Cannot iterate over" wording min_by/max_by use --
-        // confirmed live: `5 | unique_by(.)` raises "Cannot iterate over
-        // number (5)" in jq 1.7.1.
+        // #929: same "Cannot iterate over" wording min_by/max_by's own
+        // scalar arm uses -- confirmed live: `5 | unique_by(.)` raises
+        // "Cannot iterate over number (5)" in jq 1.7.1.
         _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
 }
@@ -5101,30 +5171,31 @@ fn format_html(value: &OwnedValue, _optional: bool) -> Result<String, EvalError>
 }
 
 /// Shell-quote a single value for @sh
-fn shell_quote_value(value: &OwnedValue) -> String {
+fn shell_quote_value(value: &OwnedValue) -> Result<String, EvalError> {
     match value {
         // jq always quotes strings in @sh array output
-        OwnedValue::String(s) => {
-            if s.contains('\'') {
-                let escaped = s.replace('\'', "'\\''");
-                format!("'{escaped}'")
-            } else {
-                format!("'{s}'")
-            }
-        }
+        OwnedValue::String(s) => Ok(if s.contains('\'') {
+            let escaped = s.replace('\'', "'\\''");
+            format!("'{escaped}'")
+        } else {
+            format!("'{s}'")
+        }),
         // Numbers, bools, null are NOT quoted in jq
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            numeric_display_string(value)
+            Ok(numeric_display_string(value))
         }
-        OwnedValue::Bool(b) => {
-            if *b {
-                "true".to_string()
-            } else {
-                "false".to_string()
-            }
-        }
-        OwnedValue::Null => "null".to_string(),
-        _ => String::new(),
+        OwnedValue::Bool(b) => Ok(if *b {
+            "true".to_string()
+        } else {
+            "false".to_string()
+        }),
+        OwnedValue::Null => Ok("null".to_string()),
+        // #929: a nested array/object *element* of the top-level @sh array
+        // is just as invalid as one at the top level -- confirmed live:
+        // `[{"a":1}] | @sh` raises `object ({"a":1}) can not be escaped for
+        // shell` in jq 1.7.1, `[[1,2]] | @sh` the array variant the same
+        // way.
+        _ => Err(EvalError::cannot_be_shell_escaped(value)),
     }
 }
 
@@ -5142,7 +5213,10 @@ fn format_sh(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
         }
         // jq: [1, 2, 3] | @sh => "1 2 3"
         OwnedValue::Array(arr) => {
-            let parts: Vec<String> = arr.iter().map(shell_quote_value).collect();
+            let parts: Vec<String> = arr
+                .iter()
+                .map(shell_quote_value)
+                .collect::<Result<_, _>>()?;
             Ok(parts.join(" "))
         }
         // Numbers, bools, null are converted to strings
@@ -28163,6 +28237,98 @@ mod tests {
                 assert_eq!(e.message, "strptime/1 requires string inputs and arguments");
             }
         );
+    }
+
+    /// #929's mandatory code review found six further gaps beyond the
+    /// initial wording audit above -- two pre-existing `nth` bugs the new
+    /// wording made "more confidently wrong", a missing object-input
+    /// variant for `min_by`/`max_by`/`unique_by`, and a second `@sh` site.
+    /// Confirmed against jq 1.7.1 for every case below.
+    #[test]
+    fn test_review_response_929() {
+        // nth(n) is really `.[n]`: a string key on an object behaves like
+        // any other object field access (missing key => null, not an
+        // error), and a float key truncates toward zero instead of being
+        // rejected outright.
+        assert_eq!(outputs(br#"{"a":1}"#, r#"nth("x")"#), ["null"]);
+        assert_eq!(outputs(br#"{"a":1}"#, r#"nth("a")"#), ["1"]);
+        assert_eq!(outputs(br"[1,2,3]", r"nth(1.5)"), ["2"]);
+        assert_eq!(outputs(br"[1,2,3]", r"nth(-1.5)"), ["3"]);
+        // `n` is evaluated against the original input before indexing, so
+        // it runs even when `.` is null instead of short-circuiting to
+        // null first.
+        query!(br"null", r#"nth(error("boom"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boom");
+            }
+        );
+        assert_eq!(outputs(br"null", r"nth(0)"), ["null"]);
+
+        // min_by/max_by/unique_by on an object input pair the object with
+        // the array `map([f])` computes on it -- not the generic
+        // single-value "Cannot iterate over" a bare scalar gets.
+        query!(br#"{"a":3,"b":1}"#, r"min_by(.)",
+            QueryResult::Error(e) => {
+                assert_eq!(
+                    e.message,
+                    "object ({\"a\":3,\"b\":1}) and array ([[3],[1]]) cannot be iterated over"
+                );
+            }
+        );
+        query!(br#"{"a":3,"b":1}"#, r"max_by(.)",
+            QueryResult::Error(e) => {
+                assert_eq!(
+                    e.message,
+                    "object ({\"a\":3,\"b\":1}) and array ([[3],[1]]) cannot be iterated over"
+                );
+            }
+        );
+        query!(br#"{"a":3,"b":1}"#, r"unique_by(.)",
+            QueryResult::Error(e) => {
+                assert_eq!(
+                    e.message,
+                    "object ({\"a\":3,\"b\":1}) and array ([[3],[1]]) cannot be sorted, as they are not both arrays"
+                );
+            }
+        );
+
+        // A `?`-suffixed min_by/max_by/unique_by on an object input
+        // suppresses the pairing error the same way it already did for a
+        // bare scalar, and an error `f` raises on the object's own values
+        // still propagates instead of being swallowed by that suppression.
+        assert_eq!(outputs(br#"{"a":1}"#, r"min_by(.)?"), Vec::<String>::new());
+        assert_eq!(outputs(br#"{"a":1}"#, r"max_by(.)?"), Vec::<String>::new());
+        assert_eq!(
+            outputs(br#"{"a":1}"#, r"unique_by(.)?"),
+            Vec::<String>::new()
+        );
+        query!(br#"{"a":1}"#, r#"min_by(error("boom"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boom");
+            }
+        );
+        query!(br#"{"a":1}"#, r#"max_by(error("boom"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boom");
+            }
+        );
+        query!(br#"{"a":1}"#, r#"unique_by(error("boom"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boom");
+            }
+        );
+
+        // @sh's array arm validates each *element* the same way the
+        // top-level value is validated, not just the top level itself --
+        // including the non-string scalar arms of `shell_quote_value`
+        // itself (a bool element takes a different branch than a string
+        // or number one).
+        query!(br#"[{"a":1}]"#, r"@sh",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "object ({\"a\":1}) can not be escaped for shell");
+            }
+        );
+        assert_eq!(outputs(br"[false]", r"@sh"), ["\"false\""]);
     }
 
     #[test]

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -921,8 +921,13 @@ fn test_last_on_empty_returns_null() {
 #[test]
 fn test_nth_on_null_returns_null() {
     // jq: null | nth(0) => null
+    //
+    // #929: `nth` now delegates to the generic `index_one` operator (the
+    // same one `.[0]` itself uses), so this is the lazy `One(Null)` shape
+    // rather than an eagerly-materialized `Owned(Null)` -- same value,
+    // different QueryResult variant.
     query!(b"null", "nth(0)",
-        QueryResult::Owned(OwnedValue::Null) => {}
+        QueryResult::One(StandardJson::Null) => {}
     );
 }
 


### PR DESCRIPTION
## Summary

`EvalError::type_error` is documented as reserved for error sites with no jq counterpart, but several call sites in `src/jq/eval.rs` had a real jq wording they didn't match (found in #926/#927's review, this issue is the systematic sweep). Every fix below was verified live against pinned jq 1.7.1.

**Wording fixes** (reusing existing constructors or adding narrow new ones):
- `map_values`/`min_by`/`max_by`/`unique_by` on a non-object/array input → `EvalError::cannot_iterate` ("Cannot iterate over number (5)"), matching how real jq's own `.[]`-based definitions fail.
- `nth(n)`'s two type checks (non-numeric `n`, non-array input) → `EvalError::cannot_index`, matching jq's own `.[n]` definition exactly (a non-numeric `n` names itself as the bad key; a non-array input names the successfully-parsed `n` as the key).
- `@csv`/`@tsv` on a non-array, and `@sh` on an object → two new dedicated constructors (`cannot_be_dsv_formatted`, `cannot_be_shell_escaped`) matching jq's exact wording.
- `strptime`'s two type checks and `fromdate`'s share a new `strptime_requires_string` constructor — real jq validates both the input and format argument with **one combined check**, raising the identical message regardless of which side is wrong (confirmed live for all three combinations, except the one where jq itself crashes with a C assertion failure — not reproduced, since a clean error beats a crash).

**Documented, not code-fixed** (`docs/compliance/jq/limitations.md`'s existing "where succinctly errors and jq does not" table): `@uri`/`@base64` auto-`tostring` a non-string argument in real jq rather than refusing it; `flatten` silently ignores a non-numeric depth rather than erroring.

**Deferred, filed as #991**: `join`/`sub`'s replacement function (real jq's wording depends on internal accumulator state from a `reduce`-based definition, not a direct argument — needs restructuring, not a wording swap), `limit`/`combinations`/`combinations(n)` (jq's wording is an accidental artifact of a jq-language macro definition, not a deliberately authored message — worth a second opinion on whether it's even worth chasing), and a **missing** (not just wrongly-worded) `@csv` validation gap found along the way (`[[1,2]] | @csv` silently succeeds in succinctly, where jq rejects a nested-array row element).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New regression test (`test_type_error_sites_match_real_jq_wording_929`) covering all 10 fixed call sites, each assertion verified directly against jq 1.7.1
- [x] `omni-dev coverage diff`: 100% patch coverage (66/66 new lines)

Fixes #929