### PR TITLE
fix(jq): @urid preserves UTF-8; @base64d trims not strips whitespace

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5608,6 +5608,27 @@ fn yq_stringify_scalar_or_empty<S: EvalSemantics>(value: &OwnedValue) -> String 
     }
 }
 
+/// Convert a decode loop's raw byte buffer into a `String`, using
+/// `String::from_utf8` directly (no copy: it reuses `bytes`'s own
+/// allocation) when the buffer is already valid UTF-8, and falling back to
+/// a lossy replacement-character substitution only for the genuinely
+/// invalid case -- avoiding the second full-buffer copy
+/// `String::from_utf8_lossy(&bytes).into_owned()` always pays even when
+/// `bytes` was valid all along (the common case for both callers below).
+/// Shared by `format_urid`/`format_base64d` (#1123) so the "always lossy,
+/// never error on bad UTF-8" decode policy has one definition instead of
+/// two independently-copy-pasted tails.
+///
+/// Note this is necessarily an approximation of real yq's own behavior for
+/// input that decodes to *invalid* UTF-8 (e.g. `"%FF" | @urid`): real yq
+/// (backed by Go, whose strings are arbitrary byte sequences) passes such
+/// bytes through unchanged, but Rust's `String` cannot hold invalid UTF-8
+/// at all, so lossy substitution is the closest correct representation
+/// available here, not a verified oracle match for that specific case.
+fn owned_string_from_decoded_bytes(bytes: Vec<u8>) -> String {
+    String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
 /// @urid - URI/percent decode
 ///
 /// jq has no `@urid` at all, so there's no jq-mode oracle to match; real
@@ -5634,8 +5655,7 @@ fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<S
     // instead of surviving as part of the original multi-byte UTF-8
     // sequence -- corrupting both literal pass-through bytes and genuinely
     // percent-decoded ones. Collecting into a byte buffer and converting
-    // once at the end (lossy, matching `format_base64d`'s established
-    // precedent) round-trips non-ASCII input correctly.
+    // once at the end round-trips non-ASCII input correctly.
     let mut result = Vec::with_capacity(s.len());
     let bytes = s.as_bytes();
     let mut i = 0;
@@ -5656,7 +5676,7 @@ fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<S
         result.push(bytes[i]);
         i += 1;
     }
-    Ok(String::from_utf8_lossy(&result).into_owned())
+    Ok(owned_string_from_decoded_bytes(result))
 }
 
 /// Quote a CSV/DSV string field: wrap in `"..."`, doubling inner `"`.
@@ -5821,10 +5841,15 @@ fn format_base64<S: EvalSemantics>(
 /// keeps erroring on every non-string type, unchanged from before.
 ///
 /// The decode algorithm matches real jq's exactly (see the
-/// truncate-at-first-`=` comment inside). Real yq is *stricter* than real
-/// jq for malformed/excess padding (e.g. `"===="` errors in yq, decodes to
-/// `""` in jq) — a separate, narrower divergence not addressed here, filed
-/// as #1135.
+/// truncate-at-first-`=` comment inside), and validates every character of
+/// every trailing group (2, 3, or 4 bytes long) the same way, so embedded
+/// whitespace anywhere before the first `=` is caught regardless of
+/// position (#1123 no longer has the "only a complete 4-byte group is
+/// checked" gap an earlier version of this fix had, now that #1120's
+/// truncate-then-decode-every-length rewrite validates the whole prefix
+/// uniformly). Real yq is *stricter* than real jq for malformed/excess
+/// padding (e.g. `"===="` errors in yq, decodes to `""` in jq) — a
+/// separate, narrower divergence not addressed here, filed as #1135.
 fn format_base64d<S: EvalSemantics>(
     value: &OwnedValue,
     optional: bool,
@@ -5849,9 +5874,9 @@ fn format_base64d<S: EvalSemantics>(
     }
 
     // Trim, don't strip (#1123): real yq (v4.53.3, live-verified) trims
-    // leading/trailing Unicode whitespace but rejects *embedded*
-    // whitespace as invalid base64 data (`" aGVsbG8="` decodes to
-    // `"hello"`; `"aGVs bG8="` errors) -- the previous unconditional
+    // leading/trailing Unicode whitespace but rejects embedded whitespace
+    // as invalid base64 data (`" aGVsbG8="` decodes to `"hello"`;
+    // `"aGVs bG8="` errors) -- the previous unconditional
     // `.replace(is_whitespace, "")` incorrectly stripped whitespace from
     // any position, silently accepting malformed input real yq rejects.
     // Real jq is stricter still: it trims *nothing* at all, erroring even
@@ -5950,7 +5975,7 @@ fn format_base64d<S: EvalSemantics>(
     // (`null`/`true`/... above) reaches this exact case for the first
     // time, and the strict conversion previously here would have produced
     // a different wrong error instead of matching the oracle.
-    Ok(String::from_utf8_lossy(&result).into_owned())
+    Ok(owned_string_from_decoded_bytes(result))
 }
 
 /// @html - HTML entity escape

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5629,7 +5629,14 @@ fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<S
         _ => return Err(EvalError::type_error("string", value.type_name())),
     };
 
-    let mut result = String::new();
+    // Byte-oriented, not char-oriented (#1123): a non-ASCII byte pushed
+    // individually via `as char` mis-encodes as its own Latin-1 codepoint
+    // instead of surviving as part of the original multi-byte UTF-8
+    // sequence -- corrupting both literal pass-through bytes and genuinely
+    // percent-decoded ones. Collecting into a byte buffer and converting
+    // once at the end (lossy, matching `format_base64d`'s established
+    // precedent) round-trips non-ASCII input correctly.
+    let mut result = Vec::with_capacity(s.len());
     let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -5640,16 +5647,16 @@ fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<S
                 (bytes[i + 2] as char).to_digit(16),
             ) {
                 let decoded = (h1 * 16 + h2) as u8;
-                result.push(decoded as char);
+                result.push(decoded);
                 i += 3;
                 continue;
             }
         }
-        // Not a valid percent-encoded sequence, just copy the character
-        result.push(bytes[i] as char);
+        // Not a valid percent-encoded sequence, just copy the byte
+        result.push(bytes[i]);
         i += 1;
     }
-    Ok(result)
+    Ok(String::from_utf8_lossy(&result).into_owned())
 }
 
 /// Quote a CSV/DSV string field: wrap in `"..."`, doubling inner `"`.
@@ -5841,10 +5848,27 @@ fn format_base64d<S: EvalSemantics>(
         }
     }
 
-    let stripped = s.replace(|c: char| c.is_whitespace(), "");
+    // Trim, don't strip (#1123): real yq (v4.53.3, live-verified) trims
+    // leading/trailing Unicode whitespace but rejects *embedded*
+    // whitespace as invalid base64 data (`" aGVsbG8="` decodes to
+    // `"hello"`; `"aGVs bG8="` errors) -- the previous unconditional
+    // `.replace(is_whitespace, "")` incorrectly stripped whitespace from
+    // any position, silently accepting malformed input real yq rejects.
+    // Real jq is stricter still: it trims *nothing* at all, erroring even
+    // on leading/trailing whitespace (`" aGVsbG8="` errors in jq 1.7.1) --
+    // `decode_char` below already rejects any leftover whitespace
+    // (embedded, or untrimmed-in-jq-mode) as an invalid character, so no
+    // further gating is needed past this one trim-or-not step. Just a
+    // narrowed `&str` slice, no allocation: the byte-position search right
+    // below borrows from whichever of `s`/`s.trim()` this picks.
+    let trimmed = if S::TAG == EvalTag::Yq {
+        s.trim()
+    } else {
+        s.as_str()
+    };
 
     // Real jq truncates at the *first* `=` in the (whitespace-
-    // stripped) input, discarding it and everything after it --
+    // trimmed) input, discarding it and everything after it --
     // not just within its own 4-character group, as an earlier
     // version of this fix assumed. Confirmed live against jq 1.7.1
     // across a wide matrix: `"AB=C"` -> `"AB"`'s decode (the `C` is
@@ -5859,9 +5883,9 @@ fn format_base64d<S: EvalSemantics>(
     // `break`s on any short trailing chunk, silently ignoring the
     // leftover `['=']`; a naive per-chunk fix without this
     // truncation step made it a hard error instead.
-    let prefix = match stripped.as_bytes().iter().position(|&b| b == b'=') {
-        Some(i) => &stripped.as_bytes()[..i],
-        None => stripped.as_bytes(),
+    let prefix = match trimmed.as_bytes().iter().position(|&b| b == b'=') {
+        Some(i) => &trimmed.as_bytes()[..i],
+        None => trimmed.as_bytes(),
     };
 
     let mut result = Vec::new();

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10872,3 +10872,21 @@ fn test_jq_slice_assign_scalar_still_errors_1101() -> Result<()> {
     assert_eq!(code, 5);
     Ok(())
 }
+
+/// `@urid`'s percent-decode loop must round-trip non-ASCII UTF-8 correctly
+/// -- both literal pass-through bytes (no `%` escapes present at all) and
+/// genuinely percent-decoded multi-byte sequences. Before #1123, pushing
+/// each raw byte individually via `bytes[i] as char` mis-encoded any byte
+/// at or above 0x80 as its own Latin-1 codepoint, corrupting the string
+/// even though decoding a plain string with no escapes should be a no-op.
+#[test]
+fn test_urid_nonascii_passthrough_and_decode_1123() -> Result<()> {
+    let (out, code) = run_jq_stdin("@urid", r#""café""#, &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"café\"");
+
+    let (out, code) = run_jq_stdin("@urid", r#""caf%C3%A9""#, &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"café\"");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13284,3 +13284,18 @@ fn test_jq_base64d_does_not_trim_whitespace_1123() -> Result<()> {
     assert_ne!(output.status.code().unwrap_or(-1), 0);
     Ok(())
 }
+
+/// `format_urid`'s non-ASCII UTF-8 fix isn't gated by `S::TAG`, but it
+/// needs a yq-mode regression pin of its own too, not just jq mode's
+/// `test_urid_nonascii_passthrough_and_decode_1123` (`tests/jq_cli_tests.rs`).
+#[test]
+fn test_yq_urid_nonascii_passthrough_and_decode_1123() -> Result<()> {
+    let (out, code) = run_yq_stdin("@urid", r#""café""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"café\"");
+
+    let (out, code) = run_yq_stdin("@urid", r#""caf%C3%A9""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"café\"");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13237,3 +13237,50 @@ fn base64_decode_lossy(s: &str) -> String {
     }
     String::from_utf8_lossy(&result).into_owned()
 }
+
+// ============================================================================
+// @base64d trims leading/trailing whitespace but rejects embedded (#1123)
+// ============================================================================
+//
+// Real yq (v4.53.3, live-verified) trims leading/trailing Unicode
+// whitespace before decoding, but treats any *embedded* whitespace as
+// invalid base64 data. Before #1123, an unconditional
+// `.replace(is_whitespace, "")` stripped whitespace from every position,
+// silently accepting malformed input real yq rejects.
+
+#[test]
+fn test_yq_base64d_trims_leading_and_trailing_whitespace_1123() -> Result<()> {
+    let (out, code) = run_yq_stdin("@base64d", r#"" aGVsbG8=""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""hello""#);
+
+    let (out, code) = run_yq_stdin("@base64d", r#""aGVsbG8= ""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""hello""#);
+    Ok(())
+}
+
+#[test]
+fn test_yq_base64d_rejects_embedded_whitespace_1123() -> Result<()> {
+    let (_out, code) = run_yq_stdin("@base64d", r#""aGVs bG8=""#, &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// jq is stricter than yq here: it trims nothing at all, erroring even on
+/// leading/trailing whitespace (confirmed live: `" aGVsbG8=" | @base64d`
+/// errors in jq 1.7.1).
+#[test]
+fn test_jq_base64d_does_not_trim_whitespace_1123() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg("@base64d");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(br#"" aGVsbG8=""#)?;
+    let output = child.wait_with_output()?;
+    assert_ne!(output.status.code().unwrap_or(-1), 0);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `format_urid`'s percent-decode loop pushed each raw byte individually via `bytes[i] as char`, mis-encoding any byte >= 0x80 as its own Latin-1 codepoint instead of preserving the original UTF-8 sequence. This corrupted both literal non-ASCII pass-through (`"café" | @urid` → `"cafÃ©"` even with zero `%` escapes) and genuinely percent-decoded multi-byte sequences. Fixed by collecting into a byte buffer and converting once via `String::from_utf8_lossy`, matching `format_base64d`'s existing precedent.
- `format_base64d`'s whitespace handling stripped whitespace from *any* position in the string instead of only leading/trailing. Live-verified against both oracles:
  - Real yq v4.53.3 trims leading/trailing Unicode whitespace but rejects embedded whitespace as invalid base64 data (`" aGVsbG8="` → `"hello"`, but `"aGVs bG8="` errors).
  - Real jq 1.7.1 is stricter still and trims nothing at all (`" aGVsbG8="` errors).

  Gated by `S::TAG` so each mode now matches its own oracle exactly, rather than the previous unconditional strip-everywhere behavior that was too lenient for both.

## Test plan

- [x] New regression tests: non-ASCII `@urid` pass-through and percent-decode (`tests/jq_cli_tests.rs`), `@base64d` leading/trailing-trim + embedded-whitespace-rejection in yq mode and no-trim-at-all in jq mode (`tests/yq_cli_tests.rs`)
- [x] `cargo test --features cli,simd,regex,serde` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Live-verified against real yq v4.53.3 and real jq 1.7.1

Fixes #1123