### PR TITLE
fix(jq): yq's @sh errors on an array like real yq, not jq's space-join

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5731,8 +5731,11 @@ fn format_sh<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<St
                 Ok(format!("'{s}'"))
             }
         }
-        // jq: [1, 2, 3] | @sh => "1 2 3"
-        OwnedValue::Array(arr) => {
+        // jq: [1, 2, 3] | @sh => "1 2 3" -- but real yq (confirmed live
+        // against v4.53.3) errors on *any* array input to `@sh`, regardless
+        // of content (`[[1,2],3]` and `[1,null,true]` both error the same
+        // way), unlike jq's own per-element quoting above (#1073).
+        OwnedValue::Array(arr) if S::TAG != EvalTag::Yq => {
             let parts: Vec<String> = arr
                 .iter()
                 .map(shell_quote_value::<S>)
@@ -28694,6 +28697,34 @@ mod tests {
         query!(br#"["it's", "caf\u00e9", 1, true, null]"#, "@sh",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "'it'\\''s' 'café' 1 true null");
+            }
+        );
+    }
+
+    /// #1073: real yq (confirmed live against v4.53.3) errors on *any*
+    /// array input to `@sh`, regardless of content -- unlike jq's own
+    /// per-element quoting (`test_format_sh_multibyte_boundary_647`'s array
+    /// case above, which stays jq-only after this fix). The pre-existing
+    /// object error (#929) already applied under both modes; this only adds
+    /// the array-under-yq case, so it isn't re-tested here.
+    #[test]
+    fn test_format_sh_yq_mode_errors_on_array_1073() {
+        yq_query!(br"[1, 2, 3]", "@sh",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "array ([1,2,3]) can not be escaped for shell");
+            }
+        );
+
+        // Nested/mixed-content arrays error the same way -- yq's own rule
+        // doesn't inspect elements, unlike jq's per-element quoting.
+        yq_query!(br#"[[1, 2], "x", null]"#, "@sh",
+            QueryResult::Error(_) => {}
+        );
+
+        // Scalars are unaffected by the yq-mode gate.
+        yq_query!(br"5", "@sh",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "5");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5721,6 +5721,19 @@ fn shell_quote_value<S: EvalSemantics>(value: &OwnedValue) -> Result<String, Eva
 
 /// @sh - Shell quote
 fn format_sh<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
+    // #1073: real yq (confirmed live against v4.53.3) only ever accepts a
+    // string for `@sh` -- every other type errors, not just array/object:
+    // `5 | @sh`, `1.5 | @sh`, `true | @sh`, and `null | @sh` all error the
+    // same way arrays and objects do. jq's own rules (below) are far more
+    // permissive (numbers/bools/null convert to strings, arrays quote each
+    // element), so this is a single early yq-only gate rather than a
+    // per-arm one -- threading `S::TAG != EvalTag::Yq` onto every arm below
+    // individually is exactly the shape that let the array-only version of
+    // this fix miss the scalar cases in the first place.
+    if S::TAG == EvalTag::Yq && !matches!(value, OwnedValue::String(_)) {
+        return Err(EvalError::cannot_be_shell_escaped(value));
+    }
+
     match value {
         OwnedValue::String(s) => {
             // Use single quotes and escape single quotes
@@ -5731,11 +5744,9 @@ fn format_sh<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<St
                 Ok(format!("'{s}'"))
             }
         }
-        // jq: [1, 2, 3] | @sh => "1 2 3" -- but real yq (confirmed live
-        // against v4.53.3) errors on *any* array input to `@sh`, regardless
-        // of content (`[[1,2],3]` and `[1,null,true]` both error the same
-        // way), unlike jq's own per-element quoting above (#1073).
-        OwnedValue::Array(arr) if S::TAG != EvalTag::Yq => {
+        // jq: [1, 2, 3] | @sh => "1 2 3" (yq mode never reaches here -- the
+        // gate above already returned).
+        OwnedValue::Array(arr) => {
             let parts: Vec<String> = arr
                 .iter()
                 .map(shell_quote_value::<S>)
@@ -28701,14 +28712,16 @@ mod tests {
         );
     }
 
-    /// #1073: real yq (confirmed live against v4.53.3) errors on *any*
-    /// array input to `@sh`, regardless of content -- unlike jq's own
-    /// per-element quoting (`test_format_sh_multibyte_boundary_647`'s array
-    /// case above, which stays jq-only after this fix). The pre-existing
-    /// object error (#929) already applied under both modes; this only adds
-    /// the array-under-yq case, so it isn't re-tested here.
+    /// #1073: real yq (confirmed live against v4.53.3) only ever accepts a
+    /// *string* for `@sh` -- every other type errors, not just array/object
+    /// (`5 | @sh`, `1.5 | @sh`, `true | @sh`, and `null | @sh` all error the
+    /// same way in real yq). jq's own, far more permissive rules (numbers/
+    /// bools/null convert to strings, arrays quote each element --
+    /// `test_format_sh_multibyte_boundary_647`'s array case above) stay
+    /// jq-only after this fix. The pre-existing object error (#929) already
+    /// applied under both modes.
     #[test]
-    fn test_format_sh_yq_mode_errors_on_array_1073() {
+    fn test_format_sh_yq_mode_only_accepts_strings() {
         yq_query!(br"[1, 2, 3]", "@sh",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "array ([1,2,3]) can not be escaped for shell");
@@ -28718,13 +28731,38 @@ mod tests {
         // Nested/mixed-content arrays error the same way -- yq's own rule
         // doesn't inspect elements, unlike jq's per-element quoting.
         yq_query!(br#"[[1, 2], "x", null]"#, "@sh",
-            QueryResult::Error(_) => {}
+            QueryResult::Error(e) => {
+                assert!(e.message.starts_with("array ("), "{}", e.message);
+                assert!(e.message.ends_with("can not be escaped for shell"), "{}", e.message);
+            }
         );
 
-        // Scalars are unaffected by the yq-mode gate.
+        // Every scalar type errors too -- not just containers.
         yq_query!(br"5", "@sh",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (5) can not be escaped for shell");
+            }
+        );
+        yq_query!(br"1.5", "@sh",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "number (1.5) can not be escaped for shell");
+            }
+        );
+        yq_query!(br"true", "@sh",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boolean (true) can not be escaped for shell");
+            }
+        );
+        yq_query!(br"null", "@sh",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "null (null) can not be escaped for shell");
+            }
+        );
+
+        // A string is still the one accepted type.
+        yq_query!(br#""hello""#, "@sh",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "5");
+                assert_eq!(s, "'hello'");
             }
         );
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12136,11 +12136,47 @@ fn test_yq_string_interpolation_preserves_exponent_literal_1030() -> Result<()> 
     Ok(())
 }
 
+/// #1030's own premise for this case was never checked against real yq
+/// specifically: real yq's `@sh` errors on *any* non-string input, a bare
+/// number included (confirmed live against v4.53.3 -- `#1073` widened that
+/// discovery from array/object to every non-string type), so `.a | @sh` on
+/// a numeric `1e2` was never a case where fidelity-preservation could be
+/// observed through `@sh` at all. Superseded by
+/// `test_yq_at_sh_errors_on_non_string_1073` below; kept as a named
+/// regression pin for the corrected behavior on this exact input.
 #[test]
-fn test_yq_at_sh_preserves_exponent_literal_1030() -> Result<()> {
-    let (stdout, code) = run_yq_stdin(".a | @sh", "a: 1e2\n", &["-r"])?;
+fn test_yq_at_sh_errors_on_number_input_1030() -> Result<()> {
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | @sh", "a: 1e2\n", &["-r"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("can not be escaped for shell"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// #1073: real yq's `@sh` only ever accepts a string -- confirmed live
+/// against v4.53.3 for an array, a bare number, and a boolean.
+#[test]
+fn test_yq_at_sh_errors_on_non_string_1073() -> Result<()> {
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | @sh", "a: [1, 2]\n", &["-r"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("can not be escaped for shell"),
+        "stderr: {stderr}"
+    );
+
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | @sh", "a: true\n", &["-r"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("can not be escaped for shell"),
+        "stderr: {stderr}"
+    );
+
+    // A string is still accepted.
+    let (stdout, code) = run_yq_stdin(".a | @sh", "a: hello\n", &["-r"])?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "1e2");
+    assert_eq!(stdout.trim_end(), "'hello'");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`format_sh` (`src/jq/eval.rs`) has no `S`-gated branch, so yq mode inherited jq's own,
far more permissive rules verbatim. Real yq's `@sh` only ever accepts a **string** —
every other type errors, including arrays/objects and every scalar type.

```
$ echo '[1,2]' | yq -o=json '@sh'
Error: cannot encode !!seq as URI, can only operate on strings. ...
$ echo '[1,2]' | succinctly yq -o json '@sh'
"1 2"
```

## Fix (round 1)

Initially scoped narrowly to the issue's own repro (array/object), gating just the
`Array` arm on `S::TAG != EvalTag::Yq`.

## Fix (round 2 — code review)

Code review (5-angle fan-out, several independently reproducing the same finding by
building and probing the pinned oracle live) found round 1 under-scoped: real yq's
`@sh` errors on **every** non-string type, not just array/object —

```
$ echo 5    | yq '@sh'   → errors ("cannot encode !!int as URI...")
$ echo 1.5  | yq '@sh'   → errors
$ echo true | yq '@sh'   → errors
$ echo null | yq '@sh'   → errors
```

Round 1's per-arm gate (`if S::TAG != EvalTag::Yq` on just the `Array` arm) left the
`Int`/`Float`/`NumberLiteral`/`Bool`/`Null` arms ungated, so `5 | @sh` still silently
succeeded under yq mode — and round 1's own test actively codified that as intended
behavior with the comment "Scalars are unaffected by the yq-mode gate."

Replaced the per-arm gate with a single early check ("in yq mode, anything but a string
errors"), matching the review's own suggested shape and removing the structural
fragility that produced the gap in the first place — no more risk of a sixth `OwnedValue`
variant slipping through unguarded.

This also surfaced that an existing test, `test_yq_at_sh_preserves_exponent_literal_1030`,
had a premise that was never actually checked against real yq: it asserted `.a | @sh` on
a numeric `1e2` succeeds and preserves exponent fidelity, but real yq's `@sh` errors on
that number outright — there was never a successful-passthrough case to preserve fidelity
through. Renamed/corrected to `test_yq_at_sh_errors_on_number_input_1030`, with a new
sibling `test_yq_at_sh_errors_on_non_string_1073` covering the general rule.

Both changes reuse the existing `cannot_be_shell_escaped` error (already used for the
object case in both modes since #929) rather than replicating real yq's own wording
(which oddly says "as URI" for an `@sh` failure — apparently a copy-paste artifact in
mikefarah/yq itself).

## Scoping (round 1 investigation, still applies)

- **jq mode**: unaffected — `[1,2,3] | @sh` = `"1 2 3"` still correct.
- **`@csv`/`@tsv`**: both jq and yq accept arrays (by design) — no divergence, out of
  scope.
- **`@uri`/`@base64`**: already error under yq mode today (different wording, but
  errors) — out of scope here. Investigating them surfaced a separate, real **jq-mode**
  bug (real jq stringifies non-string values for these instead of erroring; succinctly
  errors in jq mode too, which is wrong) — filed separately as #1096.

## Testing

- Library-level test `test_format_sh_yq_mode_only_accepts_strings`: array,
  nested/mixed-content array, number, float, boolean, null (all error), plus a string
  (still accepted) — using the `yq_query!` macro.
- CLI-level tests in `tests/yq_cli_tests.rs`: the corrected #1030 test, plus a new
  `test_yq_at_sh_errors_on_non_string_1073`.
- Full `cargo test --features cli,simd,regex,serde` (2530 tests) — all green.
- Both required Clippy invocations (`--all-features` and the YAML-SIMD/AVX-512 feature
  set) — clean.

Fixes #1073