### PR TITLE
fix(jq): del() accepts a parenthesized target, including chained slices

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10390,14 +10390,22 @@ pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
 /// in hand, which `through_slice` never has (it only ever sees the sliced
 /// value itself).
 fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Option<Expr> {
-    // `unwrap_paren`, not a direct match: a parenthesized chained target
-    // (`del((.a[0:1]))`) must apply the same parent-key-delete rule as its
-    // bare form (`del(.a[0:1])`) -- previously this shape-check required
+    // `unwrap_path_component`, not a direct match or the narrower
+    // `unwrap_paren`: a parenthesized chained target (`del((.a[0:1]))`)
+    // must apply the same parent-key-delete rule as its bare form
+    // (`del(.a[0:1])`) -- previously this shape-check required
     // `path_expr` to literally be `Expr::Pipe`, so wrapping it in `()`
     // silently opted out of the rule and fell through to
     // `delete_at_path`'s own per-step walk, which errors trying to slice
-    // a scalar directly (#1153).
-    let Expr::Pipe(exprs) = unwrap_paren(path_expr) else {
+    // a scalar directly (#1153). `unwrap_path_component` (already used a
+    // few lines down for `exprs.last()`, and by `navigate_read_only`
+    // below) peels both `Expr::Paren` *and* `Expr::Optional` in either
+    // order, unlike `unwrap_paren` alone -- needed so `?` applied
+    // *outside* the closing paren (`del((.a[0:1])?)`) doesn't also opt
+    // out of the rule the way a bare `unwrap_paren` would have left it
+    // (caught by review before merge: that narrower version silently
+    // no-op'd instead of deleting the parent key, for that one shape).
+    let Expr::Pipe(exprs) = unwrap_path_component(path_expr).0 else {
         return None;
     };
     let (last, _) = unwrap_path_component(exprs.last()?);
@@ -19486,11 +19494,12 @@ fn delete_at_path(
         }
         Expr::Optional(inner) => delete_at_path(root, inner, true),
         // `(EXPR)` at the top of a resolved delete target (e.g.
-        // `del((.a))`) -- mirrors `set_path`'s identical `Expr::Paren` arm
-        // (#1116), which this arm was missing entirely until now (#1153):
-        // any parenthesized `del()` target failed with "cannot use
-        // expression as delete target", whether or not a slice was
-        // involved.
+        // `del((.a))`) -- mirrors `update_path`'s identical `Expr::Paren`
+        // arm (#1116; passes `optional` through unchanged, unlike the
+        // `Optional` arm above, which forces it to `true`), which
+        // `delete_at_path` was missing entirely until now (#1153): any
+        // parenthesized `del()` target failed with "cannot use expression
+        // as delete target", whether or not a slice was involved.
         Expr::Paren(inner) => delete_at_path(root, inner, optional),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10390,7 +10390,14 @@ pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
 /// in hand, which `through_slice` never has (it only ever sees the sliced
 /// value itself).
 fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Option<Expr> {
-    let Expr::Pipe(exprs) = path_expr else {
+    // `unwrap_paren`, not a direct match: a parenthesized chained target
+    // (`del((.a[0:1]))`) must apply the same parent-key-delete rule as its
+    // bare form (`del(.a[0:1])`) -- previously this shape-check required
+    // `path_expr` to literally be `Expr::Pipe`, so wrapping it in `()`
+    // silently opted out of the rule and fell through to
+    // `delete_at_path`'s own per-step walk, which errors trying to slice
+    // a scalar directly (#1153).
+    let Expr::Pipe(exprs) = unwrap_paren(path_expr) else {
         return None;
     };
     let (last, _) = unwrap_path_component(exprs.last()?);
@@ -19478,6 +19485,13 @@ fn delete_at_path(
             }
         }
         Expr::Optional(inner) => delete_at_path(root, inner, true),
+        // `(EXPR)` at the top of a resolved delete target (e.g.
+        // `del((.a))`) -- mirrors `set_path`'s identical `Expr::Paren` arm
+        // (#1116), which this arm was missing entirely until now (#1153):
+        // any parenthesized `del()` target failed with "cannot use
+        // expression as delete target", whether or not a slice was
+        // involved.
+        Expr::Paren(inner) => delete_at_path(root, inner, optional),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
         // to the catch-all so a missed install point fails loudly here instead

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11779,3 +11779,22 @@ fn test_jq_chained_scalar_slice_assign_and_del_still_error_1116() -> Result<()> 
     assert_eq!(code, 5);
     Ok(())
 }
+
+/// #1153's `delete_at_path` `Expr::Paren` arm is general (not gated by
+/// `EvalSemantics`), so a plain parenthesized delete target now works in
+/// jq mode too, matching real jq (`del((.a))` succeeds there). But the
+/// *other* half of #1153 -- `yq_del_scalar_slice_parent_path`'s
+/// `unwrap_paren` fix -- is itself gated to yq mode by its caller
+/// (`S::TAG == EvalTag::Yq`), so a parenthesized chained scalar-slice
+/// target must still error in jq mode exactly like its unparenthesized
+/// form does (#1116's jq-mode guard above), not silently start no-oping.
+#[test]
+fn test_jq_parenthesized_del_target_works_but_chained_slice_still_errors_1153() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "del((.a))"], Some(r#"{"a":5,"b":6}"#))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+
+    let (_out, _, code) = run_jq_full(&["-c", "del((.a[0:1]))"], Some(r#"{"a":5,"b":6}"#))?;
+    assert_eq!(code, 5);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13966,6 +13966,37 @@ fn test_1153_parenthesized_chained_scalar_slice_del_array_parent_unaffected() ->
     Ok(())
 }
 
+/// `?` applied *outside* the closing paren must apply #1116's rule the
+/// same as every other placement -- an earlier draft of this fix used the
+/// narrower `unwrap_paren` (peels only `Expr::Paren`) instead of
+/// `unwrap_path_component` (peels `Expr::Paren` *and* `Expr::Optional`,
+/// in either order), which let `del((.a[0:1])?)` alone silently no-op
+/// instead of deleting the parent key -- every sibling placement
+/// (`del((.a[0:1]))`, `del((.a[0:1]?))`, `del(.a[0:1]?)`) already worked
+/// (found by review before merge; no real-yq oracle for this exact
+/// syntax exists -- its own lexer rejects `(...)?` outright -- so this
+/// locks in succinctly's own internal consistency across the four
+/// placements, not oracle conformance).
+#[test]
+fn test_1153_optional_outside_paren_still_applies_parent_key_rule() -> Result<()> {
+    let input = r#"{"a":5,"b":6}"#;
+    let expected = r#"{"b":6}"#;
+
+    let (out, code) = run_yq_stdin("del((.a[0:1])?)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), expected, "optional outside parens");
+
+    let (out, code) = run_yq_stdin("del((.a[0:1]?))", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), expected, "optional inside parens");
+
+    let (out, code) = run_yq_stdin("del(.a[0:1]?)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), expected, "no parens at all");
+
+    Ok(())
+}
+
 /// del()'s parent-key rule also applies when the resolved path fans out
 /// into more than one target (a top-level comma, or a computed key with
 /// multiple values) — `delete_expr_paths_at`'s sibling-grouping walker

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13901,6 +13901,71 @@ fn test_1116_chained_scalar_slice_del_removes_parent_key() -> Result<()> {
     Ok(())
 }
 
+// --- #1153: a parenthesized del() target must work at all, and a
+// parenthesized chained-scalar-slice target must still apply #1116's
+// parent-key-delete rule. Verified live against real yq v4.53.3.
+
+/// Gap 1: `delete_at_path` had no `Expr::Paren` arm anywhere (unlike
+/// `set_path`/`update_path`, which #1116 gave one) -- any parenthesized
+/// `del()` target failed outright, whether or not a slice was involved.
+#[test]
+fn test_1153_parenthesized_del_target_works() -> Result<()> {
+    let (out, code) = run_yq_stdin("del((.a))", r#"{"a":5,"b":6}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+
+    let (out, code) = run_yq_stdin("del((.a[0]))", r#"{"a":[1,2,3]}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[2,3]}"#);
+
+    Ok(())
+}
+
+/// Gap 2: `yq_del_scalar_slice_parent_path`'s own shape check required
+/// `path_expr` to literally be `Expr::Pipe`, so wrapping a chained
+/// scalar-slice target in `()` opted out of #1116's parent-key-delete rule
+/// entirely and fell through to `delete_at_path`'s per-step walk, which
+/// errors trying to slice a scalar directly.
+#[test]
+fn test_1153_parenthesized_chained_scalar_slice_del_removes_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin("del((.a[0:1]))", r#"{"a":5,"b":6}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+
+    let (out, code) = run_yq_stdin(
+        "del((.x.a[0:1]))",
+        r#"{"x":{"a":5,"b":6}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"x":{"b":6}}"#);
+
+    Ok(())
+}
+
+/// Control: a parenthesized chained scalar-slice target must keep the same
+/// array-parent scoping as the unparenthesized form -- `#1116`'s rule
+/// (`yq_del_scalar_slice_parent_path`) only fires for a *scalar* parent by
+/// deliberate choice, not oracle conformance: real yq's own chained
+/// slice-delete drops the whole parent key for *any* target type
+/// (confirmed live, both with and without parens), but succinctly keeps
+/// its own working, jq-consistent array slice-delete instead of matching
+/// that (see the function's own doc comment) -- this parenthesized form
+/// must inherit the identical, already-deliberate scoping, not accidentally
+/// widen or narrow it.
+#[test]
+fn test_1153_parenthesized_chained_scalar_slice_del_array_parent_unaffected() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del((.a[0:1]))",
+        r#"{"a":[1,2,3],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[2,3],"b":6}"#);
+
+    Ok(())
+}
+
 /// del()'s parent-key rule also applies when the resolved path fans out
 /// into more than one target (a top-level comma, or a computed key with
 /// multiple values) — `delete_expr_paths_at`'s sibling-grouping walker
@@ -14017,11 +14082,14 @@ fn test_1116_chained_scalar_slice_del_navigator_out_of_bounds_unaffected() -> Re
 /// `navigate_read_only` only understands `Field`/`Index` prefix steps — a
 /// `.[]` earlier in the chain (`Expr::Iterate`) hits its catch-all and
 /// bails to `None`, so the rewrite doesn't apply and the old, erroring
-/// per-element walk runs instead. Known, filed limitation (#1153) — this
-/// pins the current (imperfect) behavior as a regression guard rather than
-/// leaving it silently untested.
+/// per-element walk runs instead. Known, filed limitation — split off from
+/// #1153 (which covered this alongside the now-fixed parenthesized-target
+/// gap) into its own issue, #1182, since it needs `del()`'s own per-element
+/// handling rather than a small, self-contained fix. This pins the current
+/// (imperfect) behavior as a regression guard rather than leaving it
+/// silently untested.
 #[test]
-fn test_1116_chained_scalar_slice_del_iterate_prefix_not_yet_covered_1153() -> Result<()> {
+fn test_1116_chained_scalar_slice_del_iterate_prefix_not_yet_covered_1182() -> Result<()> {
     let (_out, stderr, code) = run_yq_stdin_with_stderr(
         "del(.a[].b[0:1])",
         r#"{"a":[{"b":5,"c":1},{"b":6,"c":2}]}"#,


### PR DESCRIPTION
## Summary

`delete_at_path` had no `Expr::Paren` arm anywhere (unlike `set_path`/
`update_path`, which #1116 already gave one) — any parenthesized `del()`
target failed outright with `cannot use expression as delete target`, in
both jq and yq mode. Adds the arm, mirroring `set_path`'s existing fix.

Also fixes a second, related gap: `yq_del_scalar_slice_parent_path`'s own
shape check required its path argument to literally be `Expr::Pipe`, so a
parenthesized chained scalar-slice target (`del((.a[0:1]))`) opted out of
#1116's parent-key-delete rule entirely and fell through to
`delete_at_path`'s per-step walk, which errors trying to slice a scalar
directly. Unwraps the `Paren` before the shape check, reusing the
existing `unwrap_paren` helper.

## Repro (before/after)

```
$ echo '{"a":5,"b":6}' | succinctly yq 'del((.a))'
Error: cannot use expression as delete target      # before
{"b":6}                                             # after (matches real yq)

$ echo '{"a":5,"b":6}' | succinctly yq -o=json 'del((.a[0:1]))'
Error: Cannot index number with object              # before
{"b":6}                                              # after (matches real yq)
```

## Scope

Issue #1153 covered a third gap (a `.[]` earlier in a chained
scalar-slice `del()` path) that needs `del()`'s own per-element handling
— a larger design change than this PR's scope, per the issue's own
analysis (the sibling `|=`/`+=` no-op rule handles this shape correctly
because it recurses per-element in-place; `del()`'s rule is an upfront
path *rewrite*, which doesn't generalize the same way). Split into
#1182 rather than attempted here — an existing regression-guard test for
that gap (pinning the current, imperfect erroring behavior) had its
reference/name updated to point at #1182 instead of #1153.

## Testing

- New tests in `tests/yq_cli_tests.rs` (both gaps' repros, plus a
  regression guard confirming the array-parent scoping of #1116's rule
  is unaffected — real yq drops the whole parent key for *any* target
  type there, but succinctly deliberately keeps its own jq-consistent
  array slice-delete instead, per the pre-existing doc comment on
  `yq_del_scalar_slice_parent_path`) and `tests/jq_cli_tests.rs`
  (confirms the general `Paren` fix works in jq mode too, matching real
  jq, while the yq-only parent-key-delete rule correctly stays gated).
- Full local suite (lib/bin/integration/golden/doc tests), both CI
  clippy feature combinations, and the `no_std` check all pass clean.
- Patch coverage: 100% (2/2 new lines).

Fixes #1153