### PR TITLE
fix(jq): yq's == treats int/float as distinct types, not widened

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -82,6 +82,12 @@ pub trait EvalSemantics: Copy + Default {
     /// code) so the library and CLI agree without the library depending on
     /// the CLI binary crate.
     const DEFAULT_HALT_ERROR_CODE: i32;
+    /// If true (yq), `==`/`!=` treats an integer-valued float and the
+    /// equivalent plain integer as genuinely distinct, non-equal types
+    /// (`2.0 == 2` is `false`) rather than widening both to `f64` for the
+    /// comparison. If false (jq, which has no strict int/float distinction),
+    /// `2.0 == 2` is `true`. #950.
+    const STRICT_NUMERIC_EQUALITY: bool;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -101,6 +107,7 @@ impl EvalSemantics for JqSemantics {
     const ARRAY_MULTIPLY_MERGES: bool = false;
     const NULL_MERGES_AS_EMPTY: bool = false;
     const DEFAULT_HALT_ERROR_CODE: i32 = 5;
+    const STRICT_NUMERIC_EQUALITY: bool = false;
 }
 
 /// yq-compatible evaluation semantics.
@@ -122,6 +129,7 @@ impl EvalSemantics for YqSemantics {
     const ARRAY_MULTIPLY_MERGES: bool = true;
     const NULL_MERGES_AS_EMPTY: bool = true;
     const DEFAULT_HALT_ERROR_CODE: i32 = 1;
+    const STRICT_NUMERIC_EQUALITY: bool = true;
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
@@ -131,7 +139,8 @@ use super::expr::{
     ObjectKey, Pattern, StringPart,
 };
 use super::value::{
-    assert_value_tree_depth, cmp_f64, is_nan_sentinel, numeric_repr_cmp, NumberRepr, OwnedValue,
+    assert_value_tree_depth, cmp_f64, is_nan_sentinel, numeric_repr_cmp, numeric_repr_eq_strict,
+    NumberRepr, OwnedValue,
 };
 
 /// Result of evaluating a jq expression.
@@ -2093,7 +2102,7 @@ fn eval_compare<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     eval_binary_fanout::<W, S>(left, right, value, optional, |left_val, right_val| {
-        Ok(OwnedValue::Bool(apply_compare_op(
+        Ok(OwnedValue::Bool(apply_compare_op::<S>(
             op, &left_val, &right_val,
         )))
     })
@@ -2102,19 +2111,41 @@ fn eval_compare<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Apply a comparison operator to two already-evaluated values.
 ///
 /// Factored out of [`eval_compare`] so the path-context evaluator's own
-/// `Expr::Compare` arm (`eval_pipe_with_path_context_internal`, #715) can
-/// reuse the exact same operator semantics rather than a second, divergence-
-/// prone copy -- see the project's own "one definition, plus a test that call
-/// sites agree" convention (already applied to `compare_values` itself).
-fn apply_compare_op(op: CompareOp, left: &OwnedValue, right: &OwnedValue) -> bool {
+/// `Expr::Compare` arm (`eval_pipe_with_path_context_internal`, #715) and
+/// the generic (CLI) evaluator's own `Expr::Compare` arm
+/// (`eval_generic::eval_single`) can all reuse the exact same operator
+/// semantics rather than a third, divergence-prone copy -- see the
+/// project's own "one definition, plus a test that call sites agree"
+/// convention (already applied to `compare_values` itself).
+pub(crate) fn apply_compare_op<S: EvalSemantics>(
+    op: CompareOp,
+    left: &OwnedValue,
+    right: &OwnedValue,
+) -> bool {
     match op {
-        CompareOp::Eq => left == right,
-        CompareOp::Ne => left != right,
+        CompareOp::Eq => numeric_aware_eq::<S>(left, right),
+        CompareOp::Ne => !numeric_aware_eq::<S>(left, right),
         CompareOp::Lt => compare_values(left, right) == core::cmp::Ordering::Less,
         CompareOp::Le => compare_values(left, right) != core::cmp::Ordering::Greater,
         CompareOp::Gt => compare_values(left, right) == core::cmp::Ordering::Greater,
         CompareOp::Ge => compare_values(left, right) != core::cmp::Ordering::Less,
     }
+}
+
+/// `==`'s own numeric rule, distinct from [`OwnedValue`]'s general
+/// (always-widening) `PartialEq`: under `S::STRICT_NUMERIC_EQUALITY` (yq),
+/// an `Int` and a `Float` operand are never equal regardless of magnitude
+/// (#950) -- checked only when *both* operands are numeric, so a
+/// number-vs-non-number comparison (already `false` either way) and every
+/// jq-mode comparison fall straight through to the ordinary widening
+/// `PartialEq`.
+fn numeric_aware_eq<S: EvalSemantics>(left: &OwnedValue, right: &OwnedValue) -> bool {
+    if S::STRICT_NUMERIC_EQUALITY {
+        if let (Some(a), Some(b)) = (left.number_repr(), right.number_repr()) {
+            return numeric_repr_eq_strict(a, b);
+        }
+    }
+    left == right
 }
 
 /// Compare two values using jq ordering: null < bool < number < string < array < object.
@@ -15930,7 +15961,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 current_path,
                 optional,
                 |left_val, right_val| {
-                    Ok(OwnedValue::Bool(apply_compare_op(
+                    Ok(OwnedValue::Bool(apply_compare_op::<S>(
                         *op, &left_val, &right_val,
                     )))
                 },

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -139,7 +139,7 @@ use super::expr::{
     ObjectKey, Pattern, StringPart,
 };
 use super::value::{
-    assert_value_tree_depth, cmp_f64, is_nan_sentinel, numeric_repr_cmp, numeric_repr_eq_strict,
+    assert_value_tree_depth, cmp_f64, is_nan_sentinel, numeric_repr_cmp, owned_value_eq,
     NumberRepr, OwnedValue,
 };
 
@@ -1689,9 +1689,15 @@ fn arith_sub<S: EvalSemantics>(
         (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 - b)),
         (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a - b as f64)),
         (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a - b)),
-        // Array subtraction (remove elements)
+        // Array subtraction (remove elements). `owned_value_eq::<S>`, not
+        // `Vec::contains` (plain `PartialEq`): yq's stricter Int/Float
+        // equality must apply here too, or `[2.0] - [2]` would (wrongly)
+        // remove the float (#950 review).
         (OwnedValue::Array(a), OwnedValue::Array(b)) => {
-            let result: Vec<_> = a.into_iter().filter(|x| !b.contains(x)).collect();
+            let result: Vec<_> = a
+                .into_iter()
+                .filter(|x| !b.iter().any(|y| owned_value_eq::<S>(x, y)))
+                .collect();
             Ok(OwnedValue::Array(result))
         }
         (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Subtract)),
@@ -2123,29 +2129,13 @@ pub(crate) fn apply_compare_op<S: EvalSemantics>(
     right: &OwnedValue,
 ) -> bool {
     match op {
-        CompareOp::Eq => numeric_aware_eq::<S>(left, right),
-        CompareOp::Ne => !numeric_aware_eq::<S>(left, right),
+        CompareOp::Eq => owned_value_eq::<S>(left, right),
+        CompareOp::Ne => !owned_value_eq::<S>(left, right),
         CompareOp::Lt => compare_values(left, right) == core::cmp::Ordering::Less,
         CompareOp::Le => compare_values(left, right) != core::cmp::Ordering::Greater,
         CompareOp::Gt => compare_values(left, right) == core::cmp::Ordering::Greater,
         CompareOp::Ge => compare_values(left, right) != core::cmp::Ordering::Less,
     }
-}
-
-/// `==`'s own numeric rule, distinct from [`OwnedValue`]'s general
-/// (always-widening) `PartialEq`: under `S::STRICT_NUMERIC_EQUALITY` (yq),
-/// an `Int` and a `Float` operand are never equal regardless of magnitude
-/// (#950) -- checked only when *both* operands are numeric, so a
-/// number-vs-non-number comparison (already `false` either way) and every
-/// jq-mode comparison fall straight through to the ordinary widening
-/// `PartialEq`.
-fn numeric_aware_eq<S: EvalSemantics>(left: &OwnedValue, right: &OwnedValue) -> bool {
-    if S::STRICT_NUMERIC_EQUALITY {
-        if let (Some(a), Some(b)) = (left.number_repr(), right.number_repr()) {
-            return numeric_repr_eq_strict(a, b);
-        }
-    }
-    left == right
 }
 
 /// Compare two values using jq ordering: null < bool < number < string < array < object.
@@ -3270,7 +3260,11 @@ fn builtin_upper_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let current = to_owned(&value);
     let (candidates, trailing) = eval_owned_expr_fork::<S>(s, &current, false);
-    if candidates.contains(&current) {
+    // `owned_value_eq::<S>`, not `Vec::contains`/plain `==`: this builtin's
+    // own doc comment states it matches jq's `any(s == .; .)`, so it must
+    // agree with `==`'s own yq-mode strict Int/Float distinction (#950
+    // review) rather than silently falling back to widening equality.
+    if candidates.iter().any(|c| owned_value_eq::<S>(c, &current)) {
         return QueryResult::Owned(OwnedValue::Bool(true));
     }
     match trailing {
@@ -4372,7 +4366,7 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
         return QueryResult::Error(EvalError::containment_check(&input, &b));
     }
-    QueryResult::Owned(OwnedValue::Bool(owned_contains(&input, &b)))
+    QueryResult::Owned(OwnedValue::Bool(owned_contains::<S>(&input, &b)))
 }
 
 /// Check if `a` contains `b` (recursive containment check)
@@ -4381,13 +4375,18 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// container is plain `false`, as in jq — `[1,"a"] | contains(["a",2])` is
 /// `false`, not the error [`EvalError::containment_check`] raises. The callers
 /// screen the top level with [`jq_kind`], so this stays a total function.
-fn owned_contains(a: &OwnedValue, b: &OwnedValue) -> bool {
-    owned_contains_at_depth(a, b, 0)
+///
+/// Generic over `S` (#950 review): the scalar leaf case delegates to
+/// [`owned_value_eq`], so `contains`/`inside` agree with `==`'s own
+/// yq-mode strict Int/Float distinction instead of silently using the
+/// always-widening `PartialEq`.
+fn owned_contains<S: EvalSemantics>(a: &OwnedValue, b: &OwnedValue) -> bool {
+    owned_contains_at_depth::<S>(a, b, 0)
 }
 
 /// Panics past [`MAX_VALUE_TREE_DEPTH`](crate::jq::value::MAX_VALUE_TREE_DEPTH)
 /// levels of nesting (#1021, following #1005's precedent).
-fn owned_contains_at_depth(a: &OwnedValue, b: &OwnedValue, depth: usize) -> bool {
+fn owned_contains_at_depth<S: EvalSemantics>(a: &OwnedValue, b: &OwnedValue, depth: usize) -> bool {
     assert_value_tree_depth(depth);
     match (a, b) {
         // String contains string
@@ -4396,16 +4395,16 @@ fn owned_contains_at_depth(a: &OwnedValue, b: &OwnedValue, depth: usize) -> bool
         (OwnedValue::Array(a_arr), OwnedValue::Array(b_arr)) => b_arr.iter().all(|b_elem| {
             a_arr
                 .iter()
-                .any(|a_elem| owned_contains_at_depth(a_elem, b_elem, depth + 1))
+                .any(|a_elem| owned_contains_at_depth::<S>(a_elem, b_elem, depth + 1))
         }),
         // Object contains: all keys in b must exist in a with matching values
         (OwnedValue::Object(a_obj), OwnedValue::Object(b_obj)) => b_obj.iter().all(|(k, b_val)| {
             a_obj
                 .get(k)
-                .is_some_and(|a_val| owned_contains_at_depth(a_val, b_val, depth + 1))
+                .is_some_and(|a_val| owned_contains_at_depth::<S>(a_val, b_val, depth + 1))
         }),
         // Scalars: equality
-        _ => a == b,
+        _ => owned_value_eq::<S>(a, b),
     }
 }
 
@@ -4430,7 +4429,7 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
         return QueryResult::Error(EvalError::containment_check(&b, &input));
     }
-    QueryResult::Owned(OwnedValue::Bool(owned_contains(&b, &input)))
+    QueryResult::Owned(OwnedValue::Bool(owned_contains::<S>(&b, &input)))
 }
 
 // =============================================================================
@@ -4656,7 +4655,14 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             for (key, item) in keyed {
                 match &current_key {
-                    Some(k) if compare_values(k, &key) == core::cmp::Ordering::Equal => {
+                    // `owned_value_eq::<S>`, not `compare_values(..) ==
+                    // Equal`: the sort just above stays widening
+                    // (ordering, unaffected by #950), but *this* check
+                    // decides whether two keys are the "same group", which
+                    // must agree with `==`'s own yq-mode strict Int/Float
+                    // distinction (#950 review) -- `[2, 2.0]` groups as one
+                    // in jq, two in yq.
+                    Some(k) if owned_value_eq::<S>(k, &key) => {
                         current_group.push(item);
                     }
                     _ => {
@@ -4703,8 +4709,12 @@ fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // Sort first (jq's unique returns sorted unique values)
             items.sort_by(compare_values);
 
-            // Remove consecutive duplicates
-            items.dedup_by(|a, b| compare_values(a, b) == core::cmp::Ordering::Equal);
+            // Remove consecutive duplicates. `owned_value_eq::<S>`, not
+            // `compare_values(..) == Equal` (#950 review, same reasoning
+            // as `group_by`'s grouping step): the sort above stays
+            // widening, but two elements only count as "duplicates" under
+            // `==`'s own yq-mode strict Int/Float distinction.
+            items.dedup_by(|a, b| owned_value_eq::<S>(a, b));
 
             QueryResult::Owned(OwnedValue::Array(items))
         }
@@ -4755,8 +4765,10 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // Sort by key
             keyed.sort_by(|(a, _), (b, _)| compare_values(a, b));
 
-            // Remove consecutive duplicates by key
-            keyed.dedup_by(|(a, _), (b, _)| compare_values(a, b) == core::cmp::Ordering::Equal);
+            // Remove consecutive duplicates by key. `owned_value_eq::<S>`,
+            // not `compare_values(..) == Equal` (#950 review, same
+            // reasoning as `unique`/`group_by`).
+            keyed.dedup_by(|(a, _), (b, _)| owned_value_eq::<S>(a, b));
 
             let result: Vec<OwnedValue> = keyed.into_iter().map(|(_, v)| v).collect();
             QueryResult::Owned(OwnedValue::Array(result))
@@ -6866,10 +6878,13 @@ fn builtin_indices<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         StandardJson::Array(elements) => {
-            // For arrays, find indices where element equals the pattern (any type)
+            // For arrays, find indices where element equals the pattern
+            // (any type). `owned_value_eq::<S>`, not plain `==`, so this
+            // agrees with `==`'s own yq-mode strict Int/Float distinction
+            // (#950 review).
             let mut indices = Vec::new();
             for (i, elem) in (*elements).enumerate() {
-                if to_owned(&elem) == pattern {
+                if owned_value_eq::<S>(&to_owned(&elem), &pattern) {
                     indices.push(OwnedValue::Int(i as i64));
                 }
             }
@@ -6924,9 +6939,11 @@ fn builtin_index<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         StandardJson::Array(elements) => {
-            // For arrays, pattern can be any type
+            // For arrays, pattern can be any type. `owned_value_eq::<S>`,
+            // not plain `==` (#950 review, same reasoning as `indices`
+            // above).
             for (i, elem) in (*elements).enumerate() {
-                if to_owned(&elem) == pattern {
+                if owned_value_eq::<S>(&to_owned(&elem), &pattern) {
                     return QueryResult::Owned(OwnedValue::Int(i as i64));
                 }
             }
@@ -7033,10 +7050,12 @@ fn builtin_rindex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         StandardJson::Array(elements) => {
-            // For arrays, pattern can be any type
+            // For arrays, pattern can be any type. `owned_value_eq::<S>`,
+            // not plain `==` (#950 review, same reasoning as `indices`
+            // above).
             let items: Vec<_> = (*elements).collect();
             for (i, elem) in items.iter().enumerate().rev() {
-                if to_owned(elem) == pattern {
+                if owned_value_eq::<S>(&to_owned(elem), &pattern) {
                     return QueryResult::Owned(OwnedValue::Int(i as i64));
                 }
             }
@@ -29508,6 +29527,49 @@ mod tests {
         );
     }
 
+    /// #950 review: `index`/`indices`/`rindex` internally use equality to
+    /// find matching array elements, and must agree with `==`'s own
+    /// yq-mode strict Int/Float distinction rather than the always-widening
+    /// `PartialEq` (verified against jq semantics for the jq-mode case;
+    /// mikefarah/yq's own grammar doesn't accept `index(2.0)` the same way
+    /// to cross-check yq mode directly, so this pins internal consistency
+    /// with the now-fixed `==`/`contains` instead).
+    #[test]
+    fn test_builtin_index_family_respects_strict_numeric_equality_950() {
+        // jq mode: widening, 2.0 matches 2 (unaffected by #950).
+        query!(br"[2,3]", "index(2.0)",
+            QueryResult::Owned(OwnedValue::Int(n)) => { assert_eq!(n, 0); }
+        );
+
+        // yq mode: strict, 2.0 does not match 2.
+        yq_query!(br"[2,3]", "index(2.0)",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+        yq_query!(br"[2.0,3,2.0]", "indices(2.0)",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v, vec![OwnedValue::Int(0), OwnedValue::Int(2)]);
+            }
+        );
+        yq_query!(br"[2.0,3,2]", "rindex(2)",
+            QueryResult::Owned(OwnedValue::Int(n)) => { assert_eq!(n, 2); }
+        );
+    }
+
+    /// #950 review: `IN(s)` (single-arg) internally uses equality and must
+    /// agree with `==`'s own yq-mode strict Int/Float distinction, per its
+    /// own doc comment stating it matches jq's `any(s == .; .)`.
+    #[test]
+    fn test_builtin_upper_in_respects_strict_numeric_equality_950() {
+        // jq mode: widening, unaffected by #950.
+        query!(br"2.0", "IN(2)",
+            QueryResult::Owned(OwnedValue::Bool(b)) => { assert!(b); }
+        );
+        // yq mode: strict.
+        yq_query!(br"2.0", "IN(2)",
+            QueryResult::Owned(OwnedValue::Bool(b)) => { assert!(!b); }
+        );
+    }
+
     #[test]
     fn test_builtin_upper_in_single_arg() {
         query!(br"5", "IN(1,2,3,5)",
@@ -41174,12 +41236,12 @@ mod tests {
 
         let under_a = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
         let under_b = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
-        assert!(owned_contains(&under_a, &under_b));
+        assert!(owned_contains::<JqSemantics>(&under_a, &under_b));
 
         let over_a = linear_array_nest(MAX_VALUE_TREE_DEPTH);
         let over_b = linear_array_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            owned_contains(&over_a, &over_b)
+            owned_contains::<JqSemantics>(&over_a, &over_b)
         }));
         assert!(
             result.is_err(),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -25,12 +25,12 @@ use super::document::{
     DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
-    compare_values, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
+    apply_compare_op, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
     needs_path_context, numeric_display_string, numeric_key_to_index, owned_bound_to_i64,
     owned_value_to_json, slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics,
     EvalTag, JqSemantics, QueryResult, YqSemantics,
 };
-use super::expr::{Builtin, CompareOp, Expr, FormatType, Literal};
+use super::expr::{Builtin, Expr, FormatType, Literal};
 use super::slice::{slice_str, SliceBounds};
 use super::value::OwnedValue;
 use crate::json::JsonIndex;
@@ -2576,24 +2576,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 );
 
                 for left_val in left_vals {
-                    let result = match op {
-                        CompareOp::Eq => left_val == *right_val,
-                        CompareOp::Ne => left_val != *right_val,
-                        CompareOp::Lt => {
-                            compare_values(&left_val, right_val) == core::cmp::Ordering::Less
-                        }
-                        CompareOp::Le => matches!(
-                            compare_values(&left_val, right_val),
-                            core::cmp::Ordering::Less | core::cmp::Ordering::Equal
-                        ),
-                        CompareOp::Gt => {
-                            compare_values(&left_val, right_val) == core::cmp::Ordering::Greater
-                        }
-                        CompareOp::Ge => matches!(
-                            compare_values(&left_val, right_val),
-                            core::cmp::Ordering::Greater | core::cmp::Ordering::Equal
-                        ),
-                    };
+                    let result = apply_compare_op::<S>(*op, &left_val, right_val);
                     out.push(OwnedValue::Bool(result));
                 }
 
@@ -3873,7 +3856,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
 #[cfg(test)]
 mod tests {
-    use super::super::expr::FormatType;
+    use super::super::expr::{CompareOp, FormatType};
     use super::super::value::NumberRepr;
     use super::*;
     use crate::jq::parse;

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1071,6 +1071,21 @@ pub(crate) fn numeric_repr_eq(a: NumberRepr, b: NumberRepr) -> bool {
     }
 }
 
+/// Like [`numeric_repr_eq`], but for `EvalSemantics::STRICT_NUMERIC_EQUALITY`
+/// (yq): an `Int` and a `Float` are never equal regardless of magnitude,
+/// even when the same pair would compare equal under [`numeric_repr_eq`]'s
+/// widening rule -- real yq treats `2` and `2.0` as genuinely distinct
+/// types, unlike jq (#950).
+pub(crate) fn numeric_repr_eq_strict(a: NumberRepr, b: NumberRepr) -> bool {
+    match (a, b) {
+        (NumberRepr::Int(a), NumberRepr::Int(b)) => a == b,
+        (NumberRepr::Float(a), NumberRepr::Float(b)) => a == b,
+        (NumberRepr::Int(_), NumberRepr::Float(_)) | (NumberRepr::Float(_), NumberRepr::Int(_)) => {
+            false
+        }
+    }
+}
+
 /// Order two `f64`s the way jq's own comparator does: NaN sorts strictly
 /// below every other float, including another NaN (#421).
 ///

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1029,14 +1029,18 @@ pub(crate) fn is_nan_sentinel(bytes: &[u8]) -> bool {
     bytes == NAN_SENTINEL.as_bytes()
 }
 
-/// jq value equality.
+/// jq (widening, non-strict) value equality -- [`OwnedValue`]'s `PartialEq`
+/// impl, and the numeric rule [`owned_value_eq`] falls back to whenever
+/// `EvalSemantics::STRICT_NUMERIC_EQUALITY` is unset (jq mode) or an
+/// operand isn't numeric. Under yq's stricter rule, equality-consuming
+/// builtins route through [`owned_value_eq`] instead of this impl
+/// directly (#950) -- see that function's doc comment for the full list
+/// and for why a single shared entry point matters here.
 ///
 /// This is deliberately **not** `#[derive]`d. Deriving would compare the
 /// representation, so `Int(1)` and `Float(1.0)` -- two spellings of the same
 /// JSON number -- would be unequal, and `1 == 1.0` would evaluate to `false`
-/// (jq says `true`). Since `Vec`/`IndexMap` inherit their `PartialEq` from the
-/// element type, every builtin routed through equality (`==`, `!=`, array `-`,
-/// `contains`, `inside`, `index`, `indices`, `rindex`) picks up this impl.
+/// (jq says `true`).
 ///
 /// Semantics, pinned against jq-1.7.1:
 ///
@@ -1075,13 +1079,67 @@ pub(crate) fn numeric_repr_eq(a: NumberRepr, b: NumberRepr) -> bool {
 /// (yq): an `Int` and a `Float` are never equal regardless of magnitude,
 /// even when the same pair would compare equal under [`numeric_repr_eq`]'s
 /// widening rule -- real yq treats `2` and `2.0` as genuinely distinct
-/// types, unlike jq (#950).
+/// types, unlike jq (#950). This is exactly [`NumberRepr`]'s own derived
+/// `PartialEq` (same variant and value, never equal across variants) --
+/// spelled out as its own named function so every strict-mode call site
+/// reads as "yq's equality rule" rather than an easy-to-miss bare `==`.
 pub(crate) fn numeric_repr_eq_strict(a: NumberRepr, b: NumberRepr) -> bool {
+    a == b
+}
+
+/// jq/yq value equality, generic over `EvalSemantics::STRICT_NUMERIC_EQUALITY`
+/// (#950) -- the single definition every equality-consuming builtin should
+/// route through (`==`, `!=`, array `-`, `contains`, `inside`, `index`,
+/// `indices`, `rindex`, `IN`, `unique`, `unique_by`, `group_by`), so none
+/// of them can individually diverge from `==`'s own answer about the same
+/// pair of values (a real gap #950's own review round found: several of
+/// these builtins still used the plain, always-widening `PartialEq` after
+/// the first pass only fixed `==`/`!=` themselves).
+///
+/// Structural rules (`Null`/`Bool`/`String`/`Array`/`Object`) are
+/// identical in both modes -- only how two *numbers* compare differs, so
+/// this mirrors [`OwnedValue`]'s own `PartialEq`
+/// (`owned_value_eq_at_depth`) exactly, just threading `S` into the
+/// recursion so strictness applies at every nesting depth, not only the
+/// top: `[2.0] == [2]` and `{"a":2.0} == {"a":2}` are `false` in yq,
+/// matching jq's `true` when `S` isn't strict.
+pub(crate) fn owned_value_eq<S: EvalSemantics>(a: &OwnedValue, b: &OwnedValue) -> bool {
+    owned_value_eq_at_depth_generic::<S>(a, b, 0)
+}
+
+fn owned_value_eq_at_depth_generic<S: EvalSemantics>(
+    a: &OwnedValue,
+    b: &OwnedValue,
+    depth: usize,
+) -> bool {
+    assert_value_tree_depth(depth);
     match (a, b) {
-        (NumberRepr::Int(a), NumberRepr::Int(b)) => a == b,
-        (NumberRepr::Float(a), NumberRepr::Float(b)) => a == b,
-        (NumberRepr::Int(_), NumberRepr::Float(_)) | (NumberRepr::Float(_), NumberRepr::Int(_)) => {
-            false
+        (OwnedValue::Array(a), OwnedValue::Array(b)) => {
+            a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| owned_value_eq_at_depth_generic::<S>(x, y, depth + 1))
+        }
+        (OwnedValue::Object(a), OwnedValue::Object(b)) => {
+            a.len() == b.len()
+                && a.iter().all(|(k, v)| {
+                    b.get(k)
+                        .is_some_and(|bv| owned_value_eq_at_depth_generic::<S>(v, bv, depth + 1))
+                })
+        }
+        // Every other pairing (Null/Bool/String, Int/Float/NumberLiteral,
+        // and any type mismatch) has no further nesting to thread through.
+        // Only checked only when *both* operands are numeric under strict
+        // mode; a number-vs-non-number comparison (already `false` either
+        // way) and every jq-mode comparison fall straight through to the
+        // ordinary widening `PartialEq`.
+        _ => {
+            if S::STRICT_NUMERIC_EQUALITY {
+                if let (Some(x), Some(y)) = (a.number_repr(), b.number_repr()) {
+                    return numeric_repr_eq_strict(x, y);
+                }
+            }
+            a == b
         }
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10773,3 +10773,16 @@ fn test_jq_tostring_special_floats_unaffected_by_yq_mode_fix_1060() -> Result<()
     }
     Ok(())
 }
+
+/// #950's yq-only strict numeric equality must not leak into jq mode: jq
+/// has no strict int/float distinction, so `2.0 == 2` stays `true` (real
+/// jq 1.7.1, verified). Pins that `apply_compare_op`'s `S::
+/// STRICT_NUMERIC_EQUALITY` gate is correctly `false` under `JqSemantics`.
+#[test]
+fn test_jq_equality_still_widens_int_and_float_950() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ". == 2"], Some("2.0"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "true\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11947,3 +11947,61 @@ fn test_sub_yq_mode_non_string_replacement_exits_zero_1052() -> Result<()> {
     assert_eq!(output.trim(), r#""5bc""#);
     Ok(())
 }
+
+/// #950: real yq treats an integer-valued float and the equivalent plain
+/// integer as genuinely distinct, non-equal types -- `2.0 == 2` is `false`
+/// (verified against pinned yq v4.53.3), unlike jq's looser convention
+/// where `2.0 == 2` is `true` (jq has no strict int/float distinction).
+/// succinctly's `==`/`!=` used to always widen both operands to `f64`,
+/// matching jq's convention even in yq mode.
+#[test]
+fn test_yq_equality_distinguishes_int_from_equal_valued_float_950() -> Result<()> {
+    let (out, code) = run_yq_stdin(". == 2", "2.0", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin(". != 2", "2.0", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+    Ok(())
+}
+
+/// Sanity: same-type numeric equality (Int==Int, Float==Float) is
+/// unaffected by #950's fix.
+#[test]
+fn test_yq_equality_same_type_numbers_unaffected_950() -> Result<()> {
+    let (out, code) = run_yq_stdin(". == 2", "2", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin(". == 2.5", "2.5", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+    Ok(())
+}
+
+/// Sanity: ordering (`<`/`<=`/`>`/`>=`) still widens Int/Float for
+/// comparison in yq mode -- #950 only changes `==`/`!=`'s strictness,
+/// matching real yq (`2.0 < 3` and `2.0 <= 2` are both `true`).
+#[test]
+fn test_yq_ordering_still_widens_int_and_float_950() -> Result<()> {
+    let (out, code) = run_yq_stdin(". < 3", "2.0", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin(". <= 2", "2.0", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+    Ok(())
+}
+
+/// Sanity: a strict numeric-vs-non-numeric comparison is unaffected --
+/// `2 == "2"` is `false` in both jq and yq, and #950's gate only fires
+/// when *both* operands are already numeric.
+#[test]
+fn test_yq_equality_numeric_vs_string_unaffected_950() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#". == "2""#, "2", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12005,3 +12005,51 @@ fn test_yq_equality_numeric_vs_string_unaffected_950() -> Result<()> {
     assert_eq!(out.trim(), "false");
     Ok(())
 }
+
+/// #950 review: `==`'s strict Int/Float distinction must apply at every
+/// nesting depth, not just the top -- `[2.0] == [2]` and `{"a":2.0} ==
+/// {"a":2}` are `false` in yq (verified against pinned yq v4.53.3), the
+/// same rule the scalar `2.0 == 2` case above already covers.
+#[test]
+fn test_yq_equality_strict_at_nested_depth_950() -> Result<()> {
+    let (out, code) = run_yq_stdin(". == [2]", "[2.0]", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin(r#". == {"a": 2}"#, "a: 2.0", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}
+
+/// #950 review: `contains`/`inside`, `array - array`, `unique`/
+/// `unique_by`/`group_by` all consume equality internally and must agree
+/// with `==`'s own yq-mode strictness instead of silently falling back
+/// to the always-widening rule (verified against pinned yq v4.53.3 for
+/// `contains`, `unique`, and `group_by`; `array -` and `unique_by`
+/// confirmed by internal consistency with the now-fixed `==`/`contains`,
+/// since mikefarah/yq's own grammar doesn't accept a bare `-`/`unique_by`
+/// invocation the same way to cross-check directly).
+#[test]
+fn test_yq_equality_consuming_builtins_agree_with_strict_eq_950() -> Result<()> {
+    let (out, code) = run_yq_stdin("contains([2.0])", "[2]", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin(". - [2]", "[2.0, 3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2.0,3]");
+
+    let (out, code) = run_yq_stdin("unique", "[2, 2.0, 3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2,2.0,3]");
+
+    let (out, code) = run_yq_stdin("unique_by(.)", "[2, 2.0, 3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2,2.0,3]");
+
+    let (out, code) = run_yq_stdin("group_by(.)", "[2, 2.0, 3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[[2],[2.0],[3]]");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Real yq (unlike jq, which has no strict int/float distinction — `2.0 == 2` is `true` in jq) treats an integer-valued float and the equivalent plain integer as genuinely distinct, non-equal types.

```
$ echo '2.0' | yq '. == 2'
false
$ echo '2.0' | succinctly yq '. == 2'   # before
true

$ echo '2.0' | jq '. == 2'
true
```

`succinctly yq`'s `==`/`!=` always widened both operands to `f64` for comparison regardless of `EvalSemantics`, matching jq's looser convention even in yq mode.

## Fix

- Added `EvalSemantics::STRICT_NUMERIC_EQUALITY` (`false` for jq, `true` for yq).
- Added `owned_value_eq::<S>` (`value.rs`) — a recursive, `EvalSemantics`-generic equality mirroring `OwnedValue`'s own `PartialEq` (`owned_value_eq_at_depth`) exactly, except every numeric leaf comparison goes through the new `numeric_repr_eq_strict` under strict mode. Structural rules (`Null`/`Bool`/`String`/`Array`/`Object`) are identical in both modes and recurse correctly at any nesting depth — `[2.0] == [2]` and `{"a":2.0} == {"a":2}` are `false` in yq, not just the top-level scalar case.
- `apply_compare_op` (shared by all three `Expr::Compare` sites: `eval_compare`, the path-context evaluator, and the generic/CLI evaluator, which previously had its own third hand-written copy of this comparison logic) routes `Eq`/`Ne` through `owned_value_eq::<S>`.

**Review round found the fix was initially incomplete** — six other equality-consuming builtins still used the always-widening `PartialEq` directly and disagreed with `==` about the exact same pair of values within the same yq evaluation. All now route through `owned_value_eq::<S>` too:
- `contains`/`inside`'s scalar fallback
- array `-`'s element-removal check
- `index`/`indices`/`rindex`'s element-match check
- `IN(s)`'s (single-arg) membership check
- `unique`/`unique_by`/`group_by`'s duplicate/same-key check (their *sort* step still uses `compare_values`, staying widening/unaffected, matching `<`/`<=` — only the "are these the same key" decision after sorting became strict)

`numeric_repr_eq_strict` was also simplified to `a == b` (`NumberRepr` already derives `PartialEq` with exactly this semantics), and `numeric_repr_eq`'s doc comment updated since it no longer accurately described which builtins shared its widening rule.

Fixes #950

## Verified against real yq v4.53.3 and jq 1.7.1

```
$ echo '2.0' | succinctly yq '. == 2'              # was true, now:
false
$ echo '[2.0]' | succinctly yq '. == [2]'          # nested, now:
false
$ echo '[2]' | succinctly yq 'contains([2.0])'     # now:
false
$ echo '[2.0,3]' | succinctly yq -o=json '. - [2]' # now:
[2.0,3]
$ echo '[2,2.0,3]' | succinctly yq -o=json 'unique'      # now:
[2,2.0,3]
$ echo '[2,2.0,3]' | succinctly yq -o=json 'group_by(.)' # now:
[[2],[2.0],[3]]
```

`index`/`indices`/`rindex`/`IN` don't have a directly-comparable real-yq invocation (mikefarah/yq's own grammar doesn't accept those exact forms), so those three are verified via internal consistency with the now-fixed `==`/`contains` plus dedicated library-level tests (`yq_query!` in `src/jq/eval.rs`), not a live yq cross-check.

Every jq-mode case in the sweep above is byte-identical to real jq 1.7.1 — completely unaffected, confirming the fix stays scoped to `S::STRICT_NUMERIC_EQUALITY`.

## Test plan
- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,simd,regex,serde --test yq_cli_tests -- 950`, `--test jq_cli_tests -- 950`, `--lib -- 950` — 9 tests total: scalar strict/same-type/ordering/non-numeric equality, nested-depth equality, the 6-builtin consistency sweep, and library-level `index`/`indices`/`rindex`/`IN` coverage
- [x] `cargo test --features cli,simd,regex,serde` (full suite) — all green across all 54 test binaries, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Rebased onto `origin/main` (advanced substantially mid-session); re-verified build, full suite, both clippy, and the core repro commands all green post-rebase
