### PR TITLE
fix(jq): filter literal numbers keep jq's source spelling through evaluation

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23982,25 +23982,31 @@ mod tests {
     }
 
     #[test]
-    fn test_substitute_vars_number_literal_degrades_to_plain_literal_387() {
+    fn test_substitute_vars_number_literal_preserves_source_text_387_1035() {
         // `substitute_vars` (the `--arg`/`--argjson`-style public API) inlines
-        // each variable's value into the AST via `owned_to_expr`. Unlike a
-        // document-sourced value flowing through a builtin argument,
-        // `Expr::Literal` has no source-text slot (#387's documented scope
-        // boundary -- see `owned_to_expr`'s doc comment), so a `NumberLiteral`
-        // substituted in degrades to its plain parsed value: the substituted
-        // filter's own re-evaluation loses jq's canonical spelling and falls
-        // back to Rust's `f64`/`i64` Display, same as any other computed
-        // (non-passthrough) number.
+        // each variable's value into the AST via `owned_to_expr`. #387's
+        // originally-documented scope boundary here -- `Expr::Literal` had
+        // no source-text slot, so a `NumberLiteral` substituted in degraded
+        // to its plain parsed value -- is now closed by #1035:
+        // `Literal::NumberLiteral` carries the same source text
+        // `OwnedValue::NumberLiteral` does, so the substituted filter's own
+        // re-evaluation keeps jq's canonical spelling instead of falling
+        // back to Rust's `f64`/`i64` Display.
         let expr = parse("$n").unwrap();
 
         let int_lit = OwnedValue::from_number_literal("42");
         let substituted = substitute_vars(&expr, [("n", &int_lit)]);
-        assert_eq!(substituted, Expr::Literal(Literal::Int(42)));
+        assert_eq!(
+            substituted,
+            Expr::Literal(Literal::NumberLiteral("42".to_string()))
+        );
 
         let float_lit = OwnedValue::from_number_literal("1e100");
         let substituted = substitute_vars(&expr, [("n", &float_lit)]);
-        assert_eq!(substituted, Expr::Literal(Literal::Float(1e100)));
+        assert_eq!(
+            substituted,
+            Expr::Literal(Literal::NumberLiteral("1e100".to_string()))
+        );
 
         let index = JsonIndex::build(b"null");
         let cursor = index.root(b"null");
@@ -24010,8 +24016,8 @@ mod tests {
                 .iter()
                 .map(OwnedValue::to_json)
                 .collect::<Vec<_>>(),
-            // Not jq's "1E+100" -- see the doc comment above.
-            ["1e100".parse::<f64>().unwrap().to_string()]
+            // jq's own canonical spelling, not Rust's f64 Display -- #1035.
+            ["1E+100"]
         );
     }
 
@@ -24305,12 +24311,50 @@ mod tests {
         );
 
         query!(br"{}", "42",
-            QueryResult::Owned(OwnedValue::Int(42)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(42) | OwnedValue::NumberLiteral(NumberRepr::Int(42), _)
+            ) => {}
         );
 
         query!(br"{}", "\"hello\"",
             QueryResult::Owned(OwnedValue::String(s)) if s == "hello" => {}
         );
+    }
+
+    /// #1035: a numeric literal written directly in filter text keeps its
+    /// own source spelling through evaluation, exactly like a
+    /// document-sourced number already does via `OwnedValue::NumberLiteral`
+    /// -- verified against jq 1.7.1, which prints `1.500`/`1E+2` unchanged
+    /// for these same filters (real jq only ever collapses a literal's
+    /// spelling once it passes through an operation that produces a *new*
+    /// number, e.g. arithmetic).
+    #[test]
+    fn test_1035_filter_literal_numeric_fidelity() {
+        assert_eq!(outputs(b"null", "[1.500]"), ["[1.500]"]);
+        assert_eq!(outputs(b"null", "1e2"), ["1E+2"]);
+        assert_eq!(outputs(b"null", "1.500"), ["1.500"]);
+
+        // Arithmetic still collapses fidelity to a freshly-formatted
+        // number, same as a document-sourced `NumberLiteral` already does.
+        assert_eq!(outputs(b"null", "1.500 + 0"), ["1.5"]);
+    }
+
+    /// #1035: jq's own grammar treats a leading `-` before a number literal
+    /// as unary negation (`0 - N`), not as part of the number token itself
+    /// -- confirmed against jq 1.7.1, whose `-1.500`/`-1e2` print
+    /// `-1.5`/`-100` (fidelity collapses through the implied subtraction),
+    /// unlike the positive spelling. A plain negative *integer* has no
+    /// alternate spelling to lose, so it keeps folding into one token (see
+    /// `test_large_integer_literal_falls_back_to_float` for why: that keeps
+    /// succinctly's i64::MIN-exact-literal capability, which jq's
+    /// double-only model can't represent either way).
+    #[test]
+    fn test_1035_negative_float_literal_collapses_fidelity_like_jq() {
+        assert_eq!(outputs(b"null", "-1.500"), ["-1.5"]);
+        assert_eq!(outputs(b"null", "-1e2"), ["-100"]);
+        // A negative integer literal is unaffected -- still one token, no
+        // spelling to lose.
+        assert_eq!(outputs(b"null", "-123"), ["-123"]);
     }
 
     #[test]
@@ -24948,7 +24992,9 @@ mod tests {
 
         // Falsy value (null) uses alternative
         query!(br#"{"a": null}"#, ".a // 0",
-            QueryResult::Owned(OwnedValue::Int(0)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(0) | OwnedValue::NumberLiteral(NumberRepr::Int(0), _)
+            ) => {}
         );
 
         // Missing value uses alternative
@@ -24958,7 +25004,9 @@ mod tests {
 
         // Chain alternatives
         query!(br#"{"a": null, "b": null}"#, ".a // .b // 42",
-            QueryResult::Owned(OwnedValue::Int(42)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(42) | OwnedValue::NumberLiteral(NumberRepr::Int(42), _)
+            ) => {}
         );
     }
 
@@ -24981,7 +25029,9 @@ mod tests {
         // through to the right side, since `.a?` never produces `Error` in
         // the first place.
         query!(br"1", ".a? // 3",
-            QueryResult::Owned(OwnedValue::Int(3)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(3) | OwnedValue::NumberLiteral(NumberRepr::Int(3), _)
+            ) => {}
         );
     }
 
@@ -25457,10 +25507,14 @@ mod tests {
         // (verified against jq 1.7.1); `last` never short-circuits, so it
         // always sees the error.
         query!(b"null", r#"first(1,2,error("x"))"#,
-            QueryResult::Owned(OwnedValue::Int(1)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            ) => {}
         );
         query!(b"null", r#"nth(1; 1,2,error("x"))"#,
-            QueryResult::Owned(OwnedValue::Int(2)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(2) | OwnedValue::NumberLiteral(NumberRepr::Int(2), _)
+            ) => {}
         );
         query!(b"null", r#"nth(5; 1,2,error("x"))"#,
             QueryResult::Error(e) => {
@@ -25948,12 +26002,16 @@ mod tests {
         // `nth` stops at index `n`, so the break is reached only when the
         // prefix is too short.
         query!(b"null", "nth(1; 1,2,break $out)",
-            QueryResult::Owned(OwnedValue::Int(2)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(2) | OwnedValue::NumberLiteral(NumberRepr::Int(2), _)
+            ) => {}
         );
         assert_collapses_to_break(b"null", "nth(5; 1,2,break $out)");
         // Same split for `first`.
         query!(b"null", "first(1,2,break $out)",
-            QueryResult::Owned(OwnedValue::Int(1)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            ) => {}
         );
         // A `limit` operand that is a *bare* break still reaches its label —
         // the arm that used to swallow it.
@@ -26098,12 +26156,16 @@ mod tests {
     fn test_if_then_else() {
         // Basic if-then-else: true condition
         query!(br#"{"a": true}"#, "if .a then 1 else 2 end",
-            QueryResult::Owned(OwnedValue::Int(1)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            ) => {}
         );
 
         // Basic if-then-else: false condition
         query!(br#"{"a": false}"#, "if .a then 1 else 2 end",
-            QueryResult::Owned(OwnedValue::Int(2)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(2) | OwnedValue::NumberLiteral(NumberRepr::Int(2), _)
+            ) => {}
         );
 
         // If with comparison condition
@@ -26113,12 +26175,16 @@ mod tests {
 
         // If with null condition (falsy)
         query!(br#"{"a": null}"#, "if .a then 1 else 2 end",
-            QueryResult::Owned(OwnedValue::Int(2)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(2) | OwnedValue::NumberLiteral(NumberRepr::Int(2), _)
+            ) => {}
         );
 
         // If with number condition (truthy, even 0)
         query!(br#"{"a": 0}"#, "if .a then 1 else 2 end",
-            QueryResult::Owned(OwnedValue::Int(1)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            ) => {}
         );
     }
 
@@ -26148,7 +26214,9 @@ mod tests {
         );
 
         query!(br#"{"a": true}"#, "if .a then 1 end",
-            QueryResult::Owned(OwnedValue::Int(1)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            ) => {}
         );
     }
 
@@ -26504,7 +26572,9 @@ mod tests {
 
         // try inside if with actual error
         query!(br#"{"a": 123}"#, "if true then try .a.foo catch 0 else 1 end",
-            QueryResult::Owned(OwnedValue::Int(0)) => {}
+            QueryResult::Owned(
+                OwnedValue::Int(0) | OwnedValue::NumberLiteral(NumberRepr::Int(0), _)
+            ) => {}
         );
 
         // Nested if with arithmetic
@@ -30942,13 +31012,17 @@ mod tests {
     #[test]
     fn test_first_last_expr_comma_generator_argument() {
         query!(br"null", r"first(1,2,3)",
-            QueryResult::Owned(OwnedValue::Int(n)) => {
+            QueryResult::Owned(
+                OwnedValue::Int(n) | OwnedValue::NumberLiteral(NumberRepr::Int(n), _)
+            ) => {
                 assert_eq!(n, 1);
             }
         );
 
         query!(br"null", r"last(1,2,3)",
-            QueryResult::Owned(OwnedValue::Int(n)) => {
+            QueryResult::Owned(
+                OwnedValue::Int(n) | OwnedValue::NumberLiteral(NumberRepr::Int(n), _)
+            ) => {
                 assert_eq!(n, 3);
             }
         );

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24340,9 +24340,9 @@ mod tests {
     }
 
     /// #1035: jq's own grammar treats a leading `-` before a number literal
-    /// as unary negation (`0 - N`), not as part of the number token itself
+    /// as unary negation (`-1 * N`), not as part of the number token itself
     /// -- confirmed against jq 1.7.1, whose `-1.500`/`-1e2` print
-    /// `-1.5`/`-100` (fidelity collapses through the implied subtraction),
+    /// `-1.5`/`-100` (fidelity collapses through the implied negation),
     /// unlike the positive spelling. A plain negative *integer* has no
     /// alternate spelling to lose, so it keeps folding into one token (see
     /// `test_large_integer_literal_falls_back_to_float` for why: that keeps
@@ -24355,6 +24355,63 @@ mod tests {
         // A negative integer literal is unaffected -- still one token, no
         // spelling to lose.
         assert_eq!(outputs(b"null", "-123"), ["-123"]);
+    }
+
+    /// #1035: the negative-literal desugaring must negate, not subtract
+    /// from zero -- `0.0 - 0.0` is IEEE-754 positive zero, silently
+    /// dropping the sign jq itself preserves (`jq -- '-0.0'` prints `-0`).
+    /// Regression-tested directly: a same-build binary predating this
+    /// fix's `Mul(-1, _)` rewrite printed plain `0` for all three of these.
+    #[test]
+    fn test_1035_negative_zero_literal_keeps_its_sign() {
+        assert_eq!(outputs(b"null", "-0.0"), ["-0"]);
+        assert_eq!(outputs(b"null", "-0e0"), ["-0"]);
+        assert_eq!(outputs(b"null", "[-0.0]"), ["[-0]"]);
+    }
+
+    /// #1035: a number spelling jq's filter grammar accepts but RFC 8259
+    /// forbids (a bare trailing dot, a leading zero) must still format
+    /// canonically once it reaches `@json`/string interpolation/`tostring`,
+    /// exactly like it always did before this issue's fix -- preserving the
+    /// literal's raw text verbatim here would leak invalid JSON, unlike the
+    /// document-number path (`from_number_bytes`), which has always gated
+    /// on this same check before ever constructing a `NumberLiteral`.
+    #[test]
+    fn test_1035_json_invalid_but_jq_valid_literal_still_formats_canonically() {
+        assert_eq!(outputs(b"null", "1."), ["1"]);
+        assert_eq!(outputs(b"null", "007"), ["7"]);
+        query!(br"null", r#""\(007)""#,
+            QueryResult::Owned(OwnedValue::String(s)) if s == "7" => {}
+        );
+    }
+
+    /// #1035: real yq (unlike jq) never collapses a negative literal's
+    /// fidelity -- `-1.500`/`-1e2` print back unchanged (verified against
+    /// yq v4.53.3), where jq's own `-1.500`/`-1e2` collapse to `-1.5`/
+    /// `-100`. The negative-literal desugaring this issue adds is gated to
+    /// jq mode specifically (`self.mode == ParserMode::Jq` in
+    /// `parse_primary_inner`) so succinctly's shared jq/yq parser doesn't
+    /// wrongly collapse these for yq too.
+    #[test]
+    fn test_1035_yq_mode_never_collapses_negative_literal_fidelity() {
+        yq_query!(br"null", "-1.500",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json_yq(), "-1.500");
+            }
+        );
+        yq_query!(br"null", "-1e2",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json_yq(), "-1e2");
+            }
+        );
+        // Positive fidelity was already covered elsewhere, but the
+        // negative-zero sign specifically diverges from jq mode (yq keeps
+        // `-0.0` verbatim; jq mode's own test above expects `-0`).
+        yq_query!(br"null", "-0.0",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json_yq(), "-0.0");
+            }
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -756,6 +756,7 @@ fn literal_to_owned(lit: &Literal) -> OwnedValue {
     match lit {
         Literal::Null => OwnedValue::Null,
         Literal::Bool(b) => OwnedValue::Bool(*b),
+        Literal::NumberLiteral(text) => OwnedValue::from_number_literal(text),
         Literal::Int(n) => OwnedValue::Int(*n),
         Literal::Float(f) => OwnedValue::Float(*f),
         Literal::String(s) => OwnedValue::String(s.clone()),
@@ -13577,11 +13578,12 @@ fn owned_to_expr_at_depth(value: &OwnedValue, depth: usize) -> Expr {
         OwnedValue::Bool(b) => Expr::Literal(Literal::Bool(*b)),
         OwnedValue::Int(i) => Expr::Literal(Literal::Int(*i)),
         OwnedValue::Float(f) => Expr::Literal(Literal::Float(*f)),
-        // A filter `Literal` has no source-text slot (out of scope -- see
-        // #387's plan), so a document-sourced literal degrades to its plain
-        // parsed form here, same as it does after arithmetic.
-        OwnedValue::NumberLiteral(NumberRepr::Int(i), _) => Expr::Literal(Literal::Int(*i)),
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) => Expr::Literal(Literal::Float(*f)),
+        // #1035: `Literal::NumberLiteral` now has a source-text slot too,
+        // so a document-sourced literal keeps its own spelling through this
+        // splice instead of degrading to a freshly-formatted f64/i64.
+        OwnedValue::NumberLiteral(_, text) => {
+            Expr::Literal(Literal::NumberLiteral(text.to_string()))
+        }
         OwnedValue::String(s) => Expr::Literal(Literal::String(s.clone())),
         OwnedValue::Array(arr) => {
             // Build array construction expression with all elements

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3868,6 +3868,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 #[cfg(test)]
 mod tests {
     use super::super::expr::FormatType;
+    use super::super::value::NumberRepr;
     use super::*;
     use crate::jq::parse;
     use crate::json::JsonIndex;
@@ -7401,10 +7402,20 @@ mod tests {
         let value = index.root(json).value();
 
         let first = eval(&crate::jq::parse("first(1)").unwrap(), value.clone());
-        assert!(matches!(first, GenericResult::Owned(OwnedValue::Int(1))));
+        assert!(matches!(
+            first,
+            GenericResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            )
+        ));
 
         let last = eval(&crate::jq::parse("last(1)").unwrap(), value);
-        assert!(matches!(last, GenericResult::Owned(OwnedValue::Int(1))));
+        assert!(matches!(
+            last,
+            GenericResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            )
+        ));
     }
 
     #[test]
@@ -7417,10 +7428,20 @@ mod tests {
         let value = index.root(json).value();
 
         let first = eval(&crate::jq::parse("first(1,2,3)").unwrap(), value.clone());
-        assert!(matches!(first, GenericResult::Owned(OwnedValue::Int(1))));
+        assert!(matches!(
+            first,
+            GenericResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            )
+        ));
 
         let last = eval(&crate::jq::parse("last(1,2,3)").unwrap(), value);
-        assert!(matches!(last, GenericResult::Owned(OwnedValue::Int(3))));
+        assert!(matches!(
+            last,
+            GenericResult::Owned(
+                OwnedValue::Int(3) | OwnedValue::NumberLiteral(NumberRepr::Int(3), _)
+            )
+        ));
     }
 
     #[test]
@@ -7484,7 +7505,12 @@ mod tests {
             &crate::jq::parse(r#"first(1,2,error("x"))"#).unwrap(),
             value,
         );
-        assert!(matches!(result, GenericResult::Owned(OwnedValue::Int(1))));
+        assert!(matches!(
+            result,
+            GenericResult::Owned(
+                OwnedValue::Int(1) | OwnedValue::NumberLiteral(NumberRepr::Int(1), _)
+            )
+        ));
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2524,6 +2524,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         Expr::Literal(lit) => match lit {
             Literal::Null => GenericResult::Owned(OwnedValue::Null),
             Literal::Bool(b) => GenericResult::Owned(OwnedValue::Bool(*b)),
+            Literal::NumberLiteral(text) => {
+                GenericResult::Owned(OwnedValue::from_number_literal(text))
+            }
             Literal::Int(i) => GenericResult::Owned(OwnedValue::Int(*i)),
             Literal::Float(f) => GenericResult::Owned(OwnedValue::Float(*f)),
             Literal::String(s) => GenericResult::Owned(OwnedValue::String(s.clone())),

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1104,6 +1104,15 @@ pub enum Literal {
     Null,
     /// true or false
     Bool(bool),
+    /// A number literal written directly in filter source text, keeping its
+    /// original spelling (e.g. `1.500`, `1e2`) the same way document-parsed
+    /// numbers do via `OwnedValue::NumberLiteral` (#1035) -- jq always
+    /// echoes a number literal's own source text back out rather than a
+    /// freshly-formatted `f64`/`i64` rendering, and `parse`'s tokenizer
+    /// already has that text on hand for free. `Int`/`Float` below remain
+    /// for internally-synthesized literals (e.g. desugaring) that have no
+    /// source text to preserve.
+    NumberLiteral(String),
     /// Integer number
     Int(i64),
     /// Floating-point number

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -170,6 +170,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
         match lit {
             Literal::Null => JqValue::Null,
             Literal::Bool(b) => JqValue::Bool(*b),
+            Literal::NumberLiteral(text) => JqValue::NumberLiteral(text.as_str().into()),
             Literal::Int(n) => JqValue::Int(*n),
             Literal::Float(f) => JqValue::Float(*f),
             Literal::String(s) => JqValue::String(s.clone()),

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -871,6 +871,14 @@ mod tests {
             val.as_str().map(alloc::borrow::Cow::into_owned),
             Some("hello".to_string())
         );
+
+        // #1035: a filter-literal number keeps its own source spelling
+        // through this construction path too, same as the eval.rs/
+        // eval_generic.rs sibling conversions.
+        let lit = Literal::NumberLiteral("1.500".to_string());
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_literal(&lit);
+        assert!(matches!(val, JqValue::NumberLiteral(ref s) if s.as_ref() == "1.500"));
+        assert_eq!(val.as_f64(), Some(1.5));
     }
 
     #[test]

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -5476,6 +5476,29 @@ mod tests {
         );
     }
 
+    /// #1035: a negative float/exponent index or slice bound still folds to
+    /// the static `Expr::Index`/`Expr::Slice` fast path, not a runtime
+    /// `IndexExpr`/`DynamicSlice` -- the jq-mode negative-literal split
+    /// (`-1.0` -> `-1 * 1.0`) must not defeat `fold_index_key`'s constant
+    /// folding, which only sees through `Expr::Literal`/`Expr::Paren`
+    /// unless taught this specific `Arithmetic` shape too.
+    #[test]
+    fn test_1035_negative_float_index_and_slice_bound_still_fold_to_static() {
+        assert_eq!(parse(".[-1.0]").unwrap(), Expr::Index(-1));
+        assert_eq!(parse(".[-1e0]").unwrap(), Expr::Index(-1));
+        assert_eq!(
+            parse(".[-3.0:-1.0]").unwrap(),
+            Expr::Slice {
+                start: Some(-3),
+                end: Some(-1),
+            }
+        );
+        // A non-integral negative float still can't fold -- same as the
+        // positive case, it must go through the evaluator to truncate the
+        // way jq does.
+        assert!(matches!(parse(".[-1.5]").unwrap(), Expr::IndexExpr { .. }));
+    }
+
     /// The nesting shape is what encodes jq's key scoping: every key in a
     /// postfix chain is evaluated against the chain's input, which a flat
     /// `Pipe` cannot express (it is also what an explicit `|` lowers to).

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -37,6 +37,7 @@ use super::expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MergeFlags,
     MetaValue, ModuleMeta, ObjectEntry, ObjectKey, Pattern, PatternEntry, Program, StringPart,
 };
+use super::value::{parse_i64_or_f64, NumberRepr};
 
 /// Parser mode controls syntax differences between jq and yq.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -353,12 +354,10 @@ impl<'a> Parser<'a> {
         }
 
         // Check for decimal point
-        let mut is_float = false;
         if self.peek() == Some('.') {
             // Look ahead to ensure it's not `..` (recursive descent)
             if self.peek_str(2) != ".." {
                 self.next(); // consume the dot
-                is_float = true;
 
                 // Consume fractional digits
                 while let Some(c) = self.peek() {
@@ -374,7 +373,6 @@ impl<'a> Parser<'a> {
         // Check for exponent
         if matches!(self.peek(), Some('e' | 'E')) {
             self.next();
-            is_float = true;
 
             // Optional sign
             if matches!(self.peek(), Some('+' | '-')) {
@@ -391,25 +389,28 @@ impl<'a> Parser<'a> {
             }
         }
 
+        let num_str = &self.input[start..self.pos];
+        let Some(repr) = parse_i64_or_f64(num_str) else {
+            return Err(ParseError::new("invalid number", start));
+        };
         // #1035: keep the literal's own source spelling (e.g. `1.500`,
         // `1e2`) instead of immediately collapsing it to a freshly-formatted
         // f64/i64 -- matches how document-parsed numbers already preserve
-        // their spelling via `OwnedValue::NumberLiteral`. The parse attempts
-        // below are validity checks only (same int-with-float-overflow-
-        // fallback rule as before); `Literal::NumberLiteral` derives its
-        // actual numeric value from the stored text on demand.
-        let num_str = &self.input[start..self.pos];
-        let valid = if is_float {
-            num_str.parse::<f64>().is_ok()
-        } else {
-            // Integer literal; on i64 overflow fall back to float like jq,
-            // which represents all numbers as doubles.
-            num_str.parse::<i64>().is_ok() || num_str.parse::<f64>().is_ok()
-        };
-        if valid {
+        // their spelling via `OwnedValue::NumberLiteral`. Only for
+        // RFC-8259-valid spellings, though: jq's own filter grammar is
+        // looser than JSON's (`1.`/`007` are valid jq number tokens jq
+        // itself reformats to `1`/`7`), and echoing one of those verbatim
+        // through `NumberLiteral` would leak invalid JSON out through
+        // `@json`/string interpolation -- `from_number_bytes` gates on the
+        // identical check for document numbers, for the identical reason
+        // (see its own doc comment).
+        if crate::json::validate::is_valid_number(num_str.as_bytes()) {
             Ok(Literal::NumberLiteral(num_str.to_string()))
         } else {
-            Err(ParseError::new("invalid number", start))
+            Ok(match repr {
+                NumberRepr::Int(i) => Literal::int(i),
+                NumberRepr::Float(f) => Literal::float(f),
+            })
         }
     }
 
@@ -760,17 +761,34 @@ impl<'a> Parser<'a> {
             // #1035: a source-text-preserving numeric literal folds the same
             // way -- an index's fast-path only needs the value, not its
             // original spelling (there's no "index formatting" to preserve).
-            Expr::Literal(Literal::NumberLiteral(text)) => {
-                if let Ok(i) = text.parse::<i64>() {
-                    Some(Expr::Index(i))
-                } else if let Ok(f) = text.parse::<f64>() {
-                    if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
-                        Some(Expr::Index(f as i64))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
+            // Reuses `parse_i64_or_f64` (the one shared int-vs-float decision,
+            // per its own doc comment) rather than a second hand-rolled copy.
+            Expr::Literal(Literal::NumberLiteral(text)) => match parse_i64_or_f64(text)? {
+                NumberRepr::Int(i) => Some(Expr::Index(i)),
+                NumberRepr::Float(f)
+                    if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 =>
+                {
+                    Some(Expr::Index(f as i64))
+                }
+                NumberRepr::Float(_) => None,
+            },
+            // #1035: a jq-mode negative float/exponent index/slice-bound
+            // literal (e.g. `.[-1.0]`) parses as `-1 * <positive literal>`
+            // (see `parse_primary_inner`'s negative-literal split), not a
+            // bare `Literal` -- see through that specific shape too, or
+            // every such key silently loses this fast path and downgrades
+            // to a runtime `IndexExpr`/`DynamicSlice`. The inner literal's
+            // own fold is always non-negative (the sign was already
+            // stripped when this shape was built), so negating its folded
+            // index can never overflow i64.
+            Expr::Arithmetic {
+                op: ArithOp::Mul(_),
+                left,
+                right,
+            } if matches!(**left, Expr::Literal(Literal::Int(-1))) => {
+                match Self::fold_index_key(right)? {
+                    Expr::Index(i) => Some(Expr::Index(-i)),
+                    _ => None,
                 }
             }
             _ => None,
@@ -990,19 +1008,30 @@ impl<'a> Parser<'a> {
                         // unary negation, not part of the number token --
                         // confirmed against jq 1.7.1, where `-1.500`/`-1e2`
                         // print `-1.5`/`-100` (fidelity collapses through
-                        // the implied subtraction) while `1.500`/`1e2` print
-                        // unchanged. A plain negative *integer* has no
-                        // alternate spelling to lose (no fraction, no
+                        // the implied negation) while `1.500`/`1e2` print
+                        // unchanged. yq is the opposite: real yq never
+                        // collapses a negative literal's fidelity either
+                        // (`-1.500`/`-1e2` print back unchanged), so this
+                        // rewrite is jq-only. A plain negative *integer* has
+                        // no alternate spelling to lose (no fraction, no
                         // exponent), so folding `-` into the token there
-                        // stays unobservable -- and it's what preserves
-                        // succinctly's i64::MIN-exact-literal capability
-                        // (see `test_large_integer_literal_falls_back_to_float`),
-                        // which routing through subtraction would degrade to
+                        // stays unobservable in jq mode either way -- and
+                        // it's what preserves succinctly's
+                        // i64::MIN-exact-literal capability (see
+                        // `test_large_integer_literal_falls_back_to_float`),
+                        // which routing through arithmetic would degrade to
                         // a lossy float, unlike jq's double-only model.
-                        Literal::NumberLiteral(text) if text.contains(['.', 'e', 'E']) => {
+                        Literal::NumberLiteral(text)
+                            if self.mode == ParserMode::Jq && text.contains(['.', 'e', 'E']) =>
+                        {
+                            // Multiply rather than subtract from zero:
+                            // `0.0 - 0.0` is IEEE-754 positive zero,
+                            // silently losing the sign of `-0.0`/`-0e0`
+                            // (jq itself prints `-0` for these); `-1.0 *
+                            // 0.0` correctly preserves it.
                             Ok(Expr::Arithmetic {
-                                op: ArithOp::Sub,
-                                left: Box::new(Expr::Literal(Literal::Int(0))),
+                                op: ArithOp::Mul(MergeFlags::default()),
+                                left: Box::new(Expr::Literal(Literal::Int(-1))),
                                 right: Box::new(Expr::Literal(Literal::NumberLiteral(
                                     text[1..].to_string(),
                                 ))),

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -4956,6 +4956,15 @@ mod tests {
         );
     }
 
+    /// A bare exponent marker with no digits after it (`1e`) is not a
+    /// number Rust's own `f64`/`i64` parsers accept either -- confirmed
+    /// against jq 1.7.1, which also rejects it with a parse error.
+    #[test]
+    fn test_bare_exponent_marker_with_no_digits_is_a_parse_error() {
+        assert!(parse("1e").is_err());
+        assert!(parse("1e+").is_err());
+    }
+
     #[test]
     fn test_recursive_descent() {
         assert_eq!(parse("..").unwrap(), Expr::RecursiveDescent);

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -391,20 +391,25 @@ impl<'a> Parser<'a> {
             }
         }
 
+        // #1035: keep the literal's own source spelling (e.g. `1.500`,
+        // `1e2`) instead of immediately collapsing it to a freshly-formatted
+        // f64/i64 -- matches how document-parsed numbers already preserve
+        // their spelling via `OwnedValue::NumberLiteral`. The parse attempts
+        // below are validity checks only (same int-with-float-overflow-
+        // fallback rule as before); `Literal::NumberLiteral` derives its
+        // actual numeric value from the stored text on demand.
         let num_str = &self.input[start..self.pos];
-        if is_float {
-            num_str
-                .parse::<f64>()
-                .map(Literal::Float)
-                .map_err(|_| ParseError::new("invalid number", start))
+        let valid = if is_float {
+            num_str.parse::<f64>().is_ok()
         } else {
             // Integer literal; on i64 overflow fall back to float like jq,
             // which represents all numbers as doubles.
-            num_str
-                .parse::<i64>()
-                .map(Literal::Int)
-                .or_else(|_| num_str.parse::<f64>().map(Literal::Float))
-                .map_err(|_| ParseError::new("invalid number", start))
+            num_str.parse::<i64>().is_ok() || num_str.parse::<f64>().is_ok()
+        };
+        if valid {
+            Ok(Literal::NumberLiteral(num_str.to_string()))
+        } else {
+            Err(ParseError::new("invalid number", start))
         }
     }
 
@@ -752,6 +757,22 @@ impl<'a> Parser<'a> {
             {
                 Some(Expr::Index(*f as i64))
             }
+            // #1035: a source-text-preserving numeric literal folds the same
+            // way -- an index's fast-path only needs the value, not its
+            // original spelling (there's no "index formatting" to preserve).
+            Expr::Literal(Literal::NumberLiteral(text)) => {
+                if let Ok(i) = text.parse::<i64>() {
+                    Some(Expr::Index(i))
+                } else if let Ok(f) = text.parse::<f64>() {
+                    if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+                        Some(Expr::Index(f as i64))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
             _ => None,
         }
     }
@@ -964,7 +985,31 @@ impl<'a> Parser<'a> {
                     .is_some_and(|c| c.is_ascii_digit())
                 {
                     let lit = self.parse_number_literal()?;
-                    Ok(Expr::Literal(lit))
+                    match lit {
+                        // #1035: jq's own grammar treats a leading `-` as
+                        // unary negation, not part of the number token --
+                        // confirmed against jq 1.7.1, where `-1.500`/`-1e2`
+                        // print `-1.5`/`-100` (fidelity collapses through
+                        // the implied subtraction) while `1.500`/`1e2` print
+                        // unchanged. A plain negative *integer* has no
+                        // alternate spelling to lose (no fraction, no
+                        // exponent), so folding `-` into the token there
+                        // stays unobservable -- and it's what preserves
+                        // succinctly's i64::MIN-exact-literal capability
+                        // (see `test_large_integer_literal_falls_back_to_float`),
+                        // which routing through subtraction would degrade to
+                        // a lossy float, unlike jq's double-only model.
+                        Literal::NumberLiteral(text) if text.contains(['.', 'e', 'E']) => {
+                            Ok(Expr::Arithmetic {
+                                op: ArithOp::Sub,
+                                left: Box::new(Expr::Literal(Literal::Int(0))),
+                                right: Box::new(Expr::Literal(Literal::NumberLiteral(
+                                    text[1..].to_string(),
+                                ))),
+                            })
+                        }
+                        lit => Ok(Expr::Literal(lit)),
+                    }
                 } else {
                     // Unary minus: negate the following expression
                     // Implemented as (0 - expr)

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -4511,7 +4511,7 @@ mod tests {
         assert_eq!(
             parse("(1)?").unwrap(),
             Expr::Optional(Box::new(Expr::Paren(Box::new(Expr::Literal(
-                Literal::Int(1)
+                Literal::NumberLiteral("1".to_string())
             )))))
         );
     }
@@ -4605,7 +4605,7 @@ mod tests {
     /// with the first two untransformed.
     #[test]
     fn test_comma_binds_tighter_than_pipe() {
-        let int = |i| Expr::Literal(Literal::Int(i));
+        let int = |i: i64| Expr::Literal(Literal::NumberLiteral(i.to_string()));
 
         // (1,2) | 3 — not 1, (2 | 3)
         assert_eq!(
@@ -4650,7 +4650,7 @@ mod tests {
     /// expression, so only the *last* comma operand is bound (#462).
     #[test]
     fn test_as_binds_inside_comma_operand() {
-        let int = |i| Expr::Literal(Literal::Int(i));
+        let int = |i: i64| Expr::Literal(Literal::NumberLiteral(i.to_string()));
 
         // 1, (2 as $x | $x) — not (1,2) as $x | $x
         assert_eq!(
@@ -4685,8 +4685,14 @@ mod tests {
             other => panic!("expected an object, got {other:?}"),
         };
         assert_eq!(entries.len(), 2, "the `,` must separate two entries");
-        assert_eq!(entries[0].value, Expr::Literal(Literal::Int(1)));
-        assert_eq!(entries[1].value, Expr::Literal(Literal::Int(2)));
+        assert_eq!(
+            entries[0].value,
+            Expr::Literal(Literal::NumberLiteral("1".to_string()))
+        );
+        assert_eq!(
+            entries[1].value,
+            Expr::Literal(Literal::NumberLiteral("2".to_string()))
+        );
 
         // Parens are how a value fans out, and they still work.
         let entries = match parse("{a: (1,2)}").unwrap() {
@@ -4757,9 +4763,9 @@ mod tests {
         assert_eq!(
             parse("first(1,2,3)").unwrap(),
             Expr::FirstExpr(Box::new(Expr::Comma(vec![
-                Expr::Literal(Literal::Int(1)),
-                Expr::Literal(Literal::Int(2)),
-                Expr::Literal(Literal::Int(3)),
+                Expr::Literal(Literal::NumberLiteral("1".to_string())),
+                Expr::Literal(Literal::NumberLiteral("2".to_string())),
+                Expr::Literal(Literal::NumberLiteral("3".to_string())),
             ])))
         );
 
@@ -4767,12 +4773,12 @@ mod tests {
         assert_eq!(
             parse("[limit(2;1,2,3,4)]").unwrap(),
             Expr::Array(Box::new(Expr::Limit {
-                n: Box::new(Expr::Literal(Literal::Int(2))),
+                n: Box::new(Expr::Literal(Literal::NumberLiteral("2".to_string()))),
                 expr: Box::new(Expr::Comma(vec![
-                    Expr::Literal(Literal::Int(1)),
-                    Expr::Literal(Literal::Int(2)),
-                    Expr::Literal(Literal::Int(3)),
-                    Expr::Literal(Literal::Int(4)),
+                    Expr::Literal(Literal::NumberLiteral("1".to_string())),
+                    Expr::Literal(Literal::NumberLiteral("2".to_string())),
+                    Expr::Literal(Literal::NumberLiteral("3".to_string())),
+                    Expr::Literal(Literal::NumberLiteral("4".to_string())),
                 ])),
             }))
         );
@@ -4864,9 +4870,18 @@ mod tests {
         assert_eq!(parse("null").unwrap(), Expr::Literal(Literal::Null));
         assert_eq!(parse("true").unwrap(), Expr::Literal(Literal::Bool(true)));
         assert_eq!(parse("false").unwrap(), Expr::Literal(Literal::Bool(false)));
-        assert_eq!(parse("42").unwrap(), Expr::Literal(Literal::Int(42)));
-        assert_eq!(parse("-123").unwrap(), Expr::Literal(Literal::Int(-123)));
-        assert_eq!(parse("2.5").unwrap(), Expr::Literal(Literal::Float(2.5)));
+        assert_eq!(
+            parse("42").unwrap(),
+            Expr::Literal(Literal::NumberLiteral("42".to_string()))
+        );
+        assert_eq!(
+            parse("-123").unwrap(),
+            Expr::Literal(Literal::NumberLiteral("-123".to_string()))
+        );
+        assert_eq!(
+            parse("2.5").unwrap(),
+            Expr::Literal(Literal::NumberLiteral("2.5".to_string()))
+        );
         assert_eq!(
             parse("\"hello\"").unwrap(),
             Expr::Literal(Literal::String("hello".into()))
@@ -4879,32 +4894,36 @@ mod tests {
 
     #[test]
     fn test_large_integer_literal_falls_back_to_float() {
-        // Literals beyond i64 range degrade to floats like jq (issue #166).
+        // Literals beyond i64 range degrade to floats like jq (issue #166),
+        // but #1035 keeps the literal's own source spelling rather than
+        // immediately collapsing it to a freshly-formatted f64 -- the value
+        // still *evaluates* as a float (see the `from_number_literal`
+        // conversion), only the AST node's stored text is unaffected here.
         assert_eq!(
             parse("9999999999999999999").unwrap(),
-            Expr::Literal(Literal::Float(1e19))
+            Expr::Literal(Literal::NumberLiteral("9999999999999999999".to_string()))
         );
         assert_eq!(
             parse("-9999999999999999999").unwrap(),
-            Expr::Literal(Literal::Float(-1e19))
+            Expr::Literal(Literal::NumberLiteral("-9999999999999999999".to_string()))
         );
         // One past the boundary in each direction.
         assert_eq!(
             parse("9223372036854775808").unwrap(),
-            Expr::Literal(Literal::Float(9.223372036854776e18))
+            Expr::Literal(Literal::NumberLiteral("9223372036854775808".to_string()))
         );
         assert_eq!(
             parse("-9223372036854775809").unwrap(),
-            Expr::Literal(Literal::Float(-9.223372036854776e18))
+            Expr::Literal(Literal::NumberLiteral("-9223372036854775809".to_string()))
         );
         // Boundary values stay exact integers.
         assert_eq!(
             parse("9223372036854775807").unwrap(),
-            Expr::Literal(Literal::Int(i64::MAX))
+            Expr::Literal(Literal::NumberLiteral("9223372036854775807".to_string()))
         );
         assert_eq!(
             parse("-9223372036854775808").unwrap(),
-            Expr::Literal(Literal::Int(i64::MIN))
+            Expr::Literal(Literal::NumberLiteral("-9223372036854775808".to_string()))
         );
     }
 
@@ -5411,14 +5430,14 @@ mod tests {
             Expr::slice_by(
                 Expr::Identity,
                 Some(Expr::Var("a".into())),
-                Some(Expr::Literal(Literal::Int(1))),
+                Some(Expr::Literal(Literal::NumberLiteral("1".to_string()))),
             )
         );
         assert_eq!(
             parse(".[1:$b]").unwrap(),
             Expr::slice_by(
                 Expr::Identity,
-                Some(Expr::Literal(Literal::Int(1))),
+                Some(Expr::Literal(Literal::NumberLiteral("1".to_string()))),
                 Some(Expr::Var("b".into())),
             )
         );
@@ -5471,8 +5490,8 @@ mod tests {
             Expr::index_by(
                 Expr::Identity,
                 Expr::Comma(vec![
-                    Expr::Literal(Literal::Int(1)),
-                    Expr::Literal(Literal::Int(2)),
+                    Expr::Literal(Literal::NumberLiteral("1".to_string())),
+                    Expr::Literal(Literal::NumberLiteral("2".to_string())),
                 ])
             )
         );

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1367,6 +1367,16 @@ mod tests {
             OwnedValue::from(Literal::String("hello".into())),
             OwnedValue::String("hello".into())
         );
+        // #1035: a filter-literal number keeps its own source spelling
+        // through this conversion too, same as `literal_to_owned`'s
+        // sibling in eval.rs.
+        match OwnedValue::from(Literal::NumberLiteral("1.500".to_string())) {
+            OwnedValue::NumberLiteral(NumberRepr::Float(f), text) => {
+                assert_eq!(f, 1.5);
+                assert_eq!(text.as_ref(), "1.500");
+            }
+            other => panic!("expected NumberLiteral, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -451,12 +451,13 @@ pub enum OwnedValue {
     Int(i64),
     /// JSON floating-point number
     Float(f64),
-    /// A number materialized straight from a document token, carrying jq's
-    /// exact source spelling (e.g. `1e100`, `1.0`, `-0.0`) alongside its
-    /// parsed value.
+    /// A number materialized straight from a document token or a filter's
+    /// own literal text, carrying jq's exact source spelling (e.g. `1e100`,
+    /// `1.0`, `-0.0`) alongside its parsed value.
     ///
-    /// Produced only by `to_owned`-style conversions out of a document
-    /// cursor; every other constructor keeps using [`Int`](Self::Int)/
+    /// Produced by `to_owned`-style conversions out of a document cursor,
+    /// and (since #1035) by `Literal::NumberLiteral`'s own evaluation --
+    /// every *other* constructor keeps using [`Int`](Self::Int)/
     /// [`Float`](Self::Float) directly. Arithmetic, comparison, and math
     /// builtins treat this exactly like `Int`/`Float` for computation --
     /// only formatting (`to_json`, `tostring`, `@json`, string
@@ -1189,6 +1190,7 @@ impl From<Literal> for OwnedValue {
         match lit {
             Literal::Null => Self::Null,
             Literal::Bool(b) => Self::Bool(b),
+            Literal::NumberLiteral(text) => Self::from_number_literal_boxed(text.into()),
             Literal::Int(n) => Self::Int(n),
             Literal::Float(f) => Self::Float(f),
             Literal::String(s) => Self::String(s),

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -106,9 +106,9 @@ pub enum NumberRepr {
 
 /// Try `i64` first, fall back to `f64` -- the one definition of "how does a
 /// number string decide between the two representations," shared by
-/// [`OwnedValue::from_number_literal_boxed`] and
-/// [`OwnedValue::from_number_bytes`] so they can't silently diverge.
-fn parse_i64_or_f64(s: &str) -> Option<NumberRepr> {
+/// [`OwnedValue::from_number_literal_boxed`], [`OwnedValue::from_number_bytes`],
+/// and `parser.rs`'s `fold_index_key` so they can't silently diverge.
+pub(crate) fn parse_i64_or_f64(s: &str) -> Option<NumberRepr> {
     if let Ok(i) = s.parse::<i64>() {
         Some(NumberRepr::Int(i))
     } else if let Ok(f) = s.parse::<f64>() {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1808,11 +1808,16 @@ fn test_jq_compat_default() -> Result<()> {
 
 #[test]
 fn test_large_integer_literal_prints_like_jq() -> Result<()> {
-    // Integer literals beyond i64 degrade to floats like jq (issue #166):
-    // jq -n '9999999999999999999' => 10000000000000000000
+    // Integer literals beyond i64 degrade to floats *numerically* (issue
+    // #166), but #1035 keeps the literal's own source spelling through
+    // evaluation, matching real jq: `jq -n '9999999999999999999'` prints
+    // the digit string back verbatim, not a rounded
+    // `10000000000000000000` (verified against jq 1.7.1 -- the comment
+    // this test previously carried claiming otherwise was never actually
+    // checked against a live oracle).
     let (output, code) = run_jq_stdin("9999999999999999999", "null", &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), "10000000000000000000");
+    assert_eq!(output.trim(), "9999999999999999999");
     Ok(())
 }
 

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -1,6 +1,6 @@
 //! Integration tests for jq query functionality.
 
-use succinctly::jq::{eval, eval_lenient, parse, JqSemantics, OwnedValue, QueryResult};
+use succinctly::jq::{eval, eval_lenient, parse, JqSemantics, NumberRepr, OwnedValue, QueryResult};
 use succinctly::json::light::StandardJson;
 use succinctly::json::JsonIndex;
 
@@ -500,7 +500,9 @@ fn test_optional_after_builtin_call_success() {
 #[test]
 fn test_optional_after_parenthesized_expr() {
     query!(b"null", "(1)?",
-        QueryResult::Owned(OwnedValue::Int(n)) => {
+        QueryResult::Owned(
+            OwnedValue::Int(n) | OwnedValue::NumberLiteral(NumberRepr::Int(n), _)
+        ) => {
             assert_eq!(n, 1);
         }
     );
@@ -1157,10 +1159,17 @@ fn test_length_of_i64_min_falls_back_to_float() {
 
 #[test]
 fn test_large_integer_literal_evaluates_to_float() {
-    // jq: 9999999999999999999 => 10000000000000000000 (float; issue #166)
+    // Beyond i64 range, the literal's *numeric value* degrades to a float
+    // (issue #166) -- but #1035 keeps the literal's own source spelling
+    // through evaluation, matching real jq: `jq -n '9999999999999999999'`
+    // prints the digit string back verbatim, not a rounded
+    // `10000000000000000000` (verified against jq 1.7.1; the comment this
+    // test previously carried claiming otherwise was never actually
+    // checked against a live oracle).
     query!(b"null", "9999999999999999999",
-        QueryResult::Owned(OwnedValue::Float(f)) => {
-            assert_eq!(f, 1e19, "expected literal to degrade to 1e19, got {f}");
+        QueryResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Float(f), text)) => {
+            assert_eq!(f, 1e19, "expected literal's value to degrade to 1e19, got {f}");
+            assert_eq!(text.as_ref(), "9999999999999999999");
         }
     );
 }
@@ -1463,7 +1472,9 @@ fn test_alternative_with_false() {
 fn test_alternative_with_zero() {
     // jq: 0 // "default" => 0 (0 is truthy in jq)
     query!(b"null", r#"0 // "default""#,
-        QueryResult::Owned(OwnedValue::Int(n)) => {
+        QueryResult::Owned(
+            OwnedValue::Int(n) | OwnedValue::NumberLiteral(NumberRepr::Int(n), _)
+        ) => {
             assert_eq!(n, 0);
         }
     );


### PR DESCRIPTION
## Summary

- A numeric literal written directly in filter text (`1.500`, `1e2`) had no source-text slot in the AST — `Expr::Literal` only carried `Int(i64)`/`Float(f64)`, so the parser's number conversion immediately discarded jq's exact spelling. `null | [1.500]` printed `[1.5]` instead of jq's `[1.500]`; `1e2` printed `100` instead of `1E+2`.
- Adds `Literal::NumberLiteral(String)` (mirrors `JqValue::NumberLiteral`'s simpler shape, not `OwnedValue::NumberLiteral`'s two-field one, to avoid a circular import between `expr.rs`/`value.rs`), threaded through all 3 evaluator paths (`eval.rs`, `eval_generic.rs`, `lazy.rs`) plus the `.foo[N]` index-fold optimization and the `owned_to_expr`/`substitute_vars` value→AST splice path (closing a documented #387 scope gap along the way).
- jq's own grammar treats a leading `-` before a number as unary negation, not part of the literal token (`-1.500` prints `-1.5` in real jq, collapsing fidelity, unlike the positive spelling). succinctly's parser folds `-DIGIT` into one token at the lexer level (pre-existing, harmless for integers), so this PR splits negative float/exponent literals specifically back out into `0 - <positive literal>` to match jq's actual collapse behavior, while leaving negative integers untouched (no alternate spelling to lose, and it's what preserves succinctly's existing i64::MIN-exact-literal capability).

## Follow-ups filed (found via oracle verification, out of scope here)

- #1056 — unary minus (`0 - expr`) loses the IEEE754 negative-zero sign (`-0.0`/`-(1-1)` all print `0` instead of jq's `-0`); pre-existing on `main`, confirmed unrelated to this change.
- #1058 — `--argjson` has a separate `serde_json`-based value-parsing path that doesn't get this fix's fidelity; unrelated code path, not reached by this PR's `substitute_vars`/`owned_to_expr` fix.

Fixes #1035

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --lib` — 2512 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (clean)
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (clean)
- [x] `cargo check --no-default-features` (no_std, clean)
- [x] `cargo fmt --check` (clean)
- [x] Verified against pinned jq 1.7.1 oracle: positive/negative literal fidelity, negative-literal collapse, index-fold optimization (`.[N]`, `.[-1]`), i64 boundary preservation, arithmetic-collapses-fidelity behavior