### PR TITLE
fix(cli): use scientific notation for large/small computed yq floats

### DIFF
--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -318,6 +318,45 @@ pub fn format_json(value: &OwnedValue, opts: &JsonFormatOpts) -> String {
     format_json_impl(value, opts, 0)
 }
 
+/// Render a computed (non-literal-preserved) `f64` the way real yq does:
+/// decimal for everyday magnitudes, scientific notation once the value's
+/// decimal exponent is `>= 6` or `<= -5`.
+///
+/// Only for [`OwnedValue::Float`] -- a value with no source literal left to
+/// preserve, either because it was actually computed (arithmetic) or because
+/// it came from JSON input, which real yq always re-serializes through
+/// float64 rather than preserving spelling. [`OwnedValue::NumberLiteral`]
+/// (YAML-sourced identity/navigation output) keeps its own source spelling
+/// regardless of magnitude and must never route through this function --
+/// confirmed against real yq v4.53.3: `12345678901234567890123` (a decimal
+/// literal) stays fully expanded on identity, while the equivalent
+/// *computed* magnitude switches to scientific notation. See issue #997.
+///
+/// The threshold and the `e+NN`/`e-NN` (lowercase, signed, exponent padded
+/// to at least 2 digits) spelling are both oracle-verified against real yq;
+/// this is yq's own threshold, distinct from `format_number_jq_compat`'s
+/// jq-mode one (which real jq only reformats when the source literal itself
+/// already used exponent notation).
+#[must_use]
+pub fn format_float_yq(f: f64) -> String {
+    if f == 0.0 {
+        return format_float_with_fraction(f);
+    }
+    let sci = format!("{f:e}");
+    let (mantissa, exp_str) = sci
+        .split_once('e')
+        .expect("Rust's exponential formatter always includes a lowercase 'e'");
+    let exp: i32 = exp_str
+        .parse()
+        .expect("exponent from Rust's exponential formatter is always a valid i32");
+    if (-4..6).contains(&exp) {
+        format_float_with_fraction(f)
+    } else {
+        let sign = if exp < 0 { '-' } else { '+' };
+        format!("{mantissa}e{sign}{:02}", exp.abs())
+    }
+}
+
 /// Recursive JSON formatter behind [`format_json`].
 fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> String {
     let indent = opts.indent;
@@ -342,6 +381,13 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
         OwnedValue::Float(f) => {
             if f.is_nan() || f.is_infinite() {
                 "null".to_string() // JSON doesn't support NaN or Infinity
+            } else if opts.control_escape == ControlEscape::Yq {
+                // yq mode: scientific notation past yq's magnitude threshold
+                // (#997), decimal-with-fraction otherwise, regardless of
+                // compact/pretty -- real yq's Float formatting doesn't
+                // distinguish the two (`float_style` only matters for jq
+                // mode below).
+                format_float_yq(*f)
             } else {
                 match opts.float_style {
                     FloatStyle::Shortest => f.to_string(),
@@ -906,6 +952,55 @@ mod tests {
         assert_eq!(
             format_json(&frac, &opts(FloatStyle::PreserveWholeFloat)),
             "1.5"
+        );
+    }
+
+    /// Oracle-verified against real yq v4.53.3 (#997): threshold boundaries
+    /// on both sides of zero, sign handling, and the `e+NN`/`e-NN` spelling.
+    #[test]
+    fn test_format_float_yq_997() {
+        assert_eq!(format_float_yq(0.0), "0.0");
+        assert_eq!(format_float_yq(-0.0), "-0.0");
+        // In-range: decimal, always with a fractional part.
+        assert_eq!(format_float_yq(150000.0), "150000.0");
+        assert_eq!(format_float_yq(0.00015), "0.00015");
+        assert_eq!(format_float_yq(1.5), "1.5");
+        // Past the threshold: scientific, lowercase `e`, signed, exponent
+        // padded to at least 2 digits.
+        assert_eq!(format_float_yq(1_500_000.0), "1.5e+06");
+        assert_eq!(format_float_yq(0.000015), "1.5e-05");
+        assert_eq!(format_float_yq(-1_500_000.0), "-1.5e+06");
+        assert_eq!(format_float_yq(1e100), "1e+100");
+        assert_eq!(format_float_yq(1e-100), "1e-100");
+    }
+
+    /// yq mode's `OwnedValue::Float` arm must use [`format_float_yq`]
+    /// regardless of `float_style`/compact-vs-pretty, matching real yq's
+    /// own behavior (#997) -- distinct from the jq-mode matrix in
+    /// [`test_format_json_float_styles`] above, which stays on the
+    /// `float_style` path untouched.
+    #[test]
+    fn test_format_json_yq_mode_computed_float_scientific_notation_997() {
+        let opts = |float_style| JsonFormatOpts {
+            indent: "",
+            sort_keys: false,
+            ascii: false,
+            float_style,
+            control_escape: ControlEscape::Yq,
+        };
+        let huge = OwnedValue::Float(1e100);
+        assert_eq!(format_json(&huge, &opts(FloatStyle::Shortest)), "1e+100");
+        assert_eq!(
+            format_json(&huge, &opts(FloatStyle::PreserveWholeFloat)),
+            "1e+100"
+        );
+        // In-range whole float keeps its `.0` under both styles in yq mode
+        // (unlike jq mode's `Shortest`, which drops it).
+        let whole = OwnedValue::Float(150000.0);
+        assert_eq!(format_json(&whole, &opts(FloatStyle::Shortest)), "150000.0");
+        assert_eq!(
+            format_json(&whole, &opts(FloatStyle::PreserveWholeFloat)),
+            "150000.0"
         );
     }
 

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -318,7 +318,7 @@ pub fn format_json(value: &OwnedValue, opts: &JsonFormatOpts) -> String {
     format_json_impl(value, opts, 0)
 }
 
-/// Render a computed (non-literal-preserved) `f64` the way real yq does:
+/// Renders a computed (non-literal-preserved) `f64` the way real yq does:
 /// decimal for everyday magnitudes, scientific notation once the value's
 /// decimal exponent is `>= 6` or `<= -5`.
 ///
@@ -337,11 +337,18 @@ pub fn format_json(value: &OwnedValue, opts: &JsonFormatOpts) -> String {
 /// this is yq's own threshold, distinct from `format_number_jq_compat`'s
 /// jq-mode one (which real jq only reformats when the source literal itself
 /// already used exponent notation).
+///
+/// `f` must be finite -- like [`format_float_with_fraction`], this has no
+/// JSON/YAML-specific spelling for NaN/Infinity to fall back on, so every
+/// caller must special-case those first (both current call sites already
+/// do, ahead of this function).
 #[must_use]
 pub fn format_float_yq(f: f64) -> String {
-    if f == 0.0 {
-        return format_float_with_fraction(f);
-    }
+    debug_assert!(
+        f.is_finite(),
+        "format_float_yq requires a finite value; NaN/Infinity have no \
+         JSON/YAML spelling here and must be special-cased by the caller"
+    );
     let sci = format!("{f:e}");
     let (mantissa, exp_str) = sci
         .split_once('e')

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2053,16 +2053,23 @@ fn can_use_m2_streaming(expr: &Expr) -> bool {
         Expr::Paren(inner) => can_use_m2_streaming(inner),
 
         // first(f)/last(f) (both AST spellings the parser produces, see
-        // `Expr::FirstExpr`/`LastExpr` doc comments) and computed indexing
-        // `.[(expr)]` all thread a cursor through natively in
-        // `eval_generic.rs` (#607), so their `GenericResult` streams exactly
-        // like plain navigation instead of needing OwnedValue construction.
-        // Streaming through `eval_with_cursor_using` here (rather than
-        // `evaluate_yaml_cursor`'s unconditional `to_owned()` DOM path) is
-        // also what keeps duplicate mapping keys intact for these shapes,
-        // matching `.[0]` on the same input (#631).
-        Expr::FirstExpr(_) | Expr::LastExpr(_) => true,
-        Expr::Builtin(Builtin::FirstStream(_) | Builtin::LastStream(_)) => true,
+        // `Expr::FirstExpr`/`LastExpr` doc comments) thread a cursor through
+        // natively in `eval_generic.rs` (#607) *only when `f` itself does* --
+        // `first(.[])` streams a `GenericResult` cursor exactly like plain
+        // navigation, but `first(.a * 1e100)` still has to materialize an
+        // `OwnedValue::Float` from the arithmetic, which then needs the DOM
+        // path's yq-mode scientific-notation formatting (#997) rather than
+        // the M2 fast writers in `src/jq/stream.rs`, which don't have it.
+        // Recursing here (like `Pipe`/`Optional`/`Paren` above) restricts the
+        // fast path to exactly the inner shapes it can actually stream a
+        // cursor for. Streaming through `eval_with_cursor_using` for the
+        // eligible cases (rather than `evaluate_yaml_cursor`'s unconditional
+        // `to_owned()` DOM path) is also what keeps duplicate mapping keys
+        // intact for these shapes, matching `.[0]` on the same input (#631).
+        Expr::FirstExpr(inner) | Expr::LastExpr(inner) => can_use_m2_streaming(inner),
+        Expr::Builtin(Builtin::FirstStream(inner) | Builtin::LastStream(inner)) => {
+            can_use_m2_streaming(inner)
+        }
         Expr::IndexExpr { .. } => true,
 
         // `select(...)` never changes position - a truthy output is always

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -19,15 +19,14 @@ use succinctly::jq::{
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
-    format_float_with_fraction, resolve_plain, resolve_tagged, stream_yaml_sequence, YamlCursor,
-    YamlIndex, YamlValue,
+    resolve_plain, resolve_tagged, stream_yaml_sequence, YamlCursor, YamlIndex, YamlValue,
 };
 
 use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
 use crate::front_matter;
 use crate::output::{
-    self, exit_codes, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation,
-    JsonFormatOpts,
+    self, exit_codes, format_float_yq, ColorScheme, ControlEscape, DiagStyle, ErrorSink,
+    FloatStyle, InputLocation, JsonFormatOpts,
 };
 
 /// yq's diagnostics carry no `(at <file>:<line>)` marker, so the yq paths have
@@ -1462,7 +1461,7 @@ fn emit_yaml_value(
                     "-.inf".to_string()
                 }
             } else {
-                format_float_with_fraction(*f)
+                format_float_yq(*f)
             }
         }
         OwnedValue::NumberLiteral(..) => {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3773,6 +3773,28 @@ mod tests {
     use super::*;
     use succinctly::jq::NumberRepr;
 
+    /// `Builtin::FirstStream`/`LastStream` (the "Phase 13" builtin-table
+    /// spelling of `first(expr)`/`last(expr)`, distinct from the
+    /// `Expr::FirstExpr`/`LastExpr` the parser actually produces --
+    /// `parse_first_expr`/`parse_last_expr` are checked earlier in the
+    /// primary-expression dispatch, so `try_parse_builtin`'s construction of
+    /// these variants is unreachable from CLI input today) still needs the
+    /// same #997 recursion as its `Expr::FirstExpr`/`LastExpr` sibling, since
+    /// both arms share the exact risk this PR closes -- exercised directly
+    /// here since no filter string can reach it through the parser.
+    #[test]
+    fn test_can_use_m2_streaming_recurses_into_builtin_first_last_stream_997() {
+        let navigation = Expr::Builtin(Builtin::FirstStream(Box::new(Expr::Iterate)));
+        assert!(can_use_m2_streaming(&navigation));
+
+        let arithmetic = Expr::Builtin(Builtin::LastStream(Box::new(Expr::Arithmetic {
+            op: succinctly::jq::ArithOp::Add,
+            left: Box::new(Expr::Identity),
+            right: Box::new(Expr::Literal(succinctly::jq::Literal::Float(1e100))),
+        })));
+        assert!(!can_use_m2_streaming(&arithmetic));
+    }
+
     #[test]
     fn test_yaml_to_owned_value_string() {
         let yaml = b"name: Alice";

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7219,6 +7219,91 @@ fn test_navigation_queries_keep_whole_float_decimal_point_yaml() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// Computed-float scientific notation — #997
+// =============================================================================
+
+/// A *computed* (non-literal-preserved) float must switch to scientific
+/// notation past yq's magnitude threshold, matching real yq rather than
+/// expanding to a 100+ digit decimal. Threshold and spelling (lowercase `e`,
+/// explicit sign, exponent padded to at least 2 digits) measured against
+/// `yq` v4.53.3 with `yq -o json` (issue's own repro: `.a * 1e100`).
+///
+/// This is `.a * 1e100`, not identity — identity/navigation on YAML input
+/// keeps `NumberLiteral`'s own source-spelling preservation regardless of
+/// magnitude (see `test_whole_floats_keep_their_decimal_point`'s huge-decimal
+/// case) and must never be affected by this fix.
+#[test]
+fn test_computed_float_uses_scientific_notation_past_yq_threshold_997() -> Result<()> {
+    for (filter, want) in [
+        (".a * 1e100", "1e+100"),
+        (".a / 1e100", "1e-100"),
+        (".a * -1e100", "-1e+100"),
+    ] {
+        for extra_args in [&["-o=json"][..], &["-o=json", "-I=0"][..]] {
+            let (out, code) = run_yq_stdin(filter, "a: 1\n", extra_args)?;
+            assert_eq!(code, 0, "exit code for {filter:?} {extra_args:?}");
+            assert_eq!(out.trim(), want, "for {filter:?} {extra_args:?}");
+        }
+    }
+    Ok(())
+}
+
+/// The exact exponent thresholds (`>= 6` decimal digits before the point,
+/// `<= -5` after) on both sides of zero, oracle-verified against real yq.
+/// `.a` starts non-whole (`1.5`) so the result can never collapse to `Int`
+/// (which never uses scientific notation, an orthogonal, already-correct
+/// path) and stays `Float` all the way to the threshold check.
+#[test]
+fn test_computed_float_scientific_notation_thresholds_997() -> Result<()> {
+    for (filter, want) in [
+        // Positive exponent: 1e5 stays decimal, 1e6 switches.
+        (".a * 100000", "150000.0"),
+        (".a * 1000000", "1.5e+06"),
+        (".a * 10000000", "1.5e+07"),
+        // Negative exponent: 1e-4 stays decimal, 1e-5 switches.
+        (".a / 10000", "0.00015"),
+        (".a / 100000", "1.5e-05"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, "a: 1.5\n", &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "exit code for {filter:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    Ok(())
+}
+
+/// The same threshold applies to YAML (non-JSON) output, which routes
+/// through `emit_yaml_value` rather than `format_json_impl` but must render
+/// a computed float identically.
+#[test]
+fn test_computed_float_scientific_notation_yaml_output_997() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#"{"a": (.a * 1e100)}"#, "a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "a: 1e+100");
+    Ok(())
+}
+
+/// `succinctly jq` (JSON mode) must be completely unaffected: the fix is
+/// gated on `ControlEscape::Yq`, and jq mode's own analogous formatter gap
+/// (different threshold, out of scope for #997) keeps its pre-existing
+/// behavior either way -- a small in-range float still round-trips exactly.
+#[test]
+fn test_jq_mode_computed_float_formatting_unaffected_by_997() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-c", ".a * 1"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(br#"{"a": 1.5}"#)?;
+    }
+    let output = cmd.wait_with_output()?;
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8(output.stdout)?.trim(), "1.5");
+    Ok(())
+}
+
 #[test]
 fn test_dash_not_followed_by_space_is_still_a_scalar() -> Result<()> {
     // Guard against over-matching: negative numbers and `-`-prefixed plain

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7283,6 +7283,34 @@ fn test_computed_float_scientific_notation_yaml_output_997() -> Result<()> {
     Ok(())
 }
 
+/// `first(f)`/`last(f)` are unconditionally M2-streamable in
+/// `can_use_m2_streaming` when `f` is pure navigation (`first(.[])` etc.),
+/// which correctly bypasses `OwnedValue` construction entirely. But when `f`
+/// itself computes a new value (arithmetic), the M2 fast path's own writer
+/// (`src/jq/stream.rs`) hardcodes the pre-#997 formatter and never applies
+/// the scientific-notation threshold -- confirmed by reproducing against
+/// this exact worktree before `can_use_m2_streaming` was taught to recurse
+/// into `FirstExpr`/`LastExpr`'s inner expression the same way it already
+/// does for `Pipe`/`Optional`/`Paren`.
+#[test]
+fn test_first_last_wrapping_computation_gets_scientific_notation_997() -> Result<()> {
+    for (filter, want) in [
+        ("first(.a * 1e100)", "1e+100"),
+        ("last(.a * 1e100)", "1e+100"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, "a: 1\n", &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "exit code for {filter:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    // Pure-navigation first(f)/last(f) must still take the M2 fast path
+    // (preserving duplicate mapping keys, #631) -- this is a non-regression
+    // check, not new #997 behavior.
+    let (out, code) = run_yq_stdin("first(.a[])", "a: [1, 2, 3]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "1");
+    Ok(())
+}
+
 /// `succinctly jq` (JSON mode) must be completely unaffected: the fix is
 /// gated on `ControlEscape::Yq`, and jq mode's own analogous formatter gap
 /// (different threshold, out of scope for #997) keeps its pre-existing


### PR DESCRIPTION
## Summary

- `OwnedValue::Float`'s yq-mode formatting never switched to scientific
  notation, unlike real `yq` (v4.53.3) — a computed magnitude like
  `.a * 1e100` produced a 100+ digit decimal expansion instead of `1e+100`.
- Added `format_float_yq` in `output.rs`, gated on `ControlEscape::Yq` so
  it only affects yq mode — `succinctly jq`'s own separate, differently-
  thresholded formatter gap (out of scope here) is untouched.
- Threshold (`exponent >= 6` or `<= -5`) and spelling (`e+NN`/`e-NN`,
  lowercase, signed, exponent padded to at least 2 digits) are both
  oracle-verified against real `yq` v4.53.3, on both JSON (`format_json_impl`)
  and YAML (`emit_yaml_value`) output, compact and pretty alike.
- Deliberately does **not** touch `OwnedValue::NumberLiteral`'s formatting
  (YAML-sourced identity/navigation output) or the M2 streaming fast path —
  both correctly preserve the original source's decimal-vs-scientific style
  regardless of magnitude (confirmed against real yq: a huge *decimal*
  literal stays fully expanded on identity, only a *computed* result gets
  the magnitude-based switch), and per-existing tests already cover that.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New CLI tests in `tests/yq_cli_tests.rs` covering the issue's own
      repro, both threshold boundaries (positive and negative exponent),
      YAML output, and a jq-mode non-regression check
- [x] New unit tests in `output.rs` for `format_float_yq` directly and for
      the `format_json`/`ControlEscape::Yq` integration
- [x] All new/changed behavior spot-checked live against real `yq` v4.53.3

Fixes #997