### PR TITLE
fix(jq): apply resolve_seq's static tail after a fan-out element escapes

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12220,6 +12220,48 @@ fn resolve_static_tail<'a, S: EvalSemantics>(
     value_after_components::<S>(components, value).map_err(|e| (Vec::new(), e))
 }
 
+/// Apply a purely-static path tail to every branch, extending each branch's
+/// path with `tail` verbatim and threading its value through
+/// [`resolve_static_tail`]. On the first tail-application failure, returns
+/// whatever branches were already extended, paired with that failure —
+/// `resolve_seq`'s own `Err`-side "keep what already resolved" contract.
+///
+/// Shared by `resolve_seq`'s success path (every fan-out element resolved
+/// without escaping) and its escape path (#977: an earlier fan-out element
+/// itself escaped with a partial prefix) so the two can't independently
+/// drift on how a static tail gets applied — before this fix, the escape
+/// path skipped tail application entirely, silently dropping a literal
+/// `.foo`/`[N]`/`[N:M]` suffix from the partial output already produced.
+fn apply_static_tail<'a, S: EvalSemantics>(
+    branches: Vec<PathBranch<'a>>,
+    tail: &[Expr],
+    trackable: bool,
+) -> PathResolveResult<'a> {
+    let mut out = Vec::with_capacity(branches.len());
+    for (mut prefix, current) in branches {
+        // A dynamic element as the pipe's last component (e.g. `.a[.k]`) is
+        // the common, still-trackable shape here, and leaves `tail` empty —
+        // reuse `current` directly rather than paying `resolve_static_tail`/
+        // `value_after_components`'s own clone-then-return-unchanged for a
+        // no-op walk. Anything else — a non-empty `tail`, or an untracked
+        // `current` even with an empty one (#843: `current` may be
+        // `Builtin::GetPath`'s own resolved-but-still-untracked result, see
+        // `resolve_static_tail`'s doc comment) — goes through the shared,
+        // trackable-aware helper.
+        let end: Cow<'a, OwnedValue> = if tail.is_empty() && trackable {
+            current
+        } else {
+            match resolve_static_tail::<S>(tail, &current, trackable) {
+                Ok(end) => Cow::Owned(end),
+                Err((_, e)) => return Err((out, e)),
+            }
+        };
+        prefix.extend_from_slice(tail);
+        out.push((prefix, end));
+    }
+    Ok(out)
+}
+
 /// Resolve a pipe of path nodes, threading the value left to right.
 ///
 /// The threading is the whole point: a computed key sees the value reaching
@@ -12303,7 +12345,21 @@ fn resolve_seq<'a, S: EvalSemantics>(
                         path.extend(components);
                         next.push((path, resulting));
                     }
-                    return Err((next, e));
+                    // #977: apply the static tail to whatever branches
+                    // survived up to this escape, instead of dropping it —
+                    // mirroring the success path below via the shared
+                    // `apply_static_tail` helper. If tail application
+                    // itself also fails, that later failure takes priority
+                    // (the same "later step's own failure outranks an
+                    // earlier deferred one" rule `resolve_slice_expr`'s
+                    // `target_escape`/`path_result` pairing already uses);
+                    // otherwise the tail's fully-extended result carries
+                    // the original deferred escape `e`.
+                    let tail = &flat[last_dynamic + 1..];
+                    return match apply_static_tail::<S>(next, tail, trackable) {
+                        Ok(tailed) => Err((tailed, e)),
+                        tail_err => tail_err,
+                    };
                 }
             }
         }
@@ -12311,29 +12367,7 @@ fn resolve_seq<'a, S: EvalSemantics>(
     }
 
     let tail = &flat[last_dynamic + 1..];
-    let mut out = Vec::with_capacity(branches.len());
-    for (mut prefix, current) in branches {
-        // A dynamic element as the pipe's last component (e.g. `.a[.k]`) is
-        // the common, still-trackable shape here, and leaves `tail` empty —
-        // reuse `current` directly rather than paying `resolve_static_tail`/
-        // `value_after_components`'s own clone-then-return-unchanged for a
-        // no-op walk. Anything else — a non-empty `tail`, or an untracked
-        // `current` even with an empty one (#843: `current` may be
-        // `Builtin::GetPath`'s own resolved-but-still-untracked result, see
-        // `resolve_static_tail`'s doc comment) — goes through the shared,
-        // trackable-aware helper.
-        let end: Cow<'a, OwnedValue> = if tail.is_empty() && trackable {
-            current
-        } else {
-            match resolve_static_tail::<S>(tail, &current, trackable) {
-                Ok(end) => Cow::Owned(end),
-                Err((_, e)) => return Err((out, e)),
-            }
-        };
-        prefix.extend_from_slice(tail);
-        out.push((prefix, end));
-    }
-    Ok(out)
+    apply_static_tail::<S>(branches, tail, trackable)
 }
 
 /// Rewrite every computed key in a path expression into the static component it

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12325,7 +12325,7 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // the one every #530 sibling repro exercises) is exact.
     let tail = &flat[last_dynamic + 1..];
     let mut branches: Vec<PathBranch<'a>> = vec![(Vec::new(), Cow::Borrowed(value))];
-    for element in &flat[..=last_dynamic] {
+    for (i, element) in flat[..=last_dynamic].iter().enumerate() {
         let mut next = Vec::new();
         // Consumes `branches` (not `&branches`) so each `current` arrives by
         // value: only then can `resolve_against_cow` recover the branch's
@@ -12355,8 +12355,25 @@ fn resolve_seq<'a, S: EvalSemantics>(
                     // otherwise the tail's fully-extended result carries
                     // `e` forward via `path_result`, the same pairing
                     // `resolve_slice_expr`'s `target_escape` already uses.
-                    let tailed = apply_static_tail::<S>(next, tail, trackable)?;
-                    return path_result(tailed, Some(e));
+                    //
+                    // Only when `i == last_dynamic`: `tail` is everything
+                    // *after* the pipe's last dynamic element, so an escape
+                    // at an *earlier* dynamic element (i < last_dynamic)
+                    // still has one or more further dynamic stages
+                    // (`flat[i+1..=last_dynamic]`) that haven't run yet —
+                    // splicing `tail` directly onto this stage's branches
+                    // would skip those entirely and fabricate a wrong
+                    // path/value (found in code review, confirmed live
+                    // against jq: `path(.a[(0,error("t"))] | .c[(0,1)] |
+                    // .foo)` produced a bogus `["a",0,"foo"]` instead of
+                    // the pre-existing, already-documented "known
+                    // simplification" truncation this preserves for that
+                    // shape instead).
+                    if i == last_dynamic {
+                        let tailed = apply_static_tail::<S>(next, tail, trackable)?;
+                        return path_result(tailed, Some(e));
+                    }
+                    return Err((next, e));
                 }
             }
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12323,6 +12323,7 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // simplification, not a byte-for-byte reproduction of jq's stream order;
     // the single-dynamic-element case (the overwhelmingly common one, and
     // the one every #530 sibling repro exercises) is exact.
+    let tail = &flat[last_dynamic + 1..];
     let mut branches: Vec<PathBranch<'a>> = vec![(Vec::new(), Cow::Borrowed(value))];
     for element in &flat[..=last_dynamic] {
         let mut next = Vec::new();
@@ -12350,23 +12351,18 @@ fn resolve_seq<'a, S: EvalSemantics>(
                     // mirroring the success path below via the shared
                     // `apply_static_tail` helper. If tail application
                     // itself also fails, that later failure takes priority
-                    // (the same "later step's own failure outranks an
-                    // earlier deferred one" rule `resolve_slice_expr`'s
-                    // `target_escape`/`path_result` pairing already uses);
+                    // over the earlier deferred `e` (propagated via `?`);
                     // otherwise the tail's fully-extended result carries
-                    // the original deferred escape `e`.
-                    let tail = &flat[last_dynamic + 1..];
-                    return match apply_static_tail::<S>(next, tail, trackable) {
-                        Ok(tailed) => Err((tailed, e)),
-                        tail_err => tail_err,
-                    };
+                    // `e` forward via `path_result`, the same pairing
+                    // `resolve_slice_expr`'s `target_escape` already uses.
+                    let tailed = apply_static_tail::<S>(next, tail, trackable)?;
+                    return path_result(tailed, Some(e));
                 }
             }
         }
         branches = next;
     }
 
-    let tail = &flat[last_dynamic + 1..];
     apply_static_tail::<S>(branches, tail, trackable)
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7839,6 +7839,61 @@ fn test_resolve_index_expr_indexes_targets_partial_fanout_before_its_own_error_8
     Ok(())
 }
 
+/// #977: `resolve_seq`'s fan-out loop used to return an escaping element's
+/// partial prefix without ever applying a purely-static tail after it (a
+/// literal `.foo`/`[N]`/`[N:M]`, desugared to a flat `Pipe` at parse time —
+/// distinct from #896's own 4 sites, which only cover a *dynamic*
+/// subscript). Verified against jq 1.7.1 for all three tail shapes.
+#[test]
+fn test_resolve_seq_applies_static_tail_after_fanout_element_escape_977() -> Result<()> {
+    // Literal index tail.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path((select(true, error("t")))[0])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    // Literal slice tail.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path((select(true, error("t")))[0:1])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":1}]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    // Literal field tail.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path((select(true, error("t"))).a)"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #977: if the static tail itself also fails while being applied to the
+/// fan-out element's partial prefix, that later failure takes priority over
+/// the earlier deferred one — the same "later step's own failure outranks
+/// an earlier deferred one" rule this codebase already applies elsewhere
+/// (`resolve_slice_expr`'s `target_escape`). Verified against jq 1.7.1:
+/// indexing a number with `[0]` raises jq's own type error, not `t`.
+#[test]
+fn test_resolve_seq_static_tail_failure_outranks_earlier_fanout_escape_977() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"path((select(true, error("t")))[0])"#], Some("5"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Cannot index number with number"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #896 review round: `GetPath`'s arm only builds its own partial-prefix
 /// branch for the exact single-array-output shape; any other shape (here,
 /// 2+ valid array outputs before the error) falls through to `resolve_leaf`,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7894,6 +7894,48 @@ fn test_resolve_seq_static_tail_failure_outranks_earlier_fanout_escape_977() -> 
     Ok(())
 }
 
+/// #977 (found in code review of the fix itself): when a pipe has 2+
+/// dynamic (fan-out) elements and an *earlier* one escapes — not the last,
+/// i.e. `flat`'s dynamic element at some index `i < last_dynamic` — the
+/// static tail lives *after* `last_dynamic`, not after `i`. Applying it
+/// directly to `i`'s partial branches (as an early version of this fix
+/// did) skips every dynamic stage between `i` and `last_dynamic` entirely
+/// and fabricates a wrong path/value instead of the pre-existing,
+/// already-documented "known simplification" truncation `resolve_seq`'s
+/// own top comment describes for this exact shape. Verified against jq
+/// 1.7.1: `.c[(0,1)]` (the second dynamic element) must still run before
+/// `.foo` (the tail) is ever applied — the correct output threads through
+/// it (`["a",0,"c",0,"foo"]`/`["a",0,"c",1,"foo"]`); this pins the
+/// truncated-but-honest fallback succinctly's own architecture produces
+/// instead (a pre-existing, accepted limitation for multi-dynamic-element
+/// pipes, not what this test asserts jq itself does).
+#[test]
+fn test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.a[(0,error("t"))] | .c[(0,1)] | .foo)"#],
+        Some(r#"{"a":[{"c":[{"foo":1},{"foo":2}]}]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    // Must not fabricate `["a",0,"foo"]` by skipping `.c[(0,1)]` — the
+    // pre-existing "known simplification" truncates to the partial prefix
+    // through the escaping element instead.
+    assert_eq!(stdout, "[\"a\",0]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    // A second shape, where the skipped-over tail would otherwise silently
+    // resolve against unrelated data and mask the original escape (found
+    // in review): confirms the original deferred "t" still surfaces,
+    // rather than a bogus type error from misapplying `.d` to `.a[0]`.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.a[(0,error("t"))] | .k[.c] | .d)"#],
+        Some(r#"{"a":[{"c":"k","k":{"d":99}}]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\",0]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #896 review round: `GetPath`'s arm only builds its own partial-prefix
 /// branch for the exact single-array-output shape; any other shape (here,
 /// 2+ valid array outputs before the error) falls through to `resolve_leaf`,


### PR DESCRIPTION
## Summary

\`resolve_seq\` flattens a pipe into static components and, when one needs a dynamic fan-out pass (\`select\`, \`if\`, a computed index/slice, \`..\`, ...), runs elements up to and including the last such dynamic one through a fan-out loop, then applies any purely-static tail (a literal \`.foo\`/\`[N]\`/\`[N:M]\`) to each surviving branch.

If the fan-out loop's own element escaped with a non-empty partial prefix (one of the keep-partial sites: \`select\`, \`if\`, \`getpath\`, a computed index), the loop returned that raw prefix immediately without ever applying the tail — silently dropping a literal \`.foo\`/\`[N]\`/\`[N:M]\` suffix from streamed partial output:

\`\`\`
$ echo '[10,20,30]' | jq -c 'path((select(true, error("t")))[0])'
jq: error (at <stdin>:1): t
[0]
$ echo '[10,20,30]' | succinctly jq -c 'path((select(true, error("t")))[0])'   # before this fix
jq: error (at <stdin>:1): t
(no path printed)
\`\`\`

Distinct from #896's own 4 sites and #973's \`resolve_slice_expr\` fix, both of which only cover a *dynamic* subscript — a literal one desugars into \`resolve_seq\`'s own flat \`Pipe\` at parse time and never reaches those functions at all.

## Approach

Extracted the tail-application logic (previously only in the success path) into a shared \`apply_static_tail\` helper, used by both the success path and the fan-out loop's escape arm, so a static tail failure encountered while applying it to the escaped branches takes priority over the earlier deferred escape — the same rule \`resolve_slice_expr\`'s \`target_escape\`/\`path_result\` pairing already uses.

Fixes #977

## Test plan

- [x] New tests for literal index, slice, and field tails after a fan-out escape, plus the case where the tail's own failure outranks the earlier deferred escape
- [x] Existing \`resolve_seq\`/path-context tests (56 tests) still pass
- [x] Full local suite: \`cargo test --features cli,simd,regex,serde\` — 54/54 suites pass
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` clean
- [x] Live-verified against pinned jq 1.7.1 oracle for every new case