### PR TITLE
fix(jq): break can now reach an outer label through builtin-argument eval

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -81,19 +81,23 @@ pub enum Control {
 /// a synthetic `EvalError::new("break $label not in label")` — correct only
 /// when nothing outside actually catches it, and wrong (loud, wrongly-worded,
 /// wrongly-exit-coded) whenever a matching `label` sits further out, e.g.
-/// across a `path(...)` call boundary. Not every caller of this type has been
-/// audited to propagate `Break` correctly yet — `result_to_owned` and
-/// `eval_owned_expr` still collapse it into that same synthetic error by
-/// design, matching this type's `eval_owned_expr_ctrl`/`eval_owned_expr`
-/// split (#575's precedent: a `_ctrl`-suffixed twin that preserves
-/// [`Control`] losslessly exists at the few call sites that have been made to
-/// need it). Only `eval_owned_multi`/`eval_owned_multi_first` and
-/// `resolve_node`'s own arms (in `eval.rs`) have been updated to propagate a
-/// real `Break` so far, which is what `path()`, and the computed-key path
-/// this type also drives for `=`/`|=`/`del()`, needed. Auditing every
-/// `result_to_owned`/`eval_owned_expr` call site for the same fix is tracked
-/// separately (#833) — it is used far more broadly than path-context
-/// resolution, so it needs its own review rather than riding along here.
+/// across a `path(...)` call boundary. `eval_owned_multi`/
+/// `eval_owned_multi_first` and `resolve_node`'s own arms (in `eval.rs`)
+/// were the first to propagate a real `Break`, for `path()` and the
+/// computed-key path this type also drives for `=`/`|=`/`del()`. `#833`
+/// closed the far broader remaining gap: `result_to_owned` and
+/// `eval_owned_expr` (used by dozens of builtins' argument evaluation, not
+/// just path context) now propagate a *bare* unmatched `Break` too, matching
+/// this type's `eval_owned_expr_ctrl`/`eval_owned_expr` split (#575's
+/// precedent: a `_ctrl`-suffixed twin that preserves [`Control`] losslessly
+/// exists at the few call sites that need it). One shape is still open,
+/// though: when the argument generator produces one or more values *before*
+/// breaking/erroring (`QueryResult::Partial`), `result_to_owned` and
+/// `eval_owned_expr_ctrl` both still silently take the first value and drop
+/// the trailing escape — tracked as #1164, since fixing it means every
+/// caller becoming `Partial`-aware itself, not something these two
+/// functions can solve alone; see their own `Partial(vs, _control)` arms in
+/// `eval.rs` for the full rationale.
 ///
 /// Consumers should write `Err(EvalEscape::Error(e))` for the catchable case
 /// and let everything else flow through the `From` conversions into
@@ -105,10 +109,11 @@ pub enum EvalEscape {
     /// A genuine evaluation error — catchable by `try`/`catch`, suppressible
     /// by `?`.
     Error(EvalError),
-    /// `break $label`, still looking for a `label $label` to catch it (#824).
-    /// Every consumer that has not been specifically updated to propagate
-    /// this should keep converting it to a synthetic "break $label not in
-    /// label" `Error` — see this type's own doc comment.
+    /// `break $label`, still looking for a `label $label` to catch it (#824,
+    /// #833). A consumer that has not been specifically updated to
+    /// propagate this converts it to a synthetic "break $label not in
+    /// label" `Error` instead — see this type's own doc comment for which
+    /// consumers still do that.
     Break(String),
     /// `halt`/`halt_error(n)`: exit the whole process with this code. Must
     /// reach the CLI unconditionally; never catchable, never suppressible.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1362,15 +1362,28 @@ fn result_to_owned<W: Clone + AsRef<[u64]>>(
         // an argument stream that produced values and *then* halted must
         // halt, not quietly compute with the first value (#791).
         QueryResult::Partial(_, Control::Halt(code)) => Err(EvalEscape::Halt(code)),
+        // A trailing `Break`/`Error` here is a separate, harder gap #833
+        // does NOT fix: real jq would still abort after this point (e.g.
+        // `ltrimstr(("a", break $out))` prints one result then unwinds to
+        // `$out`, never running whatever follows), but this function's
+        // whole contract is collapsing a generator argument to one scalar
+        // `Result` -- it cannot represent "here is a value, AND ALSO an
+        // escape for afterward" the way `QueryResult::Partial` itself can.
+        // Fixing this properly means making every caller `Partial`-aware
+        // (so it can emit its own transformed value *and* propagate the
+        // trailing escape), not something `result_to_owned` can do alone;
+        // tracked as #1164 rather than folded into this fix.
         QueryResult::Partial(vs, _control) => Ok(vs.into_iter().next().unwrap()),
         QueryResult::None => Err(EvalError::new("no value").into()),
         QueryResult::Error(e) => Err(e.into()),
-        // `break $label` escaping a builtin's argument expression now
-        // propagates losslessly instead of collapsing into a synthetic
-        // "not in label" error (#833) -- every caller either forwards the
-        // `EvalEscape` verbatim via `?`/`Err(e) => return e.into()`, or
-        // (a handful of sites) has its own dedicated arm, so the real
-        // label can unwind past the builtin call to an outer `label`.
+        // A *bare* (no prior output) `break $label` escaping a builtin's
+        // argument expression now propagates instead of collapsing into a
+        // synthetic "not in label" error (#833) -- every caller either
+        // forwards the `EvalEscape` verbatim via `?`/`Err(e) =>
+        // return e.into()`, or (a handful of sites) has its own dedicated
+        // arm, so the real label can unwind past the builtin call to an
+        // outer `label`. Doesn't cover the `Partial` case above, whose own
+        // comment explains why that's a separate, harder fix.
         QueryResult::Break(label) => Err(EvalEscape::Break(label)),
         // An operand-context halt (`1 + halt`) travels as its own
         // `EvalEscape` variant, so no consumer can mistake it for a
@@ -14998,7 +15011,10 @@ fn eval_owned_expr_ctrl<S: EvalSemantics>(
         // Same collapse-to-single-or-array policy as `Many`/`ManyOwned`
         // above; the trailing `Error`/`Break` is dropped, consistent with how
         // this function already doesn't fork over a multi-output update (a
-        // separate, pre-existing limitation, not #400/#494's concern).
+        // separate, pre-existing limitation, not #400/#494's concern) -- and,
+        // as of #833, still not this function's concern either: see
+        // `result_to_owned`'s identical arm for why a trailing escape after
+        // already-produced output needs its own, separate fix.
         QueryResult::Partial(vs, _control) => {
             if vs.len() == 1 {
                 Ok(vs.into_iter().next().unwrap())
@@ -15017,11 +15033,14 @@ fn eval_owned_expr<S: EvalSemantics>(
 ) -> Result<OwnedValue, EvalEscape> {
     eval_owned_expr_ctrl::<S>(expr, input, optional).map_err(|control| match control {
         Control::Error(e) => e.into(),
-        // Propagated losslessly rather than collapsed into a synthetic
-        // "not in label" error (#833) -- see `result_to_owned`'s identical
-        // fix just above for the full rationale; every caller here forwards
-        // the `EvalEscape` verbatim except `builtin_envvar`, which has its
-        // own dedicated arm mirroring the `Halt` one below.
+        // A *bare* break (no prior output from the argument) now propagates
+        // instead of being collapsed into a synthetic "not in label" error
+        // (#833) -- see `result_to_owned`'s identical fix just above for
+        // the full rationale, including why the `Partial` case in
+        // `eval_owned_expr_ctrl` above is a separate, still-open gap; every
+        // caller here forwards the `EvalEscape` verbatim except
+        // `builtin_envvar`, which has its own dedicated arm mirroring the
+        // `Halt` one below.
         Control::Break(label) => EvalEscape::Break(label),
         // A halt reached here (e.g. inside `reduce`/`foreach`'s INIT/UPDATE
         // via a caller that uses `eval_owned_expr` rather than
@@ -15773,6 +15792,14 @@ fn range_arg<W: Clone + AsRef<[u64]>>(result: QueryResult<'_, W>) -> Result<Rang
         // "caught"` swallow the halt entirely (#791).
         QueryResult::Halt(code) => Err(EvalEscape::Halt(code)),
         QueryResult::Partial(_, Control::Halt(code)) => Err(EvalEscape::Halt(code)),
+        // Same reasoning as `result_to_owned`'s identical arm (#833): a bare
+        // unmatched `break` in a range bound must keep unwinding toward its
+        // label, not be misreported as "Range bounds must be numeric".
+        // Doesn't extend to `Partial(_, Control::Break(_))` (a bound
+        // expression that produced a value before breaking) -- see
+        // `result_to_owned`'s own comment for why that shape needs its own,
+        // separate fix (#1164).
+        QueryResult::Break(label) => Err(EvalEscape::Break(label)),
         _ => Err(EvalError::new("Range bounds must be numeric").into()),
     }
 }
@@ -17316,13 +17343,17 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // `break` is a control signal, not a value -- `rest` (anything
         // structurally following it once a flattened pipe is split at
         // `exprs.split_first()`) never runs; the `Label` arm above is what
-        // catches this. Without this arm, `Expr::Break` fell into the
-        // generic fallback below, which unconditionally converts any
-        // `Control::Break` into a synthetic "break $label not in label"
+        // catches this. Before #833, without this arm `Expr::Break` fell
+        // into the generic fallback below, which unconditionally converted
+        // any `Control::Break` into a synthetic "break $label not in label"
         // `EvalError` (`eval_owned_expr`, above) -- wrongly reporting a
         // label miss even when a real enclosing `label` was present, just
         // not visible to that fallback's single-expression evaluation
-        // (#715 follow-up).
+        // (#715 follow-up). `eval_owned_expr` now propagates a bare break
+        // correctly too, but this dedicated arm is kept rather than
+        // re-verified as redundant -- a direct `QueryResult::Break` here is
+        // clearer than routing through the generic fallback's `Ok`/`Err`
+        // dance regardless.
         Expr::Break(name) => QueryResult::Break(name.clone()),
         _ => {
             // For other expressions, evaluate normally and continue
@@ -17850,11 +17881,10 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // produced, not just be missed. Nothing has been credited to
     // `filtered_paths` yet at this point, so any escape here is a bare
     // `Error`/`Break`/`Halt`, never a `Partial`. Uses `eval_owned_expr_ctrl`
-    // rather than its `eval_owned_expr` twin specifically for the `break`
-    // case: the latter collapses `Control::Break` into a synthetic "not in
-    // label" `EvalError` (see #833), which would make `label $out |
-    // [paths(break $out)]` on a scalar report a bogus error instead of
-    // unwinding to `$out`. Confirmed against jq 1.7.1: `{"a":1} |
+    // rather than its `eval_owned_expr` twin because this call site needs a
+    // `Control`-typed error to pass straight to `partial(...)` below --
+    // `eval_owned_expr` now propagates a bare `break` correctly too (#833),
+    // but still returns `EvalEscape`, not `Control`. Confirmed against jq 1.7.1: `{"a":1} |
     // paths(if type=="object" then error("x") else true end)` raises
     // immediately with no output (not `["a"]`), and `label $out |
     // [paths(break $out)]` on `1` produces no output and exits 0.
@@ -17910,12 +17940,15 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // error("bad") else true end)` streams `[0]` then raises,
                 // never reaching index 2. `break $label` also now correctly
                 // unwinds to a `label` lexically enclosing the whole
-                // `paths(...)` call: unlike `result_to_owned`/`eval_owned_expr`
-                // (the helpers #833 is about), `eval_owned_input` never
-                // collapses `Control::Break` into a "not in label" error --
-                // `push_truthiness` already threads it through intact, so
-                // once this loop stops swallowing it, propagation just
-                // works. Confirmed: `label $out | paths(if type=="string"
+                // `paths(...)` call: `eval_owned_input` never collapses
+                // `Control::Break` into a "not in label" error -- unlike
+                // `result_to_owned`/`eval_owned_expr` for their own
+                // still-open `Partial` case (#833's follow-up), this path
+                // has no such gap, since `push_truthiness` already threads
+                // a trailing `Break` through intact regardless of how many
+                // truthy outputs preceded it, so once this loop stops
+                // swallowing it, propagation just works. Confirmed: `label
+                // $out | paths(if type=="string"
                 // then break $out else true end)` on `[1,"x",2]` now matches
                 // real jq exactly (streams `[0]`, exit 0), including when
                 // the matching node is nested. This does not extend to
@@ -22191,6 +22224,13 @@ enum NumberError {
     /// — that would make `pow(halt_error(3); 2)` a catchable type error
     /// instead of a halt.
     Halt(i32),
+    /// A bare unmatched `break` reached while evaluating the argument
+    /// (#833): must keep unwinding toward its label, never be downgraded
+    /// to `Error`'s "expected number" — same reasoning as `Halt` above.
+    /// Doesn't cover `Partial(_, Control::Break(_))` (an argument that
+    /// produced a value before breaking); see `result_to_owned`'s own
+    /// comment for why that shape is a separate, harder fix.
+    Break(String),
 }
 
 /// Helper to get number from eval result
@@ -22221,6 +22261,7 @@ fn get_number_from_result<W: Clone + AsRef<[u64]>>(
         QueryResult::Error(e) => Err(NumberError::Error(e)),
         QueryResult::Halt(code) => Err(NumberError::Halt(code)),
         QueryResult::Partial(_, Control::Halt(code)) => Err(NumberError::Halt(code)),
+        QueryResult::Break(label) => Err(NumberError::Break(label)),
         _ if optional => Err(NumberError::None),
         _ => Err(NumberError::Error(EvalError::new("expected number"))),
     }
@@ -22241,6 +22282,7 @@ fn builtin_pow<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(NumberError::None) => return QueryResult::None,
         Err(NumberError::Halt(code)) => return QueryResult::Halt(code),
         Err(NumberError::Error(e)) => return QueryResult::Error(e),
+        Err(NumberError::Break(label)) => return QueryResult::Break(label),
     };
 
     let exp = match get_number_from_result(eval_single::<W, S>(exp_expr, value, optional), optional)
@@ -22249,6 +22291,7 @@ fn builtin_pow<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(NumberError::None) => return QueryResult::None,
         Err(NumberError::Halt(code)) => return QueryResult::Halt(code),
         Err(NumberError::Error(e)) => return QueryResult::Error(e),
+        Err(NumberError::Break(label)) => return QueryResult::Break(label),
     };
 
     QueryResult::Owned(OwnedValue::Float(libm::pow(base, exp)))
@@ -22337,6 +22380,7 @@ fn builtin_atan2<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(NumberError::None) => return QueryResult::None,
         Err(NumberError::Halt(code)) => return QueryResult::Halt(code),
         Err(NumberError::Error(e)) => return QueryResult::Error(e),
+        Err(NumberError::Break(label)) => return QueryResult::Break(label),
     };
 
     let x = match get_number_from_result(eval_single::<W, S>(x_expr, value, optional), optional) {
@@ -22344,6 +22388,7 @@ fn builtin_atan2<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(NumberError::None) => return QueryResult::None,
         Err(NumberError::Halt(code)) => return QueryResult::Halt(code),
         Err(NumberError::Error(e)) => return QueryResult::Error(e),
+        Err(NumberError::Break(label)) => return QueryResult::Break(label),
     };
 
     QueryResult::Owned(OwnedValue::Float(libm::atan2(y, x)))
@@ -22689,13 +22734,15 @@ fn builtin_envvar<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let var_name = match var_result {
         Ok(OwnedValue::String(s)) => s,
         // Checked ahead of the generic fallback below (which would
-        // otherwise flatten it into a misleading "must be a string"
+        // otherwise flatten either into a misleading "must be a string"
         // message and, when `optional`, silently swallow it): a halt must
         // never be silently downgraded (#791), and likewise a break must
         // reach its label rather than being downgraded into a bogus type
-        // error or swallowed by `optional` (#833).
-        Err(EvalEscape::Halt(code)) => return QueryResult::Halt(code),
-        Err(EvalEscape::Break(label)) => return QueryResult::Break(label),
+        // error or swallowed by `optional` (#833). One OR-pattern arm
+        // (matching this file's own precedent, e.g. `QueryResult::is_error`
+        // and `builtin_isvalid`'s `Halt`/`Break` arms) rather than two,
+        // since both escapes get identical treatment here.
+        Err(escape @ (EvalEscape::Halt(_) | EvalEscape::Break(_))) => return escape.into(),
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::new("env variable name must be a string")),
     };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1365,9 +1365,13 @@ fn result_to_owned<W: Clone + AsRef<[u64]>>(
         QueryResult::Partial(vs, _control) => Ok(vs.into_iter().next().unwrap()),
         QueryResult::None => Err(EvalError::new("no value").into()),
         QueryResult::Error(e) => Err(e.into()),
-        QueryResult::Break(label) => {
-            Err(EvalError::new(format!("break ${label} not in label")).into())
-        }
+        // `break $label` escaping a builtin's argument expression now
+        // propagates losslessly instead of collapsing into a synthetic
+        // "not in label" error (#833) -- every caller either forwards the
+        // `EvalEscape` verbatim via `?`/`Err(e) => return e.into()`, or
+        // (a handful of sites) has its own dedicated arm, so the real
+        // label can unwind past the builtin call to an outer `label`.
+        QueryResult::Break(label) => Err(EvalEscape::Break(label)),
         // An operand-context halt (`1 + halt`) travels as its own
         // `EvalEscape` variant, so no consumer can mistake it for a
         // catchable error (#791): `try`/`catch` and `?` handle only
@@ -15013,7 +15017,12 @@ fn eval_owned_expr<S: EvalSemantics>(
 ) -> Result<OwnedValue, EvalEscape> {
     eval_owned_expr_ctrl::<S>(expr, input, optional).map_err(|control| match control {
         Control::Error(e) => e.into(),
-        Control::Break(label) => EvalError::new(format!("break ${label} not in label")).into(),
+        // Propagated losslessly rather than collapsed into a synthetic
+        // "not in label" error (#833) -- see `result_to_owned`'s identical
+        // fix just above for the full rationale; every caller here forwards
+        // the `EvalEscape` verbatim except `builtin_envvar`, which has its
+        // own dedicated arm mirroring the `Halt` one below.
+        Control::Break(label) => EvalEscape::Break(label),
         // A halt reached here (e.g. inside `reduce`/`foreach`'s INIT/UPDATE
         // via a caller that uses `eval_owned_expr` rather than
         // `eval_owned_expr_ctrl`, which carries `Control` through losslessly)
@@ -22682,8 +22691,11 @@ fn builtin_envvar<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Checked ahead of the generic fallback below (which would
         // otherwise flatten it into a misleading "must be a string"
         // message and, when `optional`, silently swallow it): a halt must
-        // never be silently downgraded (#791).
+        // never be silently downgraded (#791), and likewise a break must
+        // reach its label rather than being downgraded into a bogus type
+        // error or swallowed by `optional` (#833).
         Err(EvalEscape::Halt(code)) => return QueryResult::Halt(code),
+        Err(EvalEscape::Break(label)) => return QueryResult::Break(label),
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::new("env variable name must be a string")),
     };
@@ -42785,6 +42797,31 @@ mod tests {
         let var = parse("halt_error(9)").unwrap();
         match builtin_envvar::<Vec<u64>, JqSemantics>(&var, StandardJson::Null, false) {
             QueryResult::Halt(9) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn builtin_envvar_propagates_break_from_variable_name_expression_833() {
+        // Sibling of the `Halt` test above: the audit for #833 found
+        // `builtin_envvar`'s match had a dedicated `Halt` arm (from #791)
+        // but no `Break` arm, so once `eval_owned_expr` stopped collapsing
+        // `Control::Break` into a synthetic error, a break here would have
+        // fallen into the generic `_ if optional`/`_ =>` arms instead --
+        // silently swallowed under `optional`, or misreported as "env
+        // variable name must be a string" otherwise. Exercised directly
+        // (like the `Halt` test above) since `Builtin::EnvVar` has no parser
+        // construction site.
+        let var = parse("break $out").unwrap();
+        match builtin_envvar::<Vec<u64>, JqSemantics>(&var, StandardJson::Null, false) {
+            QueryResult::Break(label) => assert_eq!(label, "out"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+        // Under `optional`, a break must still propagate -- not be
+        // downgraded to `None` the way an ordinary type error would be.
+        match builtin_envvar::<Vec<u64>, JqSemantics>(&var, StandardJson::Null, true) {
+            QueryResult::Break(label) => assert_eq!(label, "out"),
             other => panic!("unexpected result: {other:?}"),
         }
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3531,6 +3531,61 @@ fn test_pow_propagates_halt_in_argument() -> Result<()> {
 }
 
 #[test]
+fn test_range_bare_break_reaches_outer_label_833() -> Result<()> {
+    // Sibling fix to #833: `range_arg` had the same missing-`Break`-arm
+    // shape as `result_to_owned`/`eval_owned_expr` (found auditing for
+    // #833's own sibling helpers), falling into the generic "Range bounds
+    // must be numeric" wildcard instead of propagating. Matches real jq
+    // 1.7.1: `jq -n 'label $out | [range(break $out; 5)]'` exits 0 with no
+    // output.
+    let (stdout, stderr, code) = run_jq_full(&["-n", "label $out | [range(break $out; 5)]"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_pow_base_bare_break_reaches_outer_label_833() -> Result<()> {
+    // Sibling fix to #833: `get_number_from_result`/`NumberError` had the
+    // same missing-`Break`-variant shape, shared by `pow`'s base and
+    // exponent arguments and `atan2`'s y/x arguments. Matches real jq
+    // 1.7.1: `jq -n 'label $out | pow(break $out; 2)'` exits 0, no output.
+    let (stdout, stderr, code) = run_jq_full(&["-n", "label $out | pow(break $out; 2)"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_pow_exp_bare_break_reaches_outer_label_833() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "label $out | pow(2; break $out)"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_atan2_y_bare_break_reaches_outer_label_833() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "label $out | atan2(break $out; 1)"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_atan2_x_bare_break_reaches_outer_label_833() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "label $out | atan2(1; break $out)"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
 fn test_repeat_propagates_halt_instead_of_running_to_iteration_cap() -> Result<()> {
     // A halt was already threaded correctly even before #855 (`eval_repeat`
     // now uses `eval_owned_expr_fork`, not `eval_owned_expr_ctrl`, but both

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4979,23 +4979,19 @@ fn test_result_to_owned_partial_halt_outranks_its_prefix() -> Result<()> {
 }
 
 #[test]
-fn test_result_to_owned_none_error_break_arms_via_ltrimstr_argument() -> Result<()> {
-    // `result_to_owned`'s `None`/`Error`/`Break` arms -- all three now
-    // wrapped in `.into()` to fit the `Result<OwnedValue, EvalEscape>`
-    // return type this PR introduced (previously `Result<OwnedValue,
-    // EvalError>`), exercised together since they are adjacent,
-    // mechanically-identical conversions and none of them are
-    // halt-specific. Uses `ltrimstr`'s argument slot as the call site, same
-    // as the `Many`/`ManyOwned`-empty and `Partial`-halt tests above.
-    // `None`/`Break` here are a pre-existing, halt-unrelated divergence from
-    // real jq worth flagging: jq's `empty` argument yields zero output (not
-    // an error), and a `break` whose label encloses the whole expression is
-    // caught there, not reported as "not in label" -- both verified: `jq -n
-    // '"abc" | ltrimstr(empty)'` and `jq -n 'label $out | ("abc" |
-    // ltrimstr(break $out))'` both exit 0 with no output. succinctly's
+fn test_result_to_owned_none_error_arms_via_ltrimstr_argument() -> Result<()> {
+    // `result_to_owned`'s `None`/`Error` arms, both wrapped in `.into()` to
+    // fit the `Result<OwnedValue, EvalEscape>` return type. Uses `ltrimstr`'s
+    // argument slot as the call site, same as the `Many`/`ManyOwned`-empty
+    // and `Partial`-halt tests above. `None` here is a pre-existing,
+    // separately-tracked divergence from real jq (#1045): jq's `empty`
+    // argument yields zero output (not an error) -- verified: `jq -n '"abc"
+    // | ltrimstr(empty)'` exits 0 with no output, while succinctly's
     // `ltrimstr` resolves its argument through `result_to_owned`, which
-    // turns both into a generic catchable error instead. The `Error` arm,
-    // by contrast, matches real jq exactly.
+    // turns it into a generic catchable error instead. The `Error` arm, by
+    // contrast, matches real jq exactly. (The `Break` arm this test used to
+    // cover alongside these two is now fixed -- see
+    // `test_break_via_ltrimstr_argument_reaches_outer_label_833` below.)
     let (stdout, stderr, code) = run_jq_full(&["-n", r#""abc" | ltrimstr(empty)"#], None)?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
@@ -5006,16 +5002,25 @@ fn test_result_to_owned_none_error_break_arms_via_ltrimstr_argument() -> Result<
     assert_eq!(stdout, "");
     assert_eq!(stderr, "jq: error (at <unknown>): boom\n");
 
+    Ok(())
+}
+
+#[test]
+fn test_break_via_ltrimstr_argument_reaches_outer_label_833() -> Result<()> {
+    // #833: `result_to_owned`'s `Break` arm now propagates a real
+    // `EvalEscape::Break` instead of collapsing it into a synthetic "not in
+    // label" error, so a `break` in a builtin's argument expression can
+    // reach a `label` enclosing the whole call. Matches real jq exactly:
+    // `jq -n 'label $out | ("abc" | ltrimstr(break $out))'` exits 0 with no
+    // output (this test previously pinned the pre-fix "not in label" error
+    // as expected/current behavior).
     let (stdout, stderr, code) = run_jq_full(
         &["-n", r#"label $out | ("abc" | ltrimstr(break $out))"#],
         None,
     )?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
-    assert_eq!(
-        stderr,
-        "jq: error (at <unknown>): break $out not in label\n"
-    );
+    assert_eq!(stderr, "");
 
     Ok(())
 }
@@ -7422,17 +7427,20 @@ fn test_reduce_propagates_halt_from_init_expression() -> Result<()> {
 }
 
 #[test]
-fn test_parentn_n_expr_break_reported_as_break_not_in_label() -> Result<()> {
-    // `eval_owned_expr`'s `Control::Break` arm (split out from `Error`
-    // alongside the new `Control::Halt` arm one line below it, forced by
-    // `Control` gaining the `Halt` variant): an unmatched `break` raised
-    // while evaluating an owned-value-based argument -- here `parent(n)`'s
-    // `n` argument, via `ParentN`'s call to `eval_owned_expr` -- converts
-    // into the ordinary "break $label not in label" `EvalError`, the same
-    // diagnostic every other uncaught break in this file produces. `parent`
+fn test_parentn_n_expr_genuinely_uncaught_break_still_errors() -> Result<()> {
+    // No `label $out` anywhere in this filter, so `break $out` raised while
+    // evaluating `parent(n)`'s `n` argument (via `ParentN`'s call to
+    // `eval_owned_expr`) has nowhere to land regardless of #833's fix to
+    // that function -- `eval_owned_expr` now propagates a real
+    // `EvalEscape::Break` instead of collapsing it at this arm, but with no
+    // enclosing label to catch it, it still surfaces as the ordinary
+    // "break $label not in label" top-level diagnostic once fully unwound,
+    // the same as any other genuinely-uncaught break in this file. `parent`
     // is a succinctly extension (no real-jq equivalent), so this is checked
     // against succinctly's own established "break $out not in label" wording
-    // (see `test_uncaught_break_after_output_keeps_the_prefix`), not jq.
+    // (see `test_uncaught_break_after_output_keeps_the_prefix`), not jq. See
+    // `test_break_via_parentn_argument_reaches_outer_label_833` below for
+    // the case where a `label $out` genuinely encloses the call.
     let (stdout, stderr, code) = run_jq_full(
         &["-c", ".a.b | parent(break $out)"],
         Some(r#"{"a":{"b":1}}"#),
@@ -7440,6 +7448,26 @@ fn test_parentn_n_expr_break_reported_as_break_not_in_label() -> Result<()> {
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
     assert!(stderr.contains("break $out not in label"), "{stderr}");
+    Ok(())
+}
+
+#[test]
+fn test_break_via_parentn_argument_reaches_outer_label_833() -> Result<()> {
+    // #833: same fix as `test_break_via_ltrimstr_argument_reaches_outer_label_833`,
+    // but through `eval_owned_expr` (ParentN's call path) rather than
+    // `result_to_owned`. With a `label $out` genuinely enclosing the call,
+    // the break now unwinds cleanly instead of misreporting "not in label".
+    // `parent` is a succinctly extension; there's no real-jq oracle for this
+    // exact shape, but the underlying "an unmatched builtin-argument break
+    // reaches its enclosing label" contract is the same one #833 fixes
+    // uniformly for both `result_to_owned` and `eval_owned_expr` callers.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a.b | label $out | parent(break $out)"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
     Ok(())
 }
 
@@ -8614,6 +8642,43 @@ fn test_isvalid_propagates_break_through_paths_filter() -> Result<()> {
             r#"label $out | isvalid(paths(if type=="number" then break $out else true end))"#,
         ],
         Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// #833: a `key`/`parent`/`path` (or any other path-context-triggering)
+/// pipe stage ahead of `isvalid`/`isempty` routes their argument through
+/// `eval_pipe_with_path_context_internal`'s generic `Expr::Builtin`
+/// fallback -> `eval_builtin_owned` -> `eval_owned_expr`, not through
+/// `eval_single`'s ordinary dispatch -- a genuinely different call path
+/// from every other test in this file, which all evaluate `isvalid`/
+/// `isempty` directly. Before #833 this still misreported "not in label"
+/// even after #867/#879 fixed the direct-evaluation path, since the bug
+/// lived in `eval_owned_expr` itself, not in `isvalid`/`isempty`'s own
+/// match arms. Confirmed live against jq 1.7.1 (both real jq's own `key`
+/// only exists in `--eval-all`/path-context contexts here via succinctly's
+/// own routing, but the surrounding break/label semantics are jq's own):
+/// both exit 0 with no output once `break $out` reaches its label.
+#[test]
+fn test_isvalid_propagates_break_through_path_context_routing_833() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "label $out | key | isvalid(break $out), \"after\""],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_isempty_propagates_break_through_path_context_routing_833() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "label $out | key | isempty(break $out), \"after\""],
+        None,
     )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");


### PR DESCRIPTION
## Summary

Fixes #833. `result_to_owned` and `eval_owned_expr` — the two shared helpers backing single-value argument evaluation for dozens of builtins (`ltrimstr`/`rtrimstr`, `has`, `contains`, `inside`, `test`, `getpath`, regex pattern/flags, `strftime`, `parent(n)`, and many more) — collapsed an unmatched `break $label` raised while evaluating a builtin's argument into a synthetic `"break $label not in label"` error, instead of propagating it so it could reach a `label $label` sitting outside the builtin call. Real jq unwinds cleanly; succinctly misreported it as a catchable error.

```bash
$ echo '"abc"' | jq -c 'label $out | test("a"; (break $out))'
(no output, exit 0)
$ echo '"abc"' | succinctly jq -c 'label $out | test("a"; (break $out))'   # before this PR
jq: error (at <stdin>:1): break $out not in label
```

## Fix

Both functions' `Break` arm now produces `Err(EvalEscape::Break(label))` — the variant #824 added specifically for this purpose — instead of collapsing it. The pre-existing `From<EvalEscape> for QueryResult`/`Control` conversions already thread `Break` through correctly, so every "safe" call site needed zero changes of its own.

## Precursor audit

Per the issue's own suggested methodology, I enumerated and classified all 41 call sites of the two functions before making the change (36 for `result_to_owned`, 5 for `eval_owned_expr`) — 40 were already safe (plain `?` or `Err(e) => return e.into()` forwarding), and one, `builtin_envvar`, had a dedicated `Halt` arm (from #791) but no `Break` arm, so it would have fallen into the generic `optional`/type-error fallback arms instead. Fixed alongside the main change. (`builtin_envvar` has no parser construction site anywhere in the codebase today — `env.VAR`/`$ENV.VAR` resolve to plain field access instead — so this is a latent gap, not a live user-facing bug, but worth closing for consistency.)

`builtin_paths_filter`, which the issue's own comment thread flagged as needing a follow-up decision once this landed, turned out to already be independently fixed (uses `eval_owned_expr_ctrl` directly, confirmed live against jq 1.7.1) — no change needed there.

## Testing

- New/updated in `tests/jq_cli_tests.rs`: `test_break_via_ltrimstr_argument_reaches_outer_label_833`, `test_break_via_parentn_argument_reaches_outer_label_833`, `test_isvalid_propagates_break_through_path_context_routing_833`, `test_isempty_propagates_break_through_path_context_routing_833` (the latter two cover a break reaching `isvalid`/`isempty` through `eval_pipe_with_path_context_internal`'s fallback → `eval_owned_expr` routing, a genuinely different call path from direct evaluation, called out explicitly in the issue's second comment).
- Renamed/re-split two tests that previously pinned the pre-fix buggy behavior as expected (`test_result_to_owned_none_error_break_arms_via_ltrimstr_argument` → `..._none_error_arms...` (its `None`-arm coverage is untouched, a separate tracked gap, #1045) + the new break test; `test_parentn_n_expr_break_reported_as_break_not_in_label` → `..._genuinely_uncaught_break_still_errors` (unchanged assertions — no enclosing label, so still correctly errors) + a new test with an actual enclosing label).
- New in `src/jq/eval.rs`: `builtin_envvar_propagates_break_from_variable_name_expression_833`.
- All pre-existing break/halt/error propagation tests (`#791`, `#824`, `#850`, `#867`, `#879`, path-context fanout) pass unmodified.
- Full local pipeline green: `cargo build --features cli`, full `cargo test --features cli,simd,regex,serde`, both required clippy invocations, `cargo check --no-default-features` (no_std), `cargo doc --all-features` with `-D warnings`.

## Out of scope

The issue's own `None`-arm divergence in `result_to_owned` (jq's `empty` argument yields zero output; succinctly errors) is a separate, already-tracked gap (#1045), left untouched here.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, clean)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`