### PR TITLE
fix(jq): yq join's separator uses numeric_display_string, not to_json_yq

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4266,10 +4266,36 @@ fn yq_join_element_part(elem: OwnedValue) -> String {
         // special case is instead handled at the call site, on the live
         // cursor, before that collapse ever runs.
         OwnedValue::Null | OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
-        // `to_json_yq()`, not `to_json()` (#1030 code review): this function
-        // is only ever reached from `builtin_join`'s `S::TAG == EvalTag::Yq`
-        // branch, so a scientific-notation literal here must echo verbatim
-        // too, not get jq-reformatted.
+        // Int/Float/NumberLiteral: `numeric_display_string`, not
+        // `to_json_yq()` (#1124) -- `to_json_yq()`'s `Float` formatting
+        // deliberately forces a decimal point (`format_float_with_fraction`,
+        // #953) for JSON/YAML *structural* output round-trip fidelity, but a
+        // joined string isn't structural output. `NumberLiteral`'s verbatim
+        // source-text echo is unaffected either way, since
+        // `numeric_display_string` reaches the same `real_output_finite_literal`
+        // call `to_json_yq()` used for that case.
+        //
+        // This still doesn't fully close #1124's own repro
+        // (`(2.0/2) | [.] | join(",")` still gives `"1.0"`, not real yq's
+        // `"1"`): `builtin_join`'s array branch only ever sees a cursor-backed
+        // element, and a *constructed* array reaches that cursor by
+        // round-tripping through `to_json_for_reindex` first, which bakes the
+        // decimal point into synthesized `NumberLiteral` source text
+        // indistinguishable from a genuine document literal -- this arm never
+        // actually receives a bare `OwnedValue::Float` for that case. Tracked
+        // separately as #1144, since fixing it needs either tagging a
+        // reindexed `NumberLiteral` as non-document-sourced or a cursor-free
+        // path for constructed arrays, not a change here. This arm still has
+        // real, confirmed effect on [`yq_join_separator`]'s sibling case below
+        // (`sep_expr` evaluates directly to an owned value, with no cursor
+        // round-trip in between) and on any element that genuinely reaches
+        // `join` as a bare computed `Float` some other way.
+        other @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
+            numeric_display_string::<YqSemantics>(&other)
+        }
+        // Bool is unaffected either way (`to_json_yq()` and
+        // `numeric_display_string` agree on `"true"`/`"false"`); kept on
+        // `to_json_yq()` since it's not itself numeric-formatting-related.
         other => other.to_json_yq(),
     }
 }
@@ -4294,6 +4320,13 @@ fn yq_join_separator(sep: OwnedValue) -> String {
         // `"1{}2"` in real yq, not `"12"`.
         OwnedValue::Object(ref m) if m.is_empty() => "{}".to_string(),
         OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
+        // `numeric_display_string`, not `to_json_yq()` (#1124): same
+        // reasoning as `yq_join_element_part` above -- confirmed live,
+        // `[1,2] | join(2.0/2)` is `"112"` (separator `"1"`) in real yq, not
+        // `"11.02"`.
+        other @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
+            numeric_display_string::<YqSemantics>(&other)
+        }
         // `to_json_yq()` (#1030 code review): same reasoning as
         // `yq_join_element_part` above -- this function is yq-only.
         other => other.to_json_yq(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4226,8 +4226,10 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// object) becomes an empty-string part -- `[1,null,2] | join(",")` is
 /// `"1,,2"`, and `[[1,2],"a"] | join(",")` is `",a"`, not `"[1,2],a"` (real
 /// yq never JSON-encodes a nested container into a join part the way it does
-/// for other unsupported operations). Everything else (number, boolean)
-/// renders via its JSON text, same as jq's own element rule.
+/// for other unsupported operations). A number renders via
+/// `numeric_display_string` (`tostring`'s own convention, #1124), not
+/// `to_json_yq()`'s structural-output rules; boolean still renders via its
+/// JSON text.
 ///
 /// Takes `elem` by value (moved from [`to_owned_key_shape`] at the call
 /// site, not [`to_owned`]) so a container element's contents are never
@@ -4251,8 +4253,58 @@ fn yq_join_nonfinite_part(value: &OwnedValue) -> Option<String> {
     }
 }
 
+/// Stringifies a finite Int/Float/NumberLiteral `join` element or separator
+/// for yq mode, shared by [`yq_join_element_part`]/[`yq_join_separator`] the
+/// same way [`yq_join_nonfinite_part`] above already shares the NaN/Infinity
+/// case (#1124 review: this arm was initially hand-copied at both call
+/// sites, exactly the #106 "duplicated predicates diverge silently" pattern
+/// `yq_join_nonfinite_part`'s own doc comment already names).
+///
+/// `numeric_display_string`, not `to_json_yq()`: a joined string isn't
+/// structural output, so it shouldn't follow `to_json_yq()`'s structural
+/// rules, which `numeric_display_string`'s `Float` case diverges from in two
+/// confirmed ways (live-verified against yq v4.53.3): it never forces a
+/// trailing `.0` (`format_float_with_fraction`, #953, exists specifically
+/// for round-trip type fidelity, which a join part doesn't need -- `2.0/2`
+/// is `"1"`, not `"1.0"`), and it applies yq's own scientific-notation
+/// magnitude threshold instead of always staying decimal (`1e10*2` is
+/// `"2e+10"`, not `"20000000000.0"`). `NumberLiteral`'s verbatim source-text
+/// echo is unaffected by either change, since `numeric_display_string`
+/// reaches the same `real_output_finite_literal` call `to_json_yq()` used
+/// for that case, and `Int` formatting (`n.to_string()`, matching
+/// `to_json_yq()`'s `format!("{n}")` byte-for-byte) is likewise unaffected.
+///
+/// This still doesn't fully close #1124's own repro (`(2.0/2) | [.] |
+/// join(",")` still gives `"1.0"`, not real yq's `"1"`): `builtin_join`'s
+/// array branch only ever sees a cursor-backed element, and a *constructed*
+/// array reaches that cursor by round-tripping through `to_json_for_reindex`
+/// first, which bakes the decimal point into synthesized `NumberLiteral`
+/// source text indistinguishable from a genuine document literal -- this
+/// function never actually receives a bare `OwnedValue::Float` for that
+/// case. Tracked separately as #1144 (broadened to cover `@csv`/`@tsv`/
+/// string interpolation too, which share the identical root cause), since
+/// fixing it needs either tagging a reindexed `NumberLiteral` as
+/// non-document-sourced or a cursor-free path for constructed arrays, not a
+/// change here. This function still has real, confirmed effect on
+/// [`yq_join_separator`]'s case (`sep_expr` evaluates directly to an owned
+/// value, with no cursor round-trip in between) and on any element that
+/// genuinely reaches `join` as a bare computed `Float` some other way (e.g.
+/// a document-sourced `.nan`/`.inf` scalar, which `from_number_bytes`
+/// likewise degrades to a bare `Float`, not a `NumberLiteral`).
+fn yq_join_numeric_part(value: &OwnedValue) -> Option<String> {
+    match value {
+        OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+            Some(numeric_display_string::<YqSemantics>(value))
+        }
+        _ => None,
+    }
+}
+
 fn yq_join_element_part(elem: OwnedValue) -> String {
     if let Some(s) = yq_join_nonfinite_part(&elem) {
+        return s;
+    }
+    if let Some(s) = yq_join_numeric_part(&elem) {
         return s;
     }
     match elem {
@@ -4266,33 +4318,6 @@ fn yq_join_element_part(elem: OwnedValue) -> String {
         // special case is instead handled at the call site, on the live
         // cursor, before that collapse ever runs.
         OwnedValue::Null | OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
-        // Int/Float/NumberLiteral: `numeric_display_string`, not
-        // `to_json_yq()` (#1124) -- `to_json_yq()`'s `Float` formatting
-        // deliberately forces a decimal point (`format_float_with_fraction`,
-        // #953) for JSON/YAML *structural* output round-trip fidelity, but a
-        // joined string isn't structural output. `NumberLiteral`'s verbatim
-        // source-text echo is unaffected either way, since
-        // `numeric_display_string` reaches the same `real_output_finite_literal`
-        // call `to_json_yq()` used for that case.
-        //
-        // This still doesn't fully close #1124's own repro
-        // (`(2.0/2) | [.] | join(",")` still gives `"1.0"`, not real yq's
-        // `"1"`): `builtin_join`'s array branch only ever sees a cursor-backed
-        // element, and a *constructed* array reaches that cursor by
-        // round-tripping through `to_json_for_reindex` first, which bakes the
-        // decimal point into synthesized `NumberLiteral` source text
-        // indistinguishable from a genuine document literal -- this arm never
-        // actually receives a bare `OwnedValue::Float` for that case. Tracked
-        // separately as #1144, since fixing it needs either tagging a
-        // reindexed `NumberLiteral` as non-document-sourced or a cursor-free
-        // path for constructed arrays, not a change here. This arm still has
-        // real, confirmed effect on [`yq_join_separator`]'s sibling case below
-        // (`sep_expr` evaluates directly to an owned value, with no cursor
-        // round-trip in between) and on any element that genuinely reaches
-        // `join` as a bare computed `Float` some other way.
-        other @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
-            numeric_display_string::<YqSemantics>(&other)
-        }
         // Bool is unaffected either way (`to_json_yq()` and
         // `numeric_display_string` agree on `"true"`/`"false"`); kept on
         // `to_json_yq()` since it's not itself numeric-formatting-related.
@@ -4302,15 +4327,20 @@ fn yq_join_element_part(elem: OwnedValue) -> String {
 
 /// Stringifies `join`'s separator for yq mode (#1041): a string passes
 /// through, a container (array or object) becomes empty (no separator
-/// inserted at all). Everything else -- including `null`, unlike an
-/// element's own `null` handling above -- renders via its JSON text:
-/// `["a","b"] | join(null)` is `"anullb"`, the literal text "null" used as a
-/// real separator, not a no-op (confirmed live; #1003's PR #1036 review
-/// flagged this element/separator asymmetry as a real, separate divergence
-/// from jq mode, where `null` is a no-op only via `+`'s own left-identity
-/// rule, not something `join` special-cases).
+/// inserted at all). A number renders via `numeric_display_string`
+/// (`tostring`'s own convention, #1124; see [`yq_join_numeric_part`]).
+/// Everything else -- including `null`, unlike an element's own `null`
+/// handling above -- renders via its JSON text: `["a","b"] | join(null)` is
+/// `"anullb"`, the literal text "null" used as a real separator, not a no-op
+/// (confirmed live; #1003's PR #1036 review flagged this element/separator
+/// asymmetry as a real, separate divergence from jq mode, where `null` is a
+/// no-op only via `+`'s own left-identity rule, not something `join`
+/// special-cases).
 fn yq_join_separator(sep: OwnedValue) -> String {
     if let Some(s) = yq_join_nonfinite_part(&sep) {
+        return s;
+    }
+    if let Some(s) = yq_join_numeric_part(&sep) {
         return s;
     }
     match sep {
@@ -4320,13 +4350,6 @@ fn yq_join_separator(sep: OwnedValue) -> String {
         // `"1{}2"` in real yq, not `"12"`.
         OwnedValue::Object(ref m) if m.is_empty() => "{}".to_string(),
         OwnedValue::Array(_) | OwnedValue::Object(_) => String::new(),
-        // `numeric_display_string`, not `to_json_yq()` (#1124): same
-        // reasoning as `yq_join_element_part` above -- confirmed live,
-        // `[1,2] | join(2.0/2)` is `"112"` (separator `"1"`) in real yq, not
-        // `"11.02"`.
-        other @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
-            numeric_display_string::<YqSemantics>(&other)
-        }
         // `to_json_yq()` (#1030 code review): same reasoning as
         // `yq_join_element_part` above -- this function is yq-only.
         other => other.to_json_yq(),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12522,6 +12522,52 @@ fn test_yq_join_separator_computed_float_matches_tostring_1124() -> Result<()> {
     Ok(())
 }
 
+/// #1124: `numeric_display_string`'s `Float` case also drops `to_json_yq()`'s
+/// "never use scientific notation" rule, applying yq's own magnitude
+/// threshold instead -- confirmed live, real yq v4.53.3 gives `"12e+102"`
+/// (separator `"2e+10"`), not `"120000000000.02"`.
+#[test]
+fn test_yq_join_separator_scientific_notation_threshold_1124() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r"join(1e10 * 2)", "[1, 2]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "12e+102");
+    Ok(())
+}
+
+/// #1124: negative zero must lose its forced `.0` too, not just positive
+/// whole numbers -- confirmed live, real yq v4.53.3 gives `"1-02"`
+/// (separator `"-0"`), not `"1-0.02"`.
+#[test]
+fn test_yq_join_separator_negative_zero_1124() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r"join(-0.0 * 1)", "[1, 2]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1-02");
+    Ok(())
+}
+
+/// #1124: a fractional (non-whole-number) computed float was already
+/// correct before this fix (no decimal point to force either way) --
+/// pinned so a future regression in the `numeric_display_string` swap would
+/// still be caught. Confirmed live against real yq v4.53.3.
+#[test]
+fn test_yq_join_separator_fractional_float_unaffected_1124() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r"join(2.0 / 3)", "[1, 2]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "10.66666666666666662");
+    Ok(())
+}
+
+/// #1124: a genuinely computed `OwnedValue::Int` (not the `NumberLiteral`
+/// shape a bare query literal like `join(1)` takes) separator was already
+/// correct -- pinned for the same reason as the fractional-float case above.
+#[test]
+fn test_yq_join_separator_computed_int_unaffected_1124() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r"join(1 + 1)", "[1, 2]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "122");
+    Ok(())
+}
+
 /// #1124 (partial fix, tracked further as #1144): `yq_join_element_part`'s
 /// equivalent catch-all was fixed the same way as `yq_join_separator`'s
 /// above, but a *constructed* array's computed-float element still doesn't

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12509,6 +12509,39 @@ fn test_yq_join_preserves_exponent_literal_in_separator_1030() -> Result<()> {
     Ok(())
 }
 
+/// #1124: `yq_join_separator`'s catch-all used `to_json_yq()`, whose `Float`
+/// formatting deliberately forces a decimal point for JSON/YAML *structural*
+/// output round-trip fidelity (#953) -- wrong for a join separator, which
+/// isn't structural output. Confirmed live: real yq v4.53.3 gives `"112"`
+/// (separator `"1"`) for this exact filter, not `"11.02"`.
+#[test]
+fn test_yq_join_separator_computed_float_matches_tostring_1124() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r"join(2.0 / 2)", "[1, 2]\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "112");
+    Ok(())
+}
+
+/// #1124 (partial fix, tracked further as #1144): `yq_join_element_part`'s
+/// equivalent catch-all was fixed the same way as `yq_join_separator`'s
+/// above, but a *constructed* array's computed-float element still doesn't
+/// reach real yq's `"1"` answer -- `builtin_join`'s array branch only ever
+/// receives a cursor-backed element, and reaching that cursor for a
+/// constructed array requires a `to_json_for_reindex` round-trip that bakes
+/// the decimal point into synthesized `NumberLiteral` source text
+/// indistinguishable from a genuine document literal, so this fix's
+/// `numeric_display_string` call never actually sees a bare `Float` here.
+/// Pinned as a known, separately-tracked gap rather than silently
+/// unasserted -- if #1144 closes this, this assertion should change to
+/// `"1"` and the doc comment above should be updated to match.
+#[test]
+fn test_yq_join_element_computed_float_known_gap_1124() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(r#"(2.0 / 2) | [.] | join(",")"#, "null\n", &["-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1.0");
+    Ok(())
+}
+
 #[test]
 fn test_yq_array_wrapped_overflow_int_keeps_decimal_point_953() -> Result<()> {
     // #953's exact repro: `.a` alone streams straight from the YAML cursor


### PR DESCRIPTION
## Summary

- `yq_join_separator`'s catch-all arm reached for `to_json_yq()`, whose `Float` formatting deliberately forces a decimal point for JSON/YAML *structural* round-trip fidelity (#953) — wrong for a join separator, which isn't structural output. Now routes Int/Float/NumberLiteral through `numeric_display_string`, matching real yq's own `tostring`/`@urid` stringification. Live-verified against yq v4.53.3: `[1,2] | join(2.0 / 2)` now gives `"112"`, matching the oracle (previously `"11.02"`).
- `yq_join_element_part` got the identical fix, but its real-world effect is currently limited: `builtin_join`'s array branch only ever receives a cursor-backed element, and a *constructed* array (`[...]`/`map`) reaches that cursor via a `to_json_for_reindex` round-trip that bakes the decimal point into synthesized `NumberLiteral` source text — indistinguishable from a genuine document literal by the time it reaches this function. So `(2.0 / 2) | [.] | join(",")` still gives `"1.0"` instead of real yq's `"1"`. This is pinned with a regression test documenting the known gap, and tracked separately as #1144 since properly fixing it needs deeper reindex-bridge changes (tagging a reindexed `NumberLiteral` as non-document-sourced, or a cursor-free path for constructed arrays) — a materially larger, riskier change than this PR's scope.

## Test plan

- [x] New regression tests: separator fix (confirmed working), array-element known-gap pin (`tests/yq_cli_tests.rs`)
- [x] `cargo test --features cli,simd,regex,serde` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Live-verified against real yq v4.53.3

Fixes #1124