### PR TITLE
fix(yaml): generalize ambiguous-gap detection past the top two stack frames

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1818,22 +1818,95 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         }
     }
 
-    /// The #901 sibling of [`Self::compact_mapping_gap_reaches`]: `indent`
-    /// falls strictly between an open mapping's own indent and its
-    /// immediate parent *mapping's* indent (not a `SequenceItem`).
+    /// The #901 sibling of [`Self::compact_mapping_gap_reaches`]: whether
+    /// `indent` would land ambiguously if [`Self::close_deeper_indents`]
+    /// popped every frame deeper than it -- the surviving (landing) frame's
+    /// own recorded indent doesn't exactly match `indent`, so the line
+    /// belongs to neither the frame(s) that would be popped nor the one it
+    /// lands in unambiguously.
     ///
-    /// Unlike the `SequenceItem`-under-`Mapping` shape, there is no
-    /// unambiguous "exactly one possible enclosing scope" guarantee here —
-    /// so this reports the gap as an error condition rather than something
-    /// to normalize and tolerate. Bounds are strict (`>`/`<`), not
-    /// inclusive: `indent` matching either the parent's or the child's own
-    /// recorded indent exactly is the ordinary, unambiguous "sibling of
-    /// this level" case and must not be flagged here (verified against real
-    /// yq v4.53.3: both `a:\n    b: 1\nc: 2\n` and `a:\n    b: 1\n    c:
-    /// 2\n` parse cleanly; only a strictly-between indent like `a:\n    b:
-    /// 1\n  c: 2\n` is rejected, `did not find expected key`).
-    fn mapping_under_mapping_gap_reaches(&self, indent: usize) -> bool {
-        self.frame_gap_reaches(indent, NodeType::Mapping, NodeType::Mapping, false, false)
+    /// Originally scoped to only the top two stack frames (both `Mapping`)
+    /// — #958 found the identical silent-data-loss shape still reproduced,
+    /// unfixed, whenever the ambiguity wasn't between an *adjacent* pair:
+    /// a still-open intervening frame of any type (e.g. a `Sequence`
+    /// deferred as a mapping value) masked the top-two check entirely, and
+    /// a non-adjacent ancestor 3+ levels up was never examined since the
+    /// check only ever looked at `len-1`/`len-2`. Generalized here to walk
+    /// the whole stack instead, mirroring `close_deeper_indents`'s own
+    /// popping condition (`current_indent > new_indent`) exactly rather
+    /// than re-deriving a narrower approximation of it — so the two can't
+    /// silently drift apart the way #106 warns about.
+    ///
+    /// Index 0 is the permanent indent-0 root sentinel (pushed once in
+    /// `new`, never popped) — landing there is never flagged: real YAML
+    /// allows an indented top-level document (verified live: `  a: 1\n  b:
+    /// 2\n` parses cleanly), and the current root frame's own hardcoded
+    /// `0` isn't a real established indent to compare against, unlike
+    /// every other (real) frame's indent, which is always pinned by actual
+    /// prior content.
+    ///
+    /// Deliberately not restricted to a `Mapping` landing frame: verified
+    /// live that real yq rejects a mapping-entry-shaped line landing in an
+    /// *open sequence's* gap the same way (`a:\n  - x\n c: 1\n` errors,
+    /// `did not find expected key`) — succinctly had the identical
+    /// silent-data-loss bug there too before this fix, unrelated to
+    /// #901/#958's own named repros but the same root cause. An ordinary
+    /// sibling key landing exactly at a closed sequence's own indent
+    /// (`a:\n  - x\n  - y\nb: 1\n`) stays unaffected, since it matches the
+    /// landing frame's indent exactly.
+    ///
+    /// `for_sequence_item` must be `true` only for the `-` dispatch arm in
+    /// `parse_block_node`, which closes through
+    /// [`Self::close_deeper_indents_for_sequence_item`] rather than plain
+    /// `close_deeper_indents` — that closer has its own additional
+    /// tolerance (#325/#485: an out-dented `-` continuation of an *open
+    /// sequence*, checked via [`Self::sequence_frame_reaches`] at each
+    /// frame the walk would otherwise pop through), which a `key: value`
+    /// line landing in the same gap does **not** share (confirmed live:
+    /// `a:\n  - x\n c: 1\n` errors in real yq, but `a:\n  - x\n - y\n`
+    /// -- a `-` continuation at the identical out-of-range indent --
+    /// parses cleanly). Every other call site passes `false`.
+    fn mapping_under_mapping_gap_reaches(&self, indent: usize, for_sequence_item: bool) -> bool {
+        if self.indent_stack.len() < 2 {
+            return false;
+        }
+        // Defer to the top-two-frame-specific tolerances (#885's compact
+        // mapping continuation, #900's sequence-item continuation) when
+        // either applies: both are deliberate, oracle-verified "obvious
+        // extension" readings for a SequenceItem/Mapping pairing
+        // specifically (see their own doc comments), normalized by their
+        // own callers just after this check runs -- not a case with no
+        // valid reading at all, the way every other gap this function
+        // catches is. Checked before the walk below since this predicate
+        // is now general enough to otherwise also flag them (it no longer
+        // restricts itself to a Mapping-under-Mapping frame pairing).
+        if self.compact_mapping_gap_reaches(indent) || self.sequence_item_gap_reaches(indent) {
+            return false;
+        }
+        let top = self.indent_stack.len() - 1;
+        // `close_deeper_indents`/`close_deeper_indents_for_sequence_item`
+        // only ever pop (current_indent > new_indent) -- going deeper or
+        // staying flat at the current top frame never pops anything, so
+        // there's no landing-frame question to ask at all: it's either a
+        // new nested frame (handled by the caller opening one) or an
+        // ordinary sibling of the frame already open, both fine.
+        if indent >= self.indent_stack[top] {
+            return false;
+        }
+        let mut landing_idx = top;
+        while landing_idx > 0 && self.indent_stack[landing_idx] > indent {
+            // #325/#485's out-dented-sequence-continuation tolerance,
+            // mirrored from `close_deeper_indents_for_sequence_item`'s own
+            // per-frame check -- only reachable from the `-` dispatch arm.
+            if for_sequence_item
+                && self.type_stack[landing_idx] == NodeType::Sequence
+                && self.sequence_frame_reaches(landing_idx, indent)
+            {
+                return false;
+            }
+            landing_idx -= 1;
+        }
+        landing_idx > 0 && self.indent_stack[landing_idx] != indent
     }
 
     /// Check-and-error wrapper around [`Self::mapping_under_mapping_gap_reaches`]:
@@ -1842,9 +1915,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// instead of each site re-deriving it (#106's "duplicated predicates
     /// diverge silently" lesson) — the same check-and-error, `?`-friendly
     /// shape [`Self::reject_trailing_flow_content`] already uses for an
-    /// unrelated check in this file.
-    fn check_mapping_under_mapping_gap(&self, indent: usize) -> Result<(), YamlError> {
-        if self.mapping_under_mapping_gap_reaches(indent) {
+    /// unrelated check in this file. `for_sequence_item` forwards to
+    /// [`Self::mapping_under_mapping_gap_reaches`] -- see its own doc
+    /// comment for which call site must pass `true`.
+    fn check_mapping_under_mapping_gap(
+        &self,
+        indent: usize,
+        for_sequence_item: bool,
+    ) -> Result<(), YamlError> {
+        if self.mapping_under_mapping_gap_reaches(indent, for_sequence_item) {
             Err(YamlError::InconsistentIndentation {
                 offset: self.pos,
                 line: self.current_line(),
@@ -2347,7 +2426,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // silently misattributing it. Checked before the #885 normalization
         // below since the two shapes are mutually exclusive on the parent
         // frame's type (SequenceItem vs. Mapping).
-        self.check_mapping_under_mapping_gap(indent)?;
+        self.check_mapping_under_mapping_gap(indent, false)?;
 
         // Normalize an inconsistently-indented continuation of an open
         // compact mapping to the mapping's own indent, so the
@@ -2696,7 +2775,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// The key can be any value: scalar, sequence, or mapping.
     fn parse_explicit_key(&mut self, indent: usize) -> Result<(), YamlError> {
         // Same ambiguous-gap error as parse_mapping_entry (#901).
-        self.check_mapping_under_mapping_gap(indent)?;
+        self.check_mapping_under_mapping_gap(indent, false)?;
 
         // Same gap-tolerant normalization as parse_mapping_entry (#885):
         // this function has the identical close/need-new-mapping shape.
@@ -2925,7 +3004,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Parse an explicit value (`: value` after explicit key).
     fn parse_explicit_value(&mut self, indent: usize) -> Result<(), YamlError> {
         // Same ambiguous-gap error as parse_mapping_entry (#901).
-        self.check_mapping_under_mapping_gap(indent)?;
+        self.check_mapping_under_mapping_gap(indent, false)?;
 
         // Same gap-tolerant normalization as parse_mapping_entry (#885): an
         // inconsistently-indented `:` must not close the pending key's own
@@ -4989,8 +5068,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // either, distinct from #900's SequenceItem-under-Mapping
                 // tolerance (`sequence_item_gap_reaches`), which
                 // `parse_sequence_item` still applies below this check for
-                // its own, different gap shape.
-                self.check_mapping_under_mapping_gap(indent)?;
+                // its own, different gap shape. `for_sequence_item: true`
+                // since this arm closes via
+                // `close_deeper_indents_for_sequence_item`, which has its
+                // own additional #325/#485 out-dented-continuation
+                // tolerance this check must not flag as ambiguous.
+                self.check_mapping_under_mapping_gap(indent, true)?;
                 self.parse_sequence_item(indent)?;
             }
             // Tab included in both arms below: the sibling `-` arm just above
@@ -5022,7 +5105,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             Some(b'{' | b'[') => {
                 // Flow mapping or sequence at document root
                 // Same ambiguous-gap error as parse_mapping_entry (#901, #959).
-                self.check_mapping_under_mapping_gap(indent)?;
+                self.check_mapping_under_mapping_gap(indent, false)?;
                 self.close_deeper_indents(indent);
                 self.parse_value(indent)?;
             }
@@ -5049,7 +5132,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     self.parse_mapping_entry(indent)?;
                 } else {
                     // Same ambiguous-gap error as parse_mapping_entry (#901, #959).
-                    self.check_mapping_under_mapping_gap(indent)?;
+                    self.check_mapping_under_mapping_gap(indent, false)?;
                     self.close_deeper_indents(indent);
                     // Consume any leading `&anchor` and/or `!tag`, in either
                     // order, for non-mapping-key cases
@@ -5108,7 +5191,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     self.parse_mapping_entry(indent)?;
                 } else {
                     // Same ambiguous-gap error as parse_mapping_entry (#901, #959).
-                    self.check_mapping_under_mapping_gap(indent)?;
+                    self.check_mapping_under_mapping_gap(indent, false)?;
                     // Standalone alias value
                     self.close_deeper_indents(indent);
                     self.parse_alias()?;
@@ -5123,7 +5206,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     // Same ambiguous-gap error as parse_mapping_entry (#901,
                     // #959) - the original repro this issue was filed
                     // against.
-                    self.check_mapping_under_mapping_gap(indent)?;
+                    self.check_mapping_under_mapping_gap(indent, false)?;
                     // Scalar value - either bare document scalar or value in a container
                     self.close_deeper_indents(indent);
                     self.set_ib();

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1837,13 +1837,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// than re-deriving a narrower approximation of it — so the two can't
     /// silently drift apart the way #106 warns about.
     ///
-    /// Index 0 is the permanent indent-0 root sentinel (pushed once in
-    /// `new`, never popped) — landing there is never flagged: real YAML
-    /// allows an indented top-level document (verified live: `  a: 1\n  b:
-    /// 2\n` parses cleanly), and the current root frame's own hardcoded
-    /// `0` isn't a real established indent to compare against, unlike
-    /// every other (real) frame's indent, which is always pinned by actual
-    /// prior content.
+    /// Index 0 is the permanent virtual-root sentinel (`indent_stack[0]`
+    /// set to `usize::MAX` in `parse`, never popped) — landing there is
+    /// still correctly flagged whenever `indent` doesn't match it (which
+    /// no real indent ever can), not specially exempted: a dedent past an
+    /// indented top-level document's own established indentation is
+    /// itself an error in real YAML (confirmed live: `  a: 1\n  b: 2\nc:
+    /// 3\n` raises "did not find expected <document start>"), and the
+    /// walk never legitimately reaches index 0 for the ordinary "indented
+    /// top-level document, exact-match sibling" case (`  a: 1\n  b: 2\n`)
+    /// -- that stops at the earlier `indent >= indent_stack[top]`
+    /// short-circuit instead, since a sibling's indent always matches the
+    /// top-level frame's own recorded indent exactly.
     ///
     /// Deliberately not restricted to a `Mapping` landing frame: verified
     /// live that real yq rejects a mapping-entry-shaped line landing in an
@@ -1906,7 +1911,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             }
             landing_idx -= 1;
         }
-        landing_idx > 0 && self.indent_stack[landing_idx] != indent
+        self.indent_stack[landing_idx] != indent
     }
 
     /// Check-and-error wrapper around [`Self::mapping_under_mapping_gap_reaches`]:

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6858,6 +6858,119 @@ fn test_mapping_under_mapping_gap_agrees_across_all_dispatch_shapes() -> Result<
     Ok(())
 }
 
+// #958: #900/#901's ambiguous-gap check was only ever compared against the
+// top two stack frames, missing two related shapes a real document can hit:
+// a still-open intervening frame (of any type) masking the check entirely,
+// and a non-adjacent ancestor 3+ levels up that the top-two-only check never
+// examined. Generalized to walk the whole stack instead.
+
+#[test]
+fn test_ambiguous_gap_via_masked_intervening_frame_958() -> Result<()> {
+    // The intervening `y:` mapping's own deferred sequence value (`- a`)
+    // stays open when `x: 2` arrives, so the top frame is a Sequence, not
+    // a Mapping -- the original top-two-only check never even looked past
+    // it. Confirmed live: real yq v4.53.3 errors ("did not find expected
+    // key"); succinctly silently dropped "x: 2" before this fix.
+    let (_output, stderr, exit_code) = run_yq_stdin_with_stderr(
+        ".",
+        "z:\n    y:\n      - a\n  x: 2\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(exit_code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_ambiguous_gap_via_non_adjacent_ancestor_958() -> Result<()> {
+    // `c: 2`'s indent (1) is ambiguous relative to the outermost `z:`
+    // mapping (indent 0), a grandparent -- not the immediately adjacent
+    // pair the original check compared. Confirmed live against yq v4.53.3.
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "z:\n  a:\n    b: 1\n c: 2\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_ambiguous_gap_via_sequence_item_non_adjacent_958() -> Result<()> {
+    // The #900 (sequence-item) side of the same generalization: `- d`
+    // lands ambiguously 3 levels up, past two intervening compact-mapping
+    // frames. Confirmed live against yq v4.53.3.
+    let (_output, stderr, exit_code) = run_yq_stdin_with_stderr(
+        ".",
+        "-   a:\n        b:\n            c: 1\n      - d\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(exit_code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_ambiguous_gap_via_key_landing_in_sequence_958() -> Result<()> {
+    // Not one of #958's own named repros, but the same root cause: the
+    // generalized check is deliberately not restricted to a Mapping
+    // landing frame, so a mapping-entry-shaped line landing in an open
+    // *sequence's* gap is caught too. Confirmed live: real yq errors here;
+    // succinctly silently dropped "c: 1" before this fix. A `-`
+    // continuation at the identical indent stays valid (tested below),
+    // since #325/#485's tolerance is specific to that line shape.
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "a:\n  - x\n c: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_ambiguous_gap_generalization_does_not_regress_existing_tolerances_958() -> Result<()> {
+    // Every pre-existing tolerance this generalization could plausibly
+    // have swallowed, pinned to stay valid.
+    for (yaml, expected) in [
+        // #901's own exact-match sibling cases.
+        ("a:\n    b: 1\nc: 2\n", r#"{"a":{"b":1},"c":2}"#),
+        ("a:\n    b: 1\n    c: 2\n", r#"{"a":{"b":1,"c":2}}"#),
+        // Indented top-level document (real YAML need not start at
+        // column 0) -- landing on the permanent root sentinel must never
+        // be flagged.
+        ("  a: 1\n  b: 2\n", r#"{"a":1,"b":2}"#),
+        // #900's compact-mapping-under-sequence-item continuation.
+        (
+            "-   a: 1\n  - b\n- c\n-   x: 9\n",
+            r#"[{"a":1},"b","c",{"x":9}]"#,
+        ),
+        // #885's exact-match deferred-value exception.
+        ("- k: &a\n  - 1\n", r#"[{"k":[1]}]"#),
+        // #325/#485's out-dented sequence-item continuation -- the
+        // exact shape that #958's generalization first broke before the
+        // `for_sequence_item` tolerance was threaded through.
+        ("b:\n    - x\n   - y\nc: 2\n", r#"{"b":["x","y"],"c":2}"#),
+        // An ordinary sibling key landing exactly at a closed sequence's
+        // own indent, distinct from the new key-in-sequence-gap error
+        // case above (this one matches the landing frame exactly).
+        ("a:\n  - x\n  - y\nb: 1\n", r#"{"a":["x","y"],"b":1}"#),
+    ] {
+        let (output, exit_code) = run_yq_stdin(".", yaml, &["-o", "json", "-I0"])?;
+        assert_eq!(exit_code, 0, "yaml: {yaml:?}, output: {output:?}");
+        assert_eq!(output.trim(), expected, "yaml: {yaml:?}");
+    }
+    Ok(())
+}
+
 #[test]
 fn test_flow_dash_without_whitespace_is_still_a_scalar() -> Result<()> {
     // A `-` not followed by whitespace is a legitimate plain scalar in flow

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6963,10 +6963,37 @@ fn test_ambiguous_gap_generalization_does_not_regress_existing_tolerances_958() 
         // own indent, distinct from the new key-in-sequence-gap error
         // case above (this one matches the landing frame exactly).
         ("a:\n  - x\n  - y\nb: 1\n", r#"{"a":["x","y"],"b":1}"#),
+        // An indented top-level document's own ordinary sibling entries
+        // (real YAML need not start at column 0) -- the walk never
+        // legitimately reaches the virtual-root sentinel for this case,
+        // since it matches the top-level frame's own recorded indent
+        // exactly via the earlier `indent >= indent_stack[top]`
+        // short-circuit.
+        ("  a: 1\n  b: 2\n", r#"{"a":1,"b":2}"#),
     ] {
         let (output, exit_code) = run_yq_stdin(".", yaml, &["-o", "json", "-I0"])?;
         assert_eq!(exit_code, 0, "yaml: {yaml:?}, output: {output:?}");
         assert_eq!(output.trim(), expected, "yaml: {yaml:?}");
+    }
+    Ok(())
+}
+
+/// #958 (found via code review, not one of the issue's own named repros):
+/// the initial generalization's landing-walk exempted the virtual-root
+/// sentinel from the ambiguity check unconditionally, so a dedent past an
+/// indented top-level document's own established indentation was silently
+/// accepted instead of erroring. Confirmed live: real yq v4.53.3 raises
+/// "did not find expected <document start>" for both shapes below.
+#[test]
+fn test_ambiguous_gap_via_dedent_past_indented_top_level_958() -> Result<()> {
+    for yaml in ["  a: 1\n  b: 2\nc: 3\n", "  z:\n    a:\n      b: 1\nc: 2\n"] {
+        let (_output, stderr, exit_code) =
+            run_yq_stdin_with_stderr(".", yaml, &["-o", "json", "-I0"])?;
+        assert_eq!(exit_code, 1, "yaml: {yaml:?}, stderr: {stderr:?}");
+        assert!(
+            stderr.contains("inconsistent indentation"),
+            "yaml: {yaml:?}, stderr: {stderr:?}"
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

#900/#901's `mapping_under_mapping_gap_reaches` only ever compared the top two `indent_stack` frames, missing two related silent-data-loss shapes a real document can hit:

1. **A still-open intervening frame masks the check** — if the last key's value is itself deferred to a nested structure that's still open (e.g. a `Sequence`), the check's top frame isn't a `Mapping` anymore, so the top-two-only comparison never even fires:
   ```
   $ printf 'z:\n    y:\n      - a\n  x: 2\n' | succinctly yq -o json -I0 '.'
   {"z":{"y":["a"]}}      # "x: 2" silently vanishes, exit 0 -- before this fix
   ```
2. **Non-adjacent ancestors 3+ levels deep** aren't checked at all, since the predicate only ever looks at `len-1`/`len-2`:
   ```
   $ printf 'z:\n  a:\n    b: 1\n c: 2\n' | succinctly yq -o json -I0 '.'
   {"z":{"a":{"b":1}}}    # "c: 2" silently vanishes, exit 0 -- before this fix
   ```

Both, and the #900 (sequence-item) side of the identical hole, are confirmed live against real `yq` v4.53.3 as genuine parse errors (`did not find expected key`).

## Approach

Generalized the check to walk the whole stack, mirroring `close_deeper_indents`'s own popping condition (`current_indent > new_indent`) rather than re-deriving a narrower approximation of it. Deliberately **not** restricted to a `Mapping` landing frame either — verified live that real yq rejects a mapping-entry-shaped line landing in an *open sequence's* gap the same way, a pre-existing bug unrelated to #901/#958's own named repros but the same root cause.

The generalized walk defers to two existing, narrower tolerances that only look at the top two frames themselves (#885's compact-mapping continuation, #900's own sequence-item continuation), plus a third — #325/#485's out-dented sequence-item continuation (`sequence_frame_reaches`, checked per-frame during the walk) — gated by a new `for_sequence_item` parameter so it only applies to the `-` dispatch arm that actually closes via `close_deeper_indents_for_sequence_item`, not the other 7 call sites that use plain `close_deeper_indents`.

Fixes #958

## Test plan

- [x] New tests for both #958-named repros, the sequence-item-side non-adjacent case, and the (previously-unfixed, unrelated-but-same-root-cause) key-landing-in-sequence-gap case
- [x] New regression test pinning every pre-existing tolerance this generalization could plausibly have swallowed (found two real regressions during development — #900's compact-mapping tolerance and #325/#485's out-dented sequence continuation — both now fixed and covered)
- [x] Full local suite: `cargo test --features cli,simd,regex,serde` — 54/54 suites pass (615 tests in `yq_cli_tests.rs` alone)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] Live-verified against pinned yq v4.53.3 oracle for every new case and every existing tolerance