### PR TITLE
fix(jq): keep NumberLiteral spelling through *'s null-merge no-op arm

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1936,34 +1936,7 @@ fn arith_mul<S: EvalSemantics>(
     right: OwnedValue,
     flags: MergeFlags,
 ) -> Result<OwnedValue, EvalError> {
-    let (left, right) = (left.into_plain_number(), right.into_plain_number());
     match (left, right) {
-        // jq converts to float on overflow, yq wraps
-        (OwnedValue::Int(a), OwnedValue::Int(b)) => {
-            if S::OVERFLOW_WRAPS {
-                // yq behavior: wrapping mul
-                Ok(OwnedValue::Int(a.wrapping_mul(b)))
-            } else {
-                // jq behavior: convert to float on overflow
-                match a.checked_mul(b) {
-                    Some(result) => Ok(OwnedValue::Int(result)),
-                    None => Ok(OwnedValue::Float(a as f64 * b as f64)),
-                }
-            }
-        }
-        (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 * b)),
-        (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a * b as f64)),
-        (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a * b)),
-        // String repetition: "ab" * 3 = "ababab". jq >= 1.7 yields "" for
-        // n == 0 and null only for n < 0 (jqlang/jq#1593)
-        (OwnedValue::String(s), OwnedValue::Int(n))
-        | (OwnedValue::Int(n), OwnedValue::String(s)) => {
-            if n < 0 {
-                Ok(OwnedValue::Null)
-            } else {
-                Ok(OwnedValue::String(s.repeat(n as usize)))
-            }
-        }
         // Object recursive merge (yq's `*`/`*=` merge operator; also jq's
         // plain object multiply, which has always done the same thing).
         // Uses merge_existing (not merge_values) because `a`/`b` are the
@@ -1982,7 +1955,11 @@ fn arith_mul<S: EvalSemantics>(
         }
         // yq: null is an empty container for merge purposes. A null right
         // operand is a no-op regardless of flags (real yq: `x *= null`
-        // leaves `x` untouched, whatever `x` is). A null left operand
+        // leaves `x` untouched, whatever `x` is) -- `left` is relocated
+        // unchanged here, not computed, so a `NumberLiteral` operand must
+        // keep its own source spelling (#1167, mirroring #1143's identical
+        // fix for `arith_add`'s `null`-passthrough arm: this arm must run
+        // before the numeric arm below collapses it). A null left operand
         // merging with an object/array merges as if it started from
         // `{}`/`[]`, routing through the same merge_values() call as a real
         // container pair — so `?`/`n` gating (which only takes effect once
@@ -1998,9 +1975,46 @@ fn arith_mul<S: EvalSemantics>(
         (OwnedValue::Null, b @ OwnedValue::Array(_)) if S::NULL_MERGES_AS_EMPTY => {
             Ok(merge_values(OwnedValue::Array(Vec::new()), b, flags))
         }
-        // null * x = null
+        // null * x = null -- both operands are discarded outright (the
+        // result is always `Null`, never either operand), so there's
+        // nothing to relocate and no spelling to lose here.
         (OwnedValue::Null, _) | (_, OwnedValue::Null) => Ok(OwnedValue::Null),
-        (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Multiply)),
+        // Everything else: numeric multiplication or string repetition. A
+        // `NumberLiteral` operand degrades to plain `Int`/`Float` here, and
+        // only here -- these are the arms that actually compute a new
+        // value (a product, or a repeated string), so canonical formatting
+        // is correct; every arm above relocates an operand unchanged (or
+        // discards both entirely) and must not collapse a literal's
+        // spelling (#1167).
+        (left, right) => match (left.into_plain_number(), right.into_plain_number()) {
+            // jq converts to float on overflow, yq wraps
+            (OwnedValue::Int(a), OwnedValue::Int(b)) => {
+                if S::OVERFLOW_WRAPS {
+                    // yq behavior: wrapping mul
+                    Ok(OwnedValue::Int(a.wrapping_mul(b)))
+                } else {
+                    // jq behavior: convert to float on overflow
+                    match a.checked_mul(b) {
+                        Some(result) => Ok(OwnedValue::Int(result)),
+                        None => Ok(OwnedValue::Float(a as f64 * b as f64)),
+                    }
+                }
+            }
+            (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 * b)),
+            (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a * b as f64)),
+            (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a * b)),
+            // String repetition: "ab" * 3 = "ababab". jq >= 1.7 yields ""
+            // for n == 0 and null only for n < 0 (jqlang/jq#1593)
+            (OwnedValue::String(s), OwnedValue::Int(n))
+            | (OwnedValue::Int(n), OwnedValue::String(s)) => {
+                if n < 0 {
+                    Ok(OwnedValue::Null)
+                } else {
+                    Ok(OwnedValue::String(s.repeat(n as usize)))
+                }
+            }
+            (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Multiply)),
+        },
     }
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1955,11 +1955,7 @@ fn arith_mul<S: EvalSemantics>(
         }
         // yq: null is an empty container for merge purposes. A null right
         // operand is a no-op regardless of flags (real yq: `x *= null`
-        // leaves `x` untouched, whatever `x` is) -- `left` is relocated
-        // unchanged here, not computed, so a `NumberLiteral` operand must
-        // keep its own source spelling (#1167, mirroring #1143's identical
-        // fix for `arith_add`'s `null`-passthrough arm: this arm must run
-        // before the numeric arm below collapses it). A null left operand
+        // leaves `x` untouched, whatever `x` is). A null left operand
         // merging with an object/array merges as if it started from
         // `{}`/`[]`, routing through the same merge_values() call as a real
         // container pair — so `?`/`n` gating (which only takes effect once
@@ -1968,6 +1964,12 @@ fn arith_mul<S: EvalSemantics>(
         // the merge-flag suffixes (#713) work on a top-level target that's
         // `null` or entirely absent (`.a` on a missing key evaluates to
         // `null`), not just on nested fields within an existing container.
+        //
+        // `left` is relocated unchanged in the no-op arm below, not
+        // computed, so a `NumberLiteral` operand must keep its own source
+        // spelling there (#1167, mirroring #1143's identical fix for
+        // `arith_add`'s `null`-passthrough arm) -- this arm must run
+        // before the numeric arm further down collapses it.
         (left, OwnedValue::Null) if S::NULL_MERGES_AS_EMPTY => Ok(left),
         (OwnedValue::Null, b @ OwnedValue::Object(_)) if S::NULL_MERGES_AS_EMPTY => {
             Ok(merge_values(OwnedValue::Object(IndexMap::new()), b, flags))

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11639,8 +11639,17 @@ fn test_jq_compound_assign_plus_preserves_number_literal_on_null_1143() -> Resul
 /// #1167's `arith_mul` reordering (moving relocation arms before the
 /// numeric collapse) must not change jq mode's own `null * x` / `x * null`
 /// behavior -- `NULL_MERGES_AS_EMPTY` is yq-only, so both directions still
-/// fall through to the unconditional "null * x = null" arm and discard the
-/// non-null operand entirely, matching real jq (`5 * null` -> `null`).
+/// fall through to the same unconditional "null * x = null" arm as before
+/// this PR, unaffected by the reordering.
+///
+/// This locks in succinctly's *current* behavior only, not oracle
+/// conformance: real jq 1.7.1 actually *errors* on every `null`-involving
+/// multiplication (`5 * null` -> `number (5) and null (null) cannot be
+/// multiplied`, confirmed live), which succinctly's own catch-all arm
+/// (`(OwnedValue::Null, _) | (_, OwnedValue::Null) => Ok(OwnedValue::Null)`,
+/// untouched by this PR) does not replicate. Pre-existing divergence, not
+/// introduced or worsened here (identical on `main` before this PR) --
+/// filed separately as #1175.
 #[test]
 fn test_jq_null_times_number_literal_still_discards_both_ways_1167() -> Result<()> {
     let (out, _, code) = run_jq_full(&["-cn", "1e10 * null"], None)?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11636,6 +11636,23 @@ fn test_jq_compound_assign_plus_preserves_number_literal_on_null_1143() -> Resul
     Ok(())
 }
 
+/// #1167's `arith_mul` reordering (moving relocation arms before the
+/// numeric collapse) must not change jq mode's own `null * x` / `x * null`
+/// behavior -- `NULL_MERGES_AS_EMPTY` is yq-only, so both directions still
+/// fall through to the unconditional "null * x = null" arm and discard the
+/// non-null operand entirely, matching real jq (`5 * null` -> `null`).
+#[test]
+fn test_jq_null_times_number_literal_still_discards_both_ways_1167() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-cn", "1e10 * null"], None)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
+
+    let (out, _, code) = run_jq_full(&["-cn", "null * 1e10"], None)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}
+
 /// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
 /// the parent key" rules must not leak into jq mode: real jq errors on
 /// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13747,7 +13747,11 @@ fn test_1167_mul_null_noop_preserves_number_literal_spelling() -> Result<()> {
 /// Control: `null * x` (left operand `null`) discards the right operand
 /// entirely -- it must stay `null`, not "preserve" the right operand's
 /// spelling, since nothing is relocated here (unlike the `x *= null` arm
-/// above).
+/// above). Locks in succinctly's *current* behavior, not oracle
+/// conformance -- real yq v4.53.3 actually errors on `null * 1e10`
+/// ("cannot multiply !!null with !!float", confirmed live), a
+/// pre-existing divergence untouched by this PR (identical on `main`
+/// before it) and filed separately as #1175.
 #[test]
 fn test_1167_null_times_number_literal_stays_null() -> Result<()> {
     let (output, code) = run_yq_stdin("null * 1e10", "null", &["-o=json", "-I=0"])?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13789,6 +13789,10 @@ fn test_1167_object_array_merge_and_string_repeat_unchanged() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#""ababab""#);
 
+    let (output, code) = run_yq_stdin(r#"3 * "ab""#, "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""ababab""#);
+
     let (output, code) = run_yq_stdin("null * {\"a\":1}", "null", &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"{"a":1}"#);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13726,6 +13726,76 @@ fn test_1143_genuine_arithmetic_still_reformats() -> Result<()> {
     Ok(())
 }
 
+// --- #1167: `arith_mul`'s null-merge no-op arm (`x *= null`) must not
+// collapse a `NumberLiteral` operand's own source spelling either --
+// identical bug class to #1143, just in `arith_mul` instead of `arith_add`.
+// Verified live against real yq v4.53.3 (`x *= null` is a documented no-op).
+
+#[test]
+fn test_1167_mul_null_noop_preserves_number_literal_spelling() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a *= null", r#"{"a":3.00}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":3.00}"#);
+
+    let (output, code) = run_yq_stdin("1e10 * null", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1e10");
+
+    Ok(())
+}
+
+/// Control: `null * x` (left operand `null`) discards the right operand
+/// entirely -- it must stay `null`, not "preserve" the right operand's
+/// spelling, since nothing is relocated here (unlike the `x *= null` arm
+/// above).
+#[test]
+fn test_1167_null_times_number_literal_stays_null() -> Result<()> {
+    let (output, code) = run_yq_stdin("null * 1e10", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
+
+    Ok(())
+}
+
+/// Control: a genuinely *computed* product must still get canonical
+/// formatting -- #1167's fix only defers `into_plain_number()` for the
+/// relocation/discard arms, not for the arm that actually multiplies.
+#[test]
+fn test_1167_genuine_multiplication_still_reformats() -> Result<()> {
+    let (output, code) = run_yq_stdin("3.00 * 2", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "6.0");
+
+    Ok(())
+}
+
+/// Regression guards: object/array merge and string repetition are
+/// unaffected by #1167's reordering.
+#[test]
+fn test_1167_object_array_merge_and_string_repeat_unchanged() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        r#"{"a":{"x":1}} * {"a":{"y":2}}"#,
+        "null",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":{"x":1,"y":2}}"#);
+
+    let (output, code) = run_yq_stdin("[1,2] * [3,4]", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[3,4]");
+
+    let (output, code) = run_yq_stdin(r#""ab" * 3"#, "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""ababab""#);
+
+    let (output, code) = run_yq_stdin("null * {\"a\":1}", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":1}"#);
+
+    Ok(())
+}
+
 // --- #1116: chained scalar-slice-assignment no-ops too; del() differs ---
 //
 // #1101 covered only a *bare* scalar-slice path (`.[S:E]`). #1116 extends


### PR DESCRIPTION
## Summary

`arith_mul` had the identical bug #1143 just fixed in `arith_add`:
`into_plain_number()` was called unconditionally on both operands before
dispatching, collapsing a `NumberLiteral` (which preserves exact
source-text spelling, e.g. `"3.00"`, `"1e10"`) before yq's `x *= null`
no-op arm (`(left, OwnedValue::Null) if S::NULL_MERGES_AS_EMPTY => Ok(left)`)
could return it unchanged.

Restructures `arith_mul` the same way #1143 restructured `arith_add`:
defer the collapse to the one arm that actually computes a product or a
repeated string; every relocation arm (the null-merge no-op, object/array
merge) or unconditional-discard arm (`null * x = null`) runs against the
original, uncollapsed operands.

## Repro (before/after)

```
$ echo '{"a":3.00}' | succinctly yq -o=json -I=0 '.a *= null'
{"a":3.0}     # before (dropped the trailing zero)
{"a":3.00}    # after (matches real yq's documented `x *= null` no-op)

$ echo 'null' | succinctly yq -o=json -I=0 '1e10 * null'
1e+10         # before
1e10          # after
```

Control — `null * x` (left operand `null`) correctly still discards the
right operand entirely rather than "preserving" it, since nothing is
relocated there:

```
$ echo 'null' | succinctly yq -o=json -I=0 'null * 1e10'
null          # unchanged, correct — this arm always returns Null
```

## Background

Found and independently confirmed by three reviewers during #1143's own
code review (PR #1166) — filed as #1167, a scoped follow-up, since
`arith_mul` is a larger, riskier function (recursive merge logic via
`merge_values`/`merge_existing`, more relocation-shaped arms, a
`MergeFlags` parameter) than `arith_add`, so it wasn't folded into that
PR.

Audited every other arm for the same risk:
- **Object/Object and Array/Array merge arms**: unaffected. `into_plain_number()`
  is shallow — a no-op on `Object`/`Array` values — so it never touched
  these arms' inputs even before this fix; any `NumberLiteral` nested
  *inside* a merged container was never at risk.
- **`null * x` / `x * null` (unconditional discard)**: unaffected by
  design — both arms always return `Null`, discarding the non-null
  operand outright, so there's nothing to relocate.
- **String repetition (`"ab" * 3`)**: needs the eager collapse (it
  pattern-matches on `Int`, not `NumberLiteral`), so it's grouped with
  the numeric arms in the final "compute" match, same as before.

## Testing

- New tests in `tests/yq_cli_tests.rs` (yq mode: null-merge-no-op
  preservation both directions of the string-repeat pattern, a
  null-discards-everything control, a genuine-multiplication-still-
  reformats control, and object/array-merge/string-repeat regression
  guards) and `tests/jq_cli_tests.rs` (jq mode: confirms
  `NULL_MERGES_AS_EMPTY` being yq-only means jq's `null * x`/`x * null`
  is unaffected by the reordering).
- Full local suite (lib/bin/integration/golden/doc tests), both CI
  clippy feature combinations, and the `no_std` check all pass clean.
- Patch coverage: 100% (16/16 new lines).

Fixes #1167