### PR TITLE
fix(yaml): wire #901's mapping-under-mapping gap check into 4 more parse_block_node arms

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -5011,6 +5011,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             }
             Some(b'{' | b'[') => {
                 // Flow mapping or sequence at document root
+                //
+                // #959: a flow collection landing in a mapping-under-mapping
+                // gap has the identical no-unambiguous-owner shape #901 fixed
+                // for `key: value` lines - reject it the same way instead of
+                // silently misattributing it via a plain close.
+                if self.mapping_under_mapping_gap_reaches(indent) {
+                    return Err(YamlError::InconsistentIndentation {
+                        offset: self.pos,
+                        line: self.current_line(),
+                    });
+                }
                 self.close_deeper_indents(indent);
                 self.parse_value(indent)?;
             }
@@ -5036,6 +5047,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     // preempted by an unconditional close running first.
                     self.parse_mapping_entry(indent)?;
                 } else {
+                    // #959: same mapping-under-mapping gap rejection as the
+                    // flow-collection arm above, for an anchored/tagged
+                    // scalar value landing in the gap.
+                    if self.mapping_under_mapping_gap_reaches(indent) {
+                        return Err(YamlError::InconsistentIndentation {
+                            offset: self.pos,
+                            line: self.current_line(),
+                        });
+                    }
                     self.close_deeper_indents(indent);
                     // Consume any leading `&anchor` and/or `!tag`, in either
                     // order, for non-mapping-key cases
@@ -5093,6 +5113,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     // Alias is a key - let parse_mapping_entry handle it
                     self.parse_mapping_entry(indent)?;
                 } else {
+                    // #959: same mapping-under-mapping gap rejection as the
+                    // other arms in this function, for a standalone alias
+                    // value landing in the gap.
+                    if self.mapping_under_mapping_gap_reaches(indent) {
+                        return Err(YamlError::InconsistentIndentation {
+                            offset: self.pos,
+                            line: self.current_line(),
+                        });
+                    }
                     // Standalone alias value
                     self.close_deeper_indents(indent);
                     self.parse_alias()?;
@@ -5104,6 +5133,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 if self.looks_like_mapping_entry() {
                     self.parse_mapping_entry(indent)?;
                 } else {
+                    // #959: same mapping-under-mapping gap rejection as the
+                    // other arms in this function, for a bare scalar value
+                    // landing in the gap - the original repro this issue
+                    // was filed against.
+                    if self.mapping_under_mapping_gap_reaches(indent) {
+                        return Err(YamlError::InconsistentIndentation {
+                            offset: self.pos,
+                            line: self.current_line(),
+                        });
+                    }
                     // Scalar value - either bare document scalar or value in a container
                     self.close_deeper_indents(indent);
                     self.set_ib();

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1836,6 +1836,24 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.frame_gap_reaches(indent, NodeType::Mapping, NodeType::Mapping, false, false)
     }
 
+    /// Check-and-error wrapper around [`Self::mapping_under_mapping_gap_reaches`]:
+    /// every call site raises the identical `InconsistentIndentation` error
+    /// when the gap is reached, so this gives that pairing one definition
+    /// instead of each site re-deriving it (#106's "duplicated predicates
+    /// diverge silently" lesson) — the same check-and-error, `?`-friendly
+    /// shape [`Self::reject_trailing_flow_content`] already uses for an
+    /// unrelated check in this file.
+    fn check_mapping_under_mapping_gap(&self, indent: usize) -> Result<(), YamlError> {
+        if self.mapping_under_mapping_gap_reaches(indent) {
+            Err(YamlError::InconsistentIndentation {
+                offset: self.pos,
+                line: self.current_line(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+
     /// Whether a `-` sequence-item line's `indent` falls in the *lower*
     /// portion of the gap [`Self::compact_mapping_gap_reaches`] detects
     /// (#900) -- deliberately **excluding** the upper bound (`indent`
@@ -2329,12 +2347,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // silently misattributing it. Checked before the #885 normalization
         // below since the two shapes are mutually exclusive on the parent
         // frame's type (SequenceItem vs. Mapping).
-        if self.mapping_under_mapping_gap_reaches(indent) {
-            return Err(YamlError::InconsistentIndentation {
-                offset: self.pos,
-                line: self.current_line(),
-            });
-        }
+        self.check_mapping_under_mapping_gap(indent)?;
 
         // Normalize an inconsistently-indented continuation of an open
         // compact mapping to the mapping's own indent, so the
@@ -2683,12 +2696,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// The key can be any value: scalar, sequence, or mapping.
     fn parse_explicit_key(&mut self, indent: usize) -> Result<(), YamlError> {
         // Same ambiguous-gap error as parse_mapping_entry (#901).
-        if self.mapping_under_mapping_gap_reaches(indent) {
-            return Err(YamlError::InconsistentIndentation {
-                offset: self.pos,
-                line: self.current_line(),
-            });
-        }
+        self.check_mapping_under_mapping_gap(indent)?;
 
         // Same gap-tolerant normalization as parse_mapping_entry (#885):
         // this function has the identical close/need-new-mapping shape.
@@ -2917,12 +2925,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Parse an explicit value (`: value` after explicit key).
     fn parse_explicit_value(&mut self, indent: usize) -> Result<(), YamlError> {
         // Same ambiguous-gap error as parse_mapping_entry (#901).
-        if self.mapping_under_mapping_gap_reaches(indent) {
-            return Err(YamlError::InconsistentIndentation {
-                offset: self.pos,
-                line: self.current_line(),
-            });
-        }
+        self.check_mapping_under_mapping_gap(indent)?;
 
         // Same gap-tolerant normalization as parse_mapping_entry (#885): an
         // inconsistently-indented `:` must not close the pending key's own
@@ -4981,6 +4984,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Check what kind of content this is
         match self.peek() {
             Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
+                // Same ambiguous-gap error as parse_mapping_entry (#901,
+                // #959) - a sequence item has no unambiguous owner here
+                // either, distinct from #900's SequenceItem-under-Mapping
+                // tolerance (`sequence_item_gap_reaches`), which
+                // `parse_sequence_item` still applies below this check for
+                // its own, different gap shape.
+                self.check_mapping_under_mapping_gap(indent)?;
                 self.parse_sequence_item(indent)?;
             }
             // Tab included in both arms below: the sibling `-` arm just above
@@ -5011,17 +5021,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             }
             Some(b'{' | b'[') => {
                 // Flow mapping or sequence at document root
-                //
-                // #959: a flow collection landing in a mapping-under-mapping
-                // gap has the identical no-unambiguous-owner shape #901 fixed
-                // for `key: value` lines - reject it the same way instead of
-                // silently misattributing it via a plain close.
-                if self.mapping_under_mapping_gap_reaches(indent) {
-                    return Err(YamlError::InconsistentIndentation {
-                        offset: self.pos,
-                        line: self.current_line(),
-                    });
-                }
+                // Same ambiguous-gap error as parse_mapping_entry (#901, #959).
+                self.check_mapping_under_mapping_gap(indent)?;
                 self.close_deeper_indents(indent);
                 self.parse_value(indent)?;
             }
@@ -5047,15 +5048,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     // preempted by an unconditional close running first.
                     self.parse_mapping_entry(indent)?;
                 } else {
-                    // #959: same mapping-under-mapping gap rejection as the
-                    // flow-collection arm above, for an anchored/tagged
-                    // scalar value landing in the gap.
-                    if self.mapping_under_mapping_gap_reaches(indent) {
-                        return Err(YamlError::InconsistentIndentation {
-                            offset: self.pos,
-                            line: self.current_line(),
-                        });
-                    }
+                    // Same ambiguous-gap error as parse_mapping_entry (#901, #959).
+                    self.check_mapping_under_mapping_gap(indent)?;
                     self.close_deeper_indents(indent);
                     // Consume any leading `&anchor` and/or `!tag`, in either
                     // order, for non-mapping-key cases
@@ -5113,15 +5107,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     // Alias is a key - let parse_mapping_entry handle it
                     self.parse_mapping_entry(indent)?;
                 } else {
-                    // #959: same mapping-under-mapping gap rejection as the
-                    // other arms in this function, for a standalone alias
-                    // value landing in the gap.
-                    if self.mapping_under_mapping_gap_reaches(indent) {
-                        return Err(YamlError::InconsistentIndentation {
-                            offset: self.pos,
-                            line: self.current_line(),
-                        });
-                    }
+                    // Same ambiguous-gap error as parse_mapping_entry (#901, #959).
+                    self.check_mapping_under_mapping_gap(indent)?;
                     // Standalone alias value
                     self.close_deeper_indents(indent);
                     self.parse_alias()?;
@@ -5133,16 +5120,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 if self.looks_like_mapping_entry() {
                     self.parse_mapping_entry(indent)?;
                 } else {
-                    // #959: same mapping-under-mapping gap rejection as the
-                    // other arms in this function, for a bare scalar value
-                    // landing in the gap - the original repro this issue
-                    // was filed against.
-                    if self.mapping_under_mapping_gap_reaches(indent) {
-                        return Err(YamlError::InconsistentIndentation {
-                            offset: self.pos,
-                            line: self.current_line(),
-                        });
-                    }
+                    // Same ambiguous-gap error as parse_mapping_entry (#901,
+                    // #959) - the original repro this issue was filed
+                    // against.
+                    self.check_mapping_under_mapping_gap(indent)?;
                     // Scalar value - either bare document scalar or value in a container
                     self.close_deeper_indents(indent);
                     self.set_ib();

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6748,6 +6748,64 @@ fn test_mapping_under_mapping_gap_via_explicit_value() -> Result<()> {
     Ok(())
 }
 
+// #959: #901's check was only wired into parse_mapping_entry,
+// parse_explicit_key, and parse_explicit_value -- the same three
+// call sites #885 touched for the analogous compact-mapping-gap check.
+// parse_block_node dispatches several other line shapes through their own
+// arms that called close_deeper_indents directly, bypassing the check
+// entirely and reproducing #901's identical silent-data-loss shape for a
+// line that isn't `key: value`.
+
+#[test]
+fn test_mapping_under_mapping_gap_via_bare_scalar() -> Result<()> {
+    // The original repro this issue was filed against: a bare scalar
+    // landing in the gap silently vanished instead of erroring.
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "a:\n    b: 1\n  c\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_mapping_under_mapping_gap_via_flow_collection() -> Result<()> {
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "a:\n    b: 1\n  [1,2]\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_mapping_under_mapping_gap_via_anchored_scalar() -> Result<()> {
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "a:\n    b: 1\n  &x c\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_mapping_under_mapping_gap_via_standalone_alias() -> Result<()> {
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "a:\n    b: &x 1\n  *x\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_flow_dash_without_whitespace_is_still_a_scalar() -> Result<()> {
     // A `-` not followed by whitespace is a legitimate plain scalar in flow

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6807,6 +6807,58 @@ fn test_mapping_under_mapping_gap_via_standalone_alias() -> Result<()> {
 }
 
 #[test]
+fn test_mapping_under_mapping_gap_via_sequence_item() -> Result<()> {
+    // Found during code review of this fix: `parse_block_node`'s `-` arm
+    // (dispatching to `parse_sequence_item`) had no check at all, missed
+    // by the original per-arm sweep - live-confirmed to reproduce the
+    // identical silent-data-loss shape before this test was added
+    // (`{"a":{"b":1}}`, exit 0, dropping `- c` entirely). Distinct from
+    // #900's SequenceItem-under-Mapping tolerance
+    // (`sequence_item_gap_reaches`): here the frame directly under the
+    // open inner mapping is another Mapping, not a SequenceItem, so #900's
+    // "obvious extension" reasoning doesn't apply and this stays a genuine
+    // parse error like every other arm in this function.
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "a:\n    b: 1\n  - c\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #959: an invariant test that every `mapping_under_mapping_gap_reaches`
+/// call site agrees, not just that each is individually correct (the
+/// testing skill's own "Invariant Tests Over Duplicated Logic" guidance) -
+/// all 8 sites now route through the single `check_mapping_under_mapping_gap`
+/// helper, so a future edit to its error/offset logic can't silently
+/// diverge between them the way 7 independent copies could have.
+#[test]
+fn test_mapping_under_mapping_gap_agrees_across_all_dispatch_shapes() -> Result<()> {
+    let shapes = [
+        "a:\n    b: 1\n  c: 2\n",         // parse_mapping_entry
+        "a:\n    b: 1\n  ? c\n  : 2\n",   // parse_explicit_key
+        "a:\n    b: 1\n    ? c\n  : 2\n", // parse_explicit_value
+        "a:\n    b: 1\n  [1,2]\n",        // flow collection
+        "a:\n    b: 1\n  &x c\n",         // anchored scalar
+        "a:\n    b: &x 1\n  *x\n",        // standalone alias
+        "a:\n    b: 1\n  c\n",            // bare scalar
+        "a:\n    b: 1\n  - c\n",          // sequence item
+    ];
+    for yaml in shapes {
+        let (_output, stderr, exit_code) =
+            run_yq_stdin_with_stderr(".", yaml, &["-o", "json", "-I0"])?;
+        assert_eq!(exit_code, 1, "yaml: {yaml:?}, stderr: {stderr:?}");
+        assert!(
+            stderr.contains("inconsistent indentation"),
+            "yaml: {yaml:?}, stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn test_flow_dash_without_whitespace_is_still_a_scalar() -> Result<()> {
     // A `-` not followed by whitespace is a legitimate plain scalar in flow
     // context and was never affected; pinned so #332's fix cannot regress it.


### PR DESCRIPTION
## Summary

#901's fix (PR #955) added `mapping_under_mapping_gap_reaches` checks to `parse_mapping_entry`, `parse_explicit_key`, and `parse_explicit_value` — the same three call sites #885 touched for the analogous compact-mapping-gap check. `parse_block_node` dispatches several other line shapes (flow collection, anchored/tagged scalar, standalone alias, bare scalar) through their own arms that called `close_deeper_indents` directly, bypassing the check entirely.

```
$ printf 'a:\n    b: 1\n  c\n' | succinctly yq -o json -I0 '.'
{"a":{"b":1}}      # bare scalar "c" silently vanishes, exit 0
```

Confirmed live against real `yq` v4.53.3: all four shapes (bare scalar, flow collection, anchored scalar, standalone alias) error (`did not find expected key`) where succinctly previously accepted them silently with the sibling's value vanishing from the output.

Fixes #959

## Test plan

- [x] New tests for all 4 previously-uncovered shapes: `test_mapping_under_mapping_gap_via_bare_scalar`, `_via_flow_collection`, `_via_anchored_scalar`, `_via_standalone_alias`
- [x] Existing #901 regression guards (unambiguous sibling at outer/inner indent, deferred-value exception) still pass
- [x] Full local suite: `cargo test --features cli,simd,regex,serde` — 54/54 suites pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] Live-verified against pinned yq v4.53.3 oracle for all 4 new cases plus 2 boundary non-regression cases