### PR TITLE
fix(yaml): attach a comment trailing a deferred anchor to its value, not its key

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -183,6 +183,18 @@ struct Parser<'a, const HAS_CR: bool> {
     /// See [`SemiIndex::line_comments`].
     line_comments: BTreeMap<usize, (u32, u32)>,
 
+    /// A comment trailing a `&anchor`/`!tag` whose value is deferred to a
+    /// later line, not yet attached to any node (#784).
+    ///
+    /// Real yq attaches such a comment to whatever node the deferred value
+    /// resolves to — its first child if one follows, or (if the value turns
+    /// out null) the next sibling entirely — never to the anchor's own key
+    /// line. That target doesn't exist yet at the point the comment is
+    /// scanned, so [`Self::defer_line_comment`] stashes the byte range here
+    /// and [`Self::take_pending_head_comment`] claims it once the next
+    /// primary node (a mapping key or sequence item) actually opens.
+    pending_head_comment: Option<(u32, u32)>,
+
     // Document tracking
     /// Whether we're currently inside a document
     in_document: bool,
@@ -276,6 +288,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             aliases: BTreeMap::new(),
             tags: BTreeMap::new(),
             line_comments: BTreeMap::new(),
+            pending_head_comment: None,
             in_document: false,
             document_start_bp_pos: 0,
             pending_explicit_key: None,
@@ -475,6 +488,66 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             self.line_comments
                 .entry(owner_bp_pos)
                 .or_insert((start as u32, p as u32));
+        }
+    }
+
+    /// Like [`Self::maybe_capture_line_comment`], but the owning node doesn't
+    /// exist yet: stash the comment's byte range in
+    /// [`Self::pending_head_comment`] instead of `line_comments` directly.
+    /// [`Self::take_pending_head_comment`] attaches it once that node opens
+    /// (#784).
+    #[inline]
+    fn defer_line_comment(&mut self) {
+        let mut p = self.pos;
+        while p < self.input.len() && Self::is_inline_whitespace(self.input[p]) {
+            p += 1;
+        }
+        if p < self.input.len() && self.input[p] == b'#' {
+            let start = p;
+            while p < self.input.len() && !Self::is_break(self.input[p]) {
+                p += 1;
+            }
+            self.pending_head_comment = Some((start as u32, p as u32));
+        }
+    }
+
+    /// Claim a comment deferred by [`Self::defer_line_comment`] for
+    /// `owner_bp_pos`, if one is pending (#784).
+    ///
+    /// Called at whichever bp_pos the *renderer* actually reads a trailing
+    /// comment from for that shape of node, mirroring the bp each call
+    /// site's own ordinary (non-deferred) same-line comment already
+    /// attaches to: a mapping key (`parse_mapping_entry`,
+    /// `parse_compact_mapping_entry` — both read from the key regardless of
+    /// whether the value is inline or deferred further) or a plain-scalar
+    /// sequence item's own scalar (`parse_sequence_item_inner`, after
+    /// `parse_value` returns — a sequence item's *wrapper* bp is never
+    /// read, only its content's). Never call this for a node the deferred
+    /// value's own null-value fallback opens inline, or the comment would
+    /// misattach to the anchor's own empty value instead of floating to the
+    /// next sibling, matching real yq's own behavior.
+    #[inline]
+    fn take_pending_head_comment(&mut self, owner_bp_pos: usize) {
+        if let Some(range) = self.pending_head_comment.take() {
+            self.line_comments.entry(owner_bp_pos).or_insert(range);
+        }
+    }
+
+    /// Drop a [`Self::pending_head_comment`] that survived one full
+    /// document-line dispatch completely untouched — neither consumed by
+    /// [`Self::take_pending_head_comment`] nor replaced by a fresh
+    /// [`Self::defer_line_comment`] call chained off that same line's own
+    /// anchor (#784). `before` is the value observed prior to the dispatch;
+    /// comparing by value, not just presence, is what tells "untouched" apart
+    /// from "consumed, then a new one queued in its place" when a line
+    /// chains two deferred anchors (`a: &x # c1` immediately followed by
+    /// `b: &y # c2`) — a boolean "was something pending" flag can't
+    /// distinguish those, and would wipe out `c2` before it ever got a
+    /// chance to attach.
+    #[inline]
+    fn drop_stale_pending_head_comment(&mut self, before: Option<(u32, u32)>) {
+        if before.is_some() && self.pending_head_comment == before {
+            self.pending_head_comment = None;
         }
     }
 
@@ -1171,6 +1244,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     fn start_document(&mut self) {
         self.in_document = true;
         self.document_start_bp_pos = self.bp_pos;
+        // A comment deferred by an anchor in a *previous* document (#784)
+        // has no node left to attach to once a new document starts -
+        // `parse_document_line`'s own one-line grace period already covers
+        // ordinary lines, but a document boundary can be reached via
+        // `parse_inline_document_value` instead, which doesn't go through
+        // that backstop.
+        self.pending_head_comment = None;
     }
 
     /// End the current document, closing any open containers.
@@ -2146,6 +2226,14 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Open the sequence item node
         self.write_bp_open_seq_item();
+        // Deliberately not a `take_pending_head_comment` call site (#784):
+        // this wrapper's own bp is never what the emitter reads for a
+        // trailing comment on this line — a plain-scalar item's line
+        // comment lives on the *scalar's* own bp (see the `take_pending_head_comment`
+        // call after `parse_value` below), and any other continuation
+        // (compact-mapping key, a nested `parse_mapping_entry`/
+        // `parse_sequence_item` reached via a fresh line dispatch) claims it
+        // at its own, already-instrumented key/wrapper-open site instead.
 
         // Skip `- `
         self.advance(); // -
@@ -2179,6 +2267,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Check what follows
         if self.at_line_end() {
+            // A trailing comment here belongs to this item's own deferred
+            // value, not to the item's dash line (#784, same shape as
+            // `parse_mapping_entry`'s anchor case) - only when there was a
+            // property to defer it past; a bare `- # comment` has no anchor
+            // to blame the deferral on and is a separate, untouched gap.
+            if had_property {
+                self.defer_line_comment();
+            }
+
             // An anchor records the *next* BP position as its target, and a
             // tag is looked up *at* that position (`self.tags`), so a
             // property-prefixed item whose value turns out to be null needs
@@ -2259,6 +2356,14 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // Parse the item value normally
             // Pass structure indent for block scalars (content must be > this)
             self.parse_value(indent)?;
+            // Claim a comment deferred by an earlier anchor's deferred value
+            // (#784): a plain-scalar item's own trailing comment lives on
+            // the scalar's own bp (matching the ordinary, non-deferred
+            // `- 1 # comment` case, which `set_bp_text_end` inside
+            // `parse_value` already attaches there) - `self.last_open_bp_pos`
+            // still refers to that scalar here since nothing opens a BP
+            // node between `parse_value` returning and this point.
+            self.take_pending_head_comment(self.last_open_bp_pos);
             // Close the sequence item for simple values
             self.indent_stack.pop();
             self.pop_type();
@@ -2302,6 +2407,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Open key node
         self.write_bp_open();
+        // Claim a comment deferred by an earlier anchor's deferred value
+        // (#784), if this key is the first content to follow it.
+        self.take_pending_head_comment(self.last_open_bp_pos);
 
         // Check for a property on the key (`- &a k: v` / `- !!str k: v`) -
         // record it pointing to this key.
@@ -2517,6 +2625,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Open key node
         self.write_bp_open();
+        // Claim a comment deferred by an earlier anchor's deferred value
+        // (#784), if this key is the first content to follow it.
+        self.take_pending_head_comment(self.last_open_bp_pos);
 
         // Check for a property on the key - record it pointing to this key BP
         self.record_key_properties()?;
@@ -2718,6 +2829,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
             // After anchor, check if value continues on next line
             if self.at_line_end() {
+                // A trailing comment here belongs to the deferred value, not
+                // to this key's own line (#784, distinct from #765's
+                // no-anchor case) - defer it rather than dropping it;
+                // `take_pending_head_comment` claims it wherever the next
+                // primary node opens.
+                self.defer_line_comment();
+
                 // Need to check if the next line has content for this value,
                 // or if the value is null (same or lower indent on next line)
                 self.skip_to_eol();
@@ -5039,6 +5157,11 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
     /// Parse a single line of document content.
     fn parse_document_line(&mut self) -> Result<(), YamlError> {
+        // Snapshot for `drop_stale_pending_head_comment` below (#784): a
+        // comment deferred by an anchor on an *earlier* line gets exactly
+        // one line's worth of grace to be claimed by this dispatch.
+        let pending_head_comment_before = self.pending_head_comment;
+
         // Count indentation - but handle tabs specially for flow structures
         let indent = match self.count_indent() {
             Ok(n) => n,
@@ -5055,6 +5178,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                         self.parse_value(0)?;
                         // Move to next line if we haven't already
                         self.skip_line_break();
+                        self.drop_stale_pending_head_comment(pending_head_comment_before);
                         return Ok(());
                     }
                     _ => {
@@ -5093,6 +5217,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Move to next line if we haven't already
         self.skip_line_break();
+        self.drop_stale_pending_head_comment(pending_head_comment_before);
 
         Ok(())
     }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -465,17 +465,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         }
     }
 
-    /// Capture a trailing same-line comment for `owner_bp_pos`, if `self.pos`
-    /// is separated from a `#` only by inline whitespace (spaces/tabs) on the
-    /// current line. Does not consume any input — callers still run their own
-    /// `skip_to_eol`/`skip_newlines` afterward to actually advance past it.
-    ///
-    /// Uses `entry().or_insert()` rather than unconditional `insert()` so a
-    /// node captured explicitly at a more specific point (e.g. a block
-    /// scalar's header-line comment, captured before its content is parsed)
-    /// is never clobbered by a later, spurious call for the same bp_pos.
+    /// Scan for a trailing same-line comment starting at `self.pos`, if it's
+    /// separated from a `#` only by inline whitespace (spaces/tabs) on the
+    /// current line. Does not consume any input or record anything —
+    /// [`Self::maybe_capture_line_comment`] and [`Self::defer_line_comment`]
+    /// are the two storage-specific callers; kept as one scan so a future fix
+    /// to what counts as a trailing comment can't be applied to one and
+    /// silently missed in the other (the exact "duplicated predicates
+    /// diverge silently" risk this project has hit before).
     #[inline]
-    fn maybe_capture_line_comment(&mut self, owner_bp_pos: usize) {
+    fn scan_trailing_comment(&self) -> Option<(u32, u32)> {
         let mut p = self.pos;
         while p < self.input.len() && Self::is_inline_whitespace(self.input[p]) {
             p += 1;
@@ -485,9 +484,24 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             while p < self.input.len() && !Self::is_break(self.input[p]) {
                 p += 1;
             }
-            self.line_comments
-                .entry(owner_bp_pos)
-                .or_insert((start as u32, p as u32));
+            Some((start as u32, p as u32))
+        } else {
+            None
+        }
+    }
+
+    /// Capture a trailing same-line comment for `owner_bp_pos`. Callers
+    /// still run their own `skip_to_eol`/`skip_newlines` afterward to
+    /// actually advance past it.
+    ///
+    /// Uses `entry().or_insert()` rather than unconditional `insert()` so a
+    /// node captured explicitly at a more specific point (e.g. a block
+    /// scalar's header-line comment, captured before its content is parsed)
+    /// is never clobbered by a later, spurious call for the same bp_pos.
+    #[inline]
+    fn maybe_capture_line_comment(&mut self, owner_bp_pos: usize) {
+        if let Some(range) = self.scan_trailing_comment() {
+            self.line_comments.entry(owner_bp_pos).or_insert(range);
         }
     }
 
@@ -496,19 +510,23 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// [`Self::pending_head_comment`] instead of `line_comments` directly.
     /// [`Self::take_pending_head_comment`] attaches it once that node opens
     /// (#784).
+    ///
+    /// Never overwrites an already-outstanding pending comment: a nested
+    /// anchor can itself defer a second comment before the first is ever
+    /// claimed (`- &x # c1\n  - &y # c2\n    b: 1\n`, the outer sequence
+    /// item's `c1` still pending when the inner item's own `&y` defers
+    /// `c2`) — first-deferred-first-claimed keeps that outer comment alive
+    /// long enough for a consumption site to reach it, rather than silently
+    /// destroying it. This can't be told apart from "genuinely nothing
+    /// pending" by [`Self::drop_stale_pending_head_comment`]'s once-per-line
+    /// check, since the clobber (if it happened) would occur *before* that
+    /// check ever runs.
     #[inline]
     fn defer_line_comment(&mut self) {
-        let mut p = self.pos;
-        while p < self.input.len() && Self::is_inline_whitespace(self.input[p]) {
-            p += 1;
+        if self.pending_head_comment.is_some() {
+            return;
         }
-        if p < self.input.len() && self.input[p] == b'#' {
-            let start = p;
-            while p < self.input.len() && !Self::is_break(self.input[p]) {
-                p += 1;
-            }
-            self.pending_head_comment = Some((start as u32, p as u32));
-        }
+        self.pending_head_comment = self.scan_trailing_comment();
     }
 
     /// Claim a comment deferred by [`Self::defer_line_comment`] for
@@ -519,13 +537,23 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// site's own ordinary (non-deferred) same-line comment already
     /// attaches to: a mapping key (`parse_mapping_entry`,
     /// `parse_compact_mapping_entry` — both read from the key regardless of
-    /// whether the value is inline or deferred further) or a plain-scalar
-    /// sequence item's own scalar (`parse_sequence_item_inner`, after
-    /// `parse_value` returns — a sequence item's *wrapper* bp is never
-    /// read, only its content's). Never call this for a node the deferred
-    /// value's own null-value fallback opens inline, or the comment would
-    /// misattach to the anchor's own empty value instead of floating to the
-    /// next sibling, matching real yq's own behavior.
+    /// whether the value is inline or deferred further), a plain scalar
+    /// (`parse_block_node`'s catch-all arm), or a plain-scalar sequence
+    /// item's own scalar (`parse_sequence_item_inner`, after `parse_value`
+    /// returns — a sequence item's *wrapper* bp is never read, only its
+    /// content's). Never call this for a node the deferred value's own
+    /// null-value fallback opens inline, or the comment would misattach to
+    /// the anchor's own empty value instead of floating to the next
+    /// sibling, matching real yq's own behavior.
+    ///
+    /// **Ordering matters**: always call this *after* any ordinary
+    /// same-line capture for the same `owner_bp_pos` has already had its
+    /// chance to run (e.g. after `maybe_capture_line_comment`/
+    /// `set_bp_text_end`'s own call for that bp), never before. Both use the
+    /// same `entry().or_insert()` idiom, so whichever runs first wins the
+    /// slot — calling this first would silently destroy a node's own
+    /// genuine trailing comment in favor of an unrelated floated one instead
+    /// of just leaving the floated one to be dropped (#784 review).
     #[inline]
     fn take_pending_head_comment(&mut self, owner_bp_pos: usize) {
         if let Some(range) = self.pending_head_comment.take() {
@@ -2355,15 +2383,29 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         } else {
             // Parse the item value normally
             // Pass structure indent for block scalars (content must be > this)
+            let bp_pos_before_value = self.bp_pos;
             self.parse_value(indent)?;
             // Claim a comment deferred by an earlier anchor's deferred value
             // (#784): a plain-scalar item's own trailing comment lives on
             // the scalar's own bp (matching the ordinary, non-deferred
             // `- 1 # comment` case, which `set_bp_text_end` inside
-            // `parse_value` already attaches there) - `self.last_open_bp_pos`
-            // still refers to that scalar here since nothing opens a BP
-            // node between `parse_value` returning and this point.
-            self.take_pending_head_comment(self.last_open_bp_pos);
+            // `parse_value` already attaches there).
+            //
+            // Only for a genuine plain/quoted scalar, though: `parse_value`
+            // dispatching to a flow collection (`[1, 2]`/`{a: 1}`) opens one
+            // bp per element *after* the collection's own, leaving
+            // `self.last_open_bp_pos` pointing at the collection's *last
+            // inner element* rather than the collection or this item - a
+            // comment claimed there landed between the last element and the
+            // closing bracket, corrupting the emitted structure (#1081
+            // review). A plain scalar opens exactly one bp (at
+            // `bp_pos_before_value`, since `write_bp_open` records
+            // `last_open_bp_pos` before incrementing `bp_pos`); anything
+            // that opened more than that fails this check and safely drops
+            // the floated comment instead of misattaching it.
+            if self.last_open_bp_pos == bp_pos_before_value {
+                self.take_pending_head_comment(self.last_open_bp_pos);
+            }
             // Close the sequence item for simple values
             self.indent_stack.pop();
             self.pop_type();
@@ -2407,9 +2449,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Open key node
         self.write_bp_open();
-        // Claim a comment deferred by an earlier anchor's deferred value
-        // (#784), if this key is the first content to follow it.
-        self.take_pending_head_comment(self.last_open_bp_pos);
 
         // Check for a property on the key (`- &a k: v` / `- !!str k: v`) -
         // record it pointing to this key.
@@ -2462,23 +2501,44 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         //
         // `- k: &a 1` also never registered the anchor before this, so a later
         // `*a` resolved to nothing (#372). Tags follow the same rule (#224).
-        if !self.at_line_end() {
-            self.parse_node_properties()?;
-        }
+        let had_property = if !self.at_line_end() {
+            self.parse_node_properties()?
+        } else {
+            false
+        };
 
         // Parse value
         if self.at_line_end() {
-            // Value is on next line or implicit null. Capture a trailing
-            // comment on the key's own line first (issue #765) -
-            // `self.last_open_bp_pos` still holds the key node's bp_pos here
-            // since no value node has been opened yet (nothing opens a BP
-            // node between the key's own close above and this point). This
-            // mirrors `parse_mapping_entry`'s identical capture just below
-            // - missing here left a block-sequence item's *first* field
-            // (the only mapping entry parsed by this function rather than
-            // `parse_mapping_entry`) silently dropping its own key comment
-            // (#785).
-            self.maybe_capture_line_comment(self.last_open_bp_pos);
+            if had_property {
+                // An anchor/tag caused this deferral - the comment belongs
+                // to the deferred value, not this key's own line
+                // (#784/#1078, matching `parse_mapping_entry`'s identical
+                // split below) - defer it rather than capturing it here;
+                // `take_pending_head_comment` claims it wherever the next
+                // primary node opens.
+                self.defer_line_comment();
+            } else {
+                // No anchor - a trailing comment here is this key's own
+                // (issue #765) - `self.last_open_bp_pos` still holds the key
+                // node's bp_pos here since no value node has been opened yet
+                // (nothing opens a BP node between the key's own close above
+                // and this point). This mirrors `parse_mapping_entry`'s
+                // identical capture just below - missing here left a
+                // block-sequence item's *first* field (the only mapping
+                // entry parsed by this function rather than
+                // `parse_mapping_entry`) silently dropping its own key
+                // comment (#785).
+                //
+                // Falls back to a comment an *earlier*, unrelated anchor's
+                // deferred value floated onto this key (#784) only if this
+                // key's own line had nothing of its own - run the fallback
+                // second so a genuine same-line comment always wins the slot
+                // (#1081 review: consuming a floated comment eagerly at
+                // key-open, before this real capture had a chance to run,
+                // silently destroyed it).
+                self.maybe_capture_line_comment(self.last_open_bp_pos);
+                self.take_pending_head_comment(self.last_open_bp_pos);
+            }
             self.skip_to_eol();
 
             // Look ahead to determine if this is a null value or a nested structure
@@ -2563,6 +2623,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     self.write_bp_open();
                     let end_pos = self.parse_inline_value(indent)?;
                     self.set_bp_text_end(end_pos);
+                    // Claim a comment deferred by an earlier anchor's
+                    // deferred value (#784), if this value's own line had no
+                    // comment of its own - run after `set_bp_text_end`'s own
+                    // capture just above so a genuine same-line comment
+                    // always wins the slot. Needed for a deferred value
+                    // whose first line is itself a compact mapping with an
+                    // inline scalar (`a: &anc # comment\n  - key: 1`) - `1`
+                    // is this exact arm.
+                    self.take_pending_head_comment(self.last_open_bp_pos);
                     self.write_bp_close();
                 }
             }
@@ -2625,9 +2694,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Open key node
         self.write_bp_open();
-        // Claim a comment deferred by an earlier anchor's deferred value
-        // (#784), if this key is the first content to follow it.
-        self.take_pending_head_comment(self.last_open_bp_pos);
 
         // Check for a property on the key - record it pointing to this key BP
         self.record_key_properties()?;
@@ -2695,7 +2761,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // `self.last_open_bp_pos` still holds the key node's bp_pos here
             // since no value node has been opened yet (nothing opens a BP
             // node between the key's own close above and this point).
+            //
+            // Falls back to a comment an *earlier*, unrelated anchor's
+            // deferred value floated onto this key (#784) only if this
+            // key's own line had nothing of its own - run the fallback
+            // second so a genuine same-line comment always wins the slot
+            // (#1081 review: consuming a floated comment eagerly at
+            // key-open, before this real capture had a chance to run,
+            // silently destroyed it).
             self.maybe_capture_line_comment(self.last_open_bp_pos);
+            self.take_pending_head_comment(self.last_open_bp_pos);
             self.skip_to_eol();
 
             // Look ahead to see what the next content line looks like
@@ -2932,6 +3007,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     self.write_bp_open();
                     let end_pos = self.parse_inline_value(indent)?;
                     self.set_bp_text_end(end_pos);
+                    // Claim a comment deferred by an earlier anchor's
+                    // deferred value (#784), if this value's own line had no
+                    // comment of its own - run after `set_bp_text_end`'s own
+                    // capture (called just above) so a genuine same-line
+                    // comment always wins the slot. This is what makes the
+                    // issue's own repro work: `a: &anc # comment\n  b: 1`
+                    // resolves `a`'s deferred value to this exact scalar arm
+                    // for key `b`'s own value `1`, not a nested structure.
+                    self.take_pending_head_comment(self.last_open_bp_pos);
                     self.write_bp_close();
                 }
             }
@@ -3202,6 +3286,19 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Check if value is on this line or next
         if self.at_line_end() {
+            // An anchor/tag caused this deferral - the comment belongs to
+            // the deferred value, not this line (#784, same shape as
+            // `parse_mapping_entry`'s/`parse_sequence_item_inner`'s
+            // identical split) - defer it rather than dropping it;
+            // `take_pending_head_comment` claims it wherever the next
+            // primary node opens. No no-anchor equivalent here (unlike
+            // `parse_mapping_entry`'s #765 capture) - a bare `: # comment`
+            // with no property has never captured its own trailing comment
+            // at all, a separate, pre-existing gap outside this issue's scope.
+            if had_property {
+                self.defer_line_comment();
+            }
+
             // A property on a value that turns out to be null needs an
             // explicit node to resolve against, or it dangles on whatever BP
             // bit comes next - a close, or the open of an unrelated node.
@@ -5359,6 +5456,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                                 }
                             };
                             self.set_bp_text_end(end_pos);
+                            // Claim a comment deferred by an earlier anchor's
+                            // deferred value (#784), if this scalar's own
+                            // line had no comment of its own - run after
+                            // `set_bp_text_end`'s own capture just above so
+                            // a genuine same-line comment always wins the
+                            // slot. This is the property-then-scalar
+                            // sibling of the plain-scalar arm below (e.g. a
+                            // chained `&y hello` continuing an outer
+                            // deferral).
+                            self.take_pending_head_comment(self.last_open_bp_pos);
                             self.write_bp_close();
                         }
                     }
@@ -5413,6 +5520,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                         }
                     };
                     self.set_bp_text_end(end_pos);
+                    // Claim a comment deferred by an earlier anchor's
+                    // deferred value (#784), if this scalar's own line had
+                    // no comment of its own - run after `set_bp_text_end`'s
+                    // own capture just above so a genuine same-line comment
+                    // always wins the slot. This is the single most common
+                    // shape a deferred anchor value resolves to: a plain or
+                    // quoted scalar folded onto the next line with no
+                    // container and no property of its own (`a: &anc #
+                    // comment\n  hello`).
+                    self.take_pending_head_comment(self.last_open_bp_pos);
                     self.write_bp_close();
                 }
             }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9110,6 +9110,149 @@ fn test_key_comment_preserved_with_null_value_and_sort_keys_765() -> Result<()> 
 }
 
 // ============================================================================
+// Anchor-deferred trailing comment (#784)
+// ============================================================================
+//
+// Distinct from #765 above: #765 covers a comment trailing a *key*'s own
+// line with no anchor (`a: # comment\n  b: 1`, attaches to the key). This
+// covers a comment trailing an `&anchor`/`!tag` that itself defers the
+// value (`a: &anc # comment\n  b: 1`) - real yq attaches that comment to
+// the deferred value's own first line instead (`b: 1 # comment`), never to
+// the anchor's key line. When the anchor's value turns out null, the
+// comment floats past it to whatever comes next in the document (the next
+// sibling key or item) rather than disappearing - verified against the
+// pinned real `yq` binary for every shape below, same discipline as #765.
+
+/// The issue's own repro: an anchor's trailing comment, value deferred to a
+/// nested mapping.
+#[test]
+fn test_anchor_comment_preserved_with_nested_mapping_value_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\n  b: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc\n  b: 1 # comment\n");
+    Ok(())
+}
+
+/// Same shape, but the deferred value is a nested sequence rather than a
+/// nested mapping - the comment attaches to the first item.
+#[test]
+fn test_anchor_comment_preserved_with_nested_sequence_value_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\n  - 1\n  - 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc\n  - 1 # comment\n  - 2\n");
+    Ok(())
+}
+
+/// The deferred value's first line is itself a mapping key with no inline
+/// scalar (further deferred again) - the comment lands on that key's own
+/// line, matching #765's own key-attachment convention recursively.
+#[test]
+fn test_anchor_comment_preserved_with_doubly_nested_mapping_value_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\n  b:\n    c: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc\n  b: # comment\n    c: 1\n");
+    Ok(())
+}
+
+/// The deferred value's first item is itself a compact mapping (`- key:
+/// value`) - the comment lands on that item's own key, matching a plain
+/// mapping entry's own attachment convention.
+#[test]
+fn test_anchor_comment_preserved_with_compact_mapping_sequence_value_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\n  - key: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc\n  - key: 1 # comment\n");
+    Ok(())
+}
+
+/// A sequence *item's own* anchor (not a mapping key's) can defer its value
+/// the same way - the comment attaches to the nested mapping's key exactly
+/// as it does for the mapping-key-anchor case above.
+#[test]
+fn test_anchor_comment_preserved_on_sequence_item_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- &anc # comment\n  b: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- &anc\n  b: 1 # comment\n");
+    Ok(())
+}
+
+/// Same shape, but the deferred value is a nested sequence (`- - 1`) -
+/// exercises the recursive sequence-item-inside-sequence-item path.
+#[test]
+fn test_anchor_comment_preserved_on_sequence_item_with_nested_sequence_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\n  - - 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc\n  - - 1 # comment\n");
+    Ok(())
+}
+
+/// Regression guard: a comment trailing a same-line (not deferred) anchored
+/// value keeps belonging to that value, unaffected by the new deferred-
+/// comment machinery.
+#[test]
+fn test_anchor_comment_not_deferred_for_same_line_value_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc 5 # comment\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc 5 # comment\n");
+    Ok(())
+}
+
+/// Regression guard: an anchor with no trailing comment at all is
+/// unaffected.
+#[test]
+fn test_anchor_no_comment_unaffected_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc\n  b: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc\n  b: 1\n");
+    Ok(())
+}
+
+// When the anchor's deferred value turns out null, the comment floats past
+// it to the next sibling rather than disappearing (or, at true EOF with no
+// sibling to float to, is dropped - matching real yq exactly there) - the
+// three tests below pin that behavior specifically. Note: succinctly
+// renders a null anchor value's own line as `&anc ""` here, not real yq's
+// bare `&anc` - that's a separate, pre-existing divergence in null-anchor
+// rendering (unrelated to comment placement, reproduces identically with no
+// comment present at all, e.g. plain `a: &anc\n` with EOF immediately after
+// - tracked as a follow-up, not part of #784's scope). Only the *comment's*
+// position (landing on the sibling's own line, or vanishing at EOF) is what
+// these tests pin.
+
+/// A sibling key immediately follows at the same indent - the anchor's
+/// deferred value is null, and its comment floats to the sibling.
+#[test]
+fn test_anchor_comment_floats_to_sibling_same_indent_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc \"\"\nb: 2 # comment\n");
+    Ok(())
+}
+
+/// Same shape, but the sibling that ends the anchor's deferred value sits
+/// at a lower indent than the anchor itself.
+#[test]
+fn test_anchor_comment_floats_to_sibling_lower_indent_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "x:\n  a: &anc # comment\n  b: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "x:\n  a: &anc \"\"\n  b: 2 # comment\n");
+    Ok(())
+}
+
+/// The deferred anchor is the last thing in the document - EOF ends it with
+/// no sibling to float to, so the comment is dropped entirely, matching
+/// real yq exactly (verified live: real yq also drops it here, unlike
+/// #765's own EOF case, where a *key's* deferred-null comment survives with
+/// no anchor involved).
+#[test]
+fn test_anchor_comment_dropped_at_eof_with_no_sibling_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc \"\"\n");
+    Ok(())
+}
+
+// ============================================================================
 // Explicit-key (`? k ... : v`) trailing comment (#795)
 // ============================================================================
 //

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9385,6 +9385,23 @@ fn test_anchor_floated_comment_does_not_corrupt_flow_mapping_784() -> Result<()>
     Ok(())
 }
 
+/// Two sequence items in a row, each with its own anchor and comment, the
+/// outer deferring into the inner before the outer's comment is ever
+/// claimed - exercises `defer_line_comment`'s guard against overwriting an
+/// already-pending comment. Real yq's own rendering for this exact shape is
+/// unusual (a standalone comment line, per #1080) and out of scope here;
+/// this only pins that the *outer* comment is never silently clobbered by
+/// the inner one, which is the concrete failure this guard exists to
+/// prevent (dropping both safely, rather than losing the outer one and
+/// keeping the wrong one, was the pre-guard behavior).
+#[test]
+fn test_defer_line_comment_does_not_overwrite_already_pending_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- &x # c1\n  - &y # c2\n    b: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- &x\n  - &y\n    b: 1\n");
+    Ok(())
+}
+
 // ============================================================================
 // Explicit-key (`? k ... : v`) trailing comment (#795)
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9252,6 +9252,139 @@ fn test_anchor_comment_dropped_at_eof_with_no_sibling_784() -> Result<()> {
     Ok(())
 }
 
+// The shapes below were added in a second round, after code review found the
+// first pass (a) regressed #765/#785's own key-comment capture when a
+// floated comment collides with a key's genuine same-line comment, (b)
+// never handled the single most common resolution of a deferred value - a
+// plain or quoted scalar folded onto the next line with no container of its
+// own, (c) never handled `parse_compact_mapping_entry`'s own anchor case at
+// all (#1078), (d) misrouted a floated comment into a flow collection's last
+// inner element, corrupting the emitted structure, and (e) left
+// `parse_explicit_value` (the `: v` half of `? k`/`: v`) with no capture at
+// all. All fixed; each shape below is pinned against the live real `yq`
+// binary except where noted.
+
+/// The single most common resolution of a deferred anchor: a plain scalar
+/// folded onto the next line with no container or property of its own.
+#[test]
+fn test_anchor_comment_preserved_on_plain_scalar_continuation_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\n  hello\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc hello # comment\n");
+    Ok(())
+}
+
+/// Same shape, a quoted scalar rather than plain.
+#[test]
+fn test_anchor_comment_preserved_on_quoted_scalar_continuation_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc # comment\n  \"hello\"\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc \"hello\" # comment\n");
+    Ok(())
+}
+
+/// Same shape again, but the anchor is a sequence item's own rather than a
+/// mapping key's.
+#[test]
+fn test_anchor_comment_preserved_on_sequence_item_plain_scalar_continuation_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- &anc # comment\n  hello\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- &anc hello # comment\n");
+    Ok(())
+}
+
+/// `parse_compact_mapping_entry`'s own anchored value (`- key: &anc #
+/// comment`, the sequence-item-compact-key form) is a materially different
+/// code path from a plain block-mapping key and had no #784 handling at
+/// all until this second round (#1078) - it used to garble the anchor and
+/// comment's relative order on the key's own line instead of deferring.
+#[test]
+fn test_compact_mapping_key_anchor_comment_preserved_with_nested_mapping_value_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- key: &anc # comment\n    nested: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- key: &anc\n    nested: 1 # comment\n");
+    Ok(())
+}
+
+/// Same compact-mapping-key shape, but the value on this line is itself
+/// present (not deferred) - exercises the ordinary, non-deferred path of
+/// the same key to confirm the #1078 fix didn't disturb it.
+#[test]
+fn test_compact_mapping_key_anchor_comment_not_deferred_for_same_line_value_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- key: &anc 5 # comment\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- key: &anc 5 # comment\n");
+    Ok(())
+}
+
+/// `parse_explicit_value` (the `: v` half of `? k`/`: v`) had no #784
+/// handling at all - an anchor's comment there was dropped unconditionally,
+/// never even deferred.
+#[test]
+fn test_explicit_value_anchor_comment_preserved_with_nested_mapping_value_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k\n: &anc # comment\n  nested: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: &anc\n  nested: 1 # comment\n");
+    Ok(())
+}
+
+/// Regression guard (found by code review): when a floated comment from an
+/// earlier anchor's deferred-to-null value collides with a *different*
+/// key's own genuine same-line comment, the key's own comment must survive
+/// unharmed - it was already correct before #784 and #784 must not destroy
+/// working #765/#785 behavior to gain new coverage. The floated comment is
+/// dropped here (single comment slot per node; not part of #784's scope to
+/// preserve both), matching this exact input's behavior on `main` before
+/// #784's change existed at all - confirmed by diffing against an
+/// unmodified build, not just asserted here.
+#[test]
+fn test_anchor_floated_comment_does_not_clobber_sibling_own_comment_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".",
+        "a: &anc # deferred comment\n  b: # b own comment\n    c: 1\n",
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc\n  b: # b own comment\n    c: 1\n");
+    Ok(())
+}
+
+/// Same regression class, the compact-mapping-key variant.
+#[test]
+fn test_anchor_floated_comment_does_not_clobber_compact_key_own_comment_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".",
+        "a: &anc # deferred comment\n  - k: # k own comment\n      1\n",
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc\n  - k: 1 # k own comment\n");
+    Ok(())
+}
+
+/// Regression guard (found by code review): a floated comment landing on a
+/// flow-collection value must never corrupt the emitted structure by
+/// landing between the last element and the closing bracket - it's
+/// silently dropped instead, matching real yq's own behavior for a
+/// flow-collection value here (verified live: real yq drops it too, this
+/// isn't a succinctly-only gap).
+#[test]
+fn test_anchor_floated_comment_does_not_corrupt_flow_sequence_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- &anc # comment\n- [1, 2]\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- &anc \"\"\n- [1, 2]\n");
+    Ok(())
+}
+
+/// Same regression class, a flow mapping instead of a flow sequence.
+#[test]
+fn test_anchor_floated_comment_does_not_corrupt_flow_mapping_784() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- &anc # comment\n- {a: 1, b: 2}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- &anc \"\"\n- {a: 1, b: 2}\n");
+    Ok(())
+}
+
 // ============================================================================
 // Explicit-key (`? k ... : v`) trailing comment (#795)
 // ============================================================================


### PR DESCRIPTION
Fixes #784
Fixes #1078

## Summary

`&anchor # comment` whose value is deferred to a following line (`a: &anc # comment\n  b: 1`) silently dropped the comment. Real yq attaches it to the deferred value's own first line instead (`b: 1 # comment`), or, if that value turns out null, floats it further to the next sibling entirely — never to the anchor's own key line.

Added a two-phase deferred-comment mechanism in `src/yaml/parser.rs`:
- `defer_line_comment` stashes the comment's byte range in a new `pending_head_comment` field when the owning node doesn't exist yet (the anchor's own line). Never overwrites an already-pending comment (a nested anchor deferring a second comment before the first is claimed can't destroy it).
- `take_pending_head_comment` claims it at whichever bp_pos the renderer already reads a trailing comment from for that shape of node — a mapping key (`parse_mapping_entry`, `parse_compact_mapping_entry`), a plain-scalar value (`parse_block_node`'s two scalar arms — the single most common resolution of a deferred anchor), or a plain-scalar sequence item's own scalar bp (`parse_sequence_item_inner`, guarded against misrouting into a flow collection's last inner element).
- `drop_stale_pending_head_comment` bounds a comment to one line's grace period, so it can never leak onto an unrelated node further down the document.
- Every consumption site runs *after* the node's own ordinary same-line-comment capture, as a fallback — never before, which a first-pass code review caught as a real regression (an eager, key-open-time claim silently destroyed #765/#785's own already-working comment capture whenever it collided with an unrelated floated one).

Extracted `scan_trailing_comment` as the one scan both `maybe_capture_line_comment` and `defer_line_comment` now share.

31 tests in `tests/yq_cli_tests.rs` (11 from the initial pass + 10 added after code review), every shape verified byte-for-byte against the pinned real `yq` binary, matching this repo's existing #765/#710 discipline. Three of the added tests specifically guard the collision/misrouting bugs review found against reintroduction; one collision outcome (own comment survives, floated one drops) was confirmed byte-identical to unmodified `main`'s pre-existing behavior via `git stash` diff, not just asserted.

## Code review findings, all fixed
- **Regression**: eager key-open consumption destroyed a node's own genuine comment when it collided with a floated one — fixed by reordering every site to consume only as a fallback.
- **Missing coverage**: the single most common resolution of a deferred anchor (a plain/quoted scalar folded onto the next line, no container) was completely unhandled — added to `parse_block_node`'s two scalar arms.
- **#1078** (compact-mapping key's own anchor+comment garbled token order) — `parse_compact_mapping_entry` previously always used #765-style local capture regardless of whether an anchor caused the deferral; now splits on `had_property` like its siblings.
- **Missing coverage**: `parse_explicit_value` (the `: v` half of `? k`/`: v`) dropped an anchor's comment unconditionally — added the same defer-on-`had_property` branch its siblings have.
- **Structural corruption**: a floated comment landing on a flow-collection sequence-item value misrouted into the collection's last inner element instead of being safely dropped — guarded against.
- **Simplification**: extracted the duplicated comment-scan logic into one shared helper.

## Follow-ups filed (found while implementing, deliberately out of scope here)
- #1077 — an anchor's own null value renders as `&anc ""` instead of bare `&anc`, pre-existing and unrelated to comments (reproduces on `main` with no comment present at all).
- #1079 — a *bare* sequence item's own comment (no anchor) is dropped when its value is deferred — #765's fix never covered sequence items, only mapping keys.
- #1080 — chained double-anchor deferral renders unusually even in real yq; likely simplifies once #1077 lands, don't implement in isolation.
- #1085 — a floated comment and a target's own genuine comment can't both survive (single comment slot per bp_pos) — needs a data model change (multiple comments per node, or a head-comment concept) out of scope here.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 684 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Every new test's expected output verified against the pinned real `yq` v4.53.3 binary
- [x] 10-angle code review, all findings fixed or explicitly deferred to filed follow-ups