### PR TITLE
test(jq): pin the known #1098 string-decode-degradation gap

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -146,6 +146,20 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> OwnedValue {
         OwnedValue::Float(f)
     } else if let Some(s) = value.as_str() {
         OwnedValue::String(s.into_owned())
+    } else if value.type_name() == "string" {
+        // `as_str()` returned `None` despite `type_name()` reporting this
+        // node is a string -- it's structurally a JSON/YAML string scalar,
+        // but decoding it failed (invalid `\u` escape, invalid UTF-8, ...)
+        // and `as_str()`'s `Option` signature swallows the specific `Err`
+        // via `.ok()` (#1098). No live input reaches this today:
+        // `--argjson`'s `serde_json` parse and this crate's own semi-index
+        // structural checks both already reject anything that would fail
+        // here before this function is ever called -- same precondition as
+        // `assert_nesting_depth` above. Panicking rather than silently
+        // materializing `null` keeps a future drift between those two
+        // independently-maintained JSON grammars loud instead of turning
+        // it into silent data corruption.
+        panic!("string scalar failed to decode despite passing structural validation (#1098)");
     } else {
         // Covers error values and any unknown types
         OwnedValue::Null
@@ -3916,6 +3930,30 @@ mod tests {
     use super::super::expr::{CompareOp, FormatType, Literal};
     use super::super::value::NumberRepr;
     use super::*;
+
+    /// #1098: `JsonIndex::build`'s semi-index scan finds string quote/escape
+    /// *boundaries* but never decodes/validates the bytes between them --
+    /// that's deferred to `JsonString::as_str()`, called lazily by
+    /// `to_owned_at_depth`. So invalid UTF-8 inside a string span parses
+    /// and indexes fine (`JsonIndex::build` never errors), and only fails
+    /// once materialization reaches it. The CLI itself never reaches this
+    /// (its own file-reading step lossy-converts the whole input to UTF-8
+    /// before the JSON parser ever sees it -- confirmed live: a file with
+    /// `\xff\xfe` inside a string prints as replacement characters, not an
+    /// error), but any library caller feeding `JsonIndex::build` raw bytes
+    /// directly (skipping that CLI-specific safety net) can reach this.
+    #[test]
+    #[should_panic(
+        expected = "string scalar failed to decode despite passing structural validation (#1098)"
+    )]
+    fn test_to_owned_panics_on_string_decode_failure_1098() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        to_owned(&value);
+    }
     use crate::jq::parse;
     use crate::json::JsonIndex;
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -100,6 +100,32 @@ pub fn assert_nesting_depth(depth: usize) {
     super::value::assert_depth(depth, MAX_NESTING_DEPTH);
 }
 
+/// Panics on a string scalar that passed structural validation (the
+/// semi-index accepted its span as a `String` token) but failed to decode
+/// -- an invariant this crate's own document-input path and `--argjson`
+/// both currently enforce upstream (`serde_json`'s strict parse, and this
+/// crate's own semi-index structural checks), so no live CLI input reaches
+/// this today (#1098). `JsonIndex::build`'s scan finds string quote/escape
+/// *boundaries* without decoding/validating what's between them, though,
+/// so a library caller feeding raw bytes to `JsonIndex::build` directly
+/// (bypassing the CLI's own UTF-8 sanitizing file-read step) can reach it
+/// -- confirmed live in this function's own regression test. Panicking
+/// rather than silently materializing `null`/`""` keeps a future drift
+/// between this crate's lenient semi-index grammar and its own stricter
+/// decode step loud instead of turning it into silent data corruption.
+///
+/// Shared by [`to_owned_at_depth`] (which only has a bool signal here --
+/// the `DocumentValue` trait's `as_str()` already discarded the specific
+/// decode error via `.ok()`) and
+/// [`lazy::cursor_to_owned_at_depth`](super::lazy) (which works with
+/// `JsonString` directly and could recover the concrete error), so the two
+/// panic sites can't independently drift on wording (#106).
+#[cold]
+#[track_caller]
+pub(crate) fn panic_on_string_decode_failure() -> ! {
+    panic!("string scalar failed to decode despite passing structural validation (#1098)");
+}
+
 /// Convert a DocumentValue to an OwnedValue.
 ///
 /// This enables the evaluator to work with both JSON and YAML inputs.
@@ -151,15 +177,9 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> OwnedValue {
         // node is a string -- it's structurally a JSON/YAML string scalar,
         // but decoding it failed (invalid `\u` escape, invalid UTF-8, ...)
         // and `as_str()`'s `Option` signature swallows the specific `Err`
-        // via `.ok()` (#1098). No live input reaches this today:
-        // `--argjson`'s `serde_json` parse and this crate's own semi-index
-        // structural checks both already reject anything that would fail
-        // here before this function is ever called -- same precondition as
-        // `assert_nesting_depth` above. Panicking rather than silently
-        // materializing `null` keeps a future drift between those two
-        // independently-maintained JSON grammars loud instead of turning
-        // it into silent data corruption.
-        panic!("string scalar failed to decode despite passing structural validation (#1098)");
+        // via `.ok()` (#1098). See `panic_on_string_decode_failure`'s own
+        // doc comment for why this is a panic rather than a silent `null`.
+        panic_on_string_decode_failure();
     } else {
         // Covers error values and any unknown types
         OwnedValue::Null

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -100,32 +100,6 @@ pub fn assert_nesting_depth(depth: usize) {
     super::value::assert_depth(depth, MAX_NESTING_DEPTH);
 }
 
-/// Panics on a string scalar that passed structural validation (the
-/// semi-index accepted its span as a `String` token) but failed to decode
-/// -- an invariant this crate's own document-input path and `--argjson`
-/// both currently enforce upstream (`serde_json`'s strict parse, and this
-/// crate's own semi-index structural checks), so no live CLI input reaches
-/// this today (#1098). `JsonIndex::build`'s scan finds string quote/escape
-/// *boundaries* without decoding/validating what's between them, though,
-/// so a library caller feeding raw bytes to `JsonIndex::build` directly
-/// (bypassing the CLI's own UTF-8 sanitizing file-read step) can reach it
-/// -- confirmed live in this function's own regression test. Panicking
-/// rather than silently materializing `null`/`""` keeps a future drift
-/// between this crate's lenient semi-index grammar and its own stricter
-/// decode step loud instead of turning it into silent data corruption.
-///
-/// Shared by [`to_owned_at_depth`] (which only has a bool signal here --
-/// the `DocumentValue` trait's `as_str()` already discarded the specific
-/// decode error via `.ok()`) and
-/// [`lazy::cursor_to_owned_at_depth`](super::lazy) (which works with
-/// `JsonString` directly and could recover the concrete error), so the two
-/// panic sites can't independently drift on wording (#106).
-#[cold]
-#[track_caller]
-pub(crate) fn panic_on_string_decode_failure() -> ! {
-    panic!("string scalar failed to decode despite passing structural validation (#1098)");
-}
-
 /// Convert a DocumentValue to an OwnedValue.
 ///
 /// This enables the evaluator to work with both JSON and YAML inputs.
@@ -172,16 +146,23 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> OwnedValue {
         OwnedValue::Float(f)
     } else if let Some(s) = value.as_str() {
         OwnedValue::String(s.into_owned())
-    } else if value.type_name() == "string" {
-        // `as_str()` returned `None` despite `type_name()` reporting this
-        // node is a string -- it's structurally a JSON/YAML string scalar,
-        // but decoding it failed (invalid `\u` escape, invalid UTF-8, ...)
-        // and `as_str()`'s `Option` signature swallows the specific `Err`
-        // via `.ok()` (#1098). See `panic_on_string_decode_failure`'s own
-        // doc comment for why this is a panic rather than a silent `null`.
-        panic_on_string_decode_failure();
     } else {
-        // Covers error values and any unknown types
+        // Covers error values, any unknown types, and -- deliberately, see
+        // #1098 -- a string scalar that passed structural validation (the
+        // semi-index accepted its span as a `String` token) but failed to
+        // decode (invalid `\u` escape, invalid UTF-8, ...). A `PR #1190`
+        // attempt to make that last case panic instead was reverted: code
+        // review found it's reachable through completely ordinary CLI
+        // usage (any non-identity query over a document containing such a
+        // string), not just a theoretical library-only edge case, which
+        // turns a low-severity silent-`null` bug into a live crash --
+        // including mid-batch, defeating this crate's own documented
+        // "evaluation continues past one error" convention (`ErrorSink`,
+        // #355). A correct fix needs to route through `EvalError`/
+        // `ErrorSink` instead, applied consistently across every sibling
+        // copy of this conversion and to object/mapping keys too (see
+        // #1098's own follow-up discussion) -- deferred as a properly
+        // scoped design item rather than shipped as a panic.
         OwnedValue::Null
     }
 }
@@ -3955,24 +3936,26 @@ mod tests {
     /// *boundaries* but never decodes/validates the bytes between them --
     /// that's deferred to `JsonString::as_str()`, called lazily by
     /// `to_owned_at_depth`. So invalid UTF-8 inside a string span parses
-    /// and indexes fine (`JsonIndex::build` never errors), and only fails
-    /// once materialization reaches it. The CLI itself never reaches this
-    /// (its own file-reading step lossy-converts the whole input to UTF-8
-    /// before the JSON parser ever sees it -- confirmed live: a file with
-    /// `\xff\xfe` inside a string prints as replacement characters, not an
-    /// error), but any library caller feeding `JsonIndex::build` raw bytes
-    /// directly (skipping that CLI-specific safety net) can reach this.
+    /// and indexes fine (`JsonIndex::build` never errors), and only
+    /// degrades once materialization reaches it, here to `Null` for that
+    /// field -- pins the known, deliberate, low-severity gap this issue
+    /// describes (see `to_owned_at_depth`'s own `else` arm doc comment for
+    /// why a stricter fix was attempted and reverted; a panic here is
+    /// reachable via completely ordinary CLI usage, not just a library
+    /// caller feeding raw bytes directly, and defeats this crate's
+    /// "evaluation continues past one error" convention).
     #[test]
-    #[should_panic(
-        expected = "string scalar failed to decode despite passing structural validation (#1098)"
-    )]
-    fn test_to_owned_panics_on_string_decode_failure_1098() {
+    fn test_to_owned_degrades_to_null_on_string_decode_failure_1098() {
         use crate::json::JsonIndex;
         let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
-        to_owned(&value);
+        let owned = to_owned(&value);
+        let OwnedValue::Object(map) = owned else {
+            panic!("expected an object");
+        };
+        assert_eq!(map.get("a"), Some(&OwnedValue::Null));
     }
     use crate::jq::parse;
     use crate::json::JsonIndex;

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -697,12 +697,16 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(b),
         StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
-        StandardJson::String(s) => match s.as_str() {
-            Ok(cow) => OwnedValue::String(cow.into_owned()),
-            // Same gap as `eval_generic::to_owned_at_depth`'s sibling check
-            // -- see `panic_on_string_decode_failure`'s own doc comment.
-            Err(_) => super::eval_generic::panic_on_string_decode_failure(),
-        },
+        StandardJson::String(s) => {
+            // `.ok()`, not a `panic!` on `Err`: see `to_owned_at_depth`'s
+            // sibling `else` arm doc comment in eval_generic.rs (#1098) for
+            // why a stricter fix here was attempted and reverted.
+            if let Ok(cow) = s.as_str() {
+                OwnedValue::String(cow.into_owned())
+            } else {
+                OwnedValue::String(String::new())
+            }
+        }
         StandardJson::Array(_) => {
             // Use cursor navigation to iterate children
             let items: Vec<OwnedValue> = cursor
@@ -901,22 +905,26 @@ mod tests {
     /// #1098: sibling of `eval_generic::to_owned`'s own regression test --
     /// `JsonIndex::build`'s semi-index scan finds string quote/escape
     /// boundaries without decoding/validating what's between them, so
-    /// invalid UTF-8 inside a string span indexes fine and only fails once
-    /// `materialize`/`into_owned` reaches `JsonString::as_str()`. This
-    /// cursor-based materializer used to silently substitute an empty
-    /// string here instead.
+    /// invalid UTF-8 inside a string span indexes fine and only degrades,
+    /// here to an empty string, once `materialize`/`into_owned` reaches
+    /// `JsonString::as_str()`. Pins the known, deliberate gap -- see
+    /// `cursor_to_owned_at_depth`'s own `String` arm doc comment for why a
+    /// stricter (panic) fix was attempted and reverted.
     #[test]
-    #[should_panic(
-        expected = "string scalar failed to decode despite passing structural validation (#1098)"
-    )]
-    fn test_materialize_panics_on_string_decode_failure_1098() {
+    fn test_materialize_degrades_to_empty_string_on_decode_failure_1098() {
         use crate::json::JsonIndex;
 
         let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let val = JqValue::from_cursor(cursor);
-        val.materialize();
+        assert_eq!(
+            val.materialize(),
+            OwnedValue::Object(IndexMap::from([(
+                "a".to_string(),
+                OwnedValue::String(String::new())
+            )]))
+        );
     }
 
     #[test]
@@ -1140,7 +1148,7 @@ mod tests {
 
     /// Sibling of the number test above, for `cursor_to_owned_at_depth`'s
     /// `StandardJson::String` arm -- the ordinary successfully-decoding
-    /// path, alongside `test_materialize_panics_on_string_decode_failure_1098`'s
+    /// path, alongside `test_materialize_degrades_to_empty_string_on_decode_failure_1098`'s
     /// coverage of the same arm's `Err` side.
     #[test]
     fn test_jqvalue_cursor_string_materialize_and_into_owned() {

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -697,13 +697,21 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(b),
         StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
-                OwnedValue::String(cow.into_owned())
-            } else {
-                OwnedValue::String(String::new())
-            }
-        }
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => OwnedValue::String(cow.into_owned()),
+            // Same gap as `eval_generic::to_owned_at_depth`'s sibling check
+            // (#1098): decoding a structurally-valid JSON string can fail
+            // (invalid `\u` escape, invalid UTF-8), and silently
+            // materializing an empty string here would be wrong in a
+            // different, still-silent way. No live input reaches this
+            // today -- the same upstream structural validation that
+            // protects `to_owned_at_depth` protects this cursor-based
+            // materializer too, since both walk the identical semi-indexed
+            // JSON representation.
+            Err(e) => panic!(
+                "string scalar failed to decode despite passing structural validation (#1098): {e}"
+            ),
+        },
         StandardJson::Array(_) => {
             // Use cursor navigation to iterate children
             let items: Vec<OwnedValue> = cursor
@@ -897,6 +905,27 @@ mod tests {
         let val: JqValue<'_, Vec<u64>> = JqValue::from_literal(&lit);
         assert!(matches!(val, JqValue::NumberLiteral(ref s) if s.as_ref() == "1.500"));
         assert_eq!(val.as_f64(), Some(1.5));
+    }
+
+    /// #1098: sibling of `eval_generic::to_owned`'s own regression test --
+    /// `JsonIndex::build`'s semi-index scan finds string quote/escape
+    /// boundaries without decoding/validating what's between them, so
+    /// invalid UTF-8 inside a string span indexes fine and only fails once
+    /// `materialize`/`into_owned` reaches `JsonString::as_str()`. This
+    /// cursor-based materializer used to silently substitute an empty
+    /// string here instead.
+    #[test]
+    #[should_panic(
+        expected = "string scalar failed to decode despite passing structural validation (#1098)"
+    )]
+    fn test_materialize_panics_on_string_decode_failure_1098() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let val = JqValue::from_cursor(cursor);
+        val.materialize();
     }
 
     #[test]

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -1138,6 +1138,33 @@ mod tests {
         assert_eq!(into_owned_val.into_owned().to_json(), "1E+100");
     }
 
+    /// Sibling of the number test above, for `cursor_to_owned_at_depth`'s
+    /// `StandardJson::String` arm -- the ordinary successfully-decoding
+    /// path, alongside `test_materialize_panics_on_string_decode_failure_1098`'s
+    /// coverage of the same arm's `Err` side.
+    #[test]
+    fn test_jqvalue_cursor_string_materialize_and_into_owned() {
+        use crate::json::JsonIndex;
+
+        let json = br#""hello""#;
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let materialize_val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+        assert_eq!(
+            materialize_val.materialize(),
+            OwnedValue::String("hello".to_string())
+        );
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let into_owned_val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+        assert_eq!(
+            into_owned_val.into_owned(),
+            OwnedValue::String("hello".to_string())
+        );
+    }
+
     /// `depth` levels of single-element array nesting: `[[[...[null]...]]]`.
     /// Mirrors `value.rs`/`eval.rs`'s own `linear_array_nest` helper (#1005),
     /// built directly out of `JqValue` since `materialize`/`into_owned`

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -700,17 +700,8 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
         StandardJson::String(s) => match s.as_str() {
             Ok(cow) => OwnedValue::String(cow.into_owned()),
             // Same gap as `eval_generic::to_owned_at_depth`'s sibling check
-            // (#1098): decoding a structurally-valid JSON string can fail
-            // (invalid `\u` escape, invalid UTF-8), and silently
-            // materializing an empty string here would be wrong in a
-            // different, still-silent way. No live input reaches this
-            // today -- the same upstream structural validation that
-            // protects `to_owned_at_depth` protects this cursor-based
-            // materializer too, since both walk the identical semi-indexed
-            // JSON representation.
-            Err(e) => panic!(
-                "string scalar failed to decode despite passing structural validation (#1098): {e}"
-            ),
+            // -- see `panic_on_string_decode_failure`'s own doc comment.
+            Err(_) => super::eval_generic::panic_on_string_decode_failure(),
         },
         StandardJson::Array(_) => {
             // Use cursor navigation to iterate children


### PR DESCRIPTION
## Summary

`to_owned_at_depth` (`src/jq/eval_generic.rs`) and `cursor_to_owned_at_depth` (`src/jq/lazy.rs`) both silently degrade a string scalar that passes structural validation but fails to *decode* (invalid `\u` escape, invalid UTF-8) — to `null` and `""` respectively, instead of surfacing an error. Issue #1098 describes this as a low-severity, largely theoretical gap and offers two acceptable directions: propagate the decode error, or add a test pinning the gap so future drift is caught.

## What this PR does (after a reverted false start)

An earlier version of this PR made the decode-failure case `panic!()` instead. **Code review found that was the wrong fix** — verified live against built `jq`/`yq` binaries, not just by reading source:

- It's reachable through completely ordinary CLI usage (`succinctly jq 'sort' file.json`, no `--argjson` needed), not a theoretical library-only edge case — contradicting the doc comments that shipped with that attempt.
- It breaks this codebase's own documented "evaluation continues past one error" `ErrorSink` convention (#355): a multi-record stream with one malformed value now aborted the whole batch instead of reporting a per-record error.
- It was inconsistently applied (missed two sibling copies of the same conversion, and object/mapping keys).
- It also newly crashed on *valid* YAML, via an unrelated pre-existing bug in `YamlValue::Alias::as_str()`.

Full detail on all of that is in this branch's commit history (`89e015cb2`→`9169de7b3` for the attempt, `42fc1a3b1` for the revert) rather than repeated here.

**This PR now takes #1098's other suggested direction**: both functions are back to their original graceful-degradation behavior, with regression tests pinning that behavior (`test_to_owned_degrades_to_null_on_string_decode_failure_1098`, `test_materialize_degrades_to_empty_string_on_decode_failure_1098`) plus a previously-missing ordinary-string test for `cursor_to_owned`'s cursor path. No production behavior changes relative to `main`.

A correct fix for the underlying gap (routing through `EvalError`/`ErrorSink` instead, applied consistently across all sibling copies and to keys) is a properly scoped design item, filed as **#1192**. A separate, independent bug found along the way (`YamlValue::Alias::as_str()` not recursing through nested aliases) is filed as **#1191**.

Fixes #1098

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Live-verified the CLI no longer panics: `succinctly jq 'sort'`/`. + null` over malformed input degrade gracefully again (matching `main`), and a 3-record stream with one malformed value processes all 3 records
- [x] New/updated tests pin the graceful-degradation output exactly (not just "doesn't panic")