### PR TITLE
refactor(jq): add borrowed_vec_to_result, the StandardJson sibling of owned_vec_to_result

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1132,6 +1132,18 @@ fn owned_vec_to_result<'a, W>(mut vs: Vec<OwnedValue>) -> QueryResult<'a, W> {
     }
 }
 
+/// The borrowed-cursor counterpart to [`owned_vec_to_result`] (#1038):
+/// normalize a `Vec<StandardJson>` accumulator into the smallest
+/// `QueryResult` shape that represents it -- empty stays `None`, one value
+/// collapses to `One`, more than one stays `Many`.
+fn borrowed_vec_to_result<W>(mut vs: Vec<StandardJson<'_, W>>) -> QueryResult<'_, W> {
+    match vs.len() {
+        0 => QueryResult::None,
+        1 => QueryResult::One(vs.pop().unwrap()),
+        _ => QueryResult::Many(vs),
+    }
+}
+
 /// Normalize a prefix and its terminator into a `QueryResult` (#400, #494).
 ///
 /// An empty prefix collapses to the bare `Error`/`Break`/`Halt` variant, so
@@ -1318,11 +1330,7 @@ fn retain_truthy<W: Clone + AsRef<[u64]>>(result: QueryResult<'_, W>) -> QueryRe
         }
         QueryResult::Many(mut vs) => {
             vs.retain(json_is_truthy);
-            match vs.len() {
-                0 => QueryResult::None,
-                1 => QueryResult::One(vs.pop().unwrap()),
-                _ => QueryResult::Many(vs),
-            }
+            borrowed_vec_to_result(vs)
         }
         QueryResult::ManyOwned(mut vs) => {
             vs.retain(OwnedValue::is_truthy);
@@ -14010,13 +14018,7 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::One(v) if n >= 1 => QueryResult::One(v),
         QueryResult::Many(vs) => {
             let taken: Vec<_> = vs.into_iter().take(n).collect();
-            if taken.is_empty() {
-                QueryResult::None
-            } else if taken.len() == 1 {
-                QueryResult::One(taken.into_iter().next().unwrap())
-            } else {
-                QueryResult::Many(taken)
-            }
+            borrowed_vec_to_result(taken)
         }
         QueryResult::Owned(v) if n >= 1 => QueryResult::Owned(v),
         QueryResult::ManyOwned(vs) => {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2472,6 +2472,44 @@ fn test_stream_operators_emit_every_output() -> Result<()> {
 }
 
 #[test]
+fn test_stream_operator_truthy_retain_collapses_borrowed_many_to_every_arity_1038() -> Result<()> {
+    // `//`'s truthy-retain over a *borrowed* multi-output stream (`.[]`, not
+    // a constructed/owned one) collapses through `borrowed_vec_to_result`
+    // (#1038) -- pin all three arities its match covers: zero truthy values
+    // left, exactly one, and more than one.
+    for (filter, input, expected) in [
+        (r#".[] // "backup""#, "[false,null]", "\"backup\"\n"),
+        (r#".[] // "backup""#, "[false,1,null]", "1\n"),
+        (r#".[] // "backup""#, "[false,1,null,2]", "1\n2\n"),
+    ] {
+        let (stdout, code) = run_jq_stdin(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` on {input} should succeed");
+        assert_eq!(stdout, expected, "wrong output for `{filter}` on {input}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_limit_collapses_borrowed_many_to_every_arity_1038() -> Result<()> {
+    // `limit`'s `Many` arm collapses its taken prefix through
+    // `borrowed_vec_to_result` (#1038) -- pin both reachable arities (one
+    // taken, more than one) from a *borrowed* multi-output stream (`.[]`).
+    // `limit(0; ...)` takes its own dedicated early return before `expr` is
+    // even evaluated, so it never reaches the `Many` arm at all; included
+    // anyway as ordinary black-box coverage of `limit`'s zero-output case.
+    for (filter, expected) in [
+        ("[limit(0; .[])]", "[]\n"),
+        ("[limit(1; .[])]", "[1]\n"),
+        ("[limit(2; .[])]", "[1,2]\n"),
+    ] {
+        let (stdout, code) = run_jq_stdin(filter, "[1,2,3]", &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` should succeed");
+        assert_eq!(stdout, expected, "wrong output for `{filter}`");
+    }
+    Ok(())
+}
+
+#[test]
 fn test_boolean_with_empty_operand_is_silent() -> Result<()> {
     // An empty operand used to reach `result_to_owned`, which reported it as
     // `Error("no value")` and printed a diagnostic. jq emits nothing at all,


### PR DESCRIPTION
## Summary

#1029 (PR #1037) consolidated ~15 hand-rolled `Vec<OwnedValue>` → `None`/`Owned`/`ManyOwned` collapses into calls to `owned_vec_to_result`. Code review on that PR found the identical `0 => None, 1 => One, _ => Many` shape recurring for the borrowed-cursor counterpart, `Vec<StandardJson>`, in two places sitting directly beside their already-converted `ManyOwned` siblings:

- `retain_truthy`'s `Many` arm
- `eval_limit`'s `Many` arm

## Change

Adds `borrowed_vec_to_result` (mirroring `owned_vec_to_result` exactly) and routes both sites through it.

Swept the rest of `eval.rs` for the same shape (mirroring #1029's own methodology) and found three superficially similar but structurally different sites (`eval_comma`, `eval_pipe`'s equivalent, and `eval_owned_expr_ctrl`) — none has an explicit `0 => None` branch (two instead collapse an empty accumulator to `Many(vec![])`/`ManyOwned(vec![])`, one to a constructed empty array), so none is a genuine duplicate of this exact pattern. Left untouched to avoid introducing an unreviewed behavior change outside this issue's scope.

No behavior change: both call sites already produced identical external output before this refactor (`QueryResult::One`/`Many`/`None` all render identically regardless of how they were constructed) — this only removes the two remaining hand-rolled copies of the collapse logic.

## Testing

- `cargo test --features cli,simd,regex,serde`: full suite green (lib tests, `jq_cli_tests` 548/0, `yq_cli_tests`, golden tests, doctests) — confirmed after re-running twice to rule out contention noise from concurrent sessions on this machine (several unrelated tests intermittently failed with exit code -1, i.e. process-level interference, not logic errors; all passed cleanly when re-run alone or in isolation)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean (caught and fixed a real elidable-lifetime finding on the new helper)
- `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo check --no-default-features`: clean (no_std)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- New regression tests in `tests/jq_cli_tests.rs` pin both reachable arities (one remaining, more than one remaining) for both `//`'s truthy-retain and `limit`'s take-prefix, from a genuinely borrowed multi-output stream (`.[]`, not a constructed/owned one)

Fixes #1038