### PR TITLE
fix(jq): reject a nested array/object element in @csv/@tsv/@dsv rows

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -550,6 +550,18 @@ impl EvalError {
         Self::new(format!("{} can not be escaped for shell", describe(value)))
     }
 
+    /// `<type> (<value>) is not valid in a csv row` (#991).
+    ///
+    /// Raised by `@csv`/`@tsv`/`@dsv` for a row containing a nested array or
+    /// object element, instead of silently stringifying it -- confirmed live
+    /// against jq 1.7.1: `[[1,2]] | @csv` is `"array ([1,2]) is not valid in
+    /// a csv row"`. `@tsv` reports the identical "csv row" wording rather
+    /// than "tsv row" -- a real jq wording quirk (also confirmed live), not
+    /// a succinctly bug reproduced here.
+    pub fn not_valid_in_csv_row(value: &OwnedValue) -> Self {
+        Self::new(format!("{} is not valid in a csv row", describe(value)))
+    }
+
     /// `Invalid path expression with result <value>` (#530).
     ///
     /// Raised by `path()` when the filter it was given is not a path

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5003,23 +5003,39 @@ fn quote_csv_field(s: &str) -> String {
     format!("\"{}\"", s.replace('"', "\"\""))
 }
 
+/// Format one row element for `@csv`/`@tsv`/`@dsv`, sharing the
+/// null/nested-container/scalar handling all three already agreed on
+/// (only string quoting differs, via `quote_string`) so the rule has one
+/// definition instead of three copies that could silently diverge — the
+/// same reasoning `quote_csv_field` above was already extracted for
+/// (#651).
+///
+/// #991: a nested array/object element rejects the whole row instead of
+/// stringifying itself in — confirmed live: `[[1,2]] | @csv` errors in jq
+/// 1.7.1, and jq's own wording says "csv row" even for `@tsv` (a real jq
+/// wording quirk, not a succinctly bug). `@dsv` has no real jq equivalent
+/// to verify against (confirmed live: `@dsv(...)` is a syntax error in jq
+/// 1.7.1) — its use of this same rule is succinctly's own policy choice,
+/// following its documented CSV-compatibility (`@dsv(",")` == `@csv`).
+fn format_csv_row_element(
+    v: &OwnedValue,
+    quote_string: impl Fn(&str) -> String,
+) -> Result<String, EvalError> {
+    match v {
+        OwnedValue::String(s) => Ok(quote_string(s)),
+        OwnedValue::Null => Ok(String::new()),
+        OwnedValue::Array(_) | OwnedValue::Object(_) => Err(EvalError::not_valid_in_csv_row(v)),
+        other => Ok(owned_to_string(other)),
+    }
+}
+
 /// @csv - CSV format (for arrays)
 fn format_csv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
     match value {
         OwnedValue::Array(arr) => {
             let parts = arr
                 .iter()
-                .map(|v| match v {
-                    OwnedValue::String(s) => Ok(quote_csv_field(s)),
-                    OwnedValue::Null => Ok(String::new()),
-                    // #991: a nested array/object element must reject the
-                    // whole row, not stringify itself in - confirmed live:
-                    // `[[1,2]] | @csv` errors in jq 1.7.1.
-                    OwnedValue::Array(_) | OwnedValue::Object(_) => {
-                        Err(EvalError::not_valid_in_csv_row(v))
-                    }
-                    other => Ok(owned_to_string(other)),
-                })
+                .map(|v| format_csv_row_element(v, quote_csv_field))
                 .collect::<Result<Vec<String>, EvalError>>()?;
             Ok(parts.join(","))
         }
@@ -5036,20 +5052,13 @@ fn format_tsv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
         OwnedValue::Array(arr) => {
             let parts = arr
                 .iter()
-                .map(|v| match v {
-                    OwnedValue::String(s) => Ok(s
-                        .replace('\\', "\\\\")
-                        .replace('\t', "\\t")
-                        .replace('\n', "\\n")
-                        .replace('\r', "\\r")),
-                    OwnedValue::Null => Ok(String::new()),
-                    // #991: same row-level rejection as @csv above - jq's
-                    // own error wording says "csv row" even here (confirmed
-                    // live, not a succinctly bug).
-                    OwnedValue::Array(_) | OwnedValue::Object(_) => {
-                        Err(EvalError::not_valid_in_csv_row(v))
-                    }
-                    other => Ok(owned_to_string(other)),
+                .map(|v| {
+                    format_csv_row_element(v, |s| {
+                        s.replace('\\', "\\\\")
+                            .replace('\t', "\\t")
+                            .replace('\n', "\\n")
+                            .replace('\r', "\\r")
+                    })
                 })
                 .collect::<Result<Vec<String>, EvalError>>()?;
             Ok(parts.join("\t"))
@@ -5067,17 +5076,7 @@ fn format_dsv(value: &OwnedValue, delimiter: &str, optional: bool) -> Result<Str
         OwnedValue::Array(arr) => {
             let parts = arr
                 .iter()
-                .map(|v| match v {
-                    OwnedValue::String(s) => Ok(quote_csv_field(s)),
-                    OwnedValue::Null => Ok(String::new()),
-                    // #991: @dsv is documented as CSV-compatible
-                    // (`@dsv(",")` == `@csv`), so it shares @csv's row
-                    // rejection for a nested array/object element too.
-                    OwnedValue::Array(_) | OwnedValue::Object(_) => {
-                        Err(EvalError::not_valid_in_csv_row(v))
-                    }
-                    other => Ok(owned_to_string(other)),
-                })
+                .map(|v| format_csv_row_element(v, quote_csv_field))
                 .collect::<Result<Vec<String>, EvalError>>()?;
             Ok(parts.join(delimiter))
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5007,14 +5007,20 @@ fn quote_csv_field(s: &str) -> String {
 fn format_csv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
     match value {
         OwnedValue::Array(arr) => {
-            let parts: Vec<String> = arr
+            let parts = arr
                 .iter()
                 .map(|v| match v {
-                    OwnedValue::String(s) => quote_csv_field(s),
-                    OwnedValue::Null => String::new(),
-                    other => owned_to_string(other),
+                    OwnedValue::String(s) => Ok(quote_csv_field(s)),
+                    OwnedValue::Null => Ok(String::new()),
+                    // #991: a nested array/object element must reject the
+                    // whole row, not stringify itself in - confirmed live:
+                    // `[[1,2]] | @csv` errors in jq 1.7.1.
+                    OwnedValue::Array(_) | OwnedValue::Object(_) => {
+                        Err(EvalError::not_valid_in_csv_row(v))
+                    }
+                    other => Ok(owned_to_string(other)),
                 })
-                .collect();
+                .collect::<Result<Vec<String>, EvalError>>()?;
             Ok(parts.join(","))
         }
         _ if optional => Ok(String::new()),
@@ -5028,18 +5034,24 @@ fn format_csv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
 fn format_tsv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
     match value {
         OwnedValue::Array(arr) => {
-            let parts: Vec<String> = arr
+            let parts = arr
                 .iter()
                 .map(|v| match v {
-                    OwnedValue::String(s) => s
+                    OwnedValue::String(s) => Ok(s
                         .replace('\\', "\\\\")
                         .replace('\t', "\\t")
                         .replace('\n', "\\n")
-                        .replace('\r', "\\r"),
-                    OwnedValue::Null => String::new(),
-                    other => owned_to_string(other),
+                        .replace('\r', "\\r")),
+                    OwnedValue::Null => Ok(String::new()),
+                    // #991: same row-level rejection as @csv above - jq's
+                    // own error wording says "csv row" even here (confirmed
+                    // live, not a succinctly bug).
+                    OwnedValue::Array(_) | OwnedValue::Object(_) => {
+                        Err(EvalError::not_valid_in_csv_row(v))
+                    }
+                    other => Ok(owned_to_string(other)),
                 })
-                .collect();
+                .collect::<Result<Vec<String>, EvalError>>()?;
             Ok(parts.join("\t"))
         }
         _ if optional => Ok(String::new()),
@@ -5053,14 +5065,20 @@ fn format_tsv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
 fn format_dsv(value: &OwnedValue, delimiter: &str, optional: bool) -> Result<String, EvalError> {
     match value {
         OwnedValue::Array(arr) => {
-            let parts: Vec<String> = arr
+            let parts = arr
                 .iter()
                 .map(|v| match v {
-                    OwnedValue::String(s) => quote_csv_field(s),
-                    OwnedValue::Null => String::new(),
-                    other => owned_to_string(other),
+                    OwnedValue::String(s) => Ok(quote_csv_field(s)),
+                    OwnedValue::Null => Ok(String::new()),
+                    // #991: @dsv is documented as CSV-compatible
+                    // (`@dsv(",")` == `@csv`), so it shares @csv's row
+                    // rejection for a nested array/object element too.
+                    OwnedValue::Array(_) | OwnedValue::Object(_) => {
+                        Err(EvalError::not_valid_in_csv_row(v))
+                    }
+                    other => Ok(owned_to_string(other)),
                 })
-                .collect();
+                .collect::<Result<Vec<String>, EvalError>>()?;
             Ok(parts.join(delimiter))
         }
         _ if optional => Ok(String::new()),

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -1330,6 +1330,53 @@ fn test_csv_numbers_not_quoted() {
     );
 }
 
+/// #991: a nested array/object element must reject the whole row instead
+/// of silently stringifying itself in -- confirmed live against jq 1.7.1:
+/// `[[1,2]] | @csv` is `"array ([1,2]) is not valid in a csv row"`.
+#[test]
+fn test_csv_rejects_nested_array_element_991() {
+    query!(b"[[1,2]]", "@csv",
+        QueryResult::Error(e) => {
+            assert_eq!(e.message, "array ([1,2]) is not valid in a csv row");
+        }
+    );
+}
+
+/// #991: same row-level rejection as the array case above, for an object
+/// element -- confirmed live: `[{"a":1}] | @csv` errors in jq 1.7.1.
+#[test]
+fn test_csv_rejects_nested_object_element_991() {
+    query!(br#"[{"a": 1}]"#, "@csv",
+        QueryResult::Error(e) => {
+            assert_eq!(e.message, r#"object ({"a":1}) is not valid in a csv row"#);
+        }
+    );
+}
+
+/// #991: @tsv shares @csv's row-level rejection for nested arrays/objects.
+/// jq's own error wording says "csv row" even for `@tsv` (confirmed live,
+/// jq 1.7.1) -- a real jq wording quirk reproduced here, not a succinctly
+/// bug.
+#[test]
+fn test_tsv_rejects_nested_array_element_991() {
+    query!(b"[[1,2]]", "@tsv",
+        QueryResult::Error(e) => {
+            assert_eq!(e.message, "array ([1,2]) is not valid in a csv row");
+        }
+    );
+}
+
+/// #991: `@dsv` is documented as CSV-compatible (`@dsv(",")` == `@csv`),
+/// so it shares the same row rejection for a nested array/object element.
+#[test]
+fn test_dsv_rejects_nested_array_element_991() {
+    query!(b"[[1,2]]", r#"@dsv("|")"#,
+        QueryResult::Error(e) => {
+            assert_eq!(e.message, "array ([1,2]) is not valid in a csv row");
+        }
+    );
+}
+
 // =============================================================================
 // Compatibility tests - @base64d edge cases
 // =============================================================================


### PR DESCRIPTION
## Summary

`format_csv`/`format_tsv`/`format_dsv` silently stringified an array or object element instead of rejecting the whole row. Real jq validates every element is a scalar and errors before producing any output:

```
$ echo '[[1,2]]' | jq -c '@csv'
jq: error (at <stdin>:1): array ([1,2]) is not valid in a csv row
$ echo '[[1,2]]' | succinctly jq -c '@csv'   # before this fix
"[1,2]"
```

`@dsv` (succinctly's generic-delimiter extension, documented as CSV-compatible — `@dsv(",")` == `@csv`) shares the same rejection for consistency.

jq's own wording says "csv row" even for the `@tsv` case (confirmed live against jq 1.7.1) — reproduced verbatim here, not a succinctly bug.

## Scope note (split from #991)

#991 bundled 3 independent findings, each needing its own investigation per the issue's own text:
- **Item 3** (this PR) — the concrete, actionable one.
- **Item 1** (`join`/`sub` replacement-function wording) — filed separately as #1003; needs a structural investigation into where succinctly's implementation diverges from jq's own `reduce`/pipeline-based definition, not a wording swap.
- **Item 2** (`limit`/`combinations` wording) — the issue itself asks for "a second opinion on whether this is worth chasing at all," since jq's wording there is an accidental artifact of its own `builtin.jq` macro definitions, not deliberately authored. Left as an intentional non-fix; succinctly's current, clearer wording stands.

Fixes #991

## Test plan

- [x] New tests: `test_csv_rejects_nested_array_element_991`, `test_csv_rejects_nested_object_element_991`, `test_tsv_rejects_nested_array_element_991`, `test_dsv_rejects_nested_array_element_991`
- [x] Existing `@csv`/`@tsv` quoting tests still pass
- [x] Full local suite: `cargo test --features cli,simd,regex,serde` — 54/54 suites pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] Live-verified against pinned jq 1.7.1 oracle (array element, object element, scalar-only row still valid)