### PR TITLE
fix(jq): yq join() renders empty-object as {} and keeps NaN/Inf spelling

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4102,7 +4102,28 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// site, not [`to_owned`]) so a container element's contents are never
 /// materialized at all -- they're discarded unread here regardless -- and a
 /// string element is moved rather than cloned a second time.
+/// yq's own `.nan`/`.inf`/`-.inf` spelling for a non-finite element or
+/// separator (#1047, matching #1060's identical fix for `tostring`/`@text`/
+/// etc.), shared by [`yq_join_element_part`] and [`yq_join_separator`]
+/// rather than hand-copied at each -- the #106 "duplicated predicates
+/// diverge silently" lesson in `CLAUDE.md`, caught in this PR's own code
+/// review. `None` for anything else, so the caller's own catch-all
+/// (`other.to_json_yq()`) handles every other variant unchanged.
+fn yq_join_nonfinite_part(value: &OwnedValue) -> Option<String> {
+    match value {
+        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _)
+            if f.is_nan() || f.is_infinite() =>
+        {
+            Some(nonfinite_display_string::<YqSemantics>(*f))
+        }
+        _ => None,
+    }
+}
+
 fn yq_join_element_part(elem: OwnedValue) -> String {
+    if let Some(s) = yq_join_nonfinite_part(&elem) {
+        return s;
+    }
     match elem {
         OwnedValue::String(s) => s,
         // NOT a `OwnedValue::Object(m) if m.is_empty()` guard here (#1047
@@ -4114,17 +4135,6 @@ fn yq_join_element_part(elem: OwnedValue) -> String {
         // special case is instead handled at the call site, on the live
         // cursor, before that collapse ever runs.
         OwnedValue::Null | OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
-        // YAML's own `.nan`/`.inf`/`-.inf` spelling (#1047, matching #1060's
-        // identical fix for `tostring`/`@text`/etc.), not `to_json_yq()`'s
-        // RFC-8259 `"null"` substitution -- confirmed live,
-        // `[.nan, 2] | join(",")` on a document-sourced `.nan` element is
-        // `".nan,2"` in real yq, not `"null,2"`.
-        OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(f)
-        }
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(f)
-        }
         // `to_json_yq()`, not `to_json()` (#1030 code review): this function
         // is only ever reached from `builtin_join`'s `S::TAG == EvalTag::Yq`
         // branch, so a scientific-notation literal here must echo verbatim
@@ -4143,6 +4153,9 @@ fn yq_join_element_part(elem: OwnedValue) -> String {
 /// from jq mode, where `null` is a no-op only via `+`'s own left-identity
 /// rule, not something `join` special-cases).
 fn yq_join_separator(sep: OwnedValue) -> String {
+    if let Some(s) = yq_join_nonfinite_part(&sep) {
+        return s;
+    }
     match sep {
         OwnedValue::String(s) => s,
         // Empty-object special case (#1047): see `yq_join_element_part`'s
@@ -4150,16 +4163,6 @@ fn yq_join_separator(sep: OwnedValue) -> String {
         // `"1{}2"` in real yq, not `"12"`.
         OwnedValue::Object(ref m) if m.is_empty() => "{}".to_string(),
         OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
-        // YAML's own `.nan`/`.inf`/`-.inf` spelling (#1047): see
-        // `yq_join_element_part`'s identical arm above -- confirmed live,
-        // a document-sourced `.nan`/`.inf` *separator* keeps its own
-        // spelling too, not `to_json_yq()`'s `"null"`.
-        OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(f)
-        }
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(f)
-        }
         // `to_json_yq()` (#1030 code review): same reasoning as
         // `yq_join_element_part` above -- this function is yq-only.
         other => other.to_json_yq(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4105,7 +4105,26 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn yq_join_element_part(elem: OwnedValue) -> String {
     match elem {
         OwnedValue::String(s) => s,
+        // NOT a `OwnedValue::Object(m) if m.is_empty()` guard here (#1047
+        // review): `elem` was already collapsed via `to_owned_key_shape` at
+        // the call site (see this function's own doc comment), which always
+        // produces an *empty* `IndexMap` regardless of the real object's
+        // actual field count -- a guard here couldn't tell "genuinely
+        // empty" apart from "collapsed, contents unread". The empty-object
+        // special case is instead handled at the call site, on the live
+        // cursor, before that collapse ever runs.
         OwnedValue::Null | OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
+        // YAML's own `.nan`/`.inf`/`-.inf` spelling (#1047, matching #1060's
+        // identical fix for `tostring`/`@text`/etc.), not `to_json_yq()`'s
+        // RFC-8259 `"null"` substitution -- confirmed live,
+        // `[.nan, 2] | join(",")` on a document-sourced `.nan` element is
+        // `".nan,2"` in real yq, not `"null,2"`.
+        OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(f)
+        }
+        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(f)
+        }
         // `to_json_yq()`, not `to_json()` (#1030 code review): this function
         // is only ever reached from `builtin_join`'s `S::TAG == EvalTag::Yq`
         // branch, so a scientific-notation literal here must echo verbatim
@@ -4126,7 +4145,21 @@ fn yq_join_element_part(elem: OwnedValue) -> String {
 fn yq_join_separator(sep: OwnedValue) -> String {
     match sep {
         OwnedValue::String(s) => s,
+        // Empty-object special case (#1047): see `yq_join_element_part`'s
+        // identical arm above -- confirmed live, `[1,2] | join({})` is
+        // `"1{}2"` in real yq, not `"12"`.
+        OwnedValue::Object(ref m) if m.is_empty() => "{}".to_string(),
         OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
+        // YAML's own `.nan`/`.inf`/`-.inf` spelling (#1047): see
+        // `yq_join_element_part`'s identical arm above -- confirmed live,
+        // a document-sourced `.nan`/`.inf` *separator* keeps its own
+        // spelling too, not `to_json_yq()`'s `"null"`.
+        OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(f)
+        }
+        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(f)
+        }
         // `to_json_yq()` (#1030 code review): same reasoning as
         // `yq_join_element_part` above -- this function is yq-only.
         other => other.to_json_yq(),
@@ -4233,8 +4266,20 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // collapses to an empty-string part regardless of its
                 // contents (see `yq_join_element_part`'s doc comment), so
                 // deep-copying it first would be pure waste (#1044 review).
+                //
+                // The empty-object special case (#1047) is checked on the
+                // live cursor *before* that collapse: `JsonFields::is_empty`
+                // is an O(1) cursor check, and `to_owned_key_shape` always
+                // produces an empty `IndexMap` for *any* object regardless
+                // of its real field count, so checking emptiness after the
+                // collapse can't distinguish "genuinely empty" from
+                // "collapsed, contents unread" (a non-empty object would
+                // wrongly render as `{}` too).
                 let parts: Vec<String> = elements
-                    .map(|e| yq_join_element_part(to_owned_key_shape(&e)))
+                    .map(|e| match &e {
+                        StandardJson::Object(fields) if fields.is_empty() => "{}".to_string(),
+                        _ => yq_join_element_part(to_owned_key_shape(&e)),
+                    })
                     .collect();
                 QueryResult::Owned(OwnedValue::String(parts.join(&sep_str)))
             }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11630,6 +11630,60 @@ fn test_yq_join_null_separator_renders_as_literal_text_1041() -> Result<()> {
     Ok(())
 }
 
+/// #1047: an *empty* object is its own case, unlike a non-empty object or
+/// any array (empty or not), which all become the empty string (per
+/// `test_yq_join_non_scalar_element_becomes_empty_part_1041` above) -- real
+/// yq renders it as literal `{}` text, both as an element and as a
+/// separator. Regression-guards the specific bug this issue's own fix had
+/// to route around: `to_owned_key_shape` (the element materializer `join`
+/// uses to avoid deep-copying a container it's about to discard) always
+/// produces an *empty* map for any object regardless of its real field
+/// count, so the emptiness check must happen on the live cursor before that
+/// collapse, not after it -- `{"a":1}` must NOT render as `{}`.
+#[test]
+fn test_yq_join_empty_object_renders_as_literal_text_1047() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r#"join(",")"#, "- {}\n- x\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "{},x");
+
+    let (stdout, code) = run_yq_stdin(r#"join(",")"#, "- x: 1\n- a\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim_end(),
+        ",a",
+        "a non-empty object must stay empty"
+    );
+
+    let (stdout, code) = run_yq_stdin("join({})", "- 1\n- 2\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1{}2");
+    Ok(())
+}
+
+/// #1047: a document-sourced NaN/Infinity element or separator keeps its
+/// own YAML spelling (`.nan`/`.inf`/`-.inf`) instead of `to_json_yq()`'s
+/// RFC-8259 `"null"` substitution -- matching #1060's identical fix for
+/// `tostring`/`@text`/etc.
+#[test]
+fn test_yq_join_special_float_element_and_separator_use_yaml_spelling_1047() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r#"join(",")"#, "- .nan\n- 2\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), ".nan,2");
+
+    let (stdout, code) = run_yq_stdin(r#"join(",")"#, "- .inf\n- 2\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), ".inf,2");
+
+    let (stdout, code) = run_yq_stdin(
+        ". as $root | $root.a | join($root.sep)",
+        "a: [\"1\", \"2\"]\nsep: .nan\n",
+        &["-r"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1.nan2");
+    Ok(())
+}
+
 // =============================================================================
 // yq-mode `numeric_display_string`/`to_json_yq` scientific-notation fidelity
 // (#1030, #1008 follow-up) -- all live-verified against yq v4.53.3.


### PR DESCRIPTION
## Summary

Two narrower divergences from real yq's `join()` found after #1041 (PR #1044), tracked in #1047:

1. **Empty-object special case**: `[1,2] | join({})` gives `"1{}2"` in real yq — an *empty* object element or separator renders as literal `{}` text, unlike a non-empty object or any array (empty or not), which all become the empty string.

   The tricky part: `yq_join_element_part`'s element goes through `to_owned_key_shape` first (a deliberate optimization from #1044's own review, avoiding a deep-copy of a container whose contents the algorithm doesn't need) — and that helper *always* produces an empty `IndexMap` for any object, regardless of its real field count. So an `.is_empty()` check on the already-collapsed value can't distinguish "genuinely empty" from "non-empty, contents unread" — confirmed live: my first attempt at this fix wrongly rendered `{"a":1}` as `{}` too. Fixed by checking emptiness on the live `StandardJson::Object` cursor (`JsonFields::is_empty()`, O(1)) *before* the collapse, at the call site in `builtin_join`. `yq_join_separator`'s own `sep` value goes through `result_to_owned` (the full materializer) instead, so it needed no such cursor-level check — a plain `.is_empty()` guard works there.

2. **NaN/Infinity spelling**: a document-sourced `.nan`/`.inf`/`-.inf` element or separator loses its YAML spelling, rendering as `to_json_yq()`'s RFC-8259 `"null"` substitution instead. Fixed by routing through `nonfinite_display_string` — the same helper #1060 (merged just before this PR) added for the identical gap in `tostring`/`@text`/etc.

Fixes #1047

## Test plan

- [x] `test_yq_join_empty_object_renders_as_literal_text_1047` — covers empty-object element, non-empty-object element (the specific case my first attempt got wrong), and empty-object separator.
- [x] `test_yq_join_special_float_element_and_separator_use_yaml_spelling_1047` — covers `.nan`/`.inf` element and `.nan` separator.
- [x] Full oracle sweep against pinned real yq v4.53.3 across empty/non-empty object and array, both as element and separator — all match.
- [x] jq mode confirmed unaffected (both succinctly and real jq error identically on `join` with an object input, since all changes are inside the `S::TAG == EvalTag::Yq` branch).
- [x] `cargo test --features cli,simd,regex,serde` (incl. golden/path-consistency suites) — 662 passed, 0 failed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo check --no-default-features` (no_std) — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.

All verification run sequentially (no concurrent cargo invocations against the same worktree).