### PR TITLE
fix(jq): add missing 0 => None arm to 5 empty-collapse sites

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24134,6 +24134,55 @@ mod tests {
     }
 
     #[test]
+    fn test_comma_all_empty_operands_collapse_to_none_1043() {
+        // #1043: every operand producing zero outputs must collapse the whole
+        // comma to `None`, not `Many(vec![])` -- real jq exits 0 with no
+        // output for `(empty,empty)`, not an error.
+        query!(br"1", "(empty, empty)",
+            QueryResult::None => {}
+        );
+    }
+
+    #[test]
+    fn test_fanout_all_empty_branches_collapse_to_none_1043() {
+        // #1043: eval_fanout's tail match is byte-identical to eval_comma's
+        // (both fold a multi-branch stream into borrowed/owned accumulators)
+        // and had the same missing `0 => None` bug. A multi-output condition
+        // whose every branch is `empty` must collapse the whole `if` to
+        // `None`, not `Many(vec![])`. Confirmed live against jq 1.7.1.
+        query!(br"1", "if (true, false) then empty else empty end",
+            QueryResult::None => {}
+        );
+    }
+
+    #[test]
+    fn test_computed_index_and_slice_zero_results_collapse_to_none_1043() {
+        // #1043: eval_index_expr's Borrowed and Owned target arms, and
+        // eval_slice_expr's final collapse, all had the same missing
+        // `0 => None` bug -- a computed index/slice whose optional (`?`)
+        // form produces zero results collapsed to `Many(vec![])`/
+        // `ManyOwned(vec![])` instead of `None`. Confirmed live against jq
+        // 1.7.1 (all four exit 0 with no output there too).
+        //
+        // Borrowed target (`.` is the document itself, a number -- not
+        // indexable, so `?` suppresses to zero results per key).
+        query!(br"5", r#".[("a", "b")]?"#,
+            QueryResult::None => {}
+        );
+        // Owned target: `(1)` constructs an owned value rather than
+        // borrowing from the document, taking eval_index_expr's separate
+        // `Targets::Owned` arm.
+        query!(br"5", r#"(1)[("a", "b")]?"#,
+            QueryResult::None => {}
+        );
+        // eval_slice_expr's final collapse: slicing a non-array/string
+        // target with `?` suppresses to zero results per (start, end) pair.
+        query!(br"null", r#"({"a": 1})[0:(1, 2)]?"#,
+            QueryResult::None => {}
+        );
+    }
+
+    #[test]
     fn test_literals() {
         query!(br"{}", "null",
             QueryResult::Owned(OwnedValue::Null) => {}

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15085,9 +15085,12 @@ fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
             None
         }
         // `eval_fanout` (used by `Select`) returns these borrowed-cursor
-        // variants even from an all-owned-value call site -- e.g. a `select`
-        // whose condition matched nothing produces `Many(vec![])`, not
-        // `None` -- so this must convert, not treat them as unreachable.
+        // variants even from an all-owned-value call site -- e.g. `select`
+        // on a truthy condition hands back the input as `One(value)`, a
+        // genuine borrowed cursor, not `Owned` -- so this must convert, not
+        // treat them as unreachable. (A `select` that matched nothing now
+        // collapses to a bare `None` instead, since #1043 gave
+        // `eval_fanout`'s tail match its missing `0 => None` arm.)
         QueryResult::One(v) => {
             results.push(to_owned(&v));
             None
@@ -15126,8 +15129,11 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // `eval_fanout` (reached via `Select`) can hand back its borrowed-cursor
     // variants (`One`/`Many`) even here, not just Owned/ManyOwned -- e.g. a
-    // `select` that matched nothing produces `Many(vec![])` -- so those
-    // convert via `to_owned` instead of being treated as unreachable.
+    // `select` on a truthy condition hands back the input as a genuine
+    // borrowed `One` -- so those convert via `to_owned` instead of being
+    // treated as unreachable. (A `select` that matched nothing now
+    // collapses to a bare `None` instead, since #1043 gave `eval_fanout`'s
+    // tail match its missing `0 => None` arm.)
     match intermediate.materialize_cursor() {
         QueryResult::Owned(v) => eval_pipe_with_path_context_internal::<W, S>(
             rest,
@@ -24162,7 +24168,7 @@ mod tests {
         // `0 => None` bug -- a computed index/slice whose optional (`?`)
         // form produces zero results collapsed to `Many(vec![])`/
         // `ManyOwned(vec![])` instead of `None`. Confirmed live against jq
-        // 1.7.1 (all four exit 0 with no output there too).
+        // 1.7.1 (all three exit 0 with no output there too).
         //
         // Borrowed target (`.` is the document itself, a number -- not
         // indexable, so `?` suppresses to zero results per key).
@@ -26722,10 +26728,9 @@ mod tests {
             }
         );
 
-        // select outputs nothing if condition is false. `eval_fanout` shares
-        // `eval_comma`'s empty-merge shape (`Many(vec![])`, not a bare
-        // `None`) — `outputs()` is deliberately variant-agnostic about that,
-        // per its own doc comment.
+        // select outputs nothing if condition is false, collapsing to a bare
+        // `None` since #1043 — `outputs()` is deliberately variant-agnostic
+        // about the exact `QueryResult` shape, per its own doc comment.
         assert!(outputs(br"2", "select(. > 3)").is_empty());
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -844,10 +844,8 @@ fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 
     match owned {
-        Some(mut acc) if acc.len() == 1 => QueryResult::Owned(acc.pop().unwrap()),
-        Some(acc) => QueryResult::ManyOwned(acc),
-        None if borrowed.len() == 1 => QueryResult::One(borrowed.pop().unwrap()),
-        None => QueryResult::Many(borrowed),
+        Some(acc) => owned_vec_to_result(acc),
+        None => borrowed_vec_to_result(borrowed),
     }
 }
 
@@ -1498,10 +1496,8 @@ fn eval_fanout<'a, W: Clone + AsRef<[u64]>>(
     match cond_control {
         Some(control) => partial(merge_owned(borrowed, owned.unwrap_or_default()), control),
         None => match owned {
-            Some(mut acc) if acc.len() == 1 => QueryResult::Owned(acc.pop().unwrap()),
-            Some(acc) => QueryResult::ManyOwned(acc),
-            None if borrowed.len() == 1 => QueryResult::One(borrowed.pop().unwrap()),
-            None => QueryResult::Many(borrowed),
+            Some(acc) => owned_vec_to_result(acc),
+            None => borrowed_vec_to_result(borrowed),
         },
     }
 }
@@ -9232,10 +9228,7 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
             match pending_halt {
                 Some(code) => partial(out.iter().map(to_owned).collect(), Control::Halt(code)),
-                None => match out.len() {
-                    1 => QueryResult::One(out.pop().expect("len checked")),
-                    _ => QueryResult::Many(out),
-                },
+                None => borrowed_vec_to_result(out),
             }
         }
         Targets::Owned(ts) => {
@@ -9254,10 +9247,7 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
             match pending_halt {
                 Some(code) => partial(out, Control::Halt(code)),
-                None => match out.len() {
-                    1 => QueryResult::Owned(out.pop().expect("len checked")),
-                    _ => QueryResult::ManyOwned(out),
-                },
+                None => owned_vec_to_result(out),
             }
         }
     }
@@ -9370,10 +9360,7 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
     }
-    match out.len() {
-        1 => QueryResult::Owned(out.pop().expect("len checked")),
-        _ => QueryResult::ManyOwned(out),
-    }
+    owned_vec_to_result(out)
 }
 
 /// Evaluate one slice bound (`start` or `end`) against `value`, collecting

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4682,48 +4682,58 @@ fn test_try_catch_prepend_propagates_halt_from_handler() -> Result<()> {
 
 #[test]
 fn test_result_to_owned_many_empty_arm_via_ltrimstr_argument() -> Result<()> {
-    // `result_to_owned`'s `Many(vs)` arm when `vs` is empty. `(empty,empty)`
-    // is two `None`-valued comma operands, so `eval_comma` never touches its
-    // `owned` promotion path and falls out through its own `None =>
-    // QueryResult::Many(borrowed)` arm with `borrowed` still `[]` --
-    // `ltrimstr`'s argument slot then feeds that `Many(vec![])` into
-    // `result_to_owned`, hitting the "empty result" error arm. Not
-    // halt-specific (this arm predates #791; only its `.into()` wrapper is
-    // new) and a pre-existing, unrelated divergence from real jq worth
-    // flagging: jq treats `f(g)` as backtracking over every output of `g`,
-    // so a zero-output argument means zero outputs overall -- `jq -n '"abc"
-    // | ltrimstr((empty,empty))'` exits 0 with no output -- while
+    // #1043 fixed the bug this test originally probed: `eval_comma`'s tail
+    // match was missing a `0 => None` arm, so `(empty,empty)` (two
+    // `None`-valued comma operands, `owned` never promoted) fell out through
+    // `None => QueryResult::Many(borrowed)` with `borrowed` still `[]` --
+    // producing `Many(vec![])` instead of `None`. That's now routed through
+    // `borrowed_vec_to_result`, which correctly collapses an empty
+    // accumulator to `None`.
+    //
+    // `ltrimstr`'s argument slot now feeds that `None` into
+    // `result_to_owned`, which still errors -- just via its *separate*
+    // `QueryResult::None => Err("no value")` arm instead of the
+    // `Many`-empty arm this test originally pinned. That's a distinct,
+    // still-unfixed, out-of-scope divergence from real jq (#1045): jq
+    // treats `f(g)` as backtracking over every output of `g`, so a
+    // zero-output argument means zero outputs overall -- `jq -n '"abc" |
+    // ltrimstr((empty,empty))'` exits 0 with no output -- while
     // succinctly's `ltrimstr` resolves its argument to a single value via
     // `result_to_owned`, which treats "the argument stream produced
-    // nothing" as an error instead.
+    // nothing" as an error regardless of *which* empty shape produced it.
     let (stdout, stderr, code) = run_jq_full(&["-n", r#""abc" | ltrimstr((empty,empty))"#], None)?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
-    assert_eq!(stderr, "jq: error (at <unknown>): empty result\n");
+    assert_eq!(stderr, "jq: error (at <unknown>): no value\n");
     Ok(())
 }
 
 #[test]
 fn test_result_to_owned_manyowned_empty_arm_via_ltrimstr_argument() -> Result<()> {
-    // `result_to_owned`'s `ManyOwned(vs)` arm when `vs` is empty -- the
-    // `Owned`-target sibling of the `Many`-empty case above, reached through
-    // a different producer: `eval_index_expr`'s `Targets::Owned` branch ends
-    // its match on `out.len()` with only `1 => Owned(...)`, so the `_ =>
-    // ManyOwned(out)` wildcard also covers `out.len() == 0`. `(2+3)` is
-    // computed (arithmetic is always `Owned`/`ManyOwned`, never
+    // #1043 fixed the bug this test originally probed: the `Owned`-target
+    // sibling of the `Many`-empty case above, reached through a different
+    // producer -- `eval_index_expr`'s `Targets::Owned` branch used to end
+    // its match on `out.len()` with only `1 => Owned(...)`, so the
+    // `_ => ManyOwned(out)` wildcard also covered `out.len() == 0`. `(2+3)`
+    // is computed (arithmetic is always `Owned`/`ManyOwned`, never
     // document-borrowed, so its target is `Targets::Owned`), and both
     // `"x"`/`"y"` keys against the number `5` -- with the trailing `?`
     // making `optional` true -- each resolve via `index_one_owned`'s `_ if
-    // optional => Ok(None)` refusal-suppression arm, leaving `out` empty:
-    // `QueryResult::ManyOwned(vec![])`. Same pre-existing, halt-unrelated
-    // divergence from real jq as the `Many`-empty case above: `jq -n '"abc"
-    // | ltrimstr((2+3) | .[("x","y")]?)'` exits 0 with no output, while
-    // succinctly's `result_to_owned` reports it as an error.
+    // optional => Ok(None)` refusal-suppression arm, leaving `out` empty.
+    // That's now routed through `owned_vec_to_result`, which correctly
+    // collapses an empty accumulator to `None`.
+    //
+    // Same distinct, still-unfixed, out-of-scope divergence as the
+    // `Many`-empty case above (#1045) -- `result_to_owned`'s `None` arm
+    // still errors, just with a different message than before: `jq -n
+    // '"abc" | ltrimstr((2+3) | .[("x","y")]?)'` exits 0 with no output in
+    // real jq, while succinctly's `result_to_owned` reports it as an error
+    // regardless of which empty shape produced the `None`.
     let (stdout, stderr, code) =
         run_jq_full(&["-n", r#""abc" | ltrimstr((2+3) | .[("x","y")]?)"#], None)?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
-    assert_eq!(stderr, "jq: error (at <unknown>): empty result\n");
+    assert_eq!(stderr, "jq: error (at <unknown>): no value\n");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes #1043.

`eval_index_expr`'s Borrowed/Owned target arms, `eval_slice_expr`'s final collapse,
`eval_comma`'s tail match, and `eval_fanout`'s byte-identical twin all ended their
length-based match with only a `1 => One/Owned` case and a `_` wildcard covering both
"many" and "zero" — so an optional (`?`) computed index/slice, or an all-empty
comma/fanout, collapsed to `Many(vec![])`/`ManyOwned(vec![])` instead of `None`. Real jq
exits 0 with no output for these cases; succinctly raised `"empty result"`/`"no value"`
instead.

Each site now routes through the existing `owned_vec_to_result`/`borrowed_vec_to_result`
helpers (added for #1029/#1038), which already handle the 0/1/many collapse correctly,
instead of a hand-rolled 2-way match.

## Scope note: the issue's own `contains(...)`-wrapped repros don't fully resolve

Verified this fix directly (not through `contains(...)`, which the issue used as its test
vehicle): `.[("a","b")]?`, `({"a":1})[0:(1,2)]?`, `(empty,empty)`,
`if (true,false) then empty else empty end` — all now correctly emit zero output,
byte-for-byte matching real jq.

The issue's own repro commands, wrapped in `contains(...)`, still error after this fix —
just with a different message (`"no value"` instead of `"empty result"`). That's because
`contains` has a **separate**, pre-existing bug: its argument goes through
`result_to_owned`, which unconditionally errors on `QueryResult::None` regardless of which
upstream shape produced it. This PR fixes the 5 sites that were *producing* the wrong
shape; `result_to_owned`'s own `None => Err(...)` policy (and `contains`'s complete lack
of fan-out over a multi-output argument — real jq's `contains((1,2))` produces two
outputs, succinctly's produces one) is untouched here. Filed #1045 for that, since it
spans ~37 `result_to_owned` call sites and needs its own dedicated scoping.

Two existing tests already in `tests/jq_cli_tests.rs`
(`test_result_to_owned_many_empty_arm_via_ltrimstr_argument` and its `ManyOwned` sibling,
predating this issue — added alongside `borrowed_vec_to_result` itself) already documented
this exact divergence as "pre-existing, unrelated, worth flagging." Updated their expected
messages to match the new (still-wrong, differently-worded) behavior.

## Test plan

- [x] New direct-expression tests for all 5 sites, verified live against jq 1.7.1
- [x] Updated the two existing `ltrimstr`-argument tests whose pinned error message changed
- [x] Full local suite (`cargo test --features cli,simd,regex,serde`), all 3 CI clippy
      invocations, `cargo fmt --check` — all clean