### PR TITLE
fix(cli): preserve scientific-notation literals through non-identity navigation

### DIFF
--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -367,12 +367,20 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 }
             }
         }
-        OwnedValue::NumberLiteral(..) => {
+        OwnedValue::NumberLiteral(_, literal) => {
             if value
                 .as_f64()
                 .is_some_and(|f| f.is_nan() || f.is_infinite())
             {
                 "null".to_string() // JSON doesn't support NaN or Infinity
+            } else if opts.control_escape == ControlEscape::Yq {
+                // yq mode: echo the source spelling verbatim (#1008) --
+                // matches the Float arm's own yq/jq split above, and real
+                // yq's documented byte-for-byte literal preservation. jq
+                // mode keeps `number_str()`'s jq-compat reformatting
+                // (verified to match real jq's own scientific-notation
+                // rules) unchanged.
+                literal.to_string()
             } else {
                 value.number_str().expect("numeric variant").into_owned()
             }

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -9,7 +9,9 @@ use succinctly::jq::escape::{
     escape_json_body as run_escaper, write_json_body_jq, write_json_body_jq_ascii,
     write_json_body_yq, write_json_body_yq_ascii,
 };
-use succinctly::jq::{assert_value_tree_depth, EvalError, OwnedValue, StreamError};
+use succinctly::jq::{
+    assert_value_tree_depth, format_number_jq_compat, EvalError, OwnedValue, StreamError,
+};
 use succinctly::yaml::format_float_with_fraction;
 pub use succinctly::yaml::format_float_yq;
 
@@ -377,12 +379,15 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 // yq mode: echo the source spelling verbatim (#1008) --
                 // matches the Float arm's own yq/jq split above, and real
                 // yq's documented byte-for-byte literal preservation. jq
-                // mode keeps `number_str()`'s jq-compat reformatting
-                // (verified to match real jq's own scientific-notation
-                // rules) unchanged.
+                // mode keeps `format_number_jq_compat`'s reformatting
+                // unchanged. This PR fixed its `-0.0`-sign-loss bug (also
+                // #1008, since widening `is_preservable_float_literal`
+                // newly exposed it via YAML), but it has other pre-existing
+                // divergences from real jq, unrelated and left alone here,
+                // e.g. `0.1e1` -> `1E+0` here vs real jq's `1`.
                 literal.to_string()
             } else {
-                value.number_str().expect("numeric variant").into_owned()
+                format_number_jq_compat(literal.as_bytes())
             }
         }
         OwnedValue::String(s) => {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1534,7 +1534,7 @@ fn emit_yaml_value_at_depth(
                 format_float_yq(*f)
             }
         }
-        OwnedValue::NumberLiteral(..) => {
+        OwnedValue::NumberLiteral(_, literal) => {
             if value.as_f64().is_some_and(f64::is_nan) {
                 ".nan".to_string()
             } else if value.as_f64().is_some_and(f64::is_infinite) {
@@ -1544,7 +1544,12 @@ fn emit_yaml_value_at_depth(
                     "-.inf".to_string()
                 }
             } else {
-                value.number_str().expect("numeric variant").into_owned()
+                // Echo the source spelling verbatim (#1008) rather than
+                // routing through `number_str()`/`format_number_jq_compat`,
+                // which reformats per jq's own rules (uppercase `E`, forced
+                // sign) -- this file is yq-CLI-only, no jq caller to protect,
+                // and yq preserves a document literal's exact text.
+                literal.to_string()
             }
         }
         OwnedValue::String(s) => yaml_quote_string_with_style(s, comments.style()),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -131,8 +131,7 @@ use super::expr::{
     ObjectKey, Pattern, StringPart,
 };
 use super::value::{
-    assert_value_tree_depth, cmp_f64, format_number_jq_compat, is_nan_sentinel, numeric_repr_cmp,
-    NumberRepr, OwnedValue,
+    assert_value_tree_depth, cmp_f64, is_nan_sentinel, numeric_repr_cmp, NumberRepr, OwnedValue,
 };
 
 /// Result of evaluating a jq expression.
@@ -5500,7 +5499,12 @@ fn props_value_to_string(value: &OwnedValue) -> String {
                 "-.inf".to_string()
             }
         }
-        OwnedValue::NumberLiteral(_, literal) => format_number_jq_compat(literal.as_bytes()),
+        // Echo verbatim (#1008): `@props` is documented as a yq-flavored
+        // format function (CLAUDE.md's format table marks it `(yq)`) --
+        // reachable from `succinctly jq` too, but real yq's preservation
+        // convention is the correct one regardless of which binary calls
+        // it, not jq's `format_number_jq_compat` reformatting.
+        OwnedValue::NumberLiteral(_, literal) => literal.to_string(),
         OwnedValue::String(s) => {
             // Replace newlines with spaces, as yq does
             s.replace(['\n', '\r'], " ")
@@ -5548,7 +5552,12 @@ fn owned_to_yaml_at_depth(value: &OwnedValue, depth: usize) -> String {
                 "-.inf".to_string()
             }
         }
-        OwnedValue::NumberLiteral(_, literal) => format_number_jq_compat(literal.as_bytes()),
+        // Echo verbatim (#1008): `@yaml` is documented as a yq-flavored
+        // format function (CLAUDE.md's format table marks it `(yq)`) --
+        // reachable from `succinctly jq` too, but real yq's preservation
+        // convention is the correct one regardless of which binary calls
+        // it, not jq's `format_number_jq_compat` reformatting.
+        OwnedValue::NumberLiteral(_, literal) => literal.to_string(),
         OwnedValue::String(s) => yaml_quote_string(s),
         OwnedValue::Array(arr) => {
             let items: Vec<String> = arr

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -181,7 +181,19 @@ fn stream_owned_value_json<W: core::fmt::Write>(
         format_float_with_fraction,
         real_output_infinite_float,
         real_output_infinite_literal,
+        real_output_finite_literal,
     )
+}
+
+/// The `yq`/real-output convention for a finite `NumberLiteral` (#1008):
+/// echo the document's source spelling verbatim rather than reformatting
+/// it per jq's own rules -- real yq preserves a literal's exact text
+/// (`1e100` stays `1e100`, `1E5` stays `1E5`) regardless of magnitude or
+/// query shape, confirmed empirically against the pinned oracle. `raw` is
+/// always valid UTF-8 (sourced from `OwnedValue::NumberLiteral`'s own
+/// `Box<str>`), so the lossy path here is unreachable in practice.
+fn real_output_finite_literal(raw: &[u8]) -> String {
+    String::from_utf8_lossy(raw).into_owned()
 }
 
 /// The `yq`/real-output convention for an infinite `Float` (NaN is handled
@@ -232,6 +244,7 @@ pub fn stream_owned_value_json_jq<W: core::fmt::Write>(
         |f| f.to_string(),
         |negative| infinite_float_preview_text(negative).to_string(),
         preview_infinite_literal,
+        format_number_jq_compat,
     )
 }
 
@@ -278,6 +291,7 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
     float_fmt: fn(f64) -> String,
     infinite_float: fn(bool) -> String,
     infinite_literal: fn(&[u8]) -> String,
+    finite_literal: fn(&[u8]) -> String,
 ) -> core::fmt::Result {
     stream_owned_value_json_with_at_depth(
         value,
@@ -290,6 +304,7 @@ fn stream_owned_value_json_with<W: core::fmt::Write>(
         float_fmt,
         infinite_float,
         infinite_literal,
+        finite_literal,
         0,
     )
 }
@@ -308,6 +323,7 @@ fn stream_owned_value_json_with_at_depth<W: core::fmt::Write>(
     float_fmt: fn(f64) -> String,
     infinite_float: fn(bool) -> String,
     infinite_literal: fn(&[u8]) -> String,
+    finite_literal: fn(&[u8]) -> String,
     depth: usize,
 ) -> core::fmt::Result {
     assert_value_tree_depth(depth);
@@ -331,7 +347,7 @@ fn stream_owned_value_json_with_at_depth<W: core::fmt::Write>(
             NumberRepr::Float(f) if f.is_infinite() => {
                 out.write_str(&infinite_literal(literal.as_bytes()))
             }
-            _ => out.write_str(&format_number_jq_compat(literal.as_bytes())),
+            _ => out.write_str(&finite_literal(literal.as_bytes())),
         },
         OwnedValue::String(s) => stream_json_string(out, s, escape),
         OwnedValue::Array(arr) => {
@@ -359,6 +375,7 @@ fn stream_owned_value_json_with_at_depth<W: core::fmt::Write>(
                     float_fmt,
                     infinite_float,
                     infinite_literal,
+                    finite_literal,
                     depth + 1,
                 )?;
             }
@@ -408,6 +425,7 @@ fn stream_owned_value_json_with_at_depth<W: core::fmt::Write>(
                 float_fmt,
                 infinite_float,
                 infinite_literal,
+                finite_literal,
                 depth + 1,
             )?;
             if indent_spaces > 0 {
@@ -455,6 +473,7 @@ fn write_object_entries<'a, W: core::fmt::Write>(
     float_fmt: fn(f64) -> String,
     infinite_float: fn(bool) -> String,
     infinite_literal: fn(&[u8]) -> String,
+    finite_literal: fn(&[u8]) -> String,
     depth: usize,
 ) -> core::fmt::Result {
     for (i, (key, value)) in entries.enumerate() {
@@ -478,6 +497,7 @@ fn write_object_entries<'a, W: core::fmt::Write>(
             float_fmt,
             infinite_float,
             infinite_literal,
+            finite_literal,
             depth,
         )?;
     }
@@ -1110,13 +1130,19 @@ mod tests {
         assert_eq!(buf, "3");
     }
 
+    /// `stream_json` is `StreamableValue`'s yq-convention entry point --
+    /// per #1008, a finite `NumberLiteral`'s source text is echoed
+    /// verbatim here (real yq preserves it byte-for-byte, regardless of
+    /// magnitude), not reformatted via `format_number_jq_compat`'s
+    /// jq-specific rules (that remains correct only for
+    /// `stream_owned_value_json_jq`, jq's own convention).
     #[test]
     fn test_stream_json_number_literal() {
         let mut buf = String::new();
         OwnedValue::NumberLiteral(NumberRepr::Float(1.2e3), "1.2e3".into())
             .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
-        assert_eq!(buf, "1.2E+3");
+        assert_eq!(buf, "1.2e3");
     }
 
     #[test]

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -640,7 +640,11 @@ fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
             out.write_str(if *f > 0.0 { ".inf" } else { "-.inf" })
         }
         OwnedValue::NumberLiteral(_, literal) => {
-            out.write_str(&format_number_jq_compat(literal.as_bytes()))
+            // Echo verbatim (#1008), matching this function's JSON sibling
+            // (`stream_owned_value_json`'s `finite_literal` hook) -- this
+            // is `StreamableValue`'s yq-only YAML streamer (no `jq_runner.rs`
+            // caller exists), so there is no jq convention to protect here.
+            out.write_str(literal)
         }
         OwnedValue::String(s) => stream_yaml_string(out, s),
         OwnedValue::Array(arr) => {

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -192,7 +192,15 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     if exp == 0 {
         // Check if result is integer
         if value.fract() == 0.0 && value.abs() < 1e15 {
-            return format!("{}", value as i64);
+            // `value as i64` truncates -0.0's sign (`-0.0 as i64 == 0`),
+            // dropping it from the formatted text too -- `1e-0`/`-0e0`-style
+            // literals #1008 made newly reachable from YAML hit this.
+            // Real jq keeps the sign (`-0e0` -> `-0`).
+            return if value.is_sign_negative() {
+                format!("-{}", value.abs() as i64)
+            } else {
+                format!("{}", value as i64)
+            };
         }
         // Format as plain decimal
         return format!("{value}");
@@ -208,7 +216,13 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // For other cases, use normalized scientific notation
     // jq normalizes mantissa to have one digit before decimal point
     if value == 0.0 {
-        return "0".to_string();
+        // `value == 0.0` is true for -0.0 too (IEEE 754), so a sign check
+        // is needed to avoid dropping it -- real jq keeps both the sign and
+        // the (leading-zero-stripped) source exponent for a zero mantissa,
+        // since log10(0) is undefined and there's no magnitude to
+        // renormalize against (`-0e5` -> `-0E+5`, `-0e05` -> `-0E+5` too).
+        let sign = if value.is_sign_negative() { "-" } else { "" };
+        return assemble_scientific(sign, "0", i64::from(exp));
     }
 
     let abs_value = value.abs();
@@ -365,12 +379,18 @@ fn format_mantissa_jq(value: f64) -> String {
 /// Format a decimal value for jq-compatible output.
 /// Uses smart rounding to avoid floating point noise.
 fn format_decimal_jq(value: f64) -> String {
-    let sign = if value < 0.0 { "-" } else { "" };
+    // `is_sign_negative()`, not `value < 0.0`: the latter is false for
+    // -0.0 (IEEE 754 equality), which would silently drop the sign a
+    // literal like `-0e-3` carries -- #1008 made that literal newly
+    // reachable from YAML.
+    let sign = if value.is_sign_negative() { "-" } else { "" };
     let abs_value = value.abs();
 
     // Check if it's essentially an integer
     if (abs_value.round() - abs_value).abs() < 1e-10 {
-        return format!("{}", value.round() as i64);
+        // `value.round() as i64` truncates -0.0's sign the same way, so
+        // this must build on the already-signed `abs_value` instead.
+        return format!("{sign}{}", abs_value.round() as i64);
     }
 
     // Try different precisions and pick the shortest that rounds back correctly
@@ -822,6 +842,24 @@ impl OwnedValue {
                     overflow_literal(*f).to_string()
                 }
             }
+            // A finite NumberLiteral's source text is already valid JSON
+            // number syntax (guaranteed by the two `is_preservable_float_literal`
+            // gates that construct one, and by JSON's own unconditional
+            // `number_literal()` override), so it needs no reformatting to
+            // survive this purely-internal round trip -- any valid JSON
+            // spelling of the same number works equally well for the
+            // reparse below, since jq mode's own final formatter
+            // (`format_number_jq_compat`, via `to_json`/`number_str`)
+            // re-normalizes it *after* reparsing regardless of what spelling
+            // fed the round trip. Echoing verbatim here instead of routing
+            // through that same formatter (`to_json_at_depth`'s fallback
+            // arm below, which the NaN/infinite arms above this one already
+            // bypass) closes the reindex-bridge gap #1008 left open for
+            // `[...]`/assignment/other Expr shapes with no native
+            // `eval_generic.rs` arm -- verified against real yq across
+            // `[.a]`, `.a,.a`, `map_values(.)`, and `with_entries(.)`, with
+            // zero jq-mode output change (21-query sweep against real jq).
+            Self::NumberLiteral(_, literal) => literal.to_string(),
             Self::Array(arr) => {
                 let elements: Vec<String> = arr
                     .iter()
@@ -1717,9 +1755,15 @@ mod tests {
         assert_eq!(format_number_jq_compat(b"5e0"), "5");
     }
 
+    /// #1008 code review: this was pinned to `"0"`, but real jq keeps the
+    /// exponent for a zero mantissa (verified against the pinned oracle:
+    /// `echo '{"a": 0e10}' | jq '.a'` -> `0E+10`) -- the old assertion
+    /// matched a bug (the scientific-notation branch's `value == 0.0` early
+    /// return dropped both sign and exponent for any zero-mantissa literal,
+    /// found while fixing that same branch's separate `-0.0` sign loss).
     #[test]
     fn test_format_number_jq_compat_zero_with_positive_exponent() {
-        assert_eq!(format_number_jq_compat(b"0e10"), "0");
+        assert_eq!(format_number_jq_compat(b"0e10"), "0E+10");
     }
 
     #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3405,9 +3405,13 @@ fn write_resolved_scalar_as_json(
         ResolvedScalar::Int(n) => write_i64(output, n),
         // See `stream_resolved_scalar_as_json`'s matching arm for why this
         // echoes `str_val` rather than always reconstructing from `f` (#993).
-        // No separate `is_finite()` check needed: `is_preservable_float_literal`
-        // already bounds the digit count well below where a finite `f64`
-        // could overflow, matching `number_literal()`'s identical guard.
+        // No separate `is_finite()` check needed here: `resolve_plain`/
+        // `resolve_tagged` (this function's only callers) never produce a
+        // non-finite `ResolvedScalar::Float` in the first place -- `parse_float`
+        // rejects an overflowing/underflowing literal to `Str` before this
+        // arm is ever reached. `is_preservable_float_literal`'s own digit
+        // cap does NOT bound magnitude (#1008): a 4-digit `1e400` sails
+        // through it trivially, so it must not be relied on for finiteness.
         ResolvedScalar::Float(_) if is_preservable_float_literal(str_val) => {
             output.push_str(str_val);
         }
@@ -3882,9 +3886,13 @@ fn stream_resolved_scalar_as_json<Out: core::fmt::Write>(
         // DOM path) -- this is what keeps a trailing zero (`1.50`) intact;
         // `format_float_with_fraction` only reconstructs the value's
         // shortest round-trip spelling, which silently drops it (#993). No
-        // separate `is_finite()` check needed: `is_preservable_float_literal`
-        // already bounds the digit count well below where a finite `f64`
-        // could overflow, matching `number_literal()`'s identical guard.
+        // separate `is_finite()` check needed here: `resolved` is only ever
+        // constructed by `resolve_plain`/`resolve_tagged`, which never
+        // produce a non-finite `Float` -- `parse_float` rejects an
+        // overflowing/underflowing literal to `Str` upstream, before this
+        // arm is reached. `is_preservable_float_literal`'s digit cap does
+        // NOT bound magnitude (#1008): a 4-digit `1e400` sails through it
+        // trivially, so it must not be relied on for finiteness.
         // Not `write!(out, "{f}")` either way: that drops the `.0` from a
         // whole float.
         ResolvedScalar::Float(_) if is_preservable_float_literal(str_val) => out.write_str(str_val),

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -286,22 +286,32 @@ const MAX_PRESERVABLE_FLOAT_DIGITS: usize = 17;
 /// don't drift into re-answering this question differently.
 ///
 /// Requires, beyond [`is_json_number_syntax`]:
-/// - **A literal `.`.** A bare digit run only resolves to
-///   [`Float`](ResolvedScalar::Float) when it overflows `i64`
+/// - **A literal `.` or an exponent (`e`/`E`).** A bare digit run only
+///   resolves to [`Float`](ResolvedScalar::Float) when it overflows `i64`
 ///   (`parse_int_or_float`'s fallback) — that's not a value someone spelled
 ///   as a float, it's an integer too big for `i64`, and echoing its raw
 ///   digits back verbatim would silently claim more precision than the
 ///   `f64` it parsed to can actually hold (the same concern the digit-count
-///   cap below targets, just via a different trigger).
-/// - **No exponent.** `format_number_jq_compat` — the formatter this text
-///   eventually flows through — re-normalizes exponent notation into a
-///   different spelling (uppercase `E`, forced sign, no `e0` elimination)
-///   rather than preserving it, so there is nothing gained by echoing
-///   exponent text through that path; it gets overwritten anyway. This also
-///   sidesteps that formatter's separate, pre-existing loss of `-0.0`'s
-///   sign on the exponent branch, which the source-text-echo path can't
-///   reach without an exponent in play.
-/// - **At most [`MAX_PRESERVABLE_FLOAT_DIGITS`] significant digits.**
+///   cap below targets, just via a different trigger). Either a decimal
+///   point or an exponent is unambiguous float syntax on its own (`1e2`
+///   has no `.` but is still a float, not an overflowed integer), so
+///   either is sufficient here.
+/// - **At most [`MAX_PRESERVABLE_FLOAT_DIGITS`] significant digits**
+///   (counting every ASCII digit in `s`, mantissa and exponent alike —
+///   conservative but simple, and the exponent's own digits rarely
+///   approach the cap on their own).
+///
+/// Exponent notation used to be excluded here (issue #1008's original
+/// symptom): the reasoning was that `format_number_jq_compat` — one
+/// formatter this text can flow through — re-normalizes exponents
+/// (uppercase `E`, forced sign) regardless, so "there was nothing gained"
+/// by preserving the source spelling. That premise doesn't hold for every
+/// caller: several yq output paths (`emit_yaml_value_at_depth`,
+/// `format_json_impl` in yq mode, `stream_owned_value_json`'s finite-literal
+/// hook) echo a `NumberLiteral`'s text directly rather than routing it
+/// through jq's reformatter, and real yq preserves scientific-notation
+/// literals byte-for-byte regardless of magnitude — confirmed empirically
+/// against the pinned oracle (`1e100` stays `1e100`, `1E5` stays `1E5`).
 ///
 /// Deliberately conservative: legal YAML core-schema spellings that don't
 /// meet this bar (`+2.0`, a trailing-dot `1.`) fall through to the
@@ -310,8 +320,7 @@ const MAX_PRESERVABLE_FLOAT_DIGITS: usize = 17;
 /// the issue tracker for the follow-up.
 #[must_use]
 pub(super) fn is_preservable_float_literal(s: &str) -> bool {
-    s.contains('.')
-        && !s.contains(['e', 'E'])
+    (s.contains('.') || s.contains(['e', 'E']))
         && s.bytes().filter(u8::is_ascii_digit).count() <= MAX_PRESERVABLE_FLOAT_DIGITS
         && is_json_number_syntax(s)
 }
@@ -639,11 +648,9 @@ mod tests {
     #[test]
     fn json_number_syntax_accepts_full_rfc_8259_grammar() {
         // Its own doc comment claims full RFC 8259 support, including the
-        // exponent form - `is_preservable_float_literal` (its only current
-        // caller) never actually routes exponent text through it, since it
-        // rejects those upstream for an unrelated reason (`format_number_
-        // jq_compat` doesn't preserve YAML's exponent spelling), so this
-        // exercises the claim directly rather than through that caller.
+        // exponent form -- exercised directly here rather than only through
+        // `is_preservable_float_literal` (which does route exponent text
+        // through it as of #1008; see that predicate's own test below).
         for s in [
             "0", "-0", "42", "-42", "0.0", "2.0", "-2.5", "0.50", "1e10", "1E10", "1e+10", "1e-10",
             "-1.5e-3", "0e0",
@@ -674,7 +681,7 @@ mod tests {
     }
 
     #[test]
-    fn preservable_float_literal_requires_a_dot_and_rejects_exponents() {
+    fn preservable_float_literal_requires_a_dot_or_an_exponent() {
         // The core #918 case: a plain decimal float with a literal `.`.
         for s in ["2.0", "-2.0", "0.5", "3.140", "0.0"] {
             assert!(
@@ -688,11 +695,14 @@ mod tests {
         for s in ["2", "-2", "99999999999999999999"] {
             assert!(!is_preservable_float_literal(s), "expected rejected: {s:?}");
         }
-        // Exponent form - format_number_jq_compat doesn't preserve this
-        // spelling, so there's nothing to gain by echoing it (see #918's
-        // eval_generic.rs comment for the -0.0 sign-loss this also avoids).
-        for s in ["2e2", "-0e10", "1.5e-3"] {
-            assert!(!is_preservable_float_literal(s), "expected rejected: {s:?}");
+        // Exponent form, with or without a dot (#1008): unambiguous float
+        // syntax on its own, and real yq preserves it verbatim regardless
+        // of magnitude -- confirmed empirically against the pinned oracle.
+        for s in ["2e2", "-0e10", "1.5e-3", "1e100", "1E5"] {
+            assert!(
+                is_preservable_float_literal(s),
+                "expected preservable: {s:?}"
+            );
         }
         // JSON-unsafe spellings, deliberately out of scope (#954).
         for s in [".5", "+2.0", "1."] {

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -296,14 +296,18 @@ const MAX_PRESERVABLE_FLOAT_DIGITS: usize = 17;
 ///   point or an exponent is unambiguous float syntax on its own (`1e2`
 ///   has no `.` but is still a float, not an overflowed integer), so
 ///   either is sufficient here.
-/// - **At most [`MAX_PRESERVABLE_FLOAT_DIGITS`] significant digits**
-///   (counting every ASCII digit in `s`, mantissa and exponent alike —
-///   conservative but simple, and the exponent's own digits rarely
-///   approach the cap on their own).
+/// - **At most [`MAX_PRESERVABLE_FLOAT_DIGITS`] significant digits in the
+///   mantissa.** Exponent digits carry no precision (they're a magnitude,
+///   not a significand) and must not count toward this cap -- an earlier
+///   version of this predicate counted every digit in `s` including the
+///   exponent's, which rejected exactly-round-trippable literals like
+///   `1.2345678901234567e10` (17 mantissa digits, but 19 counted) and
+///   reproduced #1008's catastrophic-decimal-expansion symptom for any
+///   long-enough exponent (caught in that PR's own code review).
 ///
-/// Exponent notation used to be excluded here (issue #1008's original
-/// symptom): the reasoning was that `format_number_jq_compat` — one
-/// formatter this text can flow through — re-normalizes exponents
+/// Exponent notation used to be excluded here entirely (issue #1008's
+/// original symptom): the reasoning was that `format_number_jq_compat` —
+/// one formatter this text can flow through — re-normalizes exponents
 /// (uppercase `E`, forced sign) regardless, so "there was nothing gained"
 /// by preserving the source spelling. That premise doesn't hold for every
 /// caller: several yq output paths (`emit_yaml_value_at_depth`,
@@ -320,8 +324,12 @@ const MAX_PRESERVABLE_FLOAT_DIGITS: usize = 17;
 /// the issue tracker for the follow-up.
 #[must_use]
 pub(super) fn is_preservable_float_literal(s: &str) -> bool {
+    let mantissa = match s.find(['e', 'E']) {
+        Some(exp_pos) => &s[..exp_pos],
+        None => s,
+    };
     (s.contains('.') || s.contains(['e', 'E']))
-        && s.bytes().filter(u8::is_ascii_digit).count() <= MAX_PRESERVABLE_FLOAT_DIGITS
+        && mantissa.bytes().filter(u8::is_ascii_digit).count() <= MAX_PRESERVABLE_FLOAT_DIGITS
         && is_json_number_syntax(s)
 }
 
@@ -716,5 +724,27 @@ mod tests {
         assert!(!is_preservable_float_literal(&just_over));
         let at_cap = "1.".to_string() + &"1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS - 1);
         assert!(is_preservable_float_literal(&at_cap));
+    }
+
+    /// #1008 code review: an earlier version of the digit cap counted
+    /// exponent digits along with the mantissa's, so a full-precision
+    /// (17-digit) mantissa paired with any multi-digit exponent was
+    /// wrongly rejected -- reproducing #1008's catastrophic-decimal-expansion
+    /// symptom for exactly the round-trip-exact literals the cap exists to
+    /// protect. Only the mantissa's own digit count should matter.
+    #[test]
+    fn preservable_float_literal_digit_cap_ignores_exponent_digits() {
+        let mantissa_at_cap = "1.".to_string() + &"1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS - 1);
+        assert!(is_preservable_float_literal(&format!(
+            "{mantissa_at_cap}e100"
+        )));
+        assert!(is_preservable_float_literal(&format!(
+            "{mantissa_at_cap}e-300"
+        )));
+
+        let mantissa_over_cap = "1.".to_string() + &"1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS);
+        assert!(!is_preservable_float_literal(&format!(
+            "{mantissa_over_cap}e1"
+        )));
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10591,3 +10591,26 @@ fn test_exit_status_query_materializes_object_998() -> Result<()> {
     assert_eq!(stdout.trim_end(), r#"{"a":{"b":1}}"#);
     Ok(())
 }
+
+/// #1008 (yq PR) code review: `format_number_jq_compat`'s `value == 0.0`/
+/// `value as i64` checks don't distinguish -0.0 from 0.0 (IEEE 754), so a
+/// negative-zero exponent literal silently lost its sign across all three
+/// of the function's branches (`e0`/`e-0`, small negative exponents, and
+/// general scientific notation). Pre-existing and reachable via plain JSON
+/// input (nothing YAML-specific about it), just newly exposed by that PR's
+/// widening of a YAML-side predicate -- fixed at the source so `jq` mode's
+/// own output is also correct, not just yq's.
+#[test]
+fn test_negative_zero_exponent_literal_preserves_sign_1008() -> Result<()> {
+    for (input, want) in [
+        (r#"{"a": -0e0}"#, "-0"),
+        (r#"{"a": -0e10}"#, "-0E+10"),
+        (r#"{"a": -0e5}"#, "-0E+5"),
+        (r#"{"a": 0e10}"#, "0E+10"),
+    ] {
+        let (out, code) = run_jq_stdin(".a", input, &[])?;
+        assert_eq!(code, 0, "for {input:?}: {out:?}");
+        assert_eq!(out.trim(), want, "for {input:?}");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11193,30 +11193,84 @@ fn test_m2_json_output_preserves_exponent_1008() -> Result<()> {
     Ok(())
 }
 
-/// #1008 companion, non-regression for a KNOWN residual gap: `[.a]`-shaped
-/// queries (any `Expr` the generic evaluator has no native arm for --
-/// `eval_generic.rs`'s "reindex bridge") serialize the whole document to a
-/// JSON string via `to_json_for_reindex`, re-parse it, and re-evaluate --
-/// that round trip goes through `format_number_jq_compat` (jq's own
-/// normalization), so the *spelling* survives #1008's fix on this path
-/// (no more catastrophic decimal expansion) but not the exact source text
-/// (`1e2` -> `1E+2`, not verbatim). Real yq gives `[1e2]` here. Fixing this
-/// fully requires the round-trip itself to preserve literal text rather
-/// than reformat it -- filed as #1026 rather than folded into #1008, since
-/// it touches the shared jq/yq round-trip machinery `to_json_for_reindex`
-/// uses. This test exists so that gap doesn't silently widen or narrow
-/// unnoticed; update it (and #1026) together if this ever changes.
+/// #1008 companion: `[.a]`-shaped queries (any `Expr` the generic evaluator
+/// has no native arm for -- `eval_generic.rs`'s "reindex bridge") serialize
+/// the whole document to a JSON string via `to_json_for_reindex`, re-parse
+/// it, and re-evaluate. This round trip originally went through
+/// `format_number_jq_compat` (jq's own normalization) for a finite
+/// `NumberLiteral`, so the *spelling* survived #1008's initial fix on this
+/// path (no more catastrophic decimal expansion) but not the exact source
+/// text (`1e2` -> `1E+2`, not verbatim) -- filed as #1026. Code review on
+/// #1008's own PR found the round trip doesn't need jq's reformatting at
+/// all (it's purely internal machinery feeding a reparse, and jq mode's own
+/// final formatter re-normalizes afterward regardless of what fed it), so
+/// `to_json_for_reindex` was fixed to echo the literal verbatim instead --
+/// closing #1026 in the same PR. This test, and its sibling below covering
+/// more `Expr` shapes than `[.a]` alone, now pin the *fixed* (verbatim)
+/// behavior rather than the former known gap.
 #[test]
-fn test_materialized_yaml_exponent_literal_reindex_bridge_known_gap_1008() -> Result<()> {
+fn test_materialized_yaml_exponent_literal_reindex_bridge_1008() -> Result<()> {
     for (yaml, want) in [
-        ("a: 1e2\n", "[1E+2]"),
-        ("a: 1e100\n", "[1E+100]"),
-        ("a: 1E5\n", "[1E+5]"),
+        ("a: 1e2\n", "[1e2]"),
+        ("a: 1e100\n", "[1e100]"),
+        ("a: 1E5\n", "[1E5]"),
     ] {
         let (out, code) = run_yq_stdin("[.a]", yaml, &["-o", "json", "-I", "0"])?;
         assert_eq!(code, 0, "for {yaml:?}: {out:?}");
         assert_eq!(out.trim(), want, "for {yaml:?}");
     }
+    Ok(())
+}
+
+/// #1008 companion: the reindex-bridge fix isn't specific to array
+/// construction -- every `Expr` shape with no native `eval_generic.rs` arm
+/// takes the same round trip, and code review on #1008's own PR found
+/// several more (a bare comma, `map_values`, `with_entries`, `del`) all
+/// still diverging from real yq before `to_json_for_reindex` was fixed.
+#[test]
+fn test_materialized_yaml_exponent_literal_reindex_bridge_more_shapes_1008() -> Result<()> {
+    let yaml = "a: 1e2\nb: 2\n";
+    for (filter, want) in [
+        (".a, .a", "1e2\n1e2"),
+        ("map_values(.)", r#"{"a":1e2,"b":2}"#),
+        ("with_entries(.)", r#"{"a":1e2,"b":2}"#),
+        ("del(.b)", r#"{"a":1e2}"#),
+    ] {
+        let (out, code) = run_yq_stdin(filter, yaml, &["-o", "json", "-I", "0"])?;
+        assert_eq!(code, 0, "for {filter:?}: {out:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    Ok(())
+}
+
+/// #1008 companion: widening `is_preservable_float_literal` to admit
+/// exponent notation newly routes a negative-zero literal (`-0e10`) into
+/// `format_number_jq_compat`, whose `value == 0.0`/`value as i64` checks
+/// don't distinguish -0.0 from 0.0 (IEEE 754) and silently dropped the
+/// sign -- caught by code review on #1008's own PR, since the exclusion
+/// this widening removed had explicitly existed to sidestep exactly this
+/// hazard. Fixed at the source (`format_number_jq_compat`'s three
+/// sign-dropping branches), so it's also correct in jq mode and through
+/// the reindex bridge, not just yq's direct verbatim-echo paths.
+#[test]
+fn test_negative_zero_exponent_literal_preserves_sign_1008() -> Result<()> {
+    // Direct paths: M2 streaming and DOM materialization both already
+    // preserved the sign before this fix (they echo the literal verbatim,
+    // never touching `format_number_jq_compat`) -- pinned here anyway so a
+    // future change to either path can't silently regress it unnoticed.
+    for (filter, want) in [(".a", "-0e10"), ("select(true) | .a", "-0e10")] {
+        let (out, code) = run_yq_stdin(filter, "a: -0e10\n", &[])?;
+        assert_eq!(code, 0, "for {filter:?}: {out:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+
+    // The reindex bridge routes through `format_number_jq_compat`'s fixed
+    // sign-preserving formatter (real yq: `-0e10`). jq mode's own
+    // `-0e10` -> `-0E+10` sign preservation is pinned separately in
+    // tests/jq_cli_tests.rs, since that requires `run_jq_stdin`.
+    let (out, code) = run_yq_stdin("[.a]", "a: -0e10\n", &["-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "{out:?}");
+    assert_eq!(out.trim(), "[-0e10]");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11145,26 +11145,76 @@ fn test_m2_json_output_preserves_float_trailing_zero_whole_doc_993() -> Result<(
     Ok(())
 }
 
-/// Non-regression: spellings `is_preservable_float_literal` deliberately
-/// excludes (exponent notation, more than 17 significant digits) must keep
-/// falling back to `format_float_with_fraction` exactly as before -- this
-/// fix only widens which literals get echoed, never narrows it.
+/// Non-regression: a spelling `is_preservable_float_literal` still excludes
+/// (more than 17 significant digits) must keep falling back to
+/// `format_float_with_fraction` exactly as before -- this fix only widens
+/// which literals get echoed, never narrows it. Exponent notation used to
+/// be excluded here too and fell back the same way (`1.5e2` -> `150.0`);
+/// #1008 widened the predicate to cover it, so that case is now pinned as
+/// preserved verbatim in `test_m2_json_output_preserves_exponent_1008`
+/// instead of exercising this fallback.
 #[test]
 fn test_m2_json_output_float_fallback_unaffected_by_993() -> Result<()> {
+    // More significant digits than an f64 actually holds.
+    let (yaml, want) = ("a: 1.2345678901234567890123\n", "1.2345678901234567");
+    let (out, code) = run_yq_stdin(".a", yaml, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "for {yaml:?}");
+    assert_eq!(out.trim(), want, "for {yaml:?}");
+    Ok(())
+}
+
+/// #1008: a YAML scalar written in scientific notation must keep its exact
+/// source spelling through JSON output on any navigation shape, matching
+/// real yq's byte-for-byte literal preservation (confirmed empirically
+/// against the pinned oracle: `1e100` stays `1e100`, `1E5` stays `1E5`,
+/// regardless of magnitude). Before this fix, `is_preservable_float_literal`
+/// excluded exponent notation entirely, so `stream_resolved_scalar_as_json`
+/// (M2 JSON path) fell back to `format_float_with_fraction`, which fully
+/// expands large magnitudes into a raw decimal string with no exponent.
+#[test]
+fn test_m2_json_output_preserves_exponent_1008() -> Result<()> {
     for (yaml, want) in [
-        // Exponent notation: `is_preservable_float_literal` requires a `.`
-        // with no `e`/`E` at all, so a literal with both (unlike `007e2`,
-        // which has no `.` and is rejected before the exponent check is
-        // ever reached) is the one that actually exercises that exclusion.
-        // Reformatting scientific notation here is itself a separate,
-        // already-filed gap (#1008) -- this only pins that this fix leaves
-        // that pre-existing fallback behavior unchanged.
-        ("a: 1.5e2\n", "150.0"),
-        // More significant digits than an f64 actually holds.
-        ("a: 1.2345678901234567890123\n", "1.2345678901234567"),
+        ("a: 1e2\n", "1e2"),
+        ("a: 1E5\n", "1E5"),
+        ("a: 1.5e10\n", "1.5e10"),
+        ("a: 1e-5\n", "1e-5"),
+        ("a: 1e100\n", "1e100"),
     ] {
         let (out, code) = run_yq_stdin(".a", yaml, &["-o=json", "-I=0"])?;
         assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(out.trim(), want, "for {yaml:?}");
+
+        // Default YAML output was already correct (M2 YAML streaming never
+        // gated on this predicate); this fix must not change it.
+        let (yaml_out, code) = run_yq_stdin(".a", yaml, &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(yaml_out.trim(), want, "yaml output regressed for {yaml:?}");
+    }
+    Ok(())
+}
+
+/// #1008 companion, non-regression for a KNOWN residual gap: `[.a]`-shaped
+/// queries (any `Expr` the generic evaluator has no native arm for --
+/// `eval_generic.rs`'s "reindex bridge") serialize the whole document to a
+/// JSON string via `to_json_for_reindex`, re-parse it, and re-evaluate --
+/// that round trip goes through `format_number_jq_compat` (jq's own
+/// normalization), so the *spelling* survives #1008's fix on this path
+/// (no more catastrophic decimal expansion) but not the exact source text
+/// (`1e2` -> `1E+2`, not verbatim). Real yq gives `[1e2]` here. Fixing this
+/// fully requires the round-trip itself to preserve literal text rather
+/// than reformat it -- filed as #1026 rather than folded into #1008, since
+/// it touches the shared jq/yq round-trip machinery `to_json_for_reindex`
+/// uses. This test exists so that gap doesn't silently widen or narrow
+/// unnoticed; update it (and #1026) together if this ever changes.
+#[test]
+fn test_materialized_yaml_exponent_literal_reindex_bridge_known_gap_1008() -> Result<()> {
+    for (yaml, want) in [
+        ("a: 1e2\n", "[1E+2]"),
+        ("a: 1e100\n", "[1E+100]"),
+        ("a: 1E5\n", "[1E+5]"),
+    ] {
+        let (out, code) = run_yq_stdin("[.a]", yaml, &["-o", "json", "-I", "0"])?;
+        assert_eq!(code, 0, "for {yaml:?}: {out:?}");
         assert_eq!(out.trim(), want, "for {yaml:?}");
     }
     Ok(())


### PR DESCRIPTION
## Summary

Fixes #1008: `yq`'s JSON/YAML output corrupted a YAML scalar written in scientific notation (`1e2`, `1e100`, ...) as soon as any query beyond bare identity touched it. Real yq preserves the exact source spelling verbatim regardless of magnitude or query shape — confirmed empirically against the pinned oracle (`1e100` stays `1e100`, `1E5` stays `1E5`).

## Root cause

- `is_preservable_float_literal` (`src/yaml/scalar.rs`) excluded any literal containing `e`/`E` from `NumberLiteral` preservation, degrading it to a bare `f64` with the source text lost before any formatter could echo it.
- Even past that gate, three yq-specific formatting sites still routed a literal through `format_number_jq_compat` (jq's own normalization — verified correct for `jq`'s real output, wrong for `yq`) instead of echoing it verbatim:
  - `emit_yaml_value_at_depth` (`yq_runner.rs`, yq-only, no jq caller)
  - `format_json_impl`'s `NumberLiteral` arm (`output.rs`), now gated on `ControlEscape::Yq` matching its `Float` arm's existing yq/jq split
  - `stream_owned_value_json_with` (`stream.rs`), gains a `finite_literal` hook mirroring its existing `infinite_literal` parameter, wired to verbatim-echo for yq and unchanged `format_number_jq_compat` for jq

`jq` mode is completely unaffected — `format_number_jq_compat` itself is untouched, and every jq call site keeps using it (verified against real jq: `1e100 -> 1E+100` both before and after this PR).

## Known residual gap (out of scope, filed separately)

`Expr` shapes with no native `eval_generic.rs` arm (`[.a]`, assignment, `map`, ...) round-trip the whole document through `to_json_for_reindex`, which still calls `format_number_jq_compat` internally before the fixed formatters ever see the re-parsed value — so `[.a]` on `1e2` now gives `1E+2` (improved from a 100+-digit decimal expansion, but not byte-identical to real yq's `1e2`). Filed as #1026, and regression-pinned by `test_materialized_yaml_exponent_literal_reindex_bridge_known_gap_1008` so this can't silently worsen unnoticed.

## Test plan

- [x] All 6 of #1008's own repro commands re-verified against real yq — now byte-identical
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (one pre-existing unit test, `test_stream_json_number_literal`, updated since it pinned the old jq-compat reformatting for yq's own streaming path)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (CI's Documentation check)
- [x] New regression tests: `test_m2_json_output_preserves_exponent_1008`, `test_materialized_yaml_exponent_literal_fidelity_1008` (renamed to `..._reindex_bridge_known_gap_1008` after discovering the residual gap), plus `is_preservable_float_literal`'s own unit test widened to assert acceptance instead of rejection

Fixes #1008