### PR TITLE
fix(jq): --slurpfile/--seq preserve number-literal fidelity like --argjson

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -15,8 +15,8 @@ use succinctly::jq::eval_generic::{
     eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
 };
 use succinctly::jq::{
-    self, assert_value_tree_depth, format_number_jq_compat, nonfinite_display_string, Expr,
-    JqSemantics, JqValue, OwnedValue, Program,
+    self, format_number_jq_compat, nonfinite_display_string, Expr, JqSemantics, JqValue,
+    OwnedValue, Program,
 };
 use succinctly::json::light::{JsonCursor, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
@@ -1607,13 +1607,29 @@ fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
         return Ok(vec![]);
     }
 
-    // Try to parse as a stream of JSON values
+    // Validate the whole stream via `serde_json::Deserializer` as before
+    // (for its own error message and its rejection of anything that isn't
+    // valid, whitespace-or-self-delineated-separated JSON) -- but discard
+    // each parsed `Value` rather than converting it, and materialize the
+    // real result from the same byte span instead, via this crate's own
+    // fidelity-preserving semi-indexer (#1058's fix for `--argjson`,
+    // extended here to `--slurpfile`, #1093). `byte_offset()` gives each
+    // value's own end position after a successful `.next()`; its start is
+    // the first non-whitespace byte after the previous value's end.
     let mut values = Vec::new();
-    let deserializer = serde_json::Deserializer::from_str(s).into_iter::<serde_json::Value>();
+    let mut deserializer = serde_json::Deserializer::from_str(s).into_iter::<serde_json::Value>();
+    let mut prev_end = 0;
 
-    for result in deserializer {
-        let value = result.context("Invalid JSON in stream")?;
-        values.push(serde_to_owned(&value));
+    while let Some(result) = deserializer.next() {
+        result.context("Invalid JSON in stream")?;
+        let end = deserializer.byte_offset();
+        let start = s[prev_end..end]
+            .find(|c: char| !c.is_whitespace())
+            .map_or(prev_end, |offset| prev_end + offset);
+        values.push(crate::output::json_bytes_to_owned_value(
+            &s.as_bytes()[start..end],
+        ));
+        prev_end = end;
     }
 
     Ok(values)
@@ -1623,13 +1639,13 @@ fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
 /// Input is split on RS (0x1E) characters, each segment parsed as JSON.
 /// Parse failures are silently ignored (per RFC 7464 recommendation).
 ///
-/// Still loses number-literal source fidelity the way `parse_json_value`
-/// did before #1058 -- unlike `parse_json_stream` above, this already
-/// isolates each value as its own segment, so #1058's exact fix
-/// (`json_bytes_to_owned_value` after a `serde_json::from_str` validation
-/// pass) would apply per segment with no boundary-tracking needed. Deferred
-/// to #1093 alongside `parse_json_stream` to keep #1058/#1095 scoped to
-/// `--argjson`/`--jsonargs`.
+/// Preserves number-literal source fidelity the same way `parse_json_value`
+/// does for `--argjson` (#1058, extended here to `--seq`, #1093): each
+/// segment is already isolated by the RS split, so `serde_json::from_str`
+/// only needs to validate it (discarding the parsed `Value`) before
+/// `json_bytes_to_owned_value` materializes the real result from the same
+/// segment text -- no boundary-tracking needed, unlike `parse_json_stream`
+/// above.
 fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
     let mut values = Vec::new();
 
@@ -1641,8 +1657,8 @@ fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
         }
 
         // Try to parse as JSON, silently ignore failures
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(segment) {
-            values.push(serde_to_owned(&value));
+        if serde_json::from_str::<serde_json::Value>(segment).is_ok() {
+            values.push(crate::output::json_bytes_to_owned_value(segment.as_bytes()));
         }
         // Parse failures are silently ignored per RFC 7464
     }
@@ -1705,44 +1721,6 @@ fn strip_quotes_and_decode(field: &[u8]) -> String {
         inner.replace("\"\"", "\"")
     } else {
         s.into_owned()
-    }
-}
-
-/// Convert serde_json::Value to OwnedValue.
-fn serde_to_owned(value: &serde_json::Value) -> OwnedValue {
-    serde_to_owned_at_depth(value, 0)
-}
-
-/// Panics past `MAX_VALUE_TREE_DEPTH` levels of nesting (#1017/#1020) --
-/// mirrors `yq_runner::serde_json_to_owned_at_depth`, which this function's
-/// own doc comment names as guarded by the same PR; this twin was
-/// initially missed and is reachable the same way, via `--argjson`/`--args`
-/// and `--seq`/streamed JSON input parsing below.
-fn serde_to_owned_at_depth(value: &serde_json::Value, depth: usize) -> OwnedValue {
-    assert_value_tree_depth(depth);
-    match value {
-        serde_json::Value::Null => OwnedValue::Null,
-        serde_json::Value::Bool(b) => OwnedValue::Bool(*b),
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                OwnedValue::Int(i)
-            } else if let Some(f) = n.as_f64() {
-                OwnedValue::Float(f)
-            } else {
-                OwnedValue::Null
-            }
-        }
-        serde_json::Value::String(s) => OwnedValue::String(s.clone()),
-        serde_json::Value::Array(arr) => OwnedValue::Array(
-            arr.iter()
-                .map(|v| serde_to_owned_at_depth(v, depth + 1))
-                .collect(),
-        ),
-        serde_json::Value::Object(obj) => OwnedValue::Object(
-            obj.iter()
-                .map(|(k, v)| (k.clone(), serde_to_owned_at_depth(v, depth + 1)))
-                .collect(),
-        ),
     }
 }
 
@@ -2751,42 +2729,5 @@ mod tests {
         let stream = r#"{"a":1} {"b":2} {"c":3}"#;
         let values = parse_json_stream(stream).unwrap();
         assert_eq!(values.len(), 3);
-    }
-
-    /// `depth` levels of single-element array nesting in a `serde_json::Value`,
-    /// built directly rather than parsed from text -- `serde_json::from_str`
-    /// enforces its own independent ~128-deep recursion limit at parse time
-    /// (well under `MAX_VALUE_TREE_DEPTH`), so a JSON-text version of this
-    /// helper would hit that gate before ever reaching `serde_to_owned`'s
-    /// own guard.
-    fn linear_serde_json_nest(depth: usize) -> serde_json::Value {
-        let mut v = serde_json::Value::Null;
-        for _ in 0..depth {
-            v = serde_json::Value::Array(vec![v]);
-        }
-        v
-    }
-
-    /// #1020 code review: `yq_runner::serde_json_to_owned`'s own doc comment
-    /// names this function as its mirror, guarded by the same #1017-driven
-    /// PR -- but this twin (backing `--argjson`/`--args`-style value
-    /// parsing and `--seq`/streamed JSON input on the `jq` side) was
-    /// initially missed. Same guard, same construction as #1017's other
-    /// tests.
-    #[test]
-    fn serde_to_owned_panics_past_nesting_depth_limit_1020() {
-        use succinctly::jq::MAX_VALUE_TREE_DEPTH;
-
-        let under = linear_serde_json_nest(MAX_VALUE_TREE_DEPTH - 1);
-        let owned = serde_to_owned(&under);
-        assert!(matches!(owned, OwnedValue::Array(_)));
-
-        let over = linear_serde_json_nest(MAX_VALUE_TREE_DEPTH);
-        let result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| serde_to_owned(&over)));
-        assert!(
-            result.is_err(),
-            "serde_to_owned should panic at MAX_VALUE_TREE_DEPTH"
-        );
     }
 }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1595,12 +1595,12 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
 
 /// Parse a JSON stream (multiple JSON values) from a string (`--slurpfile`).
 ///
-/// Still loses number-literal source fidelity the way `parse_json_value`
-/// did before #1058 -- `find_json_values` (below) already splits a
-/// multi-value buffer into byte spans for the main lazy-input path and
-/// `serde_json::Deserializer::byte_offset()` could delimit each value here
-/// the same way, but wiring that up is deliberately deferred to #1093 to
-/// keep #1058/#1095 scoped to `--argjson`/`--jsonargs`.
+/// Preserves number-literal source fidelity the same way `parse_json_value`
+/// does for `--argjson` (#1058, extended here to `--slurpfile`, #1093):
+/// `serde_json::Deserializer::byte_offset()` delimits each value's own
+/// span within the stream, the same way `find_json_values` (below) does
+/// for the main lazy-input path, and `json_bytes_to_owned_value`
+/// materializes the real result from that span.
 fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
     let s = s.trim();
     if s.is_empty() {
@@ -1615,20 +1615,25 @@ fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
     // fidelity-preserving semi-indexer (#1058's fix for `--argjson`,
     // extended here to `--slurpfile`, #1093). `byte_offset()` gives each
     // value's own end position after a successful `.next()`; its start is
-    // the first non-whitespace byte after the previous value's end.
+    // the first non-whitespace byte after the previous value's end -- JSON
+    // ASCII whitespace specifically (`is_ascii_whitespace`, matching
+    // `find_json_values`'s own convention below, not Rust's broader
+    // Unicode `char::is_whitespace`), since that's the same set
+    // `serde_json`'s own separator-skipping recognizes between stream
+    // values.
     let mut values = Vec::new();
     let mut deserializer = serde_json::Deserializer::from_str(s).into_iter::<serde_json::Value>();
     let mut prev_end = 0;
+    let bytes = s.as_bytes();
 
     while let Some(result) = deserializer.next() {
         result.context("Invalid JSON in stream")?;
         let end = deserializer.byte_offset();
-        let start = s[prev_end..end]
-            .find(|c: char| !c.is_whitespace())
+        let start = bytes[prev_end..end]
+            .iter()
+            .position(|b| !b.is_ascii_whitespace())
             .map_or(prev_end, |offset| prev_end + offset);
-        values.push(crate::output::json_bytes_to_owned_value(
-            &s.as_bytes()[start..end],
-        ));
+        values.push(crate::output::json_bytes_to_owned_value(&bytes[start..end]));
         prev_end = end;
     }
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2109,8 +2109,7 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
     Ok(serde_json_to_owned(&value))
 }
 
-/// Convert a `serde_json::Value` into an `OwnedValue`
-/// (mirrors `jq_runner::serde_to_owned`).
+/// Convert a `serde_json::Value` into an `OwnedValue`.
 fn serde_json_to_owned(value: &serde_json::Value) -> OwnedValue {
     serde_json_to_owned_at_depth(value, 0)
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -794,6 +794,139 @@ fn test_slurpfile() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// #1093: `--slurpfile`/`--seq` preserve number-literal source fidelity the
+// same way `--argjson` does (#1058), instead of round-tripping through
+// `serde_json::Value`'s own `f64`/`i64` `Display`. All cases live-verified
+// against jq 1.7.1.
+// =============================================================================
+
+#[test]
+fn test_slurpfile_preserves_number_literal_fidelity_1093() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    writeln!(file, "1.500")?;
+
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-cn",
+            "--slurpfile",
+            "n",
+            file.path().to_str().unwrap(),
+            "$n",
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[1.500]");
+    Ok(())
+}
+
+/// Multiple values in one slurped file, one of which needs fidelity
+/// preservation -- confirms each value's own byte span is computed
+/// correctly, not just the first/only one.
+#[test]
+fn test_slurpfile_multiple_values_preserve_fidelity_1093() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    writeln!(file, r#"{{"a":1}}"#)?;
+    writeln!(file, r#"{{"b":1.500}}"#)?;
+
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-cn",
+            "--slurpfile",
+            "n",
+            file.path().to_str().unwrap(),
+            "$n",
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"[{"a":1},{"b":1.500}]"#);
+    Ok(())
+}
+
+/// Values separated by extra whitespace/blank lines -- confirms the
+/// leading-whitespace-skip when computing each value's start offset is
+/// correct, not just the common single-newline-separated case.
+#[test]
+fn test_slurpfile_whitespace_between_values_1093() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    writeln!(file, "  {{\"a\":1}}   ")?;
+    writeln!(file)?;
+    writeln!(file, "  {{\"b\":1.500}}  ")?;
+
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-cn",
+            "--slurpfile",
+            "n",
+            file.path().to_str().unwrap(),
+            "$n",
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"[{"a":1},{"b":1.500}]"#);
+    Ok(())
+}
+
+/// Genuinely malformed content is still rejected -- fidelity preservation
+/// doesn't widen what `--slurpfile` accepts.
+#[test]
+fn test_slurpfile_malformed_content_still_rejected_1093() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    writeln!(file, "not json")?;
+
+    let (_, _, code) = run_jq_full(
+        &[
+            "-cn",
+            "--slurpfile",
+            "n",
+            file.path().to_str().unwrap(),
+            "$n",
+        ],
+        None,
+    )?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// `--seq`'s own output format prefixes each value with the same RS
+/// (`\x1e`) byte its input uses (RFC 7464), unrelated to this fix -- kept
+/// in the expected string, not stripped, to pin the byte-exact output.
+#[test]
+fn test_seq_preserves_number_literal_fidelity_1093() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["--seq", "-c", "."], Some("\x1e1.500\n"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "\x1e1.500");
+    Ok(())
+}
+
+/// Multiple RS-separated values, each independently isolated and
+/// validated -- confirms fidelity preservation applies per-segment, not
+/// just to a single value.
+#[test]
+fn test_seq_multiple_values_preserve_fidelity_1093() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["--seq", "-c", "."], Some("\x1e1.500\n\x1e2.000\n"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "\x1e1.500\n\x1e2.000");
+    Ok(())
+}
+
+/// A malformed segment is silently skipped (RFC 7464's own recommendation,
+/// unchanged by this fix) while the surrounding valid segments still
+/// preserve their fidelity correctly.
+#[test]
+fn test_seq_malformed_segment_silently_skipped_1093() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["--seq", "-c", "."],
+        Some("\x1e1.500\n\x1egarbage\n\x1e2.000\n"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "\x1e1.500\n\x1e2.000");
+    Ok(())
+}
+
 #[test]
 fn test_rawfile() -> Result<()> {
     let mut file = NamedTempFile::new()?;


### PR DESCRIPTION
## Summary
- Follow-up from #1058, which fixed `--argjson`/`--jsonargs`'s number-literal fidelity loss but deliberately left `--slurpfile` and `--seq` (RFC 7464 JSON text sequences) untouched — they converted through `serde_json::Value`'s own `f64`/`i64` `Display`, losing e.g. trailing zeros (`1.500` → `1.5`) or exponent notation instead of preserving the source spelling.
- `parse_json_seq` (`--seq`) already isolates each value as its own RS-split segment, so #1058's exact fix applies almost verbatim: validate via `serde_json` (discarding the parsed `Value`), then materialize via this crate's own fidelity-preserving semi-indexer on the same segment text.
- `parse_json_stream` (`--slurpfile`) handles a single string containing multiple concatenated JSON values with no separator, so it needs each value's own byte span first — computed via `StreamDeserializer::byte_offset()` (each value's end) plus a leading-whitespace skip from the previous value's end (its start), reusing the same validate-then-reparse-the-span pattern this file already uses elsewhere (`find_json_values`).
- Also removes `serde_to_owned`/`serde_to_owned_at_depth`, now unreachable from any production code path (both call sites converted) — and their own depth-guard test, superseded by the shared `to_owned`/`assert_nesting_depth` path both functions now go through, which already has its own equivalent (and independently *stricter*: `MAX_NESTING_DEPTH` 256 vs `MAX_VALUE_TREE_DEPTH` 384) guard, tested elsewhere.

Fixes #1093

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green, including the bin crate's own internal tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (NEON YAML backend)
- [x] `cargo check --no-default-features` (no_std)
- [x] Verified against the pinned real `jq` binary: single/multiple values, whitespace-separated, malformed-input rejection, `--seq`'s RFC 7464 silent-skip-on-malformed-segment behavior
- [x] Patch coverage: 100% (13/13 new lines)