### PR TITLE
fix(jq): @uri/@base64 JSON-stringify a container instead of erroring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,11 @@ The jq implementation supports format functions for converting values to strings
 | **@yaml**    | `@yaml`             | YAML flow-style encoding (yq)                     | `{a: 1, b: 2}`      |
 | **@props**   | `@props`            | Java properties format (yq)                       | `key = value`       |
 
+**@uri/@base64/@html on arrays/objects (jq mode only):** a container is JSON-encoded
+first, then formatted, matching real jq (`[1,2] | @uri` => `"%5B1%2C2%5D"`) — `succinctly
+yq` still rejects a container outright for all three, matching real yq's own
+`cannot encode !!seq as URI/base64...` error (#1096).
+
 **@dsv(delimiter) specifics:**
 - Custom delimiters: Any single or multi-character string
 - Always-quoted strings: every string field is double-quoted (matching jq's `@csv`), regardless of content; non-strings are bare and null is empty

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5661,6 +5661,17 @@ fn format_base64<S: EvalSemantics>(
     // (including JSON-encoding a container in jq mode, #1096).
     let s = match stringify_for_format::<S>(value) {
         Some(s) => s,
+        // Mirrors every sibling format's own `_ if optional =>
+        // Ok(String::new())` arm (`format_urid`/`format_tsv`/`format_dsv`/
+        // `format_csv` above) for consistency, but is very likely
+        // unreachable dead code post-#693 for the same reason those are:
+        // `Expr::Optional` now forces the inner evaluation's ambient
+        // `optional` to `false` and catches the resulting `Error` itself,
+        // rather than letting a builtin's own internal `optional` flag see
+        // `true` (see `test_isvalid_reaches_every_builtins_own_optional_guard`'s
+        // doc comment). Confirmed via `cargo llvm-cov`: all four sibling
+        // arms are equally uncovered on this branch, so this one matching
+        // them isn't a new gap.
         None if optional => return Ok(String::new()),
         None => return Err(EvalError::type_error("string", value.type_name())),
     };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5420,7 +5420,7 @@ pub(crate) fn format_owned<S: EvalSemantics>(
         FormatType::Csv => format_csv::<S>(owned, optional),
         FormatType::Tsv => format_tsv::<S>(owned, optional),
         FormatType::Dsv(delimiter) => format_dsv::<S>(owned, delimiter, optional),
-        FormatType::Base64 => format_base64(owned, optional),
+        FormatType::Base64 => format_base64::<S>(owned, optional),
         FormatType::Base64d => format_base64d(owned, optional),
         FormatType::Html => format_html::<S>(owned, optional),
         FormatType::Sh => format_sh::<S>(owned, optional),
@@ -5468,6 +5468,15 @@ fn format_uri<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<S
             }
         }
         OwnedValue::Null => "null".to_string(),
+        // jq JSON-encodes a container before percent-encoding it (`[1,2] |
+        // @uri` => `"%5B1%2C2%5D"`) rather than erroring -- confirmed
+        // against real jq 1.7.1 (#1096). yq diverges here and keeps
+        // rejecting a container outright ("cannot encode !!seq as URI...",
+        // confirmed against real yq v4.53.3 -- not reproduced here, out of
+        // this issue's scope), matching the existing error below.
+        OwnedValue::Array(_) | OwnedValue::Object(_) if S::TAG == EvalTag::Jq => {
+            owned_value_to_json::<S>(value)
+        }
         _ => return Err(EvalError::type_error("string", value.type_name())),
     };
 
@@ -5629,7 +5638,24 @@ fn format_dsv<S: EvalSemantics>(
 }
 
 /// @base64 - Base64 encode (simple implementation without external crate)
-fn format_base64(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
+fn format_base64<S: EvalSemantics>(
+    value: &OwnedValue,
+    optional: bool,
+) -> Result<String, EvalError> {
+    // jq JSON-encodes a container before base64-encoding it (`[1,2] |
+    // @base64` => `"eyJhIjoxfQ=="`-style) rather than erroring -- confirmed
+    // against real jq 1.7.1 (#1096). yq diverges here and keeps rejecting a
+    // container outright ("cannot encode !!seq as base64", confirmed
+    // against real yq v4.53.3 -- not reproduced here, out of this issue's
+    // scope), matching the fallthrough in the match below.
+    let owned_string;
+    let value = match value {
+        OwnedValue::Array(_) | OwnedValue::Object(_) if S::TAG == EvalTag::Jq => {
+            owned_string = OwnedValue::String(owned_value_to_json::<S>(value));
+            &owned_string
+        }
+        other => other,
+    };
     match value {
         OwnedValue::String(s) => {
             // Simple base64 encoding
@@ -28775,6 +28801,35 @@ mod tests {
         );
     }
 
+    /// jq JSON-encodes a container before percent-encoding it, rather than
+    /// erroring \u2014 confirmed against real jq 1.7.1 (#1096).
+    #[test]
+    fn test_format_uri_container_jq_mode_1096() {
+        query!(br"[1,2]", "@uri",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "%5B1%2C2%5D");
+            }
+        );
+        query!(br#"{"a":1}"#, "@uri",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "%7B%22a%22%3A1%7D");
+            }
+        );
+    }
+
+    /// yq diverges from jq here and keeps rejecting a container outright \u2014
+    /// confirmed against real yq v4.53.3 ("cannot encode !!seq as URI...").
+    /// This fix must not touch yq mode's existing behavior.
+    #[test]
+    fn test_format_uri_container_yq_mode_unaffected_1096() {
+        yq_query!(br"[1,2]", "@uri",
+            QueryResult::Error(_) => {}
+        );
+        yq_query!(br#"{"a":1}"#, "@uri",
+            QueryResult::Error(_) => {}
+        );
+    }
+
     #[test]
     fn test_format_csv() {
         // jq always double-quotes every string field (#306).
@@ -28896,6 +28951,35 @@ mod tests {
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "aGVsbG8=");
             }
+        );
+    }
+
+    /// jq JSON-encodes a container before base64-encoding it, rather than
+    /// erroring — confirmed against real jq 1.7.1 (#1096).
+    #[test]
+    fn test_format_base64_container_jq_mode_1096() {
+        query!(br"[1,2]", "@base64",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "WzEsMl0=");
+            }
+        );
+        query!(br#"{"a":1}"#, "@base64",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "eyJhIjoxfQ==");
+            }
+        );
+    }
+
+    /// yq diverges from jq here and keeps rejecting a container outright —
+    /// confirmed against real yq v4.53.3 ("cannot encode !!seq as
+    /// base64"). This fix must not touch yq mode's existing behavior.
+    #[test]
+    fn test_format_base64_container_yq_mode_unaffected_1096() {
+        yq_query!(br"[1,2]", "@base64",
+            QueryResult::Error(_) => {}
+        );
+        yq_query!(br#"{"a":1}"#, "@base64",
+            QueryResult::Error(_) => {}
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5453,9 +5453,24 @@ fn format_json<S: EvalSemantics>(value: &OwnedValue) -> Result<String, EvalError
 }
 
 /// @uri - URI/percent encode
-fn format_uri<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
-    // jq converts non-strings to strings first (e.g., 42 | @uri => "42")
-    let s = match value {
+/// Shared non-string-to-string conversion for `@uri`/`@html`/`@base64`
+/// (`None` means "no conversion -- caller should raise its own type
+/// error"). A scalar becomes its jq-convention display string; a
+/// container only converts in jq mode, by JSON-encoding it the same way
+/// `tostring`/`@json` do (`[1,2] | @uri` => `"%5B1%2C2%5D"`, confirmed
+/// against real jq 1.7.1, #1096).
+///
+/// yq diverges here and keeps rejecting a container outright for all
+/// three of these formats ("cannot encode !!seq as URI/base64...",
+/// confirmed against real yq v4.53.3) -- `None` on that branch lets each
+/// caller's own existing type-error fallback fire unchanged, matching
+/// yq's pre-#1096 behavior exactly.
+///
+/// One definition instead of a hand-copy per caller, per this file's own
+/// #106 lesson (see [`owned_value_to_json`]'s doc comment, which this
+/// helper's own container arm calls through to for the same reason).
+fn stringify_for_format<S: EvalSemantics>(value: &OwnedValue) -> Option<String> {
+    Some(match value {
         OwnedValue::String(s) => s.clone(),
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
             numeric_display_string::<S>(value)
@@ -5468,17 +5483,17 @@ fn format_uri<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<S
             }
         }
         OwnedValue::Null => "null".to_string(),
-        // jq JSON-encodes a container before percent-encoding it (`[1,2] |
-        // @uri` => `"%5B1%2C2%5D"`) rather than erroring -- confirmed
-        // against real jq 1.7.1 (#1096). yq diverges here and keeps
-        // rejecting a container outright ("cannot encode !!seq as URI...",
-        // confirmed against real yq v4.53.3 -- not reproduced here, out of
-        // this issue's scope), matching the existing error below.
-        OwnedValue::Array(_) | OwnedValue::Object(_) if S::TAG == EvalTag::Jq => {
+        OwnedValue::Array(_) | OwnedValue::Object(_) if S::TAG != EvalTag::Yq => {
             owned_value_to_json::<S>(value)
         }
-        _ => return Err(EvalError::type_error("string", value.type_name())),
-    };
+        OwnedValue::Array(_) | OwnedValue::Object(_) => return None,
+    })
+}
+
+fn format_uri<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
+    // jq converts non-strings to strings first (e.g., 42 | @uri => "42")
+    let s = stringify_for_format::<S>(value)
+        .ok_or_else(|| EvalError::type_error("string", value.type_name()))?;
 
     // Byte-oriented rather than char-oriented: percent-encoding acts on raw
     // bytes anyway, and every safe byte is ASCII, so a multi-byte character's
@@ -5642,56 +5657,43 @@ fn format_base64<S: EvalSemantics>(
     value: &OwnedValue,
     optional: bool,
 ) -> Result<String, EvalError> {
-    // jq JSON-encodes a container before base64-encoding it (`[1,2] |
-    // @base64` => `"eyJhIjoxfQ=="`-style) rather than erroring -- confirmed
-    // against real jq 1.7.1 (#1096). yq diverges here and keeps rejecting a
-    // container outright ("cannot encode !!seq as base64", confirmed
-    // against real yq v4.53.3 -- not reproduced here, out of this issue's
-    // scope), matching the fallthrough in the match below.
-    let owned_string;
-    let value = match value {
-        OwnedValue::Array(_) | OwnedValue::Object(_) if S::TAG == EvalTag::Jq => {
-            owned_string = OwnedValue::String(owned_value_to_json::<S>(value));
-            &owned_string
-        }
-        other => other,
+    // jq converts non-strings to strings first, same as `@uri`/`@html`
+    // (including JSON-encoding a container in jq mode, #1096).
+    let s = match stringify_for_format::<S>(value) {
+        Some(s) => s,
+        None if optional => return Ok(String::new()),
+        None => return Err(EvalError::type_error("string", value.type_name())),
     };
-    match value {
-        OwnedValue::String(s) => {
-            // Simple base64 encoding
-            const ALPHABET: &[u8] =
-                b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-            let bytes = s.as_bytes();
-            let mut result = String::new();
 
-            for chunk in bytes.chunks(3) {
-                let b0 = chunk[0] as u32;
-                let b1 = chunk.get(1).map_or(0, |&b| b as u32);
-                let b2 = chunk.get(2).map_or(0, |&b| b as u32);
+    // Simple base64 encoding
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let bytes = s.as_bytes();
+    let mut result = String::new();
 
-                let triple = (b0 << 16) | (b1 << 8) | b2;
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).map_or(0, |&b| b as u32);
+        let b2 = chunk.get(2).map_or(0, |&b| b as u32);
 
-                result.push(ALPHABET[((triple >> 18) & 0x3F) as usize] as char);
-                result.push(ALPHABET[((triple >> 12) & 0x3F) as usize] as char);
+        let triple = (b0 << 16) | (b1 << 8) | b2;
 
-                if chunk.len() > 1 {
-                    result.push(ALPHABET[((triple >> 6) & 0x3F) as usize] as char);
-                } else {
-                    result.push('=');
-                }
+        result.push(ALPHABET[((triple >> 18) & 0x3F) as usize] as char);
+        result.push(ALPHABET[((triple >> 12) & 0x3F) as usize] as char);
 
-                if chunk.len() > 2 {
-                    result.push(ALPHABET[(triple & 0x3F) as usize] as char);
-                } else {
-                    result.push('=');
-                }
-            }
-
-            Ok(result)
+        if chunk.len() > 1 {
+            result.push(ALPHABET[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
         }
-        _ if optional => Ok(String::new()),
-        _ => Err(EvalError::type_error("string", value.type_name())),
+
+        if chunk.len() > 2 {
+            result.push(ALPHABET[(triple & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
     }
+
+    Ok(result)
 }
 
 /// @base64d - Base64 decode
@@ -5747,22 +5749,11 @@ fn format_base64d(value: &OwnedValue, optional: bool) -> Result<String, EvalErro
 
 /// @html - HTML entity escape
 fn format_html<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<String, EvalError> {
-    // jq converts non-strings to strings first (e.g., 42 | @html => "42")
-    let s = match value {
-        OwnedValue::String(s) => s.clone(),
-        OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            numeric_display_string::<S>(value)
-        }
-        OwnedValue::Bool(b) => {
-            if *b {
-                "true".to_string()
-            } else {
-                "false".to_string()
-            }
-        }
-        OwnedValue::Null => "null".to_string(),
-        _ => return Err(EvalError::type_error("string", value.type_name())),
-    };
+    // jq converts non-strings to strings first (e.g., 42 | @html => "42"),
+    // including JSON-encoding a container in jq mode, same as `@uri`/`@base64`
+    // (#1096: `{"a":1} | @html` => `"{&quot;a&quot;:1}"` in real jq 1.7.1).
+    let s = stringify_for_format::<S>(value)
+        .ok_or_else(|| EvalError::type_error("string", value.type_name()))?;
 
     // Byte-oriented rather than char-oriented, same reasoning as `format_uri`:
     // all five entities are single ASCII bytes, so a multi-byte character's
@@ -28983,6 +28974,37 @@ mod tests {
         );
     }
 
+    /// Before #1096, `@base64` only accepted a string and errored on every
+    /// other scalar type -- unlike `@uri`/`@html`, which always converted
+    /// scalars to their display string first. Routing `@base64` through the
+    /// same `stringify_for_format` helper incidentally fixes this too;
+    /// confirmed these exact values against real jq 1.7.1 (`42 | @base64`
+    /// => `"NDI="`, etc.) rather than assuming the shared helper is correct
+    /// by construction.
+    #[test]
+    fn test_format_base64_scalar_conversion_1096() {
+        query!(br"42", "@base64",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "NDI=");
+            }
+        );
+        query!(br"true", "@base64",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "dHJ1ZQ==");
+            }
+        );
+        query!(br"null", "@base64",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "bnVsbA==");
+            }
+        );
+        query!(br"3.14", "@base64",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "My4xNA==");
+            }
+        );
+    }
+
     #[test]
     fn test_format_base64d() {
         query!(br#""aGVsbG8=""#, "@base64d",
@@ -29016,6 +29038,37 @@ mod tests {
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "&lt;é&gt;");
             }
+        );
+    }
+
+    /// jq JSON-encodes a container before HTML-escaping it, rather than
+    /// erroring — confirmed against real jq 1.7.1 (#1096), the same gap
+    /// found for `@uri`/`@base64`.
+    #[test]
+    fn test_format_html_container_jq_mode_1096() {
+        query!(br"[1,2]", "@html",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "[1,2]");
+            }
+        );
+        query!(br#"{"a":1}"#, "@html",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "{&quot;a&quot;:1}");
+            }
+        );
+    }
+
+    /// yq's lexer rejects `@html` syntax entirely, so there's no oracle to
+    /// compare against directly — this pins succinctly's own extension
+    /// behavior to match `@uri`/`@base64`'s confirmed yq-mode container
+    /// rejection, keeping all three formats consistent with each other.
+    #[test]
+    fn test_format_html_container_yq_mode_unaffected_1096() {
+        yq_query!(br"[1,2]", "@html",
+            QueryResult::Error(_) => {}
+        );
+        yq_query!(br#"{"a":1}"#, "@html",
+            QueryResult::Error(_) => {}
         );
     }
 
@@ -32531,13 +32584,21 @@ mod tests {
             "isvalid(@csv)",
             "isvalid(@tsv)",
             r#"isvalid(@dsv("|"))"#,
-            "isvalid(@base64)",
             "isvalid(@base64d)",
         ] {
             query!(br"1", expr,
                 QueryResult::Owned(OwnedValue::Bool(false)) => {}
             );
         }
+
+        // `@base64` (encode) is the odd one out here: #1096 fixed it to
+        // convert a scalar to its display string first, same as `@uri`/
+        // `@html` already did (`1 | @base64` => `"MQ=="`, confirmed against
+        // real jq 1.7.1) -- so encoding `1` no longer errors at all, and
+        // `isvalid(@base64)` on it is genuinely `true`, not `false`.
+        query!(br"1", "isvalid(@base64)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
 
         // Assignment/update/del: the write-time path traversal fails one
         // level down (`.a` is `1`, not an object, so `.b` can't be written

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -209,15 +209,23 @@ fn test_parity_formats_string_only() {
 }
 
 /// A format that rejects its input must reject it identically in both.
+///
+/// `({"a":1}, "@uri")`, `({"a":1}, "@html")`, and `(b"42", "@base64")` used
+/// to live in this list; #1096 fixed `@uri`/`@html`/`@base64` to
+/// JSON-stringify a container, and `@base64` to convert any other scalar to
+/// its display string too, before formatting (matching real jq: `42 |
+/// jq -c '@base64'` => `"NDI="`), so none of the three error on these
+/// inputs anymore. See `test_format_uri_container_jq_mode_1096`,
+/// `test_format_html_container_jq_mode_1096`, and
+/// `test_format_base64_scalar_conversion_1096` (`src/jq/eval.rs`) for their
+/// corrected coverage instead. `{"a":1} | @sh` stays: `@sh` was never in
+/// #1096's scope and still rejects a container.
 #[test]
 fn test_parity_formats_type_errors() {
     for (json, filter) in [
-        (br#"{"a":1}"#.as_slice(), "@uri"),
-        (br#"{"a":1}"#, "@html"),
-        (br#"{"a":1}"#, "@sh"),
+        (br#"{"a":1}"#.as_slice(), "@sh"),
         (b"42", "@csv"),
         (b"42", "@tsv"),
-        (b"42", "@base64"),
         (b"42", "@urid"),
         (br#""notanarray""#, "@csv"),
     ] {
@@ -336,12 +344,21 @@ fn test_formats_non_finite_owned_pipe_parity() {
 /// `?` on a format applied to a *constructed* value (arithmetic, array/object
 /// construction, ...) must still suppress a type-mismatch error, producing no
 /// output at all -- verified against jq 1.7.1 (`jq -n '(1+1 | @csv)?'` and
-/// the `@tsv`/`@base64`/`@base64d`/`@urid` siblings all produce nothing, exit
-/// 0; `@dsv` has no jq equivalent to check directly, since it's this crate's
+/// the `@tsv`/`@base64d`/`@urid` siblings all produce nothing, exit 0;
+/// `@dsv` has no jq equivalent to check directly, since it's this crate's
 /// own extension, but shares `format_csv`'s exact suppression code path).
 ///
-/// Before #693, `format_csv`/`format_tsv`/`format_dsv`/`format_base64`/
-/// `format_base64d`/`format_urid`'s own `_ if optional => Ok(String::new())`
+/// `@base64` is deliberately *not* in this list (unlike before #1096): real
+/// jq converts a scalar to its display string before base64-encoding it, so
+/// `jq -n '(1+1 | @base64)?'` genuinely produces `"Mg=="`, not nothing --
+/// re-verified live rather than trusted from the pre-#1096 version of this
+/// comment, which had never actually checked `@base64` against real jq and
+/// merely inherited succinctly's own (then-incorrect) error-on-scalar
+/// behavior. See `test_format_base64_constructed_scalar_no_longer_suppressed_1096`
+/// below for that corrected case.
+///
+/// Before #693, `format_csv`/`format_tsv`/`format_dsv`/`format_base64d`/
+/// `format_urid`'s own `_ if optional => Ok(String::new())`
 /// arm was the *only* thing that made `?` work here -- there was no separate
 /// `Expr::Optional`-catches-`Error` fallback for this path, so a suppressed
 /// format fell back to the empty *string* `""` (a real output) rather than
@@ -361,7 +378,6 @@ fn test_formats_optional_owned_type_error_parity_124() {
         (b"null".as_slice(), "(1+1 | @csv)?"),
         (b"null", "(1+1 | @tsv)?"),
         (b"null", r#"(1+1 | @dsv("|"))?"#),
-        (b"null", "(1+1 | @base64)?"),
         (b"null", "(1+1 | @base64d)?"),
         (b"null", "(1+1 | @urid)?"),
     ] {
@@ -372,6 +388,20 @@ fn test_formats_optional_owned_type_error_parity_124() {
         );
         assert_parity(json, filter);
     }
+}
+
+/// Counterpart to `test_formats_optional_owned_type_error_parity_124` above:
+/// `@base64` on a *constructed* scalar no longer errors at all (#1096), so
+/// `?` has nothing to suppress and the pipe produces its real output --
+/// verified against real jq 1.7.1 (`jq -n '(1+1 | @base64)?'` => `"Mg=="`,
+/// exit 0), not just the two evaluators agreeing with each other.
+#[test]
+fn test_format_base64_constructed_scalar_no_longer_suppressed_1096() {
+    assert_eq!(
+        as_strs(&full_outputs(b"null", "(1+1 | @base64)?")),
+        ["\"Mg==\""]
+    );
+    assert_parity(b"null", "(1+1 | @base64)?");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`format_uri` and `format_base64` (`src/jq/eval.rs`) both raised a type error for any array/object input. Real jq 1.7.1 doesn't error there at all — it JSON-encodes the value first (the same representation `tostring`/`@json` would produce) and then applies percent-encoding or base64 encoding to that string:

```
$ echo '[1,2]' | jq -c '@uri'
"%5B1%2C2%5D"
$ echo '[1,2]' | succinctly jq -c '@uri'
jq: error (at <stdin>:1): expected string, got array
```

Fixed for jq mode by JSON-stringifying a container first, gated on `EvalTag`, same as `tostring`/string-interpolation already do.

## yq mode is deliberately unaffected

Verified directly against the pinned yq v4.53.3 binary: real yq rejects a container outright for these formats, in every combination tried:

```
$ echo '[1,2]' | yq -c '@uri'
Error: cannot encode !!seq as URI, can only operate on strings...
$ echo '{"a":1}' | yq -c '@base64'
Error: cannot encode !!map as base64, can only operate on strings
```

This matches succinctly's existing (pre-fix) behavior for yq mode exactly — jq and yq genuinely diverge here, this isn't succinctly lagging one shared oracle.

## Update after code review

Review found `@html` has the identical bug — real jq also JSON-stringifies a container before HTML-escaping it (`{"a":1} | @html` => `"{&quot;a&quot;:1}"` in real jq 1.7.1), and succinctly's `format_html` still unconditionally errored. Fixed the same way.

Also found `format_uri` and `format_base64` had each hand-copied their own container-stringify guard (and `format_base64`'s copy was more convoluted than `format_uri`'s) — exactly the "duplicated predicates diverge silently" pattern this repo's own `CLAUDE.md` names. Extracted one shared `stringify_for_format::<S>` helper that all three formats (`@uri`/`@base64`/`@html`) now call, instead of three near-identical match blocks.

Routing `@base64` through that shared helper surfaced a genuine, separate pre-existing gap: `format_base64` previously only accepted a `String` and errored on every other type — unlike `@uri`/`@html`, which always converted scalars (`Int`/`Float`/`Bool`/`Null`) to their display string first. Real jq does convert scalars for `@base64` too (confirmed live: `42 | jq -c '@base64'` => `"NDI="`, same for `true`/`null`/floats), so this is a correctness fix, not a scope creep. Running the full local suite after applying it caught three more places pinned to the old, incorrect error-on-scalar/error-on-container behavior — all updated with a fresh oracle check, not just relaxed to make them pass:

- `test_isvalid_reaches_every_builtins_own_optional_guard` expected `isvalid(@base64)` on `1` to be `false`; real jq's reference `try (f|true) catch false` desugaring says `true` (`1 | @base64` doesn't error), so the assertion moved to its own correctly-signed case.
- `test_formats_optional_owned_type_error_parity_124` (`tests/jq_evaluator_parity_tests.rs`) asserted `(1+1 | @base64)?` produces no output; real jq (`jq -n '(1+1 | @base64)?'`) actually prints `"Mg=="` — the original comment's claim of having checked this against real jq turned out to be wrong. Removed `@base64` from that list and added a dedicated counterpart test pinning the corrected output.
- `test_parity_formats_type_errors` (same file) listed `{"a":1} | @uri`, `{"a":1} | @html`, and `42 | @base64` as must-reject cases; none of the three reject anymore after this fix, so all three moved out, leaving only the cases (`@sh`, `@csv`/`@tsv` on a bare scalar, `@urid`) untouched by this PR.

Also addressed a minor style nit: the new guards now read `S::TAG != EvalTag::Yq` rather than `== EvalTag::Jq`, matching every other yq-gate in this file (all phrased as a deviation from a jq baseline).

Documented the new container behavior in `CLAUDE.md`'s jq Format Functions section.

## Also checked, confirmed out of scope (left as follow-ups, not fixed here)

- **Depth-limit panic**: a container nested deep enough (~384+ levels, reached via a literal, not just `reduce`) panics in `owned_value_to_json` rather than erroring gracefully. This is an existing, already-accepted tradeoff shared by the whole JSON-stringification family (`@json`, `tostring`) tied to issue #1005's depth guard — not a new defect introduced here, so not fixed in this PR.
- **`@base64d`/`@urid` in yq mode**: real yq silently returns `""` for a container instead of erroring; succinctly still errors. Decode-direction, and the original issue's own scope note flagged this as "not yet checked" — filed as #1109.
- `@base64d` in jq mode already errors either way for a container input (stringify-then-fail-to-decode vs an upfront type error) — different error text, same "error" outcome, so no behavior difference worth changing.
- `@urid` isn't a real jq builtin at all — real jq's own parser rejects the format name, so there's no oracle to compare against.
- `@yaml`'s flow-vs-block style for containers is a likely-intentional design choice (`CLAUDE.md` documents `@yaml` as "flow-style encoding"), not a bug.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the second CI feature-matrix invocation
- [x] `cargo fmt --check`
- [x] New unit tests covering `@uri`/`@base64`/`@html`, both container types, jq-mode-only conversion, yq-mode-unaffected, and `@base64`'s newly-correct scalar conversion
- [x] Updated `test_isvalid_reaches_every_builtins_own_optional_guard` for `@base64`'s corrected scalar behavior (verified against real jq's `try (f|true) catch false` reference semantics)
- [x] Manually verified every repro against both pinned oracles (jq 1.7.1, yq v4.53.3)
- [x] Patch coverage 98.97% (96/97 new lines); the one uncovered line (`format_base64`'s `None if optional => Ok(String::new())`) mirrors four pre-existing sibling arms in the same file that are equally uncovered on this branch (confirmed via `cargo llvm-cov`) -- very likely dead code post-#693 (`Expr::Optional` forces the inner ambient `optional` to `false`), documented in place rather than chased with a synthetic test

Fixes #1096
