### PR TITLE
fix(yaml): render a deferred-absent value bare, not as an empty-string marker

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1728,35 +1728,18 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // nothing at all writes no value token here
                             // (matching the sibling branch above, #765) --
                             // but unlike that branch, this one can still
-                            // have an anchor to write, so it can't just
-                            // skip straight to the comment. A trailing
-                            // space is only owed to something that actually
-                            // follows it: the colon alone (`a:`, no anchor,
-                            // absent value) takes none at all, matching
-                            // real yq's own bare rendering byte-for-byte.
-                            let absent = is_deferred_value_absent(&value);
-                            let anchor = value.anchor();
-                            if anchor.is_some() || !absent {
-                                out.write_char(' ')?;
-                            }
-                            if let Some(anchor) = anchor {
-                                out.write_char('&')?;
-                                out.write_str(anchor)?;
-                                if !absent {
-                                    out.write_char(' ')?;
-                                }
-                            }
-                            if !absent {
-                                let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
-                                value.stream_yaml_value(
-                                    out,
-                                    &child_indent,
-                                    indent_spaces,
-                                    unit,
-                                    sort_keys,
-                                    false,
-                                )?;
-                            }
+                            // have an anchor/tag to write, so it can't just
+                            // skip straight to the comment. See
+                            // `write_deferred_value`'s own doc comment for
+                            // the byte-for-byte spacing rule.
+                            write_deferred_value(
+                                out,
+                                &value,
+                                indent,
+                                indent_spaces,
+                                unit,
+                                sort_keys,
+                            )?;
                             // The value's own comment takes priority; fall
                             // back to the key's own comment when the value
                             // has none - covers an explicit key's trailing
@@ -1876,35 +1859,17 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             write_line_comment(out, cursor.line_comment_raw())?;
                         } else {
                             // #1077: mirrors the mapping-field branch above
-                            // -- a deferred item that materializes as
-                            // nothing at all writes no value token, and the
-                            // dash takes no trailing space unless something
-                            // (an anchor or a real value) actually follows
-                            // it, matching real yq's bare `-` byte-for-byte.
-                            let absent = is_deferred_value_absent(&cursor);
-                            let anchor = cursor.anchor();
+                            // -- see `write_deferred_value`'s own doc
+                            // comment for the byte-for-byte spacing rule.
                             out.write_char('-')?;
-                            if anchor.is_some() || !absent {
-                                out.write_char(' ')?;
-                            }
-                            if let Some(anchor) = anchor {
-                                out.write_char('&')?;
-                                out.write_str(anchor)?;
-                                if !absent {
-                                    out.write_char(' ')?;
-                                }
-                            }
-                            if !absent {
-                                let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
-                                cursor.stream_yaml_value(
-                                    out,
-                                    &child_indent,
-                                    indent_spaces,
-                                    unit,
-                                    sort_keys,
-                                    false,
-                                )?;
-                            }
+                            write_deferred_value(
+                                out,
+                                &cursor,
+                                indent,
+                                indent_spaces,
+                                unit,
+                                sort_keys,
+                            )?;
                             write_line_comment(out, cursor.line_comment_raw())?;
                         }
                         elems = rest;
@@ -6296,6 +6261,52 @@ fn is_deferred_value_absent<W: AsRef<[u64]>>(value: &YamlCursor<'_, W>) -> bool 
         YamlValue::String(s) => s.is_unquoted() && s.as_str().map_or(true, |t| t.is_empty()),
         _ => false,
     }
+}
+
+/// Writes a possibly-absent value's anchor, explicit tag, and (if not
+/// absent) its own rendering -- shared by the mapping-field and
+/// sequence-item branches of `stream_yaml_value`'s block-style loops,
+/// which differ only in what precedes this (a `:` vs a `-`, already
+/// written by the caller).
+///
+/// A leading separator space is only written when something actually
+/// follows -- an anchor, a tag, or a real value -- matching real yq's own
+/// bare rendering byte-for-byte (`a:`/`-`, not `a: `/`- `, when nothing
+/// does) (#1077). A tag is written directly here only in the absent case;
+/// when the value isn't absent, `stream_yaml_value`'s own scalar dispatch
+/// below writes it as usual, so writing it here too would duplicate it --
+/// this is what an earlier draft of #1077's fix got wrong, silently
+/// dropping a no-anchor explicit tag on an absent value instead (found by
+/// review before merge).
+fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
+    out: &mut Out,
+    value: &YamlCursor<'_, W>,
+    indent: &str,
+    indent_spaces: usize,
+    unit: char,
+    sort_keys: bool,
+) -> core::fmt::Result {
+    let absent = is_deferred_value_absent(value);
+    let anchor = value.anchor();
+    let tag = if absent { value.explicit_tag() } else { None };
+    if anchor.is_some() || tag.is_some() || !absent {
+        out.write_char(' ')?;
+    }
+    if let Some(anchor) = anchor {
+        out.write_char('&')?;
+        out.write_str(anchor)?;
+        if tag.is_some() || !absent {
+            out.write_char(' ')?;
+        }
+    }
+    if let Some(tag) = tag {
+        out.write_str(tag)?;
+    }
+    if !absent {
+        let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
+        value.stream_yaml_value(out, &child_indent, indent_spaces, unit, sort_keys, false)?;
+    }
+    Ok(())
 }
 
 /// Write `width` copies of `unit` as indentation (`unit` is `' '` for

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1724,21 +1724,39 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // yq (#765).
                             write_line_comment(out, Some(kc))?;
                         } else {
-                            out.write_char(' ')?;
-                            if let Some(anchor) = value.anchor() {
-                                out.write_char('&')?;
-                                out.write_str(anchor)?;
+                            // #1077: a deferred value that materializes as
+                            // nothing at all writes no value token here
+                            // (matching the sibling branch above, #765) --
+                            // but unlike that branch, this one can still
+                            // have an anchor to write, so it can't just
+                            // skip straight to the comment. A trailing
+                            // space is only owed to something that actually
+                            // follows it: the colon alone (`a:`, no anchor,
+                            // absent value) takes none at all, matching
+                            // real yq's own bare rendering byte-for-byte.
+                            let absent = is_deferred_value_absent(&value);
+                            let anchor = value.anchor();
+                            if anchor.is_some() || !absent {
                                 out.write_char(' ')?;
                             }
-                            let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
-                            value.stream_yaml_value(
-                                out,
-                                &child_indent,
-                                indent_spaces,
-                                unit,
-                                sort_keys,
-                                false,
-                            )?;
+                            if let Some(anchor) = anchor {
+                                out.write_char('&')?;
+                                out.write_str(anchor)?;
+                                if !absent {
+                                    out.write_char(' ')?;
+                                }
+                            }
+                            if !absent {
+                                let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
+                                value.stream_yaml_value(
+                                    out,
+                                    &child_indent,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                    false,
+                                )?;
+                            }
                             // The value's own comment takes priority; fall
                             // back to the key's own comment when the value
                             // has none - covers an explicit key's trailing
@@ -1857,21 +1875,36 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             }
                             write_line_comment(out, cursor.line_comment_raw())?;
                         } else {
-                            out.write_str("- ")?;
-                            if let Some(anchor) = cursor.anchor() {
-                                out.write_char('&')?;
-                                out.write_str(anchor)?;
+                            // #1077: mirrors the mapping-field branch above
+                            // -- a deferred item that materializes as
+                            // nothing at all writes no value token, and the
+                            // dash takes no trailing space unless something
+                            // (an anchor or a real value) actually follows
+                            // it, matching real yq's bare `-` byte-for-byte.
+                            let absent = is_deferred_value_absent(&cursor);
+                            let anchor = cursor.anchor();
+                            out.write_char('-')?;
+                            if anchor.is_some() || !absent {
                                 out.write_char(' ')?;
                             }
-                            let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
-                            cursor.stream_yaml_value(
-                                out,
-                                &child_indent,
-                                indent_spaces,
-                                unit,
-                                sort_keys,
-                                false,
-                            )?;
+                            if let Some(anchor) = anchor {
+                                out.write_char('&')?;
+                                out.write_str(anchor)?;
+                                if !absent {
+                                    out.write_char(' ')?;
+                                }
+                            }
+                            if !absent {
+                                let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
+                                cursor.stream_yaml_value(
+                                    out,
+                                    &child_indent,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                    false,
+                                )?;
+                            }
                             write_line_comment(out, cursor.line_comment_raw())?;
                         }
                         elems = rest;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9463,6 +9463,28 @@ fn test_anchor_comment_dropped_at_eof_with_no_sibling_784() -> Result<()> {
     Ok(())
 }
 
+/// #1077's own base case, with no anchor and no comment at all: a mapping
+/// field deferred to a sibling at the same indent, which never supplies any
+/// content, renders with no value token (`a:`, not `a: ""`).
+#[test]
+fn test_deferred_absent_mapping_field_no_anchor_renders_bare_1077() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a:\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a:\nb: 1\n");
+    Ok(())
+}
+
+/// Same shape, but a sequence item instead of a mapping field: a deferred
+/// item with no anchor and no comment, followed by a sibling item at the
+/// same indent, renders bare (`-`, not `- ""`).
+#[test]
+fn test_deferred_absent_sequence_item_no_anchor_renders_bare_1077() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- \n- 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "-\n- 2\n");
+    Ok(())
+}
+
 // The shapes below were added in a second round, after code review found the
 // first pass (a) regressed #765/#785's own key-comment capture when a
 // floated comment collides with a key's genuine same-line comment, (b)

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9485,6 +9485,48 @@ fn test_deferred_absent_sequence_item_no_anchor_renders_bare_1077() -> Result<()
     Ok(())
 }
 
+/// Regression guard (found by review before merge): a deferred-absent
+/// mapping field with an explicit tag but no anchor must keep the tag --
+/// an earlier draft of this fix silently dropped it, since only `anchor`
+/// was checked to decide whether anything survives the absent value.
+#[test]
+fn test_deferred_absent_mapping_field_keeps_explicit_tag_1077() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: !!str\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: !!str\nb: 1\n");
+    Ok(())
+}
+
+/// Same regression, with both an anchor and a tag present on the absent
+/// value -- both must survive, anchor before tag, matching real yq's own
+/// ordering.
+#[test]
+fn test_deferred_absent_mapping_field_keeps_anchor_and_tag_1077() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: &anc !!str\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: &anc !!str\nb: 1\n");
+    Ok(())
+}
+
+/// Same regression class, the sequence-item variant: an explicit tag with
+/// no anchor on a deferred-absent item.
+#[test]
+fn test_deferred_absent_sequence_item_keeps_explicit_tag_1077() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- !!str\n- 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- !!str\n- 2\n");
+    Ok(())
+}
+
+/// Sequence-item variant with both an anchor and a tag.
+#[test]
+fn test_deferred_absent_sequence_item_keeps_anchor_and_tag_1077() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- &anc !!str\n- 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- &anc !!str\n- 2\n");
+    Ok(())
+}
+
 // The shapes below were added in a second round, after code review found the
 // first pass (a) regressed #765/#785's own key-comment capture when a
 // floated comment collides with a key's genuine same-line comment, (b)

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9427,14 +9427,8 @@ fn test_anchor_no_comment_unaffected_784() -> Result<()> {
 // When the anchor's deferred value turns out null, the comment floats past
 // it to the next sibling rather than disappearing (or, at true EOF with no
 // sibling to float to, is dropped - matching real yq exactly there) - the
-// three tests below pin that behavior specifically. Note: succinctly
-// renders a null anchor value's own line as `&anc ""` here, not real yq's
-// bare `&anc` - that's a separate, pre-existing divergence in null-anchor
-// rendering (unrelated to comment placement, reproduces identically with no
-// comment present at all, e.g. plain `a: &anc\n` with EOF immediately after
-// - tracked as a follow-up, not part of #784's scope). Only the *comment's*
-// position (landing on the sibling's own line, or vanishing at EOF) is what
-// these tests pin.
+// three tests below pin that behavior specifically. The anchor's own line
+// renders bare (`&anc`, no value token), matching real yq - see #1077.
 
 /// A sibling key immediately follows at the same indent - the anchor's
 /// deferred value is null, and its comment floats to the sibling.
@@ -9442,7 +9436,7 @@ fn test_anchor_no_comment_unaffected_784() -> Result<()> {
 fn test_anchor_comment_floats_to_sibling_same_indent_784() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "a: &anc # comment\nb: 2\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out, "a: &anc \"\"\nb: 2 # comment\n");
+    assert_eq!(out, "a: &anc\nb: 2 # comment\n");
     Ok(())
 }
 
@@ -9452,7 +9446,7 @@ fn test_anchor_comment_floats_to_sibling_same_indent_784() -> Result<()> {
 fn test_anchor_comment_floats_to_sibling_lower_indent_784() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "x:\n  a: &anc # comment\n  b: 2\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out, "x:\n  a: &anc \"\"\n  b: 2 # comment\n");
+    assert_eq!(out, "x:\n  a: &anc\n  b: 2 # comment\n");
     Ok(())
 }
 
@@ -9465,7 +9459,7 @@ fn test_anchor_comment_floats_to_sibling_lower_indent_784() -> Result<()> {
 fn test_anchor_comment_dropped_at_eof_with_no_sibling_784() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "a: &anc # comment\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out, "a: &anc \"\"\n");
+    assert_eq!(out, "a: &anc\n");
     Ok(())
 }
 
@@ -9589,7 +9583,7 @@ fn test_anchor_floated_comment_does_not_clobber_compact_key_own_comment_784() ->
 fn test_anchor_floated_comment_does_not_corrupt_flow_sequence_784() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "- &anc # comment\n- [1, 2]\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out, "- &anc \"\"\n- [1, 2]\n");
+    assert_eq!(out, "- &anc\n- [1, 2]\n");
     Ok(())
 }
 
@@ -9598,7 +9592,7 @@ fn test_anchor_floated_comment_does_not_corrupt_flow_sequence_784() -> Result<()
 fn test_anchor_floated_comment_does_not_corrupt_flow_mapping_784() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "- &anc # comment\n- {a: 1, b: 2}\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out, "- &anc \"\"\n- {a: 1, b: 2}\n");
+    assert_eq!(out, "- &anc\n- {a: 1, b: 2}\n");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- A mapping field or sequence item deferred to a following line that never materializes any content (EOF right after, or a sibling immediately follows at the same/lower indent) streamed as an explicit `""` marker instead of real yq's bare rendering.
- Example: `a: &anc ""` where real `yq` writes `a: &anc`; `- &anc ""` where real `yq` writes `- &anc`.
- The gap predates #784 and isn't limited to anchored values — it's a general deferred-absent-value formatting bug in `stream_yaml_value`. #784's own tests had to pin the buggy `""` output for this shape since it hadn't been fixed yet; this PR updates those 5 tests to the correct expected output.

## Fix
Both the mapping-field and sequence-item streaming branches in `src/yaml/light.rs` now use the existing `is_deferred_value_absent` helper to skip the value token (and its leading space) entirely when there's nothing to write, while still emitting an anchor if one is present.

Fixes #1077

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green; one unrelated flaky test confirmed passing in isolation)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (NEON YAML backend)
- [x] `cargo check --no-default-features` (no_std)
- [x] Manually verified against the pinned real `yq` binary, byte-exact
- [x] Patch coverage checked via `omni-dev coverage diff`