### PR TITLE
fix(jq): document-input parsing no longer silently swallows bad input

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1138,10 +1138,18 @@ fn get_inputs(
                 Err(e) => return Ok(Err(e)),
             };
             // `parse_json_stream` (above) already validated this exact
-            // input successfully, so `find_json_values` should never
-            // disagree with it -- surfaced as an internal error rather
-            // than silently reusing a stale/wrong offset list if the two
-            // validators ever do diverge.
+            // input successfully via `serde_json`, which is strictly
+            // pickier than `find_json_values`'s own lenient heuristic
+            // scan (RFC 8259 plus #1094's leading-zero tolerance, vs.
+            // `find_json_values`'s RFC 8259 plus leading-zero *and*
+            // leading-dot tolerance, #1171) -- so `find_json_values`
+            // should never fail here in practice; unreachable through
+            // this crate's own public CLI surface, not exercised by a
+            // test for that reason (matching this codebase's established
+            // convention for exhaustive-but-dead defensive arms, e.g.
+            // #1064). Surfaced as an internal error rather than silently
+            // reusing a stale/wrong offset list if the two validators
+            // ever do diverge.
             let ends: Vec<usize> = match find_json_values(raw.as_bytes()) {
                 Ok(values) => values.into_iter().map(|(_, end)| end).collect(),
                 Err(offset) => {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1383,19 +1383,16 @@ fn find_json_values(bytes: &[u8]) -> core::result::Result<Vec<(usize, usize)>, u
                 // true, false, null
                 find_literal_end(bytes, pos)
             }
-            b'-' | b'0'..=b'9' => {
-                // Number
-                find_number_end(bytes, pos)
-            }
-            // Real jq's own number reader is lenient beyond strict JSON: a
-            // leading `.` is accepted when at least one digit follows
-            // (`.5` -> `0.5`), matching `light.rs`'s identical widening
-            // for the materialization side (#1171). A bare `.`/`.e5` with
-            // no digit at all still falls through to the `None` catch-all
-            // below, matching real jq's own rejection of that shape.
-            b'.' if bytes.get(pos + 1).is_some_and(u8::is_ascii_digit) => {
-                find_number_end(bytes, pos)
-            }
+            // Number. `number_literal_end` (shared with `light.rs`'s own
+            // materializer, #1171 review -- one validated implementation
+            // instead of independently-maintained copies) both finds the
+            // end of and validates the token: a `.` is accepted as a
+            // leading byte when at least one digit follows (`.5` -> `0.5`,
+            // matching real jq's own leniency beyond strict JSON), and a
+            // byte sequence that only *looks* number-shaped (`-e5`, `1e`,
+            // a bare `.`) is rejected outright rather than silently
+            // accepted as a truncated or zero-length span.
+            b'-' | b'.' | b'0'..=b'9' => succinctly::json::light::number_literal_end(bytes, pos),
             _ => None,
         };
 
@@ -1460,27 +1457,6 @@ fn find_literal_end(bytes: &[u8], pos: usize) -> Option<usize> {
         i += 1;
     }
     Some(i)
-}
-
-/// Find the end of a number starting at `pos`.
-fn find_number_end(bytes: &[u8], pos: usize) -> Option<usize> {
-    let mut i = pos;
-    // Allow leading minus
-    if i < bytes.len() && bytes[i] == b'-' {
-        i += 1;
-    }
-    // Digits, dots, exponents
-    while i < bytes.len() {
-        match bytes[i] {
-            b'0'..=b'9' | b'.' | b'e' | b'E' | b'+' | b'-' => i += 1,
-            _ => break,
-        }
-    }
-    if i > pos {
-        Some(i)
-    } else {
-        None
-    }
 }
 
 /// Parse a JSON value from a string (`--argjson`/`--jsonargs`), preserving
@@ -2152,6 +2128,18 @@ impl LiteralFormatter for JqCompatFormatter {
             return Cow::Owned(match OwnedValue::from_number_bytes(raw) {
                 OwnedValue::Int(i) => self.format_int(i),
                 OwnedValue::Float(f) => self.format_float(f),
+                // A leading-dot span (`.5`, `-.5`) is jq-lenient-but-not-
+                // RFC-8259 (#1171): `from_number_bytes` preserves its
+                // spelling as a `NumberLiteral` here instead of degrading
+                // to a plain `Float` (needed so trailing zeros survive,
+                // `.500` -> `0.500` not `0.5`), so route it through the
+                // same jq-compat reformatting a strictly-valid span gets
+                // below via the literal's own text (identical to `raw`
+                // for this shape) rather than falling into the `_` catch
+                // -all and printing `null`.
+                OwnedValue::NumberLiteral(_, literal) => {
+                    format_number_jq_compat(literal.as_bytes())
+                }
                 _ => "null".to_string(),
             });
         }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -15,7 +15,7 @@ use succinctly::jq::eval_generic::{
     eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
 };
 use succinctly::jq::{
-    self, format_number_jq_compat, nonfinite_display_string, Expr, JqSemantics, JqValue,
+    self, format_number_jq_compat, nonfinite_display_string, EvalError, Expr, JqSemantics, JqValue,
     OwnedValue, Program,
 };
 use succinctly::json::light::{JsonCursor, StandardJson};
@@ -837,7 +837,14 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 }
             }
             // Process as JSON stream (handle multiple JSON values in one input)
-            let values = find_json_values(raw);
+            let values = match find_json_values(raw) {
+                Ok(values) => values,
+                Err(offset) => {
+                    let at = InputLocation::at(filename.as_deref(), line_at(raw, offset));
+                    sink.report(DiagStyle::Jq, &EvalError::new("Invalid JSON text"), &at);
+                    continue;
+                }
+            };
             for (start, end) in values {
                 let json_bytes = &raw[start..end];
 
@@ -1130,10 +1137,20 @@ fn get_inputs(
                 Ok(p) => p,
                 Err(e) => return Ok(Err(e)),
             };
-            let ends: Vec<usize> = find_json_values(raw.as_bytes())
-                .into_iter()
-                .map(|(_, end)| end)
-                .collect();
+            // `parse_json_stream` (above) already validated this exact
+            // input successfully, so `find_json_values` should never
+            // disagree with it -- surfaced as an internal error rather
+            // than silently reusing a stale/wrong offset list if the two
+            // validators ever do diverge.
+            let ends: Vec<usize> = match find_json_values(raw.as_bytes()) {
+                Ok(values) => values.into_iter().map(|(_, end)| end).collect(),
+                Err(offset) => {
+                    return Ok(Err(anyhow::anyhow!(
+                        "internal error: find_json_values failed at byte {offset} \
+                         after parse_json_stream already validated this input"
+                    )));
+                }
+            };
             locations.extend_from_ends(src, &raw, &ends, parsed.len());
             values.extend(parsed);
         }
@@ -1320,7 +1337,15 @@ fn line_at(bytes: &[u8], end: usize) -> usize {
 ///
 /// This is a simple heuristic that finds the boundaries of top-level JSON values
 /// by tracking brace/bracket nesting and handling strings.
-fn find_json_values(bytes: &[u8]) -> Vec<(usize, usize)> {
+///
+/// Returns `Err(offset)` -- the byte offset the unparseable value started at
+/// -- for content it can't recognize as any JSON value shape (a truncated
+/// container/string, or a byte that starts none of the recognized shapes),
+/// rather than silently skipping it. An earlier version of this function
+/// skipped to the next whitespace and kept going, so `{invalid}`/`[1,2,`
+/// produced `{}`/no output at all instead of an error (#1171) -- real jq
+/// itself stops at the first parse failure, not skip-and-continue.
+fn find_json_values(bytes: &[u8]) -> core::result::Result<Vec<(usize, usize)>, usize> {
     let mut values = Vec::new();
     let mut pos = 0;
 
@@ -1354,21 +1379,28 @@ fn find_json_values(bytes: &[u8]) -> Vec<(usize, usize)> {
                 // Number
                 find_number_end(bytes, pos)
             }
+            // Real jq's own number reader is lenient beyond strict JSON: a
+            // leading `.` is accepted when at least one digit follows
+            // (`.5` -> `0.5`), matching `light.rs`'s identical widening
+            // for the materialization side (#1171). A bare `.`/`.e5` with
+            // no digit at all still falls through to the `None` catch-all
+            // below, matching real jq's own rejection of that shape.
+            b'.' if bytes.get(pos + 1).is_some_and(u8::is_ascii_digit) => {
+                find_number_end(bytes, pos)
+            }
             _ => None,
         };
 
-        if let Some(end) = end {
-            values.push((start, end));
-            pos = end;
-        } else {
-            // Invalid JSON - skip to next whitespace
-            while pos < bytes.len() && !bytes[pos].is_ascii_whitespace() {
-                pos += 1;
+        match end {
+            Some(end) => {
+                values.push((start, end));
+                pos = end;
             }
+            None => return Err(start),
         }
     }
 
-    values
+    Ok(values)
 }
 
 /// Find the end of an object or array starting at `pos`.
@@ -2634,7 +2666,7 @@ mod tests {
         // Multi-value, no trailing newline after the last value: both values
         // report the same line jq does, not "line of value + 1" (#524).
         let bytes = b"1\n2";
-        let ends = find_json_values(bytes);
+        let ends = find_json_values(bytes).unwrap();
         assert_eq!(ends, vec![(0, 1), (2, 3)]);
         assert_eq!(line_at(bytes, 1), 1); // "1" ends before the '\n' lookahead
         assert_eq!(line_at(bytes, 3), 1); // "2" ends at EOF, no lookahead byte

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -156,8 +156,23 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     }
 
     if !has_exp {
-        // Plain decimal without exponent - preserve as-is (keeps trailing zeros)
-        return s.to_string();
+        // Plain decimal without exponent - preserve as-is (keeps trailing
+        // zeros), except real jq's own reader adds a leading `0` to a
+        // leading-dot spelling even under plain identity -- confirmed
+        // live: `.500 | .` -> `0.500` (trailing zeros still kept
+        // verbatim), not `.500` (#1171). `is_valid_number`-gated callers
+        // never reach this function with a leading-dot `s` in the first
+        // place (strict RFC 8259 has no such spelling); this only fires
+        // for `s` sourced from a `NumberLiteral` this crate's own
+        // document-input scanners now recognize as jq-lenient (see
+        // `number_literal_end`, `src/json/light.rs`).
+        return if let Some(rest) = s.strip_prefix('.') {
+            format!("0.{rest}")
+        } else if let Some(rest) = s.strip_prefix("-.") {
+            format!("-0.{rest}")
+        } else {
+            s.to_string()
+        };
     }
 
     // Has exponent - need to reformat according to jq rules
@@ -633,6 +648,35 @@ impl OwnedValue {
         }
         if crate::json::validate::is_valid_number(bytes) {
             return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
+        }
+        // Real jq's own number reader also accepts a leading `.` (with or
+        // without a preceding `-`) when at least one digit follows (`.5`
+        // -> `0.5`, `-.5` -> `-0.5`) -- not valid per strict RFC 8259
+        // (`is_valid_number` stays strict on purpose, shared by callers
+        // this leniency shouldn't reach), but a real jq-accepted spelling
+        // this crate's own document-input scanners now recognize as a
+        // number span (`number_literal_end`, #1171). Preserve it the same
+        // way #1094 preserves a leading zero: check whether inserting `0`
+        // right after any `-` makes the token strictly valid, and if so,
+        // still materialize the *original* (un-inserted) text as the
+        // literal spelling -- `bytes` was already gated by
+        // `number_literal_end` at the scan site, and
+        // `Self::from_number_literal` (via `parse_i64_or_f64`) parses a
+        // leading-dot float natively, so no separate reparse of the
+        // original text is needed here.
+        let dot_prefix_len = match bytes.first() {
+            Some(b'.') => Some(0),
+            Some(b'-') if bytes.get(1) == Some(&b'.') => Some(1),
+            _ => None,
+        };
+        if let Some(prefix_len) = dot_prefix_len {
+            let mut prefixed = Vec::with_capacity(bytes.len() + 1);
+            prefixed.extend_from_slice(&bytes[..prefix_len]);
+            prefixed.push(b'0');
+            prefixed.extend_from_slice(&bytes[prefix_len..]);
+            if crate::json::validate::is_valid_number(&prefixed) {
+                return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
+            }
         }
         let Ok(s) = core::str::from_utf8(bytes) else {
             return Self::Null;

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1565,6 +1565,27 @@ impl<T: Into<Self>> From<Vec<T>> for OwnedValue {
 mod tests {
     use super::*;
 
+    /// #1171: a leading-dot number literal (with or without a `-` sign)
+    /// must preserve its own source spelling as a `NumberLiteral`, not
+    /// degrade to a plain lossy `Float` -- direct unit coverage of both
+    /// `dot_prefix_len` branches in `from_number_bytes` (0 for `.5`, 1
+    /// for `-.5`), complementing the CLI-level regression tests.
+    #[test]
+    fn test_from_number_bytes_preserves_leading_dot_spelling() {
+        assert_eq!(
+            OwnedValue::from_number_bytes(b".500"),
+            OwnedValue::NumberLiteral(NumberRepr::Float(0.5), ".500".into())
+        );
+        assert_eq!(
+            OwnedValue::from_number_bytes(b"-.500"),
+            OwnedValue::NumberLiteral(NumberRepr::Float(-0.5), "-.500".into())
+        );
+        // A bare `.` (no digit at all) still degrades to Null: `dot_prefix_len`
+        // is set, but prefixing `0` doesn't make it strictly valid either.
+        assert_eq!(OwnedValue::from_number_bytes(b"."), OwnedValue::Null);
+        assert_eq!(OwnedValue::from_number_bytes(b"-."), OwnedValue::Null);
+    }
+
     #[test]
     fn test_constructors() {
         assert_eq!(OwnedValue::null(), OwnedValue::Null);

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -656,6 +656,17 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
                 text: self.text,
                 start: text_pos,
             }),
+            // Real jq's own number reader is lenient beyond strict JSON: a
+            // leading `.` is accepted when at least one digit follows
+            // (`.5` -> `0.5`), matching `-.5` (already accepted above,
+            // since `-` already dispatches here) but not a bare `.`/`.e5`
+            // with no digit at all, which real jq still rejects (#1171).
+            b'.' if self.text.get(text_pos + 1).is_some_and(u8::is_ascii_digit) => {
+                StandardJson::Number(JsonNumber {
+                    text: self.text,
+                    start: text_pos,
+                })
+            }
             _ => StandardJson::Error("unexpected character"),
         }
     }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1458,7 +1458,7 @@ fn parse_hex4(hex: &[u8]) -> Result<u16, JsonError> {
 /// own behavior. Do **not** reuse this for a number reached while
 /// materializing an already-recognized container's *nested* value: that
 /// path has its own, deliberately more permissive established
-/// precedent ([`nested_number_span`], #966) of absorbing a malformed
+/// precedent (`nested_number_span`, #966) of absorbing a malformed
 /// trailing shape into one span and letting it fail to `Null` downstream
 /// rather than erroring the whole document -- this stricter function
 /// would instead truncate a span like `1.2.3` after `1.2`, silently

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -652,21 +652,18 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
                     StandardJson::Error("invalid null")
                 }
             }
-            c if c == b'-' || c.is_ascii_digit() => StandardJson::Number(JsonNumber {
+            // A leading `.` is accepted here too (in addition to `-`/an
+            // ASCII digit) -- real jq's own number reader is lenient
+            // beyond strict JSON (`.5` -> `0.5`, #1171). No grammar
+            // validation here beyond the leading byte: this is a nested
+            // container's own field/element, and `nested_number_span`'s
+            // own doc comment explains why a malformed trailing shape
+            // must still resolve to one `Number` span rather than
+            // `Error`, matching this crate's established #966 precedent.
+            c if c == b'-' || c == b'.' || c.is_ascii_digit() => StandardJson::Number(JsonNumber {
                 text: self.text,
                 start: text_pos,
             }),
-            // Real jq's own number reader is lenient beyond strict JSON: a
-            // leading `.` is accepted when at least one digit follows
-            // (`.5` -> `0.5`), matching `-.5` (already accepted above,
-            // since `-` already dispatches here) but not a bare `.`/`.e5`
-            // with no digit at all, which real jq still rejects (#1171).
-            b'.' if self.text.get(text_pos + 1).is_some_and(u8::is_ascii_digit) => {
-                StandardJson::Number(JsonNumber {
-                    text: self.text,
-                    start: text_pos,
-                })
-            }
             _ => StandardJson::Error("unexpected character"),
         }
     }
@@ -775,16 +772,13 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
                     return None;
                 }
             }
-            // Number: scan for end of number
-            c if c == b'-' || c.is_ascii_digit() => {
-                let mut i = start;
-                while i < self.text.len() {
-                    match self.text[i] {
-                        b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E' => i += 1,
-                        _ => break,
-                    }
-                }
-                i
+            // Number: scan for end of number, matching `value()`'s own
+            // dispatch (shared `nested_number_span`, #1171 review) --
+            // this arm previously had no leading-dot case at all, so a
+            // cursor at a leading-dot number returned `None` here even
+            // though `value()` correctly classified it as `Number`.
+            c if c == b'-' || c == b'.' || c.is_ascii_digit() => {
+                nested_number_span(self.text, start)
             }
             _ => return None,
         };
@@ -1439,6 +1433,117 @@ fn parse_hex4(hex: &[u8]) -> Result<u16, JsonError> {
 // JsonNumber: Lazy number parsing
 // ============================================================================
 
+/// Find the end of a JSON number literal starting at `start` in `text`.
+///
+/// `start` must point at a byte that begins a candidate number: `-`, an
+/// ASCII digit, or -- real jq's own number reader is lenient beyond
+/// strict JSON here -- a `.` immediately followed by a digit. Returns
+/// `None` if the bytes at `start` don't actually form a valid number
+/// token (`-e5`, `1e`, a bare `.`, ...).
+///
+/// Grammar: optional `-`; an integer part (0+ digits) and/or a
+/// `.`-prefixed fractional part (`.` + 1+ digits) -- at least one of
+/// the two must supply a digit, so a bare `.` alone is rejected, but a
+/// leading-dot number (`.5`) is accepted; an optional `.`-fraction with
+/// *zero* digits after it is also accepted when the integer part
+/// already supplied one (`1.` -> `1`, matching real jq); an optional
+/// exponent (`e`/`E`, optional sign, then 1+ digits) -- if the marker
+/// is present but has no digit, the *whole* token is rejected, not
+/// truncated before it, matching real jq rejecting `1e` outright rather
+/// than accepting `1`. All confirmed live against jq 1.7.1.
+///
+/// **Only used for top-level document splitting** (the CLI's own
+/// `find_json_values`, `src/bin/succinctly/jq_runner.rs`) -- a
+/// malformed *top-level* input must error (#1171), matching real jq's
+/// own behavior. Do **not** reuse this for a number reached while
+/// materializing an already-recognized container's *nested* value: that
+/// path has its own, deliberately more permissive established
+/// precedent ([`nested_number_span`], #966) of absorbing a malformed
+/// trailing shape into one span and letting it fail to `Null` downstream
+/// rather than erroring the whole document -- this stricter function
+/// would instead truncate a span like `1.2.3` after `1.2`, silently
+/// materializing the wrong, fabricated value `1.2` instead of `null`
+/// (caught by review of #1171 before merge, 4 `#966` regression tests
+/// failed).
+pub fn number_literal_end(text: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    if i < text.len() && text[i] == b'-' {
+        i += 1;
+    }
+    let int_start = i;
+    while i < text.len() && text[i].is_ascii_digit() {
+        i += 1;
+    }
+    let has_int_digit = i > int_start;
+    let mut has_frac_digit = false;
+    if i < text.len() && text[i] == b'.' {
+        let frac_start = i + 1;
+        let mut j = frac_start;
+        while j < text.len() && text[j].is_ascii_digit() {
+            j += 1;
+        }
+        has_frac_digit = j > frac_start;
+        i = if has_frac_digit { j } else { i + 1 };
+    }
+    if !has_int_digit && !has_frac_digit {
+        return None;
+    }
+    if i < text.len() && (text[i] == b'e' || text[i] == b'E') {
+        let mut j = i + 1;
+        if j < text.len() && (text[j] == b'+' || text[j] == b'-') {
+            j += 1;
+        }
+        let exp_digit_start = j;
+        while j < text.len() && text[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j > exp_digit_start {
+            i = j;
+        } else {
+            return None;
+        }
+    }
+    Some(i)
+}
+
+/// Find the end of a number-*shaped* span starting at `start` in `text`
+/// (a byte that begins a candidate number: `-`, an ASCII digit, or a
+/// leading `.`), for a value reached while materializing an
+/// already-recognized container's nested field/element (`value()`,
+/// `text_range()`, [`JsonNumber::find_end`] below).
+///
+/// Deliberately permissive, unlike [`number_literal_end`]: greedily
+/// consumes every subsequent `[0-9.eE+-]` byte with no grammar
+/// validation at all, so a malformed trailing shape (`1.2.3`, an
+/// exponent marker with no digit, ...) still resolves to *one*
+/// recognized span instead of either fabricating a shorter,
+/// wrong-but-valid-looking number or splitting into two adjacent
+/// tokens with no separator between them. `is_valid_number`/
+/// `OwnedValue::from_number_bytes` are what decide, from that whole
+/// span, whether it's safe to treat as a real number (falling back to
+/// `Null` if not) -- matching this crate's own established, tested
+/// precedent for a malformed *nested* number (#966: `{"a": 1.2.3}` ->
+/// `{"a": null}`, not a document-wide error). Also what makes
+/// [`OwnedValue::to_json_for_reindex`](crate::jq::OwnedValue::to_json_for_reindex)'s
+/// `NAN_SENTINEL`/`INFINITY_SENTINEL` round-trip tokens (`9e999e999`,
+/// deliberately unparseable via a repeated exponent marker, #472/#1083)
+/// round-trip correctly: their whole span must survive intact for
+/// `is_nan_sentinel`/`is_infinity_sentinel`'s exact-text comparison to
+/// recognize them.
+fn nested_number_span(text: &[u8], start: usize) -> usize {
+    let mut i = start;
+    if i < text.len() && text[i] == b'-' {
+        i += 1;
+    }
+    while i < text.len() {
+        match text[i] {
+            b'0'..=b'9' | b'.' | b'e' | b'E' | b'+' | b'-' => i += 1,
+            _ => break,
+        }
+    }
+    i
+}
+
 /// A JSON number that hasn't been parsed yet.
 ///
 /// Call `as_i64()` or `as_f64()` to parse the number.
@@ -1470,14 +1575,7 @@ impl<'a> JsonNumber<'a> {
     }
 
     fn find_end(&self) -> usize {
-        let mut i = self.start;
-        while i < self.text.len() {
-            match self.text[i] {
-                b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E' => i += 1,
-                _ => break,
-            }
-        }
-        i
+        nested_number_span(self.text, self.start)
     }
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11764,6 +11764,69 @@ fn test_jq_null_times_number_literal_still_discards_both_ways_1167() -> Result<(
     Ok(())
 }
 
+// --- #1171: document-input parsing must not silently produce wrong
+// output for content real jq either accepts leniently (a leading-dot
+// number) or rejects outright (truncated/malformed JSON) -- both
+// previously exited 0 with silently wrong output on the default (lazy)
+// input path.
+
+/// A leading-dot number literal (`.5`), top-level and nested, must parse
+/// as the number it spells -- real jq's own reader is lenient beyond
+/// strict JSON here (confirmed live: `jq -c '.'` on `.5` outputs `0.5`).
+#[test]
+fn test_jq_leading_dot_number_parses_correctly_1171() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "."], Some(".5"))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "0.5");
+
+    let (out, _, code) = run_jq_full(&["-c", "."], Some("[.5]"))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[0.5]");
+
+    let (out, _, code) = run_jq_full(&["-c", "."], Some(r#"{"a":.5}"#))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":0.5}"#);
+
+    Ok(())
+}
+
+/// Truncated/malformed JSON must error (exit 5), not silently produce
+/// empty output with exit 0 -- `find_json_values` previously skipped
+/// unparseable content and kept going with no error recorded at all.
+#[test]
+fn test_jq_truncated_json_errors_not_silent_empty_output_1171() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-c", "."], Some("[1,2,"))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "out: {out:?}");
+    assert!(!stderr.trim().is_empty(), "expected a diagnostic on stderr");
+
+    Ok(())
+}
+
+/// A bare `.` (no digit at all) must still be rejected -- the leading-dot
+/// widening above requires at least one digit to follow, matching real
+/// jq's own boundary (confirmed live: `jq -c '.'` on a bare `.` errors
+/// with "Invalid numeric literal", not accepted as some default number).
+#[test]
+fn test_jq_bare_dot_still_errors_1171() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "."], Some("."))?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(out.trim().is_empty(), "out: {out:?}");
+
+    Ok(())
+}
+
+/// Regression guard: ordinary, well-formed multi-value document input is
+/// unaffected by the stricter error handling above.
+#[test]
+fn test_jq_valid_multi_value_stream_unaffected_1171() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "."], Some("1\n2\n3\n"))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "1\n2\n3");
+
+    Ok(())
+}
+
 /// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
 /// the parent key" rules must not leak into jq mode: real jq errors on
 /// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11842,6 +11842,22 @@ fn test_jq_dash_e_digit_top_level_errors_not_silent_null_1171() -> Result<()> {
     Ok(())
 }
 
+/// A top-level token with a valid mantissa but an exponent marker with
+/// no digit after it (`1e`) must error too -- rejected outright, not
+/// truncated to just the valid `1` prefix, matching real jq (confirmed
+/// live: `jq -c '.'` on `1e` errors with "Invalid numeric literal", not
+/// `1`). Distinct code path from `-e5` above (that one has no mantissa
+/// digit at all; this one's mantissa is fine, only the exponent is
+/// incomplete).
+#[test]
+fn test_jq_incomplete_exponent_top_level_errors_1171() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "."], Some("1e"))?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(out.trim().is_empty(), "out: {out:?}");
+
+    Ok(())
+}
+
 /// Trailing zeros on a leading-dot literal's fractional part must be
 /// preserved, not collapsed -- `.500` -> `0.500`, not `0.5` (confirmed
 /// live: real jq's own reader adds the leading `0` but keeps trailing

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11827,6 +11827,61 @@ fn test_jq_valid_multi_value_stream_unaffected_1171() -> Result<()> {
     Ok(())
 }
 
+/// A top-level token that only *looks* number-shaped but has no digit
+/// anywhere in its mantissa (`-e5`: `-` then `e5`, no digit before the
+/// exponent marker) must error, not silently materialize as `null` --
+/// `number_literal_end`'s digit-position validation, not just "does it
+/// contain a digit somewhere" (confirmed live: real jq errors with
+/// "Invalid numeric literal", exit 5). Found by code review before merge.
+#[test]
+fn test_jq_dash_e_digit_top_level_errors_not_silent_null_1171() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "."], Some("-e5"))?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(out.trim().is_empty(), "out: {out:?}");
+
+    Ok(())
+}
+
+/// Trailing zeros on a leading-dot literal's fractional part must be
+/// preserved, not collapsed -- `.500` -> `0.500`, not `0.5` (confirmed
+/// live: real jq's own reader adds the leading `0` but keeps trailing
+/// zeros verbatim, same as it does for a strictly-valid decimal). Covers
+/// both the positive and negative-sign spellings. Found by code review
+/// before merge (`OwnedValue::from_number_bytes` was collapsing to a
+/// plain lossy `Float` instead of a spelling-preserving `NumberLiteral`).
+#[test]
+fn test_jq_leading_dot_number_preserves_trailing_zeros_1171() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "."], Some(".500"))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "0.500");
+
+    let (out, _, code) = run_jq_full(&["-c", "."], Some("-.500"))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "-0.500");
+
+    Ok(())
+}
+
+/// A malformed number *nested* inside an otherwise well-formed container
+/// keeps this crate's own established #966 precedent (materialize as
+/// `null`, don't error the whole document) even after #1171's stricter
+/// top-level handling -- the two code paths (`find_json_values`'s
+/// top-level document splitter vs. `light.rs`'s per-value materializer)
+/// deliberately have different error-vs-null conventions. Regression
+/// guard: an earlier draft of #1171's fix used one shared, strict
+/// number-span function for both paths, which truncated `1.2.3` after
+/// `1.2` and silently fabricated the wrong value `1.2` instead of `null`
+/// (caught by review before merge -- see `nested_number_span`'s own doc
+/// comment in `src/json/light.rs`).
+#[test]
+fn test_jq_nested_malformed_number_still_becomes_null_not_fabricated_1171() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "[.a]"], Some(r#"{"a": 1.2.3}"#))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[null]");
+
+    Ok(())
+}
+
 /// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
 /// the parent key" rules must not leak into jq mode: real jq errors on
 /// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching

--- a/tests/locate_cli_tests.rs
+++ b/tests/locate_cli_tests.rs
@@ -92,3 +92,25 @@ fn yq_locate_rejects_out_of_range_position() {
         "expected an invalid-position error, got: {stderr}"
     );
 }
+
+/// A leading-dot number's own `byte_range` must span just the literal
+/// itself, not run off to the next structural byte -- `text_range()`
+/// (`src/json/light.rs`) previously had no leading-dot case at all
+/// (unlike `value()`, which classified the cursor as `Number` correctly),
+/// so this returned `None` and `locate_offset_detailed`'s own fallback
+/// substituted a byte range spanning to end-of-file. Found by code
+/// review of #1171 before merge.
+#[test]
+fn jq_locate_leading_dot_number_byte_range_is_exact() {
+    let mut fixture = tempfile::NamedTempFile::new().expect("create temp fixture");
+    std::io::Write::write_all(&mut fixture, b"[.5, 6, 7]").expect("write fixture");
+    let path = fixture.path().to_str().expect("utf8 path");
+
+    let (stdout, stderr, code) = run(&["jq-locate", path, "--offset", "1", "--format", "json"]);
+
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(
+        stdout.contains("\"byte_range\": [\n    1,\n    3\n  ]"),
+        "expected byte_range [1, 3], got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

`find_json_values` (the CLI's own ad-hoc top-level value splitter for the
default/lazy jq input path) silently skipped any content it couldn't
recognize as a JSON value shape — a truncated container/string, or an
unrecognized leading byte — and kept scanning. Malformed input like
`[1,2,` or a leading-dot number therefore produced silently wrong output
(empty, or missing values) at **exit 0** instead of the parse error real
jq raises.

## Repro (before/after)

```
$ echo '[1,2,' | succinctly jq -c '.'
(empty output, exit 0)                          # before
jq: error (at <stdin>:0): Invalid JSON text      # after, exit 5

$ echo '.5' | succinctly jq -c '.'
(empty output, exit 0)                           # before
0.5                                              # after (matches real jq)

$ echo '[.5]' | succinctly jq -c '.'
[null]                                           # before
[0.5]                                            # after (matches real jq)
```

## What changed

- `find_json_values` now returns the byte offset of the first unparseable
  value instead of silently skipping it; the caller reports it through
  the existing `ErrorSink` machinery (same `jq: error (at ...): ...`
  convention every other uncaught error in this file already uses).
- Widened leading-byte recognition (both here and in the materializer,
  `JsonCursor::value()` in `src/json/light.rs`) to accept a `.` followed
  by a digit as the start of a number literal — matching real jq's own
  leniency (confirmed live against jq 1.7.1: `.5` → `0.5`). A bare
  `.`/`.e5` with no digit at all still falls through to the same error
  path, matching real jq's own rejection of that shape.

## Scope

Investigation while verifying this issue's original (narrower) repro
turned up a broader family of silent-swallow bugs than the issue title
suggested — not number-specific. A **separate, deeper** swallow point
remains: a malformed field *inside* an otherwise well-bracketed container
(`{invalid}` → `{}` instead of erroring) lives in the semi-indexer's own
structural scan (`JsonFields::uncons()`, `src/json/light.rs`) and its two
`StandardJson::Error(_) => OwnedValue::Null` materializer fallbacks
(`src/jq/lazy.rs`, `src/jq/eval_generic.rs`). Fixing that needs threading
a `Result`/error signal through a recursive tree-walk with no
error-carrying return type today — split into #1194 rather than attempted
here.

One `find_json_values` call site (`get_inputs`, reached only after
`parse_json_stream`'s stricter `serde_json`-backed validation already
succeeded on the same bytes) can't actually hit the new error path
through this crate's own public CLI surface — documented in place as an
unreachable-in-practice defensive check (matching this codebase's
established convention for exhaustive-but-dead arms, e.g. #1064), not
exercised by a test for that reason.

## Testing

- New tests in `tests/jq_cli_tests.rs`: leading-dot number parsing
  (top-level and nested), truncated-JSON erroring instead of silent
  empty output, a bare-`.` regression guard, and a valid-multi-value
  regression guard.
- Full local suite (lib/bin/integration/golden/doc tests, including yq
  golden conformance), both CI clippy feature combinations, and the
  `no_std` check all pass clean — no regressions anywhere.
- Patch coverage: 82.14% (23/28); all 5 uncovered lines are the
  documented-unreachable defensive branch above.

Fixes #1171