### PR TITLE
fix(jq): yq slices a null/number/boolean scalar to [], not no-output

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9701,17 +9701,7 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             for s in &starts {
                 for e in &ends {
                     for t in ts {
-                        // yq's empty-container slicing rule (#1065) — kept
-                        // out of `slice_owned_value` itself, since that
-                        // function is *also* used by `resolve_slice_expr`
-                        // for assignment targets, where real yq's own
-                        // behavior is a silent no-op (`5 | .[0:1] = 99`
-                        // stays `5`), not this read-path rule.
-                        if S::TAG == EvalTag::Yq && is_yq_slice_empty_container_scalar(t) {
-                            out.push(OwnedValue::Array(Vec::new()));
-                            continue;
-                        }
-                        match slice_owned_value(t, *s, *e, optional) {
+                        match slice_owned_value_read::<S>(t, *s, *e, optional) {
                             Ok(Some(v)) => out.push(v),
                             Ok(None) => {}
                             Err(e) => return e.into(),
@@ -9834,6 +9824,25 @@ pub(crate) fn slice_owned_value(
             "object",
         )),
     }
+}
+
+/// Slice one `OwnedValue` target on the *read* path (`.[S:E]`), applying
+/// yq's empty-container-scalar rule (#1065) before falling back to
+/// `slice_owned_value`. Shared by `eval_slice_expr`'s `Targets::Owned` loop
+/// here and `eval_generic::eval_slice_expr`'s equivalent loop, so the rule
+/// has exactly one call site to keep in sync instead of two hand-copied
+/// ones — the same duplicated-predicate shape this codebase has already
+/// been bitten by once (see the crate's own optimization-lessons doc).
+pub(crate) fn slice_owned_value_read<S: EvalSemantics>(
+    target: &OwnedValue,
+    start: Option<i64>,
+    end: Option<i64>,
+    optional: bool,
+) -> Result<Option<OwnedValue>, EvalError> {
+    if S::TAG == EvalTag::Yq && is_yq_slice_empty_container_scalar(target) {
+        return Ok(Some(OwnedValue::Array(Vec::new())));
+    }
+    slice_owned_value(target, start, end, optional)
 }
 
 /// Get element at index (supports negative indexing).

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9783,13 +9783,9 @@ pub(crate) fn owned_bound_to_i64(
 /// 99` stays `5`) rather than this read-path rule — verified live, not
 /// assumed, since the two are easy to conflate (#1101).
 pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
-    matches!(
+    !matches!(
         target,
-        OwnedValue::Null
-            | OwnedValue::Int(_)
-            | OwnedValue::Float(_)
-            | OwnedValue::NumberLiteral(..)
-            | OwnedValue::Bool(_)
+        OwnedValue::Array(_) | OwnedValue::String(_) | OwnedValue::Object(_)
     )
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -523,6 +523,24 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     .collect();
                 QueryResult::Owned(OwnedValue::Array(items))
             }
+            // yq treats a null/number/boolean target as an empty container
+            // for slicing purposes (#1065, verified live against real yq
+            // across all three) rather than jq's own null-passthrough rule
+            // or "not sliceable" error -- checked before the jq-only Null
+            // arm below so this wins under yq mode. Object targets are
+            // deliberately excluded: real yq's own slicing there follows
+            // its internal AST child-node layout (`{"a":1,"b":2} | .[0:2]`
+            // -> `["a",1]`, alternating keys and values), not a clean
+            // "empty container" rule, and isn't replicated here (#1102).
+            // Assignment targets are a separate, unverified case -- real
+            // yq's own behavior there is a silent no-op, not this rule
+            // (#1101) -- see `is_yq_slice_empty_container_scalar`'s doc
+            // comment, which this arm mirrors.
+            StandardJson::Null | StandardJson::Number(_) | StandardJson::Bool(_)
+                if S::TAG == EvalTag::Yq =>
+            {
+                QueryResult::Owned(OwnedValue::Array(Vec::new()))
+            }
             // jq returns null for slice on null
             StandardJson::Null => QueryResult::One(StandardJson::Null),
             // jq supports string slicing
@@ -9683,6 +9701,16 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             for s in &starts {
                 for e in &ends {
                     for t in ts {
+                        // yq's empty-container slicing rule (#1065) — kept
+                        // out of `slice_owned_value` itself, since that
+                        // function is *also* used by `resolve_slice_expr`
+                        // for assignment targets, where real yq's own
+                        // behavior is a silent no-op (`5 | .[0:1] = 99`
+                        // stays `5`), not this read-path rule.
+                        if S::TAG == EvalTag::Yq && is_yq_slice_empty_container_scalar(t) {
+                            out.push(OwnedValue::Array(Vec::new()));
+                            continue;
+                        }
                         match slice_owned_value(t, *s, *e, optional) {
                             Ok(Some(v)) => out.push(v),
                             Ok(None) => {}
@@ -9747,6 +9775,32 @@ pub(crate) fn owned_bound_to_i64(
     round: fn(f64) -> f64,
 ) -> Result<Option<i64>, EvalError> {
     Ok(SliceBounds::resolved_bound(v)?.map(|f| round(f) as i64))
+}
+
+/// Whether `target` is one of the scalar shapes real yq treats as an empty
+/// container when it's the target of a *read* slice (`.[S:E]`, #1065) —
+/// null, any number representation, or a boolean. Object is deliberately
+/// excluded: real yq's own slicing there follows its internal AST
+/// child-node layout (`{"a":1,"b":2} | .[0:2]` -> `["a",1]`, alternating
+/// keys and values), not a clean "empty container" rule, and isn't
+/// replicated here (#1102). `Array`/`String` are excluded too — those
+/// already slice meaningfully and never reach this check's call sites for
+/// that reason (see [`slice_owned_value`]'s own `Array`/`String` arms).
+///
+/// Deliberately its own free function, not folded into `slice_owned_value`:
+/// that function is *also* used by `resolve_slice_expr` for assignment
+/// targets, where real yq's own behavior is a silent no-op (`5 | .[0:1] =
+/// 99` stays `5`) rather than this read-path rule — verified live, not
+/// assumed, since the two are easy to conflate (#1101).
+pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
+    matches!(
+        target,
+        OwnedValue::Null
+            | OwnedValue::Int(_)
+            | OwnedValue::Float(_)
+            | OwnedValue::NumberLiteral(..)
+            | OwnedValue::Bool(_)
+    )
 }
 
 /// Apply a resolved slice directly to an owned value.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -26,10 +26,9 @@ use super::document::{
 };
 use super::eval::{
     apply_compare_op, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
-    is_yq_slice_empty_container_scalar, literal_to_owned, needs_path_context,
-    numeric_display_string, numeric_key_to_index, owned_bound_to_i64, owned_value_to_json,
-    slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag, JqSemantics,
-    QueryResult, YqSemantics,
+    literal_to_owned, needs_path_context, numeric_display_string, numeric_key_to_index,
+    owned_bound_to_i64, owned_value_to_json, slice_owned_value_read, tonumber_from_str, Control,
+    EvalError, EvalSemantics, EvalTag, JqSemantics, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -3084,15 +3083,7 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
             for s in &starts {
                 for e in &ends {
                     for t in ts {
-                        // yq's empty-container slicing rule (#1065) — kept
-                        // out of `slice_owned_value` itself; see
-                        // `is_yq_slice_empty_container_scalar`'s doc
-                        // comment for why.
-                        if S::TAG == EvalTag::Yq && is_yq_slice_empty_container_scalar(t) {
-                            out.push(OwnedValue::Array(Vec::new()));
-                            continue;
-                        }
-                        match slice_owned_value(t, *s, *e, optional) {
+                        match slice_owned_value_read::<S>(t, *s, *e, optional) {
                             Ok(Some(v)) => out.push(v),
                             Ok(None) => {}
                             Err(e) => return GenericResult::Error(e),
@@ -3168,16 +3159,17 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
     // yq's empty-container slicing rule (#1065) — see
     // `is_yq_slice_empty_container_scalar`'s doc comment for the full
     // rationale and why Object is excluded. Checked before the jq-only
-    // `is_null` arm below so it wins under yq mode. `as_i64`/`as_f64`, not
-    // `number_literal` — the latter is `None` for plenty of legitimate
-    // numbers (ints, or floats with no safe literal spelling to preserve,
-    // #387/#966/#918), so it can't stand in for "is this a number".
-    if S::TAG == EvalTag::Yq
-        && (target.is_null()
-            || target.as_bool().is_some()
-            || target.as_i64().is_some()
-            || target.as_f64().is_some())
-    {
+    // `is_null` arm below so it wins under yq mode. Classified via
+    // `type_name()`, a variant-based check, not by chaining
+    // `as_bool()`/`as_i64()`/`as_f64()` — those are parseability checks,
+    // and a JSON number whose scanner-accepted span isn't valid number
+    // syntax (e.g. `1.2.3`, #966) fails all three despite `type_name()`
+    // correctly still reporting `"number"`, which would silently disagree
+    // with `is_yq_slice_empty_container_scalar`'s type-based `OwnedValue`
+    // match. For YAML this also collapses what was up to two separate
+    // `resolve_plain` re-derivations of the same scalar into the one
+    // `type_name()` already performs.
+    if S::TAG == EvalTag::Yq && matches!(target.type_name(), "null" | "boolean" | "number") {
         return GenericResult::Owned(OwnedValue::Array(Vec::new()));
     }
     if target.is_null() {
@@ -7151,6 +7143,30 @@ mod tests {
 
         let yq_result = eval_using::<YqSemantics, _>(&expr, index.root(json).value());
         assert_eq!(yq_result.into_owned(), Some(OwnedValue::Float(1.5)));
+    }
+
+    #[test]
+    fn test_yq_slice_scalar_empty_array_classifies_by_type_not_parseability_1065() {
+        // `slice_one_generic`'s yq empty-container check (#1065) must
+        // classify "is this a number" the same way `eval.rs`'s own
+        // `StandardJson::Number(_)` match and `is_yq_slice_empty_container_scalar`
+        // do: by variant, not by whether the raw text happens to parse as
+        // i64/f64. `1.2.3` is a JSON number span the semi-index scanner
+        // accepts leniently (#966) but that fails `as_i64`/`as_f64` parsing
+        // — an earlier version of this check used exactly that parseability
+        // test and returned an error here instead of `[]`, disagreeing with
+        // the concrete evaluator on the identical input. Uses a computed
+        // (non-literal-folding) slice so evaluation stays inside
+        // `eval_generic.rs`'s own `slice_one_generic` rather than bridging
+        // out to `eval.rs`, which is what let the divergence hide.
+        use crate::jq::YqSemantics;
+
+        let json = b"1.2.3";
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(".[(1-1):(1+0)]").unwrap();
+
+        let result = eval_using::<YqSemantics, _>(&expr, index.root(json).value());
+        assert_eq!(result.into_owned(), Some(OwnedValue::Array(Vec::new())));
     }
 
     // Coverage follow-ups for #532: the tests above exercise the common

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -26,9 +26,10 @@ use super::document::{
 };
 use super::eval::{
     apply_compare_op, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
-    literal_to_owned, needs_path_context, numeric_display_string, numeric_key_to_index,
-    owned_bound_to_i64, owned_value_to_json, slice_owned_value, tonumber_from_str, Control,
-    EvalError, EvalSemantics, EvalTag, JqSemantics, QueryResult, YqSemantics,
+    is_yq_slice_empty_container_scalar, literal_to_owned, needs_path_context,
+    numeric_display_string, numeric_key_to_index, owned_bound_to_i64, owned_value_to_json,
+    slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag, JqSemantics,
+    QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -3069,7 +3070,7 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
             for s in &starts {
                 for e in &ends {
                     for t in ts {
-                        match slice_one_generic::<V>(t.clone(), *s, *e, optional) {
+                        match slice_one_generic::<S, V>(t.clone(), *s, *e, optional) {
                             GenericResult::Owned(v) => out.push(v),
                             GenericResult::None => {}
                             GenericResult::Error(e) => return GenericResult::Error(e),
@@ -3083,6 +3084,14 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
             for s in &starts {
                 for e in &ends {
                     for t in ts {
+                        // yq's empty-container slicing rule (#1065) — kept
+                        // out of `slice_owned_value` itself; see
+                        // `is_yq_slice_empty_container_scalar`'s doc
+                        // comment for why.
+                        if S::TAG == EvalTag::Yq && is_yq_slice_empty_container_scalar(t) {
+                            out.push(OwnedValue::Array(Vec::new()));
+                            continue;
+                        }
                         match slice_owned_value(t, *s, *e, optional) {
                             Ok(Some(v)) => out.push(v),
                             Ok(None) => {}
@@ -3139,7 +3148,11 @@ fn eval_slice_bound<S: EvalSemantics, V: DocumentValue>(
 /// non-generic evaluator. Always returns owned, since slicing always
 /// constructs a fresh value; parallels `index_one_generic` returning `One` or
 /// `Owned`.
-fn slice_one_generic<V: DocumentValue>(
+///
+/// Only called from `eval_slice_expr`'s *read* path, never for an
+/// assignment target — no `S`-gated equivalent of `is_yq_slice_empty_container_scalar`'s
+/// caution about `resolve_slice_expr` applies here.
+fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
     target: V,
     start: Option<i64>,
     end: Option<i64>,
@@ -3151,6 +3164,21 @@ fn slice_one_generic<V: DocumentValue>(
         return GenericResult::Owned(OwnedValue::Array(
             items[range].iter().map(to_owned).collect(),
         ));
+    }
+    // yq's empty-container slicing rule (#1065) — see
+    // `is_yq_slice_empty_container_scalar`'s doc comment for the full
+    // rationale and why Object is excluded. Checked before the jq-only
+    // `is_null` arm below so it wins under yq mode. `as_i64`/`as_f64`, not
+    // `number_literal` — the latter is `None` for plenty of legitimate
+    // numbers (ints, or floats with no safe literal spelling to preserve,
+    // #387/#966/#918), so it can't stand in for "is this a number".
+    if S::TAG == EvalTag::Yq
+        && (target.is_null()
+            || target.as_bool().is_some()
+            || target.as_i64().is_some()
+            || target.as_f64().is_some())
+    {
+        return GenericResult::Owned(OwnedValue::Array(Vec::new()));
     }
     if target.is_null() {
         return GenericResult::Owned(OwnedValue::Null);

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10809,3 +10809,14 @@ fn test_jq_equality_still_widens_int_and_float_950() -> Result<()> {
     assert_eq!(stderr, "");
     Ok(())
 }
+
+/// #1065's yq-only "scalar slices to an empty array" rule must not leak
+/// into jq mode: real jq gives no output for `.[0:1]?` on a number (matches
+/// succinctly's pre-existing, unaffected behavior).
+#[test]
+fn test_jq_slice_number_scalar_still_gives_no_output_1065() -> Result<()> {
+    let (output, code) = run_jq_stdin(".[0:1]?", "5", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12657,3 +12657,34 @@ fn test_slice_string_and_array_unaffected_1065() -> Result<()> {
     assert_eq!(out.trim(), "[1]");
     Ok(())
 }
+
+/// The tests above all slice `.` directly against a *borrowed* document
+/// cursor, which exercises `eval.rs`'s `Expr::Slice` match arm (or
+/// `eval_generic.rs`'s `slice_one_generic`) but never `eval_slice_expr`'s
+/// `Targets::Owned` branch. That branch requires two things at once: an
+/// `Expr::SliceExpr` node (only built when a bound doesn't fold to a
+/// literal, #499 -- plain `[0:1]` folds into `Expr::Slice` instead, which
+/// never has an `Owned` target case) *and* a target sub-expression that
+/// evaluates straight to `QueryResult::Owned` with no intervening pipe
+/// boundary -- `5 | .[($a):1]` still doesn't qualify, since piping through
+/// `.` re-enters via `eval_owned_pipe`'s serialize/reparse round-trip
+/// (`eval_owned_input`), handing `eval_slice_expr` a fresh *borrowed*
+/// `StandardJson` cursor instead. `(5)[(1-1):(1+0)]` -- a bare literal in
+/// postfix-slice position, with arithmetic (non-folding) bounds -- is
+/// confirmed live (via a temporary trace) to be the one shape that reaches
+/// `slice_owned_value_read`/`is_yq_slice_empty_container_scalar` directly.
+#[test]
+fn test_slice_owned_target_scalar_is_empty_array_1065() -> Result<()> {
+    let (out, code) = run_yq_stdin("(5)[(1-1):(1+0)]", "", &["-n", "-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+
+    let (out, code) = run_yq_stdin("(true)[(1-1):(1+0)]", "", &["-n", "-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+
+    let (out, code) = run_yq_stdin("(null)[(1-1):(1+0)]", "", &["-n", "-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12592,3 +12592,68 @@ fn test_yq_equality_consuming_builtins_agree_with_strict_eq_950() -> Result<()> 
     assert_eq!(out.trim(), "[[2],[2.0],[3]]");
     Ok(())
 }
+
+// ============================================================================
+// yq slicing a non-array/string scalar gives `[]`, not no-output (#1065)
+// ============================================================================
+//
+// Real yq treats a null/number/boolean target as an empty container when
+// it's the target of a read slice (`.[S:E]`) rather than erroring (matching
+// jq's own behavior) or passing null through unchanged. Every case here is
+// pinned against the live real `yq` v4.53.3 binary. Object targets are
+// deliberately excluded (#1065's own follow-up, #1102) -- real yq's own
+// slicing there follows its internal AST child-node layout, not this
+// empty-container rule.
+
+#[test]
+fn test_slice_number_scalar_is_empty_array_1065() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1]?", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+
+    // Same result without `?` -- yq's own slicing never errors here at all,
+    // unlike jq's.
+    let (out, code) = run_yq_stdin(".[0:1]", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
+#[test]
+fn test_slice_bool_scalar_is_empty_array_1065() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1]?", "true", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
+#[test]
+fn test_slice_null_scalar_is_empty_array_1065() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1]?", "null", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
+/// A document-sourced number (`OwnedValue::NumberLiteral`, not a bare
+/// `Int`/`Float`) must be covered too, not just filter-computed scalars.
+#[test]
+fn test_slice_number_literal_scalar_is_empty_array_1065() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1]?", "1.500", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
+/// Regression guard: string/array slicing on the read path is unaffected.
+#[test]
+fn test_slice_string_and_array_unaffected_1065() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1]", r#""hello""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"h\"");
+
+    let (out, code) = run_yq_stdin(".[0:1]", "[1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1]");
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1065

## Summary

Found while verifying #1048's fix. Real yq treats a null/number/boolean target as an empty container when it's the target of a *read* slice (`.[S:E]`), never erroring even without `?`:

```
$ echo '5' | yq -o=json '.[0:1]?'
[]
$ echo '5' | succinctly yq -o json '.[0:1]?'
(no output)
```

succinctly matched jq's own "not sliceable" rule instead (no output with `?`, "Cannot index X with object" without it).

## Live-probed real yq across target shapes before implementing (per this repo's own documented discipline)

- number/bool/null → `[]` (matches the issue's own repro)
- string → normal string slicing (already correct, unaffected)
- array → normal array slicing (already correct, unaffected)
- object → a genuinely different, unusual result (`{"a":1,"b":2} | .[0:2]` → `["a",1]`, alternating keys/values — real yq's own internal AST child-node layout leaking through) — deliberately **not** replicated, filed as #1102
- assignment targets (`.[S:E] = X`) → a silent no-op (`5 | .[0:1] = 99` stays `5`), a different rule again from the read-path fix here — deliberately left untouched, filed as #1101

## Implementation

Fixed at all three parallel evaluator sites this needs: `eval.rs`'s `Expr::Slice` arm (borrowed-target path), `eval_generic.rs`'s `slice_one_generic` (borrowed-target path for the generic/yq document model), and both evaluators' `Targets::Owned` loops (materialized targets), via a new shared `is_yq_slice_empty_container_scalar` check.

The check lives in its own free function rather than inside `slice_owned_value` itself, specifically because that function is *also* shared with `resolve_slice_expr`'s assignment-path resolution, where applying this rule would have been wrong — confirmed by testing the assignment case live before assuming it should behave the same way, not after.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Every new test's expected output verified against the pinned real `yq` v4.53.3 binary; a jq-mode control test confirms the fix doesn't leak into jq's own semantics