### PR TITLE
fix(yaml): clear stale pending_explicit_key after a same-indent sequence closes

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2181,6 +2181,22 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.indent_stack.pop();
                 self.pop_type();
                 self.write_bp_close();
+
+                // The sequence just closed may itself have been the
+                // pending explicit key's own implicit value (`? k\n-
+                // item\n`, at the same indent as the key). Clear the
+                // stale flag now that the key's real value is fully
+                // closed -- unlike every other pop site's
+                // `close_pending_explicit_key()` call, no null is
+                // synthesized here: the key already received a real
+                // value, so this isn't the "encountered without an
+                // explicit value" case that helper handles. Left stale,
+                // a later mapping entry at this same indent would be
+                // silently misattributed to the closed key instead of
+                // starting fresh (#1040).
+                if self.pending_explicit_key == Some(self.indent_stack.len()) {
+                    self.pending_explicit_key = None;
+                }
             }
         }
     }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -591,19 +591,36 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.bp_pos += 1;
     }
 
+    /// Whether the mapping on top of `indent_stack` right now is the owner
+    /// of `pending_explicit_key` — i.e. the frame that would receive the
+    /// key's value if one were written this instant. A complex key can
+    /// itself be an open container (`? k: v` leaves the key mapping above
+    /// its owner), so this is only true once the stack has unwound back to
+    /// exactly the owner's own recorded depth.
+    ///
+    /// Shared by every pending-key-aware pop site (#106: one definition,
+    /// not a copy of this same equality test re-derived at each call site).
+    fn pending_explicit_key_owns_current_frame(&self) -> bool {
+        self.pending_explicit_key == Some(self.indent_stack.len())
+    }
+
     /// Close a pending explicit key by adding a null value node.
     /// Call this when a new key or end of mapping is encountered without an explicit value.
     ///
     /// The null goes to the mapping that *owns* the key, which is only the mapping on
-    /// top of the stack when the depths match. A complex key can itself be an open
-    /// container — `? k: v` leaves the key mapping above its owner — and writing the
-    /// owner's null into that key would give the key a stray third child and consume
+    /// top of the stack when the depths match (see
+    /// [`Self::pending_explicit_key_owns_current_frame`]) — writing the owner's null
+    /// into a still-open complex key would give the key a stray third child and consume
     /// the pending state before the real `: value` line arrives.
     ///
-    /// Every caller funnels through here rather than repeating the ownership test at
-    /// the call site: three copies of one predicate is how #106 happened.
+    /// Every caller that wants a null synthesized funnels through here rather than
+    /// repeating the ownership test at the call site: three copies of one predicate is
+    /// how #106 happened. [`Self::close_same_indent_sequence_before_mapping_entry`]
+    /// checks the same predicate directly instead, since it must clear the flag
+    /// *without* synthesizing a null — the key there already has a real value (the
+    /// sequence just closed), not a missing one.
     fn close_pending_explicit_key(&mut self) {
-        if self.pending_explicit_key == Some(self.indent_stack.len()) {
+        if self.pending_explicit_key_owns_current_frame() {
             // Add a null value node (empty open/close pair)
             // Use input.len() as the text position to indicate "no text" / null value
             self.write_bp_open_at(self.input.len());
@@ -2193,8 +2210,11 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // explicit value" case that helper handles. Left stale,
                 // a later mapping entry at this same indent would be
                 // silently misattributed to the closed key instead of
-                // starting fresh (#1040).
-                if self.pending_explicit_key == Some(self.indent_stack.len()) {
+                // starting fresh (#1040). Shares
+                // `pending_explicit_key_owns_current_frame`'s predicate
+                // with `close_pending_explicit_key` rather than
+                // re-deriving it here (#106).
+                if self.pending_explicit_key_owns_current_frame() {
                     self.pending_explicit_key = None;
                 }
             }
@@ -3055,6 +3075,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // If there's a pending explicit key without value, close it with null
         self.close_pending_explicit_key();
+
+        // Close a sequence that was a *previous* explicit key's same-indent
+        // implicit value, exactly as `parse_mapping_entry` does for an
+        // ordinary `key:` entry (#1040) -- `? k\n- item\n? k2\n: v2\n`
+        // reaches this function for `? k2`, not `parse_mapping_entry`, so
+        // without this call the still-open sequence stays the top frame,
+        // `need_new_mapping` below sees `current_type == Sequence` and
+        // wrongly nests `k2` as a second element of `k`'s array instead of
+        // opening a sibling mapping entry.
+        self.close_same_indent_sequence_before_mapping_entry(indent);
 
         // Check if we need to open a new mapping
         let need_new_mapping = self.current_type != Some(NodeType::Mapping)

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4396,6 +4396,63 @@ fn test_yaml_explicit_key_colon_without_space_stays_key_text() -> Result<()> {
 }
 
 // =============================================================================
+// Explicit key followed by a same-indent sequence (#1040) --
+// `close_same_indent_sequence_before_mapping_entry` popped the sequence
+// without clearing `pending_explicit_key`, so a later mapping entry at the
+// same indent was silently misattributed to the already-closed key instead
+// of starting fresh.
+//
+// Note: real yq v4.53.3 actually *rejects* `? k\n- item\n...` outright
+// ("did not find expected key") -- an explicit key's value must always be
+// introduced by `:`, unlike an ordinary `key:` entry, which does accept a
+// same-indent sequence as an implicit value. succinctly doesn't reproduce
+// that rejection (a deeper, separate gap -- see the issue's follow-up); the
+// fix here is scoped to what #1040 actually named: eliminating the silent
+// data loss and phantom key once the parser has (incorrectly, but
+// harmlessly by this point) accepted the sequence as the key's value.
+// =============================================================================
+
+#[test]
+fn test_yaml_explicit_key_same_indent_sequence_then_new_entry_1040() -> Result<()> {
+    // The issue's second (worse) repro: a field after the sequence used to
+    // vanish entirely, replaced by a phantom "" key stealing the next
+    // field's value.
+    let input = "? k\n- item\nnewkey: v\nthirdkey: w\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        output.trim(),
+        r#"{"k":["item"],"newkey":"v","thirdkey":"w"}"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_yaml_explicit_key_same_indent_sequence_then_new_entry_agrees_across_positions_1040(
+) -> Result<()> {
+    // Two new entries after the sequence, and a third to confirm the
+    // mapping keeps accepting ordinary entries afterward rather than only
+    // recovering for one.
+    let input = "? k\n- item\na: 1\nb: 2\nc: 3\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"k":["item"],"a":1,"b":2,"c":3}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_ordinary_key_same_indent_sequence_unaffected_by_1040_fix() -> Result<()> {
+    // The fix must not touch the pre-existing, always-legal ordinary-key
+    // shape `close_same_indent_sequence_before_mapping_entry` documents
+    // (no `?`/`pending_explicit_key` involved at all).
+    let input = "foo:\n- item\nbar: v\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"foo":["item"],"bar":"v"}"#);
+    Ok(())
+}
+
+// =============================================================================
 // Alias cycle rejection (#153) - cyclic anchors must be a clean parse error,
 // not a stack-overflow abort
 // =============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4452,6 +4452,29 @@ fn test_yaml_ordinary_key_same_indent_sequence_unaffected_by_1040_fix() -> Resul
     Ok(())
 }
 
+#[test]
+fn test_yaml_chained_explicit_keys_with_same_indent_sequences_1040() -> Result<()> {
+    // Code review's own follow-up finding: the first fix only wired
+    // `close_same_indent_sequence_before_mapping_entry` into
+    // `parse_mapping_entry`, so a same-indent sequence value followed by
+    // *another* explicit key (rather than an ordinary `key:` entry) hit
+    // the identical staleness bug through `parse_explicit_key` instead --
+    // `k2`'s whole entry silently nested as a second element of `k`'s
+    // array rather than becoming a sibling key.
+    let input = "? k\n- item\n? k2\n: v2\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"k":["item"],"k2":"v2"}"#);
+
+    // Chained across three explicit keys, each with its own same-indent
+    // sequence value, confirms the fix isn't a one-shot recovery.
+    let input = "? k1\n- a\n? k2\n- b\n? k3\n: v3\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"k1":["a"],"k2":["b"],"k3":"v3"}"#);
+    Ok(())
+}
+
 // =============================================================================
 // Alias cycle rejection (#153) - cyclic anchors must be a clean parse error,
 // not a stack-overflow abort


### PR DESCRIPTION
## Summary

`close_same_indent_sequence_before_mapping_entry` (`src/yaml/parser.rs`) pops a `Sequence` frame that was an explicit key's implicit same-indent value (`? k\n- item\n`) without clearing `pending_explicit_key` first — unlike every other frame-popping site in this file. Left stale, a later mapping entry at the same indent was silently misattributed to the already-closed key:

```
$ printf '? k\n- item\nnewkey: v\nthirdkey: w\n' | succinctly yq -o json -I0 '.'
{"k":["item"],"newkey":"v","":"thirdkey"}   # before: drops "w", invents a phantom "" key
{"k":["item"],"newkey":"v","thirdkey":"w"}  # after: correct
```

Clears the flag directly (`self.pending_explicit_key = None` when it still names this exact depth) rather than routing through `close_pending_explicit_key()`, which synthesizes a null value — wrong here, since the key already received a real value (the sequence that was just closed).

**Update after code review**: the first commit only wired `close_same_indent_sequence_before_mapping_entry` into `parse_mapping_entry`'s own call site. Review found `parse_explicit_key` has the identical staleness bug through a sibling dispatch path — a same-indent sequence value followed by *another* explicit key (rather than an ordinary `key:` entry) still got silently misattributed:

```
$ printf '? k\n- item\n? k2\n: v2\n' | succinctly yq -o json -I0 '.'
{"k":["item",{"k2":"v2"}]}   # before: k2 nested as a second array element of k's value
{"k":["item"],"k2":"v2"}     # after: correct
```

Fixed by calling `close_same_indent_sequence_before_mapping_entry` from `parse_explicit_key` too. Also extracted the ownership-equality predicate both call sites (and `close_pending_explicit_key`) now share into a named `pending_explicit_key_owns_current_frame` helper, per review feedback that the first commit hand-duplicated that predicate instead of centralizing it — the exact #106 pattern this file's own doc comments warn against.

## Scope note (important — read before assuming this fully matches real yq)

Real yq v4.53.3 actually **rejects** `? k\n- item\n...` outright (`did not find expected key`) — an explicit key's value must always be introduced by `:`, unlike an ordinary `key:` entry, which *does* accept a same-indent sequence as an implicit value. succinctly doesn't reproduce that rejection; this PR only fixes the data-loss/misattribution consequences the issue named, not the underlying acceptance gap.

I tried both natural locations for a stricter "reject this" fix during investigation:
- A check in `parse_explicit_value` (before clearing `pending_explicit_key`)
- A check at the `-` sequence-item dispatch in `parse_block_node`

**Both independently broke the official YAML test suite's conformance run** on case **6PBE** ("Zero-indented sequences in explicit mapping keys"):
```yaml
---
?
- a
- b
:
- c
- d
```
Here a *bare* `?` (nothing on its own line) followed by a zero-indented sequence is legitimate — the sequence is the key's own content. Tracing `parse_explicit_key`'s `self.at_line_end()` branch, this legitimate case reaches the *exact same* `pending_explicit_key` state (`Some(owner_depth)`, nothing pushed) as the buggy case this PR fixes, with no remaining structural signal to distinguish "genuinely empty key, next sequence is an erroneous value" from "zero-indented sequence key, already (mis)classified as an empty key by that same branch." Filed as #1104 for whoever wants to take on the deeper state-tracking change that would be needed.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, green, including `yaml_test_suite_conformance`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the second CI feature-matrix invocation
- [x] `cargo fmt --check`
- [x] Regression tests in `tests/yq_cli_tests.rs` (`_1040` suffix), including chained explicit keys — verified these fail without the fix
- [x] Confirmed the pre-existing, always-legal *ordinary*-key same-indent-sequence shape (`foo:\n- item\nbar: v\n`) is unaffected
- [x] Confirmed the YAML test suite's 6PBE case still passes

Fixes #1040
