### PR TITLE
fix(jq): --argjson tolerates a leading-zero number, matching real jq

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1536,6 +1536,22 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
             while i < bytes.len() && bytes[i].is_ascii_digit() {
                 i += 1;
             }
+            if int_start == i {
+                // A bare `-` with no digit following it at all (`-`,
+                // `[-,1]`, `{"a":-}`) isn't a number token in the first
+                // place -- only reachable when `b == '-'`, since a digit
+                // `b` always advances the scan above by at least one.
+                // Leaving it untouched (not fabricating a `0` digit) is
+                // required, not just tidier: filling one in turns a
+                // genuinely malformed token into a syntactically valid
+                // one (`-0`), which would make the retried `serde_json`
+                // validation below wrongly pass and this genuinely
+                // invalid input silently reach `json_bytes_to_owned_value`
+                // as `null` instead of erroring (found by review before
+                // merge).
+                out.push(b'-');
+                continue;
+            }
             let stripped = s[int_start..i].trim_start_matches('0');
             out.extend_from_slice(&bytes[start..int_start]);
             out.extend_from_slice(if stripped.is_empty() {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1474,9 +1474,106 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
         return Ok(OwnedValue::Null);
     }
 
-    serde_json::from_str::<serde_json::Value>(s).with_context(|| format!("Invalid JSON: {s}"))?;
+    if let Err(e) = serde_json::from_str::<serde_json::Value>(s) {
+        // Real jq's own number parser tolerates a leading zero (`007`,
+        // `00`, `007.5`) that strict JSON doesn't (#1094) -- retry once
+        // with every number token's leading zero stripped (string
+        // contents/keys left untouched) before surfacing the original
+        // error. Only paid on this (rare) failure path, so the common
+        // case's validation cost is unaffected. `json_bytes_to_owned_value`
+        // below still runs on the *original* text, not the normalized one:
+        // this crate's own semi-indexer already tolerates a leading zero
+        // on its own (confirmed live), so there's nothing left to repair
+        // for it.
+        let normalized = normalize_leading_zero_numbers(s);
+        if normalized == s || serde_json::from_str::<serde_json::Value>(&normalized).is_err() {
+            return Err(e).with_context(|| format!("Invalid JSON: {s}"));
+        }
+    }
 
     Ok(crate::output::json_bytes_to_owned_value(s.as_bytes()))
+}
+
+/// Strip a leading zero from every JSON number token in `s` (`007` ->
+/// `7`, `-00` -> `-0`, `007.5` -> `7.5`), leaving string contents/keys and
+/// all other structure untouched. Real jq's own number parser tolerates a
+/// leading zero (unlike strict RFC 8259 JSON); this repairs just that one
+/// divergence before re-validating with `serde_json` (#1094) -- the
+/// trailing-garbage/number-range checks that validation exists for still
+/// apply to the normalized text exactly as before.
+fn normalize_leading_zero_numbers(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(s.len());
+    let mut i = 0;
+    let mut in_string = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_string {
+            out.push(b);
+            if b == b'\\' && i + 1 < bytes.len() {
+                out.push(bytes[i + 1]);
+                i += 2;
+                continue;
+            }
+            if b == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if b == b'"' {
+            in_string = true;
+            out.push(b);
+            i += 1;
+            continue;
+        }
+        if b == b'-' || b.is_ascii_digit() {
+            let start = i;
+            if b == b'-' {
+                i += 1;
+            }
+            let int_start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            let stripped = s[int_start..i].trim_start_matches('0');
+            out.extend_from_slice(&bytes[start..int_start]);
+            out.extend_from_slice(if stripped.is_empty() {
+                b"0"
+            } else {
+                stripped.as_bytes()
+            });
+            if i < bytes.len() && bytes[i] == b'.' {
+                let frac_start = i;
+                i += 1;
+                while i < bytes.len() && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                out.extend_from_slice(&bytes[frac_start..i]);
+            }
+            if i < bytes.len() && (bytes[i] == b'e' || bytes[i] == b'E') {
+                let exp_start = i;
+                i += 1;
+                if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+                    i += 1;
+                }
+                while i < bytes.len() && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                out.extend_from_slice(&bytes[exp_start..i]);
+            }
+            continue;
+        }
+        // Every byte reaching here is copied verbatim, one at a time,
+        // whether ASCII structural syntax or (only possible inside a
+        // string, already handled above) a multi-byte UTF-8 continuation
+        // byte -- `out` ends up byte-identical to `s` except for the
+        // leading-zero digits actually stripped above, so `from_utf8`
+        // below can never fail.
+        out.push(b);
+        i += 1;
+    }
+    String::from_utf8(out).expect("only ever copies s's own bytes verbatim or drops leading ASCII '0' digits, never splits a multi-byte sequence")
 }
 
 /// Parse a JSON stream (multiple JSON values) from a string (`--slurpfile`).

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -690,6 +690,26 @@ fn test_argjson_malformed_json_still_rejected_1094() -> Result<()> {
     Ok(())
 }
 
+/// Regression guard (found by review before merge): a bare `-` with no
+/// digit following it isn't a number token at all, but an earlier draft
+/// of `normalize_leading_zero_numbers` fabricated a `0` digit for it
+/// (turning the genuinely invalid `-` into the valid number `-0`), which
+/// made the retried validation wrongly pass and let this malformed input
+/// silently reach materialization as `null` instead of erroring. Real jq
+/// rejects all three of these outright.
+#[test]
+fn test_argjson_bare_hyphen_rejected_not_fabricated_into_negative_zero_1094() -> Result<()> {
+    let (_, _, code) = run_jq_full(&["-n", "--argjson", "n", "-", "$n"], None)?;
+    assert_ne!(code, 0);
+
+    let (_, _, code) = run_jq_full(&["-cn", "--argjson", "n", "[-,1]", "$n"], None)?;
+    assert_ne!(code, 0);
+
+    let (_, _, code) = run_jq_full(&["-cn", "--argjson", "n", r#"{"a":-}"#, "$n"], None)?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
 /// A negative leading-zero number, reached nested inside an array so it
 /// doesn't hit the unrelated CLI arg-parsing issue a bare negative
 /// `--argjson` value has (#1150) -- exercises

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -579,6 +579,117 @@ fn test_argjson_preserves_number_literal_fidelity_1058() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// #1094: `--argjson` tolerates a leading-zero number the way real jq's own
+// number parser does, instead of rejecting it outright via strict RFC 8259
+// validation. All cases live-verified against jq 1.7.1.
+// =============================================================================
+
+/// The issue's own repro: a leading-zero integer/float, accepted and
+/// normalized exactly like real jq.
+#[test]
+fn test_argjson_tolerates_leading_zero_number_1094() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "7");
+
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "00", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "0");
+
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007.5", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "7.5");
+    Ok(())
+}
+
+/// A leading-zero number combined with a *trailing* zero (`007.500`) is
+/// accepted (not rejected outright, this issue's own scope), but loses the
+/// trailing zero's spelling (`7.5`, not real jq's `7.500`) -- a pre-existing
+/// gap in this crate's own `NumberLiteral`-preservation fast path for any
+/// leading-zero literal, reproducing identically via plain document input
+/// (`echo '007.500' | succinctly jq '.'`), unrelated to `--argjson` and out
+/// of this fix's scope. Tracked as #1149 (filed for the sibling
+/// scientific-notation case; same root cause, broader than its title
+/// suggests). This test pins current, non-regressed behavior, not the
+/// (still wrong) spelling.
+#[test]
+fn test_argjson_leading_zero_accepted_but_trailing_zero_spelling_lost_1094() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007.500", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "7.5");
+    Ok(())
+}
+
+/// Trailing garbage after a leading-zero number is still rejected --
+/// leading-zero tolerance must not accidentally widen the #284 guard it
+/// sits next to.
+#[test]
+fn test_argjson_leading_zero_still_rejects_trailing_garbage_1094() -> Result<()> {
+    let (_, _, code) = run_jq_full(&["-n", "--argjson", "n", "007 garbage", "$n"], None)?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// Plain trailing garbage (no leading zero involved at all) is still
+/// rejected -- confirms the fast, common-case path (no normalization
+/// needed) is unaffected by this fix.
+#[test]
+fn test_argjson_plain_trailing_garbage_still_rejected_1094() -> Result<()> {
+    let (_, _, code) = run_jq_full(&["-n", "--argjson", "n", "42 garbage", "$n"], None)?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// A leading-zero number nested inside an array or object is tolerated
+/// too, not just a bare top-level scalar.
+#[test]
+fn test_argjson_leading_zero_tolerated_when_nested_1094() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-cn", "--argjson", "n", "[007, 1]", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[7,1]");
+
+    let (stdout, _, code) = run_jq_full(&["-cn", "--argjson", "n", r#"{"a": 007}"#, "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"{"a":7}"#);
+    Ok(())
+}
+
+/// Digits that merely *look* like a leading-zero number, but are actually
+/// inside a string (a value or an object key), are left completely
+/// untouched by the normalization pass.
+#[test]
+fn test_argjson_leading_zero_inside_string_or_key_untouched_1094() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", r#""007""#, "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#""007""#);
+
+    let (stdout, _, code) = run_jq_full(&["-cn", "--argjson", "n", r#"{"007": 1}"#, "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"{"007":1}"#);
+    Ok(())
+}
+
+/// A normal number with no leading zero is completely unaffected --
+/// confirms the fast path (strict validation succeeds on the first try,
+/// no normalization attempted) isn't disturbed by this fix.
+#[test]
+fn test_argjson_normal_number_unaffected_1094() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "42", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "42");
+    Ok(())
+}
+
+/// Genuinely malformed JSON (not just a leading zero) is still rejected --
+/// normalization doesn't accidentally make garbage input parse.
+#[test]
+fn test_argjson_malformed_json_still_rejected_1094() -> Result<()> {
+    let (_, _, code) = run_jq_full(&["-n", "--argjson", "n", "not json", "$n"], None)?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
 #[test]
 fn test_multiple_variables() -> Result<()> {
     let (output, code) = run_jq_null("$a + $b", &["--argjson", "a", "10", "--argjson", "b", "20"])?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -690,6 +690,56 @@ fn test_argjson_malformed_json_still_rejected_1094() -> Result<()> {
     Ok(())
 }
 
+/// A negative leading-zero number, reached nested inside an array so it
+/// doesn't hit the unrelated CLI arg-parsing issue a bare negative
+/// `--argjson` value has (#1150) -- exercises
+/// `normalize_leading_zero_numbers`'s own leading-`-` handling.
+#[test]
+fn test_argjson_negative_leading_zero_when_nested_1094() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-cn", "--argjson", "n", "[-007, 1]", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[-7,1]");
+    Ok(())
+}
+
+/// A string containing a backslash escape sequence, alongside a
+/// leading-zero number that triggers normalization -- confirms the escape
+/// handling inside `normalize_leading_zero_numbers`'s string-tracking
+/// correctly copies the escaped character without misreading it as ending
+/// the string early.
+#[test]
+fn test_argjson_escaped_string_alongside_leading_zero_1094() -> Result<()> {
+    let (stdout, _, code) =
+        run_jq_full(&["-cn", "--argjson", "n", r#"["a\nb", 007]"#, "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"["a\nb",7]"#);
+    Ok(())
+}
+
+/// A leading-zero number combined with scientific notation is accepted
+/// (not rejected outright), exercising `normalize_leading_zero_numbers`'s
+/// exponent-handling branch -- exact spelling is a separate, pre-existing
+/// gap (#1149), so this only pins acceptance and the correct numeric
+/// value, not the display spelling.
+#[test]
+fn test_argjson_leading_zero_with_exponent_accepted_1094() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007e5", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "700000");
+    Ok(())
+}
+
+/// Same as above, but with an explicit `+` sign on the exponent --
+/// exercises `normalize_leading_zero_numbers`'s explicit-exponent-sign
+/// branch specifically.
+#[test]
+fn test_argjson_leading_zero_with_signed_exponent_accepted_1094() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007e+5", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "700000");
+    Ok(())
+}
+
 #[test]
 fn test_multiple_variables() -> Result<()> {
     let (output, code) = run_jq_null("$a + $b", &["--argjson", "a", "10", "--argjson", "b", "20"])?;


### PR DESCRIPTION
## Summary
- Real jq's own number parser accepts leading-zero numbers (`007`, `00`, `007.5`) — not RFC 8259-valid JSON, but more lenient than strict JSON here. succinctly's `--argjson` rejected them outright via `serde_json::from_str`'s strict validation, which exists to reject trailing garbage (`42 garbage`, #284) and range-check magnitude overflow — neither of which this fix touches.
- Fixed by normalizing away a leading zero from every number token (skipping string contents/keys) only on the failure path, then retrying the same strict `serde_json` validation against the normalized text — so trailing-garbage rejection and the common (no-leading-zero) case's validation cost are both unaffected. The crate's own JSON semi-indexer already tolerates a leading zero on its own (confirmed live), so materialization still runs on the original text unchanged.

## Deliberately out of scope (filed as follow-ups)
- #1149 — a leading-zero literal loses full spelling fidelity on redisplay (`007.500` → `7.5`, `007e5` → `700000`, not real jq's `7.500`/`7E+5`). Reproduces identically via plain document input, unrelated to `--argjson` — a pre-existing gap in this crate's `NumberLiteral`-preservation fast path.
- #1150 — `--argjson` can't accept a negative-number value at all due to a CLI arg-parsing issue (affects every negative number, not just leading-zero ones).

Fixes #1094

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (NEON YAML backend)
- [x] `cargo check --no-default-features` (no_std)
- [x] Verified against the pinned real `jq` binary across leading-zero variants, trailing-garbage combinations, nesting, string/key false-positives, and malformed input
- [x] Patch coverage: 100% (71/71 new lines)