### PR TITLE
fix(jq): unary minus preserves IEEE754 negative-zero sign

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -717,6 +717,14 @@ impl EvalError {
         Self::subject(value, "has no keys")
     }
 
+    /// `<v> cannot be negated` — unary minus (`-expr`) on a non-numeric
+    /// operand (#1056). Matches real jq's own dedicated wording, confirmed
+    /// live against jq 1.7.1 (`-"abc"` -> `string ("abc") cannot be
+    /// negated`).
+    pub fn cannot_be_negated(value: &OwnedValue) -> Self {
+        Self::subject(value, "cannot be negated")
+    }
+
     /// `<v> has no length`.
     pub fn has_no_length(value: &OwnedValue) -> Self {
         Self::subject(value, "has no length")

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1718,19 +1718,31 @@ fn arith_sub<S: EvalSemantics>(
 /// sign bit for every value including `0.0`. `Int(n)` negates via
 /// `checked_neg`/`wrapping_neg` (jq/yq's usual overflow conventions,
 /// matching `arith_sub`'s `0 - n` handling exactly: only `i64::MIN` can
-/// overflow, since `-i64::MIN` doesn't fit in `i64`) -- *except* for `n ==
-/// 0`, which promotes to `Float(-0.0)` instead of staying `Int(0)`: unlike
-/// `arith_mul`, this function has exactly one caller (unary minus itself),
-/// so special-casing zero here can't accidentally reinterpret some
-/// unrelated expression the way special-casing `-1 * 0` inside `arith_mul`
-/// would have (see this function's own history above) -- real jq has no
-/// separate integer type, so an all-integer computation that reduces to
-/// exactly zero (`-(1-1)`) is already the double `0.0` there, and negating
-/// it naturally yields `-0.0`; this promotion is the one place `Int`
-/// deliberately gives up exact-integer fidelity to match that.
+/// overflow, since `-i64::MIN` doesn't fit in `i64`) -- *except* for jq mode
+/// specifically with `n == 0`, which promotes to `Float(-0.0)` instead of
+/// staying `Int(0)`: unlike `arith_mul`, this function has exactly one
+/// caller (unary minus itself), so special-casing zero here can't
+/// accidentally reinterpret some unrelated expression the way
+/// special-casing `-1 * 0` inside `arith_mul` would have (see this
+/// function's own history above) -- real jq has no separate integer type,
+/// so an all-integer computation that reduces to exactly zero (`-(1-1)`) is
+/// already the double `0.0` there, and negating it naturally yields `-0.0`;
+/// this promotion is the one place `Int` deliberately gives up
+/// exact-integer fidelity to match that.
+///
+/// **jq-mode only**: real yq has no unary-minus operator at all (confirmed
+/// live against yq v4.53.3: `-.a` is a hard parse error, `'-' expects 2
+/// args but there is 1`) -- succinctly's own support for it in yq mode is
+/// a pre-existing, unrelated extension (#1056 doesn't touch whether it
+/// exists), so there's no oracle to say a zero-valued yq integer field
+/// negating to a float (`-.replicas` on `0` becoming `-0.0` instead of
+/// staying `0`) is the *intended* behavior rather than a surprising type
+/// change to a config value -- caught by code review before reaching
+/// `main`. Leaving yq's `Int(0)` un-promoted keeps this fix scoped to
+/// jq-mode's own verified, oracle-backed convention.
 fn arith_negate<S: EvalSemantics>(operand: OwnedValue) -> Result<OwnedValue, EvalError> {
     match operand.into_plain_number() {
-        OwnedValue::Int(0) => Ok(OwnedValue::Float(-0.0)),
+        OwnedValue::Int(0) if S::TAG != EvalTag::Yq => Ok(OwnedValue::Float(-0.0)),
         OwnedValue::Int(n) => Ok(OwnedValue::Int(if S::OVERFLOW_WRAPS {
             n.wrapping_neg()
         } else {
@@ -25236,6 +25248,37 @@ mod tests {
         query!(br"null", "-(-9223372036854775808)",
             QueryResult::Owned(OwnedValue::Float(f)) => {
                 assert_eq!(f, 9223372036854775808.0);
+            }
+        );
+    }
+
+    /// #1056 review: the `Int(0) -> Float(-0.0)` promotion above is jq-mode
+    /// only. Real yq has no unary-minus operator at all (confirmed live
+    /// against yq v4.53.3: `-.a` is a hard parse error, `'-' expects 2 args
+    /// but there is 1`), so there's no oracle backing an integer-to-float
+    /// type change for a yq config field's zero value (`-.replicas` on `0`
+    /// silently becoming `-0.0`) -- an earlier draft applied the promotion
+    /// unconditionally and was caught by code review with zero yq-mode test
+    /// coverage of this exact case. yq mode's `Float` operand still
+    /// preserves sign correctly (unaffected by the gate, since that's a
+    /// genuine `f64` value with no type-change question), and a non-numeric
+    /// operand still errors rather than silently succeeding.
+    #[test]
+    fn test_unary_minus_yq_mode_integer_zero_stays_integer_1056() {
+        yq_query!(br"null", "-(1-1)",
+            QueryResult::Owned(OwnedValue::Int(0)) => {}
+        );
+
+        yq_query!(br#"{"a":0.0}"#, "-.a",
+            QueryResult::Owned(OwnedValue::Float(f)) => {
+                assert_eq!(f, 0.0);
+                assert!(f.is_sign_negative());
+            }
+        );
+
+        yq_query!(br#"{"a":"abc"}"#, "-.a",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, r#"string ("abc") cannot be negated"#);
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37945,6 +37945,15 @@ mod tests {
         assert_eq!(outputs(b"[10,20]", ".[] | (1+1) | key"), vec!["0", "1"]);
     }
 
+    /// #1056: `eval_pipe_with_path_context_internal`'s own `Expr::Arithmetic`
+    /// arm (separate from `eval_arithmetic`'s) needs the same
+    /// `ArithOp::Negate` handling `key`/`file_index` mid-pipe after a unary
+    /// minus.
+    #[test]
+    fn test_key_survives_unary_minus_mid_pipe_1056() {
+        assert_eq!(outputs(b"[10,20]", ".[] | -(1) | key"), vec!["0", "1"]);
+    }
+
     #[test]
     fn test_key_survives_if_then_else_mid_pipe() {
         assert_eq!(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25124,6 +25124,71 @@ mod tests {
         );
     }
 
+    /// #1056: unary minus on a non-literal operand used to lower to `(0 -
+    /// expr)`, whose IEEE-754 `0.0 - 0.0` silently loses the sign of a
+    /// zero-valued operand -- `(-1) * expr` preserves it instead, matching
+    /// the fix #1035 already applied to the filter-literal rewrite just
+    /// above this test. Confirmed live against jq 1.7.1.
+    #[test]
+    fn test_unary_minus_float_zero_preserves_sign_1056() {
+        query!(br#"{"a":0.0}"#, "-.a",
+            QueryResult::Owned(OwnedValue::Float(f)) => {
+                assert_eq!(f, 0.0);
+                assert!(f.is_sign_negative());
+            }
+        );
+
+        query!(br"null", "-(1.0-1.0)",
+            QueryResult::Owned(OwnedValue::Float(f)) => {
+                assert_eq!(f, 0.0);
+                assert!(f.is_sign_negative());
+            }
+        );
+
+        // Negating a positive-signed float zero still gives negative zero
+        // (not a no-op) -- same as real jq.
+        query!(br"null", "-(0.0)",
+            QueryResult::Owned(OwnedValue::Float(f)) => {
+                assert_eq!(f, 0.0);
+                assert!(f.is_sign_negative());
+            }
+        );
+
+        // Sanity: ordinary (non-zero) negation is unaffected by the
+        // Sub-to-Mul rewrite.
+        query!(br#"{"a":5.5}"#, "-.a",
+            QueryResult::Owned(OwnedValue::Float(f)) => {
+                assert_eq!(f, -5.5);
+            }
+        );
+        query!(br#"{"a":5}"#, "-.a",
+            QueryResult::Owned(OwnedValue::Int(n)) => {
+                assert_eq!(n, -5);
+            }
+        );
+    }
+
+    /// #1056 follow-up (filed as #1091, not fixed here): unlike real jq --
+    /// which has no separate integer type, so `1 - 1` is already the double
+    /// `0.0` internally -- succinctly's `Int`/`Float` split means an
+    /// all-integer computation that reduces to exactly zero stays
+    /// `OwnedValue::Int(0)`, which has no negative-zero representation to
+    /// preserve at all. `(-1) * 0` (this issue's own fix) can't help here:
+    /// `Int * Int` correctly stays `Int` for genuine multiplication, so
+    /// special-casing it would incorrectly reinterpret a literal `(-1) * 0`
+    /// a user actually wrote. A full fix needs a representation that's
+    /// unambiguously "this is a negation" (e.g. a dedicated unary AST
+    /// variant), not an arithmetic rewrite -- pinned here so a future
+    /// evaluator change can't silently "fix" this by accident without
+    /// updating the test (which would then need `is_sign_negative()`
+    /// added, matching the float cases above).
+    #[test]
+    fn test_unary_minus_integer_zero_still_loses_sign_1056_followup() {
+        query!(br"null", "-(1-1)",
+            QueryResult::Owned(OwnedValue::Int(0)) => {}
+        );
+    }
+
     #[test]
     fn test_comparison_eq() {
         query!(br#"{"a": 1, "b": 1}"#, ".a == .b",

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1615,6 +1615,9 @@ fn eval_arithmetic<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, flags),
             ArithOp::Div => arith_div::<S>(left_val, right_val),
             ArithOp::Mod => arith_mod::<S>(left_val, right_val),
+            // `left_val` is always the unused dummy (see `ArithOp::Negate`'s
+            // own doc comment).
+            ArithOp::Negate => arith_negate::<S>(right_val),
         },
     )
 }
@@ -1701,6 +1704,43 @@ fn arith_sub<S: EvalSemantics>(
             Ok(OwnedValue::Array(result))
         }
         (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Subtract)),
+    }
+}
+
+/// Unary minus (`-expr`, #1056): true IEEE-754 negation, not `0 - expr`
+/// (loses the sign of a zero-valued operand) and not `-1 * expr` (silently
+/// inherits `*`'s string-repetition and null-passthrough semantics instead
+/// of erroring on a non-numeric operand -- an earlier draft of this fix did
+/// exactly that and was caught by code review before reaching `main`, since
+/// `-"abc"`/`-null` both silently returned `null` instead of erroring).
+///
+/// `Float(f)` negates via Rust's own unary `-`, which correctly flips the
+/// sign bit for every value including `0.0`. `Int(n)` negates via
+/// `checked_neg`/`wrapping_neg` (jq/yq's usual overflow conventions,
+/// matching `arith_sub`'s `0 - n` handling exactly: only `i64::MIN` can
+/// overflow, since `-i64::MIN` doesn't fit in `i64`) -- *except* for `n ==
+/// 0`, which promotes to `Float(-0.0)` instead of staying `Int(0)`: unlike
+/// `arith_mul`, this function has exactly one caller (unary minus itself),
+/// so special-casing zero here can't accidentally reinterpret some
+/// unrelated expression the way special-casing `-1 * 0` inside `arith_mul`
+/// would have (see this function's own history above) -- real jq has no
+/// separate integer type, so an all-integer computation that reduces to
+/// exactly zero (`-(1-1)`) is already the double `0.0` there, and negating
+/// it naturally yields `-0.0`; this promotion is the one place `Int`
+/// deliberately gives up exact-integer fidelity to match that.
+fn arith_negate<S: EvalSemantics>(operand: OwnedValue) -> Result<OwnedValue, EvalError> {
+    match operand.into_plain_number() {
+        OwnedValue::Int(0) => Ok(OwnedValue::Float(-0.0)),
+        OwnedValue::Int(n) => Ok(OwnedValue::Int(if S::OVERFLOW_WRAPS {
+            n.wrapping_neg()
+        } else {
+            match n.checked_neg() {
+                Some(result) => result,
+                None => return Ok(OwnedValue::Float(-(n as f64))),
+            }
+        })),
+        OwnedValue::Float(f) => Ok(OwnedValue::Float(-f)),
+        other => Err(EvalError::cannot_be_negated(&other)),
     }
 }
 
@@ -15991,6 +16031,9 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, *flags),
                     ArithOp::Div => arith_div::<S>(left_val, right_val),
                     ArithOp::Mod => arith_mod::<S>(left_val, right_val),
+                    // `left_val` is always the unused dummy (see
+                    // `ArithOp::Negate`'s own doc comment).
+                    ArithOp::Negate => arith_negate::<S>(right_val),
                 },
             );
             if rest.is_empty() {
@@ -25126,11 +25169,19 @@ mod tests {
 
     /// #1056: unary minus on a non-literal operand used to lower to `(0 -
     /// expr)`, whose IEEE-754 `0.0 - 0.0` silently loses the sign of a
-    /// zero-valued operand -- `(-1) * expr` preserves it instead, matching
-    /// the fix #1035 already applied to the filter-literal rewrite just
-    /// above this test. Confirmed live against jq 1.7.1.
+    /// zero-valued operand -- a dedicated `ArithOp::Negate` (`arith_negate`)
+    /// preserves it instead, matching the fix #1035 already applied to the
+    /// filter-literal rewrite just above this test. Also covers an
+    /// all-integer computation that reduces to exactly zero (`-(1-1)`):
+    /// unlike real jq (no separate integer type, so `1 - 1` is already the
+    /// double `0.0` there), `OwnedValue::Int(0)` has no negative-zero
+    /// representation of its own, so `arith_negate` promotes exactly this
+    /// one case to `Float(-0.0)` -- safe *only* because this function has
+    /// exactly one caller (unary minus), unlike the `(-1) * expr` rewrite an
+    /// earlier draft tried (see `test_unary_minus_non_numeric_errors_1056`
+    /// below for why that was reverted). Confirmed live against jq 1.7.1.
     #[test]
-    fn test_unary_minus_float_zero_preserves_sign_1056() {
+    fn test_unary_minus_zero_preserves_sign_1056() {
         query!(br#"{"a":0.0}"#, "-.a",
             QueryResult::Owned(OwnedValue::Float(f)) => {
                 assert_eq!(f, 0.0);
@@ -25154,8 +25205,15 @@ mod tests {
             }
         );
 
-        // Sanity: ordinary (non-zero) negation is unaffected by the
-        // Sub-to-Mul rewrite.
+        // The all-integer case: -(1-1) promotes Int(0) to Float(-0.0).
+        query!(br"null", "-(1-1)",
+            QueryResult::Owned(OwnedValue::Float(f)) => {
+                assert_eq!(f, 0.0);
+                assert!(f.is_sign_negative());
+            }
+        );
+
+        // Sanity: ordinary (non-zero) negation is unaffected.
         query!(br#"{"a":5.5}"#, "-.a",
             QueryResult::Owned(OwnedValue::Float(f)) => {
                 assert_eq!(f, -5.5);
@@ -25166,26 +25224,61 @@ mod tests {
                 assert_eq!(n, -5);
             }
         );
+
+        // Sanity: a generator operand still fans out to one negated result
+        // per output (the dummy `left` in `ArithOp::Negate`'s rewrite must
+        // not collapse this to a single value).
+        assert_eq!(outputs(b"null", "-(1,2,3)"), ["-1", "-2", "-3"]);
+
+        // i64::MIN overflows i64 negation (matching arith_sub's own
+        // 0 - i64::MIN overflow handling): falls back to Float, same
+        // (including precision loss) as real jq's own uniform-double model.
+        query!(br"null", "-(-9223372036854775808)",
+            QueryResult::Owned(OwnedValue::Float(f)) => {
+                assert_eq!(f, 9223372036854775808.0);
+            }
+        );
     }
 
-    /// #1056 follow-up (filed as #1091, not fixed here): unlike real jq --
-    /// which has no separate integer type, so `1 - 1` is already the double
-    /// `0.0` internally -- succinctly's `Int`/`Float` split means an
-    /// all-integer computation that reduces to exactly zero stays
-    /// `OwnedValue::Int(0)`, which has no negative-zero representation to
-    /// preserve at all. `(-1) * 0` (this issue's own fix) can't help here:
-    /// `Int * Int` correctly stays `Int` for genuine multiplication, so
-    /// special-casing it would incorrectly reinterpret a literal `(-1) * 0`
-    /// a user actually wrote. A full fix needs a representation that's
-    /// unambiguously "this is a negation" (e.g. a dedicated unary AST
-    /// variant), not an arithmetic rewrite -- pinned here so a future
-    /// evaluator change can't silently "fix" this by accident without
-    /// updating the test (which would then need `is_sign_negative()`
-    /// added, matching the float cases above).
+    /// #1056 review: an earlier draft implemented unary minus as
+    /// `(-1) * expr` instead of a dedicated `ArithOp::Negate` -- silently
+    /// wrong, not just imprecise: `arith_mul` has its own string-repetition
+    /// (`Int * String`) and null-passthrough (`NULL_MERGES_AS_EMPTY`/`null *
+    /// x = null`) semantics that have nothing to do with negation, so
+    /// `-"abc"`/`-null` both returned `null` with exit code 0 instead of
+    /// erroring -- caught by code review before reaching `main`, with zero
+    /// test coverage of any non-numeric unary-minus operand at the time.
+    /// Confirmed live against jq 1.7.1: every non-numeric type errors with
+    /// jq's own dedicated "cannot be negated" wording (`EvalError::
+    /// cannot_be_negated`), not `arith_sub`'s pre-#1056 "cannot be
+    /// subtracted" or a hypothetical `arith_mul`-derived "cannot be
+    /// multiplied".
     #[test]
-    fn test_unary_minus_integer_zero_still_loses_sign_1056_followup() {
-        query!(br"null", "-(1-1)",
-            QueryResult::Owned(OwnedValue::Int(0)) => {}
+    fn test_unary_minus_non_numeric_errors_1056() {
+        query!(br#""abc""#, "-.",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, r#"string ("abc") cannot be negated"#);
+            }
+        );
+        query!(br"null", "-.",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "null (null) cannot be negated");
+            }
+        );
+        query!(br"true", "-.",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boolean (true) cannot be negated");
+            }
+        );
+        query!(br"[1,2]", "-.",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "array ([1,2]) cannot be negated");
+            }
+        );
+        query!(br"{}", "-.",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "object ({}) cannot be negated");
+            }
         );
     }
 

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1024,6 +1024,16 @@ pub enum ArithOp {
     Div,
     /// Modulo: `%`
     Mod,
+    /// Unary minus: `-expr` (#1056). A true IEEE-754 negation, not `0 -
+    /// expr` (loses the sign of a zero-valued operand) or `-1 * expr`
+    /// (silently inherits `*`'s unrelated string-repetition and
+    /// null-passthrough semantics instead of erroring on a non-numeric
+    /// operand -- caught by code review before this reached `main`). Reuses
+    /// `Expr::Arithmetic`'s binary shape purely for its existing fan-out
+    /// machinery (a generator operand like `-(1,2,3)` still needs to
+    /// produce one negated result per output); `left` is always a dummy
+    /// `Expr::Literal(Literal::Null)` that the evaluator ignores.
+    Negate,
 }
 
 /// yq merge-flag suffixes on the `*`/`*=` merge operator (e.g. `*+d`, `*=nd`).

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1060,18 +1060,22 @@ impl<'a> Parser<'a> {
                 } else {
                     // Unary minus: negate the following expression.
                     //
-                    // Implemented as (-1 * expr), not (0 - expr) (#1056):
-                    // IEEE-754 `0.0 - 0.0` is positive zero, silently losing
-                    // the sign of a zero-valued operand (`-.a` on `0.0`
-                    // dropped jq's `-0` to plain `0`) -- `-1.0 * 0.0`
-                    // correctly preserves it, the same fix already applied
-                    // to the filter-literal rewrite above (#1035) for
-                    // exactly this reason.
+                    // `ArithOp::Negate`, not `(0 - expr)` (#1056): IEEE-754
+                    // `0.0 - 0.0` is positive zero, silently losing the sign
+                    // of a zero-valued operand (`-.a` on `0.0` dropped jq's
+                    // `-0` to plain `0`). Also not `(-1 * expr)` (an earlier
+                    // draft of this fix, reverted after code review): `*`
+                    // has its own string-repetition and null-passthrough
+                    // semantics that have nothing to do with negation, so
+                    // `-"abc"`/`-null` silently returned `null` instead of
+                    // erroring. `left` here is an unused dummy -- see
+                    // `ArithOp::Negate`'s own doc comment for why this still
+                    // reuses `Expr::Arithmetic`'s binary shape.
                     self.next(); // consume '-'
                     let operand = self.parse_primary()?;
                     Ok(Expr::Arithmetic {
-                        op: ArithOp::Mul(MergeFlags::default()),
-                        left: Box::new(Expr::Literal(Literal::Int(-1))),
+                        op: ArithOp::Negate,
+                        left: Box::new(Expr::Literal(Literal::Null)),
                         right: Box::new(operand),
                     })
                 }

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1058,13 +1058,20 @@ impl<'a> Parser<'a> {
                         lit => Ok(Expr::Literal(lit)),
                     }
                 } else {
-                    // Unary minus: negate the following expression
-                    // Implemented as (0 - expr)
+                    // Unary minus: negate the following expression.
+                    //
+                    // Implemented as (-1 * expr), not (0 - expr) (#1056):
+                    // IEEE-754 `0.0 - 0.0` is positive zero, silently losing
+                    // the sign of a zero-valued operand (`-.a` on `0.0`
+                    // dropped jq's `-0` to plain `0`) -- `-1.0 * 0.0`
+                    // correctly preserves it, the same fix already applied
+                    // to the filter-literal rewrite above (#1035) for
+                    // exactly this reason.
                     self.next(); // consume '-'
                     let operand = self.parse_primary()?;
                     Ok(Expr::Arithmetic {
-                        op: ArithOp::Sub,
-                        left: Box::new(Expr::Literal(Literal::Int(0))),
+                        op: ArithOp::Mul(MergeFlags::default()),
+                        left: Box::new(Expr::Literal(Literal::Int(-1))),
                         right: Box::new(operand),
                     })
                 }


### PR DESCRIPTION
## Summary

- Unary minus on a non-literal operand (`-.a`, `-(expr)`) was lowered to `(0 - expr)`, whose IEEE-754 `0.0 - 0.0` evaluates to positive zero, silently dropping the sign of a zero-valued operand — real jq prints `-0` for these (`-.a` on `0.0`, `-(1.0-1.0)`, `-(0.0)`, `-(1-1)`), but succinctly printed plain `0`.
- **First draft rewrote it to `(-1 * expr)`** (matching #1035's precedent for the filter-literal case) — **code review caught a critical regression**: `arith_mul` has its own string-repetition (`Int * String`) and null-passthrough semantics that have nothing to do with negation, so `-"abc"`/`-null` silently returned `null` (exit 0) instead of erroring like real jq.
- **Final fix**: a dedicated `ArithOp::Negate`/`arith_negate`, reusing `Expr::Arithmetic`'s binary shape only for its existing fan-out machinery (a dummy `left` operand). `Int` negates via `checked_neg`/`wrapping_neg` (matching `arith_sub`'s existing `i64::MIN` overflow handling exactly); `Float` negates via Rust's own unary `-`, correctly preserving zero's sign. Non-numeric operands now error with real jq's own `"cannot be negated"` wording.
- Since `arith_negate` has exactly one caller (unlike `arith_mul`), it can also safely promote an all-integer computation that reduces to exactly zero (`-(1-1)`) to `Float(-0.0)` — real jq has no separate integer type, so this is already the double `0.0` there. This closes the fix's own remaining gap in full.

Closes #1056. Closes #1091 (opened mid-review for the two gaps the `(-1 * expr)` draft couldn't reach; both are fixed by the final `arith_negate` approach, so closed as resolved rather than left open).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full workspace suite, twice — once per draft) — 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo check --no-default-features` — `no_std` compiles clean
- [x] Diffed output against pinned real `jq` 1.7.1 for every original repro, the regression the review caught (`-"abc"`, `-null`, `-true`, `-[1,2]`, `-{}`), and sanity checks (ordinary negation, double negation, generator fan-out `-(1,2,3)`, `i64::MIN` overflow)
- [x] `test_unary_minus_zero_preserves_sign_1056` (all 4 original repro cases + sanity), `test_unary_minus_non_numeric_errors_1056` (the regression the review caught, previously zero coverage)