### PR TITLE
refactor(jq): dedup Literal->OwnedValue conversion from 4 copies to 2

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -761,12 +761,17 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Convert a literal to an owned value.
-/// Delegates to `OwnedValue`'s own `From<Literal>` impl (#1062) rather than
-/// re-listing the same six arms a third time -- `Literal: Clone` makes the
-/// borrow-to-owned crossing a single clone of the `Literal` itself (its
-/// `String`/`NumberLiteral` payload, same as this function's own arms used
-/// to clone directly), not an extra allocation on top of what was here
-/// before.
+///
+/// Delegates to `OwnedValue`'s own `From<Literal>` impl (#1062, see its doc
+/// comment for the two other conversions this crate carries: `eval_generic.rs`'s
+/// call site here, and `lazy.rs`'s partial one for `JqValue`) rather than
+/// re-listing the same six arms a third time. For the `String`/
+/// `NumberLiteral` variants this is the same single text-payload clone the
+/// old per-arm body paid directly; for the trivially-`Copy` variants
+/// (`Null`/`Bool`/`Int`/`Float`) it clones the whole (small, stack-only)
+/// `Literal` enum rather than reading the matched field alone -- no heap
+/// allocation either way, just a few extra bytes copied on the stack, not
+/// worth a second hand-matched arm to avoid.
 pub(crate) fn literal_to_owned(lit: &Literal) -> OwnedValue {
     OwnedValue::from(lit.clone())
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -761,15 +761,14 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Convert a literal to an owned value.
-fn literal_to_owned(lit: &Literal) -> OwnedValue {
-    match lit {
-        Literal::Null => OwnedValue::Null,
-        Literal::Bool(b) => OwnedValue::Bool(*b),
-        Literal::NumberLiteral(text) => OwnedValue::from_number_literal(text),
-        Literal::Int(n) => OwnedValue::Int(*n),
-        Literal::Float(f) => OwnedValue::Float(*f),
-        Literal::String(s) => OwnedValue::String(s.clone()),
-    }
+/// Delegates to `OwnedValue`'s own `From<Literal>` impl (#1062) rather than
+/// re-listing the same six arms a third time -- `Literal: Clone` makes the
+/// borrow-to-owned crossing a single clone of the `Literal` itself (its
+/// `String`/`NumberLiteral` payload, same as this function's own arms used
+/// to clone directly), not an extra allocation on top of what was here
+/// before.
+pub(crate) fn literal_to_owned(lit: &Literal) -> OwnedValue {
+    OwnedValue::from(lit.clone())
 }
 
 /// Evaluate a comma expression (multiple outputs).

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2534,8 +2534,10 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             eval_first_or_last_generic::<S, _>(inner, value, optional, cursor, true)
         }
 
-        // #1062: was a fourth hand-rolled arm-for-arm copy of the same six
-        // `Literal` variants; delegates to the one canonical conversion now.
+        // #1062: was a hand-rolled arm-for-arm copy of the same six
+        // `Literal` variants (one of three targeting `OwnedValue` -- see
+        // `literal_to_owned`'s own doc comment for the other two); delegates
+        // to the shared conversion now instead.
         Expr::Literal(lit) => GenericResult::Owned(literal_to_owned(lit)),
 
         // Formats are pure functions of the value, so evaluate them here rather

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -26,11 +26,11 @@ use super::document::{
 };
 use super::eval::{
     apply_compare_op, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
-    needs_path_context, numeric_display_string, numeric_key_to_index, owned_bound_to_i64,
-    owned_value_to_json, slice_owned_value, tonumber_from_str, Control, EvalError, EvalSemantics,
-    EvalTag, JqSemantics, QueryResult, YqSemantics,
+    literal_to_owned, needs_path_context, numeric_display_string, numeric_key_to_index,
+    owned_bound_to_i64, owned_value_to_json, slice_owned_value, tonumber_from_str, Control,
+    EvalError, EvalSemantics, EvalTag, JqSemantics, QueryResult, YqSemantics,
 };
-use super::expr::{Builtin, Expr, FormatType, Literal};
+use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
 use super::value::OwnedValue;
 use crate::json::JsonIndex;
@@ -2534,16 +2534,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             eval_first_or_last_generic::<S, _>(inner, value, optional, cursor, true)
         }
 
-        Expr::Literal(lit) => match lit {
-            Literal::Null => GenericResult::Owned(OwnedValue::Null),
-            Literal::Bool(b) => GenericResult::Owned(OwnedValue::Bool(*b)),
-            Literal::NumberLiteral(text) => {
-                GenericResult::Owned(OwnedValue::from_number_literal(text))
-            }
-            Literal::Int(i) => GenericResult::Owned(OwnedValue::Int(*i)),
-            Literal::Float(f) => GenericResult::Owned(OwnedValue::Float(*f)),
-            Literal::String(s) => GenericResult::Owned(OwnedValue::String(s.clone())),
-        },
+        // #1062: was a fourth hand-rolled arm-for-arm copy of the same six
+        // `Literal` variants; delegates to the one canonical conversion now.
+        Expr::Literal(lit) => GenericResult::Owned(literal_to_owned(lit)),
 
         // Formats are pure functions of the value, so evaluate them here rather
         // than falling through to the catch-all, which would serialize the
@@ -3857,7 +3850,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
 #[cfg(test)]
 mod tests {
-    use super::super::expr::{CompareOp, FormatType};
+    use super::super::expr::{CompareOp, FormatType, Literal};
     use super::super::value::NumberRepr;
     use super::*;
     use crate::jq::parse;

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -166,14 +166,19 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     }
 
     /// Create from a literal.
+    ///
+    /// Only `NumberLiteral` needs its own arm (#1062): `JqValue` defers
+    /// parsing a number literal's text until it's actually read, unlike
+    /// `OwnedValue::from_number_literal_boxed` (via `super::value::OwnedValue:
+    /// From<Literal>`), which parses eagerly -- the two target types
+    /// genuinely disagree on when that work happens, so this one arm can't
+    /// delegate. Every other variant carries no such difference, so those
+    /// route through the same canonical conversion `literal_to_owned` uses,
+    /// rather than re-listing five arms a third time.
     pub fn from_literal(lit: &Literal) -> Self {
         match lit {
-            Literal::Null => JqValue::Null,
-            Literal::Bool(b) => JqValue::Bool(*b),
             Literal::NumberLiteral(text) => JqValue::NumberLiteral(text.as_str().into()),
-            Literal::Int(n) => JqValue::Int(*n),
-            Literal::Float(f) => JqValue::Float(*f),
-            Literal::String(s) => JqValue::String(s.clone()),
+            _ => JqValue::from_owned(OwnedValue::from(lit.clone())),
         }
     }
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1259,8 +1259,8 @@ fn owned_value_eq_at_depth(a: &OwnedValue, b: &OwnedValue, depth: usize) -> bool
 }
 
 /// The single `Literal -> OwnedValue` conversion every call site should go
-/// through (#1062, same pattern as [`from_number_literal_boxed`](Self::from_number_literal_boxed)'s
-/// own #966 fix): `eval.rs`'s `literal_to_owned` delegates here rather than
+/// through (#1062, same pattern as `from_number_literal_boxed`'s own #966
+/// fix): `eval.rs`'s `literal_to_owned` delegates here rather than
 /// re-matching the same six variants itself. `lazy.rs`'s `JqValue::from_literal`
 /// also delegates here for every variant except `NumberLiteral` -- `JqValue`
 /// defers that one's parsing until read, a genuine target-type difference

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1258,6 +1258,13 @@ fn owned_value_eq_at_depth(a: &OwnedValue, b: &OwnedValue, depth: usize) -> bool
     }
 }
 
+/// The single `Literal -> OwnedValue` conversion every call site should go
+/// through (#1062, same pattern as [`from_number_literal_boxed`](Self::from_number_literal_boxed)'s
+/// own #966 fix): `eval.rs`'s `literal_to_owned` delegates here rather than
+/// re-matching the same six variants itself. `lazy.rs`'s `JqValue::from_literal`
+/// also delegates here for every variant except `NumberLiteral` -- `JqValue`
+/// defers that one's parsing until read, a genuine target-type difference
+/// this impl doesn't share, so it can't fully delegate.
 impl From<Literal> for OwnedValue {
     fn from(lit: Literal) -> Self {
         match lit {


### PR DESCRIPTION
## Summary

`eval.rs`'s `literal_to_owned`, `value.rs`'s `impl From<Literal> for OwnedValue`, and
`eval_generic.rs`'s inline `Expr::Literal` match arm were three arm-for-arm-identical
copies of the same six-variant `Literal -> OwnedValue` conversion. #1059 had to
hand-edit all three in lockstep to add the `NumberLiteral` arm. `value.rs`'s
`From<Literal>` impl in particular had no production caller at all before this PR —
only its own unit tests exercised it, so a contributor extending the enum could
reasonably assume it was dead and skip it.

## Fix (round 1)

- `literal_to_owned` delegates to `OwnedValue`'s own `From<Literal>` impl instead of
  re-listing the six arms a third time.
- `eval_generic.rs`'s inline match arm is replaced with a call to `literal_to_owned`
  (now `pub(crate)`), removing its copy entirely.
- Fixed the resulting unused-import warning the same way this codebase's own existing
  precedent does for this exact shape (`CompareOp`, from #950 earlier this session):
  moved `Literal` out of the top-level `use` and into the `#[cfg(test)] mod tests`'s
  own import.

## Fix (round 2 — code review)

10-angle fan-out converged on two low-severity, non-blocking findings worth acting on
(most angles reported no correctness issues — this is a small, mechanical, verified
refactor):

- **`lazy.rs`'s `JqValue::from_literal` still hand-rolled 5 of its 6 arms** identically
  to the now-canonical `OwnedValue: From<Literal>` impl — only `NumberLiteral` has a
  real reason to stay separate (`JqValue` defers parsing that text until read;
  `OwnedValue` parses eagerly). Routed the other five through the shared conversion,
  closing the "ideally fewer" gap the original issue's text left open. Confirmed safe:
  `Literal` has no `Array`/`Object` variants, so this always hits `from_owned_at_depth`'s
  depth-0 scalar base case directly — no recursion/depth-guard concern.
- **`value.rs`'s `From<Literal>` impl had no doc comment** marking it as the canonical
  conversion or pointing at its two call sites, unlike this codebase's own #966
  precedent for the identical bug class (`from_number_literal_boxed`'s doc comment says
  "the single conversion every call site should go through"). Added one, and tightened
  `literal_to_owned`'s own comment, which slightly overclaimed full parity with the old
  per-arm code — true for the `String`/`NumberLiteral` variants' one clone, but the
  `Copy`-like variants (`Null`/`Bool`/`Int`/`Float`) now clone the whole (small,
  stack-only) `Literal` enum rather than reading one field directly. No heap cost either
  way, just not literally the same instructions.

**Not acted on**: one review angle compiled both the pre- and post-PR commits in
release mode and found a small, disassembly-verified extra function call for the
`Copy`-like variants (the inlined clone gets followed by a genuine out-of-line call to
`From::from`, which re-dispatches on the same discriminant a second time). Verified
real, but consciously left as-is: avoiding it needs a second `From<&Literal>` impl,
which is more complexity than this "mechanical dedup, no behavior change" PR should
carry for a cost assessed as very unlikely to be visible outside a microbenchmark
isolating literal-heavy evaluation (this repo's own benchmarking discipline argues
against optimizing for an unmeasured, sub-benchmark-threshold effect).

## Testing

- Manual spot-check: number-literal source-text fidelity (`1.500`, `1e2`) and every
  other `Literal` variant still evaluate identically pre/post, across all three
  conversion sites including `lazy.rs`'s `JqValue::from_literal`.
- Full `cargo test --features cli,simd,regex,serde` (2531 tests) — all green.
- Both required Clippy invocations (`--all-features` and the YAML-SIMD/AVX-512 feature
  set) — clean.
- `cargo check --no-default-features` (no_std) — clean (pre-existing, unrelated dead-code
  warnings only).

Addresses item 1 of #1062 (and its `lazy.rs` corollary raised in review). Item 2
(caching `Literal::NumberLiteral`'s parsed `NumberRepr` to avoid re-parsing on every
evaluation) still needs a module-layout decision and is left for a follow-up.