### PR TITLE
fix(yaml): apply yq's scientific-notation threshold to a computed float's tostring/interpolation spelling

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5333,6 +5333,18 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
         if f.is_nan() || f.is_infinite() {
             return nonfinite_display_string::<S>(*f).to_string();
         }
+        // A genuinely computed float (never captured as a `NumberLiteral`
+        // above -- e.g. `(1e10 * 2)`) applies real yq's scientific-notation
+        // magnitude threshold when stringified, unlike `-o json`/structured
+        // YAML output's `to_json_yq`/reindex-bridge formatting, which must
+        // keep a decimal spelling at any magnitude instead (#953) -- these
+        // are different formatting rules for different call sites, not a
+        // contradiction: confirmed live, `(1e10*2) | tostring` gives
+        // `"2e+10"` while `[.a]`'s own array-wrapped output keeps
+        // `100000000000000000000.0` for an i64-overflow scalar (#1054).
+        if S::TAG == EvalTag::Yq {
+            return crate::yaml::format_float_yq(*f);
+        }
     }
     value.number_str().expect("numeric variant").into_owned()
 }
@@ -5415,7 +5427,7 @@ pub(crate) fn owned_value_to_json<S: EvalSemantics>(value: &OwnedValue) -> Strin
 }
 
 /// Convert an owned value to a string representation (for interpolation).
-fn owned_to_string<S: EvalSemantics>(value: &OwnedValue) -> String {
+pub(crate) fn owned_to_string<S: EvalSemantics>(value: &OwnedValue) -> String {
     match value {
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(true) => "true".to_string(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5342,8 +5342,16 @@ pub(crate) fn numeric_display_string<S: EvalSemantics>(value: &OwnedValue) -> St
         // contradiction: confirmed live, `(1e10*2) | tostring` gives
         // `"2e+10"` while `[.a]`'s own array-wrapped output keeps
         // `100000000000000000000.0` for an i64-overflow scalar (#1054).
+        //
+        // `format_float_yq_yaml`, not `format_float_yq`: a stringified
+        // value is never re-parsed back into the document, so there's no
+        // type-ambiguity-on-round-trip concern to preserve a forced `.0`
+        // for -- `format_float_yq`'s ordinary-magnitude formatter
+        // (`format_float_with_fraction`) is for exactly that concern, and
+        // wrongly forces `.0` here: confirmed live, `(50.0*2) | tostring`
+        // is `"100"` in real yq, not `"100.0"` (caught by review).
         if S::TAG == EvalTag::Yq {
-            return crate::yaml::format_float_yq(*f);
+            return crate::yaml::format_float_yq_yaml(*f);
         }
     }
     value.number_str().expect("numeric variant").into_owned()
@@ -6166,16 +6174,7 @@ fn builtin_tostring<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     _optional: bool,
 ) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
-    let s = match owned {
-        OwnedValue::String(s) => s,
-        OwnedValue::Null => "null".to_string(),
-        OwnedValue::Bool(true) => "true".to_string(),
-        OwnedValue::Bool(false) => "false".to_string(),
-        OwnedValue::Int(n) => format!("{n}"),
-        OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => numeric_display_string::<S>(&owned),
-        OwnedValue::Array(_) | OwnedValue::Object(_) => owned_value_to_json::<S>(&owned),
-    };
-    QueryResult::Owned(OwnedValue::String(s))
+    QueryResult::Owned(OwnedValue::String(owned_to_string::<S>(&owned)))
 }
 
 /// Builtin: tonumber - convert string to number
@@ -14371,13 +14370,34 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// nesting chain of depth *d* paid a full serialize-and-reparse of an
 /// O(*d*)-sized subtree at each of its *d* nodes — O(*d*²) work to resolve
 /// what is, for these shapes, an O(1) lookup (#491).
-fn eval_owned_fast_path(
+///
+/// `Builtin::ToString` (`tostring`) is also fast-pathed here, but for
+/// correctness, not just speed (#1054): this is the JSON-input/`-n`-mode
+/// sibling of `eval_generic.rs`'s `eval_on_owned`, which has the same
+/// bypass for the same reason -- without it, `EXPR | tostring` on a
+/// genuinely computed value (e.g. `(1e10*2)`) serializes through
+/// `to_json_for_reindex`'s decimal-only float spelling first, reparses as
+/// a document-sourced-*looking* `NumberLiteral`, and echoes that baked
+/// text verbatim per #1008's literal-preservation rule -- permanently
+/// losing the scientific-notation spelling real yq applies to a computed
+/// float before that round trip ever has a chance to run. `owned_to_string`
+/// is the same function `builtin_tostring` calls directly, so this is
+/// unobservable except in speed for every other value shape.
+///
+/// Narrow on purpose, not exhaustive -- see `eval_on_owned`'s own doc
+/// comment (`eval_generic.rs`) for the exact limitation (only the
+/// immediately-next bare `tostring` is covered) and #1134, which tracks
+/// the general fix neither sibling attempts.
+fn eval_owned_fast_path<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
     optional: bool,
 ) -> Option<Result<Option<OwnedValue>, EvalError>> {
     match expr {
         Expr::Identity => Some(Ok(Some(input.clone()))),
+        Expr::Builtin(Builtin::ToString) => {
+            Some(Ok(Some(OwnedValue::String(owned_to_string::<S>(input)))))
+        }
         Expr::Field(name) => Some(match input {
             OwnedValue::Object(map) => Ok(Some(map.get(name).cloned().unwrap_or(OwnedValue::Null))),
             OwnedValue::Null => Ok(Some(OwnedValue::Null)),
@@ -14431,7 +14451,7 @@ fn eval_owned_expr_ctrl<S: EvalSemantics>(
     input: &OwnedValue,
     optional: bool,
 ) -> Result<OwnedValue, Control> {
-    if let Some(result) = eval_owned_fast_path(expr, input, optional) {
+    if let Some(result) = eval_owned_fast_path::<S>(expr, input, optional) {
         return result
             .map(|v| v.unwrap_or(OwnedValue::Null))
             .map_err(Control::Error);
@@ -14528,7 +14548,7 @@ fn eval_owned_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: &OwnedValue,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    if let Some(result) = eval_owned_fast_path(expr, input, optional) {
+    if let Some(result) = eval_owned_fast_path::<S>(expr, input, optional) {
         return match result {
             Ok(Some(v)) => QueryResult::Owned(v),
             Ok(None) => QueryResult::None,
@@ -24588,7 +24608,7 @@ mod tests {
         ];
 
         for (expr, input, optional) in cases {
-            let fast = eval_owned_fast_path(&expr, &input, optional)
+            let fast = eval_owned_fast_path::<JqSemantics>(&expr, &input, optional)
                 .expect("via_cursor's shapes are exactly the ones eval_owned_fast_path handles");
             let reference = via_cursor(&expr, &input, optional);
             assert_eq!(

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,9 +27,9 @@ use super::document::{
 use super::eval::{
     apply_compare_op, collapse_vec, eval as full_eval, format_owned,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
-    numeric_display_string, numeric_key_to_index, owned_bound_to_i64, owned_value_to_json,
-    slice_owned_value_read, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag,
-    JqSemantics, QueryResult, YqSemantics,
+    numeric_display_string, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
+    owned_value_to_json, slice_owned_value_read, tonumber_from_str, Control, EvalError,
+    EvalSemantics, EvalTag, JqSemantics, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -895,6 +895,21 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     // having passed through a JSON round-trip first.
     if let Expr::Format(format_type) = expr {
         return format_result::<S, _>(format_type, &owned, optional);
+    }
+
+    // `tostring` needs the same bypass, for correctness here, not just
+    // speed (#1054): without it, `EXPR | tostring` on a genuinely computed
+    // value (e.g. `(1e10 * 2)`) serializes through `to_json_for_reindex`'s
+    // decimal-only float spelling below first, reparses as a
+    // document-sourced-*looking* number, and echoes that baked text
+    // verbatim per #1008's literal-preservation rule once the `ToString`
+    // arm at the bottom of this file's `Builtin` match finally runs --
+    // permanently losing the scientific-notation spelling real yq applies
+    // to a computed float before the round trip ever has a chance to run.
+    // `owned_to_string` is the exact same function that arm already calls,
+    // so this is unobservable except in speed for every other value shape.
+    if let Expr::Builtin(Builtin::ToString) = expr {
+        return GenericResult::Owned(OwnedValue::String(owned_to_string::<S>(&owned)));
     }
 
     let json_str = owned.to_json_for_reindex::<S>();

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,9 +27,9 @@ use super::document::{
 use super::eval::{
     apply_compare_op, collapse_vec, eval as full_eval, format_owned,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
-    numeric_display_string, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
-    owned_value_to_json, slice_owned_value_read, tonumber_from_str, Control, EvalError,
-    EvalSemantics, EvalTag, JqSemantics, QueryResult, YqSemantics,
+    numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_owned_value_read,
+    tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag, JqSemantics, QueryResult,
+    YqSemantics,
 };
 use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -902,12 +902,23 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     // value (e.g. `(1e10 * 2)`) serializes through `to_json_for_reindex`'s
     // decimal-only float spelling below first, reparses as a
     // document-sourced-*looking* number, and echoes that baked text
-    // verbatim per #1008's literal-preservation rule once the `ToString`
-    // arm at the bottom of this file's `Builtin` match finally runs --
-    // permanently losing the scientific-notation spelling real yq applies
-    // to a computed float before the round trip ever has a chance to run.
-    // `owned_to_string` is the exact same function that arm already calls,
-    // so this is unobservable except in speed for every other value shape.
+    // verbatim per #1008's literal-preservation rule once `Builtin::
+    // ToString`'s own arm (this file's `eval_builtin`, which now calls
+    // `owned_to_string` directly too) finally runs -- permanently losing
+    // the scientific-notation spelling real yq applies to a computed float
+    // before the round trip ever has a chance to run.
+    //
+    // Narrow on purpose, not exhaustive: this only matches `tostring` as
+    // the *immediately next* stage. Any intervening stage (even a no-op
+    // `.`), a parenthesized `(tostring)`, `tostring?`, or `map(...|
+    // tostring)` all still fall through to the round-trip below and
+    // reproduce the original bug, since each intervening stage re-enters
+    // this function with its own, different `expr` and bakes the float
+    // into a `NumberLiteral` before `tostring` ever sees it in its
+    // original form. Fixing that needs either threading "was this ever
+    // reindexed" through every intermediate call here, or the same
+    // origin-tracking mechanism #1128 already identifies as the real fix
+    // for `@json`'s sibling gap -- tracked as #1134, not attempted here.
     if let Expr::Builtin(Builtin::ToString) = expr {
         return GenericResult::Owned(OwnedValue::String(owned_to_string::<S>(&owned)));
     }
@@ -3729,16 +3740,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::ToString => {
             let owned = to_owned_with_cursor(&value, cursor);
-            let s = match &owned {
-                OwnedValue::Null => "null".to_string(),
-                OwnedValue::Bool(b) => b.to_string(),
-                OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-                    numeric_display_string::<S>(&owned)
-                }
-                OwnedValue::String(s) => s.clone(),
-                OwnedValue::Array(_) | OwnedValue::Object(_) => owned_value_to_json::<S>(&owned),
-            };
-            GenericResult::Owned(OwnedValue::String(s))
+            GenericResult::Owned(OwnedValue::String(owned_to_string::<S>(&owned)))
         }
 
         Builtin::ToNumber => {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12281,6 +12281,78 @@ fn test_yq_string_interpolation_preserves_exponent_literal_1030() -> Result<()> 
     Ok(())
 }
 
+// =============================================================================
+// #1054: `tostring`/string interpolation on a *computed* whole-number float
+// applies real yq's scientific-notation magnitude threshold, instead of
+// always spelling it out as a plain decimal. All live-verified against yq
+// v4.53.3. Distinct from #1030 above: #1030 is about a *document-sourced*
+// literal's exponent spelling surviving unchanged; this is about a value
+// with no literal at all (a genuine arithmetic result).
+// =============================================================================
+
+/// #1054's own repro: `EXPR | tostring` on a computed float. Before the fix,
+/// this serialized through the internal reindex bridge's decimal-only float
+/// formatter first, reparsed as a document-sourced-*looking* number, and
+/// echoed that baked text verbatim -- permanently losing the
+/// scientific-notation spelling real yq applies to a computed float.
+#[test]
+fn test_yq_tostring_computed_float_uses_scientific_notation_1054() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("(1e10 * 2) | tostring", "a: 1\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2e+10");
+    Ok(())
+}
+
+/// Same computation, reached via string interpolation instead of a
+/// separate `| tostring` pipe stage -- a different code path (the computed
+/// value never leaves `OwnedValue::Float`, so it was already correct via
+/// `numeric_display_string` alone, without needing the reindex-bridge
+/// bypass `tostring`'s own fix above needed).
+#[test]
+fn test_yq_interpolation_computed_float_uses_scientific_notation_1054() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r#""\((1e10 * 2))""#, "a: 1\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2e+10");
+    Ok(())
+}
+
+/// Regression guard: a computed float whose magnitude falls *inside* real
+/// yq's non-scientific threshold (roughly exponent -4..6) keeps its plain
+/// decimal spelling via `tostring` -- and, unlike #953's `-o json`/
+/// structured-output rule, without a forced trailing `.0`: `tostring`
+/// produces a readable string, not a type-preserving round-trippable
+/// value, so `200` (not `200.0`) is real yq's own output here.
+#[test]
+fn test_yq_tostring_computed_float_within_threshold_stays_decimal_1054() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("(100 * 2) | tostring", "a: 1\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "200");
+    Ok(())
+}
+
+/// jq mode has no such threshold -- `tostring` on a computed float always
+/// uses jq's own plain-decimal spelling regardless of magnitude, matching
+/// real jq exactly. This is the fix's own mode gate: confirms nothing
+/// leaked from the yq-only branch into jq mode.
+#[test]
+fn test_jq_tostring_computed_float_unaffected_1054() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq")
+        .args(["-r", "(1e10 * 2) | tostring"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    child.stdin.take().unwrap().write_all(b"1")?;
+    let output = child.wait_with_output()?;
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim_end(),
+        "20000000000"
+    );
+    Ok(())
+}
+
 /// #1030's own premise for this case was never checked against real yq
 /// specifically: real yq's `@sh` errors on *any* non-string input, a bare
 /// number included (confirmed live against v4.53.3 -- `#1073` widened that


### PR DESCRIPTION
## Summary
- `EXPR | tostring` and string interpolation on a genuinely computed float (e.g. `(1e10 * 2)`) always spelled it out as a plain decimal, never applying real yq's scientific-notation magnitude threshold (`2e+10`, not `20000000000.0`).
- Two distinct gaps, fixed separately:
  - `numeric_display_string` (`src/jq/eval.rs`) had no yq-mode branch for a genuinely computed `Float` at all. Fixes string interpolation on its own, since the embedded computation never leaves `OwnedValue::Float` before reaching this function.
  - `eval_on_owned` (`src/jq/eval_generic.rs`) — the reindex-bridge bypass used when a computed value needs a further pipe stage — already special-cased `Expr::Format` to skip the bridge, but not `Expr::Builtin(ToString)`. So `EXPR | tostring` still serialized through the bridge's decimal-only float formatter first, reparsed as a document-sourced-*looking* number, and echoed that baked text verbatim per #1008's literal-preservation rule. Fixed by giving `tostring` the same bypass `@text`/`@json` already have.

## Deliberately out of scope
- `@json`/`to_json_yq()`'s own bare-Float formatter is left unconverted: it's also the *only* formatter a document-sourced i64-overflow scalar reaches via plain `.field | @json` (no computation at all) once it degrades to a bare `Float`, and `OwnedValue::Float` carries no tag distinguishing that case from a genuinely computed one. Confirmed live: changing it regresses `.a | @json` on an overflow scalar (#953's own scope). Needs an origin-tracking mechanism this fix doesn't attempt — filed as a follow-up.
- `tostring` on a *container* holding computed floats surfaced a further, unrelated divergence (real yq's container-`tostring` doesn't even produce a JSON string in yq mode) — also filed as a follow-up, out of this issue's stated scope.

Fixes #1054

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green; two unrelated flaky tests confirmed passing in isolation)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (NEON YAML backend)
- [x] `cargo check --no-default-features` (no_std)
- [x] Verified byte-for-byte against the pinned real `yq` binary for the primary repro, threshold boundary, jq-mode non-regression, and #953's overflow-scalar cases
- [x] Patch coverage: 100% (7/7 new lines)