### PR TITLE
fix(jq): a computed Infinity's JSON output is DBL_MAX text, not null

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -15,7 +15,8 @@ use succinctly::jq::eval_generic::{
     eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
 };
 use succinctly::jq::{
-    self, assert_value_tree_depth, format_number_jq_compat, Expr, JqValue, OwnedValue, Program,
+    self, assert_value_tree_depth, format_number_jq_compat, nonfinite_display_string, Expr,
+    JqSemantics, JqValue, OwnedValue, Program,
 };
 use succinctly::json::light::{JsonCursor, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
@@ -2017,32 +2018,33 @@ impl LiteralFormatter for JqCompatFormatter {
                 _ => "null".to_string(),
             });
         }
-        // A source literal that overflows to ±Infinity/NaN (e.g. `1e400`)
-        // must not be fed to `format_number_jq_compat` here: this is real
-        // JSON output (`--jq-compat`), which RFC 8259 forbids an Infinity/NaN
-        // literal from, so it must substitute "null" regardless of what text
-        // the function would produce - match `format_float`'s guard below.
-        // (`format_number_jq_compat` itself now handles a non-finite input
-        // correctly rather than the "NaNE+2147483647"-style garbage #561
-        // fixed for the plain-overflow case - #930 closed the same gap for
-        // the *literal*-with-exponent case - but that's jq's real-text
-        // convention for error-message previews, the wrong one for this
-        // RFC-8259-constrained call site.)
-        let overflows = core::str::from_utf8(raw)
-            .ok()
-            .and_then(|s| s.parse::<f64>().ok())
-            .is_some_and(|f| f.is_nan() || f.is_infinite());
-        if overflows {
-            return Cow::Borrowed("null");
-        }
+        // A source literal that overflows to +/-Infinity (e.g. `1e400`) goes
+        // through `format_number_jq_compat` like any other literal (#1087):
+        // it already special-cases a non-finite input via
+        // `format_overflow_literal_mantissa`, giving jq's own mantissa-
+        // preserving renormalized text (`1e400` -> `1E+400`) -- confirmed
+        // live against jq 1.7.1, where `1e400 | .` (identity, no
+        // computation) echoes `1E+400`, not `null` or `DBL_MAX` text; only
+        // an actual *computed* Infinity (`format_float` below) gets the
+        // `DBL_MAX` substitution. JSON's number grammar has no NaN spelling,
+        // so a NaN literal can't reach this function at all -- only via
+        // `format_float`.
         Cow::Owned(format_number_jq_compat(raw))
     }
 
     fn format_float(&self, f: f64) -> String {
-        if f.is_nan() || f.is_infinite() {
-            "null".to_string()
-        } else {
+        // A computed Infinity (`infinite`, an arithmetic overflow) has no
+        // source literal to echo, so it renders jq's own `DBL_MAX` text
+        // instead of `null` (#1087, confirmed live against jq 1.7.1: `null |
+        // infinite` is `1.7976931348623157e+308`, not `null`). NaN has no
+        // such fallback text in real jq either and stays `null`. Reuses
+        // #1075's `nonfinite_display_string` (the same NaN-vs-Infinity split
+        // already pinned for jq's *text*-format path) rather than a fourth
+        // hand-rolled copy of the same two branches.
+        if f.is_finite() {
             format!("{f}")
+        } else {
+            nonfinite_display_string::<JqSemantics>(f).to_string()
         }
     }
 
@@ -2065,10 +2067,14 @@ impl LiteralFormatter for PreserveFormatter {
     }
 
     fn format_float(&self, f: f64) -> String {
-        if f.is_nan() || f.is_infinite() {
-            "null".to_string()
-        } else {
+        // Same split as `JqCompatFormatter::format_float` above (#1087): a
+        // computed Infinity has no source literal for preserve mode to keep
+        // either, so both formatters need the identical jq-real-output rule
+        // here, not just the jq_compat one.
+        if f.is_finite() {
             format!("{f}")
+        } else {
+            nonfinite_display_string::<JqSemantics>(f).to_string()
         }
     }
 
@@ -2507,15 +2513,18 @@ mod tests {
     fn test_jq_compat_formatter_format_raw_number() {
         // Finite numbers fall through the NaN/Infinity guard unchanged.
         assert_eq!(JqCompatFormatter.format_raw_number(b"42").as_ref(), "42");
-        // Overflowed literals substitute "null" instead of reaching
-        // `format_number_jq_compat`, which assumes a finite value (#561).
+        // Overflowed literals echo `format_number_jq_compat`'s own
+        // mantissa-preserving reformat, not "null" (#1087 -- #561's original
+        // premise, that this function "assumes a finite value," stopped
+        // holding once #930 gave it a non-finite special case;
+        // confirmed live against jq 1.7.1, `1e400 | .` echoes `1E+400`).
         assert_eq!(
             JqCompatFormatter.format_raw_number(b"1e400").as_ref(),
-            "null"
+            "1E+400"
         );
         assert_eq!(
             JqCompatFormatter.format_raw_number(b"-1e400").as_ref(),
-            "null"
+            "-1E+400"
         );
     }
 

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -11,7 +11,8 @@ use succinctly::jq::escape::{
 };
 use succinctly::jq::eval_generic::to_owned as generic_to_owned;
 use succinctly::jq::{
-    assert_value_tree_depth, format_number_jq_compat, EvalError, OwnedValue, StreamError,
+    assert_value_tree_depth, format_number_jq_compat, nonfinite_display_string, EvalError,
+    JqSemantics, OwnedValue, StreamError,
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::format_float_with_fraction;
@@ -377,8 +378,26 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
         OwnedValue::Bool(b) => b.to_string(),
         OwnedValue::Int(i) => i.to_string(),
         OwnedValue::Float(f) => {
-            if f.is_nan() || f.is_infinite() {
-                "null".to_string() // JSON doesn't support NaN or Infinity
+            if f.is_nan() {
+                "null".to_string() // JSON doesn't support NaN
+            } else if f.is_infinite() {
+                if opts.control_escape == ControlEscape::Yq {
+                    // yq mode: still "null" -- real yq's own Go
+                    // encoding/json refuses to marshal Infinity at all and
+                    // errors instead, so this is a deliberate, open design
+                    // question left unresolved here, not a parity bug
+                    // (#1087's own scope note).
+                    "null".to_string()
+                } else {
+                    // jq mode: a computed Infinity has no source literal to
+                    // echo, so it renders jq's own DBL_MAX text instead of
+                    // "null" (#1087, confirmed live against jq 1.7.1: `null
+                    // | infinite` is `1.7976931348623157e+308`). Reuses
+                    // #1075's `nonfinite_display_string` rather than a
+                    // fourth hand-rolled copy of the same split (`value.rs`,
+                    // `jq_runner.rs`'s two `LiteralFormatter` impls).
+                    nonfinite_display_string::<JqSemantics>(*f).to_string()
+                }
             } else if opts.control_escape == ControlEscape::Yq {
                 // yq mode: scientific notation past yq's magnitude threshold
                 // (#997), decimal-with-fraction otherwise, regardless of
@@ -397,21 +416,23 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
             }
         }
         OwnedValue::NumberLiteral(_, literal) => {
-            if value
-                .as_f64()
-                .is_some_and(|f| f.is_nan() || f.is_infinite())
-            {
-                "null".to_string() // JSON doesn't support NaN or Infinity
+            if value.as_f64().is_some_and(f64::is_nan) {
+                "null".to_string() // JSON doesn't support NaN
             } else if opts.control_escape == ControlEscape::Yq {
                 // yq mode: echo the source spelling verbatim (#1008) --
                 // matches the Float arm's own yq/jq split above, and real
-                // yq's documented byte-for-byte literal preservation. jq
-                // mode keeps `format_number_jq_compat`'s reformatting
-                // unchanged. This PR fixed its `-0.0`-sign-loss bug (also
-                // #1008, since widening `is_preservable_float_literal`
-                // newly exposed it via YAML), but it has other pre-existing
-                // divergences from real jq, unrelated and left alone here,
-                // e.g. `0.1e1` -> `1E+0` here vs real jq's `1`.
+                // yq's documented byte-for-byte literal preservation,
+                // regardless of finiteness (confirmed live: a genuine
+                // document `1e999` literal echoes verbatim in real yq too).
+                // jq mode keeps `format_number_jq_compat`'s reformatting
+                // unchanged, which itself already reformats a non-finite
+                // literal's mantissa correctly (#1083/#1087) rather than
+                // assuming finiteness. This PR fixed its `-0.0`-sign-loss
+                // bug (also #1008, since widening
+                // `is_preservable_float_literal` newly exposed it via
+                // YAML), but it has other pre-existing divergences from
+                // real jq, unrelated and left alone here, e.g. `0.1e1` ->
+                // `1E+0` here vs real jq's `1`.
                 literal.to_string()
             } else {
                 format_number_jq_compat(literal.as_bytes())
@@ -1109,7 +1130,12 @@ mod tests {
     }
 
     #[test]
-    fn test_format_json_non_finite_floats_are_null() {
+    fn test_format_json_non_finite_floats_1087() {
+        // NaN has no fallback text and stays "null" in jq mode; a computed
+        // Infinity (no source literal) renders jq's own DBL_MAX text
+        // instead, matching #1087's fix to `value.rs`'s `to_json` and
+        // `jq_runner.rs`'s CLI formatters -- this is the third formatter
+        // that needed the identical split.
         let opts = JsonFormatOpts {
             indent: "",
             sort_keys: false,
@@ -1120,14 +1146,33 @@ mod tests {
         assert_eq!(format_json(&OwnedValue::Float(f64::NAN), &opts), "null");
         assert_eq!(
             format_json(&OwnedValue::Float(f64::INFINITY), &opts),
+            "1.7976931348623157e+308"
+        );
+        assert_eq!(
+            format_json(&OwnedValue::Float(f64::NEG_INFINITY), &opts),
+            "-1.7976931348623157e+308"
+        );
+
+        // yq mode is deliberately left unchanged (#1087's own open design
+        // question -- real yq's Go encoding/json errors on Infinity rather
+        // than substituting anything).
+        let yq_opts = JsonFormatOpts {
+            control_escape: ControlEscape::Yq,
+            ..opts
+        };
+        assert_eq!(
+            format_json(&OwnedValue::Float(f64::INFINITY), &yq_opts),
             "null"
         );
     }
 
     #[test]
-    fn test_format_json_non_finite_number_literal_is_null() {
+    fn test_format_json_non_finite_number_literal_1087() {
         // A `NumberLiteral` whose source text overflows f64 to infinity
-        // (`1e400`) must be treated the same as a plain non-finite Float.
+        // (`1e400`) still has its own text to fall back to -- jq mode
+        // echoes the mantissa-preserving reformat (`format_number_jq_compat`
+        // already handles this correctly), not `DBL_MAX` text or "null" --
+        // confirmed live against jq 1.7.1, `1e400 | .` echoes `1E+400`.
         let opts = JsonFormatOpts {
             indent: "",
             sort_keys: false,
@@ -1139,7 +1184,21 @@ mod tests {
             succinctly::jq::NumberRepr::Float(f64::INFINITY),
             "1e400".into(),
         );
-        assert_eq!(format_json(&overflowed, &opts), "null");
+        assert_eq!(format_json(&overflowed, &opts), "1E+400");
+
+        // yq mode echoes the literal verbatim regardless of finiteness
+        // (#1008's byte-for-byte preservation convention) -- confirmed live
+        // against real yq.
+        let yq_opts = JsonFormatOpts {
+            control_escape: ControlEscape::Yq,
+            ..opts
+        };
+        assert_eq!(format_json(&overflowed, &yq_opts), "1e400");
+
+        // NaN still has no fallback text in either mode.
+        let nan_lit =
+            OwnedValue::NumberLiteral(succinctly::jq::NumberRepr::Float(f64::NAN), "nan".into());
+        assert_eq!(format_json(&nan_lit, &opts), "null");
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -139,8 +139,8 @@ use super::expr::{
     ObjectKey, Pattern, StringPart,
 };
 use super::value::{
-    assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_nan_sentinel,
-    numeric_repr_cmp, owned_value_eq, NumberRepr, OwnedValue,
+    assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_infinity_sentinel,
+    is_nan_sentinel, numeric_repr_cmp, owned_value_eq, NumberRepr, OwnedValue,
 };
 
 /// Result of evaluating a jq expression.
@@ -3038,6 +3038,10 @@ fn builtin_length<W: Clone + AsRef<[u64]>>(
             // checked_abs: i64::MIN has no i64 absolute value; use f64
             if is_nan_sentinel(n.raw_bytes()) {
                 QueryResult::Owned(OwnedValue::Float(f64::NAN))
+            } else if is_infinity_sentinel(n.raw_bytes()).is_some() {
+                // Sign doesn't matter: `.abs()` of either infinity is the
+                // same positive infinity (#1083/#1087).
+                QueryResult::Owned(OwnedValue::Float(f64::INFINITY))
             } else if let Ok(i) = n.as_i64() {
                 QueryResult::Owned(match i.checked_abs() {
                     Some(a) => OwnedValue::Int(a),
@@ -19015,6 +19019,12 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // helper's generic `not_a_number` case would be unreachable.
             let timestamp = if is_nan_sentinel(n.raw_bytes()) {
                 f64::NAN
+            } else if let Some(negative) = is_infinity_sentinel(n.raw_bytes()) {
+                if negative {
+                    f64::NEG_INFINITY
+                } else {
+                    f64::INFINITY
+                }
             } else if let Ok(f) = n.as_f64() {
                 f
             } else if optional {
@@ -21165,6 +21175,12 @@ fn get_float_value_with<'a, W: Clone + AsRef<[u64]>>(
         StandardJson::Number(n) => {
             if is_nan_sentinel(n.raw_bytes()) {
                 Ok(f64::NAN)
+            } else if let Some(negative) = is_infinity_sentinel(n.raw_bytes()) {
+                Ok(if negative {
+                    f64::NEG_INFINITY
+                } else {
+                    f64::INFINITY
+                })
             } else if let Ok(f) = n.as_f64() {
                 Ok(f)
             } else if optional {
@@ -21387,6 +21403,12 @@ fn get_number_from_result<W: Clone + AsRef<[u64]>>(
         QueryResult::One(StandardJson::Number(n)) => {
             if is_nan_sentinel(n.raw_bytes()) {
                 Ok(f64::NAN)
+            } else if let Some(negative) = is_infinity_sentinel(n.raw_bytes()) {
+                Ok(if negative {
+                    f64::NEG_INFINITY
+                } else {
+                    f64::INFINITY
+                })
             } else {
                 n.as_f64()
                     .map_err(|_| NumberError::Error(EvalError::new("invalid number")))

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -27,7 +27,7 @@ use crate::json::light::{JsonCursor, StandardJson};
 
 use super::escape::write_json_body_jq;
 use super::expr::Literal;
-use super::value::{assert_value_tree_depth, OwnedValue};
+use super::value::{assert_value_tree_depth, infinite_float_preview_text, OwnedValue};
 
 /// A JSON value for jq evaluation - lazy by default, materialized when needed.
 ///
@@ -524,8 +524,16 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Bool(false) => out.write_str("false"),
             JqValue::Int(n) => write!(out, "{n}"),
             JqValue::Float(f) => {
-                if f.is_nan() || f.is_infinite() {
-                    out.write_str("null")
+                if f.is_nan() {
+                    out.write_str("null") // JSON doesn't support NaN
+                } else if f.is_infinite() {
+                    // A computed Infinity has no source literal to echo, so
+                    // it renders jq's own DBL_MAX text instead of "null"
+                    // (#1087) -- `JqValue` is jq-mode-only (no
+                    // `yq_runner.rs` caller exists), so there's no yq
+                    // convention to preserve here, unlike `OwnedValue::to_json`'s
+                    // mode-generic sibling.
+                    out.write_str(infinite_float_preview_text(f.is_sign_negative()))
                 } else {
                     write!(out, "{f}")
                 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -755,7 +755,12 @@ impl OwnedValue {
     /// entirely: no adversarial document is involved, only enough loop
     /// iterations to grow the accumulator past the limit.
     pub fn to_json(&self) -> String {
-        self.to_json_at_depth(0, format_number_jq_compat, jq_bare_float_display)
+        self.to_json_at_depth(
+            0,
+            format_number_jq_compat,
+            jq_bare_float_display,
+            jq_infinite_float_json_text,
+        )
     }
 
     /// The yq-mode sibling of [`to_json`](Self::to_json) (#1030): identical
@@ -782,6 +787,7 @@ impl OwnedValue {
             0,
             crate::jq::stream::real_output_finite_literal,
             crate::yaml::format_float_with_fraction,
+            yq_infinite_float_json_text,
         )
     }
 
@@ -793,11 +799,23 @@ impl OwnedValue {
     /// [`stream::stream_owned_value_json_with`](crate::jq::stream) already
     /// threads through for the M2 streaming path (#1008), so this doesn't
     /// grow a third hand-copied jq/yq-formatting branch.
+    ///
+    /// `infinite_fmt` is the analogous fork for a computed (non-`NaN`)
+    /// Infinity (#1087): jq mode renders `DBL_MAX` text
+    /// ([`infinite_float_preview_text`]), matching real jq's own `1.7976...e+308`
+    /// rather than substituting `null` (RFC 8259 forbids the literal
+    /// `Infinity`, but a finite-magnitude stand-in is representable). `NaN`
+    /// has no such stand-in and stays `null` unconditionally in both modes.
+    /// yq mode's own correct behavior is still an open design question (real
+    /// yq's Go `encoding/json` refuses to marshal Infinity at all and
+    /// errors) -- `to_json_yq` keeps the pre-existing `null` substitution
+    /// rather than guessing at that answer here.
     fn to_json_at_depth(
         &self,
         depth: usize,
         finite_literal: fn(&[u8]) -> String,
         float_fmt: fn(f64) -> String,
+        infinite_fmt: fn(bool) -> String,
     ) -> String {
         assert_value_tree_depth(depth);
         match self {
@@ -806,21 +824,43 @@ impl OwnedValue {
             Self::Bool(false) => "false".into(),
             Self::Int(n) => format!("{n}"),
             Self::Float(f) => {
-                if f.is_nan() || f.is_infinite() {
-                    "null".into() // JSON doesn't support NaN or Infinity
+                if f.is_nan() {
+                    "null".into() // JSON doesn't support NaN
+                } else if f.is_infinite() {
+                    infinite_fmt(f.is_sign_negative())
                 } else {
                     float_fmt(*f)
                 }
             }
-            Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
-                "null".into() // JSON doesn't support NaN or Infinity
+            Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() => "null".into(),
+            // The reindex-bridge's self-overflowing sentinel (#1087, see
+            // `is_overflow_literal_sentinel`'s own doc comment): a computed
+            // Infinity that passed through `to_json_for_reindex` and got
+            // reparsed is structurally a `NumberLiteral` now, but it stood
+            // in for a value with no real source text, so it needs
+            // `infinite_fmt`'s `DBL_MAX` text (what a bare computed `Float`
+            // above gets), not a mantissa-preserving echo of "1e999" itself.
+            Self::NumberLiteral(NumberRepr::Float(f), literal)
+                if is_overflow_literal_sentinel(literal) =>
+            {
+                infinite_fmt(f.is_sign_negative())
             }
+            // Any other infinite `NumberLiteral` is a genuine document
+            // literal, which still has its own source text to fall back
+            // to -- `1e400 | .` (identity, no computation) echoes jq's
+            // mantissa-preserving `1E+400`, not `DBL_MAX` text, confirmed
+            // live against jq 1.7.1 (#1087). `finite_literal` already
+            // handles this correctly in both modes despite its name: jq's
+            // `format_number_jq_compat` special-cases a non-finite input via
+            // `format_overflow_literal_mantissa` rather than assuming
+            // finiteness, and yq's `real_output_finite_literal` echoes raw
+            // text verbatim regardless of the parsed value.
             Self::NumberLiteral(_, literal) => finite_literal(literal.as_bytes()),
             Self::String(s) => format!("\"{}\"", escape_json_body(write_json_body_jq, s)),
             Self::Array(arr) => {
                 let elements: Vec<String> = arr
                     .iter()
-                    .map(|v| v.to_json_at_depth(depth + 1, finite_literal, float_fmt))
+                    .map(|v| v.to_json_at_depth(depth + 1, finite_literal, float_fmt, infinite_fmt))
                     .collect();
                 format!("[{}]", elements.join(","))
             }
@@ -831,7 +871,7 @@ impl OwnedValue {
                         format!(
                             "\"{}\":{}",
                             escape_json_body(write_json_body_jq, k),
-                            v.to_json_at_depth(depth + 1, finite_literal, float_fmt)
+                            v.to_json_at_depth(depth + 1, finite_literal, float_fmt, infinite_fmt)
                         )
                     })
                     .collect();
@@ -961,12 +1001,22 @@ impl OwnedValue {
             // magnitude (#953); jq keeps the original bare `Display` (see
             // this function's own doc comment for why the fork is required,
             // not optional).
+            // `infinite_fmt` is unreachable from here either way -- every
+            // NaN/infinite case is already handled by the arms above, before
+            // this fallback -- so which one is passed only matters for
+            // reading, not behavior; picked per-mode for consistency.
             other if S::TAG == EvalTag::Yq => other.to_json_at_depth(
                 depth,
                 format_number_jq_compat,
                 crate::yaml::format_float_with_fraction,
+                yq_infinite_float_json_text,
             ),
-            other => other.to_json_at_depth(depth, format_number_jq_compat, jq_bare_float_display),
+            other => other.to_json_at_depth(
+                depth,
+                format_number_jq_compat,
+                jq_bare_float_display,
+                jq_infinite_float_json_text,
+            ),
         }
     }
 }
@@ -981,6 +1031,24 @@ fn overflow_literal(f: f64) -> &'static str {
     } else {
         "1e999"
     }
+}
+
+/// True if `literal` is exactly one of [`overflow_literal`]'s two spellings
+/// (#1087). Unlike [`NAN_SENTINEL`], which is syntactically invalid JSON
+/// (two exponent markers) and so gets intercepted during reparse before it
+/// can ever become a `NumberLiteral` at all (`from_number_bytes`'s
+/// `is_nan_sentinel` check), `"1e999"`/`"-1e999"` are deliberately *valid*
+/// JSON number syntax -- the whole point is that they reparse cleanly to
+/// the right-signed infinity -- so a reindexed computed Infinity does
+/// become a genuine `NumberLiteral(Float(inf), "1e999")`, structurally
+/// identical to a document literal that happened to be spelled the same
+/// way. `to_json_at_depth` needs to tell them apart: the sentinel should
+/// render as a computed value's `DBL_MAX` text (what it actually stood in
+/// for), not get `format_number_jq_compat`'s mantissa-preserving echo (the
+/// correct treatment for a genuine, if coincidentally-identical, document
+/// literal).
+fn is_overflow_literal_sentinel(literal: &str) -> bool {
+    literal == overflow_literal(f64::INFINITY) || literal == overflow_literal(f64::NEG_INFINITY)
 }
 
 /// The exact text real jq's error-message value previews use for an
@@ -1003,6 +1071,26 @@ pub(crate) fn infinite_float_preview_text(negative: bool) -> &'static str {
     } else {
         "1.7976931348623157e+308"
     }
+}
+
+/// `to_json`'s `infinite_fmt` for jq mode (#1087): a computed Infinity
+/// serializes as [`infinite_float_preview_text`]'s `DBL_MAX` text, matching
+/// real jq (`echo null | jq -c infinite` is `1.7976931348623157e+308`, not
+/// `null`) -- `to_json_at_depth` already substitutes `null` for `NaN`
+/// unconditionally, so this fn only ever runs for the non-`NaN` infinite
+/// case.
+fn jq_infinite_float_json_text(negative: bool) -> String {
+    infinite_float_preview_text(negative).to_string()
+}
+
+/// `to_json_yq`'s `infinite_fmt` for yq mode (#1087): keeps the
+/// pre-existing `null` substitution. Real yq's own Go `encoding/json`
+/// refuses to marshal Infinity at all and errors instead, so replicating
+/// jq's `DBL_MAX`-text behavior here would not actually match either
+/// oracle -- an open design question this fn deliberately doesn't resolve,
+/// see #1087's own text.
+fn yq_infinite_float_json_text(_negative: bool) -> String {
+    "null".into()
 }
 
 /// The reserved JSON number literal [`OwnedValue::to_json_for_reindex`]
@@ -1778,16 +1866,38 @@ mod tests {
     }
 
     #[test]
-    fn test_number_literal_to_json_overflow_to_infinity_is_null() {
+    fn test_number_literal_to_json_overflow_to_infinity_echoes_mantissa_1087() {
         // "1e400" overflows f64 to infinity during parsing even though the
         // source text is a normal-looking (if extreme) JSON number token.
-        // JSON has no Infinity, so, like plain Float, this renders as null.
+        // Unlike a bare computed `Float` (which has no source text and
+        // renders `DBL_MAX` text), a `NumberLiteral` still has one to fall
+        // back to -- confirmed live against jq 1.7.1, `1e400 | .` (identity)
+        // echoes `1E+400`, not `null` (#1087; this test's own name/premise
+        // predates that finding).
         let lit = OwnedValue::from_number_literal("1e400");
         assert!(matches!(
             lit,
             OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_infinite()
         ));
-        assert_eq!(lit.to_json(), "null");
+        assert_eq!(lit.to_json(), "1E+400");
+    }
+
+    #[test]
+    fn test_computed_float_to_json_infinity_is_dbl_max_text_1087() {
+        // A genuinely *computed* Infinity (no source literal to echo, e.g.
+        // the `infinite` builtin or an arithmetic overflow) renders jq's own
+        // `DBL_MAX` text instead -- confirmed live against jq 1.7.1, `null |
+        // infinite` is `1.7976931348623157e+308`.
+        assert_eq!(
+            OwnedValue::Float(f64::INFINITY).to_json(),
+            "1.7976931348623157e+308"
+        );
+        assert_eq!(
+            OwnedValue::Float(f64::NEG_INFINITY).to_json(),
+            "-1.7976931348623157e+308"
+        );
+        // NaN still has no fallback text in either case and stays `null`.
+        assert_eq!(OwnedValue::Float(f64::NAN).to_json(), "null");
     }
 
     #[test]

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -544,6 +544,13 @@ impl OwnedValue {
         if is_nan_sentinel(bytes) {
             return Self::Float(f64::NAN);
         }
+        if let Some(negative) = is_infinity_sentinel(bytes) {
+            return Self::Float(if negative {
+                f64::NEG_INFINITY
+            } else {
+                f64::INFINITY
+            });
+        }
         if crate::json::validate::is_valid_number(bytes) {
             return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
         }
@@ -759,7 +766,7 @@ impl OwnedValue {
             0,
             format_number_jq_compat,
             jq_bare_float_display,
-            jq_infinite_float_json_text,
+            infinite_float_preview_text,
         )
     }
 
@@ -815,7 +822,7 @@ impl OwnedValue {
         depth: usize,
         finite_literal: fn(&[u8]) -> String,
         float_fmt: fn(f64) -> String,
-        infinite_fmt: fn(bool) -> String,
+        infinite_fmt: fn(bool) -> &'static str,
     ) -> String {
         assert_value_tree_depth(depth);
         match self {
@@ -827,34 +834,28 @@ impl OwnedValue {
                 if f.is_nan() {
                     "null".into() // JSON doesn't support NaN
                 } else if f.is_infinite() {
-                    infinite_fmt(f.is_sign_negative())
+                    infinite_fmt(f.is_sign_negative()).into()
                 } else {
                     float_fmt(*f)
                 }
             }
             Self::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() => "null".into(),
-            // The reindex-bridge's self-overflowing sentinel (#1087, see
-            // `is_overflow_literal_sentinel`'s own doc comment): a computed
-            // Infinity that passed through `to_json_for_reindex` and got
-            // reparsed is structurally a `NumberLiteral` now, but it stood
-            // in for a value with no real source text, so it needs
-            // `infinite_fmt`'s `DBL_MAX` text (what a bare computed `Float`
-            // above gets), not a mantissa-preserving echo of "1e999" itself.
-            Self::NumberLiteral(NumberRepr::Float(f), literal)
-                if is_overflow_literal_sentinel(literal) =>
-            {
-                infinite_fmt(f.is_sign_negative())
-            }
-            // Any other infinite `NumberLiteral` is a genuine document
-            // literal, which still has its own source text to fall back
-            // to -- `1e400 | .` (identity, no computation) echoes jq's
-            // mantissa-preserving `1E+400`, not `DBL_MAX` text, confirmed
-            // live against jq 1.7.1 (#1087). `finite_literal` already
-            // handles this correctly in both modes despite its name: jq's
-            // `format_number_jq_compat` special-cases a non-finite input via
-            // `format_overflow_literal_mantissa` rather than assuming
-            // finiteness, and yq's `real_output_finite_literal` echoes raw
-            // text verbatim regardless of the parsed value.
+            // An infinite `NumberLiteral` reaching here is always a genuine
+            // document literal, which still has its own source text to
+            // fall back to -- `1e400 | .` (identity, no computation) echoes
+            // jq's mantissa-preserving `1E+400`, not `DBL_MAX` text,
+            // confirmed live against jq 1.7.1 (#1087). The reindex bridge's
+            // own computed-Infinity sentinel can never reach this arm: it's
+            // intercepted during reparse by `from_number_bytes`'s
+            // `is_infinity_sentinel` check (#1083/#1087, mirroring
+            // `is_nan_sentinel`'s sibling interception) and becomes a plain
+            // `Self::Float` above instead, before it can ever masquerade as
+            // a `NumberLiteral`. `finite_literal` already handles a genuine
+            // overflow literal correctly in both modes despite its name:
+            // jq's `format_number_jq_compat` special-cases a non-finite
+            // input via `format_overflow_literal_mantissa` rather than
+            // assuming finiteness, and yq's `real_output_finite_literal`
+            // echoes raw text verbatim regardless of the parsed value.
             Self::NumberLiteral(_, literal) => finite_literal(literal.as_bytes()),
             Self::String(s) => format!("\"{}\"", escape_json_body(write_json_body_jq, s)),
             Self::Array(arr) => {
@@ -1015,40 +1016,59 @@ impl OwnedValue {
                 depth,
                 format_number_jq_compat,
                 jq_bare_float_display,
-                jq_infinite_float_json_text,
+                infinite_float_preview_text,
             ),
         }
     }
 }
 
-/// A JSON number literal guaranteed to overflow to the correctly-signed
-/// infinity when parsed as `f64`, used only by
-/// [`OwnedValue::to_json_for_reindex`] to smuggle ±Infinity through a
-/// JSON-text round-trip.
-fn overflow_literal(f: f64) -> &'static str {
-    if f.is_sign_negative() {
-        "-1e999"
+/// The reserved JSON number literal [`OwnedValue::to_json_for_reindex`]
+/// writes in place of a computed +Infinity (see [`NEG_INFINITY_SENTINEL`]
+/// for -Infinity's spelling) -- #1083/#1087: originally `"1e999"`
+/// (naturally overflowing, valid JSON syntax), but that let a reindexed
+/// computed Infinity reparse into a `NumberLiteral(Float(inf), "1e999")`
+/// bit-for-bit indistinguishable from a genuine document literal that
+/// happened to be spelled the same way, misclassifying either direction
+/// depending which one a given call site assumed. Redesigned to mirror
+/// [`NAN_SENTINEL`]'s already-safe two-exponent-marker trick: guaranteed
+/// unparseable as an ordinary number (so it can never collide with real
+/// document text), intercepted early by [`is_infinity_sentinel`] the same
+/// way `is_nan_sentinel` intercepts its sibling, and still built entirely
+/// from `[0-9-+.eE]` so `JsonNumber::find_end()`'s span scan captures it
+/// whole. Distinguished from `NAN_SENTINEL` (`"9e999e999"`) by leading
+/// digit rather than a sign prefix, so the sign survives as plain text for
+/// [`is_infinity_sentinel`] to read back off, uniformly for both spellings.
+pub(crate) const INFINITY_SENTINEL: &str = "8e999e999";
+
+/// The negative-Infinity sibling of [`INFINITY_SENTINEL`].
+pub(crate) const NEG_INFINITY_SENTINEL: &str = "-8e999e999";
+
+/// `true`/`false` for [`NEG_INFINITY_SENTINEL`]/[`INFINITY_SENTINEL`],
+/// `None` for anything else -- the one definition every call site that
+/// reads a `to_json_for_reindex`-bridge number token must check before
+/// falling back to ordinary parsing, mirroring [`is_nan_sentinel`]'s own
+/// doc comment and existing call-site list exactly (#1083/#1087).
+pub(crate) fn is_infinity_sentinel(bytes: &[u8]) -> Option<bool> {
+    if bytes == NEG_INFINITY_SENTINEL.as_bytes() {
+        Some(true)
+    } else if bytes == INFINITY_SENTINEL.as_bytes() {
+        Some(false)
     } else {
-        "1e999"
+        None
     }
 }
 
-/// True if `literal` is exactly one of [`overflow_literal`]'s two spellings
-/// (#1087). Unlike [`NAN_SENTINEL`], which is syntactically invalid JSON
-/// (two exponent markers) and so gets intercepted during reparse before it
-/// can ever become a `NumberLiteral` at all (`from_number_bytes`'s
-/// `is_nan_sentinel` check), `"1e999"`/`"-1e999"` are deliberately *valid*
-/// JSON number syntax -- the whole point is that they reparse cleanly to
-/// the right-signed infinity -- so a reindexed computed Infinity does
-/// become a genuine `NumberLiteral(Float(inf), "1e999")`, structurally
-/// identical to a document literal that happened to be spelled the same
-/// way. `to_json_at_depth` needs to tell them apart: the sentinel should
-/// render as a computed value's `DBL_MAX` text (what it actually stood in
-/// for), not get `format_number_jq_compat`'s mantissa-preserving echo (the
-/// correct treatment for a genuine, if coincidentally-identical, document
-/// literal).
-fn is_overflow_literal_sentinel(literal: &str) -> bool {
-    literal == overflow_literal(f64::INFINITY) || literal == overflow_literal(f64::NEG_INFINITY)
+/// The correctly-signed sentinel text, used only by
+/// [`OwnedValue::to_json_for_reindex`] to smuggle ±Infinity through a
+/// JSON-text round-trip -- see [`INFINITY_SENTINEL`]'s own doc comment for
+/// why a guaranteed-unparseable (rather than naturally-overflowing)
+/// spelling is what makes this safe.
+fn overflow_literal(f: f64) -> &'static str {
+    if f.is_sign_negative() {
+        NEG_INFINITY_SENTINEL
+    } else {
+        INFINITY_SENTINEL
+    }
 }
 
 /// The exact text real jq's error-message value previews use for an
@@ -1073,24 +1093,14 @@ pub(crate) fn infinite_float_preview_text(negative: bool) -> &'static str {
     }
 }
 
-/// `to_json`'s `infinite_fmt` for jq mode (#1087): a computed Infinity
-/// serializes as [`infinite_float_preview_text`]'s `DBL_MAX` text, matching
-/// real jq (`echo null | jq -c infinite` is `1.7976931348623157e+308`, not
-/// `null`) -- `to_json_at_depth` already substitutes `null` for `NaN`
-/// unconditionally, so this fn only ever runs for the non-`NaN` infinite
-/// case.
-fn jq_infinite_float_json_text(negative: bool) -> String {
-    infinite_float_preview_text(negative).to_string()
-}
-
 /// `to_json_yq`'s `infinite_fmt` for yq mode (#1087): keeps the
 /// pre-existing `null` substitution. Real yq's own Go `encoding/json`
 /// refuses to marshal Infinity at all and errors instead, so replicating
 /// jq's `DBL_MAX`-text behavior here would not actually match either
 /// oracle -- an open design question this fn deliberately doesn't resolve,
 /// see #1087's own text.
-fn yq_infinite_float_json_text(_negative: bool) -> String {
-    "null".into()
+fn yq_infinite_float_json_text(_negative: bool) -> &'static str {
+    "null"
 }
 
 /// The reserved JSON number literal [`OwnedValue::to_json_for_reindex`]
@@ -1911,16 +1921,59 @@ mod tests {
 
     #[test]
     fn test_to_json_for_reindex_preserves_nan() {
-        // Unlike ±Infinity (which self-overflows via `1e999`), NaN has no
-        // natural JSON-number spelling, so `to_json_for_reindex` must emit
-        // the reserved sentinel instead of falling back to `to_json`'s
-        // "null" substitution (#472).
+        // NaN has no natural JSON-number spelling, so `to_json_for_reindex`
+        // must emit the reserved sentinel instead of falling back to
+        // `to_json`'s "null" substitution (#472).
         assert_eq!(
             OwnedValue::Float(f64::NAN).to_json_for_reindex::<JqSemantics>(),
             NAN_SENTINEL
         );
         let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into());
         assert_eq!(lit.to_json_for_reindex::<JqSemantics>(), NAN_SENTINEL);
+    }
+
+    /// #1083/#1087: the infinity sentinel must be as collision-safe as
+    /// `NAN_SENTINEL` already is -- guaranteed unparseable as an ordinary
+    /// number (so `from_number_bytes` can reliably recognize it as *the*
+    /// sentinel rather than a genuine document literal that happens to
+    /// share its spelling), yet still recoverable via
+    /// [`is_infinity_sentinel`] once reparsed.
+    #[test]
+    fn test_infinity_sentinel_is_unparseable_but_recoverable_1087() {
+        assert!(INFINITY_SENTINEL.parse::<f64>().is_err());
+        assert!(INFINITY_SENTINEL.parse::<i64>().is_err());
+        assert!(NEG_INFINITY_SENTINEL.parse::<f64>().is_err());
+        assert!(NEG_INFINITY_SENTINEL.parse::<i64>().is_err());
+
+        assert_eq!(
+            is_infinity_sentinel(INFINITY_SENTINEL.as_bytes()),
+            Some(false)
+        );
+        assert_eq!(
+            is_infinity_sentinel(NEG_INFINITY_SENTINEL.as_bytes()),
+            Some(true)
+        );
+        assert_eq!(is_infinity_sentinel(b"1e400"), None);
+        assert_eq!(is_infinity_sentinel(NAN_SENTINEL.as_bytes()), None);
+
+        // Round-trips correctly through the same public entry point real
+        // document numbers go through.
+        assert_eq!(
+            OwnedValue::from_number_bytes(INFINITY_SENTINEL.as_bytes()),
+            OwnedValue::Float(f64::INFINITY)
+        );
+        assert_eq!(
+            OwnedValue::from_number_bytes(NEG_INFINITY_SENTINEL.as_bytes()),
+            OwnedValue::Float(f64::NEG_INFINITY)
+        );
+
+        // A genuine document literal spelled coincidentally like the *old*
+        // (pre-#1083/#1087) sentinel no longer collides with anything --
+        // it round-trips as an ordinary overflow literal now.
+        assert_eq!(
+            OwnedValue::from_number_bytes(b"1e999"),
+            OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1e999".into())
+        );
     }
 
     /// #939: an infinite `NumberLiteral` backed by real document text (any
@@ -1950,7 +2003,7 @@ mod tests {
     fn test_to_json_for_reindex_bounds_an_unrealistically_long_literal() {
         let huge_literal = format!("{}e400", "9".repeat(300));
         let lit = OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), huge_literal.into());
-        assert_eq!(lit.to_json_for_reindex::<JqSemantics>(), "1e999");
+        assert_eq!(lit.to_json_for_reindex::<JqSemantics>(), INFINITY_SENTINEL);
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3969,16 +3969,26 @@ fn test_number_literal_overflow_text_formats_via_cli() -> Result<()> {
 /// `format_number_jq_compat`), and had the same overflow-renders-as-garbage
 /// bug (#561): unlike JSON output's established "NaN/Infinity -> null"
 /// convention (`OwnedValue::to_json`), it printed
-/// `"NaNE+2147483647"` for `1e400 | .` instead of `null`.
+/// `"NaNE+2147483647"` for `1e400 | .` instead of `null`. #561's "null"
+/// fallback was itself superseded by #1087: `format_number_jq_compat`
+/// already reformats a non-finite input's mantissa correctly
+/// (`format_overflow_literal_mantissa`, added by #930, after #561 landed),
+/// so a *literal* overflow now echoes it (`1E+400`) rather than "null" --
+/// confirmed live against jq 1.7.1, `1e400 | .` (identity, no computation)
+/// echoes `1E+400` too. "null" remains correct only for a genuinely
+/// *computed* Infinity with no source text of its own (see
+/// `test_jq_infinite_direct_json_output_matches_real_jq_1087`, where it's
+/// `DBL_MAX` text instead), and for NaN in both cases (no fallback text
+/// exists for NaN in real jq either).
 #[test]
-fn test_number_literal_overflow_identity_prints_null_via_cli() -> Result<()> {
+fn test_number_literal_overflow_identity_echoes_mantissa_via_cli_1087() -> Result<()> {
     let (output, code) = run_jq_stdin(".", "1e400", &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), "null");
+    assert_eq!(output.trim(), "1E+400");
 
     let (output, code) = run_jq_stdin(".", "-1e400", &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), "null");
+    assert_eq!(output.trim(), "-1E+400");
 
     Ok(())
 }
@@ -10793,6 +10803,38 @@ fn test_jq_tostring_special_floats_unaffected_by_yq_mode_fix_1060() -> Result<()
         let (out, code) = run_jq_stdin(filter, "null", &["-c"])?;
         assert_eq!(code, 0, "for {filter:?}: {out:?}");
         assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    Ok(())
+}
+
+/// #1087: a computed Infinity's direct `-c`/pretty JSON output (not just
+/// `tostring`'s *text*-format path, already correct since #1075) was
+/// `null` regardless of sign -- `JqCompatFormatter` (the default) and
+/// `PreserveFormatter` (`--preserve-input`) in `jq_runner.rs` both
+/// hand-rolled the same `is_nan() || is_infinite() => "null"` collapse.
+/// Confirmed live against jq 1.7.1: `null | infinite` is
+/// `1.7976931348623157e+308`, not `null`; only NaN has no such
+/// fallback text. Covers both formatters, since #1087 found the identical
+/// bug independently duplicated in each.
+#[test]
+fn test_jq_infinite_direct_json_output_matches_real_jq_1087() -> Result<()> {
+    for extra_args in [vec!["-c"], vec!["-c", "--preserve-input"]] {
+        for (filter, want) in [
+            ("infinite", "1.7976931348623157e+308"),
+            ("(-1) * infinite", "-1.7976931348623157e+308"),
+            ("[infinite]", "[1.7976931348623157e+308]"),
+            (r#"{"a":infinite}"#, r#"{"a":1.7976931348623157e+308}"#),
+            (
+                "[1, infinite] | join(\",\")",
+                "\"1,1.7976931348623157e+308\"",
+            ),
+            ("nan", "null"),
+            ("[nan]", "[null]"),
+        ] {
+            let (out, code) = run_jq_stdin(filter, "null", &extra_args)?;
+            assert_eq!(code, 0, "for {filter:?} {extra_args:?}: {out:?}");
+            assert_eq!(out.trim(), want, "for {filter:?} {extra_args:?}");
+        }
     }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5469,24 +5469,31 @@ fn test_yaml_special_floats_to_json_are_null() -> Result<()> {
 
 /// #939: fixed `keys`/`.[]`-style previews of a document-sourced overflow
 /// *number* literal (`123e400`) to reuse the literal's own text instead of
-/// `OwnedValue::to_json_for_reindex`'s generic `1e999` sentinel.
+/// `OwnedValue::to_json_for_reindex`'s generic sentinel.
 ///
 /// #918 later gave YAML floats their own `number_literal()` override too
 /// (previously only JSON had one), but it deliberately excludes non-finite
 /// values: `.inf`/`-.inf`'s YAML spelling isn't valid JSON number syntax,
 /// so unlike a finite YAML float (`2.0`), they still fall through to the
 /// unrelated, unmodified `OwnedValue::Float` arm and never construct an
-/// `OwnedValue::NumberLiteral`. Pinning here that the sentinel text they've
-/// always used stays unchanged by either fix.
+/// `OwnedValue::NumberLiteral`. `.inf`/`-.inf` have no overflow literal of
+/// their own to preserve either way (unlike `123e400`), so they always go
+/// through the reindex bridge's sentinel -- pinning here that #1083/#1087's
+/// sentinel redesign changed *what that preview looks like* (`DBL_MAX`
+/// text, not a mantissa-echo of the old sentinel's own now-collision-prone
+/// spelling), while #939's actual fix (reusing a genuine literal's text)
+/// still doesn't apply to these two, unaffected by either change.
 #[test]
-fn test_yaml_special_float_keys_preview_is_unaffected_by_939() -> Result<()> {
+fn test_yaml_special_float_keys_preview_1087() -> Result<()> {
+    // `describe()`'s own value-preview truncation (unrelated to #1083/#1087)
+    // shortens the `DBL_MAX` text before it ever reaches this message.
     let (output, exit_code) = run_yq_stdin("try keys catch .", ".inf\n", &[])?;
     assert_eq!(exit_code, 0);
-    assert_eq!(output, "number (1E+999) has no keys\n");
+    assert_eq!(output, "number (1.797693134...) has no keys\n");
 
     let (output, exit_code) = run_yq_stdin("try keys catch .", "-.inf\n", &[])?;
     assert_eq!(exit_code, 0);
-    assert_eq!(output, "number (-1E+999) has no keys\n");
+    assert_eq!(output, "number (-1.79769313...) has no keys\n");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`OwnedValue::to_json`/`to_json_at_depth` substituted `null` for both NaN and a computed
Infinity in jq mode. Real jq only does that for NaN — a computed Infinity (`infinite`
builtin, an arithmetic overflow) renders its own `DBL_MAX` text
(`1.7976931348623157e+308`), matching what #1075 already wired into
`nonfinite_display_string` for the *text*-format path, but `to_json` never got the
equivalent fix.

```
$ echo null | jq -c 'infinite'
1.7976931348623157e+308
$ echo null | succinctly jq -c 'infinite'
null
```

## Round 1: scope turned out much larger than the issue's own framing

The issue named `value.rs`'s `to_json`/`to_json_at_depth` as *the* fix. Investigating
found the same bug independently duplicated in the CLI's own separate formatter layer
(`jq_runner.rs`'s `JqCompatFormatter`/`PreserveFormatter`), which is what `-c`/pretty
output actually goes through — `to_json()` alone doesn't fix the issue's own headline
repro at all. Fixed both, plus removed a stale `"null"` override in
`format_raw_number` that was bypassing `format_number_jq_compat`'s own (already-correct,
since #930) mantissa-preserving reformat for a genuine overflow literal like `1e400`.

## Round 2 (code review): two more un-migrated formatters, and a real regression

10-angle fan-out (several independently reproducing the same findings live against jq
1.7.1/yq v4.53.3) found:

- **Two more JSON formatters never got the fix**: `output.rs`'s `format_json_impl`
  (backs `-S`/`--sort-keys`, `-C`/color output, `-n`, `--slurp`, `--ascii-output`) and
  `lazy.rs`'s `JqValue::write_json` (public library API, jq-mode-only). Both still gave
  `null` for a computed Infinity. Fixed both with the same jq/yq-mode split as round 1.
- **A real regression**: round 1's `is_overflow_literal_sentinel` heuristic (matching a
  `NumberLiteral`'s text against the reindex bridge's `"1e999"`/`"-1e999"` sentinel)
  could not actually distinguish that sentinel from a genuine document literal spelled
  the same way — because that spelling is ordinary, valid JSON syntax. This is exactly
  the ambiguity issue **#1083** already diagnosed and prescribed a fix for (mirror
  `NAN_SENTINEL`'s already-safe two-exponent-marker trick). Two confirmed live failure
  directions: a genuine `1e999` document literal got misclassified as `DBL_MAX` text
  (should mantissa-echo, like any other overflow literal); and worse, a computed
  Infinity crossing the reindex bridge through `map`/`sort_by`/`--preserve-input` leaked
  the raw internal sentinel text (`"1E+999"`/`"1e999"`) to the user — worse than the
  pre-round-1 `null`.

## Fixed at the root: redesigned the sentinel (closes #1083 too)

Rather than patch the symptom with more text-matching heuristics, redesigned
`INFINITY_SENTINEL`/`NEG_INFINITY_SENTINEL` to mirror `NAN_SENTINEL`'s already-safe
design: `"8e999e999"`/`"-8e999e999"`, guaranteed unparseable as an ordinary number (two
exponent markers), instead of the old naturally-overflowing-but-collision-prone
`"1e999"`/`"-1e999"`. `from_number_bytes` now intercepts it the same way it already
intercepts `NAN_SENTINEL`, converting straight to a plain `Float` before it can ever
masquerade as a `NumberLiteral` — which let `is_overflow_literal_sentinel` be deleted
entirely rather than patched, and closes #1083 in the same stroke (a `NumberLiteral`
reaching `to_json_at_depth` is now *always* genuine document text, so it unconditionally
gets the mantissa-preserving echo #1083 asked for).

Four downstream `eval.rs` call sites that read raw cursor bytes directly (`length`,
`gmtime`'s timestamp conversion, `get_float_value_with`, `get_number_from_result`)
needed the same symmetric interception to keep treating a reindexed computed Infinity as
infinity rather than a parse failure, mirroring their existing `is_nan_sentinel` checks.

Also simplified `to_json_at_depth`'s `infinite_fmt` parameter from `fn(bool) -> String`
to `fn(bool) -> &'static str` (both real implementations only ever return a fixed
string, per review feedback) — jq mode now passes `infinite_float_preview_text`
directly instead of through a wrapper function.

## yq mode: still an open design question

Real yq's own Go `encoding/json` refuses to marshal Infinity at all and errors instead.
Whether succinctly should replicate that error or keep `null` as a documented policy
choice remains open — `to_json_yq` and every formatter's yq-mode behavior are all
deliberately left unchanged throughout both rounds.

## Testing

- New library-level tests: the corrected `NumberLiteral` overflow case (mantissa echo),
  a genuinely computed `Float`/`Infinity`/`NaN` case (`DBL_MAX` text / `null`), and the
  new sentinel's own collision-safety (unparseable, round-trips correctly, no longer
  collides with a genuine `1e999` document literal).
- New CLI-level tests: direct `-c` output for `infinite` across scalar/array/object/
  `join` shapes, in both formatters.
- Updated seven pre-existing tests whose own premise was superseded by these fixes
  (three from round 1's `format_number_jq_compat` fix, four from round 2's sentinel
  redesign), each reverified against real jq/yq before updating — including one that
  was itself unknowingly pinning a symptom of the sentinel-collision bug (a `describe()`
  preview of YAML's `.inf`).
- Full `cargo test --features cli,simd,regex,serde` (2538+ tests across all binaries) —
  all green, including after rebasing onto main's own concurrent unary-minus/slice fixes
  in the same files.
- Both required Clippy invocations, `cargo check --no-default-features` (no_std), and
  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — all clean.

Fixes #1087, fixes #1083