### PR TITLE
fix(jq): reimplement join to match jq's accumulator-derived error wording

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4085,6 +4085,62 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Stringifies each element for yq's `join`: strings pass through, nulls
+/// are skipped, everything else is rendered as JSON. Pre-#1003 behavior,
+/// kept only for `YqSemantics` — see `builtin_join`'s doc comment for why.
+fn join_parts<'a, W: Clone + AsRef<[u64]> + 'a>(
+    elements: impl Iterator<Item = StandardJson<'a, W>>,
+) -> Vec<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for elem in elements {
+        match &elem {
+            StandardJson::String(s) => {
+                if let Ok(cow) = s.as_str() {
+                    parts.push(cow.into_owned());
+                }
+            }
+            StandardJson::Null => {
+                // Skip nulls in join
+            }
+            _ => {
+                // For non-strings, convert to string representation
+                parts.push(to_owned(&elem).to_json());
+            }
+        }
+    }
+    parts
+}
+
+/// One step of `join`'s jq-mode fold: combine the running accumulator with
+/// the next element, interleaving the separator. See `builtin_join`'s doc
+/// comment for the algorithm this implements.
+fn join_step<S: EvalSemantics>(
+    acc: Option<OwnedValue>,
+    elem: OwnedValue,
+    sep: &OwnedValue,
+) -> Result<Option<OwnedValue>, EvalError> {
+    let left = match acc {
+        None => OwnedValue::String(String::new()),
+        Some(a) => arith_add::<S>(a, sep.clone())?,
+    };
+    let right = match elem {
+        OwnedValue::Null => OwnedValue::String(String::new()),
+        // `to_json()`, not `owned_to_string()`: jq's `tostring` renders
+        // NaN as `null` (confirmed live, jq 1.7.1: `nan | tostring` ->
+        // `"null"`), and `to_json()` already matches that -- `owned_to_string`
+        // doesn't (renders Rust's `"NaN"` literally instead), a real
+        // regression an earlier draft of this fix introduced and #1036's
+        // review caught. `to_json()` also preserves `NumberLiteral` source
+        // fidelity the same way (`1.500 | tojson` -> `"1.500"`).
+        OwnedValue::Bool(_)
+        | OwnedValue::Int(_)
+        | OwnedValue::Float(_)
+        | OwnedValue::NumberLiteral(..) => OwnedValue::String(elem.to_json()),
+        other => other, // String passes through; Array/Object stay raw so `+` fails naturally below.
+    };
+    Ok(Some(arith_add::<S>(left, right)?))
+}
+
 /// Builtin: join(s) - join array elements with separator
 ///
 /// `.[] over an object iterates its values, so jq accepts an object here as
@@ -4116,6 +4172,18 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// previous implementation *skipped* `null` elements entirely instead of
 /// treating them as an empty-string part, so `[1,null,2] | join(",")` gave
 /// `"1,2"` (missing separator) instead of jq's own `"1,,2"`.
+///
+/// **yq-mode note (#1036 review):** the algorithm above is jq-specific.
+/// Real yq's `join` (v4.53.3) diverges from it in several confirmed ways:
+/// a non-scalar element silently becomes an empty-string part instead of
+/// erroring, a non-string separator is implicitly stringified instead of
+/// erroring, a `null` separator renders as the literal text `"null"`
+/// instead of being a no-op, and an object input is rejected outright
+/// (`"cannot join with !!map"`). #1003 is scoped to jq's error wording
+/// only, so `YqSemantics` keeps the pre-#1003 `join_parts`-based behavior
+/// unchanged below (itself not yq-accurate on every point, but not newly
+/// regressed either) — real yq-compatible `join` semantics are their own
+/// follow-up (#1041).
 fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     sep_expr: &Expr,
     value: StandardJson<'a, W>,
@@ -4127,44 +4195,48 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(e) => return e.into(),
     };
 
+    if S::TAG == EvalTag::Yq {
+        let sep_str = match sep {
+            OwnedValue::String(s) => s,
+            _ => return QueryResult::Error(EvalError::type_error("string", "non-string")),
+        };
+        return match value {
+            StandardJson::Array(elements) => {
+                QueryResult::Owned(OwnedValue::String(join_parts(elements).join(&sep_str)))
+            }
+            StandardJson::Object(fields) => QueryResult::Owned(OwnedValue::String(
+                join_parts(fields.map(|f| f.value())).join(&sep_str),
+            )),
+            _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
+        };
+    }
+
     // No `_ if optional` guard on the non-iterable case below, and no
-    // `optional`-gated arm on either `arith_add` failure further down:
-    // `optional` is never forced `true` reaching a nested `Call` node like
-    // this one (see `Expr::Optional`'s dispatch in `eval_single`, #693) — a
-    // bare `join(...)?` suppresses these errors via the ancestor
-    // `eval_try`'s catch, not locally. Confirmed dead per #928's identical
-    // finding in the regex builtins: a dedicated `join(...)?` test for each
-    // site still showed 0 coverage hits on the guard itself.
-    let elements: Vec<OwnedValue> = match &value {
-        StandardJson::Array(elements) => (*elements).map(|e| to_owned(&e)).collect(),
-        StandardJson::Object(fields) => (*fields).map(|f| to_owned(&f.value())).collect(),
+    // `optional`-gated arm on `join_step`'s `arith_add` failures: `optional`
+    // is never forced `true` reaching a nested `Call` node like this one
+    // (see `Expr::Optional`'s dispatch in `eval_single`, #693) — a bare
+    // `join(...)?` suppresses these errors via the ancestor `eval_try`'s
+    // catch, not locally. Confirmed dead per #928's identical finding in
+    // the regex builtins: a dedicated `join(...)?` test for each site still
+    // showed 0 coverage hits on the guard itself.
+    //
+    // `try_fold` over the raw element iterator (not a collected `Vec`) so a
+    // type-mismatch error on an early element short-circuits immediately
+    // instead of paying to `to_owned` every later element first.
+    let result = match value {
+        StandardJson::Array(mut elements) => {
+            elements.try_fold(None, |acc, e| join_step::<S>(acc, to_owned(&e), &sep))
+        }
+        StandardJson::Object(mut fields) => fields.try_fold(None, |acc, f| {
+            join_step::<S>(acc, to_owned(&f.value()), &sep)
+        }),
         _ => return QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     };
 
-    let mut acc: Option<OwnedValue> = None;
-    for elem in elements {
-        let left = match acc {
-            None => OwnedValue::String(String::new()),
-            Some(a) => match arith_add::<S>(a, sep.clone()) {
-                Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
-            },
-        };
-        let right = match elem {
-            OwnedValue::Null => OwnedValue::String(String::new()),
-            OwnedValue::Bool(_)
-            | OwnedValue::Int(_)
-            | OwnedValue::Float(_)
-            | OwnedValue::NumberLiteral(..) => OwnedValue::String(owned_to_string(&elem)),
-            other => other, // String passes through; Array/Object stay raw so `+` fails naturally below.
-        };
-        acc = Some(match arith_add::<S>(left, right) {
-            Ok(v) => v,
-            Err(e) => return QueryResult::Error(e),
-        });
+    match result {
+        Ok(acc) => QueryResult::Owned(acc.unwrap_or(OwnedValue::String(String::new()))),
+        Err(e) => QueryResult::Error(e),
     }
-
-    QueryResult::Owned(acc.unwrap_or_else(|| OwnedValue::String(String::new())))
 }
 
 /// Builtin: contains(b) - check if input contains b
@@ -27273,6 +27345,57 @@ mod tests {
         );
         query!(br#"["a", [1, 2]]"#, r#"join(",")?"#,
             QueryResult::None => {}
+        );
+
+        // #1036 review: NaN must stringify the way jq's own `tostring` does
+        // (as `null`), not Rust's `f64::to_string()` spelling (`"NaN"`) --
+        // an earlier draft of this fix used `owned_to_string` here and
+        // regressed this exact case (`join`'s own pre-#1003 code got it
+        // right by accident, via `to_json()`). Confirmed live: `nan |
+        // tostring` is `"null"` in jq 1.7.1.
+        query!(br"1", r#"[., nan] | join(",")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "1,null");
+            }
+        );
+    }
+
+    #[test]
+    fn test_builtin_join_yq_mode() {
+        // #1036 review: builtin_join<S> has no S-gated branch, so #1003's
+        // jq-accurate rewrite silently changed yq's `join` behavior too --
+        // including a new silent-wrong-output regression (a `null`
+        // separator used to error, matching pre-#1003 behavior; the
+        // rewrite made it silently succeed with jq's no-op-separator
+        // semantics instead, diverging further from real yq without any
+        // test catching it). These pin the restored pre-#1003 behavior for
+        // `YqSemantics` -- see `builtin_join`'s doc comment and #1041 for
+        // why yq keeps the old, still-yq-inaccurate-but-not-newly-regressed
+        // `join_parts` path rather than jq's new algorithm.
+        yq_query!(br#"["x", "y", "z"]"#, r"join(null)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "expected string, got non-string");
+            }
+        );
+        yq_query!(br"[1, 2]", r"join(1)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "expected string, got non-string");
+            }
+        );
+        yq_query!(br#"[[1, 2], "a"]"#, r#"join(",")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "[1,2],a");
+            }
+        );
+        yq_query!(br#"["a", null, "c"]"#, r#"join("-")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "a-c");
+            }
+        );
+        yq_query!(br#"["a", "b"]"#, r#"join(",")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "a,b");
+            }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4127,10 +4127,17 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(e) => return e.into(),
     };
 
+    // No `_ if optional` guard on the non-iterable case below, and no
+    // `optional`-gated arm on either `arith_add` failure further down:
+    // `optional` is never forced `true` reaching a nested `Call` node like
+    // this one (see `Expr::Optional`'s dispatch in `eval_single`, #693) — a
+    // bare `join(...)?` suppresses these errors via the ancestor
+    // `eval_try`'s catch, not locally. Confirmed dead per #928's identical
+    // finding in the regex builtins: a dedicated `join(...)?` test for each
+    // site still showed 0 coverage hits on the guard itself.
     let elements: Vec<OwnedValue> = match &value {
         StandardJson::Array(elements) => (*elements).map(|e| to_owned(&e)).collect(),
         StandardJson::Object(fields) => (*fields).map(|f| to_owned(&f.value())).collect(),
-        _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     };
 
@@ -4140,13 +4147,7 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             None => OwnedValue::String(String::new()),
             Some(a) => match arith_add::<S>(a, sep.clone()) {
                 Ok(v) => v,
-                Err(e) => {
-                    return if optional {
-                        QueryResult::None
-                    } else {
-                        QueryResult::Error(e)
-                    }
-                }
+                Err(e) => return QueryResult::Error(e),
             },
         };
         let right = match elem {
@@ -4159,13 +4160,7 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         };
         acc = Some(match arith_add::<S>(left, right) {
             Ok(v) => v,
-            Err(e) => {
-                return if optional {
-                    QueryResult::None
-                } else {
-                    QueryResult::Error(e)
-                }
-            }
+            Err(e) => return QueryResult::Error(e),
         });
     }
 
@@ -27263,10 +27258,13 @@ mod tests {
             }
         );
 
-        // #1003: the `?` suffix suppresses every error path above -- the
-        // non-iterable input, the separator-add failure, and the element-add
-        // failure -- to None instead of propagating. Confirmed live against
-        // jq 1.7.1 (all three are silently empty there too).
+        // #1003: `join(...)?` suppresses every error path above -- the
+        // non-iterable input, the separator-add failure, and the
+        // element-add failure -- to None instead of propagating. This is
+        // the ancestor `eval_try`'s catch at work (#693), not an
+        // `optional`-gated branch inside builtin_join itself -- there isn't
+        // one, per the doc comment above. Confirmed live against jq 1.7.1
+        // (all three are silently empty there too).
         query!(br"5", r#"join(",")?"#,
             QueryResult::None => {}
         );

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27262,6 +27262,20 @@ mod tests {
                 assert_eq!(s, "true,false");
             }
         );
+
+        // #1003: the `?` suffix suppresses every error path above -- the
+        // non-iterable input, the separator-add failure, and the element-add
+        // failure -- to None instead of propagating. Confirmed live against
+        // jq 1.7.1 (all three are silently empty there too).
+        query!(br"5", r#"join(",")?"#,
+            QueryResult::None => {}
+        );
+        query!(br"[1, 2]", r"join([1, 2])?",
+            QueryResult::None => {}
+        );
+        query!(br#"["a", [1, 2]]"#, r#"join(",")?"#,
+            QueryResult::None => {}
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27397,6 +27397,16 @@ mod tests {
                 assert_eq!(s, "a,b");
             }
         );
+        yq_query!(br#"{"x": "p", "y": "q"}"#, r#"join(",")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "p,q");
+            }
+        );
+        yq_query!(br"5", r#"join(",")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot iterate over number (5)");
+            }
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27196,10 +27196,15 @@ mod tests {
             }
         );
 
-        // Join with null values (should be skipped)
+        // #1003: a null element contributes an empty-string part -- it is
+        // NOT skipped (that was a real, separate pre-existing bug this
+        // issue's fix corrected as a side effect of matching jq's own
+        // reduce-based definition exactly). Confirmed live against jq
+        // 1.7.1: `["a",null,"c"] | join("-")` is `"a--c"`, with the
+        // separator still appearing on both sides of the empty part.
         query!(br#"["a", null, "c"]"#, r#"join("-")"#,
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "a-c");
+                assert_eq!(s, "a--c");
             }
         );
 
@@ -27214,6 +27219,47 @@ mod tests {
         query!(br"{}", r#"join(",")"#,
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "");
+            }
+        );
+
+        // #1003: numbers and booleans stringify via tostring, but arrays and
+        // objects are passed raw into the accumulator's `+`, so they surface
+        // jq's own binary-op wording ("string (...) and array/object (...)
+        // cannot be added") instead of a bespoke join-specific error.
+        // Confirmed live against jq 1.7.1.
+        query!(br#"[[1, 2], "a"]"#, r#"join(",")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "string (\"\") and array ([1,2]) cannot be added");
+            }
+        );
+        query!(br#"["a", [1, 2]]"#, r#"join(",")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "string (\"a,\") and array ([1,2]) cannot be added");
+            }
+        );
+        query!(br#"["a", {"x": 1}]"#, r#"join(",")"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "string (\"a,\") and object ({\"x\":1}) cannot be added");
+            }
+        );
+
+        // #1003's own repro: a non-string separator surfaces this same
+        // accumulator-derived wording too, because the separator is fed
+        // through the identical `+` accumulator step as every element --
+        // it is never type-checked up front. Confirmed live against jq 1.7.1.
+        query!(br"[1, 2]", r"join(1)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "string (\"1\") and number (1) cannot be added");
+            }
+        );
+        query!(br"[1, 2, 3]", r#"join(",")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "1,2,3");
+            }
+        );
+        query!(br"[true, false]", r#"join(",")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "true,false");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4085,58 +4085,91 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
-/// Stringifies each element for `join`: strings pass through, nulls are
-/// skipped, everything else is rendered as JSON.
-fn join_parts<'a, W: Clone + AsRef<[u64]> + 'a>(
-    elements: impl Iterator<Item = StandardJson<'a, W>>,
-) -> Vec<String> {
-    let mut parts: Vec<String> = Vec::new();
-    for elem in elements {
-        match &elem {
-            StandardJson::String(s) => {
-                if let Ok(cow) = s.as_str() {
-                    parts.push(cow.into_owned());
-                }
-            }
-            StandardJson::Null => {
-                // Skip nulls in join
-            }
-            _ => {
-                // For non-strings, convert to string representation
-                parts.push(to_owned(&elem).to_json());
-            }
-        }
-    }
-    parts
-}
-
 /// Builtin: join(s) - join array elements with separator
 ///
-/// join(s) is [.[] | tostring] joined by s, and .[] over an object iterates
-/// its values, so jq accepts an object here as readily as an array (#422).
+/// `.[] over an object iterates its values, so jq accepts an object here as
+/// readily as an array (#422).
+///
+/// #1003: real jq defines this as `def join($x): reduce .[] as $i (null;
+/// (if . == null then "" else . + $x end) + ($i | if . == null then ""
+/// elif (type == "number" or type == "boolean") then tostring else . end))
+/// // "";` (reverse-engineered from live probes against jq 1.7.1, not from
+/// jq's own source text — the exact `def` wasn't available to consult, but
+/// this reproduces every probed case byte-for-byte). Two consequences that
+/// make this genuinely different from "evaluate the separator, type-check
+/// it, then join stringified parts":
+/// - The separator (`$x`) is bound once but never itself type-checked
+///   up front — it only participates in `+` starting from the *second*
+///   element's accumulation step, so `[1] | join(1)` succeeds (`"1"`, the
+///   separator is bound but never used) and `[] | join(1)` is `""` (the
+///   reduce body never runs at all). Confirmed live both ways.
+/// - Only `null`/number/boolean elements are converted to a string before
+///   the `+`; an array or object element is passed through raw, so `+`
+///   fails on it naturally with jq's own array/object binary-op wording
+///   (`[[1,2]] | join(",")` -> `"string (\"\") and array ([1,2]) cannot be
+///   added"`) instead of a bespoke "non-string" message — confirmed this is
+///   *not* the same as `tostring`, which succeeds (JSON-encodes) on an
+///   array/object; join deliberately doesn't extend that leniency to
+///   containers.
+///
+/// This also happens to fix a real, separate null-handling bug: the
+/// previous implementation *skipped* `null` elements entirely instead of
+/// treating them as an empty-string part, so `[1,null,2] | join(",")` gave
+/// `"1,2"` (missing separator) instead of jq's own `"1,,2"`.
 fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     sep_expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get the separator string
     let sep_result = eval_single::<W, S>(sep_expr, value.clone(), optional);
     let sep = match result_to_owned(sep_result) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "non-string")),
+        Ok(v) => v,
         Err(e) => return e.into(),
     };
 
-    match value {
-        StandardJson::Array(elements) => {
-            QueryResult::Owned(OwnedValue::String(join_parts(elements).join(&sep)))
-        }
-        StandardJson::Object(fields) => QueryResult::Owned(OwnedValue::String(
-            join_parts(fields.map(|f| f.value())).join(&sep),
-        )),
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
+    let elements: Vec<OwnedValue> = match &value {
+        StandardJson::Array(elements) => (*elements).map(|e| to_owned(&e)).collect(),
+        StandardJson::Object(fields) => (*fields).map(|f| to_owned(&f.value())).collect(),
+        _ if optional => return QueryResult::None,
+        _ => return QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
+    };
+
+    let mut acc: Option<OwnedValue> = None;
+    for elem in elements {
+        let left = match acc {
+            None => OwnedValue::String(String::new()),
+            Some(a) => match arith_add::<S>(a, sep.clone()) {
+                Ok(v) => v,
+                Err(e) => {
+                    return if optional {
+                        QueryResult::None
+                    } else {
+                        QueryResult::Error(e)
+                    }
+                }
+            },
+        };
+        let right = match elem {
+            OwnedValue::Null => OwnedValue::String(String::new()),
+            OwnedValue::Bool(_)
+            | OwnedValue::Int(_)
+            | OwnedValue::Float(_)
+            | OwnedValue::NumberLiteral(..) => OwnedValue::String(owned_to_string(&elem)),
+            other => other, // String passes through; Array/Object stay raw so `+` fails naturally below.
+        };
+        acc = Some(match arith_add::<S>(left, right) {
+            Ok(v) => v,
+            Err(e) => {
+                return if optional {
+                    QueryResult::None
+                } else {
+                    QueryResult::Error(e)
+                }
+            }
+        });
     }
+
+    QueryResult::Owned(acc.unwrap_or_else(|| OwnedValue::String(String::new())))
 }
 
 /// Builtin: contains(b) - check if input contains b


### PR DESCRIPTION
## Summary

Fixes #1003 (scoped to `join` only — `sub`/`gsub`'s replacement-function wording is
structurally different and split out to #1034; see below).

Real jq defines `join(s)` as a `reduce` over `+`, not "stringify each element, then
join with a separator":

```jq
def join($x): reduce .[] as $i (null;
  (if . == null then "" else . + $x end)
  + ($i | if . == null then "" elif (type == "number" or type == "boolean")
          then tostring else . end)
) // "";
```

(Reverse-engineered from live probes against jq 1.7.1 — its source text wasn't
available to consult directly, but this reproduces every probed case byte-for-byte.)

This PR reimplements `builtin_join` as that same fold, reusing the existing
`arith_add` helper, which naturally reproduces jq's exact `<left> and <right> cannot
be added` wording for the two divergences #1003 identified:

- **Non-string separator**: the separator is bound once but never type-checked up
  front — it only participates in `+` from the *second* element's accumulation step
  onward. `[1,2] | join(1)` (the issue's own repro) now errors with
  `"string (\"1\") and number (1) cannot be added"`, matching real jq exactly.
- **Array/object elements**: only `null`/number/boolean elements are stringified
  before the `+`; arrays/objects are passed through raw, so `+` fails on them
  naturally with jq's own binary-op wording instead of a bespoke "non-string"
  message.

As a side effect, this also fixes a real, separate bug: the previous implementation
*skipped* `null` elements entirely instead of treating them as an empty-string part
(`[1,null,2] | join(",")` gave `"1,2"` instead of jq's own `"1,,2"`).

## Follow-ups filed (out of scope here)

- #1034 — `sub`/`gsub`'s replacement-function error wording (same accumulator-state
  idea, but structurally different: regex-based, per-match filter evaluation, not a
  simple `reduce`/`+` fold — needs its own investigation).
- #1035 — an unrelated, pre-existing bug discovered during verification: numeric
  literals typed directly in filter source text (e.g. `jq '[1.500]'`) lose source
  fidelity, while the same value arriving via document input preserves it correctly.
  Confirmed unconnected to `join`/accumulator logic.

## Test plan

- [x] New unit tests covering array/object elements and non-string separators
      surfacing jq's binary-op wording, including the issue's own `join(1)` repro
- [x] Updated the existing null-element test from the old skip-null behavior to jq's
      actual `"a--c"` output (verified live against jq 1.7.1)
- [x] Full local suite: `cargo test --features cli,simd,regex,serde` (2501 lib tests +
      all integration/doctest binaries, 0 failures)
- [x] All three CI clippy invocations (`--all-features`; explicit x86 feature set;
      `broadword-yaml` variant) clean
- [x] `cargo fmt --check` clean
- [x] Manually verified ~20 cases against the pinned jq 1.7.1 oracle