### PR TITLE
fix(cli): yq never preserves a JSON-sourced number's literal spelling

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -15,7 +15,8 @@ use succinctly::jq::eval_generic::{
     GenericResult,
 };
 use succinctly::jq::{
-    self, sync_aliased_paths, Builtin, EvalError, Expr, OwnedValue, QueryResult, YqSemantics,
+    self, sync_aliased_paths, Builtin, EvalError, Expr, NumberRepr, OwnedValue, QueryResult,
+    YqSemantics,
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
@@ -400,6 +401,36 @@ fn gather_input_sources(
     Ok(GatheredSources::Sources(sources))
 }
 
+/// Recursively collapses every `NumberLiteral` in `value` into a bare
+/// `Int`/`Float`, discarding the number's original source-text spelling.
+///
+/// Unlike YAML input (#918, correctly preserved), real `yq` never
+/// preserves a JSON-sourced number's exact spelling — `1.0` always renders
+/// as `1`, whether touched by the filter or not — most plausibly because
+/// its `--input-format json` path reads through Go's `encoding/json` into
+/// a plain `float64`, with no "untouched literal" concept at all (#978).
+/// `generic_to_owned` (this crate's shared `OwnedValue` materializer) has
+/// no such format-awareness — it's also `succinctly jq`'s own conversion,
+/// which correctly *does* preserve JSON literal spelling — so this stays
+/// local to `yq_runner.rs`'s own JSON-input call sites rather than
+/// touching that shared function.
+fn canonicalize_json_numbers(value: OwnedValue) -> OwnedValue {
+    match value {
+        OwnedValue::NumberLiteral(NumberRepr::Int(n), _) => OwnedValue::Int(n),
+        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) => OwnedValue::Float(f),
+        OwnedValue::Array(items) => {
+            OwnedValue::Array(items.into_iter().map(canonicalize_json_numbers).collect())
+        }
+        OwnedValue::Object(fields) => OwnedValue::Object(
+            fields
+                .into_iter()
+                .map(|(k, v)| (k, canonicalize_json_numbers(v)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
 /// Parse input bytes according to the specified format.
 fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
     match format {
@@ -407,7 +438,9 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
             // Parse as JSON
             let index = JsonIndex::build(bytes);
             let cursor = index.root(bytes);
-            Ok(vec![generic_to_owned(&cursor.value())])
+            Ok(vec![canonicalize_json_numbers(generic_to_owned(
+                &cursor.value(),
+            ))])
         }
         InputFormat::Yaml | InputFormat::Auto => {
             // Parse as YAML (Auto defaults to YAML when no extension hint)
@@ -2455,7 +2488,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     //
     // Supports both JSON and YAML output formats.
     let is_identity = matches!(program.expr, Expr::Identity);
-    let is_m2_streamable = can_use_m2_streaming(&program.expr);
+    // #978: every M2 fast path below streams a scalar's *value* straight
+    // from the parsed cursor rather than materializing an OwnedValue, and
+    // neither streamer (JSON or YAML output) reliably discards a JSON
+    // number's own decimal-point/exponent spelling the way the DOM path's
+    // canonicalize_json_numbers now does - `can_json_fast_path`'s
+    // stream_resolved_scalar_as_json still keeps a computed whole-number
+    // float's trailing `.0` (matching #918's YAML convention, wrong for
+    // JSON input: `1e2` -> `100.0`, real yq gives `100`), and
+    // `can_yaml_fast_path`'s streamer echoes the raw source span outright
+    // (`1.50` stays `1.50`). Real yq never preserves a JSON-sourced
+    // number's literal spelling at all, so explicit `--input-format json`
+    // always falls back to the (already-fixed) DOM path instead.
+    let is_m2_streamable =
+        can_use_m2_streaming(&program.expr) && args.input_format != InputFormat::Json;
     // pretty_print isn't implemented by the cursor streamers, so it still
     // falls back to the DOM path, unchanged, rather than silently ignoring
     // the flag the way compact mode already does today. `sort_keys` and
@@ -2545,6 +2591,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     let can_slurp_fast_path = is_identity
         && can_stream_pretty_or_colored
         && output_config.output_format == OutputFormat::Yaml
+        // #978: same JSON-literal-spelling leak as can_yaml_fast_path above
+        // - this gate is YAML-output-only (see its own doc comment), so no
+        // JSON-output sibling to worry about excluding correctly here.
+        && args.input_format != InputFormat::Json
         && !args.null_input
         && !args.raw_input
         && args.front_matter.is_none()

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -15,8 +15,7 @@ use succinctly::jq::eval_generic::{
     GenericResult,
 };
 use succinctly::jq::{
-    self, sync_aliased_paths, Builtin, EvalError, Expr, NumberRepr, OwnedValue, QueryResult,
-    YqSemantics,
+    self, sync_aliased_paths, Builtin, EvalError, Expr, OwnedValue, QueryResult, YqSemantics,
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
@@ -416,8 +415,6 @@ fn gather_input_sources(
 /// touching that shared function.
 fn canonicalize_json_numbers(value: OwnedValue) -> OwnedValue {
     match value {
-        OwnedValue::NumberLiteral(NumberRepr::Int(n), _) => OwnedValue::Int(n),
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) => OwnedValue::Float(f),
         OwnedValue::Array(items) => {
             OwnedValue::Array(items.into_iter().map(canonicalize_json_numbers).collect())
         }
@@ -427,7 +424,7 @@ fn canonicalize_json_numbers(value: OwnedValue) -> OwnedValue {
                 .map(|(k, v)| (k, canonicalize_json_numbers(v)))
                 .collect(),
         ),
-        other => other,
+        other => other.into_plain_number(),
     }
 }
 
@@ -2488,7 +2485,26 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     //
     // Supports both JSON and YAML output formats.
     let is_identity = matches!(program.expr, Expr::Identity);
-    // #978: every M2 fast path below streams a scalar's *value* straight
+    // #978: `args.input_format` is the *raw*, unresolved CLI flag - it's
+    // `Auto` whenever the user relies on `.json`-extension detection
+    // instead of typing `--input-format json` explicitly, which
+    // `resolve_input_format` (used everywhere else JSON input is handled)
+    // still correctly resolves to `Json`. The M2 gates below need that
+    // same resolution, not the raw flag, or a bare `succinctly yq '.'
+    // file.json` (arguably the more common way to hit this than the
+    // explicit flag) would still leak. Conservative for a mixed-format
+    // multi-file `--inplace`/`--doc` invocation (`-i '.' a.yaml b.json`):
+    // this disables M2 for every file, not just the JSON one(s), since
+    // `is_m2_streamable`/`can_slurp_fast_path` are single, run-wide
+    // booleans with no per-file M2-vs-DOM switch to hook into instead.
+    let any_input_is_json = if input_files.is_empty() {
+        resolve_input_format(args.input_format, None) == InputFormat::Json
+    } else {
+        input_files.iter().any(|f| {
+            resolve_input_format(args.input_format, Some(Path::new(f))) == InputFormat::Json
+        })
+    };
+    // every M2 fast path below streams a scalar's *value* straight
     // from the parsed cursor rather than materializing an OwnedValue, and
     // neither streamer (JSON or YAML output) reliably discards a JSON
     // number's own decimal-point/exponent spelling the way the DOM path's
@@ -2498,10 +2514,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // JSON input: `1e2` -> `100.0`, real yq gives `100`), and
     // `can_yaml_fast_path`'s streamer echoes the raw source span outright
     // (`1.50` stays `1.50`). Real yq never preserves a JSON-sourced
-    // number's literal spelling at all, so explicit `--input-format json`
+    // number's literal spelling at all, so JSON input (explicit flag or
+    // resolved from a `.json` extension - see `any_input_is_json` above)
     // always falls back to the (already-fixed) DOM path instead.
-    let is_m2_streamable =
-        can_use_m2_streaming(&program.expr) && args.input_format != InputFormat::Json;
+    //
+    // Known trade-off (#996): the DOM path's `OwnedValue::Object` is
+    // `IndexMap`-backed and can't represent duplicate keys, unlike M2
+    // streaming, which never materializes a map at all and so happened to
+    // preserve them - `{"a":1,"a":2}` correctly stays that way through M2
+    // (matching real yq) but collapses to `{"a":2}` once routed through
+    // here. #442 already solved this for YAML input with its own
+    // `OwnedValue`-avoiding fast path; a proper fix for JSON input needs
+    // an equivalent (most likely teaching the shared streaming formatters
+    // in `src/yaml/light.rs` to canonicalize a JSON-sourced number
+    // in-stream, restoring M2 eligibility instead of disabling it) rather
+    // than the DOM-fallback trade-off made here.
+    let is_m2_streamable = can_use_m2_streaming(&program.expr) && !any_input_is_json;
     // pretty_print isn't implemented by the cursor streamers, so it still
     // falls back to the DOM path, unchanged, rather than silently ignoring
     // the flag the way compact mode already does today. `sort_keys` and
@@ -2594,7 +2622,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // #978: same JSON-literal-spelling leak as can_yaml_fast_path above
         // - this gate is YAML-output-only (see its own doc comment), so no
         // JSON-output sibling to worry about excluding correctly here.
-        && args.input_format != InputFormat::Json
+        && !any_input_is_json
         && !args.null_input
         && !args.raw_input
         && args.front_matter.is_none()

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -458,7 +458,7 @@ impl OwnedValue {
     /// through untouched should normalize its operands through this first --
     /// arithmetic calls it at the top of each operator function so a
     /// literal-carrying operand degrades before the value/value match runs.
-    pub(crate) fn into_plain_number(self) -> Self {
+    pub fn into_plain_number(self) -> Self {
         match self {
             Self::NumberLiteral(NumberRepr::Int(n), _) => Self::Int(n),
             Self::NumberLiteral(NumberRepr::Float(f), _) => Self::Float(f),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1244,6 +1244,58 @@ fn test_json_input_never_preserves_literal_spelling_978() -> Result<()> {
     Ok(())
 }
 
+/// #978 companion: `args.input_format` is the *raw*, unresolved CLI flag
+/// -- it stays `Auto` whenever a `.json`-extension file is opened without
+/// an explicit `--input-format json`, which `resolve_input_format`
+/// nonetheless correctly resolves to `Json` for every *other* JSON-input
+/// call site. The M2 fast-path gates initially missed this (caught by
+/// code review): a bare `succinctly yq '.' file.json` -- arguably the
+/// more common way to hit this than typing the explicit flag -- still
+/// leaked. Fixed via `any_input_is_json`, which resolves every input
+/// file's format up front instead of trusting the raw flag alone.
+#[test]
+fn test_json_extension_auto_detected_file_never_preserves_literal_spelling_978() -> Result<()> {
+    let mut input_file = NamedTempFile::with_suffix(".json")?;
+    writeln!(input_file, "{{\"a\": 1.50, \"b\": 1e2}}")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o")
+        .arg("json")
+        .arg("-I")
+        .arg("0")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout)?.trim(),
+        "{\"a\":1.5,\"b\":100}"
+    );
+    Ok(())
+}
+
+/// #996 (known limitation, tracked separately -- not fixed here): routing
+/// JSON input through the DOM path to canonicalize its numbers (#978)
+/// loses M2 streaming's incidental duplicate-key preservation, since
+/// `OwnedValue::Object` is `IndexMap`-backed and can only keep the last
+/// value for a repeated key. Real yq preserves `{"a":1,"a":2}` unchanged
+/// (confirmed live); this pins the current, documented gap so a future
+/// change doesn't silently make it worse without anyone noticing --
+/// flip this assertion to the correct behavior once #996 is fixed.
+#[test]
+fn test_json_input_duplicate_keys_collapse_known_limitation_996() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".",
+        "{\"a\":1,\"a\":2}",
+        &["--input-format", "json", "-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "{\"a\":2}");
+    Ok(())
+}
+
 /// #631: `first(.[])`/`last(.[])` (the `Expr::FirstExpr`/`LastExpr` one-arg
 /// stream form `first(f)`/`last(f)` compiles to) fell through
 /// `evaluate_yaml_cursor`'s unconditional `to_owned()` DOM path, unlike

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1153,24 +1153,94 @@ fn test_integer_valued_float_survives_slurp_eval_all_load_907() -> Result<()> {
     Ok(())
 }
 
-/// #907 companion: `standard_json_to_owned`'s removal (see the test above)
-/// changes `--slurp`/`--eval-all --input-format json`'s number formatting,
-/// not just YAML input's -- `StandardJson::number_literal()` is
-/// unconditional (unlike YAML's gated override), so every JSON number now
-/// preserves its own source spelling through this path instead of
-/// `as_i64`/`as_f64`'s lossy round-trip. Pinned against the pinned jq
-/// oracle: `echo '{"a":1e2}' | jq '.'` also gives `1E+2`, confirming this
-/// is a correctness fix (the old behavior silently normalized to `100.0`),
-/// not a new divergence.
+/// #907 companion, corrected by #978: `standard_json_to_owned`'s removal
+/// (see the test above) changed `--slurp`/`--eval-all --input-format
+/// json`'s number formatting, not just YAML input's -- `StandardJson::
+/// number_literal()` is unconditional (unlike YAML's gated override), so
+/// every JSON number briefly preserved its own source spelling through
+/// this path instead of `as_i64`/`as_f64`'s lossy round-trip. #907's own
+/// pin here (`1e2` -> `1E+2`) was checked against the pinned *jq* oracle,
+/// which genuinely does preserve it -- but yq's own JSON-input convention
+/// is different (#978): real yq *never* preserves a JSON-sourced number's
+/// spelling, touched or not (`jq` and `yq` diverge on this, confirmed
+/// live: `jq` keeps `1.0`, `yq --input-format json` always normalizes it
+/// to `1`). #978's `canonicalize_json_numbers` fixes this back to `100`,
+/// which is what this test now pins.
 #[test]
-fn test_json_input_slurp_preserves_exponent_literal_spelling_907() -> Result<()> {
+fn test_json_input_slurp_canonicalizes_exponent_literal_spelling_978() -> Result<()> {
     let (out, code) = run_yq_stdin(
         ".",
         "{\"a\":1e2}",
         &["--input-format", "json", "--slurp", "-o", "json", "-I", "0"],
     )?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "[{\"a\":1E+2}]");
+    assert_eq!(out.trim(), "[{\"a\":100}]");
+    Ok(())
+}
+
+/// #978: unlike YAML input (#918, correctly preserved), real yq never
+/// preserves a JSON-sourced number's exact source spelling -- `1.0`
+/// renders as `1` whether touched by the filter or not, in every output
+/// format. Confirmed live against the pinned yq oracle for every case
+/// here. Two independent leak sites needed fixing:
+/// - the M2 fast path (`can_json_fast_path`/`can_yaml_fast_path`/
+///   `can_slurp_fast_path`, `src/bin/succinctly/yq_runner.rs`) streams a
+///   scalar's value straight from the parsed cursor without ever
+///   materializing an `OwnedValue`, so it doesn't go through this fix's
+///   `canonicalize_json_numbers` at all -- disabled outright for explicit
+///   `--input-format json`, falling back to the (now-fixed) DOM path.
+/// - `parse_input`'s `InputFormat::Json` arm (the DOM path's single
+///   choke point for every JSON-input call site: the default path,
+///   `--slurp`, `--eval-all`, `--split-exp`, `--inplace`'s DOM fallback)
+///   now recursively strips `NumberLiteral` down to bare `Int`/`Float`.
+#[test]
+fn test_json_input_never_preserves_literal_spelling_978() -> Result<()> {
+    // M2 path, default (YAML) output, bare identity.
+    let (out, code) = run_yq_stdin(".", "1.0", &["--input-format", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "1");
+
+    // M2 path, default (YAML) output, field access + exponent notation.
+    let (out, code) = run_yq_stdin(
+        ".a",
+        "{\"a\": 1.50, \"b\": 1e2}",
+        &["--input-format", "json"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "1.5");
+
+    // M2 path, -o json output (previously already-correct for a plain
+    // decimal, but still leaked the exponent case via
+    // format_float_with_fraction's trailing-.0 preservation).
+    let (out, code) = run_yq_stdin(
+        ".",
+        "{\"a\": 1.50, \"b\": 1e2, \"c\": 3}",
+        &["--input-format", "json", "-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "{\"a\":1.5,\"b\":100,\"c\":3}");
+
+    // DOM path (a non-M2-streamable filter forces this regardless of the
+    // M2-path fix above).
+    let (out, code) = run_yq_stdin(
+        "[.a]",
+        "{\"a\": 1.50}",
+        &["--input-format", "json", "-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1.5]");
+
+    // YAML input (no --input-format json) must stay unaffected -- #918's
+    // literal preservation is correct there and this fix must not touch it.
+    // Default (YAML) output, not -o json: -o json on YAML-sourced input
+    // has its own separate, pre-existing trailing-zero-loss gap
+    // (`a: 1.50` -> `{"a":1.5}` via -o json, confirmed unrelated to and
+    // unchanged by this fix -- filed as a follow-up), which isn't what
+    // this assertion is trying to pin.
+    let (out, code) = run_yq_stdin(".a", "a: 1.50", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "1.50");
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Unlike YAML input (#918, correctly preserved), real yq always normalizes a JSON-sourced number to its canonical form — `1.0` renders as `1` whether touched by the filter or not, in every output format. succinctly's `yq --input-format json` had two independent leak sites:

**1. The M2 fast path** streams a scalar's value straight from the parsed cursor without ever materializing an `OwnedValue`, so it never went through #918's literal-preservation gate — it just always echoes/reformats via whichever streamer (JSON or YAML output) is active:
- The YAML-output streamer echoes the raw source span outright (`1.50` stays `1.50`).
- The JSON-output streamer keeps a whole-number float's trailing `.0` (matching #918's YAML convention, wrong for JSON: `1e2` → `100.0` instead of `100`).

Disabled outright for explicit `--input-format json` by folding the check into `is_m2_streamable`, falling back to the DOM path instead — this single change fixes `can_json_fast_path`/`can_yaml_fast_path`/`can_inplace_json_fast_path`/`can_inplace_yaml_fast_path` (all four derive from it) plus `can_slurp_fast_path` (checked separately, since it derives from `is_identity` instead).

**2. `parse_input`'s `InputFormat::Json` arm** — the DOM path's single choke point for every JSON-input call site (the default path, `--slurp`, `--eval-all`, `--split-exp`, `--inplace`'s DOM fallback) — now recursively strips `NumberLiteral` down to bare `Int`/`Float` via a new `canonicalize_json_numbers` helper, kept local to `yq_runner.rs` so it can't affect `generic_to_owned`'s other callers — including `succinctly jq`'s own JSON handling, which correctly *does* preserve literal spelling and must stay untouched.

Also corrects an #907 regression test that had pinned the pre-#978 (wrong) behavior — it was verified at the time only against the pinned *jq* oracle, not yq's differing convention for the same input.

Found and filed a separate, pre-existing, unrelated bug along the way: `-o json` output loses a genuinely YAML-sourced float's trailing zero — #993 (confirmed unaffected by this fix either way).

Fixes #978

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 53 binaries, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New regression test `test_json_input_never_preserves_literal_spelling_978` covering M2 identity, M2 field access, M2 `-o json` (exponent case), DOM path, and confirming YAML input stays unaffected
- [x] Live-verified every case against the pinned yq oracle