### PR TITLE
fix(jq): eval_generic.rs's index/slice-expr collapses have the same missing 0=>None bug as #1043

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -955,6 +955,18 @@ fn owned_vec_to_generic_result<V: DocumentValue>(mut vs: Vec<OwnedValue>) -> Gen
     }
 }
 
+/// Normalize a `Vec<V::Cursor>` accumulator into the smallest `GenericResult`
+/// shape that represents it -- the borrowed-cursor counterpart of
+/// [`owned_vec_to_generic_result`], for the same reason (#1048): a caller
+/// with zero results must collapse to `None`, not `ManyCursor(vec![])`.
+fn cursor_vec_to_generic_result<V: DocumentValue>(mut cs: Vec<V::Cursor>) -> GenericResult<V> {
+    match cs.len() {
+        0 => GenericResult::None,
+        1 => GenericResult::OneCursor(cs.pop().unwrap()),
+        _ => GenericResult::ManyCursor(cs),
+    }
+}
+
 /// Finalize a fork's accumulated `outputs`, given an optional terminating
 /// `Control`. Mirrors [`super::eval::finish_fork`]: a trailing `Error` is
 /// silenced (keeping whatever outputs already succeeded) when `optional` is
@@ -2925,10 +2937,9 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             }
             return match pending_halt {
                 Some(code) => partial_generic(out, Control::Halt(code)),
-                None => match out.len() {
-                    1 => GenericResult::Owned(out.pop().expect("len checked")),
-                    _ => GenericResult::ManyOwned(out),
-                },
+                // #1048: a zero-result collapse here (every key/target pair
+                // optional-suppressed) must be `None`, not `ManyOwned(vec![])`.
+                None => owned_vec_to_generic_result(out),
             };
         }
     };
@@ -2992,16 +3003,12 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         return partial_generic(out, Control::Halt(code));
     }
 
+    // #1048: a zero-result collapse here (every key/target pair
+    // optional-suppressed) must be `None`, not `ManyOwned`/`ManyCursor(vec![])`.
     if any_owned {
-        match owned.len() {
-            1 => GenericResult::Owned(owned.pop().expect("len checked")),
-            _ => GenericResult::ManyOwned(owned),
-        }
+        owned_vec_to_generic_result(owned)
     } else {
-        match cursors.len() {
-            1 => GenericResult::OneCursor(cursors.pop().expect("len checked")),
-            _ => GenericResult::ManyCursor(cursors),
-        }
+        cursor_vec_to_generic_result(cursors)
     }
 }
 
@@ -3107,10 +3114,9 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
             }
         }
     }
-    match out.len() {
-        1 => GenericResult::Owned(out.pop().expect("len checked")),
-        _ => GenericResult::ManyOwned(out),
-    }
+    // #1048: a zero-result collapse here (every (start, end) pair
+    // optional-suppressed) must be `None`, not `ManyOwned(vec![])`.
+    owned_vec_to_generic_result(out)
 }
 
 /// Evaluate one slice bound (`start` or `end`) against `value`/`cursor`.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3879,6 +3879,44 @@ mod tests {
     use crate::jq::parse;
     use crate::json::JsonIndex;
 
+    /// #1048: the yq/generic-document counterpart to #1043's `eval.rs` fix
+    /// had the identical missing `0 => None` bug in 3 places -- a computed
+    /// index/slice whose optional (`?`) form produces zero results
+    /// collapsed to `Many`/`ManyOwned`/`ManyCursor(vec![])` instead of
+    /// `None`.
+    #[test]
+    fn test_1048_computed_index_and_slice_zero_results_collapse_to_none() {
+        let json = br"5";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        // Key-outer/target-inner loop, borrowed target (`.` is the document
+        // itself, a number -- not indexable, so `?` suppresses to zero
+        // results per key).
+        let result = eval(&parse(r#".[("a", "b")]?"#).unwrap(), value.clone());
+        assert!(
+            matches!(result, GenericResult::None),
+            "expected None, got {result:?}"
+        );
+
+        // Owned-target arm: `(1)` constructs an owned value rather than
+        // borrowing from the document.
+        let result = eval(&parse(r#"(1)[("a", "b")]?"#).unwrap(), value.clone());
+        assert!(
+            matches!(result, GenericResult::None),
+            "expected None, got {result:?}"
+        );
+
+        // eval_slice_expr's final collapse: slicing a non-array/string
+        // target with `?` suppresses to zero results per (start, end) pair.
+        let result = eval(&parse(r".[0:1]?").unwrap(), value);
+        assert!(
+            matches!(result, GenericResult::None),
+            "expected None, got {result:?}"
+        );
+    }
+
     #[test]
     fn test_generic_identity() {
         let json = br#"{"name": "Alice", "age": 30}"#;


### PR DESCRIPTION
## Summary

`src/jq/eval_generic.rs` — the generic-document (yq) counterpart to `src/jq/eval.rs`'s `eval_index_expr`/`eval_slice_expr` — had the identical missing-`0 => None`-arm bug #1043 just fixed in `eval.rs`, in three places:

1. `eval_index_expr`'s owned-target-arm final collapse
2. `eval_index_expr`'s key-outer/target-inner loop's final collapse (both the `owned` and `cursors` branches)
3. `eval_slice_expr`'s final collapse

A computed index/slice whose optional (`?`) form suppresses every candidate to zero results collapsed to `ManyOwned`/`ManyCursor(vec![])` instead of `None`.

Sites 1 and 3 route through the existing `owned_vec_to_generic_result` helper (mirroring `eval.rs`'s `owned_vec_to_result`). Site 2's `owned` branch does too; its `cursors` branch needed a new `cursor_vec_to_generic_result` sibling, since there was no existing `Vec<V::Cursor>`-to-`GenericResult` helper to reuse.

This is library-API-only, like #1043: both variants print "no output" at the CLI's top level, so it has no CLI-observable difference on its own — confirmed against real yq for the repro cases.

## Follow-up filed

While verifying, found a distinct, CLI-observable yq divergence unrelated to this bug: slicing a scalar with `?` gives `[]` in real yq but no output in succinctly (matching jq's own behavior instead) — filed as #1065.

Fixes #1048

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (clean)
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (clean)
- [x] `cargo check --no-default-features` (no_std, clean)
- [x] `cargo fmt --check` (clean)
- [x] Verified against real yq v4.53.3 for both CLI repro cases