### PR TITLE
fix(jq): --argjson/--jsonargs preserve number-literal source fidelity

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1453,10 +1453,20 @@ fn find_number_end(bytes: &[u8], pos: usize) -> Option<usize> {
 /// Validates strictly via `serde_json::from_str` first -- not for its
 /// resulting `Value` (discarded), but for its error message and its
 /// rejection of trailing garbage (`42 garbage`) that `JsonIndex`'s own
-/// semi-indexing wouldn't catch on its own -- then reparses the same,
-/// now-known-valid text through this crate's own fidelity-preserving JSON
-/// semi-indexer (the same one the primary input path already uses, see
-/// `evaluate_input` above).
+/// semi-indexing wouldn't catch on its own. Deliberately parses to
+/// `serde_json::Value` here rather than the cheaper `serde::de::IgnoredAny`
+/// (which drives the identical grammar/trailing-content check without
+/// allocating a parse tree this function then discards): `IgnoredAny`
+/// doesn't range-check numbers at all, so a magnitude-overflowing literal
+/// (`1e400`) that `Value` correctly rejects ("number out of range") would
+/// instead silently reach `json_bytes_to_owned_value` and materialize as
+/// `null` -- trading a clear error for silent data loss, a worse outcome
+/// than the allocation this would save (#1095 review).
+///
+/// Then reparses the same, now-known-valid text through this crate's own
+/// fidelity-preserving JSON semi-indexer (the same one the primary input
+/// path already uses, see `evaluate_input` above) via the shared
+/// `json_bytes_to_owned_value`.
 fn parse_json_value(s: &str) -> Result<OwnedValue> {
     let s = s.trim();
     if s.is_empty() {
@@ -1465,13 +1475,17 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 
     serde_json::from_str::<serde_json::Value>(s).with_context(|| format!("Invalid JSON: {s}"))?;
 
-    let bytes = s.as_bytes();
-    let index = JsonIndex::build(bytes);
-    let cursor = index.root(bytes);
-    Ok(generic_to_owned(&cursor.value()))
+    Ok(crate::output::json_bytes_to_owned_value(s.as_bytes()))
 }
 
-/// Parse a JSON stream (multiple JSON values) from a string.
+/// Parse a JSON stream (multiple JSON values) from a string (`--slurpfile`).
+///
+/// Still loses number-literal source fidelity the way `parse_json_value`
+/// did before #1058 -- `find_json_values` (below) already splits a
+/// multi-value buffer into byte spans for the main lazy-input path and
+/// `serde_json::Deserializer::byte_offset()` could delimit each value here
+/// the same way, but wiring that up is deliberately deferred to #1093 to
+/// keep #1058/#1095 scoped to `--argjson`/`--jsonargs`.
 fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
     let s = s.trim();
     if s.is_empty() {
@@ -1490,9 +1504,17 @@ fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
     Ok(values)
 }
 
-/// Parse JSON sequence format (RFC 7464).
+/// Parse JSON sequence format (RFC 7464) (`--seq`).
 /// Input is split on RS (0x1E) characters, each segment parsed as JSON.
 /// Parse failures are silently ignored (per RFC 7464 recommendation).
+///
+/// Still loses number-literal source fidelity the way `parse_json_value`
+/// did before #1058 -- unlike `parse_json_stream` above, this already
+/// isolates each value as its own segment, so #1058's exact fix
+/// (`json_bytes_to_owned_value` after a `serde_json::from_str` validation
+/// pass) would apply per segment with no boundary-tracking needed. Deferred
+/// to #1093 alongside `parse_json_stream` to keep #1058/#1095 scoped to
+/// `--argjson`/`--jsonargs`.
 fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
     let mut values = Vec::new();
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1441,18 +1441,34 @@ fn find_number_end(bytes: &[u8], pos: usize) -> Option<usize> {
     }
 }
 
-/// Parse a JSON value from a string.
+/// Parse a JSON value from a string (`--argjson`/`--jsonargs`), preserving
+/// the original number-literal spelling the way document-sourced numbers
+/// already do (#1058) -- unlike `serde_json::Value::Number`, which
+/// round-trips only through Rust's own `f64`/`i64` `Display` and loses e.g.
+/// trailing zeros (`1.500` -> `1.5`) or exponent notation (`1e100` -> the
+/// fully-expanded digit string), the way a filter-literal number
+/// (`Literal::NumberLiteral`, #1035) or a document-sourced one
+/// (`OwnedValue::from_number_bytes`) does not.
+///
+/// Validates strictly via `serde_json::from_str` first -- not for its
+/// resulting `Value` (discarded), but for its error message and its
+/// rejection of trailing garbage (`42 garbage`) that `JsonIndex`'s own
+/// semi-indexing wouldn't catch on its own -- then reparses the same,
+/// now-known-valid text through this crate's own fidelity-preserving JSON
+/// semi-indexer (the same one the primary input path already uses, see
+/// `evaluate_input` above).
 fn parse_json_value(s: &str) -> Result<OwnedValue> {
     let s = s.trim();
     if s.is_empty() {
         return Ok(OwnedValue::Null);
     }
 
-    // Use serde_json for parsing, then convert to OwnedValue
-    let value: serde_json::Value =
-        serde_json::from_str(s).with_context(|| format!("Invalid JSON: {s}"))?;
+    serde_json::from_str::<serde_json::Value>(s).with_context(|| format!("Invalid JSON: {s}"))?;
 
-    Ok(serde_to_owned(&value))
+    let bytes = s.as_bytes();
+    let index = JsonIndex::build(bytes);
+    let cursor = index.root(bytes);
+    Ok(generic_to_owned(&cursor.value()))
 }
 
 /// Parse a JSON stream (multiple JSON values) from a string.
@@ -2547,14 +2563,42 @@ mod tests {
             parse_json_value("true").unwrap(),
             OwnedValue::Bool(true)
         ));
-        assert!(matches!(
-            parse_json_value("42").unwrap(),
-            OwnedValue::Int(42)
-        ));
+        // A whole number still round-trips its value (#1058: no longer a
+        // bare `OwnedValue::Int` -- `parse_json_value` now goes through the
+        // same fidelity-preserving semi-indexer as document input, which
+        // always reconstructs `NumberLiteral` for valid number text).
+        assert_eq!(parse_json_value("42").unwrap().to_json(), "42");
         assert!(matches!(
             parse_json_value("\"hello\"").unwrap(),
             OwnedValue::String(_)
         ));
+    }
+
+    /// #1058: `--argjson`/`--jsonargs`' number literals preserve their exact
+    /// source spelling, matching a filter-embedded literal (#1035) and a
+    /// document-sourced one -- previously lost via a `serde_json::Value`
+    /// round-trip through Rust's own `f64`/`i64` `Display`. Verified against
+    /// the pinned real `jq` binary, which also preserves these exactly.
+    #[test]
+    fn test_parse_json_value_preserves_number_literal_fidelity_1058() {
+        assert_eq!(parse_json_value("1.500").unwrap().to_json(), "1.500");
+        assert_eq!(parse_json_value("1e100").unwrap().to_json(), "1E+100");
+        assert_eq!(
+            parse_json_value(r#"{"a": 1.500, "b": [1e100, 2.0]}"#)
+                .unwrap()
+                .to_json(),
+            r#"{"a":1.500,"b":[1E+100,2.0]}"#
+        );
+    }
+
+    /// #1058 regression guard: preserving fidelity must not weaken the
+    /// existing strict-validation behavior (#284) -- trailing garbage after
+    /// a complete JSON value is still rejected, not silently truncated to
+    /// just the leading value the way `JsonIndex`'s own lenient semi-index
+    /// would accept on its own.
+    #[test]
+    fn test_parse_json_value_still_rejects_trailing_garbage_1058() {
+        assert!(parse_json_value("42 garbage").is_err());
     }
 
     #[test]

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -9,11 +9,38 @@ use succinctly::jq::escape::{
     escape_json_body as run_escaper, write_json_body_jq, write_json_body_jq_ascii,
     write_json_body_yq, write_json_body_yq_ascii,
 };
+use succinctly::jq::eval_generic::to_owned as generic_to_owned;
 use succinctly::jq::{
     assert_value_tree_depth, format_number_jq_compat, EvalError, OwnedValue, StreamError,
 };
+use succinctly::json::JsonIndex;
 use succinctly::yaml::format_float_with_fraction;
 pub use succinctly::yaml::format_float_yq;
+
+/// Materialize a complete JSON document into an `OwnedValue`, preserving
+/// each number's exact source spelling (`1.500` stays `1.500`, `1e100`
+/// stays exponent notation) the way a document read from the program's
+/// primary input already does -- unlike routing through
+/// `serde_json::Value`, whose `Number` variant round-trips only through
+/// Rust's own `f64`/`i64` `Display` and loses that spelling (#1058).
+///
+/// `bytes` must already be known-valid JSON with no trailing content --
+/// this crate's own semi-indexer is deliberately lenient (`42 garbage`
+/// parses as `42` with the rest silently ignored, #284) and performs no
+/// validation of its own. Callers that accept raw external text (a CLI
+/// argument, a file) need their own strict pre-validation pass first; see
+/// `jq_runner::parse_json_value`'s doc comment for why that pass can't
+/// simply reuse the `serde_json::Value` it produces.
+///
+/// Shared by `jq_runner::parse_json_value` (`--argjson`/`--jsonargs`) and
+/// `yq_runner::parse_input`'s `InputFormat::Json` arm (the primary input
+/// path) -- previously two independent copies of the same three-line
+/// `JsonIndex::build`/`.root()`/`generic_to_owned` sequence (#1095 review).
+pub fn json_bytes_to_owned_value(bytes: &[u8]) -> OwnedValue {
+    let index = JsonIndex::build(bytes);
+    let cursor = index.root(bytes);
+    generic_to_owned(&cursor.value())
+}
 
 /// Exit codes matching jq behavior
 pub mod exit_codes {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -447,12 +447,12 @@ fn canonicalize_json_numbers_at_depth(value: OwnedValue, depth: usize) -> OwnedV
 fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
     match format {
         InputFormat::Json => {
-            // Parse as JSON
-            let index = JsonIndex::build(bytes);
-            let cursor = index.root(bytes);
-            Ok(vec![canonicalize_json_numbers(generic_to_owned(
-                &cursor.value(),
-            ))])
+            // Parse as JSON, then immediately drop the number-literal
+            // fidelity `json_bytes_to_owned_value` preserves -- real yq's
+            // own `--input-format json` path never keeps it either (#978).
+            Ok(vec![canonicalize_json_numbers(
+                crate::output::json_bytes_to_owned_value(bytes),
+            )])
         }
         InputFormat::Yaml | InputFormat::Auto => {
             // Parse as YAML (Auto defaults to YAML when no extension hint)
@@ -2071,10 +2071,20 @@ fn colorize_yaml(yaml: &str) -> String {
 
 /// Parse a `--argjson` value into an `OwnedValue`.
 ///
-/// Validates strictly (RFC 8259) via `serde_json`, matching jq's `--argjson`
-/// (see `jq_runner::parse_json_value`). The lenient JSON semi-index would
-/// otherwise silently coerce malformed input (e.g. `42 garbage` → `42`)
-/// instead of surfacing an error (#284).
+/// Validates strictly (RFC 8259) via `serde_json`, matching jq's own
+/// `--argjson` validation *strategy* (see `jq_runner::parse_json_value`).
+/// The lenient JSON semi-index would otherwise silently coerce malformed
+/// input (e.g. `42 garbage` → `42`) instead of surfacing an error (#284).
+///
+/// Unlike `jq_runner::parse_json_value`, this does *not* preserve a number
+/// literal's exact source spelling (#1058 fixed that for `succinctly jq`,
+/// deliberately not for `succinctly yq`) -- real mikefarah/yq has no
+/// `--argjson` flag at all, so there's no oracle to match on fidelity
+/// specifically, and yq's own `--input-format json` path already discards
+/// JSON-sourced number fidelity on purpose (#978,
+/// `canonicalize_json_numbers`). Adding fidelity only here would make
+/// `--argjson` *inconsistent* with that established convention rather than
+/// fix a real divergence.
 fn parse_json_value(s: &str) -> Result<OwnedValue> {
     let s = s.trim();
     if s.is_empty() {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -562,6 +562,23 @@ fn test_argjson_variable() -> Result<()> {
     Ok(())
 }
 
+/// `--argjson`'s number literal preserves its exact source spelling when
+/// echoed back untouched, matching a filter-embedded literal (#1035) and a
+/// document-sourced one, rather than round-tripping through
+/// `serde_json::Value`'s own `f64`/`i64` `Display` (#1058). Verified
+/// against the pinned real `jq` binary, which also preserves these exactly.
+#[test]
+fn test_argjson_preserves_number_literal_fidelity_1058() -> Result<()> {
+    let (output, code) = run_jq_null("$n", &["--argjson", "n", "1.500"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1.500");
+
+    let (output, code) = run_jq_null("$n", &["--argjson", "n", "1e100"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1E+100");
+    Ok(())
+}
+
 #[test]
 fn test_multiple_variables() -> Result<()> {
     let (output, code) = run_jq_null("$a + $b", &["--argjson", "a", "10", "--argjson", "b", "20"])?;


### PR DESCRIPTION
Fixes #1058

## Summary

Since #1035, a filter-embedded number literal (`1.500`, `1e100`) preserves jq's exact source spelling. `--argjson`'s value parsing was a separate code path that didn't — `parse_json_value` built its `OwnedValue` via `serde_json::Value`'s own `Number` arm, which round-trips only through Rust's own `f64`/`i64` `Display`, discarding the original digit spelling before an `OwnedValue` even exists.

```
$ succinctly jq -n --argjson n 1.500 '$n'
1.5          # now: 1.500
$ succinctly jq -n --argjson n 1e100 '$n'
1000...000   # now: 1E+100 (matches real jq)
```

Fix: `parse_json_value` still validates strictly via `serde_json::from_str` first (unchanged — same error messages, same rejection of trailing garbage per #284), then discards that `Value` and reparses the same, now-known-valid text through this crate's own fidelity-preserving JSON semi-indexer (`JsonIndex::build` + `to_owned`) — the same path `evaluate_input` already uses for the program's primary input. Fixes both `--argjson` and `--jsonargs`, which share `parse_json_value`.

## Deliberately out of scope
- **`--slurpfile`/`--seq`** (`parse_json_stream`/`parse_json_seq`) have the identical gap but need per-value byte-span tracking within a concatenated JSON stream to fix the same way (`JsonIndex` handles one document per call, not a stream) — filed as #1093.
- **`succinctly yq`'s own `--argjson`** (a succinctly-only extension — real mikefarah/yq has no `--argjson` flag at all, confirmed via `yq --help`) is deliberately left unfixed. yq's main `--input-format json` path already discards JSON-sourced number fidelity on purpose (#978, `canonicalize_json_numbers`), and `--argjson`'s current output already matches that established convention — extending fidelity there would make `--argjson` *inconsistent* with yq's own JSON-input behavior, not fix a divergence from a real oracle, since none exists for this flag. This is a premise correction to the issue's own "Root cause" section, which pointed at `yq_runner.rs` without checking whether real yq even has this flag.
- **Leading-zero numbers** (`--argjson n '007'`) are rejected by succinctly (strict RFC 8259 via `serde_json`) but accepted leniently by real jq — a separate, pre-existing validation-strictness gap found incidentally while testing, filed as #1094.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Every new/updated test's expected output verified against the pinned real `jq` binary; `yq`'s unchanged output also verified