### PR TITLE
fix(jq): route subnormal underflow literals through the string-based mantissa path

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -239,26 +239,35 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
 
     // For other cases, use normalized scientific notation
     // jq normalizes mantissa to have one digit before decimal point
-    if value == 0.0 || value.abs() < f64::MIN_POSITIVE {
-        // `value == 0.0` is true both for a genuinely-zero-mantissa literal
-        // (`0e-400`) and for a *nonzero*-mantissa literal whose magnitude
-        // simply underflowed `f64` during parsing (`1e-400`, far below
-        // `f64::MIN_POSITIVE`) -- the two can't be told apart from `value`
-        // alone (#1099). `format_underflow_literal_mantissa` (and the
-        // shared `normalize_extreme_literal_mantissa` beneath it) tells
-        // them apart from the literal's own source digits.
-        //
-        // `value.abs() < f64::MIN_POSITIVE` (nonzero but *subnormal*, #1177):
-        // the finite `log10`/`pow` renormalization below breaks down at the
-        // extreme low end of the subnormal range -- `libm::pow(10.0,
-        // log10(abs_value).floor())` can itself underflow to exactly `0.0`
-        // (its own result is smaller than the smallest representable
-        // subnormal), making `abs_value / 0.0 = +inf` and rendering the
-        // mantissa as the literal text `"inf"`, which isn't valid JSON.
-        // Routing every subnormal through the same string-based path as
-        // exact-zero underflow sidesteps this entirely: that path derives
-        // the mantissa from `s`'s own source digits, never from `f64`
-        // arithmetic that's already lost precision by this magnitude.
+    //
+    // `!value.is_normal()` -- `value` is already known finite (the
+    // `!value.is_finite()` overflow check above returned first), so this
+    // is exactly "zero or subnormal," covering two distinct situations
+    // that both need the string-based path below instead of the
+    // `log10`/`pow` renormalization that follows it:
+    //
+    // - `value == 0.0`: true both for a genuinely-zero-mantissa literal
+    //   (`0e-400`) and for a *nonzero*-mantissa literal whose magnitude
+    //   simply underflowed `f64` during parsing (`1e-400`, far below
+    //   `f64::MIN_POSITIVE`) -- the two can't be told apart from `value`
+    //   alone (#1099). `format_underflow_literal_mantissa` (and the shared
+    //   `normalize_extreme_literal_mantissa` beneath it) tells them apart
+    //   from the literal's own source digits.
+    // - nonzero but *subnormal* (#1177): the `log10`/`pow` renormalization
+    //   below is already measurably imprecise across most of the subnormal
+    //   range (e.g. `1e-315` mis-renormalizes to a mantissa of
+    //   `10.000000148219696` instead of `1.0`, oracle-verified), and at
+    //   the extreme low end `libm::pow(10.0, log10(abs_value).floor())`
+    //   can itself underflow to exactly `0.0` (its own result is smaller
+    //   than the smallest representable subnormal), making
+    //   `abs_value / 0.0 = +inf` and rendering the mantissa as the literal
+    //   text `"inf"`, which isn't valid JSON at all.
+    //
+    // Routing every subnormal through the same string-based path as
+    // exact-zero underflow sidesteps both: that path derives the mantissa
+    // from `s`'s own source digits, never from `f64` arithmetic that's
+    // already lost precision by this magnitude.
+    if !value.is_normal() {
         return format_underflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
     }
 
@@ -437,9 +446,15 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
 /// A literal whose magnitude underflows `f64` to exactly `0.0` (nonzero
 /// mantissa, deeply negative exponent) can't be told apart from a
 /// genuinely-zero-mantissa literal by looking at the parsed value alone --
-/// both are `0.0`. The caller (`format_number_jq_compat`'s `value == 0.0`
-/// branch) already checked the mantissa's own source digits before calling
-/// this, so `s`'s mantissa is guaranteed nonzero here.
+/// both are `0.0`. Unlike an earlier version of this function, the caller
+/// does *not* pre-check the mantissa's own source digits before calling
+/// this -- `normalize_extreme_literal_mantissa` (below) makes that
+/// determination itself and returns `None` for a genuinely all-zero
+/// mantissa, handled explicitly in the `match` below. The single call site
+/// in `format_number_jq_compat` reaches here for both `value == 0.0` (#1099)
+/// and nonzero-but-subnormal `value` (#1177) -- in the subnormal case the
+/// mantissa is always nonzero in practice (a subnormal `f64` can't come
+/// from an all-zero-mantissa literal), but nothing here depends on that.
 ///
 /// Oracle-verified against real jq: `1e-400` -> `1E-400`, `12.34e-400` ->
 /// `1.234E-399`, `0.5e-400` -> `5E-401`, `100.5e-400` -> `1.005E-398`.
@@ -2467,13 +2482,18 @@ mod tests {
     }
 
     /// #1177 review self-check: a normal (non-subnormal) tiny value right
-    /// at and just above the `f64::MIN_POSITIVE` boundary must still take
-    /// the finite `log10`/`pow` path unchanged -- the new subnormal check
-    /// uses `<`, not `<=`, so it doesn't over-broaden into values the
-    /// existing path already handles correctly.
+    /// at and just above the `f64::MIN_POSITIVE` boundary (2.2250738585072014e-308)
+    /// must still take the finite `log10`/`pow` path unchanged -- the new
+    /// subnormal check uses `<`, not `<=`, so it doesn't over-broaden into
+    /// values the existing path already handles correctly. All three
+    /// literals here are individually confirmed `f64::is_normal() == true`
+    /// (an earlier draft of this test used `1.5e-308`, which is actually
+    /// *subnormal* -- `1.5 < 2.2250738585072014` -- and so silently tested
+    /// the new code path instead of the old one it claimed to guard,
+    /// caught in code review).
     #[test]
     fn test_format_number_jq_compat_normal_boundary_near_min_positive_unaffected_1177() {
-        assert_eq!(format_number_jq_compat(b"1.5e-308"), "1.5E-308");
+        assert_eq!(format_number_jq_compat(b"2.3e-308"), "2.3E-308");
         assert_eq!(format_number_jq_compat(b"3e-308"), "3E-308");
         assert_eq!(format_number_jq_compat(b"1e-300"), "1E-300");
     }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -239,7 +239,7 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
 
     // For other cases, use normalized scientific notation
     // jq normalizes mantissa to have one digit before decimal point
-    if value == 0.0 {
+    if value == 0.0 || value.abs() < f64::MIN_POSITIVE {
         // `value == 0.0` is true both for a genuinely-zero-mantissa literal
         // (`0e-400`) and for a *nonzero*-mantissa literal whose magnitude
         // simply underflowed `f64` during parsing (`1e-400`, far below
@@ -247,6 +247,18 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
         // alone (#1099). `format_underflow_literal_mantissa` (and the
         // shared `normalize_extreme_literal_mantissa` beneath it) tells
         // them apart from the literal's own source digits.
+        //
+        // `value.abs() < f64::MIN_POSITIVE` (nonzero but *subnormal*, #1177):
+        // the finite `log10`/`pow` renormalization below breaks down at the
+        // extreme low end of the subnormal range -- `libm::pow(10.0,
+        // log10(abs_value).floor())` can itself underflow to exactly `0.0`
+        // (its own result is smaller than the smallest representable
+        // subnormal), making `abs_value / 0.0 = +inf` and rendering the
+        // mantissa as the literal text `"inf"`, which isn't valid JSON.
+        // Routing every subnormal through the same string-based path as
+        // exact-zero underflow sidesteps this entirely: that path derives
+        // the mantissa from `s`'s own source digits, never from `f64`
+        // arithmetic that's already lost precision by this magnitude.
         return format_underflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
     }
 
@@ -2434,6 +2446,36 @@ mod tests {
             format_number_jq_compat(b"1e-99999999999999999999"),
             "1E-9223372036854775808"
         );
+    }
+
+    /// #1177: a literal that parses to a nonzero but *subnormal* `f64`
+    /// (below `f64::MIN_POSITIVE`, but still representable) used to render
+    /// its mantissa as the literal text `"inf"` -- not valid JSON.
+    /// `libm::pow(10.0, log10(abs_value).floor())` itself underflows to
+    /// `0.0` at the extreme low end of the subnormal range, making
+    /// `abs_value / 0.0 = +inf`. Verified live against jq 1.7.1.
+    #[test]
+    fn test_format_number_jq_compat_subnormal_preserves_mantissa_1177() {
+        assert_eq!(format_number_jq_compat(b"5e-324"), "5E-324");
+        assert_eq!(format_number_jq_compat(b"-5e-324"), "-5E-324");
+        assert_eq!(format_number_jq_compat(b"1e-323"), "1E-323");
+        assert_eq!(format_number_jq_compat(b"4.9e-324"), "4.9E-324");
+        assert_eq!(format_number_jq_compat(b"9.9e-324"), "9.9E-324");
+        assert_eq!(format_number_jq_compat(b"2.5e-320"), "2.5E-320");
+        assert_eq!(format_number_jq_compat(b"1e-315"), "1E-315");
+        assert_eq!(format_number_jq_compat(b"1e-310"), "1E-310");
+    }
+
+    /// #1177 review self-check: a normal (non-subnormal) tiny value right
+    /// at and just above the `f64::MIN_POSITIVE` boundary must still take
+    /// the finite `log10`/`pow` path unchanged -- the new subnormal check
+    /// uses `<`, not `<=`, so it doesn't over-broaden into values the
+    /// existing path already handles correctly.
+    #[test]
+    fn test_format_number_jq_compat_normal_boundary_near_min_positive_unaffected_1177() {
+        assert_eq!(format_number_jq_compat(b"1.5e-308"), "1.5E-308");
+        assert_eq!(format_number_jq_compat(b"3e-308"), "3E-308");
+        assert_eq!(format_number_jq_compat(b"1e-300"), "1E-300");
     }
 
     /// #930 review: an overflowed literal's mantissa can be arbitrarily long

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4565,6 +4565,12 @@ fn test_number_literal_underflow_beyond_i32_exponent_range_1099() -> Result<()> 
 /// `libm::pow(10.0, log10(abs_value).floor())` itself underflows to `0.0`
 /// at the extreme low end of the subnormal range, making
 /// `abs_value / 0.0 = +inf`. Verified live against jq 1.7.1.
+///
+/// CLI-level counterpart to `value.rs`'s
+/// `test_format_number_jq_compat_subnormal_preserves_mantissa_1177` (same
+/// #1099-established pattern: `run_jq_stdin` spawns a subprocess, invisible
+/// to `cargo llvm-cov`, so both an in-process and a CLI-level test exist
+/// for the same fix rather than one being redundant with the other).
 #[test]
 fn test_number_literal_subnormal_preserves_mantissa_1177() -> Result<()> {
     let (output, code) = run_jq_stdin(".", "5e-324", &["-c"])?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4559,6 +4559,33 @@ fn test_number_literal_underflow_beyond_i32_exponent_range_1099() -> Result<()> 
     Ok(())
 }
 
+/// #1177: a literal that parses to a nonzero but *subnormal* `f64` (below
+/// `f64::MIN_POSITIVE`, but still representable) used to render its
+/// mantissa as the literal text `"inf"` -- not valid JSON.
+/// `libm::pow(10.0, log10(abs_value).floor())` itself underflows to `0.0`
+/// at the extreme low end of the subnormal range, making
+/// `abs_value / 0.0 = +inf`. Verified live against jq 1.7.1.
+#[test]
+fn test_number_literal_subnormal_preserves_mantissa_1177() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "5e-324", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "5E-324");
+
+    let (output, code) = run_jq_stdin(".", "-5e-324", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "-5E-324");
+
+    let (output, code) = run_jq_stdin(".", "4.9e-324", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "4.9E-324");
+
+    let (output, code) = run_jq_stdin(".", "1e-315", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1E-315");
+
+    Ok(())
+}
+
 /// `eval_owned_expr`/`eval_owned_input` (backing `reduce`/`foreach`/`as $x`
 /// variable binding) and `with_entries`'s `owned_to_json_bytes` each have
 /// their own serialize-and-reparse bridge, separate from `eval_generic`'s


### PR DESCRIPTION
## Summary

`format_number_jq_compat`'s finite scientific-notation path computed the normalized mantissa via `libm::pow(10.0, log10(abs_value).floor())`. For a literal that parses to a nonzero but **subnormal** `f64` (below `f64::MIN_POSITIVE`, at the extreme low end of the representable range), that `pow()` call itself underflows to `0.0`, making `abs_value / 0.0 = +inf` and rendering the mantissa as the literal text `"inf"` — which isn't valid JSON.

## Repro

```console
$ echo '5e-324' | succinctly jq -c .
infE-324
$ echo '5e-324' | jq -c .
5E-324
```

## Design

#1099 already added a check that routes `value == 0.0` through the exact, string-based `normalize_extreme_literal_mantissa` path (derives the mantissa from the literal's own source digits) rather than trusting `f64` arithmetic that's already lost precision at that magnitude. That same reasoning applies identically to subnormals — the `log10`/`pow` path is measurably imprecise across most of the subnormal range (not just the literal divide-by-zero cliff at the very bottom), so the fix collapses both cases into a single `!value.is_normal()` check (value is already known finite by an earlier early-return, so this is exactly "zero or subnormal").

## Code review

Review (10 parallel finder agents, several with live oracle verification against built binaries) found and fixed:
- The PR's own new "normal boundary" regression test used `1.5e-308`, which is itself subnormal — the assertion passed only because both code paths happened to agree on that value, not because it tested what it claimed to. Replaced with `2.3e-308`, individually confirmed normal.
- `value == 0.0 || value.abs() < f64::MIN_POSITIVE` reimplements `!value.is_normal()` by hand, with the first disjunct fully redundant — collapsed to the named predicate.
- Two stale/inaccurate doc comments (one predating this PR, one newly added) corrected.

Also surfaced, and filed separately as **#1206** (confirmed pre-existing, unrelated to this PR's own diff): the untouched `log10`/`pow` renormalization has further precision bugs across its *normal*-magnitude domain — trailing zeros silently trimmed, the `[1,10)` mantissa invariant violated near power-of-ten boundaries (producing a numerically wrong mantissa+exponent pair while still emitting valid JSON), and `format_decimal_jq`'s `-5..0` branch has the identical magnitude-vs-written-exponent bug #1099/#1177 fixed elsewhere. Not in scope for this PR.

Fixes #1177

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Local patch coverage: 100% (16/16 new lines)
- [x] New tests: in-process, CLI-level, and a corrected boundary regression guard confirming genuinely-normal near-`MIN_POSITIVE` values are unaffected
- [x] Live-verified against jq 1.7.1: `5e-324`, `-5e-324`, `1e-323`, `4.9e-324`, `9.9e-324`, `2.5e-320`, `1e-315`, `1e-310`, `2.3e-308`, `3e-308`, `1e-300` all match exactly