### PR TITLE
fix(jq): apply yq's del() parent-key rule per-element through a .[] prefix

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18884,9 +18884,13 @@ fn delete_expr_paths_through_absent(
 /// [`delete_expr_paths_through_absent`]'s single-path counterpart, for
 /// [`delete_at_path`]'s chain-walk. Same contract: errors propagate, the
 /// rebuilt `null` is discarded, the container is untouched.
-fn delete_at_path_through_absent(rest: &Expr, optional: bool) -> Result<(), EvalError> {
+fn delete_at_path_through_absent(
+    rest: &Expr,
+    optional: bool,
+    yq_mode: bool,
+) -> Result<(), EvalError> {
     let mut absent = OwnedValue::Null;
-    delete_at_path(&mut absent, rest, optional)
+    delete_at_path(&mut absent, rest, optional, yq_mode)
 }
 
 /// [`delete_expr_paths_at`]'s `Field` case: group by field name, delete the
@@ -19233,7 +19237,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 .then(|| yq_del_scalar_slice_parent_path(path, &result))
                 .flatten();
             let path = rewritten.as_ref().unwrap_or(path);
-            if let Err(e) = delete_at_path(&mut result, path, false) {
+            if let Err(e) = delete_at_path(&mut result, path, false, S::TAG == EvalTag::Yq) {
                 return if optional {
                     QueryResult::None
                 } else {
@@ -19286,10 +19290,24 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Delete a value at a path expression.
+///
+/// `yq_mode` (#1182): `S::TAG == EvalTag::Yq` from the caller, threaded
+/// through every recursive call rather than making this function generic
+/// over `S` (mirroring `through_slice`'s own `scalar_noop`/`container_noop`
+/// bools over a full generic, since this is the only thing here that needs
+/// mode-awareness at all). Consulted only by the `Expr::Iterate` arm below,
+/// to apply yq's chained-scalar-slice parent-key-delete rule
+/// (`yq_del_scalar_slice_parent_path`) *per element* when a `.[]` precedes
+/// the trailing slice (`del(.a[].b[0:1])`) -- the top-level caller's own
+/// upfront rewrite (see this function's caller) can't handle that shape at
+/// all, since `navigate_read_only` has no way to peek through an
+/// as-yet-unresolved `Iterate` step to find each element's own scalar
+/// target.
 fn delete_at_path(
     root: &mut OwnedValue,
     path_expr: &Expr,
     optional: bool,
+    yq_mode: bool,
 ) -> Result<(), EvalError> {
     match path_expr {
         Expr::Identity => {
@@ -19369,7 +19387,7 @@ fn delete_at_path(
         Expr::Pipe(exprs) if !exprs.is_empty() => {
             // Chain: navigate and delete at the last path
             if exprs.len() == 1 {
-                delete_at_path(root, &exprs[0], optional)
+                delete_at_path(root, &exprs[0], optional, yq_mode)
             } else {
                 // Same unwrap as `update_path`'s chain arm: a resolved
                 // component can still be wrapped in `?`, and matching the
@@ -19384,7 +19402,7 @@ fn delete_at_path(
                 match first {
                     Expr::Field(name) => match root {
                         OwnedValue::Object(map) => match map.get_mut(name) {
-                            Some(current) => delete_at_path(current, &rest, optional),
+                            Some(current) => delete_at_path(current, &rest, optional, yq_mode),
                             // Same "reads as `null`, keep walking" rule as
                             // `delete_expr_object_paths`' missing-field arm
                             // (#527): `del(.a.b.c)` is a no-op, `del(.a.b[])`
@@ -19392,7 +19410,7 @@ fn delete_at_path(
                             // `?` on the missing step does not suppress what
                             // the tail itself raises, and the walk into a
                             // throwaway `null` cannot create the key.
-                            None => delete_at_path_through_absent(&rest, optional),
+                            None => delete_at_path_through_absent(&rest, optional, yq_mode),
                         },
                         // `null` tolerates any key — `null | del(.a.b)` and
                         // `{"x":null} | del(.x.a)` are both no-ops (#476) —
@@ -19401,7 +19419,7 @@ fn delete_at_path(
                         // included, so `{"x":null} | del(.x.a[])` no-op'd
                         // where jq raises `Cannot iterate over null (null)`
                         // (#527).
-                        OwnedValue::Null => delete_at_path_through_absent(&rest, optional),
+                        OwnedValue::Null => delete_at_path_through_absent(&rest, optional, yq_mode),
                         _ if here => Ok(()),
                         _ => Err(EvalError::cannot_index_with_field(
                             owned_type_name(root),
@@ -19413,20 +19431,25 @@ fn delete_at_path(
                             let len = arr.len() as i64;
                             let actual_idx = if *idx < 0 { len + idx } else { *idx };
                             if actual_idx >= 0 && (actual_idx as usize) < arr.len() {
-                                delete_at_path(&mut arr[actual_idx as usize], &rest, optional)
+                                delete_at_path(
+                                    &mut arr[actual_idx as usize],
+                                    &rest,
+                                    optional,
+                                    yq_mode,
+                                )
                             } else {
                                 // An out-of-range index resolves to null, and
                                 // deleting further into null is a no-op for
                                 // most tails, `?` or not (#477) — but not
                                 // `[]`, which still raises `Cannot iterate
                                 // over null (null)` (#527/#529).
-                                delete_at_path_through_absent(&rest, optional)
+                                delete_at_path_through_absent(&rest, optional, yq_mode)
                             }
                         }
                         // Same per-step `null` exemption as the `Field` case
                         // above — `null | del(.[0].a)` is a no-op (#476),
                         // `null | del(.[0][])` still raises (#527).
-                        OwnedValue::Null => delete_at_path_through_absent(&rest, optional),
+                        OwnedValue::Null => delete_at_path_through_absent(&rest, optional, yq_mode),
                         _ if here => Ok(()),
                         _ => Err(EvalError::cannot_index_with_type(
                             owned_type_name(root),
@@ -19436,13 +19459,46 @@ fn delete_at_path(
                     Expr::Iterate => match root {
                         OwnedValue::Array(arr) => {
                             for elem in arr.iter_mut() {
-                                delete_at_path(elem, &rest, optional)?;
+                                // #1182: yq's chained-scalar-slice del() rule
+                                // (#1116) can't be applied upfront for this
+                                // shape -- the caller's own rewrite
+                                // (`yq_del_scalar_slice_parent_path`) only
+                                // runs once, before this walk even starts,
+                                // and its `navigate_read_only` prefix-peek
+                                // has no way to look *through* an
+                                // as-yet-unresolved `.[]` to find each
+                                // element's own scalar target. So the rule is
+                                // attempted again here, once per element,
+                                // against `rest` (the path remaining after
+                                // this `.[]`) -- `None` (rule doesn't apply
+                                // to this element, or not yq mode at all)
+                                // just walks `rest` unchanged, exactly as
+                                // before this fix.
+                                let rewritten = yq_mode
+                                    .then(|| yq_del_scalar_slice_parent_path(&rest, elem))
+                                    .flatten();
+                                delete_at_path(
+                                    elem,
+                                    rewritten.as_ref().unwrap_or(&rest),
+                                    optional,
+                                    yq_mode,
+                                )?;
                             }
                             Ok(())
                         }
                         OwnedValue::Object(map) => {
                             for value in map.values_mut() {
-                                delete_at_path(value, &rest, optional)?;
+                                // Same per-element rewrite as the array arm
+                                // above.
+                                let rewritten = yq_mode
+                                    .then(|| yq_del_scalar_slice_parent_path(&rest, value))
+                                    .flatten();
+                                delete_at_path(
+                                    value,
+                                    rewritten.as_ref().unwrap_or(&rest),
+                                    optional,
+                                    yq_mode,
+                                )?;
                             }
                             Ok(())
                         }
@@ -19454,7 +19510,7 @@ fn delete_at_path(
                     Expr::Pipe(inner) => {
                         let mut spliced = inner.clone();
                         spliced.extend_from_slice(&exprs[1..]);
-                        delete_at_path(root, &Expr::Pipe(spliced), here)
+                        delete_at_path(root, &Expr::Pipe(spliced), here, yq_mode)
                     }
                     // The chain continues *inside* the slice, so the delete
                     // happens in the sub-array and the remainder is spliced
@@ -19470,7 +19526,7 @@ fn delete_at_path(
                     // `null` instead of no-op'ing (a separate, documented
                     // divergence — see docs/compliance/jq/limitations.md).
                     Expr::Slice { .. } if matches!(root, OwnedValue::Null) => {
-                        delete_at_path_through_absent(&rest, optional)
+                        delete_at_path_through_absent(&rest, optional, yq_mode)
                     }
                     // `scalar_noop`/`container_noop: false` — del()'s own
                     // yq rules (#1116's scalar case, #1162's tracked
@@ -19492,14 +19548,14 @@ fn delete_at_path(
                     // follow-up before it's fixed.
                     Expr::Slice { start, end } => {
                         through_slice(root, *start, *end, here, false, false, |sub| {
-                            delete_at_path(sub, &rest, optional)
+                            delete_at_path(sub, &rest, optional, yq_mode)
                         })
                     }
-                    _ => delete_at_path(root, first, here),
+                    _ => delete_at_path(root, first, here, yq_mode),
                 }
             }
         }
-        Expr::Optional(inner) => delete_at_path(root, inner, true),
+        Expr::Optional(inner) => delete_at_path(root, inner, true, yq_mode),
         // `(EXPR)` at the top of a resolved delete target (e.g.
         // `del((.a))`) -- mirrors `update_path`'s identical `Expr::Paren`
         // arm (#1116; passes `optional` through unchanged, unlike the
@@ -19507,7 +19563,7 @@ fn delete_at_path(
         // `delete_at_path` was missing entirely until now (#1153): any
         // parenthesized `del()` target failed with "cannot use expression
         // as delete target", whether or not a slice was involved.
-        Expr::Paren(inner) => delete_at_path(root, inner, optional),
+        Expr::Paren(inner) => delete_at_path(root, inner, optional, yq_mode),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
         // to the catch-all so a missed install point fails loudly here instead
@@ -41941,7 +41997,7 @@ mod tests {
         #[test]
         fn test_delete_at_path_refuses_an_unresolved_key() {
             let mut root = OwnedValue::Null;
-            let err = delete_at_path(&mut root, &unresolved(), false).unwrap_err();
+            let err = delete_at_path(&mut root, &unresolved(), false, false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed index in delete path"
@@ -42038,7 +42094,7 @@ mod tests {
         #[test]
         fn test_delete_at_path_refuses_an_unresolved_slice() {
             let mut root = OwnedValue::Null;
-            let err = delete_at_path(&mut root, &unresolved(), false).unwrap_err();
+            let err = delete_at_path(&mut root, &unresolved(), false, false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed slice in delete path"

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10425,15 +10425,26 @@ fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Optio
         return None;
     }
     Some(match prefix.len() {
-        // Unreachable in practice: `resolve_dynamic_indexes`'s own
-        // `assemble()` never wraps a single resolved component in
-        // `Expr::Pipe` (a length-1 component list returns that component
-        // directly, `strip_resolved_optional` only strips wrappers *within*
-        // an existing `Pipe`, never collapses one), so `exprs.len() >= 2`
-        // always holds here and `prefix.len()` can never be `0`. Kept
-        // explicit (rather than folded into the `_` arm) for clarity, since
-        // it's still the semantically correct value if that invariant ever
-        // changes.
+        // Unreachable from `builtin_del`'s own top-level call site:
+        // `resolve_dynamic_indexes`'s own `assemble()` never wraps a single
+        // resolved component in `Expr::Pipe` (a length-1 component list
+        // returns that component directly, `strip_resolved_optional` only
+        // strips wrappers *within* an existing `Pipe`, never collapses
+        // one), so `exprs.len() >= 2` always holds there and `prefix.len()`
+        // can never be `0` for that caller.
+        //
+        // *Is* reached from `delete_at_path`'s `Expr::Iterate` arm (#1182),
+        // which always wraps its `rest` in `Expr::Pipe` regardless of
+        // length -- a bare `.[]` directly followed by the trailing slice
+        // (`del(.a[][0:1])`, no `Field`/`Index` between) resolves `prefix`
+        // to the empty slice, so `target` (from `navigate_read_only` with
+        // zero steps) is the element itself. `Expr::Identity` signals that
+        // case back to the caller: there is no parent *key* to drop here,
+        // the element itself is the thing to remove from its container --
+        // that caller special-cases this return value rather than
+        // recursing `delete_at_path` on it (which would just null the
+        // element in place via its own `Expr::Identity` arm, not remove
+        // it).
         0 => Expr::Identity,
         1 => prefix[0].clone(),
         _ => Expr::Pipe(prefix.to_vec()),
@@ -19458,47 +19469,76 @@ fn delete_at_path(
                     },
                     Expr::Iterate => match root {
                         OwnedValue::Array(arr) => {
-                            for elem in arr.iter_mut() {
-                                // #1182: yq's chained-scalar-slice del() rule
-                                // (#1116) can't be applied upfront for this
-                                // shape -- the caller's own rewrite
-                                // (`yq_del_scalar_slice_parent_path`) only
-                                // runs once, before this walk even starts,
-                                // and its `navigate_read_only` prefix-peek
-                                // has no way to look *through* an
-                                // as-yet-unresolved `.[]` to find each
-                                // element's own scalar target. So the rule is
-                                // attempted again here, once per element,
-                                // against `rest` (the path remaining after
-                                // this `.[]`) -- `None` (rule doesn't apply
-                                // to this element, or not yq mode at all)
-                                // just walks `rest` unchanged, exactly as
-                                // before this fix.
+                            // #1182: yq's chained-scalar-slice del() rule
+                            // (#1116) can't be applied upfront for this
+                            // shape -- the caller's own rewrite
+                            // (`yq_del_scalar_slice_parent_path`) only
+                            // runs once, before this walk even starts,
+                            // and its `navigate_read_only` prefix-peek
+                            // has no way to look *through* an
+                            // as-yet-unresolved `.[]` to find each
+                            // element's own scalar target. So the rule is
+                            // attempted again here, once per element,
+                            // against `rest` (the path remaining after
+                            // this `.[]`) -- `None` (rule doesn't apply
+                            // to this element, or not yq mode at all)
+                            // just walks `rest` unchanged, exactly as
+                            // before this fix.
+                            //
+                            // `Some(Expr::Identity)` is a distinct signal
+                            // from any other rewrite: it means the *element
+                            // itself* is the scalar the trailing slice would
+                            // have targeted (`.[]` directly followed by the
+                            // slice, no `Field`/`Index` between). There is
+                            // no parent key to drop one level down from an
+                            // `&mut` reference into this array slot --
+                            // `delete_at_path`'s own `Expr::Identity` arm
+                            // would just null the element in place, not
+                            // remove it, so this element's index is queued
+                            // for removal from `arr` itself after the loop
+                            // instead of being recursed into.
+                            let mut remove_indices = Vec::new();
+                            for (i, elem) in arr.iter_mut().enumerate() {
                                 let rewritten = yq_mode
                                     .then(|| yq_del_scalar_slice_parent_path(&rest, elem))
                                     .flatten();
-                                delete_at_path(
-                                    elem,
-                                    rewritten.as_ref().unwrap_or(&rest),
-                                    optional,
-                                    yq_mode,
-                                )?;
+                                if matches!(rewritten, Some(Expr::Identity)) {
+                                    remove_indices.push(i);
+                                } else {
+                                    delete_at_path(
+                                        elem,
+                                        rewritten.as_ref().unwrap_or(&rest),
+                                        optional,
+                                        yq_mode,
+                                    )?;
+                                }
+                            }
+                            for i in remove_indices.into_iter().rev() {
+                                arr.remove(i);
                             }
                             Ok(())
                         }
                         OwnedValue::Object(map) => {
-                            for value in map.values_mut() {
-                                // Same per-element rewrite as the array arm
-                                // above.
+                            // Same per-element rewrite and elem-is-target
+                            // removal as the array arm above.
+                            let mut remove_keys = Vec::new();
+                            for (key, value) in map.iter_mut() {
                                 let rewritten = yq_mode
                                     .then(|| yq_del_scalar_slice_parent_path(&rest, value))
                                     .flatten();
-                                delete_at_path(
-                                    value,
-                                    rewritten.as_ref().unwrap_or(&rest),
-                                    optional,
-                                    yq_mode,
-                                )?;
+                                if matches!(rewritten, Some(Expr::Identity)) {
+                                    remove_keys.push(key.clone());
+                                } else {
+                                    delete_at_path(
+                                        value,
+                                        rewritten.as_ref().unwrap_or(&rest),
+                                        optional,
+                                        yq_mode,
+                                    )?;
+                                }
+                            }
+                            for key in remove_keys {
+                                map.shift_remove(&key);
                             }
                             Ok(())
                         }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14414,23 +14414,64 @@ fn test_1182_chained_scalar_slice_del_through_iterate_array_target_unaffected() 
 /// a scalar target, same as real jq) instead of yq's parent-key-drop rule.
 #[test]
 fn test_1182_chained_scalar_slice_del_through_iterate_jq_mode_unaffected() -> Result<()> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
-    cmd.arg("jq")
-        .arg("-c")
-        .arg("del(.a[].b[0:1])")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = cmd.spawn()?;
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(br#"{"a":[{"b":5,"c":1}]}"#)?;
-    let output = child.wait_with_output()?;
-    assert_ne!(output.status.code(), Some(0));
-    let stderr = String::from_utf8(output.stderr)?;
+    let (_out, stderr, code) =
+        run_jq_stdin_with_stderr("del(.a[].b[0:1])", r#"{"a":[{"b":5,"c":1}]}"#, &["-c"])?;
+    assert_ne!(code, 0);
     assert!(stderr.contains("Cannot index"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// `.[]` directly followed by the trailing slice, with no `Field`/`Index`
+/// between -- the element itself (not a field reached through it) is the
+/// scalar the rule applies to. `yq_del_scalar_slice_parent_path`'s
+/// `prefix.len() == 0` case signals this back as `Expr::Identity`; the
+/// `Expr::Iterate` arm must special-case that as "remove this element from
+/// its container" rather than recursing `delete_at_path` on it (which would
+/// just null the element in place via its own `Expr::Identity` arm). Caught
+/// during review of the initial #1182 fix, which recursed unconditionally
+/// and silently corrupted this shape (`{"a":[null,null,null]}` instead of
+/// removing the elements) where the pre-fix code had at least errored
+/// loudly. Real yq drops every element (verified live).
+#[test]
+fn test_1182_bare_iterate_directly_followed_by_slice_removes_elements() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[][0:1])", r#"{"a":[5,6,7]}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[]}"#);
+    Ok(())
+}
+
+/// Same as above but iterating an object's values instead of an array --
+/// the `OwnedValue::Object` arm of the same `Expr::Iterate` match needs the
+/// identical elem-is-target removal, via `map.shift_remove` instead of
+/// `arr.remove`. Real yq drops every value, leaving `.a` an empty mapping
+/// (verified live).
+#[test]
+fn test_1182_bare_iterate_directly_followed_by_slice_removes_object_values() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[][0:1])",
+        r#"{"a":{"x":5,"y":6}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":{}}"#);
+    Ok(())
+}
+
+/// The `OwnedValue::Object` branch of `delete_at_path`'s `Expr::Iterate` arm
+/// (`.[]` iterating an object's *values*, as opposed to an array) is a
+/// separate, hand-duplicated match arm from the array case exercised by
+/// every other `_1182` test above -- give it its own direct coverage so a
+/// future edit to one arm without the other (e.g. dropping the `yq_mode`
+/// gate, swapping which variable gets rewritten) doesn't go unnoticed.
+#[test]
+fn test_1182_chained_scalar_slice_del_through_object_iterate() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[].b[0:1])",
+        r#"{"a":{"x":{"b":5,"c":1},"y":{"b":6,"c":2}}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":{"x":{"c":1},"y":{"c":2}}}"#);
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14344,23 +14344,92 @@ fn test_1116_chained_scalar_slice_del_navigator_out_of_bounds_unaffected() -> Re
     Ok(())
 }
 
-/// `navigate_read_only` only understands `Field`/`Index` prefix steps — a
-/// `.[]` earlier in the chain (`Expr::Iterate`) hits its catch-all and
-/// bails to `None`, so the rewrite doesn't apply and the old, erroring
-/// per-element walk runs instead. Known, filed limitation — split off from
-/// #1153 (which covered this alongside the now-fixed parenthesized-target
-/// gap) into its own issue, #1182, since it needs `del()`'s own per-element
-/// handling rather than a small, self-contained fix. This pins the current
-/// (imperfect) behavior as a regression guard rather than leaving it
-/// silently untested.
+/// #1182: `navigate_read_only`'s own prefix-peek still can't look through
+/// an unresolved `.[]` (there's no single element to peek at until the walk
+/// actually reaches one), so the *upfront*, once-per-call rewrite this
+/// helper backs still can't apply to `.a[].b[0:1]` -- but `delete_at_path`'s
+/// own `Expr::Iterate` arm now retries the same rule per element, against
+/// each element's own remaining path, once the walk actually reaches it.
+/// Real yq drops the whole `b` key from every element (verified live),
+/// matching #1116's existing bare/chained parent-key-delete rule, just
+/// applied per element instead of once upfront.
 #[test]
-fn test_1116_chained_scalar_slice_del_iterate_prefix_not_yet_covered_1182() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+fn test_1182_chained_scalar_slice_del_through_iterate_removes_parent_key_per_element() -> Result<()>
+{
+    let (out, code) = run_yq_stdin(
         "del(.a[].b[0:1])",
         r#"{"a":[{"b":5,"c":1},{"b":6,"c":2}]}"#,
-        &[],
+        &["-o=json", "-I=0"],
     )?;
-    assert_ne!(code, 0);
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[{"c":1},{"c":2}]}"#);
+    Ok(())
+}
+
+/// Two `.[]` steps before the trailing slice -- the per-element retry in
+/// `delete_at_path`'s `Expr::Iterate` arm fires independently at each
+/// nesting level (the first iterate's own `rest` still contains the second
+/// iterate, so `yq_del_scalar_slice_parent_path` correctly returns `None`
+/// there and only fires once the walk reaches the second, innermost
+/// iterate). Live-verified against real yq.
+#[test]
+fn test_1182_chained_scalar_slice_del_through_nested_iterate() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[].b[].c[0:1])",
+        r#"{"a":[{"b":[{"c":5,"d":1},{"c":6,"d":2}]},{"b":[{"c":7,"d":3}]}]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(
+        out.trim(),
+        r#"{"a":[{"b":[{"d":1},{"d":2}]},{"b":[{"d":3}]}]}"#
+    );
+    Ok(())
+}
+
+/// The per-element rewrite is scoped to a genuinely scalar target the same
+/// way the pre-existing bare/chained rule already is -- an array-valued
+/// element reached through the same `.[]` keeps succinctly's own working
+/// partial-range delete instead of the parent-key-drop rule, exactly
+/// mirroring the pre-existing (unrelated to #1182, untouched by this fix)
+/// bare-chained divergence from real yq for an array target
+/// (`{"b":[1,2,3]} | del(.b[0:1])` already gives real yq `{}` vs
+/// succinctly's `{"b":[2,3]}` before and after this fix alike -- tracked
+/// separately as #1162, not fixed here).
+#[test]
+fn test_1182_chained_scalar_slice_del_through_iterate_array_target_unaffected() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[].b[0:1])",
+        r#"{"a":[{"b":[1,2,3]},{"b":6}]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[{"b":[2,3]},{}]}"#);
+    Ok(())
+}
+
+/// jq mode is unaffected -- `yq_mode` gates the per-element retry the same
+/// way it already gates the upfront rewrite, so a chained scalar slice
+/// through `.[]` keeps jq's own ordinary per-element behavior (erroring on
+/// a scalar target, same as real jq) instead of yq's parent-key-drop rule.
+#[test]
+fn test_1182_chained_scalar_slice_del_through_iterate_jq_mode_unaffected() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq")
+        .arg("-c")
+        .arg("del(.a[].b[0:1])")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(br#"{"a":[{"b":5,"c":1}]}"#)?;
+    let output = child.wait_with_output()?;
+    assert_ne!(output.status.code(), Some(0));
+    let stderr = String::from_utf8(output.stderr)?;
     assert!(stderr.contains("Cannot index"), "stderr: {stderr}");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14475,6 +14475,21 @@ fn test_1182_chained_scalar_slice_del_through_object_iterate() -> Result<()> {
     Ok(())
 }
 
+/// jq-mode counterpart of the Object-iterate test above -- in jq mode
+/// `yq_mode` is false, so the per-element rewrite always short-circuits to
+/// `None` and the ordinary (non-yq) recursive `delete_at_path` call runs
+/// instead, which errors trying to slice the scalar `.b` directly. Confirms
+/// the Object arm's `Expr::Iterate` else-branch propagates that error
+/// through its own `?` the same way the Array arm already does.
+#[test]
+fn test_1182_chained_scalar_slice_del_through_object_iterate_jq_mode_errors() -> Result<()> {
+    let (_out, stderr, code) =
+        run_jq_stdin_with_stderr("del(.a[].b[0:1])", r#"{"a":{"x":{"b":5,"c":1}}}"#, &["-c"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Cannot index"), "stderr: {stderr}");
+    Ok(())
+}
+
 /// `(.[0:1]) = 99` / `(.[0:1]) |= 99` — a parenthesized *bare* slice at the
 /// top of a resolved path. #1101 covered this only by accident (its old
 /// pre-check ran before `set_path`/`update_path` were ever reached with a


### PR DESCRIPTION
## Summary
- Fixes #1182: `yq_del_scalar_slice_parent_path`'s rewrite (#1116's parent-key-delete rule) runs exactly once, upfront, before `delete_at_path`'s own walk starts. Its `navigate_read_only` prefix-peek only understands `Field`/`Index` steps, so a `.[]` anywhere in the chain before the trailing slice (`del(.a[].b[0:1])`) made the whole rewrite bail to `None`, falling back to the old per-element walk that tries to slice each element's scalar `.b` directly and errors.
- Fix: `delete_at_path`'s own `Expr::Iterate` arm (reached once the walk actually gets to a `.[]`, with each real element in hand) now retries the same rule per element, against that element's own remaining path — the per-element retry the issue's root-cause analysis called for, since a single upfront `Option<Expr>` rewrite structurally can't express "some elements need the rewrite, some don't."
- Threaded a new `yq_mode: bool` through `delete_at_path` (and its `delete_at_path_through_absent` sibling) rather than making the function generic over `S` — mirroring how `through_slice`/`set_path` already made the same choice for their own no-op flags.
- Live-verified against yq v4.53.3 across single/double/triple-nested `.[]` prefixes, object iteration, missing/null intermediate fields, and jq-mode isolation. One pre-existing, unrelated divergence found during testing (an array/string-valued target through the same `.[]` prefix) turned out to already be tracked by #1162 — confirmed it reproduces identically for the bare, non-iterated case too.

## Test plan
- [x] `cargo build --features cli`
- [x] Live-verified against yq v4.53.3: original repro, nested iterates (2-3 levels), object iteration, out-of-range/missing/null intermediates, `?` interactions, jq-mode
- [x] Updated the pre-existing pinned regression test (previously asserted the old, imperfect erroring behavior) to assert the newly-correct output
- [x] New tests in `tests/yq_cli_tests.rs` (`_1182` suffix, 4 tests) — all pass
- [x] Full existing `_1116` regression suite (11 tests) — unaffected, still pass
- [x] Full `cargo test --features cli,simd,regex,serde` (no-fail-fast) — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's scalar-yaml-avoiding leg) — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --no-default-features` — clean (pre-existing unrelated warnings only)