### PR TITLE
fix(jq): preserve an underflowed literal's mantissa in jq-mode output

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -170,7 +170,13 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // Parse exponent to check for e0/e-0. `has_exp` above guarantees `e`/`E`
     // is present, so the position is always found.
     let exp_pos = s.find(['e', 'E']).expect("has_exp guarantees e/E present");
-    let exp: i32 = s[exp_pos + 1..].parse().unwrap_or(0);
+    // `i64`, not `i32`: an exponent digit string beyond `i32` range (e.g.
+    // `1e-2147483649`) used to silently become 0 via `.unwrap_or(0)`,
+    // misrouting into the `exp == 0` "eliminate exponent" fast path below
+    // and reintroducing #1099's exact symptom one exponent-digit past this
+    // PR's own tested boundary (found in code review). `i64` comfortably
+    // covers any exponent that can appear here.
+    let exp: i64 = parse_literal_exponent(&s[exp_pos + 1..]);
 
     // A literal whose magnitude overflows f64 (e.g. `1e400`) parses to
     // +/-infinity, not a parse error - `value` above is non-finite in that
@@ -223,19 +229,10 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
         // (`0e-400`) and for a *nonzero*-mantissa literal whose magnitude
         // simply underflowed `f64` during parsing (`1e-400`, far below
         // `f64::MIN_POSITIVE`) -- the two can't be told apart from `value`
-        // alone (#1099). Check the mantissa's own source digits before
-        // falling back to the zero-mantissa spelling.
-        let mantissa_text = s[..exp_pos].strip_prefix('-').unwrap_or(&s[..exp_pos]);
-        if mantissa_text.bytes().any(|b| b != b'0' && b != b'.') {
-            return format_underflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
-        }
-        // `value == 0.0` is true for -0.0 too (IEEE 754), so a sign check
-        // is needed to avoid dropping it -- real jq keeps both the sign and
-        // the (leading-zero-stripped) source exponent for a zero mantissa,
-        // since log10(0) is undefined and there's no magnitude to
-        // renormalize against (`-0e5` -> `-0E+5`, `-0e05` -> `-0E+5` too).
-        let sign = if value.is_sign_negative() { "-" } else { "" };
-        return assemble_scientific(sign, "0", i64::from(exp));
+        // alone (#1099). `format_underflow_literal_mantissa` (and the
+        // shared `normalize_extreme_literal_mantissa` beneath it) tells
+        // them apart from the literal's own source digits.
+        return format_underflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
     }
 
     let abs_value = value.abs();
@@ -273,14 +270,37 @@ fn assemble_scientific(sign: &str, mantissa_str: &str, exp: i64) -> String {
     format!("{sign}{mantissa_str}E{exp_sign}{exp}")
 }
 
+/// Parse a literal's exponent digit string at wide (`i64`) precision,
+/// saturating to `i64::MIN`/`MAX` by sign on overflow rather than erroring
+/// -- the exponent digit string can itself be longer than `i64` can hold
+/// (e.g. `1e99999999999999999999`), and any such value is already certain
+/// to be past whichever ceiling (or lack thereof) the caller applies.
+/// Shared so `format_number_jq_compat`'s own exponent dispatch and
+/// [`normalize_extreme_literal_mantissa`]'s shift math can't independently
+/// drift on how an out-of-range exponent is handled (#1099 code review:
+/// an earlier `i32`-width, `.unwrap_or(0)` version of this parse at the
+/// `format_number_jq_compat` call site silently treated an out-of-range
+/// exponent as exactly `0`, misrouting extreme-underflow literals into the
+/// "eliminate exponent" fast path before ever reaching this module).
+fn parse_literal_exponent(exp_text: &str) -> i64 {
+    exp_text.parse().unwrap_or_else(|_| {
+        if exp_text.trim_start_matches('+').starts_with('-') {
+            i64::MIN
+        } else {
+            i64::MAX
+        }
+    })
+}
+
 /// Shift a literal's own mantissa digits (the text before `exp_pos`, i.e.
 /// before `e`/`E`) into jq's one-digit-before-the-point normalized form,
 /// and fold that shift into the literal's own written exponent -- returns
-/// `(mantissa_str, new_exp)`. Entirely via string manipulation on `s`
-/// rather than `log10`/`pow` on the parsed value, since the caller only
-/// reaches here when the parsed value has already lost the precision this
-/// exists to recover (`+/-infinity` on overflow, exactly `0.0` on
-/// underflow).
+/// `Some((mantissa_str, new_exp))`, or `None` if the mantissa is genuinely
+/// all-zero (`0.0e400`, `0.00e-400`), which has no magnitude to normalize
+/// against. Entirely via string manipulation on `s` rather than
+/// `log10`/`pow` on the parsed value, since the caller only reaches here
+/// when the parsed value has already lost the precision this exists to
+/// recover (`+/-infinity` on overflow, exactly `0.0` on underflow).
 ///
 /// Shared by [`format_overflow_literal_mantissa`] and
 /// [`format_underflow_literal_mantissa`] (#1099) -- the shift math is
@@ -288,14 +308,11 @@ fn assemble_scientific(sign: &str, mantissa_str: &str, exp: i64) -> String {
 /// (overflow) or enormous-negative (underflow); only what each caller does
 /// with `new_exp` afterward differs (overflow caps to infinity text past a
 /// ceiling; underflow has no such ceiling, oracle-verified on its own doc
-/// comment).
-///
-/// The exponent digit string can itself be longer than `i64` can hold
-/// (e.g. `1e99999999999999999999`) -- an out-of-range parse saturates to
-/// `i64::MAX`/`MIN` by sign rather than erroring, since any such value is
-/// already certain to be past whichever ceiling (or lack thereof) the
-/// caller applies.
-fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> (String, i64) {
+/// comment). The `None` case is centralized here rather than pre-checked
+/// separately by each caller, so "is this mantissa all-zero" has exactly
+/// one implementation instead of two that must be kept in sync by
+/// convention (#106).
+fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Option<(String, i64)> {
     // `dump_truncated`'s whole design keeps preview cost independent of the
     // value's own size (see its doc comment) - a document-controlled
     // mantissa of unbounded length must not turn into unbounded work here
@@ -313,21 +330,16 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> (String, i64) 
     // A leading-dot literal (`.5e400`) has an empty `int_part`, not `"0"` --
     // treat both the same way (mantissa magnitude < 1).
     let (shift, leading, rest): (i64, &str, String) = if int_part.is_empty() || int_part == "0" {
-        // Shift right to the first nonzero fractional digit.
-        match frac_part.find(|c: char| c != '0') {
-            Some(k) => {
-                let after = &frac_part[k + 1..];
-                (
-                    -(k as i64 + 1),
-                    &frac_part[k..=k],
-                    after[..after.len().min(MAX_RENDERED_MANTISSA_DIGITS)].to_string(),
-                )
-            }
-            // An all-zero mantissa (`0.0e400`/`0.0e-400`) parses to a
-            // finite `0.0` and never reaches either caller -- both gate on
-            // a genuinely nonzero mantissa digit existing first.
-            None => unreachable!("caller guarantees a nonzero mantissa digit exists"),
-        }
+        // Shift right to the first nonzero fractional digit. Genuinely
+        // all-zero mantissa (`0.0e400`/`0.0e-400`) has no nonzero digit to
+        // shift to -- `?` propagates that as `None`.
+        let k = frac_part.find(|c: char| c != '0')?;
+        let after = &frac_part[k + 1..];
+        (
+            -(k as i64 + 1),
+            &frac_part[k..=k],
+            after[..after.len().min(MAX_RENDERED_MANTISSA_DIGITS)].to_string(),
+        )
     } else {
         // Mantissa >= 1: shift left past every extra integer-part digit.
         // `int_part[1..]` is a slice (no copy); only what actually gets
@@ -345,14 +357,7 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> (String, i64) 
         (int_part.len() as i64 - 1, &int_part[..1], rest)
     };
 
-    let exp_text = &s[exp_pos + 1..];
-    let parsed_exp: i64 = exp_text.parse().unwrap_or_else(|_| {
-        if exp_text.trim_start_matches('+').starts_with('-') {
-            i64::MIN
-        } else {
-            i64::MAX
-        }
-    });
+    let parsed_exp = parse_literal_exponent(&s[exp_pos + 1..]);
     let new_exp = parsed_exp.saturating_add(shift);
 
     let mantissa_str = if rest.is_empty() {
@@ -360,7 +365,7 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> (String, i64) 
     } else {
         format!("{leading}.{rest}")
     };
-    (mantissa_str, new_exp)
+    Some((mantissa_str, new_exp))
 }
 
 /// Renormalize an overflowed literal's own mantissa digits into jq's
@@ -379,7 +384,12 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> (String, i64) 
 /// `1.7976931348623157e+308`, matching a computed infinity).
 fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> String {
     let sign = if negative { "-" } else { "" };
-    let (mantissa_str, new_exp) = normalize_extreme_literal_mantissa(s, exp_pos);
+    // A mantissa of exactly `0` times any exponent is still exactly `0.0`,
+    // never `+/-infinity` -- callers only reach this function when `value`
+    // has already overflowed, which guarantees a nonzero mantissa.
+    let Some((mantissa_str, new_exp)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
+        unreachable!("overflow implies a nonzero mantissa")
+    };
 
     // jq's own literal-preserving text (as opposed to a computed value's
     // DBL_MAX text) only goes up to this exponent magnitude (decNumber's
@@ -406,13 +416,27 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
 ///
 /// Oracle-verified against real jq: `1e-400` -> `1E-400`, `12.34e-400` ->
 /// `1.234E-399`, `0.5e-400` -> `5E-401`, `100.5e-400` -> `1.005E-398`.
-/// Unlike overflow, underflow has **no** ceiling -- `1e-1000000000`
-/// (exponent magnitude *at* the overflow ceiling) still prints
-/// `1E-1000000000` unchanged, not a fallback to plain `0`.
+/// Unlike overflow, underflow has no *deliberate* ceiling here --
+/// `1e-1000000000` (exponent magnitude *at* the overflow ceiling) still
+/// prints `1E-1000000000` unchanged, not a fallback to plain `0`. Real jq
+/// itself, however, breaks down for magnitudes beyond ~1,147,483,647
+/// (`i32::MAX - 1e9`; an apparent internal int32-overflow bug in its own
+/// decNumber), printing a fixed sentinel (`1e-1200000000` -> real jq's
+/// `0E-1147483646`) rather than continuing to preserve the mantissa. This
+/// function deliberately does **not** replicate that breakdown -- it keeps
+/// preserving the mantissa past jq's own failure point, on the basis that
+/// jq's behavior there is itself a bug, not a rule worth matching.
 fn format_underflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> String {
     let sign = if negative { "-" } else { "" };
-    let (mantissa_str, new_exp) = normalize_extreme_literal_mantissa(s, exp_pos);
-    assemble_scientific(sign, &mantissa_str, new_exp)
+    match normalize_extreme_literal_mantissa(s, exp_pos) {
+        Some((mantissa_str, new_exp)) => assemble_scientific(sign, &mantissa_str, new_exp),
+        // Genuinely all-zero mantissa (`0.0e-400`) -- no magnitude to
+        // renormalize against. `value == 0.0` is true for `-0.0` too (IEEE
+        // 754), so the sign still needs preserving -- real jq keeps both
+        // the sign and the source exponent for a zero mantissa, since
+        // log10(0) is undefined (`-0e5` -> `-0E+5`, `-0e05` -> `-0E+5`).
+        None => assemble_scientific(sign, "0", parse_literal_exponent(&s[exp_pos + 1..])),
+    }
 }
 
 /// Format a mantissa value for jq-compatible output.

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -2315,6 +2315,62 @@ mod tests {
         assert_eq!(format_number_jq_compat(digits.as_bytes()), digits);
     }
 
+    /// #1099: the symmetric *underflow* case (a literal whose magnitude
+    /// underflows `f64` to exactly `0.0`, e.g. `1e-400`) used to lose the
+    /// mantissa entirely (`0E-400` instead of `1E-400`) -- `value == 0.0`
+    /// can't tell a genuinely-zero-mantissa literal apart from a nonzero
+    /// one that simply underflowed. In-process counterpart to
+    /// `jq_cli_tests.rs`'s CLI-level coverage of the same cases: those
+    /// spawn a subprocess and so are invisible to `cargo llvm-cov`, which
+    /// only instruments the test binary itself.
+    #[test]
+    fn test_format_number_jq_compat_underflow_preserves_mantissa_1099() {
+        assert_eq!(format_number_jq_compat(b"1e-400"), "1E-400");
+        assert_eq!(format_number_jq_compat(b"-1e-400"), "-1E-400");
+        assert_eq!(format_number_jq_compat(b"12.34e-400"), "1.234E-399");
+        assert_eq!(format_number_jq_compat(b"0.5e-400"), "5E-401");
+        assert_eq!(format_number_jq_compat(b"100.5e-400"), "1.005E-398");
+    }
+
+    /// #1099 code review: the exponent digit string was parsed at `i32`
+    /// width for `format_number_jq_compat`'s own fast-path dispatch
+    /// (`exp == 0` / `(-5..0)` checks), and an out-of-`i32`-range exponent
+    /// silently became `0` via `.unwrap_or(0)` -- misrouting into the
+    /// "eliminate exponent" fast path before the mantissa-preserving logic
+    /// above ever ran. Widening that parse to `i64` (`parse_literal_exponent`)
+    /// fixes it for any realistic exponent.
+    #[test]
+    fn test_format_number_jq_compat_underflow_beyond_i32_exponent_range_1099() {
+        // One exponent digit past i32::MIN (-2147483648) -- used to
+        // silently dispatch through `exp == 0` and print bare `0`, losing
+        // sign, mantissa, and exponent entirely.
+        assert_eq!(format_number_jq_compat(b"1e-2147483649"), "1E-2147483649");
+        assert_eq!(format_number_jq_compat(b"-1e-2147483649"), "-1E-2147483649");
+        // Right at the (now-irrelevant) old i32 boundary -- must stay
+        // correct too, not just the one-past case.
+        assert_eq!(format_number_jq_compat(b"1e-2147483648"), "1E-2147483648");
+        // Same bug, zero-mantissa side: a genuinely-zero mantissa at an
+        // out-of-i32-range exponent also mis-dispatched through `exp == 0`,
+        // wrongly eliminating (rather than preserving) the huge exponent.
+        assert_eq!(format_number_jq_compat(b"0e-2147483649"), "0E-2147483649");
+    }
+
+    /// `parse_literal_exponent`'s own saturating fallback: an exponent
+    /// digit string that overflows even `i64` (not just `i32`) saturates to
+    /// `i64::MIN`/`MAX` by sign rather than erroring. The overflow-ceiling
+    /// test above already exercises the positive (`i64::MAX`) side via
+    /// `1e99999999999999999999`; this covers the negative (`i64::MIN`)
+    /// side, which only underflow's unlimited exponent range can reach (the
+    /// overflow path's own ceiling check fires at a much smaller magnitude,
+    /// long before an exponent could overflow `i64`).
+    #[test]
+    fn test_format_number_jq_compat_underflow_exponent_beyond_i64_range_1099() {
+        assert_eq!(
+            format_number_jq_compat(b"1e-99999999999999999999"),
+            "1E-9223372036854775808"
+        );
+    }
+
     /// #930 review: an overflowed literal's mantissa can be arbitrarily long
     /// (it's document-controlled text), but only a handful of its leading
     /// digits ever survive `dump_truncated`'s later preview truncation - so

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -219,6 +219,16 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // For other cases, use normalized scientific notation
     // jq normalizes mantissa to have one digit before decimal point
     if value == 0.0 {
+        // `value == 0.0` is true both for a genuinely-zero-mantissa literal
+        // (`0e-400`) and for a *nonzero*-mantissa literal whose magnitude
+        // simply underflowed `f64` during parsing (`1e-400`, far below
+        // `f64::MIN_POSITIVE`) -- the two can't be told apart from `value`
+        // alone (#1099). Check the mantissa's own source digits before
+        // falling back to the zero-mantissa spelling.
+        let mantissa_text = s[..exp_pos].strip_prefix('-').unwrap_or(&s[..exp_pos]);
+        if mantissa_text.bytes().any(|b| b != b'0' && b != b'.') {
+            return format_underflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
+        }
         // `value == 0.0` is true for -0.0 too (IEEE 754), so a sign check
         // is needed to avoid dropping it -- real jq keeps both the sign and
         // the (leading-zero-stripped) source exponent for a zero mantissa,
@@ -263,22 +273,29 @@ fn assemble_scientific(sign: &str, mantissa_str: &str, exp: i64) -> String {
     format!("{sign}{mantissa_str}E{exp_sign}{exp}")
 }
 
-/// Renormalize an overflowed literal's own mantissa digits into jq's
-/// one-digit-before-the-point scientific form, entirely via string
-/// manipulation on `s` rather than the finite path's `log10`/`pow` on the
-/// (here, non-finite) parsed value -- see the call site above for why. `s`
-/// is the full literal text and `exp_pos` the byte index of its `e`/`E`;
-/// `negative` is `value.is_sign_negative()` from the caller, which (unlike
-/// re-deriving a sign from `s` itself) is correct for `-0.0`-style edge
-/// cases too and matches this module's usual `if value < 0.0` idiom.
+/// Shift a literal's own mantissa digits (the text before `exp_pos`, i.e.
+/// before `e`/`E`) into jq's one-digit-before-the-point normalized form,
+/// and fold that shift into the literal's own written exponent -- returns
+/// `(mantissa_str, new_exp)`. Entirely via string manipulation on `s`
+/// rather than `log10`/`pow` on the parsed value, since the caller only
+/// reaches here when the parsed value has already lost the precision this
+/// exists to recover (`+/-infinity` on overflow, exactly `0.0` on
+/// underflow).
 ///
-/// Oracle-verified against real jq (issue #930): `1e400` -> `1E+400`,
-/// `123e400` -> `1.23E+402`, `12.34e400` -> `1.234E+401`, `0.5e400` ->
-/// `5E+399`, `100e400` -> `1.00E+402` (trailing zeros preserved, matching
-/// this module's general trailing-zero rule), and beyond jq's own
-/// literal-preservation ceiling, DBL_MAX text (`1e1000000000` ->
-/// `1.7976931348623157e+308`, matching a computed infinity).
-fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> String {
+/// Shared by [`format_overflow_literal_mantissa`] and
+/// [`format_underflow_literal_mantissa`] (#1099) -- the shift math is
+/// identical whether the literal's written exponent is enormous-positive
+/// (overflow) or enormous-negative (underflow); only what each caller does
+/// with `new_exp` afterward differs (overflow caps to infinity text past a
+/// ceiling; underflow has no such ceiling, oracle-verified on its own doc
+/// comment).
+///
+/// The exponent digit string can itself be longer than `i64` can hold
+/// (e.g. `1e99999999999999999999`) -- an out-of-range parse saturates to
+/// `i64::MAX`/`MIN` by sign rather than erroring, since any such value is
+/// already certain to be past whichever ceiling (or lack thereof) the
+/// caller applies.
+fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> (String, i64) {
     // `dump_truncated`'s whole design keeps preview cost independent of the
     // value's own size (see its doc comment) - a document-controlled
     // mantissa of unbounded length must not turn into unbounded work here
@@ -290,7 +307,6 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // actually get rendered.
     const MAX_RENDERED_MANTISSA_DIGITS: usize = 32;
 
-    let sign = if negative { "-" } else { "" };
     let mantissa = s[..exp_pos].strip_prefix('-').unwrap_or(&s[..exp_pos]);
     let (int_part, frac_part) = mantissa.split_once('.').unwrap_or((mantissa, ""));
 
@@ -307,9 +323,10 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
                     after[..after.len().min(MAX_RENDERED_MANTISSA_DIGITS)].to_string(),
                 )
             }
-            // An all-zero mantissa (`0.0e400`) parses to a finite `0.0` and
-            // never reaches this function.
-            None => unreachable!("overflow literal mantissa is provably nonzero"),
+            // An all-zero mantissa (`0.0e400`/`0.0e-400`) parses to a
+            // finite `0.0` and never reaches either caller -- both gate on
+            // a genuinely nonzero mantissa digit existing first.
+            None => unreachable!("caller guarantees a nonzero mantissa digit exists"),
         }
     } else {
         // Mantissa >= 1: shift left past every extra integer-part digit.
@@ -328,11 +345,6 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
         (int_part.len() as i64 - 1, &int_part[..1], rest)
     };
 
-    // The exponent digit string can itself be longer than `i32`/`i64` can
-    // hold (e.g. `1e99999999999999999999`) -- any such value is already
-    // certain to be past jq's literal-preservation ceiling below, so an
-    // out-of-range parse can saturate to `i64::MAX`/`MIN` rather than being
-    // treated as an error.
     let exp_text = &s[exp_pos + 1..];
     let parsed_exp: i64 = exp_text.parse().unwrap_or_else(|_| {
         if exp_text.trim_start_matches('+').starts_with('-') {
@@ -343,6 +355,32 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     });
     let new_exp = parsed_exp.saturating_add(shift);
 
+    let mantissa_str = if rest.is_empty() {
+        leading.to_string()
+    } else {
+        format!("{leading}.{rest}")
+    };
+    (mantissa_str, new_exp)
+}
+
+/// Renormalize an overflowed literal's own mantissa digits into jq's
+/// one-digit-before-the-point scientific form -- see
+/// [`normalize_extreme_literal_mantissa`] for the shared shift math. `s` is
+/// the full literal text and `exp_pos` the byte index of its `e`/`E`;
+/// `negative` is `value.is_sign_negative()` from the caller, which (unlike
+/// re-deriving a sign from `s` itself) is correct for `-0.0`-style edge
+/// cases too and matches this module's usual `if value < 0.0` idiom.
+///
+/// Oracle-verified against real jq (issue #930): `1e400` -> `1E+400`,
+/// `123e400` -> `1.23E+402`, `12.34e400` -> `1.234E+401`, `0.5e400` ->
+/// `5E+399`, `100e400` -> `1.00E+402` (trailing zeros preserved, matching
+/// this module's general trailing-zero rule), and beyond jq's own
+/// literal-preservation ceiling, DBL_MAX text (`1e1000000000` ->
+/// `1.7976931348623157e+308`, matching a computed infinity).
+fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> String {
+    let sign = if negative { "-" } else { "" };
+    let (mantissa_str, new_exp) = normalize_extreme_literal_mantissa(s, exp_pos);
+
     // jq's own literal-preserving text (as opposed to a computed value's
     // DBL_MAX text) only goes up to this exponent magnitude (decNumber's
     // limit) -- oracle-verified: `1e999999999` keeps `1E+999999999`,
@@ -351,11 +389,29 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
         return infinite_float_preview_text(negative).to_string();
     }
 
-    let mantissa_str = if rest.is_empty() {
-        leading.to_string()
-    } else {
-        format!("{leading}.{rest}")
-    };
+    assemble_scientific(sign, &mantissa_str, new_exp)
+}
+
+/// Renormalize an underflowed literal's own mantissa digits into jq's
+/// one-digit-before-the-point scientific form (#1099) -- see
+/// [`normalize_extreme_literal_mantissa`] for the shared shift math, and
+/// [`format_overflow_literal_mantissa`] for the symmetric overflow case.
+///
+/// A literal whose magnitude underflows `f64` to exactly `0.0` (nonzero
+/// mantissa, deeply negative exponent) can't be told apart from a
+/// genuinely-zero-mantissa literal by looking at the parsed value alone --
+/// both are `0.0`. The caller (`format_number_jq_compat`'s `value == 0.0`
+/// branch) already checked the mantissa's own source digits before calling
+/// this, so `s`'s mantissa is guaranteed nonzero here.
+///
+/// Oracle-verified against real jq: `1e-400` -> `1E-400`, `12.34e-400` ->
+/// `1.234E-399`, `0.5e-400` -> `5E-401`, `100.5e-400` -> `1.005E-398`.
+/// Unlike overflow, underflow has **no** ceiling -- `1e-1000000000`
+/// (exponent magnitude *at* the overflow ceiling) still prints
+/// `1E-1000000000` unchanged, not a fallback to plain `0`.
+fn format_underflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> String {
+    let sign = if negative { "-" } else { "" };
+    let (mantissa_str, new_exp) = normalize_extreme_literal_mantissa(s, exp_pos);
     assemble_scientific(sign, &mantissa_str, new_exp)
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4362,6 +4362,66 @@ fn test_number_literal_overflow_identity_echoes_mantissa_via_cli_1087() -> Resul
     Ok(())
 }
 
+/// #1099: the symmetric *underflow* case (a literal whose magnitude
+/// underflows `f64` to exactly `0.0`, e.g. `1e-400`) used to lose the
+/// mantissa entirely (`0E-400` instead of `1E-400`) -- `value == 0.0` can't
+/// tell a genuinely-zero-mantissa literal apart from a nonzero one that
+/// simply underflowed, so `format_number_jq_compat` used to always spell
+/// the mantissa as `"0"`. Verified live against jq 1.7.1.
+#[test]
+fn test_number_literal_underflow_preserves_mantissa_via_cli_1099() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "1e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1E-400");
+
+    let (output, code) = run_jq_stdin(".", "-1e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "-1E-400");
+
+    let (output, code) = run_jq_stdin(".", "12.34e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1.234E-399");
+
+    let (output, code) = run_jq_stdin(".", "0.5e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "5E-401");
+
+    let (output, code) = run_jq_stdin(".", "100.5e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1.005E-398");
+
+    Ok(())
+}
+
+/// A genuinely-zero-mantissa literal at an extreme negative exponent is
+/// unaffected by #1099's fix -- regression guard alongside the nonzero
+/// case above.
+#[test]
+fn test_number_literal_zero_mantissa_extreme_exponent_still_zero_1099() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "0e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0E-400");
+
+    let (output, code) = run_jq_stdin(".", "-0e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "-0E-400");
+
+    Ok(())
+}
+
+/// Unlike overflow (which falls back to `DBL_MAX` text past a documented
+/// exponent-magnitude ceiling), underflow has no such ceiling -- verified
+/// live against jq 1.7.1: `1e-1000000000` (exponent magnitude *at* the
+/// overflow ceiling) still prints the literal mantissa unchanged.
+#[test]
+fn test_number_literal_underflow_has_no_ceiling_unlike_overflow_1099() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "1e-1000000000", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1E-1000000000");
+
+    Ok(())
+}
+
 /// `eval_owned_expr`/`eval_owned_input` (backing `reduce`/`foreach`/`as $x`
 /// variable binding) and `with_entries`'s `owned_to_json_bytes` each have
 /// their own serialize-and-reparse bridge, separate from `eval_generic`'s

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4410,14 +4410,56 @@ fn test_number_literal_zero_mantissa_extreme_exponent_still_zero_1099() -> Resul
 }
 
 /// Unlike overflow (which falls back to `DBL_MAX` text past a documented
-/// exponent-magnitude ceiling), underflow has no such ceiling -- verified
-/// live against jq 1.7.1: `1e-1000000000` (exponent magnitude *at* the
-/// overflow ceiling) still prints the literal mantissa unchanged.
+/// exponent-magnitude ceiling), this crate imposes no *deliberate* ceiling
+/// on underflow -- verified live against jq 1.7.1: `1e-1000000000`
+/// (exponent magnitude *at* the overflow ceiling) still prints the literal
+/// mantissa unchanged. (Real jq itself breaks down for magnitudes beyond
+/// ~1,147,483,647 -- an apparent internal bug in its own decNumber, not
+/// replicated here; see `format_underflow_literal_mantissa`'s doc comment.)
 #[test]
 fn test_number_literal_underflow_has_no_ceiling_unlike_overflow_1099() -> Result<()> {
     let (output, code) = run_jq_stdin(".", "1e-1000000000", &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "1E-1000000000");
+
+    Ok(())
+}
+
+/// Code review finding on #1099's own PR: the exponent digit string was
+/// parsed at `i32` width for dispatch (`exp == 0` / `(-5..0)` fast-path
+/// checks), and an out-of-`i32`-range exponent silently became `0` via
+/// `.unwrap_or(0)` -- misrouting into the "eliminate exponent" fast path
+/// *before* the mantissa-preserving logic above ever ran, reintroducing
+/// #1099's exact original symptom one exponent-digit past `i32::MIN`
+/// (`-2147483648`). Verified live: real jq already falls into its own
+/// ~1.147B breakdown by this magnitude (see the no-ceiling test above), so
+/// this is a succinctly-only boundary, not oracle-comparable.
+#[test]
+fn test_number_literal_underflow_beyond_i32_exponent_range_1099() -> Result<()> {
+    // One exponent digit past i32::MIN (-2147483648) -- used to silently
+    // dispatch through `exp == 0` and print bare `0`, losing sign,
+    // mantissa, and exponent entirely.
+    let (output, code) = run_jq_stdin(".", "1e-2147483649", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1E-2147483649");
+
+    let (output, code) = run_jq_stdin(".", "-1e-2147483649", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "-1E-2147483649");
+
+    // Right at the (now-irrelevant) old i32 boundary -- must stay correct
+    // too, not just the one-past case.
+    let (output, code) = run_jq_stdin(".", "1e-2147483648", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1E-2147483648");
+
+    // Same bug, zero-mantissa side: a genuinely-zero mantissa at an
+    // out-of-i32-range exponent used to also mis-dispatch through
+    // `exp == 0`, wrongly eliminating (rather than preserving) the huge
+    // exponent.
+    let (output, code) = run_jq_stdin(".", "0e-2147483649", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0E-2147483649");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`format_number_jq_compat`'s `value == 0.0` branch couldn't distinguish a genuinely-zero-mantissa literal (`0e-400`) from a nonzero-mantissa literal whose magnitude simply underflowed `f64` during parsing (`1e-400`, far below `f64::MIN_POSITIVE`) — both parse to the identical `0.0`, so the function always stitched the correct exponent onto a wrong `"0"` mantissa:

```
$ echo '1e-400' | succinctly jq '.'
0E-400          # should be 1E-400, matching real jq
```

## Design

Fixed by checking the literal's own source mantissa digits before falling back to the zero-mantissa spelling, mirroring how `format_overflow_literal_mantissa` already handles the symmetric overflow case (deriving the mantissa from source text, not the already-imprecise parsed value). The shift-computation math (identical whether the written exponent is enormous-positive or enormous-negative) lives in a shared `normalize_extreme_literal_mantissa` helper both the overflow function and the new underflow one call, rather than duplicating it.

Unlike overflow, underflow has no *deliberate* ceiling: real jq keeps printing an arbitrarily negative exponent (verified live: `1e-1000000000`, exponent magnitude *at* the overflow ceiling, still prints unchanged) rather than falling back to a sentinel the way overflow falls back to `DBL_MAX` text past its own ceiling. Real jq *itself* does break down past ~1,147,483,647 (an apparent internal `i32`-overflow bug in its own decNumber) — this crate deliberately doesn't replicate that breakdown.

Item 2 of #1099 (high-precision mantissas losing precision beyond ~15-17 significant digits in the finite normalized-scientific-notation branch) is a separate, harder problem needing arbitrary-precision decimal handling and is left open.

Also filed #1171 (unrelated, pre-existing): a leading-dot number literal (`.5e-400`) in document input silently produces no output instead of an error or a parsed value, found while live-verifying this fix's oracle cases.

**Code review update:** review of the first version of this fix found a real, corroborated bug: the exponent digit string was parsed at `i32` width for `format_number_jq_compat`'s own fast-path dispatch (`exp == 0` / `(-5..0)` checks), and an out-of-`i32`-range exponent silently became `0` via `.unwrap_or(0)` — misrouting extreme-underflow literals (e.g. `1e-2147483649`) into the "eliminate exponent" fast path *before* this PR's mantissa-preserving fix ever ran, reintroducing #1099's exact symptom one exponent-digit past the originally-tested boundary. Fixed by widening that parse to `i64` via a new shared `parse_literal_exponent` helper (also deduped into `normalize_extreme_literal_mantissa`'s own exponent parse). The review also found the caller-side "is this mantissa nonzero" check duplicated the callee's own zero-mantissa detection (`normalize_extreme_literal_mantissa`'s `unreachable!()` guard) — folded into one `Option`-returning implementation instead of two independently-maintained checks. Three further findings were genuinely separate, pre-existing bugs (different code paths, not touched by this PR's own diff) and are filed as follow-ups rather than fixed here: #1177 (subnormal nonzero underflow renders mantissa as literal `"inf"`), #1178 (the pre-existing genuinely-zero-mantissa fallback doesn't shift its exponent for extra fractional-zero digits), #1180 (`normalize_extreme_literal_mantissa` mis-normalizes an insignificant-leading-zero or leading-`+` mantissa, unreachable via the CLI today since JSON/YAML grammar already rejects such spellings).

Fixes #1099

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Local patch coverage: 98% (49/50 new lines); the one uncovered line is a documented, provably-unreachable `unreachable!()` arm
- [x] New tests: underflow mantissa preservation, the zero-mantissa regression guard, no-ceiling behavior, the `i32`-exponent-boundary fix (both CLI-level and in-process, since the CLI-level ones spawn a subprocess invisible to coverage instrumentation), and `parse_literal_exponent`'s `i64::MIN` saturating fallback
- [x] Live-verified against jq 1.7.1: `1e-400`, `-1e-400`, `12.34e-400`, `0.5e-400`, `9.99e-400`, `100.5e-400`, `1e-1000000000`, `1e-2147483649`, plus overflow/zero/normal regression cases