### PR TITLE
fix(jq): guard 3 more unguarded recursive OwnedValue/JqValue walkers

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13366,6 +13366,16 @@ fn substitute_var_in_builtin(
 
 /// Convert an OwnedValue to an Expr, preserving complex types.
 fn owned_to_expr(value: &OwnedValue) -> Expr {
+    owned_to_expr_at_depth(value, 0)
+}
+
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1025) -- splices a compound-assignment RHS or
+/// pattern-substitution value back into the AST as literals, reachable from
+/// `.a += rhs_expr`/`.a //= rhs_expr` and `as`-pattern variable substitution
+/// with no adversarial document involved.
+fn owned_to_expr_at_depth(value: &OwnedValue, depth: usize) -> Expr {
+    assert_value_tree_depth(depth);
     match value {
         OwnedValue::Null => Expr::Literal(Literal::Null),
         OwnedValue::Bool(b) => Expr::Literal(Literal::Bool(*b)),
@@ -13382,7 +13392,10 @@ fn owned_to_expr(value: &OwnedValue) -> Expr {
             if arr.is_empty() {
                 Expr::Array(Box::new(Expr::Builtin(Builtin::Empty)))
             } else {
-                let elements: Vec<Expr> = arr.iter().map(owned_to_expr).collect();
+                let elements: Vec<Expr> = arr
+                    .iter()
+                    .map(|v| owned_to_expr_at_depth(v, depth + 1))
+                    .collect();
                 Expr::Array(Box::new(Expr::Comma(elements)))
             }
         }
@@ -13392,7 +13405,7 @@ fn owned_to_expr(value: &OwnedValue) -> Expr {
                 .iter()
                 .map(|(k, v)| ObjectEntry {
                     key: ObjectKey::Literal(k.clone()),
-                    value: owned_to_expr(v),
+                    value: owned_to_expr_at_depth(v, depth + 1),
                 })
                 .collect();
             Expr::Object(entries)
@@ -16742,11 +16755,18 @@ fn get_value_at_path(value: &OwnedValue, path: &[OwnedValue]) -> Option<OwnedVal
 /// side effect of `select()`'s falsy handling, not a design choice) and
 /// empty containers (whose `type` isn't scalar even though they have no
 /// children either). See #771.
+/// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+/// levels of nesting (#1025) -- reuses `current_path.len()` as the depth
+/// counter rather than threading a separate parameter, the same shape
+/// `collect_paths`/`collect_tostream_events` (#1021) already established:
+/// `current_path` grows by exactly one element per descent, so its length
+/// already tracks tree depth without duplicating a counter.
 fn collect_leaf_paths(
     value: &OwnedValue,
     current_path: &[OwnedValue],
     paths: &mut Vec<OwnedValue>,
 ) {
+    assert_value_tree_depth(current_path.len());
     match value {
         OwnedValue::Object(entries) => {
             if entries.is_empty() {
@@ -40434,5 +40454,50 @@ mod tests {
             ),
             QueryResult::Owned(OwnedValue::Int(1))
         ));
+    }
+
+    /// #1025: `owned_to_expr` had no depth guard -- splices a
+    /// compound-assignment RHS or pattern-substitution value back into the
+    /// AST as literals, reachable from `.a += rhs_expr`/`.a //= rhs_expr`
+    /// and `as`-pattern variable substitution with no adversarial document
+    /// involved.
+    #[test]
+    fn owned_to_expr_panics_past_nesting_depth_limit_1025() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert!(matches!(owned_to_expr(&under), Expr::Array(_)));
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| owned_to_expr(&over)));
+        assert!(
+            result.is_err(),
+            "owned_to_expr should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1025: `collect_leaf_paths` (backs `leaf_paths`) had no depth guard
+    /// of its own -- previously protected only transitively (its callers
+    /// already run the guarded `to_owned` first), a fragile invariant
+    /// rather than an independent guard.
+    #[test]
+    fn collect_leaf_paths_panics_past_nesting_depth_limit_1025() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut paths = Vec::new();
+        collect_leaf_paths(&under, &[], &mut paths);
+        assert_eq!(paths.len(), 1);
+
+        let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut paths = Vec::new();
+            collect_leaf_paths(&over, &[], &mut paths);
+        }));
+        assert!(
+            result.is_err(),
+            "collect_leaf_paths should panic at MAX_VALUE_TREE_DEPTH"
+        );
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40456,6 +40456,21 @@ mod tests {
         ));
     }
 
+    /// `depth` levels of single-key object nesting: `{"k":{"k":...{}...}}`
+    /// -- the `Object`-arm counterpart to [`linear_array_nest`], since a
+    /// depth-threading bug isolated to an `Object` match arm (e.g. `depth`
+    /// instead of `depth + 1` in an object-value closure) would pass every
+    /// boundary test built only from array nesting (#1025 code review).
+    fn linear_object_nest(depth: usize) -> OwnedValue {
+        let mut v = OwnedValue::Object(IndexMap::new());
+        for _ in 0..depth {
+            let mut obj = IndexMap::new();
+            obj.insert("k".to_string(), v);
+            v = OwnedValue::Object(obj);
+        }
+        v
+    }
+
     /// #1025: `owned_to_expr` had no depth guard -- splices a
     /// compound-assignment RHS or pattern-substitution value back into the
     /// AST as literals, reachable from `.a += rhs_expr`/`.a //= rhs_expr`
@@ -40474,6 +40489,19 @@ mod tests {
         assert!(
             result.is_err(),
             "owned_to_expr should panic at MAX_VALUE_TREE_DEPTH"
+        );
+
+        // The `Object` arm is a separate match arm with its own recursive
+        // closure -- exercise its own boundary too, not just `Array`'s.
+        let under_obj = linear_object_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert!(matches!(owned_to_expr(&under_obj), Expr::Object(_)));
+
+        let over_obj = linear_object_nest(MAX_VALUE_TREE_DEPTH);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| owned_to_expr(&over_obj)));
+        assert!(
+            result.is_err(),
+            "owned_to_expr should panic at MAX_VALUE_TREE_DEPTH (Object arm)"
         );
     }
 
@@ -40498,6 +40526,23 @@ mod tests {
         assert!(
             result.is_err(),
             "collect_leaf_paths should panic at MAX_VALUE_TREE_DEPTH"
+        );
+
+        // The `Object` arm builds its own `new_path` independently of
+        // `Array`'s -- exercise its own boundary too (#1025 code review).
+        let under_obj = linear_object_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut paths = Vec::new();
+        collect_leaf_paths(&under_obj, &[], &mut paths);
+        assert_eq!(paths.len(), 1);
+
+        let over_obj = linear_object_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut paths = Vec::new();
+            collect_leaf_paths(&over_obj, &[], &mut paths);
+        }));
+        assert!(
+            result.is_err(),
+            "collect_leaf_paths should panic at MAX_VALUE_TREE_DEPTH (Object arm)"
         );
     }
 }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -178,6 +178,16 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
 
     /// Create from an OwnedValue.
     pub fn from_owned(owned: OwnedValue) -> Self {
+        Self::from_owned_at_depth(owned, 0)
+    }
+
+    /// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+    /// levels of nesting (#1025) -- `OwnedValue::Array`/`Object` are `pub`
+    /// and re-exported from `succinctly::jq`, so any library consumer can
+    /// build a deeply-nested value with a plain loop (no recursion needed
+    /// to construct it) and hand it to this constructor.
+    fn from_owned_at_depth(owned: OwnedValue, depth: usize) -> Self {
+        assert_value_tree_depth(depth);
         match owned {
             OwnedValue::Null => JqValue::Null,
             OwnedValue::Bool(b) => JqValue::Bool(b),
@@ -185,12 +195,14 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             OwnedValue::Float(f) => JqValue::Float(f),
             OwnedValue::NumberLiteral(_, literal) => JqValue::NumberLiteral(literal),
             OwnedValue::String(s) => JqValue::String(s),
-            OwnedValue::Array(arr) => {
-                JqValue::Array(arr.into_iter().map(JqValue::from_owned).collect())
-            }
+            OwnedValue::Array(arr) => JqValue::Array(
+                arr.into_iter()
+                    .map(|v| Self::from_owned_at_depth(v, depth + 1))
+                    .collect(),
+            ),
             OwnedValue::Object(obj) => JqValue::Object(
                 obj.into_iter()
-                    .map(|(k, v)| (k, JqValue::from_owned(v)))
+                    .map(|(k, v)| (k, Self::from_owned_at_depth(v, depth + 1)))
                     .collect(),
             ),
         }
@@ -475,6 +487,20 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     /// This is the preferred way to output JqValue because it preserves
     /// number formatting like `4e4` for cursor values.
     pub fn write_json<Out: core::fmt::Write>(&self, out: &mut Out) -> core::fmt::Result {
+        self.write_json_at_depth(out, 0)
+    }
+
+    /// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+    /// levels of nesting (#1025) -- `OwnedValue::Array`/`Object` are `pub`
+    /// and re-exported from `succinctly::jq`, so any library consumer can
+    /// build a deeply-nested `JqValue` (via [`Self::from_owned`], itself
+    /// guarded) and hand it to this serializer.
+    fn write_json_at_depth<Out: core::fmt::Write>(
+        &self,
+        out: &mut Out,
+        depth: usize,
+    ) -> core::fmt::Result {
+        assert_value_tree_depth(depth);
         match self {
             JqValue::Cursor(c) => {
                 if let Some(bytes) = c.raw_bytes() {
@@ -515,7 +541,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                     if i > 0 {
                         out.write_char(',')?;
                     }
-                    v.write_json(out)?;
+                    v.write_json_at_depth(out, depth + 1)?;
                 }
                 out.write_char(']')
             }
@@ -532,7 +558,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                     out.write_char('"')?;
                     write_json_body_jq(out, k)?;
                     out.write_str("\":")?;
-                    v.write_json(out)?;
+                    v.write_json_at_depth(out, depth + 1)?;
                 }
                 out.write_char('}')
             }
@@ -1128,6 +1154,57 @@ mod tests {
         assert!(
             result.is_err(),
             "into_owned should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// `depth` levels of single-element array nesting: `[[[...[Null]...]]]`.
+    fn linear_owned_nest(depth: usize) -> OwnedValue {
+        let mut v = OwnedValue::Null;
+        for _ in 0..depth {
+            v = OwnedValue::Array(vec![v]);
+        }
+        v
+    }
+
+    /// #1025: `JqValue::from_owned` had no depth guard at all -- since
+    /// `OwnedValue::Array`/`Object` are `pub` and re-exported from
+    /// `succinctly::jq`, any library consumer can build a deeply-nested
+    /// value with a plain loop and hand it to this constructor.
+    #[test]
+    fn from_owned_panics_past_nesting_depth_limit_1025() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_owned_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let value: JqValue<'_, Vec<u64>> = JqValue::from_owned(under);
+        assert!(matches!(value, JqValue::Array(_)));
+
+        let over = linear_owned_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            JqValue::<Vec<u64>>::from_owned(over)
+        }));
+        assert!(
+            result.is_err(),
+            "from_owned should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    /// #1025: `JqValue::write_json` (and its `to_json_string` caller) had
+    /// no depth guard at all -- reachable the same way as `materialize`/
+    /// `into_owned` above, just on the serialization path instead.
+    #[test]
+    fn write_json_panics_past_nesting_depth_limit_1025() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut buf = String::new();
+        assert!(under.write_json(&mut buf).is_ok());
+
+        let over = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.to_json_string()));
+        assert!(
+            result.is_err(),
+            "write_json/to_json_string should panic at MAX_VALUE_TREE_DEPTH"
         );
     }
 }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -1158,10 +1158,27 @@ mod tests {
     }
 
     /// `depth` levels of single-element array nesting: `[[[...[Null]...]]]`.
+    /// Mirrors `eval.rs`/`value.rs`'s own identically-shaped `linear_array_nest`
+    /// helper -- a separate copy (rather than a shared one) because
+    /// `OwnedValue` construction has no cross-module-visible builder to
+    /// share, same as `stream.rs`'s own copy of this shape.
     fn linear_owned_nest(depth: usize) -> OwnedValue {
         let mut v = OwnedValue::Null;
         for _ in 0..depth {
             v = OwnedValue::Array(vec![v]);
+        }
+        v
+    }
+
+    /// The `Object`-arm counterpart to [`linear_owned_nest`] -- a
+    /// depth-threading bug isolated to an `Object` match arm would pass a
+    /// boundary test built only from array nesting (#1025 code review).
+    fn linear_owned_object_nest(depth: usize) -> OwnedValue {
+        let mut v = OwnedValue::Object(IndexMap::new());
+        for _ in 0..depth {
+            let mut obj = IndexMap::new();
+            obj.insert("k".to_string(), v);
+            v = OwnedValue::Object(obj);
         }
         v
     }
@@ -1186,6 +1203,32 @@ mod tests {
             result.is_err(),
             "from_owned should panic at MAX_VALUE_TREE_DEPTH"
         );
+
+        let under_obj = linear_owned_object_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let value: JqValue<'_, Vec<u64>> = JqValue::from_owned(under_obj);
+        assert!(matches!(value, JqValue::Object(_)));
+
+        let over_obj = linear_owned_object_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            JqValue::<Vec<u64>>::from_owned(over_obj)
+        }));
+        assert!(
+            result.is_err(),
+            "from_owned should panic at MAX_VALUE_TREE_DEPTH (Object arm)"
+        );
+    }
+
+    /// The `Object`-arm counterpart to `linear_jqvalue_nest` -- see
+    /// [`linear_owned_object_nest`]'s doc comment for why this arm needs
+    /// its own boundary coverage, not just `Array`'s.
+    fn linear_jqvalue_object_nest(depth: usize) -> JqValue<'static, Vec<u64>> {
+        let mut v = JqValue::Object(IndexMap::new());
+        for _ in 0..depth {
+            let mut obj = IndexMap::new();
+            obj.insert("k".to_string(), v);
+            v = JqValue::Object(obj);
+        }
+        v
     }
 
     /// #1025: `JqValue::write_json` (and its `to_json_string` caller) had
@@ -1205,6 +1248,18 @@ mod tests {
         assert!(
             result.is_err(),
             "write_json/to_json_string should panic at MAX_VALUE_TREE_DEPTH"
+        );
+
+        let under_obj = linear_jqvalue_object_nest(MAX_VALUE_TREE_DEPTH - 1);
+        let mut buf = String::new();
+        assert!(under_obj.write_json(&mut buf).is_ok());
+
+        let over_obj = linear_jqvalue_object_nest(MAX_VALUE_TREE_DEPTH);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over_obj.to_json_string()));
+        assert!(
+            result.is_err(),
+            "write_json/to_json_string should panic at MAX_VALUE_TREE_DEPTH (Object arm)"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1025. #1025's own audit (a `/code-review` pass on #1021's PR #1024) named 6 functions as unguarded; 3 of them (`owned_to_yaml`, `format_props_recursive`, `flatten_owned`) turned out to already be guarded — fixed earlier the same day by #1017/#1020, which #1025's filing didn't have visibility into since it reviewed a parallel PR. This PR guards the 3 that genuinely remained:

- `owned_to_expr` — splices a compound-assignment RHS or pattern-substitution value back into the AST as literals, reachable from `.a += rhs_expr`/`.a //= rhs_expr` and `as`-pattern variable substitution.
- `JqValue::from_owned` + `write_json` — `to_json_string` delegates to `write_json`, so guarding it alone covers both. Public recursive walkers with no guard anywhere; since `OwnedValue::Array`/`Object` are `pub` and re-exported from `succinctly::jq`, any library consumer can build a deeply-nested value with a plain loop (no recursion needed to construct it) and hand it to either.
- `collect_leaf_paths` (backs `leaf_paths`) — reuses `current_path.len()` as the depth counter rather than threading a new parameter, mirroring the shape #1021 already established for `collect_paths`/`collect_tostream_events` (both share the identical `current_path.to_vec()`-per-descent invariant).

Item 7 (`eval_array_construction`) needs its own investigation per the issue's own text and stays out of scope. Items 8-11 are explicitly non-blocking architectural observations.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, including 4 new regression tests
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (CI's Documentation check)
- [x] Live-verified against CLAUDE.md's documented `leaf_paths` example and `+=` compound assignment — unchanged, correct output

Fixes #1025