### PR TITLE
feat(jq): implement ?// alternative destructuring patterns

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -347,11 +347,11 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
         },
         Expr::AsPattern {
             expr,
-            pattern,
+            patterns,
             body,
         } => Expr::AsPattern {
             expr: Box::new(rewrite_namespaced_calls(*expr)),
-            pattern,
+            patterns,
             body: Box::new(rewrite_namespaced_calls(*body)),
         },
         Expr::StringInterpolation(parts) => {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23081,11 +23081,16 @@ fn eval_as_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // still resolves to `null`, not "undefined variable" (confirmed live
     // against jq 1.7.1: `. as [$a] ?// {$b} | [$a,$b]` on `[1]` gives
     // `[1,null]`). A no-op allocation when `patterns` has one element (the
-    // common, non-`?//` case).
+    // common, non-`?//` case). Deduped (found by review): two alternatives
+    // commonly share a name (`. as [$a] ?// {a: $a}`), and each duplicate
+    // would otherwise cost `try_pattern_alternatives` a wasted
+    // `substitute_var` body clone-and-walk per matched alternative.
     let mut all_var_names: Vec<String> = Vec::new();
     for pattern in patterns {
         collect_pattern_var_names(pattern, &mut all_var_names);
     }
+    all_var_names.sort_unstable();
+    all_var_names.dedup();
 
     let mut all_results: Vec<OwnedValue> = Vec::new();
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -738,9 +738,9 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Phase 9: Variables & Definitions
         Expr::AsPattern {
             expr,
-            pattern,
+            patterns,
             body,
-        } => eval_as_pattern::<W, S>(expr, pattern, body, value, optional),
+        } => eval_as_pattern::<W, S>(expr, patterns, body, value, optional),
         Expr::FuncDef {
             name,
             params,
@@ -13819,14 +13819,16 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
         // Phase 9: Variables & Definitions
         Expr::AsPattern {
             expr,
-            pattern,
+            patterns,
             body,
         } => {
-            // Check if any pattern variable shadows the var_name
-            let shadowed = pattern_binds_var(pattern, var_name);
+            // Shadowed if *any* alternative binds var_name -- the body's
+            // scope has to treat the name consistently across every
+            // alternative it might actually run under (#720).
+            let shadowed = patterns.iter().any(|p| pattern_binds_var(p, var_name));
             Expr::AsPattern {
                 expr: Box::new(substitute_var(expr, var_name, replacement)),
-                pattern: pattern.clone(),
+                patterns: patterns.clone(),
                 body: if shadowed {
                     body.clone()
                 } else {
@@ -23045,10 +23047,11 @@ fn pivot_objects<'a, W: Clone + AsRef<[u64]>>(items: &[OwnedValue]) -> QueryResu
 // Phase 9: Variables & Definitions
 // ============================================================================
 
-/// Evaluate destructuring pattern binding: `expr as {key: $var, ...} | body`.
+/// Evaluate destructuring pattern binding: `expr as {key: $var, ...} | body`,
+/// including `?//`-separated alternatives (#720).
 fn eval_as_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
-    pattern: &Pattern,
+    patterns: &[Pattern],
     body: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
@@ -23073,42 +23076,158 @@ fn eval_as_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Partial(vs, control) => (vs, Some(control)),
         };
 
+    // Every variable name any alternative might bind -- a var referenced in
+    // the body but bound only by an alternative that didn't end up matching
+    // still resolves to `null`, not "undefined variable" (confirmed live
+    // against jq 1.7.1: `. as [$a] ?// {$b} | [$a,$b]` on `[1]` gives
+    // `[1,null]`). A no-op allocation when `patterns` has one element (the
+    // common, non-`?//` case).
+    let mut all_var_names: Vec<String> = Vec::new();
+    for pattern in patterns {
+        collect_pattern_var_names(pattern, &mut all_var_names);
+    }
+
     let mut all_results: Vec<OwnedValue> = Vec::new();
 
     for bound_val in bound_values {
-        // Extract bindings from the pattern
-        let bindings = match extract_pattern_bindings(pattern, &bound_val) {
-            Ok(b) => b,
-            Err(e) => return e.into(),
-        };
-
-        // Substitute all bindings in the body
-        let mut substituted_body = body.clone();
-        for (var_name, var_value) in &bindings {
-            substituted_body = substitute_var(&substituted_body, var_name, var_value);
-        }
-
-        match eval_single::<W, S>(&substituted_body, value.clone(), optional).materialize_cursor() {
-            QueryResult::One(v) => all_results.push(to_owned(&v)),
-            QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => all_results.extend(vs.iter().map(to_owned)),
-            QueryResult::Owned(v) => all_results.push(v),
-            QueryResult::ManyOwned(vs) => all_results.extend(vs),
-            QueryResult::None => {}
-            // The outputs already produced no longer vanish (#400, #494).
-            QueryResult::Error(e) => return partial(all_results, Control::Error(e)),
-            QueryResult::Break(label) => return partial(all_results, Control::Break(label)),
-            QueryResult::Halt(code) => return partial(all_results, Control::Halt(code)),
-            QueryResult::Partial(vs, control) => {
+        match try_pattern_alternatives::<W, S>(
+            patterns,
+            &all_var_names,
+            body,
+            &bound_val,
+            &value,
+            optional,
+        ) {
+            Ok((vs, None)) => all_results.extend(vs),
+            Ok((vs, Some(control))) => {
                 all_results.extend(vs);
                 return partial(all_results, control);
             }
+            Err(e) => return e.into(),
         }
     }
 
     match bound_control {
         Some(control) => partial(all_results, control),
         None => owned_vec_to_result(all_results),
+    }
+}
+
+/// Try each `?//`-separated pattern alternative against `bound_val`, in
+/// order. The first alternative whose pattern matches *and* whose
+/// substituted body doesn't error wins. A pattern-match failure or a body
+/// `error(...)`/type error falls through to the next alternative; `break`,
+/// `halt`, and empty output do not (confirmed live: both propagate
+/// immediately, never retried). On the *last* alternative, either failure
+/// is the final outcome -- this degrades to exactly the pre-`?//` single-
+/// pattern behavior when `patterns` has one element.
+///
+/// A body error's own partial output (if the body is itself a generator,
+/// e.g. `(1, error("x"))`) is *not* discarded on fallthrough -- confirmed
+/// live: each tried alternative's own partial output before its error is
+/// kept, not just the winning alternative's (or the last one's, if none
+/// win) -- so the returned `Vec<OwnedValue>` accumulates across every
+/// alternative actually attempted, not just the final one.
+fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    patterns: &[Pattern],
+    all_var_names: &[String],
+    body: &Expr,
+    bound_val: &OwnedValue,
+    value: &StandardJson<'_, W>,
+    optional: bool,
+) -> Result<(Vec<OwnedValue>, Option<Control>), EvalError> {
+    let last_idx = patterns.len() - 1;
+    let mut carried: Vec<OwnedValue> = Vec::new();
+
+    for (i, pattern) in patterns.iter().enumerate() {
+        let is_last = i == last_idx;
+
+        let bindings = match extract_pattern_bindings(pattern, bound_val) {
+            Ok(b) => b,
+            Err(e) => {
+                if is_last {
+                    return Err(e);
+                }
+                continue;
+            }
+        };
+
+        let mut substituted_body = body.clone();
+        let mut bound_names: Vec<&str> = Vec::with_capacity(bindings.len());
+        for (var_name, var_value) in &bindings {
+            substituted_body = substitute_var(&substituted_body, var_name, var_value);
+            bound_names.push(var_name.as_str());
+        }
+        for var_name in all_var_names {
+            if !bound_names.contains(&var_name.as_str()) {
+                substituted_body = substitute_var(&substituted_body, var_name, &OwnedValue::Null);
+            }
+        }
+
+        match eval_single::<W, S>(&substituted_body, value.clone(), optional).materialize_cursor() {
+            QueryResult::One(v) => {
+                carried.push(to_owned(&v));
+                return Ok((carried, None));
+            }
+            QueryResult::OneCursor(_) => unreachable!(),
+            QueryResult::Many(vs) => {
+                carried.extend(vs.iter().map(to_owned));
+                return Ok((carried, None));
+            }
+            QueryResult::Owned(v) => {
+                carried.push(v);
+                return Ok((carried, None));
+            }
+            QueryResult::ManyOwned(vs) => {
+                carried.extend(vs);
+                return Ok((carried, None));
+            }
+            QueryResult::None => return Ok((carried, None)),
+            QueryResult::Error(e) => {
+                if is_last {
+                    return Ok((carried, Some(Control::Error(e))));
+                }
+                continue;
+            }
+            QueryResult::Break(label) => return Ok((carried, Some(Control::Break(label)))),
+            QueryResult::Halt(code) => return Ok((carried, Some(Control::Halt(code)))),
+            QueryResult::Partial(vs, control) => match control {
+                Control::Error(e) => {
+                    carried.extend(vs);
+                    if is_last {
+                        return Ok((carried, Some(Control::Error(e))));
+                    }
+                    continue;
+                }
+                Control::Break(_) | Control::Halt(_) => {
+                    carried.extend(vs);
+                    return Ok((carried, Some(control)));
+                }
+            },
+        }
+    }
+
+    unreachable!(
+        "patterns is always non-empty by construction (the parser never \
+         builds an empty AsPattern), and every loop iteration above \
+         returns on its `is_last` pass"
+    )
+}
+
+/// Collect every variable name a pattern would bind, recursively.
+fn collect_pattern_var_names(pattern: &Pattern, names: &mut Vec<String>) {
+    match pattern {
+        Pattern::Var(name) => names.push(name.clone()),
+        Pattern::Object(entries) => {
+            for entry in entries {
+                collect_pattern_var_names(&entry.pattern, names);
+            }
+        }
+        Pattern::Array(patterns) => {
+            for p in patterns {
+                collect_pattern_var_names(p, names);
+            }
+        }
     }
 }
 
@@ -23391,11 +23510,11 @@ fn expand_func_calls(expr: &Expr, func_name: &str, params: &[String], body: &Exp
         },
         Expr::AsPattern {
             expr,
-            pattern,
+            patterns,
             body: pattern_body,
         } => Expr::AsPattern {
             expr: Box::new(expand_func_calls(expr, func_name, params, body)),
-            pattern: pattern.clone(),
+            patterns: patterns.clone(),
             body: Box::new(expand_func_calls(pattern_body, func_name, params, body)),
         },
         Expr::FuncDef {
@@ -23676,13 +23795,13 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
         },
         Expr::AsPattern {
             expr,
-            pattern,
+            patterns,
             body,
         } => {
-            let shadowed = pattern_binds_var(pattern, param);
+            let shadowed = patterns.iter().any(|p| pattern_binds_var(p, param));
             Expr::AsPattern {
                 expr: Box::new(substitute_func_param(expr, param, arg)),
-                pattern: pattern.clone(),
+                patterns: patterns.clone(),
                 body: if shadowed {
                     body.clone()
                 } else {

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -266,12 +266,19 @@ pub enum Expr {
 
     // Phase 9: Variables & Definitions
     /// Destructuring variable binding: `. as {name: $n, age: $a} | ...`
-    /// or `. as [$first, $second] | ...`
+    /// or `. as [$first, $second] | ...`, optionally with `?//`-separated
+    /// alternatives (`. as [$a] ?// {$a} | ...`): the first alternative
+    /// whose pattern matches *and* whose body doesn't error is used: a
+    /// pattern-match failure or a body-evaluation error (not `break`/
+    /// `halt`/empty output) falls through to the next alternative, except
+    /// on the last one, where either failure propagates normally. A single
+    /// pattern (the common case) is just a one-element `patterns`.
     AsPattern {
         /// Expression to evaluate and destructure
         expr: Box<Self>,
-        /// Pattern to match against
-        pattern: Pattern,
+        /// Pattern alternatives to try in order (`?//`-separated); usually
+        /// just one
+        patterns: Vec<Pattern>,
         /// Body expression where the variables are in scope
         body: Box<Self>,
     },

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3924,41 +3924,58 @@ impl<'a> Parser<'a> {
         Ok(expr)
     }
 
-    /// Parse the pattern part of an `as` binding.
+    /// Parse the pattern part of an `as` binding, including any
+    /// `?//`-separated alternatives (`. as [$a] ?// {$a} | ...`).
     /// Called after "as" has been consumed.
     fn parse_as_pattern(&mut self, expr: Expr) -> Result<Expr, ParseError> {
-        match self.peek() {
-            Some('$') => {
-                // Simple variable binding: `$var`
+        let first_pattern = self.parse_pattern()?;
+        self.skip_ws();
+
+        // `?//` is real jq syntax (since jq 1.6) but real yq's own parser
+        // rejects it outright ("lexer: invalid input text", confirmed live
+        // against yq v4.53.3) -- gated to jq mode only so yq mode keeps
+        // erroring on it the same way, rather than silently accepting
+        // broader syntax than the oracle it's meant to match.
+        if self.mode == ParserMode::Jq && self.peek_str(3) == "?//" {
+            let mut patterns = vec![first_pattern];
+            while self.peek_str(3) == "?//" {
                 self.next();
-                let var = self.parse_ident()?;
+                self.next();
+                self.next();
                 self.skip_ws();
-                self.expect('|')?;
+                patterns.push(self.parse_pattern()?);
                 self.skip_ws();
-                let body = self.parse_expr()?;
-                Ok(Expr::As {
-                    expr: Box::new(expr),
-                    var,
-                    body: Box::new(body),
-                })
             }
-            Some('{' | '[') => {
-                // Pattern destructuring: `{key: $var}` or `[$first, $second]`
-                let pattern = self.parse_pattern()?;
-                self.skip_ws();
-                self.expect('|')?;
-                self.skip_ws();
-                let body = self.parse_expr()?;
-                Ok(Expr::AsPattern {
-                    expr: Box::new(expr),
-                    pattern,
-                    body: Box::new(body),
-                })
-            }
-            _ => Err(ParseError::new(
-                "expected '$var' or pattern after 'as'",
-                self.pos,
-            )),
+            self.expect('|')?;
+            self.skip_ws();
+            let body = self.parse_expr()?;
+            return Ok(Expr::AsPattern {
+                expr: Box::new(expr),
+                patterns,
+                body: Box::new(body),
+            });
+        }
+
+        self.expect('|')?;
+        self.skip_ws();
+        let body = self.parse_expr()?;
+
+        // No `?//` alternatives: keep the simpler, pre-existing `Expr::As`
+        // shape for a bare `$var` pattern (every other `Expr::As` call site
+        // in this file is unaffected by `?//`'s addition), and
+        // `Expr::AsPattern` with a single-element `patterns` for `{...}`/
+        // `[...]`, exactly as before this feature existed.
+        match first_pattern {
+            Pattern::Var(var) => Ok(Expr::As {
+                expr: Box::new(expr),
+                var,
+                body: Box::new(body),
+            }),
+            other => Ok(Expr::AsPattern {
+                expr: Box::new(expr),
+                patterns: vec![other],
+                body: Box::new(body),
+            }),
         }
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9335,6 +9335,184 @@ fn test_as_pattern_propagates_halt_after_partial_body_output() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// #720: `?//` alternative destructuring patterns. All cases live-verified
+// against jq 1.7.1.
+// =============================================================================
+
+/// The issue's own repro: a pattern-match failure (array pattern against a
+/// non-array input) falls through to the next alternative.
+#[test]
+fn test_as_pattern_alt_falls_through_on_pattern_mismatch_720() -> Result<()> {
+    let (stdout, code) = run_jq_stdin(". as [$a] ?// {a: $a} | $a", "[1]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// A 3-way alternation, the last (bare-var, always-matches) alternative
+/// used as a catch-all fallback.
+#[test]
+fn test_as_pattern_alt_three_way_chain_720() -> Result<()> {
+    let (stdout, code) = run_jq_stdin(". as [$a] ?// {a: $a} ?// $a | $a", r#"{"a":5}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "5");
+    Ok(())
+}
+
+/// An error raised in the matched branch's *body* (not the pattern match
+/// itself) also falls through, retrying under the next alternative's
+/// bindings -- confirmed live: `jq -c '. as {a:$a} ?// $a | $a + "x"'` on
+/// `{"a":1}` gives `object ({"a":1}) and string ("x") cannot be added`,
+/// meaning the second alternative (bare `$a`, binding the whole input) is
+/// what actually produced the surfaced error, not the first.
+#[test]
+fn test_as_pattern_alt_falls_through_on_body_error_720() -> Result<()> {
+    let (_, stderr, code) = run_jq_full(
+        &["-c", r#". as {a: $a} ?// $a | $a + "x""#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains(r#"object ({"a":1}) and string ("x") cannot be added"#),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// The *last* alternative's own error propagates normally once matched --
+/// no further fallback exists.
+#[test]
+fn test_as_pattern_alt_last_alternative_error_propagates_720() -> Result<()> {
+    let (_, stderr, code) = run_jq_full(
+        &["-c", r#". as $a ?// {a: $a} | $a + "x""#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains(r#"number (1) and string ("x") cannot be added"#),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// Every alternative's pattern fails to match -> the last alternative's
+/// own error is the final one.
+#[test]
+fn test_as_pattern_alt_all_mismatch_errors_720() -> Result<()> {
+    let (_, stderr, code) = run_jq_full(&["-c", ". as [$a] ?// {a: $a} | $a"], Some("5"))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains(r#"Cannot index number with string "a""#),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// A variable bound only by a *non-matching* alternative still resolves to
+/// `null` in the body, rather than an "undefined variable" error --
+/// confirmed live against jq 1.7.1.
+#[test]
+fn test_as_pattern_alt_unbound_var_from_other_alt_is_null_720() -> Result<()> {
+    let (stdout, code) = run_jq_stdin(". as [$a] ?// {b: $b} | [$a, $b]", "[1]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[1,null]");
+
+    let (stdout, code) = run_jq_stdin(". as [$a] ?// {b: $b} | [$a, $b]", r#"{"b":9}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[null,9]");
+    Ok(())
+}
+
+/// `?//`'s bind expression can still be a generator -- each output is
+/// independently destructured and fanned out, matching `as`'s existing
+/// (non-`?//`) generator behavior.
+#[test]
+fn test_as_pattern_alt_bind_expr_generator_fans_out_720() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-cn", "(1,2) as [$a] ?// $a | $a"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "1\n2\n");
+    Ok(())
+}
+
+/// `break`/`halt`/empty output inside the body do *not* trigger
+/// fallthrough -- only a genuine `error(...)`/type error does. Confirmed
+/// live: `break` propagates cleanly with no output (not caught as a
+/// pattern/body failure), and `empty` is genuinely empty output, not an
+/// implicit retry signal.
+#[test]
+fn test_as_pattern_alt_break_and_empty_are_not_fallthrough_720() -> Result<()> {
+    let (stdout, code) = run_jq_stdin(
+        "label $out | (. as {a: $a} ?// $a | (break $out))",
+        r#"{"a":1}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "");
+
+    let (stdout, code) = run_jq_stdin("[. as {a: $a} ?// $a | empty]", r#"{"a":1}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[]");
+    Ok(())
+}
+
+/// A body error's own partial output before it errors is *not* discarded
+/// on fallthrough -- each alternative actually tried contributes whatever
+/// it managed to produce before failing, not just the last one. Confirmed
+/// live: two failing alternatives (a generator body producing `1` then
+/// erroring, tried under two different bindings) each contribute their own
+/// `1` to the final output stream before the last alternative's error
+/// terminates it.
+#[test]
+fn test_as_pattern_alt_partial_output_survives_fallthrough_720() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#". as {a: $a} ?// $a | (1, error("boom"))"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_ne!(code, 0);
+    assert_eq!(stdout, "1\n1\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// Without `?//`, a bare `$var`/single-pattern `as` binding is completely
+/// unaffected by this feature's addition -- same AST shape (`Expr::As`),
+/// same behavior as before.
+#[test]
+fn test_as_pattern_no_alt_unaffected_720() -> Result<()> {
+    let (stdout, code) = run_jq_stdin(". as $a | $a", "5", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "5");
+
+    let (stdout, code) = run_jq_stdin(". as [$a,$b] | $a + $b", "[1,2]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "3");
+    Ok(())
+}
+
+/// yq mode does not support `?//` at all -- real yq's own parser rejects
+/// it ("lexer: invalid input text", confirmed live against yq v4.53.3) --
+/// so succinctly's shared jq/yq parser must keep erroring on it in yq mode
+/// too, rather than silently accepting broader syntax than the oracle.
+#[test]
+fn test_as_pattern_alt_rejected_in_yq_mode_720() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("yq")
+        .arg(". as [$a] ?// {a: $a} | $a")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    child.stdin.take().unwrap().write_all(b"a: 5\n")?;
+    let output = child.wait_with_output()?;
+    assert_ne!(
+        output.status.code().unwrap_or(-1),
+        0,
+        "yq mode must reject ?// as a parse error, matching real yq"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_func_def_expand_recurses_through_halt_stderr_and_halt_error_builtins() -> Result<()> {
     // `expand_func_calls_in_builtin`'s `Halt`/`Stderr`/`HaltError`/

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9344,9 +9344,34 @@ fn test_as_pattern_propagates_halt_after_partial_body_output() -> Result<()> {
 /// non-array input) falls through to the next alternative.
 #[test]
 fn test_as_pattern_alt_falls_through_on_pattern_mismatch_720() -> Result<()> {
-    let (stdout, code) = run_jq_stdin(". as [$a] ?// {a: $a} | $a", "[1]", &["-c"])?;
+    let (stdout, _, code) = run_jq_full(&["-c", ". as [$a] ?// {a: $a} | $a"], Some("[1]"))?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// A body that references `.` (the original, cursor-backed document) rather
+/// than only substituted variables -- exercises `try_pattern_alternatives`'s
+/// `QueryResult::One`/`Many` arms specifically, which a body built entirely
+/// from substituted-literal variable references (like the test above) never
+/// reaches.
+#[test]
+fn test_as_pattern_alt_body_references_original_document_720() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ". as [$a] ?// {a: $a} | ."], Some("[1]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[1]");
+    Ok(())
+}
+
+/// Same idea, but the body also fans out (`.[]` on the original,
+/// cursor-backed document) -- exercises the `QueryResult::Many` arm
+/// specifically, distinct from the single-value `QueryResult::One` case
+/// above.
+#[test]
+fn test_as_pattern_alt_body_fans_out_over_original_document_720() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ". as [$a] ?// {a: $a} | .[]"], Some("[1,2]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "1\n2\n");
     Ok(())
 }
 
@@ -9354,7 +9379,10 @@ fn test_as_pattern_alt_falls_through_on_pattern_mismatch_720() -> Result<()> {
 /// used as a catch-all fallback.
 #[test]
 fn test_as_pattern_alt_three_way_chain_720() -> Result<()> {
-    let (stdout, code) = run_jq_stdin(". as [$a] ?// {a: $a} ?// $a | $a", r#"{"a":5}"#, &["-c"])?;
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ". as [$a] ?// {a: $a} ?// $a | $a"],
+        Some(r#"{"a":5}"#),
+    )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "5");
     Ok(())
@@ -9414,11 +9442,14 @@ fn test_as_pattern_alt_all_mismatch_errors_720() -> Result<()> {
 /// confirmed live against jq 1.7.1.
 #[test]
 fn test_as_pattern_alt_unbound_var_from_other_alt_is_null_720() -> Result<()> {
-    let (stdout, code) = run_jq_stdin(". as [$a] ?// {b: $b} | [$a, $b]", "[1]", &["-c"])?;
+    let (stdout, _, code) = run_jq_full(&["-c", ". as [$a] ?// {b: $b} | [$a, $b]"], Some("[1]"))?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "[1,null]");
 
-    let (stdout, code) = run_jq_stdin(". as [$a] ?// {b: $b} | [$a, $b]", r#"{"b":9}"#, &["-c"])?;
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ". as [$a] ?// {b: $b} | [$a, $b]"],
+        Some(r#"{"b":9}"#),
+    )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "[null,9]");
     Ok(())
@@ -9442,15 +9473,15 @@ fn test_as_pattern_alt_bind_expr_generator_fans_out_720() -> Result<()> {
 /// implicit retry signal.
 #[test]
 fn test_as_pattern_alt_break_and_empty_are_not_fallthrough_720() -> Result<()> {
-    let (stdout, code) = run_jq_stdin(
-        "label $out | (. as {a: $a} ?// $a | (break $out))",
-        r#"{"a":1}"#,
-        &["-c"],
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | (. as {a: $a} ?// $a | (break $out))"],
+        Some(r#"{"a":1}"#),
     )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "");
 
-    let (stdout, code) = run_jq_stdin("[. as {a: $a} ?// $a | empty]", r#"{"a":1}"#, &["-c"])?;
+    let (stdout, _, code) =
+        run_jq_full(&["-c", "[. as {a: $a} ?// $a | empty]"], Some(r#"{"a":1}"#))?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "[]");
     Ok(())
@@ -9480,11 +9511,11 @@ fn test_as_pattern_alt_partial_output_survives_fallthrough_720() -> Result<()> {
 /// same behavior as before.
 #[test]
 fn test_as_pattern_no_alt_unaffected_720() -> Result<()> {
-    let (stdout, code) = run_jq_stdin(". as $a | $a", "5", &["-c"])?;
+    let (stdout, _, code) = run_jq_full(&["-c", ". as $a | $a"], Some("5"))?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "5");
 
-    let (stdout, code) = run_jq_stdin(". as [$a,$b] | $a + $b", "[1,2]", &["-c"])?;
+    let (stdout, _, code) = run_jq_full(&["-c", ". as [$a,$b] | $a + $b"], Some("[1,2]"))?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "3");
     Ok(())
@@ -9510,6 +9541,30 @@ fn test_as_pattern_alt_rejected_in_yq_mode_720() -> Result<()> {
         0,
         "yq mode must reject ?// as a parse error, matching real yq"
     );
+    Ok(())
+}
+
+/// `substitute_func_param`'s `Expr::AsPattern` arm: a `$`-parameter used
+/// directly as a `?//` binding's own bind expression, inside a
+/// parameterized function body.
+#[test]
+fn test_as_pattern_alt_substituted_as_func_param_bind_expr_720() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "def f($x): $x as [$a] ?// $a | $a; f(5)"],
+        Some("1"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "5");
+    Ok(())
+}
+
+/// `expand_func_calls`'s `Expr::AsPattern` arm: a call to a zero-arg
+/// function reached only by recursing into a `?//` binding's body.
+#[test]
+fn test_as_pattern_alt_func_call_inside_body_expanded_720() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "def f: 1; (. as [$a] ?// $a | f)"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Implements jq's `?//` operator (since jq 1.6): `. as [$a] ?// {a: $a} | ...` lets a filter try multiple destructuring shapes against the same input, falling through to the next alternative on either a pattern-match failure or a body-evaluation error.
- `Expr::AsPattern`'s `pattern: Pattern` field becomes `patterns: Vec<Pattern>`. The pre-existing bare-`$var` `Expr::As` shape is untouched — the parser still produces it whenever no `?//` follows a plain variable pattern, so this is purely additive for the common non-`?//` case.
- Every AST-rewrite pass touching `AsPattern` (`substitute_var`, `expand_func_calls`, `substitute_func_param`, `jq_runner`'s namespaced-call rewrite) updated for the field rename; "shadowed" now means "any alternative binds this name."
- Gated to jq mode only: real yq's own parser rejects `?//` outright, confirmed live against yq v4.53.3 — succinctly's shared parser keeps erroring on it in yq mode too, rather than silently accepting broader syntax than the oracle.

## Semantics (all live-verified against jq 1.7.1)
- First alternative whose pattern matches *and* whose body doesn't error wins.
- A pattern-match failure or a body `error(...)`/type error falls through to the next alternative (retried from scratch — the whole body re-runs under the next alternative's bindings, not resumed).
- `break`, `halt`, and empty output do **not** trigger fallthrough — only a genuine error does.
- A variable bound only by a non-matching alternative resolves to `null` in the body, not an "undefined variable" error.
- The bind expression can be a generator; each output is independently destructured and fanned out.
- A body error's own partial output (if the body is itself a generator) is not discarded on fallthrough — each alternative actually tried contributes whatever it produced before failing.

## Deliberately out of scope (filed as follow-ups)
- #1139 — the `{$a}` object-pattern shorthand (implicit key from var name) isn't parsed at all; pre-existing, confirmed on `main`'s own binary, unrelated to `?//`.

Fixes #720

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green; two unrelated flaky tests confirmed passing in isolation)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (NEON YAML backend)
- [x] `cargo check --no-default-features` (no_std)
- [x] Verified against the pinned real `jq` binary across the full semantic matrix; verified yq mode correctly rejects `?//`
- [x] Patch coverage: 100% (18/18 new lines)