### PR TITLE
fix(jq): @urid errors on a malformed percent-escape instead of passing it through

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -611,6 +611,21 @@ impl EvalError {
         Self::new(format!("illegal base64 data at input byte {pos}"))
     }
 
+    /// `invalid URL escape "<escape>"` (#1138).
+    ///
+    /// Raised by `@urid` (yq mode only, like [`Self::base64_illegal_data`]
+    /// above -- jq has no `@urid` at all) when a `%` isn't immediately
+    /// followed by two valid hex digits. `escape` is `%` plus whatever 0,
+    /// 1, or 2 bytes actually follow it in the input (not validated --
+    /// confirmed live against yq v4.53.3 that both bytes are echoed
+    /// verbatim even when only one, or neither, is a valid hex digit, and
+    /// that a literal `%` immediately after the first one is included
+    /// unchanged rather than treated as a new escape's start: `"x%y%zz" |
+    /// @urid` -> `invalid URL escape "%y%"`, not `"%y"`).
+    pub fn urid_invalid_escape(escape: &str) -> Self {
+        Self::new(format!("invalid URL escape {escape:?}"))
+    }
+
     /// `Invalid path expression with result <value>` (#530).
     ///
     /// Raised by `path()` when the filter it was given is not a path

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -613,15 +613,29 @@ impl EvalError {
 
     /// `invalid URL escape "<escape>"` (#1138).
     ///
-    /// Raised by `@urid` (yq mode only, like [`Self::base64_illegal_data`]
-    /// above -- jq has no `@urid` at all) when a `%` isn't immediately
-    /// followed by two valid hex digits. `escape` is `%` plus whatever 0,
-    /// 1, or 2 bytes actually follow it in the input (not validated --
-    /// confirmed live against yq v4.53.3 that both bytes are echoed
-    /// verbatim even when only one, or neither, is a valid hex digit, and
-    /// that a literal `%` immediately after the first one is included
-    /// unchanged rather than treated as a new escape's start: `"x%y%zz" |
-    /// @urid` -> `invalid URL escape "%y%"`, not `"%y"`).
+    /// Raised by `@urid` when a `%` isn't immediately followed by two
+    /// valid hex digits. Unlike [`Self::base64_illegal_data`] above --
+    /// genuinely yq-only, since jq's own real `@base64d` has independently
+    /// verified wording to diverge against -- `@urid` is a succinctly
+    /// extension with **no jq analogue at all**, so there's no competing
+    /// jq-mode wording to preserve: this fires identically in both jq and
+    /// yq mode (`format_urid`'s malformed-escape check has no `S::TAG`
+    /// branch).
+    ///
+    /// `escape` is `%` plus whatever 0, 1, or 2 bytes actually follow it
+    /// in the input (not validated -- confirmed live against yq v4.53.3
+    /// that both bytes are echoed verbatim even when only one, or
+    /// neither, is a valid hex digit, and that a literal `%` immediately
+    /// after the first one is included unchanged rather than treated as a
+    /// new escape's start: `"x%y%zz" | @urid` -> `invalid URL escape
+    /// "%y%"`, not `"%y"`). The `Debug`-quoted `{escape:?}` below matches
+    /// real yq's own Go-style escaping for embedded `"`/`\`/control
+    /// characters exactly (confirmed live: `%"y` -> `%\"y`, `%\y` ->
+    /// `%\\y`, a literal tab -> `%\ty`) -- but for a multi-byte UTF-8
+    /// character split by the raw 2-byte cutoff, the caller widens to the
+    /// whole character rather than corrupting it into U+FFFD, which is
+    /// *not* a byte-for-byte oracle match (real yq hex-escapes the raw,
+    /// truncated bytes instead, e.g. `\xe4\xb8`) -- filed as #1216.
     pub fn urid_invalid_escape(escape: &str) -> Self {
         Self::new(format!("invalid URL escape {escape:?}"))
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5879,13 +5879,26 @@ fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<S
             // Malformed escape (#1138): real yq errors rather than
             // silently passing the `%` through, quoting `%` plus
             // whatever 0, 1, or 2 bytes actually follow it (up to end of
-            // string) -- `(i + 3).min(bytes.len())` covers all three
-            // lengths with one expression, matching the boundary
-            // `EvalError::urid_invalid_escape`'s own doc comment
-            // verifies live.
-            let end = (i + 3).min(bytes.len());
-            let escape = String::from_utf8_lossy(&bytes[i..end]);
-            return Err(EvalError::urid_invalid_escape(&escape));
+            // string). `i` is always a valid char boundary here -- `%` is
+            // ASCII (0x25), and no UTF-8 continuation byte can equal an
+            // ASCII value, so `bytes[i] == b'%'` being true is on its own
+            // sufficient proof `i` doesn't sit inside another character --
+            // so `s[i..]` is a valid `&str` to walk char-wise. Widening to
+            // the next full character (rather than a fixed 3-byte window)
+            // when the raw 2-byte cutoff would otherwise split one avoids
+            // corrupting it into a single lossy replacement character;
+            // see `EvalError::urid_invalid_escape`'s own doc comment for
+            // why this is a deliberate, documented divergence from real
+            // yq's raw-byte hex-escaping for that specific case (#1216).
+            let rest = &s[i..];
+            let mut escape_len = 0;
+            for ch in rest.chars() {
+                if escape_len >= 3 {
+                    break;
+                }
+                escape_len += ch.len_utf8();
+            }
+            return Err(EvalError::urid_invalid_escape(&rest[..escape_len]));
         }
         // Not a percent sign at all, just copy the byte
         result.push(bytes[i]);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5863,19 +5863,31 @@ fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<S
     let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            // Try to parse the next two characters as hex
-            if let (Some(h1), Some(h2)) = (
-                (bytes[i + 1] as char).to_digit(16),
-                (bytes[i + 2] as char).to_digit(16),
-            ) {
-                let decoded = (h1 * 16 + h2) as u8;
-                result.push(decoded);
-                i += 3;
-                continue;
+        if bytes[i] == b'%' {
+            if i + 2 < bytes.len() {
+                // Try to parse the next two characters as hex
+                if let (Some(h1), Some(h2)) = (
+                    (bytes[i + 1] as char).to_digit(16),
+                    (bytes[i + 2] as char).to_digit(16),
+                ) {
+                    let decoded = (h1 * 16 + h2) as u8;
+                    result.push(decoded);
+                    i += 3;
+                    continue;
+                }
             }
+            // Malformed escape (#1138): real yq errors rather than
+            // silently passing the `%` through, quoting `%` plus
+            // whatever 0, 1, or 2 bytes actually follow it (up to end of
+            // string) -- `(i + 3).min(bytes.len())` covers all three
+            // lengths with one expression, matching the boundary
+            // `EvalError::urid_invalid_escape`'s own doc comment
+            // verifies live.
+            let end = (i + 3).min(bytes.len());
+            let escape = String::from_utf8_lossy(&bytes[i..end]);
+            return Err(EvalError::urid_invalid_escape(&escape));
         }
-        // Not a valid percent-encoded sequence, just copy the byte
+        // Not a percent sign at all, just copy the byte
         result.push(bytes[i]);
         i += 1;
     }
@@ -40464,10 +40476,23 @@ mod tests {
                 assert_eq!(s, "hello world");
             }
         );
-        // Invalid percent encoding should pass through
+    }
+
+    /// #1138: a malformed `%` escape (not immediately followed by two
+    /// valid hex digits) errors rather than silently passing the `%`
+    /// through -- matching real yq's `invalid URL escape "..."` wording
+    /// (yq is the only oracle here; real jq has no `@urid` at all). An
+    /// earlier version of `test_format_urid` above pinned the old
+    /// passthrough behavior for exactly this input
+    /// (`"hello%GGworld"` -> `"hello%GGworld"`); this replaces it.
+    #[test]
+    fn test_format_urid_malformed_escape_errors_1138() {
         query!(br#""hello%GGworld""#, "@urid",
-            QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "hello%GGworld");
+            QueryResult::Error(e) => {
+                assert!(
+                    e.to_string().contains(r#"invalid URL escape "%GG""#),
+                    "error: {e}"
+                );
             }
         );
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14747,6 +14747,32 @@ fn test_yq_urid_valid_escape_still_decodes_1138() -> Result<()> {
     Ok(())
 }
 
+/// #1138 review self-check: a malformed escape immediately followed by a
+/// multi-byte UTF-8 character (so the raw 2-byte error-message cutoff
+/// would otherwise land mid-character) must widen to include the whole
+/// character rather than corrupt it into a lossy replacement character --
+/// not a byte-for-byte match for real yq's own raw-byte hex-escaping in
+/// this specific case (`\xe4\xb8`), a documented, deliberate divergence
+/// (see `EvalError::urid_invalid_escape`'s doc comment and #1216).
+#[test]
+fn test_yq_urid_malformed_escape_multibyte_boundary_1138() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", "\"%\u{4e2d}\"", &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid URL escape \"%\u{4e2d}\""),
+        "stderr: {stderr:?}"
+    );
+
+    // A 4-byte character (outside the BMP) too, not just 3-byte.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", "\"%\u{1f600}\"", &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid URL escape \"%\u{1f600}\""),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 // ============================================================================
 // @base64d error message wording (#1146)
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14703,6 +14703,50 @@ fn test_yq_urid_nonascii_passthrough_and_decode_1123() -> Result<()> {
     Ok(())
 }
 
+/// #1138: a `%` not immediately followed by two valid hex digits used to
+/// silently pass the `%` itself through unchanged instead of erroring the
+/// way real yq does. The quoted escape in the error is `%` plus whatever
+/// 0, 1, or 2 bytes actually follow it -- not validated, and not stopped
+/// early by a second `%` (`"x%y%zz"` quotes `"%y%"`, treating the second
+/// `%` as ordinary data for the *first* escape's error, not the start of
+/// a new one). All cases live-verified against yq v4.53.3.
+#[test]
+fn test_yq_urid_malformed_escape_errors_1138() -> Result<()> {
+    let cases: &[(&str, &str)] = &[
+        (r#""abc%""#, r#"invalid URL escape "%""#),
+        (r#""abc%A""#, r#"invalid URL escape "%A""#),
+        (r#""abc%ZZ""#, r#"invalid URL escape "%ZZ""#),
+        (r#""%""#, r#"invalid URL escape "%""#),
+        (r#""%A""#, r#"invalid URL escape "%A""#),
+        (r#""%AZ""#, r#"invalid URL escape "%AZ""#),
+        (r#""%Z5""#, r#"invalid URL escape "%Z5""#),
+        (r#""%5Z""#, r#"invalid URL escape "%5Z""#),
+        (r#""x%y%zz""#, r#"invalid URL escape "%y%""#),
+        (r#""%%""#, r#"invalid URL escape "%%""#),
+        (r#""%4""#, r#"invalid URL escape "%4""#),
+    ];
+    for (input, expected) in cases {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", input, &[])?;
+        assert_ne!(code, 0, "input {input:?}, stderr: {stderr:?}");
+        assert!(
+            stderr.contains(expected),
+            "input {input:?}: expected stderr to contain {expected:?}, got {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #1138 review self-check: a genuinely valid escape (both hex digits
+/// present and valid) must still decode successfully, not just malformed
+/// ones now erroring correctly.
+#[test]
+fn test_yq_urid_valid_escape_still_decodes_1138() -> Result<()> {
+    let (out, code) = run_yq_stdin("@urid", r#""hello%20world""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"hello world\"");
+    Ok(())
+}
+
 // ============================================================================
 // @base64d error message wording (#1146)
 // ============================================================================
@@ -14870,5 +14914,22 @@ fn test_jq_urid_invalid_utf8_after_percent_decode_is_lossy_1146() -> Result<()> 
     let (out, _stderr, code) = run_jq_stdin_with_stderr("@urid", "\"%FF\"", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "\"\u{fffd}\"");
+    Ok(())
+}
+
+/// #1138: real jq has no `@urid` at all (it's a succinctly extension
+/// reachable in both modes, per `format_urid`'s own doc comment), so
+/// there's no jq oracle to preserve the old silent-passthrough behavior
+/// against -- the malformed-escape decode loop has no mode-specific
+/// branch, so jq mode gets the same error yq mode does (#1138's own
+/// primary fix, verified against real yq above).
+#[test]
+fn test_jq_urid_malformed_escape_errors_1138() -> Result<()> {
+    let (_out, stderr, code) = run_jq_stdin_with_stderr("@urid", "\"abc%\"", &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"invalid URL escape "%""#),
+        "stderr: {stderr:?}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

`format_urid`'s decode loop (`src/jq/eval.rs`) fell through to "copy the `%` byte and continue" whenever a `%` wasn't immediately followed by two valid hex digits (or didn't have two more bytes at all), silently corrupting the string instead of erroring the way real yq does.

## Repro (verified against real yq v4.53.3)

```console
$ echo '"abc%"' | succinctly yq -o=json '@urid'
"abc%"                            # real yq: Error: invalid URL escape "%"
```

## Design

Raises a new `EvalError::urid_invalid_escape`, quoting `%` plus whatever 0, 1, or 2 bytes actually follow it — not validated, matching real yq's own wording exactly. Live-verified across 11 cases spanning every boundary the issue's own text flagged as needing probing, including a second literal `%` immediately after the first being treated as ordinary trailing data for the *first* escape's error rather than the start of a new one (`"x%y%zz"` → `invalid URL escape "%y%"`, not `"%y"`).

`@urid` is a succinctly extension reachable in both jq and yq mode (real jq has no `@urid` at all, so there's no jq-mode oracle to preserve the old passthrough behavior against), and the decode loop itself has no mode-specific branch, so the fix applies uniformly to both.

## Code review

Review (10 parallel finder agents, several with live rustc/oracle verification) found and fixed two real issues:
- The error-message truncation sliced raw bytes without regard for UTF-8 char boundaries — a malformed `%` immediately followed by a 3- or 4-byte UTF-8 character got collapsed into a single U+FFFD replacement character by `from_utf8_lossy`, silently destroying the real bytes despite the doc comments' own "echoed verbatim" claim. Fixed by widening to the whole character instead of splitting it (not a byte-for-byte match for real yq's own raw-byte hex-escaping in this specific edge case — filed as **#1216** for that).
- A doc comment claimed the new error fires "yq mode only" (copy-pasted from a neighboring, genuinely-mode-gated constructor without adjusting for `@urid` having no jq analogue at all) — corrected; the PR's own jq-mode test already proved this wrong.

Also verified, not a bug: Rust's `{escape:?}` Debug-formatting of embedded `"`/`\`/control characters matches real yq's own Go-style escaping exactly (confirmed live) — looked like a possible divergence on first read, wasn't one.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Local patch coverage: 100% (27/27 new lines)
- [x] New tests: in-process unit test, CLI-level tests for both yq mode (11 boundary cases) and jq mode, a valid-escape regression guard, and a multi-byte-character boundary test
- [x] Live-verified against yq v4.53.3 across 13 boundary cases including multi-byte UTF-8

Fixes #1138