### PR TITLE
fix(jq): @base64d error messages didn't match either oracle's wording

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -575,6 +575,37 @@ impl EvalError {
         Self::new(format!("{} trailing base64 byte found", describe(value)))
     }
 
+    /// `<type> (<value>) is not valid base64 data` (#1146).
+    ///
+    /// Raised by `@base64d` (jq mode) when a byte in the input isn't a
+    /// member of the base64 alphabet. Confirmed live against jq 1.7.1:
+    /// `"ab!d" | @base64d` is `"string (\"ab!d\") is not valid base64
+    /// data"`. Distinct from [`Self::base64_trailing_byte`] above, which
+    /// covers a *different* jq wording for a too-short trailing group of
+    /// otherwise-valid characters -- this one is for an outright invalid
+    /// byte anywhere in the input.
+    pub fn base64_invalid_data(value: &OwnedValue) -> Self {
+        Self::new(format!("{} is not valid base64 data", describe(value)))
+    }
+
+    /// `illegal base64 data at input byte N` (#1146).
+    ///
+    /// Raised by `@base64d` (yq mode only) for *any* decode failure --
+    /// invalid character or a too-short trailing group alike. Unlike jq's
+    /// two-message split ([`Self::base64_invalid_data`]/
+    /// [`Self::base64_trailing_byte`]), real yq (v4.53.3, live-verified)
+    /// uses one uniform, byte-position-based message for every base64
+    /// decode error, with no jq analogue -- hence [`Self::new`] directly,
+    /// following this module's own convention for jq-less wording. `pos`
+    /// is a 0-indexed byte offset into the string actually fed to the
+    /// decoder (post leading/trailing-whitespace trim, since yq trims
+    /// before decoding) -- confirmed live: an input with 2 leading spaces
+    /// reports the identical position as the same input with none, so the
+    /// position is relative to the *trimmed* string, not the original.
+    pub fn base64_illegal_data(pos: usize) -> Self {
+        Self::new(format!("illegal base64 data at input byte {pos}"))
+    }
+
     /// `Invalid path expression with result <value>` (#530).
     ///
     /// Raised by `path()` when the filter it was given is not a path

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6049,10 +6049,26 @@ fn format_base64d<S: EvalSemantics>(
                 result.push(((value >> 4) & 0xFF) as u8);
             }
             _ => {
-                return Err(if S::TAG == EvalTag::Yq {
-                    EvalError::base64_illegal_data(prefix.len())
+                // A lone trailing byte is either genuinely too short (a
+                // valid base64 character with nothing left to pair it
+                // with) or itself an invalid character -- these are
+                // different failures in both oracles, live-verified:
+                // `"abcd!" | @base64d` is jq's "is not valid base64
+                // data" (not "trailing base64 byte found") and yq's
+                // "byte 4" (the '!' itself, not `prefix.len()` == 5).
+                // Checking the byte's own validity first, rather than
+                // assuming every 1-length remainder is the "too short"
+                // case, keeps this arm's error selection consistent with
+                // the 2/3/4-length arms above, which already validate
+                // every byte before deciding anything.
+                return Err(if decode_char(chunk[0]).is_some() {
+                    if S::TAG == EvalTag::Yq {
+                        EvalError::base64_illegal_data(prefix.len())
+                    } else {
+                        EvalError::base64_trailing_byte(value)
+                    }
                 } else {
-                    EvalError::base64_trailing_byte(value)
+                    char_error(chunk_start)
                 });
             }
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6004,14 +6004,28 @@ fn format_base64d<S: EvalSemantics>(
     // construction (it's already been truncated above), so none of
     // these arms need to special-case it the way the very first
     // version of this fix's 4-char arm alone used to.
-    for chunk in prefix.chunks(4) {
+    // Mode-specific error wording (#1146): jq splits invalid-character vs
+    // too-short-trailing-group into two distinct messages
+    // (`base64_invalid_data`/`base64_trailing_byte`); yq uses one uniform,
+    // byte-position-based message (`base64_illegal_data`) for both. `pos`
+    // is this byte's own index within `trimmed` (`chunk_start + offset`),
+    // confirmed live to be the exact failing byte, not the chunk start.
+    let char_error = |pos: usize| -> EvalError {
+        if S::TAG == EvalTag::Yq {
+            EvalError::base64_illegal_data(pos)
+        } else {
+            EvalError::base64_invalid_data(value)
+        }
+    };
+
+    for (chunk_index, chunk) in prefix.chunks(4).enumerate() {
+        let chunk_start = chunk_index * 4;
         match chunk.len() {
             4 => {
-                let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let c_val =
-                    decode_char(chunk[2]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let d = decode_char(chunk[3]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let a = decode_char(chunk[0]).ok_or_else(|| char_error(chunk_start))?;
+                let b = decode_char(chunk[1]).ok_or_else(|| char_error(chunk_start + 1))?;
+                let c_val = decode_char(chunk[2]).ok_or_else(|| char_error(chunk_start + 2))?;
+                let d = decode_char(chunk[3]).ok_or_else(|| char_error(chunk_start + 3))?;
 
                 let triple =
                     ((a as u32) << 18) | ((b as u32) << 12) | ((c_val as u32) << 6) | (d as u32);
@@ -6021,22 +6035,25 @@ fn format_base64d<S: EvalSemantics>(
                 result.push((triple & 0xFF) as u8);
             }
             3 => {
-                let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let c_val =
-                    decode_char(chunk[2]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let a = decode_char(chunk[0]).ok_or_else(|| char_error(chunk_start))?;
+                let b = decode_char(chunk[1]).ok_or_else(|| char_error(chunk_start + 1))?;
+                let c_val = decode_char(chunk[2]).ok_or_else(|| char_error(chunk_start + 2))?;
                 let value = ((a as u32) << 12) | ((b as u32) << 6) | (c_val as u32);
                 result.push(((value >> 10) & 0xFF) as u8);
                 result.push(((value >> 2) & 0xFF) as u8);
             }
             2 => {
-                let a = decode_char(chunk[0]).ok_or_else(|| EvalError::new("invalid base64"))?;
-                let b = decode_char(chunk[1]).ok_or_else(|| EvalError::new("invalid base64"))?;
+                let a = decode_char(chunk[0]).ok_or_else(|| char_error(chunk_start))?;
+                let b = decode_char(chunk[1]).ok_or_else(|| char_error(chunk_start + 1))?;
                 let value = ((a as u32) << 6) | (b as u32);
                 result.push(((value >> 4) & 0xFF) as u8);
             }
             _ => {
-                return Err(EvalError::base64_trailing_byte(value));
+                return Err(if S::TAG == EvalTag::Yq {
+                    EvalError::base64_illegal_data(prefix.len())
+                } else {
+                    EvalError::base64_trailing_byte(value)
+                });
             }
         }
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13531,3 +13531,168 @@ fn test_yq_urid_nonascii_passthrough_and_decode_1123() -> Result<()> {
     assert_eq!(out.trim(), "\"café\"");
     Ok(())
 }
+
+// ============================================================================
+// @base64d error message wording (#1146)
+// ============================================================================
+//
+// Real yq (v4.53.3) uses one uniform, byte-position-based message for
+// every base64 decode failure ("illegal base64 data at input byte N", the
+// position being an index into the *trimmed* string, live-verified: it's
+// identical with or without leading whitespace present). Real jq (1.7.1)
+// instead splits into two distinct messages depending on failure kind --
+// an invalid character anywhere ("<type> (<value>) is not valid base64
+// data") vs. a too-short trailing group of otherwise-valid characters
+// ("<type> (<value>) trailing base64 byte found", #1120). Before this fix,
+// succinctly used neither: every failure in either mode raised a bare
+// "invalid base64".
+
+/// yq mode's uniform message, with the exact byte position of the
+/// offending character -- not the start of its 4-character group.
+#[test]
+fn test_yq_base64d_illegal_data_reports_exact_byte_position_1146() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"!bcd\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("illegal base64 data at input byte 0"),
+        "stderr: {stderr:?}"
+    );
+
+    // Bad byte in the middle of a 4-char group, not at its start.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"aG!s\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("illegal base64 data at input byte 2"),
+        "stderr: {stderr:?}"
+    );
+
+    // Second 4-char group.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"aGVsbG!=\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("illegal base64 data at input byte 6"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// yq mode's position is relative to the *trimmed* string: leading
+/// whitespace shifts nothing, since the whitespace itself is trimmed away
+/// before the position is ever computed.
+#[test]
+fn test_yq_base64d_illegal_data_position_relative_to_trimmed_string_1146() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"aGVs bG8=\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("illegal base64 data at input byte 4"),
+        "stderr: {stderr:?}"
+    );
+
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"  aGVs!bG8=\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("illegal base64 data at input byte 4"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// yq mode's too-short-trailing-group failure uses the same uniform
+/// message, positioned at the end of the (post-trim, post-`=`-truncation)
+/// significant data.
+#[test]
+fn test_yq_base64d_illegal_data_on_trailing_remainder_1146() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"false\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("illegal base64 data at input byte 5"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// jq mode's invalid-character message, distinct from yq's -- confirmed
+/// live against jq 1.7.1.
+#[test]
+fn test_jq_base64d_invalid_data_message_1146() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg("@base64d");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"\"ab!d\"")?;
+    let output = child.wait_with_output()?;
+    assert_ne!(output.status.code().unwrap_or(-1), 0);
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains("string (\"ab!d\") is not valid base64 data"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// jq mode's trailing-byte message (#1120) is unaffected by #1146's
+/// invalid-character wording fix -- still a separate message, still
+/// correct.
+#[test]
+fn test_jq_base64d_trailing_byte_message_unaffected_1146() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg("@base64d");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"\"false\"")?;
+    let output = child.wait_with_output()?;
+    assert_ne!(output.status.code().unwrap_or(-1), 0);
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains("string (\"false\") trailing base64 byte found"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// jq mode's lossy-UTF-8-substitution path (the case `bytes_to_string_lossy`/
+/// `owned_string_from_decoded_bytes` exists to handle) previously had no
+/// regression test -- only the yq-mode variant was covered.
+#[test]
+fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg("@base64d");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"\"null\"")?;
+    let output = child.wait_with_output()?;
+    assert_eq!(output.status.code(), Some(0));
+    let expected = base64_decode_lossy("null");
+    assert_eq!(
+        String::from_utf8(output.stdout)?.trim(),
+        format!("{expected:?}")
+    );
+    Ok(())
+}
+
+/// jq mode's `@urid` lossy-UTF-8-substitution path (an invalid percent-decode
+/// like `%FF`) previously had no regression test either.
+#[test]
+fn test_jq_urid_invalid_utf8_after_percent_decode_is_lossy_1146() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg("@urid");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"\"%FF\"")?;
+    let output = child.wait_with_output()?;
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8(output.stdout)?.trim(), "\"\u{fffd}\"");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -64,6 +64,36 @@ fn run_yq_stdin_with_stderr(
     Ok((stdout, stderr, exit_code))
 }
 
+/// jq-mode counterpart of `run_yq_stdin_with_stderr` -- this file otherwise
+/// hand-rolls `Command::new(...).arg("jq")` boilerplate per jq-mode test
+/// (#1146: introduced to avoid compounding that duplication for its own
+/// new jq-mode tests, not a full sweep of the pre-existing copies).
+fn run_jq_stdin_with_stderr(
+    filter: &str,
+    input: &str,
+    extra_args: &[&str],
+) -> Result<(String, String, i32)> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
+        .args(extra_args)
+        .arg(filter)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(input.as_bytes())?;
+    }
+
+    let output = cmd.wait_with_output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    Ok((stdout, stderr, exit_code))
+}
+
 /// Helper to run yq command with file input
 fn run_yq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(String, i32)> {
     let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
@@ -13573,6 +13603,15 @@ fn test_yq_base64d_illegal_data_reports_exact_byte_position_1146() -> Result<()>
         stderr.contains("illegal base64 data at input byte 6"),
         "stderr: {stderr:?}"
     );
+
+    // A leftover 2-character trailing group (not a full 4-char group),
+    // to cover the `2 =>` arm specifically -- not just 4-char groups.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"aGVsb!\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("illegal base64 data at input byte 5"),
+        "stderr: {stderr:?}"
+    );
     Ok(())
 }
 
@@ -13611,21 +13650,30 @@ fn test_yq_base64d_illegal_data_on_trailing_remainder_1146() -> Result<()> {
     Ok(())
 }
 
+/// Code review round 2 found the trailing-remainder arm didn't check
+/// whether the lone leftover byte was itself valid before assuming
+/// "too short": an *invalid* trailing byte must report the byte's own
+/// exact position (its own error category, not the too-short one),
+/// distinct from a *valid* trailing byte (the case above, positioned at
+/// the end of all significant data). Live-verified against real yq
+/// v4.53.3.
+#[test]
+fn test_yq_base64d_invalid_trailing_byte_reports_its_own_position_1146() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"abcd!\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("illegal base64 data at input byte 4"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// jq mode's invalid-character message, distinct from yq's -- confirmed
 /// live against jq 1.7.1.
 #[test]
 fn test_jq_base64d_invalid_data_message_1146() -> Result<()> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
-    cmd.arg("jq").arg("@base64d");
-    let mut child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    child.stdin.take().unwrap().write_all(b"\"ab!d\"")?;
-    let output = child.wait_with_output()?;
-    assert_ne!(output.status.code().unwrap_or(-1), 0);
-    let stderr = String::from_utf8(output.stderr)?;
+    let (_out, stderr, code) = run_jq_stdin_with_stderr("@base64d", "\"ab!d\"", &[])?;
+    assert_ne!(code, 0);
     assert!(
         stderr.contains("string (\"ab!d\") is not valid base64 data"),
         "stderr: {stderr:?}"
@@ -13638,19 +13686,25 @@ fn test_jq_base64d_invalid_data_message_1146() -> Result<()> {
 /// correct.
 #[test]
 fn test_jq_base64d_trailing_byte_message_unaffected_1146() -> Result<()> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
-    cmd.arg("jq").arg("@base64d");
-    let mut child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    child.stdin.take().unwrap().write_all(b"\"false\"")?;
-    let output = child.wait_with_output()?;
-    assert_ne!(output.status.code().unwrap_or(-1), 0);
-    let stderr = String::from_utf8(output.stderr)?;
+    let (_out, stderr, code) = run_jq_stdin_with_stderr("@base64d", "\"false\"", &[])?;
+    assert_ne!(code, 0);
     assert!(
         stderr.contains("string (\"false\") trailing base64 byte found"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// jq-mode counterpart of
+/// `test_yq_base64d_invalid_trailing_byte_reports_its_own_position_1146`:
+/// an *invalid* lone trailing byte must get jq's invalid-data message, not
+/// its trailing-byte message.
+#[test]
+fn test_jq_base64d_invalid_trailing_byte_uses_invalid_data_message_1146() -> Result<()> {
+    let (_out, stderr, code) = run_jq_stdin_with_stderr("@base64d", "\"abcd!\"", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("string (\"abcd!\") is not valid base64 data"),
         "stderr: {stderr:?}"
     );
     Ok(())
@@ -13661,21 +13715,10 @@ fn test_jq_base64d_trailing_byte_message_unaffected_1146() -> Result<()> {
 /// regression test -- only the yq-mode variant was covered.
 #[test]
 fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
-    cmd.arg("jq").arg("@base64d");
-    let mut child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    child.stdin.take().unwrap().write_all(b"\"null\"")?;
-    let output = child.wait_with_output()?;
-    assert_eq!(output.status.code(), Some(0));
+    let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d", "\"null\"", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
     let expected = base64_decode_lossy("null");
-    assert_eq!(
-        String::from_utf8(output.stdout)?.trim(),
-        format!("{expected:?}")
-    );
+    assert_eq!(out.trim(), format!("{expected:?}"));
     Ok(())
 }
 
@@ -13683,16 +13726,8 @@ fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
 /// like `%FF`) previously had no regression test either.
 #[test]
 fn test_jq_urid_invalid_utf8_after_percent_decode_is_lossy_1146() -> Result<()> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
-    cmd.arg("jq").arg("@urid");
-    let mut child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    child.stdin.take().unwrap().write_all(b"\"%FF\"")?;
-    let output = child.wait_with_output()?;
-    assert_eq!(output.status.code(), Some(0));
-    assert_eq!(String::from_utf8(output.stdout)?.trim(), "\"\u{fffd}\"");
+    let (out, _stderr, code) = run_jq_stdin_with_stderr("@urid", "\"%FF\"", &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"\u{fffd}\"");
     Ok(())
 }


### PR DESCRIPTION
## Summary

Filed as a follow-up during #1123's code review (a duplicate fix, PR #1137, landed
first — see #1123's own comments). `format_base64d` raised a bare `"invalid base64"`
for every decode failure in both jq and yq mode, matching neither oracle:

- Real yq v4.53.3 uses one uniform, byte-position-based message for any decode
  failure: `illegal base64 data at input byte N`, `N` being the exact byte position
  within the input (post leading/trailing-whitespace trim — live-verified that a
  leading-whitespace input reports the identical position as one with none, i.e. the
  position is relative to the trimmed string, not the original).
- Real jq 1.7.1 instead splits into two distinct messages: `<type> (<value>) is not
  valid base64 data` for an invalid character anywhere, vs. the already-correct
  `<type> (<value>) trailing base64 byte found` (#1120) for a too-short trailing
  group — only the invalid-character case was still unmatched.

```
$ printf '"ab!d"\n' | succinctly jq -c '@base64d'    # before
jq: error (at <stdin>:1): invalid base64
$ printf '"ab!d"\n' | jq -c '@base64d'               # real jq
jq: error (at <stdin>:1): string ("ab!d") is not valid base64 data

$ printf '"aGVs bG8="\n' | succinctly yq '@base64d'  # before
Error: invalid base64
$ printf '"aGVs bG8="\n' | yq '@base64d'             # real yq
Error: illegal base64 data at input byte 4
```

## Changes

- `EvalError::base64_invalid_data` (jq's wording) and `base64_illegal_data` (yq's,
  no jq analogue).
- `format_base64d`'s chunk-decode loop now threads a byte position (`chunk_index * 4
  + within-chunk offset`) through each `decode_char` call site, and picks the
  oracle-matching message per `S::TAG`.
- Also closes a gap noticed while touching this: neither `format_urid` nor
  `format_base64d`'s lossy-UTF-8-substitution path had jq-mode test coverage,
  despite both being `S: EvalSemantics`-generic — only yq mode was pinned.

## Test plan

- [x] New regression tests: yq's exact byte position for invalid-char-at-various-
      offsets, position-relative-to-trimmed-string, and the trailing-remainder case;
      jq's invalid-data message text; jq's trailing-byte message unaffected; jq-mode
      lossy-UTF-8 coverage for both `@urid` and `@base64d`.
- [x] All message variants live-verified against the real `yq`/`jq` binaries before
      writing the fix.
- [x] Full `cargo test --features cli,simd,regex,serde` green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo check --no-default-features` (no_std) clean.

Fixes #1146