### PR TITLE
fix(cli): restore M2 streaming for JSON input, fixing duplicate-key collapse

### DIFF
--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -11,6 +11,7 @@ use succinctly::jq::escape::{
 };
 use succinctly::jq::{assert_value_tree_depth, EvalError, OwnedValue, StreamError};
 use succinctly::yaml::format_float_with_fraction;
+pub use succinctly::yaml::format_float_yq;
 
 /// Exit codes matching jq behavior
 pub mod exit_codes {
@@ -316,52 +317,6 @@ fn escape_json_body(s: &str, opts: &JsonFormatOpts) -> String {
 /// Format a value as JSON text (compact or pretty, per `opts`).
 pub fn format_json(value: &OwnedValue, opts: &JsonFormatOpts) -> String {
     format_json_impl(value, opts, 0)
-}
-
-/// Renders a computed (non-literal-preserved) `f64` the way real yq does:
-/// decimal for everyday magnitudes, scientific notation once the value's
-/// decimal exponent is `>= 6` or `<= -5`.
-///
-/// Only for [`OwnedValue::Float`] -- a value with no source literal left to
-/// preserve, either because it was actually computed (arithmetic) or because
-/// it came from JSON input, which real yq always re-serializes through
-/// float64 rather than preserving spelling. [`OwnedValue::NumberLiteral`]
-/// (YAML-sourced identity/navigation output) keeps its own source spelling
-/// regardless of magnitude and must never route through this function --
-/// confirmed against real yq v4.53.3: `12345678901234567890123` (a decimal
-/// literal) stays fully expanded on identity, while the equivalent
-/// *computed* magnitude switches to scientific notation. See issue #997.
-///
-/// The threshold and the `e+NN`/`e-NN` (lowercase, signed, exponent padded
-/// to at least 2 digits) spelling are both oracle-verified against real yq;
-/// this is yq's own threshold, distinct from `format_number_jq_compat`'s
-/// jq-mode one (which real jq only reformats when the source literal itself
-/// already used exponent notation).
-///
-/// `f` must be finite -- like [`format_float_with_fraction`], this has no
-/// JSON/YAML-specific spelling for NaN/Infinity to fall back on, so every
-/// caller must special-case those first (both current call sites already
-/// do, ahead of this function).
-#[must_use]
-pub fn format_float_yq(f: f64) -> String {
-    debug_assert!(
-        f.is_finite(),
-        "format_float_yq requires a finite value; NaN/Infinity have no \
-         JSON/YAML spelling here and must be special-cased by the caller"
-    );
-    let sci = format!("{f:e}");
-    let (mantissa, exp_str) = sci
-        .split_once('e')
-        .expect("Rust's exponential formatter always includes a lowercase 'e'");
-    let exp: i32 = exp_str
-        .parse()
-        .expect("exponent from Rust's exponential formatter is always a valid i32");
-    if (-4..6).contains(&exp) {
-        format_float_with_fraction(f)
-    } else {
-        let sign = if exp < 0 { '-' } else { '+' };
-        format!("{mantissa}e{sign}{:02}", exp.abs())
-    }
 }
 
 /// Recursive JSON formatter behind [`format_json`].

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2517,47 +2517,25 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // `Auto` whenever the user relies on `.json`-extension detection
     // instead of typing `--input-format json` explicitly, which
     // `resolve_input_format` (used everywhere else JSON input is handled)
-    // still correctly resolves to `Json`. The M2 gates below need that
-    // same resolution, not the raw flag, or a bare `succinctly yq '.'
-    // file.json` (arguably the more common way to hit this than the
-    // explicit flag) would still leak. Conservative for a mixed-format
-    // multi-file `--inplace`/`--doc` invocation (`-i '.' a.yaml b.json`):
-    // this disables M2 for every file, not just the JSON one(s), since
-    // `is_m2_streamable`/`can_slurp_fast_path` are single, run-wide
-    // booleans with no per-file M2-vs-DOM switch to hook into instead.
-    let any_input_is_json = if input_files.is_empty() {
-        resolve_input_format(args.input_format, None) == InputFormat::Json
-    } else {
-        input_files.iter().any(|f| {
-            resolve_input_format(args.input_format, Some(Path::new(f))) == InputFormat::Json
-        })
-    };
-    // every M2 fast path below streams a scalar's *value* straight
-    // from the parsed cursor rather than materializing an OwnedValue, and
-    // neither streamer (JSON or YAML output) reliably discards a JSON
-    // number's own decimal-point/exponent spelling the way the DOM path's
-    // canonicalize_json_numbers now does - `can_json_fast_path`'s
-    // stream_resolved_scalar_as_json still keeps a computed whole-number
-    // float's trailing `.0` (matching #918's YAML convention, wrong for
-    // JSON input: `1e2` -> `100.0`, real yq gives `100`), and
-    // `can_yaml_fast_path`'s streamer echoes the raw source span outright
-    // (`1.50` stays `1.50`). Real yq never preserves a JSON-sourced
-    // number's literal spelling at all, so JSON input (explicit flag or
-    // resolved from a `.json` extension - see `any_input_is_json` above)
-    // always falls back to the (already-fixed) DOM path instead.
+    // still correctly resolves to `Json`. `mark_json_sourced_indices`
+    // below needs that same resolution, not the raw flag, or a bare
+    // `succinctly yq '.' file.json` (arguably the more common way to hit
+    // this than the explicit flag) would still leak the #978 bug back in.
     //
-    // Known trade-off (#996): the DOM path's `OwnedValue::Object` is
-    // `IndexMap`-backed and can't represent duplicate keys, unlike M2
-    // streaming, which never materializes a map at all and so happened to
-    // preserve them - `{"a":1,"a":2}` correctly stays that way through M2
-    // (matching real yq) but collapses to `{"a":2}` once routed through
-    // here. #442 already solved this for YAML input with its own
-    // `OwnedValue`-avoiding fast path; a proper fix for JSON input needs
-    // an equivalent (most likely teaching the shared streaming formatters
-    // in `src/yaml/light.rs` to canonicalize a JSON-sourced number
-    // in-stream, restoring M2 eligibility instead of disabling it) rather
-    // than the DOM-fallback trade-off made here.
-    let is_m2_streamable = can_use_m2_streaming(&program.expr) && !any_input_is_json;
+    // #978 originally disabled M2 streaming outright for JSON input here
+    // (`is_m2_streamable` used to `&& !any_input_is_json`), trading away
+    // M2's performance *and* its incidental duplicate-key preservation
+    // (#996) to fix a real bug: neither M2 streamer discarded a JSON
+    // number's own decimal-point/exponent spelling the way the DOM path's
+    // `canonicalize_json_numbers` does (`1.50` stayed `1.50`, `1e2` became
+    // `100.0` instead of real yq's `100`). #996 fixed that at the source
+    // instead — `YamlIndex::mark_json_sourced` (set below, right after
+    // each M2-path `YamlIndex::build` call) makes `src/yaml/light.rs`'s
+    // streaming formatters canonicalize a `Float` the same way the DOM
+    // path already does, so M2 no longer needs to be disabled for JSON
+    // input at all: it now gets *both* correct numbers and duplicate-key
+    // preservation, matching real yq on both counts.
+    let is_m2_streamable = can_use_m2_streaming(&program.expr);
     // pretty_print isn't implemented by the cursor streamers, so it still
     // falls back to the DOM path, unchanged, rather than silently ignoring
     // the flag the way compact mode already does today. `sort_keys` and
@@ -2647,10 +2625,6 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     let can_slurp_fast_path = is_identity
         && can_stream_pretty_or_colored
         && output_config.output_format == OutputFormat::Yaml
-        // #978: same JSON-literal-spelling leak as can_yaml_fast_path above
-        // - this gate is YAML-output-only (see its own doc comment), so no
-        // JSON-output sibling to worry about excluding correctly here.
-        && !any_input_is_json
         && !args.null_input
         && !args.raw_input
         && args.front_matter.is_none()
@@ -2785,8 +2759,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             if let Some(code) = yaml_validate_guard(&yaml_bytes, fmt, args.validate, None) {
                 return Ok(code);
             }
-            let index = YamlIndex::build(&yaml_bytes)
+            let mut index = YamlIndex::build(&yaml_bytes)
                 .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
+            if fmt == InputFormat::Json {
+                index.mark_json_sourced();
+            }
             let root = index.root(&yaml_bytes);
 
             // Output each document using M2 streaming
@@ -2868,8 +2845,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 {
                     return Ok(code);
                 }
-                let index = YamlIndex::build(&yaml_bytes)
+                let mut index = YamlIndex::build(&yaml_bytes)
                     .map_err(|e| anyhow::anyhow!("YAML parse error in {file_path}: {e}"))?;
+                if fmt == InputFormat::Json {
+                    index.mark_json_sourced();
+                }
                 let root = index.root(&yaml_bytes);
 
                 match root.value() {
@@ -3255,9 +3235,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // `Vec` unless their backing bytes/index all outlive that `Vec`.
             let mut parsed_sources: Vec<(Vec<u8>, YamlIndex<Vec<u64>>)> =
                 Vec::with_capacity(input_sources.len());
-            for (bytes, _format, _) in input_sources {
-                let index = YamlIndex::build(&bytes)
+            for (bytes, format, _) in input_sources {
+                let mut index = YamlIndex::build(&bytes)
                     .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
+                if format == InputFormat::Json {
+                    index.mark_json_sourced();
+                }
                 parsed_sources.push((bytes, index));
             }
 
@@ -3396,8 +3379,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // directly into this file's buffer, skipping the OwnedValue
                 // DOM (and its IndexMap, which cannot represent duplicate
                 // mapping keys) the same way the stdout M2 path above does.
-                let index = YamlIndex::build(&input_bytes)
+                let mut index = YamlIndex::build(&input_bytes)
                     .map_err(|e| anyhow::anyhow!("YAML parse error in {file_path}: {e}"))?;
+                if format == InputFormat::Json {
+                    index.mark_json_sourced();
+                }
                 let root = index.root(&input_bytes);
 
                 {

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -272,8 +272,8 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         self.bp_to_text_end.get(open_idx)
     }
 
-    /// Marks this index's text as JSON-sourced (#996) -- see
-    /// [`Self::canonicalize_numbers`]'s own doc comment for what this
+    /// Marks this index's text as JSON-sourced (#996) -- see the private
+    /// `canonicalize_numbers` field's own doc comment for what this
     /// changes. Callers building an index over JSON bytes (JSON is a
     /// syntactic subset of YAML's flow grammar, so `YamlIndex::build`
     /// parses it fine) call this once, right after `build`, before

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -79,6 +79,25 @@ pub struct YamlIndex<W = Vec<u64>> {
     /// Only needed by `to_line_column()` and `to_offset()` (used by the
     /// `yq-locate` CLI and the `at_position` jq builtin).
     lines: OnceCell<crate::text::LineIndex>,
+    /// Set via [`Self::mark_json_sourced`] when this index's text is
+    /// JSON, not genuine YAML, run through this parser only because JSON
+    /// is a syntactic subset of YAML's flow grammar (#996).
+    ///
+    /// Read by [`YamlCursor`]'s M2 streaming formatters
+    /// (`stream_resolved_scalar_as_json`/`stream_yaml_string_value`) to
+    /// switch a float scalar's rendering from YAML's literal-spelling
+    /// preservation to real yq's JSON-input convention (always
+    /// re-serialize through `f64`, matching [`format_float_yq`] /
+    /// bare-`Display` -- never preserve `1.50`'s trailing zero or `1e2`'s
+    /// exponent notation). Carried on the index itself (read via
+    /// `YamlCursor`'s existing `&YamlIndex` reference) rather than as a
+    /// parameter threaded through every streaming call site, since the
+    /// M2 formatters recurse through the entire `Expr`-independent value
+    /// tree and back through `DocumentCursor`'s trait methods (shared
+    /// with the unrelated `JsonCursor` implementor) -- a field on the one
+    /// struct already in scope everywhere it's needed avoids a much
+    /// larger, cross-crate signature change for the same effect.
+    canonicalize_numbers: bool,
 }
 
 /// Build cumulative popcount index for IB.
@@ -141,6 +160,7 @@ impl YamlIndex<Vec<u64>> {
             tags: semi.tags,
             line_comments: semi.line_comments,
             lines: OnceCell::new(),
+            canonicalize_numbers: false,
         };
         index.validate_alias_acyclicity()?;
         Ok(index)
@@ -198,6 +218,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             // given an explicit parameter then.
             line_comments: BTreeMap::new(),
             lines: OnceCell::new(),
+            canonicalize_numbers: false,
         }
     }
 
@@ -249,6 +270,22 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     #[inline]
     pub fn text_end_pos_by_open_idx(&self, open_idx: usize) -> Option<usize> {
         self.bp_to_text_end.get(open_idx)
+    }
+
+    /// Marks this index's text as JSON-sourced (#996) -- see
+    /// [`Self::canonicalize_numbers`]'s own doc comment for what this
+    /// changes. Callers building an index over JSON bytes (JSON is a
+    /// syntactic subset of YAML's flow grammar, so `YamlIndex::build`
+    /// parses it fine) call this once, right after `build`, before
+    /// streaming through any [`YamlCursor`] derived from it.
+    pub fn mark_json_sourced(&mut self) {
+        self.canonicalize_numbers = true;
+    }
+
+    /// Whether [`Self::mark_json_sourced`] was called on this index.
+    #[inline]
+    pub(crate) fn canonicalize_numbers(&self) -> bool {
+        self.canonicalize_numbers
     }
 
     /// Get a reference to the interest bits words.

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1324,7 +1324,22 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         self_.write_leading_anchor(out)?;
         let value = self_.value();
         if let YamlValue::String(s) = &value {
-            out.write_str(&s.as_str().unwrap_or(Cow::Borrowed("\"\"")))?;
+            let str_val = s.as_str().unwrap_or(Cow::Borrowed("\"\""));
+            // #996: this root-scalar shortcut bypasses `stream_yaml_value`/
+            // `stream_yaml_string_value` entirely (see this function's own
+            // doc comment on why -- #852's "a scalar root drops its own
+            // styling"), so it needs its own copy of the same
+            // canonicalize-aware check, or a JSON-sourced float navigated
+            // out as a standalone result (`.b`, not nested under a parent
+            // Mapping/Sequence) would echo its raw spelling unchanged.
+            if self_.index.canonicalize_numbers() {
+                if let ResolvedScalar::Float(f) = resolve_plain(&str_val) {
+                    if f.is_finite() {
+                        return write!(out, "{f}");
+                    }
+                }
+            }
+            out.write_str(&str_val)?;
         } else {
             self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)?;
         }
@@ -1582,7 +1597,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         }
                     }
                 }
-                stream_yaml_string_value(out, &s)
+                stream_yaml_string_value(out, &s, self.index.canonicalize_numbers())
             }
             YamlValue::Mapping(_) => {
                 // A bare `-` sequence-item wrapper (dash-alone-then-indented
@@ -1893,7 +1908,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if let Some(explicit) = self.explicit_tag() {
                     if let Ok(str_val) = s.as_str() {
                         if let Some(resolved) = resolve_tagged(&str_val, explicit) {
-                            return stream_resolved_scalar_as_json(out, resolved, &str_val);
+                            return stream_resolved_scalar_as_json(
+                                out,
+                                resolved,
+                                &str_val,
+                                self.index.canonicalize_numbers(),
+                            );
                         }
                     }
                 }
@@ -1904,7 +1924,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         if let Ok(str_val) = s.as_str() {
                             if s.is_unquoted() {
                                 // Plain scalar - resolve per the core schema
-                                stream_yaml_scalar_as_json(out, &str_val)
+                                stream_yaml_scalar_as_json(
+                                    out,
+                                    &str_val,
+                                    self.index.canonicalize_numbers(),
+                                )
                             } else {
                                 // Block scalars are always strings
                                 stream_json_string(out, &str_val)
@@ -3219,6 +3243,55 @@ pub fn format_float_with_fraction(f: f64) -> String {
     buf
 }
 
+/// Renders a computed (non-literal-preserved) `f64` the way real yq does:
+/// decimal for everyday magnitudes, scientific notation once the value's
+/// decimal exponent is `>= 6` or `<= -5`.
+///
+/// Only for a value with no source literal left to preserve, either because
+/// it was actually computed (arithmetic) or because it came from JSON
+/// input, which real yq always re-serializes through float64 rather than
+/// preserving spelling. A YAML-sourced identity/navigation output keeps its
+/// own source spelling regardless of magnitude and must never route through
+/// this function -- confirmed against real yq v4.53.3:
+/// `12345678901234567890123` (a decimal literal) stays fully expanded on
+/// identity, while the equivalent *computed* magnitude switches to
+/// scientific notation (#997).
+///
+/// The threshold and the `e+NN`/`e-NN` (lowercase, signed, exponent padded
+/// to at least 2 digits) spelling are both oracle-verified against real yq;
+/// this is yq's own threshold, distinct from jq mode's (which only
+/// reformats when the source literal itself already used exponent
+/// notation).
+///
+/// Lives here (not in the CLI binary) so [`YamlCursor`]'s M2 streaming
+/// formatters can share it with the CLI's own DOM-path printer (#996) --
+/// `src/bin/succinctly/output.rs` re-exports this under the same name.
+///
+/// `f` must be finite -- like [`format_float_with_fraction`], this has no
+/// JSON/YAML-specific spelling for NaN/Infinity to fall back on, so every
+/// caller must special-case those first.
+#[must_use]
+pub fn format_float_yq(f: f64) -> String {
+    debug_assert!(
+        f.is_finite(),
+        "format_float_yq requires a finite value; NaN/Infinity have no \
+         JSON/YAML spelling here and must be special-cased by the caller"
+    );
+    let sci = format!("{f:e}");
+    let (mantissa, exp_str) = sci
+        .split_once('e')
+        .expect("Rust's exponential formatter always includes a lowercase 'e'");
+    let exp: i32 = exp_str
+        .parse()
+        .expect("exponent from Rust's exponential formatter is always a valid i32");
+    if (-4..6).contains(&exp) {
+        format_float_with_fraction(f)
+    } else {
+        let sign = if exp < 0 { '-' } else { '+' };
+        format!("{mantissa}e{sign}{:02}", exp.abs())
+    }
+}
+
 /// Fast f64 to string formatting.
 #[inline]
 fn write_f64(output: &mut String, f: f64) {
@@ -3687,24 +3760,39 @@ fn stream_yaml_string_to_json<Out: core::fmt::Write>(
 fn stream_yaml_scalar_as_json<Out: core::fmt::Write>(
     out: &mut Out,
     str_val: &str,
+    canonicalize: bool,
 ) -> core::fmt::Result {
-    stream_resolved_scalar_as_json(out, resolve_plain(str_val), str_val)
+    stream_resolved_scalar_as_json(out, resolve_plain(str_val), str_val, canonicalize)
 }
 
 /// Stream an already-resolved scalar as JSON. `str_val` is the original
 /// source text, used for the `Str` case (and only if `resolved` didn't come
 /// from resolving it, e.g. tag-forced `!!str` on non-string content), and
 /// for a preservable `Float` literal (#993).
+///
+/// `canonicalize` (#996) is
+/// [`YamlIndex::canonicalize_numbers`](super::index::YamlIndex::canonicalize_numbers)
+/// -- when set, a `Float` always re-serializes through `f64` (real yq's
+/// JSON-input convention) instead of preserving `str_val`'s own spelling,
+/// which only makes sense for genuine YAML source text.
 fn stream_resolved_scalar_as_json<Out: core::fmt::Write>(
     out: &mut Out,
     resolved: ResolvedScalar,
     str_val: &str,
+    canonicalize: bool,
 ) -> core::fmt::Result {
     match resolved {
         ResolvedScalar::Null => out.write_str("null"),
         ResolvedScalar::Bool(true) => out.write_str("true"),
         ResolvedScalar::Bool(false) => out.write_str("false"),
         ResolvedScalar::Int(n) => write!(out, "{n}"),
+        // #996: real yq never preserves a JSON-sourced float's literal
+        // spelling -- `1.50` becomes `1.5`, `1e2` becomes `100` -- matching
+        // `OwnedValue::to_json`'s own bare `write!(out, "{f}")` for the DOM
+        // path's already-canonicalized `Float` variant (`canonicalize_json_numbers`
+        // in `yq_runner.rs`). Checked before the literal-preserving arms
+        // below, which exist only for genuine YAML source text.
+        ResolvedScalar::Float(f) if canonicalize && f.is_finite() => write!(out, "{f}"),
         // Echo the source text when it's already safe, valid JSON number
         // syntax (`number_literal()` below uses the same predicate for the
         // DOM path) -- this is what keeps a trailing zero (`1.50`) intact;
@@ -6108,7 +6196,11 @@ fn write_yaml_field_key<W: AsRef<[u64]>, Out: core::fmt::Write>(
         {
             out.write_str("!!merge ")?;
         }
-        stream_yaml_string_value(out, s)
+        // A JSON object key is always itself a JSON string (never a bare
+        // number), so #996's canonicalization never applies to a key -
+        // `false` unconditionally, not `self.index.canonicalize_numbers()`
+        // (this function has no cursor/self to read that from anyway).
+        stream_yaml_string_value(out, s, false)
     } else {
         stream_yaml_nonstring_key(out, &key)
     }
@@ -6561,9 +6653,21 @@ fn widen_folded_breaks(decoded: &str, explicit_indent_used: bool) -> Cow<'_, str
     Cow::Owned(result)
 }
 
+///
+/// `canonicalize` (#996) is
+/// [`YamlIndex::canonicalize_numbers`](super::index::YamlIndex::canonicalize_numbers)
+/// -- see [`stream_resolved_scalar_as_json`]'s doc comment for what this
+/// means. Only the `Unquoted` arm is affected: a JSON-sourced plain
+/// scalar's own source spelling is what's wrong for a `Float` (real yq
+/// re-serializes it through `f64`, e.g. `1.50` -> `1.5`), the same way it's
+/// wrong for JSON output -- this arm just didn't have any type-resolution
+/// logic to begin with (a genuine YAML plain scalar echoes verbatim by
+/// design, #918/#836), so the fix is to add it rather than bypass existing
+/// arms.
 fn stream_yaml_string_value<Out: core::fmt::Write>(
     out: &mut Out,
     s: &YamlString<'_>,
+    canonicalize: bool,
 ) -> core::fmt::Result {
     // Try to get the string value
     let str_val = match s.as_str() {
@@ -6576,6 +6680,31 @@ fn stream_yaml_string_value<Out: core::fmt::Write>(
         YamlString::DoubleQuoted { .. } => stream_yaml_double_quoted(out, &str_val),
         YamlString::SingleQuoted { .. } => stream_yaml_single_quoted(out, &str_val),
         YamlString::Unquoted { .. } => {
+            // #996: a JSON-sourced float re-serializes through `f64`
+            // (bare `Display`: no forced trailing `.0`, and -- matching
+            // `canonicalize_json_numbers`'s own DOM-path baseline, which
+            // this mirrors exactly rather than trying to independently
+            // improve on -- no scientific notation either, even for
+            // extreme magnitudes; `format_float_yq`'s threshold-switching
+            // is for computed/arithmetic results, a different, unrelated
+            // case that was already correct before this fix and is left
+            // untouched) - checked before the verbatim-echo fallback
+            // below, which is for genuine YAML source text only.
+            if canonicalize {
+                if let ResolvedScalar::Float(f) = resolve_plain(&str_val) {
+                    if f.is_finite() {
+                        return write!(out, "{f}");
+                    }
+                    // `.inf`/`-.inf`/`.nan` in JSON-sourced text is
+                    // unreachable (JSON has no such literal), but a value
+                    // computed at query-evaluation time and re-emitted
+                    // through the identity/M2 path shouldn't exist either
+                    // - falls through to the verbatim echo, matching this
+                    // arm's pre-#996 behavior, rather than fabricating a
+                    // YAML-specific non-finite spelling this function has
+                    // never needed before.
+                }
+            }
             // Source plain scalar: re-emit verbatim so both the scalar type and
             // its representation survive (`1`, `true`, `1.0`, `.5`, `yes`),
             // matching yq. Quote only when the decoded value cannot round-trip

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1340,11 +1340,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             // quoted JSON *string* that happens to look numeric (`"1.50"`)
             // got its quotes silently dropped and its type corrupted into
             // a bare float (`1.5`) -- caught in review before merge.
-            if self_.index.canonicalize_numbers() && s.is_unquoted() {
-                if let ResolvedScalar::Float(f) = resolve_plain(&str_val) {
-                    if f.is_finite() {
-                        return write!(out, "{f}");
-                    }
+            if s.is_unquoted() {
+                if let Some(f) = json_sourced_canonical_float(
+                    resolve_plain(&str_val),
+                    self_.index.canonicalize_numbers(),
+                ) {
+                    return write!(out, "{f}");
                 }
             }
             out.write_str(&str_val)?;
@@ -2069,7 +2070,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if let Some(explicit) = self.explicit_tag() {
                     if let Ok(str_val) = s.as_str() {
                         if let Some(resolved) = resolve_tagged(&str_val, explicit) {
-                            write_resolved_scalar_as_json(output, resolved, &str_val);
+                            write_resolved_scalar_as_json(
+                                output,
+                                resolved,
+                                &str_val,
+                                self.index.canonicalize_numbers(),
+                            );
                             return;
                         }
                     }
@@ -2081,7 +2087,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         if let Ok(str_val) = s.as_str() {
                             if s.is_unquoted() {
                                 // Plain scalar - resolve per the core schema
-                                write_yaml_scalar_as_json(output, &str_val);
+                                write_yaml_scalar_as_json(
+                                    output,
+                                    &str_val,
+                                    self.index.canonicalize_numbers(),
+                                );
                             } else {
                                 // Block scalars are always strings
                                 write_json_string(output, &str_val);
@@ -2678,8 +2688,13 @@ fn write_yaml_value_as_json<W: AsRef<[u64]>>(output: &mut String, value: YamlVal
                 Ok(false) => {
                     if let Ok(str_val) = s.as_str() {
                         if s.is_unquoted() {
-                            // Plain scalar - resolve per the core schema
-                            write_yaml_scalar_as_json(output, &str_val);
+                            // Plain scalar - resolve per the core schema.
+                            // `false`: this function takes a bare `YamlValue`
+                            // with no `YamlIndex` to read #996's
+                            // `canonicalize_numbers` flag from, and per this
+                            // function's own doc comment has no production
+                            // call site to matter for anyway (test-only).
+                            write_yaml_scalar_as_json(output, &str_val, false);
                         } else {
                             // Block scalars are always strings
                             write_json_string(output, &str_val);
@@ -3255,15 +3270,21 @@ pub fn format_float_with_fraction(f: f64) -> String {
 /// decimal for everyday magnitudes, scientific notation once the value's
 /// decimal exponent is `>= 6` or `<= -5`.
 ///
-/// Only for a value with no source literal left to preserve, either because
-/// it was actually computed (arithmetic) or because it came from JSON
-/// input, which real yq always re-serializes through float64 rather than
-/// preserving spelling. A YAML-sourced identity/navigation output keeps its
-/// own source spelling regardless of magnitude and must never route through
-/// this function -- confirmed against real yq v4.53.3:
-/// `12345678901234567890123` (a decimal literal) stays fully expanded on
-/// identity, while the equivalent *computed* magnitude switches to
-/// scientific notation (#997).
+/// Only for a value with no source literal left to preserve because it was
+/// actually computed (arithmetic) -- **not** for JSON-sourced input
+/// (#996): real yq's JSON-input convention is a plain re-serialize through
+/// bare `f64` `Display` with no scientific-notation threshold at all (see
+/// [`json_sourced_canonical_float`], which the M2 streaming formatters use
+/// instead of this function for that case -- confirmed against a baseline
+/// build of unmodified `main`, an extreme-magnitude JSON-sourced float
+/// like `1e100` renders as a 100+-digit decimal expansion on `-o json`
+/// today, not `1e+100`; #996 matches that existing baseline rather than
+/// independently improving on it). A YAML-sourced identity/navigation
+/// output keeps its own source spelling regardless of magnitude and must
+/// never route through this function either -- confirmed against real yq
+/// v4.53.3: `12345678901234567890123` (a decimal literal) stays fully
+/// expanded on identity, while the equivalent *computed* magnitude
+/// switches to scientific notation (#997).
 ///
 /// The threshold and the `e+NN`/`e-NN` (lowercase, signed, exponent padded
 /// to at least 2 digits) spelling are both oracle-verified against real yq;
@@ -3271,9 +3292,13 @@ pub fn format_float_with_fraction(f: f64) -> String {
 /// reformats when the source literal itself already used exponent
 /// notation).
 ///
-/// Lives here (not in the CLI binary) so [`YamlCursor`]'s M2 streaming
-/// formatters can share it with the CLI's own DOM-path printer (#996) --
-/// `src/bin/succinctly/output.rs` re-exports this under the same name.
+/// Lives here (not in the CLI binary) rather than only in
+/// `src/bin/succinctly/output.rs`, which now re-exports this under the
+/// same name, so a future library-side computed-float formatter (there is
+/// none yet -- `succinctly jq`'s own arithmetic results have no yq-mode
+/// concept to begin with) could share it without duplicating the
+/// threshold logic; not because the M2 streaming path calls it today (it
+/// doesn't -- see above).
 ///
 /// `f` must be finite -- like [`format_float_with_fraction`], this has no
 /// JSON/YAML-specific spelling for NaN/Infinity to fall back on, so every
@@ -3306,6 +3331,39 @@ fn write_f64(output: &mut String, f: f64) {
     output.push_str(&format_float_with_fraction(f));
 }
 
+/// If `canonicalize` and `resolved` is a finite `Float`, the value to
+/// re-serialize through bare `f64` `Display` instead of the scalar's own
+/// source-text spelling -- matching the DOM path's
+/// `canonicalize_json_numbers`/`OwnedValue::into_plain_number` baseline
+/// for JSON-sourced input (#996), not real yq's own threshold-switching
+/// convention for *computed* floats ([`format_float_yq`], a different,
+/// unrelated case -- see that function's own doc comment). `None`
+/// otherwise: the caller falls back to its own literal-preserving logic
+/// unchanged, which covers every non-JSON-sourced case (`canonicalize`
+/// false), every non-`Float` scalar, and non-finite floats (JSON has no
+/// `.inf`/`.nan`/`NaN` literal to begin with, so this is unreachable
+/// through `canonicalize`'s only caller, but is still the semantically
+/// correct answer if it weren't).
+///
+/// The single point every canonicalize-aware call site routes through
+/// (`stream_resolved_scalar_as_json`/`write_resolved_scalar_as_json`,
+/// `stream_yaml_string_value`, `stream_yaml_as_document`'s scalar-root
+/// shortcut) -- extracted after code review on #996 found three
+/// independently-hand-copied versions of the same check, one of them
+/// missing the `is_unquoted()` gate its siblings had (a genuinely quoted
+/// JSON string that merely looked numeric, e.g. `"1.50"`, was silently
+/// reinterpreted as a bare float). Callers still own their own
+/// `is_unquoted()`/quoting-style checks -- this only answers "is the
+/// *value*, once you've already decided it's eligible, a float that needs
+/// canonicalizing."
+#[inline]
+fn json_sourced_canonical_float(resolved: ResolvedScalar, canonicalize: bool) -> Option<f64> {
+    match resolved {
+        ResolvedScalar::Float(f) if canonicalize && f.is_finite() => Some(f),
+        _ => None,
+    }
+}
+
 /// Fast YAML scalar to JSON conversion.
 ///
 /// Resolution is delegated to [`resolve_plain`] (YAML 1.2 core schema);
@@ -3313,17 +3371,32 @@ fn write_f64(output: &mut String, f: f64) {
 /// Numeric values are emitted from the parsed value, never echoed from the
 /// source text (hex/octal like `0x2A` must appear as `42` in JSON).
 #[inline]
-fn write_yaml_scalar_as_json(output: &mut String, str_val: &str) {
-    write_resolved_scalar_as_json(output, resolve_plain(str_val), str_val);
+fn write_yaml_scalar_as_json(output: &mut String, str_val: &str, canonicalize: bool) {
+    write_resolved_scalar_as_json(output, resolve_plain(str_val), str_val, canonicalize);
 }
 
 /// Write an already-resolved scalar as JSON. `str_val` is the original
 /// source text, used for the `Str` case (and only if `resolved` didn't come
 /// from resolving it, e.g. tag-forced `!!str` on non-string content), and
 /// for a preservable `Float` literal (#993) -- kept in lockstep with the
-/// streaming sibling [`stream_resolved_scalar_as_json`].
+/// streaming sibling [`stream_resolved_scalar_as_json`]. `canonicalize`
+/// (#996) is [`YamlIndex::canonicalize_numbers`](super::index::YamlIndex::canonicalize_numbers) --
+/// see [`json_sourced_canonical_float`].
 #[inline]
-fn write_resolved_scalar_as_json(output: &mut String, resolved: ResolvedScalar, str_val: &str) {
+fn write_resolved_scalar_as_json(
+    output: &mut String,
+    resolved: ResolvedScalar,
+    str_val: &str,
+    canonicalize: bool,
+) {
+    if let Some(f) = json_sourced_canonical_float(resolved, canonicalize) {
+        // Bare `Display`, not `write_f64` (which forces a trailing `.0`
+        // via `format_float_with_fraction` -- correct for genuine YAML
+        // source text, wrong here: real yq drops it for JSON-sourced
+        // input, matching `OwnedValue::to_json`'s own bare-Float arm).
+        output.push_str(&f.to_string());
+        return;
+    }
     match resolved {
         ResolvedScalar::Null => output.push_str("null"),
         ResolvedScalar::Bool(true) => output.push_str("true"),
@@ -3789,18 +3862,20 @@ fn stream_resolved_scalar_as_json<Out: core::fmt::Write>(
     str_val: &str,
     canonicalize: bool,
 ) -> core::fmt::Result {
+    // #996: real yq never preserves a JSON-sourced float's literal
+    // spelling -- `1.50` becomes `1.5`, `1e2` becomes `100` -- matching
+    // `OwnedValue::to_json`'s own bare `write!(out, "{f}")` for the DOM
+    // path's already-canonicalized `Float` variant (`canonicalize_json_numbers`
+    // in `yq_runner.rs`). Checked before the literal-preserving arms
+    // below, which exist only for genuine YAML source text.
+    if let Some(f) = json_sourced_canonical_float(resolved, canonicalize) {
+        return write!(out, "{f}");
+    }
     match resolved {
         ResolvedScalar::Null => out.write_str("null"),
         ResolvedScalar::Bool(true) => out.write_str("true"),
         ResolvedScalar::Bool(false) => out.write_str("false"),
         ResolvedScalar::Int(n) => write!(out, "{n}"),
-        // #996: real yq never preserves a JSON-sourced float's literal
-        // spelling -- `1.50` becomes `1.5`, `1e2` becomes `100` -- matching
-        // `OwnedValue::to_json`'s own bare `write!(out, "{f}")` for the DOM
-        // path's already-canonicalized `Float` variant (`canonicalize_json_numbers`
-        // in `yq_runner.rs`). Checked before the literal-preserving arms
-        // below, which exist only for genuine YAML source text.
-        ResolvedScalar::Float(f) if canonicalize && f.is_finite() => write!(out, "{f}"),
         // Echo the source text when it's already safe, valid JSON number
         // syntax (`number_literal()` below uses the same predicate for the
         // DOM path) -- this is what keeps a trailing zero (`1.50`) intact;
@@ -6204,10 +6279,14 @@ fn write_yaml_field_key<W: AsRef<[u64]>, Out: core::fmt::Write>(
         {
             out.write_str("!!merge ")?;
         }
-        // A JSON object key is always itself a JSON string (never a bare
-        // number), so #996's canonicalization never applies to a key -
-        // `false` unconditionally, not `self.index.canonicalize_numbers()`
-        // (this function has no cursor/self to read that from anyway).
+        // `false` unconditionally, not `field.key_cursor().index.canonicalize_numbers()`
+        // (available, but deliberately not read): a JSON object key
+        // always parses as `YamlString::DoubleQuoted`/`SingleQuoted`,
+        // never `Unquoted` -- the only variant `stream_yaml_string_value`'s
+        // canonicalize branch touches -- so the real flag would be a
+        // provable no-op here. Hardcoding `false` documents that as an
+        // invariant of the call site rather than leaving a live (if inert)
+        // flag read to explain.
         stream_yaml_string_value(out, s, false)
     } else {
         stream_yaml_nonstring_key(out, &key)
@@ -6661,17 +6740,17 @@ fn widen_folded_breaks(decoded: &str, explicit_indent_used: bool) -> Cow<'_, str
     Cow::Owned(result)
 }
 
+/// Stream a YAML string value, preserving its own quoting style.
 ///
 /// `canonicalize` (#996) is
 /// [`YamlIndex::canonicalize_numbers`](super::index::YamlIndex::canonicalize_numbers)
-/// -- see [`stream_resolved_scalar_as_json`]'s doc comment for what this
-/// means. Only the `Unquoted` arm is affected: a JSON-sourced plain
-/// scalar's own source spelling is what's wrong for a `Float` (real yq
-/// re-serializes it through `f64`, e.g. `1.50` -> `1.5`), the same way it's
-/// wrong for JSON output -- this arm just didn't have any type-resolution
-/// logic to begin with (a genuine YAML plain scalar echoes verbatim by
-/// design, #918/#836), so the fix is to add it rather than bypass existing
-/// arms.
+/// -- see [`json_sourced_canonical_float`] for what this means. Only the
+/// `Unquoted` arm is affected: a JSON-sourced plain scalar's own source
+/// spelling is what's wrong for a `Float` (real yq re-serializes it
+/// through `f64`, e.g. `1.50` -> `1.5`), the same way it's wrong for JSON
+/// output -- this arm just didn't have any type-resolution logic to begin
+/// with (a genuine YAML plain scalar echoes verbatim by design, #918/#836),
+/// so the fix is to add it rather than bypass existing arms.
 fn stream_yaml_string_value<Out: core::fmt::Write>(
     out: &mut Out,
     s: &YamlString<'_>,
@@ -6688,30 +6767,16 @@ fn stream_yaml_string_value<Out: core::fmt::Write>(
         YamlString::DoubleQuoted { .. } => stream_yaml_double_quoted(out, &str_val),
         YamlString::SingleQuoted { .. } => stream_yaml_single_quoted(out, &str_val),
         YamlString::Unquoted { .. } => {
-            // #996: a JSON-sourced float re-serializes through `f64`
-            // (bare `Display`: no forced trailing `.0`, and -- matching
-            // `canonicalize_json_numbers`'s own DOM-path baseline, which
-            // this mirrors exactly rather than trying to independently
-            // improve on -- no scientific notation either, even for
-            // extreme magnitudes; `format_float_yq`'s threshold-switching
-            // is for computed/arithmetic results, a different, unrelated
-            // case that was already correct before this fix and is left
-            // untouched) - checked before the verbatim-echo fallback
-            // below, which is for genuine YAML source text only.
-            if canonicalize {
-                if let ResolvedScalar::Float(f) = resolve_plain(&str_val) {
-                    if f.is_finite() {
-                        return write!(out, "{f}");
-                    }
-                    // `.inf`/`-.inf`/`.nan` in JSON-sourced text is
-                    // unreachable (JSON has no such literal), but a value
-                    // computed at query-evaluation time and re-emitted
-                    // through the identity/M2 path shouldn't exist either
-                    // - falls through to the verbatim echo, matching this
-                    // arm's pre-#996 behavior, rather than fabricating a
-                    // YAML-specific non-finite spelling this function has
-                    // never needed before.
-                }
+            // #996: checked before the verbatim-echo fallback below,
+            // which is for genuine YAML source text only. A non-finite
+            // `.inf`/`-.inf`/`.nan` result from `json_sourced_canonical_float`
+            // is unreachable here (JSON has no such literal), but if it
+            // ever weren't, falling through to the verbatim echo (this
+            // arm's pre-#996 behavior) is still the right answer, rather
+            // than fabricating a YAML-specific non-finite spelling this
+            // function has never needed before.
+            if let Some(f) = json_sourced_canonical_float(resolve_plain(&str_val), canonicalize) {
+                return write!(out, "{f}");
             }
             // Source plain scalar: re-emit verbatim so both the scalar type and
             // its representation survive (`1`, `true`, `1.0`, `.5`, `yes`),

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -10,7 +10,7 @@
 use alloc::vec;
 #[cfg(not(test))]
 use alloc::{
-    borrow::Cow, collections::BTreeMap, rc::Rc, string::String, string::ToString, vec::Vec,
+    borrow::Cow, collections::BTreeMap, format, rc::Rc, string::String, string::ToString, vec::Vec,
 };
 
 #[cfg(test)]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1332,7 +1332,15 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             // canonicalize-aware check, or a JSON-sourced float navigated
             // out as a standalone result (`.b`, not nested under a parent
             // Mapping/Sequence) would echo its raw spelling unchanged.
-            if self_.index.canonicalize_numbers() {
+            //
+            // `s.is_unquoted()` gating is required, not optional: `s` here
+            // is any `YamlValue::String` regardless of quoting style, and
+            // `resolve_plain` documents itself as only meaningful for a
+            // plain (unquoted) scalar. Without this check, a genuinely
+            // quoted JSON *string* that happens to look numeric (`"1.50"`)
+            // got its quotes silently dropped and its type corrupted into
+            // a bare float (`1.5`) -- caught in review before merge.
+            if self_.index.canonicalize_numbers() && s.is_unquoted() {
                 if let ResolvedScalar::Float(f) = resolve_plain(&str_val) {
                     if f.is_finite() {
                         return write!(out, "{f}");

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3274,8 +3274,9 @@ pub fn format_float_with_fraction(f: f64) -> String {
 /// actually computed (arithmetic) -- **not** for JSON-sourced input
 /// (#996): real yq's JSON-input convention is a plain re-serialize through
 /// bare `f64` `Display` with no scientific-notation threshold at all (see
-/// [`json_sourced_canonical_float`], which the M2 streaming formatters use
-/// instead of this function for that case -- confirmed against a baseline
+/// the private `json_sourced_canonical_float` helper, which the M2
+/// streaming formatters use instead of this function for that case --
+/// confirmed against a baseline
 /// build of unmodified `main`, an extreme-magnitude JSON-sourced float
 /// like `1e100` renders as a 100+-digit decimal expansion on `-o json`
 /// today, not `1e+100`; #996 matches that existing baseline rather than

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -275,8 +275,8 @@ pub(crate) enum QuotedSpanEnd {
 pub use error::YamlError;
 pub use index::YamlIndex;
 pub use light::{
-    format_float_with_fraction, stream_yaml_sequence, ChompingIndicator, YamlCursor, YamlElements,
-    YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
+    format_float_with_fraction, format_float_yq, stream_yaml_sequence, ChompingIndicator,
+    YamlCursor, YamlElements, YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
 pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1276,23 +1276,24 @@ fn test_json_extension_auto_detected_file_never_preserves_literal_spelling_978()
     Ok(())
 }
 
-/// #996 (known limitation, tracked separately -- not fixed here): routing
-/// JSON input through the DOM path to canonicalize its numbers (#978)
-/// loses M2 streaming's incidental duplicate-key preservation, since
-/// `OwnedValue::Object` is `IndexMap`-backed and can only keep the last
-/// value for a repeated key. Real yq preserves `{"a":1,"a":2}` unchanged
-/// (confirmed live); this pins the current, documented gap so a future
-/// change doesn't silently make it worse without anyone noticing --
-/// flip this assertion to the correct behavior once #996 is fixed.
+/// #996: JSON input's M2 streaming eligibility was restored (`YamlIndex`
+/// parses JSON's flow-mapping syntax fine, and `stream_resolved_scalar_as_json`/
+/// `stream_yaml_string_value`/`stream_yaml_as_document` now canonicalize a
+/// JSON-sourced float the way the DOM path's `canonicalize_json_numbers`
+/// already did, restoring #978's fix without the DOM-fallback trade-off),
+/// so M2's incidental duplicate-key preservation (it never materializes an
+/// `IndexMap` at all) now applies to JSON input too. Real yq preserves
+/// `{"a":1,"a":2}` unchanged; this used to pin the opposite (collapsed)
+/// behavior as a documented, known gap -- flipped to the fixed behavior.
 #[test]
-fn test_json_input_duplicate_keys_collapse_known_limitation_996() -> Result<()> {
+fn test_json_input_duplicate_keys_preserved_996() -> Result<()> {
     let (out, code) = run_yq_stdin(
         ".",
         "{\"a\":1,\"a\":2}",
         &["--input-format", "json", "-o", "json", "-I", "0"],
     )?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "{\"a\":2}");
+    assert_eq!(out.trim(), "{\"a\":1,\"a\":2}");
     Ok(())
 }
 
@@ -11180,23 +11181,49 @@ fn test_isvalid_has_yq_type_mismatch_is_valid_917() -> Result<()> {
     Ok(())
 }
 
-/// #998: `yq --input-format json` routes JSON input through the DOM path
-/// (`eval_generic::to_owned`/`generic_to_owned`, per #978/#994), which now
-/// carries its own recursion-depth guard -- confirmed live before this fix,
-/// `succinctly yq --input-format json '.'` on a 200,000-level-deep document
-/// aborted with a raw stack overflow (SIGABRT, exit 134). The guard panics
-/// cleanly instead (exit 101, not a controlled `anyhow` error like the jq
-/// CLI's own `print_json` guard gets -- `to_owned` sits too deep in the
-/// evaluator's hot path for a `Result`-based fix without a much larger
-/// signature change, see the PR discussion), which is still strictly better
-/// than an uncontrolled stack overflow: a raw stack overflow is undefined
-/// behavior, a panic is not.
+/// #998: `yq --input-format json` on adversarially deep input must never
+/// raw stack-overflow (confirmed live before #998, `succinctly yq
+/// --input-format json '.'` on a 200,000-level-deep document aborted with
+/// SIGABRT, exit 134) -- some guard must reject it cleanly.
+///
+/// #996 changed *which* guard fires first for the common (M2-eligible)
+/// case: JSON input's M2 streaming eligibility was restored by parsing it
+/// through `YamlIndex::build` (JSON is a syntactic subset of YAML's flow
+/// grammar), which carries its own unconditional parse-time depth-128
+/// guard (`yaml/parser.rs`) -- tighter than, and reached before, #998's
+/// own `eval_generic::to_owned` conversion-time 256 guard, and a clean
+/// `anyhow` parse error (exit 1) rather than a panic (exit 101). This is
+/// strictly safer (caught earlier, no panic) and closer to real jq/yq's
+/// own ~128 parse-time limit than the 256 guard was. #998's own guard is
+/// unchanged and still reachable -- see the companion test below for the
+/// DOM-forced path (`-P`), which never goes through `YamlIndex` at all.
 #[test]
-fn test_json_input_rejects_adversarial_nesting_998() -> Result<()> {
+fn test_json_input_rejects_adversarial_nesting_via_m2_path_996() -> Result<()> {
     let depth = 500;
     let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
     let (_stdout, stderr, code) =
         run_yq_stdin_with_stderr(".", &input, &["--input-format", "json"])?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 128"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// Companion to the above: `-P` forces the DOM path (pretty-print isn't
+/// implemented by the M2 streamers), which parses JSON input through
+/// `JsonIndex::build` (no parse-time depth guard of its own) rather than
+/// `YamlIndex::build` -- #998's own `eval_generic::to_owned`
+/// conversion-time 256 guard is the one that fires here, unchanged by
+/// #996, confirming it's still live and not dead code now that the
+/// YAML-parser guard catches the M2-eligible case earlier.
+#[test]
+fn test_json_input_rejects_adversarial_nesting_via_dom_path_998() -> Result<()> {
+    let depth = 500;
+    let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "-P"])?;
     assert_eq!(code, 101, "stderr: {stderr:?}");
     assert!(
         stderr.contains("nesting depth exceeds limit of 256"),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1300,6 +1300,67 @@ fn test_json_input_duplicate_keys_preserved_996() -> Result<()> {
     Ok(())
 }
 
+/// #996 regression: a genuinely quoted JSON *string* that merely looks
+/// numeric (`"1.50"`, `"1e2"`) must never be reinterpreted as a bare
+/// float -- #996's own first attempt at the root-scalar shortcut in
+/// `stream_yaml_as_document` did exactly that (missing the same
+/// `is_unquoted()` gate its sibling call sites had), silently corrupting
+/// the value's *type*, not just its spelling. Confirmed live against real
+/// yq (v4.53.3), which preserves both unchanged.
+///
+/// Exercises several distinct M2-reachable shapes per the `testing`
+/// skill's "assert call sites agree with each other" guidance -- each
+/// routes through a different function this PR touches: a bare navigated
+/// scalar result (`stream_yaml_as_document`'s shortcut, the one that was
+/// actually broken), a value nested under an object (`stream_yaml_value`
+/// -> `stream_yaml_string_value`), and JSON-target output of the same
+/// (`stream_json_value` -> `stream_yaml_scalar_as_json`, which was always
+/// correctly gated).
+#[test]
+fn test_json_input_quoted_numeric_looking_string_not_corrupted_996() -> Result<()> {
+    // Bare navigated scalar result -- YAML output (the shape that shipped
+    // broken).
+    let (out, code) = run_yq_stdin(".b", "{\"b\": \"1.50\"}", &["--input-format", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "1.50");
+
+    let (out, code) = run_yq_stdin(".b", "{\"b\": \"1e2\"}", &["--input-format", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "1e2");
+
+    // Nested under an object -- YAML output. Asserts the *value* survives
+    // quoted and uncorrupted, not the exact block-vs-flow structural
+    // spelling: M2 preserves JSON's own flow-mapping syntax here (a
+    // separate, pre-existing, out-of-#996's-scope divergence from real
+    // yq, which forces block style for JSON input regardless of source
+    // style -- unrelated to this regression).
+    let (out, code) = run_yq_stdin(
+        ".",
+        "{\"nested\": {\"b\": \"1.50\"}}",
+        &["--input-format", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert!(
+        out.contains("\"1.50\""),
+        "expected the quoted string preserved verbatim, got: {out:?}"
+    );
+    assert!(
+        !out.contains("1.5\n") && !out.contains(": 1.5"),
+        "value must not have been corrupted into a bare float, got: {out:?}"
+    );
+
+    // Bare navigated scalar result -- JSON output.
+    let (out, code) = run_yq_stdin(
+        ".b",
+        "{\"b\": \"1.50\"}",
+        &["--input-format", "json", "-o", "json"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"1.50\"");
+
+    Ok(())
+}
+
 /// #631: `first(.[])`/`last(.[])` (the `Expr::FirstExpr`/`LastExpr` one-arg
 /// stream form `first(f)`/`last(f)` compiles to) fell through
 /// `evaluate_yaml_cursor`'s unconditional `to_owned()` DOM path, unlike

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1251,8 +1251,10 @@ fn test_json_input_never_preserves_literal_spelling_978() -> Result<()> {
 /// call site. The M2 fast-path gates initially missed this (caught by
 /// code review): a bare `succinctly yq '.' file.json` -- arguably the
 /// more common way to hit this than typing the explicit flag -- still
-/// leaked. Fixed via `any_input_is_json`, which resolves every input
-/// file's format up front instead of trusting the raw flag alone.
+/// leaked. Fixed by resolving each input source's own format via
+/// `resolve_input_format` before deciding whether to call
+/// `YamlIndex::mark_json_sourced` on it (#996), rather than trusting the
+/// raw flag alone.
 #[test]
 fn test_json_extension_auto_detected_file_never_preserves_literal_spelling_978() -> Result<()> {
     let mut input_file = NamedTempFile::with_suffix(".json")?;
@@ -1283,8 +1285,9 @@ fn test_json_extension_auto_detected_file_never_preserves_literal_spelling_978()
 /// already did, restoring #978's fix without the DOM-fallback trade-off),
 /// so M2's incidental duplicate-key preservation (it never materializes an
 /// `IndexMap` at all) now applies to JSON input too. Real yq preserves
-/// `{"a":1,"a":2}` unchanged; this used to pin the opposite (collapsed)
-/// behavior as a documented, known gap -- flipped to the fixed behavior.
+/// `{"a":1,"a":2}` unchanged (confirmed live, yq v4.53.3); this used to
+/// pin the opposite (collapsed) behavior as a documented, known gap --
+/// flipped to the fixed behavior.
 #[test]
 fn test_json_input_duplicate_keys_preserved_996() -> Result<()> {
     let (out, code) = run_yq_stdin(
@@ -11227,6 +11230,27 @@ fn test_json_input_rejects_adversarial_nesting_via_dom_path_998() -> Result<()> 
     assert_eq!(code, 101, "stderr: {stderr:?}");
     assert!(
         stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #996's `can_slurp_fast_path` also dropped its own `!any_input_is_json`
+/// gate, so `--slurp`'s default (YAML) output now routes adversarially
+/// deep JSON input through `YamlIndex::build`'s parse-time depth-128
+/// guard too, same as identity above -- pinned separately since
+/// `can_slurp_fast_path`/`is_m2_streamable` are independent gates with
+/// their own call sites, not a shared code path that the identity test
+/// above would also exercise.
+#[test]
+fn test_json_input_rejects_adversarial_nesting_via_slurp_996() -> Result<()> {
+    let depth = 500;
+    let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "--slurp"])?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 128"),
         "stderr: {stderr:?}"
     );
     Ok(())


### PR DESCRIPTION
## Summary

#978 (PR #994) fixed `yq --input-format json` incorrectly preserving a JSON-sourced number's literal spelling by disabling M2 cursor-streaming for all JSON input and falling back to the DOM path. That fix was correct for its stated goal, but M2 was also incidentally providing a second, unrelated invariant: duplicate JSON object keys survive unchanged, since M2 never materializes a map at all. The DOM path's `OwnedValue::Object` is `IndexMap`-backed and can only keep the last value for a repeated key — the same class of bug #442 already fixed for YAML input.

```
$ echo '{"a":1,"a":2}' | succinctly yq --input-format json -o json -I0 '.'
{"a":2}                                          # wrong — collapsed (before this PR)
$ echo '{"a":1,"a":2}' | yq --input-format json -o json -I0 '.'
{"a":1,"a":2}                                    # correct — preserved
```

## Fix

Restores M2 eligibility for JSON input instead of disabling it, by teaching `src/yaml/light.rs`'s streaming formatters to canonicalize a JSON-sourced float the same way the DOM path's `canonicalize_json_numbers` already does — matching **#978's own documented baseline exactly**, not attempting to independently improve past it (verified extensively against a baseline build of unmodified `main`; #978's own DOM path already diverges from real yq for extreme-magnitude floats like `1e100`, e.g. never switching to scientific notation — that's a separate, pre-existing gap, out of scope here).

`YamlIndex::build` already parses JSON input correctly (JSON is a syntactic subset of YAML's flow grammar — this is how M2 handled JSON input before #978 disabled it). The only missing piece was number-formatting awareness in the streaming formatters.

**Design**: rather than threading a `canonicalize: bool` parameter through the ~30 internal `stream_json_value`/`stream_yaml_value` recursive call sites (which would also mean changing the shared `DocumentCursor` trait's method signatures, affecting the unrelated `JsonCursor` implementor too), the flag is carried as a new `canonicalize_numbers` field on `YamlIndex` itself, set once via `YamlIndex::mark_json_sourced()` right after building the index for JSON input. Every `YamlCursor` already holds a reference to its `YamlIndex`, so the formatters read it directly with zero signature changes to the trait or its other implementor.

Three call sites needed the canonicalize check (found via careful tracing, including one non-obvious "scalar document root" bypass that skips the normal formatter dispatch entirely):
- `stream_resolved_scalar_as_json` (JSON-target output)
- `stream_yaml_string_value` (YAML-target output, nested values)
- `stream_yaml_as_document`'s scalar-root shortcut (YAML-target output, a bare navigated scalar result like `.b`)

Also moves `format_float_yq` from the CLI binary (`output.rs`) into the library (`yaml/light.rs`) so the new M2 code path and the existing DOM-path formatter share one definition instead of two — though ultimately unused by the JSON-canonicalize path itself (see below), it stays alongside `format_float_with_fraction` as the natural shared home for float-formatting helpers.

## A wrong turn worth documenting

My first attempt used `format_float_yq`'s scientific-notation threshold for the canonicalize case, reasoning that real yq would want it. Live-testing against a baseline build of `main` revealed #978's own DOM path does **not** do this (`1e100` renders as a 100+ digit decimal expansion, not `1e+100`, on `main` today) — so using `format_float_yq` there would have made M2 diverge from #978's own established DOM-path baseline for M2-eligible queries specifically, not converge with it. Corrected to bare `write!(out, "{f}")`, matching #978's actual behavior exactly. Verified byte-for-byte against a temporary baseline worktree of unmodified `main` across 7 test values (fractional, whole, extreme-magnitude, tiny) in both JSON and YAML output.

## Test changes

- `test_json_input_duplicate_keys_collapse_known_limitation_996` → `test_json_input_duplicate_keys_preserved_996`: flipped from pinning the bug to pinning the fix (its own doc comment said to do exactly this once #996 landed).
- `test_json_input_rejects_adversarial_nesting_998` split into two: restoring M2 means adversarially-deep JSON input (for M2-eligible shapes) now hits `YamlIndex`'s own parse-time depth-128 guard first (clean `anyhow` error, exit 1) instead of `eval_generic::to_owned`'s conversion-time depth-256 guard (panic, exit 101) — strictly safer (caught earlier, no panic), and closer to real jq/yq's own ~128 parse-time limit. Added a companion test confirming #998's own guard is still reachable (and unchanged) via the DOM-forced path (`-P`), so it isn't silently dead code now that the M2 path usually catches this earlier.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 2 unrelated tests flaked under contention from concurrent sessions on this machine — confirmed by re-running in isolation, then a clean full re-run: 100% pass)
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual verification: duplicate-key repro fixed, number formatting verified byte-for-byte against a baseline build of `main` across 7 test values × 2 output formats × root/nested/array positions
- [x] Manual verification: #998's depth guard still reachable via DOM-forced path (`-P`), M2 path's own (earlier, safer) guard confirmed working

Fixes #996