### PR TITLE
fix(yaml): keep an anchor/tag on an explicit key's absent deferred value

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1713,16 +1713,27 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 true,
                             )?;
                             write_line_comment(out, value.line_comment_raw())?;
-                        } else if let Some(kc) = field
-                            .key_cursor()
-                            .line_comment_raw()
-                            .filter(|_| is_deferred_value_absent(&value))
+                        } else if is_deferred_value_absent(&value)
+                            && field.key_cursor().line_comment_raw().is_some()
                         {
                             // The deferred value materialized as nothing
                             // at all - the key's own comment stands
                             // alone with no value token, matching real
-                            // yq (#765).
-                            write_line_comment(out, Some(kc))?;
+                            // yq (#765). The value can still carry an
+                            // anchor/tag though (an explicit key's own
+                            // comment, `? k # c\n: &anc`), which must be
+                            // written before the key's comment (#1113) --
+                            // `write_deferred_value` is a no-op beyond
+                            // that since the value is absent.
+                            write_deferred_value(
+                                out,
+                                &value,
+                                indent,
+                                indent_spaces,
+                                unit,
+                                sort_keys,
+                            )?;
+                            write_line_comment(out, field.key_cursor().line_comment_raw())?;
                         } else {
                             // #1077: a deferred value that materializes as
                             // nothing at all writes no value token here

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1713,36 +1713,22 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 true,
                             )?;
                             write_line_comment(out, value.line_comment_raw())?;
-                        } else if is_deferred_value_absent(&value)
-                            && field.key_cursor().line_comment_raw().is_some()
-                        {
-                            // The deferred value materialized as nothing
-                            // at all - the key's own comment stands
-                            // alone with no value token, matching real
-                            // yq (#765). The value can still carry an
-                            // anchor/tag though (an explicit key's own
-                            // comment, `? k # c\n: &anc`), which must be
-                            // written before the key's comment (#1113) --
-                            // `write_deferred_value` is a no-op beyond
-                            // that since the value is absent.
-                            write_deferred_value(
-                                out,
-                                &value,
-                                indent,
-                                indent_spaces,
-                                unit,
-                                sort_keys,
-                            )?;
-                            write_line_comment(out, field.key_cursor().line_comment_raw())?;
                         } else {
                             // #1077: a deferred value that materializes as
-                            // nothing at all writes no value token here
-                            // (matching the sibling branch above, #765) --
-                            // but unlike that branch, this one can still
-                            // have an anchor/tag to write, so it can't just
-                            // skip straight to the comment. See
-                            // `write_deferred_value`'s own doc comment for
-                            // the byte-for-byte spacing rule.
+                            // nothing at all writes no value token here,
+                            // but can still have an anchor/tag to write, so
+                            // it can't just skip straight to the comment.
+                            // See `write_deferred_value`'s own doc comment
+                            // for the byte-for-byte spacing rule. This
+                            // covers the explicit-key-comment-with-absent-
+                            // value shape too (`? k # c\n: &anc`, #1113) --
+                            // an earlier, narrower special case for that
+                            // shape (added by #765) wrote the key's comment
+                            // without ever consulting the value's own
+                            // anchor/tag; once #1077 taught this general
+                            // path about anchors/tags, the special case
+                            // became redundant with it (verified: deleting
+                            // it changes no test outcome) and was removed.
                             write_deferred_value(
                                 out,
                                 &value,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9736,6 +9736,61 @@ fn test_implicit_key_same_line_value_comment_unaffected_by_795_fallback_dom_path
 }
 
 // ============================================================================
+// Explicit key's own comment must keep an anchor/tag on a deferred-absent
+// value (#1113)
+// ============================================================================
+//
+// #765/#795's own "key comment stands alone" branch (immediately above)
+// never consulted the deferred value's anchor/tag before returning -- fine
+// for the plain case (nothing to lose), but silently dropped an anchor or
+// tag when the explicit key's comment coincided with one. Any `*alias`
+// elsewhere in the document referencing that anchor now resolves to
+// nothing. #1077 already fixed the sibling (no key-comment) branch for the
+// exact same shape; these are the explicit-key-comment counterpart.
+
+/// The issue's own repro: an explicit key's comment, paired with a deferred
+/// value that resolves absent but carries an anchor -- the anchor must
+/// survive alongside the comment.
+#[test]
+fn test_explicit_key_comment_keeps_anchor_on_deferred_absent_value_1113() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k # key comment\n: &anc\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: &anc # key comment\n");
+    Ok(())
+}
+
+/// Same shape, but with a sibling field following instead of EOF ending the
+/// document right after the deferred anchor.
+#[test]
+fn test_explicit_key_comment_keeps_anchor_on_deferred_absent_value_with_sibling_1113() -> Result<()>
+{
+    let (out, code) = run_yq_stdin(".", "? k # key comment\n: &anc\nb: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: &anc # key comment\nb: 1\n");
+    Ok(())
+}
+
+/// Same bug class, an explicit tag instead of an anchor.
+#[test]
+fn test_explicit_key_comment_keeps_tag_on_deferred_absent_value_1113() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k # key comment\n: !!str\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: !!str # key comment\n");
+    Ok(())
+}
+
+/// Both an anchor and a tag on the deferred-absent value -- both must
+/// survive, anchor before tag, matching `write_deferred_value`'s own
+/// ordering (same as #1077's sibling-branch regression guard).
+#[test]
+fn test_explicit_key_comment_keeps_anchor_and_tag_on_deferred_absent_value_1113() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k # key comment\n: &anc !!str\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: &anc !!str # key comment\n");
+    Ok(())
+}
+
+// ============================================================================
 // Merge-flag suffixes on `*`/`*=` (#713)
 // ============================================================================
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9740,13 +9740,16 @@ fn test_implicit_key_same_line_value_comment_unaffected_by_795_fallback_dom_path
 // value (#1113)
 // ============================================================================
 //
-// #765/#795's own "key comment stands alone" branch (immediately above)
-// never consulted the deferred value's anchor/tag before returning -- fine
-// for the plain case (nothing to lose), but silently dropped an anchor or
-// tag when the explicit key's comment coincided with one. Any `*alias`
-// elsewhere in the document referencing that anchor now resolves to
-// nothing. #1077 already fixed the sibling (no key-comment) branch for the
-// exact same shape; these are the explicit-key-comment counterpart.
+// #765/#795 added a narrow "key comment stands alone" branch for this
+// shape that never consulted the deferred value's anchor/tag before
+// returning -- fine for the plain case (nothing to lose), but silently
+// dropped an anchor or tag when the explicit key's comment coincided with
+// one. Any `*alias` elsewhere in the document referencing that anchor now
+// resolves to nothing. #1077 already taught the general (no-key-comment)
+// deferred-value branch about anchors/tags for the identical shape; once
+// it had, the narrower #765 branch was redundant with it and was deleted
+// rather than patched -- these tests exercise the general branch handling
+// the explicit-key-comment case on its own.
 
 /// The issue's own repro: an explicit key's comment, paired with a deferred
 /// value that resolves absent but carries an anchor -- the anchor must


### PR DESCRIPTION
## Summary

`stream_yaml_value`'s "key comment stands alone" branch (`src/yaml/light.rs`,
added by #765/#795 for the explicit-key `? k # comment\n: v` shape) wrote the
key's own same-line comment for a deferred value that resolves absent —
without ever consulting that value's anchor or tag first. This silently
dropped the anchor/tag, orphaning any `*alias` elsewhere in the document that
referenced it.

```
$ printf '? k # key comment\n: &anc\n' | succinctly yq '.'
k: # key comment          # anchor lost

$ printf '? k # key comment\n: &anc\n' | yq '.'    # real yq
k: &anc # key comment
```

#1077 already fixed the *sibling* branch (no key comment) for the identical
absent-value-with-anchor shape via a new `write_deferred_value` helper. This
routes the explicit-key-comment branch through that same helper before
falling back to writing the key's comment, so the fix is consistent with
#1077's own ordering (anchor before tag, before the comment).

## Test plan

- [x] New regression tests: anchor at EOF (issue's own repro), anchor with a
      following sibling, tag only, and anchor+tag combined — all against the
      block-style writer.
- [x] Existing `#765`/`#795`/`#1077` tests unaffected (25/25 pass in the
      targeted run).
- [x] Full `cargo test --features cli,simd,regex,serde` green (2546+ tests,
      0 failed).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean, plus
      the scalar/broadword-yaml feature-gated clippy invocation.
- [x] `cargo fmt --check` clean.
- [x] `cargo check --no-default-features` (no_std) clean.

Fixes #1113