### PR TITLE
refactor(jq): share the Vec-to-{None,One,Many} collapse across 4 sites

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16961,12 +16961,16 @@ fn builtin_tostream<W: Clone + AsRef<[u64]>>(
     let mut events = Vec::new();
     collect_tostream_events(&owned, &[], &mut events);
     // Always non-empty: every value (including an empty container or a
-    // top-level scalar) produces at least one leaf event.
-    if events.len() == 1 {
-        QueryResult::Owned(events.pop().unwrap())
-    } else {
-        QueryResult::ManyOwned(events)
-    }
+    // top-level scalar) produces at least one leaf event -- routed through
+    // `collapse_vec` anyway (#1067) so a future change to
+    // `collect_tostream_events` that ever violates that invariant degrades
+    // to `QueryResult::None` instead of silently returning `ManyOwned(vec![])`.
+    collapse_vec(
+        events,
+        || QueryResult::None,
+        QueryResult::Owned,
+        QueryResult::ManyOwned,
+    )
 }
 
 /// Builtin: fromstream(f) - reconstruct values from a stream of tostream-style events

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1151,27 +1151,55 @@ fn merge_owned<W: Clone + AsRef<[u64]>>(
     merged
 }
 
+/// Collapse a `Vec<T>` accumulator into the smallest shape representing it:
+/// empty calls `none`, exactly one calls `one` with that value, more than one
+/// calls `many` with the whole vec. The one definition every
+/// `Vec<T>`-to-`{None,One(T)/Owned(T),Many(Vec<T>)}` collapse in this module
+/// (and [`eval_generic`](super::eval_generic)) routes through, instead of
+/// hand-rolling the same 3-arm length match at each call site -- that
+/// pattern independently drifted the same way three times before
+/// consolidation (#1038, #1043, #1048): a hand-rolled match missing the
+/// `0 => None` arm silently collapses an optional (`?`)-suppressed
+/// zero-result computed index/slice into an empty `Many`/`ManyOwned`/
+/// `ManyCursor` instead of `None`. A shared definition can't drift per call
+/// site; a fresh call site gets the right shape for free instead of risking
+/// a fourth rediscovery of the same bug.
+pub(crate) fn collapse_vec<T, R>(
+    mut items: Vec<T>,
+    none: impl FnOnce() -> R,
+    one: impl FnOnce(T) -> R,
+    many: impl FnOnce(Vec<T>) -> R,
+) -> R {
+    match items.len() {
+        0 => none(),
+        1 => one(items.pop().expect("len() == 1 guarantees a first element")),
+        _ => many(items),
+    }
+}
+
 /// Normalize a `Vec<OwnedValue>` accumulator into the smallest `QueryResult`
 /// shape that represents it: empty stays `None`, one value collapses to
 /// `Owned`, more than one stays `ManyOwned`.
-fn owned_vec_to_result<'a, W>(mut vs: Vec<OwnedValue>) -> QueryResult<'a, W> {
-    match vs.len() {
-        0 => QueryResult::None,
-        1 => QueryResult::Owned(vs.pop().unwrap()),
-        _ => QueryResult::ManyOwned(vs),
-    }
+fn owned_vec_to_result<'a, W>(vs: Vec<OwnedValue>) -> QueryResult<'a, W> {
+    collapse_vec(
+        vs,
+        || QueryResult::None,
+        QueryResult::Owned,
+        QueryResult::ManyOwned,
+    )
 }
 
 /// The borrowed-cursor counterpart to [`owned_vec_to_result`] (#1038):
 /// normalize a `Vec<StandardJson>` accumulator into the smallest
 /// `QueryResult` shape that represents it -- empty stays `None`, one value
 /// collapses to `One`, more than one stays `Many`.
-fn borrowed_vec_to_result<W>(mut vs: Vec<StandardJson<'_, W>>) -> QueryResult<'_, W> {
-    match vs.len() {
-        0 => QueryResult::None,
-        1 => QueryResult::One(vs.pop().unwrap()),
-        _ => QueryResult::Many(vs),
-    }
+fn borrowed_vec_to_result<W>(vs: Vec<StandardJson<'_, W>>) -> QueryResult<'_, W> {
+    collapse_vec(
+        vs,
+        || QueryResult::None,
+        QueryResult::One,
+        QueryResult::Many,
+    )
 }
 
 /// Normalize a prefix and its terminator into a `QueryResult` (#400, #494).
@@ -24088,6 +24116,46 @@ mod tests {
                 other => panic!("unexpected result: {:?}", other),
             }
         }};
+    }
+
+    /// #1067: pins `collapse_vec`'s own 0/1/2+ shape, independent of any
+    /// particular caller's enum -- every `Vec<T>`-to-`{None,One,Many}`
+    /// collapse in `eval.rs`/`eval_generic.rs` now shares this one
+    /// definition (`owned_vec_to_result`, `borrowed_vec_to_result`,
+    /// `eval_generic::owned_vec_to_generic_result`,
+    /// `eval_generic::cursor_vec_to_generic_result`), so a regression here
+    /// would silently reintroduce the exact "missing `0 => None` arm" bug
+    /// class already independently rediscovered three times (#1038, #1043,
+    /// #1048).
+    #[test]
+    fn test_collapse_vec_1067() {
+        assert_eq!(
+            collapse_vec(Vec::<i32>::new(), || "none", |_| "one", |_| "many"),
+            "none"
+        );
+        assert_eq!(
+            collapse_vec(vec![1], || "none", |_| "one", |_| "many"),
+            "one"
+        );
+        assert_eq!(
+            collapse_vec(vec![1, 2], || "none", |_| "one", |_| "many"),
+            "many"
+        );
+        assert_eq!(
+            collapse_vec(vec![1, 2, 3], || "none", |_| "one", |_| "many"),
+            "many"
+        );
+        // The `one` closure receives the single element itself, not a
+        // one-element `Vec` -- confirmed by using it, not just a constant arm.
+        assert_eq!(
+            collapse_vec(vec![42], || 0, |v| v, |vs| vs.len() as i32),
+            42
+        );
+        // The `many` closure receives the whole `Vec` back, unmodified.
+        assert_eq!(
+            collapse_vec(vec![1, 2, 3], Vec::new, |v| vec![v], |vs| vs),
+            vec![1, 2, 3]
+        );
     }
 
     /// Every output of `filter` on `json`, rendered as compact JSON.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1963,12 +1963,19 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // ever gets constructed (#400, #494) — the same invariant the
             // unconditional `.next().unwrap()` elsewhere in this file (e.g.
             // `eval_first_or_last_generic`) relies on.
-            GenericResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => {
-                match prefix.len() {
-                    1 => GenericResult::Owned(prefix.into_iter().next().unwrap()),
-                    _ => GenericResult::ManyOwned(prefix),
-                }
-            }
+            // Routed through `collapse_vec` anyway (#1067), so a future
+            // change that ever violates the "never empty here" invariant
+            // above degrades to `None` instead of silently returning
+            // `ManyOwned(vec![])` -- mirrors `eval::prepend`, which
+            // `eval::eval_try`'s identical jq-mode arm calls into and which
+            // already routes its own prefix-collapse through
+            // `owned_vec_to_result`/`collapse_vec`.
+            GenericResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => collapse_vec(
+                prefix,
+                || GenericResult::None,
+                GenericResult::Owned,
+                GenericResult::ManyOwned,
+            ),
             // A `LazySeq` hasn't necessarily failed *yet* -- it's lazy, so
             // it never matches the `Error`/`Break`/`Partial` arms above even
             // when pulling it would fail (#724, #725). `E?` needs to know

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -25,10 +25,11 @@ use super::document::{
     DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
-    apply_compare_op, eval as full_eval, format_owned, index_one_owned as index_owned_by_key,
-    literal_to_owned, needs_path_context, numeric_display_string, numeric_key_to_index,
-    owned_bound_to_i64, owned_value_to_json, slice_owned_value_read, tonumber_from_str, Control,
-    EvalError, EvalSemantics, EvalTag, JqSemantics, QueryResult, YqSemantics,
+    apply_compare_op, collapse_vec, eval as full_eval, format_owned,
+    index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
+    numeric_display_string, numeric_key_to_index, owned_bound_to_i64, owned_value_to_json,
+    slice_owned_value_read, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag,
+    JqSemantics, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -947,25 +948,28 @@ fn partial_generic<V: DocumentValue>(
 }
 
 /// Normalize a `Vec<OwnedValue>` accumulator into the smallest `GenericResult`
-/// shape that represents it. Mirrors [`super::eval::owned_vec_to_result`].
-fn owned_vec_to_generic_result<V: DocumentValue>(mut vs: Vec<OwnedValue>) -> GenericResult<V> {
-    match vs.len() {
-        0 => GenericResult::None,
-        1 => GenericResult::Owned(vs.pop().unwrap()),
-        _ => GenericResult::ManyOwned(vs),
-    }
+/// shape that represents it. Mirrors [`super::eval::owned_vec_to_result`];
+/// both share [`collapse_vec`]'s one definition of the actual collapse (#1067).
+fn owned_vec_to_generic_result<V: DocumentValue>(vs: Vec<OwnedValue>) -> GenericResult<V> {
+    collapse_vec(
+        vs,
+        || GenericResult::None,
+        GenericResult::Owned,
+        GenericResult::ManyOwned,
+    )
 }
 
 /// Normalize a `Vec<V::Cursor>` accumulator into the smallest `GenericResult`
 /// shape that represents it -- the borrowed-cursor counterpart of
 /// [`owned_vec_to_generic_result`], for the same reason (#1048): a caller
 /// with zero results must collapse to `None`, not `ManyCursor(vec![])`.
-fn cursor_vec_to_generic_result<V: DocumentValue>(mut cs: Vec<V::Cursor>) -> GenericResult<V> {
-    match cs.len() {
-        0 => GenericResult::None,
-        1 => GenericResult::OneCursor(cs.pop().unwrap()),
-        _ => GenericResult::ManyCursor(cs),
-    }
+fn cursor_vec_to_generic_result<V: DocumentValue>(cs: Vec<V::Cursor>) -> GenericResult<V> {
+    collapse_vec(
+        cs,
+        || GenericResult::None,
+        GenericResult::OneCursor,
+        GenericResult::ManyCursor,
+    )
 }
 
 /// Finalize a fork's accumulated `outputs`, given an optional terminating


### PR DESCRIPTION
## Summary

`owned_vec_to_result`/`borrowed_vec_to_result` (`src/jq/eval.rs`) and `owned_vec_to_generic_result`/`cursor_vec_to_generic_result` (`src/jq/eval_generic.rs`) each hand-rolled the identical 3-arm length match (`0 => None, 1 => the single element, _ => the whole Vec`), differing only in which enum variant (`QueryResult`/`GenericResult`) and element type (`OwnedValue`/`StandardJson`/`V::Cursor`) got plugged in.

This exact bug class — a hand-rolled match missing the `0 => None` arm, silently collapsing an optional (`?`)-suppressed zero-result computed index/slice into an empty `Many`/`ManyOwned`/`ManyCursor` instead of `None` — was independently rediscovered and fixed **three times** in this codebase (#1038, #1043, #1048), each needing its own from-scratch investigation and oracle verification.

Extracts `collapse_vec<T, R>`, generic over both the element type and the result enum via three constructor closures (`none`/`one`/`many`). Each of the 4 existing helpers becomes a thin wrapper plugging in its own constructors — every existing call site and function signature stays unchanged, this is a pure internal refactor with no behavior change (the actual collapse algorithm is identical to what each helper already did).

`QueryResult`/`GenericResult` are different enums with different variant sets (`GenericResult` additionally has `OneCursor`/`ManyCursor`), so full unification into one type wasn't attempted — closures over the constructors sidestep that without needing a shared trait or a macro.

Fixes #1067

## Test plan

- [x] `test_collapse_vec_1067` — new unit test pinning `collapse_vec`'s own 0/1/2+ shape directly (empty → `none`, one element → `one` receiving the element itself not a 1-vec, 2+ → `many` receiving the untouched `Vec`), independent of any particular caller's enum. A future regression here now surfaces in one place instead of silently affecting all 4 call sites.
- [x] Full lib unit tests (2532 passed, up 1 from the new test).
- [x] `jq_cli_tests` (555), `yq_cli_tests` (702), `yq_golden_tests`/`yq_path_consistency_tests` (6), plus every other jq-specific integration suite (`jq_golden_tests`, `jq_evaluator_parity_tests`, `jq_numeric_equality_tests`, `jq_computed_key_tests`, `jq_containment_tests`, `jq_error_message_tests`, `jq_recurse_depth_tests`, `jq_tests` — 247 more) — all pass, each run in isolation.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo check --no-default-features` (no_std) — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.