### PR TITLE
fix(jq): shift a zero-mantissa literal's exponent by its fraction length

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -307,6 +307,19 @@ fn parse_literal_exponent(exp_text: &str) -> i64 {
     })
 }
 
+/// Split a literal's mantissa text (`s[..exp_pos]`, sign stripped) into its
+/// integer and fractional parts -- shared by
+/// [`normalize_extreme_literal_mantissa`] and
+/// [`format_underflow_literal_mantissa`]'s own genuinely-all-zero-mantissa
+/// fallback (#1178), so "how do we split the mantissa out of `s`" has
+/// exactly one implementation instead of two hand-copied ones that must be
+/// kept in sync by convention (#106) -- the same duplicated-predicate shape
+/// this codebase has already been bitten by once.
+fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
+    let mantissa = s[..exp_pos].strip_prefix('-').unwrap_or(&s[..exp_pos]);
+    mantissa.split_once('.').unwrap_or((mantissa, ""))
+}
+
 /// Shift a literal's own mantissa digits (the text before `exp_pos`, i.e.
 /// before `e`/`E`) into jq's one-digit-before-the-point normalized form,
 /// and fold that shift into the literal's own written exponent -- returns
@@ -339,8 +352,7 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Option<(String
     // actually get rendered.
     const MAX_RENDERED_MANTISSA_DIGITS: usize = 32;
 
-    let mantissa = s[..exp_pos].strip_prefix('-').unwrap_or(&s[..exp_pos]);
-    let (int_part, frac_part) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    let (int_part, frac_part) = split_mantissa(s, exp_pos);
 
     // A leading-dot literal (`.5e400`) has an empty `int_part`, not `"0"` --
     // treat both the same way (mantissa magnitude < 1).
@@ -455,10 +467,14 @@ fn format_underflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) ->
         // jq keeps both the sign and this shifted exponent for a zero
         // mantissa, since log10(0) is undefined (`-0e5` -> `-0E+5`).
         None => {
-            let mantissa = s[..exp_pos].strip_prefix('-').unwrap_or(&s[..exp_pos]);
-            let frac_len = mantissa.split_once('.').map_or(0, |(_, frac)| frac.len());
-            let shifted_exp =
-                parse_literal_exponent(&s[exp_pos + 1..]).saturating_sub(frac_len as i64);
+            let (_, frac_part) = split_mantissa(s, exp_pos);
+            // `try_from`, not a bare `as` cast: `frac_part.len()` is
+            // document-controlled and unbounded, same as the exponent digit
+            // string `parse_literal_exponent` already saturates rather than
+            // wraps for a couple lines up -- matching that same discipline
+            // here instead of silently flipping sign past `i64::MAX` bytes.
+            let frac_len = i64::try_from(frac_part.len()).unwrap_or(i64::MAX);
+            let shifted_exp = parse_literal_exponent(&s[exp_pos + 1..]).saturating_sub(frac_len);
             assemble_scientific(sign, "0", shifted_exp)
         }
     }
@@ -2405,6 +2421,26 @@ mod tests {
         assert_eq!(format_number_jq_compat(b"12.34e-400"), "1.234E-399");
         assert_eq!(format_number_jq_compat(b"0.5e-400"), "5E-401");
         assert_eq!(format_number_jq_compat(b"100.5e-400"), "1.005E-398");
+    }
+
+    /// #1178: a genuinely-all-zero mantissa still shifts its printed
+    /// exponent by the fractional-zero-digit count, the same normalization
+    /// #1099's nonzero-mantissa case above already gets -- #1099's own
+    /// `test_format_number_jq_compat_underflow_beyond_i32_exponent_range_1099`
+    /// zero-mantissa case (`0e-2147483649`) only covers a no-fraction
+    /// spelling (shift 0), which is why this gap wasn't caught there.
+    /// In-process counterpart to `jq_cli_tests.rs`'s CLI-level `_1178`
+    /// tests, for the same `cargo llvm-cov` visibility reason as #1099's
+    /// own in-process test above.
+    #[test]
+    fn test_format_number_jq_compat_zero_mantissa_shifts_by_fraction_length_1178() {
+        assert_eq!(format_number_jq_compat(b"0.000e-400"), "0E-403");
+        assert_eq!(format_number_jq_compat(b"0.0e400"), "0E+399");
+        assert_eq!(format_number_jq_compat(b"0.00e-400"), "0E-402");
+        assert_eq!(format_number_jq_compat(b"-0.00e-400"), "-0E-402");
+        // No-fraction spelling still has shift 0 -- unaffected regression
+        // guard alongside #1099's existing one.
+        assert_eq!(format_number_jq_compat(b"0e-400"), "0E-400");
     }
 
     /// #1099 code review: the exponent digit string was parsed at `i32`

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -445,12 +445,22 @@ fn format_underflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) ->
     let sign = if negative { "-" } else { "" };
     match normalize_extreme_literal_mantissa(s, exp_pos) {
         Some((mantissa_str, new_exp)) => assemble_scientific(sign, &mantissa_str, new_exp),
-        // Genuinely all-zero mantissa (`0.0e-400`) -- no magnitude to
-        // renormalize against. `value == 0.0` is true for `-0.0` too (IEEE
-        // 754), so the sign still needs preserving -- real jq keeps both
-        // the sign and the source exponent for a zero mantissa, since
-        // log10(0) is undefined (`-0e5` -> `-0E+5`, `-0e05` -> `-0E+5`).
-        None => assemble_scientific(sign, "0", parse_literal_exponent(&s[exp_pos + 1..])),
+        // Genuinely all-zero mantissa (`0.0e-400`) -- no nonzero digit to
+        // shift *to*, but real jq still shifts the printed exponent by the
+        // fractional-zero-digit count, the same normalization it applies to
+        // a nonzero mantissa (#1178) -- `0.000e-400` -> `0E-403`, not
+        // `0E-400`. A no-fraction spelling (`0e-400`, empty `frac_part`) has
+        // shift `0` and was already correct. `value == 0.0` is true for
+        // `-0.0` too (IEEE 754), so the sign still needs preserving -- real
+        // jq keeps both the sign and this shifted exponent for a zero
+        // mantissa, since log10(0) is undefined (`-0e5` -> `-0E+5`).
+        None => {
+            let mantissa = s[..exp_pos].strip_prefix('-').unwrap_or(&s[..exp_pos]);
+            let frac_len = mantissa.split_once('.').map_or(0, |(_, frac)| frac.len());
+            let shifted_exp =
+                parse_literal_exponent(&s[exp_pos + 1..]).saturating_sub(frac_len as i64);
+            assemble_scientific(sign, "0", shifted_exp)
+        }
     }
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4504,6 +4504,42 @@ fn test_number_literal_zero_mantissa_extreme_exponent_still_zero_1099() -> Resul
     Ok(())
 }
 
+/// #1178: a genuinely-zero-mantissa literal's printed exponent must still
+/// shift by the fractional-zero-digit count, the same normalization real
+/// jq applies to a nonzero mantissa -- #1099's own zero-mantissa test above
+/// only covers a no-fraction spelling (`0e-400`, shift 0), which is why
+/// this gap wasn't caught by that PR's suite. Live-verified against jq
+/// 1.7.1.
+#[test]
+fn test_number_literal_zero_mantissa_exponent_shifts_by_fraction_length_1178() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "0.000e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0E-403");
+
+    let (output, code) = run_jq_stdin(".", "0.0e400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0E+399");
+
+    let (output, code) = run_jq_stdin(".", "0.00e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "0E-402");
+
+    Ok(())
+}
+
+/// The sign is preserved through the shift, and `-0.00e-400` shifts
+/// identically to the unsigned case above -- confirmed live against jq
+/// 1.7.1 (`-0e5` also still unaffected: shift is 0 when there's no
+/// fraction, matching #1099's existing `-0e-400` test above).
+#[test]
+fn test_number_literal_negative_zero_mantissa_exponent_shifts_1178() -> Result<()> {
+    let (output, code) = run_jq_stdin(".", "-0.00e-400", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "-0E-402");
+
+    Ok(())
+}
+
 /// Unlike overflow (which falls back to `DBL_MAX` text past a documented
 /// exponent-magnitude ceiling), this crate imposes no *deliberate* ceiling
 /// on underflow -- verified live against jq 1.7.1: `1e-1000000000`


### PR DESCRIPTION
## Summary
- Fixes #1178: `format_underflow_literal_mantissa`'s genuinely-all-zero-mantissa fallback (`0.000e-400`, `0.0e400`) echoed the literal's own written exponent unchanged, unlike the nonzero-mantissa path a few lines above it, which already shifts by the leading-zero-digit count. Real jq shifts the printed exponent by the fractional-zero-digit count even when the mantissa has no nonzero digit to shift *to*.
- Fix: computed the shift (`-frac_part.len()`) directly in the `None` arm of `format_underflow_literal_mantissa`'s match, rather than threading it through the shared `normalize_extreme_literal_mantissa`'s return type — keeps the overflow call site's `unreachable!()` (a zero mantissa can never overflow to +/-infinity) provably unreachable without needing to learn about the zero case at all.
- A no-fraction spelling (`0e-400`) is unaffected (shift 0, matching #1099's existing regression test).
- Filed #1207 for a distinct, out-of-scope bug found while testing: real jq's own choice of scientific/decimal/plain-integer notation for a zero-mantissa literal follows a different threshold than succinctly's dispatch logic — `0.0e1` gives plain `0` in real jq, `0.0e-1` gives decimal `0.00`, neither of which even reaches the code this fix touches. Pre-existing, unaffected either way by this PR.

## Test plan
- [x] `cargo build --features cli`
- [x] Live-verified against jq 1.7.1 across positive/negative exponents, multiple fraction lengths, and the negative-sign case
- [x] New tests in `tests/jq_cli_tests.rs` (`_1178` suffix, 2 tests) — all pass
- [x] Existing `_1099` regression suite (4 tests) — unaffected, still pass
- [x] Full `cargo test --features cli,simd,regex,serde` (no-fail-fast) — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's scalar-yaml-avoiding leg) — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --no-default-features` — clean (pre-existing unrelated warnings only)