### PR TITLE
fix(jq): keep decimal point on reindex-bridge whole-number floats

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4958,7 +4958,7 @@ fn builtin_with_entries<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // map(f)
     let mut transformed: Vec<OwnedValue> = Vec::new();
     for entry in entries {
-        let entry_json = owned_to_json_bytes(&entry);
+        let entry_json = owned_to_json_bytes::<S>(&entry);
         let index = crate::json::JsonIndex::build(&entry_json);
         let cursor = index.root(&entry_json);
 
@@ -4999,8 +4999,8 @@ fn builtin_with_entries<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// purely internal (e.g. `with_entries`'s per-entry re-evaluation), so an
 /// overflowed `NumberLiteral`/`Float` must keep its ±Infinity rather than
 /// being silently substituted with JSON's `"null"` (#561).
-fn owned_to_json_bytes(value: &OwnedValue) -> Vec<u8> {
-    value.to_json_for_reindex().into_bytes()
+fn owned_to_json_bytes<S: EvalSemantics>(value: &OwnedValue) -> Vec<u8> {
+    value.to_json_for_reindex::<S>().into_bytes()
 }
 
 // =============================================================================
@@ -13899,7 +13899,7 @@ fn eval_owned_expr_ctrl<S: EvalSemantics>(
     // `to_json_for_reindex` (not `to_json`): this round-trip is purely
     // internal, so an overflowed `NumberLiteral`/`Float` must keep its
     // ±Infinity rather than being silently substituted with "null" (#561).
-    let json_str = input.to_json_for_reindex();
+    let json_str = input.to_json_for_reindex::<S>();
     let json_bytes = json_str.as_bytes();
 
     // We need to create a temporary index and cursor
@@ -13996,7 +13996,7 @@ fn eval_owned_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `to_json_for_reindex` (not `to_json`): this round-trip is purely
     // internal, so an overflowed `NumberLiteral`/`Float` must keep its
     // ±Infinity rather than being silently substituted with "null" (#561).
-    let json_str = input.to_json_for_reindex();
+    let json_str = input.to_json_for_reindex::<S>();
     let json_bytes = json_str.as_bytes();
 
     use crate::json::JsonIndex;
@@ -23888,7 +23888,7 @@ mod tests {
         input: &OwnedValue,
         optional: bool,
     ) -> Result<Option<OwnedValue>, EvalError> {
-        let json_str = input.to_json_for_reindex();
+        let json_str = input.to_json_for_reindex::<JqSemantics>();
         let json_bytes = json_str.as_bytes();
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -895,7 +895,7 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
         return format_result::<S, _>(format_type, &owned, optional);
     }
 
-    let json_str = owned.to_json_for_reindex();
+    let json_str = owned.to_json_for_reindex::<S>();
     let json_bytes = json_str.as_bytes();
     let index = JsonIndex::build(json_bytes);
     let cursor = index.root(json_bytes);
@@ -2594,7 +2594,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         _ => {
             // Convert to OwnedValue, then to JSON, then evaluate with full evaluator
             let owned = to_owned_with_cursor(&value, cursor);
-            let json_str = owned.to_json_for_reindex();
+            let json_str = owned.to_json_for_reindex::<S>();
             let json_bytes = json_str.as_bytes();
             let index = JsonIndex::build(json_bytes);
             let cursor = index.root(json_bytes);

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -26,8 +26,8 @@ use alloc::vec::Vec;
 use super::document::{DocumentFields, IndentSpec};
 use super::escape::{write_json_body_jq, write_json_body_yq};
 use super::value::{
-    assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text, NumberRepr,
-    OwnedValue,
+    assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text,
+    jq_bare_float_display, NumberRepr, OwnedValue,
 };
 use crate::yaml::format_float_with_fraction;
 
@@ -241,7 +241,7 @@ pub fn stream_owned_value_json_jq<W: core::fmt::Write>(
         ' ',
         false,
         write_json_body_jq,
-        |f| f.to_string(),
+        jq_bare_float_display,
         |negative| infinite_float_preview_text(negative).to_string(),
         preview_infinite_literal,
         format_number_jq_compat,

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -738,7 +738,7 @@ impl OwnedValue {
     /// entirely: no adversarial document is involved, only enough loop
     /// iterations to grow the accumulator past the limit.
     pub fn to_json(&self) -> String {
-        self.to_json_at_depth(0, format_number_jq_compat)
+        self.to_json_at_depth(0, format_number_jq_compat, |f| f.to_string())
     }
 
     /// The yq-mode sibling of [`to_json`](Self::to_json) (#1030): identical
@@ -750,17 +750,38 @@ impl OwnedValue {
     /// interpolation's container arm (`owned_to_string`), both of which need
     /// this same literal-preserving JSON text, not [`to_json`](Self::to_json)'s
     /// jq-normalized one.
+    ///
+    /// Also keeps a whole-number `Float`'s decimal point (`format_float_with_fraction`,
+    /// #953) -- unlike jq, which happily prints `1.0` as `1` in JSON (matching
+    /// real jq's own `tojson`), yq must not: `1.0` and `1` are different YAML
+    /// types, and dropping the point on a round trip changes it (#169's own
+    /// reasoning, reused here for the same class of value reached from a
+    /// different path -- an i64-overflow decimal integer scalar, which
+    /// `resolve_plain` also classifies as `!!float`, confirmed live against
+    /// the pinned oracle: real yq's `-o json` gives `100...0.0`, not
+    /// `100...0`).
     pub(crate) fn to_json_yq(&self) -> String {
-        self.to_json_at_depth(0, crate::jq::stream::real_output_finite_literal)
+        self.to_json_at_depth(
+            0,
+            crate::jq::stream::real_output_finite_literal,
+            crate::yaml::format_float_with_fraction,
+        )
     }
 
-    /// `finite_literal` formats a `NumberLiteral`'s source text -- jq's
-    /// [`format_number_jq_compat`] for [`to_json`](Self::to_json), or a
-    /// verbatim echo for [`to_json_yq`](Self::to_json_yq) -- mirroring the
-    /// same fork [`stream::stream_owned_value_json_with`](crate::jq::stream)
-    /// already threads through for the M2 streaming path (#1008), so this
-    /// doesn't grow a third hand-copied "echo verbatim for yq" branch.
-    fn to_json_at_depth(&self, depth: usize, finite_literal: fn(&[u8]) -> String) -> String {
+    /// `finite_literal` formats a `NumberLiteral`'s source text, and
+    /// `float_fmt` a plain `Float`'s -- jq's [`format_number_jq_compat`]/bare
+    /// `Display` for [`to_json`](Self::to_json), or a verbatim echo/
+    /// decimal-point-preserving format for [`to_json_yq`](Self::to_json_yq)
+    /// -- mirroring the same fork
+    /// [`stream::stream_owned_value_json_with`](crate::jq::stream) already
+    /// threads through for the M2 streaming path (#1008), so this doesn't
+    /// grow a third hand-copied jq/yq-formatting branch.
+    fn to_json_at_depth(
+        &self,
+        depth: usize,
+        finite_literal: fn(&[u8]) -> String,
+        float_fmt: fn(f64) -> String,
+    ) -> String {
         assert_value_tree_depth(depth);
         match self {
             Self::Null => "null".into(),
@@ -771,7 +792,7 @@ impl OwnedValue {
                 if f.is_nan() || f.is_infinite() {
                     "null".into() // JSON doesn't support NaN or Infinity
                 } else {
-                    format!("{f}")
+                    float_fmt(*f)
                 }
             }
             Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
@@ -782,7 +803,7 @@ impl OwnedValue {
             Self::Array(arr) => {
                 let elements: Vec<String> = arr
                     .iter()
-                    .map(|v| v.to_json_at_depth(depth + 1, finite_literal))
+                    .map(|v| v.to_json_at_depth(depth + 1, finite_literal, float_fmt))
                     .collect();
                 format!("[{}]", elements.join(","))
             }
@@ -793,7 +814,7 @@ impl OwnedValue {
                         format!(
                             "\"{}\":{}",
                             escape_json_body(write_json_body_jq, k),
-                            v.to_json_at_depth(depth + 1, finite_literal)
+                            v.to_json_at_depth(depth + 1, finite_literal, float_fmt)
                         )
                     })
                     .collect();
@@ -901,7 +922,28 @@ impl OwnedValue {
                     .collect();
                 format!("{{{}}}", entries.join(","))
             }
-            other => other.to_json_at_depth(depth, format_number_jq_compat),
+            // `format_float_with_fraction`, not `|f| f.to_string()`: this
+            // bridge is *not* purely internal for every caller — for any
+            // `Expr` shape `eval_generic.rs` has no native cursor arm for
+            // (`[...]`, `with_entries`, ...), it's the actual conversion
+            // path from a YAML cursor's plain (non-`NumberLiteral`) `Float`
+            // through to the final JSON reparse `format_json_impl`/
+            // `to_json_yq` echo unchanged (#953: `.a` alone streams
+            // correctly, but `[.a]` round-trips an overflowed-`i64` scalar
+            // through here, and a bare `f.to_string()` silently drops the
+            // decimal point real yq always keeps on a float). Reparsing
+            // `100000000000000000000.0` yields the identical `f64` as
+            // `100000000000000000000` would, so this is a no-op for the
+            // round-trip's own correctness -- and jq mode's own final
+            // formatter (`format_number_jq_compat`, via `to_json`/
+            // `number_str`) re-normalizes away the added `.0` after
+            // reparsing regardless, so jq-mode output is unaffected (same
+            // reasoning already verified for the `NumberLiteral` arm above).
+            other => other.to_json_at_depth(
+                depth,
+                format_number_jq_compat,
+                crate::yaml::format_float_with_fraction,
+            ),
         }
     }
 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -20,6 +20,9 @@ use std::borrow::Cow;
 use indexmap::IndexMap;
 
 use super::escape::{escape_json_body, write_json_body_jq};
+#[cfg(test)]
+use super::eval::JqSemantics;
+use super::eval::{EvalSemantics, EvalTag};
 use super::expr::Literal;
 
 /// Recursion-depth ceiling for tree-walkers over an already-materialized
@@ -834,8 +837,26 @@ impl OwnedValue {
     /// `numeric_display_string()` (in `src/jq/eval.rs`) needs downstream once
     /// the bridge re-parses this text and hands the cursor to the full
     /// evaluator (#561, #472).
-    pub(crate) fn to_json_for_reindex(&self) -> String {
-        self.to_json_for_reindex_at_depth(0)
+    ///
+    /// `S: EvalSemantics` picks the plain (non-`NumberLiteral`) `Float`
+    /// fallback's spelling (#953): yq keeps a decimal point regardless of
+    /// magnitude (`format_float_with_fraction`), matching real yq's own
+    /// `-o json '[.a]'` output for a value with no preserved literal (e.g.
+    /// an i64-overflow YAML scalar reaching this bridge via `[...]`/
+    /// `map_values`/`with_entries`, which have no native `eval_generic.rs`
+    /// cursor arm). jq keeps the pre-existing bare `Display` (no forced
+    /// point): real jq's own convention drops a computed value's literal
+    /// formatting entirely (`1.0 + 4.0` prints `5`, not `5.0`), and a bare
+    /// `Float` reaching this fallback is by construction one that already
+    /// lost its `NumberLiteral` text — confirmed live this must stay
+    /// mode-gated, not unconditional: an earlier draft hardcoded yq's
+    /// formatter here unconditionally, which silently flipped
+    /// `reduce (1,2) as $i (1.0 + 4.0; [.])` in **jq** mode from the
+    /// correct `[[[5]]]` to `[[[5.0]]]` (caught in code review) since
+    /// `format_number_jq_compat` does not strip an explicit `.0` back off a
+    /// literal it's handed after the reparse.
+    pub(crate) fn to_json_for_reindex<S: EvalSemantics>(&self) -> String {
+        self.to_json_for_reindex_at_depth::<S>(0)
     }
 
     /// Panics past [`MAX_VALUE_TREE_DEPTH`] levels of nesting (#1005) — see
@@ -845,7 +866,7 @@ impl OwnedValue {
     /// reindex bridge) are exactly the ones that grow a value one level
     /// deeper per loop iteration with no adversarial document involved, so
     /// it needs the same guard [`to_json`](Self::to_json) does.
-    fn to_json_for_reindex_at_depth(&self, depth: usize) -> String {
+    fn to_json_for_reindex_at_depth<S: EvalSemantics>(&self, depth: usize) -> String {
         assert_value_tree_depth(depth);
         match self {
             Self::Float(f) if f.is_nan() => NAN_SENTINEL.to_string(),
@@ -905,7 +926,7 @@ impl OwnedValue {
             Self::Array(arr) => {
                 let elements: Vec<String> = arr
                     .iter()
-                    .map(|v| v.to_json_for_reindex_at_depth(depth + 1))
+                    .map(|v| v.to_json_for_reindex_at_depth::<S>(depth + 1))
                     .collect();
                 format!("[{}]", elements.join(","))
             }
@@ -916,34 +937,22 @@ impl OwnedValue {
                         format!(
                             "\"{}\":{}",
                             escape_json_body(write_json_body_jq, k),
-                            v.to_json_for_reindex_at_depth(depth + 1)
+                            v.to_json_for_reindex_at_depth::<S>(depth + 1)
                         )
                     })
                     .collect();
                 format!("{{{}}}", entries.join(","))
             }
-            // `format_float_with_fraction`, not `|f| f.to_string()`: this
-            // bridge is *not* purely internal for every caller — for any
-            // `Expr` shape `eval_generic.rs` has no native cursor arm for
-            // (`[...]`, `with_entries`, ...), it's the actual conversion
-            // path from a YAML cursor's plain (non-`NumberLiteral`) `Float`
-            // through to the final JSON reparse `format_json_impl`/
-            // `to_json_yq` echo unchanged (#953: `.a` alone streams
-            // correctly, but `[.a]` round-trips an overflowed-`i64` scalar
-            // through here, and a bare `f.to_string()` silently drops the
-            // decimal point real yq always keeps on a float). Reparsing
-            // `100000000000000000000.0` yields the identical `f64` as
-            // `100000000000000000000` would, so this is a no-op for the
-            // round-trip's own correctness -- and jq mode's own final
-            // formatter (`format_number_jq_compat`, via `to_json`/
-            // `number_str`) re-normalizes away the added `.0` after
-            // reparsing regardless, so jq-mode output is unaffected (same
-            // reasoning already verified for the `NumberLiteral` arm above).
-            other => other.to_json_at_depth(
+            // yq keeps a whole-number `Float`'s decimal point at any
+            // magnitude (#953); jq keeps the original bare `Display` (see
+            // this function's own doc comment for why the fork is required,
+            // not optional).
+            other if S::TAG == EvalTag::Yq => other.to_json_at_depth(
                 depth,
                 format_number_jq_compat,
                 crate::yaml::format_float_with_fraction,
             ),
+            other => other.to_json_at_depth(depth, format_number_jq_compat, |f| f.to_string()),
         }
     }
 }
@@ -1692,11 +1701,11 @@ mod tests {
         // the reserved sentinel instead of falling back to `to_json`'s
         // "null" substitution (#472).
         assert_eq!(
-            OwnedValue::Float(f64::NAN).to_json_for_reindex(),
+            OwnedValue::Float(f64::NAN).to_json_for_reindex::<JqSemantics>(),
             NAN_SENTINEL
         );
         let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into());
-        assert_eq!(lit.to_json_for_reindex(), NAN_SENTINEL);
+        assert_eq!(lit.to_json_for_reindex::<JqSemantics>(), NAN_SENTINEL);
     }
 
     /// #939: an infinite `NumberLiteral` backed by real document text (any
@@ -1708,10 +1717,10 @@ mod tests {
     #[test]
     fn test_to_json_for_reindex_reuses_overflow_literal_text() {
         let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "123e400".into());
-        assert_eq!(lit.to_json_for_reindex(), "123e400");
+        assert_eq!(lit.to_json_for_reindex::<JqSemantics>(), "123e400");
 
         let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-1e400".into());
-        assert_eq!(lit.to_json_for_reindex(), "-1e400");
+        assert_eq!(lit.to_json_for_reindex::<JqSemantics>(), "-1e400");
     }
 
     /// #939 review: reusing the literal's own text is O(its length), and
@@ -1726,7 +1735,7 @@ mod tests {
     fn test_to_json_for_reindex_bounds_an_unrealistically_long_literal() {
         let huge_literal = format!("{}e400", "9".repeat(300));
         let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), huge_literal.into());
-        assert_eq!(lit.to_json_for_reindex(), "1e999");
+        assert_eq!(lit.to_json_for_reindex::<JqSemantics>(), "1e999");
     }
 
     #[test]
@@ -1984,7 +1993,7 @@ mod tests {
         let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
         // Under the limit: succeeds (doesn't panic).
         let _ = under.to_json();
-        let _ = under.to_json_for_reindex();
+        let _ = under.to_json_for_reindex::<JqSemantics>();
 
         let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.to_json()));
@@ -1992,8 +2001,9 @@ mod tests {
             result.is_err(),
             "to_json should panic at MAX_VALUE_TREE_DEPTH"
         );
-        let result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.to_json_for_reindex()));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            over.to_json_for_reindex::<JqSemantics>()
+        }));
         assert!(
             result.is_err(),
             "to_json_for_reindex should panic at MAX_VALUE_TREE_DEPTH"

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -241,6 +241,19 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     assemble_scientific(sign, &mantissa_str, i64::from(new_exp))
 }
 
+/// jq mode's bare `Float` display: no forced decimal point, matching real
+/// jq's own convention that a computed value (one with no preserved
+/// `NumberLiteral` source text) loses its literal formatting entirely
+/// (`1.0 + 4.0` prints `5`, not `5.0`). Named and shared, rather than a
+/// hand-copied `|f| f.to_string()` closure at each call site, per the #106
+/// "duplicated predicates diverge silently" lesson in `CLAUDE.md` --
+/// [`to_json`](OwnedValue::to_json), [`to_json_for_reindex_at_depth`]'s
+/// jq-mode fallback, and [`stream::stream_owned_value_json_jq`](crate::jq::stream)
+/// all need this exact formatter.
+pub(crate) fn jq_bare_float_display(f: f64) -> String {
+    f.to_string()
+}
+
 /// Join a sign, an already-normalized mantissa, and an exponent into jq's
 /// scientific-notation text (`{sign}{mantissa}E{+/-}{exp}`) -- the shared
 /// final step of both the finite path above and the overflow path below, so
@@ -741,7 +754,7 @@ impl OwnedValue {
     /// entirely: no adversarial document is involved, only enough loop
     /// iterations to grow the accumulator past the limit.
     pub fn to_json(&self) -> String {
-        self.to_json_at_depth(0, format_number_jq_compat, |f| f.to_string())
+        self.to_json_at_depth(0, format_number_jq_compat, jq_bare_float_display)
     }
 
     /// The yq-mode sibling of [`to_json`](Self::to_json) (#1030): identical
@@ -952,7 +965,7 @@ impl OwnedValue {
                 format_number_jq_compat,
                 crate::yaml::format_float_with_fraction,
             ),
-            other => other.to_json_at_depth(depth, format_number_jq_compat, |f| f.to_string()),
+            other => other.to_json_at_depth(depth, format_number_jq_compat, jq_bare_float_display),
         }
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10693,15 +10693,12 @@ fn test_jq_tostring_and_json_and_interpolation_unaffected_by_yq_verbatim_echo_10
     Ok(())
 }
 
-/// #953: `to_json_for_reindex`'s `Float` fallback now formats through
-/// `format_float_with_fraction` (adding a `.0`) instead of bare `Display`,
-/// so any `Expr` shape with no native `eval_generic.rs` cursor arm (e.g.
-/// `[...]`) round-trips a computed whole-number float through JSON text
-/// with a decimal point where it previously had none. jq mode's own final
-/// formatter (`format_number_jq_compat`, reached via `to_json`) strips that
-/// `.0` back off after reparsing regardless -- real jq matches this on both
-/// cases (`[5]`, `[1]`, confirmed live), so the reindex bridge's added `.0`
-/// must stay invisible in jq's own output.
+/// #953: top-level `[...]` array construction (`eval.rs`'s native
+/// `Expr::Array` cursor arm) never reaches `to_json_for_reindex` at all, so
+/// this doesn't exercise the reindex-bridge fix directly -- kept as a
+/// baseline sanity check that jq's own array construction is unaffected.
+/// See `test_jq_reduce_accumulator_unaffected_by_yq_float_fraction_fix_953`
+/// below for a case that actually reaches the bridge.
 #[test]
 fn test_jq_array_construction_unaffected_by_yq_float_fraction_fix_953() -> Result<()> {
     for (filter, input, want) in [
@@ -10712,5 +10709,24 @@ fn test_jq_array_construction_unaffected_by_yq_float_fraction_fix_953() -> Resul
         assert_eq!(code, 0, "for {filter:?}: {out:?}");
         assert_eq!(out.trim(), want, "for {filter:?}");
     }
+    Ok(())
+}
+
+/// #953 code review: `to_json_for_reindex`'s `Float` fallback must format
+/// through the yq-only `format_float_with_fraction` behind an
+/// `S::TAG == EvalTag::Yq` gate, not unconditionally -- an earlier draft
+/// applied it unconditionally, which silently regressed this exact case in
+/// **jq** mode. `reduce`'s owned accumulator (`1.0 + 4.0` computes a plain,
+/// non-`NumberLiteral` `Float` with no fast path in
+/// `eval_owned_fast_path`) genuinely reaches `to_json_for_reindex` each
+/// iteration, unlike the top-level `[...]` case above. Real jq gives
+/// `[[[5]]]` (a computed value loses its literal formatting entirely, per
+/// jq's own normalize-computed-floats convention) -- confirmed live against
+/// the pinned oracle.
+#[test]
+fn test_jq_reduce_accumulator_unaffected_by_yq_float_fraction_fix_953() -> Result<()> {
+    let (out, code) = run_jq_stdin("[reduce (1,2) as $i (1.0 + 4.0; [.])]", "{}", &["-c"])?;
+    assert_eq!(code, 0, "{out:?}");
+    assert_eq!(out.trim(), "[[[5]]]");
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10692,3 +10692,25 @@ fn test_jq_tostring_and_json_and_interpolation_unaffected_by_yq_verbatim_echo_10
     }
     Ok(())
 }
+
+/// #953: `to_json_for_reindex`'s `Float` fallback now formats through
+/// `format_float_with_fraction` (adding a `.0`) instead of bare `Display`,
+/// so any `Expr` shape with no native `eval_generic.rs` cursor arm (e.g.
+/// `[...]`) round-trips a computed whole-number float through JSON text
+/// with a decimal point where it previously had none. jq mode's own final
+/// formatter (`format_number_jq_compat`, reached via `to_json`) strips that
+/// `.0` back off after reparsing regardless -- real jq matches this on both
+/// cases (`[5]`, `[1]`, confirmed live), so the reindex bridge's added `.0`
+/// must stay invisible in jq's own output.
+#[test]
+fn test_jq_array_construction_unaffected_by_yq_float_fraction_fix_953() -> Result<()> {
+    for (filter, input, want) in [
+        ("[.a * 1.0]", r#"{"a": 5}"#, "[5]"),
+        ("[.a / 5]", r#"{"a": 5}"#, "[1]"),
+    ] {
+        let (out, code) = run_jq_stdin(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "for {filter:?}: {out:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11652,3 +11652,40 @@ fn test_yq_join_preserves_exponent_literal_in_separator_1030() -> Result<()> {
     assert_eq!(stdout.trim_end(), "1e21e2a1e2b");
     Ok(())
 }
+
+#[test]
+fn test_yq_array_wrapped_overflow_int_keeps_decimal_point_953() -> Result<()> {
+    // #953's exact repro: `.a` alone streams straight from the YAML cursor
+    // and was already correct; `[.a]` forces `eval_generic.rs`'s
+    // reindex bridge (no native cursor arm for `Expr::Array`), which used
+    // to drop the decimal point on the round-tripped `Float` (real yq
+    // v4.53.3: `100000000000000000000.0`).
+    let (stdout, code) = run_yq_stdin("[.a]", "a: 99999999999999999999\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[100000000000000000000.0]");
+    Ok(())
+}
+
+#[test]
+fn test_yq_bare_overflow_int_scalar_unaffected_953() -> Result<()> {
+    // The streaming path this issue compared against must stay unaffected
+    // by the reindex-bridge fix above.
+    let (stdout, code) = run_yq_stdin(".a", "a: 99999999999999999999\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "100000000000000000000.0");
+    Ok(())
+}
+
+#[test]
+fn test_yq_map_values_overflow_int_keeps_decimal_point_953() -> Result<()> {
+    // Another `eval_generic.rs`-unhandled `Expr` shape that routes through
+    // the same reindex bridge as `[...]`.
+    let (stdout, code) = run_yq_stdin(
+        "map_values(.)",
+        "a: 99999999999999999999\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"{"a":100000000000000000000.0}"#);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `OwnedValue::to_json_for_reindex`'s `Float` fallback formatted whole-number floats with bare `f64::to_string()`, which drops the trailing `.0` (`1e20_f64.to_string() == "100000000000000000000"`, no decimal point).
- This "purely-internal" reindex bridge turns out to be the actual materialization path used by `eval_generic.rs`'s cursor-based evaluator for any `Expr` shape it has no native cursor arm for — `[...]` array construction, `map_values`, `with_entries`, etc. So a YAML scalar too large for `i64` (which resolves to a plain `Float`, not a literal-preserving `NumberLiteral`, per `is_preservable_float_literal`'s deliberate bare-digit-run exclusion) lost its decimal point specifically when reached through one of those shapes, while the plain streaming path (`.a` alone, no array wrapper) already showed it correctly.
- Root-caused by adding temporary debug tracing to confirm the exact `OwnedValue` reaching the CLI's JSON formatter for `[.a]` — it was a freshly-reconstructed `NumberLiteral` whose text had already lost the decimal point *before* formatting, tracing back through `eval_on_owned`'s JSON-text round trip in `src/jq/eval_generic.rs`.
- Fix: thread the yq `float_fmt` (`format_float_with_fraction`) through the reindex bridge's `Float` fallback instead of the bare-`Display` closure. Verified this is a no-op for the round-trip's own correctness (reparsing `100000000000000000000.0` yields the identical `f64`), and for jq mode specifically (jq's own final formatter, `format_number_jq_compat`, re-normalizes away the added `.0` after reparsing regardless — confirmed live against pinned jq for `[.a * 1.0]`/`[.a / 5]`).
- Also threads the same fix into `to_json`/`to_json_yq`'s shared `to_json_at_depth`, covering `to_json_yq`'s own direct callers (`tostring`, `tojson`, string interpolation) alongside the reindex bridge — both routes can reach a plain (non-`NumberLiteral`) whole-number `Float`.

Fixes #953

## Test plan

- [x] `cargo build --features cli`
- [x] New regression tests in `tests/yq_cli_tests.rs` pin the issue's exact repro (`[.a]` on an i64-overflow YAML scalar, `-o json`) plus the streaming-path (`.a` alone) and `map_values(.)` cases, verified byte-for-byte against pinned real `yq` v4.53.3.
- [x] New regression test in `tests/jq_cli_tests.rs` confirms jq mode's own array construction (`[.a * 1.0]`, `[.a / 5]`) is unaffected, verified against pinned real `jq`.
- [x] Full local sweep against pinned `yq`/`jq` oracles across `[.a]`, `.a,.a`, `map_values(.)`, `with_entries(.)`, normal floats/ints, negative overflow ints — all match.
- [x] `cargo test --features cli,simd,regex,serde` (including `yq_golden_tests`, `yq_path_consistency_tests`) — all pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo check --no-default-features` (no_std) — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.