### PR TITLE
feat(jq): parse object destructuring pattern shorthand {$a}

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1644,19 +1644,32 @@ impl<'a> Parser<'a> {
 
                 loop {
                     self.skip_ws();
-                    // Parse key (must be identifier or string)
-                    let key = if self.peek() == Some('"') {
-                        self.parse_string_literal()?
+                    // `{$a}` shorthand: real jq desugars a bare `$var` entry
+                    // to `a: $var` -- the variable's own name doubles as
+                    // both the key to match and the binding pattern, with
+                    // no `:` at all. Checked before the identifier/string-
+                    // key branch below since `$` can't start either of
+                    // those.
+                    let (key, pattern) = if self.peek() == Some('$') {
+                        self.next();
+                        let name = self.parse_ident()?;
+                        (name.clone(), Pattern::Var(name))
                     } else {
-                        self.parse_ident()?
+                        // Parse key (must be identifier or string)
+                        let key = if self.peek() == Some('"') {
+                            self.parse_string_literal()?
+                        } else {
+                            self.parse_ident()?
+                        };
+
+                        self.skip_ws();
+                        self.expect(':')?;
+                        self.skip_ws();
+
+                        // Parse the pattern for this key
+                        let pattern = self.parse_pattern()?;
+                        (key, pattern)
                     };
-
-                    self.skip_ws();
-                    self.expect(':')?;
-                    self.skip_ws();
-
-                    // Parse the pattern for this key
-                    let pattern = self.parse_pattern()?;
                     entries.push(PatternEntry { key, pattern });
 
                     self.skip_ws();

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10260,6 +10260,22 @@ fn test_object_pattern_var_shorthand_nested_1139() -> Result<()> {
     Ok(())
 }
 
+/// The shorthand works as either side of a `?//` alternative (#720):
+/// falls through to a shorthand-using second alternative when the first
+/// genuinely fails (an array pattern against a non-array input), and is
+/// also reachable directly when the first alternative succeeds.
+#[test]
+fn test_object_pattern_var_shorthand_with_alt_patterns_720_1139() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ". as [$x] ?// {$a} | $a"], Some(r#"{"a":9}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "9");
+
+    let (stdout, _, code) = run_jq_full(&["-c", ". as [$x] ?// {$a} | $x"], Some("[9]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "9");
+    Ok(())
+}
+
 #[test]
 fn test_func_def_expand_recurses_through_halt_stderr_and_halt_error_builtins() -> Result<()> {
     // `expand_func_calls_in_builtin`'s `Halt`/`Stderr`/`HaltError`/

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10199,6 +10199,67 @@ fn test_as_pattern_alt_func_call_inside_body_expanded_720() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// #1139: object destructuring pattern shorthand `{$a}` (implicit key from
+// var name). Real jq desugars a bare `$var` entry inside an object pattern
+// to `key: $var`, where `key` is the variable's own name -- e.g. `{$a}` is
+// sugar for `{a: $a}`. All cases live-verified against jq 1.7.1.
+// =============================================================================
+
+#[test]
+fn test_object_pattern_var_shorthand_bare_1139() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ". as {$a} | $a"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// Mixed with an ordinary explicit `key: $var` entry in the same pattern.
+#[test]
+fn test_object_pattern_var_shorthand_mixed_with_explicit_1139() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ". as {$a, b: $c} | [$a,$c]"],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[1,2]");
+    Ok(())
+}
+
+/// Two shorthand entries in the same pattern.
+#[test]
+fn test_object_pattern_var_shorthand_multiple_1139() -> Result<()> {
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ". as {$a, $b} | [$a,$b]"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[1,2]");
+    Ok(())
+}
+
+/// A missing field binds `null`, same as an explicit `key: $var` would.
+#[test]
+fn test_object_pattern_var_shorthand_missing_key_is_null_1139() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ". as {$a} | $a"], Some(r#"{"b":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "null");
+    Ok(())
+}
+
+/// Nested inside an array pattern, and nested inside another object
+/// pattern -- confirms the shorthand works at any recursion depth for
+/// free, since it's handled by the same recursive `parse_pattern` call.
+#[test]
+fn test_object_pattern_var_shorthand_nested_1139() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ". as [{$a}] | $a"], Some(r#"[{"a":1}]"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+
+    let (stdout, _, code) = run_jq_full(&["-c", ". as {a: {$b}} | $b"], Some(r#"{"a":{"b":2}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
 #[test]
 fn test_func_def_expand_recurses_through_halt_stderr_and_halt_error_builtins() -> Result<()> {
     // `expand_func_calls_in_builtin`'s `Halt`/`Stderr`/`HaltError`/

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10214,6 +10214,18 @@ fn test_object_pattern_var_shorthand_bare_1139() -> Result<()> {
     Ok(())
 }
 
+/// A quoted string key (needed for a key that isn't a valid bare
+/// identifier, e.g. one containing a space) still works in the non-
+/// shorthand branch, unaffected by threading it through the new
+/// `(key, pattern)`-tuple restructuring.
+#[test]
+fn test_object_pattern_string_literal_key_unaffected_1139() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", r#". as {"a b": $x} | $x"#], Some(r#"{"a b":5}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "5");
+    Ok(())
+}
+
 /// Mixed with an ordinary explicit `key: $var` entry in the same pattern.
 #[test]
 fn test_object_pattern_var_shorthand_mixed_with_explicit_1139() -> Result<()> {


### PR DESCRIPTION
## Summary
- Fixes #1139: real jq desugars a bare `$var` entry inside an object destructuring pattern to `key: $var` (the variable's own name doubles as the key) — `. as {$a} | $a` is sugar for `. as {a: $a} | $a`. `parse_pattern`'s object-pattern loop always required a `key: pattern` shape, so this errored in both jq and yq mode.
- Fix: check for a leading `$` before the identifier/string-key branch, and restructured both branches to converge on shared separator-matching code instead of duplicating the `,`/`}` handling.
- Because `parse_pattern` recurses for nested entries, the shorthand works at any depth (array patterns, nested object patterns, mixed with explicit entries) with no extra plumbing.
- Filed #1201 for a related but unaffected pre-existing gap found while testing: `reduce`/`foreach`'s own `as` clause only accepts a bare `$var`, never a full pattern at all — reproduces identically with or without this fix.

## Test plan
- [x] `cargo build --features cli`
- [x] Live-verified against jq 1.7.1: bare shorthand, mixed with explicit entries, multiple shorthand entries, missing-key-binds-null, nested inside array/object patterns
- [x] New tests in `tests/jq_cli_tests.rs` (`_1139` suffix, 5 tests) — all pass
- [x] Full `cargo test --features cli,simd,regex,serde` (no-fail-fast) — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's scalar-yaml-avoiding leg) — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --no-default-features` — clean (pre-existing unrelated warnings only)