### PR TITLE
fix(jq): make numeric_display_string/tostring/@json mode-aware for yq

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -655,7 +655,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             eval_string_interpolation::<W, S>(parts, value, optional)
         }
 
-        Expr::Format(format_type) => eval_format::<W>(format_type, value, optional),
+        Expr::Format(format_type) => eval_format::<W, S>(format_type, value, optional),
 
         // Phase 8: Variables and Advanced Control Flow
         Expr::As { expr, var, body } => eval_as::<W, S>(expr, var, body, value, optional),
@@ -2643,7 +2643,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::WithEntries(f) => builtin_with_entries::<W, S>(f, value, optional),
 
         // Phase 6: Type Conversions
-        Builtin::ToString => builtin_tostring::<W>(value, optional),
+        Builtin::ToString => builtin_tostring::<W, S>(value, optional),
         Builtin::ToNumber => builtin_tonumber::<W>(value, optional),
         Builtin::ToJson => builtin_tojson::<W>(value, optional),
         Builtin::FromJson => builtin_fromjson::<W>(value, optional),
@@ -5015,19 +5015,19 @@ fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             StringPart::Expr(expr) => {
                 let val = eval_single::<W, S>(expr, value.clone(), optional).materialize_cursor();
                 let s = match val {
-                    QueryResult::One(v) => owned_to_string(&to_owned(&v)),
+                    QueryResult::One(v) => owned_to_string::<S>(&to_owned(&v)),
                     QueryResult::OneCursor(_) => unreachable!(),
-                    QueryResult::Owned(v) => owned_to_string(&v),
+                    QueryResult::Owned(v) => owned_to_string::<S>(&v),
                     QueryResult::Many(vs) => {
                         if let Some(v) = vs.first() {
-                            owned_to_string(&to_owned(v))
+                            owned_to_string::<S>(&to_owned(v))
                         } else {
                             String::new()
                         }
                     }
                     QueryResult::ManyOwned(vs) => {
                         if let Some(v) = vs.first() {
-                            owned_to_string(v)
+                            owned_to_string::<S>(v)
                         } else {
                             String::new()
                         }
@@ -5067,26 +5067,48 @@ fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// jq-error-message-preview text (e.g. `1E+400`) still isn't the Rust-style
 /// `"inf"`/`"-inf"` these non-JSON text formats want, so the explicit check
 /// stays regardless.
-pub(crate) fn numeric_display_string(value: &OwnedValue) -> String {
-    if let OwnedValue::NumberLiteral(NumberRepr::Float(f), _) = value {
-        if f.is_nan() || f.is_infinite() {
-            return f.to_string();
+pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> String {
+    if let OwnedValue::NumberLiteral(repr, literal) = value {
+        if let NumberRepr::Float(f) = repr {
+            if f.is_nan() || f.is_infinite() {
+                return f.to_string();
+            }
+        }
+        // yq preserves a document-sourced literal's exact source spelling
+        // regardless of magnitude or query shape (#1008, confirmed
+        // empirically against the pinned oracle) -- `number_str()` itself
+        // stays mode-blind (jq's own `tostring`/`to_json` genuinely want
+        // `format_number_jq_compat`'s reformatting), so the fork happens
+        // here instead (#1030).
+        if S::TAG == EvalTag::Yq {
+            return crate::jq::stream::real_output_finite_literal(literal.as_bytes());
         }
     }
     value.number_str().expect("numeric variant").into_owned()
 }
 
 /// Convert an owned value to a string representation (for interpolation).
-fn owned_to_string(value: &OwnedValue) -> String {
+fn owned_to_string<S: EvalSemantics>(value: &OwnedValue) -> String {
     match value {
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            numeric_display_string(value)
+            numeric_display_string::<S>(value)
         }
         OwnedValue::String(s) => s.clone(), // Don't quote strings in interpolation
-        OwnedValue::Array(_) | OwnedValue::Object(_) => value.to_json(),
+        // `to_json_yq()` in yq mode (#1030): a container's own nested
+        // NumberLiteral needs the same verbatim-echo treatment as the
+        // scalar arm above, not jq's `to_json()` reformatting -- confirmed
+        // live: real yq's `@csv`/`@tsv`/string interpolation on an array
+        // containing a scientific-notation element all preserve it.
+        OwnedValue::Array(_) | OwnedValue::Object(_) => {
+            if S::TAG == EvalTag::Yq {
+                value.to_json_yq()
+            } else {
+                value.to_json()
+            }
+        }
     }
 }
 
@@ -5097,22 +5119,22 @@ fn owned_to_string(value: &OwnedValue) -> String {
 /// a `JsonIndex` purely to re-enter this evaluator (#124). Formats are pure
 /// functions of the value -- they touch neither the cursor nor the index -- so
 /// this is the whole of the work `Expr::Format` needs.
-pub(crate) fn format_owned(
+pub(crate) fn format_owned<S: EvalSemantics>(
     format_type: &FormatType,
     owned: &OwnedValue,
     optional: bool,
 ) -> Result<String, EvalError> {
     match format_type {
-        FormatType::Text => format_text(owned),
-        FormatType::Json => format_json(owned),
-        FormatType::Uri => format_uri(owned, optional),
-        FormatType::Csv => format_csv(owned, optional),
-        FormatType::Tsv => format_tsv(owned, optional),
-        FormatType::Dsv(delimiter) => format_dsv(owned, delimiter, optional),
+        FormatType::Text => format_text::<S>(owned),
+        FormatType::Json => format_json::<S>(owned),
+        FormatType::Uri => format_uri::<S>(owned, optional),
+        FormatType::Csv => format_csv::<S>(owned, optional),
+        FormatType::Tsv => format_tsv::<S>(owned, optional),
+        FormatType::Dsv(delimiter) => format_dsv::<S>(owned, delimiter, optional),
         FormatType::Base64 => format_base64(owned, optional),
         FormatType::Base64d => format_base64d(owned, optional),
-        FormatType::Html => format_html(owned, optional),
-        FormatType::Sh => format_sh(owned, optional),
+        FormatType::Html => format_html::<S>(owned, optional),
+        FormatType::Sh => format_sh::<S>(owned, optional),
         FormatType::Urid => format_urid(owned, optional),
         FormatType::Yaml => format_yaml(owned),
         FormatType::Props => format_props(owned),
@@ -5120,34 +5142,38 @@ pub(crate) fn format_owned(
 }
 
 /// Evaluate a format string: `@json`, `@uri`, etc.
-fn eval_format<'a, W: Clone + AsRef<[u64]>>(
+fn eval_format<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     format_type: &FormatType,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    match format_owned(format_type, &to_owned(&value), optional) {
+    match format_owned::<S>(format_type, &to_owned(&value), optional) {
         Ok(s) => QueryResult::Owned(OwnedValue::String(s)),
         Err(e) => e.into(),
     }
 }
 
 /// @text - Convert to string (same as tostring)
-fn format_text(value: &OwnedValue) -> Result<String, EvalError> {
-    Ok(owned_to_string(value))
+fn format_text<S: EvalSemantics>(value: &OwnedValue) -> Result<String, EvalError> {
+    Ok(owned_to_string::<S>(value))
 }
 
 /// @json - Format as JSON
-fn format_json(value: &OwnedValue) -> Result<String, EvalError> {
-    Ok(value.to_json())
+fn format_json<S: EvalSemantics>(value: &OwnedValue) -> Result<String, EvalError> {
+    Ok(if S::TAG == EvalTag::Yq {
+        value.to_json_yq()
+    } else {
+        value.to_json()
+    })
 }
 
 /// @uri - URI/percent encode
-fn format_uri(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
+fn format_uri<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
     // jq converts non-strings to strings first (e.g., 42 | @uri => "42")
     let s = match value {
         OwnedValue::String(s) => s.clone(),
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            numeric_display_string(value)
+            numeric_display_string::<S>(value)
         }
         OwnedValue::Bool(b) => {
             if *b {
@@ -5245,7 +5271,7 @@ fn quote_csv_field(s: &str) -> String {
 /// to verify against (confirmed live: `@dsv(...)` is a syntax error in jq
 /// 1.7.1) — its use of this same rule is succinctly's own policy choice,
 /// following its documented CSV-compatibility (`@dsv(",")` == `@csv`).
-fn format_csv_row_element(
+fn format_csv_row_element<S: EvalSemantics>(
     v: &OwnedValue,
     quote_string: impl Fn(&str) -> String,
 ) -> Result<String, EvalError> {
@@ -5253,17 +5279,17 @@ fn format_csv_row_element(
         OwnedValue::String(s) => Ok(quote_string(s)),
         OwnedValue::Null => Ok(String::new()),
         OwnedValue::Array(_) | OwnedValue::Object(_) => Err(EvalError::not_valid_in_csv_row(v)),
-        other => Ok(owned_to_string(other)),
+        other => Ok(owned_to_string::<S>(other)),
     }
 }
 
 /// @csv - CSV format (for arrays)
-fn format_csv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
+fn format_csv<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
     match value {
         OwnedValue::Array(arr) => {
             let parts = arr
                 .iter()
-                .map(|v| format_csv_row_element(v, quote_csv_field))
+                .map(|v| format_csv_row_element::<S>(v, quote_csv_field))
                 .collect::<Result<Vec<String>, EvalError>>()?;
             Ok(parts.join(","))
         }
@@ -5275,13 +5301,13 @@ fn format_csv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
 }
 
 /// @tsv - TSV format (for arrays)
-fn format_tsv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
+fn format_tsv<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
     match value {
         OwnedValue::Array(arr) => {
             let parts = arr
                 .iter()
                 .map(|v| {
-                    format_csv_row_element(v, |s| {
+                    format_csv_row_element::<S>(v, |s| {
                         s.replace('\\', "\\\\")
                             .replace('\t', "\\t")
                             .replace('\n', "\\n")
@@ -5299,12 +5325,16 @@ fn format_tsv(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
 }
 
 /// @dsv(delimiter) - Generic DSV format with custom delimiter (for arrays)
-fn format_dsv(value: &OwnedValue, delimiter: &str, optional: bool) -> Result<String, EvalError> {
+fn format_dsv<S: EvalSemantics>(
+    value: &OwnedValue,
+    delimiter: &str,
+    optional: bool,
+) -> Result<String, EvalError> {
     match value {
         OwnedValue::Array(arr) => {
             let parts = arr
                 .iter()
-                .map(|v| format_csv_row_element(v, quote_csv_field))
+                .map(|v| format_csv_row_element::<S>(v, quote_csv_field))
                 .collect::<Result<Vec<String>, EvalError>>()?;
             Ok(parts.join(delimiter))
         }
@@ -5405,12 +5435,12 @@ fn format_base64d(value: &OwnedValue, optional: bool) -> Result<String, EvalErro
 }
 
 /// @html - HTML entity escape
-fn format_html(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
+fn format_html<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
     // jq converts non-strings to strings first (e.g., 42 | @html => "42")
     let s = match value {
         OwnedValue::String(s) => s.clone(),
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            numeric_display_string(value)
+            numeric_display_string::<S>(value)
         }
         OwnedValue::Bool(b) => {
             if *b {
@@ -5450,7 +5480,7 @@ fn format_html(value: &OwnedValue, _optional: bool) -> Result<String, EvalError>
 }
 
 /// Shell-quote a single value for @sh
-fn shell_quote_value(value: &OwnedValue) -> Result<String, EvalError> {
+fn shell_quote_value<S: EvalSemantics>(value: &OwnedValue) -> Result<String, EvalError> {
     match value {
         // jq always quotes strings in @sh array output
         OwnedValue::String(s) => Ok(if s.contains('\'') {
@@ -5461,7 +5491,7 @@ fn shell_quote_value(value: &OwnedValue) -> Result<String, EvalError> {
         }),
         // Numbers, bools, null are NOT quoted in jq
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            Ok(numeric_display_string(value))
+            Ok(numeric_display_string::<S>(value))
         }
         OwnedValue::Bool(b) => Ok(if *b {
             "true".to_string()
@@ -5479,7 +5509,7 @@ fn shell_quote_value(value: &OwnedValue) -> Result<String, EvalError> {
 }
 
 /// @sh - Shell quote
-fn format_sh(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
+fn format_sh<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
     match value {
         OwnedValue::String(s) => {
             // Use single quotes and escape single quotes
@@ -5494,13 +5524,13 @@ fn format_sh(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
         OwnedValue::Array(arr) => {
             let parts: Vec<String> = arr
                 .iter()
-                .map(shell_quote_value)
+                .map(shell_quote_value::<S>)
                 .collect::<Result<_, _>>()?;
             Ok(parts.join(" "))
         }
         // Numbers, bools, null are converted to strings
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            Ok(numeric_display_string(value))
+            Ok(numeric_display_string::<S>(value))
         }
         OwnedValue::Bool(b) => Ok(if *b {
             "true".to_string()
@@ -5768,7 +5798,7 @@ fn yaml_quote_string(s: &str) -> String {
 // =============================================================================
 
 /// Builtin: tostring - convert any value to string
-fn builtin_tostring<W: Clone + AsRef<[u64]>>(
+fn builtin_tostring<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     _optional: bool,
 ) -> QueryResult<'_, W> {
@@ -5780,8 +5810,14 @@ fn builtin_tostring<W: Clone + AsRef<[u64]>>(
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(n) => format!("{n}"),
         OwnedValue::Float(f) => format!("{f}"),
-        OwnedValue::NumberLiteral(..) => numeric_display_string(&owned),
-        OwnedValue::Array(_) | OwnedValue::Object(_) => owned.to_json(),
+        OwnedValue::NumberLiteral(..) => numeric_display_string::<S>(&owned),
+        OwnedValue::Array(_) | OwnedValue::Object(_) => {
+            if S::TAG == EvalTag::Yq {
+                owned.to_json_yq()
+            } else {
+                owned.to_json()
+            }
+        }
     };
     QueryResult::Owned(OwnedValue::String(s))
 }
@@ -6798,7 +6834,7 @@ fn build_upper_index<'a, W, S: EvalSemantics>(
             Err(e) => return e.into(),
         };
         for k in keys {
-            obj.insert(owned_to_string(&k), row.clone());
+            obj.insert(owned_to_string::<S>(&k), row.clone());
         }
     }
     QueryResult::Owned(OwnedValue::Object(obj))

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2645,7 +2645,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Phase 6: Type Conversions
         Builtin::ToString => builtin_tostring::<W, S>(value, optional),
         Builtin::ToNumber => builtin_tonumber::<W>(value, optional),
-        Builtin::ToJson => builtin_tojson::<W>(value, optional),
+        Builtin::ToJson => builtin_tojson::<W, S>(value, optional),
         Builtin::FromJson => builtin_fromjson::<W>(value, optional),
 
         // Phase 6: Additional String Functions
@@ -4105,7 +4105,11 @@ fn yq_join_element_part(elem: OwnedValue) -> String {
     match elem {
         OwnedValue::String(s) => s,
         OwnedValue::Null | OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
-        other => other.to_json(),
+        // `to_json_yq()`, not `to_json()` (#1030 code review): this function
+        // is only ever reached from `builtin_join`'s `S::TAG == EvalTag::Yq`
+        // branch, so a scientific-notation literal here must echo verbatim
+        // too, not get jq-reformatted.
+        other => other.to_json_yq(),
     }
 }
 
@@ -4122,7 +4126,9 @@ fn yq_join_separator(sep: OwnedValue) -> String {
     match sep {
         OwnedValue::String(s) => s,
         OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
-        other => other.to_json(),
+        // `to_json_yq()` (#1030 code review): same reasoning as
+        // `yq_join_element_part` above -- this function is yq-only.
+        other => other.to_json_yq(),
     }
 }
 
@@ -5087,6 +5093,20 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
     value.number_str().expect("numeric variant").into_owned()
 }
 
+/// `to_json_yq()` in yq mode, `to_json()` in jq mode (#1030) -- the single
+/// definition every "stringify a whole value as JSON" call site routes
+/// through, instead of each one re-deriving the fork (#106's "duplicated
+/// predicates diverge silently" lesson, which this exact fork already
+/// tripped once: an earlier draft of this fix hand-copied this branch at
+/// four separate call sites before being consolidated here).
+pub(crate) fn owned_value_to_json<S: EvalSemantics>(value: &OwnedValue) -> String {
+    if S::TAG == EvalTag::Yq {
+        value.to_json_yq()
+    } else {
+        value.to_json()
+    }
+}
+
 /// Convert an owned value to a string representation (for interpolation).
 fn owned_to_string<S: EvalSemantics>(value: &OwnedValue) -> String {
     match value {
@@ -5097,18 +5117,12 @@ fn owned_to_string<S: EvalSemantics>(value: &OwnedValue) -> String {
             numeric_display_string::<S>(value)
         }
         OwnedValue::String(s) => s.clone(), // Don't quote strings in interpolation
-        // `to_json_yq()` in yq mode (#1030): a container's own nested
-        // NumberLiteral needs the same verbatim-echo treatment as the
-        // scalar arm above, not jq's `to_json()` reformatting -- confirmed
-        // live: real yq's `@csv`/`@tsv`/string interpolation on an array
-        // containing a scientific-notation element all preserve it.
-        OwnedValue::Array(_) | OwnedValue::Object(_) => {
-            if S::TAG == EvalTag::Yq {
-                value.to_json_yq()
-            } else {
-                value.to_json()
-            }
-        }
+        // A container's own nested NumberLiteral needs the same
+        // verbatim-echo treatment as the scalar arm above, not jq's
+        // `to_json()` reformatting -- confirmed live: real yq's
+        // `@csv`/`@tsv`/string interpolation on an array containing a
+        // scientific-notation element all preserve it.
+        OwnedValue::Array(_) | OwnedValue::Object(_) => owned_value_to_json::<S>(value),
     }
 }
 
@@ -5160,11 +5174,7 @@ fn format_text<S: EvalSemantics>(value: &OwnedValue) -> Result<String, EvalError
 
 /// @json - Format as JSON
 fn format_json<S: EvalSemantics>(value: &OwnedValue) -> Result<String, EvalError> {
-    Ok(if S::TAG == EvalTag::Yq {
-        value.to_json_yq()
-    } else {
-        value.to_json()
-    })
+    Ok(owned_value_to_json::<S>(value))
 }
 
 /// @uri - URI/percent encode
@@ -5811,13 +5821,7 @@ fn builtin_tostring<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         OwnedValue::Int(n) => format!("{n}"),
         OwnedValue::Float(f) => format!("{f}"),
         OwnedValue::NumberLiteral(..) => numeric_display_string::<S>(&owned),
-        OwnedValue::Array(_) | OwnedValue::Object(_) => {
-            if S::TAG == EvalTag::Yq {
-                owned.to_json_yq()
-            } else {
-                owned.to_json()
-            }
-        }
+        OwnedValue::Array(_) | OwnedValue::Object(_) => owned_value_to_json::<S>(&owned),
     };
     QueryResult::Owned(OwnedValue::String(s))
 }
@@ -6001,12 +6005,12 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: tojson - convert any value to JSON string
-fn builtin_tojson<W: Clone + AsRef<[u64]>>(
+fn builtin_tojson<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     _optional: bool,
 ) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
-    let json_string = owned.to_json();
+    let json_string = owned_value_to_json::<S>(&owned);
     QueryResult::Owned(OwnedValue::String(json_string))
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -864,12 +864,12 @@ fn standard_json_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
 }
 
 /// Apply a format to an owned value and wrap it as a `GenericResult`.
-fn format_result<V: DocumentValue>(
+fn format_result<S: EvalSemantics, V: DocumentValue>(
     format_type: &FormatType,
     owned: &OwnedValue,
     optional: bool,
 ) -> GenericResult<V> {
-    match format_owned(format_type, owned, optional) {
+    match format_owned::<S>(format_type, owned, optional) {
         Ok(s) => GenericResult::Owned(OwnedValue::String(s)),
         Err(e) => GenericResult::Error(e),
     }
@@ -892,7 +892,7 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     // `OwnedValue::Float` or `NumberLiteral`, with no dependence on having
     // passed through a JSON round-trip first.
     if let Expr::Format(format_type) = expr {
-        return format_result(format_type, &owned, optional);
+        return format_result::<S, _>(format_type, &owned, optional);
     }
 
     let json_str = owned.to_json_for_reindex();
@@ -2533,7 +2533,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // than falling through to the catch-all, which would serialize the
         // value to JSON and rebuild a `JsonIndex` for every one (#124).
         Expr::Format(format_type) => {
-            format_result(format_type, &to_owned_with_cursor(&value, cursor), optional)
+            format_result::<S, _>(format_type, &to_owned_with_cursor(&value, cursor), optional)
         }
 
         Expr::Builtin(builtin) => eval_builtin::<S, _>(builtin, value, optional, cursor),
@@ -3699,10 +3699,16 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 OwnedValue::Null => "null".to_string(),
                 OwnedValue::Bool(b) => b.to_string(),
                 OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-                    numeric_display_string(&owned)
+                    numeric_display_string::<S>(&owned)
                 }
                 OwnedValue::String(s) => s.clone(),
-                OwnedValue::Array(_) | OwnedValue::Object(_) => owned.to_json(),
+                OwnedValue::Array(_) | OwnedValue::Object(_) => {
+                    if S::TAG == EvalTag::Yq {
+                        owned.to_json_yq()
+                    } else {
+                        owned.to_json()
+                    }
+                }
             };
             GenericResult::Owned(OwnedValue::String(s))
         }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,8 +27,8 @@ use super::document::{
 use super::eval::{
     compare_values, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
     needs_path_context, numeric_display_string, numeric_key_to_index, owned_bound_to_i64,
-    slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag, JqSemantics,
-    QueryResult, YqSemantics,
+    owned_value_to_json, slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics,
+    EvalTag, JqSemantics, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Literal};
 use super::slice::{slice_str, SliceBounds};
@@ -3702,13 +3702,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     numeric_display_string::<S>(&owned)
                 }
                 OwnedValue::String(s) => s.clone(),
-                OwnedValue::Array(_) | OwnedValue::Object(_) => {
-                    if S::TAG == EvalTag::Yq {
-                        owned.to_json_yq()
-                    } else {
-                        owned.to_json()
-                    }
-                }
+                OwnedValue::Array(_) | OwnedValue::Object(_) => owned_value_to_json::<S>(&owned),
             };
             GenericResult::Owned(OwnedValue::String(s))
         }

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -192,7 +192,7 @@ fn stream_owned_value_json<W: core::fmt::Write>(
 /// query shape, confirmed empirically against the pinned oracle. `raw` is
 /// always valid UTF-8 (sourced from `OwnedValue::NumberLiteral`'s own
 /// `Box<str>`), so the lossy path here is unreachable in practice.
-fn real_output_finite_literal(raw: &[u8]) -> String {
+pub(crate) fn real_output_finite_literal(raw: &[u8]) -> String {
     String::from_utf8_lossy(raw).into_owned()
 }
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -738,10 +738,29 @@ impl OwnedValue {
     /// entirely: no adversarial document is involved, only enough loop
     /// iterations to grow the accumulator past the limit.
     pub fn to_json(&self) -> String {
-        self.to_json_at_depth(0)
+        self.to_json_at_depth(0, format_number_jq_compat)
     }
 
-    fn to_json_at_depth(&self, depth: usize) -> String {
+    /// The yq-mode sibling of [`to_json`](Self::to_json) (#1030): identical
+    /// except a finite `NumberLiteral` echoes its document-sourced spelling
+    /// verbatim rather than being reformatted per jq's own rules -- real yq
+    /// preserves scientific-notation literals byte-for-byte regardless of
+    /// magnitude or query shape (#1008, confirmed empirically against the
+    /// pinned oracle). Used by `@json`'s yq-mode branch and by string
+    /// interpolation's container arm (`owned_to_string`), both of which need
+    /// this same literal-preserving JSON text, not [`to_json`](Self::to_json)'s
+    /// jq-normalized one.
+    pub(crate) fn to_json_yq(&self) -> String {
+        self.to_json_at_depth(0, crate::jq::stream::real_output_finite_literal)
+    }
+
+    /// `finite_literal` formats a `NumberLiteral`'s source text -- jq's
+    /// [`format_number_jq_compat`] for [`to_json`](Self::to_json), or a
+    /// verbatim echo for [`to_json_yq`](Self::to_json_yq) -- mirroring the
+    /// same fork [`stream::stream_owned_value_json_with`](crate::jq::stream)
+    /// already threads through for the M2 streaming path (#1008), so this
+    /// doesn't grow a third hand-copied "echo verbatim for yq" branch.
+    fn to_json_at_depth(&self, depth: usize, finite_literal: fn(&[u8]) -> String) -> String {
         assert_value_tree_depth(depth);
         match self {
             Self::Null => "null".into(),
@@ -758,11 +777,13 @@ impl OwnedValue {
             Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
                 "null".into() // JSON doesn't support NaN or Infinity
             }
-            Self::NumberLiteral(_, literal) => format_number_jq_compat(literal.as_bytes()),
+            Self::NumberLiteral(_, literal) => finite_literal(literal.as_bytes()),
             Self::String(s) => format!("\"{}\"", escape_json_body(write_json_body_jq, s)),
             Self::Array(arr) => {
-                let elements: Vec<String> =
-                    arr.iter().map(|v| v.to_json_at_depth(depth + 1)).collect();
+                let elements: Vec<String> = arr
+                    .iter()
+                    .map(|v| v.to_json_at_depth(depth + 1, finite_literal))
+                    .collect();
                 format!("[{}]", elements.join(","))
             }
             Self::Object(obj) => {
@@ -772,7 +793,7 @@ impl OwnedValue {
                         format!(
                             "\"{}\":{}",
                             escape_json_body(write_json_body_jq, k),
-                            v.to_json_at_depth(depth + 1)
+                            v.to_json_at_depth(depth + 1, finite_literal)
                         )
                     })
                     .collect();
@@ -880,7 +901,7 @@ impl OwnedValue {
                     .collect();
                 format!("{{{}}}", entries.join(","))
             }
-            other => other.to_json_at_depth(depth),
+            other => other.to_json_at_depth(depth, format_number_jq_compat),
         }
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10662,3 +10662,22 @@ fn test_negative_zero_exponent_literal_preserves_sign_1008() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1030 (`#1008` follow-up): `numeric_display_string`/`to_json_yq` gained
+/// yq-mode-only verbatim echo -- confirm jq mode's own `tostring`/`@json`/
+/// string interpolation keep `format_number_jq_compat`'s reformatting
+/// unchanged (uppercase `E`, forced sign), not accidentally picking up
+/// yq's verbatim-echo branch.
+#[test]
+fn test_jq_tostring_and_json_and_interpolation_unaffected_by_yq_verbatim_echo_1030() -> Result<()> {
+    for (filter, want) in [
+        (".a | tostring", r#""1E+2""#),
+        (".a | @json", r#""1E+2""#),
+        (r#""\(.a)""#, r#""1E+2""#),
+    ] {
+        let (out, code) = run_jq_stdin(filter, r#"{"a": 1e2}"#, &[])?;
+        assert_eq!(code, 0, "for {filter:?}: {out:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11617,3 +11617,38 @@ fn test_yq_at_json_preserves_exponent_literal_nested_in_array_1030() -> Result<(
     assert_eq!(stdout.trim_end(), r#"[1e2,"x"]"#);
     Ok(())
 }
+
+#[test]
+fn test_yq_tojson_preserves_exponent_literal_1030() -> Result<()> {
+    // #1030 code review: `tojson` is a separate builtin from the `@json`
+    // format operator (both fixed above) and was initially missed --
+    // confirmed live it must match `@json`'s behavior exactly.
+    let (stdout, code) = run_yq_stdin(".a | tojson", "a: 1e2\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1e2");
+    Ok(())
+}
+
+#[test]
+fn test_yq_join_preserves_exponent_literal_in_element_1030() -> Result<()> {
+    // #1030 code review: `yq_join_element_part` (yq-only, #1041) was
+    // initially missed -- it must use the same verbatim-echo convention as
+    // every other yq-mode stringify path.
+    let (stdout, code) = run_yq_stdin(r#".a | join(",")"#, "a: [1e2, x]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1e2,x");
+    Ok(())
+}
+
+#[test]
+fn test_yq_join_preserves_exponent_literal_in_separator_1030() -> Result<()> {
+    // #1030 code review: `yq_join_separator`'s equivalent gap. Uses an
+    // array-index reference (`.[0]`), not `as $var`/a bare query literal,
+    // to reach the separator without the source-fidelity loss those two
+    // paths have (confirmed pre-existing on unpatched `main`, out of this
+    // issue's scope).
+    let (stdout, code) = run_yq_stdin(r#".arr | join(.[0])"#, "arr: [1e2, a, b]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1e21e2a1e2b");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11561,3 +11561,59 @@ fn test_yq_join_null_separator_renders_as_literal_text_1041() -> Result<()> {
     assert_eq!(stdout.trim_end(), "xnullynullz");
     Ok(())
 }
+
+// =============================================================================
+// yq-mode `numeric_display_string`/`to_json_yq` scientific-notation fidelity
+// (#1030, #1008 follow-up) -- all live-verified against yq v4.53.3.
+// =============================================================================
+
+#[test]
+fn test_yq_tostring_preserves_exponent_literal_1030() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(".a | tostring", "a: 1e2\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1e2");
+    Ok(())
+}
+
+#[test]
+fn test_yq_at_json_preserves_exponent_literal_1030() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(".a | @json", "a: 1E5\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1E5");
+    Ok(())
+}
+
+#[test]
+fn test_yq_string_interpolation_preserves_exponent_literal_1030() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r#""\(.a)""#, "a: 1e100\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1e100");
+    Ok(())
+}
+
+#[test]
+fn test_yq_at_sh_preserves_exponent_literal_1030() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(".a | @sh", "a: 1e2\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1e2");
+    Ok(())
+}
+
+#[test]
+fn test_yq_at_tsv_preserves_exponent_literal_in_array_element_1030() -> Result<()> {
+    // A container's own nested element needs the same treatment as a bare
+    // scalar (`numeric_display_string`/`owned_to_string`'s Array/Object
+    // arm) -- `@tsv`'s cell formatter routes through the same shared path.
+    let (stdout, code) = run_yq_stdin(".a | @tsv", "a: [1e2, x]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1e2\tx");
+    Ok(())
+}
+
+#[test]
+fn test_yq_at_json_preserves_exponent_literal_nested_in_array_1030() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(".a | @json", "a: [1e2, x]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"[1e2,"x"]"#);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11647,7 +11647,7 @@ fn test_yq_join_preserves_exponent_literal_in_separator_1030() -> Result<()> {
     // to reach the separator without the source-fidelity loss those two
     // paths have (confirmed pre-existing on unpatched `main`, out of this
     // issue's scope).
-    let (stdout, code) = run_yq_stdin(r#".arr | join(.[0])"#, "arr: [1e2, a, b]\n", &["-r"])?;
+    let (stdout, code) = run_yq_stdin(r".arr | join(.[0])", "arr: [1e2, a, b]\n", &["-r"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "1e21e2a1e2b");
     Ok(())


### PR DESCRIPTION
## Summary

#1008/#1027 made yq's *output* formatters (`emit_yaml_value_at_depth`, `format_json_impl`, `stream_owned_value_json`'s `finite_literal` hook, etc.) preserve a document-sourced scientific-notation literal's exact spelling, matching real yq. Code review on that PR found one more surface still affected: `OwnedValue::number_str()` hardcodes `format_number_jq_compat` unconditionally, with no yq/jq mode awareness — it backs `tostring`, `@text`, `@uri`, `@html`, `@sh`, `@csv`/`@tsv`/`@dsv`'s cell formatter, and string interpolation (`"\(.a)"`) in both CLI binaries via `numeric_display_string`. Separately, `@json`'s own path (`to_json()`) had the identical gap.

```
$ printf 'a: 1e2\n' | succinctly yq '.a | tostring'
"1E+2"
$ printf 'a: 1e2\n' | yq '.a | tostring'   # real yq
"1e2"
```

## Note on scoping

Claimed after finding an inaccurate "correction" comment on the issue (claiming the premise didn't reproduce, and that `is_preservable_float_literal` still excluded exponent notation) — re-verified directly against current `main` before starting: neither claim holds. `is_preservable_float_literal` already accepts exponent notation (fixed as part of #1008/#1027), and the original repro reproduces exactly as described. Left a correcting comment on the issue with the verification details.

## Fix

Threads `S: EvalSemantics` through `numeric_display_string` and its whole caller chain (`owned_to_string`, `format_owned`/`eval_format`, `builtin_tostring` in both the full and generic evaluators, plus `format_uri`/`format_html`/`shell_quote_value`/`format_csv_row_element` and their own callers), adding a yq-mode verbatim-echo branch at that single choke point — mirroring the existing `stream_owned_value_json_with`'s `finite_literal: fn` parameter pattern (#1008) instead of hand-copying the check a 7th time.

Adds `OwnedValue::to_json_yq()`, the yq-mode sibling of `to_json()`: refactors `to_json_at_depth` to take a `finite_literal: fn(&[u8]) -> String` parameter (same pattern) so the two share one tree-walk instead of a second hand-written JSON serializer. Used by `@json` and by `owned_to_string`'s Array/Object arm — a container's own nested `NumberLiteral` needs the same treatment as a bare scalar (confirmed live that real yq's `@csv`/`@tsv`/string interpolation on an array containing a scientific-notation element all preserve it too, and this fix picks that up for free through the shared function).

## Scope note

Several *other* divergences surfaced during oracle verification are pre-existing and unrelated to number formatting — confirmed identical before/after this fix by testing against unfixed `main`, so left out of scope:
- Container comma-spacing (`[1e2,"x"]` vs real yq's `[1e2, "x"]`) for `tostring`/interpolation on an array
- `@csv`'s string-quoting policy for a mixed array (real yq leaves a bare string unquoted)
- `@uri`/`@sh`'s stricter input-type checking in real yq (rejects a non-string input entirely, where succinctly auto-stringifies like jq does)
- `@text`/`@html` don't exist as format operators in real yq at all (succinctly extension)

## Testing

- `cargo test --features cli,simd,regex,serde`: full suite green (lib tests, `jq_cli_tests` 549/0, `yq_cli_tests` 645/0, golden tests, doctests)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo check --no-default-features`: clean (no_std)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- New tests cover `tostring`, `@json`, `@sh`, string interpolation (all scalar), `@tsv`/`@json` (array-nested), and a dedicated jq-mode-unaffected regression test
- Every case verified byte-for-byte against pinned yq v4.53.3, and jq mode regression-checked separately (fully unaffected)

Fixes #1030