### PR TITLE
fix(jq): guard remaining recursive value/yaml walkers against stack overflow

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -14,7 +14,9 @@ use succinctly::jq::document::DocumentFields;
 use succinctly::jq::eval_generic::{
     eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
 };
-use succinctly::jq::{self, format_number_jq_compat, Expr, JqValue, OwnedValue, Program};
+use succinctly::jq::{
+    self, assert_value_tree_depth, format_number_jq_compat, Expr, JqValue, OwnedValue, Program,
+};
 use succinctly::json::light::{JsonCursor, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
 use succinctly::json::JsonIndex;
@@ -1555,6 +1557,16 @@ fn strip_quotes_and_decode(field: &[u8]) -> String {
 
 /// Convert serde_json::Value to OwnedValue.
 fn serde_to_owned(value: &serde_json::Value) -> OwnedValue {
+    serde_to_owned_at_depth(value, 0)
+}
+
+/// Panics past `MAX_VALUE_TREE_DEPTH` levels of nesting (#1017/#1020) --
+/// mirrors `yq_runner::serde_json_to_owned_at_depth`, which this function's
+/// own doc comment names as guarded by the same PR; this twin was
+/// initially missed and is reachable the same way, via `--argjson`/`--args`
+/// and `--seq`/streamed JSON input parsing below.
+fn serde_to_owned_at_depth(value: &serde_json::Value, depth: usize) -> OwnedValue {
+    assert_value_tree_depth(depth);
     match value {
         serde_json::Value::Null => OwnedValue::Null,
         serde_json::Value::Bool(b) => OwnedValue::Bool(*b),
@@ -1568,12 +1580,14 @@ fn serde_to_owned(value: &serde_json::Value) -> OwnedValue {
             }
         }
         serde_json::Value::String(s) => OwnedValue::String(s.clone()),
-        serde_json::Value::Array(arr) => {
-            OwnedValue::Array(arr.iter().map(serde_to_owned).collect())
-        }
+        serde_json::Value::Array(arr) => OwnedValue::Array(
+            arr.iter()
+                .map(|v| serde_to_owned_at_depth(v, depth + 1))
+                .collect(),
+        ),
         serde_json::Value::Object(obj) => OwnedValue::Object(
             obj.iter()
-                .map(|(k, v)| (k.clone(), serde_to_owned(v)))
+                .map(|(k, v)| (k.clone(), serde_to_owned_at_depth(v, depth + 1)))
                 .collect(),
         ),
     }
@@ -2548,5 +2562,42 @@ mod tests {
         let stream = r#"{"a":1} {"b":2} {"c":3}"#;
         let values = parse_json_stream(stream).unwrap();
         assert_eq!(values.len(), 3);
+    }
+
+    /// `depth` levels of single-element array nesting in a `serde_json::Value`,
+    /// built directly rather than parsed from text -- `serde_json::from_str`
+    /// enforces its own independent ~128-deep recursion limit at parse time
+    /// (well under `MAX_VALUE_TREE_DEPTH`), so a JSON-text version of this
+    /// helper would hit that gate before ever reaching `serde_to_owned`'s
+    /// own guard.
+    fn linear_serde_json_nest(depth: usize) -> serde_json::Value {
+        let mut v = serde_json::Value::Null;
+        for _ in 0..depth {
+            v = serde_json::Value::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1020 code review: `yq_runner::serde_json_to_owned`'s own doc comment
+    /// names this function as its mirror, guarded by the same #1017-driven
+    /// PR -- but this twin (backing `--argjson`/`--args`-style value
+    /// parsing and `--seq`/streamed JSON input on the `jq` side) was
+    /// initially missed. Same guard, same construction as #1017's other
+    /// tests.
+    #[test]
+    fn serde_to_owned_panics_past_nesting_depth_limit_1020() {
+        use succinctly::jq::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_serde_json_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let owned = serde_to_owned(&under);
+        assert!(matches!(owned, OwnedValue::Array(_)));
+
+        let over = linear_serde_json_nest(MAX_VALUE_TREE_DEPTH);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| serde_to_owned(&over)));
+        assert!(
+            result.is_err(),
+            "serde_to_owned should panic at MAX_VALUE_TREE_DEPTH"
+        );
     }
 }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4425,4 +4425,118 @@ mod tests {
             "reconcile_presentation should panic at MAX_VALUE_TREE_DEPTH"
         );
     }
+
+    /// #1017: `emit_yaml_value` (the YAML-target default output emitter —
+    /// see its own doc comment) had no guard, reachable on a value
+    /// constructed via `reduce`/`foreach`/etc. with no adversarial document
+    /// involved.
+    #[test]
+    fn emit_yaml_value_panics_past_nesting_depth_limit_1017() {
+        use succinctly::jq::MAX_VALUE_TREE_DEPTH;
+
+        let config = OutputConfig {
+            output_format: OutputFormat::Yaml,
+            compact: false,
+            raw_output: false,
+            join_output: false,
+            nul_output: false,
+            ascii_output: false,
+            sort_keys: false,
+            no_doc: false,
+            indent_str: String::new(),
+            use_color: false,
+        };
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let _ = emit_yaml_value(&under, &CommentTree::empty(), &config, "", false);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            emit_yaml_value(&over, &CommentTree::empty(), &config, "", false)
+        }));
+        assert!(
+            result.is_err(),
+            "emit_yaml_value should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1017: yq's JSON-input number canonicalization pass had no guard,
+    /// reachable the same way as every other value-tree walker guarded in
+    /// this PR — a value constructed with no adversarial document behind it.
+    #[test]
+    fn canonicalize_json_numbers_panics_past_nesting_depth_limit_1017() {
+        use succinctly::jq::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let _ = canonicalize_json_numbers(under);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            canonicalize_json_numbers(over)
+        }));
+        assert!(
+            result.is_err(),
+            "canonicalize_json_numbers should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// `depth` levels of single-child `CommentTree::Array` nesting, mirroring
+    /// [`linear_array_nest`]'s `OwnedValue` shape.
+    fn linear_comment_tree_nest(depth: usize) -> CommentTree {
+        let mut t = CommentTree::empty();
+        for _ in 0..depth {
+            t = CommentTree::Array(None, "", vec![t]);
+        }
+        t
+    }
+
+    /// #1017: `strip_presentation_style` had no guard, reachable on a
+    /// `CommentTree` built up alongside a computed value with no live
+    /// document cursor behind it.
+    #[test]
+    fn strip_presentation_style_panics_past_nesting_depth_limit_1017() {
+        use succinctly::jq::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_comment_tree_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let _ = strip_presentation_style(&under);
+
+        let over = linear_comment_tree_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            strip_presentation_style(&over)
+        }));
+        assert!(
+            result.is_err(),
+            "strip_presentation_style should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// `depth` levels of single-element array nesting in a `serde_json::Value`.
+    fn linear_serde_json_nest(depth: usize) -> serde_json::Value {
+        let mut v = serde_json::Value::Null;
+        for _ in 0..depth {
+            v = serde_json::Value::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1017: `serde_json_to_owned` (used by `--argjson`/`--args`-style CLI
+    /// value parsing) had no guard of its own, unlike the `serde_json`
+    /// parse step feeding it, which enforces an independent ~128-deep
+    /// limit before this conversion ever runs.
+    #[test]
+    fn serde_json_to_owned_panics_past_nesting_depth_limit_1017() {
+        use succinctly::jq::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_serde_json_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let owned = serde_json_to_owned(&under);
+        assert!(matches!(owned, OwnedValue::Array(_)));
+
+        let over = linear_serde_json_nest(MAX_VALUE_TREE_DEPTH);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| serde_json_to_owned(&over)));
+        assert!(
+            result.is_err(),
+            "serde_json_to_owned should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
 }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -414,14 +414,29 @@ fn gather_input_sources(
 /// local to `yq_runner.rs`'s own JSON-input call sites rather than
 /// touching that shared function.
 fn canonicalize_json_numbers(value: OwnedValue) -> OwnedValue {
+    canonicalize_json_numbers_at_depth(value, 0)
+}
+
+/// Panics past `succinctly::jq::MAX_VALUE_TREE_DEPTH` levels of nesting
+/// (#1017). Currently only reachable at a depth this deep via `value`
+/// already capped there by `generic_to_owned`'s own guard (#998, a
+/// tighter 256), since this function's only caller (`parse_input`'s JSON
+/// arm) feeds it that function's direct output -- defense-in-depth
+/// against that call chain changing, not a currently-live independent
+/// crash path.
+fn canonicalize_json_numbers_at_depth(value: OwnedValue, depth: usize) -> OwnedValue {
+    assert_value_tree_depth(depth);
     match value {
-        OwnedValue::Array(items) => {
-            OwnedValue::Array(items.into_iter().map(canonicalize_json_numbers).collect())
-        }
+        OwnedValue::Array(items) => OwnedValue::Array(
+            items
+                .into_iter()
+                .map(|v| canonicalize_json_numbers_at_depth(v, depth + 1))
+                .collect(),
+        ),
         OwnedValue::Object(fields) => OwnedValue::Object(
             fields
                 .into_iter()
-                .map(|(k, v)| (k, canonicalize_json_numbers(v)))
+                .map(|(k, v)| (k, canonicalize_json_numbers_at_depth(v, depth + 1)))
                 .collect(),
         ),
         other => other.into_plain_number(),
@@ -1205,19 +1220,33 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
 /// keeping its comments and tree shape untouched — see the `strip_style`
 /// call in [`evaluate_yaml_cursor`].
 fn strip_presentation_style(tree: &CommentTree) -> CommentTree {
+    strip_presentation_style_at_depth(tree, 0)
+}
+
+/// Panics past `succinctly::jq::MAX_VALUE_TREE_DEPTH` levels of nesting
+/// (#1017) -- unlike its sibling [`reconcile_presentation`], which #1015
+/// already guards, this walker over the same `CommentTree` shape had no
+/// guard at all. Currently only fed an already-reconciled/bounded tree,
+/// so this is defense-in-depth against that call chain changing, not a
+/// currently-live independent crash path.
+fn strip_presentation_style_at_depth(tree: &CommentTree, depth: usize) -> CommentTree {
+    assert_value_tree_depth(depth);
     match tree {
         CommentTree::Leaf(c, _) => CommentTree::Leaf(c.clone(), ""),
         CommentTree::Array(c, _, items) => CommentTree::Array(
             c.clone(),
             "",
-            items.iter().map(strip_presentation_style).collect(),
+            items
+                .iter()
+                .map(|v| strip_presentation_style_at_depth(v, depth + 1))
+                .collect(),
         ),
         CommentTree::Object(c, _, fields, key_comments) => CommentTree::Object(
             c.clone(),
             "",
             fields
                 .iter()
-                .map(|(k, v)| (k.clone(), strip_presentation_style(v)))
+                .map(|(k, v)| (k.clone(), strip_presentation_style_at_depth(v, depth + 1)))
                 .collect(),
             key_comments.clone(),
         ),
@@ -1469,6 +1498,25 @@ fn emit_yaml_value(
     indent: &str,
     in_flow: bool,
 ) -> String {
+    emit_yaml_value_at_depth(value, comments, config, indent, in_flow, 0)
+}
+
+/// Panics past `succinctly::jq::MAX_VALUE_TREE_DEPTH` levels of nesting
+/// (#1017) -- see [`reconcile_presentation_at_depth`], the sibling this
+/// mirrors: both are the default YAML-target output emitters for a
+/// filter's evaluated result (JSON-target has `output::format_json_impl`,
+/// guarded by #1015; this is YAML-target's own copy), reachable on a
+/// value constructed via `reduce`/`foreach`/etc. with no adversarial
+/// document on either side.
+fn emit_yaml_value_at_depth(
+    value: &OwnedValue,
+    comments: &CommentTree,
+    config: &OutputConfig,
+    indent: &str,
+    in_flow: bool,
+    depth: usize,
+) -> String {
+    assert_value_tree_depth(depth);
     match value {
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(b) => b.to_string(),
@@ -1508,7 +1556,16 @@ fn emit_yaml_value(
                 let items: Vec<_> = arr
                     .iter()
                     .enumerate()
-                    .map(|(i, v)| emit_yaml_value(v, comments.at_index(i), config, indent, true))
+                    .map(|(i, v)| {
+                        emit_yaml_value_at_depth(
+                            v,
+                            comments.at_index(i),
+                            config,
+                            indent,
+                            true,
+                            depth + 1,
+                        )
+                    })
                     .collect();
                 format!("[{}]", items.join(", "))
             } else {
@@ -1545,8 +1602,14 @@ fn emit_yaml_value(
                             // sibling gets for free from its per-field/
                             // per-element loop only indenting 2nd+ items.
                             let compact_indent = format!("{indent}  ");
-                            let rendered =
-                                emit_yaml_value(v, elem_comments, config, &compact_indent, false);
+                            let rendered = emit_yaml_value_at_depth(
+                                v,
+                                elem_comments,
+                                config,
+                                &compact_indent,
+                                false,
+                                depth + 1,
+                            );
                             // The element's own comment goes on its own
                             // line rather than glued onto its last
                             // grandchild's line (#793).
@@ -1561,8 +1624,14 @@ fn emit_yaml_value(
                             format!("{indent}- {first_line}")
                         } else {
                             let val_indent = format!("{indent}{}", config.indent_str);
-                            let item =
-                                emit_yaml_value(v, elem_comments, config, &val_indent, false);
+                            let item = emit_yaml_value_at_depth(
+                                v,
+                                elem_comments,
+                                config,
+                                &val_indent,
+                                false,
+                                depth + 1,
+                            );
                             let comment_suffix = trailing_comment_suffix(elem_comments);
                             format!("{indent}- {item}{comment_suffix}")
                         }
@@ -1580,7 +1649,14 @@ fn emit_yaml_value(
                     .iter()
                     .map(|(k, v)| {
                         let key = yaml_quote_key(k);
-                        let val = emit_yaml_value(v, comments.field(k), config, indent, true);
+                        let val = emit_yaml_value_at_depth(
+                            v,
+                            comments.field(k),
+                            config,
+                            indent,
+                            true,
+                            depth + 1,
+                        );
                         format!("{key}: {val}")
                     })
                     .collect();
@@ -1621,8 +1697,14 @@ fn emit_yaml_value(
                             // The value's own comment goes on its own line
                             // rather than glued onto its last grandchild's
                             // line (#793).
-                            let val =
-                                emit_yaml_value(v, field_comments, config, &val_indent, false);
+                            let val = emit_yaml_value_at_depth(
+                                v,
+                                field_comments,
+                                config,
+                                &val_indent,
+                                false,
+                                depth + 1,
+                            );
                             let val =
                                 append_own_comment_line(val, field_comments.own(), &val_indent);
                             format!("{indent}{key}:{key_comment_suffix}\n{val}")
@@ -1632,8 +1714,14 @@ fn emit_yaml_value(
                             // no value token, matching real yq (#765).
                             format!("{indent}{key}: {kc}")
                         } else {
-                            let val =
-                                emit_yaml_value(v, field_comments, config, &val_indent, false);
+                            let val = emit_yaml_value_at_depth(
+                                v,
+                                field_comments,
+                                config,
+                                &val_indent,
+                                false,
+                                depth + 1,
+                            );
                             // The value's own comment takes priority; fall
                             // back to the key's own comment when the value
                             // has none - covers an explicit key's trailing
@@ -1974,6 +2062,16 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// Convert a `serde_json::Value` into an `OwnedValue`
 /// (mirrors `jq_runner::serde_to_owned`).
 fn serde_json_to_owned(value: &serde_json::Value) -> OwnedValue {
+    serde_json_to_owned_at_depth(value, 0)
+}
+
+/// Panics past `succinctly::jq::MAX_VALUE_TREE_DEPTH` levels of nesting
+/// (#1017). `serde_json::from_str`'s own `Deserializer` already enforces
+/// an independent ~128-deep parse-time limit before `value` can exist at
+/// all, so this is defense-in-depth against that upstream limit changing,
+/// not a currently-live independent crash path.
+fn serde_json_to_owned_at_depth(value: &serde_json::Value, depth: usize) -> OwnedValue {
+    assert_value_tree_depth(depth);
     match value {
         serde_json::Value::Null => OwnedValue::Null,
         serde_json::Value::Bool(b) => OwnedValue::Bool(*b),
@@ -1987,12 +2085,14 @@ fn serde_json_to_owned(value: &serde_json::Value) -> OwnedValue {
             }
         }
         serde_json::Value::String(s) => OwnedValue::String(s.clone()),
-        serde_json::Value::Array(arr) => {
-            OwnedValue::Array(arr.iter().map(serde_json_to_owned).collect())
-        }
+        serde_json::Value::Array(arr) => OwnedValue::Array(
+            arr.iter()
+                .map(|v| serde_json_to_owned_at_depth(v, depth + 1))
+                .collect(),
+        ),
         serde_json::Value::Object(obj) => OwnedValue::Object(
             obj.iter()
-                .map(|(k, v)| (k.clone(), serde_json_to_owned(v)))
+                .map(|(k, v)| (k.clone(), serde_json_to_owned_at_depth(v, depth + 1)))
                 .collect(),
         ),
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1781,14 +1781,31 @@ fn arith_mul<S: EvalSemantics>(
 /// structurally, recursing into positions gated individually by
 /// [`merge_position`]; anything else is a plain leaf replace.
 fn merge_values(left: OwnedValue, right: OwnedValue, flags: MergeFlags) -> OwnedValue {
+    merge_values_at_depth(left, right, flags, 0)
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1017) -- `*`/`*=` had no guard anywhere in this
+/// mutually-recursive family (`merge_values`/`merge_existing`/
+/// `merge_position`/`merge_object_fields`/`merge_arrays_by_index`),
+/// unlike the tree-walkers #1015 already guarded. Reachable on a value
+/// constructed via `reduce`/`foreach`/etc. with no adversarial document
+/// involved on either side.
+fn merge_values_at_depth(
+    left: OwnedValue,
+    right: OwnedValue,
+    flags: MergeFlags,
+    depth: usize,
+) -> OwnedValue {
+    assert_value_tree_depth(depth);
     match (left, right) {
         (OwnedValue::Object(a), OwnedValue::Object(b)) => {
-            OwnedValue::Object(merge_object_fields(a, b, flags))
+            OwnedValue::Object(merge_object_fields(a, b, flags, depth))
         }
         (OwnedValue::Array(a), OwnedValue::Array(b))
             if flags.deep_merge_arrays && !flags.append_arrays =>
         {
-            OwnedValue::Array(merge_arrays_by_index(a, b, flags))
+            OwnedValue::Array(merge_arrays_by_index(a, b, flags, depth))
         }
         (existing, incoming) => merge_leaf(existing, incoming, flags),
     }
@@ -1820,14 +1837,27 @@ fn merge_leaf(existing: OwnedValue, incoming: OwnedValue, flags: MergeFlags) -> 
 /// exists still gets recursed into, so *its* new children can be added (or
 /// blocked) individually.
 fn merge_existing(existing: OwnedValue, incoming: OwnedValue, flags: MergeFlags) -> OwnedValue {
+    merge_existing_at_depth(existing, incoming, flags, 0)
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1017) -- see [`merge_values_at_depth`], which this
+/// mirrors.
+fn merge_existing_at_depth(
+    existing: OwnedValue,
+    incoming: OwnedValue,
+    flags: MergeFlags,
+    depth: usize,
+) -> OwnedValue {
+    assert_value_tree_depth(depth);
     match (existing, incoming) {
         (OwnedValue::Object(a), OwnedValue::Object(b)) => {
-            OwnedValue::Object(merge_object_fields(a, b, flags))
+            OwnedValue::Object(merge_object_fields(a, b, flags, depth))
         }
         (OwnedValue::Array(a), OwnedValue::Array(b))
             if flags.deep_merge_arrays && !flags.append_arrays =>
         {
-            OwnedValue::Array(merge_arrays_by_index(a, b, flags))
+            OwnedValue::Array(merge_arrays_by_index(a, b, flags, depth))
         }
         (existing, incoming) => {
             // `n`: only write if the existing value is already null. `?`
@@ -1858,6 +1888,7 @@ fn merge_position(
     incoming: OwnedValue,
     flags: MergeFlags,
     only_existing_applies: bool,
+    depth: usize,
 ) -> Option<OwnedValue> {
     match existing {
         None => {
@@ -1867,7 +1898,7 @@ fn merge_position(
                 Some(incoming)
             }
         }
-        Some(existing) => Some(merge_existing(existing, incoming, flags)),
+        Some(existing) => Some(merge_existing_at_depth(existing, incoming, flags, depth)),
     }
 }
 
@@ -1876,19 +1907,24 @@ fn merge_position(
 /// `left.get(&k).cloned()` + `left.insert(..)` so an existing value that's
 /// itself a large nested container moves into the merge instead of being
 /// deep-cloned first.
+///
+/// `depth` is the *parent* object's own depth (not yet incremented) --
+/// each field merged below is one level deeper, so every call back into
+/// [`merge_existing_at_depth`]/[`merge_position`] passes `depth + 1`.
 fn merge_object_fields(
     mut left: IndexMap<String, OwnedValue>,
     right: IndexMap<String, OwnedValue>,
     flags: MergeFlags,
+    depth: usize,
 ) -> IndexMap<String, OwnedValue> {
     for (k, v) in right {
         match left.entry(k) {
             indexmap::map::Entry::Occupied(mut e) => {
                 let existing = e.insert(OwnedValue::Null);
-                e.insert(merge_existing(existing, v, flags));
+                e.insert(merge_existing_at_depth(existing, v, flags, depth + 1));
             }
             indexmap::map::Entry::Vacant(e) => {
-                if let Some(new_value) = merge_position(None, v, flags, true) {
+                if let Some(new_value) = merge_position(None, v, flags, true, depth + 1) {
                     e.insert(new_value);
                 }
             }
@@ -1902,15 +1938,19 @@ fn merge_object_fields(
 /// Indices only present in `right` extend `left` — real yq's `?` never
 /// blocks this (see [`merge_position`]'s doc comment), so extension is
 /// unconditional here rather than routed through `merge_position`.
+///
+/// `depth` is the *parent* array's own depth, same convention as
+/// [`merge_object_fields`].
 fn merge_arrays_by_index(
     mut left: Vec<OwnedValue>,
     right: Vec<OwnedValue>,
     flags: MergeFlags,
+    depth: usize,
 ) -> Vec<OwnedValue> {
     for (i, v) in right.into_iter().enumerate() {
         if i < left.len() {
             let existing = core::mem::replace(&mut left[i], OwnedValue::Null);
-            left[i] = merge_existing(existing, v, flags);
+            left[i] = merge_existing_at_depth(existing, v, flags, depth + 1);
         } else {
             left.push(v);
         }
@@ -4309,17 +4349,39 @@ fn builtin_flatten<W: Clone + AsRef<[u64]>>(
     QueryResult::Owned(OwnedValue::Array(flattened))
 }
 
-/// Flatten owned values to a specific depth
+/// Flatten owned values to a specific depth.
 fn flatten_owned(items: Vec<OwnedValue>, depth: usize) -> Vec<OwnedValue> {
+    flatten_owned_at_depth(items, depth, 0)
+}
+
+/// `depth` (the *remaining flatten levels* the caller asked for, e.g. from
+/// `flatten(depth)`) and `tree_depth` (this recursion's own descent so
+/// far) are two independent counters: `depth` already self-terminates
+/// (`depth == 0` stops), but a user-supplied `flatten(N)` for a large `N`
+/// places no ceiling of its own on how deep the *array's own structure*
+/// (not the flatten count) can be walked before that termination kicks
+/// in. Panics past
+/// [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH) levels of
+/// `tree_depth` (#1017) -- currently only reachable at a `tree_depth`
+/// this deep via a value already capped there by an upstream guard
+/// (#1005's `to_owned`/reindex-bridge), so this is defense-in-depth
+/// against that invariant changing, not a currently-live independent
+/// crash path.
+fn flatten_owned_at_depth(
+    items: Vec<OwnedValue>,
+    depth: usize,
+    tree_depth: usize,
+) -> Vec<OwnedValue> {
     if depth == 0 {
         return items;
     }
+    assert_value_tree_depth(tree_depth);
 
     let mut result = Vec::new();
     for item in items {
         match item {
             OwnedValue::Array(inner) => {
-                result.extend(flatten_owned(inner, depth - 1));
+                result.extend(flatten_owned_at_depth(inner, depth - 1, tree_depth + 1));
             }
             other => result.push(other),
         }
@@ -5349,12 +5411,24 @@ fn format_yaml(value: &OwnedValue) -> Result<String, EvalError> {
 /// Non-objects are converted to strings.
 fn format_props(value: &OwnedValue) -> Result<String, EvalError> {
     let mut lines = Vec::new();
-    format_props_recursive(value, String::new(), &mut lines);
+    format_props_recursive(value, String::new(), &mut lines, 0);
     Ok(lines.join("\n"))
 }
 
-/// Recursively format a value into Java properties lines
-fn format_props_recursive(value: &OwnedValue, prefix: String, lines: &mut Vec<String>) {
+/// Recursively format a value into Java properties lines.
+///
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1017) -- unlike its sibling format functions
+/// (`format_json_impl`, guarded by #1015), this one had no guard at all;
+/// reachable on a value constructed via `reduce`/`foreach`/etc. with no
+/// adversarial document involved.
+fn format_props_recursive(
+    value: &OwnedValue,
+    prefix: String,
+    lines: &mut Vec<String>,
+    depth: usize,
+) {
+    assert_value_tree_depth(depth);
     match value {
         OwnedValue::Object(obj) => {
             for (key, val) in obj {
@@ -5363,7 +5437,7 @@ fn format_props_recursive(value: &OwnedValue, prefix: String, lines: &mut Vec<St
                 } else {
                     format!("{prefix}.{key}")
                 };
-                format_props_recursive(val, new_prefix, lines);
+                format_props_recursive(val, new_prefix, lines, depth + 1);
             }
         }
         OwnedValue::Array(arr) => {
@@ -5373,7 +5447,7 @@ fn format_props_recursive(value: &OwnedValue, prefix: String, lines: &mut Vec<St
                 } else {
                     format!("{prefix}.{idx}")
                 };
-                format_props_recursive(val, new_prefix, lines);
+                format_props_recursive(val, new_prefix, lines, depth + 1);
             }
         }
         _ => {
@@ -5430,6 +5504,15 @@ fn props_value_to_string(value: &OwnedValue) -> String {
 /// Convert OwnedValue to YAML flow-style (compact, single-line like JSON).
 /// This matches yq's @yaml behavior which outputs flow-style YAML.
 fn owned_to_yaml(value: &OwnedValue) -> String {
+    owned_to_yaml_at_depth(value, 0)
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1017) -- see [`format_props_recursive`], the
+/// sibling this mirrors: both were unguarded, unlike `format_json_impl`
+/// (#1015).
+fn owned_to_yaml_at_depth(value: &OwnedValue, depth: usize) -> String {
+    assert_value_tree_depth(depth);
     match value {
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(true) => "true".to_string(),
@@ -5459,13 +5542,22 @@ fn owned_to_yaml(value: &OwnedValue) -> String {
         OwnedValue::NumberLiteral(_, literal) => format_number_jq_compat(literal.as_bytes()),
         OwnedValue::String(s) => yaml_quote_string(s),
         OwnedValue::Array(arr) => {
-            let items: Vec<String> = arr.iter().map(owned_to_yaml).collect();
+            let items: Vec<String> = arr
+                .iter()
+                .map(|v| owned_to_yaml_at_depth(v, depth + 1))
+                .collect();
             format!("[{}]", items.join(", "))
         }
         OwnedValue::Object(obj) => {
             let pairs: Vec<String> = obj
                 .iter()
-                .map(|(k, v)| format!("{}: {}", yaml_quote_string(k), owned_to_yaml(v)))
+                .map(|(k, v)| {
+                    format!(
+                        "{}: {}",
+                        yaml_quote_string(k),
+                        owned_to_yaml_at_depth(v, depth + 1)
+                    )
+                })
                 .collect();
             format!("{{{}}}", pairs.join(", "))
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40082,4 +40082,95 @@ mod tests {
             "to_owned should panic at MAX_VALUE_TREE_DEPTH"
         );
     }
+
+    /// #1017: `*`/`*=` merge had no guard anywhere in the mutually-recursive
+    /// `merge_values`/`merge_existing`/`merge_object_fields`/
+    /// `merge_arrays_by_index` family; `deep_merge_arrays` (the `d` flag)
+    /// exercises the array leg, which -- unlike the object leg -- is only
+    /// reachable when both sides are arrays at every level.
+    #[test]
+    fn merge_values_panics_past_nesting_depth_limit_1017() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let flags = MergeFlags {
+            deep_merge_arrays: true,
+            ..Default::default()
+        };
+
+        let under_a = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let under_b = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let _ = merge_values(under_a, under_b, flags);
+
+        let over_a = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let over_b = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            merge_values(over_a, over_b, flags)
+        }));
+        assert!(
+            result.is_err(),
+            "merge_values should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1017: `flatten` had no guard on its own tree-recursion depth,
+    /// distinct from the pre-existing `depth` parameter (remaining flatten
+    /// levels) it already threads. Passes `usize::MAX` for that parameter
+    /// so it can never be the thing that stops recursion first -- with a
+    /// flatten-level count matched to the actual nesting instead, `depth`
+    /// and the tree-depth counter reach zero on the same call, and the
+    /// early `if depth == 0` return happens *before* the assert, masking
+    /// it entirely.
+    #[test]
+    fn flatten_owned_panics_past_nesting_depth_limit_1017() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = vec![linear_array_nest(MAX_VALUE_TREE_DEPTH - 1)];
+        let _ = flatten_owned(under, usize::MAX);
+
+        let over = vec![linear_array_nest(MAX_VALUE_TREE_DEPTH)];
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            flatten_owned(over, usize::MAX)
+        }));
+        assert!(
+            result.is_err(),
+            "flatten_owned should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1017: `@props`'s recursive formatter had no guard, reachable on a
+    /// value constructed via `reduce`/`foreach`/etc. with no adversarial
+    /// document involved.
+    #[test]
+    fn format_props_panics_past_nesting_depth_limit_1017() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert!(format_props(&under).is_ok());
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| format_props(&over)));
+        assert!(
+            result.is_err(),
+            "format_props should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1017: `@yaml`'s flow-style formatter had no guard, reachable on a
+    /// value constructed via `reduce`/`foreach`/etc. with no adversarial
+    /// document involved.
+    #[test]
+    fn owned_to_yaml_panics_past_nesting_depth_limit_1017() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let _ = owned_to_yaml(&under);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| owned_to_yaml(&over)));
+        assert!(
+            result.is_err(),
+            "owned_to_yaml should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -84,16 +84,15 @@ pub const MAX_NESTING_DEPTH: usize = 256;
 
 /// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998).
 ///
-/// The one place every guarded recursive function in the binary raises, so
-/// they can't drift on wording or the comparison itself the way three
-/// independently hand-copied `assert!`s already had before this extraction
-/// (review finding: `to_owned`/`to_owned_cursor`/`to_owned_with_comments`
-/// each carried a byte-identical copy).
+/// A thin wrapper around
+/// [`value::assert_depth`](super::value::assert_depth) (#1018) -- the
+/// underlying `assert!` used to be hand-copied here (fixing a #998 review
+/// finding that `to_owned`/`to_owned_cursor`/`to_owned_with_comments` each
+/// carried their own byte-identical copy), and again independently in
+/// `value.rs` for [`value::MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)'s
+/// own guard -- the same duplication shape recurring one level up.
 pub fn assert_nesting_depth(depth: usize) {
-    assert!(
-        depth < MAX_NESTING_DEPTH,
-        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
-    );
+    super::value::assert_depth(depth, MAX_NESTING_DEPTH);
 }
 
 /// Convert a DocumentValue to an OwnedValue.
@@ -813,10 +812,25 @@ fn into_lazy_items<V: DocumentValue>(
 }
 
 /// Convert a StandardJson value to an OwnedValue.
+///
+/// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#1017) -- a third,
+/// independent copy of the cursor-to-`OwnedValue` conversion `to_owned`/
+/// `to_owned_cursor` already guard in this same file (#998); reached from
+/// `eval_on_owned`/`eval_single`'s fallback arm on a value this module
+/// constructs internally (e.g. a `reduce`/`foreach` accumulator), the same
+/// gap #998's own guards on the other two copies were added to close.
 fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(
     value: &crate::json::light::StandardJson<'_, W>,
 ) -> OwnedValue {
+    standard_json_to_owned_at_depth(value, 0)
+}
+
+fn standard_json_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
+    value: &crate::json::light::StandardJson<'_, W>,
+    depth: usize,
+) -> OwnedValue {
     use crate::json::light::StandardJson;
+    assert_nesting_depth(depth);
     match value {
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(*b),
@@ -824,9 +838,11 @@ fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(
         StandardJson::String(s) => {
             OwnedValue::String(s.as_str().map(|c| c.to_string()).unwrap_or_default())
         }
-        StandardJson::Array(elements) => {
-            OwnedValue::Array((*elements).map(|e| standard_json_to_owned(&e)).collect())
-        }
+        StandardJson::Array(elements) => OwnedValue::Array(
+            (*elements)
+                .map(|e| standard_json_to_owned_at_depth(&e, depth + 1))
+                .collect(),
+        ),
         StandardJson::Object(fields) => OwnedValue::Object(
             (*fields)
                 .filter_map(|field| {
@@ -834,7 +850,7 @@ fn standard_json_to_owned<W: Clone + AsRef<[u64]>>(
                         StandardJson::String(s) => s.as_str().ok()?.to_string(),
                         _ => return None,
                     };
-                    let value = standard_json_to_owned(&field.value());
+                    let value = standard_json_to_owned_at_depth(&field.value(), depth + 1);
                     Some((key, value))
                 })
                 .collect(),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -84,8 +84,7 @@ pub const MAX_NESTING_DEPTH: usize = 256;
 
 /// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998).
 ///
-/// A thin wrapper around
-/// [`value::assert_depth`](super::value::assert_depth) (#1018) -- the
+/// A thin wrapper around `value::assert_depth` (#1018) -- the
 /// underlying `assert!` used to be hand-copied here (fixing a #998 review
 /// finding that `to_owned`/`to_owned_cursor`/`to_owned_with_comments` each
 /// carried their own byte-identical copy), and again independently in

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -91,6 +91,11 @@ pub const MAX_NESTING_DEPTH: usize = 256;
 /// carried their own byte-identical copy), and again independently in
 /// `value.rs` for [`value::MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)'s
 /// own guard -- the same duplication shape recurring one level up.
+///
+/// `#[track_caller]` so a panic reports the guarded function's own call
+/// site rather than collapsing to `assert_depth`'s shared body (#1020
+/// code review).
+#[track_caller]
 pub fn assert_nesting_depth(depth: usize) {
     super::value::assert_depth(depth, MAX_NESTING_DEPTH);
 }
@@ -9074,5 +9079,30 @@ mod tests {
         let result =
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| to_owned_cursor(&cursor)));
         assert!(result.is_err(), "to_owned_cursor should panic at depth 256");
+    }
+
+    /// #1017: `standard_json_to_owned` is a third, independent copy of the
+    /// cursor-to-`OwnedValue` conversion `to_owned`/`to_owned_cursor` are
+    /// already guarded above (#998) -- same limit, same construction, its
+    /// own guard.
+    #[test]
+    fn standard_json_to_owned_panics_past_nesting_depth_limit_1017() {
+        let json = linear_nest(255);
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let owned = standard_json_to_owned(&cursor.value());
+        assert!(matches!(owned, OwnedValue::Object(_)));
+
+        let json = linear_nest(256);
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let value = cursor.value();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            standard_json_to_owned(&value)
+        }));
+        assert!(
+            result.is_err(),
+            "standard_json_to_owned should panic at depth 256"
+        );
     }
 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -70,6 +70,14 @@ pub const MAX_VALUE_TREE_DEPTH: usize = 384;
 /// silently" shape #998 had already fixed once for three earlier copies
 /// of this exact check. Both are now thin wrappers around this one,
 /// parameterized by `max` instead of re-deriving the assertion.
+///
+/// `#[track_caller]` (and on both wrappers below) so a panic reports the
+/// call site inside the actual `_at_depth` recursive function that
+/// overflowed, not this shared body's own line -- otherwise every one of
+/// the ~15 guarded call sites collapses to the same file:line, making a
+/// crash report impossible to attribute without a full backtrace (#1020
+/// code review).
+#[track_caller]
 pub fn assert_depth(depth: usize, max: usize) {
     assert!(depth < max, "nesting depth exceeds limit of {max}");
 }
@@ -79,6 +87,7 @@ pub fn assert_depth(depth: usize, max: usize) {
 /// See that constant's own doc comment for why this exists as a second,
 /// independently-tuned ceiling alongside
 /// [`eval_generic::assert_nesting_depth`](super::eval_generic::assert_nesting_depth).
+#[track_caller]
 pub fn assert_value_tree_depth(depth: usize) {
     assert_depth(depth, MAX_VALUE_TREE_DEPTH);
 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -59,16 +59,28 @@ use super::expr::Literal;
 /// smaller default stack than the dev machine this was measured on.
 pub const MAX_VALUE_TREE_DEPTH: usize = 384;
 
+/// Panics past `max` levels of nesting.
+///
+/// The one place every depth-guarded recursive function in the binary
+/// raises, regardless of which ceiling it's checked against (#1018) --
+/// before this, [`assert_value_tree_depth`] and
+/// [`eval_generic::assert_nesting_depth`](super::eval_generic::assert_nesting_depth)
+/// each carried their own byte-identical `assert!` body, hardcoding a
+/// different constant -- the same "duplicated predicates diverge
+/// silently" shape #998 had already fixed once for three earlier copies
+/// of this exact check. Both are now thin wrappers around this one,
+/// parameterized by `max` instead of re-deriving the assertion.
+pub fn assert_depth(depth: usize, max: usize) {
+    assert!(depth < max, "nesting depth exceeds limit of {max}");
+}
+
 /// Panics past [`MAX_VALUE_TREE_DEPTH`] levels of nesting (#1005).
 ///
 /// See that constant's own doc comment for why this exists as a second,
 /// independently-tuned ceiling alongside
 /// [`eval_generic::assert_nesting_depth`](super::eval_generic::assert_nesting_depth).
 pub fn assert_value_tree_depth(depth: usize) {
-    assert!(
-        depth < MAX_VALUE_TREE_DEPTH,
-        "nesting depth exceeds limit of {MAX_VALUE_TREE_DEPTH}"
-    );
+    assert_depth(depth, MAX_VALUE_TREE_DEPTH);
 }
 
 /// The parsed value backing a [`OwnedValue::NumberLiteral`], kept separate


### PR DESCRIPTION
## Summary

Extends #1005's depth-guard pattern (established in #998) to every remaining unguarded `OwnedValue`/`CommentTree` tree-walker that #1017 identified:

- `standard_json_to_owned`
- `emit_yaml_value`
- `format_props_recursive`
- `owned_to_yaml`
- the `merge_values`/`merge_existing`/`merge_position`/`merge_object_fields`/`merge_arrays_by_index` family (backs `*`/`*=` merge semantics)
- `flatten_owned`
- `canonicalize_json_numbers`
- `strip_presentation_style`
- `serde_json_to_owned`

Each gains an `_at_depth` sibling threading an explicit `depth: usize` that increments only at actual descent into a child node (not at every function-call hop), guarded via a new shared `value::assert_depth(depth, max)` helper (#1018) — replacing the two byte-identical `assert!` bodies that `assert_value_tree_depth` and `eval_generic::assert_nesting_depth` previously each carried independently against their own constant.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Live-verified merge/flatten output against CLAUDE.md's documented `*=`/`flatten` examples — byte-identical to pre-change behavior

Fixes #1017
Fixes #1018