### PR TITLE
test(jq): pin strptime's correct weekday for century-non-leap years

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34683,6 +34683,48 @@ mod tests {
         );
     }
 
+    /// #970: `strptime`'s weekday (`checked_days_from_civil`, #912's shared
+    /// Howard Hinnant `days_from_civil` formula) is astronomically correct
+    /// for every century-non-leap year (1900, 2100, 2200, 2300, ...) —
+    /// verified against macOS's own `date -j` command and independently
+    /// cross-checked by hand via Zeller's congruence.
+    ///
+    /// This is a deliberate divergence from jq's own **macOS/BSD** build,
+    /// not a succinctly bug: jq's `src/builtin.c` `set_tm_wday()` (a
+    /// hand-rolled Gauss's-algorithm fallback) carries its own doc comment
+    /// admitting it "produces the wrong day-of-the-week number for dates
+    /// in the range 1900-01-01..1900-02-28, and for 2100-01-01..2100-02-28"
+    /// — and jq's macOS build *always* uses this fallback (unlike Linux,
+    /// which only falls back to it if glibc's own `strptime()` left
+    /// `tm_wday` unset, which it doesn't). So jq's own weekday output for
+    /// this date range is platform-dependent, and the macOS build is the
+    /// one jq's own maintainers call wrong — confirmed by diffing jq's
+    /// output against this test's dates: jq-on-macOS gives one day
+    /// earlier for every date below except the two `-03-01` boundary
+    /// dates, where the bug self-corrects (matching jq's own comment
+    /// exactly). Decision (John Ky, issue #970): keep succinctly's
+    /// correct behavior rather than reproduce jq's platform-specific bug.
+    #[test]
+    fn test_strptime_weekday_correct_for_century_non_leap_years_970() {
+        for (date, expected_weekday) in [
+            ("1900-01-01", 1), // Monday; jq-macOS wrongly gives 0 (Sunday)
+            ("1900-02-28", 3), // Wednesday; jq-macOS wrongly gives 2 (Tuesday)
+            ("1900-03-01", 4), // Thursday; bug self-corrects here
+            ("2100-01-01", 5), // Friday; jq-macOS wrongly gives 4 (Thursday)
+            ("2100-02-28", 0), // Sunday; jq-macOS wrongly gives 6 (Saturday)
+            ("2100-03-01", 1), // Monday; bug self-corrects here
+            ("2200-02-15", 6), // Saturday; jq-macOS wrongly gives 5 (Friday)
+            ("2300-02-15", 4), // Thursday; jq-macOS wrongly gives 3 (Wednesday)
+        ] {
+            let input = format!("\"{date}\"");
+            query!(input.as_bytes(), r#"strptime("%Y-%m-%d")[6]"#,
+                QueryResult::Owned(OwnedValue::Int(weekday)) => {
+                    assert_eq!(weekday, expected_weekday, "date: {date}");
+                }
+            );
+        }
+    }
+
     #[test]
     fn test_todate() {
         // todate converts timestamp to ISO 8601 string


### PR DESCRIPTION
## Summary

#968/#912's investigation raised whether succinctly's \`strptime\` weekday computation was off-by-one for century-non-leap years (1900, 2100, ...), based on a diff against this machine's pinned jq oracle. Investigation found the premise inverted: succinctly's \`checked_days_from_civil\` (Howard Hinnant's \`days_from_civil\`, extracted in #912) is astronomically correct; jq's own macOS/BSD build has a documented, admitted bug for exactly this date range (\`src/builtin.c\`'s \`set_tm_wday()\` comment says so verbatim), and always uses that buggy fallback on macOS — unlike Linux, where a working glibc \`strptime()\` means the fallback is never reached.

Confirmed live: jq-on-macOS gives one day earlier than the astronomically correct weekday for every date in Jan 1 – Feb 28 of a century-non-leap year, self-correcting from March 1 onward (matching jq's own source comment exactly) — verified against macOS's own \`date -j\` command and independently cross-checked by hand via Zeller's congruence.

Decision (issue #970, John Ky): keep succinctly's correct behavior rather than reproduce jq's platform-specific bug, and pin it with a test noting jq's own divergence so a future contributor comparing against a local macOS jq binary doesn't misdiagnose this range as a regression again.

Fixes #970

## Test plan

- [x] New test: \`test_strptime_weekday_correct_for_century_non_leap_years_970\`, covering 8 dates across 4 century-non-leap years (1900, 2100, 2200, 2300), including both bug-range dates and the March 1 self-correction boundary
- [x] All 8 expected values verified against both the built binary and macOS's own \`date -j\` command before writing the test
- [x] Full local suite: \`cargo test --features cli,simd,regex,serde\` — 54/54 suites pass
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` clean