### PR TITLE
fix(jq): yq's + appends a non-array RHS onto an array LHS

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -70,6 +70,12 @@ pub trait EvalSemantics: Copy + Default {
     /// If true, unflagged array `*`/`*=` replaces/merges instead of erroring (yq).
     /// If false, array * array is a type error (jq) — real jq has no array-merge concept.
     const ARRAY_MULTIPLY_MERGES: bool;
+    /// If true, `array + x` appends any non-array, non-null `x` as a single
+    /// new element (yq, #1119) — asymmetric: `x + array` for a non-array/
+    /// non-null `x` still errors regardless of this flag, matching real
+    /// yq. If false, array + non-array is a type error on either side (jq)
+    /// — real jq has no array-append concept.
+    const ARRAY_PLUS_APPENDS: bool;
     /// If true, `null` acts as an empty container on either side of `*`/`*=`:
     /// a null right operand is a no-op (left passes through unchanged), and a
     /// null left operand merging with an object/array merges as if starting
@@ -105,6 +111,7 @@ impl EvalSemantics for JqSemantics {
     const MOD_TRUNCATES_FLOATS: bool = true;
     const TAG: EvalTag = EvalTag::Jq;
     const ARRAY_MULTIPLY_MERGES: bool = false;
+    const ARRAY_PLUS_APPENDS: bool = false;
     const NULL_MERGES_AS_EMPTY: bool = false;
     const DEFAULT_HALT_ERROR_CODE: i32 = 5;
     const STRICT_NUMERIC_EQUALITY: bool = false;
@@ -127,6 +134,7 @@ impl EvalSemantics for YqSemantics {
     const MOD_TRUNCATES_FLOATS: bool = false;
     const TAG: EvalTag = EvalTag::Yq;
     const ARRAY_MULTIPLY_MERGES: bool = true;
+    const ARRAY_PLUS_APPENDS: bool = true;
     const NULL_MERGES_AS_EMPTY: bool = true;
     const DEFAULT_HALT_ERROR_CODE: i32 = 1;
     const STRICT_NUMERIC_EQUALITY: bool = true;
@@ -1722,7 +1730,7 @@ fn arith_add<S: EvalSemantics>(
         // error arm below, matching real yq (verified live against yq
         // v4.53.3: `[1,2] + 3` succeeds, `3 + [1,2]` errors). Array+array
         // and array+null are already handled above/before this arm.
-        (OwnedValue::Array(mut a), b) if S::TAG == EvalTag::Yq => {
+        (OwnedValue::Array(mut a), b) if S::ARRAY_PLUS_APPENDS => {
             a.push(b);
             Ok(OwnedValue::Array(a))
         }
@@ -8997,17 +9005,34 @@ fn eval_regex_pattern_and_concat_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSeman
     // and `EvalError::binary_op` for any other type pairing. Reusing it
     // here instead of hand-rolling the same three arms keeps this in sync
     // with jq's real `+` semantics automatically if they're ever adjusted.
+    //
+    // #1119 added a yq-only Array+non-array append arm to `arith_add`
+    // *for user-facing `+`*, which breaks that invariant here: an Array
+    // `flags` value in yq mode would now hit `Ok(Array(...))` instead of
+    // erroring. This is purely an internal flags-string-concat helper, not
+    // the user's own `+`, so it explicitly rejects a non-String/non-null
+    // `raw_flags` up front rather than trusting whatever `arith_add`
+    // happens to accept -- restoring the original (String, String) / (Null,
+    // String) invariant regardless of `+`'s own evolving semantics.
     let raw_flags = result_to_owned(eval_single::<W, S>(flags_expr, value, optional))?;
+    if !matches!(raw_flags, OwnedValue::String(_) | OwnedValue::Null) {
+        let g = OwnedValue::String("g".to_string());
+        let (a, b) = match concat {
+            FlagsConcat::Append => (&raw_flags, &g),
+            FlagsConcat::Prepend => (&g, &raw_flags),
+        };
+        return Err(EvalError::binary_op(a, b, BinOp::Add).into());
+    }
     let g = OwnedValue::String("g".to_string());
     let (a, b) = match concat {
         FlagsConcat::Append => (raw_flags, g),
         FlagsConcat::Prepend => (g, raw_flags),
     };
     let global_flags = match arith_add::<S>(a, b) {
-        // One operand is always the literal string "g", so the only ways
+        // `raw_flags` is now known to be String or Null, so the only ways
         // `arith_add` can succeed are (String, String) -> concat, or the
-        // other operand being `null` -> the "g" identity wins outright;
-        // both cases produce a String.
+        // Null side -> the "g" identity wins outright; both cases produce
+        // a String.
         Ok(OwnedValue::String(s)) => s,
         Ok(other) => unreachable!(
             "arith_add(_, \"g\"-or-\"g\"-paired) always yields a String, got {other:?}"
@@ -10561,27 +10586,22 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // rationale, including why this can't be a blanket check before
         // the filter runs at all.
         //
-        // The throwaway clones `result` (the scalar itself), not `[]` —
-        // real yq's own discarded-write `.` binding is actually `[]` (`5 |
-        // .[0:1] += [1]` no-ops in real yq, consistent with `[] + [1]`
-        // succeeding there), but real yq's `+` *also* has an array-append
-        // semantic succinctly's `+` doesn't implement at all (`[] + 99`
-        // gives `[99]` in real yq, errors in succinctly — a real,
-        // pre-existing, unrelated gap, filed as #1119). Binding `.` to `[]`
-        // here without that append semantic would turn the common `5 |
-        // .[0:1] += 99` case from a working no-op into a fresh regression
-        // (`array ([]) and number (99) cannot be added`) to fix an
-        // obscure array-filter edge case (`|= keys`) instead — the wrong
-        // trade. Scalar cloning keeps `+= <number>`/`|= <number filter>`
-        // correct; `|=`/`+=` with a filter whose behavior differs between
-        // an array and the raw scalar (`keys`, `+= [1]`) remain wrong,
-        // tracked alongside #1119.
+        // The throwaway binds `.` to `[]`, not a clone of `result` (the
+        // scalar itself) — matching real yq's own discarded-write model
+        // exactly (`5 | .[0:1] += [1]` and `5 | .[0:1] |= keys` both no-op
+        // to `5` in real yq, since the write target reads as an empty
+        // array). This was previously scalar-cloning instead, since
+        // `arith_add` had no array-append semantic yet (`[] + 99` errored)
+        // — #1119 added it, so `[] + 99` now succeeds too, and this switch
+        // closes the exact gap #1119 was filed to unblock (verified live
+        // against yq v4.53.3 for `+= <number>`, `+= <string>`, `+= [x]`,
+        // `|= keys`, `|= length`, `|= tostring`, `|= (. + 1)`).
         if scalar_slice_noop
             && S::TAG == EvalTag::Yq
             && is_yq_scalar_slice_assign_path(path)
             && is_yq_slice_empty_container_scalar(&result)
         {
-            let mut throwaway = result.clone();
+            let mut throwaway = OwnedValue::Array(Vec::new());
             // No `if optional`-gated arm here, unlike the sibling call
             // below: `optional` at this point is `eval_update`'s *own*
             // outer `?` (`(.a |= f)?`), and per #693, `Expr::Optional`/

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1715,6 +1715,17 @@ fn arith_add<S: EvalSemantics>(
         }
         // null + x = x, x + null = x
         (OwnedValue::Null, other) | (other, OwnedValue::Null) => Ok(other),
+        // yq: `array + x` appends any non-array, non-null `x` as a single
+        // new element (`[] + 99` => `[99]`) -- unlike jq, which has no
+        // array-append concept and errors here (#1119). Asymmetric: `x +
+        // array` for a non-array/non-null `x` still falls through to the
+        // error arm below, matching real yq (verified live against yq
+        // v4.53.3: `[1,2] + 3` succeeds, `3 + [1,2]` errors). Array+array
+        // and array+null are already handled above/before this arm.
+        (OwnedValue::Array(mut a), b) if S::TAG == EvalTag::Yq => {
+            a.push(b);
+            Ok(OwnedValue::Array(a))
+        }
         (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Add)),
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10890,3 +10890,16 @@ fn test_urid_nonascii_passthrough_and_decode_1123() -> Result<()> {
     assert_eq!(out.trim(), "\"café\"");
     Ok(())
 }
+
+/// #1119's yq-only "array + non-array appends" rule must not leak into jq
+/// mode: real jq has no array-append concept and errors on `[] + 99`,
+/// matching succinctly's pre-existing, unaffected behavior.
+#[test]
+fn test_jq_array_plus_scalar_still_errors_1119() -> Result<()> {
+    let (_out, code) = run_jq_stdin("[] + 99", "null", &[])?;
+    assert_eq!(code, 5);
+
+    let (_out, code) = run_jq_stdin("[1,2] + 3", "null", &[])?;
+    assert_eq!(code, 5);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13202,6 +13202,103 @@ fn test_base64d_invalid_utf8_is_lossy_not_error_1109() -> Result<()> {
     Ok(())
 }
 
+// --- #1119: yq's `+` appends a non-array RHS to an array LHS ---
+//
+// Verified live against real yq v4.53.3. Asymmetric: only fires when the
+// array is on the *left*. `array + array` (concat) and `array + null` /
+// `null + array` (no-op) already worked before this fix and are re-checked
+// here only as regression guards.
+
+#[test]
+fn test_1119_array_plus_number_appends() -> Result<()> {
+    let (output, code) = run_yq_stdin("[] + 99", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[99]");
+
+    let (output, code) = run_yq_stdin("[1,2] + 3", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[1,2,3]");
+
+    Ok(())
+}
+
+#[test]
+fn test_1119_array_plus_string_bool_object_appends() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"[1,2] + "a""#, "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"[1,2,"a"]"#);
+
+    let (output, code) = run_yq_stdin("[1,2] + true", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[1,2,true]");
+
+    let (output, code) = run_yq_stdin(r#"[1,2] + {"a":1}"#, "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"[1,2,{"a":1}]"#);
+
+    Ok(())
+}
+
+/// Asymmetric: `non-array + array` still errors, matching real yq (`3 +
+/// [1,2]` errors there too — this is not a general merge).
+#[test]
+fn test_1119_non_array_plus_array_still_errors() -> Result<()> {
+    let (_, stderr, code) = run_yq_stdin_with_stderr("3 + [1,2]", "null", &[])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("cannot be added"), "stderr: {stderr}");
+
+    let (_, stderr, code) = run_yq_stdin_with_stderr(r#""a" + [1,2]"#, "null", &[])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("cannot be added"), "stderr: {stderr}");
+
+    let (_, stderr, code) = run_yq_stdin_with_stderr(r#"{"a":1} + [1,2]"#, "null", &[])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("cannot be added"), "stderr: {stderr}");
+
+    Ok(())
+}
+
+/// Array+array (concat) and array+null / null+array (no-op) already worked
+/// pre-#1119 — regression guards, not new behavior.
+#[test]
+fn test_1119_array_plus_array_and_null_unchanged() -> Result<()> {
+    let (output, code) = run_yq_stdin("[1,2] + [3,4]", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[1,2,3,4]");
+
+    let (output, code) = run_yq_stdin("[1,2] + null", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[1,2]");
+
+    let (output, code) = run_yq_stdin("null + [1,2]", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[1,2]");
+
+    Ok(())
+}
+
+#[test]
+fn test_1119_compound_assign_plus_equals_appends() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a += 5", "a: [1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":[1,2,5]}"#);
+
+    Ok(())
+}
+
+/// #1101/#1112's scalar-slice-assignment no-op still works after this fix
+/// (its throwaway clone binds `.` to the scalar itself, not `[]` — see
+/// `eval_update`'s doc comment — so this array-append change doesn't touch
+/// that path at all; regression guard).
+#[test]
+fn test_1119_scalar_slice_assign_noop_still_works() -> Result<()> {
+    let (output, code) = run_yq_stdin("5 | .[0:1] += 99", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "5");
+
+    Ok(())
+}
+
 /// Reference decoder used only to compute expected lossy-UTF-8 output for
 /// the tests above, independent of the implementation under test.
 fn base64_decode_lossy(s: &str) -> String {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13286,15 +13286,71 @@ fn test_1119_compound_assign_plus_equals_appends() -> Result<()> {
     Ok(())
 }
 
-/// #1101/#1112's scalar-slice-assignment no-op still works after this fix
-/// (its throwaway clone binds `.` to the scalar itself, not `[]` — see
-/// `eval_update`'s doc comment — so this array-append change doesn't touch
-/// that path at all; regression guard).
+/// #1101/#1112's scalar-slice-assignment no-op still works after this fix.
+/// Regression guard for the common numeric case.
 #[test]
 fn test_1119_scalar_slice_assign_noop_still_works() -> Result<()> {
     let (output, code) = run_yq_stdin("5 | .[0:1] += 99", "null", &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "5");
+
+    Ok(())
+}
+
+/// This fix's own motivating trigger (#1119's "Why this surfaced now"
+/// section): `eval_update`'s scalar-slice no-op throwaway now binds `.` to
+/// `[]` (matching real yq's actual internal model), which this array-append
+/// arm is what makes safe -- previously switching to `[]` would have
+/// regressed the common `+= <number>` case (`[] + 99` errored pre-#1119).
+/// Verified live against yq v4.53.3: all of these no-op to the original
+/// scalar in real yq.
+#[test]
+fn test_1119_scalar_slice_assign_noop_covers_array_and_filter_rhs() -> Result<()> {
+    let (output, code) = run_yq_stdin("5 | .[0:1] += [1]", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "5");
+
+    let (output, code) = run_yq_stdin("5 | .[0:1] += \"x\"", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "5");
+
+    let (output, code) = run_yq_stdin("5 | .[0:1] |= keys", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "5");
+
+    let (output, code) = run_yq_stdin("5 | .[0:1] |= length", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "5");
+
+    Ok(())
+}
+
+/// `add` is documented (`builtin_add`'s own comment) as `[.[] | .]` folded
+/// with `+`, so it intentionally inherits `+`'s exact semantics, including
+/// this array-append arm -- not a separate scope decision. Real yq has no
+/// `add`/`reduce` syntax at all, so this locks in succinctly's own
+/// consistent-with-`+` behavior rather than verifying against an oracle.
+#[test]
+fn test_1119_add_builtin_inherits_array_append_consistently() -> Result<()> {
+    let (output, code) = run_yq_stdin("[[1,2],3,4] | add", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[1,2,3,4]");
+
+    Ok(())
+}
+
+/// #1119 (Array+non-array in `arith_add`) must not resurrect the panic this
+/// broke in `gsub`'s flags-concatenation helper: an Array-typed `flags`
+/// argument now type-checks explicitly before ever reaching `arith_add`,
+/// rather than relying on `arith_add` to keep always producing a String.
+#[test]
+fn test_1119_gsub_array_flags_still_errors_cleanly_not_panics() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(r#"gsub("t"; "x"; [])"#, "\"test\"", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("cannot be added"),
+        "expected a clean type error, got: {stderr}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Real yq's `+` operator appends any non-array, non-null RHS to an array LHS as a single new element (`[] + 99` => `[99]`), unlike jq which has no array-append concept and errors on this shape. succinctly's yq mode was reusing jq's strict typing here.

## Verification

Live-verified against real yq v4.53.3. The append is **asymmetric** — it only fires when the array is on the left:

```
$ echo 'null' | yq -o=json '[] + 99'
[99]
$ echo 'null' | yq -o=json '3 + [1,2]'
Error: !!seq () cannot be added to a !!int ()   # still errors, unchanged
```

Array+array (concat) and array+null/null+array (no-op) were already correct pre-fix and are covered here as regression guards. jq mode is untouched (gated on the new `EvalSemantics::ARRAY_PLUS_APPENDS` const).

## Code review fixes (round 2)

Mandatory `/code-review` (8 parallel finder agents + adversarial verification) surfaced two real, live-reproduced bugs, both fixed in the second commit:

- **Reachable panic**: `gsub(re; replacement; flags)`'s flags-concatenation helper assumed `arith_add` could only ever produce a `String`, an invariant this PR's new arm broke for an Array-typed `flags` value in yq mode (`unreachable!()` → exit 101). Now type-checks `flags` explicitly before the concat, independent of `arith_add`'s own semantics.
- **The fix didn't close #1119's own named motivating trigger**: `eval_update`'s scalar-slice no-op throwaway now binds `.` to `[]` (real yq's actual internal model) instead of cloning the scalar, closing `5 | .[0:1] += [1]` / `5 | .[0:1] |= keys` — the exact cases the issue's "Why this surfaced now" section names. Verified live against yq v4.53.3.
- Promoted the new arm's yq-only gate to a named `EvalSemantics` const (`ARRAY_PLUS_APPENDS`), matching the trait's existing convention (`ARRAY_MULTIPLY_MERGES`).
- Locked in `add()`'s consistent inheritance of array-append with an explicit test — `add` is documented as `[.[] | .]` folded with `+`, so this is intended, not scope creep (real yq has no `add`/`reduce` syntax to verify against).

Two **pre-existing, unrelated** bugs surfaced during review are filed as follow-ups rather than fixed here (both reproduce independently of this PR's own diff):

- #1142 — slice compound-assignment on a real array/string target silently corrupts data instead of real yq's no-op (`.a[0:2] += [99]` reproduces identically on `main`; this PR just makes it reachable via the far more common `+= 99` shape).
- #1143 — a `NumberLiteral`'s source-text spelling is lost when appended (`[] + 1e10` → `1e+10`), sharing root cause with the pre-existing `null`-passthrough arm's identical loss.

Fixes #1119

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] 17 new tests across `tests/yq_cli_tests.rs` / `tests/jq_cli_tests.rs`, covering the append semantics, the panic fix, the throwaway-switch fix, and `add()`'s consistent behavior