### PR TITLE
refactor(jq): give unary minus its own dedicated Expr::Negate variant

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -261,6 +261,7 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
             left: Box::new(rewrite_namespaced_calls(*left)),
             right: Box::new(rewrite_namespaced_calls(*right)),
         },
+        Expr::Negate(inner) => Expr::Negate(Box::new(rewrite_namespaced_calls(*inner))),
         Expr::Compare { op, left, right } => Expr::Compare {
             op,
             left: Box::new(rewrite_namespaced_calls(*left)),

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2279,6 +2279,7 @@ fn contains_split_doc(expr: &Expr) -> bool {
         | Expr::FirstExpr(inner)
         | Expr::LastExpr(inner)
         | Expr::Repeat(inner)
+        | Expr::Negate(inner)
         | Expr::Error(Some(inner)) => contains_split_doc(inner),
         Expr::Arithmetic { left, right, .. }
         | Expr::Compare { left, right, .. }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -461,6 +461,13 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         Expr::Arithmetic { left, right, .. } => {
             needs_path_context(left) || needs_path_context(right)
         }
+        // Same reasoning as `Arithmetic` above: a `key`/`file_index` can
+        // hide inside unary minus's single operand too, e.g.
+        // `-(file_index)` (#1100). Without this arm the whole pipe reports
+        // `needs_path_context == false` and silently falls back to
+        // `eval_single`'s 0-stub `file_index` instead of erroring or
+        // resolving correctly.
+        Expr::Negate(inner) => needs_path_context(inner),
         Expr::Builtin(Builtin::Select(cond)) => needs_path_context(cond),
         // `map(f)` needs the same recursion as `Select` above -- e.g.
         // `map(select(file_index == 0))`, previously silently stubbed to 0
@@ -661,6 +668,8 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Expr::Arithmetic { op, left, right } => {
             eval_arithmetic::<W, S>(*op, left, right, value, optional)
         }
+
+        Expr::Negate(operand) => eval_negate::<W, S>(operand, value, optional),
 
         Expr::Compare { op, left, right } => {
             eval_compare::<W, S>(*op, left, right, value, optional)
@@ -1638,6 +1647,78 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     }
 }
 
+/// Shared unary fork/negate/finish core behind [`eval_negate`] and its
+/// path-context sibling -- the same operand-evaluation-strategy split
+/// [`binary_fanout_core`] established for the binary case (#768), applied
+/// here to unary minus's single operand (#1100): fork `operand_result` into
+/// every output it produces, negating each one via `arith_negate`.
+/// `-(1,2,3)` still yields one negated result per generator output. The
+/// operand's own trailing escape goes through `partial` unconditionally;
+/// `arith_negate`'s own error is what `finish_fork` gates on `optional` --
+/// deliberately a dedicated function rather than reusing
+/// [`eval_binary_fanout`] with a dummy left operand the way
+/// `ArithOp::Negate` used to, since that dummy was evaluated once per real
+/// output instead of once overall.
+fn negate_fanout_core<W, S: EvalSemantics>(
+    operand_result: QueryResult<'_, W>,
+    optional: bool,
+) -> QueryResult<'_, W>
+where
+    W: Clone + AsRef<[u64]>,
+{
+    let mut vals = Vec::new();
+    let control = push_owned_values(operand_result, &mut vals);
+
+    let mut out: Vec<OwnedValue> = Vec::new();
+    for val in vals {
+        match arith_negate::<S>(val) {
+            Ok(v) => out.push(v),
+            Err(e) => return finish_fork(out, Some(e.into()), optional),
+        }
+    }
+
+    match control {
+        Some(c) => partial(out, c),
+        None => owned_vec_to_result(out),
+    }
+}
+
+fn eval_negate<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    operand: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    negate_fanout_core::<W, S>(eval_single::<W, S>(operand, value, optional), optional)
+}
+
+/// Path-context analog of [`eval_negate`] (mirroring
+/// [`eval_binary_fanout_with_path_context`]'s relationship to
+/// [`eval_binary_fanout`]): routes the operand through
+/// [`eval_pipe_with_path_context_internal`] instead of [`eval_single`] so
+/// `key`/`parent`/`file_index` nested inside `-expr` still resolve against
+/// `root`/`current_path`/`file_origin`, matching `Expr::Arithmetic`'s own
+/// dedicated path-context arm just above (#715/#822).
+fn eval_negate_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    operand: &Expr,
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    optional: bool,
+) -> QueryResult<'a, W> {
+    negate_fanout_core::<W, S>(
+        eval_pipe_with_path_context_internal::<W, S>(
+            core::slice::from_ref(operand),
+            value,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        ),
+        optional,
+    )
+}
+
 fn eval_binary_fanout<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     left: &Expr,
     right: &Expr,
@@ -1673,9 +1754,6 @@ fn eval_arithmetic<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, flags),
             ArithOp::Div => arith_div::<S>(left_val, right_val),
             ArithOp::Mod => arith_mod::<S>(left_val, right_val),
-            // `left_val` is always the unused dummy (see `ArithOp::Negate`'s
-            // own doc comment).
-            ArithOp::Negate => arith_negate::<S>(right_val),
         },
     )
 }
@@ -13762,6 +13840,9 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
             left: Box::new(substitute_var(left, var_name, replacement)),
             right: Box::new(substitute_var(right, var_name, replacement)),
         },
+        Expr::Negate(operand) => {
+            Expr::Negate(Box::new(substitute_var(operand, var_name, replacement)))
+        }
         Expr::Compare { op, left, right } => Expr::Compare {
             op: *op,
             left: Box::new(substitute_var(left, var_name, replacement)),
@@ -16587,9 +16668,6 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, *flags),
                     ArithOp::Div => arith_div::<S>(left_val, right_val),
                     ArithOp::Mod => arith_mod::<S>(left_val, right_val),
-                    // `left_val` is always the unused dummy (see
-                    // `ArithOp::Negate`'s own doc comment).
-                    ArithOp::Negate => arith_negate::<S>(right_val),
                 },
             );
             if rest.is_empty() {
@@ -16604,6 +16682,31 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // `ManyOwned`/`Partial`/`Break`, not just `Owned`/`None`/`Error`.
             continue_rest_with_context::<W, S>(
                 arith_result,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        Expr::Negate(operand) => {
+            // Same `key`/`file_index`-inside-the-operand reasoning as
+            // `Arithmetic` above -- `-select(file_index==0)` needs the
+            // path-context evaluator too, not the 0-stub `eval_single`
+            // would otherwise use for the operand (#1100).
+            let negate_result = eval_negate_with_path_context::<W, S>(
+                operand,
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            if rest.is_empty() {
+                return negate_result;
+            }
+            continue_rest_with_context::<W, S>(
+                negate_result,
                 rest,
                 root,
                 file_origin,
@@ -23483,6 +23586,9 @@ fn expand_func_calls(expr: &Expr, func_name: &str, params: &[String], body: &Exp
             left: Box::new(expand_func_calls(left, func_name, params, body)),
             right: Box::new(expand_func_calls(right, func_name, params, body)),
         },
+        Expr::Negate(operand) => Expr::Negate(Box::new(expand_func_calls(
+            operand, func_name, params, body,
+        ))),
         Expr::Compare { op, left, right } => Expr::Compare {
             op: *op,
             left: Box::new(expand_func_calls(left, func_name, params, body)),
@@ -23745,6 +23851,7 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
             left: Box::new(substitute_func_param(left, param, arg)),
             right: Box::new(substitute_func_param(right, param, arg)),
         },
+        Expr::Negate(operand) => Expr::Negate(Box::new(substitute_func_param(operand, param, arg))),
         Expr::Compare { op, left, right } => Expr::Compare {
             op: *op,
             left: Box::new(substitute_func_param(left, param, arg)),
@@ -39105,6 +39212,57 @@ mod tests {
             eval_all_outputs(b"[10]", &[0], ".[] | (((1,2) + (10,20)), file_index)"),
             vec!["11", "12", "21", "22", "0"]
         );
+    }
+
+    #[test]
+    fn test_negate_continues_pipe_with_path_context_1100() {
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[7, 8], ".[] | -(file_index) | tostring"),
+            vec![r#""-7""#, r#""-8""#]
+        );
+    }
+
+    #[test]
+    fn test_negate_operand_error_propagates_with_path_context_1100() {
+        match eval_all_result(b"[1]", &[0], r#".[] | (-error("boom")) | file_index"#) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_negate_multi_output_operand_fans_out_with_path_context_1100() {
+        // Same "one negated result per generator output" contract
+        // `test_unary_minus_zero_preserves_sign_1056` already asserts for
+        // `eval_single`'s non-path-context `eval_negate`, but for
+        // `eval_negate_with_path_context` (#1100).
+        assert_eq!(
+            eval_all_outputs(b"[10]", &[0], ".[] | (-(1,2,3), file_index)"),
+            vec!["-1", "-2", "-3", "0"]
+        );
+    }
+
+    #[test]
+    fn test_negate_inside_select_condition_with_path_context_1100() {
+        // `needs_path_context`'s own `Compare`/`Select` arms recurse into
+        // their operands to catch a nested `key`/`file_index` (#715) --
+        // `-file_index` is a `Negate` wrapping the same `FileIndex` builtin,
+        // so it needs the identical recursion (#1100). This regressed to
+        // silently comparing against the 0-stub `file_index` (always false
+        // for file 1) before `needs_path_context` grew a `Negate` arm.
+        assert_eq!(
+            eval_all_outputs(b"[10,20]", &[0, 1], ".[] | select(-file_index == -1)"),
+            vec!["20"]
+        );
+    }
+
+    #[test]
+    fn test_map_negate_preserves_all_elements() {
+        // Regression for #1100: `Expr::Negate` maps `arith_negate` over each
+        // generator output directly rather than routing through
+        // `eval_binary_fanout`'s dummy-`left`-operand rewrite -- confirm
+        // `map(-.)` still negates every element, not just the first.
+        assert_eq!(outputs(b"[1,2,3]", "map(-.)"), vec!["[-1,-2,-3]"]);
     }
 
     #[test]

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -119,7 +119,7 @@ pub enum Expr {
 
     /// Unary minus: `-expr` (#1100). A dedicated single-child variant,
     /// matching this AST's own convention for unary operations (`Paren`,
-    /// `Optional`, `Select`, etc. above) -- unlike the `ArithOp::Negate`
+    /// `Optional`, etc. above) -- unlike the `ArithOp::Negate`
     /// approach it replaces, which reused `Expr::Arithmetic`'s binary shape
     /// with an always-unused dummy `left` operand purely to borrow its
     /// existing fan-out (cartesian-product) machinery. That reuse worked

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -117,6 +117,19 @@ pub enum Expr {
         right: Box<Self>,
     },
 
+    /// Unary minus: `-expr` (#1100). A dedicated single-child variant,
+    /// matching this AST's own convention for unary operations (`Paren`,
+    /// `Optional`, `Select`, etc. above) -- unlike the `ArithOp::Negate`
+    /// approach it replaces, which reused `Expr::Arithmetic`'s binary shape
+    /// with an always-unused dummy `left` operand purely to borrow its
+    /// existing fan-out (cartesian-product) machinery. That reuse worked
+    /// correctly but re-evaluated the dummy operand once per output the
+    /// real operand produced (`map(-.)` over N elements: N wasted dummy
+    /// evaluations); this variant evaluates its one real operand directly,
+    /// mapping `arith_negate` over each output instead of routing through
+    /// the binary fan-out path at all.
+    Negate(Box<Self>),
+
     /// Comparison operation: `.a == .b`, `.a != .b`, `.a < .b`, etc.
     Compare {
         op: CompareOp,
@@ -1031,16 +1044,6 @@ pub enum ArithOp {
     Div,
     /// Modulo: `%`
     Mod,
-    /// Unary minus: `-expr` (#1056). A true IEEE-754 negation, not `0 -
-    /// expr` (loses the sign of a zero-valued operand) or `-1 * expr`
-    /// (silently inherits `*`'s unrelated string-repetition and
-    /// null-passthrough semantics instead of erroring on a non-numeric
-    /// operand -- caught by code review before this reached `main`). Reuses
-    /// `Expr::Arithmetic`'s binary shape purely for its existing fan-out
-    /// machinery (a generator operand like `-(1,2,3)` still needs to
-    /// produce one negated result per output); `left` is always a dummy
-    /// `Expr::Literal(Literal::Null)` that the evaluator ignores.
-    Negate,
 }
 
 /// yq merge-flag suffixes on the `*`/`*=` merge operator (e.g. `*+d`, `*=nd`).

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1060,7 +1060,7 @@ impl<'a> Parser<'a> {
                 } else {
                     // Unary minus: negate the following expression.
                     //
-                    // `ArithOp::Negate`, not `(0 - expr)` (#1056): IEEE-754
+                    // `Expr::Negate`, not `(0 - expr)` (#1056): IEEE-754
                     // `0.0 - 0.0` is positive zero, silently losing the sign
                     // of a zero-valued operand (`-.a` on `0.0` dropped jq's
                     // `-0` to plain `0`). Also not `(-1 * expr)` (an earlier
@@ -1068,16 +1068,10 @@ impl<'a> Parser<'a> {
                     // has its own string-repetition and null-passthrough
                     // semantics that have nothing to do with negation, so
                     // `-"abc"`/`-null` silently returned `null` instead of
-                    // erroring. `left` here is an unused dummy -- see
-                    // `ArithOp::Negate`'s own doc comment for why this still
-                    // reuses `Expr::Arithmetic`'s binary shape.
+                    // erroring.
                     self.next(); // consume '-'
                     let operand = self.parse_primary()?;
-                    Ok(Expr::Arithmetic {
-                        op: ArithOp::Negate,
-                        left: Box::new(Expr::Literal(Literal::Null)),
-                        right: Box::new(operand),
-                    })
+                    Ok(Expr::Negate(Box::new(operand)))
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixes #1100. Replaces `ArithOp::Negate`'s reuse of `Expr::Arithmetic { op, left, right }` (with `left` always an unused dummy `Expr::Literal(Literal::Null)`, purely to borrow the binary fan-out machinery) with a dedicated `Expr::Negate(Box<Expr>)`, matching the AST's existing convention for unary operations (`Optional`, `Paren`, `Select`, etc.).

- `negate_fanout_core`/`eval_negate`/`eval_negate_with_path_context` map `arith_negate` over each operand output directly, instead of routing through `eval_binary_fanout`'s dummy-left-operand rewrite. That rewrite re-evaluated the dummy `Null` once per output the real operand produced (`map(-.)` over N elements: N wasted dummy evaluations) — this eliminates that entirely.
- Removed the four "left is always the unused dummy" reminder comments the old approach needed (`src/jq/expr.rs`, `src/jq/eval.rs` x2, `src/jq/parser.rs`) — nothing to remind readers of now, since there's no shared binary shape to misuse.
- Swept every exhaustive `Expr` match this repo maintains for the new variant: `eval_single`, `eval_pipe_with_path_context_internal` (both the dispatch match *and* the separate `needs_path_context` gating function — see below), `substitute_var`, `expand_func_calls`, `substitute_func_param`, plus two CLI-side recursive rewriters (`jq_runner.rs`'s `rewrite_namespaced_calls`, `yq_runner.rs`'s `contains_split_doc`).

## A real gap the new regression tests caught

While adding path-context regression tests I found `needs_path_context` (a separate gating function that decides whether a pipe enters path-context evaluation at all) had no `Expr::Negate` arm. Without it, something like `select(-file_index == -1)` silently fell back to `eval_single`'s 0-stub `file_index` instead of resolving via the real `--eval-all` path context — same class of bug `Arithmetic`/`Compare`/`Select` already guard against for #715. Fixed by adding the missing arm; `test_negate_inside_select_condition_with_path_context_1100` pins it.

## Testing

- New: `test_negate_continues_pipe_with_path_context_1100`, `test_negate_operand_error_propagates_with_path_context_1100`, `test_negate_multi_output_operand_fans_out_with_path_context_1100`, `test_negate_inside_select_condition_with_path_context_1100`, `test_map_negate_preserves_all_elements`.
- All pre-existing `#1056` unary-minus tests still pass unmodified (sign preservation, yq-mode gating, non-numeric errors, `-(1,2,3)` generator fan-out, mid-pipe `key` survival).
- Full local pipeline green: `cargo build --features cli`, full `cargo test --features cli,simd,regex,serde` (2 clean runs), both required clippy invocations, `cargo check --no-default-features` (no_std), `cargo doc --all-features` with `-D warnings`.

## Out of scope

The issue's own "Minor: overflow-handling pattern now written a third time" suggestion (a shared `checked_or_wrapping_i64` helper for `arith_negate`/`arith_add`/`arith_sub`) is left for a future pass, as the issue itself frames it as optional/lower-priority.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, twice, both clean)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`