### PR TITLE
fix(yaml): preserve a YAML float literal's trailing zero on -o json

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3682,8 +3682,9 @@ fn stream_yaml_scalar_as_json<Out: core::fmt::Write>(
 }
 
 /// Stream an already-resolved scalar as JSON. `str_val` is the original
-/// source text, used only for the `Str` case (and only if `resolved` didn't
-/// come from resolving it, e.g. tag-forced `!!str` on non-string content).
+/// source text, used for the `Str` case (and only if `resolved` didn't come
+/// from resolving it, e.g. tag-forced `!!str` on non-string content), and
+/// for a preservable `Float` literal (#993).
 fn stream_resolved_scalar_as_json<Out: core::fmt::Write>(
     out: &mut Out,
     resolved: ResolvedScalar,
@@ -3694,7 +3695,16 @@ fn stream_resolved_scalar_as_json<Out: core::fmt::Write>(
         ResolvedScalar::Bool(true) => out.write_str("true"),
         ResolvedScalar::Bool(false) => out.write_str("false"),
         ResolvedScalar::Int(n) => write!(out, "{n}"),
-        // Not `write!(out, "{f}")`: that drops the `.0` from a whole float.
+        // Echo the source text when it's already safe, valid JSON number
+        // syntax (`number_literal()` below uses the same predicate for the
+        // DOM path) -- this is what keeps a trailing zero (`1.50`) intact;
+        // `format_float_with_fraction` only reconstructs the value's
+        // shortest round-trip spelling, which silently drops it (#993).
+        // Not `write!(out, "{f}")` either way: that drops the `.0` from a
+        // whole float.
+        ResolvedScalar::Float(f) if f.is_finite() && is_preservable_float_literal(str_val) => {
+            out.write_str(str_val)
+        }
         ResolvedScalar::Float(f) if f.is_finite() => out.write_str(&format_float_with_fraction(f)),
         // JSON cannot represent the `.inf`/`.nan` family.
         ResolvedScalar::Float(_) => out.write_str("null"),

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3237,8 +3237,10 @@ fn write_yaml_scalar_as_json(output: &mut String, str_val: &str) {
 }
 
 /// Write an already-resolved scalar as JSON. `str_val` is the original
-/// source text, used only for the `Str` case (and only if `resolved` didn't
-/// come from resolving it, e.g. tag-forced `!!str` on non-string content).
+/// source text, used for the `Str` case (and only if `resolved` didn't come
+/// from resolving it, e.g. tag-forced `!!str` on non-string content), and
+/// for a preservable `Float` literal (#993) -- kept in lockstep with the
+/// streaming sibling [`stream_resolved_scalar_as_json`].
 #[inline]
 fn write_resolved_scalar_as_json(output: &mut String, resolved: ResolvedScalar, str_val: &str) {
     match resolved {
@@ -3246,6 +3248,14 @@ fn write_resolved_scalar_as_json(output: &mut String, resolved: ResolvedScalar, 
         ResolvedScalar::Bool(true) => output.push_str("true"),
         ResolvedScalar::Bool(false) => output.push_str("false"),
         ResolvedScalar::Int(n) => write_i64(output, n),
+        // See `stream_resolved_scalar_as_json`'s matching arm for why this
+        // echoes `str_val` rather than always reconstructing from `f` (#993).
+        // No separate `is_finite()` check needed: `is_preservable_float_literal`
+        // already bounds the digit count well below where a finite `f64`
+        // could overflow, matching `number_literal()`'s identical guard.
+        ResolvedScalar::Float(_) if is_preservable_float_literal(str_val) => {
+            output.push_str(str_val);
+        }
         ResolvedScalar::Float(f) if f.is_finite() => write_f64(output, f),
         // JSON cannot represent the `.inf`/`.nan` family.
         ResolvedScalar::Float(_) => output.push_str("null"),
@@ -3699,12 +3709,13 @@ fn stream_resolved_scalar_as_json<Out: core::fmt::Write>(
         // syntax (`number_literal()` below uses the same predicate for the
         // DOM path) -- this is what keeps a trailing zero (`1.50`) intact;
         // `format_float_with_fraction` only reconstructs the value's
-        // shortest round-trip spelling, which silently drops it (#993).
+        // shortest round-trip spelling, which silently drops it (#993). No
+        // separate `is_finite()` check needed: `is_preservable_float_literal`
+        // already bounds the digit count well below where a finite `f64`
+        // could overflow, matching `number_literal()`'s identical guard.
         // Not `write!(out, "{f}")` either way: that drops the `.0` from a
         // whole float.
-        ResolvedScalar::Float(f) if f.is_finite() && is_preservable_float_literal(str_val) => {
-            out.write_str(str_val)
-        }
+        ResolvedScalar::Float(_) if is_preservable_float_literal(str_val) => out.write_str(str_val),
         ResolvedScalar::Float(f) if f.is_finite() => out.write_str(&format_float_with_fraction(f)),
         // JSON cannot represent the `.inf`/`.nan` family.
         ResolvedScalar::Float(_) => out.write_str("null"),
@@ -10603,6 +10614,27 @@ mod tests {
             }
         }
         panic!("Could not find value");
+    }
+
+    /// #993: the buffered (`to_json`/`write_resolved_scalar_as_json`) and
+    /// streaming (`stream_json`/`stream_resolved_scalar_as_json`) JSON
+    /// emitters must agree on a float literal's trailing zero, same as the
+    /// custom-tag lockstep check above. An earlier version of this fix
+    /// updated only the streaming twin, leaving the buffered one -- reached
+    /// by the public `YamlCursor::to_json()`/`to_json_document()` API and
+    /// `tests/yaml_test_suite.rs`'s conformance harness, though not by the
+    /// `succinctly yq` CLI itself -- silently diverging on exactly this
+    /// input.
+    #[test]
+    fn test_float_trailing_zero_lockstep_between_emitters_993() {
+        let yaml = b"a: 1.50\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let root = index.root(yaml);
+        assert_eq!(root.to_json_document(), r#"{"a":1.50}"#);
+        let mut streamed = String::new();
+        root.stream_json_document(&mut streamed, IndentSpec::COMPACT, false)
+            .expect("streams");
+        assert_eq!(streamed, r#"{"a":1.50}"#);
     }
 
     #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11036,6 +11036,70 @@ fn test_tag_yq_leading_dot_float_is_not_confused_for_null_918() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// M2 JSON-output float literal fidelity — #993
+// =============================================================================
+
+/// A bare `.field` navigation query stays on the M2 fast path
+/// (`can_json_fast_path`), which streams straight from
+/// `stream_resolved_scalar_as_json` rather than materializing an
+/// `OwnedValue` -- a different code path than the `#918` tests above (which
+/// force the DOM path via `[.]` array construction). Before this fix, that
+/// streamer always reconstructed a float's text from the parsed `f64`
+/// (`format_float_with_fraction`), silently dropping a source literal's
+/// trailing zero even though default (YAML) output preserved it correctly.
+/// Both sides pinned against the real yq oracle (v4.53.3).
+#[test]
+fn test_m2_json_output_preserves_float_trailing_zero_993() -> Result<()> {
+    for (yaml, want) in [
+        ("a: 1.50\n", "1.50"),
+        ("a: 1.500\n", "1.500"),
+        ("a: 0.10\n", "0.10"),
+        ("a: 1.0\n", "1.0"),
+    ] {
+        let (out, code) = run_yq_stdin(".a", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(out.trim(), want, "for {yaml:?}");
+
+        // Default YAML output was already correct; this fix must not change it.
+        let (yaml_out, code) = run_yq_stdin(".a", yaml, &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(yaml_out.trim(), want, "yaml output regressed for {yaml:?}");
+    }
+    Ok(())
+}
+
+/// Same fix, whole-document identity query rather than field access --
+/// `stream_resolved_scalar_as_json` is reached the same way either way, but
+/// the issue's own repro used `.` and this locks in that exact shape too.
+#[test]
+fn test_m2_json_output_preserves_float_trailing_zero_whole_doc_993() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: 1.50\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":1.50}"#);
+    Ok(())
+}
+
+/// Non-regression: spellings `is_preservable_float_literal` deliberately
+/// excludes (exponent notation, more than 17 significant digits) must keep
+/// falling back to `format_float_with_fraction` exactly as before -- this
+/// fix only widens which literals get echoed, never narrows it.
+#[test]
+fn test_m2_json_output_float_fallback_unaffected_by_993() -> Result<()> {
+    for (yaml, want) in [
+        // Exponent notation: excluded by `is_preservable_float_literal`
+        // itself (unrelated follow-up scope, #1008), unaffected either way.
+        ("a: 007e2\n", "700.0"),
+        // More significant digits than an f64 actually holds.
+        ("a: 1.2345678901234567890123\n", "1.2345678901234567"),
+    ] {
+        let (out, code) = run_yq_stdin(".a", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(out.trim(), want, "for {yaml:?}");
+    }
+    Ok(())
+}
+
 /// #917: real yq (confirmed live against the pinned v4.53.3) never raises a
 /// type-mismatch error for `has()` -- a string key on an array, a numeric
 /// key on an object, and any key at all on a bare scalar are all `false`,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11087,9 +11087,14 @@ fn test_m2_json_output_preserves_float_trailing_zero_whole_doc_993() -> Result<(
 #[test]
 fn test_m2_json_output_float_fallback_unaffected_by_993() -> Result<()> {
     for (yaml, want) in [
-        // Exponent notation: excluded by `is_preservable_float_literal`
-        // itself (unrelated follow-up scope, #1008), unaffected either way.
-        ("a: 007e2\n", "700.0"),
+        // Exponent notation: `is_preservable_float_literal` requires a `.`
+        // with no `e`/`E` at all, so a literal with both (unlike `007e2`,
+        // which has no `.` and is rejected before the exponent check is
+        // ever reached) is the one that actually exercises that exclusion.
+        // Reformatting scientific notation here is itself a separate,
+        // already-filed gap (#1008) -- this only pins that this fix leaves
+        // that pre-existing fallback behavior unchanged.
+        ("a: 1.5e2\n", "150.0"),
         // More significant digits than an f64 actually holds.
         ("a: 1.2345678901234567890123\n", "1.2345678901234567"),
     ] {


### PR DESCRIPTION
## Summary

- `stream_resolved_scalar_as_json` — the M2 fast path's JSON scalar writer
  (used by ordinary `.field`/`.`/navigation queries when `-o json` is
  requested) — always reconstructed a float's text from its parsed `f64` via
  `format_float_with_fraction`, silently dropping any extra trailing zero a
  source literal carried (`1.50` → `1.5`), even though default (YAML) output
  preserved the same literal correctly through a different writer.
- Fixed by echoing the source text when `is_preservable_float_literal`
  confirms it's safe — the exact predicate the DOM path's existing
  `number_literal()` mechanism already uses for the same decision (#918),
  so this doesn't introduce a new preservation policy, just applies the
  existing one to a writer that had been missing it.
- Deliberately does not touch the cases `is_preservable_float_literal`
  excludes on purpose (exponent notation — that's #1008's separate scope;
  >17 significant digits) — those keep falling back to
  `format_float_with_fraction` exactly as before.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New CLI tests in `tests/yq_cli_tests.rs`: the issue's own repro
      (`.a` and whole-doc `.`), a non-regression check that excluded
      spellings (exponent, >17 digits) keep their existing fallback
      behavior, and a check that default YAML output (already correct)
      didn't regress
- [x] Spot-checked live against real `yq` v4.53.3

Fixes #993