### PR TITLE
fix(yaml): validate trailing content after a flow collection everywhere

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2612,7 +2612,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // `parse_sequence_item_inner` and `parse_explicit_value` where the
             // placeholder is conditional. `test_every_anchor_targets_an_open_bit`
             // is the whole-corpus guard on that.
-        } else if self.try_dispatch_flow_or_block_value(indent)? {
+        } else if self.try_dispatch_flow_or_block_value(indent, false)? {
             // Flow sequence/mapping value (`- a: [1, 2]` / `- a: {x: 1}`), or
             // block scalar value (`- a: |`) — handled. Missing this used to
             // leave every flow-value fallback through the scalar arm's
@@ -3009,7 +3009,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             }
 
             // Check for flow style or block scalar - these handle their own BP
-            if self.try_dispatch_flow_or_block_value(indent)? {
+            if self.try_dispatch_flow_or_block_value(indent, false)? {
                 return Ok(());
             }
             match self.peek() {
@@ -3237,14 +3237,14 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // position, just mirrored here at the key position).
                 self.write_bp_open();
                 self.parse_flow_sequence()?;
-                self.reject_trailing_flow_content()?;
+                self.reject_trailing_flow_content(true)?;
                 self.write_bp_close();
             }
             Some(b'{') => {
                 // Flow mapping as key -- see the `[` arm above (#902).
                 self.write_bp_open();
                 self.parse_flow_mapping()?;
-                self.reject_trailing_flow_content()?;
+                self.reject_trailing_flow_content(true)?;
                 self.write_bp_close();
             }
             Some(b'|' | b'>') => {
@@ -3389,7 +3389,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // trailing-content check (#902) permits exactly this `:`-following
         // shape, so it doesn't reject real, non-garbage input before
         // `looks_like_mapping_entry` below gets a chance to run on it.
-        if self.try_dispatch_flow_or_block_value(indent)? {
+        if self.try_dispatch_flow_or_block_value(indent, true)? {
             return Ok(());
         }
         match self.peek() {
@@ -3474,7 +3474,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // mapping *key* rather than a standalone value — see
         // `try_dispatch_flow_or_block_value`'s doc comment for why its own
         // trailing-content check permits that shape rather than rejecting it.
-        if self.try_dispatch_flow_or_block_value(min_indent)? {
+        if self.try_dispatch_flow_or_block_value(min_indent, true)? {
             return Ok(());
         }
 
@@ -3865,37 +3865,46 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// content and relative ordering (see each call site) that folding them
     /// in too would trade one duplication bug class for a worse one.
     ///
-    /// #878's validation (`reject_trailing_flow_content`) now runs
-    /// unconditionally at every call site (#902) — it used to be gated by a
-    /// caller-supplied `check_trailing: bool`, `false` wherever the flow
+    /// `permit_colon_terminator` gates #902's widening of #878's validation
+    /// (see `reject_trailing_flow_content`): `true` wherever the flow
     /// collection might turn out to be an *implicit mapping key* rather
-    /// than a standalone value (real YAML allows `[a, b]: value` /
+    /// than a standalone value — real YAML allows `[a, b]: value` /
     /// `{a: 1}: value`, where `:` legitimately follows the closing
-    /// delimiter — confirmed against the YAML test suite's own "Implicit
-    /// Flow Mapping Key" case, which an unconditional check broke before
-    /// #902). That caller-granularity split is no longer needed:
-    /// `reject_trailing_flow_content` itself now recognizes a real
-    /// mapping-value indicator (`:` followed by whitespace/break/EOF, the
-    /// same rule `looks_like_mapping_entry` already uses for a scalar key)
-    /// as a permitted terminator, not just `#`/whitespace/break/EOF — so
-    /// every caller can run the same occurrence-granular check regardless
-    /// of whether its own position happens to be ambiguous with an
-    /// implicit-mapping-key reading.
+    /// delimiter (confirmed against the YAML test suite's own "Implicit
+    /// Flow Mapping Key" case). Two of the four callers are that ambiguous:
+    /// `parse_value` (reached for a sequence item's value once
+    /// `looks_like_mapping_entry` has already ruled out a *scalar*-keyed
+    /// compact mapping, and for document-root/deferred content starting
+    /// with `[`/`{`) and `parse_explicit_value` (its own value position can
+    /// equally be a compact mapping keyed by a flow collection — confirmed
+    /// live against real `yq`: `? k\n: [a, b]: value\n` parses as
+    /// `{"k":{"":"value"}}`). The other two callers
+    /// (`parse_compact_mapping_entry`, `parse_mapping_entry`) only ever
+    /// reach this helper *after* an unambiguous `key:` has already been
+    /// parsed, where a following `:` cannot be anything but real trailing
+    /// garbage — confirmed live: real `yq` rejects `key1: [a, b]: value2`
+    /// outright, which an earlier version of this fix (before review
+    /// caught it) wrongly stopped rejecting by making the `:` exception
+    /// unconditional at every call site instead of gating it here.
     ///
     /// Returns `Ok(true)` if a flow collection or block scalar was found and
     /// fully consumed (the caller does nothing further for this value), or
     /// `Ok(false)` if the current byte isn't one of the four (the caller
     /// falls through to its own remaining arms).
-    fn try_dispatch_flow_or_block_value(&mut self, indent: usize) -> Result<bool, YamlError> {
+    fn try_dispatch_flow_or_block_value(
+        &mut self,
+        indent: usize,
+        permit_colon_terminator: bool,
+    ) -> Result<bool, YamlError> {
         match self.peek() {
             Some(b'[') => {
                 self.parse_flow_sequence()?;
-                self.reject_trailing_flow_content()?;
+                self.reject_trailing_flow_content(permit_colon_terminator)?;
                 Ok(true)
             }
             Some(b'{') => {
                 self.parse_flow_mapping()?;
-                self.reject_trailing_flow_content()?;
+                self.reject_trailing_flow_content(permit_colon_terminator)?;
                 Ok(true)
             }
             Some(b'|' | b'>') => {
@@ -3924,32 +3933,38 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// made the gap observable: confirmed live, `at_line_end()` would
     /// false-positive-reject `a: [1, 2]\t# comment`, which real `yq` accepts.
     ///
-    /// Only called for `[`/`{`, and only when the caller has ruled out an
-    /// implicit-mapping-key reading (see `try_dispatch_flow_or_block_value`'s
-    /// `check_trailing`) — a block scalar (`|`/`>`) has no equivalent
+    /// `permit_colon_terminator` (#902): when `true`, a real mapping-value
+    /// indicator (`:` followed by whitespace/break/EOF — the same
+    /// disambiguation `looks_like_mapping_entry` uses for a scalar key) is
+    /// ALSO a permitted terminator, alongside `#`/whitespace/break/EOF.
+    /// When `false`, a `:` here is ordinary trailing garbage like any other
+    /// byte, matching #878's original unconditional rejection. This has to
+    /// stay a caller-supplied flag, not something this function can infer
+    /// from the bytes alone: `[a, b]: value` and `key1: [a, b]: value2` are
+    /// byte-identical *after* the closing delimiter, and only the caller
+    /// knows whether its own position could legitimately be an implicit
+    /// mapping key (see `try_dispatch_flow_or_block_value`'s doc comment
+    /// for exactly which callers pass which value, and why an earlier
+    /// version of this fix that made the exception unconditional
+    /// everywhere silently reopened #878's own corruption bug at the two
+    /// callers that need `false`). Confirmed live that a colon with no
+    /// following whitespace (`[1, 2]:value`) is never this exception,
+    /// regardless of the flag — it still errors the same as any other
+    /// trailing garbage either way.
+    ///
+    /// Only called for `[`/`{` — a block scalar (`|`/`>`) has no equivalent
     /// same-line trailing-content shape to reject, since its own terminator
     /// is a dedent, not a delimiter byte a stray token could follow.
-    fn reject_trailing_flow_content(&self) -> Result<(), YamlError> {
+    fn reject_trailing_flow_content(&self, permit_colon_terminator: bool) -> Result<(), YamlError> {
         let mut i = self.pos;
         while i < self.input.len() {
             match self.input[i] {
                 b'#' => return Ok(()),
                 b if Self::is_inline_whitespace(b) => i += 1,
                 b if Self::is_break(b) => return Ok(()),
-                // A real mapping-value indicator (#902) -- the same
-                // disambiguation `looks_like_mapping_entry` uses for a
-                // scalar key (`: ` or `:<EOL>`/`:<EOF>`, never a bare `:`
-                // immediately followed by more content). This is what makes
-                // the check occurrence-granular instead of a blanket
-                // per-caller `check_trailing: bool`: every call site can now
-                // run it unconditionally, since a flow collection that
-                // genuinely turns out to be an implicit mapping key (`[a,
-                // b]: value`) still passes, while everything else that isn't
-                // whitespace/comment/break/EOF still doesn't -- confirmed
-                // live against real yq that a colon with no following
-                // whitespace (`[1, 2]:value`) is NOT this exception and
-                // still errors the same as any other trailing garbage.
-                b':' if Self::is_ws_break_or_eoi(self.input.get(i + 1).copied()) => {
+                b':' if permit_colon_terminator
+                    && Self::is_ws_break_or_eoi(self.input.get(i + 1).copied()) =>
+                {
                     return Ok(());
                 }
                 _ => break,

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2612,7 +2612,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // `parse_sequence_item_inner` and `parse_explicit_value` where the
             // placeholder is conditional. `test_every_anchor_targets_an_open_bit`
             // is the whole-corpus guard on that.
-        } else if self.try_dispatch_flow_or_block_value(indent, true)? {
+        } else if self.try_dispatch_flow_or_block_value(indent)? {
             // Flow sequence/mapping value (`- a: [1, 2]` / `- a: {x: 1}`), or
             // block scalar value (`- a: |`) — handled. Missing this used to
             // leave every flow-value fallback through the scalar arm's
@@ -3009,7 +3009,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             }
 
             // Check for flow style or block scalar - these handle their own BP
-            if self.try_dispatch_flow_or_block_value(indent, true)? {
+            if self.try_dispatch_flow_or_block_value(indent)? {
                 return Ok(());
             }
             match self.peek() {
@@ -3220,15 +3220,31 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.write_bp_close(); // close item
             }
             Some(b'[') => {
-                // Flow sequence as key
+                // Flow sequence as key. #902: this dispatch is a 5th,
+                // deliberately-unmerged copy of `try_dispatch_flow_or_block_
+                // value`'s `[`/`{` arms (it wraps the key in its own
+                // `write_bp_open`/`write_bp_close` pair, which that shared
+                // helper can't represent without double-wrapping the BP
+                // tree) -- it never gained #878's trailing-content
+                // validation either, so `? [1, 2] extra\n: v\n` silently
+                // dropped the real `: v` line instead of erroring the way
+                // real yq does. `reject_trailing_flow_content` still
+                // correctly permits a genuine same-line `? [1, 2]: value`
+                // (confirmed live: real yq reads that as the compact-
+                // mapping-keyed-by-flow-collection shape, not trailing
+                // garbage -- same ambiguity `try_dispatch_flow_or_block_
+                // value`'s doc comment already covers for the value
+                // position, just mirrored here at the key position).
                 self.write_bp_open();
                 self.parse_flow_sequence()?;
+                self.reject_trailing_flow_content()?;
                 self.write_bp_close();
             }
             Some(b'{') => {
-                // Flow mapping as key
+                // Flow mapping as key -- see the `[` arm above (#902).
                 self.write_bp_open();
                 self.parse_flow_mapping()?;
+                self.reject_trailing_flow_content()?;
                 self.write_bp_close();
             }
             Some(b'|' | b'>') => {
@@ -3364,18 +3380,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             return Ok(());
         }
 
-        // Parse the value. `check_trailing: false` — same ambiguity as
-        // `parse_value`: the node after `: ` may itself be a compact mapping
-        // whose *key* is a flow collection (`: [a, b]: value`), mirroring
-        // the scalar-keyed case the `looks_like_mapping_entry` arm below
-        // already handles (`: b: c`) — real YAML accepts both (confirmed
-        // live against real `yq`: `? k\n: [a, b]: value\n` parses as
-        // `{"k":{"":"value"}}`). `looks_like_mapping_entry` itself can't
-        // catch the flow-collection-keyed case (it returns `false`
-        // immediately for `[`/`{`), so an unconditional trailing-content
-        // check here would reject real, non-garbage input before that arm
-        // ever gets a chance to run.
-        if self.try_dispatch_flow_or_block_value(indent, false)? {
+        // Parse the value. The node after `: ` may itself be a compact
+        // mapping whose *key* is a flow collection (`: [a, b]: value`),
+        // mirroring the scalar-keyed case the `looks_like_mapping_entry` arm
+        // below already handles (`: b: c`) — real YAML accepts both
+        // (confirmed live against real `yq`: `? k\n: [a, b]: value\n` parses
+        // as `{"k":{"":"value"}}`). `try_dispatch_flow_or_block_value`'s own
+        // trailing-content check (#902) permits exactly this `:`-following
+        // shape, so it doesn't reject real, non-garbage input before
+        // `looks_like_mapping_entry` below gets a chance to run on it.
+        if self.try_dispatch_flow_or_block_value(indent)? {
             return Ok(());
         }
         match self.peek() {
@@ -3456,10 +3470,11 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             return self.parse_alias();
         }
 
-        // `check_trailing: false` — a flow collection reached here may turn
-        // out to be an implicit mapping *key* rather than a standalone
-        // value (see `try_dispatch_flow_or_block_value`'s doc comment).
-        if self.try_dispatch_flow_or_block_value(min_indent, false)? {
+        // A flow collection reached here may turn out to be an implicit
+        // mapping *key* rather than a standalone value — see
+        // `try_dispatch_flow_or_block_value`'s doc comment for why its own
+        // trailing-content check permits that shape rather than rejecting it.
+        if self.try_dispatch_flow_or_block_value(min_indent)? {
             return Ok(());
         }
 
@@ -3850,53 +3865,37 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// content and relative ordering (see each call site) that folding them
     /// in too would trade one duplication bug class for a worse one.
     ///
-    /// `check_trailing` gates #878's validation (see
-    /// `reject_trailing_flow_content`) and must be `false` wherever the
-    /// flow collection might turn out to be an *implicit mapping key*
-    /// rather than a standalone value — real YAML allows `[a, b]: value` /
+    /// #878's validation (`reject_trailing_flow_content`) now runs
+    /// unconditionally at every call site (#902) — it used to be gated by a
+    /// caller-supplied `check_trailing: bool`, `false` wherever the flow
+    /// collection might turn out to be an *implicit mapping key* rather
+    /// than a standalone value (real YAML allows `[a, b]: value` /
     /// `{a: 1}: value`, where `:` legitimately follows the closing
-    /// delimiter (confirmed against the YAML test suite's own "Implicit
-    /// Flow Mapping Key" case, which a `true`-everywhere version of this
-    /// check broke). Two of the four callers are that ambiguous:
-    /// `parse_value` (reached for a sequence item's value once
-    /// `looks_like_mapping_entry` has already ruled out a *scalar*-keyed
-    /// compact mapping, and for document-root/deferred content starting
-    /// with `[`/`{`) and `parse_explicit_value` (its own value position can
-    /// equally be a compact mapping keyed by a flow collection — confirmed
-    /// live against real `yq`: `? k\n: [a, b]: value\n` parses as
-    /// `{"k":{"":"value"}}` — mirroring the *scalar*-keyed case its own
-    /// `looks_like_mapping_entry` arm already handles a few lines below; an
-    /// unconditional check here used to reject that real input before that
-    /// arm ever ran). The other two callers (`parse_compact_mapping_entry`,
-    /// `parse_mapping_entry`) only ever reach this helper *after* an
-    /// unambiguous `key:` has already been parsed with no equivalent "value
-    /// could itself be a keyed mapping" arm of their own, where a following
-    /// `:` cannot be anything but real trailing garbage (confirmed live:
-    /// real `yq` rejects `key1: [a, b]: value2` outright) — so they pass
-    /// `true`.
+    /// delimiter — confirmed against the YAML test suite's own "Implicit
+    /// Flow Mapping Key" case, which an unconditional check broke before
+    /// #902). That caller-granularity split is no longer needed:
+    /// `reject_trailing_flow_content` itself now recognizes a real
+    /// mapping-value indicator (`:` followed by whitespace/break/EOF, the
+    /// same rule `looks_like_mapping_entry` already uses for a scalar key)
+    /// as a permitted terminator, not just `#`/whitespace/break/EOF — so
+    /// every caller can run the same occurrence-granular check regardless
+    /// of whether its own position happens to be ambiguous with an
+    /// implicit-mapping-key reading.
     ///
     /// Returns `Ok(true)` if a flow collection or block scalar was found and
     /// fully consumed (the caller does nothing further for this value), or
     /// `Ok(false)` if the current byte isn't one of the four (the caller
     /// falls through to its own remaining arms).
-    fn try_dispatch_flow_or_block_value(
-        &mut self,
-        indent: usize,
-        check_trailing: bool,
-    ) -> Result<bool, YamlError> {
+    fn try_dispatch_flow_or_block_value(&mut self, indent: usize) -> Result<bool, YamlError> {
         match self.peek() {
             Some(b'[') => {
                 self.parse_flow_sequence()?;
-                if check_trailing {
-                    self.reject_trailing_flow_content()?;
-                }
+                self.reject_trailing_flow_content()?;
                 Ok(true)
             }
             Some(b'{') => {
                 self.parse_flow_mapping()?;
-                if check_trailing {
-                    self.reject_trailing_flow_content()?;
-                }
+                self.reject_trailing_flow_content()?;
                 Ok(true)
             }
             Some(b'|' | b'>') => {
@@ -3937,6 +3936,22 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 b'#' => return Ok(()),
                 b if Self::is_inline_whitespace(b) => i += 1,
                 b if Self::is_break(b) => return Ok(()),
+                // A real mapping-value indicator (#902) -- the same
+                // disambiguation `looks_like_mapping_entry` uses for a
+                // scalar key (`: ` or `:<EOL>`/`:<EOF>`, never a bare `:`
+                // immediately followed by more content). This is what makes
+                // the check occurrence-granular instead of a blanket
+                // per-caller `check_trailing: bool`: every call site can now
+                // run it unconditionally, since a flow collection that
+                // genuinely turns out to be an implicit mapping key (`[a,
+                // b]: value`) still passes, while everything else that isn't
+                // whitespace/comment/break/EOF still doesn't -- confirmed
+                // live against real yq that a colon with no following
+                // whitespace (`[1, 2]:value`) is NOT this exception and
+                // still errors the same as any other trailing garbage.
+                b':' if Self::is_ws_break_or_eoi(self.input.get(i + 1).copied()) => {
+                    return Ok(());
+                }
                 _ => break,
             }
         }

--- a/tests/data/yaml-test-suite-known-failures.txt
+++ b/tests/data/yaml-test-suite-known-failures.txt
@@ -22,11 +22,16 @@
 #               must-fail case as handled if the loader OR that validator rejects
 #               it, so the `lax:*` entries that remain here are the cases the
 #               validator does not yet reject (deeper structural analysis). -> #223
-#               `lax:tags` (LHL4, U99R) is the tag-specific slice of this: a
+#               `lax:tags` (U99R) is the tag-specific slice of this: a
 #               malformed tag (disallowed characters, a `%TAG`-mid-stream
 #               placement) is absorbed rather than rejected, the same as every
 #               other `lax:*` construct — #224 implemented tag *resolution*,
 #               not tag *validation*, matching the rest of this loader.
+#               (LHL4, the `{}`-flow-indicator variant of this, was moved off
+#               this list by #902's trailing-flow-content validation, which
+#               now incidentally rejects `!invalid{}tag scalar` as "extra
+#               content after the flow mapping's `}`" — not itself a tag
+#               validator, but strict enough to catch this specific shape.)
 #   scalars     Scalar content or block-scalar folding differs from the spec.
 #               Not yet individually triaged.
 #   structure   Document or block structure differs from the spec. Not yet
@@ -55,7 +60,6 @@ HU3P      lax:mapping       mapping/key rules not validated — #223
 JEF9/02   scalars           blank final line with no break — follows yq, which gives "" — #344
 KS4U      lax:flow          flow syntax not validated — #223
 L24T/00   scalars           scalar content/folding differs from spec
-LHL4      lax:tags          tag containing a disallowed flow indicator (`!invalid{}tag`) absorbed as text/flow-mapping rather than rejected — #224
 M5C3      scalars           scalar content/folding differs from spec
 M7A3      structure         bare document / `...` end-marker mis-parsed (both paths agree)
 MUS6/01   lax:documents     directive/document rules not validated — #223

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6609,30 +6609,55 @@ fn test_flow_collection_as_implicit_mapping_key_still_permitted_878() -> Result<
 // the rest of the document instead of erroring the way real yq does.
 // `parse_explicit_key`'s own `[`/`{` dispatch (a 5th, deliberately unmerged
 // copy of the shared flow-value dispatch table) never gained the check at
-// all. #902 replaced the caller-level `bool` with an occurrence-granular
-// check inside `reject_trailing_flow_content` itself (permit only `#`,
-// whitespace, a line break, EOF, or a real `:` mapping-value indicator),
-// applied unconditionally at every site including the previously-missing
-// one -- confirmed live against real yq v4.53.3 throughout.
+// all.
+//
+// #902 widened `reject_trailing_flow_content` itself to recognize a real
+// mapping-value indicator (`:` followed by whitespace/break/EOF) as a
+// permitted terminator too, alongside `#`/whitespace/break/EOF -- but kept
+// the check caller-parameterized (`permit_colon_terminator: bool`), not
+// unconditional: an earlier version of this fix made the `:` exception
+// apply everywhere, which silently re-opened #878's own corruption bug at
+// `parse_mapping_entry`/`parse_compact_mapping_entry` (a trailing `:`
+// *there* can never be legitimate, since those callers only ever reach
+// this helper after an unambiguous `key:` has already been parsed) --
+// caught in review, confirmed live against both real yq and this repo's
+// own pre-#902 baseline, and fixed by keeping the two truly ambiguous call
+// sites (`parse_value`, `parse_explicit_value`, plus `parse_explicit_key`'s
+// new 5th site) as the only ones permitting the `:` exception.
 
 #[test]
 fn test_sequence_item_flow_collection_trailing_content_errors_902() -> Result<()> {
-    let (_out, code) = run_yq_stdin(".", "- [1, 2] extra content\nb: 2\n", &["-o", "json"])?;
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(".", "- [1, 2] extra content\nb: 2\n", &["-o", "json"])?;
     assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
     Ok(())
 }
 
 #[test]
 fn test_mapping_value_flow_collection_trailing_content_errors_902() -> Result<()> {
-    let (_out, code) = run_yq_stdin(".", "a:\n  [1, 2] extra\nb: 2\n", &["-o", "json"])?;
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(".", "a:\n  [1, 2] extra\nb: 2\n", &["-o", "json"])?;
     assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
     Ok(())
 }
 
 #[test]
 fn test_explicit_key_flow_collection_trailing_content_errors_902() -> Result<()> {
-    let (_out, code) = run_yq_stdin(".", "? [1, 2] extra\n: v\n", &["-o", "json"])?;
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(".", "? [1, 2] extra\n: v\n", &["-o", "json"])?;
     assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
     Ok(())
 }
 
@@ -6640,8 +6665,54 @@ fn test_explicit_key_flow_collection_trailing_content_errors_902() -> Result<()>
 /// flow sequence -- confirms the fix isn't accidentally scoped to `[` alone.
 #[test]
 fn test_explicit_key_flow_mapping_trailing_content_errors_902() -> Result<()> {
-    let (_out, code) = run_yq_stdin(".", "? {a: 1} extra\n: v\n", &["-o", "json"])?;
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(".", "? {a: 1} extra\n: v\n", &["-o", "json"])?;
     assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// The two *unambiguous* call sites (`parse_mapping_entry`,
+/// `parse_compact_mapping_entry`) reach a flow collection only after an
+/// ordinary `key:` has already committed -- a following `:` there can
+/// never be a legitimate implicit-mapping-key reading, so
+/// `permit_colon_terminator` must stay `false` for both, unlike the three
+/// genuinely ambiguous sites above. This is exactly the shape an earlier,
+/// over-broad version of this fix regressed: confirmed live that real yq
+/// hard-errors here (`mapping values are not allowed in this context`),
+/// and that this repo's own pre-#902 baseline already correctly did too --
+/// #902 must not lose that.
+#[test]
+fn test_unambiguous_mapping_value_flow_collection_followed_by_colon_still_errors_902() -> Result<()>
+{
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(".", "key1: [a, b]: value2\nkey3: c\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
+
+    // Flow mapping variant, and the compact-mapping (sequence-item) form of
+    // the same unambiguous site.
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(".", "key1: {a: 1}: value2\nkey3: c\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
+
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(".", "- key1: [a, b]: value2\n  key3: c\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
     Ok(())
 }
 
@@ -6651,7 +6722,12 @@ fn test_explicit_key_flow_mapping_trailing_content_errors_902() -> Result<()> {
 /// didn't at `parse_value`/`parse_explicit_value` (pinned by
 /// `test_flow_collection_as_implicit_mapping_key_still_permitted_878`
 /// above). Pins the *current* (pre-existing, item-5-scoped) output exactly,
-/// not just the exit code -- confirmed unchanged from before this fix.
+/// not just the exit code -- confirmed unchanged from before this fix. Real
+/// yq's own answer for this exact one-line form is actually `{"":null}`,
+/// not `{"":"value"}` (it reads the whole `[1, 2]: value` as the *key's*
+/// own compact-mapping content, not this entry's value -- confirmed live)
+/// -- this test only asserts "doesn't error, output unchanged from before
+/// #902," not real-yq equivalence, which is #1188's separate scope.
 #[test]
 fn test_explicit_key_flow_collection_followed_by_colon_still_permitted_902() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "? [1, 2]: value\n", &["-o", "json", "-I0"])?;
@@ -6668,8 +6744,12 @@ fn test_explicit_key_flow_collection_followed_by_colon_still_permitted_902() -> 
 /// not a bare `:`.
 #[test]
 fn test_flow_collection_colon_without_whitespace_still_errors_902() -> Result<()> {
-    let (_out, code) = run_yq_stdin(".", "[1, 2]:value\n", &["-o", "json"])?;
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(".", "[1, 2]:value\n", &["-o", "json"])?;
     assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6598,6 +6598,82 @@ fn test_flow_collection_as_implicit_mapping_key_still_permitted_878() -> Result<
 }
 
 // ============================================================================
+// Trailing content after a flow collection is rejected everywhere, not just
+// where #878 originally checked it (#902)
+// ============================================================================
+//
+// #878 added `reject_trailing_flow_content`, but `parse_value` and
+// `parse_explicit_value` passed `check_trailing: false` unconditionally --
+// not just for the genuinely ambiguous "this could be an implicit mapping
+// key" shape, but for every flow value reaching them, silently corrupting
+// the rest of the document instead of erroring the way real yq does.
+// `parse_explicit_key`'s own `[`/`{` dispatch (a 5th, deliberately unmerged
+// copy of the shared flow-value dispatch table) never gained the check at
+// all. #902 replaced the caller-level `bool` with an occurrence-granular
+// check inside `reject_trailing_flow_content` itself (permit only `#`,
+// whitespace, a line break, EOF, or a real `:` mapping-value indicator),
+// applied unconditionally at every site including the previously-missing
+// one -- confirmed live against real yq v4.53.3 throughout.
+
+#[test]
+fn test_sequence_item_flow_collection_trailing_content_errors_902() -> Result<()> {
+    let (_out, code) = run_yq_stdin(".", "- [1, 2] extra content\nb: 2\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+#[test]
+fn test_mapping_value_flow_collection_trailing_content_errors_902() -> Result<()> {
+    let (_out, code) = run_yq_stdin(".", "a:\n  [1, 2] extra\nb: 2\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+#[test]
+fn test_explicit_key_flow_collection_trailing_content_errors_902() -> Result<()> {
+    let (_out, code) = run_yq_stdin(".", "? [1, 2] extra\n: v\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// Same shape as above but for a flow *mapping* key (`{...}`), not just a
+/// flow sequence -- confirms the fix isn't accidentally scoped to `[` alone.
+#[test]
+fn test_explicit_key_flow_mapping_trailing_content_errors_902() -> Result<()> {
+    let (_out, code) = run_yq_stdin(".", "? {a: 1} extra\n: v\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// A genuine same-line `? [flow-key]: value` must keep working -- #902's
+/// fix must not turn the legitimate mapping-value-indicator `:` into a new
+/// false rejection at `parse_explicit_key`'s site, the same way it already
+/// didn't at `parse_value`/`parse_explicit_value` (pinned by
+/// `test_flow_collection_as_implicit_mapping_key_still_permitted_878`
+/// above). Pins the *current* (pre-existing, item-5-scoped) output exactly,
+/// not just the exit code -- confirmed unchanged from before this fix.
+#[test]
+fn test_explicit_key_flow_collection_followed_by_colon_still_permitted_902() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? [1, 2]: value\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"":"value"}"#);
+    Ok(())
+}
+
+/// A `:` immediately followed by more content (no whitespace/break/EOF) is
+/// NOT the mapping-value-indicator exception -- still trailing garbage,
+/// still an error. Confirmed live: real yq also rejects `[1, 2]:value`
+/// (compact, no space) while accepting `[1, 2]: value` (#878's existing
+/// test above) -- the exception is `:`-followed-by-whitespace specifically,
+/// not a bare `:`.
+#[test]
+fn test_flow_collection_colon_without_whitespace_still_errors_902() -> Result<()> {
+    let (_out, code) = run_yq_stdin(".", "[1, 2]:value\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+// ============================================================================
 // Extra spaces after a block-sequence dash (#877)
 // ============================================================================
 // `parse_sequence_item`'s compact-mapping dispatch used to hardcode


### PR DESCRIPTION
## Summary
- Fixes #902 (items 1 & 2): `reject_trailing_flow_content` (#878) was gated by a caller-level `check_trailing: bool`, disabled entirely at `parse_value`/`parse_explicit_value` to allow the legitimate `[a, b]: value` implicit-mapping-key shape — but that blanket disable meant genuine trailing garbage after a flow collection (`- [1, 2] extra content`) was silently accepted and corrupted the rest of the document instead of erroring like real yq.
- `parse_explicit_key`'s own `[`/`{` dispatch (a 5th, deliberately unmerged copy of the shared flow-value dispatch table) never had the check at all — same corruption class for `? [1, 2] extra\n: v\n`.
- Fix: made the check occurrence-granular instead of caller-granular. `reject_trailing_flow_content` now permits a real mapping-value indicator (`:` followed by whitespace/break/EOF) alongside `#`/whitespace/break/EOF, so every call site can run it unconditionally — removed the now-constant `check_trailing` parameter, flipped both `false` sites to always-check, and added the missing call at `parse_explicit_key`.
- Verified against the pinned YAML test suite conformance run (no regressions; one previously-known-failure, LHL4, now incidentally passes too — manifest updated) and live against real yq v4.53.3 across every repro shape plus the pre-existing ambiguous-key cases that must keep working unchanged.
- Filed 3 follow-ups for the issue's remaining scope, all deliberately untouched here: #1186 (unrelated tab bug), #1187 (duplication cleanup), #1188 (flow-collection-keyed mappings aren't actually built as mappings — a feature gap, not this fix's concern).

## Test plan
- [x] `cargo build --features cli`
- [x] Live-verified every repro + edge case against pinned `yq` v4.53.3 (trailing garbage now errors for sequence-item/mapping-value/explicit-key positions and both `[`/`{`; legitimate same-line `:` still works; `:` without following whitespace still errors)
- [x] New tests in `tests/yq_cli_tests.rs` (`_902` suffix, 6 tests) — all pass
- [x] Existing pinned test `test_flow_collection_as_implicit_mapping_key_still_permitted_878` — unchanged, passes
- [x] `cargo test --test yaml_test_suite` (full conformance run) — clean, no regressions, one known-failure now passes (manifest updated)
- [x] Full `cargo test --features cli,simd,regex,serde` (no-fail-fast) — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's scalar-yaml-avoiding leg) — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --no-default-features` — clean (pre-existing unrelated warnings only)