### PR TITLE
fix(jq): fold_index_key rejects .[2^63] instead of silently folding to i64::MAX

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -752,9 +752,15 @@ impl<'a> Parser<'a> {
             Expr::Literal(Literal::String(s)) => Some(Expr::Field(s.clone())),
             Expr::Literal(Literal::Int(i)) => Some(Expr::Index(*i)),
             // `.[1.0]` is an integer index; `.[1.7]` is not, and must go through
-            // the evaluator to truncate the way jq does.
+            // the evaluator to truncate the way jq does. The upper bound is a
+            // strict `<`, not `<=`: `i64::MAX as f64` rounds *up* to `2^63`
+            // (`i64::MAX` isn't exactly representable as `f64`), so a `<=`
+            // check let `.[2^63]` through and `as i64` silently saturated it
+            // to `i64::MAX` -- one past what was actually written (#1061).
+            // `i64::MIN as f64` has no such rounding (`-2^63` is an exact
+            // power of two), so the lower bound stays `>=`.
             Expr::Literal(Literal::Float(f))
-                if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 =>
+                if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f < i64::MAX as f64 =>
             {
                 Some(Expr::Index(*f as i64))
             }
@@ -766,7 +772,7 @@ impl<'a> Parser<'a> {
             Expr::Literal(Literal::NumberLiteral(text)) => match parse_i64_or_f64(text)? {
                 NumberRepr::Int(i) => Some(Expr::Index(i)),
                 NumberRepr::Float(f)
-                    if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 =>
+                    if f.fract() == 0.0 && f >= i64::MIN as f64 && f < i64::MAX as f64 =>
                 {
                     Some(Expr::Index(f as i64))
                 }
@@ -777,21 +783,45 @@ impl<'a> Parser<'a> {
             // (see `parse_primary_inner`'s negative-literal split), not a
             // bare `Literal` -- see through that specific shape too, or
             // every such key silently loses this fast path and downgrades
-            // to a runtime `IndexExpr`/`DynamicSlice`. The inner literal's
-            // own fold is always non-negative (the sign was already
-            // stripped when this shape was built), so negating its folded
-            // index can never overflow i64.
+            // to a runtime `IndexExpr`/`DynamicSlice`.
+            //
+            // #1061: `i64::MIN`'s magnitude (`2^63`) is one larger than
+            // `i64::MAX`'s, so it is exactly the one value the bound above
+            // rejects (correctly, for a direct *positive* index) that is
+            // still in range once negated -- `fold_index_key(right)` alone
+            // won't fold it, so it needs its own check here first.
             Expr::Arithmetic {
                 op: ArithOp::Mul(_),
                 left,
                 right,
             } if matches!(**left, Expr::Literal(Literal::Int(-1))) => {
+                if Self::is_literal_i64_max_as_f64(right) {
+                    return Some(Expr::Index(i64::MIN));
+                }
                 match Self::fold_index_key(right)? {
                     Expr::Index(i) => Some(Expr::Index(-i)),
                     _ => None,
                 }
             }
             _ => None,
+        }
+    }
+
+    /// True if `key` is a literal (or number-literal) integral float whose
+    /// value is exactly `i64::MAX as f64` (`2^63` -- one past `i64::MAX`
+    /// itself, since `i64::MAX` isn't exactly representable as `f64`). This
+    /// is the sole magnitude [`Self::fold_index_key`]'s own bound rejects
+    /// for a direct positive index that is still exactly `i64::MIN` once
+    /// negated (#1061); any other float `fold_index_key` rejects is either
+    /// non-integral or genuinely out of `i64` range in both signs.
+    fn is_literal_i64_max_as_f64(key: &Expr) -> bool {
+        match key {
+            Expr::Paren(inner) => Self::is_literal_i64_max_as_f64(inner),
+            Expr::Literal(Literal::Float(f)) => *f == i64::MAX as f64,
+            Expr::Literal(Literal::NumberLiteral(text)) => {
+                matches!(parse_i64_or_f64(text), Some(NumberRepr::Float(f)) if f == i64::MAX as f64)
+            }
+            _ => false,
         }
     }
 
@@ -5506,6 +5536,55 @@ mod tests {
         // positive case, it must go through the evaluator to truncate the
         // way jq does.
         assert!(matches!(parse(".[-1.5]").unwrap(), Expr::IndexExpr { .. }));
+    }
+
+    /// #1061: `i64::MAX as f64` rounds *up* to `2^63` (`i64::MAX` itself isn't
+    /// exactly representable as `f64`), so a `<=` bound let `.[2^63]` fold to
+    /// `Expr::Index(i64::MAX)` -- silently one lower than what was written,
+    /// with no error or truncation notice. The fix must reject the whole
+    /// `[2^63, +inf)` range (both the nearest-representable spellings, since
+    /// `9223372036854775807.0` and `9223372036854775808.0` round to the same
+    /// `f64`) while still folding every value strictly below it, through both
+    /// the plain-float and the source-text-preserving `NumberLiteral` arms.
+    /// The negative bound is unaffected -- `i64::MIN` (`-2^63`) *is* an exact
+    /// power of two, so `-2^63` itself must still fold.
+    #[test]
+    fn test_1061_i64_max_boundary_no_longer_off_by_one() {
+        assert!(matches!(
+            parse(".[9223372036854775808.0]").unwrap(),
+            Expr::IndexExpr { .. }
+        ));
+        // Same `f64` bit pattern as the value above (`i64::MAX` rounds up to
+        // `2^63`), so it must be rejected too, not just the round-numbered
+        // spelling.
+        assert!(matches!(
+            parse(".[9223372036854775807.0]").unwrap(),
+            Expr::IndexExpr { .. }
+        ));
+        // Exponent-notation spelling goes through the `NumberLiteral` arm,
+        // not the plain-`Float` arm -- both need the same fix.
+        assert!(matches!(
+            parse(".[9223372036854775808e0]").unwrap(),
+            Expr::IndexExpr { .. }
+        ));
+
+        // A value strictly below the boundary still takes the fast path.
+        assert_eq!(
+            parse(".[9223372036854774784.0]").unwrap(),
+            Expr::Index(9223372036854774784)
+        );
+        assert_eq!(
+            parse(".[9223372036854774784e0]").unwrap(),
+            Expr::Index(9223372036854774784)
+        );
+
+        // The lower bound is unaffected: `i64::MIN` is an exact power of two,
+        // so it still folds (through the `Arithmetic` negative-literal shape
+        // documented above).
+        assert_eq!(
+            parse(".[-9223372036854775808.0]").unwrap(),
+            Expr::Index(i64::MIN)
+        );
     }
 
     /// The nesting shape is what encodes jq's key scoping: every key in a

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -785,43 +785,31 @@ impl<'a> Parser<'a> {
             // every such key silently loses this fast path and downgrades
             // to a runtime `IndexExpr`/`DynamicSlice`.
             //
-            // #1061: `i64::MIN`'s magnitude (`2^63`) is one larger than
-            // `i64::MAX`'s, so it is exactly the one value the bound above
-            // rejects (correctly, for a direct *positive* index) that is
-            // still in range once negated -- `fold_index_key(right)` alone
-            // won't fold it, so it needs its own check here first.
+            // #1061: negating `fold_index_key(right)`'s own result can
+            // overflow `i64` -- not just for the float/exponent spelling of
+            // `i64::MIN`'s magnitude (`2^63`, one past `i64::MAX`, so it
+            // reaches here rather than folding directly), but for *any*
+            // producer of `Expr::Index(i64::MIN)`, including a bare
+            // `Literal::Int(i64::MIN)` on `right` (reachable from ordinary
+            // jq source: `left` need not come from the negative-literal
+            // split at all, just any `-1 * <literal>` spelling, and a
+            // leading-zero integer like `-01` parses to `Literal::Int(-1)`
+            // directly rather than jq's number grammar rejecting it).
+            // `checked_neg` covers every such producer uniformly: it falls
+            // through to `None` (a runtime `IndexExpr`, which computes the
+            // same value correctly via ordinary float arithmetic) instead
+            // of panicking in a debug build or silently wrapping in release.
             Expr::Arithmetic {
                 op: ArithOp::Mul(_),
                 left,
                 right,
             } if matches!(**left, Expr::Literal(Literal::Int(-1))) => {
-                if Self::is_literal_i64_max_as_f64(right) {
-                    return Some(Expr::Index(i64::MIN));
-                }
                 match Self::fold_index_key(right)? {
-                    Expr::Index(i) => Some(Expr::Index(-i)),
+                    Expr::Index(i) => i.checked_neg().map(Expr::Index),
                     _ => None,
                 }
             }
             _ => None,
-        }
-    }
-
-    /// True if `key` is a literal (or number-literal) integral float whose
-    /// value is exactly `i64::MAX as f64` (`2^63` -- one past `i64::MAX`
-    /// itself, since `i64::MAX` isn't exactly representable as `f64`). This
-    /// is the sole magnitude [`Self::fold_index_key`]'s own bound rejects
-    /// for a direct positive index that is still exactly `i64::MIN` once
-    /// negated (#1061); any other float `fold_index_key` rejects is either
-    /// non-integral or genuinely out of `i64` range in both signs.
-    fn is_literal_i64_max_as_f64(key: &Expr) -> bool {
-        match key {
-            Expr::Paren(inner) => Self::is_literal_i64_max_as_f64(inner),
-            Expr::Literal(Literal::Float(f)) => *f == i64::MAX as f64,
-            Expr::Literal(Literal::NumberLiteral(text)) => {
-                matches!(parse_i64_or_f64(text), Some(NumberRepr::Float(f)) if f == i64::MAX as f64)
-            }
-            _ => false,
         }
     }
 
@@ -5546,8 +5534,6 @@ mod tests {
     /// `9223372036854775807.0` and `9223372036854775808.0` round to the same
     /// `f64`) while still folding every value strictly below it, through both
     /// the plain-float and the source-text-preserving `NumberLiteral` arms.
-    /// The negative bound is unaffected -- `i64::MIN` (`-2^63`) *is* an exact
-    /// power of two, so `-2^63` itself must still fold.
     #[test]
     fn test_1061_i64_max_boundary_no_longer_off_by_one() {
         assert!(matches!(
@@ -5577,14 +5563,70 @@ mod tests {
             parse(".[9223372036854774784e0]").unwrap(),
             Expr::Index(9223372036854774784)
         );
+    }
 
-        // The lower bound is unaffected: `i64::MIN` is an exact power of two,
-        // so it still folds (through the `Arithmetic` negative-literal shape
-        // documented above).
-        assert_eq!(
+    /// #1061 (review follow-up): negating `fold_index_key(right)`'s result in
+    /// the `-1 * <literal>` desugar arm has no `i64::MIN` guard on its own --
+    /// `i64::MIN`'s magnitude (`2^63`) is one larger than `i64::MAX`'s, so
+    /// `-i64::MIN` overflows `i64`. That's reachable two ways: the intended
+    /// negative-float-literal spelling (`.[-9223372036854775808.0]`, whose
+    /// magnitude is a `NumberLiteral` that parses to exactly `i64::MAX as
+    /// f64`), and separately, unrelated to any float spelling at all, a bare
+    /// `Literal::Int(i64::MIN)` reaching this arm as `right` (ordinary jq
+    /// multiplication with a `Literal::Int(-1)` on the left -- reachable from
+    /// real source via a leading-zero integer like `-01`, since that spelling
+    /// fails JSON's number grammar and falls back to a bare `Literal::Int`
+    /// rather than the source-text-preserving `NumberLiteral`). Both must
+    /// fall through to a runtime `IndexExpr` instead of folding to a wrong
+    /// value (previously a silent two's-complement wrap in release builds,
+    /// or a debug-build panic).
+    #[test]
+    fn test_1061_negating_i64_min_does_not_overflow() {
+        assert!(matches!(
             parse(".[-9223372036854775808.0]").unwrap(),
-            Expr::Index(i64::MIN)
+            Expr::IndexExpr { .. }
+        ));
+        assert!(matches!(
+            parse(".[-9223372036854775808e0]").unwrap(),
+            Expr::IndexExpr { .. }
+        ));
+        // The `right` operand need not come from the negative-literal split
+        // at all -- any `-1 * <literal>` shape matches the same arm.
+        assert!(matches!(
+            parse(".[-01 * -9223372036854775808]").unwrap(),
+            Expr::IndexExpr { .. }
+        ));
+
+        // Every other magnitude on this path still negates correctly --
+        // one `f64` ULP below the boundary above, so distinct from it
+        // (`9223372036854775807.0` isn't usable here: it rounds to the same
+        // `f64` as `2^63` and collapses onto the boundary case rather than
+        // testing a separate value). `test_1035_...` above already covers
+        // the ordinary case through the intended desugar path (`.[-1.0]`
+        // etc.), so this only needs the one large-but-safe magnitude.
+        assert_eq!(
+            parse(".[-9223372036854774784.0]").unwrap(),
+            Expr::Index(-9223372036854774784)
         );
+    }
+
+    /// #1061: `finish_slice`'s bounds fold through `fold_int_literal`, which
+    /// itself delegates to `fold_index_key` -- so a slice bound at either
+    /// boundary must inherit the same fix as a bare index, not just be
+    /// exercised at the index call site.
+    #[test]
+    fn test_1061_boundary_fix_applies_to_slice_bounds_too() {
+        // A slice's upper bound at `2^63` can't fold, same as an index.
+        assert!(matches!(
+            parse(".[1:9223372036854775808.0]").unwrap(),
+            Expr::SliceExpr { .. }
+        ));
+        // A slice's lower bound at `i64::MIN`'s magnitude no longer
+        // overflows on negation, same as an index.
+        assert!(matches!(
+            parse(".[-9223372036854775808.0:]").unwrap(),
+            Expr::SliceExpr { .. }
+        ));
     }
 
     /// The nesting shape is what encodes jq's key scoping: every key in a


### PR DESCRIPTION
## Summary

`fold_index_key` (`src/jq/parser.rs`) constant-folds a literal float/exponent array
index into `Expr::Index(i64)` at parse time, bounded by `f >= i64::MIN as f64 && f <=
i64::MAX as f64`. `i64::MAX` (`9223372036854775807`) isn't exactly representable as
`f64` — it rounds *up* to `2^63` (`9223372036854775808.0`) — so the `<=` bound let a
literal index of exactly `2^63` pass the check, and the subsequent `f as i64` cast then
*saturated* the value to `i64::MAX`: one lower than what was actually written, with no
error or truncation notice.

## Fix (round 1)

Tightened the upper bound to a strict `<` in both the plain `Literal::Float` arm and the
source-text-preserving `Literal::NumberLiteral` arm. The lower bound (`i64::MIN as f64`)
is untouched — `-2^63` is an exact power of two, so no equivalent off-by-one exists
there.

## Fix (round 2 — code review)

Code review (10-angle fan-out, several independently reproducing the same finding by
building and A/B-testing `main` against this branch) found two things:

**A genuine, severe bug directly adjacent to the round-1 fix.** The `-1 * <literal>`
desugar arm computed `Expr::Index(-i)` with no guard against `i == i64::MIN` —
negating it overflows `i64`, panicking in debug builds and silently wrapping to a wrong
value in release builds. This is **pre-existing on `main`**, not introduced by round 1,
but sits in the exact match arm round 1 touches, and is reachable from ordinary jq
syntax: a leading-zero integer literal like `-01` fails jq's number grammar and
collapses to a bare `Literal::Int` instead of the source-text-preserving
`NumberLiteral`, so `.[-01 * -9223372036854775808]` reaches this arm directly. Fixed by
replacing round 1's `is_literal_i64_max_as_f64` special case (which only covered one
specific producer of `Expr::Index(i64::MIN)`) with a general `.checked_neg()` guard that
covers every producer uniformly — falling through to a runtime `IndexExpr` (which
computes the same value correctly via ordinary jq arithmetic) instead of folding to a
wrong one. This also deleted the special case's own dead code (3 of its 4 match arms
were unreachable at its sole call site, confirmed via `cargo llvm-cov`) and its
redundant re-parse of the same literal text.

**The PR's original "no CLI-visible effect" claim was inaccurate.** Round 1's own
description said the whole fix had no end-to-end observable effect, citing a separate
masking bug in `eval.rs` (see Scope note below). Review correctly caught that this only
holds for the *positive* `.[2^63]` case — the *negative* case genuinely changed:
`path(.[-9223372036854775808.0])` was `[-9223372036854775807]` (wrong) before round 1,
now correctly `[-9223372036854775808]`. That distinction is now reflected in the test
names/comments (`test_1061_i64_max_boundary_no_longer_off_by_one` for the still-masked
positive case, `test_1061_negating_i64_min_does_not_overflow` for the genuinely-fixed
negative case) and in this description.

## Testing

- Parser-level unit tests: boundary spellings for both signs and both literal forms
  (plain float / exponent `NumberLiteral`), a value strictly below the boundary, the
  live negation-overflow repro (`.[-01 * -9223372036854775808]`, previously a panic),
  and slice-bound propagation (`fold_int_literal` delegates to the same `fold_index_key`,
  so a slice bound at either boundary needs the same coverage as a bare index).
- Full `cargo test --features cli,simd,regex,serde` (2528 tests) — all green.
- Both required Clippy invocations (`--all-features` and the YAML-SIMD/AVX-512 feature
  set) — clean.

## Scope note — a deeper, separate divergence found along the way

Verifying the original fix against real jq (1.7.1) turned up a materially larger,
pre-existing divergence: `key_to_path_component`/`numeric_key_to_index` (`src/jq/eval.rs`)
unconditionally convert *every* float array index into an integer path component, while
real jq preserves the float's type in `path()` output regardless of magnitude
(`path(.[2.0])` is `[2.0]` in jq, `[2]` in succinctly — reproduces even for a genuinely
dynamic, non-foldable key, so it's unrelated to this issue's parser-level fix). That's
why the *positive*-boundary half of this fix has no end-to-end CLI-visible effect on its
own: the downstream conversion masks it, saturating to the same wrong `i64::MAX` whether
or not the parser folds it. The fix is still correct and worth having on its own terms —
a wrong compile-time AST is a bug independent of what currently happens to mask it
downstream, and this issue's own repro was explicitly a parser-level probe, not a
claimed CLI-observable one.

Filed the deeper divergence separately as #1088 (needs a design decision — jq's own
int/float path behavior turns out to be asymmetric by sign, not a simple "always
preserve the float" rule, and representing a float-valued path component at all is an
architectural change to `Expr::Index`, not a point fix).

Fixes #1061