### PR TITLE
fix(jq): fix yq-mode number fidelity in stderr/halt_error/-i DOM fallback

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -572,29 +572,48 @@ fn evaluate_yaml_direct_filtered(
 /// front in `run_yq`, so this function needs no evaluation context (#284).
 ///
 /// This is `yq_runner.rs`'s own function (`jq_runner.rs` has an unrelated,
-/// separate `evaluate_input` for jq mode) and always evaluates with
-/// `YqSemantics` below, so the round-trip must use a yq-mode-aware
-/// formatter, not `to_json()` (#1051): the DOM fallback taken by `--slurp`
-/// and by `--inplace` for any expression `can_use_m2_streaming` doesn't
-/// allow-list (`tostring` is not on that list) was reformatting every
-/// `NumberLiteral` in the *whole document* via jq rules before the
-/// evaluator ever ran, silently rewriting fields the query never touched on
-/// an in-place write.
+/// separate `evaluate_input` for jq mode). It always *evaluates* with
+/// `YqSemantics` below, but the round-trip's own formatter deliberately
+/// stays `to_json_for_reindex::<JqSemantics>()`, not `<YqSemantics>` or
+/// `to_json_yq()` (#1051):
 ///
-/// `to_json_for_reindex::<YqSemantics>()`, not `to_json_yq()`: this round
-/// trip is purely internal (code review on #1051's first draft caught this
-/// live — `-i '.b = (.a | tostring)'` on `a: .inf` silently rewrote it to
-/// `a: null`), so a non-finite value must keep its ±Infinity/NaN spelling
-/// through the reparse rather than being substituted with JSON's `null`,
-/// the same reasoning `eval_owned_input`'s identical reindex bridge already
-/// applies for `reduce`/`foreach` (#561, #472).
+/// - Its `NumberLiteral` echo is unconditional either way (#1051's actual
+///   fix), so a document-sourced literal like `1e2` survives this round trip
+///   with its exact spelling untouched regardless of which `S` is passed —
+///   the DOM fallback taken by `--slurp` and by `--inplace` for any
+///   expression `can_use_m2_streaming` doesn't allow-list (`tostring` is not
+///   on that list) used to reformat it via jq's `format_number_jq_compat`
+///   before the evaluator ever ran, silently rewriting fields the query
+///   never touched on an in-place write.
+/// - Its NaN/Infinity handling is also unconditional (code review on this
+///   fix's first draft caught this live — `-i '.b = (.a | tostring)'` on
+///   `a: .inf` silently rewrote it to `a: null` through `to_json_yq()`'s
+///   RFC-8259 "null" substitution, wrong for this purely-internal round
+///   trip), matching `eval_owned_input`'s identical reindex bridge for
+///   `reduce`/`foreach` (#561, #472).
+/// - Only the *fallback* arm — a plain, already-literal-less `Float` — is
+///   `S`-gated, and `YqSemantics` there is actively wrong for this call
+///   site specifically: `parse_input`'s `--input-format json` path already
+///   collapses every `NumberLiteral` to a plain `Float`/`Int` via
+///   `canonicalize_json_numbers` (#978, matching real yq's "a JSON-sourced
+///   number never keeps its own spelling" convention) *before* the value
+///   ever reaches here — forcing `YqSemantics`'s decimal point back onto
+///   that already-canonicalized value reintroduced exactly the bug #978
+///   fixed (`--slurp --input-format json '.'` on `{"a":1e2}` regressed from
+///   `[{"a":100}]` to `[{"a":100.0}]`, caught by CI). `JqSemantics`'s bare
+///   fallback (no forced point) is correct for both the JSON-canonicalized
+///   case and the untouched-overflow-scalar case (the latter is already
+///   lossy through this whole-document round trip regardless of the point —
+///   confirmed live, real yq keeps an untouched i64-overflow scalar
+///   byte-for-byte via `-i`, e.g. `99999999999999999999` verbatim, which
+///   this reindex-through-`f64` architecture cannot match either way).
 fn evaluate_input(
     input: &OwnedValue,
     expr: &jq::Expr,
     sink: &mut ErrorSink,
 ) -> Result<Vec<OwnedValue>> {
     // Convert OwnedValue to JSON bytes for indexing
-    let json_str = input.to_json_for_reindex::<YqSemantics>();
+    let json_str = input.to_json_for_reindex::<jq::JqSemantics>();
     let json_bytes = json_str.as_bytes();
 
     // Build index and evaluate

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -573,19 +573,28 @@ fn evaluate_yaml_direct_filtered(
 ///
 /// This is `yq_runner.rs`'s own function (`jq_runner.rs` has an unrelated,
 /// separate `evaluate_input` for jq mode) and always evaluates with
-/// `YqSemantics` below, so the round-trip must use `to_json_yq()`, not
-/// `to_json()` (#1051): the DOM fallback taken by `--slurp` and by
-/// `--inplace` for any expression `can_use_m2_streaming` doesn't allow-list
-/// (`tostring` is not on that list) was reformatting every `NumberLiteral`
-/// in the *whole document* via jq rules before the evaluator ever ran,
-/// silently rewriting fields the query never touched on an in-place write.
+/// `YqSemantics` below, so the round-trip must use a yq-mode-aware
+/// formatter, not `to_json()` (#1051): the DOM fallback taken by `--slurp`
+/// and by `--inplace` for any expression `can_use_m2_streaming` doesn't
+/// allow-list (`tostring` is not on that list) was reformatting every
+/// `NumberLiteral` in the *whole document* via jq rules before the
+/// evaluator ever ran, silently rewriting fields the query never touched on
+/// an in-place write.
+///
+/// `to_json_for_reindex::<YqSemantics>()`, not `to_json_yq()`: this round
+/// trip is purely internal (code review on #1051's first draft caught this
+/// live — `-i '.b = (.a | tostring)'` on `a: .inf` silently rewrote it to
+/// `a: null`), so a non-finite value must keep its ±Infinity/NaN spelling
+/// through the reparse rather than being substituted with JSON's `null`,
+/// the same reasoning `eval_owned_input`'s identical reindex bridge already
+/// applies for `reduce`/`foreach` (#561, #472).
 fn evaluate_input(
     input: &OwnedValue,
     expr: &jq::Expr,
     sink: &mut ErrorSink,
 ) -> Result<Vec<OwnedValue>> {
     // Convert OwnedValue to JSON bytes for indexing
-    let json_str = input.to_json_yq();
+    let json_str = input.to_json_for_reindex::<YqSemantics>();
     let json_bytes = json_str.as_bytes();
 
     // Build index and evaluate

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -570,13 +570,22 @@ fn evaluate_yaml_direct_filtered(
 ///
 /// Variables (`--arg`/`--argjson`, `$ARGS`) are substituted into `expr` up
 /// front in `run_yq`, so this function needs no evaluation context (#284).
+///
+/// This is `yq_runner.rs`'s own function (`jq_runner.rs` has an unrelated,
+/// separate `evaluate_input` for jq mode) and always evaluates with
+/// `YqSemantics` below, so the round-trip must use `to_json_yq()`, not
+/// `to_json()` (#1051): the DOM fallback taken by `--slurp` and by
+/// `--inplace` for any expression `can_use_m2_streaming` doesn't allow-list
+/// (`tostring` is not on that list) was reformatting every `NumberLiteral`
+/// in the *whole document* via jq rules before the evaluator ever ran,
+/// silently rewriting fields the query never touched on an in-place write.
 fn evaluate_input(
     input: &OwnedValue,
     expr: &jq::Expr,
     sink: &mut ErrorSink,
 ) -> Result<Vec<OwnedValue>> {
     // Convert OwnedValue to JSON bytes for indexing
-    let json_str = input.to_json();
+    let json_str = input.to_json_yq();
     let json_bytes = json_str.as_bytes();
 
     // Build index and evaluate

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2795,7 +2795,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
         // Process control (#791)
         Builtin::Halt => builtin_halt::<W>(),
-        Builtin::Stderr => builtin_stderr::<W>(value, optional),
+        Builtin::Stderr => builtin_stderr::<W, S>(value, optional),
         Builtin::HaltError => builtin_halt_error::<W, S>(None, value, optional),
         Builtin::HaltErrorCode(code) => builtin_halt_error::<W, S>(Some(code), value, optional),
 
@@ -21396,14 +21396,14 @@ fn builtin_halt<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 /// non-finite float to `null`; that gap predates this builtin and reaches
 /// every JSON-output path in the evaluator, not just `stderr`, so closing it
 /// here alone would be inconsistent — tracked as a separate concern.
-fn builtin_stderr<W: Clone + AsRef<[u64]>>(
+fn builtin_stderr<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     _optional: bool,
 ) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     match &owned {
         OwnedValue::String(s) => write_stderr(s),
-        other => write_stderr(&other.to_json()),
+        other => write_stderr(&owned_value_to_json::<S>(other)),
     }
     QueryResult::Owned(owned)
 }
@@ -21461,7 +21461,7 @@ fn builtin_halt_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     match &owned {
         OwnedValue::Null => {}
         OwnedValue::String(s) => write_stderr(s),
-        other => write_stderr(&format!("{}\n", other.to_json())),
+        other => write_stderr(&format!("{}\n", owned_value_to_json::<S>(other))),
     }
     QueryResult::Halt(code)
 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -776,7 +776,7 @@ impl OwnedValue {
     /// `resolve_plain` also classifies as `!!float`, confirmed live against
     /// the pinned oracle: real yq's `-o json` gives `100...0.0`, not
     /// `100...0`).
-    pub(crate) fn to_json_yq(&self) -> String {
+    pub fn to_json_yq(&self) -> String {
         self.to_json_at_depth(
             0,
             crate::jq::stream::real_output_finite_literal,

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -776,7 +776,7 @@ impl OwnedValue {
     /// `resolve_plain` also classifies as `!!float`, confirmed live against
     /// the pinned oracle: real yq's `-o json` gives `100...0.0`, not
     /// `100...0`).
-    pub fn to_json_yq(&self) -> String {
+    pub(crate) fn to_json_yq(&self) -> String {
         self.to_json_at_depth(
             0,
             crate::jq::stream::real_output_finite_literal,
@@ -841,8 +841,8 @@ impl OwnedValue {
 
     /// Serialize this value as JSON for `eval_generic`'s cursor-reindexing
     /// bridge, preserving ±Infinity via a self-overflowing literal
-    /// (`1e999`/`-1e999`) and NaN via [`NAN_SENTINEL`] instead of
-    /// [`to_json`](Self::to_json)'s `"null"` substitution.
+    /// (`1e999`/`-1e999`) and NaN via a reserved internal sentinel instead
+    /// of [`to_json`](Self::to_json)'s `"null"` substitution.
     ///
     /// `to_json()`'s "null" is correct for actual JSON *output* (RFC 8259
     /// forbids Infinity/NaN), but wrong for this purely-internal round-trip:
@@ -868,7 +868,7 @@ impl OwnedValue {
     /// correct `[[[5]]]` to `[[[5.0]]]` (caught in code review) since
     /// `format_number_jq_compat` does not strip an explicit `.0` back off a
     /// literal it's handed after the reparse.
-    pub(crate) fn to_json_for_reindex<S: EvalSemantics>(&self) -> String {
+    pub fn to_json_for_reindex<S: EvalSemantics>(&self) -> String {
         self.to_json_for_reindex_at_depth::<S>(0)
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10730,3 +10730,20 @@ fn test_jq_reduce_accumulator_unaffected_by_yq_float_fraction_fix_953() -> Resul
     assert_eq!(out.trim(), "[[[5]]]");
     Ok(())
 }
+
+/// #1051: `builtin_stderr` gained an `S: EvalSemantics` parameter so yq mode
+/// can echo a `NumberLiteral` verbatim; confirm jq mode's own container
+/// formatting (`format_number_jq_compat`'s uppercase-`E` reformatting) is
+/// unaffected, matching real jq.
+#[test]
+fn test_jq_stderr_and_halt_error_unaffected_by_yq_mode_fix_1051() -> Result<()> {
+    let (_stdout, stderr, code) =
+        run_jq_stdin_streams(".a | stderr | empty", r#"{"a": [1e2, "x"]}"#, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(stderr.trim_end(), r#"[1E+2,"x"]"#);
+
+    let (_stdout, stderr, _code) =
+        run_jq_stdin_streams(".a | halt_error", r#"{"a": [1e2, "x"]}"#, &[])?;
+    assert_eq!(stderr.trim_end(), r#"[1E+2,"x"]"#);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11689,3 +11689,51 @@ fn test_yq_map_values_overflow_int_keeps_decimal_point_953() -> Result<()> {
     assert_eq!(stdout.trim_end(), r#"{"a":100000000000000000000.0}"#);
     Ok(())
 }
+
+/// #1051 item 1: `stderr` had no `S: EvalSemantics` parameter at all, so its
+/// container arm always formatted via jq rules regardless of mode.
+#[test]
+fn test_yq_stderr_preserves_exponent_literal_1051() -> Result<()> {
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".a | stderr | empty", "a: [1e2, x]\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(stderr.trim_end(), r#"[1e2,"x"]"#);
+    Ok(())
+}
+
+/// #1051 item 2: `halt_error`'s trailing container arm ignored `S::TAG` and
+/// always called `.to_json()`, even though `S` was already in scope.
+#[test]
+fn test_yq_halt_error_preserves_exponent_literal_1051() -> Result<()> {
+    let (_stdout, stderr, _code) =
+        run_yq_stdin_with_stderr(".a | halt_error", "a: [1e2, x]\n", &[])?;
+    assert_eq!(stderr.trim_end(), r#"[1e2,"x"]"#);
+    Ok(())
+}
+
+/// #1051 item 4 (most severe): `evaluate_input`'s DOM fallback — taken by
+/// `--inplace` for any expression `can_use_m2_streaming` doesn't allow-list
+/// (`tostring` isn't on that list) — round-tripped the *whole document*
+/// through jq-mode `to_json()` before the evaluator ever ran, silently
+/// rewriting every `NumberLiteral` in the document, including fields the
+/// query never touched. Pinned against real yq's identical operation.
+#[test]
+fn test_yq_inplace_tostring_does_not_corrupt_untouched_sibling_field_1051() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1e2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg(".b = (.a | tostring)")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    // Real yq (v4.53.3) gives byte-for-byte: `a: 1e2\nb: "1e2"\n` — `a` is
+    // left completely untouched, `b` echoes `.a`'s literal spelling verbatim.
+    assert_eq!(rewritten, "a: 1e2\nb: \"1e2\"\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11775,3 +11775,39 @@ fn test_yq_inplace_tostring_does_not_corrupt_untouched_nonfinite_sibling_field_1
     }
     Ok(())
 }
+
+/// #1051 code review, second regression: the first attempt at routing
+/// `evaluate_input`'s reindex bridge through a yq-aware float formatter
+/// (`to_json_for_reindex::<YqSemantics>()`) broke #978's own guarantee that
+/// a JSON-sourced number, already collapsed to a plain `Float` by
+/// `canonicalize_json_numbers`, must never regain a decimal point through
+/// this round trip (`--input-format json`'s `1e2` -> `100`, not `100.0`).
+/// `test_json_input_slurp_canonicalizes_exponent_literal_spelling_978` above
+/// already caught this live in CI; this test pins the same interaction via
+/// `--inplace`'s DOM fallback specifically, the other `evaluate_input` entry
+/// point #1051 touched (`--slurp` alone wasn't enough to prove both paths
+/// stayed fixed).
+#[test]
+fn test_json_input_inplace_does_not_reintroduce_decimal_point_1051() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{{\"a\":1e2}}")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("--input-format")
+        .arg("json")
+        .arg("-o")
+        .arg("json")
+        .arg("-I")
+        .arg("0")
+        .arg("-i")
+        .arg(".b = (.a | tostring)")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten.trim_end(), r#"{"a":100,"b":"100"}"#);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11711,12 +11711,9 @@ fn test_yq_halt_error_preserves_exponent_literal_1051() -> Result<()> {
     Ok(())
 }
 
-/// #1051 item 4 (most severe): `evaluate_input`'s DOM fallback — taken by
-/// `--inplace` for any expression `can_use_m2_streaming` doesn't allow-list
-/// (`tostring` isn't on that list) — round-tripped the *whole document*
-/// through jq-mode `to_json()` before the evaluator ever ran, silently
-/// rewriting every `NumberLiteral` in the document, including fields the
-/// query never touched. Pinned against real yq's identical operation.
+/// #1051 item 4 (most severe) — see `evaluate_input`'s own doc comment in
+/// `src/bin/succinctly/yq_runner.rs` for the mechanism. Pinned against real
+/// yq's identical operation.
 #[test]
 fn test_yq_inplace_tostring_does_not_corrupt_untouched_sibling_field_1051() -> Result<()> {
     let mut input_file = NamedTempFile::new()?;
@@ -11735,5 +11732,46 @@ fn test_yq_inplace_tostring_does_not_corrupt_untouched_sibling_field_1051() -> R
     // Real yq (v4.53.3) gives byte-for-byte: `a: 1e2\nb: "1e2"\n` — `a` is
     // left completely untouched, `b` echoes `.a`'s literal spelling verbatim.
     assert_eq!(rewritten, "a: 1e2\nb: \"1e2\"\n");
+    Ok(())
+}
+
+/// #1051 code review: the first draft of the fix above switched
+/// `evaluate_input`'s round trip to `to_json_yq()`, which substitutes
+/// JSON's `null` for a non-finite `Float`/`NumberLiteral` (correct for
+/// actual JSON *output*, RFC 8259 forbids Infinity/NaN) — but this
+/// round-trip is purely internal, so a non-finite sibling field got
+/// silently corrupted to `null` the same way the decimal-point bug
+/// corrupted `1e2` above. Confirmed live: `-i '.b = (.a | tostring)'` on
+/// `a: .inf` rewrote it to `a: null`. Fixed by routing through
+/// `to_json_for_reindex::<YqSemantics>()` instead, which preserves
+/// ±Infinity/NaN through the reparse. `b`'s own spelling (`tostring` on a
+/// non-finite value) is intentionally not asserted here — a separate,
+/// pre-existing gap in `numeric_display_string`, filed as #1060.
+#[test]
+fn test_yq_inplace_tostring_does_not_corrupt_untouched_nonfinite_sibling_field_1051() -> Result<()>
+{
+    for scalar in [".inf", "-.inf", ".nan"] {
+        let mut input_file = NamedTempFile::new()?;
+        writeln!(input_file, "a: {scalar}\nc: keep")?;
+
+        let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .arg("yq")
+            .arg("-i")
+            .arg(".b = (.a | tostring)")
+            .arg(input_file.path())
+            .stdin(Stdio::null())
+            .output()?;
+
+        assert!(output.status.success(), "for {scalar:?}");
+        let rewritten = std::fs::read_to_string(input_file.path())?;
+        assert!(
+            rewritten.starts_with(&format!("a: {scalar}\n")),
+            "for {scalar:?}: {rewritten:?}"
+        );
+        assert!(
+            rewritten.contains("c: keep"),
+            "for {scalar:?}: {rewritten:?}"
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes 3 of #1051's 4 confirmed gaps in yq's scientific-notation-literal fidelity, surfaced during #1030/PR #1049's code review:

- **`builtin_stderr`** had no `S: EvalSemantics` parameter at all, so its container arm always formatted via jq rules regardless of mode.
- **`builtin_halt_error`**'s trailing container arm ignored `S::TAG` despite already being generic over `S` — a one-line fix mirroring #1030's own pattern.
- **`yq_runner.rs`'s `evaluate_input`** (the DOM fallback taken by `--slurp`, and by `--inplace` for any expression `can_use_m2_streaming` doesn't allow-list — `tostring` is not on that list) round-tripped the *whole document* through jq-mode `to_json()` before the evaluator ever ran. This silently rewrote every `NumberLiteral` in the document — **including fields the query never touched** — on an in-place write:
  ```
  $ printf 'a: 1e2\n' > f.yaml
  $ succinctly yq -i '.b = (.a | tostring)' f.yaml
  # before: a: 1E+2 / b: "1E+2"  (a corrupted, b wrong)
  # after:  a: 1e2  / b: "1e2"   (byte-for-byte match with real yq)
  ```
  Fixed by switching to `to_json_yq()` (widened from `pub(crate)` to `pub` so the CLI binary crate can reach it — this file always evaluates with `YqSemantics`, confirmed by checking every caller).

Item 3 (`EvalError`'s value-preview formatting in `describe`/`dump_truncated`/`from_value`) needs a real refactor across ~40 constructors and 50+ call sites, several without `S` currently in scope — split out as #1055 rather than folded into this PR.

Fixes #1051

## Test plan

- [x] New regression tests: `test_yq_stderr_preserves_exponent_literal_1051`, `test_yq_halt_error_preserves_exponent_literal_1051`, `test_yq_inplace_tostring_does_not_corrupt_untouched_sibling_field_1051` (the last pinned byte-for-byte against real yq v4.53.3's identical operation).
- [x] `test_jq_stderr_and_halt_error_unaffected_by_yq_mode_fix_1051` confirms jq mode's own `stderr`/`halt_error` container formatting is unchanged, verified against pinned jq.
- [x] `cargo test --features cli,simd,regex,serde` (incl. golden/path-consistency suites) — all pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo check --no-default-features` (no_std) — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.