### PR TITLE
refactor(jq): route more inline None/Owned/ManyOwned splits through owned_vec_to_result

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1379,12 +1379,8 @@ fn push_truthiness<W: Clone + AsRef<[u64]>>(
 }
 
 /// Turn a stream of booleans into the result of a boolean operator.
-fn bools_to_result<'a, W: Clone + AsRef<[u64]>>(mut bools: Vec<bool>) -> QueryResult<'a, W> {
-    match bools.len() {
-        0 => QueryResult::None,
-        1 => QueryResult::Owned(OwnedValue::Bool(bools.pop().unwrap())),
-        _ => QueryResult::ManyOwned(bools.into_iter().map(OwnedValue::Bool).collect()),
-    }
+fn bools_to_result<'a, W: Clone + AsRef<[u64]>>(bools: Vec<bool>) -> QueryResult<'a, W> {
+    owned_vec_to_result(bools.into_iter().map(OwnedValue::Bool).collect())
 }
 
 /// The `OwnedValue`-collecting analog of [`push_truthiness`]: pushes every

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1074,13 +1074,7 @@ fn eval_object_construction<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
 
-    if objects.is_empty() {
-        QueryResult::None
-    } else if objects.len() == 1 {
-        QueryResult::Owned(objects.pop().unwrap())
-    } else {
-        QueryResult::ManyOwned(objects)
-    }
+    owned_vec_to_result(objects)
 }
 
 /// Evaluate recursive descent.
@@ -1332,11 +1326,7 @@ fn retain_truthy<W: Clone + AsRef<[u64]>>(result: QueryResult<'_, W>) -> QueryRe
         }
         QueryResult::ManyOwned(mut vs) => {
             vs.retain(OwnedValue::is_truthy);
-            match vs.len() {
-                0 => QueryResult::None,
-                1 => QueryResult::Owned(vs.pop().unwrap()),
-                _ => QueryResult::ManyOwned(vs),
-            }
+            owned_vec_to_result(vs)
         }
         // The prefix is filtered exactly like `ManyOwned` above — jq's `//`
         // retains truthy outputs regardless of whether the stream that
@@ -5830,23 +5820,11 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Many(results) => {
             let skipped: Vec<OwnedValue> =
                 results.into_iter().skip(n).map(|v| to_owned(&v)).collect();
-            if skipped.is_empty() {
-                QueryResult::None
-            } else if skipped.len() == 1 {
-                QueryResult::Owned(skipped.into_iter().next().unwrap())
-            } else {
-                QueryResult::ManyOwned(skipped)
-            }
+            owned_vec_to_result(skipped)
         }
         QueryResult::ManyOwned(results) => {
             let skipped: Vec<OwnedValue> = results.into_iter().skip(n).collect();
-            if skipped.is_empty() {
-                QueryResult::None
-            } else if skipped.len() == 1 {
-                QueryResult::Owned(skipped.into_iter().next().unwrap())
-            } else {
-                QueryResult::ManyOwned(skipped)
-            }
+            owned_vec_to_result(skipped)
         }
         QueryResult::None => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),
@@ -14047,13 +14025,7 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Owned(v) if n >= 1 => QueryResult::Owned(v),
         QueryResult::ManyOwned(vs) => {
             let taken: Vec<_> = vs.into_iter().take(n).collect();
-            if taken.is_empty() {
-                QueryResult::None
-            } else if taken.len() == 1 {
-                QueryResult::Owned(taken.into_iter().next().unwrap())
-            } else {
-                QueryResult::ManyOwned(taken)
-            }
+            owned_vec_to_result(taken)
         }
         QueryResult::None => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),
@@ -14572,6 +14544,12 @@ fn eval_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Cap on the number of values `range(from; to; step)` will accumulate --
+/// shared by [`eval_range_values`] and [`eval_range_values_f64`] (#1029: was
+/// two independent `const MAX_RANGE` copies, the structural twin of the
+/// `MAX_ITEMS` triplication #1023 fixed for the recurse family).
+const MAX_RANGE: usize = 100000;
+
 /// Helper to generate range values.
 fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
     from: i64,
@@ -14579,7 +14557,6 @@ fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
     step: i64,
 ) -> QueryResult<'a, W> {
     let mut values: Vec<OwnedValue> = Vec::new();
-    const MAX_RANGE: usize = 100000;
 
     if step > 0 {
         let mut i = from;
@@ -14595,13 +14572,7 @@ fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
         }
     }
 
-    if values.is_empty() {
-        QueryResult::None
-    } else if values.len() == 1 {
-        QueryResult::Owned(values.pop().unwrap())
-    } else {
-        QueryResult::ManyOwned(values)
-    }
+    owned_vec_to_result(values)
 }
 
 /// Helper to generate range values over floats.
@@ -14615,7 +14586,6 @@ fn eval_range_values_f64<'a, W: Clone + AsRef<[u64]>>(
     step: f64,
 ) -> QueryResult<'a, W> {
     let mut values: Vec<OwnedValue> = Vec::new();
-    const MAX_RANGE: usize = 100000;
 
     if step > 0.0 {
         let mut i = from;
@@ -14631,13 +14601,7 @@ fn eval_range_values_f64<'a, W: Clone + AsRef<[u64]>>(
         }
     }
 
-    if values.is_empty() {
-        QueryResult::None
-    } else if values.len() == 1 {
-        QueryResult::Owned(values.pop().unwrap())
-    } else {
-        QueryResult::ManyOwned(values)
-    }
+    owned_vec_to_result(values)
 }
 
 /// Builtin: recurse (recurse(.[]))
@@ -16127,7 +16091,7 @@ fn builtin_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
 
-    let mut paths: Vec<OwnedValue> = reached
+    let paths: Vec<OwnedValue> = reached
         .into_iter()
         .map(|(path, _)| OwnedValue::Array(path))
         .collect();
@@ -16140,15 +16104,11 @@ fn builtin_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         };
     }
 
-    match paths.len() {
-        // "No paths at all" is *no output*, never `Array(vec![])`. The empty
-        // path is a real answer — it is what `path(.)` returns — and the one
-        // path that always resolves, so rendering emptiness as it aims a
-        // caller's `getpath`/`setpath`/`delpaths` at the document root (#489).
-        0 => QueryResult::None,
-        1 => QueryResult::Owned(paths.pop().expect("len checked")),
-        _ => QueryResult::ManyOwned(paths),
-    }
+    // "No paths at all" is *no output*, never `Array(vec![])`. The empty
+    // path is a real answer — it is what `path(.)` returns — and the one
+    // path that always resolves, so rendering emptiness as it aims a
+    // caller's `getpath`/`setpath`/`delpaths` at the document root (#489).
+    owned_vec_to_result(paths)
 }
 
 /// Walk `expr` as a path expression, pushing `(path, value-at-path)` for every
@@ -16477,11 +16437,7 @@ fn builtin_fromstream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     match control {
         Some(control) => partial(outputs, control),
-        None => match outputs.len() {
-            0 => QueryResult::None,
-            1 => QueryResult::Owned(outputs.pop().unwrap()),
-            _ => QueryResult::ManyOwned(outputs),
-        },
+        None => owned_vec_to_result(outputs),
     }
 }
 
@@ -16545,11 +16501,7 @@ fn builtin_truncate_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     match control {
         Some(control) => partial(outputs, control),
-        None => match outputs.len() {
-            0 => QueryResult::None,
-            1 => QueryResult::Owned(outputs.pop().unwrap()),
-            _ => QueryResult::ManyOwned(outputs),
-        },
+        None => owned_vec_to_result(outputs),
     }
 }
 
@@ -16563,13 +16515,7 @@ fn builtin_paths<W: Clone + AsRef<[u64]>>(
     let mut paths = Vec::new();
     collect_paths(&owned, &[], &mut paths);
     // Stream individual paths instead of wrapping in array
-    if paths.is_empty() {
-        QueryResult::None
-    } else if paths.len() == 1 {
-        QueryResult::Owned(paths.pop().unwrap())
-    } else {
-        QueryResult::ManyOwned(paths)
-    }
+    owned_vec_to_result(paths)
 }
 
 /// Builtin: paths(filter) - paths to values matching filter
@@ -16703,13 +16649,7 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
     // Stream individual paths instead of wrapping in array
-    if filtered_paths.is_empty() {
-        QueryResult::None
-    } else if filtered_paths.len() == 1 {
-        QueryResult::Owned(filtered_paths.pop().unwrap())
-    } else {
-        QueryResult::ManyOwned(filtered_paths)
-    }
+    owned_vec_to_result(filtered_paths)
 }
 
 /// Helper to get value at a path (alias for convenience)
@@ -16813,13 +16753,7 @@ fn builtin_leaf_paths<W: Clone + AsRef<[u64]>>(
     let mut paths = Vec::new();
     collect_leaf_paths(&owned, &[], &mut paths);
     // Stream individual paths instead of wrapping in array
-    if paths.is_empty() {
-        QueryResult::None
-    } else if paths.len() == 1 {
-        QueryResult::Owned(paths.pop().unwrap())
-    } else {
-        QueryResult::ManyOwned(paths)
-    }
+    owned_vec_to_result(paths)
 }
 
 /// Resolve a `setpath` array index against the array's current length.
@@ -20314,23 +20248,11 @@ fn builtin_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Many(results) => {
             let limited: Vec<OwnedValue> =
                 results.into_iter().take(n).map(|v| to_owned(&v)).collect();
-            if limited.is_empty() {
-                QueryResult::None
-            } else if limited.len() == 1 {
-                QueryResult::Owned(limited.into_iter().next().unwrap())
-            } else {
-                QueryResult::ManyOwned(limited)
-            }
+            owned_vec_to_result(limited)
         }
         QueryResult::ManyOwned(results) => {
             let limited: Vec<OwnedValue> = results.into_iter().take(n).collect();
-            if limited.is_empty() {
-                QueryResult::None
-            } else if limited.len() == 1 {
-                QueryResult::Owned(limited.into_iter().next().unwrap())
-            } else {
-                QueryResult::ManyOwned(limited)
-            }
+            owned_vec_to_result(limited)
         }
         QueryResult::None => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),


### PR DESCRIPTION
## Summary

Fixes #1029. #1029's own audit (a `/code-review` pass on #1023's PR #1028) named 6 sites in `eval.rs` that hand-rolled `owned_vec_to_result`'s exact `Vec<OwnedValue>` → `None`/`Owned`/`ManyOwned` three-way collapse instead of calling it:

- `eval_range_values`/`eval_range_values_f64` — also had a duplicated `MAX_RANGE` constant, now a single shared one (the structural twin of the `MAX_ITEMS` triplication #1023 fixed for the recurse family).
- `eval_object_construction`
- `builtin_fromstream`
- `builtin_truncate_stream`
- `builtin_paths`, `builtin_paths_filter`, `builtin_leaf_paths`
- `retain_truthy`'s `ManyOwned` arm

A follow-up sweep for the same exact shape (not exhaustively enumerated by the issue) found 4 more genuine duplicates: `eval_skip`'s `Many`/`ManyOwned` arms, an `eval_limit`-shaped function at two call sites (`take`-style and `limit`-style), and the `path()` resolver's own `paths.len()` match.

Several similar-looking sites were deliberately left untouched after checking their behavior wasn't identical — the `capture(re;"g")`/`split`/`scan`-family builtins collapse an empty result the same way as a non-empty one (a 2-way split: empty → `None`, else → `ManyOwned` unconditionally, even for a single match), which `owned_vec_to_result` does not replicate (it collapses a single-element result to `Owned`, not `ManyOwned`). Converting those would have changed behavior.

Pure consolidation, no behavior change — every touched site keeps its exact `Vec<OwnedValue>` → `None`/`Owned`(len 1)/`ManyOwned`(len > 1) mapping, just via the shared helper instead of a hand-copied match.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (no behavior change, so no new tests needed; existing coverage for `range`, object construction, `paths`/`leaf_paths`, `fromstream`/`truncate_stream`, `limit`, `//` already exercises every touched site)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (CI's Documentation check)
- [x] Live-verified `range`, object construction, `leaf_paths`, `paths`, `path()`, `limit`, `tostream`, and `//` against expected output

Fixes #1029