### PR TITLE
fix(jq): guard 9 more recursive OwnedValue/JqValue walkers against stack overflow (#1021)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4184,18 +4184,27 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `false`, not the error [`EvalError::containment_check`] raises. The callers
 /// screen the top level with [`jq_kind`], so this stays a total function.
 fn owned_contains(a: &OwnedValue, b: &OwnedValue) -> bool {
+    owned_contains_at_depth(a, b, 0)
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](crate::jq::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1021, following #1005's precedent).
+fn owned_contains_at_depth(a: &OwnedValue, b: &OwnedValue, depth: usize) -> bool {
+    assert_value_tree_depth(depth);
     match (a, b) {
         // String contains string
         (OwnedValue::String(a_str), OwnedValue::String(b_str)) => a_str.contains(b_str.as_str()),
         // Array contains: all elements of b must be contained in a
-        (OwnedValue::Array(a_arr), OwnedValue::Array(b_arr)) => b_arr
-            .iter()
-            .all(|b_elem| a_arr.iter().any(|a_elem| owned_contains(a_elem, b_elem))),
+        (OwnedValue::Array(a_arr), OwnedValue::Array(b_arr)) => b_arr.iter().all(|b_elem| {
+            a_arr
+                .iter()
+                .any(|a_elem| owned_contains_at_depth(a_elem, b_elem, depth + 1))
+        }),
         // Object contains: all keys in b must exist in a with matching values
         (OwnedValue::Object(a_obj), OwnedValue::Object(b_obj)) => b_obj.iter().all(|(k, b_val)| {
             a_obj
                 .get(k)
-                .is_some_and(|a_val| owned_contains(a_val, b_val))
+                .is_some_and(|a_val| owned_contains_at_depth(a_val, b_val, depth + 1))
         }),
         // Scalars: equality
         _ => a == b,
@@ -11538,11 +11547,20 @@ fn resolve_recursive_descent(value: &OwnedValue) -> Vec<PathBranch<'_>> {
 /// `Vec<Expr>` path components rather than the value — tracked separately as
 /// #701 since it needs a different technique (structural sharing over the
 /// path list, not `Cow`) and #668 never scoped it in.
+///
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](crate::jq::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1021, following #1005's precedent) — `prefix` already
+/// grows by exactly one component per descent from its sole call site
+/// (`resolve_recursive_descent`, starting at `&[]`), so its length doubles
+/// as the recursion depth with no extra parameter needed. `tests/
+/// jq_recurse_depth_tests.rs` already pins a depth-300 correctness floor
+/// through this exact function (#626/#661) — well under the 384 ceiling.
 fn push_recursive_branches<'a>(
     prefix: &[Expr],
     value: &'a OwnedValue,
     out: &mut Vec<PathBranch<'a>>,
 ) {
+    assert_value_tree_depth(prefix.len());
     out.push((prefix.to_vec(), Cow::Borrowed(value)));
     match value {
         OwnedValue::Array(items) => {
@@ -14799,11 +14817,23 @@ fn walk_impl<S: EvalSemantics>(
     value: OwnedValue,
     optional: bool,
 ) -> (Vec<OwnedValue>, Option<Control>) {
+    walk_impl_at_depth::<S>(f, value, optional, 0)
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](crate::jq::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1021, following #1005's precedent).
+fn walk_impl_at_depth<S: EvalSemantics>(
+    f: &Expr,
+    value: OwnedValue,
+    optional: bool,
+    depth: usize,
+) -> (Vec<OwnedValue>, Option<Control>) {
+    assert_value_tree_depth(depth);
     let processed = match value {
         OwnedValue::Array(arr) => {
             let mut new_arr = Vec::with_capacity(arr.len());
             for v in arr {
-                let (vs, control) = walk_impl::<S>(f, v, optional);
+                let (vs, control) = walk_impl_at_depth::<S>(f, v, optional, depth + 1);
                 new_arr.extend(vs);
                 if let Some(control) = control {
                     return (Vec::new(), Some(control));
@@ -14814,7 +14844,7 @@ fn walk_impl<S: EvalSemantics>(
         OwnedValue::Object(obj) => {
             let mut new_obj = IndexMap::with_capacity(obj.len());
             for (k, v) in obj {
-                let (vs, control) = walk_impl::<S>(f, v, optional);
+                let (vs, control) = walk_impl_at_depth::<S>(f, v, optional, depth + 1);
                 if let Some(control) = control {
                     return (Vec::new(), Some(control));
                 }
@@ -16282,8 +16312,15 @@ fn extend(current_path: &[OwnedValue], component: OwnedValue) -> Vec<OwnedValue>
     path
 }
 
-/// Helper to collect all paths recursively
+/// Helper to collect all paths recursively.
+///
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](crate::jq::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1021, following #1005's precedent) — `current_path`
+/// already grows by exactly one component per descent from both call sites
+/// (`builtin_paths`/`builtin_paths_filter`, both starting at `&[]`), so its
+/// length doubles as the recursion depth with no extra parameter needed.
 fn collect_paths(value: &OwnedValue, current_path: &[OwnedValue], paths: &mut Vec<OwnedValue>) {
+    assert_value_tree_depth(current_path.len());
     match value {
         OwnedValue::Object(entries) => {
             for (key, val) in entries {
@@ -16310,7 +16347,14 @@ fn collect_paths(value: &OwnedValue, current_path: &[OwnedValue], paths: &mut Ve
 /// every *non-empty* container, whose path is the container's own path with
 /// its last key/index appended (jq's own convention — verified against
 /// jq-1.7.1, see `test_tostream_*` below).
+///
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](crate::jq::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1021, following #1005's precedent) — `path` already
+/// grows by exactly one component per descent from its sole call site
+/// (`builtin_tostream`, starting at `&[]`), so its length doubles as the
+/// recursion depth with no extra parameter needed.
 fn collect_tostream_events(value: &OwnedValue, path: &[OwnedValue], events: &mut Vec<OwnedValue>) {
+    assert_value_tree_depth(path.len());
     match value {
         OwnedValue::Object(entries) if !entries.is_empty() => {
             let mut last_path = path.to_vec();
@@ -40171,6 +40215,121 @@ mod tests {
         assert!(
             result.is_err(),
             "owned_to_yaml should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1021: `owned_contains` (backs `contains`/`inside`) had no depth
+    /// guard at all before this issue.
+    #[test]
+    fn owned_contains_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under_a = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let under_b = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert!(owned_contains(&under_a, &under_b));
+
+        let over_a = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let over_b = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            owned_contains(&over_a, &over_b)
+        }));
+        assert!(
+            result.is_err(),
+            "owned_contains should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1021: `collect_paths` (backs `paths`/`paths(node_filter)`) had no
+    /// depth guard at all before this issue -- `current_path.len()` doubles
+    /// as the recursion depth, so no new parameter was needed, just the
+    /// assertion.
+    #[test]
+    fn collect_paths_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut paths = Vec::new();
+        collect_paths(&under, &[], &mut paths);
+        assert_eq!(paths.len(), MAX_VALUE_TREE_DEPTH - 1);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut paths = Vec::new();
+            collect_paths(&over, &[], &mut paths);
+        }));
+        assert!(
+            result.is_err(),
+            "collect_paths should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1021: `collect_tostream_events` (backs `tostream`) had no depth
+    /// guard at all before this issue -- `path.len()` doubles as the
+    /// recursion depth, so no new parameter was needed, just the assertion.
+    #[test]
+    fn collect_tostream_events_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut events = Vec::new();
+        collect_tostream_events(&under, &[], &mut events);
+        assert!(!events.is_empty());
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut events = Vec::new();
+            collect_tostream_events(&over, &[], &mut events);
+        }));
+        assert!(
+            result.is_err(),
+            "collect_tostream_events should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1021: `push_recursive_branches` (backs `..`/bare `recurse`) had no
+    /// depth guard at all before this issue -- `prefix.len()` doubles as the
+    /// recursion depth, so no new parameter was needed, just the assertion.
+    /// `tests/jq_recurse_depth_tests.rs` already pins a depth-300
+    /// correctness floor through this exact function (#626/#661), well
+    /// under the 384 ceiling asserted here.
+    #[test]
+    fn push_recursive_branches_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut out = Vec::new();
+        push_recursive_branches(&[], &under, &mut out);
+        assert_eq!(out.len(), MAX_VALUE_TREE_DEPTH);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut out = Vec::new();
+            push_recursive_branches(&[], &over, &mut out);
+        }));
+        assert!(
+            result.is_err(),
+            "push_recursive_branches should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1021: `walk_impl` (backs `walk(f)`) had no depth guard at all
+    /// before this issue.
+    #[test]
+    fn walk_impl_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let (vals, control) = walk_impl::<JqSemantics>(&Expr::Identity, under, false);
+        assert!(control.is_none());
+        assert_eq!(vals.len(), 1);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            walk_impl::<JqSemantics>(&Expr::Identity, over, false)
+        }));
+        assert!(
+            result.is_err(),
+            "walk_impl should panic at MAX_VALUE_TREE_DEPTH"
         );
     }
 }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -27,7 +27,7 @@ use crate::json::light::{JsonCursor, StandardJson};
 
 use super::escape::write_json_body_jq;
 use super::expr::Literal;
-use super::value::OwnedValue;
+use super::value::{assert_value_tree_depth, OwnedValue};
 
 /// A JSON value for jq evaluation - lazy by default, materialized when needed.
 ///
@@ -385,6 +385,13 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     /// This recursively materializes all nested values. Use sparingly -
     /// prefer keeping values as cursors when possible.
     pub fn materialize(&self) -> OwnedValue {
+        self.materialize_at_depth(0)
+    }
+
+    /// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+    /// levels of nesting (#1021, following #1005's precedent).
+    fn materialize_at_depth(&self, depth: usize) -> OwnedValue {
+        assert_value_tree_depth(depth);
         match self {
             JqValue::Cursor(c) => cursor_to_owned(c),
             JqValue::Null => OwnedValue::Null,
@@ -394,12 +401,14 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::RawNumber(bytes) => OwnedValue::from_number_bytes(bytes),
             JqValue::NumberLiteral(literal) => OwnedValue::from_number_literal(literal),
             JqValue::String(s) => OwnedValue::String(s.clone()),
-            JqValue::Array(arr) => {
-                OwnedValue::Array(arr.iter().map(JqValue::materialize).collect())
-            }
+            JqValue::Array(arr) => OwnedValue::Array(
+                arr.iter()
+                    .map(|v| v.materialize_at_depth(depth + 1))
+                    .collect(),
+            ),
             JqValue::Object(obj) => OwnedValue::Object(
                 obj.iter()
-                    .map(|(k, v)| (k.clone(), v.materialize()))
+                    .map(|(k, v)| (k.clone(), v.materialize_at_depth(depth + 1)))
                     .collect(),
             ),
             JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(fields),
@@ -411,6 +420,13 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     ///
     /// More efficient than `materialize()` when you don't need to keep the original.
     pub fn into_owned(self) -> OwnedValue {
+        self.into_owned_at_depth(0)
+    }
+
+    /// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+    /// levels of nesting (#1021, following #1005's precedent).
+    fn into_owned_at_depth(self, depth: usize) -> OwnedValue {
+        assert_value_tree_depth(depth);
         match self {
             JqValue::Cursor(c) => cursor_to_owned(&c),
             JqValue::Null => OwnedValue::Null,
@@ -420,12 +436,16 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::RawNumber(bytes) => OwnedValue::from_number_bytes(bytes),
             JqValue::NumberLiteral(literal) => OwnedValue::from_number_literal_boxed(literal),
             JqValue::String(s) => OwnedValue::String(s),
-            JqValue::Array(arr) => {
-                OwnedValue::Array(arr.into_iter().map(JqValue::into_owned).collect())
-            }
-            JqValue::Object(obj) => {
-                OwnedValue::Object(obj.into_iter().map(|(k, v)| (k, v.into_owned())).collect())
-            }
+            JqValue::Array(arr) => OwnedValue::Array(
+                arr.into_iter()
+                    .map(|v| v.into_owned_at_depth(depth + 1))
+                    .collect(),
+            ),
+            JqValue::Object(obj) => OwnedValue::Object(
+                obj.into_iter()
+                    .map(|(k, v)| (k, v.into_owned_at_depth(depth + 1)))
+                    .collect(),
+            ),
             JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(&fields),
             JqValue::LazyIndexRange(len) => lazy_index_range_to_owned(len),
         }
@@ -1043,5 +1063,53 @@ mod tests {
         let cursor = index.root(json);
         let into_owned_val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
         assert_eq!(into_owned_val.into_owned().to_json(), "1E+100");
+    }
+
+    /// `depth` levels of single-element array nesting: `[[[...[null]...]]]`.
+    /// Mirrors `value.rs`/`eval.rs`'s own `linear_array_nest` helper (#1005),
+    /// built directly out of `JqValue` since `materialize`/`into_owned`
+    /// recurse over that type, not `OwnedValue`.
+    fn linear_jqvalue_nest(depth: usize) -> JqValue<'static, Vec<u64>> {
+        let mut v = JqValue::Null;
+        for _ in 0..depth {
+            v = JqValue::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1021: `JqValue::materialize` had no depth guard at all before this
+    /// issue -- unlike its `Cursor` arm (already guarded independently via
+    /// `cursor_to_owned_at_depth`), the `Array`/`Object` arms recursed
+    /// unbounded.
+    #[test]
+    fn materialize_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert!(matches!(under.materialize(), OwnedValue::Array(_)));
+
+        let over = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.materialize()));
+        assert!(
+            result.is_err(),
+            "materialize should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1021: `JqValue::into_owned` had no depth guard at all before this
+    /// issue -- same gap as `materialize`, just on the consuming twin.
+    #[test]
+    fn into_owned_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert!(matches!(under.into_owned(), OwnedValue::Array(_)));
+
+        let over = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.into_owned()));
+        assert!(
+            result.is_err(),
+            "into_owned should panic at MAX_VALUE_TREE_DEPTH"
+        );
     }
 }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -1088,6 +1088,16 @@ mod tests {
         let under = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH - 1);
         assert!(matches!(under.materialize(), OwnedValue::Array(_)));
 
+        // The `Object` arm is a separate match arm from `Array`'s, with its
+        // own recursive `.map()` closure -- exercise it too so both arms are
+        // covered, not just the array-nesting shape `linear_jqvalue_nest`
+        // builds.
+        let nested_object: JqValue<'_, Vec<u64>> = JqValue::Object(IndexMap::from([(
+            "a".to_string(),
+            JqValue::Array(vec![JqValue::Null]),
+        )]));
+        assert!(matches!(nested_object.materialize(), OwnedValue::Object(_)));
+
         let over = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.materialize()));
         assert!(
@@ -1104,6 +1114,14 @@ mod tests {
 
         let under = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH - 1);
         assert!(matches!(under.into_owned(), OwnedValue::Array(_)));
+
+        // Exercise the `Object` arm too -- see `materialize`'s sibling test
+        // above for why.
+        let nested_object: JqValue<'_, Vec<u64>> = JqValue::Object(IndexMap::from([(
+            "a".to_string(),
+            JqValue::Array(vec![JqValue::Null]),
+        )]));
+        assert!(matches!(nested_object.into_owned(), OwnedValue::Object(_)));
 
         let over = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.into_owned()));

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -584,7 +584,6 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
 
 /// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
 /// levels of nesting (#1021, following #1005's precedent).
-#[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors stream_owned_value_json_with's own suppression above.
 fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
     value: &OwnedValue,
     out: &mut W,

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -25,7 +25,10 @@ use alloc::vec::Vec;
 
 use super::document::{DocumentFields, IndentSpec};
 use super::escape::{write_json_body_jq, write_json_body_yq};
-use super::value::{format_number_jq_compat, infinite_float_preview_text, NumberRepr, OwnedValue};
+use super::value::{
+    assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text, NumberRepr,
+    OwnedValue,
+};
 use crate::yaml::format_float_with_fraction;
 
 /// A value that can be streamed directly to output without intermediate allocation.
@@ -276,6 +279,38 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
     infinite_float: fn(bool) -> String,
     infinite_literal: fn(&[u8]) -> String,
 ) -> core::fmt::Result {
+    stream_owned_value_json_with_at_depth(
+        value,
+        out,
+        current_indent,
+        indent_spaces,
+        unit,
+        sort_keys,
+        escape,
+        float_fmt,
+        infinite_float,
+        infinite_literal,
+        0,
+    )
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1021, following #1005's precedent).
+#[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors stream_owned_value_json_with's own suppression above.
+fn stream_owned_value_json_with_at_depth<W: core::fmt::Write>(
+    value: &OwnedValue,
+    out: &mut W,
+    current_indent: usize,
+    indent_spaces: usize,
+    unit: char,
+    sort_keys: bool,
+    escape: fn(&mut W, &str) -> core::fmt::Result,
+    float_fmt: fn(f64) -> String,
+    infinite_float: fn(bool) -> String,
+    infinite_literal: fn(&[u8]) -> String,
+    depth: usize,
+) -> core::fmt::Result {
+    assert_value_tree_depth(depth);
     match value {
         OwnedValue::Null => out.write_str("null"),
         OwnedValue::Bool(true) => out.write_str("true"),
@@ -313,7 +348,7 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
                     out.write_char('\n')?;
                     write_indent(out, next_indent, unit)?;
                 }
-                stream_owned_value_json_with(
+                stream_owned_value_json_with_at_depth(
                     elem,
                     out,
                     next_indent,
@@ -324,6 +359,7 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
                     float_fmt,
                     infinite_float,
                     infinite_literal,
+                    depth + 1,
                 )?;
             }
             if indent_spaces > 0 {
@@ -372,6 +408,7 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
                 float_fmt,
                 infinite_float,
                 infinite_literal,
+                depth + 1,
             )?;
             if indent_spaces > 0 {
                 out.write_char('\n')?;
@@ -418,6 +455,7 @@ fn write_object_entries<'a, W: core::fmt::Write>(
     float_fmt: fn(f64) -> String,
     infinite_float: fn(bool) -> String,
     infinite_literal: fn(&[u8]) -> String,
+    depth: usize,
 ) -> core::fmt::Result {
     for (i, (key, value)) in entries.enumerate() {
         if i > 0 {
@@ -429,7 +467,7 @@ fn write_object_entries<'a, W: core::fmt::Write>(
         }
         stream_json_string(out, key, escape)?;
         out.write_str(if indent_spaces > 0 { ": " } else { ":" })?;
-        stream_owned_value_json_with(
+        stream_owned_value_json_with_at_depth(
             value,
             out,
             next_indent,
@@ -440,6 +478,7 @@ fn write_object_entries<'a, W: core::fmt::Write>(
             float_fmt,
             infinite_float,
             infinite_literal,
+            depth,
         )?;
     }
     Ok(())
@@ -540,6 +579,22 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
     unit: char,
     sort_keys: bool,
 ) -> core::fmt::Result {
+    stream_owned_value_yaml_at_depth(value, out, indent, indent_spaces, unit, sort_keys, 0)
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1021, following #1005's precedent).
+#[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors stream_owned_value_json_with's own suppression above.
+fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
+    value: &OwnedValue,
+    out: &mut W,
+    indent: &str,
+    indent_spaces: usize,
+    unit: char,
+    sort_keys: bool,
+    depth: usize,
+) -> core::fmt::Result {
+    assert_value_tree_depth(depth);
     match value {
         OwnedValue::Null => out.write_str("null"),
         OwnedValue::Bool(true) => out.write_str("true"),
@@ -579,7 +634,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                     if i > 0 {
                         out.write_str(", ")?;
                     }
-                    stream_owned_value_yaml(elem, out, "", 0, unit, sort_keys)?;
+                    stream_owned_value_yaml_at_depth(elem, out, "", 0, unit, sort_keys, depth + 1)?;
                 }
                 out.write_char(']')
             } else {
@@ -603,23 +658,25 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                         && !is_empty_container(elem)
                     {
                         let child_indent = compact_indent(indent);
-                        stream_owned_value_yaml(
+                        stream_owned_value_yaml_at_depth(
                             elem,
                             out,
                             &child_indent,
                             indent_spaces,
                             unit,
                             sort_keys,
+                            depth + 1,
                         )?;
                     } else {
                         let child_indent = deeper_indent(indent, indent_spaces, unit);
-                        stream_owned_value_yaml(
+                        stream_owned_value_yaml_at_depth(
                             elem,
                             out,
                             &child_indent,
                             indent_spaces,
                             unit,
                             sort_keys,
+                            depth + 1,
                         )?;
                     }
                 }
@@ -643,7 +700,7 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                     }
                     stream_yaml_string(out, key)?;
                     out.write_str(": ")?;
-                    stream_owned_value_yaml(val, out, "", 0, unit, sort_keys)?;
+                    stream_owned_value_yaml_at_depth(val, out, "", 0, unit, sort_keys, depth + 1)?;
                 }
                 out.write_char('}')
             } else {
@@ -662,24 +719,26 @@ fn stream_owned_value_yaml<W: core::fmt::Write>(
                         out.write_char('\n')?;
                         let child_indent = deeper_indent(indent, indent_spaces, unit);
                         out.write_str(&child_indent)?;
-                        stream_owned_value_yaml(
+                        stream_owned_value_yaml_at_depth(
                             val,
                             out,
                             &child_indent,
                             indent_spaces,
                             unit,
                             sort_keys,
+                            depth + 1,
                         )?;
                     } else {
                         out.write_char(' ')?;
                         let child_indent = deeper_indent(indent, indent_spaces, unit);
-                        stream_owned_value_yaml(
+                        stream_owned_value_yaml_at_depth(
                             val,
                             out,
                             &child_indent,
                             indent_spaces,
                             unit,
                             sort_keys,
+                            depth + 1,
                         )?;
                     }
                 }
@@ -1434,5 +1493,64 @@ mod tests {
         assert!(!OwnedValue::Bool(true).is_falsy());
         assert!(!OwnedValue::Int(0).is_falsy());
         assert!(!OwnedValue::String(String::new()).is_falsy());
+    }
+
+    /// `depth` levels of single-element array nesting: `[[[...[null]...]]]`.
+    /// Mirrors `value.rs`/`eval.rs`'s own `linear_array_nest` helper (#1005).
+    fn linear_array_nest(depth: usize) -> OwnedValue {
+        let mut v = OwnedValue::Null;
+        for _ in 0..depth {
+            v = OwnedValue::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1021: `stream_owned_value_json_with` (backs `stream_json`/`syq -o
+    /// json`, and `stream_owned_value_json_jq`'s error-message convention)
+    /// had no depth guard at all before this issue.
+    #[test]
+    fn stream_owned_value_json_with_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut buf = String::new();
+        under
+            .stream_json(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert!(!buf.is_empty());
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut buf = String::new();
+            over.stream_json(&mut buf, IndentSpec::COMPACT, false)
+        }));
+        assert!(
+            result.is_err(),
+            "stream_owned_value_json_with should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1021: `stream_owned_value_yaml` (backs `stream_yaml`/`yq`'s default
+    /// output) had no depth guard at all before this issue.
+    #[test]
+    fn stream_owned_value_yaml_panics_past_nesting_depth_limit_1021() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut buf = String::new();
+        under
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert!(!buf.is_empty());
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut buf = String::new();
+            over.stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+        }));
+        assert!(
+            result.is_err(),
+            "stream_owned_value_yaml should panic at MAX_VALUE_TREE_DEPTH"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1005/#1015/#1017/#1018/#1020: those PRs guarded the recursive `OwnedValue`/`CommentTree` walkers their own audits named, but #1020's own code review found 9 more with no depth guard at all — including two on the **primary output path of nearly every successful `jq`/`yq` invocation** (`stream_owned_value_json_with`, `stream_owned_value_yaml`), making this a live, directly user-triggerable stack-overflow crash (SIGABRT) on a deeply-nested adversarial input document, not just defense-in-depth for an internally-bounded case.

Applied the established pattern (`assert_value_tree_depth(depth)` before matching, threading `depth + 1` into every actual descent into an `Array`/`Object` child) to all 9:

- `collect_paths`, `collect_tostream_events`, `push_recursive_branches` (`src/jq/eval.rs`) needed **no new parameter at all** — `current_path.len()`/`path.len()`/`prefix.len()` already doubles as the recursion depth at every call site.
- `owned_contains`, `walk_impl` (`src/jq/eval.rs`), `JqValue::materialize`, `JqValue::into_owned` (`src/jq/lazy.rs`), `stream_owned_value_json_with` (+ its `write_object_entries` helper) and `stream_owned_value_yaml` (`src/jq/stream.rs`) needed a new `depth: usize` threaded through a public wrapper + private `_at_depth` twin, mirroring `to_json`/`to_json_at_depth` (#1005).

One dedicated panic test per function, mirroring `compare_values_panics_past_nesting_depth_limit_1005` and its siblings.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (all 53 test binaries, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] 9 new panic tests, one per guarded function, verified individually
- [x] `tests/jq_recurse_depth_tests.rs`'s existing depth-300 correctness floor through `push_recursive_branches` re-verified passing (well under the new 384 ceiling)

Fixes #1021