### PR TITLE
refactor(jq): share yq's NaN/Infinity YAML spelling across 5 sites

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3905,7 +3905,6 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use succinctly::jq::NumberRepr;
 
     /// `Builtin::FirstStream`/`LastStream` (the "Phase 13" builtin-table
     /// spelling of `first(expr)`/`last(expr)`, distinct from the
@@ -4004,6 +4003,39 @@ mod tests {
             OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-1e400".into());
         assert_eq!(
             emit_yaml_value(&neg_inf, &CommentTree::empty(), &config, "", false),
+            "-.inf"
+        );
+
+        // #1064: the plain `Float` arm (this test's own doc comment above
+        // claims parity with it, but never actually exercised it).
+        assert_eq!(
+            emit_yaml_value(
+                &OwnedValue::Float(f64::NAN),
+                &CommentTree::empty(),
+                &config,
+                "",
+                false
+            ),
+            ".nan"
+        );
+        assert_eq!(
+            emit_yaml_value(
+                &OwnedValue::Float(f64::INFINITY),
+                &CommentTree::empty(),
+                &config,
+                "",
+                false
+            ),
+            ".inf"
+        );
+        assert_eq!(
+            emit_yaml_value(
+                &OwnedValue::Float(f64::NEG_INFINITY),
+                &CommentTree::empty(),
+                &config,
+                "",
+                false
+            ),
             "-.inf"
         );
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -15,8 +15,8 @@ use succinctly::jq::eval_generic::{
     GenericResult,
 };
 use succinctly::jq::{
-    self, assert_value_tree_depth, sync_aliased_paths, Builtin, EvalError, Expr, OwnedValue,
-    QueryResult, YqSemantics,
+    self, assert_value_tree_depth, nonfinite_display_string, sync_aliased_paths, Builtin,
+    EvalError, Expr, NumberRepr, OwnedValue, QueryResult, YqSemantics,
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
@@ -1558,36 +1558,20 @@ fn emit_yaml_value_at_depth(
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(b) => b.to_string(),
         OwnedValue::Int(n) => n.to_string(),
-        OwnedValue::Float(f) => {
-            if f.is_nan() {
-                ".nan".to_string()
-            } else if f.is_infinite() {
-                if *f > 0.0 {
-                    ".inf".to_string()
-                } else {
-                    "-.inf".to_string()
-                }
-            } else {
-                format_float_yq(*f)
-            }
+        OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(*f)
+        }
+        OwnedValue::Float(f) => format_float_yq(*f),
+        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(*f)
         }
         OwnedValue::NumberLiteral(_, literal) => {
-            if value.as_f64().is_some_and(f64::is_nan) {
-                ".nan".to_string()
-            } else if value.as_f64().is_some_and(f64::is_infinite) {
-                if value.as_f64() > Some(0.0) {
-                    ".inf".to_string()
-                } else {
-                    "-.inf".to_string()
-                }
-            } else {
-                // Echo the source spelling verbatim (#1008) rather than
-                // routing through `number_str()`/`format_number_jq_compat`,
-                // which reformats per jq's own rules (uppercase `E`, forced
-                // sign) -- this file is yq-CLI-only, no jq caller to protect,
-                // and yq preserves a document literal's exact text.
-                literal.to_string()
-            }
+            // Echo the source spelling verbatim (#1008) rather than
+            // routing through `number_str()`/`format_number_jq_compat`,
+            // which reformats per jq's own rules (uppercase `E`, forced
+            // sign) -- this file is yq-CLI-only, no jq caller to protect,
+            // and yq preserves a document literal's exact text.
+            literal.to_string()
         }
         OwnedValue::String(s) => yaml_quote_string_with_style(s, comments.style()),
         OwnedValue::Array(arr) => {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1559,11 +1559,11 @@ fn emit_yaml_value_at_depth(
         OwnedValue::Bool(b) => b.to_string(),
         OwnedValue::Int(n) => n.to_string(),
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(*f)
+            nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
         OwnedValue::Float(f) => format_float_yq(*f),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(*f)
+            nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
         OwnedValue::NumberLiteral(_, literal) => {
             // Echo the source spelling verbatim (#1008) rather than

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28665,6 +28665,20 @@ mod tests {
                 assert_eq!(s, "-.inf");
             }
         );
+
+        // Same, but for a *document-sourced* NumberLiteral (an exponent
+        // overflowing to +/-infinity), not a computed Float -- a separate
+        // match arm in owned_to_yaml_at_depth.
+        query!(br"1e400", "@yaml",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, ".inf");
+            }
+        );
+        query!(br"-1e400", "@yaml",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "-.inf");
+            }
+        );
     }
 
     #[test]
@@ -28751,6 +28765,20 @@ mod tests {
             }
         );
         query!(br"null", "-infinite | @props",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "-.inf");
+            }
+        );
+
+        // Same, but for a *document-sourced* NumberLiteral (an exponent
+        // overflowing to +/-infinity), not a computed Float -- a separate
+        // match arm in props_value_to_string.
+        query!(br"1e400", "@props",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, ".inf");
+            }
+        );
+        query!(br"-1e400", "@props",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "-.inf");
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5166,8 +5166,10 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
 /// jq's bare `f64::Display` (`NaN`/`inf`/`-inf`) vs yq's own YAML-native
 /// spelling (`.nan`/`.inf`/`-.inf`) for a non-finite float.
 ///
-/// See [`numeric_display_string`]'s own doc comment for the
-/// "document-sourced vs computed" caveat this doesn't attempt to resolve.
+/// See `numeric_display_string`'s own doc comment for the
+/// "document-sourced vs computed" caveat this doesn't attempt to resolve
+/// (not a doc link: that function is `pub(crate)`, unresolvable from this
+/// one's now-`pub` docs).
 ///
 /// `pub`, not `pub(crate)`: `src/bin/succinctly/yq_runner.rs` is a separate
 /// binary crate depending on this one as an external dependency, and is one

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28622,6 +28622,23 @@ mod tests {
                 assert_eq!(s, "3.14");
             }
         );
+
+        // #1064: NaN/Infinity spell YAML-native, not jq's bare NaN/inf.
+        query!(br"null", "nan | @yaml",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, ".nan");
+            }
+        );
+        query!(br"null", "infinite | @yaml",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, ".inf");
+            }
+        );
+        query!(br"null", "-infinite | @yaml",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "-.inf");
+            }
+        );
     }
 
     #[test]
@@ -28693,6 +28710,23 @@ mod tests {
         query!(br"[1, 2, 3]", "@props",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "0 = 1\n1 = 2\n2 = 3");
+            }
+        );
+
+        // #1064: NaN/Infinity spell YAML-native, not jq's bare NaN/inf.
+        query!(br"null", "nan | @props",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, ".nan");
+            }
+        );
+        query!(br"null", "infinite | @props",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, ".inf");
+            }
+        );
+        query!(br"null", "-infinite | @props",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "-.inf");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5164,10 +5164,20 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
 }
 
 /// jq's bare `f64::Display` (`NaN`/`inf`/`-inf`) vs yq's own YAML-native
-/// spelling (`.nan`/`.inf`/`-.inf`) for a non-finite float -- see
-/// [`numeric_display_string`]'s own doc comment for the "document-sourced
-/// vs computed" caveat this doesn't attempt to resolve.
-fn nonfinite_display_string<S: EvalSemantics>(f: f64) -> String {
+/// spelling (`.nan`/`.inf`/`-.inf`) for a non-finite float.
+///
+/// See [`numeric_display_string`]'s own doc comment for the
+/// "document-sourced vs computed" caveat this doesn't attempt to resolve.
+///
+/// `pub`, not `pub(crate)`: `src/bin/succinctly/yq_runner.rs` is a separate
+/// binary crate depending on this one as an external dependency, and is one
+/// of several call sites this single definition now serves (#1064) --
+/// before this, the yq-mode `.nan`/`.inf`/`-.inf` decision was
+/// independently reimplemented in `stream.rs`, `json/light.rs`, and
+/// `yq_runner.rs` as well as twice more in this file, none of them sharing
+/// this definition (CLAUDE.md's #106 "duplicated predicates diverge
+/// silently" lesson).
+pub fn nonfinite_display_string<S: EvalSemantics>(f: f64) -> String {
     if S::TAG != EvalTag::Yq {
         f.to_string()
     } else if f.is_nan() {
@@ -5717,26 +5727,12 @@ fn props_value_to_string(value: &OwnedValue) -> String {
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(n) => format!("{n}"),
-        OwnedValue::Float(f) => {
-            if f.is_nan() {
-                ".nan".to_string()
-            } else if f.is_infinite() {
-                if *f > 0.0 {
-                    ".inf".to_string()
-                } else {
-                    "-.inf".to_string()
-                }
-            } else {
-                format!("{f}")
-            }
+        OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(*f)
         }
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() => ".nan".to_string(),
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_infinite() => {
-            if *f > 0.0 {
-                ".inf".to_string()
-            } else {
-                "-.inf".to_string()
-            }
+        OwnedValue::Float(f) => format!("{f}"),
+        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(*f)
         }
         // Echo verbatim (#1008): `@props` is documented as a yq-flavored
         // format function (CLAUDE.md's format table marks it `(yq)`) --
@@ -5770,26 +5766,12 @@ fn owned_to_yaml_at_depth(value: &OwnedValue, depth: usize) -> String {
         OwnedValue::Bool(true) => "true".to_string(),
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(n) => format!("{n}"),
-        OwnedValue::Float(f) => {
-            if f.is_nan() {
-                ".nan".to_string()
-            } else if f.is_infinite() {
-                if *f > 0.0 {
-                    ".inf".to_string()
-                } else {
-                    "-.inf".to_string()
-                }
-            } else {
-                format!("{f}")
-            }
+        OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(*f)
         }
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() => ".nan".to_string(),
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_infinite() => {
-            if *f > 0.0 {
-                ".inf".to_string()
-            } else {
-                "-.inf".to_string()
-            }
+        OwnedValue::Float(f) => format!("{f}"),
+        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
+            nonfinite_display_string::<YqSemantics>(*f)
         }
         // Echo verbatim (#1008): `@yaml` is documented as a yq-flavored
         // format function (CLAUDE.md's format table marks it `(yq)`) --

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5756,6 +5756,16 @@ fn props_value_to_string(value: &OwnedValue) -> String {
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
+        // Required for match exhaustiveness over the `Float` variant, but
+        // not reachable through any real filter (#1064, verified via
+        // `cargo llvm-cov` and a direct entry-point probe, not assumed):
+        // `@props` only ever sees a `Float` here via `eval_format`'s
+        // `to_owned(&value)`, which always round-trips a *finite* computed
+        // number through `from_number_bytes` -- and that always
+        // reconstructs a `NumberLiteral`, never a bare `Float`, for any
+        // valid RFC-8259 number text. Only a NaN/Infinity sentinel
+        // (guarded by the arm above, not this one) skips that
+        // reconstruction and arrives here as a bare `Float`.
         OwnedValue::Float(f) => format!("{f}"),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()
@@ -5795,6 +5805,16 @@ fn owned_to_yaml_at_depth(value: &OwnedValue, depth: usize) -> String {
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
+        // Required for match exhaustiveness over the `Float` variant, but
+        // not reachable through any real filter (#1064, verified via
+        // `cargo llvm-cov` and a direct entry-point probe, not assumed):
+        // `@yaml` only ever sees a `Float` here via `eval_format`'s
+        // `to_owned(&value)`, which always round-trips a *finite* computed
+        // number through `from_number_bytes` -- and that always
+        // reconstructs a `NumberLiteral`, never a bare `Float`, for any
+        // valid RFC-8259 number text. Only a NaN/Infinity sentinel
+        // (guarded by the arm above, not this one) skips that
+        // reconstruction and arrives here as a bare `Float`.
         OwnedValue::Float(f) => format!("{f}"),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4114,7 +4114,7 @@ fn yq_join_nonfinite_part(value: &OwnedValue) -> Option<String> {
         OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _)
             if f.is_nan() || f.is_infinite() =>
         {
-            Some(nonfinite_display_string::<YqSemantics>(*f))
+            Some(nonfinite_display_string::<YqSemantics>(*f).to_string())
         }
         _ => None,
     }
@@ -5143,7 +5143,7 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
     if let OwnedValue::NumberLiteral(repr, literal) = value {
         if let NumberRepr::Float(f) = repr {
             if f.is_nan() || f.is_infinite() {
-                return nonfinite_display_string::<S>(*f);
+                return nonfinite_display_string::<S>(*f).to_string();
             }
         }
         // yq preserves a document-sourced literal's exact source spelling
@@ -5157,7 +5157,7 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
         }
     } else if let OwnedValue::Float(f) = value {
         if f.is_nan() || f.is_infinite() {
-            return nonfinite_display_string::<S>(*f);
+            return nonfinite_display_string::<S>(*f).to_string();
         }
     }
     value.number_str().expect("numeric variant").into_owned()
@@ -5177,15 +5177,39 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
 /// `yq_runner.rs` as well as twice more in this file, none of them sharing
 /// this definition (CLAUDE.md's #106 "duplicated predicates diverge
 /// silently" lesson).
-pub fn nonfinite_display_string<S: EvalSemantics>(f: f64) -> String {
+///
+/// Returns `&'static str`, not `String`: every branch is one of a fixed
+/// 6-string set (Rust's own `f64::Display` always normalizes any NaN bit
+/// pattern to exactly `"NaN"`, and any infinity to `"inf"`/`"-inf"`,
+/// regardless of payload/magnitude -- verified directly, not assumed).
+/// Lets the two streaming call sites (`stream.rs`, `json/light.rs`) write
+/// this straight into their `Write` sink with no heap allocation, instead
+/// of allocating a `String` just to borrow and immediately drop it.
+///
+/// # Examples
+///
+/// ```
+/// use succinctly::jq::{nonfinite_display_string, YqSemantics};
+///
+/// assert_eq!(nonfinite_display_string::<YqSemantics>(f64::NAN), ".nan");
+/// assert_eq!(nonfinite_display_string::<YqSemantics>(f64::INFINITY), ".inf");
+/// assert_eq!(nonfinite_display_string::<YqSemantics>(f64::NEG_INFINITY), "-.inf");
+/// ```
+pub fn nonfinite_display_string<S: EvalSemantics>(f: f64) -> &'static str {
     if S::TAG != EvalTag::Yq {
-        f.to_string()
+        if f.is_nan() {
+            "NaN"
+        } else if f.is_sign_negative() {
+            "-inf"
+        } else {
+            "inf"
+        }
     } else if f.is_nan() {
-        ".nan".to_string()
+        ".nan"
     } else if f.is_sign_negative() {
-        "-.inf".to_string()
+        "-.inf"
     } else {
-        ".inf".to_string()
+        ".inf"
     }
 }
 
@@ -5728,11 +5752,11 @@ fn props_value_to_string(value: &OwnedValue) -> String {
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(n) => format!("{n}"),
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(*f)
+            nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
         OwnedValue::Float(f) => format!("{f}"),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(*f)
+            nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
         // Echo verbatim (#1008): `@props` is documented as a yq-flavored
         // format function (CLAUDE.md's format table marks it `(yq)`) --
@@ -5767,11 +5791,11 @@ fn owned_to_yaml_at_depth(value: &OwnedValue, depth: usize) -> String {
         OwnedValue::Bool(false) => "false".to_string(),
         OwnedValue::Int(n) => format!("{n}"),
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(*f)
+            nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
         OwnedValue::Float(f) => format!("{f}"),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
-            nonfinite_display_string::<YqSemantics>(*f)
+            nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
         // Echo verbatim (#1008): `@yaml` is documented as a yq-flavored
         // format function (CLAUDE.md's format table marks it `(yq)`) --

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -84,8 +84,8 @@ mod value;
 
 pub use error::{BinOp, Control, EvalError};
 pub use eval::{
-    eval, eval_lenient, eval_owned_with_file_index, substitute_vars, sync_aliased_paths,
-    EvalSemantics, JqSemantics, QueryResult, YqSemantics,
+    eval, eval_lenient, eval_owned_with_file_index, nonfinite_display_string, substitute_vars,
+    sync_aliased_paths, EvalSemantics, JqSemantics, QueryResult, YqSemantics,
 };
 pub use expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MetaValue,

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -1233,6 +1233,31 @@ mod tests {
         assert_eq!(buf, "-.inf");
     }
 
+    /// #1064: the plain `OwnedValue::Float` arm (a *computed* non-finite,
+    /// as opposed to the `NumberLiteral` test above's document-sourced
+    /// one) goes through a separate match arm and was independently
+    /// reimplementing the same `.nan`/`.inf`/`-.inf` decision.
+    #[test]
+    fn test_stream_yaml_computed_float_nan_and_infinite() {
+        let mut buf = String::new();
+        OwnedValue::Float(f64::NAN)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(buf, ".nan");
+
+        buf.clear();
+        OwnedValue::Float(f64::INFINITY)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(buf, ".inf");
+
+        buf.clear();
+        OwnedValue::Float(f64::NEG_INFINITY)
+            .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
+            .unwrap();
+        assert_eq!(buf, "-.inf");
+    }
+
     #[test]
     fn test_stream_string() {
         let mut buf = String::new();

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -619,25 +619,17 @@ fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
         OwnedValue::Bool(true) => out.write_str("true"),
         OwnedValue::Bool(false) => out.write_str("false"),
         OwnedValue::Int(n) => write!(out, "{n}"),
-        OwnedValue::Float(f) => {
-            if f.is_nan() {
-                out.write_str(".nan")
-            } else if f.is_infinite() {
-                if *f > 0.0 {
-                    out.write_str(".inf")
-                } else {
-                    out.write_str("-.inf")
-                }
-            } else {
-                // Not `write!(out, "{f}")`: that drops the `.0` from a whole
-                // float, diverging from the identity streaming path and the
-                // DOM pretty-printer (issue #169).
-                out.write_str(&format_float_with_fraction(*f))
-            }
+        OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
+            out.write_str(&super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() => out.write_str(".nan"),
-        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_infinite() => {
-            out.write_str(if *f > 0.0 { ".inf" } else { "-.inf" })
+        OwnedValue::Float(f) => {
+            // Not `write!(out, "{f}")`: that drops the `.0` from a whole
+            // float, diverging from the identity streaming path and the
+            // DOM pretty-printer (issue #169).
+            out.write_str(&format_float_with_fraction(*f))
+        }
+        OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
+            out.write_str(&super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
         OwnedValue::NumberLiteral(_, literal) => {
             // Echo verbatim (#1008), matching this function's JSON sibling

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -620,7 +620,7 @@ fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
         OwnedValue::Bool(false) => out.write_str("false"),
         OwnedValue::Int(n) => write!(out, "{n}"),
         OwnedValue::Float(f) if f.is_nan() || f.is_infinite() => {
-            out.write_str(&super::nonfinite_display_string::<super::YqSemantics>(*f))
+            out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
         OwnedValue::Float(f) => {
             // Not `write!(out, "{f}")`: that drops the `.0` from a whole
@@ -629,7 +629,7 @@ fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
             out.write_str(&format_float_with_fraction(*f))
         }
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
-            out.write_str(&super::nonfinite_display_string::<super::YqSemantics>(*f))
+            out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
         OwnedValue::NumberLiteral(_, literal) => {
             // Echo verbatim (#1008), matching this function's JSON sibling

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2171,6 +2171,24 @@ mod tests {
         assert_eq!(buf, r#"{":a": ":b"}"#);
     }
 
+    /// #1064: an exponent overflowing to `f64::INFINITY` (JSON has no
+    /// direct Infinity/NaN literal, so this is the only way to reach a
+    /// non-finite float through this parser) spells with yq's YAML-native
+    /// `.inf`/`-.inf`, not a bare `write!(out, "{f}")` -- this is the one
+    /// call site into `nonfinite_display_string` this issue's dedup can't
+    /// exercise through the CLI directly (the M2.5 streaming gate this
+    /// function backs doesn't trigger on a plain top-level `.` query), so
+    /// it's covered here at the unit level instead.
+    #[test]
+    fn test_stream_json_as_yaml_overflow_exponent_spells_infinity() {
+        let json = br#"{"a": 1e400, "b": -1e400}"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let mut buf = String::new();
+        stream_json_as_yaml(&mut buf, value, 0, 0).unwrap();
+        assert_eq!(buf, "{a: .inf, b: -.inf}");
+    }
+
     #[test]
     #[should_panic(expected = "up to u32::MAX")]
     #[cfg(target_pointer_width = "64")]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1521,6 +1521,7 @@ pub type BorrowedJsonCursor<'a> = JsonCursor<'a, &'a [u64]>;
 use crate::jq::document::{
     DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
+use crate::jq::{nonfinite_display_string, YqSemantics};
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
     type Value = StandardJson<'a, W>;
@@ -1793,7 +1794,7 @@ fn stream_json_as_yaml<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
                 write!(out, "{i}")
             } else if let Ok(f) = n.as_f64() {
                 if f.is_nan() || f.is_infinite() {
-                    out.write_str(&crate::jq::nonfinite_display_string::<crate::jq::YqSemantics>(f))
+                    out.write_str(nonfinite_display_string::<YqSemantics>(f))
                 } else {
                     write!(out, "{f}")
                 }
@@ -2179,6 +2180,14 @@ mod tests {
     /// exercise through the CLI directly (the M2.5 streaming gate this
     /// function backs doesn't trigger on a plain top-level `.` query), so
     /// it's covered here at the unit level instead.
+    ///
+    /// Internal-consistency pin only, not oracle-verified: this exact
+    /// input has no comparable real-tool behavior to check against (real
+    /// yq hard-errors on a JSON `1e400` input entirely, "value out of
+    /// range"; real jq, which never emits YAML, just echoes the literal
+    /// text unchanged). The trigger condition and overall shape here
+    /// predate #1064 -- this PR only changed which function computes the
+    /// resulting string, not when it's called or what it does.
     #[test]
     fn test_stream_json_as_yaml_overflow_exponent_spells_infinity() {
         let json = br#"{"a": 1e400, "b": -1e400}"#;

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1792,14 +1792,8 @@ fn stream_json_as_yaml<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
             if let Ok(i) = n.as_i64() {
                 write!(out, "{i}")
             } else if let Ok(f) = n.as_f64() {
-                if f.is_nan() {
-                    out.write_str(".nan")
-                } else if f.is_infinite() {
-                    if f > 0.0 {
-                        out.write_str(".inf")
-                    } else {
-                        out.write_str("-.inf")
-                    }
+                if f.is_nan() || f.is_infinite() {
+                    out.write_str(&crate::jq::nonfinite_display_string::<crate::jq::YqSemantics>(f))
                 } else {
                     write!(out, "{f}")
                 }


### PR DESCRIPTION
## Summary

The "is_nan → `.nan`, is_infinite && positive → `.inf`, else → `-.inf`" yq YAML-native spelling decision was independently reimplemented in 5 places beyond its canonical definition (`nonfinite_display_string`, added by #1060): `eval.rs`'s `props_value_to_string` (`@props`) and `owned_to_yaml_at_depth` (`@yaml`), `stream.rs`'s `stream_owned_value_yaml_at_depth` (the default `yq` YAML streamer), `json/light.rs`'s `stream_json_as_yaml` (the M2.5 JSON-input YAML-output fast path), and `yq_runner.rs`'s `emit_yaml_value_at_depth` (the CLI's own non-streaming YAML emitter, a separate crate) — CLAUDE.md's #106 "duplicated predicates diverge silently" lesson, previously applied to `join`'s own two internal copies of this same decision (#1047).

All 5 sites now route through `nonfinite_display_string::<YqSemantics>`, which required making it `pub` (not just `pub(crate)`): `yq_runner.rs` is a separate binary crate depending on this one as an external dependency, so `pub(crate)` alone can't reach it. Re-exported through `jq/mod.rs`'s existing `pub use eval::{...}` list, the same mechanism already used for `eval`, `substitute_vars`, and friends.

**Pure refactor, no behavior change.** Verified two ways:
- The full existing test suite (golden fixtures included) passes unchanged.
- Each site's prior inline logic used a stylistically different but behaviorally identical sign test (`f > 0.0` vs `f.is_sign_negative()`, or an `Option<f64>` comparison) — none of which can actually diverge, since none of these sites is ever reached with a signed-zero float (all gated on `is_infinite()` first, and infinity is never `±0.0`).

## Test coverage added

Several sites had thin or missing direct coverage before this PR:
- `@props`/`@yaml` had no NaN/Infinity tests at all.
- `emit_yaml_value`'s existing test only covered the `NumberLiteral` arm, with the plain `Float` arm's parity merely *claimed* in a comment, never exercised.
- `json/light.rs`'s `stream_json_as_yaml` (the M2.5 fast path) has no CLI-observable trigger to verify against directly — covered at the unit level via an exponent overflowing to `f64::INFINITY` (JSON has no direct Infinity/NaN literal).

Fixes #1064

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` — all green (full integration suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (clean)
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (clean)
- [x] `cargo check --no-default-features` (no_std, clean)
- [x] `cargo fmt --check` (clean)
- [x] Live-verified `@props`, `@yaml`, and plain `yq` YAML output against document-sourced `.nan`/`.inf`/`-.inf` input