### PR TITLE
fix(jq): yq scalar-slice-assignment no-op extends to computed bounds

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13654,11 +13654,32 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
                 // `false`, not `optional`: the failure has to arrive as an
                 // error for the two spellings to be told apart here, same
                 // as `resolve_index_expr`'s `index_one_owned` call.
-                let next_value = match slice_owned_value(target_value, *s, *e, false) {
-                    Ok(v) => v.expect("non-optional slice yields a value or errors"),
-                    Err(_) if optional => continue,
-                    Err(e) => return Err((out, e.into())),
-                };
+                //
+                // yq mode (#1117): a scalar target still needs to resolve
+                // to a real path here, not error, the same way a *literal*
+                // bound already does -- real yq no-ops a computed-bound
+                // slice-assignment on a scalar identically to a literal one
+                // (#1101/#1116), but that no-op lives downstream in
+                // `through_slice`, which only ever runs once path
+                // resolution has actually produced an `Expr::Slice` for
+                // `set_path`/`update_path` to walk. Seeding the same empty-
+                // array placeholder `through_slice`'s own scalar-noop arm
+                // uses lets resolution succeed here; the eventual write is
+                // still discarded there, not here -- so `-=`/`*=`, which
+                // gate their no-op *after* resolution
+                // (`eval_update`'s `scalar_slice_noop`), still reach
+                // `through_slice`'s catch-all for a scalar target and raise
+                // the identical error this used to raise here instead.
+                let next_value =
+                    if S::TAG == EvalTag::Yq && is_yq_slice_empty_container_scalar(target_value) {
+                        OwnedValue::Array(Vec::new())
+                    } else {
+                        match slice_owned_value(target_value, *s, *e, false) {
+                            Ok(v) => v.expect("non-optional slice yields a value or errors"),
+                            Err(_) if optional => continue,
+                            Err(e) => return Err((out, e.into())),
+                        }
+                    };
                 let mut path = components.clone();
                 path.push(if optional {
                     Expr::Optional(Box::new(slice_expr.clone()))

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13655,31 +13655,30 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
                 // error for the two spellings to be told apart here, same
                 // as `resolve_index_expr`'s `index_one_owned` call.
                 //
-                // yq mode (#1117): a scalar target still needs to resolve
-                // to a real path here, not error, the same way a *literal*
-                // bound already does -- real yq no-ops a computed-bound
-                // slice-assignment on a scalar identically to a literal one
-                // (#1101/#1116), but that no-op lives downstream in
-                // `through_slice`, which only ever runs once path
-                // resolution has actually produced an `Expr::Slice` for
-                // `set_path`/`update_path` to walk. Seeding the same empty-
-                // array placeholder `through_slice`'s own scalar-noop arm
-                // uses lets resolution succeed here; the eventual write is
-                // still discarded there, not here -- so `-=`/`*=`, which
-                // gate their no-op *after* resolution
+                // `slice_owned_value_read::<S>`, not the raw
+                // `slice_owned_value` (#1117): a scalar target still needs
+                // to resolve to a real path here, not error, the same way a
+                // *literal* bound already does -- real yq no-ops a
+                // computed-bound slice-assignment on a scalar identically to
+                // a literal one (#1101/#1116), but that no-op lives
+                // downstream in `through_slice`, which only ever runs once
+                // path resolution has actually produced an `Expr::Slice` for
+                // `set_path`/`update_path` to walk. `slice_owned_value_read`
+                // already seeds the exact same empty-array placeholder
+                // `through_slice`'s own scalar-noop arm uses (it exists for
+                // the read-path #1065 case, which needs the identical
+                // yq-scalar substitution) -- reusing it here keeps the rule
+                // to one definition instead of a second hand-copied one. The
+                // eventual write is still discarded downstream, not here --
+                // so `-=`/`*=`, which gate their no-op *after* resolution
                 // (`eval_update`'s `scalar_slice_noop`), still reach
                 // `through_slice`'s catch-all for a scalar target and raise
                 // the identical error this used to raise here instead.
-                let next_value =
-                    if S::TAG == EvalTag::Yq && is_yq_slice_empty_container_scalar(target_value) {
-                        OwnedValue::Array(Vec::new())
-                    } else {
-                        match slice_owned_value(target_value, *s, *e, false) {
-                            Ok(v) => v.expect("non-optional slice yields a value or errors"),
-                            Err(_) if optional => continue,
-                            Err(e) => return Err((out, e.into())),
-                        }
-                    };
+                let next_value = match slice_owned_value_read::<S>(target_value, *s, *e, false) {
+                    Ok(v) => v.expect("non-optional slice yields a value or errors"),
+                    Err(_) if optional => continue,
+                    Err(e) => return Err((out, e.into())),
+                };
                 let mut path = components.clone();
                 path.push(if optional {
                     Expr::Optional(Box::new(slice_expr.clone()))

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13015,9 +13015,10 @@ fn test_slice_owned_target_scalar_is_empty_array_1065() -> Result<()> {
 // this same no-op to them too (any operator, including `-=`/`*=`, unlike
 // the scalar case), and #1116 (PR #1151) separately widened the *scalar*
 // case here to any chain depth, not just the bare-root shape this section
-// was originally scoped to. `.[$a:$b]` (computed bounds) still fails
-// earlier, inside `resolve_slice_expr`'s own eager path-resolution slice --
-// a separate and more delicate piece of machinery neither fix touches.
+// was originally scoped to. `.[$a:$b]` (computed bounds) used to fail
+// earlier still, inside `resolve_slice_expr`'s own eager path-resolution
+// slice -- a separate piece of machinery none of the above touched --
+// fixed by #1117 (see that section further down).
 
 #[test]
 fn test_slice_assign_number_scalar_is_noop_1101() -> Result<()> {
@@ -13970,6 +13971,188 @@ fn test_1116_paren_wrapped_bare_slice_assign_still_noops() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "5");
 
+    Ok(())
+}
+
+// ============================================================================
+// yq scalar-slice-assignment no-op extends to computed bounds too (#1117)
+// ============================================================================
+//
+// #1101/#1116's no-op only ever covered a *literal*-bound slice (`.[0:1]`),
+// which parses straight to `Expr::Slice` -- a *computed*-bound slice
+// (`.[$a:$b]`) instead parses to `Expr::SliceExpr` and has to be folded
+// down to a literal `Expr::Slice` by `resolve_slice_expr` before any of
+// that write-time no-op logic ever runs. `resolve_slice_expr` called
+// `slice_owned_value` eagerly as part of path *resolution* itself, on the
+// real scalar target, erroring before `through_slice`'s no-op ever got a
+// chance to fire. Live-verified against real yq v4.53.3 that the no-op
+// applies identically regardless of whether the bounds are literal or
+// computed.
+
+#[test]
+fn test_slice_assign_number_scalar_computed_bound_is_noop_1117() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b] = 99",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+#[test]
+fn test_slice_update_and_compound_add_scalar_computed_bound_is_noop_1117() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b] |= .",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b] += 1",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+#[test]
+fn test_slice_del_scalar_computed_bound_is_noop_1117() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | del(.[$a:$b])",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+#[test]
+fn test_slice_assign_bool_computed_bound_is_noop_1117() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b] = 99",
+        "true",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+    Ok(())
+}
+
+/// `-=`/`*=` on a scalar target still error for a computed bound, exactly
+/// as they already do for a literal one (#1101) -- the no-op is gated
+/// per-operator downstream in `through_slice`, not by resolution, so this
+/// fix doesn't touch that posture.
+#[test]
+fn test_slice_sub_and_mul_scalar_computed_bound_still_errors_1117() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b] -= 99",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_ne!(code, 0, "out: {out:?}");
+
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b] *= 99",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_ne!(code, 0, "out: {out:?}");
+    Ok(())
+}
+
+/// A computed bound reached through a chained field, and a computed-bound
+/// slice with more path *after* it (an index) -- both no-op on a scalar
+/// target too, matching #1116's chain-depth widening for the literal case.
+#[test]
+fn test_slice_assign_scalar_computed_bound_chained_and_nested_is_noop_1117() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .foo[$a:$b] = 99",
+        r#"{"foo":5}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"foo":5}"#);
+
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b][0] = 99",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// A computed bound genuinely incompatible with the sliced type (field
+/// access on what a scalar's no-op placeholder resolves as) still errors,
+/// the same way `.[0:2].foo = v` does for a literal bound (#1142) -- the
+/// fix must not swallow a real type error along with the no-op.
+#[test]
+fn test_slice_assign_scalar_computed_bound_through_field_after_slice_still_errors_1117(
+) -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b].foo = 1",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_ne!(code, 0, "out: {out:?}");
+    Ok(())
+}
+
+/// A computed bound on an already-working target (array/string container,
+/// #1142; null; a genuinely optional `?`-suffixed slice) is unaffected by
+/// this fix -- confirms the change is scoped to the scalar case only.
+#[test]
+fn test_slice_assign_computed_bound_unaffected_targets_1117() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b] = [99]",
+        "[1,2,3]",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1,2,3]");
+
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b] = 99",
+        "null",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
+
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b]? = 99",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// jq mode has no yq-style no-op at all -- a computed-bound scalar slice
+/// still errors there, matching real jq exactly.
+#[test]
+fn test_slice_assign_scalar_computed_bound_jq_mode_unaffected_1117() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq")
+        .arg("-c")
+        .arg("0 as $a | 1 as $b | .[$a:$b] = 99");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"5")?;
+    let output = child.wait_with_output()?;
+    assert_ne!(output.status.code(), Some(0));
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14067,6 +14067,44 @@ fn test_slice_sub_and_mul_scalar_computed_bound_still_errors_1117() -> Result<()
     Ok(())
 }
 
+/// Unlike a *literal* bound (`.[0:1]?`, `resolve_dynamic_indexes`'s own
+/// `Expr::Optional` path, untouched by this fix), a *computed* bound's `?`
+/// wrapper gets stripped by `assemble()`'s `strip_resolved_optional` once
+/// resolution succeeds via this fix's placeholder -- so it no longer
+/// protects `-=`/`*=`'s downstream type error, or an erroring `|=` filter,
+/// the way the un-suffixed form never did either. Confirmed live against
+/// real yq v4.53.3: `?` here does *not* suppress either error there
+/// (it only ever swallows a genuine slice-navigation failure, not the
+/// compound operator's own error) -- so this is the fix's own placeholder
+/// making the computed-bound case match real yq's actual behavior more
+/// closely than the pre-existing literal-bound sibling still does (a
+/// separate, unaffected, pre-existing gap, not fixed here).
+#[test]
+fn test_slice_optional_suffix_does_not_swallow_sub_mul_or_filter_errors_computed_bound_1117(
+) -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b]? -= 99",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_ne!(code, 0, "out: {out:?}");
+
+    let (out, code) = run_yq_stdin(
+        "0 as $a | 1 as $b | .[$a:$b]? *= 99",
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_ne!(code, 0, "out: {out:?}");
+
+    let (out, code) = run_yq_stdin(
+        r#"0 as $a | 1 as $b | .[$a:$b]? |= error("boom")"#,
+        "5",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_ne!(code, 0, "out: {out:?}");
+    Ok(())
+}
+
 /// A computed bound reached through a chained field, and a computed-bound
 /// slice with more path *after* it (an index) -- both no-op on a scalar
 /// target too, matching #1116's chain-depth widening for the literal case.


### PR DESCRIPTION
## Summary
- Fixes #1117: `succinctly yq`'s scalar-slice-assignment no-op (`.[S:E] = v`/`|=`/`+=`/`del()`, from #1101/#1116) only worked for a *literal* slice bound (`.[0:1]`); a computed bound (`.[$a:$b]`) still errored with `Cannot index number with object`, because path *resolution* itself (`resolve_slice_expr`) eagerly called `slice_owned_value` on the real scalar target before the write-time no-op logic in `through_slice` ever got a chance to run.
- Fix seeds the same empty-array placeholder `through_slice`'s existing scalar-noop arm uses, letting resolution succeed and hand a real `Expr::Slice` downstream — the write is still discarded there, not in resolution, so `-=`/`*=` (which gate their no-op after resolution) are unaffected and still error with the identical message as before.
- Live-verified against yq v4.53.3 across bare-root, chained, nested-after-slice-with-more-path, and jq-mode-unaffected shapes. `del()` is fixed identically since it shares the same resolution path.
- Implemented carefully around `resolve_slice_expr`'s three existing edge-case fixes (#843's two trackability gates, #896/#973's keep-partial-prefix structure) — the change is entirely local to the per-branch slice computation inside the existing loop, not a restructuring of the surrounding control flow. Their three regression tests still pass unchanged.

## Test plan
- [x] `cargo build --features cli`
- [x] Live-verified fix + all edge cases against pinned oracle `yq` v4.53.3 (bare-root/chained/nested/jq-mode/`-=`,`*=`-still-errors/`?`-optional/array-string-container-unaffected)
- [x] New tests in `tests/yq_cli_tests.rs` (`_1117` suffix, 9 tests) — all pass
- [x] Full `cargo test --features cli,simd,regex,serde` (no-fail-fast) — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's scalar-yaml-avoiding leg) — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --no-default-features` — clean (pre-existing unrelated warnings only)