### PR TITLE
fix(jq): paths preserves duplicate YAML mapping keys

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3227,6 +3227,46 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// Cursor-aware counterpart to `eval.rs`'s `collect_paths` (#868): walks
+/// `value` directly via `DocumentFields`/`DocumentElements::uncons()`
+/// instead of requiring a `to_owned()`'d `OwnedValue` first, so duplicate
+/// YAML mapping keys are never collapsed by `OwnedValue::Object`'s
+/// `IndexMap` before path collection runs — the same #443 pattern
+/// `Builtin::ToEntries` above already established for this file. `uncons()`
+/// walks a cons-list (or, for YAML's merge-resolved mappings, an `Rc`-shared
+/// entry list), never a shared map, so no key is ever put somewhere a
+/// duplicate could overwrite it.
+fn collect_paths_cursor<V: DocumentValue>(
+    value: &V,
+    current_path: &mut Vec<OwnedValue>,
+    paths: &mut Vec<OwnedValue>,
+) {
+    assert_nesting_depth(current_path.len());
+    if let Some(fields) = value.as_object() {
+        let mut f = fields;
+        while let Some((field, rest)) = f.uncons() {
+            if let Some(key) = field.key_str() {
+                current_path.push(OwnedValue::String(key.into_owned()));
+                paths.push(OwnedValue::Array(current_path.clone()));
+                collect_paths_cursor(&field.value, current_path, paths);
+                current_path.pop();
+            }
+            f = rest;
+        }
+    } else if let Some(elements) = value.as_array() {
+        let mut i: i64 = 0;
+        let mut e = elements;
+        while let Some((elem, rest)) = e.uncons() {
+            current_path.push(OwnedValue::Int(i));
+            paths.push(OwnedValue::Array(current_path.clone()));
+            collect_paths_cursor(&elem, current_path, paths);
+            current_path.pop();
+            i += 1;
+            e = rest;
+        }
+    }
+}
+
 /// Evaluate a builtin function.
 fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
     builtin: &Builtin,
@@ -3615,6 +3655,44 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     &value, cursor,
                 )))
             }
+        }
+
+        // Handled natively rather than through the `_` fallback below, for
+        // the same reason as `Builtin::ToEntries` just above: the fallback
+        // materializes the whole value via `to_owned()` first, which merges
+        // duplicate YAML mapping keys into one `IndexMap` entry before
+        // `collect_paths` ever runs, so a duplicate key's second path is
+        // silently lost (#868). `collect_paths_cursor` walks `as_object()`/
+        // `as_array()` directly instead, mirroring `eval.rs`'s own
+        // `collect_paths` shape but off `uncons()` rather than an
+        // already-materialized `IndexMap`/`Vec`.
+        //
+        // Doesn't cover `Builtin::PathsFilter`/`LeafPaths`/`Recurse*`/
+        // `Walk` -- those share the same wildcard fallback and likely the
+        // same bug, but fixing them needs fusing path-collection with
+        // per-node filter evaluation into one walk, which is real,
+        // separate work (#868 itself only scoped plain `paths`).
+        //
+        // Also doesn't help `[paths]` -- the array-constructor form #868's
+        // own issue text used as its repro. `Expr::Array` (like `Comma`)
+        // has no native arm in `eval_single` at all, so wrapping *any*
+        // expression in `[...]` re-materializes the whole document from
+        // scratch via the `_` fallback below and hands it to `eval.rs`'s
+        // full evaluator, discarding this arm's fix entirely -- confirmed
+        // this isn't specific to `paths`: `to_entries` has its own,
+        // already-shipped cursor-native fix (#443) and exhibits the
+        // identical silent regression once wrapped (`[to_entries]` still
+        // collapses duplicates even though bare `to_entries` doesn't).
+        // That's a separate, broader architectural gap, filed as #1168.
+        Builtin::Paths => {
+            let mut paths = Vec::new();
+            collect_paths_cursor(&value, &mut Vec::new(), &mut paths);
+            collapse_vec(
+                paths,
+                || GenericResult::None,
+                GenericResult::Owned,
+                GenericResult::ManyOwned,
+            )
         }
 
         // The `is*` family reads through `tagged_type_name` rather than

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -913,6 +913,42 @@ fn test_duplicate_mapping_key_to_entries_json_compact() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_duplicate_mapping_key_paths_preserves_both_868() -> Result<()> {
+    // Same #443 pattern as `to_entries` above, applied to bare `paths`
+    // (#868): `collect_paths_cursor` walks the field cons-list directly
+    // instead of requiring a `to_owned()`'d `OwnedValue` first, so a
+    // duplicate key's second occurrence gets its own path instead of being
+    // silently merged away.
+    let yaml = "a: 1\na: 2\nb: 3\n";
+    let (output, code) = run_yq_stdin("paths", yaml, &["-o=json", "-I=0"])?;
+
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[\"a\"]\n[\"a\"]\n[\"b\"]");
+    Ok(())
+}
+
+#[test]
+fn test_duplicate_mapping_key_array_wrapped_paths_still_collapses_868_known_gap() -> Result<()> {
+    // Characterization test, not a regression: `[paths]` -- the exact form
+    // issue #868's own repro used -- still collapses the duplicate, because
+    // `Expr::Array` has no cursor-native arm in `eval_generic.rs::eval_single`
+    // at all (unlike `Builtin::Paths` itself, which #868 fixed). Wrapping
+    // *anything* in `[...]` re-materializes the whole document via
+    // `to_owned()` before evaluating the inner expression, discarding
+    // whatever cursor-native fix that inner expression has -- confirmed this
+    // isn't `paths`-specific: `[to_entries]` has the identical gap despite
+    // `to_entries`'s own already-shipped #443 fix. Filed as #1168; pinning
+    // the current (still-buggy) behavior here so a future fix for #1168
+    // has a test to flip, and so this doesn't silently regress further.
+    let yaml = "a: 1\na: 2\nb: 3\n";
+    let (output, code) = run_yq_stdin("[paths]", yaml, &["-o=json", "-I=0"])?;
+
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"[["a"],["b"]]"#);
+    Ok(())
+}
+
 /// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion
 /// (`yaml_to_owned_value`) #442 didn't touch, so it kept collapsing
 /// duplicate keys within each slurped element even after plain `yq '.'`


### PR DESCRIPTION
## Summary

Addresses #868 (does not close it — see "Scope" below). `builtin_paths_filter`'s `to_owned(&value)` call collapsed duplicate YAML mapping keys into `OwnedValue::Object`'s `IndexMap` (last-value-wins) before `collect_paths` ever ran, so `paths` on YAML input with a repeated key reported only one path even though identity output preserves every occurrence:

```bash
$ printf 'a: 1\na: 2\nb: 3\n' | succinctly yq -o json '.'
{"a": 1, "a": 2, "b": 3}
$ printf 'a: 1\na: 2\nb: 3\n' | succinctly yq -o json 'paths'   # before this PR
["a"]
["b"]
```

## Fix

Adds a native `Builtin::Paths` arm to `eval_generic.rs`'s cursor-native evaluator, mirroring `Builtin::ToEntries`'s existing fix for the identical bug shape (#443): a new `collect_paths_cursor` walks `as_object()`/`as_array()` directly via `DocumentFields`/`DocumentElements::uncons()` (a cons-list, or for YAML's merge-resolved mappings an `Rc`-shared entry list — never a shared map) instead of requiring a `to_owned()`'d `OwnedValue` first, so no key ever passes through a structure that could collapse a duplicate. Depth-guarded via `assert_nesting_depth`, matching this module's own convention for recursive walkers.

## Scope — why this doesn't close #868

Investigating the fix surfaced a broader, separate gap: `Expr::Array` (and `Comma`) have no cursor-native handling at all in `eval_generic.rs::eval_single` — both fall to a wildcard that materializes the **entire input document** into an `OwnedValue` and hands the whole expression to `eval.rs`'s full evaluator, before the inner expression (including this fix's own `Builtin::Paths` arm) ever runs. That's exactly the shape of #868's own issue-text repro:

```bash
$ printf 'a: 1\na: 2\nb: 3\n' | succinctly yq -o json '[paths]'   # still, after this PR
[["a"],["b"]]
```

Confirmed this isn't `paths`-specific — `[to_entries]` has the identical silent regression despite `to_entries`'s own already-shipped #443 fix (bare `to_entries` is correct, `[to_entries]` collapses). This is a foundational, separate architectural gap (which combinators `eval_generic.rs` natively understands), not a quick follow-up to either #443 or #868 — filed as #1168.

So: `paths` (bare/streamed) is fixed by this PR; `[paths]` (the array-wrapped form, and the exact command #868's own repro used) is not, pending #1168. Left #868 open rather than closing it, since a reader testing the issue's own literal repro would still see it fail.

## Testing

- `test_duplicate_mapping_key_paths_preserves_both_868` — the newly-fixed bare `paths` case.
- `test_duplicate_mapping_key_array_wrapped_paths_still_collapses_868_known_gap` — a characterization test pinning the still-open `[paths]` gap (documented, not silently regressed), with a test ready to flip once #1168 lands.
- Verified live against real `jq`/`yq` across nested objects/arrays, empty containers, scalar roots, and (unaffected, still routing through the old fallback) `paths(node_filter)`/`leaf_paths`.
- Full local pipeline green: `cargo build --features cli`, full `cargo test --features cli,simd,regex,serde`, both required clippy invocations, `cargo check --no-default-features` (no_std), `cargo doc --all-features` with `-D warnings`.

## Out of scope

- `Builtin::PathsFilter`/`LeafPaths`/`Recurse*`/`Walk` share the same wildcard fallback and likely the same duplicate-key bug for their own bare-dispatch case, but `paths(node_filter)` specifically needs its two-phase collect-then-filter logic fused into one walk (today's `builtin_paths_filter` collects all paths first, then re-looks-up each value — two duplicate keys produce the *same* path array, so a later re-lookup can't disambiguate which occurrence to filter). That's real, separate restructuring work on a function with dense, hard-won correctness properties from #773/#850/#881/#833/#861 — left for #868 itself to keep tracking, not attempted here.
- #1168 (the `Expr::Array`/`Comma` cursor-native gap) is its own, larger design question.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, clean)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`