### PR TITLE
fix(jq): correct nonfinite_display_string's jq-mode NaN/Infinity spelling

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5156,7 +5156,11 @@ fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Render a numeric value the way the non-JSON text formats want it.
 ///
 /// `number_str()` deliberately skips NaN/Infinity handling (see its doc
-/// comment) because `to_json` needs "null" instead. Text formats (`@text`,
+/// comment) because `to_json` needs its own substitution instead (currently
+/// "null" for both NaN and Infinity in jq mode -- correct for NaN, but not
+/// for a *computed* Infinity, which real jq instead gives `DBL_MAX` text the
+/// same as this function now does; that's issue #1087, separate from and
+/// out of scope for this function's own fix). Text formats (`@text`,
 /// `@uri`, `@html`, `@sh`, and the CSV/TSV/DSV cell formatter that falls back
 /// to `owned_to_string`) instead want jq's own JSON-substitution spelling for
 /// a non-finite `Float`/`NumberLiteral` (#1075: `null` for NaN, `DBL_MAX`'s
@@ -5239,13 +5243,10 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
 /// `infinite | tostring` -> `"1.7976931348623157e+308"`, `-infinite |
 /// tostring` -> `"-1.7976931348623157e+308"`).
 ///
-/// See `numeric_display_string`'s own doc comment for the
-/// "document-sourced vs computed" caveat this doesn't attempt to resolve
-/// (not a doc link: that function is `pub(crate)`, unresolvable from this
-/// one's now-`pub` docs) -- this includes jq mode's own version of that gap
-/// (a jq-mode `NumberLiteral` overflowing to infinity, e.g. `1e400`, is
-/// still routed through here rather than real jq's own literal-preserving
-/// reformat; see that function's doc comment for why, and issue #1083).
+/// See `numeric_display_string`'s own doc comment (`src/jq/eval.rs`, not
+/// doc-linkable from here since it's `pub(crate)`) for the
+/// "document-sourced vs computed" caveat this doesn't attempt to resolve,
+/// and issue #1083 for the gap that leaves open.
 ///
 /// `pub`, not `pub(crate)`: `src/bin/succinctly/yq_runner.rs` is a separate
 /// binary crate depending on this one as an external dependency, and is one
@@ -28979,14 +28980,20 @@ mod tests {
         //
         // Both signs now take jq mode's `DBL_MAX`-text substitution
         // (`nonfinite_display_string`, #1075) -- this still isn't a full
-        // match for real jq, which reformats a *positive* overflowed
-        // literal's own source text instead (`1e400 | tostring` ->
-        // `"1E+400"`, live-verified) rather than substituting; see
+        // match for real jq, which reformats *both* an overflowed literal's
+        // own source text (`1e400 | tostring` -> `"1E+400"`, `-1e400 |
+        // tostring` -> `"-1E+400"`, live-verified against jq 1.7.1 for this
+        // exact input-document shape -- i.e. the literal typed directly as
+        // the JSON document, which is what `query!`'s first argument always
+        // is) rather than substituting `DBL_MAX` for either sign; see
         // `numeric_display_string`'s own doc comment and issue #1083 for why
-        // that gap is deliberately left open here. The negative case,
-        // though, genuinely does match real jq's own `DBL_MAX` substitution
-        // (confirmed live: `-1e400 | tostring` -> the negative `DBL_MAX`
-        // text, not `"-1E+400"`).
+        // that gap is deliberately left open here. (A leading `-` typed
+        // *inside a filter expression* instead, e.g. `-1e400 | tostring` as
+        // the filter text rather than the input, is a different story --
+        // jq's own filter grammar treats that as unary negation on the
+        // positive literal, degrading fidelity the same way #1035 already
+        // documents for smaller literals -- but that's not the shape any
+        // test here exercises.)
         query!(br"1e400", "tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "1.7976931348623157e+308");

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -139,8 +139,8 @@ use super::expr::{
     ObjectKey, Pattern, StringPart,
 };
 use super::value::{
-    assert_value_tree_depth, cmp_f64, is_nan_sentinel, numeric_repr_cmp, owned_value_eq,
-    NumberRepr, OwnedValue,
+    assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_nan_sentinel,
+    numeric_repr_cmp, owned_value_eq, NumberRepr, OwnedValue,
 };
 
 /// Result of evaluating a jq expression.
@@ -5158,13 +5158,34 @@ fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `number_str()` deliberately skips NaN/Infinity handling (see its doc
 /// comment) because `to_json` needs "null" instead. Text formats (`@text`,
 /// `@uri`, `@html`, `@sh`, and the CSV/TSV/DSV cell formatter that falls back
-/// to `owned_to_string`) want the same `"inf"`/`"-inf"`/`"NaN"` rendering a
-/// plain `Int`/`Float` already gets from `f64::to_string()` in jq mode -- a
-/// `NumberLiteral` just needs that check made explicit: `format_number_jq_compat`
-/// now formats an overflowed literal's source text correctly (#930), but its
-/// jq-error-message-preview text (e.g. `1E+400`) still isn't the Rust-style
-/// `"inf"`/`"-inf"` these non-JSON text formats want, so the explicit check
-/// stays regardless.
+/// to `owned_to_string`) instead want jq's own JSON-substitution spelling for
+/// a non-finite `Float`/`NumberLiteral` (#1075: `null` for NaN, `DBL_MAX`'s
+/// literal text for +/-infinity -- confirmed live against jq 1.7.1, e.g.
+/// `nan | tostring` -> `"null"`, `infinite | tostring` ->
+/// `"1.7976931348623157e+308"`), not Rust's own `f64::Display`
+/// (`"NaN"`/`"inf"`/`"-inf"`), which this unconditionally rendered before
+/// #1075.
+///
+/// This also applies to a jq-mode `NumberLiteral` overflowing to infinity
+/// (e.g. `1e400`), even though real jq's own decNumber-backed literal
+/// preservation would reformat *some* such literals' source text instead
+/// (`1e400 | tostring` -> `"1E+400"`, live-verified) rather than substituting
+/// `DBL_MAX` text -- deliberately not attempted here (#1075 review): the
+/// `eval_owned_expr`/`eval_owned_pipe` reindex bridge (`reduce`/`foreach`/
+/// `as $x`/multi-stage pipes) round-trips a *computed* infinity through its
+/// own smuggling literal (`to_json_for_reindex`'s `1e999`/`-1e999`, see
+/// `overflow_literal` in `value.rs`) which -- unlike its NaN-sentinel sibling
+/// -- is NOT guaranteed-unparseable as a genuine document literal, so once
+/// reparsed it is bit-for-bit indistinguishable from a real `1e999` literal a
+/// user actually typed. Letting jq mode fall through to
+/// `format_number_jq_compat` here (an earlier draft of this fix did exactly
+/// that) reformats that reindexed sentinel as `"1E+999"` instead of the
+/// correct `DBL_MAX` substitution -- a real, oracle-confirmed regression this
+/// review caught. See issue #1083 (filed alongside this fix) for the
+/// literal-preservation gap this leaves: it needs the reindex bridge's own
+/// infinity sentinel made collision-safe first (mirroring `NAN_SENTINEL`'s
+/// already-safe two-exponent-marker trick) before this function can safely
+/// stop intercepting a jq-mode `NumberLiteral` here.
 ///
 /// yq mode instead wants YAML's own `.nan`/`.inf`/`-.inf` spelling (#1060) --
 /// this was previously unconditional (`f.to_string()`, jq's own spelling in
@@ -5206,13 +5227,25 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
     value.number_str().expect("numeric variant").into_owned()
 }
 
-/// jq's bare `f64::Display` (`NaN`/`inf`/`-inf`) vs yq's own YAML-native
-/// spelling (`.nan`/`.inf`/`-.inf`) for a non-finite float.
+/// jq's own JSON-substitution spelling for a *computed* non-finite float
+/// (`null` for NaN, `DBL_MAX`'s literal text for +/-infinity) vs yq's own
+/// YAML-native spelling (`.nan`/`.inf`/`-.inf`).
+///
+/// The jq-mode branch was Rust's bare `f64::Display` (`"NaN"`/`"inf"`/
+/// `"-inf"`) before #1075 -- that never matched real jq, which spells a
+/// computed NaN as JSON `null` (the same substitution `to_json` already uses)
+/// and a computed +/-infinity as `f64::MAX`'s decimal expansion, sign
+/// preserved (confirmed live against jq 1.7.1: `nan | tostring` -> `"null"`,
+/// `infinite | tostring` -> `"1.7976931348623157e+308"`, `-infinite |
+/// tostring` -> `"-1.7976931348623157e+308"`).
 ///
 /// See `numeric_display_string`'s own doc comment for the
 /// "document-sourced vs computed" caveat this doesn't attempt to resolve
 /// (not a doc link: that function is `pub(crate)`, unresolvable from this
-/// one's now-`pub` docs).
+/// one's now-`pub` docs) -- this includes jq mode's own version of that gap
+/// (a jq-mode `NumberLiteral` overflowing to infinity, e.g. `1e400`, is
+/// still routed through here rather than real jq's own literal-preserving
+/// reformat; see that function's doc comment for why, and issue #1083).
 ///
 /// `pub`, not `pub(crate)`: `src/bin/succinctly/yq_runner.rs` is a separate
 /// binary crate depending on this one as an external dependency, and is one
@@ -5224,17 +5257,21 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
 /// silently" lesson).
 ///
 /// Returns `&'static str`, not `String`: every branch is one of a fixed
-/// 6-string set (Rust's own `f64::Display` always normalizes any NaN bit
-/// pattern to exactly `"NaN"`, and any infinity to `"inf"`/`"-inf"`,
-/// regardless of payload/magnitude -- verified directly, not assumed).
-/// Lets the two streaming call sites (`stream.rs`, `json/light.rs`) write
-/// this straight into their `Write` sink with no heap allocation, instead
-/// of allocating a `String` just to borrow and immediately drop it.
+/// 6-string set (each of jq/yq mode's NaN/+infinity/-infinity spelling is a
+/// fixed string regardless of the input float's exact bit pattern/payload --
+/// verified directly, not assumed). Lets the two streaming call sites
+/// (`stream.rs`, `json/light.rs`) write this straight into their `Write`
+/// sink with no heap allocation, instead of allocating a `String` just to
+/// borrow and immediately drop it.
 ///
 /// # Examples
 ///
 /// ```
-/// use succinctly::jq::{nonfinite_display_string, YqSemantics};
+/// use succinctly::jq::{nonfinite_display_string, JqSemantics, YqSemantics};
+///
+/// assert_eq!(nonfinite_display_string::<JqSemantics>(f64::NAN), "null");
+/// assert_eq!(nonfinite_display_string::<JqSemantics>(f64::INFINITY), "1.7976931348623157e+308");
+/// assert_eq!(nonfinite_display_string::<JqSemantics>(f64::NEG_INFINITY), "-1.7976931348623157e+308");
 ///
 /// assert_eq!(nonfinite_display_string::<YqSemantics>(f64::NAN), ".nan");
 /// assert_eq!(nonfinite_display_string::<YqSemantics>(f64::INFINITY), ".inf");
@@ -5243,11 +5280,9 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
 pub fn nonfinite_display_string<S: EvalSemantics>(f: f64) -> &'static str {
     if S::TAG != EvalTag::Yq {
         if f.is_nan() {
-            "NaN"
-        } else if f.is_sign_negative() {
-            "-inf"
+            "null"
         } else {
-            "inf"
+            infinite_float_preview_text(f.is_sign_negative())
         }
     } else if f.is_nan() {
         ".nan"
@@ -28880,44 +28915,111 @@ mod tests {
         );
     }
 
+    /// #1075: a *computed* non-finite float (the bare `nan`/`infinite`
+    /// builtins, not a document-sourced literal) must spell itself the way
+    /// real jq's own JSON-substitution convention does, not Rust's bare
+    /// `f64::Display` -- confirmed live against jq 1.7.1.
     #[test]
-    fn test_number_literal_overflow_renders_as_inf_not_garbage() {
+    fn test_builtin_tostring_computed_nonfinite_matches_jq_1075() {
+        query!(br"null", "nan | tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "null");
+            }
+        );
+
+        query!(br"null", "infinite | tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "1.7976931348623157e+308");
+            }
+        );
+
+        query!(br"null", "-infinite | tostring",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "-1.7976931348623157e+308");
+            }
+        );
+
+        query!(br"null", "[nan] | @sh",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "null");
+            }
+        );
+
+        query!(br"null", "nan | @uri",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "null");
+            }
+        );
+
+        query!(br"null", "infinite | @uri",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "1.7976931348623157e%2B308");
+            }
+        );
+
+        query!(br"null", "nan | @html",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "null");
+            }
+        );
+
+        query!(br"null", r#"nan | "\(.)""#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "null");
+            }
+        );
+    }
+
+    #[test]
+    fn test_number_literal_overflow_renders_correctly_not_garbage() {
         // A `NumberLiteral` whose parsed f64 overflows to infinity used to
         // re-render its raw source text through `format_number_jq_compat`,
-        // producing garbage like "NaNE+2147483647" instead of "inf" (#561).
+        // producing garbage like "NaNE+2147483647" (#561), then later
+        // "inf"/"-inf" (Rust's own `f64::Display`, still wrong -- #1075).
+        //
+        // Both signs now take jq mode's `DBL_MAX`-text substitution
+        // (`nonfinite_display_string`, #1075) -- this still isn't a full
+        // match for real jq, which reformats a *positive* overflowed
+        // literal's own source text instead (`1e400 | tostring` ->
+        // `"1E+400"`, live-verified) rather than substituting; see
+        // `numeric_display_string`'s own doc comment and issue #1083 for why
+        // that gap is deliberately left open here. The negative case,
+        // though, genuinely does match real jq's own `DBL_MAX` substitution
+        // (confirmed live: `-1e400 | tostring` -> the negative `DBL_MAX`
+        // text, not `"-1E+400"`).
         query!(br"1e400", "tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inf");
+                assert_eq!(s, "1.7976931348623157e+308");
             }
         );
 
         query!(br"-1e400", "tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "-inf");
+                assert_eq!(s, "-1.7976931348623157e+308");
             }
         );
 
         query!(br"1e400", "@uri",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inf");
+                assert_eq!(s, "1.7976931348623157e%2B308");
             }
         );
 
         query!(br"1e400", "@html",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inf");
+                assert_eq!(s, "1.7976931348623157e+308");
             }
         );
 
         query!(br"1e400", "@sh",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inf");
+                assert_eq!(s, "1.7976931348623157e+308");
             }
         );
 
         query!(br"1e400", r#""\(.)""#,
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inf");
+                assert_eq!(s, "1.7976931348623157e+308");
             }
         );
     }
@@ -28930,36 +29032,45 @@ mod tests {
         // `OwnedValue` back to JSON text and reparse it to keep evaluating --
         // the same bridge pattern `eval_generic.rs` had. Before switching
         // these to `to_json_for_reindex`, an overflowed `NumberLiteral` was
-        // silently turned into JSON `null` by that round-trip, so `. as $x |
-        // $x | tostring` produced "null" instead of "inf" even though a
-        // direct `tostring` (tested above) was already fixed (#561).
+        // silently turned into JSON `null` by that round-trip (#561); now it
+        // survives as the same `DBL_MAX`-text substitution the bare-literal
+        // test above uses (#1075) -- these bridges are exactly the reason
+        // `numeric_display_string` cannot safely stop substituting here for
+        // *any* jq-mode overflowed `NumberLiteral` yet (see its own doc
+        // comment and issue #1083): `to_json_for_reindex`'s own `1e999`
+        // smuggling literal reparses into a `NumberLiteral` indistinguishable
+        // from a real one, so a literal-preserving reformat here would wrongly
+        // reformat that internal sentinel too.
         query!(br"1e400", ". as $x | $x | tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inf");
+                assert_eq!(s, "1.7976931348623157e+308");
             }
         );
 
         query!(br"-1e400", ". as $x | $x | tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "-inf");
+                assert_eq!(s, "-1.7976931348623157e+308");
             }
         );
 
         query!(br"1e400", "reduce (1) as $x (.; .) | tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inf");
+                assert_eq!(s, "1.7976931348623157e+308");
             }
         );
 
         query!(br"1e400", "foreach (1) as $x (.; .) | tostring",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inf");
+                assert_eq!(s, "1.7976931348623157e+308");
             }
         );
 
         query!(br#"{"a":1e400}"#, "with_entries(.value |= (. | tostring))",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
-                assert_eq!(obj.get("a"), Some(&OwnedValue::String("inf".to_string())));
+                assert_eq!(
+                    obj.get("a"),
+                    Some(&OwnedValue::String("1.7976931348623157e+308".to_string()))
+                );
             }
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4197,9 +4197,11 @@ mod tests {
     }
 
     #[test]
-    fn test_generic_tostring_overflow_literal_renders_as_inf() {
-        // Mirrors eval.rs's test_number_literal_overflow_renders_as_inf_not_garbage
-        // (#561): the generic evaluator's ToString arm had the same bug.
+    fn test_generic_tostring_overflow_literal_renders_correctly() {
+        // Mirrors eval.rs's test_number_literal_overflow_renders_correctly_not_garbage
+        // (#561, #1075): the generic evaluator's ToString arm had the same
+        // bug, first as raw-text-reformatting garbage, then as Rust's own
+        // `f64::Display` ("inf") instead of jq's `DBL_MAX`-text substitution.
         let json = br"1e400";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
@@ -4208,7 +4210,10 @@ mod tests {
         let result = eval(&Expr::Builtin(Builtin::ToString), value);
         let owned = result.into_owned().unwrap();
 
-        assert_eq!(owned, OwnedValue::String("inf".to_string()));
+        assert_eq!(
+            owned,
+            OwnedValue::String("1.7976931348623157e+308".to_string())
+        );
     }
 
     #[test]
@@ -4220,9 +4225,10 @@ mod tests {
         // reserialization used to call `OwnedValue::to_json()`, which
         // substitutes "null" for ±Infinity (correct for real JSON output,
         // but not for this internal round-trip) -- silently destroying the
-        // overflowed literal before `eval.rs`'s (already-fixed) `@uri`
-        // formatting ever saw it (#561). This exercises that bridge
-        // directly, independent of the CLI.
+        // overflowed literal before `eval.rs`'s `@uri` formatting ever saw it
+        // (#561), then rendering Rust's own `f64::Display` ("inf") instead of
+        // jq's `DBL_MAX`-text substitution (#1075). This exercises that
+        // bridge directly, independent of the CLI.
         let json = br"1e400";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
@@ -4231,7 +4237,10 @@ mod tests {
         let result = eval(&Expr::Format(FormatType::Uri), value);
         let owned = result.into_owned().unwrap();
 
-        assert_eq!(owned, OwnedValue::String("inf".to_string()));
+        assert_eq!(
+            owned,
+            OwnedValue::String("1.7976931348623157e%2B308".to_string())
+        );
     }
 
     #[test]
@@ -4248,7 +4257,10 @@ mod tests {
         let result = eval(&Expr::Format(FormatType::Uri), value);
         let owned = result.into_owned().unwrap();
 
-        assert_eq!(owned, OwnedValue::String("-inf".to_string()));
+        assert_eq!(
+            owned,
+            OwnedValue::String("-1.7976931348623157e%2B308".to_string())
+        );
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -888,9 +888,10 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     // pure overhead for them (#124). No non-finite-float guard is needed here
     // either: every non-JSON format bottoms out in `numeric_display_string`,
     // `owned_to_yaml`, or `props_value_to_string` (eval.rs), which already
-    // render NaN/Infinity as `"inf"`/`".nan"`/etc. directly from an
-    // `OwnedValue::Float` or `NumberLiteral`, with no dependence on having
-    // passed through a JSON round-trip first.
+    // render NaN/Infinity directly from an `OwnedValue::Float` or
+    // `NumberLiteral` -- jq mode's `"null"`/`DBL_MAX`-text substitution
+    // (#1075) or yq mode's `.nan`/`.inf`/`-.inf` -- with no dependence on
+    // having passed through a JSON round-trip first.
     if let Expr::Format(format_type) = expr {
         return format_result::<S, _>(format_type, &owned, optional);
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3906,41 +3906,43 @@ fn regression_issue_575_break_in_loop_constructs_reaches_label() -> Result<()> {
 
 /// A `NumberLiteral` that overflows to infinity (e.g. `1e400`) used to render
 /// as garbage like `"NaNE+2147483647"` in every non-JSON text format instead
-/// of `"inf"`/`"-inf"` (#561). `tostring` reaches the fix directly, but
-/// `@uri`/`@html`/`@sh`/string interpolation/`@csv` are dispatched through
-/// `eval_generic`'s cursor-reindexing bridge, which round-trips the value
-/// through JSON text -- and used to substitute `"null"` for the overflowed
-/// value before the fix ever saw it. This test exercises the real CLI (not
-/// `eval.rs::eval()` directly) so it actually covers that bridge.
+/// of jq's own `DBL_MAX`-text substitution (#561), then as Rust's own
+/// `f64::Display` (`"inf"`/`"-inf"`, still wrong -- #1075). `tostring`
+/// reaches the fix directly, but `@uri`/`@html`/`@sh`/string
+/// interpolation/`@csv` are dispatched through `eval_generic`'s
+/// cursor-reindexing bridge, which round-trips the value through JSON text --
+/// and used to substitute `"null"` for the overflowed value before the fix
+/// ever saw it. This test exercises the real CLI (not `eval.rs::eval()`
+/// directly) so it actually covers that bridge.
 #[test]
 fn test_number_literal_overflow_text_formats_via_cli() -> Result<()> {
     let (output, code) = run_jq_stdin("tostring", "1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin("tostring", "-1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""-inf""#);
+    assert_eq!(output.trim(), r#""-1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin("@uri", "1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e%2B308""#);
 
     let (output, code) = run_jq_stdin("@html", "1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin("@sh", "1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin(r#""\(.)""#, "1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin("@csv", "[1e400]", &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e+308""#);
 
     Ok(())
 }
@@ -3970,25 +3972,26 @@ fn test_number_literal_overflow_identity_prints_null_via_cli() -> Result<()> {
 /// (already covered by `test_number_literal_overflow_text_formats_via_cli`).
 /// Before switching these to `to_json_for_reindex`, they too silently turned
 /// an overflowed `NumberLiteral` into JSON `null`, so `. as $x | $x |
-/// tostring` printed `"null"` instead of `"inf"` even though a direct
-/// `tostring` was already fixed (#561).
+/// tostring` printed `"null"` instead of jq's `DBL_MAX`-text substitution
+/// even though a direct `tostring` was already fixed (#561, then #1075 for
+/// the exact substitution text).
 #[test]
 fn test_number_literal_overflow_owned_reindex_bridges_via_cli() -> Result<()> {
     let (output, code) = run_jq_stdin(". as $x | $x | tostring", "1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin(". as $x | $x | tostring", "-1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""-inf""#);
+    assert_eq!(output.trim(), r#""-1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin("reduce (1) as $x (.; .) | tostring", "1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin("foreach (1) as $x (.; .) | tostring", "1e400", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#""inf""#);
+    assert_eq!(output.trim(), r#""1.7976931348623157e+308""#);
 
     let (output, code) = run_jq_stdin(
         "with_entries(.value |= (. | tostring))",
@@ -3996,7 +3999,7 @@ fn test_number_literal_overflow_owned_reindex_bridges_via_cli() -> Result<()> {
         &["-c"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#"{"a":"inf"}"#);
+    assert_eq!(output.trim(), r#"{"a":"1.7976931348623157e+308"}"#);
 
     Ok(())
 }
@@ -10755,17 +10758,20 @@ fn test_jq_stderr_and_halt_error_unaffected_by_yq_mode_fix_1051() -> Result<()> 
 
 /// #1060: `numeric_display_string`'s NaN/Infinity fast path gained an
 /// `S`-gated yq-only branch (`.nan`/`.inf`/`-.inf`); confirm jq mode's own
-/// bare `f64::Display` spelling (`NaN`/`inf`/`-inf`) is unaffected. (Real
-/// jq's own `infinite` builtin substitutes `DBL_MAX` rather than true IEEE
-/// infinity -- succinctly doesn't replicate that quirk, a pre-existing,
-/// unrelated divergence; this test pins succinctly's own actual jq-mode
-/// output, not real jq's.)
+/// spelling is unaffected by that yq-only addition. jq mode's own spelling
+/// was, at the time #1060 landed, still Rust's bare `f64::Display`
+/// (`NaN`/`inf`/`-inf`) -- a separate, pre-existing divergence from real
+/// jq's actual `DBL_MAX`/`null` substitution, since fixed by #1075. This test
+/// now pins that corrected, oracle-matching jq-mode output instead.
 #[test]
 fn test_jq_tostring_special_floats_unaffected_by_yq_mode_fix_1060() -> Result<()> {
     for (filter, want) in [
-        ("infinite | tostring", r#""inf""#),
-        ("(-1 * infinite) | tostring", r#""-inf""#),
-        ("nan | tostring", r#""NaN""#),
+        ("infinite | tostring", r#""1.7976931348623157e+308""#),
+        (
+            "(-1 * infinite) | tostring",
+            r#""-1.7976931348623157e+308""#,
+        ),
+        ("nan | tostring", r#""null""#),
     ] {
         let (out, code) = run_jq_stdin(filter, "null", &["-c"])?;
         assert_eq!(code, 0, "for {filter:?}: {out:?}");

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -265,30 +265,38 @@ fn test_parity_formats_over_iteration() {
 
 /// Non-finite floats exercise `numeric_display_string`/`owned_to_yaml`/
 /// `props_value_to_string` (eval.rs), which already rendered `"inf"`/`".nan"`/
-/// etc. correctly before #124 -- both evaluators agreed on these even when the
-/// generic evaluator had no direct `Expr::Format` arm, since its catch-all
+/// etc. consistently before #124 -- both evaluators agreed on these even when
+/// the generic evaluator had no direct `Expr::Format` arm, since its catch-all
 /// round-trip goes through `to_json_for_reindex` (preserving, #561), not plain
 /// `to_json` (nulling). #124's direct arm doesn't change that outcome, only
 /// how cheaply it's reached.
 ///
+/// jq mode's own spelling changed under #1075 (`"inf"`/`"-inf"`, Rust's bare
+/// `f64::Display`, to jq's actual `DBL_MAX`-text substitution) -- yq mode's
+/// (`.inf`/`.nan`) is unaffected.
+///
 /// The pinned full-evaluator values below are asserted explicitly so parity
 /// can't silently re-agree on a *new* wrong answer.
 ///
-/// Note neither evaluator matches real jq here: jq 1.7.1 preserves the source
-/// literal and prints `1E+400` for all of these. That literal-preservation gap
-/// is a separate pre-existing issue, out of scope for #124.
+/// Note neither evaluator fully matches real jq here even after #1075: jq
+/// 1.7.1 preserves a *positive* overflowed literal's own source text and
+/// prints `1E+400` for it (though it does substitute `DBL_MAX` text for a
+/// *negative* one, which #1075 does match). That literal-preservation gap is
+/// a separate pre-existing issue (#1083), out of scope for both #124 and
+/// #1075 -- see `numeric_display_string`'s own doc comment (`src/jq/eval.rs`)
+/// for why.
 #[test]
 fn test_formats_non_finite_parity_124() {
     for (json, filter, expected) in [
-        (b"1e400".as_slice(), "@text", r#""inf""#),
-        (b"-1e400", "@text", r#""-inf""#),
-        (b"1e400", "@uri", r#""inf""#),
-        (b"1e400", "@html", r#""inf""#),
+        (b"1e400".as_slice(), "@text", r#""1.7976931348623157e+308""#),
+        (b"-1e400", "@text", r#""-1.7976931348623157e+308""#),
+        (b"1e400", "@uri", r#""1.7976931348623157e%2B308""#),
+        (b"1e400", "@html", r#""1.7976931348623157e+308""#),
         (b"1e400", "@yaml", r#"".inf""#),
         (b"1e400", "@props", r#"".inf""#),
-        (b"[1e400]", "@csv", r#""inf""#),
-        (b"[1e400]", "@tsv", r#""inf""#),
-        (b"[1e400]", "@sh", r#""inf""#),
+        (b"[1e400]", "@csv", r#""1.7976931348623157e+308""#),
+        (b"[1e400]", "@tsv", r#""1.7976931348623157e+308""#),
+        (b"[1e400]", "@sh", r#""1.7976931348623157e+308""#),
     ] {
         assert_eq!(
             as_strs(&full_outputs(json, filter)),

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -279,12 +279,16 @@ fn test_parity_formats_over_iteration() {
 /// can't silently re-agree on a *new* wrong answer.
 ///
 /// Note neither evaluator fully matches real jq here even after #1075: jq
-/// 1.7.1 preserves a *positive* overflowed literal's own source text and
-/// prints `1E+400` for it (though it does substitute `DBL_MAX` text for a
-/// *negative* one, which #1075 does match). That literal-preservation gap is
-/// a separate pre-existing issue (#1083), out of scope for both #124 and
-/// #1075 -- see `numeric_display_string`'s own doc comment (`src/jq/eval.rs`)
-/// for why.
+/// 1.7.1 preserves an overflowed literal's own source text for *either*
+/// sign when it's the input document itself (as every case below is) --
+/// `1e400 | tostring` -> `"1E+400"`, `-1e400 | tostring` -> `"-1E+400"` --
+/// rather than substituting `DBL_MAX` text for either. (A leading `-`
+/// typed inside the *filter* text instead, rather than the document, is a
+/// different, unrelated case: jq's own grammar treats that as unary
+/// negation on the positive literal, degrading fidelity -- not what any
+/// case here exercises.) That literal-preservation gap is a separate
+/// pre-existing issue (#1083), out of scope for both #124 and #1075 -- see
+/// `numeric_display_string`'s own doc comment (`src/jq/eval.rs`) for why.
 #[test]
 fn test_formats_non_finite_parity_124() {
     for (json, filter, expected) in [


### PR DESCRIPTION
## Summary

- `nonfinite_display_string`'s jq-mode branch spelled a non-finite float via Rust's own `f64::Display` (`"NaN"`/`"inf"`/`"-inf"`) instead of real jq's own JSON-substitution convention (`null` for NaN, `f64::MAX`'s literal decimal text for ±infinity) — confirmed live against jq 1.7.1: `nan | tostring` -> `"null"`, `infinite | tostring` -> `"1.7976931348623157e+308"`.
- Affected `tostring`, `@uri`, `@html`, `@sh`, `@csv`/`@tsv`/`@dsv`, and string interpolation in jq mode (yq mode's `.nan`/`.inf`/`-.inf` spelling is unaffected).
- Reuses the existing `infinite_float_preview_text` helper (already used by `format_number_jq_compat`'s own overflow ceiling and error-preview text) instead of duplicating the `DBL_MAX` literal — one definition, not two.

A related, deeper gap was found and deliberately **not** fixed here: a jq-mode `NumberLiteral` overflowing to infinity (e.g. `1e400`) still takes this same substitution rather than real jq's own literal-preserving reformat (`1e400 | tostring` -> `"1E+400"` in real jq). An earlier draft of this fix removed that interception, but it turned out unsafe: the `eval_owned_expr`/`eval_generic` reindex bridge (`reduce`/`foreach`/`as $x`/multi-stage pipes — reached by almost any non-trivial expression, not just explicit loops) round-trips a *computed* infinity through its own `1e999`/`-1e999` smuggling literal, which — unlike its `NAN_SENTINEL` sibling — is not guaranteed-unparseable as a genuine document literal. Letting jq mode fall through to `format_number_jq_compat` reformatted that internal sentinel as `"1E+999"` instead of substituting `DBL_MAX` text, a real regression caught during review. Filed as #1083 for whoever picks it up next; it needs the reindex bridge's own sentinel made collision-safe first (mirroring `NAN_SENTINEL`'s design).

Closes #1075.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full workspace suite, worktree-isolated build) — 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean (catches YAML SIMD backends `--all-features` compiles out)
- [x] `cargo check --no-default-features` — `no_std` compiles clean
- [x] Diffed output against pinned real `jq` 1.7.1 directly for every affected format (`tostring`, `@uri`, `@html`, `@sh`, `@csv`, string interpolation, plus the `reduce`/`foreach`/`as $x`/`with_entries` reindex-bridge paths)
- [x] Updated every existing test that encoded the old (incorrect) `"inf"`/`"-inf"`/`"NaN"` expectations across `src/jq/eval.rs`, `src/jq/eval_generic.rs`, `tests/jq_cli_tests.rs`, and `tests/jq_evaluator_parity_tests.rs`
- [x] Added a new regression test (`test_builtin_tostring_computed_nonfinite_matches_jq_1075`) directly covering the issue's own repro