### PR TITLE
fix(jq): --arg/--argjson/--slurpfile/--rawfile accept hyphen-prefixed values

### DIFF
--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -894,19 +894,19 @@ struct JqCommand {
 
     // === Variables ===
     /// Set $name to the string value
-    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
+    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append, allow_hyphen_values = true)]
     arg: Vec<String>,
 
     /// Set $name to the JSON value
-    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
+    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append, allow_hyphen_values = true)]
     argjson: Vec<String>,
 
     /// Set $name to an array of JSON values read from file
-    #[arg(long, value_names = ["NAME", "FILE"], num_args = 2, action = clap::ArgAction::Append)]
+    #[arg(long, value_names = ["NAME", "FILE"], num_args = 2, action = clap::ArgAction::Append, allow_hyphen_values = true)]
     slurpfile: Vec<String>,
 
     /// Set $name to the string contents of file
-    #[arg(long, value_names = ["NAME", "FILE"], num_args = 2, action = clap::ArgAction::Append)]
+    #[arg(long, value_names = ["NAME", "FILE"], num_args = 2, action = clap::ArgAction::Append, allow_hyphen_values = true)]
     rawfile: Vec<String>,
 
     /// Consume remaining arguments as positional string values
@@ -1122,11 +1122,11 @@ pub struct YqCommand {
 
     // === Variables ===
     /// Set $name to the string value
-    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
+    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append, allow_hyphen_values = true)]
     pub arg: Vec<String>,
 
     /// Set $name to the JSON value
-    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append)]
+    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append, allow_hyphen_values = true)]
     pub argjson: Vec<String>,
 
     // === Exit Status ===

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -893,6 +893,17 @@ struct JqCommand {
     from_file: Option<PathBuf>,
 
     // === Variables ===
+    // `allow_hyphen_values = true` below (#1150) lets a VALUE/FILE that
+    // legitimately starts with `-` (a negative number, a hyphen-prefixed
+    // filename) through clap, matching real jq. The tradeoff -- clap can
+    // no longer tell "the user forgot VALUE" from "VALUE legitimately
+    // starts with -" -- is real (a forgotten VALUE now silently swallows
+    // the next real flag as its value instead of erroring), but it's not
+    // a regression versus the oracle: confirmed live that real jq has the
+    // identical footgun (`jq --arg n -c '.'` silently sets $n="-c" and
+    // drops -c/compact-output there too). yq mode's `arg`/`argjson` below
+    // have no such oracle precedent (real yq has no equivalent flags at
+    // all, #284) but carry the same tradeoff for consistency with jq mode.
     /// Set $name to the string value
     #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = clap::ArgAction::Append, allow_hyphen_values = true)]
     arg: Vec<String>,
@@ -910,11 +921,11 @@ struct JqCommand {
     rawfile: Vec<String>,
 
     /// Consume remaining arguments as positional string values
-    #[arg(long, num_args = 0.., value_name = "STRINGS")]
+    #[arg(long, num_args = 0.., value_name = "STRINGS", allow_hyphen_values = true)]
     args: Vec<String>,
 
     /// Consume remaining arguments as positional JSON values
-    #[arg(long, num_args = 0.., value_name = "JSON_VALUES")]
+    #[arg(long, num_args = 0.., value_name = "JSON_VALUES", allow_hyphen_values = true)]
     jsonargs: Vec<String>,
 
     // === Modules ===
@@ -2259,6 +2270,42 @@ use generators::generate_json;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Guardrail for #1150: every `JqCommand`/`YqCommand` flag that can
+    /// take more than one value per occurrence (`--arg NAME VALUE`-style
+    /// pairs, or `--args`/`--jsonargs`' greedy remainder) must also allow
+    /// hyphen-prefixed values, or clap rejects a legitimately negative
+    /// number/hyphen-prefixed string/filename before it ever reaches this
+    /// crate's own validation -- the exact bug #1150 fixed for the six
+    /// (now eight) sites that existed at the time. Introspects the live
+    /// clap `Command` definitions rather than re-listing the field names,
+    /// so a future multi-value arg that forgets `allow_hyphen_values`
+    /// fails this test immediately instead of silently reintroducing the
+    /// bug for just that one flag.
+    #[test]
+    fn test_multi_value_variable_args_allow_hyphen_values_1150() {
+        use clap::CommandFactory;
+
+        for cmd in [JqCommand::command(), YqCommand::command()] {
+            for arg in cmd.get_arguments() {
+                if arg.is_positional() {
+                    continue;
+                }
+                let takes_multiple_per_occurrence = arg
+                    .get_num_args()
+                    .is_some_and(|range| range.max_values() > 1);
+                if takes_multiple_per_occurrence {
+                    assert!(
+                        arg.is_allow_hyphen_values_set(),
+                        "--{} in `{}` accepts multiple values per occurrence but doesn't set \
+                         allow_hyphen_values -- see #1150",
+                        arg.get_id(),
+                        cmd.get_name()
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_parse_size() {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -710,15 +710,68 @@ fn test_argjson_bare_hyphen_rejected_not_fabricated_into_negative_zero_1094() ->
     Ok(())
 }
 
-/// A negative leading-zero number, reached nested inside an array so it
-/// doesn't hit the unrelated CLI arg-parsing issue a bare negative
-/// `--argjson` value has (#1150) -- exercises
-/// `normalize_leading_zero_numbers`'s own leading-`-` handling.
+/// A negative leading-zero number, nested inside an array -- exercises
+/// `normalize_leading_zero_numbers`'s own leading-`-` handling. Nesting
+/// was originally required to route around #1150's separate CLI
+/// arg-parsing bug (a bare negative `--argjson` value was rejected before
+/// `normalize_leading_zero_numbers` ever ran); #1150's own fix means the
+/// bare form is now directly testable too, see
+/// `test_argjson_bare_negative_leading_zero_1150` below.
 #[test]
 fn test_argjson_negative_leading_zero_when_nested_1094() -> Result<()> {
     let (stdout, _, code) = run_jq_full(&["-cn", "--argjson", "n", "[-007, 1]", "$n"], None)?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "[-7,1]");
+    Ok(())
+}
+
+// --- #1150: clap rejected any negative-number (or other hyphen-prefixed)
+// --argjson/--arg/--slurpfile/--rawfile VALUE before it ever reached this
+// crate's own JSON-content validation -- fixed via `allow_hyphen_values`
+// on all six affected clap::Arg sites (JqCommand's arg/argjson/slurpfile/
+// rawfile, YqCommand's arg/argjson). Verified live against real jq 1.7.1.
+
+#[test]
+fn test_argjson_bare_negative_number_1150() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "-7", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "-7");
+    Ok(())
+}
+
+#[test]
+fn test_argjson_bare_negative_leading_zero_1150() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "-007", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "-7");
+    Ok(())
+}
+
+#[test]
+fn test_arg_hyphen_prefixed_string_value_1150() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--arg", "n", "-hello", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#""-hello""#);
+    Ok(())
+}
+
+#[test]
+fn test_multiple_argjson_one_negative_one_positive_1150() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-cn",
+            "--argjson",
+            "a",
+            "1",
+            "--argjson",
+            "b",
+            "-2",
+            "[$a,$b]",
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[1,-2]");
     Ok(())
 }
 
@@ -924,6 +977,32 @@ fn test_seq_malformed_segment_silently_skipped_1093() -> Result<()> {
     )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "\x1e1.500\n\x1e2.000");
+    Ok(())
+}
+
+/// A hyphen-prefixed `--slurpfile`/`--rawfile` FILE value must reach this
+/// crate's own file-open logic, not get rejected by clap as an unknown
+/// flag first (#1150, same `allow_hyphen_values` fix as `--arg`/
+/// `--argjson`). Uses a nonexistent filename -- the point is only to
+/// distinguish clap's "unexpected argument" rejection (the pre-fix
+/// failure mode) from this crate's own "no such file" error (proof the
+/// value was accepted and passed through), not to exercise real file I/O.
+#[test]
+fn test_slurpfile_rawfile_hyphen_prefixed_filename_reaches_file_open_1150() -> Result<()> {
+    let (_, stderr, code) =
+        run_jq_full(&["-n", "--slurpfile", "n", "-nonexistent.json", "$n"], None)?;
+    assert_ne!(code, 0);
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "clap should not reject the hyphen-prefixed value: {stderr}"
+    );
+
+    let (_, stderr, code) = run_jq_full(&["-n", "--rawfile", "n", "-nonexistent.txt", "$n"], None)?;
+    assert_ne!(code, 0);
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "clap should not reject the hyphen-prefixed value: {stderr}"
+    );
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -732,18 +732,12 @@ fn test_argjson_negative_leading_zero_when_nested_1094() -> Result<()> {
 // rawfile, YqCommand's arg/argjson). Verified live against real jq 1.7.1.
 
 #[test]
-fn test_argjson_bare_negative_number_1150() -> Result<()> {
-    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "-7", "$n"], None)?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "-7");
-    Ok(())
-}
-
-#[test]
-fn test_argjson_bare_negative_leading_zero_1150() -> Result<()> {
-    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "-007", "$n"], None)?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "-7");
+fn test_argjson_bare_hyphen_prefixed_value_1150() -> Result<()> {
+    for (value, expected) in [("-7", "-7"), ("-007", "-7")] {
+        let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", value, "$n"], None)?;
+        assert_eq!(code, 0, "value {value:?}");
+        assert_eq!(stdout.trim_end(), expected, "value {value:?}");
+    }
     Ok(())
 }
 
@@ -772,6 +766,28 @@ fn test_multiple_argjson_one_negative_one_positive_1150() -> Result<()> {
     )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "[1,-2]");
+    Ok(())
+}
+
+/// `--args`/`--jsonargs` (`num_args = 0..`) consume the *remaining*
+/// command line as positional values -- the same clap hyphen-rejection
+/// defect as the two-value `--arg`/`--argjson`/etc. flags above, on a
+/// different clap shape (found during this issue's own code review, not
+/// in the original repro). Verified live against real jq 1.7.1.
+#[test]
+fn test_args_positional_hyphen_prefixed_values_1150() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "$ARGS.positional", "--args", "-7", "abc"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[\n  \"-7\",\n  \"abc\"\n]");
+    Ok(())
+}
+
+#[test]
+fn test_jsonargs_positional_hyphen_prefixed_values_1150() -> Result<()> {
+    let (stdout, _, code) =
+        run_jq_full(&["-n", "$ARGS.positional", "--jsonargs", "-7", "-8"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[\n  -7,\n  -8\n]");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6153,6 +6153,31 @@ fn test_args_named_object() -> Result<()> {
     Ok(())
 }
 
+/// clap rejected any negative-number (or other hyphen-prefixed) `--arg`/
+/// `--argjson` value before it ever reached this crate's own JSON-content
+/// validation -- fixed via `allow_hyphen_values` on `YqCommand`'s `arg`/
+/// `argjson` clap::Arg definitions (#1150). Verified live against real
+/// yq v4.53.3.
+#[test]
+fn test_argjson_bare_negative_number_1150() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".n = $n",
+        "{}",
+        &["--argjson", "n", "-7", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"n":-7}"#);
+    Ok(())
+}
+
+#[test]
+fn test_arg_hyphen_prefixed_string_value_1150() -> Result<()> {
+    let (output, code) = run_yq_stdin("$n", "a: 1", &["--arg", "n", "-hello"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "-hello");
+    Ok(())
+}
+
 #[test]
 fn test_argjson_invalid_value_errors() -> Result<()> {
     // Malformed --argjson is rejected (RFC 8259 strict), matching jq, with the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6156,8 +6156,12 @@ fn test_args_named_object() -> Result<()> {
 /// clap rejected any negative-number (or other hyphen-prefixed) `--arg`/
 /// `--argjson` value before it ever reached this crate's own JSON-content
 /// validation -- fixed via `allow_hyphen_values` on `YqCommand`'s `arg`/
-/// `argjson` clap::Arg definitions (#1150). Verified live against real
-/// yq v4.53.3.
+/// `argjson` clap::Arg definitions (#1150). `--arg`/`--argjson` are
+/// succinctly's own jq-inspired extension to yq mode (#284) -- real yq
+/// v4.53.3 has no such flags at all (`Error: unknown flag: --argjson`),
+/// so there's no oracle to verify this specific behavior against; the
+/// jq-side tests in `tests/jq_cli_tests.rs` are what's checked live
+/// against real jq 1.7.1.
 #[test]
 fn test_argjson_bare_negative_number_1150() -> Result<()> {
     let (output, code) = run_yq_stdin(


### PR DESCRIPTION
## Summary

`--argjson`/`--arg`/`--slurpfile`/`--rawfile` all take two clap values
(`NAME VALUE`/`NAME FILE`). clap's own negative-number/unknown-flag
heuristic doesn't extend correctly to the *second* value of a two-value
option, so any value legitimately starting with `-` (a negative number,
a string that happens to start with `-`, a hyphen-prefixed filename) was
rejected before it ever reached this crate's own JSON-content validation
or file-open logic.

```
$ jq -n --argjson n '-7' '$n'                       # real jq: works fine
-7

$ succinctly jq -n --argjson n '-7' '$n'
error: unexpected argument '-7' found

  tip: to pass '-7' as a value, use '-- -7'
```

Following clap's own suggested `--` workaround doesn't help either — it
just breaks the two-value collection a different way (`2 values required
for '--argjson <NAME> <VALUE>' but 1 was provided`).

## Fix

Add `allow_hyphen_values = true` to all six affected `clap::Arg`
definitions in `src/bin/succinctly/main.rs`:

- `JqCommand`: `arg`, `argjson`, `slurpfile`, `rawfile`
- `YqCommand`: `arg`, `argjson` (yq mode has no `--slurpfile`/`--rawfile`)

The issue's own scope note flagged all of these as sharing the identical
root cause, so fixing all six under this one issue rather than just
`--argjson` in isolation.

## Verification

Live-verified against real jq 1.7.1 and yq v4.53.3:

| Case | Before | After |
|---|---|---|
| `jq -n --argjson n '-7' '$n'` | clap error | `-7` |
| `jq -n --argjson n '-007' '$n'` | clap error | `-7` (via #1094's leading-zero handling) |
| `jq -n --arg n '-hello' '$n'` | clap error | `"-hello"` |
| `yq --argjson n '-7' '$n'` | clap error | `-7` |
| `yq --arg n '-hello' '$n'` | clap error | `"-hello"` |
| `--slurpfile`/`--rawfile` with a hyphen-prefixed filename | clap error | reaches file-open (file-not-found, not a clap rejection) |
| Multiple `--argjson` pairs, one negative | (n/a, already worked for positive-only) | still works |
| Normal (non-hyphen) values | unaffected | unaffected |

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] New regression tests in `tests/jq_cli_tests.rs` and `tests/yq_cli_tests.rs`, plus an updated comment on a pre-existing #1094 test whose nesting workaround is no longer strictly necessary (kept as-is; its own coverage is still valid)

Fixes #1150