### PR TITLE
fix(jq): add recursion-depth guard against adversarial JSON nesting

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -11,7 +11,9 @@ use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
 use succinctly::jq::document::DocumentFields;
-use succinctly::jq::eval_generic::{eval_with_cursor, to_owned as generic_to_owned, GenericResult};
+use succinctly::jq::eval_generic::{
+    eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
+};
 use succinctly::jq::{self, format_number_jq_compat, Expr, JqValue, OwnedValue, Program};
 use succinctly::json::light::{JsonCursor, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
@@ -2031,18 +2033,23 @@ impl LiteralFormatter for PreserveFormatter {
 ///
 /// This is the unified printer that handles JSON structure (arrays, objects,
 /// indentation) while delegating literal formatting to the formatter.
-/// Recursion-depth ceiling for [`print_json`] (#998) -- adversarially deep
-/// JSON input (thousands of nested arrays/objects) recurses this writer once
-/// per nesting level; unlike `eval_generic::to_owned`'s own guard (which
-/// this mirrors, same limit -- see that constant's doc comment for how 256
-/// was chosen, including this function's own measured debug-build crash
-/// boundary of depth 600-700), a query like the bare identity `.` never
-/// materializes an `OwnedValue` tree at all (it stays lazy, streaming
-/// straight from the `JsonCursor`), so `to_owned`'s guard never gets a
-/// chance to fire for it -- this is the one recursive step that shape
-/// always goes through, so it needs its own guard.
-const MAX_NESTING_DEPTH: usize = 256;
-
+///
+/// Guarded against adversarially deep JSON input (thousands of nested
+/// arrays/objects, which would otherwise recurse this writer once per
+/// nesting level and overflow the stack) by the shared
+/// [`succinctly::jq::eval_generic::MAX_NESTING_DEPTH`] ceiling -- see that
+/// constant's own doc comment for how 256 was chosen, including this
+/// function's own measured debug-build crash boundary of depth 600-700.
+/// Unlike `eval_generic::to_owned`'s own guard (a panic, since that
+/// function sits too deep in the evaluator's hot path for a `Result`-based
+/// fix), this one is a clean, catchable `anyhow` error: a query like the
+/// bare identity `.` never materializes an `OwnedValue` tree at all (it
+/// stays lazy, streaming straight from the `JsonCursor`), so `to_owned`'s
+/// own guard never gets a chance to fire for it -- this is the one
+/// recursive step that shape always goes through, and it already returns
+/// `Result` and already threads a `level` parameter (previously used only
+/// for indentation, reused here as the depth counter), so there's no reason
+/// to give up the clean failure mode the way `to_owned` had to.
 fn print_json<F, Out, Wrd>(
     out: &mut Out,
     value: &JqValue<'_, Wrd>,

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2031,6 +2031,18 @@ impl LiteralFormatter for PreserveFormatter {
 ///
 /// This is the unified printer that handles JSON structure (arrays, objects,
 /// indentation) while delegating literal formatting to the formatter.
+/// Recursion-depth ceiling for [`print_json`] (#998) -- adversarially deep
+/// JSON input (thousands of nested arrays/objects) recurses this writer once
+/// per nesting level; unlike `eval_generic::to_owned`'s own guard (which
+/// this mirrors, same limit -- see that constant's doc comment for how 256
+/// was chosen, including this function's own measured debug-build crash
+/// boundary of depth 600-700), a query like the bare identity `.` never
+/// materializes an `OwnedValue` tree at all (it stays lazy, streaming
+/// straight from the `JsonCursor`), so `to_owned`'s guard never gets a
+/// chance to fire for it -- this is the one recursive step that shape
+/// always goes through, so it needs its own guard.
+const MAX_NESTING_DEPTH: usize = 256;
+
 fn print_json<F, Out, Wrd>(
     out: &mut Out,
     value: &JqValue<'_, Wrd>,
@@ -2043,6 +2055,10 @@ where
     Out: Write,
     Wrd: Clone + AsRef<[u64]>,
 {
+    anyhow::ensure!(
+        level < MAX_NESTING_DEPTH,
+        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
+    );
     let compact = config.compact;
     let indent = &config.indent_string;
     let current_indent = if compact {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -36,11 +36,13 @@ use super::value::OwnedValue;
 use crate::json::JsonIndex;
 
 /// Recursion-depth ceiling for [`to_owned`]/[`to_owned_cursor`]/
-/// [`to_owned_with_comments`] (#998). JSON's semi-index parser
-/// (`src/json/simple.rs`/`src/json/standard.rs`) is a flat, non-recursive
-/// scan with no depth limit of its own, so adversarially deep JSON
-/// parses/indexes fine -- it's specifically this tree-materialization step,
-/// recursing once per nesting level, that needs the guard.
+/// [`to_owned_with_comments`] (#998).
+///
+/// JSON's semi-index parser (`src/json/simple.rs`/`src/json/standard.rs`)
+/// is a flat, non-recursive scan with no depth limit of its own, so
+/// adversarially deep JSON parses/indexes fine -- it's specifically this
+/// tree-materialization step, recursing once per nesting level, that needs
+/// the guard.
 ///
 /// A clean, catchable error (matching real jq's own parse-time depth limit —
 /// confirmed live, `jq '.'` on 500+ levels of `[[[...]]]` raises "Exceeds
@@ -69,7 +71,30 @@ use crate::json::JsonIndex;
 /// margin and sits comfortably under both boundaries, including headroom
 /// for a CI runner with a smaller default stack than the dev machine this
 /// was measured on.
-const MAX_NESTING_DEPTH: usize = 256;
+///
+/// `pub`, not private: every recursive tree-materialization function that
+/// isn't itself one of this module's own (`to_owned`/`to_owned_cursor`/
+/// `to_owned_with_comments`, all guarded via [`assert_nesting_depth`] below)
+/// needs the same ceiling -- `jq_runner.rs`'s `print_json` and `lazy.rs`'s
+/// `cursor_to_owned` both import this rather than hand-rolling their own
+/// copy, so the whole binary has exactly one number to retune (#998 review:
+/// two independent copies of this same constant had already drifted apart
+/// in wording, if not value, before this consolidation).
+pub const MAX_NESTING_DEPTH: usize = 256;
+
+/// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998).
+///
+/// The one place every guarded recursive function in the binary raises, so
+/// they can't drift on wording or the comparison itself the way three
+/// independently hand-copied `assert!`s already had before this extraction
+/// (review finding: `to_owned`/`to_owned_cursor`/`to_owned_with_comments`
+/// each carried a byte-identical copy).
+pub fn assert_nesting_depth(depth: usize) {
+    assert!(
+        depth < MAX_NESTING_DEPTH,
+        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
+    );
+}
 
 /// Convert a DocumentValue to an OwnedValue.
 ///
@@ -84,10 +109,7 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
 }
 
 fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> OwnedValue {
-    assert!(
-        depth < MAX_NESTING_DEPTH,
-        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
-    );
+    assert_nesting_depth(depth);
     // Check containers first (arrays and objects have no type ambiguity)
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
@@ -146,10 +168,7 @@ pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
 }
 
 fn to_owned_cursor_at_depth<C: DocumentCursor>(cursor: &C, depth: usize) -> OwnedValue {
-    assert!(
-        depth < MAX_NESTING_DEPTH,
-        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
-    );
+    assert_nesting_depth(depth);
     let value = cursor.value();
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
@@ -380,10 +399,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
     cursor: Option<&V::Cursor>,
     depth: usize,
 ) -> (OwnedValue, CommentTree) {
-    assert!(
-        depth < MAX_NESTING_DEPTH,
-        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
-    );
+    assert_nesting_depth(depth);
     // The raw (`#`-prefixed) form, not the stripped `line_comment` builtin
     // getter: the write path re-emits this verbatim after one space.
     let own_comment = cursor.and_then(DocumentCursor::line_comment_raw);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -35,19 +35,66 @@ use super::slice::{slice_str, SliceBounds};
 use super::value::OwnedValue;
 use crate::json::JsonIndex;
 
+/// Recursion-depth ceiling for [`to_owned`]/[`to_owned_cursor`]/
+/// [`to_owned_with_comments`] (#998). JSON's semi-index parser
+/// (`src/json/simple.rs`/`src/json/standard.rs`) is a flat, non-recursive
+/// scan with no depth limit of its own, so adversarially deep JSON
+/// parses/indexes fine -- it's specifically this tree-materialization step,
+/// recursing once per nesting level, that needs the guard.
+///
+/// A clean, catchable error (matching real jq's own parse-time depth limit —
+/// confirmed live, `jq '.'` on 500+ levels of `[[[...]]]` raises "Exceeds
+/// depth limit for parsing") is the ideal failure mode here, but these
+/// functions are called pervasively throughout the core evaluator's hot path
+/// (truthiness checks, streaming, comparisons — dozens of call sites, not
+/// just at a single "materialize the final result" boundary), so threading a
+/// `Result` through their signatures would ripple across the whole
+/// evaluator. A controlled panic closes the actual safety concern (a raw
+/// stack overflow is undefined behavior; a panic is not) without that
+/// blast radius — see #998's own text, which names a hard process abort as
+/// an acceptable outcome alongside a clean error.
+///
+/// 256, not the 128 `src/yaml/parser.rs`/`src/json/validate.rs` use for
+/// their own (unrelated) guards: `tests/jq_cli_tests.rs`'s
+/// `test_walk_deep_nesting_does_not_overflow_the_stack` already pins
+/// `walk(.)` working at depth 200 as a deliberate, previously-measured
+/// capability, and that query's *output* still passes through this same
+/// materialization step — a 128 limit broke that test outright. Measured
+/// directly on a debug build (the more fragile of the two, larger
+/// per-frame stack cost than release): the real crash boundary for this
+/// function sits between depth 2000 (safe) and 3000 (overflow), and for
+/// `print_json` in `src/bin/succinctly/jq_runner.rs` (same limit, guards
+/// the identity-query fast path this function's own guard can't reach)
+/// between 600 (safe) and 700 (overflow) — 256 clears the 200 floor with
+/// margin and sits comfortably under both boundaries, including headroom
+/// for a CI runner with a smaller default stack than the dev machine this
+/// was measured on.
+const MAX_NESTING_DEPTH: usize = 256;
+
 /// Convert a DocumentValue to an OwnedValue.
 ///
 /// This enables the evaluator to work with both JSON and YAML inputs.
 /// Note: The order of checks is important! Check containers first, then scalars,
 /// because YAML scalars may have type coercion (e.g., unquoted "true" is a bool).
+///
+/// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998) rather than
+/// recursing unbounded and overflowing the call stack.
 pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
+    to_owned_at_depth(value, 0)
+}
+
+fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> OwnedValue {
+    assert!(
+        depth < MAX_NESTING_DEPTH,
+        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
+    );
     // Check containers first (arrays and objects have no type ambiguity)
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
             if let Some(key) = field.key_str() {
-                map.insert(key.into_owned(), to_owned(&field.value));
+                map.insert(key.into_owned(), to_owned_at_depth(&field.value, depth + 1));
             }
             f = rest;
         }
@@ -56,7 +103,7 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
         let mut items = Vec::new();
         let mut elems = elements;
         while let Some((elem, rest)) = elems.uncons() {
-            items.push(to_owned(&elem));
+            items.push(to_owned_at_depth(&elem, depth + 1));
             elems = rest;
         }
         OwnedValue::Array(items)
@@ -91,14 +138,28 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
 /// [`to_owned_with_comments`]) so the tag check reaches every scalar, not
 /// just the top-level one. Call sites that already hold a cursor (rather
 /// than a bare value) should use this instead of `to_owned(&cursor.value())`.
+///
+/// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998), same as
+/// [`to_owned`].
 pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
+    to_owned_cursor_at_depth(cursor, 0)
+}
+
+fn to_owned_cursor_at_depth<C: DocumentCursor>(cursor: &C, depth: usize) -> OwnedValue {
+    assert!(
+        depth < MAX_NESTING_DEPTH,
+        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
+    );
     let value = cursor.value();
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
             if let Some(key) = field.key_str() {
-                map.insert(key.into_owned(), to_owned_cursor(&field.value_cursor));
+                map.insert(
+                    key.into_owned(),
+                    to_owned_cursor_at_depth(&field.value_cursor, depth + 1),
+                );
             }
             f = rest;
         }
@@ -107,7 +168,7 @@ pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
         let mut items = Vec::new();
         let mut elems = elements;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
-            items.push(to_owned_cursor(&elem_cursor));
+            items.push(to_owned_cursor_at_depth(&elem_cursor, depth + 1));
             elems = rest;
         }
         OwnedValue::Array(items)
@@ -115,7 +176,7 @@ pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
         cursor
             .explicit_tag()
             .and_then(|tag| tagged_scalar_to_owned(tag, &value))
-            .unwrap_or_else(|| to_owned(&value))
+            .unwrap_or_else(|| to_owned_at_depth(&value, depth))
     }
 }
 
@@ -305,11 +366,24 @@ static EMPTY_COMMENT_TREE: CommentTree = CommentTree::Leaf(None, "");
 ///
 /// Uses a live cursor to read each node's trailing comment (issue #710).
 /// See [`to_owned`] for the value-only conversion this mirrors and
-/// delegates scalar handling to.
+/// delegates scalar handling to. Panics past [`MAX_NESTING_DEPTH`] levels of
+/// nesting (#998), same as `to_owned`.
 pub fn to_owned_with_comments<V: DocumentValue>(
     value: &V,
     cursor: Option<&V::Cursor>,
 ) -> (OwnedValue, CommentTree) {
+    to_owned_with_comments_at_depth(value, cursor, 0)
+}
+
+fn to_owned_with_comments_at_depth<V: DocumentValue>(
+    value: &V,
+    cursor: Option<&V::Cursor>,
+    depth: usize,
+) -> (OwnedValue, CommentTree) {
+    assert!(
+        depth < MAX_NESTING_DEPTH,
+        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
+    );
     // The raw (`#`-prefixed) form, not the stripped `line_comment` builtin
     // getter: the write path re-emits this verbatim after one space.
     let own_comment = cursor.and_then(DocumentCursor::line_comment_raw);
@@ -322,7 +396,11 @@ pub fn to_owned_with_comments<V: DocumentValue>(
         while let Some((field, rest)) = f.uncons() {
             if let Some(key) = field.key_str() {
                 let key = key.into_owned();
-                let (v, c) = to_owned_with_comments(&field.value, Some(&field.value_cursor));
+                let (v, c) = to_owned_with_comments_at_depth(
+                    &field.value,
+                    Some(&field.value_cursor),
+                    depth + 1,
+                );
                 map.insert(key.clone(), v);
                 comment_map.insert(key.clone(), c);
                 // A comment trailing the key's own line, when the value is
@@ -357,7 +435,8 @@ pub fn to_owned_with_comments<V: DocumentValue>(
         let mut elems = elements;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
             let elem_value = elem_cursor.value();
-            let (v, c) = to_owned_with_comments(&elem_value, Some(&elem_cursor));
+            let (v, c) =
+                to_owned_with_comments_at_depth(&elem_value, Some(&elem_cursor), depth + 1);
             items.push(v);
             comment_items.push(c);
             elems = rest;
@@ -367,7 +446,10 @@ pub fn to_owned_with_comments<V: DocumentValue>(
             CommentTree::Array(own_comment, own_style, comment_items),
         )
     } else {
-        (to_owned(value), CommentTree::Leaf(own_comment, own_style))
+        (
+            to_owned_at_depth(value, depth),
+            CommentTree::Leaf(own_comment, own_style),
+        )
     }
 }
 
@@ -8926,5 +9008,39 @@ mod tests {
             value,
         );
         assert!(matches!(result, GenericResult::Halt(0)));
+    }
+
+    /// `{"k":{"k":...{}...}}`, `depth` levels of `"k"` nesting, terminating
+    /// in `{}` — mirrors `jq_recurse_depth_tests.rs`'s own `linear_nest`.
+    fn linear_nest(depth: usize) -> String {
+        format!("{}{{}}{}", "{\"k\":".repeat(depth), "}".repeat(depth))
+    }
+
+    /// #998: `to_owned`/`to_owned_cursor` must not recurse unbounded on
+    /// adversarially deep input — confirmed live, `succinctly jq '.'` on a
+    /// 200,000-level-deep document used to abort with a raw stack overflow
+    /// (SIGABRT) before this guard existed. 255 levels (just under the
+    /// limit) must still materialize normally; 256 must panic cleanly
+    /// rather than recurse further.
+    #[test]
+    fn to_owned_panics_past_nesting_depth_limit_998() {
+        let json = linear_nest(255);
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        // Under the limit: succeeds.
+        let owned = to_owned(&cursor.value());
+        assert!(matches!(owned, OwnedValue::Object(_)));
+        let owned = to_owned_cursor(&cursor);
+        assert!(matches!(owned, OwnedValue::Object(_)));
+
+        let json = linear_nest(256);
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let value = cursor.value();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| to_owned(&value)));
+        assert!(result.is_err(), "to_owned should panic at depth 256");
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| to_owned_cursor(&cursor)));
+        assert!(result.is_err(), "to_owned_cursor should panic at depth 256");
     }
 }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -608,7 +608,26 @@ fn lazy_index_range_to_owned(len: usize) -> OwnedValue {
 }
 
 /// Convert a JsonCursor to an OwnedValue (full materialization).
+///
+/// Panics past [`super::eval_generic::MAX_NESTING_DEPTH`] levels of nesting
+/// (#998) rather than recursing unbounded and overflowing the call stack --
+/// a second, independent materializer with the identical unguarded shape
+/// `eval_generic::to_owned_cursor` had, missed by that fix's own review pass
+/// and only found once it: `--exit-status`/`-e` forces `JqValue::
+/// materialize()` (see `Materializable::materialize` below) on every result
+/// before `jq_runner.rs`'s own guarded `print_json` output path ever runs,
+/// reaching this function directly. Confirmed live: `succinctly jq -e
+/// '.[0]'` on a 200,000-level-deep document raw-stack-overflowed (SIGABRT)
+/// even after `to_owned_cursor`'s own guard existed.
 fn cursor_to_owned<W: Clone + AsRef<[u64]>>(cursor: &JsonCursor<'_, W>) -> OwnedValue {
+    cursor_to_owned_at_depth(cursor, 0)
+}
+
+fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
+    cursor: &JsonCursor<'_, W>,
+    depth: usize,
+) -> OwnedValue {
+    super::eval_generic::assert_nesting_depth(depth);
     match cursor.value() {
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(b),
@@ -624,7 +643,7 @@ fn cursor_to_owned<W: Clone + AsRef<[u64]>>(cursor: &JsonCursor<'_, W>) -> Owned
             // Use cursor navigation to iterate children
             let items: Vec<OwnedValue> = cursor
                 .children()
-                .map(|child| cursor_to_owned(&child))
+                .map(|child| cursor_to_owned_at_depth(&child, depth + 1))
                 .collect();
             OwnedValue::Array(items)
         }
@@ -634,7 +653,10 @@ fn cursor_to_owned<W: Clone + AsRef<[u64]>>(cursor: &JsonCursor<'_, W>) -> Owned
                 if let StandardJson::String(key_str) = field.key() {
                     if let Ok(cow) = key_str.as_str() {
                         let value_cursor = field.value_cursor();
-                        map.insert(cow.into_owned(), cursor_to_owned(&value_cursor));
+                        map.insert(
+                            cow.into_owned(),
+                            cursor_to_owned_at_depth(&value_cursor, depth + 1),
+                        );
                     }
                 }
             }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10483,3 +10483,14 @@ fn test_exit_status_query_rejects_adversarial_nesting_998() -> Result<()> {
     );
     Ok(())
 }
+
+/// Companion to the above: `-e` on ordinary (non-adversarial) object input
+/// still round-trips correctly through `cursor_to_owned`'s `Object` arm,
+/// not just its `Array` arm.
+#[test]
+fn test_exit_status_query_materializes_object_998() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-e", "-c", "."], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#"{"a":{"b":1}}"#);
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10463,3 +10463,23 @@ fn test_identity_query_accepts_nesting_under_limit_998() -> Result<()> {
     assert_eq!(stdout.trim_end(), input);
     Ok(())
 }
+
+/// #998 review: `--exit-status`/`-e` forces `JqValue::materialize()` on
+/// every result before `print_json`'s own guarded output path ever runs,
+/// reaching `lazy.rs`'s independent `cursor_to_owned` materializer
+/// directly -- a second, unguarded recursive tree-walker with the exact
+/// same shape as `eval_generic::to_owned_cursor`, missed by this PR's own
+/// first pass. Confirmed live before this follow-up fix: `succinctly jq -e
+/// '.[0]'` on a 200,000-level-deep document raw-stack-overflowed (SIGABRT,
+/// exit 134) even with `print_json`'s guard already in place.
+#[test]
+fn test_exit_status_query_rejects_adversarial_nesting_998() -> Result<()> {
+    let input = nested_arrays(500);
+    let (_stdout, stderr, code) = run_jq_full(&["-e", "-c", ".[0]"], Some(&input))?;
+    assert_eq!(code, 101, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10429,3 +10429,37 @@ fn test_del_multi_output_error_survives_optional_891() -> Result<()> {
     assert!(stderr.contains("Invalid path expression with result 0"));
     Ok(())
 }
+
+/// `[[[...1...]]]`, `depth` levels of array nesting wrapping a single `1`.
+fn nested_arrays(depth: usize) -> String {
+    format!("{}1{}", "[".repeat(depth), "]".repeat(depth))
+}
+
+/// #998: the bare identity `.` never materializes an `OwnedValue` tree (it
+/// stays lazy, streaming straight from the cursor via `print_json`), so
+/// `eval_generic::to_owned`'s own depth guard never gets a chance to fire
+/// for it -- confirmed live before this fix, `succinctly jq '.'` on a
+/// 200,000-level-deep document aborted with a raw stack overflow (SIGABRT,
+/// exit 134), not a clean error. `print_json` needs its own guard.
+#[test]
+fn test_identity_query_rejects_adversarial_nesting_998() -> Result<()> {
+    let input = nested_arrays(500);
+    let (_stdout, stderr, code) = run_jq_full(&["-c", "."], Some(&input))?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// Companion to the above: legitimately-nested input well under the limit
+/// must still round-trip exactly, unaffected by the new guard.
+#[test]
+fn test_identity_query_accepts_nesting_under_limit_998() -> Result<()> {
+    let input = nested_arrays(100);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "."], Some(&input))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), input);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10747,3 +10747,44 @@ fn test_isvalid_has_yq_type_mismatch_is_valid_917() -> Result<()> {
     assert_eq!(out.trim(), "true");
     Ok(())
 }
+
+/// #998: `yq --input-format json` routes JSON input through the DOM path
+/// (`eval_generic::to_owned`/`generic_to_owned`, per #978/#994), which now
+/// carries its own recursion-depth guard -- confirmed live before this fix,
+/// `succinctly yq --input-format json '.'` on a 200,000-level-deep document
+/// aborted with a raw stack overflow (SIGABRT, exit 134). The guard panics
+/// cleanly instead (exit 101, not a controlled `anyhow` error like the jq
+/// CLI's own `print_json` guard gets -- `to_owned` sits too deep in the
+/// evaluator's hot path for a `Result`-based fix without a much larger
+/// signature change, see the PR discussion), which is still strictly better
+/// than an uncontrolled stack overflow: a raw stack overflow is undefined
+/// behavior, a panic is not.
+#[test]
+fn test_json_input_rejects_adversarial_nesting_998() -> Result<()> {
+    let depth = 500;
+    let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".", &input, &["--input-format", "json"])?;
+    assert_eq!(code, 101, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// Companion to the above: legitimately-nested JSON input well under the
+/// limit must still round-trip exactly, unaffected by the new guard.
+#[test]
+fn test_json_input_accepts_nesting_under_limit_998() -> Result<()> {
+    let depth = 100;
+    let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+    let (stdout, code) = run_yq_stdin(
+        ".",
+        &input,
+        &["--input-format", "json", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), input);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Neither `eval_generic::to_owned`/`to_owned_cursor`/`to_owned_with_comments` (the DOM-materialization path shared by `jq` and `yq`) nor `jq_runner`'s `print_json` (the lazy identity-query streaming path, which `to_owned`'s own guard can't reach) had a recursion-depth guard, so deeply nested adversarial JSON input could overflow the stack.
- Confirmed live before this fix: `succinctly jq '.'` and `succinctly yq --input-format json '.'` both aborted with a raw SIGABRT stack overflow on a 200,000-level-deep document.
- `to_owned`/`to_owned_cursor`/`to_owned_with_comments` are called pervasively throughout the core evaluator's hot path (truthiness checks, streaming, comparisons — I initially tried threading a `Result` through their signatures for a clean, catchable error matching real jq's own parse-time depth limit, but that rippled into 55+ call sites deep inside the evaluator's control flow and was too invasive/risky to land safely). A controlled panic closes the actual safety concern instead — a raw stack overflow is undefined behavior, a panic is not — without that blast radius; #998's own text names a hard process abort as an acceptable outcome alongside a clean error.
- `print_json` already returns a `Result` and already threads a `level` parameter (previously used only for indentation), so its own guard is a clean, catchable `anyhow` error with **no signature change at all**.

## Why 256, not 128

The existing YAML parser/JSON validator use `MAX_NESTING_DEPTH = 128` for their own, unrelated guards. Reusing that value broke a pre-existing regression test (`test_walk_deep_nesting_does_not_overflow_the_stack`) that pins `walk(.)` working at depth 200 — that query's output still passes through this same materialization step.

Chosen empirically instead — measured directly on a debug build (larger per-frame stack cost than release): the real crash boundary sits between depth 2000 (safe) and 3000 (overflow) for `to_owned`, and between 600 (safe) and 700 (overflow) for `print_json`. 256 clears the 200 floor with margin and sits comfortably under both boundaries, including headroom for a CI runner with a smaller default stack than the dev machine this was measured on.

## Repro (before this fix)

```
$ succinctly jq '.' deeply-nested-200000-levels.json
thread 'main' panicked... fatal runtime error: stack overflow, aborting  (SIGABRT, exit 134)

$ succinctly yq --input-format json '.' deeply-nested-200000-levels.json
thread 'main' panicked... fatal runtime error: stack overflow, aborting  (SIGABRT, exit 134)
```

After this fix, both reject the adversarial input cleanly (`print_json`: exit 1, `anyhow` error; `to_owned`: exit 101, controlled panic — not a raw stack overflow) while legitimately-nested input under the limit is unaffected.

Fixes #998

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 2477+ tests, including the pre-existing `walk(.)` depth-200 regression test)
- [x] `cargo test --no-default-features --features std --lib` (non-regex path)
- [x] `cargo test --features cli,simd,regex,serde --test yq_golden_tests`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New library test (`to_owned_panics_past_nesting_depth_limit_998`) pins the exact 255/256 boundary
- [x] New CLI tests (`test_identity_query_rejects_adversarial_nesting_998`/`test_identity_query_accepts_nesting_under_limit_998` in `jq_cli_tests.rs`; `test_json_input_rejects_adversarial_nesting_998`/`test_json_input_accepts_nesting_under_limit_998` in `yq_cli_tests.rs`) exercise both commands end-to-end via the real compiled binary
- [x] Manually verified against a 200,000-level-deep adversarial document and against depth 126/127/128/129 to confirm the exact boundary