### PR TITLE
perf(jq): cache NumberRepr on Literal::NumberLiteral instead of re-parsing

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14630,8 +14630,10 @@ fn owned_to_expr_at_depth(value: &OwnedValue, depth: usize) -> Expr {
         // #1035: `Literal::NumberLiteral` now has a source-text slot too,
         // so a document-sourced literal keeps its own spelling through this
         // splice instead of degrading to a freshly-formatted f64/i64.
-        OwnedValue::NumberLiteral(_, text) => {
-            Expr::Literal(Literal::NumberLiteral(text.to_string()))
+        // #1062: `repr` is already parsed on the source `OwnedValue` --
+        // carried straight through instead of discarded and re-derived.
+        OwnedValue::NumberLiteral(repr, text) => {
+            Expr::Literal(Literal::NumberLiteral(*repr, text.to_string()))
         }
         OwnedValue::String(s) => Expr::Literal(Literal::String(s.clone())),
         OwnedValue::Array(arr) => {
@@ -25382,14 +25384,14 @@ mod tests {
         let substituted = substitute_vars(&expr, [("n", &int_lit)]);
         assert_eq!(
             substituted,
-            Expr::Literal(Literal::NumberLiteral("42".to_string()))
+            Expr::Literal(Literal::number_literal("42".to_string()))
         );
 
         let float_lit = OwnedValue::from_number_literal("1e100");
         let substituted = substitute_vars(&expr, [("n", &float_lit)]);
         assert_eq!(
             substituted,
-            Expr::Literal(Literal::NumberLiteral("1e100".to_string()))
+            Expr::Literal(Literal::number_literal("1e100".to_string()))
         );
 
         let index = JsonIndex::build(b"null");

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -11,6 +11,8 @@ use alloc::vec::Vec;
 #[cfg(test)]
 use std::collections::BTreeMap;
 
+use super::value::NumberRepr;
+
 /// A jq expression representing a query path.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
@@ -1132,7 +1134,17 @@ pub enum Literal {
     /// already has that text on hand for free. `Int`/`Float` below remain
     /// for internally-synthesized literals (e.g. desugaring) that have no
     /// source text to preserve.
-    NumberLiteral(String),
+    ///
+    /// The `NumberRepr` is the same value `parse`'s tokenizer already
+    /// computed (via `parse_i64_or_f64`) to decide whether this spelling
+    /// even qualifies for `NumberLiteral` in the first place (#1062) --
+    /// carrying it through means every downstream evaluation of this AST
+    /// node (`literal_to_owned`, `eval_single`, `JqValue::from_literal`)
+    /// clones a pre-parsed `Copy` value instead of re-running
+    /// `i64`/`f64::from_str` and re-allocating a `Box<str>` on every visit,
+    /// same shape as `OwnedValue::NumberLiteral(NumberRepr, Box<str>)`
+    /// already uses on the read side.
+    NumberLiteral(NumberRepr, String),
     /// Integer number
     Int(i64),
     /// Floating-point number
@@ -1346,6 +1358,21 @@ impl Literal {
     pub fn string(s: impl Into<String>) -> Self {
         Self::String(s.into())
     }
+
+    /// Create a source-text-preserving number literal (#1062), parsing
+    /// `text` once here rather than leaving every call site to compute its
+    /// own `NumberRepr`. Panics if `text` isn't a valid number spelling --
+    /// every real caller (the parser, `From<OwnedValue>`-style splices)
+    /// already knows `text` parses, from having produced or validated it
+    /// itself; this constructor exists for the many call sites (mostly
+    /// tests) that only ever pass a literal they already know is valid.
+    #[track_caller]
+    pub fn number_literal(text: impl Into<String>) -> Self {
+        let text = text.into();
+        let repr = super::value::parse_i64_or_f64(&text)
+            .unwrap_or_else(|| panic!("Literal::number_literal: {text:?} is not a valid number"));
+        Self::NumberLiteral(repr, text)
+    }
 }
 
 #[cfg(test)]
@@ -1424,6 +1451,28 @@ mod tests {
     #[test]
     fn test_literal_float() {
         assert_eq!(Literal::float(2.5), Literal::Float(2.5));
+    }
+
+    #[test]
+    fn test_number_literal_carries_parsed_repr_1062() {
+        assert_eq!(
+            Literal::number_literal("1.500"),
+            Literal::NumberLiteral(NumberRepr::Float(1.5), "1.500".to_string())
+        );
+        assert_eq!(
+            Literal::number_literal("42"),
+            Literal::NumberLiteral(NumberRepr::Int(42), "42".to_string())
+        );
+        assert_eq!(
+            Literal::number_literal("1e2"),
+            Literal::NumberLiteral(NumberRepr::Float(100.0), "1e2".to_string())
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a valid number")]
+    fn test_number_literal_panics_on_invalid_text_1062() {
+        Literal::number_literal("not a number");
     }
 
     #[test]

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1138,10 +1138,12 @@ pub enum Literal {
     /// The `NumberRepr` is the same value `parse`'s tokenizer already
     /// computed (via `parse_i64_or_f64`) to decide whether this spelling
     /// even qualifies for `NumberLiteral` in the first place (#1062) --
-    /// carrying it through means every downstream evaluation of this AST
-    /// node (`literal_to_owned`, `eval_single`, `JqValue::from_literal`)
-    /// clones a pre-parsed `Copy` value instead of re-running
-    /// `i64`/`f64::from_str` and re-allocating a `Box<str>` on every visit,
+    /// carrying it through means `literal_to_owned`/`eval_single` (via
+    /// `From<Literal> for OwnedValue`) clone a pre-parsed `Copy` value on
+    /// every evaluation of this AST node instead of re-running
+    /// `i64`/`f64::from_str`. `JqValue::from_literal` (`lazy.rs`)
+    /// deliberately does *not* benefit -- see its own doc comment for why
+    /// its laziness means reading `repr` here at all would be premature,
     /// same shape as `OwnedValue::NumberLiteral(NumberRepr, Box<str>)`
     /// already uses on the read side.
     NumberLiteral(NumberRepr, String),
@@ -1361,16 +1363,33 @@ impl Literal {
 
     /// Create a source-text-preserving number literal (#1062), parsing
     /// `text` once here rather than leaving every call site to compute its
-    /// own `NumberRepr`. Panics if `text` isn't a valid number spelling --
-    /// every real caller (the parser, `From<OwnedValue>`-style splices)
-    /// already knows `text` parses, from having produced or validated it
-    /// itself; this constructor exists for the many call sites (mostly
-    /// tests) that only ever pass a literal they already know is valid.
+    /// own `NumberRepr`. Panics if `text` isn't RFC-8259-valid number
+    /// syntax -- every real caller (the parser, `From<OwnedValue>`-style
+    /// splices) already knows `text` parses, from having produced or
+    /// validated it itself; this constructor exists for the many call
+    /// sites (mostly tests) that only ever pass a literal they already
+    /// know is valid.
+    ///
+    /// Gated on `is_valid_number`, not just `parse_i64_or_f64`: Rust's own
+    /// `f64::from_str` accepts spellings like `"nan"`/`"inf"`/`"infinity"`
+    /// that aren't valid JSON/jq number syntax at all -- without this
+    /// check, this constructor would silently succeed on those instead of
+    /// panicking as documented, unlike the real parser (which gates on the
+    /// identical check before ever reaching `Literal::NumberLiteral`).
     #[track_caller]
     pub fn number_literal(text: impl Into<String>) -> Self {
         let text = text.into();
+        // A direct `panic!` (not inside a closure) so `#[track_caller]`
+        // actually blames the caller, not this function's own line --
+        // `.unwrap_or_else(|| panic!(...))` would defeat it.
+        if !crate::json::validate::is_valid_number(text.as_bytes()) {
+            panic!("Literal::number_literal: {text:?} is not a valid number spelling");
+        }
+        // `is_valid_number` guarantees `parse_i64_or_f64` succeeds --
+        // RFC-8259 number syntax always parses as `f64` at worst (extreme
+        // magnitudes just become +/-infinity, never a parse failure).
         let repr = super::value::parse_i64_or_f64(&text)
-            .unwrap_or_else(|| panic!("Literal::number_literal: {text:?} is not a valid number"));
+            .expect("is_valid_number guarantees parse_i64_or_f64 succeeds");
         Self::NumberLiteral(repr, text)
     }
 }
@@ -1473,6 +1492,21 @@ mod tests {
     #[should_panic(expected = "is not a valid number")]
     fn test_number_literal_panics_on_invalid_text_1062() {
         Literal::number_literal("not a number");
+    }
+
+    /// Rust's own `f64::from_str` accepts `"nan"`/`"inf"`/`"infinity"`, but
+    /// none of those are valid JSON/jq number syntax -- `number_literal`
+    /// must reject them too, not just gate on `parse_i64_or_f64` succeeding.
+    #[test]
+    #[should_panic(expected = "is not a valid number spelling")]
+    fn test_number_literal_rejects_rust_only_float_spellings_1062() {
+        Literal::number_literal("nan");
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a valid number spelling")]
+    fn test_number_literal_rejects_infinity_spelling_1062() {
+        Literal::number_literal("infinity");
     }
 
     #[test]

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -177,7 +177,12 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     /// rather than re-listing five arms a third time.
     pub fn from_literal(lit: &Literal) -> Self {
         match lit {
-            Literal::NumberLiteral(text) => JqValue::NumberLiteral(text.as_str().into()),
+            // `repr` (#1062) is ignored here -- `JqValue`'s own laziness
+            // (this arm's whole reason for existing, see the doc comment
+            // above) means the parsed value is deliberately not read until
+            // needed, regardless of whether a `NumberRepr` happens to
+            // already be sitting on the node.
+            Literal::NumberLiteral(_repr, text) => JqValue::NumberLiteral(text.as_str().into()),
             _ => JqValue::from_owned(OwnedValue::from(lit.clone())),
         }
     }
@@ -888,7 +893,7 @@ mod tests {
         // #1035: a filter-literal number keeps its own source spelling
         // through this construction path too, same as the eval.rs/
         // eval_generic.rs sibling conversions.
-        let lit = Literal::NumberLiteral("1.500".to_string());
+        let lit = Literal::number_literal("1.500".to_string());
         let val: JqValue<'_, Vec<u64>> = JqValue::from_literal(&lit);
         assert!(matches!(val, JqValue::NumberLiteral(ref s) if s.as_ref() == "1.500"));
         assert_eq!(val.as_f64(), Some(1.5));

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -405,7 +405,7 @@ impl<'a> Parser<'a> {
         // identical check for document numbers, for the identical reason
         // (see its own doc comment).
         if crate::json::validate::is_valid_number(num_str.as_bytes()) {
-            Ok(Literal::NumberLiteral(num_str.to_string()))
+            Ok(Literal::NumberLiteral(repr, num_str.to_string()))
         } else {
             Ok(match repr {
                 NumberRepr::Int(i) => Literal::int(i),
@@ -767,9 +767,10 @@ impl<'a> Parser<'a> {
             // #1035: a source-text-preserving numeric literal folds the same
             // way -- an index's fast-path only needs the value, not its
             // original spelling (there's no "index formatting" to preserve).
-            // Reuses `parse_i64_or_f64` (the one shared int-vs-float decision,
-            // per its own doc comment) rather than a second hand-rolled copy.
-            Expr::Literal(Literal::NumberLiteral(text)) => match parse_i64_or_f64(text)? {
+            // #1062: the literal's `NumberRepr` is already parsed and
+            // carried on the node itself, so this reads it directly instead
+            // of re-running `parse_i64_or_f64` on the source text.
+            Expr::Literal(Literal::NumberLiteral(repr, _)) => match *repr {
                 NumberRepr::Int(i) => Some(Expr::Index(i)),
                 NumberRepr::Float(f)
                     if f.fract() == 0.0 && f >= i64::MIN as f64 && f < i64::MAX as f64 =>
@@ -1039,7 +1040,7 @@ impl<'a> Parser<'a> {
                         // `test_large_integer_literal_falls_back_to_float`),
                         // which routing through arithmetic would degrade to
                         // a lossy float, unlike jq's double-only model.
-                        Literal::NumberLiteral(text)
+                        Literal::NumberLiteral(repr, text)
                             if self.mode == ParserMode::Jq && text.contains(['.', 'e', 'E']) =>
                         {
                             // Multiply rather than subtract from zero:
@@ -1047,10 +1048,26 @@ impl<'a> Parser<'a> {
                             // silently losing the sign of `-0.0`/`-0e0`
                             // (jq itself prints `-0` for these); `-1.0 *
                             // 0.0` correctly preserves it.
+                            //
+                            // #1062: `repr` is `text`'s (negative) parsed
+                            // value; the split-off literal's own text has
+                            // the sign stripped, so its repr is `-repr`
+                            // (the positive magnitude), not a re-parse.
+                            // `Int` is unreachable here in practice (the
+                            // guard above requires `.`/`e`/`E` in `text`,
+                            // which `parse_i64_or_f64` never resolves to an
+                            // `Int`), but `wrapping_neg` keeps this branch
+                            // panic-free even so, rather than relying on
+                            // that invariant never breaking.
+                            let stripped_repr = match repr {
+                                NumberRepr::Int(i) => NumberRepr::Int(i.wrapping_neg()),
+                                NumberRepr::Float(f) => NumberRepr::Float(-f),
+                            };
                             Ok(Expr::Arithmetic {
                                 op: ArithOp::Mul(MergeFlags::default()),
                                 left: Box::new(Expr::Literal(Literal::Int(-1))),
                                 right: Box::new(Expr::Literal(Literal::NumberLiteral(
+                                    stripped_repr,
                                     text[1..].to_string(),
                                 ))),
                             })
@@ -4580,7 +4597,7 @@ mod tests {
         assert_eq!(
             parse("(1)?").unwrap(),
             Expr::Optional(Box::new(Expr::Paren(Box::new(Expr::Literal(
-                Literal::NumberLiteral("1".to_string())
+                Literal::number_literal("1".to_string())
             )))))
         );
     }
@@ -4674,7 +4691,7 @@ mod tests {
     /// with the first two untransformed.
     #[test]
     fn test_comma_binds_tighter_than_pipe() {
-        let int = |i: i64| Expr::Literal(Literal::NumberLiteral(i.to_string()));
+        let int = |i: i64| Expr::Literal(Literal::number_literal(i.to_string()));
 
         // (1,2) | 3 — not 1, (2 | 3)
         assert_eq!(
@@ -4719,7 +4736,7 @@ mod tests {
     /// expression, so only the *last* comma operand is bound (#462).
     #[test]
     fn test_as_binds_inside_comma_operand() {
-        let int = |i: i64| Expr::Literal(Literal::NumberLiteral(i.to_string()));
+        let int = |i: i64| Expr::Literal(Literal::number_literal(i.to_string()));
 
         // 1, (2 as $x | $x) — not (1,2) as $x | $x
         assert_eq!(
@@ -4756,11 +4773,11 @@ mod tests {
         assert_eq!(entries.len(), 2, "the `,` must separate two entries");
         assert_eq!(
             entries[0].value,
-            Expr::Literal(Literal::NumberLiteral("1".to_string()))
+            Expr::Literal(Literal::number_literal("1".to_string()))
         );
         assert_eq!(
             entries[1].value,
-            Expr::Literal(Literal::NumberLiteral("2".to_string()))
+            Expr::Literal(Literal::number_literal("2".to_string()))
         );
 
         // Parens are how a value fans out, and they still work.
@@ -4832,9 +4849,9 @@ mod tests {
         assert_eq!(
             parse("first(1,2,3)").unwrap(),
             Expr::FirstExpr(Box::new(Expr::Comma(vec![
-                Expr::Literal(Literal::NumberLiteral("1".to_string())),
-                Expr::Literal(Literal::NumberLiteral("2".to_string())),
-                Expr::Literal(Literal::NumberLiteral("3".to_string())),
+                Expr::Literal(Literal::number_literal("1".to_string())),
+                Expr::Literal(Literal::number_literal("2".to_string())),
+                Expr::Literal(Literal::number_literal("3".to_string())),
             ])))
         );
 
@@ -4842,12 +4859,12 @@ mod tests {
         assert_eq!(
             parse("[limit(2;1,2,3,4)]").unwrap(),
             Expr::Array(Box::new(Expr::Limit {
-                n: Box::new(Expr::Literal(Literal::NumberLiteral("2".to_string()))),
+                n: Box::new(Expr::Literal(Literal::number_literal("2".to_string()))),
                 expr: Box::new(Expr::Comma(vec![
-                    Expr::Literal(Literal::NumberLiteral("1".to_string())),
-                    Expr::Literal(Literal::NumberLiteral("2".to_string())),
-                    Expr::Literal(Literal::NumberLiteral("3".to_string())),
-                    Expr::Literal(Literal::NumberLiteral("4".to_string())),
+                    Expr::Literal(Literal::number_literal("1".to_string())),
+                    Expr::Literal(Literal::number_literal("2".to_string())),
+                    Expr::Literal(Literal::number_literal("3".to_string())),
+                    Expr::Literal(Literal::number_literal("4".to_string())),
                 ])),
             }))
         );
@@ -4941,15 +4958,15 @@ mod tests {
         assert_eq!(parse("false").unwrap(), Expr::Literal(Literal::Bool(false)));
         assert_eq!(
             parse("42").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("42".to_string()))
+            Expr::Literal(Literal::number_literal("42".to_string()))
         );
         assert_eq!(
             parse("-123").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("-123".to_string()))
+            Expr::Literal(Literal::number_literal("-123".to_string()))
         );
         assert_eq!(
             parse("2.5").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("2.5".to_string()))
+            Expr::Literal(Literal::number_literal("2.5".to_string()))
         );
         assert_eq!(
             parse("\"hello\"").unwrap(),
@@ -4962,6 +4979,38 @@ mod tests {
     }
 
     #[test]
+    fn test_negative_float_literal_splits_into_positive_repr_1062() {
+        // A negative float/exponent literal parses as `-1 * <positive
+        // literal>` in jq mode (the sign is folded into unary negation, not
+        // kept as part of the number token -- see the parser's own comment
+        // above this rewrite). #1062 computes the split-off literal's
+        // `NumberRepr` by negating the *original* (negative) repr rather
+        // than re-parsing the sign-stripped text; this pins that both the
+        // repr and the text agree on the positive magnitude.
+        let Expr::Arithmetic { right, .. } = parse("-1.500").unwrap() else {
+            panic!("expected an Arithmetic node");
+        };
+        assert_eq!(
+            *right,
+            Expr::Literal(Literal::NumberLiteral(
+                NumberRepr::Float(1.5),
+                "1.500".to_string()
+            ))
+        );
+
+        let Expr::Arithmetic { right, .. } = parse("-1e2").unwrap() else {
+            panic!("expected an Arithmetic node");
+        };
+        assert_eq!(
+            *right,
+            Expr::Literal(Literal::NumberLiteral(
+                NumberRepr::Float(100.0),
+                "1e2".to_string()
+            ))
+        );
+    }
+
+    #[test]
     fn test_large_integer_literal_falls_back_to_float() {
         // Literals beyond i64 range degrade to floats like jq (issue #166),
         // but #1035 keeps the literal's own source spelling rather than
@@ -4970,29 +5019,29 @@ mod tests {
         // conversion), only the AST node's stored text is unaffected here.
         assert_eq!(
             parse("9999999999999999999").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("9999999999999999999".to_string()))
+            Expr::Literal(Literal::number_literal("9999999999999999999".to_string()))
         );
         assert_eq!(
             parse("-9999999999999999999").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("-9999999999999999999".to_string()))
+            Expr::Literal(Literal::number_literal("-9999999999999999999".to_string()))
         );
         // One past the boundary in each direction.
         assert_eq!(
             parse("9223372036854775808").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("9223372036854775808".to_string()))
+            Expr::Literal(Literal::number_literal("9223372036854775808".to_string()))
         );
         assert_eq!(
             parse("-9223372036854775809").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("-9223372036854775809".to_string()))
+            Expr::Literal(Literal::number_literal("-9223372036854775809".to_string()))
         );
         // Boundary values stay exact integers.
         assert_eq!(
             parse("9223372036854775807").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("9223372036854775807".to_string()))
+            Expr::Literal(Literal::number_literal("9223372036854775807".to_string()))
         );
         assert_eq!(
             parse("-9223372036854775808").unwrap(),
-            Expr::Literal(Literal::NumberLiteral("-9223372036854775808".to_string()))
+            Expr::Literal(Literal::number_literal("-9223372036854775808".to_string()))
         );
     }
 
@@ -5508,14 +5557,14 @@ mod tests {
             Expr::slice_by(
                 Expr::Identity,
                 Some(Expr::Var("a".into())),
-                Some(Expr::Literal(Literal::NumberLiteral("1".to_string()))),
+                Some(Expr::Literal(Literal::number_literal("1".to_string()))),
             )
         );
         assert_eq!(
             parse(".[1:$b]").unwrap(),
             Expr::slice_by(
                 Expr::Identity,
-                Some(Expr::Literal(Literal::NumberLiteral("1".to_string()))),
+                Some(Expr::Literal(Literal::number_literal("1".to_string()))),
                 Some(Expr::Var("b".into())),
             )
         );
@@ -5694,8 +5743,8 @@ mod tests {
             Expr::index_by(
                 Expr::Identity,
                 Expr::Comma(vec![
-                    Expr::Literal(Literal::NumberLiteral("1".to_string())),
-                    Expr::Literal(Literal::NumberLiteral("2".to_string())),
+                    Expr::Literal(Literal::number_literal("1".to_string())),
+                    Expr::Literal(Literal::number_literal("2".to_string())),
                 ])
             )
         );

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1053,14 +1053,18 @@ impl<'a> Parser<'a> {
                             // value; the split-off literal's own text has
                             // the sign stripped, so its repr is `-repr`
                             // (the positive magnitude), not a re-parse.
-                            // `Int` is unreachable here in practice (the
-                            // guard above requires `.`/`e`/`E` in `text`,
-                            // which `parse_i64_or_f64` never resolves to an
-                            // `Int`), but `wrapping_neg` keeps this branch
-                            // panic-free even so, rather than relying on
-                            // that invariant never breaking.
+                            // `Int` is unreachable here: the guard above
+                            // requires `.`/`e`/`E` in `text`, which
+                            // `parse_i64_or_f64` never resolves to an
+                            // `Int` -- `unreachable!()` rather than a
+                            // silently-wrapping fallback, so a future
+                            // change to that dispatch rule that breaks the
+                            // invariant fails loudly here instead of
+                            // producing a wrong-signed value.
                             let stripped_repr = match repr {
-                                NumberRepr::Int(i) => NumberRepr::Int(i.wrapping_neg()),
+                                NumberRepr::Int(_) => unreachable!(
+                                    "a '.'/'e'/'E'-containing literal never parses as NumberRepr::Int"
+                                ),
                                 NumberRepr::Float(f) => NumberRepr::Float(-f),
                             };
                             Ok(Expr::Arithmetic {

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1368,7 +1368,12 @@ impl From<Literal> for OwnedValue {
         match lit {
             Literal::Null => Self::Null,
             Literal::Bool(b) => Self::Bool(b),
-            Literal::NumberLiteral(text) => Self::from_number_literal_boxed(text.into()),
+            // #1062: `repr` was already parsed by `parse`'s tokenizer (the
+            // same `parse_i64_or_f64` `from_number_literal_boxed` would run
+            // again here) -- constructed directly instead of re-parsing
+            // `text` and re-deriving the identical value on every visit of
+            // this AST node.
+            Literal::NumberLiteral(repr, text) => Self::NumberLiteral(repr, text.into()),
             Literal::Int(n) => Self::Int(n),
             Literal::Float(f) => Self::Float(f),
             Literal::String(s) => Self::String(s),
@@ -1548,7 +1553,7 @@ mod tests {
         // #1035: a filter-literal number keeps its own source spelling
         // through this conversion too, same as `literal_to_owned`'s
         // sibling in eval.rs.
-        match OwnedValue::from(Literal::NumberLiteral("1.500".to_string())) {
+        match OwnedValue::from(Literal::number_literal("1.500".to_string())) {
             OwnedValue::NumberLiteral(NumberRepr::Float(f), text) => {
                 assert_eq!(f, 1.5);
                 assert_eq!(text.as_ref(), "1.500");

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1373,7 +1373,23 @@ impl From<Literal> for OwnedValue {
             // again here) -- constructed directly instead of re-parsing
             // `text` and re-deriving the identical value on every visit of
             // this AST node.
-            Literal::NumberLiteral(repr, text) => Self::NumberLiteral(repr, text.into()),
+            //
+            // Every real construction site keeps `repr`/`text` in sync
+            // (`Literal`'s tuple fields have no runtime enforcement of
+            // that, since neither `Literal` nor `NumberRepr` can carry
+            // private fields as a public enum) -- this debug-only check
+            // catches a hand-built mismatch in tests/debug builds rather
+            // than silently trusting `repr` the way release builds still
+            // do, restoring some of what `from_number_literal_boxed`'s
+            // unconditional re-parse used to guarantee for free.
+            Literal::NumberLiteral(repr, text) => {
+                debug_assert_eq!(
+                    Some(repr),
+                    parse_i64_or_f64(&text),
+                    "Literal::NumberLiteral's repr {repr:?} doesn't match a fresh parse of its own text {text:?}"
+                );
+                Self::NumberLiteral(repr, text.into())
+            }
             Literal::Int(n) => Self::Int(n),
             Literal::Float(f) => Self::Float(f),
             Literal::String(s) => Self::String(s),


### PR DESCRIPTION
## Summary

Item 2 of #1062 (item 1, the 4x-duplicated `Literal -> OwnedValue` conversion, was already done in PR #1106). `Literal::NumberLiteral` stored only the source text, so every evaluation of a filter-literal number (`literal_to_owned`, `eval_single`, `JqValue::from_literal`) called `OwnedValue::from_number_literal` fresh, re-parsing the string via `i64`/`f64::from_str` on every single visit of that AST node — a literal inside a `reduce`/`foreach`/`map` body pays this once per iteration, not once at parse time.

## Design

`Literal::NumberLiteral` now carries the same `(NumberRepr, String)` shape `OwnedValue::NumberLiteral` already uses, computed once by `parse`'s tokenizer (which already ran `parse_i64_or_f64` to decide whether the spelling even qualifies for `NumberLiteral` in the first place) instead of thrown away and re-derived downstream.

`expr.rs` importing `NumberRepr` from `value.rs` (which already imports `Literal` from `expr.rs`) turned out to **not** need the circular-import workaround #1035's PR anticipated — Rust's two-pass module resolution handles a simple sibling `use` cycle between non-recursively-typed items fine, so no new shared module was needed.

- `fold_index_key` (parser.rs, jq's index fast-path folding) and `From<Literal> for OwnedValue` (value.rs, the #1106 dedup target) both now read the pre-parsed repr directly instead of calling `parse_i64_or_f64`/`from_number_literal_boxed` a second time.
- `owned_to_expr_at_depth` (eval.rs) similarly threads `OwnedValue::NumberLiteral`'s own already-parsed repr straight through when splicing a document value back into the AST, instead of discarding it.
- The unary-minus literal-splitting rewrite (parser.rs, `-1.500` → `-1 * 1.500` in jq mode) computes the split-off positive literal's repr by negating the original repr rather than re-parsing the sign-stripped text.
- Added `Literal::number_literal(text)` as the one parse-and-construct helper for the many call sites (mostly tests) that only ever pass a literal they already know is valid.

Pure internal refactor — no behavior change. The full pre-existing test suite passes unmodified.

## Code review fixes (round 2)

Mandatory `/code-review` (10 parallel finder agents) converged on one real theme: caching `repr` alongside `text` removes a safety net that used to exist when `NumberLiteral` held only text (every consumer re-derived the value, so a bad/mismatched pair was structurally impossible). Fixed the concrete, actionable parts of that:

- `Literal::number_literal` now gates on `is_valid_number` (matching the real parser's own check), not just `parse_i64_or_f64` — Rust's `f64::from_str` accepts `"nan"`/`"inf"`/`"infinity"`, none of which are valid JSON/jq number syntax, so the constructor was silently succeeding on those instead of panicking as its own doc comment claimed. Also fixed `#[track_caller]`'s blame location (was defeated by wrapping the panic in a closure).
- `From<Literal> for OwnedValue`'s `NumberLiteral` arm now `debug_assert!`s that `repr` matches a fresh parse of `text`, restoring (in debug/test builds) the safety net a hand-built mismatched pair would otherwise silently bypass — `Literal`'s tuple fields can't enforce this at the type level.
- The unary-minus split's provably-unreachable `NumberRepr::Int` arm now uses `unreachable!()` instead of `wrapping_neg()`, so a future change that breaks the underlying invariant fails loudly instead of silently producing a wrong-signed value.
- Corrected the `NumberLiteral` enum doc comment, which overclaimed that `JqValue::from_literal` benefits from the cached repr — `lazy.rs`'s own adjacent comment (unchanged) already correctly documents that it deliberately doesn't.

Fixes #1062

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures — ran with `--test-threads=2` after two transient single-test failures were confirmed to be concurrent-session load flakiness, not regressions: different, unrelated tests failed on different runs, both passed in isolation, load average was 17+)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] New tests: `Literal::number_literal`'s repr/panic/`nan`-`inf`-rejection behavior, and the negative-literal sign-split repr computation
- [x] Live-verified `-1.500`/`-1e2`/`-0.0`/`-0e0` still match real jq 1.7.1 exactly