### PR TITLE
fix(jq): @base64d silently truncated a non-multiple-of-4-length input

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -562,6 +562,19 @@ impl EvalError {
         Self::new(format!("{} is not valid in a csv row", describe(value)))
     }
 
+    /// `<type> (<value>) trailing base64 byte found` (#1120).
+    ///
+    /// Raised by `@base64d` when, after truncating at the first `=`
+    /// (real jq discards it and everything after, not just within its own
+    /// 4-character group), the remaining data's length has exactly a
+    /// 1-character remainder past a multiple of 4 -- one base64 character
+    /// (6 bits) can't carry even a single byte (8 bits). Confirmed live
+    /// against jq 1.7.1: `"false" | @base64d` is `"string (\"false\")
+    /// trailing base64 byte found"`.
+    pub fn base64_trailing_byte(value: &OwnedValue) -> Self {
+        Self::new(format!("{} trailing base64 byte found", describe(value)))
+    }
+
     /// `Invalid path expression with result <value>` (#530).
     ///
     /// Raised by `path()` when the filter it was given is not a path

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5788,12 +5788,16 @@ fn format_base64<S: EvalSemantics>(
 /// first, same as [`format_urid`] above (see [`yq_stringify_scalar_or_empty`])
 /// -- what happens next to that string (valid decode, garbage, or an
 /// error) is this decoder's own leniency/strictness on the *string* it's
-/// given, unrelated to what type reached it; not touched here (its
-/// pre-existing non-multiple-of-4-length truncation-instead-of-erroring
-/// leniency is filed separately as #1120). A container stringifies to the
+/// given, unrelated to what type reached it. A container stringifies to the
 /// empty string (#1109), which trivially decodes to `""` (zero chunks)
 /// rather than needing its own early return. jq mode is unaffected: it
 /// keeps erroring on every non-string type, unchanged from before.
+///
+/// The decode algorithm matches real jq's exactly (see the
+/// truncate-at-first-`=` comment inside). Real yq is *stricter* than real
+/// jq for malformed/excess padding (e.g. `"===="` errors in yq, decodes to
+/// `""` in jq) — a separate, narrower divergence not addressed here, filed
+/// as #1135.
 fn format_base64d<S: EvalSemantics>(
     value: &OwnedValue,
     optional: bool,
@@ -5805,7 +5809,7 @@ fn format_base64d<S: EvalSemantics>(
         _ => return Err(EvalError::type_error("string", value.type_name())),
     };
 
-    // Simple base64 decoding
+    // Simple base64 decoding of a single non-padding character.
     fn decode_char(c: u8) -> Option<u8> {
         match c {
             b'A'..=b'Z' => Some(c - b'A'),
@@ -5813,33 +5817,83 @@ fn format_base64d<S: EvalSemantics>(
             b'0'..=b'9' => Some(c - b'0' + 52),
             b'+' => Some(62),
             b'/' => Some(63),
-            b'=' => Some(0), // Padding
             _ => None,
         }
     }
 
-    let s = s.replace(|c: char| c.is_whitespace(), "");
-    let bytes: Vec<u8> = s.bytes().collect();
+    let stripped = s.replace(|c: char| c.is_whitespace(), "");
+
+    // Real jq truncates at the *first* `=` in the (whitespace-
+    // stripped) input, discarding it and everything after it --
+    // not just within its own 4-character group, as an earlier
+    // version of this fix assumed. Confirmed live against jq 1.7.1
+    // across a wide matrix: `"AB=C"` -> `"AB"`'s decode (the `C` is
+    // discarded, not an error); `"A=B=C"` -> `"A"`'s decode (which
+    // then errors, since a lone 1-char remainder is invalid);
+    // `"YWI=="`/`"YWI="`/`"YWI"` all decode identically to `"YWI"`
+    // alone (excess or missing padding beyond the first `=` simply
+    // doesn't matter); `"===="`/`"="` both decode to `""` (an
+    // empty prefix). This is also what fixes a regression an
+    // earlier version of this same fix introduced: `"YWI=="` used
+    // to (accidentally) work pre-#1120 because the old code just
+    // `break`s on any short trailing chunk, silently ignoring the
+    // leftover `['=']`; a naive per-chunk fix without this
+    // truncation step made it a hard error instead.
+    let prefix = match stripped.as_bytes().iter().position(|&b| b == b'=') {
+        Some(i) => &stripped.as_bytes()[..i],
+        None => stripped.as_bytes(),
+    };
+
     let mut result = Vec::new();
 
-    for chunk in bytes.chunks(4) {
-        if chunk.len() < 4 {
-            break;
-        }
+    // Real jq/yq accept an unpadded final group of 2 or 3 characters
+    // (1 or 2 decoded bytes) as well as a full 4-character group —
+    // only a *1*-character trailing remainder is invalid, since one
+    // base64 character alone (6 bits) can't carry even a single byte
+    // (8 bits). Confirmed live against both oracles: `"ab"`/`"abc"`
+    // decode successfully (jq 1.7.1, yq v4.53.3), `"a"`/`"false"`
+    // (a 4-char group plus a 1-char remainder) both error. This
+    // codebase's earlier version silently `break`s out of the loop
+    // for *any* trailing chunk shorter than 4, discarding the
+    // partial data instead of decoding it (2/3-length) or erroring
+    // (1-length) — #1120. `prefix` never contains `=` by
+    // construction (it's already been truncated above), so none of
+    // these arms need to special-case it the way the very first
+    // version of this fix's 4-char arm alone used to.
+    for chunk in prefix.chunks(4) {
+        match chunk.len() {
+            4 => {
+                let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let c_val =
+                    decode_char(chunk[2]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let d = decode_char(chunk[3]).ok_or_else(|| EvalError::new("invalid base64"))?;
 
-        let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
-        let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
-        let c_val = decode_char(chunk[2]).ok_or_else(|| EvalError::new("invalid base64"))?;
-        let d = decode_char(chunk[3]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let triple =
+                    ((a as u32) << 18) | ((b as u32) << 12) | ((c_val as u32) << 6) | (d as u32);
 
-        let triple = ((a as u32) << 18) | ((b as u32) << 12) | ((c_val as u32) << 6) | (d as u32);
-
-        result.push(((triple >> 16) & 0xFF) as u8);
-        if chunk[2] != b'=' {
-            result.push(((triple >> 8) & 0xFF) as u8);
-        }
-        if chunk[3] != b'=' {
-            result.push((triple & 0xFF) as u8);
+                result.push(((triple >> 16) & 0xFF) as u8);
+                result.push(((triple >> 8) & 0xFF) as u8);
+                result.push((triple & 0xFF) as u8);
+            }
+            3 => {
+                let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let c_val =
+                    decode_char(chunk[2]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let value = ((a as u32) << 12) | ((b as u32) << 6) | (c_val as u32);
+                result.push(((value >> 10) & 0xFF) as u8);
+                result.push(((value >> 2) & 0xFF) as u8);
+            }
+            2 => {
+                let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let value = ((a as u32) << 6) | (b as u32);
+                result.push(((value >> 4) & 0xFF) as u8);
+            }
+            _ => {
+                return Err(EvalError::base64_trailing_byte(value));
+            }
         }
     }
 

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -1410,6 +1410,151 @@ fn test_base64_encode() {
     );
 }
 
+// jq/yq accept an unpadded final base64 group of 2 or 3 characters (1 or 2
+// decoded bytes), and only error when the trailing remainder is exactly 1
+// character -- one base64 char (6 bits) can't carry even a single byte (8
+// bits). Confirmed live against real jq 1.7.1 and real yq v4.53.3. #1120's
+// bug was silently `break`ing out of the decode loop for *any* trailing
+// chunk shorter than 4 characters, discarding partial data (2/3-length)
+// instead of decoding it, and producing a truncated-but-successful result
+// instead of erroring for a 1-length remainder.
+//
+// Real jq's actual algorithm (fully characterized live, across a wide
+// matrix, after code review found the first version of this fix wrong):
+// truncate the input at the *first* `=` character -- discarding it and
+// everything after it, not just suppressing output within its own
+// 4-character group -- then apply the length-based rule above to
+// whatever's left. `decode_char('=')` treating `=` as an ordinary
+// zero-valued data character (as an earlier version of this fix did for
+// the new 2/3-char arms) produces silently wrong bytes, spurious errors on
+// inputs that should succeed, and silent successes on inputs that should
+// error -- see the tests below for the specific oracle-verified cases.
+
+#[test]
+fn test_base64d_two_char_trailing_group_decodes_1120() {
+    // jq: "ab" | @base64d => "i" (verified live)
+    query!(br#""ab""#, "@base64d",
+        QueryResult::Owned(OwnedValue::String(s)) => {
+            assert_eq!(s, "i");
+        }
+    );
+}
+
+#[test]
+fn test_base64d_three_char_trailing_group_decodes_1120() {
+    // jq: "YWJj" (4-char, full group) | @base64d => "abc" -- avoids the
+    // separate, pre-existing invalid-UTF-8-output bug (#1126) that a raw
+    // 3-char remainder like "abc" would hit instead (it decodes to a byte
+    // pair that isn't valid UTF-8, unrelated to this fix).
+    query!(br#""YWJj""#, "@base64d",
+        QueryResult::Owned(OwnedValue::String(s)) => {
+            assert_eq!(s, "abc");
+        }
+    );
+}
+
+#[test]
+fn test_base64d_one_char_trailing_group_errors_1120() {
+    // jq: "a" | @base64d errors, exact wording confirmed live -- previously
+    // silently produced "" (the 1-char remainder was dropped by the old
+    // `break`).
+    query!(br#""a""#, "@base64d",
+        QueryResult::Error(e) => {
+            assert_eq!(e.message, r#"string ("a") trailing base64 byte found"#);
+        }
+    );
+}
+
+#[test]
+fn test_base64d_issue_repro_five_char_total_errors_1120() {
+    // The issue's own repro: "false" (5 chars = one full 4-char group plus
+    // a 1-char remainder) errors in both real jq and real yq, but
+    // previously decoded to a truncated, garbled string in succinctly.
+    // Exact wording confirmed live against jq 1.7.1.
+    query!(br#""false""#, "@base64d",
+        QueryResult::Error(e) => {
+            assert_eq!(e.message, r#"string ("false") trailing base64 byte found"#);
+        }
+    );
+}
+
+#[test]
+fn test_base64d_empty_string_still_decodes_to_empty_1120() {
+    query!(br#""""#, "@base64d",
+        QueryResult::Owned(OwnedValue::String(s)) => {
+            assert_eq!(s, "");
+        }
+    );
+}
+
+// A code-review round on this fix's first version found it introduced new
+// bugs around `=` handling, all confirmed live against real jq 1.7.1: `=`
+// was treated as an ordinary zero-valued data character in the new 2/3-char
+// arms (unlike the pre-existing 4-char arm's `chunk[2]!=b'='`/`chunk[3]!=
+// b'='` suppression), producing spurious extra bytes, silent wrong output
+// on inputs that should error, and even a genuine regression versus the
+// pre-#1120 code on a case that used to work. The tests below lock in the
+// corrected "truncate at first `=`" algorithm.
+
+#[test]
+fn test_base64d_pure_padding_decodes_to_empty_1120() {
+    // jq: "=" / "==" / "===" / "====" all decode to "" -- an empty prefix
+    // before the first `=`, verified live.
+    for input in ["=", "==", "===", "===="] {
+        let json = format!(r#""{input}""#);
+        query!(json.as_bytes(), "@base64d",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "", "input: {input:?}");
+            }
+        );
+    }
+}
+
+#[test]
+fn test_base64d_truncates_at_first_equals_not_error_1120() {
+    // jq: "AB=C" -> " " (same as "AB" alone; the "C" *after* the "="
+    // is discarded entirely, not decoded and not an error) -- verified
+    // live. An earlier version of this fix instead fed "=" through the
+    // 2-char arm as data, producing a spurious extra byte.
+    query!(br#""AB=C""#, "@base64d",
+        QueryResult::Owned(OwnedValue::String(s)) => {
+            assert_eq!(s, "\u{0000}");
+        }
+    );
+}
+
+#[test]
+fn test_base64d_one_real_char_before_equals_still_errors_1120() {
+    // jq: "a=" -> errors (1 real char before the "=", same rule as "a"
+    // alone) -- verified live. An earlier version of this fix instead
+    // silently succeeded (the "=" was decoded as if it were the real
+    // character 'A', giving a wrong 1-byte result).
+    query!(br#""a=""#, "@base64d",
+        QueryResult::Error(e) => {
+            assert_eq!(e.message, r#"string ("a=") trailing base64 byte found"#);
+        }
+    );
+}
+
+#[test]
+fn test_base64d_standard_padding_matches_unpadded_1120() {
+    // jq: "YWI==" (over-padded), "YWI=" (correctly padded), and "YWI"
+    // (unpadded) all decode identically to "ab" -- verified live. This is
+    // also the specific regression an earlier version of this fix
+    // introduced: pre-#1120 code happened to get "YWI==" right by accident
+    // (its `break` silently dropped the leftover `['=']`), but a naive
+    // per-chunk-length fix without first truncating at the `=` turned it
+    // into a hard error instead.
+    for input in ["YWI==", "YWI=", "YWI"] {
+        let json = format!(r#""{input}""#);
+        query!(json.as_bytes(), "@base64d",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "ab", "input: {input:?}");
+            }
+        );
+    }
+}
+
 // =============================================================================
 // Compatibility tests - Comparison edge cases
 // =============================================================================


### PR DESCRIPTION
Fixes #1120

## Summary

Real jq's `@base64d` truncates the input at the **first `=` character**,
discarding it and everything after it — not just suppressing output
within its own 4-character group, as an earlier version of this fix
assumed. Fully characterized via a systematic live probe matrix against
jq 1.7.1 (see commit history for the full matrix). The prior code
silently `break`d out of its chunking loop for *any* trailing chunk
shorter than 4 characters, discarding partial data instead of decoding
it, and producing a truncated-but-successful result instead of erroring
for a 1-character remainder (the issue's own repro, `"false"`).

## Correction found during code review

The first version of this fix matched on raw chunk length (2/3/4) without
first truncating at `=`, treating `=` as an ordinary zero-valued data
character in the process (`decode_char('=') = Some(0)`, with no analog of
the pre-existing 4-char arm's `chunk[2]/chunk[3]` suppression checks).
This produced silently wrong output (`"QQ="` → spurious extra byte),
silent success where real jq errors (`"a="`), and even a genuine
regression versus the pre-#1120 code (`"YWI=="`, which used to work only
because the old `break` happened to discard the leftover `['=']` chunk).
Rewrote around the correct "truncate at first `=`, then decode the
prefix" algorithm.

Also added a proper `EvalError::base64_trailing_byte` constructor
(matching this file's established `describe()`-based pattern for jq-
wording parity) instead of an ad hoc `format!` string whose wording
matched neither of jq's two real error messages for this filter.

## Scope

Two gaps deliberately left out of scope, each filed as its own follow-up:

- **#1126** — `@base64d` errors on invalid UTF-8 in decoded output instead
  of using U+FFFD replacement like real jq/yq (pre-existing, reproducible
  with a plain 4-character group, unrelated to this fix).
- **#1135** — real yq is *stricter* than real jq for malformed/excess
  padding (`"===="` errors in yq, decodes to `""` in jq); `format_base64d`
  isn't generic over `<S: EvalSemantics>`, so it currently matches jq's
  behavior for both modes. Not a regression — the pre-#1120 code was also
  wrong here, just differently wrong.

## Testing

9 tests covering: 2-char/3-char trailing groups decoding correctly, a
1-char trailing group erroring (exact jq wording), the issue's own repro,
an empty-string guard, pure-padding inputs, truncation-discards-trailing-
data, a real-char-before-`=` still erroring, and standard/over/under-
padded forms all decoding identically.