### PR TITLE
fix(jq): yq mode spells NaN/Infinity as .nan/.inf, not jq's NaN/inf

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5857,8 +5857,7 @@ fn builtin_tostring<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(n) => format!("{n}"),
-        OwnedValue::Float(f) => format!("{f}"),
-        OwnedValue::NumberLiteral(..) => numeric_display_string::<S>(&owned),
+        OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => numeric_display_string::<S>(&owned),
         OwnedValue::Array(_) | OwnedValue::Object(_) => owned_value_to_json::<S>(&owned),
     };
     QueryResult::Owned(OwnedValue::String(s))

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5068,17 +5068,34 @@ fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// comment) because `to_json` needs "null" instead. Text formats (`@text`,
 /// `@uri`, `@html`, `@sh`, and the CSV/TSV/DSV cell formatter that falls back
 /// to `owned_to_string`) want the same `"inf"`/`"-inf"`/`"NaN"` rendering a
-/// plain `Int`/`Float` already gets from `f64::to_string()` -- a
+/// plain `Int`/`Float` already gets from `f64::to_string()` in jq mode -- a
 /// `NumberLiteral` just needs that check made explicit: `format_number_jq_compat`
 /// now formats an overflowed literal's source text correctly (#930), but its
 /// jq-error-message-preview text (e.g. `1E+400`) still isn't the Rust-style
 /// `"inf"`/`"-inf"` these non-JSON text formats want, so the explicit check
 /// stays regardless.
+///
+/// yq mode instead wants YAML's own `.nan`/`.inf`/`-.inf` spelling (#1060) --
+/// this was previously unconditional (`f.to_string()`, jq's own spelling in
+/// both modes), the same class of gap #1030 fixed for finite literals.
+/// Real yq's own Go-based number model actually distinguishes a
+/// document-sourced non-finite scalar (`.inf`) from a genuinely *computed*
+/// one (`1/0` -> Go's own `+Inf`, confirmed live against the pinned oracle)
+/// -- but succinctly's `OwnedValue` can't make that distinction once a
+/// document-sourced `.inf`/`.nan` degrades to a plain `Float`: YAML's
+/// `number_literal()` override never captures these spellings as a
+/// `NumberLiteral` in the first place (`is_preservable_float_literal`'s
+/// JSON-syntax gate rejects them, since neither starts with a digit or
+/// `-digit`). So this always answers with the document-sourced spelling --
+/// correct for the common case (`.a | tostring` on an untouched `.inf`/
+/// `.nan` scalar), diverging from real yq's Go-style spelling only for a
+/// genuinely computed non-finite result, a narrower, rarer case left
+/// unaddressed here.
 pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> String {
     if let OwnedValue::NumberLiteral(repr, literal) = value {
         if let NumberRepr::Float(f) = repr {
             if f.is_nan() || f.is_infinite() {
-                return f.to_string();
+                return nonfinite_display_string::<S>(*f);
             }
         }
         // yq preserves a document-sourced literal's exact source spelling
@@ -5090,8 +5107,28 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
         if S::TAG == EvalTag::Yq {
             return crate::jq::stream::real_output_finite_literal(literal.as_bytes());
         }
+    } else if let OwnedValue::Float(f) = value {
+        if f.is_nan() || f.is_infinite() {
+            return nonfinite_display_string::<S>(*f);
+        }
     }
     value.number_str().expect("numeric variant").into_owned()
+}
+
+/// jq's bare `f64::Display` (`NaN`/`inf`/`-inf`) vs yq's own YAML-native
+/// spelling (`.nan`/`.inf`/`-.inf`) for a non-finite float -- see
+/// [`numeric_display_string`]'s own doc comment for the "document-sourced
+/// vs computed" caveat this doesn't attempt to resolve.
+fn nonfinite_display_string<S: EvalSemantics>(f: f64) -> String {
+    if S::TAG != EvalTag::Yq {
+        f.to_string()
+    } else if f.is_nan() {
+        ".nan".to_string()
+    } else if f.is_sign_negative() {
+        "-.inf".to_string()
+    } else {
+        ".inf".to_string()
+    }
 }
 
 /// `to_json_yq()` in yq mode, `to_json()` in jq mode (#1030) -- the single

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10752,3 +10752,24 @@ fn test_jq_stderr_and_halt_error_unaffected_by_yq_mode_fix_1051() -> Result<()> 
     assert_eq!(stderr.trim_end(), r#"[1E+2,"x"]"#);
     Ok(())
 }
+
+/// #1060: `numeric_display_string`'s NaN/Infinity fast path gained an
+/// `S`-gated yq-only branch (`.nan`/`.inf`/`-.inf`); confirm jq mode's own
+/// bare `f64::Display` spelling (`NaN`/`inf`/`-inf`) is unaffected. (Real
+/// jq's own `infinite` builtin substitutes `DBL_MAX` rather than true IEEE
+/// infinity -- succinctly doesn't replicate that quirk, a pre-existing,
+/// unrelated divergence; this test pins succinctly's own actual jq-mode
+/// output, not real jq's.)
+#[test]
+fn test_jq_tostring_special_floats_unaffected_by_yq_mode_fix_1060() -> Result<()> {
+    for (filter, want) in [
+        ("infinite | tostring", r#""inf""#),
+        ("(-1 * infinite) | tostring", r#""-inf""#),
+        ("nan | tostring", r#""NaN""#),
+    ] {
+        let (out, code) = run_jq_stdin(filter, "null", &["-c"])?;
+        assert_eq!(code, 0, "for {filter:?}: {out:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5450,6 +5450,34 @@ fn test_yq_json_output_special_floats_still_null_after_1060() -> Result<()> {
     Ok(())
 }
 
+/// #1060 code review: `test_yq_tostring_special_floats_use_yaml_spelling_1060`
+/// above (`.a | tostring` on a *document-sourced* scalar) doesn't actually
+/// exercise `eval.rs`'s own `builtin_tostring` -- a direct field access
+/// resolves through `eval_generic.rs`'s cursor-based `Builtin::ToString` arm
+/// instead, which already called `numeric_display_string` correctly before
+/// this fix. `builtin_tostring`'s *own* `OwnedValue::Float` arm (only
+/// reached via the reindex bridge -- `nan`/`infinite`'s jq-builtin
+/// evaluation, `--slurp`, `-i` with an expression `can_use_m2_streaming`
+/// doesn't allow-list, `reduce`/`foreach`, ...) had a separate, unfixed
+/// `format!("{f}")` that this exact test caught live: `nan | tostring` gave
+/// `"NaN"` instead of `.nan`, silently inconsistent with `nan | @text`
+/// (documented in CLAUDE.md as "same as tostring") which already gave
+/// `.nan`.
+#[test]
+fn test_yq_tostring_computed_nan_uses_yaml_spelling_1060() -> Result<()> {
+    for filter in ["nan | tostring", "(0/0) | tostring"] {
+        let (stdout, code) = run_yq_stdin(filter, "a: 1\n", &["-r"])?;
+        assert_eq!(code, 0, "for {filter:?}: {stdout:?}");
+        assert_eq!(stdout.trim_end(), ".nan", "for {filter:?}");
+    }
+    // `@text` is documented as identical to `tostring` -- confirm they now
+    // agree on the same computed value.
+    let (stdout, code) = run_yq_stdin("nan | @text", "a: 1\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), ".nan");
+    Ok(())
+}
+
 #[test]
 fn test_build_configuration_flag() -> Result<()> {
     // --build-configuration prints diagnostics and exits successfully.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5410,6 +5410,46 @@ fn test_yaml_special_float_keys_preview_is_unaffected_by_939() -> Result<()> {
     Ok(())
 }
 
+/// #1060: `numeric_display_string`'s NaN/Infinity fast path was
+/// unconditional (`f.to_string()`, jq's own `NaN`/`inf`/`-inf` spelling in
+/// both modes) -- yq mode wants YAML's own `.nan`/`.inf`/`-.inf`, matching
+/// `tostring`/`@text`/`@sh`/CSV-TSV-DSV cell formatting on a document-sourced
+/// non-finite scalar. Verified byte-for-byte against pinned real yq v4.53.3.
+#[test]
+fn test_yq_tostring_special_floats_use_yaml_spelling_1060() -> Result<()> {
+    for (input, want) in [
+        ("a: .inf\n", ".inf"),
+        ("a: -.inf\n", "-.inf"),
+        ("a: .nan\n", ".nan"),
+    ] {
+        let (stdout, code) = run_yq_stdin(".a | tostring", input, &["-r"])?;
+        assert_eq!(code, 0, "for {input:?}: {stdout:?}");
+        assert_eq!(stdout.trim_end(), want, "for {input:?}");
+    }
+    Ok(())
+}
+
+/// #1060: the same fix applies to every other text format sharing
+/// `numeric_display_string` (not just `tostring`).
+#[test]
+fn test_yq_at_csv_special_floats_use_yaml_spelling_1060() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(".a | @csv", "a: [.inf, -.inf, .nan]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), ".inf,-.inf,.nan");
+    Ok(())
+}
+
+/// #1060 scope note: `@json`/`-o json` output is untouched by this fix (a
+/// separate code path, `to_json`/`to_json_yq`, already RFC-8259-correct) --
+/// pinning that this stays `null` after the `numeric_display_string` change.
+#[test]
+fn test_yq_json_output_special_floats_still_null_after_1060() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(".", "x: .nan\ny: .inf\nz: -.inf\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"{"x":null,"y":null,"z":null}"#);
+    Ok(())
+}
+
 #[test]
 fn test_build_configuration_flag() -> Result<()> {
     // --build-configuration prints diagnostics and exits successfully.


### PR DESCRIPTION
## Summary

- `numeric_display_string`'s NaN/Infinity fast path was unconditional (`f.to_string()`, jq's own spelling in both modes), so `tostring`/`@text`/`@sh`/CSV-TSV-DSV cell formatting on a document-sourced `.inf`/`-.inf`/`.nan` scalar gave `"inf"`/`"-inf"`/`"NaN"` instead of real yq's own YAML-native `.inf`/`-.inf`/`.nan` spelling:
  ```
  $ echo 'a: .inf' | succinctly yq -r '.a | tostring'
  inf
  $ echo 'a: .inf' | yq -r '.a | tostring'   # pinned v4.53.3
  .inf
  ```
- Real yq's own Go-based number model distinguishes a document-sourced non-finite scalar from a genuinely *computed* one (`1/0` → Go's `+Inf`, confirmed live against the pinned oracle), but succinctly's `OwnedValue` can't make that distinction once a document-sourced `.inf`/`.nan` degrades to a plain `Float` — YAML's `number_literal()` override never captures these spellings as a `NumberLiteral` in the first place (`is_preservable_float_literal`'s JSON-syntax gate rejects them). So this fix always answers with the document-sourced spelling — correct for the common case (`tostring` on an untouched `.inf`/`.nan` scalar), diverging from real yq's Go-style spelling only for a genuinely computed non-finite result — a narrower, rarer residual gap left unaddressed here rather than expanding scope, matching the same "computed vs literal" tension already documented for #953/#1051.
- `@json`/`-o json` output is unaffected — a separate, already-RFC-8259-correct code path (`to_json`/`to_json_yq`).
- jq mode is unaffected — verified against succinctly's own pre-existing jq-mode output for `infinite`/`nan` (which doesn't replicate real jq's `DBL_MAX`-substitution quirk either, an unrelated, pre-existing divergence not touched by this fix).

Fixes #1060

## Test plan

- [x] New regression tests: `test_yq_tostring_special_floats_use_yaml_spelling_1060`, `test_yq_at_csv_special_floats_use_yaml_spelling_1060` (verified byte-for-byte against pinned real yq v4.53.3), `test_yq_json_output_special_floats_still_null_after_1060` (confirms the separate JSON-output path is untouched).
- [x] `test_jq_tostring_special_floats_unaffected_by_yq_mode_fix_1060` confirms jq mode's own output is unchanged.
- [x] `cargo test --features cli,simd,regex,serde` (incl. golden/path-consistency suites) — 659 passed, 0 failed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo check --no-default-features` (no_std) — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.

All verification steps run sequentially (not concurrently) to avoid a build-artifact race that caused a false-green local result on a previous PR this session (#1057).