### PR TITLE
fix(jq): yq slice compound-assign no-ops on a container target too

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10763,20 +10763,32 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             } else {
                 new_value.clone()
             };
-            // yq's slice-assignment no-op (#1101, generalized to any chain
-            // depth by #1116) — `set_path` itself now no-ops the *write*
-            // whenever it reaches a slice step targeting a scalar (see
-            // `through_slice`'s doc comment), whether that's the whole path
-            // (`5 | .[0:1] = 99`) or reached through a chain (`.a[0:1] = 99`
-            // on a scalar `.a`). The RHS (`value`, already fully computed
-            // above) is always evaluated normally either way, so its own
-            // errors/halt/break still propagate (`.[0:1] = error("boom")`
-            // genuinely errors in real yq; only `.[0:1] = 99`-shaped
-            // *successful* RHS values are silently discarded) — `=` has no
-            // filter of its own left to protect from a discarded write, so
-            // unlike `eval_update` there's no throwaway-execution step
-            // needed here at all, just passing the yq-mode flag through.
-            if let Err(e) = set_path(&mut result, path, value, S::TAG == EvalTag::Yq) {
+            // yq's slice-assignment no-op (#1101/#1116's scalar case,
+            // widened to a real array/string target by #1142) — `set_path`
+            // itself now no-ops the *write* whenever it reaches a slice
+            // step targeting a scalar or container (see `through_slice`'s
+            // doc comment), whether that's the whole path (`5 | .[0:1] =
+            // 99`) or reached through a chain (`.a[0:1] = 99` on a scalar
+            // or array/string `.a`). The RHS (`value`, already fully
+            // computed above) is always evaluated normally either way, so
+            // its own errors/halt/break still propagate (`.[0:1] = error(
+            // "boom")` genuinely errors in real yq; only `.[0:1] = 99`
+            // -shaped *successful* RHS values are silently discarded) —
+            // `=` has no filter of its own left to protect from a
+            // discarded write, so unlike `eval_update` there's no
+            // throwaway-execution step needed here at all, just passing
+            // the yq-mode flag through (twice: `=` has no operator-based
+            // exception the way `-=`/`*=` do for a *scalar* target, so
+            // both the scalar and container no-op flags are simply
+            // `S::TAG == EvalTag::Yq` here, unlike `eval_update`'s
+            // operator-gated `scalar_noop` below).
+            if let Err(e) = set_path(
+                &mut result,
+                path,
+                value,
+                S::TAG == EvalTag::Yq,
+                S::TAG == EvalTag::Yq,
+            ) {
                 // Atomic per RHS output, like `reduce`: this value's own
                 // path list contributes nothing, and the whole fan-out
                 // terminates here -- `docs` (only the strictly earlier,
@@ -11001,6 +11013,7 @@ fn set_path(
     path_expr: &Expr,
     new_value: OwnedValue,
     scalar_noop: bool,
+    container_noop: bool,
 ) -> Result<(), EvalError> {
     match path_expr {
         Expr::Identity => {
@@ -11034,15 +11047,19 @@ fn set_path(
         Expr::Pipe(exprs) if !exprs.is_empty() => {
             // For chained paths like .a.b.c, navigate to parent and set at last element
             if exprs.len() == 1 {
-                set_path(root, &exprs[0], new_value, scalar_noop)
+                set_path(root, &exprs[0], new_value, scalar_noop, container_noop)
             } else if let Some(split) = split_at_slice(exprs) {
                 match get_path_mut(root, split.before)? {
                     None => Ok(()),
-                    Some(parent) => {
-                        through_slice(parent, split.start, split.end, false, scalar_noop, |sub| {
-                            set_path(sub, &split.tail, new_value, scalar_noop)
-                        })
-                    }
+                    Some(parent) => through_slice(
+                        parent,
+                        split.start,
+                        split.end,
+                        false,
+                        scalar_noop,
+                        container_noop,
+                        |sub| set_path(sub, &split.tail, new_value, scalar_noop, container_noop),
+                    ),
                 }
             } else {
                 // Navigate to parent
@@ -11051,20 +11068,24 @@ fn set_path(
 
                 match get_path_mut(root, parent_path)? {
                     None => Ok(()),
-                    Some(parent) => set_path(parent, last_path, new_value, scalar_noop),
+                    Some(parent) => {
+                        set_path(parent, last_path, new_value, scalar_noop, container_noop)
+                    }
                 }
             }
         }
-        Expr::Optional(inner) => match set_path(root, inner, new_value, scalar_noop) {
-            Ok(()) => Ok(()),
-            // jq's `?` suppresses errors raised while *collecting* a path,
-            // but not the write-time bounds check on a still-negative array
-            // index — the one error left that `Index`'s arm above can still
-            // raise now that a positive overrun pads instead of erroring
-            // (#498).
-            Err(e) if e.is_negative_index_out_of_bounds() => Err(e),
-            Err(_) => Ok(()), // Silently succeed for optional
-        },
+        Expr::Optional(inner) => {
+            match set_path(root, inner, new_value, scalar_noop, container_noop) {
+                Ok(()) => Ok(()),
+                // jq's `?` suppresses errors raised while *collecting* a path,
+                // but not the write-time bounds check on a still-negative array
+                // index — the one error left that `Index`'s arm above can still
+                // raise now that a positive overrun pads instead of erroring
+                // (#498).
+                Err(e) if e.is_negative_index_out_of_bounds() => Err(e),
+                Err(_) => Ok(()), // Silently succeed for optional
+            }
+        }
         // `(EXPR)` at the top of a resolved path (e.g. `(.[0:1]) = 99`) —
         // previously always intercepted by #1101's pre-check before ever
         // reaching `set_path`, so this arm was never needed; #1116
@@ -11073,7 +11094,7 @@ fn set_path(
         // one, exposing the gap. Mirrors the `Optional` arm just above,
         // minus the swallow-on-error behavior `?` gets and bare parens
         // don't.
-        Expr::Paren(inner) => set_path(root, inner, new_value, scalar_noop),
+        Expr::Paren(inner) => set_path(root, inner, new_value, scalar_noop, container_noop),
         Expr::Iterate => match root {
             OwnedValue::Array(arr) => {
                 for elem in arr.iter_mut() {
@@ -11093,12 +11114,18 @@ fn set_path(
         // an array — that is the whole reason jq has a separate sentence for
         // it. An out-of-range range clamps rather than erroring, unlike the
         // `Expr::Index` arm above: `[1,2,3] | .[5:9] = ["x"]` appends.
-        Expr::Slice { start, end } => {
-            through_slice(root, *start, *end, false, scalar_noop, |sub| {
+        Expr::Slice { start, end } => through_slice(
+            root,
+            *start,
+            *end,
+            false,
+            scalar_noop,
+            container_noop,
+            |sub| {
                 *sub = new_value;
                 Ok(())
-            })
-        }
+            },
+        ),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
         // to the catch-all so a missed install point fails loudly here instead
@@ -11162,9 +11189,33 @@ fn through_slice<E: From<EvalError>>(
     end: Option<i64>,
     optional: bool,
     scalar_noop: bool,
+    container_noop: bool,
     edit: impl FnOnce(&mut OwnedValue) -> Result<(), E>,
 ) -> Result<(), E> {
     match root {
+        // yq's slice-write no-op (#1101/#1116's scalar case, widened to a
+        // real array/string target by #1142) — live-verified against yq
+        // v4.53.3 that this applies unconditionally to every write
+        // operator here (unlike the scalar case below, `-=`/`*=` no-op
+        // for a container target too, not just `=`/`|=`/`+=`, so callers
+        // pass `container_noop` independent of `scalar_noop`'s
+        // operator-gating). Unlike the scalar case's `[]` throwaway, real
+        // yq's discarded filter sees the slice's *actual* content
+        // (confirmed live: `.a[0:2] |= (length as $l | error($l|tostring))`
+        // on a 3-element array raises "2", the real two-element slice's
+        // own length, not 0) — so the throwaway here is the genuine
+        // `slice_owned_value` read, not an empty placeholder. This also
+        // means a chained slice with more path *after* it that's
+        // genuinely incompatible with the sliced type still errors
+        // (`.a[0:2].foo = v`, field access on an array) -- the attempt
+        // against the throwaway fails the same way it would against the
+        // real array, it just never gets spliced back on success.
+        OwnedValue::Array(_) | OwnedValue::String(_) if container_noop => {
+            let mut throwaway =
+                slice_owned_value(root, start, end, optional)?.unwrap_or(OwnedValue::Null);
+            edit(&mut throwaway)?;
+            Ok(())
+        }
         OwnedValue::Array(arr) => {
             let range = SliceBounds::from_literals(start, end).resolve(arr.len());
             let mut sub = OwnedValue::Array(arr[range.clone()].to_vec());
@@ -11492,11 +11543,24 @@ fn update_path<S: EvalSemantics>(
                     // The chain continues *inside* the slice, so the update
                     // runs against the sub-array and is spliced back:
                     // `[1,2,3,4] | .[1:3][] |= .*10` is `[1,20,30,4]`.
-                    Expr::Slice { start, end } => {
-                        through_slice(root, *start, *end, here, scalar_noop, |sub| {
-                            update_path::<S>(sub, &rest, filter_expr, optional, scalar_noop)
-                        })
-                    }
+                    //
+                    // yq mode: same container no-op as the terminal
+                    // `Expr::Slice` arm below (#1142) -- `container_noop`
+                    // is unconditional on the operator (unlike
+                    // `scalar_noop`, gated by the caller to exclude
+                    // `-=`/`*=`), since real yq no-ops a container slice
+                    // target for every operator, live-verified
+                    // (`.a[1:3][] |= . * 10` on `a: [1,2,3,4]` stays
+                    // unchanged).
+                    Expr::Slice { start, end } => through_slice(
+                        root,
+                        *start,
+                        *end,
+                        here,
+                        scalar_noop,
+                        S::TAG == EvalTag::Yq,
+                        |sub| update_path::<S>(sub, &rest, filter_expr, optional, scalar_noop),
+                    ),
                     _ => update_path::<S>(root, first, filter_expr, here, scalar_noop),
                 }
             }
@@ -11510,11 +11574,19 @@ fn update_path<S: EvalSemantics>(
         // splices the answer back, so `[1,2,3] | .[1:2] |= . + ["q"]` is
         // `[1,2,"q",3]`. `f` may return an array of any length, but it has to
         // be an array.
-        Expr::Slice { start, end } => {
-            through_slice(root, *start, *end, optional, scalar_noop, |sub| {
-                update_path::<S>(sub, &Expr::Identity, filter_expr, optional, scalar_noop)
-            })
-        }
+        //
+        // yq mode: real yq's container no-op (#1142) applies here too,
+        // unconditional on the operator -- see the Pipe-chain arm's
+        // matching comment above for the full rationale.
+        Expr::Slice { start, end } => through_slice(
+            root,
+            *start,
+            *end,
+            optional,
+            scalar_noop,
+            S::TAG == EvalTag::Yq,
+            |sub| update_path::<S>(sub, &Expr::Identity, filter_expr, optional, scalar_noop),
+        ),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
         // to the catch-all so a missed install point fails loudly here instead
@@ -19311,16 +19383,19 @@ fn delete_at_path(
                     Expr::Slice { .. } if matches!(root, OwnedValue::Null) => {
                         delete_at_path_through_absent(&rest, optional)
                     }
-                    // `scalar_noop: false` — del()'s own yq-scalar rule
-                    // (#1116) is intercepted earlier, via path truncation
-                    // (see `yq_del_scalar_slice_parent_path`), for the case
-                    // this fix actually covers (the slice is the *last*
-                    // path component). This arm only fires when there's
-                    // more path *after* the slice (`.[1:3][0]`), which
-                    // isn't that shape — it descends into the sliced
-                    // sub-range and deletes within it, same as jq.
+                    // `scalar_noop`/`container_noop: false` — del()'s own
+                    // yq rules (#1116's scalar case, #1162's tracked
+                    // container-target follow-up) are handled by del()'s
+                    // own separate mechanisms, not `through_slice`'s
+                    // built-in no-op (see `yq_del_scalar_slice_parent_path`
+                    // for the case this fix actually covers -- the slice
+                    // is the *last* path component). This arm only fires
+                    // when there's more path *after* the slice
+                    // (`.[1:3][0]`), which isn't that shape — it descends
+                    // into the sliced sub-range and deletes within it,
+                    // same as jq.
                     Expr::Slice { start, end } => {
-                        through_slice(root, *start, *end, here, false, |sub| {
+                        through_slice(root, *start, *end, here, false, false, |sub| {
                             delete_at_path(sub, &rest, optional)
                         })
                     }
@@ -38635,6 +38710,7 @@ mod tests {
             &Expr::Field("a".to_string()),
             OwnedValue::Int(1),
             false,
+            false,
         )
         .unwrap();
         assert_eq!(
@@ -38643,11 +38719,11 @@ mod tests {
         );
 
         let mut root = OwnedValue::Null;
-        set_path(&mut root, &Expr::Index(0), OwnedValue::Int(1), false).unwrap();
+        set_path(&mut root, &Expr::Index(0), OwnedValue::Int(1), false, false).unwrap();
         assert_eq!(root, OwnedValue::Array(vec![OwnedValue::Int(1)]));
 
         let mut root = OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
-        set_path(&mut root, &Expr::Index(4), OwnedValue::Int(9), false).unwrap();
+        set_path(&mut root, &Expr::Index(4), OwnedValue::Int(9), false, false).unwrap();
         assert_eq!(
             root,
             OwnedValue::Array(vec![
@@ -41715,7 +41791,8 @@ mod tests {
         #[test]
         fn test_set_path_refuses_an_unresolved_key() {
             let mut root = OwnedValue::Null;
-            let err = set_path(&mut root, &unresolved(), OwnedValue::Int(1), false).unwrap_err();
+            let err =
+                set_path(&mut root, &unresolved(), OwnedValue::Int(1), false, false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed index in assignment path"
@@ -41811,7 +41888,8 @@ mod tests {
         #[test]
         fn test_set_path_refuses_an_unresolved_slice() {
             let mut root = OwnedValue::Null;
-            let err = set_path(&mut root, &unresolved(), OwnedValue::Int(1), false).unwrap_err();
+            let err =
+                set_path(&mut root, &unresolved(), OwnedValue::Int(1), false, false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed slice in assignment path"

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10667,7 +10667,14 @@ fn eval_rhs_once<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// attempted either. Earlier, already-completed documents are kept as a
 /// `Partial` prefix (#400, #494): `[1,2,3,4] | .[0:2] = ([8,8],1,[9,9])`
 /// streams `[8,8,3,4]`, then raises on `1` (not an array), and `[9,9]` never
-/// appears.
+/// appears. That specific example is jq-mode behavior (or any target
+/// `through_slice` doesn't no-op): in yq mode, #1142's container no-op
+/// discards every RHS output's write to an array/string slice target
+/// unconditionally, so the same expression never reaches the failing
+/// `setpath`, and instead streams three unchanged copies of the input. The
+/// partial-prefix-on-failure model above still governs whatever `edit`
+/// closure `through_slice` actually runs; yq's array/string target just
+/// never fails there to demonstrate it.
 ///
 /// `optional` is `=`'s own `?` (`(.a = 1)?`) -- see `eval_update`'s matching
 /// comment for why it is caught here at the call boundary rather than
@@ -11211,8 +11218,14 @@ fn through_slice<E: From<EvalError>>(
         // against the throwaway fails the same way it would against the
         // real array, it just never gets spliced back on success.
         OwnedValue::Array(_) | OwnedValue::String(_) if container_noop => {
-            let mut throwaway =
-                slice_owned_value(root, start, end, optional)?.unwrap_or(OwnedValue::Null);
+            // `expect`, not `unwrap_or(Null)`: the guard above has already
+            // narrowed `root` to Array/String, and `slice_owned_value` only
+            // ever returns `Ok(None)` for a target that's neither
+            // Array/Null/String -- unreachable here. A silent `Null`
+            // fallback would hide that invariant breaking if this guard is
+            // ever widened (e.g. to `Object`, per #1157/#1162).
+            let mut throwaway = slice_owned_value(root, start, end, optional)?
+                .expect("Array/String target always yields Some from slice_owned_value");
             edit(&mut throwaway)?;
             Ok(())
         }
@@ -11376,6 +11389,12 @@ fn update_path<S: EvalSemantics>(
     optional: bool,
     scalar_noop: bool,
 ) -> Result<(), EvalEscape> {
+    // yq's slice-write container no-op (#1142) is unconditional on the
+    // operator, unlike `scalar_noop` (a caller-gated parameter, `false` for
+    // `-=`/`*=`) -- so it only needs `S::TAG`, not threading through every
+    // recursive call. Bound once here rather than recomputed inline at each
+    // `Expr::Slice` arm below, so the two can't drift out of sync.
+    let container_noop = S::TAG == EvalTag::Yq;
     match path_expr {
         Expr::Identity => {
             // The filter runs as an ordinary sub-expression, not one
@@ -11558,7 +11577,7 @@ fn update_path<S: EvalSemantics>(
                         *end,
                         here,
                         scalar_noop,
-                        S::TAG == EvalTag::Yq,
+                        container_noop,
                         |sub| update_path::<S>(sub, &rest, filter_expr, optional, scalar_noop),
                     ),
                     _ => update_path::<S>(root, first, filter_expr, here, scalar_noop),
@@ -11584,7 +11603,7 @@ fn update_path<S: EvalSemantics>(
             *end,
             optional,
             scalar_noop,
-            S::TAG == EvalTag::Yq,
+            container_noop,
             |sub| update_path::<S>(sub, &Expr::Identity, filter_expr, optional, scalar_noop),
         ),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
@@ -19391,9 +19410,16 @@ fn delete_at_path(
                     // for the case this fix actually covers -- the slice
                     // is the *last* path component). This arm only fires
                     // when there's more path *after* the slice
-                    // (`.[1:3][0]`), which isn't that shape — it descends
-                    // into the sliced sub-range and deletes within it,
-                    // same as jq.
+                    // (`.[1:3][0]`), which isn't that shape — in jq mode it
+                    // correctly descends into the sliced sub-range and
+                    // deletes within it. In yq mode this is a known,
+                    // currently-untracked-by-#1162 divergence: real yq
+                    // no-ops the whole thing instead (live-verified,
+                    // `del(.a[1:3][0])` on `a: [1,2,3,4]` leaves `.a`
+                    // untouched, for both a container and a scalar target
+                    // reached through the slice) — this shape is broader
+                    // than #1162's stated scope and needs its own
+                    // follow-up before it's fixed.
                     Expr::Slice { start, end } => {
                         through_slice(root, *start, *end, here, false, false, |sub| {
                             delete_at_path(sub, &rest, optional)

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13308,10 +13308,31 @@ fn test_slice_update_through_iterate_array_target_is_noop_1142() -> Result<()> {
     Ok(())
 }
 
+/// `=` with an index or iterate *after* a slice no-ops too, not just the
+/// terminal-slice shape -- live-verified against real yq v4.53.3
+/// (`.a[0:2][0] = 99` and `.a[1:3][] = 99` both no-op). `set_path`'s
+/// `split_at_slice` arm handles this by attempting the write against a
+/// throwaway seeded with the slice's *real* content and discarding the
+/// result on success, rather than special-casing "only when the slice is
+/// terminal" -- see the next test for why a plain "always no-op past a
+/// slice" rule would be wrong.
+#[test]
+fn test_slice_assign_through_index_and_iterate_after_slice_is_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a[0:2][0] = 99", "a: [1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+
+    let (out, code) = run_yq_stdin(".a[1:3][] = 99", "a: [1,2,3,4]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4]}"#);
+    Ok(())
+}
+
 /// Regression guard: a slice followed by a *field* access still errors --
 /// `.a[0:2]` produces a plain array, and `.foo` can't index one. This must
-/// not be swallowed into a no-op by #1142's fix, which is specifically for
-/// a slice as the path's terminal component.
+/// not be swallowed into a no-op by #1142's fix: the throwaway-write
+/// attempt genuinely fails here (the same way it would against the real
+/// array), so the error propagates instead of being discarded.
 #[test]
 fn test_slice_assign_through_field_after_slice_still_errors_1142() -> Result<()> {
     let (_out, _stderr, code) = run_yq_stdin_with_stderr(

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13006,19 +13006,18 @@ fn test_slice_owned_target_scalar_is_empty_array_1065() -> Result<()> {
 // based on a misread of `.[0:1] = (1/0)` appearing not to error (`1/0`
 // isn't a catchable error in real yq at all; it's `+Inf`, which only fails
 // at JSON-output time for a value that, being part of a no-op write, is
-// never actually written or serialized). `-=`/`*=` are NOT no-ops -- they
-// error instead, with Go-internal-looking messages this crate deliberately
-// does not replicate (not a stable compatibility target). Object, string,
-// and array targets are deliberately unaffected: succinctly's own working
-// array/string slice-assignment is preserved rather than matched to what
-// looks like a real-yq gap rather than a real-yq rule. This fix is also
-// deliberately scoped to a *bare* root slice with *literal* bounds only --
-// see `is_yq_scalar_slice_assign_path`'s doc comment, and the follow-up
-// issues filed for chained paths (`.foo[S:E]`, where `del()` in particular
-// has a materially different real-yq behavior: it deletes the whole parent
-// key, not a no-op) and computed bounds (`.[$a:$b]`, which fails earlier
-// inside `resolve_slice_expr`'s own eager path-resolution slice, a
-// separate and more delicate piece of machinery than this fix touches).
+// never actually written or serialized). `-=`/`*=` are NOT no-ops for a
+// *scalar* target -- they error instead, with Go-internal-looking messages
+// this crate deliberately does not replicate (not a stable compatibility
+// target). Object is still deliberately unaffected -- see #1157/#1102 for
+// why replicating it needs real yq's own AST-child-layout read rule first
+// -- but array/string targets are *not* unaffected any more: #1142 widened
+// this same no-op to them too (any operator, including `-=`/`*=`, unlike
+// the scalar case), and #1116 (PR #1151) separately widened the *scalar*
+// case here to any chain depth, not just the bare-root shape this section
+// was originally scoped to. `.[$a:$b]` (computed bounds) still fails
+// earlier, inside `resolve_slice_expr`'s own eager path-resolution slice --
+// a separate and more delicate piece of machinery neither fix touches.
 
 #[test]
 fn test_slice_assign_number_scalar_is_noop_1101() -> Result<()> {
@@ -13674,21 +13673,23 @@ fn test_1116_chained_scalar_slice_sub_and_mul_still_error() -> Result<()> {
     Ok(())
 }
 
-/// A chained slice-assign through an *array* or *object* target is
-/// unaffected — succinctly deliberately keeps its own working slice-write
-/// there rather than replicating real yq's own broken behavior for those
-/// target types too (verified live: real yq no-ops `.a[1:3] = [...]` even
-/// for an array `.a`, unlike jq; succinctly intentionally diverges,
-/// matching `is_yq_scalar_slice_assign_path`'s existing precedent).
+/// A chained slice-assign through an *array* target no-ops too, same as
+/// the scalar case above — #1142 (live-verified against real yq v4.53.3:
+/// `.a[1:3] = [...]` no-ops even for an array `.a`, matching every other
+/// slice-assignment target type). An earlier version of this test asserted
+/// the opposite (succinctly's own pre-#1142 splice-write behavior,
+/// deliberately preserved by #1116's own narrower scope at the time) — the
+/// live-verified oracle output is unchanged from `{"a":[1,2,3,4,5],"b":6}`,
+/// not `{"a":[1,"x","y",4,5],"b":6}`.
 #[test]
-fn test_1116_chained_array_slice_assign_still_works() -> Result<()> {
+fn test_1142_chained_array_slice_assign_is_noop() -> Result<()> {
     let (out, code) = run_yq_stdin(
         r#".a[1:3] = ["x","y"]"#,
         r#"{"a":[1,2,3,4,5],"b":6}"#,
         &["-o=json", "-I=0"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), r#"{"a":[1,"x","y",4,5],"b":6}"#);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4,5],"b":6}"#);
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13206,6 +13206,37 @@ fn test_slice_assign_string_and_array_bare_root_noop_1142() -> Result<()> {
     Ok(())
 }
 
+/// Same as the `=` case above but for `|=`/`+=`/`-=`/`*=`, exercising
+/// `update_path`'s own bare-root terminal `Expr::Slice` arm -- a distinct
+/// code path from every other `_1142` compound-assign test in this file,
+/// which all go through a leading `.a` and hit the `Pipe`-chain `Expr::Slice`
+/// arm instead. Without this, a regression isolated to the bare-root arm
+/// (e.g. a transposed `container_noop` argument) would pass every other test
+/// here.
+#[test]
+fn test_slice_compound_bare_root_array_and_string_target_is_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:2] |= .", "[1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1,2,3]");
+
+    let (out, code) = run_yq_stdin(".[0:2] += [9]", "[1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1,2,3]");
+
+    let (out, code) = run_yq_stdin(".[0:2] -= [1]", "[1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1,2,3]");
+
+    let (out, code) = run_yq_stdin(".[0:2] *= [5]", "[1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1,2,3]");
+
+    let (out, code) = run_yq_stdin(r#".[0:1] += "X""#, r#""hello""#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""hello""#);
+    Ok(())
+}
+
 // ============================================================================
 // yq slice-assignment no-op widened to a chained container target (#1142)
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13183,21 +13183,161 @@ fn test_slice_sub_and_mul_number_scalar_still_errors_1101() -> Result<()> {
     Ok(())
 }
 
-/// Regression guard: succinctly's own array/string slice-assignment is
-/// unaffected by this scalar-only scope decision.
+/// #1101 deliberately scoped its no-op to scalar targets only, preserving
+/// succinctly's own array/string slice-assignment rather than replicating
+/// what looked like a real-yq gap at the time -- succinctly's array
+/// behavior back then was "splice `v` into the range" (`.[0:1] = [9]` on
+/// `[1,2,3]` gave `[9,2,3]`), and string slice-assignment errored
+/// (`cannot update string slices`). #1142 found this splicing was itself
+/// corrupting data relative to the true oracle: real yq no-ops a bare-root
+/// array/string slice-assignment too, live-verified (`.[0:1] = [9]` on
+/// `[1,2,3]` stays `[1,2,3]` in real yq; `.[0:1] = "X"` on `"hello"` stays
+/// `"hello"`, not an error). Renamed from
+/// `test_slice_assign_string_and_array_unaffected_1101` now that this is
+/// no longer true.
 #[test]
-fn test_slice_assign_string_and_array_unaffected_1101() -> Result<()> {
-    let (_out, stderr, code) =
-        run_yq_stdin_with_stderr(r#".[0:1] = "X""#, r#""hello""#, &["-o", "json"])?;
-    assert_eq!(code, 1);
-    assert!(
-        stderr.contains("cannot update string slices") || stderr.contains("Cannot update string"),
-        "stderr: {stderr:?}"
-    );
+fn test_slice_assign_string_and_array_bare_root_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#".[0:1] = "X""#, r#""hello""#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""hello""#);
 
     let (out, code) = run_yq_stdin(".[0:1] = [9]", "[1,2,3]", &["-o", "json", "-I0"])?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "[9,2,3]");
+    assert_eq!(out.trim(), "[1,2,3]");
+    Ok(())
+}
+
+// ============================================================================
+// yq slice-assignment no-op widened to a chained container target (#1142)
+// ============================================================================
+//
+// #1101's no-op was scoped to a scalar target only -- for a *chained* path
+// onto a real array/string (`.a[S:E] op= v`, `.a` itself the container, not
+// the whole input), succinctly instead silently spliced the write-through
+// result into the array at the slice position, corrupting it. Live-verified
+// against real yq v4.53.3: the no-op applies here identically across
+// `=`/`|=`/`+=`/`-=`/`*=` and array/string targets -- unlike the bare-root
+// scalar case, `-=`/`*=` do *not* error for a container target, they no-op
+// too.
+
+/// The issue's own repro: `+=` with an array RHS, a bare number RHS, and a
+/// zero-width slice, all on a chained array target.
+#[test]
+fn test_slice_compound_add_array_target_is_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a[0:2] += [99]", "a: [1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+
+    let (out, code) = run_yq_stdin(".a[0:2] += 99", "a: [1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+
+    let (out, code) = run_yq_stdin(".a[0:0] += 99", "a: [1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+    Ok(())
+}
+
+/// `=`/`|=` on a chained array target, including a same-length replacement
+/// (`[7,8]` for a 2-element slice) that might look like it should "just
+/// work" -- it doesn't, real yq no-ops unconditionally.
+#[test]
+fn test_slice_assign_and_update_array_target_is_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a[0:2] = [7,8]", "a: [1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+
+    let (out, code) = run_yq_stdin(".a[0:2] |= .", "a: [1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+    Ok(())
+}
+
+/// `-=`/`*=` on a chained array target no-op too -- unlike the bare-root
+/// scalar case (`test_slice_sub_and_mul_number_scalar_still_errors_1101`),
+/// where these two error instead.
+#[test]
+fn test_slice_sub_and_mul_array_target_is_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a[0:2] -= [1]", "a: [1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+
+    let (out, code) = run_yq_stdin(".a[0:2] *= [5]", "a: [1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+    Ok(())
+}
+
+/// A chained *string* target no-ops the same way an array does.
+#[test]
+fn test_slice_compound_add_string_target_is_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#".a[0:2] += "X""#, r#"a: "hello""#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":"hello"}"#);
+    Ok(())
+}
+
+/// Nested slices (`.a[0][0:1] += 99`, one of #1142's own cited repro
+/// shapes) resolve to the identical terminal-slice-onto-array case one
+/// level deeper.
+#[test]
+fn test_slice_compound_add_nested_array_target_is_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".a[0][0:1] += 99",
+        "a: [[1,2,3],[4,5,6]]",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[[1,2,3],[4,5,6]]}"#);
+    Ok(())
+}
+
+/// A slice with more path *after* it (`.a[0:2][] |= f`) no-ops too --
+/// unlike a slice followed by a *field* access (the next test), `[]`
+/// (iterate) is a valid operation on an array, so this doesn't hit a type
+/// error first the way `.foo` would.
+#[test]
+fn test_slice_update_through_iterate_array_target_is_noop_1142() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".a[1:3][] |= . * 10",
+        "a: [1,2,3,4]",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4]}"#);
+    Ok(())
+}
+
+/// Regression guard: a slice followed by a *field* access still errors --
+/// `.a[0:2]` produces a plain array, and `.foo` can't index one. This must
+/// not be swallowed into a no-op by #1142's fix, which is specifically for
+/// a slice as the path's terminal component.
+#[test]
+fn test_slice_assign_through_field_after_slice_still_errors_1142() -> Result<()> {
+    let (_out, _stderr, code) = run_yq_stdin_with_stderr(
+        ".a[0:2].x = 99",
+        r#"a: [{"x":1},{"y":2},{"z":3}]"#,
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1);
+    Ok(())
+}
+
+/// Regression guard: jq mode is unaffected by any of this -- it keeps
+/// splicing the write-through result into the array, matching real jq.
+#[test]
+fn test_slice_compound_add_array_target_jq_mode_unaffected_1142() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg("-c").arg(".[0:2] += [99]");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"[1,2,3]")?;
+    let output = child.wait_with_output()?;
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8(output.stdout)?.trim(), "[1,2,99,3]");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Real yq's slice-write no-op (#1101) isn't scoped to a scalar target the way
succinctly's implementation was. Live-verified against yq v4.53.3 across
`=`/`|=`/`+=`/`-=`/`*=` and array/string targets alike:

```
$ printf 'a: [1,2,3]\n' | yq '.a[0:2] += [99]' -o=json
{"a": [1, 2, 3]}                      # real yq: no-op, unchanged

$ printf 'a: [1,2,3]\n' | succinctly yq '.a[0:2] += [99]' -o=json
{"a": [1, 2, 99, 3]}                  # wrong: splices [1,2]+[99] into positions 0:2
```

succinctly instead silently spliced the write-through result into the array
at the slice position, corrupting it — confirmed for both a **chained** path
(`.a` itself the array) and, less obviously, the **bare-root** case
(`.[0:2] = [9]` on `[1,2,3]`), which #1101's own test suite had explicitly
pinned to the old splicing/erroring behavior as "unaffected" by its
scalar-only scope.

## Root cause and fix

Widens the no-op to any array/string target, in the three places that
independently reach a slice write:

- `set_path`'s own terminal-slice arm and its `split_at_slice`-based
  chained-path arm (`=`).
- `update_path`'s two equivalent arms (`|=`/`+=`/`-=`/`*=`, both the terminal
  case and a slice with more path after it, e.g. `.a[1:3][] |= f`).

A slice followed by more path that *isn't* a valid array operation
(`.a[0:2].foo = v`) still errors as before — real yq errors there too (a
plain type mismatch: `.a[0:2]` produces an array, `.foo` can't index one —
not the no-op rule at all).

For `|=`/`+=`/`-=`/`*=`, the discarded filter still has to run (for its own
error/halt/break propagation) against a throwaway seeded with the slice's
*real* content — unlike the scalar case's `[]` throwaway, live-verified that
real yq's discarded filter sees the actual sliced sub-array
(`.a[0:2] |= (length as $l | error($l|tostring))` on a 3-element array raises
`"2"`, not `"0"`).

**Object targets are deliberately left unfixed** — real yq's write no-op
appears to also apply there, but replicating the discarded filter's own
visible content faithfully needs #1102's unreplicated AST-child-layout read
rule first. Filed as a follow-up (#1157) rather than approximated.

## Test plan

- [x] New regression tests: the issue's own repro (`+=` with array/number
      RHS, zero-width slice), `=`/`|=`/`-=`/`*=` on array and string targets,
      nested slices, a slice-then-iterate chain, and a regression guard that
      a slice-then-field-access still errors correctly.
- [x] Updated an existing test (`test_slice_assign_string_and_array_unaffected_1101`,
      renamed) that was pinning the old, now-confirmed-wrong bare-root
      array/string behavior — verified against the live oracle before
      changing the expectation.
- [x] All message variants live-verified against the real `yq` binary before
      implementing.
- [x] Full `cargo test --features cli,simd,regex,serde` green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo check --no-default-features` (no_std) clean.

Fixes #1142