### PR TITLE
fix(jq): null-involving multiplication errors instead of returning null

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ printf 'a:\n  x: 1\nb:\n  x: 2\n  y: 3\n' | succinctly yq '.a *=n .b'  # a: {x: 
 
 `+`/`d` combined on the same array is a documented simplification: real yq has a surprising, untested-upstream double-effect here; succinctly makes `+` take clean priority (pure append, `d` ignored) instead.
 
-`null` acts as an empty container on either side of a yq-mode merge (jq mode keeps plain `null * x = null`): a null/absent *left* operand merges as if starting from `{}`/`[]` (`.a *=n .b` on `a: null` writes the full `.b` in; `.a *=? .b` on an absent `.a` leaves `a: {}`, blocked field-by-field rather than staying `null`), and a null *right* operand is always a no-op (`.a *= null` leaves `.a` untouched).
+`null` acts as an empty container on either side of a yq-mode merge (jq mode has no such exception -- every `null`-involving `*` pairing errors there, #1175): a null/absent *left* operand merges as if starting from `{}`/`[]` (`.a *=n .b` on `a: null` writes the full `.b` in; `.a *=? .b` on an absent `.a` leaves `a: {}`, blocked field-by-field rather than staying `null`), and a null *right* operand is always a no-op (`.a *= null` leaves `.a` untouched).
 
 ### jq Position-Based Navigation (succinctly extension)
 

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -216,8 +216,9 @@ printf 'a: [{name: fred, age: 12}, {name: bob, age: 32}]\nb: [{name: fred, age: 
   `a: null` writes the full `.b` in, and `.a *=? .b` on an absent `.a`
   leaves it as `a: {}` (blocked by `?`, not `a: null`). A null *right*
   operand is always a no-op — `.a *= null` (with or without flags) leaves
-  `.a` untouched, whatever it is. This only applies to yq mode; jq mode
-  keeps its plain `null * x = null` behavior.
+  `.a` untouched, whatever it is. This only applies to yq mode; jq mode has
+  no such exception and errors on every `null`-involving `*` pairing
+  (#1175).
 - `?`/`n` propagate through every nesting depth: a parent key that already
   exists still gets recursed into so its own new children can be added or
   blocked individually. Combining `?` and `n` is an AND of both gates (net

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -79,8 +79,8 @@ pub trait EvalSemantics: Copy + Default {
     /// If true, `null` acts as an empty container on either side of `*`/`*=`:
     /// a null right operand is a no-op (left passes through unchanged), and a
     /// null left operand merging with an object/array merges as if starting
-    /// from `{}`/`[]` (yq). If false, any null operand short-circuits to
-    /// `null` (jq).
+    /// from `{}`/`[]` (yq). If false, every null-involving pairing errors
+    /// instead, with no exceptions (jq, #1175).
     const NULL_MERGES_AS_EMPTY: bool;
     /// Exit code for a bare `halt_error` (no explicit argument). Mirrors
     /// `DiagStyle::error_exit_code()` in the CLI's `output.rs` (5 for jq's
@@ -1993,9 +1993,8 @@ fn arith_mul<S: EvalSemantics>(
         // `NumberLiteral` operand degrades to plain `Int`/`Float` here, and
         // only here -- these are the arms that actually compute a new
         // value (a product, or a repeated string), so canonical formatting
-        // is correct; every arm above relocates an operand unchanged (or
-        // discards both entirely) and must not collapse a literal's
-        // spelling (#1167).
+        // is correct; every arm above relocates an operand unchanged and
+        // must not collapse a literal's spelling (#1167).
         (left, right) => match (left.into_plain_number(), right.into_plain_number()) {
             // jq converts to float on overflow, yq wraps
             (OwnedValue::Int(a), OwnedValue::Int(b)) => {
@@ -26577,11 +26576,15 @@ mod tests {
     /// #1056 review: an earlier draft implemented unary minus as
     /// `(-1) * expr` instead of a dedicated `ArithOp::Negate` -- silently
     /// wrong, not just imprecise: `arith_mul` has its own string-repetition
-    /// (`Int * String`) and null-passthrough (`NULL_MERGES_AS_EMPTY`/`null *
-    /// x = null`) semantics that have nothing to do with negation, so
-    /// `-"abc"`/`-null` both returned `null` with exit code 0 instead of
-    /// erroring -- caught by code review before reaching `main`, with zero
-    /// test coverage of any non-numeric unary-minus operand at the time.
+    /// (`Int * String`) and null-merge (`NULL_MERGES_AS_EMPTY`) semantics
+    /// that have nothing to do with negation, so `-"abc"`/`-null` both
+    /// returned `null` with exit code 0 instead of erroring at the time --
+    /// caught by code review before reaching `main`, with zero test
+    /// coverage of any non-numeric unary-minus operand at the time. (Since
+    /// #1175, `arith_mul`'s own jq-mode null handling errors unconditionally
+    /// too, so this exact failure mode is doubly moot today -- but the
+    /// underlying lesson, that `arith_mul` carries semantics unrelated to
+    /// negation, still holds.)
     /// Confirmed live against jq 1.7.1: every non-numeric type errors with
     /// jq's own dedicated "cannot be negated" wording (`EvalError::
     /// cannot_be_negated`), not `arith_sub`'s pre-#1056 "cannot be

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1977,10 +1977,18 @@ fn arith_mul<S: EvalSemantics>(
         (OwnedValue::Null, b @ OwnedValue::Array(_)) if S::NULL_MERGES_AS_EMPTY => {
             Ok(merge_values(OwnedValue::Array(Vec::new()), b, flags))
         }
-        // null * x = null -- both operands are discarded outright (the
-        // result is always `Null`, never either operand), so there's
-        // nothing to relocate and no spelling to lose here.
-        (OwnedValue::Null, _) | (_, OwnedValue::Null) => Ok(OwnedValue::Null),
+        // Every other `Null`-involving pairing falls through to the
+        // generic numeric/string match below, where `Null` matches none
+        // of its patterns and lands on the final `EvalError::binary_op`
+        // arm (#1175). Both oracles error here: jq unconditionally (its
+        // `NULL_MERGES_AS_EMPTY = false` means the three arms above never
+        // fire, so every jq null pairing reaches this point), and yq for
+        // every case its own arms above don't already special-case --
+        // `x * null` (no-op) and `null * {}`/`null * []` (empty-container
+        // merge). `null * null` is *not* an exception needing its own arm:
+        // it's already handled by the `(left, Null)` no-op arm above,
+        // since `left` binds to `Null` there too (live-verified against
+        // yq v4.53.3: `null * null` -> `null`, exit 0, not an error).
         // Everything else: numeric multiplication or string repetition. A
         // `NumberLiteral` operand degrades to plain `Int`/`Float` here, and
         // only here -- these are the arms that actually compute a new
@@ -26370,13 +26378,19 @@ mod tests {
             }
         );
 
-        // jq mode is unaffected: null is still a hard `null` result on
-        // either side, matching jq mode's pre-existing (non-merge) behavior.
+        // jq mode is unaffected by the merge-flag machinery above (it has
+        // no merge concept for a null operand at all) -- both directions
+        // error, matching real jq's own unconditional null-multiply error
+        // (#1175).
         query!(br#"{"a": null, "b": {"x": 1}}"#, ".a * .b",
-            QueryResult::Owned(OwnedValue::Null) => {}
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("cannot be multiplied"), "{}", e.message);
+            }
         );
         query!(br#"{"a": {"x": 1}}"#, ".a * null",
-            QueryResult::Owned(OwnedValue::Null) => {}
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("cannot be multiplied"), "{}", e.message);
+            }
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11738,20 +11738,35 @@ fn test_jq_compound_assign_plus_preserves_number_literal_on_null_1143() -> Resul
     Ok(())
 }
 
-/// Real jq 1.7.1 errors on every `null`-involving multiplication, both
-/// directions, with no exceptions (`NULL_MERGES_AS_EMPTY` is yq-only, so
-/// jq mode never takes any of `arith_mul`'s no-op/merge arms) -- #1175.
-/// Supersedes a prior version of this test that locked in succinctly's
-/// then-current (wrong) `null`-returning behavior for both directions.
+/// Real jq 1.7.1 errors on every `null`-involving multiplication, with no
+/// exceptions (`NULL_MERGES_AS_EMPTY` is yq-only, so jq mode never takes
+/// any of `arith_mul`'s no-op/merge arms) -- #1175. Supersedes a prior
+/// version of this test that locked in succinctly's then-current (wrong)
+/// `null`-returning behavior. Covers both operand orders, a number
+/// literal (`1e10`, to guard against a literal-spelling special case),
+/// scalars of every remaining type, `null * null`, and containers
+/// (`{}`/`[]`) on both sides -- the last two of which yq mode treats as a
+/// no-op/empty-container-merge instead (see the yq-side tests), so jq's
+/// unconditional error here is exactly what distinguishes the two modes.
 #[test]
-fn test_jq_null_times_number_literal_errors_both_ways_1175() -> Result<()> {
-    let (_, err, code) = run_jq_full(&["-cn", "1e10 * null"], None)?;
-    assert_eq!(code, 5);
-    assert!(err.contains("cannot be multiplied"), "{err}");
-
-    let (_, err, code) = run_jq_full(&["-cn", "null * 1e10"], None)?;
-    assert_eq!(code, 5);
-    assert!(err.contains("cannot be multiplied"), "{err}");
+fn test_jq_null_times_anything_errors_1175() -> Result<()> {
+    for expr in [
+        "1e10 * null",
+        "null * 1e10",
+        "5 * null",
+        "null * 5",
+        r#"null * "ab""#,
+        "null * true",
+        "null * null",
+        "null * {}",
+        "null * []",
+        "{} * null",
+        "[] * null",
+    ] {
+        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
+        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
+        assert!(err.contains("cannot be multiplied"), "expr {expr:?}: {err}");
+    }
     Ok(())
 }
 
@@ -11787,39 +11802,5 @@ fn test_jq_parenthesized_del_target_works_but_chained_slice_still_errors_1153() 
 
     let (_out, _, code) = run_jq_full(&["-c", "del((.a[0:1]))"], Some(r#"{"a":5,"b":6}"#))?;
     assert_eq!(code, 5);
-    Ok(())
-}
-
-// --- #1175: every `null`-involving `*` multiplication must error in jq
-// mode, with zero exceptions -- confirmed live against real jq 1.7.1 for
-// every pairing below, including the two (`null * {}`, `null * []`) that
-// yq mode treats as an empty-container merge but jq does not
-// (`NULL_MERGES_AS_EMPTY` is yq-only).
-
-#[test]
-fn test_jq_null_times_scalar_errors_1175() -> Result<()> {
-    for expr in ["5 * null", "null * 5", r#"null * "ab""#, "null * true"] {
-        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
-        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
-        assert!(err.contains("cannot be multiplied"), "expr {expr:?}: {err}");
-    }
-    Ok(())
-}
-
-#[test]
-fn test_jq_null_times_null_errors_1175() -> Result<()> {
-    let (_, err, code) = run_jq_full(&["-cn", "null * null"], None)?;
-    assert_eq!(code, 5);
-    assert!(err.contains("cannot be multiplied"), "{err}");
-    Ok(())
-}
-
-#[test]
-fn test_jq_null_times_container_errors_1175() -> Result<()> {
-    for expr in ["null * {}", "null * []", "{} * null", "[] * null"] {
-        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
-        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
-        assert!(err.contains("cannot be multiplied"), "expr {expr:?}: {err}");
-    }
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11738,29 +11738,20 @@ fn test_jq_compound_assign_plus_preserves_number_literal_on_null_1143() -> Resul
     Ok(())
 }
 
-/// #1167's `arith_mul` reordering (moving relocation arms before the
-/// numeric collapse) must not change jq mode's own `null * x` / `x * null`
-/// behavior -- `NULL_MERGES_AS_EMPTY` is yq-only, so both directions still
-/// fall through to the same unconditional "null * x = null" arm as before
-/// this PR, unaffected by the reordering.
-///
-/// This locks in succinctly's *current* behavior only, not oracle
-/// conformance: real jq 1.7.1 actually *errors* on every `null`-involving
-/// multiplication (`5 * null` -> `number (5) and null (null) cannot be
-/// multiplied`, confirmed live), which succinctly's own catch-all arm
-/// (`(OwnedValue::Null, _) | (_, OwnedValue::Null) => Ok(OwnedValue::Null)`,
-/// untouched by this PR) does not replicate. Pre-existing divergence, not
-/// introduced or worsened here (identical on `main` before this PR) --
-/// filed separately as #1175.
+/// Real jq 1.7.1 errors on every `null`-involving multiplication, both
+/// directions, with no exceptions (`NULL_MERGES_AS_EMPTY` is yq-only, so
+/// jq mode never takes any of `arith_mul`'s no-op/merge arms) -- #1175.
+/// Supersedes a prior version of this test that locked in succinctly's
+/// then-current (wrong) `null`-returning behavior for both directions.
 #[test]
-fn test_jq_null_times_number_literal_still_discards_both_ways_1167() -> Result<()> {
-    let (out, _, code) = run_jq_full(&["-cn", "1e10 * null"], None)?;
-    assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "null");
+fn test_jq_null_times_number_literal_errors_both_ways_1175() -> Result<()> {
+    let (_, err, code) = run_jq_full(&["-cn", "1e10 * null"], None)?;
+    assert_eq!(code, 5);
+    assert!(err.contains("cannot be multiplied"), "{err}");
 
-    let (out, _, code) = run_jq_full(&["-cn", "null * 1e10"], None)?;
-    assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "null");
+    let (_, err, code) = run_jq_full(&["-cn", "null * 1e10"], None)?;
+    assert_eq!(code, 5);
+    assert!(err.contains("cannot be multiplied"), "{err}");
     Ok(())
 }
 
@@ -11796,5 +11787,39 @@ fn test_jq_parenthesized_del_target_works_but_chained_slice_still_errors_1153() 
 
     let (_out, _, code) = run_jq_full(&["-c", "del((.a[0:1]))"], Some(r#"{"a":5,"b":6}"#))?;
     assert_eq!(code, 5);
+    Ok(())
+}
+
+// --- #1175: every `null`-involving `*` multiplication must error in jq
+// mode, with zero exceptions -- confirmed live against real jq 1.7.1 for
+// every pairing below, including the two (`null * {}`, `null * []`) that
+// yq mode treats as an empty-container merge but jq does not
+// (`NULL_MERGES_AS_EMPTY` is yq-only).
+
+#[test]
+fn test_jq_null_times_scalar_errors_1175() -> Result<()> {
+    for expr in ["5 * null", "null * 5", r#"null * "ab""#, "null * true"] {
+        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
+        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
+        assert!(err.contains("cannot be multiplied"), "expr {expr:?}: {err}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_jq_null_times_null_errors_1175() -> Result<()> {
+    let (_, err, code) = run_jq_full(&["-cn", "null * null"], None)?;
+    assert_eq!(code, 5);
+    assert!(err.contains("cannot be multiplied"), "{err}");
+    Ok(())
+}
+
+#[test]
+fn test_jq_null_times_container_errors_1175() -> Result<()> {
+    for expr in ["null * {}", "null * []", "{} * null", "[] * null"] {
+        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
+        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
+        assert!(err.contains("cannot be multiplied"), "expr {expr:?}: {err}");
+    }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13745,19 +13745,16 @@ fn test_1167_mul_null_noop_preserves_number_literal_spelling() -> Result<()> {
     Ok(())
 }
 
-/// Control: `null * x` (left operand `null`) discards the right operand
-/// entirely -- it must stay `null`, not "preserve" the right operand's
-/// spelling, since nothing is relocated here (unlike the `x *= null` arm
-/// above). Locks in succinctly's *current* behavior, not oracle
-/// conformance -- real yq v4.53.3 actually errors on `null * 1e10`
-/// ("cannot multiply !!null with !!float", confirmed live), a
-/// pre-existing divergence untouched by this PR (identical on `main`
-/// before it) and filed separately as #1175.
+/// Control: `null * x` (left operand `null`, non-container right operand)
+/// must error, matching real yq v4.53.3 ("cannot multiply !!null with
+/// !!float", confirmed live) -- #1175. Superseded a prior version of this
+/// test that locked in succinctly's then-current (wrong) `null`-returning
+/// behavior.
 #[test]
-fn test_1167_null_times_number_literal_stays_null() -> Result<()> {
-    let (output, code) = run_yq_stdin("null * 1e10", "null", &["-o=json", "-I=0"])?;
-    assert_eq!(code, 0);
-    assert_eq!(output.trim(), "null");
+fn test_1175_null_times_number_literal_errors() -> Result<()> {
+    let (_, err, code) = run_yq_stdin_with_stderr("null * 1e10", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 1);
+    assert!(err.contains("cannot be multiplied"), "{err}");
 
     Ok(())
 }
@@ -13802,6 +13799,58 @@ fn test_1167_object_array_merge_and_string_repeat_unchanged() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"{"a":1}"#);
 
+    Ok(())
+}
+
+// --- #1175: yq's asymmetric null-multiply rule -- `x * null` is a no-op,
+// `null * {}`/`null * []` merge as an empty container, `null * null` stays
+// `null`, and every other `null`-left/non-container-right pairing errors.
+// Verified live against real yq v4.53.3 for every case below.
+
+#[test]
+fn test_yq_right_null_is_always_a_noop_1175() -> Result<()> {
+    for (expr, expected) in [
+        ("5 * null", "5"),
+        (r#""a" * null"#, r#""a""#),
+        ("true * null", "true"),
+        ("{} * null", "{}"),
+        ("[] * null", "[]"),
+    ] {
+        let (output, code) = run_yq_stdin(expr, "null", &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "expr {expr:?}");
+        assert_eq!(output.trim(), expected, "expr {expr:?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_yq_left_null_container_still_merges_as_empty_1175() -> Result<()> {
+    let (output, code) = run_yq_stdin("null * {}", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "{}");
+
+    let (output, code) = run_yq_stdin("null * []", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[]");
+
+    Ok(())
+}
+
+#[test]
+fn test_yq_null_times_null_stays_null_1175() -> Result<()> {
+    let (output, code) = run_yq_stdin("null * null", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
+    Ok(())
+}
+
+#[test]
+fn test_yq_left_null_scalar_errors_1175() -> Result<()> {
+    for expr in ["null * 5", r#"null * "a""#, "null * true"] {
+        let (_, err, code) = run_yq_stdin_with_stderr(expr, "null", &["-o=json", "-I=0"])?;
+        assert_eq!(code, 1, "expr {expr:?}: {err}");
+        assert!(err.contains("cannot be multiplied"), "expr {expr:?}: {err}");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`arith_mul`'s unconditional catch-all `(Null, _) | (_, Null) => Ok(Null)`
silently returned `null` for every `null`-involving `*` pairing not
already handled by the merge/no-op arms above it. Real jq and real yq
both error on most of these — succinctly did not.

## Fix

Delete the catch-all arm. `OwnedValue::Null` matches none of the
patterns in the numeric/string match below it, so the remaining
null-involving pairings now fall through naturally to that match's
existing generic `Err(EvalError::binary_op(&a, &b, BinOp::Multiply))`
arm — the same error path every other type-mismatch multiply already
uses.

- **jq mode**: `NULL_MERGES_AS_EMPTY` is yq-only (`false` for jq), so jq
  never took any of the no-op/merge arms above the deleted catch-all —
  every null-involving pairing now errors, with zero exceptions, matching
  real jq 1.7.1 (verified live for every combination: scalar, bool,
  string, object, array, `null * null`, both operand orders).
- **yq mode**: the existing `x * null` no-op arm and
  `null * {}`/`null * []` empty-container-merge arms are untouched (they
  sit above the deleted arm and still match first). Only the remaining
  null-left/non-container-right pairings (`null * 5`, `null * "a"`,
  `null * true`) now error, matching real yq v4.53.3's asymmetric rule.
  `null * null` needed no special casing — it was already routed through
  the `(left, Null)` no-op arm (since `left` binds to `Null` there too),
  and live-verified against real yq: `null * null` stays a no-op
  (`null`, exit 0), not an error.

## Verification

Every case below was live-verified against the pinned oracles (jq 1.7.1,
yq v4.53.3) before and after the fix:

| Expression | jq (real) | yq (real) | succinctly before | succinctly after |
|---|---|---|---|---|
| `5 * null` | error | `5` | `null` (wrong) | error (jq) / `5` (yq, unaffected) |
| `null * 5` | error | error | `null` (wrong) | error |
| `null * null` | error | `null` | `null` (wrong for jq) | error (jq) / `null` (yq, unaffected) |
| `null * "ab"` | error | error | `null` (wrong) | error |
| `null * {}` | error | `{}` | `null` (wrong for jq) | error (jq) / `{}` (yq, unaffected) |
| `null * []` | error | `[]` | `null` (wrong for jq) | error (jq) / `[]` (yq, unaffected) |
| `{} * null` | error | `{}` | `null` (wrong for jq) | error (jq) / `{}` (yq, unaffected) |

Also updated two existing unit/integration tests that had explicitly
locked in the old (wrong) behavior as a documented, cited "known gap"
(`test_yq_merge_flags_null_or_absent_target`'s jq-mode control cases in
`src/jq/eval.rs`, and `test_1167_null_times_number_literal_stays_null` in
`tests/yq_cli_tests.rs`, and `test_jq_null_times_number_literal_still_discards_both_ways_1167`
in `tests/jq_cli_tests.rs` — all three cited #1175 directly).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] New/updated regression tests in `tests/jq_cli_tests.rs`, `tests/yq_cli_tests.rs`, and `src/jq/eval.rs`'s unit tests

Fixes #1175