### PR TITLE
fix(yaml): reject a `:` misaligned with its own `?` in an explicit key/value pair

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3016,6 +3016,34 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // compact mapping out from under it.
         let indent = self.resolve_compact_mapping_gap_indent(indent);
 
+        // The `:` must land at exactly its own `?`'s column: YAML ties both
+        // productions to the same indentation parameter `n`
+        // (c-l-block-map-explicit-key/value(n)), so any deviation -- not
+        // just a dedent -- is ambiguous (#1010). This is a different shape
+        // than the dedent ambiguity `check_mapping_under_mapping_gap` above
+        // detects: that check's `indent >= indent_stack[top]` short-circuit
+        // is correct for `parse_mapping_entry`'s "deeper indent opens a new
+        // nested mapping" semantics, but wrongly waves through an
+        // over-indented `:` here, since a `:` value line never opens a new
+        // frame the way an ordinary `key: value` line does. Checked against
+        // the #885-resolved `indent` above, not the raw column, so the
+        // sequence-item-compact-mapping gap tolerance that normalization
+        // grants stays intact (`-   a: hello\n  ? b\n  : 2\n` must still
+        // resolve `: 2` to the compact mapping's own indent, not reject it).
+        // Confirmed live against real yq: `? k\n : v\n` (`:` one column past
+        // `?`) and deeper misalignments both error ("did not find expected
+        // key"); only exact alignment, or no pending key at all (a bare
+        // `: value` with no `?`, a separate and pre-existing out-of-scope
+        // shape), is left alone here.
+        if let Some(owner_depth) = self.pending_explicit_key {
+            if self.indent_stack[owner_depth - 1] != indent {
+                return Err(YamlError::InconsistentIndentation {
+                    offset: self.pos,
+                    line: self.current_line(),
+                });
+            }
+        }
+
         // Close deeper structures, but keep the mapping at this indent open
         self.close_deeper_indents(indent + 1);
 
@@ -6412,15 +6440,24 @@ mod tests {
     /// corpus shape (id `35KP`, "Tags for Root Objects") that used to
     /// exercise this before this PR's tag-support change routed that corpus
     /// case through a different path (#224).
+    ///
+    /// #1010: this `:` (column 2) doesn't actually align with its own `?`
+    /// (column 0) either, which real yq rejects ("did not find expected
+    /// key") -- confirmed live. Before #1010's fix, `parse_explicit_value`
+    /// had no alignment check at all, so this silently resolved to `{"a":1}`
+    /// once the guard above stopped the scalar from swallowing `: 1`; the
+    /// guard's own job (stopping the scalar there rather than absorbing the
+    /// line as text) is unchanged and still exercised here, but the
+    /// now-separated `: 1` line is correctly rejected instead of silently
+    /// accepted.
     #[test]
     fn multiline_plain_scalar_stops_before_explicit_value_indicator() {
         let yaml: &[u8] = b"?   a\n  : 1\n";
-        let index = crate::yaml::YamlIndex::build(yaml).unwrap();
-        let cursor = index.root(yaml);
-        assert_eq!(
-            cursor.to_json(),
-            r#"[{"a":1}]"#,
-            "explicit key 'a' must map to 1, not swallow the ': 1' line into the key scalar"
+        let err = crate::yaml::YamlIndex::build(yaml).unwrap_err();
+        assert!(
+            matches!(err, YamlError::InconsistentIndentation { line: 2, .. }),
+            "explicit key 'a's scalar must stop before ': 1' (not swallow it into the key text), \
+             and the resulting misaligned ':' must then be rejected, not silently paired with 'a'; got {err:?}"
         );
     }
 

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1818,6 +1818,45 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         }
     }
 
+    /// Whether an explicit value's (already #885-gap-resolved) `indent`
+    /// matches the mapping frame opened by its own pending `?`, if one is
+    /// pending (#1010). YAML ties both the explicit-key and explicit-value
+    /// productions to the same indentation parameter `n`
+    /// (c-l-block-map-explicit-key/value(n)), so any deviation -- not just a
+    /// dedent -- is ambiguous. This is a different shape than the dedent
+    /// ambiguity [`Self::mapping_under_mapping_gap_reaches`] detects: that
+    /// predicate's `indent >= indent_stack[top]` short-circuit is correct for
+    /// `parse_mapping_entry`'s "deeper indent opens a new nested mapping"
+    /// semantics, but would wrongly wave through an over-indented `:` here,
+    /// since a `:` value line never opens a new frame the way an ordinary
+    /// `key: value` line does. Confirmed live against real yq: `? k\n : v\n`
+    /// (`:` one column past `?`) and deeper misalignments both error ("did
+    /// not find expected key"); only exact alignment, or no pending key at
+    /// all (a bare `: value` with no `?`, a separate and pre-existing
+    /// out-of-scope shape), passes.
+    ///
+    /// `owner_depth` is `parse_explicit_key`'s own `indent_stack.len()`,
+    /// captured immediately after the owning mapping frame is opened/reused
+    /// and before any key-content parsing that could push extra frames (a
+    /// sequence or compact-mapping key) -- so `indent_stack[owner_depth - 1]`
+    /// always resolves to the owner's own recorded indent, never a deeper
+    /// frame the key's own content pushed. `close_pending_explicit_key`
+    /// clears `pending_explicit_key` before that frame can ever be popped
+    /// (it only fires when `indent_stack.len() == owner_depth` exactly), so
+    /// `owner_depth - 1` is always in bounds whenever this observes `Some`.
+    fn explicit_value_matches_key_indent(&self, indent: usize) -> bool {
+        match self.pending_explicit_key {
+            Some(owner_depth) => {
+                debug_assert!(
+                    owner_depth >= 1 && owner_depth <= self.indent_stack.len(),
+                    "pending_explicit_key must name a frame still on indent_stack"
+                );
+                self.indent_stack[owner_depth - 1] == indent
+            }
+            None => true,
+        }
+    }
+
     /// The #901 sibling of [`Self::compact_mapping_gap_reaches`]: whether
     /// `indent` would land ambiguously if [`Self::close_deeper_indents`]
     /// popped every frame deeper than it -- the surviving (landing) frame's
@@ -1914,13 +1953,25 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.indent_stack[landing_idx] != indent
     }
 
-    /// Check-and-error wrapper around [`Self::mapping_under_mapping_gap_reaches`]:
-    /// every call site raises the identical `InconsistentIndentation` error
-    /// when the gap is reached, so this gives that pairing one definition
-    /// instead of each site re-deriving it (#106's "duplicated predicates
-    /// diverge silently" lesson) — the same check-and-error, `?`-friendly
-    /// shape [`Self::reject_trailing_flow_content`] already uses for an
-    /// unrelated check in this file. `for_sequence_item` forwards to
+    /// Shared `Err` construction for every indentation-ambiguity predicate in
+    /// this cluster of the file (#106: one definition instead of each call
+    /// site re-deriving it) -- `ok` is the specific predicate's own verdict;
+    /// this only owns the error's shape, at the current position.
+    fn require_consistent_indentation(&self, ok: bool) -> Result<(), YamlError> {
+        if ok {
+            Ok(())
+        } else {
+            Err(YamlError::InconsistentIndentation {
+                offset: self.pos,
+                line: self.current_line(),
+            })
+        }
+    }
+
+    /// Check-and-error wrapper around [`Self::mapping_under_mapping_gap_reaches`],
+    /// via [`Self::require_consistent_indentation`] -- the same check-and-error,
+    /// `?`-friendly shape [`Self::reject_trailing_flow_content`] already uses
+    /// for an unrelated check in this file. `for_sequence_item` forwards to
     /// [`Self::mapping_under_mapping_gap_reaches`] -- see its own doc
     /// comment for which call site must pass `true`.
     fn check_mapping_under_mapping_gap(
@@ -1928,14 +1979,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         indent: usize,
         for_sequence_item: bool,
     ) -> Result<(), YamlError> {
-        if self.mapping_under_mapping_gap_reaches(indent, for_sequence_item) {
-            Err(YamlError::InconsistentIndentation {
-                offset: self.pos,
-                line: self.current_line(),
-            })
-        } else {
-            Ok(())
-        }
+        self.require_consistent_indentation(
+            !self.mapping_under_mapping_gap_reaches(indent, for_sequence_item),
+        )
     }
 
     /// Whether a `-` sequence-item line's `indent` falls in the *lower*
@@ -3016,33 +3062,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // compact mapping out from under it.
         let indent = self.resolve_compact_mapping_gap_indent(indent);
 
-        // The `:` must land at exactly its own `?`'s column: YAML ties both
-        // productions to the same indentation parameter `n`
-        // (c-l-block-map-explicit-key/value(n)), so any deviation -- not
-        // just a dedent -- is ambiguous (#1010). This is a different shape
-        // than the dedent ambiguity `check_mapping_under_mapping_gap` above
-        // detects: that check's `indent >= indent_stack[top]` short-circuit
-        // is correct for `parse_mapping_entry`'s "deeper indent opens a new
-        // nested mapping" semantics, but wrongly waves through an
-        // over-indented `:` here, since a `:` value line never opens a new
-        // frame the way an ordinary `key: value` line does. Checked against
-        // the #885-resolved `indent` above, not the raw column, so the
-        // sequence-item-compact-mapping gap tolerance that normalization
-        // grants stays intact (`-   a: hello\n  ? b\n  : 2\n` must still
-        // resolve `: 2` to the compact mapping's own indent, not reject it).
-        // Confirmed live against real yq: `? k\n : v\n` (`:` one column past
-        // `?`) and deeper misalignments both error ("did not find expected
-        // key"); only exact alignment, or no pending key at all (a bare
-        // `: value` with no `?`, a separate and pre-existing out-of-scope
-        // shape), is left alone here.
-        if let Some(owner_depth) = self.pending_explicit_key {
-            if self.indent_stack[owner_depth - 1] != indent {
-                return Err(YamlError::InconsistentIndentation {
-                    offset: self.pos,
-                    line: self.current_line(),
-                });
-            }
-        }
+        // Same ambiguous-column error for a `:` that doesn't match its own
+        // `?` (#1010) -- checked against the #885-resolved `indent` above,
+        // not the raw column, so that normalization's tolerance stays intact.
+        self.require_consistent_indentation(self.explicit_value_matches_key_indent(indent))?;
 
         // Close deeper structures, but keep the mapping at this indent open
         self.close_deeper_indents(indent + 1);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6824,28 +6824,21 @@ fn test_mapping_under_mapping_gap_via_explicit_value() -> Result<()> {
 // expected key". Confirmed live against pinned yq v4.53.3.
 
 #[test]
-fn test_explicit_value_one_column_past_its_key_errors_1010() -> Result<()> {
-    // The issue's own headline repro: `:` one column deeper than its `?`.
-    let (_output, stderr, exit_code) =
-        run_yq_stdin_with_stderr(".", "? k\n : v\nc: 3\n", &["-o", "json", "-I0"])?;
-    assert_eq!(exit_code, 1);
-    assert!(
-        stderr.contains("inconsistent indentation"),
-        "stderr: {stderr:?}"
-    );
-    Ok(())
-}
-
-#[test]
-fn test_explicit_value_several_columns_past_its_key_errors_1010() -> Result<()> {
-    // Not just an off-by-one: any over-indentation is ambiguous.
-    let (_output, stderr, exit_code) =
-        run_yq_stdin_with_stderr(".", "? k\n   : v\nc: 3\n", &["-o", "json", "-I0"])?;
-    assert_eq!(exit_code, 1);
-    assert!(
-        stderr.contains("inconsistent indentation"),
-        "stderr: {stderr:?}"
-    );
+fn test_explicit_value_past_its_key_errors_1010() -> Result<()> {
+    for (name, input) in [
+        // The issue's own headline repro: `:` one column deeper than its `?`.
+        ("one column past", "? k\n : v\nc: 3\n"),
+        // Not just an off-by-one: any over-indentation is ambiguous.
+        ("several columns past", "? k\n   : v\nc: 3\n"),
+    ] {
+        let (_output, stderr, exit_code) =
+            run_yq_stdin_with_stderr(".", input, &["-o", "json", "-I0"])?;
+        assert_eq!(exit_code, 1, "{name}");
+        assert!(
+            stderr.contains("inconsistent indentation"),
+            "{name}: stderr: {stderr:?}"
+        );
+    }
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6813,6 +6813,75 @@ fn test_mapping_under_mapping_gap_via_explicit_value() -> Result<()> {
     Ok(())
 }
 
+// #1010: `parse_explicit_value`'s ambiguous-gap check ran on the raw `:`
+// column, which only ever detects a *dedent* landing in a gap between two
+// open frames (#901/#958's own shape) -- it structurally cannot fire for a
+// `:` indented *past* its own `?`, since `mapping_under_mapping_gap_reaches`
+// short-circuits to "no gap" whenever `indent >= indent_stack[top]`, which an
+// over-indented `:` always satisfies. YAML ties both the explicit key and
+// value productions to the same indentation parameter, so any deviation --
+// not just a dedent -- is ambiguous; real yq rejects it with "did not find
+// expected key". Confirmed live against pinned yq v4.53.3.
+
+#[test]
+fn test_explicit_value_one_column_past_its_key_errors_1010() -> Result<()> {
+    // The issue's own headline repro: `:` one column deeper than its `?`.
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "? k\n : v\nc: 3\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_explicit_value_several_columns_past_its_key_errors_1010() -> Result<()> {
+    // Not just an off-by-one: any over-indentation is ambiguous.
+    let (_output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", "? k\n   : v\nc: 3\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains("inconsistent indentation"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_explicit_value_exact_alignment_still_works_1010() -> Result<()> {
+    // The #1010 fix must not disturb the ordinary, exactly-aligned case.
+    let (output, exit_code) = run_yq_stdin(".", "? k\n: v\nc: 3\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"k":"v","c":3}"#);
+    Ok(())
+}
+
+#[test]
+fn test_explicit_value_legitimately_nested_value_still_works_1010() -> Result<()> {
+    // The `:` itself stays aligned with `?`; only its *value* (a nested
+    // mapping) sits deeper on following lines -- `close_deeper_indents`'s
+    // `indent + 1` tolerance this fix leaves untouched is what keeps this
+    // working, distinct from the `:` marker's own column checked here.
+    let (output, exit_code) = run_yq_stdin(".", "? k\n:\n  a: 1\nc: 3\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"k":{"a":1},"c":3}"#);
+    Ok(())
+}
+
+#[test]
+fn test_explicit_value_complex_key_alignment_still_works_1010() -> Result<()> {
+    // A complex (sequence) key leaves extra frames open above its owning
+    // mapping; the `:` must still align with `?`'s own column, not the
+    // deeper key content's.
+    let (output, exit_code) =
+        run_yq_stdin(".", "? - a\n  - b\n: v\nc: 3\n", &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"":"v","c":3}"#);
+    Ok(())
+}
+
 // #959: #901's check was only wired into parse_mapping_entry,
 // parse_explicit_key, and parse_explicit_value -- the same three
 // call sites #885 touched for the analogous compact-mapping-gap check.


### PR DESCRIPTION
## Summary

`parse_explicit_value` had no check that the `:` marker's column matches the mapping frame opened by its own `?`. The existing `check_mapping_under_mapping_gap` call (shared with `parse_mapping_entry`/`parse_explicit_key`, #901/#958) only ever detects a *dedent* landing ambiguously between two open frames — its `indent >= indent_stack[top]` short-circuit treats "at or past the owning frame's own indent" as unconditionally fine, which an over-indented `:` always satisfies. That's correct for `parse_mapping_entry` (a deeper `key: value` line legitimately opens a new nested mapping) but wrong for `parse_explicit_value`, since YAML ties both the `?` and `:` productions to the *same* indentation parameter — any deviation, not just a dedent, is ambiguous.

```
$ printf '? k\n : v\nc: 3\n' | succinctly yq -o json -I0 '.'
{"k":"v","c":3}      # wrong: silently accepted despite the 1-column misalignment
$ printf '? k\n : v\nc: 3\n' | yq -o json -I0 '.'
Error: bad file '-': yaml: while parsing a block mapping at <unknown position>: line 1, column 2: did not find expected key
```

## Fix

Adds a direct equality check in `parse_explicit_value`: the `:`'s (#885-gap-tolerant-normalized) indent must equal the owning mapping's own recorded indent, recovered via `pending_explicit_key` → `indent_stack[owner_depth - 1]`. Placed *after* the existing `resolve_compact_mapping_gap_indent` normalization so the #885 sequence-item-compact-mapping tolerance (`-   a: hello\n  ? b\n  : 2\n`) stays intact — an earlier version of this fix checked the raw column first and broke that case; caught by the full test suite and fixed before this PR.

A pre-existing unit test (`multiline_plain_scalar_stops_before_explicit_value_indicator`) asserted that `"?   a\n  : 1\n"` (a `:` two columns off from its `?`) resolves to `{"a":1}` — confirmed live that real yq rejects this input too, so the test was asserting oracle-incorrect behavior. Updated it to assert the (now correct) error, while preserving its original purpose (confirming the plain-scalar-continuation scanner still stops before an over-indented `:` rather than swallowing it as key text).

## Investigation note

An earlier session (agent `cadence`) investigated this issue first, correctly determined the issue's own suggested fix (`check_mapping_under_mapping_gap(indent + 1, ...)`) doesn't work — traced that `mapping_under_mapping_gap_reaches`'s short-circuit fires identically for both `indent` and `indent + 1` here, since the ambiguity this repro exercises is an over-indent, not the dedent shape that check looks for — and released the issue rather than rushing a fix. This PR picks up from that analysis with the actual root-cause fix (a separate, dedicated equality check, not a tweak to the shared dedent-gap detector).

## Testing

- `cargo test --features cli,simd,regex,serde`: full suite green (lib tests, `yq_cli_tests`, `yq_golden_tests`, `yq_path_consistency_tests`, doctests)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo check --no-default-features`: clean (no_std)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- New regression tests in `tests/yq_cli_tests.rs` cover: the issue's exact repro, a larger over-indent, exact alignment (still works), a legitimately-nested value under an aligned `:` (still works, exercising `close_deeper_indents`'s untouched `indent + 1` tolerance), and a complex (sequence) key with extra open frames above the owning mapping (still works)
- All new/changed behavior verified live against pinned `yq` v4.53.3

Fixes #1010