### PR TITLE
fix(jq): guard reduce/foreach-constructed values against stack overflow

### DIFF
--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -9,7 +9,7 @@ use succinctly::jq::escape::{
     escape_json_body as run_escaper, write_json_body_jq, write_json_body_jq_ascii,
     write_json_body_yq, write_json_body_yq_ascii,
 };
-use succinctly::jq::{EvalError, OwnedValue, StreamError};
+use succinctly::jq::{assert_value_tree_depth, EvalError, OwnedValue, StreamError};
 use succinctly::yaml::format_float_with_fraction;
 
 /// Exit codes matching jq behavior
@@ -365,7 +365,14 @@ pub fn format_float_yq(f: f64) -> String {
 }
 
 /// Recursive JSON formatter behind [`format_json`].
+///
+/// Panics past `succinctly::jq::MAX_VALUE_TREE_DEPTH` levels of nesting
+/// (#1005) — see that constant's own doc comment for why. `value` is the
+/// filter's evaluated output, constructible via `reduce`/`foreach`/etc.
+/// with no adversarial document involved; `serde_json`'s own input-depth
+/// limit (used elsewhere on this eager-output path) never sees it.
 fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> String {
+    assert_value_tree_depth(level);
     let indent = opts.indent;
     let compact = indent.is_empty();
     let current_indent = if compact {
@@ -1210,5 +1217,43 @@ mod tests {
         // Diagnostic output; assert it runs without panicking for both tools.
         print_build_configuration("jq");
         print_build_configuration("yq");
+    }
+
+    /// `depth` levels of single-element array nesting: `[[[...[Null]...]]]`.
+    fn linear_array_nest(depth: usize) -> OwnedValue {
+        let mut v = OwnedValue::Null;
+        for _ in 0..depth {
+            v = OwnedValue::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1005: `value` is a filter's evaluated output (e.g. a `reduce`
+    /// accumulator growing one level per iteration), which has no
+    /// adversarial *document* behind it — `format_json_impl` must
+    /// independently refuse to recurse past the same limit rather than
+    /// overflow the stack.
+    #[test]
+    fn format_json_panics_past_nesting_depth_limit_1005() {
+        use succinctly::jq::MAX_VALUE_TREE_DEPTH;
+
+        let opts = JsonFormatOpts {
+            indent: "",
+            sort_keys: false,
+            ascii: false,
+            float_style: FloatStyle::Shortest,
+            control_escape: ControlEscape::Jq,
+        };
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let _ = format_json(&under, &opts);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| format_json(&over, &opts)));
+        assert!(
+            result.is_err(),
+            "format_json should panic at MAX_VALUE_TREE_DEPTH"
+        );
     }
 }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -15,7 +15,8 @@ use succinctly::jq::eval_generic::{
     GenericResult,
 };
 use succinctly::jq::{
-    self, sync_aliased_paths, Builtin, EvalError, Expr, OwnedValue, QueryResult, YqSemantics,
+    self, assert_value_tree_depth, sync_aliased_paths, Builtin, EvalError, Expr, OwnedValue,
+    QueryResult, YqSemantics,
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
@@ -812,6 +813,20 @@ fn reconcile_presentation(
     pristine_tree: &CommentTree,
     result_value: &OwnedValue,
 ) -> CommentTree {
+    reconcile_presentation_at_depth(pristine_value, pristine_tree, result_value, 0)
+}
+
+/// Panics past `succinctly::jq::MAX_VALUE_TREE_DEPTH` levels of nesting
+/// (#1005) — see that constant's own doc comment for why. `result_value` is
+/// the evaluated filter output, which can be constructed via `reduce`/
+/// `foreach`/etc. with no adversarial document involved on either side.
+fn reconcile_presentation_at_depth(
+    pristine_value: &OwnedValue,
+    pristine_tree: &CommentTree,
+    result_value: &OwnedValue,
+    depth: usize,
+) -> CommentTree {
+    assert_value_tree_depth(depth);
     match (pristine_value, result_value) {
         (OwnedValue::Object(p_fields), OwnedValue::Object(r_fields)) => {
             let own_comment = pristine_tree.own().map(str::to_string);
@@ -820,7 +835,9 @@ fn reconcile_presentation(
             let mut key_comments = IndexMap::new();
             for (k, r_v) in r_fields {
                 let child = match p_fields.get(k) {
-                    Some(p_v) => reconcile_presentation(p_v, pristine_tree.field(k), r_v),
+                    Some(p_v) => {
+                        reconcile_presentation_at_depth(p_v, pristine_tree.field(k), r_v, depth + 1)
+                    }
                     None => CommentTree::empty(),
                 };
                 fields.insert(k.clone(), child);
@@ -852,7 +869,12 @@ fn reconcile_presentation(
                 .iter()
                 .enumerate()
                 .map(|(i, r_v)| match p_items.get(i) {
-                    Some(p_v) => reconcile_presentation(p_v, pristine_tree.at_index(i), r_v),
+                    Some(p_v) => reconcile_presentation_at_depth(
+                        p_v,
+                        pristine_tree.at_index(i),
+                        r_v,
+                        depth + 1,
+                    ),
                     None => CommentTree::empty(),
                 })
                 .collect();
@@ -4281,5 +4303,40 @@ mod tests {
         } else {
             panic!("expected object, got {:?}", results[0]);
         }
+    }
+
+    /// `depth` levels of single-element array nesting: `[[[...[Null]...]]]`.
+    fn linear_array_nest(depth: usize) -> OwnedValue {
+        let mut v = OwnedValue::Null;
+        for _ in 0..depth {
+            v = OwnedValue::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1005: `result_value` is a filter's evaluated output (e.g. a
+    /// `reduce` accumulator growing one level per iteration), which has no
+    /// adversarial *document* behind it — `reconcile_presentation` must
+    /// independently refuse to recurse past the same limit rather than
+    /// overflow the stack. `pristine_tree` is `CommentTree::empty()` here
+    /// since only `pristine_value`'s/`result_value`'s own nesting drives
+    /// the recursion depth (`CommentTree::at_index` on a non-`Array` variant
+    /// falls back to the empty tree at every level, which is exactly what a
+    /// computed value with no live cursor of its own already looks like).
+    #[test]
+    fn reconcile_presentation_panics_past_nesting_depth_limit_1005() {
+        use succinctly::jq::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let _ = reconcile_presentation(&under, &CommentTree::empty(), &under);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            reconcile_presentation(&over, &CommentTree::empty(), &over)
+        }));
+        assert!(
+            result.is_err(),
+            "reconcile_presentation should panic at MAX_VALUE_TREE_DEPTH"
+        );
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -131,7 +131,8 @@ use super::expr::{
     ObjectKey, Pattern, StringPart,
 };
 use super::value::{
-    cmp_f64, format_number_jq_compat, is_nan_sentinel, numeric_repr_cmp, NumberRepr, OwnedValue,
+    assert_value_tree_depth, cmp_f64, format_number_jq_compat, is_nan_sentinel, numeric_repr_cmp,
+    NumberRepr, OwnedValue,
 };
 
 /// Result of evaluating a jq expression.
@@ -325,7 +326,29 @@ fn type_name<W>(value: &StandardJson<'_, W>) -> &'static str {
 }
 
 /// Convert a StandardJson value to an OwnedValue.
+///
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1005) — see that constant's own doc comment for why
+/// this uses a different ceiling than `eval_generic::to_owned`'s own guard
+/// (#998). This is a second, independent copy of that same
+/// cursor-to-`OwnedValue` conversion; document-sourced input is protected
+/// transitively (it already passed through `eval_generic`'s guarded
+/// conversion before reaching this evaluator), but a value this module
+/// constructs internally afterward (a `reduce`/`foreach`/`while`/`until`/
+/// `repeat` accumulator, growing one level per loop iteration) reaches this
+/// copy directly and bypasses that upfront guard entirely — as does
+/// ordinary deep `..`/`recurse` document navigation, which is why this
+/// needs the higher, separately-tuned ceiling rather than
+/// `eval_generic::MAX_NESTING_DEPTH`.
 fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> OwnedValue {
+    to_owned_at_depth(value, 0)
+}
+
+fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
+    value: &StandardJson<'_, W>,
+    depth: usize,
+) -> OwnedValue {
+    assert_value_tree_depth(depth);
     match value {
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(*b),
@@ -338,7 +361,9 @@ fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> OwnedValue 
             }
         }
         StandardJson::Array(elements) => {
-            let items: Vec<OwnedValue> = (*elements).map(|e| to_owned(&e)).collect();
+            let items: Vec<OwnedValue> = (*elements)
+                .map(|e| to_owned_at_depth(&e, depth + 1))
+                .collect();
             OwnedValue::Array(items)
         }
         StandardJson::Object(fields) => {
@@ -347,7 +372,10 @@ fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> OwnedValue 
                 // Get the key as a string
                 if let StandardJson::String(key_str_val) = field.key() {
                     if let Ok(cow) = key_str_val.as_str() {
-                        map.insert(cow.into_owned(), to_owned(&field.value()));
+                        map.insert(
+                            cow.into_owned(),
+                            to_owned_at_depth(&field.value(), depth + 1),
+                        );
                     }
                 }
             }
@@ -2085,7 +2113,24 @@ fn apply_compare_op(op: CompareOp, left: &OwnedValue, right: &OwnedValue) -> boo
 /// adjacent elements, so neither has any panic surface at all. See
 /// `test_sort_many_nans_does_not_panic_421`.
 pub(crate) fn compare_values(left: &OwnedValue, right: &OwnedValue) -> core::cmp::Ordering {
+    compare_values_at_depth(left, right, 0)
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1005) — see that constant's own doc comment for why
+/// this uses a different ceiling than `eval_generic::to_owned`'s guard
+/// (#998). Needed because a value `reduce`/`foreach`/`while`/`until`/
+/// `repeat` build up at query-evaluation time bypasses #998's
+/// document-input guards entirely: no adversarial document is involved,
+/// only enough loop iterations to grow the accumulator past the limit.
+fn compare_values_at_depth(
+    left: &OwnedValue,
+    right: &OwnedValue,
+    depth: usize,
+) -> core::cmp::Ordering {
     use core::cmp::Ordering;
+
+    assert_value_tree_depth(depth);
 
     let left_type = sort_rank(left);
     let right_type = sort_rank(right);
@@ -2115,7 +2160,7 @@ pub(crate) fn compare_values(left: &OwnedValue, right: &OwnedValue) -> core::cmp
         (OwnedValue::String(a), OwnedValue::String(b)) => a.cmp(b),
         (OwnedValue::Array(a), OwnedValue::Array(b)) => {
             for (av, bv) in a.iter().zip(b.iter()) {
-                match compare_values(av, bv) {
+                match compare_values_at_depth(av, bv, depth + 1) {
                     Ordering::Equal => continue,
                     other => return other,
                 }
@@ -2134,7 +2179,7 @@ pub(crate) fn compare_values(left: &OwnedValue, right: &OwnedValue) -> core::cmp
                 other => return other,
             }
             for k in a_keys {
-                match compare_values(&a[k], &b[k]) {
+                match compare_values_at_depth(&a[k], &b[k], depth + 1) {
                     Ordering::Equal => continue,
                     other => return other,
                 }
@@ -39826,5 +39871,72 @@ mod tests {
         // re-scanning from byte 0.
         assert_eq!(cursor.byte, input.len());
         assert_eq!(cursor.chars, input.chars().count());
+    }
+
+    /// `depth` levels of single-element array nesting: `[[[...[Null]...]]]`.
+    fn linear_array_nest(depth: usize) -> OwnedValue {
+        let mut v = OwnedValue::Null;
+        for _ in 0..depth {
+            v = OwnedValue::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1005: a value built at query-evaluation time (e.g. a `reduce`
+    /// accumulator growing one level per iteration) has no adversarial
+    /// *document* behind it, so #998's input-side guards never see it —
+    /// `compare_values` must independently refuse to recurse past the same
+    /// limit rather than overflow the stack.
+    #[test]
+    fn compare_values_panics_past_nesting_depth_limit_1005() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under_a = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let under_b = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert_eq!(
+            compare_values(&under_a, &under_b),
+            core::cmp::Ordering::Equal
+        );
+
+        let over_a = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let over_b = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            compare_values(&over_a, &over_b)
+        }));
+        assert!(
+            result.is_err(),
+            "compare_values should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1005: `eval.rs`'s own private `to_owned` is a second, independent
+    /// copy of `eval_generic::to_owned`'s cursor-to-`OwnedValue` conversion
+    /// — #998 guarded that one, not this one. Document-sourced input is
+    /// protected transitively (already converted once via the guarded
+    /// copy), but this copy is reachable directly on values this module
+    /// constructs internally, so it needs its own independent guard.
+    #[test]
+    fn eval_rs_to_owned_panics_past_nesting_depth_limit_1005() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        fn linear_nest(depth: usize) -> String {
+            format!("{}{{}}{}", "{\"k\":".repeat(depth), "}".repeat(depth))
+        }
+
+        let json = linear_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let owned = to_owned(&cursor.value());
+        assert!(matches!(owned, OwnedValue::Object(_)));
+
+        let json = linear_nest(MAX_VALUE_TREE_DEPTH);
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let value = cursor.value();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| to_owned(&value)));
+        assert!(
+            result.is_err(),
+            "to_owned should panic at MAX_VALUE_TREE_DEPTH"
+        );
     }
 }

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -96,4 +96,6 @@ pub use parser::{
     parse, parse_program, parse_program_with_mode, parse_with_mode, ParseError, ParserMode,
 };
 pub use stream::{StreamError, StreamStats, StreamableValue};
-pub use value::{format_number_jq_compat, NumberRepr, OwnedValue};
+pub use value::{
+    assert_value_tree_depth, format_number_jq_compat, NumberRepr, OwnedValue, MAX_VALUE_TREE_DEPTH,
+};

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -42,10 +42,14 @@ use super::expr::Literal;
 /// `eval.rs`'s own `to_owned` between 1800-2000. Reusing 256 here would be
 /// wrong in the *other* direction: 256 does not clear
 /// `tests/jq_recurse_depth_tests.rs`'s deliberately-pinned depth-300
-/// document-navigation capability (#626's de-risk step for
-/// `push_recursive_branches`/`resolve_recurse`), which routes through
-/// `eval.rs`'s own `to_owned` during ordinary `..`/`recurse` traversal, not
-/// just query-time-constructed accumulator growth.
+/// correctness capability for `path(..)`/`path(recurse)` (#626's de-risk
+/// step for `push_recursive_branches`/`resolve_recurse`), which that test
+/// exercises via the library's own `eval()` entry point and which routes
+/// through `eval.rs`'s own `to_owned` — a real, tested capability of this
+/// crate's public API, independent of whether the `succinctly` CLI binary's
+/// own document-parsing entry point happens to hit a different, earlier
+/// guard (`eval_generic::MAX_NESTING_DEPTH`, unaffected by this constant)
+/// first for the same document depth.
 ///
 /// 384, not 300: needs margin above the pinned floor for the same reason
 /// `eval_generic`'s own 256 needed margin above its 200-deep `walk` floor

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -22,6 +22,51 @@ use indexmap::IndexMap;
 use super::escape::{escape_json_body, write_json_body_jq};
 use super::expr::Literal;
 
+/// Recursion-depth ceiling for tree-walkers over an already-materialized
+/// [`OwnedValue`] (#1005).
+///
+/// Guards [`OwnedValue::to_json`]/`to_json_for_reindex`/`==`/
+/// `eval::compare_values`/`eval.rs`'s own `to_owned`/
+/// `yq_runner::reconcile_presentation`/`output::format_json_impl`.
+///
+/// Deliberately a *separate* constant from
+/// [`eval_generic::MAX_NESTING_DEPTH`](super::eval_generic::MAX_NESTING_DEPTH)
+/// (256), not a reuse of it: that ceiling guards cursor-to-`OwnedValue`
+/// *conversion* functions, individually tuned against their own measured
+/// crash boundaries (600-700 for the tightest of that set, `print_json`).
+/// This constant's own guarded functions are a different shape with
+/// different measured boundaries (debug build, default 2MiB test-thread
+/// stack — the more fragile of debug/release, matching how 256 was itself
+/// measured): `reconcile_presentation` crashes between depth 580-600 (the
+/// tightest of this set), `format_json_impl` between 650-700, and
+/// `eval.rs`'s own `to_owned` between 1800-2000. Reusing 256 here would be
+/// wrong in the *other* direction: 256 does not clear
+/// `tests/jq_recurse_depth_tests.rs`'s deliberately-pinned depth-300
+/// document-navigation capability (#626's de-risk step for
+/// `push_recursive_branches`/`resolve_recurse`), which routes through
+/// `eval.rs`'s own `to_owned` during ordinary `..`/`recurse` traversal, not
+/// just query-time-constructed accumulator growth.
+///
+/// 384, not 300: needs margin above the pinned floor for the same reason
+/// `eval_generic`'s own 256 needed margin above its 200-deep `walk` floor
+/// (256 is `200 * 1.28`; 384 is `300 * 1.28`, the same proportional
+/// headroom) — while staying comfortably under 580, the tightest of this
+/// set's measured boundaries, with margin to spare for a CI runner with a
+/// smaller default stack than the dev machine this was measured on.
+pub const MAX_VALUE_TREE_DEPTH: usize = 384;
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`] levels of nesting (#1005).
+///
+/// See that constant's own doc comment for why this exists as a second,
+/// independently-tuned ceiling alongside
+/// [`eval_generic::assert_nesting_depth`](super::eval_generic::assert_nesting_depth).
+pub fn assert_value_tree_depth(depth: usize) {
+    assert!(
+        depth < MAX_VALUE_TREE_DEPTH,
+        "nesting depth exceeds limit of {MAX_VALUE_TREE_DEPTH}"
+    );
+}
+
 /// The parsed value backing a [`OwnedValue::NumberLiteral`], kept separate
 /// from the source text so arithmetic/comparison can read it without
 /// touching the `Box<str>`.
@@ -640,7 +685,19 @@ impl OwnedValue {
     }
 
     /// Format this value as JSON string.
+    ///
+    /// Panics past [`MAX_VALUE_TREE_DEPTH`] levels of nesting (#1005) — see
+    /// that constant's own doc comment for why. Needed because a value
+    /// `reduce`/`foreach`/`while`/`until`/`repeat` build up at
+    /// query-evaluation time bypasses #998's document-input guards
+    /// entirely: no adversarial document is involved, only enough loop
+    /// iterations to grow the accumulator past the limit.
     pub fn to_json(&self) -> String {
+        self.to_json_at_depth(0)
+    }
+
+    fn to_json_at_depth(&self, depth: usize) -> String {
+        assert_value_tree_depth(depth);
         match self {
             Self::Null => "null".into(),
             Self::Bool(true) => "true".into(),
@@ -659,7 +716,8 @@ impl OwnedValue {
             Self::NumberLiteral(_, literal) => format_number_jq_compat(literal.as_bytes()),
             Self::String(s) => format!("\"{}\"", escape_json_body(write_json_body_jq, s)),
             Self::Array(arr) => {
-                let elements: Vec<String> = arr.iter().map(Self::to_json).collect();
+                let elements: Vec<String> =
+                    arr.iter().map(|v| v.to_json_at_depth(depth + 1)).collect();
                 format!("[{}]", elements.join(","))
             }
             Self::Object(obj) => {
@@ -669,7 +727,7 @@ impl OwnedValue {
                         format!(
                             "\"{}\":{}",
                             escape_json_body(write_json_body_jq, k),
-                            v.to_json()
+                            v.to_json_at_depth(depth + 1)
                         )
                     })
                     .collect();
@@ -690,6 +748,18 @@ impl OwnedValue {
     /// the bridge re-parses this text and hands the cursor to the full
     /// evaluator (#561, #472).
     pub(crate) fn to_json_for_reindex(&self) -> String {
+        self.to_json_for_reindex_at_depth(0)
+    }
+
+    /// Panics past [`MAX_VALUE_TREE_DEPTH`] levels of nesting (#1005) — see
+    /// that constant's own doc comment for why, and
+    /// [`to_json_at_depth`](Self::to_json_at_depth), which this mirrors.
+    /// This function's own callers (`reduce`/`foreach`/etc.'s per-iteration
+    /// reindex bridge) are exactly the ones that grow a value one level
+    /// deeper per loop iteration with no adversarial document involved, so
+    /// it needs the same guard [`to_json`](Self::to_json) does.
+    fn to_json_for_reindex_at_depth(&self, depth: usize) -> String {
+        assert_value_tree_depth(depth);
         match self {
             Self::Float(f) if f.is_nan() => NAN_SENTINEL.to_string(),
             Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() => NAN_SENTINEL.to_string(),
@@ -728,7 +798,10 @@ impl OwnedValue {
                 }
             }
             Self::Array(arr) => {
-                let elements: Vec<String> = arr.iter().map(Self::to_json_for_reindex).collect();
+                let elements: Vec<String> = arr
+                    .iter()
+                    .map(|v| v.to_json_for_reindex_at_depth(depth + 1))
+                    .collect();
                 format!("[{}]", elements.join(","))
             }
             Self::Object(obj) => {
@@ -738,13 +811,13 @@ impl OwnedValue {
                         format!(
                             "\"{}\":{}",
                             escape_json_body(write_json_body_jq, k),
-                            v.to_json_for_reindex()
+                            v.to_json_for_reindex_at_depth(depth + 1)
                         )
                     })
                     .collect();
                 format!("{{{}}}", entries.join(","))
             }
-            other => other.to_json(),
+            other => other.to_json_at_depth(depth),
         }
     }
 }
@@ -909,25 +982,57 @@ pub(crate) fn numeric_repr_cmp(a: NumberRepr, b: NumberRepr) -> core::cmp::Order
 
 impl PartialEq for OwnedValue {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Null, Self::Null) => true,
-            (Self::Bool(a), Self::Bool(b)) => a == b,
-            (Self::Int(a), Self::Int(b)) => a == b,
-            (Self::Float(a), Self::Float(b)) => a == b,
-            (Self::Int(a), Self::Float(b)) => (*a as f64) == *b,
-            (Self::Float(a), Self::Int(b)) => *a == (*b as f64),
-            (Self::NumberLiteral(a, _), Self::NumberLiteral(b, _)) => numeric_repr_eq(*a, *b),
-            (Self::NumberLiteral(a, _), Self::Int(b))
-            | (Self::Int(b), Self::NumberLiteral(a, _)) => numeric_repr_eq(*a, NumberRepr::Int(*b)),
-            (Self::NumberLiteral(a, _), Self::Float(b))
-            | (Self::Float(b), Self::NumberLiteral(a, _)) => {
-                numeric_repr_eq(*a, NumberRepr::Float(*b))
-            }
-            (Self::String(a), Self::String(b)) => a == b,
-            (Self::Array(a), Self::Array(b)) => a == b,
-            (Self::Object(a), Self::Object(b)) => a == b,
-            _ => false,
+        owned_value_eq_at_depth(self, other, 0)
+    }
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`] levels of nesting (#1005) — see
+/// that constant's own doc comment for why.
+///
+/// Can't thread a depth counter through [`PartialEq::eq`] itself (the trait
+/// method's signature is fixed), so `Array`/`Object` recurse into this
+/// helper directly rather than delegating to `Vec`'s/`IndexMap`'s own `==`
+/// (which would call back into [`PartialEq::eq`] and silently reset the
+/// depth count to 0 every level, defeating the guard). `Array` mirrors
+/// `Vec`'s own positional `==`; `Object` mirrors `IndexMap`'s own
+/// order-independent `==` (same length, and every key in `a` maps to an
+/// equal value in `b`) — changing either's semantics here would make `==`
+/// disagree with itself depending on nesting depth.
+fn owned_value_eq_at_depth(a: &OwnedValue, b: &OwnedValue, depth: usize) -> bool {
+    assert_value_tree_depth(depth);
+    match (a, b) {
+        (OwnedValue::Null, OwnedValue::Null) => true,
+        (OwnedValue::Bool(a), OwnedValue::Bool(b)) => a == b,
+        (OwnedValue::Int(a), OwnedValue::Int(b)) => a == b,
+        (OwnedValue::Float(a), OwnedValue::Float(b)) => a == b,
+        (OwnedValue::Int(a), OwnedValue::Float(b)) => (*a as f64) == *b,
+        (OwnedValue::Float(a), OwnedValue::Int(b)) => *a == (*b as f64),
+        (OwnedValue::NumberLiteral(a, _), OwnedValue::NumberLiteral(b, _)) => {
+            numeric_repr_eq(*a, *b)
         }
+        (OwnedValue::NumberLiteral(a, _), OwnedValue::Int(b))
+        | (OwnedValue::Int(b), OwnedValue::NumberLiteral(a, _)) => {
+            numeric_repr_eq(*a, NumberRepr::Int(*b))
+        }
+        (OwnedValue::NumberLiteral(a, _), OwnedValue::Float(b))
+        | (OwnedValue::Float(b), OwnedValue::NumberLiteral(a, _)) => {
+            numeric_repr_eq(*a, NumberRepr::Float(*b))
+        }
+        (OwnedValue::String(a), OwnedValue::String(b)) => a == b,
+        (OwnedValue::Array(a), OwnedValue::Array(b)) => {
+            a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| owned_value_eq_at_depth(x, y, depth + 1))
+        }
+        (OwnedValue::Object(a), OwnedValue::Object(b)) => {
+            a.len() == b.len()
+                && a.iter().all(|(k, v)| {
+                    b.get(k)
+                        .is_some_and(|bv| owned_value_eq_at_depth(v, bv, depth + 1))
+                })
+        }
+        _ => false,
     }
 }
 
@@ -1726,5 +1831,56 @@ mod tests {
             "must not render anywhere near the full 2,000,000-digit mantissa: got {} bytes",
             result.len()
         );
+    }
+
+    /// `depth` levels of single-element array nesting: `[[[...[Null]...]]]`.
+    fn linear_array_nest(depth: usize) -> OwnedValue {
+        let mut v = OwnedValue::Null;
+        for _ in 0..depth {
+            v = OwnedValue::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1005: a value built at query-evaluation time (e.g. a `reduce`
+    /// accumulator growing one array level per iteration) has no adversarial
+    /// *document* behind it, so #998's input-side guards never see it -
+    /// `to_json`/`to_json_for_reindex`/`==` must each independently refuse
+    /// to recurse past the same limit rather than overflow the stack.
+    #[test]
+    fn to_json_panics_past_nesting_depth_limit_1005() {
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        // Under the limit: succeeds (doesn't panic).
+        let _ = under.to_json();
+        let _ = under.to_json_for_reindex();
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.to_json()));
+        assert!(
+            result.is_err(),
+            "to_json should panic at MAX_VALUE_TREE_DEPTH"
+        );
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.to_json_for_reindex()));
+        assert!(
+            result.is_err(),
+            "to_json_for_reindex should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1005: `==` recurses through a private depth-tracked helper instead
+    /// of delegating to `Vec`'s/`IndexMap`'s own `==` (which would silently
+    /// reset the depth count every level) - confirm the guard actually
+    /// fires through the `PartialEq` impl, not just when called directly.
+    #[test]
+    fn eq_panics_past_nesting_depth_limit_1005() {
+        let under_a = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let under_b = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert_eq!(under_a, under_b);
+
+        let over_a = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let over_b = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over_a == over_b));
+        assert!(result.is_err(), "== should panic at MAX_VALUE_TREE_DEPTH");
     }
 }


### PR DESCRIPTION
## Summary

`reduce`/`foreach`/`while`/`until`/`repeat` can build a value one level deeper per loop iteration with no adversarial *document* involved — plain `null` input is enough:

```
$ echo null | succinctly yq 'reduce range(50000) as $i (null; [.]) | empty'
thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting   (SIGABRT, exit 134)
```

#998 guarded the document-input conversion path (`eval_generic::to_owned`/`to_owned_cursor`/`to_owned_with_comments`, `print_json`, `lazy::cursor_to_owned`) against adversarially deep *input*. This issue is a structurally different vulnerability: a value constructed at query-evaluation time reaches six entirely different, still-unguarded recursive tree-walkers that #998's fix never touched:

1. `OwnedValue::to_json` (`src/jq/value.rs`) — the confirmed proximate cause; called on every `reduce`/`foreach` accumulator-update iteration via `to_json_for_reindex`.
2. `OwnedValue::to_json_for_reindex` (`src/jq/value.rs`)
3. `OwnedValue`'s `PartialEq`/`==` (`src/jq/value.rs`)
4. `compare_values` (`src/jq/eval.rs`) — reachable from `sort`/`<`/`>`/etc.
5. `eval.rs`'s own private `to_owned<W>` (`src/jq/eval.rs`) — a second, independent copy of the cursor-to-`OwnedValue` conversion, distinct from the one #998 patched in `eval_generic.rs`.
6. `reconcile_presentation` (`src/bin/succinctly/yq_runner.rs`) — `yq -i`'s comment-preserving merge.
7. `format_json_impl` (`src/bin/succinctly/output.rs`) — the eager JSON output formatter.

## Fix

Each function now threads an explicit `depth` parameter through a private `_at_depth` helper (mirroring #998's own pattern) and panics past a depth ceiling rather than recursing unbounded — a controlled panic (catchable, clean exit code) instead of a raw stack overflow (SIGABRT/undefined behavior).

**New, separately-tuned constant** (`value::MAX_VALUE_TREE_DEPTH = 384`), not a reuse of `eval_generic::MAX_NESTING_DEPTH` (256): reusing 256 broke `tests/jq_recurse_depth_tests.rs`'s pre-existing, deliberately-pinned depth-300 document-navigation capability (`..`/`recurse` correctness at depth 300, a #626 de-risk step) — that test routes through eval.rs's own `to_owned` during ordinary traversal, not just accumulator construction, so it needs a higher ceiling. I empirically measured each guarded function's real stack-overflow boundary (debug build, default 2MiB test-thread stack — the more fragile combination, matching how #998's own 256 was measured):

| Function | Measured crash boundary |
|---|---|
| `reconcile_presentation` | 580 (safe) / 600 (crash) — tightest |
| `format_json_impl` | 600 (safe) / 650 (crash) |
| `eval.rs`'s `to_owned` | 1800 (safe) / 2000 (crash) |

384 clears the 300-deep pinned test with the same proportional margin #998's own 256 used to clear its 200-deep `walk` floor (`256 = 200 * 1.28`; `384 = 300 * 1.28`), while sitting comfortably under the tightest measured boundary (580) with margin to spare for a CI runner with a smaller default stack.

## Testing

- New unit test per guarded function (6 total, one per file/function) confirming success just under `MAX_VALUE_TREE_DEPTH` and a panic exactly at it.
- Full `cargo test --features cli,simd,regex,serde` suite green, including `tests/jq_recurse_depth_tests.rs` (previously would have regressed with a naive reuse of the 256 constant — caught locally before this PR, not left in the diff).
- `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings` and the `scalar-yaml`-inclusive second CI invocation both clean.
- Manually confirmed the original repro now exits 101 with a clean panic message instead of SIGABRT/134.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, including new #1005 tests and `jq_recurse_depth_tests.rs`)
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual repro verification (both the original crash and the depth-300 regression test)

Fixes #1005