### PR TITLE
fix(jq): yq's chained scalar-slice-assignment no-ops; del() deletes the parent key

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37646,6 +37646,31 @@ mod tests {
     }
 
     #[test]
+    fn test_update_assign_iterate_then_field() {
+        // Unlike `.a[] |= f` above (a single trailing `Iterate` collapses
+        // to the simpler top-level bare-`Expr::Iterate` arm once past
+        // `.a`), `.a[].b |= f` keeps something *after* the iterate, so it's
+        // the shape that actually dispatches through the Pipe-chain arm's
+        // *own* `first == Expr::Iterate` branch, not the bare one.
+        query!(br#"{"a": [{"b": 1}, {"b": 2}]}"#, r".a[].b |= . * 10",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                let OwnedValue::Array(arr) = obj.get("a").unwrap() else {
+                    panic!("expected array");
+                };
+                assert_eq!(arr[0].as_object().unwrap().get("b").unwrap(), &OwnedValue::Int(10));
+                assert_eq!(arr[1].as_object().unwrap().get("b").unwrap(), &OwnedValue::Int(20));
+            }
+        );
+    }
+
+    #[test]
+    fn test_update_assign_iterate_then_field_propagates_element_error() {
+        query!(br#"{"a": [{"b": 1}, {"b": "x"}]}"#, r#".a[].b |= (if type == "number" then . * 10 else error("boom") end)"#,
+            QueryResult::Error(e) => assert_eq!(e.message, "boom")
+        );
+    }
+
+    #[test]
     fn test_update_assign_array_iterate_propagates_element_error() {
         // Bare `Expr::Iterate` arm's Array branch: `?` on the per-element
         // recursive `update_path` call must propagate a genuine error from

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10282,6 +10282,15 @@ fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Optio
         return None;
     }
     Some(match prefix.len() {
+        // Unreachable in practice: `resolve_dynamic_indexes`'s own
+        // `assemble()` never wraps a single resolved component in
+        // `Expr::Pipe` (a length-1 component list returns that component
+        // directly, `strip_resolved_optional` only strips wrappers *within*
+        // an existing `Pipe`, never collapses one), so `exprs.len() >= 2`
+        // always holds here and `prefix.len()` can never be `0`. Kept
+        // explicit (rather than folded into the `_` arm) for clarity, since
+        // it's still the semantically correct value if that invariant ever
+        // changes.
         0 => Expr::Identity,
         1 => prefix[0].clone(),
         _ => Expr::Pipe(prefix.to_vec()),
@@ -37589,6 +37598,100 @@ mod tests {
                 assert_eq!(arr[0], OwnedValue::Int(2));
                 assert_eq!(arr[1], OwnedValue::Int(4));
                 assert_eq!(arr[2], OwnedValue::Int(6));
+            }
+        );
+    }
+
+    #[test]
+    fn test_update_assign_object_values() {
+        // `update_path`'s bare `Expr::Iterate` arm's Object branch (the
+        // whole resolved path is `.[]`, root is an object) -- #392's
+        // sibling test above only exercises the Array branch.
+        query!(br#"{"a": 1, "b": 2}"#, r".[] |= . * 2",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(*obj.get("a").unwrap(), OwnedValue::Int(2));
+                assert_eq!(*obj.get("b").unwrap(), OwnedValue::Int(4));
+            }
+        );
+    }
+
+    #[test]
+    fn test_update_assign_chained_iterate_array() {
+        // `update_path`'s Pipe-chain arm's `Expr::Iterate` branch (a
+        // *chained* `.a[]`, not the bare top-level case above), Array side.
+        query!(br#"{"a": [1, 2, 3]}"#, r".a[] |= . * 2",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                let OwnedValue::Array(arr) = obj.get("a").unwrap() else {
+                    panic!("expected array");
+                };
+                assert_eq!(arr[0], OwnedValue::Int(2));
+                assert_eq!(arr[1], OwnedValue::Int(4));
+                assert_eq!(arr[2], OwnedValue::Int(6));
+            }
+        );
+    }
+
+    #[test]
+    fn test_update_assign_chained_iterate_object() {
+        // Same Pipe-chain `Expr::Iterate` branch, Object side.
+        query!(br#"{"a": {"x": 1, "y": 2}}"#, r".a[] |= . * 2",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                let OwnedValue::Object(inner) = obj.get("a").unwrap() else {
+                    panic!("expected object");
+                };
+                assert_eq!(*inner.get("x").unwrap(), OwnedValue::Int(2));
+                assert_eq!(*inner.get("y").unwrap(), OwnedValue::Int(4));
+            }
+        );
+    }
+
+    #[test]
+    fn test_update_assign_array_iterate_propagates_element_error() {
+        // Bare `Expr::Iterate` arm's Array branch: `?` on the per-element
+        // recursive `update_path` call must propagate a genuine error from
+        // a later element, not just the successful case the tests above
+        // cover.
+        query!(br#"[1, "x", 3]"#, r#".[] |= (if type == "number" then . * 2 else error("boom") end)"#,
+            QueryResult::Error(e) => assert_eq!(e.message, "boom")
+        );
+    }
+
+    #[test]
+    fn test_update_assign_object_iterate_propagates_element_error() {
+        // Same as above, Object branch.
+        query!(br#"{"a": 1, "b": "x"}"#, r#".[] |= (if type == "number" then . * 2 else error("boom") end)"#,
+            QueryResult::Error(e) => assert_eq!(e.message, "boom")
+        );
+    }
+
+    #[test]
+    fn test_update_assign_chained_iterate_propagates_element_error() {
+        // The Pipe-chain arm's own `Expr::Iterate` branch (a *chained*
+        // `.a[]`, not the bare top-level case above) needs the same
+        // propagation check.
+        query!(br#"{"a": [1, "x", 3]}"#, r#".a[] |= (if type == "number" then . * 2 else error("boom") end)"#,
+            QueryResult::Error(e) => assert_eq!(e.message, "boom")
+        );
+        query!(br#"{"a": {"x": 1, "y": "z"}}"#, r#".a[] |= (if type == "number" then . * 2 else error("boom") end)"#,
+            QueryResult::Error(e) => assert_eq!(e.message, "boom")
+        );
+    }
+
+    #[test]
+    fn test_update_assign_slice_mid_chain() {
+        // `update_path`'s Pipe-chain arm's `Expr::Slice` branch: the chain
+        // continues *inside* the slice (something after it), so the update
+        // runs against the sub-array and splices back -- distinct from the
+        // top-level `Expr::Slice` arm, which is the slice terminating the
+        // whole path (`.[1:3] |= f`, already covered elsewhere).
+        query!(br"[1, 2, 3, 4]", r".[1:3][] |= . * 10",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![
+                    OwnedValue::Int(1),
+                    OwnedValue::Int(20),
+                    OwnedValue::Int(30),
+                    OwnedValue::Int(4),
+                ]);
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18936,7 +18936,24 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `flatten_delete_path` reduces each resolved `Expr` to the same
     // atomic-steps shape so `delete_expr_paths_at` can delete every resolved
     // path together.
-    let flattened: Vec<Vec<DeleteStep>> = paths
+    //
+    // Each path is rewritten by #1116's chained-scalar-slice del() rule
+    // first, same as the `paths.len() <= 1` branch above — `flatten_delete_path`/
+    // `delete_expr_paths_at` are complex, heavily-tested sibling-grouping
+    // machinery this fix doesn't otherwise need to touch, so the rewrite
+    // happens once, per path, before either ever sees it, rather than
+    // teaching them the rule directly.
+    let rewritten: Vec<Expr> = paths
+        .iter()
+        .map(|path| {
+            if S::TAG == EvalTag::Yq {
+                yq_del_scalar_slice_parent_path(path, &result).unwrap_or_else(|| path.clone())
+            } else {
+                path.clone()
+            }
+        })
+        .collect();
+    let flattened: Vec<Vec<DeleteStep>> = rewritten
         .iter()
         .map(|path| {
             let mut steps = Vec::new();

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10244,6 +10244,86 @@ pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
     }
 }
 
+/// Whether a *resolved* `del()` path ends in a slice whose target (found by
+/// navigating everything before it) is a scalar — yq's own, *different*
+/// del()-specific rule (#1116): unlike `=`/`|=`/`+=` (which no-op just the
+/// write, see `through_slice`'s doc comment), a chained scalar-slice delete
+/// removes the *entire parent key* instead (`{"a":5,"b":6} | del(.a[0:1])`
+/// -> `{"b":6}` in real yq, verified live). Returns the truncated path
+/// (every component up to, but not including, the trailing slice) to
+/// delete instead, when this rule applies — `None` when it doesn't: a bare
+/// slice (`del(.[0:1])`, #1101's existing scope, untouched by this), no
+/// trailing slice at all, or the navigated-to value isn't a scalar. An
+/// array/object parent deliberately keeps succinctly's own working
+/// slice-delete there too, mirroring `is_yq_scalar_slice_assign_path`'s own
+/// scoping choice — real yq's chained slice-delete turns out to drop the
+/// whole parent key for *any* target type, not just scalars (verified
+/// live), but replicating that for arrays/objects would remove working,
+/// jq-consistent behavior to match what looks like a real-yq gap, not a
+/// deliberate feature.
+///
+/// Deliberately its own walker, not reusing `through_slice`: `del()` has no
+/// "edit closure producing a replacement value" to discard the result of —
+/// it removes content outright, and the rule for *what* to remove (the
+/// parent key, not the slice's own contents) needs the parent *container*
+/// in hand, which `through_slice` never has (it only ever sees the sliced
+/// value itself).
+fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Option<Expr> {
+    let Expr::Pipe(exprs) = path_expr else {
+        return None;
+    };
+    let (last, _) = unwrap_path_component(exprs.last()?);
+    if !matches!(last, Expr::Slice { .. }) {
+        return None;
+    }
+    let prefix = &exprs[..exprs.len() - 1];
+    let target = navigate_read_only(root, prefix)?;
+    if !is_yq_slice_empty_container_scalar(target) {
+        return None;
+    }
+    Some(match prefix.len() {
+        0 => Expr::Identity,
+        1 => prefix[0].clone(),
+        _ => Expr::Pipe(prefix.to_vec()),
+    })
+}
+
+/// Read-only navigation for [`yq_del_scalar_slice_parent_path`]'s prefix
+/// peek. Unlike `get_path_mut`, never autovivifies (a peek must not create
+/// structure the delete itself would otherwise leave untouched) and simply
+/// returns `None` for anything it can't resolve — a missing field, an
+/// out-of-bounds index, a wrong container type (including `Null`), or a
+/// step shape that can't appear in a resolved path's prefix before its own
+/// trailing slice. The caller treats `None` as "this rule doesn't apply,"
+/// deferring to `delete_at_path`'s own already-correct del()-through-absent
+/// handling rather than duplicating it here.
+fn navigate_read_only<'a>(root: &'a OwnedValue, steps: &[Expr]) -> Option<&'a OwnedValue> {
+    let mut current = root;
+    for step in steps {
+        let (step, _optional) = unwrap_path_component(step);
+        current = match step {
+            Expr::Field(name) => match current {
+                OwnedValue::Object(map) => map.get(name)?,
+                _ => return None,
+            },
+            Expr::Index(idx) => match current {
+                OwnedValue::Array(arr) => {
+                    let len = arr.len() as i64;
+                    let actual = if *idx < 0 { len + idx } else { *idx };
+                    if actual >= 0 && (actual as usize) < arr.len() {
+                        &arr[actual as usize]
+                    } else {
+                        return None;
+                    }
+                }
+                _ => return None,
+            },
+            _ => return None,
+        };
+    }
+    Some(current)
+}
+
 /// Apply a resolved slice directly to an owned value.
 ///
 /// Slicing is a plain `Vec`/`&str` operation once the bounds are known, so
@@ -10579,26 +10659,20 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             } else {
                 new_value.clone()
             };
-            // yq's slice-assignment no-op (#1101) — checked here, per
-            // resolved path, rather than before RHS evaluation: the RHS
-            // (`value`, already fully computed above) still needs to have
-            // been evaluated normally so its own errors/halt/break
-            // propagate (`.[0:1] = error("boom")` genuinely errors in real
-            // yq; only `.[0:1] = 99`-shaped *successful* RHS values are
-            // silently discarded). Checking the *resolved* `path` (not the
-            // raw `path_expr`) means a computed-bound `.[$a:$b]` and a
-            // `.[0:1]?` both reach this the same way a literal `.[0:1]`
-            // does, since `resolve_dynamic_indexes` has already folded
-            // them into the same shape by this point. See
-            // `is_yq_scalar_slice_assign_path`'s doc comment for the full
-            // rationale.
-            if S::TAG == EvalTag::Yq
-                && is_yq_scalar_slice_assign_path(path)
-                && is_yq_slice_empty_container_scalar(&result)
-            {
-                continue;
-            }
-            if let Err(e) = set_path(&mut result, path, value) {
+            // yq's slice-assignment no-op (#1101, generalized to any chain
+            // depth by #1116) — `set_path` itself now no-ops the *write*
+            // whenever it reaches a slice step targeting a scalar (see
+            // `through_slice`'s doc comment), whether that's the whole path
+            // (`5 | .[0:1] = 99`) or reached through a chain (`.a[0:1] = 99`
+            // on a scalar `.a`). The RHS (`value`, already fully computed
+            // above) is always evaluated normally either way, so its own
+            // errors/halt/break still propagate (`.[0:1] = error("boom")`
+            // genuinely errors in real yq; only `.[0:1] = 99`-shaped
+            // *successful* RHS values are silently discarded) — `=` has no
+            // filter of its own left to protect from a discarded write, so
+            // unlike `eval_update` there's no throwaway-execution step
+            // needed here at all, just passing the yq-mode flag through.
+            if let Err(e) = set_path(&mut result, path, value, S::TAG == EvalTag::Yq) {
                 // Atomic per RHS output, like `reduce`: this value's own
                 // path list contributes nothing, and the whole fan-out
                 // terminates here -- `docs` (only the strictly earlier,
@@ -10665,50 +10739,25 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err((_, escape)) => return escape.into(),
     };
 
+    // yq's slice-assignment no-op (#1101, generalized to any chain depth by
+    // #1116) — `update_path` itself now no-ops the *write* whenever it
+    // reaches a slice step targeting a scalar, binding the filter's `.` to
+    // `[]` there instead (matching real yq's actual discarded-write model,
+    // #1119's follow-up), while still running the filter normally so its
+    // own errors/`halt`/`break` propagate exactly as they would for any
+    // other `|=` — see `through_slice`'s doc comment for the full
+    // rationale, including why this can't be a blanket check before the
+    // filter runs at all. No `optional`-gating here beyond what
+    // `update_path` already threads: per #693, `Expr::Optional`/
+    // `Expr::Try`'s dispatch never forces `optional = true` into the
+    // expression it wraps, so an outer `(.a |= f)?` still swallows the
+    // discarded filter's error correctly via its own catch, not through
+    // this flag.
+    let scalar_noop = scalar_slice_noop && S::TAG == EvalTag::Yq;
+
     // Get current value at path, apply filter, and set back
     for path in &paths {
-        // yq's slice-assignment no-op (#1101) — the filter still has to run
-        // normally (against a throwaway clone) so its own errors/`halt`/
-        // `break` propagate exactly as they would for any other `|=`; only
-        // the *write* back into `result` is skipped. See
-        // `is_yq_scalar_slice_assign_path`'s doc comment for the full
-        // rationale, including why this can't be a blanket check before
-        // the filter runs at all.
-        //
-        // The throwaway binds `.` to `[]`, not a clone of `result` (the
-        // scalar itself) — matching real yq's own discarded-write model
-        // exactly (`5 | .[0:1] += [1]` and `5 | .[0:1] |= keys` both no-op
-        // to `5` in real yq, since the write target reads as an empty
-        // array). This was previously scalar-cloning instead, since
-        // `arith_add` had no array-append semantic yet (`[] + 99` errored)
-        // — #1119 added it, so `[] + 99` now succeeds too, and this switch
-        // closes the exact gap #1119 was filed to unblock (verified live
-        // against yq v4.53.3 for `+= <number>`, `+= <string>`, `+= [x]`,
-        // `|= keys`, `|= length`, `|= tostring`, `|= (. + 1)`).
-        if scalar_slice_noop
-            && S::TAG == EvalTag::Yq
-            && is_yq_scalar_slice_assign_path(path)
-            && is_yq_slice_empty_container_scalar(&result)
-        {
-            let mut throwaway = OwnedValue::Array(Vec::new());
-            // No `if optional`-gated arm here, unlike the sibling call
-            // below: `optional` at this point is `eval_update`'s *own*
-            // outer `?` (`(.a |= f)?`), and per #693, `Expr::Optional`/
-            // `Expr::Try`'s dispatch (`eval_try`, called for both) never
-            // forces `optional = true` into the expression it wraps — it
-            // evaluates with the ambient value (`false` at the top level)
-            // and catches the resulting `Error` itself instead. A `?`
-            // wrapping this whole `|=`/`+=` therefore still swallows the
-            // discarded filter's error correctly (verified live), just via
-            // that outer catch, never through this branch reaching `true`.
-            if let Err(escape) =
-                update_path::<S>(&mut throwaway, &Expr::Identity, filter_expr, false)
-            {
-                return escape.into();
-            }
-            continue;
-        }
-        if let Err(escape) = update_path::<S>(&mut result, path, filter_expr, false) {
+        if let Err(escape) = update_path::<S>(&mut result, path, filter_expr, false, scalar_noop) {
             return match escape {
                 EvalEscape::Error(_) if optional => QueryResult::None,
                 other => other.into(),
@@ -10847,6 +10896,7 @@ fn set_path(
     root: &mut OwnedValue,
     path_expr: &Expr,
     new_value: OwnedValue,
+    scalar_noop: bool,
 ) -> Result<(), EvalError> {
     match path_expr {
         Expr::Identity => {
@@ -10880,13 +10930,15 @@ fn set_path(
         Expr::Pipe(exprs) if !exprs.is_empty() => {
             // For chained paths like .a.b.c, navigate to parent and set at last element
             if exprs.len() == 1 {
-                set_path(root, &exprs[0], new_value)
+                set_path(root, &exprs[0], new_value, scalar_noop)
             } else if let Some(split) = split_at_slice(exprs) {
                 match get_path_mut(root, split.before)? {
                     None => Ok(()),
-                    Some(parent) => through_slice(parent, split.start, split.end, false, |sub| {
-                        set_path(sub, &split.tail, new_value)
-                    }),
+                    Some(parent) => {
+                        through_slice(parent, split.start, split.end, false, scalar_noop, |sub| {
+                            set_path(sub, &split.tail, new_value, scalar_noop)
+                        })
+                    }
                 }
             } else {
                 // Navigate to parent
@@ -10895,11 +10947,11 @@ fn set_path(
 
                 match get_path_mut(root, parent_path)? {
                     None => Ok(()),
-                    Some(parent) => set_path(parent, last_path, new_value),
+                    Some(parent) => set_path(parent, last_path, new_value, scalar_noop),
                 }
             }
         }
-        Expr::Optional(inner) => match set_path(root, inner, new_value) {
+        Expr::Optional(inner) => match set_path(root, inner, new_value, scalar_noop) {
             Ok(()) => Ok(()),
             // jq's `?` suppresses errors raised while *collecting* a path,
             // but not the write-time bounds check on a still-negative array
@@ -10909,6 +10961,15 @@ fn set_path(
             Err(e) if e.is_negative_index_out_of_bounds() => Err(e),
             Err(_) => Ok(()), // Silently succeed for optional
         },
+        // `(EXPR)` at the top of a resolved path (e.g. `(.[0:1]) = 99`) —
+        // previously always intercepted by #1101's pre-check before ever
+        // reaching `set_path`, so this arm was never needed; #1116
+        // generalized that check into `through_slice`'s own recursion,
+        // which only sees this shape via a top-level entry point like this
+        // one, exposing the gap. Mirrors the `Optional` arm just above,
+        // minus the swallow-on-error behavior `?` gets and bare parens
+        // don't.
+        Expr::Paren(inner) => set_path(root, inner, new_value, scalar_noop),
         Expr::Iterate => match root {
             OwnedValue::Array(arr) => {
                 for elem in arr.iter_mut() {
@@ -10928,10 +10989,12 @@ fn set_path(
         // an array — that is the whole reason jq has a separate sentence for
         // it. An out-of-range range clamps rather than erroring, unlike the
         // `Expr::Index` arm above: `[1,2,3] | .[5:9] = ["x"]` appends.
-        Expr::Slice { start, end } => through_slice(root, *start, *end, false, |sub| {
-            *sub = new_value;
-            Ok(())
-        }),
+        Expr::Slice { start, end } => {
+            through_slice(root, *start, *end, false, scalar_noop, |sub| {
+                *sub = new_value;
+                Ok(())
+            })
+        }
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
         // to the catch-all so a missed install point fails loudly here instead
@@ -10994,6 +11057,7 @@ fn through_slice<E: From<EvalError>>(
     start: Option<i64>,
     end: Option<i64>,
     optional: bool,
+    scalar_noop: bool,
     edit: impl FnOnce(&mut OwnedValue) -> Result<(), E>,
 ) -> Result<(), E> {
     match root {
@@ -11010,6 +11074,24 @@ fn through_slice<E: From<EvalError>>(
         // jq reads a string slice but will not write one back, whatever the
         // replacement — the refusal beats the non-array one above.
         OwnedValue::String(_) => Err(EvalError::cannot_update_string_slices().into()),
+        // yq's slice-assignment no-op (#1101, generalized to any nesting
+        // depth by #1116): `through_slice` is the single choke point every
+        // slice write passes through, in both `set_path` (`=`) and
+        // `update_path` (`|=`/`+=`) — whether the slice is the whole path
+        // (`5 | .[0:1] = 99`) or reached through a chain (`.a[0:1] = 99`
+        // where `.a` is itself a scalar), `root` here is exactly the value
+        // the slice would act on either way, so this one check covers both
+        // shapes with no separate chained-path detection needed. `edit`
+        // still runs, against a throwaway `[]` (matching real yq's actual
+        // internal model, #1119's `eval_update` follow-up) so its own
+        // errors/halt/break still propagate; only the write to `root` is
+        // skipped. Callers gate `scalar_noop` to `false` for `-=`/`*=`,
+        // which real yq errors on instead (confirmed live).
+        _ if scalar_noop && is_yq_slice_empty_container_scalar(root) => {
+            let mut throwaway = OwnedValue::Array(Vec::new());
+            edit(&mut throwaway)?;
+            Ok(())
+        }
         _ if optional => Ok(()),
         other => Err(EvalError::cannot_index_with_type(owned_type_name(other), "object").into()),
     }
@@ -11137,6 +11219,7 @@ fn update_path<S: EvalSemantics>(
     path_expr: &Expr,
     filter_expr: &Expr,
     optional: bool,
+    scalar_noop: bool,
 ) -> Result<(), EvalEscape> {
     match path_expr {
         Expr::Identity => {
@@ -11177,7 +11260,7 @@ fn update_path<S: EvalSemantics>(
             autovivify_object(root);
             if let OwnedValue::Object(map) = root {
                 let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
-                update_path::<S>(current, &Expr::Identity, filter_expr, optional)
+                update_path::<S>(current, &Expr::Identity, filter_expr, optional, scalar_noop)
             } else if optional {
                 Ok(())
             } else {
@@ -11192,6 +11275,7 @@ fn update_path<S: EvalSemantics>(
                     &Expr::Identity,
                     filter_expr,
                     optional,
+                    scalar_noop,
                 )
             } else if optional {
                 Ok(())
@@ -11204,13 +11288,25 @@ fn update_path<S: EvalSemantics>(
             match root {
                 OwnedValue::Array(arr) => {
                     for elem in arr.iter_mut() {
-                        update_path::<S>(elem, &Expr::Identity, filter_expr, optional)?;
+                        update_path::<S>(
+                            elem,
+                            &Expr::Identity,
+                            filter_expr,
+                            optional,
+                            scalar_noop,
+                        )?;
                     }
                     Ok(())
                 }
                 OwnedValue::Object(map) => {
                     for value in map.values_mut() {
-                        update_path::<S>(value, &Expr::Identity, filter_expr, optional)?;
+                        update_path::<S>(
+                            value,
+                            &Expr::Identity,
+                            filter_expr,
+                            optional,
+                            scalar_noop,
+                        )?;
                     }
                     Ok(())
                 }
@@ -11221,7 +11317,7 @@ fn update_path<S: EvalSemantics>(
         Expr::Pipe(exprs) if !exprs.is_empty() => {
             // Chain: navigate and update
             if exprs.len() == 1 {
-                update_path::<S>(root, &exprs[0], filter_expr, optional)
+                update_path::<S>(root, &exprs[0], filter_expr, optional, scalar_noop)
             } else {
                 // Navigate to the penultimate path, then update the last.
                 // `here` is whether *this step* may fail quietly; `optional`
@@ -11235,7 +11331,7 @@ fn update_path<S: EvalSemantics>(
                         autovivify_object(root);
                         if let OwnedValue::Object(map) = root {
                             let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
-                            update_path::<S>(current, &rest, filter_expr, optional)
+                            update_path::<S>(current, &rest, filter_expr, optional, scalar_noop)
                         } else if here {
                             Ok(())
                         } else {
@@ -11248,7 +11344,13 @@ fn update_path<S: EvalSemantics>(
                     Expr::Index(idx) => {
                         autovivify_array(root);
                         if let OwnedValue::Array(arr) = root {
-                            update_path::<S>(write_index(arr, *idx)?, &rest, filter_expr, optional)
+                            update_path::<S>(
+                                write_index(arr, *idx)?,
+                                &rest,
+                                filter_expr,
+                                optional,
+                                scalar_noop,
+                            )
                         } else if here {
                             Ok(())
                         } else {
@@ -11261,13 +11363,13 @@ fn update_path<S: EvalSemantics>(
                     Expr::Iterate => match root {
                         OwnedValue::Array(arr) => {
                             for elem in arr.iter_mut() {
-                                update_path::<S>(elem, &rest, filter_expr, optional)?;
+                                update_path::<S>(elem, &rest, filter_expr, optional, scalar_noop)?;
                             }
                             Ok(())
                         }
                         OwnedValue::Object(map) => {
                             for value in map.values_mut() {
-                                update_path::<S>(value, &rest, filter_expr, optional)?;
+                                update_path::<S>(value, &rest, filter_expr, optional, scalar_noop)?;
                             }
                             Ok(())
                         }
@@ -11281,26 +11383,34 @@ fn update_path<S: EvalSemantics>(
                     Expr::Pipe(inner) => {
                         let mut spliced = inner.clone();
                         spliced.extend_from_slice(&exprs[1..]);
-                        update_path::<S>(root, &Expr::Pipe(spliced), filter_expr, here)
+                        update_path::<S>(root, &Expr::Pipe(spliced), filter_expr, here, scalar_noop)
                     }
                     // The chain continues *inside* the slice, so the update
                     // runs against the sub-array and is spliced back:
                     // `[1,2,3,4] | .[1:3][] |= .*10` is `[1,20,30,4]`.
-                    Expr::Slice { start, end } => through_slice(root, *start, *end, here, |sub| {
-                        update_path::<S>(sub, &rest, filter_expr, optional)
-                    }),
-                    _ => update_path::<S>(root, first, filter_expr, here),
+                    Expr::Slice { start, end } => {
+                        through_slice(root, *start, *end, here, scalar_noop, |sub| {
+                            update_path::<S>(sub, &rest, filter_expr, optional, scalar_noop)
+                        })
+                    }
+                    _ => update_path::<S>(root, first, filter_expr, here, scalar_noop),
                 }
             }
         }
-        Expr::Optional(inner) => update_path::<S>(root, inner, filter_expr, true),
+        Expr::Optional(inner) => update_path::<S>(root, inner, filter_expr, true, scalar_noop),
+        // `(EXPR)` at the top of a resolved path (e.g. `(.[0:1]) |= 99`) —
+        // see `set_path`'s matching `Expr::Paren` arm for why this was
+        // never needed before #1116.
+        Expr::Paren(inner) => update_path::<S>(root, inner, filter_expr, optional, scalar_noop),
         // `.[a:b] |= f` runs `f` on the sub-array — not on each element — and
         // splices the answer back, so `[1,2,3] | .[1:2] |= . + ["q"]` is
         // `[1,2,"q",3]`. `f` may return an array of any length, but it has to
         // be an array.
-        Expr::Slice { start, end } => through_slice(root, *start, *end, optional, |sub| {
-            update_path::<S>(sub, &Expr::Identity, filter_expr, optional)
-        }),
+        Expr::Slice { start, end } => {
+            through_slice(root, *start, *end, optional, scalar_noop, |sub| {
+                update_path::<S>(sub, &Expr::Identity, filter_expr, optional, scalar_noop)
+            })
+        }
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
         // to the catch-all so a missed install point fails loudly here instead
@@ -18799,6 +18909,15 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     if paths.len() <= 1 {
         let mut result = result;
         for path in &paths {
+            // yq's chained-scalar-slice del() rule (#1116) — a *different*
+            // rule from #1101's no-op above: rewrite the path to delete the
+            // parent key outright, rather than walking the original path
+            // at all, when it applies. See
+            // `yq_del_scalar_slice_parent_path`'s doc comment.
+            let rewritten = (S::TAG == EvalTag::Yq)
+                .then(|| yq_del_scalar_slice_parent_path(path, &result))
+                .flatten();
+            let path = rewritten.as_ref().unwrap_or(path);
             if let Err(e) = delete_at_path(&mut result, path, false) {
                 return if optional {
                     QueryResult::None
@@ -19021,9 +19140,19 @@ fn delete_at_path(
                     Expr::Slice { .. } if matches!(root, OwnedValue::Null) => {
                         delete_at_path_through_absent(&rest, optional)
                     }
-                    Expr::Slice { start, end } => through_slice(root, *start, *end, here, |sub| {
-                        delete_at_path(sub, &rest, optional)
-                    }),
+                    // `scalar_noop: false` — del()'s own yq-scalar rule
+                    // (#1116) is intercepted earlier, via path truncation
+                    // (see `yq_del_scalar_slice_parent_path`), for the case
+                    // this fix actually covers (the slice is the *last*
+                    // path component). This arm only fires when there's
+                    // more path *after* the slice (`.[1:3][0]`), which
+                    // isn't that shape — it descends into the sliced
+                    // sub-range and deletes within it, same as jq.
+                    Expr::Slice { start, end } => {
+                        through_slice(root, *start, *end, here, false, |sub| {
+                            delete_at_path(sub, &rest, optional)
+                        })
+                    }
                     _ => delete_at_path(root, first, here),
                 }
             }
@@ -38190,18 +38319,24 @@ mod tests {
         // Direct-function coverage for the three walkers `autovivify_object`/
         // `autovivify_array`/`write_index` touch (#486), bypassing the parser.
         let mut root = OwnedValue::Null;
-        set_path(&mut root, &Expr::Field("a".to_string()), OwnedValue::Int(1)).unwrap();
+        set_path(
+            &mut root,
+            &Expr::Field("a".to_string()),
+            OwnedValue::Int(1),
+            false,
+        )
+        .unwrap();
         assert_eq!(
             root,
             OwnedValue::Object(IndexMap::from([("a".to_string(), OwnedValue::Int(1),)]))
         );
 
         let mut root = OwnedValue::Null;
-        set_path(&mut root, &Expr::Index(0), OwnedValue::Int(1)).unwrap();
+        set_path(&mut root, &Expr::Index(0), OwnedValue::Int(1), false).unwrap();
         assert_eq!(root, OwnedValue::Array(vec![OwnedValue::Int(1)]));
 
         let mut root = OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
-        set_path(&mut root, &Expr::Index(4), OwnedValue::Int(9)).unwrap();
+        set_path(&mut root, &Expr::Index(4), OwnedValue::Int(9), false).unwrap();
         assert_eq!(
             root,
             OwnedValue::Array(vec![
@@ -41218,7 +41353,7 @@ mod tests {
         #[test]
         fn test_set_path_refuses_an_unresolved_key() {
             let mut root = OwnedValue::Null;
-            let err = set_path(&mut root, &unresolved(), OwnedValue::Int(1)).unwrap_err();
+            let err = set_path(&mut root, &unresolved(), OwnedValue::Int(1), false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed index in assignment path"
@@ -41238,8 +41373,9 @@ mod tests {
         #[test]
         fn test_update_path_refuses_an_unresolved_key() {
             let mut root = OwnedValue::Null;
-            let err = update_path::<JqSemantics>(&mut root, &unresolved(), &Expr::Identity, false)
-                .unwrap_err();
+            let err =
+                update_path::<JqSemantics>(&mut root, &unresolved(), &Expr::Identity, false, false)
+                    .unwrap_err();
             let EvalEscape::Error(err) = err else {
                 panic!("expected EvalEscape::Error, got {err:?}");
             };
@@ -41313,7 +41449,7 @@ mod tests {
         #[test]
         fn test_set_path_refuses_an_unresolved_slice() {
             let mut root = OwnedValue::Null;
-            let err = set_path(&mut root, &unresolved(), OwnedValue::Int(1)).unwrap_err();
+            let err = set_path(&mut root, &unresolved(), OwnedValue::Int(1), false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed slice in assignment path"
@@ -41333,8 +41469,9 @@ mod tests {
         #[test]
         fn test_update_path_refuses_an_unresolved_slice() {
             let mut root = OwnedValue::Null;
-            let err = update_path::<JqSemantics>(&mut root, &unresolved(), &Expr::Identity, false)
-                .unwrap_err();
+            let err =
+                update_path::<JqSemantics>(&mut root, &unresolved(), &Expr::Identity, false, false)
+                    .unwrap_err();
             let EvalEscape::Error(err) = err else {
                 panic!("expected EvalEscape::Error, got {err:?}");
             };
@@ -42122,8 +42259,13 @@ mod tests {
         // produces -- to prove the fallback still reports a real error instead
         // of silently succeeding or panicking.
         let mut root = OwnedValue::Int(1);
-        let result =
-            update_path::<JqSemantics>(&mut root, &Expr::RecursiveDescent, &Expr::Identity, false);
+        let result = update_path::<JqSemantics>(
+            &mut root,
+            &Expr::RecursiveDescent,
+            &Expr::Identity,
+            false,
+            false,
+        );
         assert!(matches!(result, Err(EvalEscape::Error(_))));
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11317,3 +11317,19 @@ fn test_jq_array_plus_scalar_still_errors_1119() -> Result<()> {
     assert_eq!(code, 5);
     Ok(())
 }
+
+/// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
+/// the parent key" rules must not leak into jq mode: real jq errors on
+/// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching
+/// succinctly's pre-existing, unaffected behavior.
+#[test]
+fn test_jq_chained_scalar_slice_assign_and_del_still_error_1116() -> Result<()> {
+    let input = r#"{"a":5,"b":6}"#;
+
+    let (_out, code) = run_jq_stdin(".a[0:1] = 99", input, &[])?;
+    assert_eq!(code, 5);
+
+    let (_out, code) = run_jq_stdin("del(.a[0:1])", input, &[])?;
+    assert_eq!(code, 5);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13621,6 +13621,74 @@ fn test_1116_chained_scalar_slice_del_through_missing_still_noops() -> Result<()
     Ok(())
 }
 
+/// A genuinely nested Index-then-Field prefix (`.a[0].b[0:1]`) reaching a
+/// scalar `.b` — exercises `navigate_read_only`'s successful in-bounds
+/// `Expr::Index` branch, not just the single-`Field`-step prefix the other
+/// #1116 tests use. `.a[0].b` was 5, a scalar, so this is a genuine fix
+/// (main errors "Cannot index number with object" for the same query).
+#[test]
+fn test_1116_chained_scalar_slice_del_nested_index_and_field() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0].b[0:1])",
+        r#"{"a":[{"b":5}]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[{}]}"#);
+    Ok(())
+}
+
+/// `navigate_read_only`'s type-mismatch fallbacks (`Field` against a
+/// non-object, `Index` against a non-array) both bail out to `None`,
+/// deferring to `delete_at_path`'s own pre-existing, unaffected error —
+/// regression guards confirming #1116's rewrite doesn't fire (or change
+/// the error) for these shapes.
+#[test]
+fn test_1116_chained_scalar_slice_del_navigator_type_mismatches_unaffected() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("del(.a.b[0:1])", r#"{"a":[1,2,3]}"#, &[])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Cannot index array"), "stderr: {stderr}");
+
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.a[0].b[0:1])", r#"{"a":{"x":1}}"#, &[])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Cannot index object"), "stderr: {stderr}");
+
+    Ok(())
+}
+
+/// An out-of-bounds index in the prefix (`.a[99].b[0:1]`) falls through
+/// `navigate_read_only` to `None` (rule doesn't apply) rather than the
+/// rewrite firing on a bogus navigation — regression guard confirming
+/// succinctly's own pre-existing out-of-range del()-through no-op (#477)
+/// is unaffected.
+#[test]
+fn test_1116_chained_scalar_slice_del_navigator_out_of_bounds_unaffected() -> Result<()> {
+    let input = r#"{"a":[{"b":5}]}"#;
+    let (out, code) = run_yq_stdin("del(.a[99].b[0:1])", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+    Ok(())
+}
+
+/// `navigate_read_only` only understands `Field`/`Index` prefix steps — a
+/// `.[]` earlier in the chain (`Expr::Iterate`) hits its catch-all and
+/// bails to `None`, so the rewrite doesn't apply and the old, erroring
+/// per-element walk runs instead. Known, filed limitation (#1153) — this
+/// pins the current (imperfect) behavior as a regression guard rather than
+/// leaving it silently untested.
+#[test]
+fn test_1116_chained_scalar_slice_del_iterate_prefix_not_yet_covered_1153() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.a[].b[0:1])",
+        r#"{"a":[{"b":5,"c":1},{"b":6,"c":2}]}"#,
+        &[],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Cannot index"), "stderr: {stderr}");
+    Ok(())
+}
+
 /// `(.[0:1]) = 99` / `(.[0:1]) |= 99` — a parenthesized *bare* slice at the
 /// top of a resolved path. #1101 covered this only by accident (its old
 /// pre-check ran before `set_path`/`update_path` were ever reached with a

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13464,6 +13464,156 @@ fn test_1119_gsub_array_flags_still_errors_cleanly_not_panics() -> Result<()> {
     Ok(())
 }
 
+// --- #1116: chained scalar-slice-assignment no-ops too; del() differs ---
+//
+// #1101 covered only a *bare* scalar-slice path (`.[S:E]`). #1116 extends
+// the same no-op to a *chained* one (`.foo[S:E]` where `.foo` is itself a
+// scalar) for `=`/`|=`/`+=`, but `del()` has a genuinely different rule for
+// the chained shape: it deletes the whole parent key, not a no-op. Verified
+// live against real yq v4.53.3 for every case below.
+
+#[test]
+fn test_1116_chained_scalar_slice_assign_noops() -> Result<()> {
+    let input = r#"{"a":5,"b":6}"#;
+
+    let (out, code) = run_yq_stdin(".a[0:1] = 99", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+
+    let (out, code) = run_yq_stdin(".a[0:1] |= 99", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+
+    let (out, code) = run_yq_stdin(".a[0:1] += 99", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+
+    Ok(())
+}
+
+#[test]
+fn test_1116_chained_scalar_slice_assign_noops_at_deeper_nesting() -> Result<()> {
+    let input = r#"{"x":{"a":5,"b":6}}"#;
+    let (out, code) = run_yq_stdin(".x.a[0:1] = 99", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+    Ok(())
+}
+
+/// `-=`/`*=` still error on the chained shape too, matching #1101's
+/// existing bare-root precedent (real yq errors on both, not a no-op).
+#[test]
+fn test_1116_chained_scalar_slice_sub_and_mul_still_error() -> Result<()> {
+    let input = r#"{"a":5,"b":6}"#;
+    let (_out, code) = run_yq_stdin(".a[0:1] -= 99", input, &["-o=json", "-I=0"])?;
+    assert_ne!(code, 0);
+
+    let (_out, code) = run_yq_stdin(".a[0:1] *= 99", input, &["-o=json", "-I=0"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// A chained slice-assign through an *array* or *object* target is
+/// unaffected — succinctly deliberately keeps its own working slice-write
+/// there rather than replicating real yq's own broken behavior for those
+/// target types too (verified live: real yq no-ops `.a[1:3] = [...]` even
+/// for an array `.a`, unlike jq; succinctly intentionally diverges,
+/// matching `is_yq_scalar_slice_assign_path`'s existing precedent).
+#[test]
+fn test_1116_chained_array_slice_assign_still_works() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        r#".a[1:3] = ["x","y"]"#,
+        r#"{"a":[1,2,3,4,5],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,"x","y",4,5],"b":6}"#);
+    Ok(())
+}
+
+/// del()'s genuinely different rule: a chained scalar-slice delete removes
+/// the whole parent key, not a no-op.
+#[test]
+fn test_1116_chained_scalar_slice_del_removes_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[0:1])", r#"{"a":5,"b":6}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+
+    let (out, code) = run_yq_stdin(
+        "del(.x.a[0:1])",
+        r#"{"x":{"a":5,"b":6}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"x":{"b":6}}"#);
+
+    let (out, code) = run_yq_stdin(
+        "del(.x.y.a[0:1])",
+        r#"{"x":{"y":{"a":5,"b":6}}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"x":{"y":{"b":6}}}"#);
+
+    Ok(())
+}
+
+/// del()'s parent-key rule survives a `?` on the slice component itself.
+#[test]
+fn test_1116_chained_scalar_slice_del_with_optional() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[0:1]?)", r#"{"a":5,"b":6}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// del()'s parent-key rule is scalar-only — an array target keeps
+/// succinctly's own working chained slice-delete, same rationale as the
+/// assign-side regression guard above.
+#[test]
+fn test_1116_chained_array_slice_del_still_works() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3])",
+        r#"{"a":[1,2,3,4,5],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,4,5],"b":6}"#);
+    Ok(())
+}
+
+/// Deleting through a missing/absent intermediate step stays a no-op —
+/// untouched by #1116, regression guard against the new path-rewrite logic
+/// accidentally firing where the prefix doesn't even resolve.
+#[test]
+fn test_1116_chained_scalar_slice_del_through_missing_still_noops() -> Result<()> {
+    let input = r#"{"a":{"b":1}}"#;
+    let (out, code) = run_yq_stdin("del(.a.c[0:1])", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+    Ok(())
+}
+
+/// `(.[0:1]) = 99` / `(.[0:1]) |= 99` — a parenthesized *bare* slice at the
+/// top of a resolved path. #1101 covered this only by accident (its old
+/// pre-check ran before `set_path`/`update_path` were ever reached with a
+/// `Paren`-wrapped path); #1116 removed that pre-check in favor of pushing
+/// the whole check into `through_slice`'s own recursion, which exposed that
+/// neither function had ever had its own `Expr::Paren` arm. Regression
+/// guard for the fix.
+#[test]
+fn test_1116_paren_wrapped_bare_slice_assign_still_noops() -> Result<()> {
+    let (out, code) = run_yq_stdin("(.[0:1]) = 99", "5", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin("(.[0:1]) |= 99", "5", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "5");
+
+    Ok(())
+}
+
 /// Reference decoder used only to compute expected lossy-UTF-8 output for
 /// the tests above, independent of the implementation under test.
 fn base64_decode_lossy(s: &str) -> String {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13558,6 +13558,33 @@ fn test_1116_chained_scalar_slice_del_removes_parent_key() -> Result<()> {
     Ok(())
 }
 
+/// del()'s parent-key rule also applies when the resolved path fans out
+/// into more than one target (a top-level comma, or a computed key with
+/// multiple values) — `delete_expr_paths_at`'s sibling-grouping walker
+/// never sees the original chained-scalar-slice path at all, since each
+/// resolved path is rewritten *before* flattening, the same way #1101's
+/// own no-op rule already had to be special-cased for this branch.
+#[test]
+fn test_1116_chained_scalar_slice_del_multi_path() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:1], .b[0:1])",
+        r#"{"a":5,"b":6,"c":7}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"c":7}"#);
+
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:1], .c)",
+        r#"{"a":5,"b":6,"c":7}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+
+    Ok(())
+}
+
 /// del()'s parent-key rule survives a `?` on the slice component itself.
 #[test]
 fn test_1116_chained_scalar_slice_del_with_optional() -> Result<()> {


### PR DESCRIPTION
## Summary

#1101 covered only a **bare** scalar-slice path (`.[S:E]`). This extends the same no-op to a **chained** one (`.foo[S:E]` where `.foo` is itself a scalar) for `=`/`|=`/`+=`, and implements `del()`'s genuinely different rule for the same shape: it deletes the whole parent key instead of no-op'ing.

```
$ echo '{"a":5,"b":6}' | yq -o=json '.a[0:1] = 99'
{"a": 5, "b": 6}                      # no-op, same as the bare-root case

$ echo '{"a":5,"b":6}' | yq -o=json 'del(.a[0:1])'
{"b": 6}                              # .a is gone entirely, NOT a no-op
```

## Design

`through_slice` is the single choke point every slice write passes through in both `set_path` (`=`) and `update_path` (`|=`/`+=`), regardless of nesting depth — so pushing the yq-scalar-noop check there (instead of `eval_assign`/`eval_update`'s old bare-root-only pre-check) covers any chain depth for free, and simplifies both callers.

Threading the new `scalar_noop` bool down also surfaced that neither `set_path` nor `update_path` had ever needed an `Expr::Paren` top-level arm — the old pre-check always intercepted a `Paren`-wrapped bare slice (`(.[0:1]) = 99`) before either function was reached at all. Added both, with regression tests.

`del()`'s rule needed its own walker (`yq_del_scalar_slice_parent_path` + `navigate_read_only`): `del()` has no "edit closure" to discard a result from, and the parent *key* it needs to remove requires the parent container in hand, which `through_slice`'s own recursion never has.

Scoped to **scalar** targets only, matching `is_yq_scalar_slice_assign_path`'s existing precedent — real yq's chained slice-delete turns out to drop the whole parent key for array/object targets too (verified live), but replicating that would remove succinctly's own working, jq-consistent slicing there to match what looks like a real-yq gap, not a deliberate feature.

## Code review fixes (round 2)

Mandatory `/code-review` (8 parallel finder agents) found `del()`'s new rule was wired into `builtin_del`'s single-path branch only — a multi-path `del()` (top-level comma, or a multi-valued computed key) never got the rewrite, mirroring the exact gap #1101's own no-op rule already had to be special-cased for in the same function. Fixed by rewriting each resolved path before `flatten_delete_path`/`delete_expr_paths_at` (the complex, heavily-tested sibling-grouping walker) ever sees it, rather than teaching that machinery the rule directly.

Two remaining, architecturally separate gaps found in the same review — a `.[]` earlier in the path preventing `del()`'s rule from applying per-element, and a parenthesized `del()` target (pre-existing, unrelated to slices at all, predates this PR) — are filed as #1153 rather than fixed here.

## Coverage

Patch coverage was 79.7% after the initial implementation. Closed it to 96%+ with targeted tests for previously-unexercised branches surfaced by threading the new parameter through `set_path`/`update_path`/`navigate_read_only` (nested Index+Field prefixes, type-mismatch/out-of-bounds fallbacks, Object-side `Expr::Iterate` arms, and error-propagation through the discarded-filter throwaway) — one of which (`del(.a[0].b[0:1])`) turned out to be a genuine additional fix, not just a coverage exercise. The couple of remaining lines are either documented as unreachable by construction (`resolve_dynamic_indexes` never produces a length-1 `Expr::Pipe`) or genuinely hard-to-trigger pre-existing branches this PR only touched by adding a parameter, not new logic.

Fixes #1116

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] 25 new tests total across `tests/yq_cli_tests.rs`, `tests/jq_cli_tests.rs`, and `src/jq/eval.rs`'s embedded unit tests