### PR TITLE
fix(jq): yq's @base64d/@urid stringify a scalar instead of erroring

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5453,10 +5453,10 @@ pub(crate) fn format_owned<S: EvalSemantics>(
         FormatType::Tsv => format_tsv::<S>(owned, optional),
         FormatType::Dsv(delimiter) => format_dsv::<S>(owned, delimiter, optional),
         FormatType::Base64 => format_base64::<S>(owned, optional),
-        FormatType::Base64d => format_base64d(owned, optional),
+        FormatType::Base64d => format_base64d::<S>(owned, optional),
         FormatType::Html => format_html::<S>(owned, optional),
         FormatType::Sh => format_sh::<S>(owned, optional),
-        FormatType::Urid => format_urid(owned, optional),
+        FormatType::Urid => format_urid::<S>(owned, optional),
         FormatType::Yaml => format_yaml(owned),
         FormatType::Props => format_props(owned),
     }
@@ -5559,34 +5559,64 @@ fn format_uri<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<S
 }
 
 /// @urid - URI/percent decode
-fn format_urid(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
-    match value {
-        OwnedValue::String(s) => {
-            let mut result = String::new();
-            let bytes = s.as_bytes();
-            let mut i = 0;
-            while i < bytes.len() {
-                if bytes[i] == b'%' && i + 2 < bytes.len() {
-                    // Try to parse the next two characters as hex
-                    if let (Some(h1), Some(h2)) = (
-                        (bytes[i + 1] as char).to_digit(16),
-                        (bytes[i + 2] as char).to_digit(16),
-                    ) {
-                        let decoded = (h1 * 16 + h2) as u8;
-                        result.push(decoded as char);
-                        i += 3;
-                        continue;
-                    }
-                }
-                // Not a valid percent-encoded sequence, just copy the character
-                result.push(bytes[i] as char);
-                i += 1;
+///
+/// jq has no `@urid` at all, so there's no jq-mode oracle to match; real
+/// yq (v4.53.3, live-verified) accepts any scalar by stringifying it first
+/// (`numeric_display_string`/`true`/`false`/`"null"`, the same conversion
+/// [`format_uri`]'s encode direction already applies) -- decoding a plain
+/// string with no `%` escapes is a no-op, so a stringified scalar just
+/// echoes back unchanged (`1.5 | @urid` is `"1.5"`). A container
+/// stringifies to the empty string rather than erroring (#1109) -- the
+/// same "container stringifies to empty" convention already duplicated at
+/// [`yq_join_element_part`]/[`yq_join_separator`]/`combine_sub_gap`'s own
+/// yq branch (#1072 tracks consolidating those), reused here rather than
+/// grown a fifth copy of a *different* rule. jq mode is unaffected: it
+/// keeps erroring on every non-string type, unchanged from before.
+fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
+    let s = match value {
+        OwnedValue::String(s) => s.clone(),
+        _ if S::TAG == EvalTag::Yq => match value {
+            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+                numeric_display_string::<S>(value)
             }
-            Ok(result)
+            OwnedValue::Bool(b) => {
+                if *b {
+                    "true".to_string()
+                } else {
+                    "false".to_string()
+                }
+            }
+            OwnedValue::Null => "null".to_string(),
+            // Array/Object: stringifies to "" (#1109) -- decoding an empty
+            // string is itself a no-op below, so this needs no further
+            // special-casing past this stringification step.
+            _ => String::new(),
+        },
+        _ if optional => return Ok(String::new()),
+        _ => return Err(EvalError::type_error("string", value.type_name())),
+    };
+
+    let mut result = String::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            // Try to parse the next two characters as hex
+            if let (Some(h1), Some(h2)) = (
+                (bytes[i + 1] as char).to_digit(16),
+                (bytes[i + 2] as char).to_digit(16),
+            ) {
+                let decoded = (h1 * 16 + h2) as u8;
+                result.push(decoded as char);
+                i += 3;
+                continue;
+            }
         }
-        _ if optional => Ok(String::new()),
-        _ => Err(EvalError::type_error("string", value.type_name())),
+        // Not a valid percent-encoded sequence, just copy the character
+        result.push(bytes[i] as char);
+        i += 1;
     }
+    Ok(result)
 }
 
 /// Quote a CSV/DSV string field: wrap in `"..."`, doubling inner `"`.
@@ -5740,54 +5770,89 @@ fn format_base64<S: EvalSemantics>(
 }
 
 /// @base64d - Base64 decode
-fn format_base64d(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
-    match value {
-        OwnedValue::String(s) => {
-            // Simple base64 decoding
-            fn decode_char(c: u8) -> Option<u8> {
-                match c {
-                    b'A'..=b'Z' => Some(c - b'A'),
-                    b'a'..=b'z' => Some(c - b'a' + 26),
-                    b'0'..=b'9' => Some(c - b'0' + 52),
-                    b'+' => Some(62),
-                    b'/' => Some(63),
-                    b'=' => Some(0), // Padding
-                    _ => None,
+///
+/// Real yq (v4.53.3, live-verified) accepts any scalar by stringifying it
+/// first, same as [`format_urid`] above -- most stringified scalars then
+/// fail to decode as valid base64 (`1 | @base64d` errors, since `"1"` is
+/// the wrong length), but that's this decoder's own leniency/strictness
+/// on the *string* it's given, unrelated to what type reached it; not
+/// touched here. A container stringifies to the empty string (#1109,
+/// same "container stringifies to empty" convention as `format_urid`),
+/// which trivially decodes to `""` (zero chunks) rather than needing its
+/// own early return. jq mode is unaffected: it keeps erroring on every
+/// non-string type, unchanged from before.
+fn format_base64d<S: EvalSemantics>(
+    value: &OwnedValue,
+    optional: bool,
+) -> Result<String, EvalError> {
+    let s = match value {
+        OwnedValue::String(s) => s.clone(),
+        _ if S::TAG == EvalTag::Yq => match value {
+            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+                numeric_display_string::<S>(value)
+            }
+            OwnedValue::Bool(b) => {
+                if *b {
+                    "true".to_string()
+                } else {
+                    "false".to_string()
                 }
             }
+            OwnedValue::Null => "null".to_string(),
+            _ => String::new(),
+        },
+        _ if optional => return Ok(String::new()),
+        _ => return Err(EvalError::type_error("string", value.type_name())),
+    };
 
-            let s = s.replace(|c: char| c.is_whitespace(), "");
-            let bytes: Vec<u8> = s.bytes().collect();
-            let mut result = Vec::new();
-
-            for chunk in bytes.chunks(4) {
-                if chunk.len() < 4 {
-                    break;
-                }
-
-                let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let c_val =
-                    decode_char(chunk[2]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let d = decode_char(chunk[3]).ok_or_else(|| EvalError::new("invalid base64"))?;
-
-                let triple =
-                    ((a as u32) << 18) | ((b as u32) << 12) | ((c_val as u32) << 6) | (d as u32);
-
-                result.push(((triple >> 16) & 0xFF) as u8);
-                if chunk[2] != b'=' {
-                    result.push(((triple >> 8) & 0xFF) as u8);
-                }
-                if chunk[3] != b'=' {
-                    result.push((triple & 0xFF) as u8);
-                }
-            }
-
-            String::from_utf8(result).map_err(|_| EvalError::new("invalid UTF-8 in decoded base64"))
+    // Simple base64 decoding
+    fn decode_char(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            b'=' => Some(0), // Padding
+            _ => None,
         }
-        _ if optional => Ok(String::new()),
-        _ => Err(EvalError::type_error("string", value.type_name())),
     }
+
+    let s = s.replace(|c: char| c.is_whitespace(), "");
+    let bytes: Vec<u8> = s.bytes().collect();
+    let mut result = Vec::new();
+
+    for chunk in bytes.chunks(4) {
+        if chunk.len() < 4 {
+            break;
+        }
+
+        let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
+        let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
+        let c_val = decode_char(chunk[2]).ok_or_else(|| EvalError::new("invalid base64"))?;
+        let d = decode_char(chunk[3]).ok_or_else(|| EvalError::new("invalid base64"))?;
+
+        let triple = ((a as u32) << 18) | ((b as u32) << 12) | ((c_val as u32) << 6) | (d as u32);
+
+        result.push(((triple >> 16) & 0xFF) as u8);
+        if chunk[2] != b'=' {
+            result.push(((triple >> 8) & 0xFF) as u8);
+        }
+        if chunk[3] != b'=' {
+            result.push((triple & 0xFF) as u8);
+        }
+    }
+
+    // Lossy, not strict: real jq/yq's own `@base64d` never errors on
+    // invalid UTF-8 in the decoded bytes -- it substitutes the standard
+    // replacement character, confirmed live against both oracles
+    // (`"null" | @base64d` succeeds as `"\u{fffd}\u{fffd}e"` in jq 1.7.1,
+    // not an error). This surfaced while adding this function's `S`
+    // parameter (#1109): yq mode's new scalar-stringification path
+    // (`null`/`true`/... above) reaches this exact case for the first
+    // time, and the strict conversion previously here would have produced
+    // a different wrong error instead of matching the oracle.
+    Ok(String::from_utf8_lossy(&result).into_owned())
 }
 
 /// @html - HTML entity escape

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5558,40 +5558,53 @@ fn format_uri<S: EvalSemantics>(value: &OwnedValue, _optional: bool) -> Result<S
     Ok(result)
 }
 
+/// Stringify a scalar the way real yq (v4.53.3, live-verified) does before
+/// handing it to `@urid`/`@base64d`'s decode step: numbers via
+/// `numeric_display_string`, `true`/`false`, `"null"`, and a container
+/// (array/object) to the empty string rather than erroring (#1109) -- the
+/// same "container stringifies to empty" convention already duplicated at
+/// [`yq_join_element_part`]/[`yq_join_separator`]/`combine_sub_gap`'s own
+/// yq branch (#1072 tracks consolidating those; this is a *separate*,
+/// smaller duplicate shared only between `format_urid`/`format_base64d`
+/// themselves, factored out here rather than left as two copies). Callers
+/// gate this on `S::TAG == EvalTag::Yq` themselves and only ever reach it
+/// for a non-`String` `OwnedValue` -- jq mode never calls this at all.
+fn yq_stringify_scalar_or_empty<S: EvalSemantics>(value: &OwnedValue) -> String {
+    match value {
+        OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+            numeric_display_string::<S>(value)
+        }
+        OwnedValue::Bool(b) => {
+            if *b {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        }
+        OwnedValue::Null => "null".to_string(),
+        // String is handled by the caller before reaching here; Array/Object
+        // stringify to "" (#1109).
+        _ => String::new(),
+    }
+}
+
 /// @urid - URI/percent decode
 ///
 /// jq has no `@urid` at all, so there's no jq-mode oracle to match; real
-/// yq (v4.53.3, live-verified) accepts any scalar by stringifying it first
-/// (`numeric_display_string`/`true`/`false`/`"null"`, the same conversion
-/// [`format_uri`]'s encode direction already applies) -- decoding a plain
-/// string with no `%` escapes is a no-op, so a stringified scalar just
-/// echoes back unchanged (`1.5 | @urid` is `"1.5"`). A container
-/// stringifies to the empty string rather than erroring (#1109) -- the
-/// same "container stringifies to empty" convention already duplicated at
-/// [`yq_join_element_part`]/[`yq_join_separator`]/`combine_sub_gap`'s own
-/// yq branch (#1072 tracks consolidating those), reused here rather than
-/// grown a fifth copy of a *different* rule. jq mode is unaffected: it
-/// keeps erroring on every non-string type, unchanged from before.
+/// yq accepts any scalar by stringifying it first (see
+/// [`yq_stringify_scalar_or_empty`]) -- decoding a plain string with no `%`
+/// escapes is a no-op, so a stringified scalar just echoes back unchanged
+/// (`1.5 | @urid` is `"1.5"`). jq mode is unaffected: it keeps erroring on
+/// every non-string type, unchanged from before. Note real yq's `@uri`
+/// *encode* direction does not share this behavior -- it errors on a
+/// non-string scalar rather than stringifying it (`42 | @uri` errors in
+/// real yq); [`format_uri`]'s own unconditional stringification (in both
+/// jq and yq mode) is a separate, pre-existing divergence from real yq,
+/// not touched here.
 fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
     let s = match value {
         OwnedValue::String(s) => s.clone(),
-        _ if S::TAG == EvalTag::Yq => match value {
-            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-                numeric_display_string::<S>(value)
-            }
-            OwnedValue::Bool(b) => {
-                if *b {
-                    "true".to_string()
-                } else {
-                    "false".to_string()
-                }
-            }
-            OwnedValue::Null => "null".to_string(),
-            // Array/Object: stringifies to "" (#1109) -- decoding an empty
-            // string is itself a no-op below, so this needs no further
-            // special-casing past this stringification step.
-            _ => String::new(),
-        },
+        _ if S::TAG == EvalTag::Yq => yq_stringify_scalar_or_empty::<S>(value),
         _ if optional => return Ok(String::new()),
         _ => return Err(EvalError::type_error("string", value.type_name())),
     };
@@ -5772,35 +5785,22 @@ fn format_base64<S: EvalSemantics>(
 /// @base64d - Base64 decode
 ///
 /// Real yq (v4.53.3, live-verified) accepts any scalar by stringifying it
-/// first, same as [`format_urid`] above -- most stringified scalars then
-/// fail to decode as valid base64 (`1 | @base64d` errors, since `"1"` is
-/// the wrong length), but that's this decoder's own leniency/strictness
-/// on the *string* it's given, unrelated to what type reached it; not
-/// touched here. A container stringifies to the empty string (#1109,
-/// same "container stringifies to empty" convention as `format_urid`),
-/// which trivially decodes to `""` (zero chunks) rather than needing its
-/// own early return. jq mode is unaffected: it keeps erroring on every
-/// non-string type, unchanged from before.
+/// first, same as [`format_urid`] above (see [`yq_stringify_scalar_or_empty`])
+/// -- what happens next to that string (valid decode, garbage, or an
+/// error) is this decoder's own leniency/strictness on the *string* it's
+/// given, unrelated to what type reached it; not touched here (its
+/// pre-existing non-multiple-of-4-length truncation-instead-of-erroring
+/// leniency is filed separately as #1120). A container stringifies to the
+/// empty string (#1109), which trivially decodes to `""` (zero chunks)
+/// rather than needing its own early return. jq mode is unaffected: it
+/// keeps erroring on every non-string type, unchanged from before.
 fn format_base64d<S: EvalSemantics>(
     value: &OwnedValue,
     optional: bool,
 ) -> Result<String, EvalError> {
     let s = match value {
         OwnedValue::String(s) => s.clone(),
-        _ if S::TAG == EvalTag::Yq => match value {
-            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-                numeric_display_string::<S>(value)
-            }
-            OwnedValue::Bool(b) => {
-                if *b {
-                    "true".to_string()
-                } else {
-                    "false".to_string()
-                }
-            }
-            OwnedValue::Null => "null".to_string(),
-            _ => String::new(),
-        },
+        _ if S::TAG == EvalTag::Yq => yq_stringify_scalar_or_empty::<S>(value),
         _ if optional => return Ok(String::new()),
         _ => return Err(EvalError::type_error("string", value.type_name())),
     };

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12961,3 +12961,149 @@ fn test_slice_assign_string_and_array_unaffected_1101() -> Result<()> {
     assert_eq!(out.trim(), "[9,2,3]");
     Ok(())
 }
+
+// ============================================================================
+// @urid / @base64d scalar-stringification (#1109)
+// ============================================================================
+//
+// Real yq (v4.53.3, live-verified) stringifies any scalar before decoding,
+// unlike jq which errors on every non-string type. A container (array or
+// object) stringifies to the empty string, matching the established
+// "container stringifies to empty" convention already used by `@sh`/`@uri`/
+// `@html` (#1072).
+
+#[test]
+fn test_yq_urid_stringifies_scalars_1109() -> Result<()> {
+    let (out, code) = run_yq_stdin("@urid", "null", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""null""#);
+
+    let (out, code) = run_yq_stdin("@urid", "true", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""true""#);
+
+    let (out, code) = run_yq_stdin("@urid", "false", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""false""#);
+
+    let (out, code) = run_yq_stdin("@urid", "42", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""42""#);
+
+    let (out, code) = run_yq_stdin("@urid", "1.5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""1.5""#);
+    Ok(())
+}
+
+#[test]
+fn test_yq_urid_container_stringifies_to_empty_1109() -> Result<()> {
+    let (out, code) = run_yq_stdin("@urid", "[1,2,3]", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""""#);
+
+    let (out, code) = run_yq_stdin("@urid", "{a: 1}", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""""#);
+    Ok(())
+}
+
+#[test]
+fn test_yq_base64d_stringifies_scalars_1109() -> Result<()> {
+    // "true" and "null" are both valid (if odd) base64 payloads by length;
+    // decode them and confirm the decoded bytes, not just success/failure.
+    let (out, code) = run_yq_stdin("@base64d", "true", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    let expected = base64_decode_lossy("true");
+    assert_eq!(out.trim(), format!("{expected:?}"));
+    Ok(())
+}
+
+#[test]
+fn test_yq_base64d_container_stringifies_to_empty_1109() -> Result<()> {
+    let (out, code) = run_yq_stdin("@base64d", "[1,2,3]", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""""#);
+
+    let (out, code) = run_yq_stdin("@base64d", "{a: 1}", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""""#);
+    Ok(())
+}
+
+/// jq mode is unaffected by #1109's yq-only stringification: it must keep
+/// erroring on every non-string scalar, exactly as before.
+#[test]
+fn test_jq_urid_base64d_still_reject_non_string_1109() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg("@urid");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"42")?;
+    let output = child.wait_with_output()?;
+    assert_ne!(output.status.code().unwrap_or(-1), 0);
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg("@base64d");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"42")?;
+    let output = child.wait_with_output()?;
+    assert_ne!(output.status.code().unwrap_or(-1), 0);
+    Ok(())
+}
+
+/// `@base64d` never errors on invalid UTF-8 in the decoded bytes -- it
+/// substitutes the replacement character, matching real jq/yq (confirmed
+/// live: `"null" | @base64d` succeeds as `"��e"` in jq 1.7.1
+/// rather than erroring).
+#[test]
+fn test_base64d_invalid_utf8_is_lossy_not_error_1109() -> Result<()> {
+    let (out, code) = run_yq_stdin("@base64d", r#""null""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    let expected = base64_decode_lossy("null");
+    assert_eq!(out.trim(), format!("{expected:?}"));
+    Ok(())
+}
+
+/// Reference decoder used only to compute expected lossy-UTF-8 output for
+/// the tests above, independent of the implementation under test.
+fn base64_decode_lossy(s: &str) -> String {
+    fn decode_char(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            b'=' => Some(0),
+            _ => None,
+        }
+    }
+    let bytes: Vec<u8> = s.bytes().collect();
+    let mut result = Vec::new();
+    for chunk in bytes.chunks(4) {
+        if chunk.len() < 4 {
+            break;
+        }
+        let a = decode_char(chunk[0]).unwrap();
+        let b = decode_char(chunk[1]).unwrap();
+        let c_val = decode_char(chunk[2]).unwrap();
+        let d = decode_char(chunk[3]).unwrap();
+        let triple = ((a as u32) << 18) | ((b as u32) << 12) | ((c_val as u32) << 6) | (d as u32);
+        result.push(((triple >> 16) & 0xFF) as u8);
+        if chunk[2] != b'=' {
+            result.push(((triple >> 8) & 0xFF) as u8);
+        }
+        if chunk[3] != b'=' {
+            result.push((triple & 0xFF) as u8);
+        }
+    }
+    String::from_utf8_lossy(&result).into_owned()
+}


### PR DESCRIPTION
## Summary

- `format_urid`/`format_base64d` (`src/jq/eval.rs`) are now generic over `S: EvalSemantics`. In yq mode, a non-string scalar (`Int`/`Float`/`NumberLiteral`/`Bool`/`Null`) is stringified before decoding, and a container (array/object) stringifies to `""` — matching real yq v4.53.3 (live-verified) and the same "container stringifies to empty" convention already established for `@sh`/`@uri`/`@html` in #1072. jq mode is unaffected: it keeps erroring on every non-string type, unchanged.
- `format_base64d` now uses lossy UTF-8 conversion on the decoded bytes instead of erroring on invalid UTF-8 — confirmed live that both real jq 1.7.1 and real yq v4.53.3 never error here, they substitute the replacement character.

## Out of scope (filed as follow-up)

While verifying this fix I confirmed `format_base64d` also silently truncates a trailing base64 chunk shorter than 4 characters instead of erroring (e.g. `"false" | @base64d` gives garbage instead of an error), which both real jq and real yq do error on. This is a pre-existing bug, reachable via plain string input on both jq and yq mode before this PR — filed separately as #1120.

## Test plan

- [x] New regression tests in `tests/yq_cli_tests.rs`: scalar stringification for `@urid`/`@base64d`, container → `""`, jq mode still rejects non-strings, lossy-UTF8 decode.
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 714 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Live-verified against real yq v4.53.3 and real jq 1.7.1

Fixes #1109