### PR TITLE
fix(jq): yq assigning through a scalar slice target is a silent no-op

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9903,65 +9903,39 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
 
 /// Whether a *resolved* assignment-target path (a `paths`/`delete_at_path`
 /// entry, already past `resolve_dynamic_indexes`, not the raw `path_expr`
-/// the user wrote) is a bare slice — `.[S:E]`, or `.[S:E]?` (`resolve_
-/// dynamic_indexes` doesn't always strip an outer `Expr::Optional`, unlike
-/// `Expr::Paren`, which never survives parsing at all) — as opposed to
-/// `.foo[S:E]`, `.[S:E][]`, or any other chaining. Checking the *resolved*
-/// path rather than the original `path_expr` is what makes a computed-bound
-/// `.[$a:$b]` (`Expr::SliceExpr` pre-resolution) reach this the same way a
-/// literal `.[0:1]` (`Expr::Slice` from the start) does — both fold to the
-/// identical `Expr::Slice{start,end}` shape by the time `resolve_dynamic_
-/// indexes` is done, per its own `needs_path_prepass` gate.
+/// the user wrote) is a bare slice — `.[S:E]`, `.[S:E]?`, or `(.[S:E])` —
+/// as opposed to `.foo[S:E]`, `.[S:E][]`, or any other chaining. Checking
+/// the *resolved* path rather than the original `path_expr` is what makes
+/// a computed-bound `.[$a:$b]` (`Expr::SliceExpr` pre-resolution) reach
+/// this the same way a literal `.[0:1]` (`Expr::Slice` from the start)
+/// does — both fold to the identical `Expr::Slice{start,end}` shape by the
+/// time `resolve_dynamic_indexes` is done, per its own `needs_path_prepass`
+/// gate.
 ///
 /// Combine with [`is_yq_slice_empty_container_scalar`] against the *current*
 /// value at this point in the fold (not the original input — #1101's no-op
 /// is a per-path, per-fold-step decision, same granularity as `set_path`/
 /// `update_path`'s own error checks) to get the full #1101 condition: a bare
 /// slice targeting a scalar, the shape real yq's own slice-assignment
-/// machinery silently no-ops the *write* portion of (#1101).
+/// machinery silently no-ops the *write* portion of. The RHS/filter itself
+/// is still evaluated normally at every call site — only the final write is
+/// skipped, so `.[0:1] = error("boom")`/`halt`/`break` still propagate
+/// exactly as they would for any other assignment.
 ///
-/// **Premise correction, found while live-probing #1101 against real yq
-/// v4.53.3**: the no-op is *not* scalar-specific the way #1065's read-path
-/// rule is. `[1,2,3] | .[0:1] = [9]` and `"hi" | .[0:1] = "X"` are *also*
-/// silent no-ops in real yq — `.[S:E] = v` / `.[S:E] |= f` / `.[S:E] += v`
-/// never actually *writes* anywhere, for *any* target type. This looks like
-/// real yq's slice-assignment path resolution never being wired up at all,
-/// not a deliberate design choice. succinctly's own array/string
-/// slice-assignment already works correctly and is a genuinely useful
-/// feature beyond what real yq offers — matching the universal no-op
-/// exactly would mean *removing* that working feature to replicate what
-/// looks like a real-yq gap, not a real-yq rule worth porting. So this
-/// check is deliberately narrowed to the scalar case only (matching #1065's
-/// own scope), preserving succinctly's array/string slice-assignment
-/// untouched — a deliberate scope decision, not an oversight.
-///
-/// **Second correction, found via code review**: only the *write* is a
-/// no-op — the RHS/filter is still evaluated normally, with its own
-/// errors/`halt`/`break` propagating exactly as they would for any other
-/// assignment (`.[0:1] = error("boom")` genuinely errors in real yq; only
-/// a *successful* RHS value is silently discarded rather than written). An
-/// earlier version of this fix short-circuited *before* evaluating the RHS
-/// at all, based on a since-corrected misreading of `.[0:1] = (1/0)`
-/// appearing not to error — `1/0` doesn't actually raise a catchable error
-/// in real yq (it evaluates to `+Inf`, which only fails at JSON-output time
-/// for a value that was never written and thus never serialized), so that
-/// probe never actually tested whether RHS evaluation happens. Every call
-/// site now evaluates the RHS/filter through the ordinary machinery and
-/// only skips the final write.
-///
-/// Also confirmed asymmetric by operator: `=`/`|=`/`+=`/`del()` no-op, but
-/// `-=`/`*=` *error* instead (with odd, clearly Go-internal-leak messages
-/// like `strconv.ParseInt: parsing "": invalid syntax` — not a stable
-/// compatibility target, so not replicated). Callers gate this check to
-/// only `=`, `|=`, `+=` (`AssignOp::Add` specifically), and `del()`;
-/// `-=`/`*=` are deliberately left calling the unmodified, still-erroring
-/// path. `/=`, `%=`, `//=`, and `path(...)` aren't valid real-yq syntax at
-/// all (confirmed live — e.g. `'/' expects 2 args but there is 1`), so
-/// there is no oracle to match for those and no scope decision to make.
+/// Real yq's no-op is *not* scalar-specific the way #1065's read-path rule
+/// is (`[1,2,3] | .[0:1] = [9]` is *also* a silent no-op there — slice
+/// *writes* appear to never be wired up at all, for any target type), but
+/// this check stays deliberately scoped to scalars, preserving succinctly's
+/// own working array/string slice-assignment rather than removing it to
+/// replicate what looks like a real-yq gap. `=`/`|=`/`+=`/`del()` no-op;
+/// `-=`/`*=` *error* instead (confirmed live, with odd Go-internal-leak
+/// messages not worth replicating) — callers gate accordingly. `/=`, `%=`,
+/// `//=`, and `path(...)` aren't valid real-yq syntax at all, so there's no
+/// oracle to match for those.
 pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
     match path_expr {
         Expr::Slice { .. } => true,
-        Expr::Optional(inner) => is_yq_scalar_slice_assign_path(inner),
+        Expr::Optional(inner) | Expr::Paren(inner) => is_yq_scalar_slice_assign_path(inner),
         _ => false,
     }
 }
@@ -10396,6 +10370,22 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // `is_yq_scalar_slice_assign_path`'s doc comment for the full
         // rationale, including why this can't be a blanket check before
         // the filter runs at all.
+        //
+        // The throwaway clones `result` (the scalar itself), not `[]` —
+        // real yq's own discarded-write `.` binding is actually `[]` (`5 |
+        // .[0:1] += [1]` no-ops in real yq, consistent with `[] + [1]`
+        // succeeding there), but real yq's `+` *also* has an array-append
+        // semantic succinctly's `+` doesn't implement at all (`[] + 99`
+        // gives `[99]` in real yq, errors in succinctly — a real,
+        // pre-existing, unrelated gap, filed as #1119). Binding `.` to `[]`
+        // here without that append semantic would turn the common `5 |
+        // .[0:1] += 99` case from a working no-op into a fresh regression
+        // (`array ([]) and number (99) cannot be added`) to fix an
+        // obscure array-filter edge case (`|= keys`) instead — the wrong
+        // trade. Scalar cloning keeps `+= <number>`/`|= <number filter>`
+        // correct; `|=`/`+=` with a filter whose behavior differs between
+        // an array and the raw scalar (`keys`, `+= [1]`) remain wrong,
+        // tracked alongside #1119.
         if scalar_slice_noop
             && S::TAG == EvalTag::Yq
             && is_yq_scalar_slice_assign_path(path)
@@ -18450,6 +18440,25 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
         Err((_, escape)) => return escape.into(),
     };
+
+    // yq's slice-assignment no-op (#1101) — the `paths.len() <= 1` branch
+    // below already checks this per path, but `delete_expr_paths_at` (the
+    // `paths.len() > 1` branch after it) is a completely separate
+    // sibling-grouping walker that has no equivalent check at all, so a
+    // multi-path `del()` (e.g. `del(.[0:1], .[2:3])`, or any comma that
+    // resolves to 2+ paths) skipped the no-op entirely — confirmed live
+    // against real yq (a comma of bare scalar slices still no-ops there,
+    // same as the single-path case). Checked once, up front, for the
+    // common case where every resolved path individually qualifies —
+    // rather than teaching `delete_expr_paths_at`'s own sibling-comparison
+    // logic about it, which is complex, heavily-tested machinery this fix
+    // doesn't otherwise need to touch.
+    if S::TAG == EvalTag::Yq
+        && is_yq_slice_empty_container_scalar(&result)
+        && paths.iter().all(is_yq_scalar_slice_assign_path)
+    {
+        return QueryResult::Owned(result);
+    }
 
     // The overwhelmingly common case — no computed key at all, or one that
     // resolved to a single value — has no sibling that could shift under it,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -762,7 +762,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
         // Assignment operators
         Expr::Assign { path, value: val } => eval_assign::<W, S>(path, val, value, optional),
-        Expr::Update { path, filter } => eval_update::<W, S>(path, filter, value, optional),
+        Expr::Update { path, filter } => eval_update::<W, S>(path, filter, value, optional, true),
         Expr::CompoundAssign {
             op,
             path,
@@ -9901,6 +9901,48 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
     )
 }
 
+/// Whether `path_expr` (assignment-target position) is a bare slice
+/// (`.[S:E]`, not `.foo[S:E]`, `.[S:E][]`, or any other chaining) applied
+/// directly to a scalar `value` — the shape real yq's own slice-assignment
+/// machinery silently no-ops on (#1101).
+///
+/// **Premise correction, found while live-probing #1101 against real yq
+/// v4.53.3**: the no-op is *not* scalar-specific the way #1065's read-path
+/// rule is. `[1,2,3] | .[0:1] = [9]` and `"hi" | .[0:1] = "X"` are *also*
+/// silent no-ops in real yq — `.[S:E] = v` / `.[S:E] |= f` / `.[S:E] += v`
+/// never actually writes anywhere, for *any* target type, and does so
+/// without even evaluating the RHS/filter (`5 | .[0:1] = (1/0)` stays `5`
+/// with no error). This looks like real yq's slice-assignment path
+/// resolution never being wired up at all, not a deliberate design choice.
+/// succinctly's own array/string slice-assignment already works correctly
+/// and is a genuinely useful feature beyond what real yq offers — matching
+/// the universal no-op exactly would mean *removing* that working feature
+/// to replicate what looks like a real-yq gap, not a real-yq rule worth
+/// porting. So this check is deliberately narrowed to the scalar case only
+/// (matching #1065's own scope), preserving succinctly's array/string
+/// slice-assignment untouched — a deliberate scope decision, not an
+/// oversight.
+///
+/// Also confirmed asymmetric by operator: `=`/`|=`/`+=`/`del()` no-op, but
+/// `-=`/`*=` *error* instead (with odd, clearly Go-internal-leak messages
+/// like `strconv.ParseInt: parsing "": invalid syntax` — not a stable
+/// compatibility target, so not replicated). Callers gate this check to
+/// only `=`, `|=`, `+=` (`AssignOp::Add` specifically), and `del()`;
+/// `-=`/`*=` are deliberately left calling the unmodified, still-erroring
+/// path. `/=`, `%=`, `//=`, and `path(...)` aren't valid real-yq syntax at
+/// all (confirmed live — e.g. `'/' expects 2 args but there is 1`), so
+/// there is no oracle to match for those and no scope decision to make.
+pub(crate) fn is_yq_scalar_slice_assign_target<W: Clone + AsRef<[u64]>>(
+    path_expr: &Expr,
+    value: &StandardJson<'_, W>,
+) -> bool {
+    matches!(path_expr, Expr::Slice { .. })
+        && matches!(
+            value,
+            StandardJson::Null | StandardJson::Number(_) | StandardJson::Bool(_)
+        )
+}
+
 /// Apply a resolved slice directly to an owned value.
 ///
 /// Slicing is a plain `Vec`/`&str` operation once the bounds are known, so
@@ -10153,6 +10195,18 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // yq's slice-assignment no-op (#1101) — checked before RHS evaluation,
+    // matching real yq's own behavior of never evaluating the RHS at all
+    // for this shape (`5 | .[0:1] = (1/0)` stays `5` with no error, verified
+    // live). See `is_yq_scalar_slice_assign_target`'s doc comment for the
+    // full rationale, including the premise correction (real yq's no-op
+    // isn't scalar-specific, but this fix deliberately stays scoped to
+    // scalars to preserve succinctly's own working array/string
+    // slice-assignment).
+    if S::TAG == EvalTag::Yq && is_yq_scalar_slice_assign_target(path_expr, &input) {
+        return QueryResult::One(input);
+    }
+
     // Evaluate the RHS once, keeping every output instead of collapsing to
     // the first (#392). `terminal` carries a trailing `Error`/`Break` when
     // the stream didn't simply run out -- the same `Partial` shape every
@@ -10267,12 +10321,28 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
 /// Evaluate update assignment: `.path |= filter`
 /// Applies filter to the value at path and updates it.
+///
+/// `scalar_slice_noop` gates #1101's yq no-op check (see
+/// `is_yq_scalar_slice_assign_target`'s doc comment): `true` for a genuine
+/// `|=` and for `+=` (`AssignOp::Add`), `false` for `-=`/`*=`, which
+/// real yq errors on instead of no-op'ing for this same shape — verified
+/// live, not assumed, since both routes reduce to this same function via
+/// `eval_compound_assign`'s `.p op= v` -> `.p |= (. op v)` rewrite and
+/// would otherwise be indistinguishable once here.
 fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
     filter_expr: &Expr,
     input: StandardJson<'a, W>,
     optional: bool,
+    scalar_slice_noop: bool,
 ) -> QueryResult<'a, W> {
+    if scalar_slice_noop
+        && S::TAG == EvalTag::Yq
+        && is_yq_scalar_slice_assign_target(path_expr, &input)
+    {
+        return QueryResult::One(input);
+    }
+
     // Convert input to owned for modification
     let mut result = to_owned(&input);
 
@@ -10315,6 +10385,21 @@ fn eval_compound_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // yq's slice-assignment no-op (#1101) — `+=` only (verified live against
+    // real yq that `-=`/`*=` error instead for this same shape). Checked
+    // here, before the RHS is evaluated at all: real yq's `+=` doesn't
+    // evaluate its RHS for this shape either (`5 | .[0:1] += (1/0)` stays
+    // `5` with no error, verified live), so this must run before
+    // `eval_rhs_once` below, not inside `eval_update` after the RHS is
+    // already computed. See `is_yq_scalar_slice_assign_target`'s doc
+    // comment for the full rationale.
+    if matches!(op, AssignOp::Add)
+        && S::TAG == EvalTag::Yq
+        && is_yq_scalar_slice_assign_target(path_expr, &input)
+    {
+        return QueryResult::One(input);
+    }
+
     // Convert to update: .path op= value  becomes  .path |= . op value
     let arith_op = match op {
         AssignOp::Add => ArithOp::Add,
@@ -10342,7 +10427,11 @@ fn eval_compound_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         right: Box::new(owned_to_expr(&rhs_value)),
     };
 
-    eval_update::<W, S>(path_expr, &filter, input, optional)
+    // `false`: the one case that wants #1101's no-op (`AssignOp::Add` on a
+    // scalar slice target) was already intercepted above, before the RHS
+    // was evaluated. `Sub`/`Mul`/`Div`/`Mod` reaching this point should
+    // keep the unmodified, still-erroring behavior.
+    eval_update::<W, S>(path_expr, &filter, input, optional, false)
 }
 
 /// Evaluate alternative assignment: `.path //= value`
@@ -10366,7 +10455,10 @@ fn eval_alternative_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Box::new(owned_to_expr(&rhs_value)),
     );
 
-    eval_update::<W, S>(path_expr, &filter, input, optional)
+    // `false`: real yq has no `//=` syntax at all (`'//' expects 2 args but
+    // there is 1`, confirmed live), so there's no oracle to verify a no-op
+    // against here — left at the pre-#1101 (unmodified, erroring) behavior.
+    eval_update::<W, S>(path_expr, &filter, input, optional, false)
 }
 
 /// Turn `root` into a fresh empty object if it is `Null`, otherwise leave it
@@ -18290,6 +18382,14 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // yq's slice-assignment no-op (#1101) — `del(.[S:E])` on a scalar target
+    // is confirmed live to be a no-op in real yq too, same as `=`/`|=`/`+=`.
+    // See `is_yq_scalar_slice_assign_target`'s doc comment for the full
+    // rationale.
+    if S::TAG == EvalTag::Yq && is_yq_scalar_slice_assign_target(path_expr, &value) {
+        return QueryResult::One(value);
+    }
+
     // Convert to owned and delete the path
     let result = to_owned(&value);
 
@@ -41623,7 +41723,13 @@ mod tests {
         let cursor = index.root(json_bytes);
         let path_expr = parse(".[({})]").unwrap();
         let filter_expr = Expr::Identity;
-        match eval_update::<Vec<u64>, JqSemantics>(&path_expr, &filter_expr, cursor.value(), true) {
+        match eval_update::<Vec<u64>, JqSemantics>(
+            &path_expr,
+            &filter_expr,
+            cursor.value(),
+            true,
+            true,
+        ) {
             QueryResult::None => {}
             other => panic!("expected None, got {other:?}"),
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9901,27 +9901,53 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
     )
 }
 
-/// Whether `path_expr` (assignment-target position) is a bare slice
-/// (`.[S:E]`, not `.foo[S:E]`, `.[S:E][]`, or any other chaining) applied
-/// directly to a scalar `value` — the shape real yq's own slice-assignment
-/// machinery silently no-ops on (#1101).
+/// Whether a *resolved* assignment-target path (a `paths`/`delete_at_path`
+/// entry, already past `resolve_dynamic_indexes`, not the raw `path_expr`
+/// the user wrote) is a bare slice — `.[S:E]`, or `.[S:E]?` (`resolve_
+/// dynamic_indexes` doesn't always strip an outer `Expr::Optional`, unlike
+/// `Expr::Paren`, which never survives parsing at all) — as opposed to
+/// `.foo[S:E]`, `.[S:E][]`, or any other chaining. Checking the *resolved*
+/// path rather than the original `path_expr` is what makes a computed-bound
+/// `.[$a:$b]` (`Expr::SliceExpr` pre-resolution) reach this the same way a
+/// literal `.[0:1]` (`Expr::Slice` from the start) does — both fold to the
+/// identical `Expr::Slice{start,end}` shape by the time `resolve_dynamic_
+/// indexes` is done, per its own `needs_path_prepass` gate.
+///
+/// Combine with [`is_yq_slice_empty_container_scalar`] against the *current*
+/// value at this point in the fold (not the original input — #1101's no-op
+/// is a per-path, per-fold-step decision, same granularity as `set_path`/
+/// `update_path`'s own error checks) to get the full #1101 condition: a bare
+/// slice targeting a scalar, the shape real yq's own slice-assignment
+/// machinery silently no-ops the *write* portion of (#1101).
 ///
 /// **Premise correction, found while live-probing #1101 against real yq
 /// v4.53.3**: the no-op is *not* scalar-specific the way #1065's read-path
 /// rule is. `[1,2,3] | .[0:1] = [9]` and `"hi" | .[0:1] = "X"` are *also*
 /// silent no-ops in real yq — `.[S:E] = v` / `.[S:E] |= f` / `.[S:E] += v`
-/// never actually writes anywhere, for *any* target type, and does so
-/// without even evaluating the RHS/filter (`5 | .[0:1] = (1/0)` stays `5`
-/// with no error). This looks like real yq's slice-assignment path
-/// resolution never being wired up at all, not a deliberate design choice.
-/// succinctly's own array/string slice-assignment already works correctly
-/// and is a genuinely useful feature beyond what real yq offers — matching
-/// the universal no-op exactly would mean *removing* that working feature
-/// to replicate what looks like a real-yq gap, not a real-yq rule worth
-/// porting. So this check is deliberately narrowed to the scalar case only
-/// (matching #1065's own scope), preserving succinctly's array/string
-/// slice-assignment untouched — a deliberate scope decision, not an
-/// oversight.
+/// never actually *writes* anywhere, for *any* target type. This looks like
+/// real yq's slice-assignment path resolution never being wired up at all,
+/// not a deliberate design choice. succinctly's own array/string
+/// slice-assignment already works correctly and is a genuinely useful
+/// feature beyond what real yq offers — matching the universal no-op
+/// exactly would mean *removing* that working feature to replicate what
+/// looks like a real-yq gap, not a real-yq rule worth porting. So this
+/// check is deliberately narrowed to the scalar case only (matching #1065's
+/// own scope), preserving succinctly's array/string slice-assignment
+/// untouched — a deliberate scope decision, not an oversight.
+///
+/// **Second correction, found via code review**: only the *write* is a
+/// no-op — the RHS/filter is still evaluated normally, with its own
+/// errors/`halt`/`break` propagating exactly as they would for any other
+/// assignment (`.[0:1] = error("boom")` genuinely errors in real yq; only
+/// a *successful* RHS value is silently discarded rather than written). An
+/// earlier version of this fix short-circuited *before* evaluating the RHS
+/// at all, based on a since-corrected misreading of `.[0:1] = (1/0)`
+/// appearing not to error — `1/0` doesn't actually raise a catchable error
+/// in real yq (it evaluates to `+Inf`, which only fails at JSON-output time
+/// for a value that was never written and thus never serialized), so that
+/// probe never actually tested whether RHS evaluation happens. Every call
+/// site now evaluates the RHS/filter through the ordinary machinery and
+/// only skips the final write.
 ///
 /// Also confirmed asymmetric by operator: `=`/`|=`/`+=`/`del()` no-op, but
 /// `-=`/`*=` *error* instead (with odd, clearly Go-internal-leak messages
@@ -9932,15 +9958,12 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
 /// path. `/=`, `%=`, `//=`, and `path(...)` aren't valid real-yq syntax at
 /// all (confirmed live — e.g. `'/' expects 2 args but there is 1`), so
 /// there is no oracle to match for those and no scope decision to make.
-pub(crate) fn is_yq_scalar_slice_assign_target<W: Clone + AsRef<[u64]>>(
-    path_expr: &Expr,
-    value: &StandardJson<'_, W>,
-) -> bool {
-    matches!(path_expr, Expr::Slice { .. })
-        && matches!(
-            value,
-            StandardJson::Null | StandardJson::Number(_) | StandardJson::Bool(_)
-        )
+pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
+    match path_expr {
+        Expr::Slice { .. } => true,
+        Expr::Optional(inner) => is_yq_scalar_slice_assign_path(inner),
+        _ => false,
+    }
 }
 
 /// Apply a resolved slice directly to an owned value.
@@ -10195,18 +10218,6 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // yq's slice-assignment no-op (#1101) — checked before RHS evaluation,
-    // matching real yq's own behavior of never evaluating the RHS at all
-    // for this shape (`5 | .[0:1] = (1/0)` stays `5` with no error, verified
-    // live). See `is_yq_scalar_slice_assign_target`'s doc comment for the
-    // full rationale, including the premise correction (real yq's no-op
-    // isn't scalar-specific, but this fix deliberately stays scoped to
-    // scalars to preserve succinctly's own working array/string
-    // slice-assignment).
-    if S::TAG == EvalTag::Yq && is_yq_scalar_slice_assign_target(path_expr, &input) {
-        return QueryResult::One(input);
-    }
-
     // Evaluate the RHS once, keeping every output instead of collapsing to
     // the first (#392). `terminal` carries a trailing `Error`/`Break` when
     // the stream didn't simply run out -- the same `Partial` shape every
@@ -10290,6 +10301,25 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             } else {
                 new_value.clone()
             };
+            // yq's slice-assignment no-op (#1101) — checked here, per
+            // resolved path, rather than before RHS evaluation: the RHS
+            // (`value`, already fully computed above) still needs to have
+            // been evaluated normally so its own errors/halt/break
+            // propagate (`.[0:1] = error("boom")` genuinely errors in real
+            // yq; only `.[0:1] = 99`-shaped *successful* RHS values are
+            // silently discarded). Checking the *resolved* `path` (not the
+            // raw `path_expr`) means a computed-bound `.[$a:$b]` and a
+            // `.[0:1]?` both reach this the same way a literal `.[0:1]`
+            // does, since `resolve_dynamic_indexes` has already folded
+            // them into the same shape by this point. See
+            // `is_yq_scalar_slice_assign_path`'s doc comment for the full
+            // rationale.
+            if S::TAG == EvalTag::Yq
+                && is_yq_scalar_slice_assign_path(path)
+                && is_yq_slice_empty_container_scalar(&result)
+            {
+                continue;
+            }
             if let Err(e) = set_path(&mut result, path, value) {
                 // Atomic per RHS output, like `reduce`: this value's own
                 // path list contributes nothing, and the whole fan-out
@@ -10323,7 +10353,7 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Applies filter to the value at path and updates it.
 ///
 /// `scalar_slice_noop` gates #1101's yq no-op check (see
-/// `is_yq_scalar_slice_assign_target`'s doc comment): `true` for a genuine
+/// `is_yq_scalar_slice_assign_path`'s doc comment): `true` for a genuine
 /// `|=` and for `+=` (`AssignOp::Add`), `false` for `-=`/`*=`, which
 /// real yq errors on instead of no-op'ing for this same shape — verified
 /// live, not assumed, since both routes reduce to this same function via
@@ -10336,13 +10366,6 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
     scalar_slice_noop: bool,
 ) -> QueryResult<'a, W> {
-    if scalar_slice_noop
-        && S::TAG == EvalTag::Yq
-        && is_yq_scalar_slice_assign_target(path_expr, &input)
-    {
-        return QueryResult::One(input);
-    }
-
     // Convert input to owned for modification
     let mut result = to_owned(&input);
 
@@ -10366,6 +10389,29 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     // Get current value at path, apply filter, and set back
     for path in &paths {
+        // yq's slice-assignment no-op (#1101) — the filter still has to run
+        // normally (against a throwaway clone) so its own errors/`halt`/
+        // `break` propagate exactly as they would for any other `|=`; only
+        // the *write* back into `result` is skipped. See
+        // `is_yq_scalar_slice_assign_path`'s doc comment for the full
+        // rationale, including why this can't be a blanket check before
+        // the filter runs at all.
+        if scalar_slice_noop
+            && S::TAG == EvalTag::Yq
+            && is_yq_scalar_slice_assign_path(path)
+            && is_yq_slice_empty_container_scalar(&result)
+        {
+            let mut throwaway = result.clone();
+            if let Err(escape) =
+                update_path::<S>(&mut throwaway, &Expr::Identity, filter_expr, false)
+            {
+                return match escape {
+                    EvalEscape::Error(_) if optional => QueryResult::None,
+                    other => other.into(),
+                };
+            }
+            continue;
+        }
         if let Err(escape) = update_path::<S>(&mut result, path, filter_expr, false) {
             return match escape {
                 EvalEscape::Error(_) if optional => QueryResult::None,
@@ -10385,21 +10431,6 @@ fn eval_compound_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // yq's slice-assignment no-op (#1101) — `+=` only (verified live against
-    // real yq that `-=`/`*=` error instead for this same shape). Checked
-    // here, before the RHS is evaluated at all: real yq's `+=` doesn't
-    // evaluate its RHS for this shape either (`5 | .[0:1] += (1/0)` stays
-    // `5` with no error, verified live), so this must run before
-    // `eval_rhs_once` below, not inside `eval_update` after the RHS is
-    // already computed. See `is_yq_scalar_slice_assign_target`'s doc
-    // comment for the full rationale.
-    if matches!(op, AssignOp::Add)
-        && S::TAG == EvalTag::Yq
-        && is_yq_scalar_slice_assign_target(path_expr, &input)
-    {
-        return QueryResult::One(input);
-    }
-
     // Convert to update: .path op= value  becomes  .path |= . op value
     let arith_op = match op {
         AssignOp::Add => ArithOp::Add,
@@ -10427,11 +10458,17 @@ fn eval_compound_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         right: Box::new(owned_to_expr(&rhs_value)),
     };
 
-    // `false`: the one case that wants #1101's no-op (`AssignOp::Add` on a
-    // scalar slice target) was already intercepted above, before the RHS
-    // was evaluated. `Sub`/`Mul`/`Div`/`Mod` reaching this point should
-    // keep the unmodified, still-erroring behavior.
-    eval_update::<W, S>(path_expr, &filter, input, optional, false)
+    // #1101's no-op applies to `Add` only (verified live that `-=`/`*=`
+    // error instead for this same shape) — `eval_update` runs the filter
+    // normally either way, only skipping the final write when this is
+    // `true` and the resolved target qualifies.
+    eval_update::<W, S>(
+        path_expr,
+        &filter,
+        input,
+        optional,
+        matches!(op, AssignOp::Add),
+    )
 }
 
 /// Evaluate alternative assignment: `.path //= value`
@@ -10455,10 +10492,16 @@ fn eval_alternative_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Box::new(owned_to_expr(&rhs_value)),
     );
 
-    // `false`: real yq has no `//=` syntax at all (`'//' expects 2 args but
-    // there is 1`, confirmed live), so there's no oracle to verify a no-op
-    // against here — left at the pre-#1101 (unmodified, erroring) behavior.
-    eval_update::<W, S>(path_expr, &filter, input, optional, false)
+    // `true`: real yq has no `//=` syntax at all (`'//' expects 2 args but
+    // there is 1`, confirmed live), so there's no external oracle for this
+    // operator specifically — but `//=` desugars to exactly the same `.path
+    // |= (. // value)` shape a genuine `|=` call already no-ops on for this
+    // target (confirmed live: `.[0:1] |= (. // 99)` no-ops), through this
+    // same `eval_update` function. Leaving this `false` would make two
+    // spellings of the identical operation disagree purely because of which
+    // AST shape reached `eval_update` — internal consistency, not an
+    // external-compat claim, is the justification here.
+    eval_update::<W, S>(path_expr, &filter, input, optional, true)
 }
 
 /// Turn `root` into a fresh empty object if it is `Null`, otherwise leave it
@@ -18382,14 +18425,6 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // yq's slice-assignment no-op (#1101) — `del(.[S:E])` on a scalar target
-    // is confirmed live to be a no-op in real yq too, same as `=`/`|=`/`+=`.
-    // See `is_yq_scalar_slice_assign_target`'s doc comment for the full
-    // rationale.
-    if S::TAG == EvalTag::Yq && is_yq_scalar_slice_assign_target(path_expr, &value) {
-        return QueryResult::One(value);
-    }
-
     // Convert to owned and delete the path
     let result = to_owned(&value);
 
@@ -18422,6 +18457,20 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     if paths.len() <= 1 {
         let mut result = result;
         for path in &paths {
+            // yq's slice-assignment no-op (#1101) — `del(.[S:E])` on a bare
+            // scalar target is confirmed live to be a no-op in real yq too,
+            // same as `=`/`|=`/`+=`. Checked per resolved path (not the raw
+            // `path_expr`) so a computed-bound `.[$a:$b]` and `.[0:1]?`
+            // reach this the same way a literal `.[0:1]` does. See
+            // `is_yq_scalar_slice_assign_path`'s doc comment for the full
+            // rationale. `del()` has no RHS/filter, so there's nothing to
+            // evaluate before skipping — unlike `=`/`|=`/`+=`.
+            if S::TAG == EvalTag::Yq
+                && is_yq_scalar_slice_assign_path(path)
+                && is_yq_slice_empty_container_scalar(&result)
+            {
+                continue;
+            }
             if let Err(e) = delete_at_path(&mut result, path, false) {
                 return if optional {
                     QueryResult::None

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10392,13 +10392,20 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             && is_yq_slice_empty_container_scalar(&result)
         {
             let mut throwaway = result.clone();
+            // No `if optional`-gated arm here, unlike the sibling call
+            // below: `optional` at this point is `eval_update`'s *own*
+            // outer `?` (`(.a |= f)?`), and per #693, `Expr::Optional`/
+            // `Expr::Try`'s dispatch (`eval_try`, called for both) never
+            // forces `optional = true` into the expression it wraps — it
+            // evaluates with the ambient value (`false` at the top level)
+            // and catches the resulting `Error` itself instead. A `?`
+            // wrapping this whole `|=`/`+=` therefore still swallows the
+            // discarded filter's error correctly (verified live), just via
+            // that outer catch, never through this branch reaching `true`.
             if let Err(escape) =
                 update_path::<S>(&mut throwaway, &Expr::Identity, filter_expr, false)
             {
-                return match escape {
-                    EvalEscape::Error(_) if optional => QueryResult::None,
-                    other => other.into(),
-                };
+                return escape.into();
             }
             continue;
         }
@@ -18462,24 +18469,14 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     // The overwhelmingly common case — no computed key at all, or one that
     // resolved to a single value — has no sibling that could shift under it,
-    // so it keeps the simple per-path walk.
+    // so it keeps the simple per-path walk. (#1101's no-op is already fully
+    // handled by the upfront `paths.iter().all(...)` check above — for
+    // `paths.len() <= 1` specifically, "all paths qualify" and "the one
+    // path qualifies" are the same condition, so a second per-path check
+    // here would be unreachable dead code, not a real fallback.)
     if paths.len() <= 1 {
         let mut result = result;
         for path in &paths {
-            // yq's slice-assignment no-op (#1101) — `del(.[S:E])` on a bare
-            // scalar target is confirmed live to be a no-op in real yq too,
-            // same as `=`/`|=`/`+=`. Checked per resolved path (not the raw
-            // `path_expr`) so a computed-bound `.[$a:$b]` and `.[0:1]?`
-            // reach this the same way a literal `.[0:1]` does. See
-            // `is_yq_scalar_slice_assign_path`'s doc comment for the full
-            // rationale. `del()` has no RHS/filter, so there's nothing to
-            // evaluate before skipping — unlike `=`/`|=`/`+=`.
-            if S::TAG == EvalTag::Yq
-                && is_yq_scalar_slice_assign_path(path)
-                && is_yq_slice_empty_container_scalar(&result)
-            {
-                continue;
-            }
             if let Err(e) = delete_at_path(&mut result, path, false) {
                 return if optional {
                     QueryResult::None

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10862,3 +10862,13 @@ fn test_jq_slice_number_scalar_still_gives_no_output_1065() -> Result<()> {
     assert_eq!(output.trim(), "");
     Ok(())
 }
+
+/// #1101's yq-only "assigning through a scalar slice target is a no-op"
+/// rule must not leak into jq mode: real jq errors on `.[0:1] = 99` for a
+/// number target, matching succinctly's pre-existing, unaffected behavior.
+#[test]
+fn test_jq_slice_assign_scalar_still_errors_1101() -> Result<()> {
+    let (_out, code) = run_jq_stdin(".[0:1] = 99", "5", &[])?;
+    assert_eq!(code, 5);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12759,18 +12759,27 @@ fn test_slice_owned_target_scalar_is_empty_array_1065() -> Result<()> {
 // ============================================================================
 //
 // Real yq's `.[S:E] = v` / `.[S:E] |= f` / `.[S:E] += v` / `del(.[S:E])`
-// silently leave the document untouched on a null/number/boolean target --
-// confirmed live against real yq v4.53.3, including the surprising detail
-// that the RHS/filter is never even evaluated (`5 | .[0:1] += (1/0)` stays
-// `5` with no division-by-zero error). `-=`/`*=` are NOT no-ops -- they
+// silently leave the document's *write* untouched on a null/number/boolean
+// target -- confirmed live against real yq v4.53.3. The RHS/filter is
+// still evaluated normally, though, and its own errors/halt/break still
+// propagate (`.[0:1] = error("boom")` genuinely errors in real yq) -- an
+// earlier version of this fix incorrectly skipped RHS evaluation entirely,
+// based on a misread of `.[0:1] = (1/0)` appearing not to error (`1/0`
+// isn't a catchable error in real yq at all; it's `+Inf`, which only fails
+// at JSON-output time for a value that, being part of a no-op write, is
+// never actually written or serialized). `-=`/`*=` are NOT no-ops -- they
 // error instead, with Go-internal-looking messages this crate deliberately
 // does not replicate (not a stable compatibility target). Object, string,
 // and array targets are deliberately unaffected: succinctly's own working
 // array/string slice-assignment is preserved rather than matched to what
-// looks like a real-yq gap rather than a real-yq rule (see
-// `is_yq_scalar_slice_assign_target`'s doc comment for the full premise
-// correction -- the no-op turned out not to be scalar-specific in real yq
-// at all, but this fix stays scoped to scalars anyway).
+// looks like a real-yq gap rather than a real-yq rule. This fix is also
+// deliberately scoped to a *bare* root slice with *literal* bounds only --
+// see `is_yq_scalar_slice_assign_path`'s doc comment, and the follow-up
+// issues filed for chained paths (`.foo[S:E]`, where `del()` in particular
+// has a materially different real-yq behavior: it deletes the whole parent
+// key, not a no-op) and computed bounds (`.[$a:$b]`, which fails earlier
+// inside `resolve_slice_expr`'s own eager path-resolution slice, a
+// separate and more delicate piece of machinery than this fix touches).
 
 #[test]
 fn test_slice_assign_number_scalar_is_noop_1101() -> Result<()> {
@@ -12816,19 +12825,63 @@ fn test_slice_assign_bool_and_null_scalar_is_noop_1101() -> Result<()> {
     Ok(())
 }
 
-/// The RHS/filter is never evaluated for the no-op cases -- a side-effecting
-/// or erroring RHS produces no observable effect, matching real yq exactly.
+/// The RHS/filter is still evaluated normally for the no-op cases -- only
+/// the *write* is skipped, so an erroring RHS/filter still raises exactly
+/// as it would for any other `=`/`|=`/`+=` (confirmed live against real
+/// yq: `.[0:1] = error("boom")` raises `boom`, not a silent no-op).
 #[test]
-fn test_slice_assign_scalar_noop_never_evaluates_rhs_1101() -> Result<()> {
-    let (out, code) = run_yq_stdin(".[0:1] = (1/0)", "5", &["-o", "json"])?;
+fn test_slice_assign_scalar_noop_still_propagates_rhs_errors_1101() -> Result<()> {
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(r#".[0:1] = error("boom")"#, "5", &["-o", "json"])?;
+    assert_eq!(code, 1);
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(r#".[0:1] |= error("boom")"#, "5", &["-o", "json"])?;
+    assert_eq!(code, 1);
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(r#".[0:1] += error("boom")"#, "5", &["-o", "json"])?;
+    assert_eq!(code, 1);
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// `halt_error`/`break` in the RHS/filter must also still escape, not just
+/// plain errors -- succinctly's own extension (real yq has no `halt_error`
+/// at all), so this is checked against the codebase's own documented
+/// invariant (`EvalEscape`'s doc comment: a halt or break addressed to an
+/// outer label must never be silently discarded) rather than an external
+/// oracle.
+#[test]
+fn test_slice_assign_scalar_noop_still_propagates_halt_1101() -> Result<()> {
+    let (_out, _stderr, code) =
+        run_yq_stdin_with_stderr(".[0:1] = halt_error(3)", "5", &["-o", "json"])?;
+    assert_eq!(code, 3);
+    Ok(())
+}
+
+/// `.[0:1]?` (the postfix-optional form) still no-ops -- confirmed live
+/// against real yq, and confirmed to reach the same code path as the
+/// un-suffixed form via `resolve_dynamic_indexes`'s own `Expr::Optional`
+/// handling (it isn't stripped for the non-computed-bound case the way a
+/// resolved computed bound's wrapper is).
+#[test]
+fn test_slice_assign_scalar_noop_with_optional_suffix_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1]? = 99", "5", &["-o", "json"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "5");
+    Ok(())
+}
 
-    let (out, code) = run_yq_stdin(".[0:1] |= (1/0)", "5", &["-o", "json"])?;
-    assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "5");
-
-    let (out, code) = run_yq_stdin(".[0:1] += (1/0)", "5", &["-o", "json"])?;
+/// `//=` desugars to exactly the `.path |= (. // value)` shape a genuine
+/// `|=` call already no-ops on for this target, through the same
+/// `eval_update` function -- kept consistent with `|=` even though real
+/// yq has no `//=` syntax at all to verify against directly.
+#[test]
+fn test_slice_alternative_assign_scalar_is_noop_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1] //= 99", "5", &["-o", "json"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "5");
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12887,6 +12887,35 @@ fn test_slice_alternative_assign_scalar_is_noop_1101() -> Result<()> {
     Ok(())
 }
 
+/// `del()` with 2+ resolved paths (a comma of bare slices) must also
+/// no-op -- confirmed live against real yq. `builtin_del` forks into a
+/// separate multi-path deletion walker that has no per-path equivalent of
+/// the single-path check, so this needs its own upfront guard (see the
+/// comment above the `paths.len() <= 1` branch in `builtin_del`).
+#[test]
+fn test_slice_del_multi_path_number_scalar_is_noop_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[0:1], .[2:3])", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// A parenthesized bare slice (`(.[0:1])`) must reach the same no-op as
+/// the un-parenthesized form -- `Expr::Paren` does survive parsing (unlike
+/// an earlier version of `is_yq_scalar_slice_assign_path`'s doc comment
+/// incorrectly claimed) and needs its own unwrap arm.
+#[test]
+fn test_slice_assign_scalar_noop_with_parens_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin("(.[0:1]) = 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin("del((.[0:1]))", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
 /// `-=`/`*=` are NOT no-ops on a scalar slice target -- real yq errors on
 /// both (with odd, unreplicated messages); succinctly's own pre-existing
 /// error is left unchanged rather than matched to that wording.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12753,3 +12753,114 @@ fn test_slice_owned_target_scalar_is_empty_array_1065() -> Result<()> {
     assert_eq!(out.trim(), "[]");
     Ok(())
 }
+
+// ============================================================================
+// yq assigning through a scalar slice target is a silent no-op (#1101)
+// ============================================================================
+//
+// Real yq's `.[S:E] = v` / `.[S:E] |= f` / `.[S:E] += v` / `del(.[S:E])`
+// silently leave the document untouched on a null/number/boolean target --
+// confirmed live against real yq v4.53.3, including the surprising detail
+// that the RHS/filter is never even evaluated (`5 | .[0:1] += (1/0)` stays
+// `5` with no division-by-zero error). `-=`/`*=` are NOT no-ops -- they
+// error instead, with Go-internal-looking messages this crate deliberately
+// does not replicate (not a stable compatibility target). Object, string,
+// and array targets are deliberately unaffected: succinctly's own working
+// array/string slice-assignment is preserved rather than matched to what
+// looks like a real-yq gap rather than a real-yq rule (see
+// `is_yq_scalar_slice_assign_target`'s doc comment for the full premise
+// correction -- the no-op turned out not to be scalar-specific in real yq
+// at all, but this fix stays scoped to scalars anyway).
+
+#[test]
+fn test_slice_assign_number_scalar_is_noop_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1] = 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+#[test]
+fn test_slice_update_number_scalar_is_noop_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1] |= 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+#[test]
+fn test_slice_compound_add_number_scalar_is_noop_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1] += 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+#[test]
+fn test_slice_del_number_scalar_is_noop_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[0:1])", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+#[test]
+fn test_slice_assign_bool_and_null_scalar_is_noop_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1] = 99", "true", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin(".[0:1] = 99", "null", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}
+
+/// The RHS/filter is never evaluated for the no-op cases -- a side-effecting
+/// or erroring RHS produces no observable effect, matching real yq exactly.
+#[test]
+fn test_slice_assign_scalar_noop_never_evaluates_rhs_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1] = (1/0)", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin(".[0:1] |= (1/0)", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin(".[0:1] += (1/0)", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// `-=`/`*=` are NOT no-ops on a scalar slice target -- real yq errors on
+/// both (with odd, unreplicated messages); succinctly's own pre-existing
+/// error is left unchanged rather than matched to that wording.
+#[test]
+fn test_slice_sub_and_mul_number_scalar_still_errors_1101() -> Result<()> {
+    let (_out, _stderr, code) = run_yq_stdin_with_stderr(".[0:1] -= 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 1);
+
+    let (_out, _stderr, code) = run_yq_stdin_with_stderr(".[0:1] *= 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 1);
+    Ok(())
+}
+
+/// Regression guard: succinctly's own array/string slice-assignment is
+/// unaffected by this scalar-only scope decision.
+#[test]
+fn test_slice_assign_string_and_array_unaffected_1101() -> Result<()> {
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(r#".[0:1] = "X""#, r#""hello""#, &["-o", "json"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("cannot update string slices") || stderr.contains("Cannot update string"),
+        "stderr: {stderr:?}"
+    );
+
+    let (out, code) = run_yq_stdin(".[0:1] = [9]", "[1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[9,2,3]");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12862,6 +12862,21 @@ fn test_slice_assign_scalar_noop_still_propagates_halt_1101() -> Result<()> {
     Ok(())
 }
 
+/// A `?` wrapping the *whole* `|=`/`+=` expression (not an inline path
+/// `?`) still swallows the discarded filter's error, same as it would for
+/// any other `|=` -- `is not real yq syntax to verify this exact form
+/// against (`(EXPR)?` after a slice-assign errors at yq's own lexer), so
+/// this is checked against succinctly's own internal invariant instead:
+/// the throwaway-filter error path must still honor the ordinary `optional`
+/// catch, not just propagate unconditionally.
+#[test]
+fn test_slice_update_scalar_noop_optional_swallows_filter_error_1101() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#"(.[0:1] |= error("boom"))?"#, "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "");
+    Ok(())
+}
+
 /// `.[0:1]?` (the postfix-optional form) still no-ops -- confirmed live
 /// against real yq, and confirmed to reach the same code path as the
 /// un-suffixed form via `resolve_dynamic_indexes`'s own `Expr::Optional`


### PR DESCRIPTION
Fixes #1101

## Summary

Real yq (v4.53.3) leaves the *write* untouched for `.[S:E] = v`,
`.[S:E] |= f`, `.[S:E] += v`, and `del(.[S:E])` when the target is null, a
number, or a boolean — but the RHS/filter is still evaluated normally,
and its own errors/`halt`/`break` propagate exactly as they would for any
other assignment (`.[0:1] = error("boom")` genuinely errors in real yq).

This PR went through two rounds of live-oracle-driven correction during
its own code review — see below.

## Premise correction (found before implementing)

The issue as filed assumed this was a scalar-specific quirk. Live-probing
against real yq found otherwise: `.[0:1] = [9]` on an **array** target is
*also* a silent no-op in real yq — real yq's slice-assignment machinery
appears to simply not be wired up for any target type, not a deliberate
scalar-specific design choice. This fix deliberately stays scoped to
**scalars only** (matching #1065's own scope), preserving succinctly's
own working array/string slice-assignment.

## Correction found during round 1 of code review

An earlier version short-circuited *before* evaluating the RHS/filter at
all, based on a misread of `.[0:1] = (1/0)` appearing not to error. `1/0`
isn't actually a catchable error in real yq — it evaluates to `+Inf`,
which only fails at JSON-output time for a value that, being part of a
no-op write, is never written or serialized. Fixed by checking the no-op
condition per resolved path, inside the existing per-path loops, so the
RHS/filter always runs through the ordinary machinery first (errors,
`halt`, `break` all correctly propagate now).

## Corrections found during round 2 of code review

- `builtin_del`'s multi-path branch (`del(.[0:1], .[2:3])`) forks into a
  separate sibling-grouping deletion walker with no equivalent guard —
  fixed with an upfront check that skips both branches when every
  resolved path qualifies.
- `eval_update`'s no-op branch ran the discarded `|=`/`+=` filter with
  `.` bound to a clone of the whole document. Real yq's own internal
  model binds it to `[]` instead (confirmed: `[] + 99` succeeds as `[99]`
  in real yq, explaining why `.[0:1] += 99` no-ops there even though
  `true + 99` errors directly) — but succinctly's own `+` operator
  doesn't implement that array-append semantic at all, so switching to
  `[]` would have regressed the common `+= <number>` case. Kept the
  scalar clone, which stays correct for that case; filed the underlying
  `+`-semantics gap as #1119 alongside the array-filter edge cases
  (`|= keys`, `+= [1]`) it would also fix.
- `Expr::Paren` wasn't unwrapped (`(.[0:1]) = 99` still errored),
  contradicting the helper's own doc comment.

## Scope

Deliberately limited to a **bare root slice with literal bounds**
(`.[0:1]`, `.[0:1]?`, `(.[0:1])`) — further gaps found live-probing were
filed as their own follow-ups rather than folded into this PR:

- **#1116** — chained paths (`.foo[S:E]` on a scalar sub-value)
- **#1117** — computed bounds (`.[$a:$b]`)
- **#1119** — yq's `+` operator missing real yq's array-append semantics

## Implementation

- `is_yq_scalar_slice_assign_path` — checks whether a *resolved* path
  (not the raw, pre-resolution `path_expr`) is a bare slice.
- Combined with the existing `is_yq_slice_empty_container_scalar`
  (#1065) for the target-value half of the condition.
- `eval_assign` (`=`), `eval_update` (`|=`, and — via
  `eval_compound_assign`'s rewrite — the `Add`-only case for `+=`), and
  `builtin_del` each check per resolved path/all-resolved-paths.
- `-=`/`*=` and `path(...)`/`/=`/`%=` are left calling the unmodified,
  still-erroring path. jq mode is untouched.

## Testing

18 tests covering: `=`/`|=`/`+=`/`del()` no-op on number/bool/null, RHS
errors/`halt` still propagating, `-=`/`*=` still erroring, the `?`-suffixed
and parenthesized forms, `//=` consistency, multi-path `del()`,
array/string slice-assignment regression guard, and a jq-mode regression
guard.