### PR TITLE
refactor(cli): dedupe normalize_leading_zero_numbers's hand-rolled scanning

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1541,8 +1541,22 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
     }
 }
 
-/// Find the end (exclusive) of a lenient, JSON-*ish* number token starting
-/// at `pos`, which must point at `-` or an ASCII digit. Unlike
+/// Where a lenient, JSON-*ish* number token's integer-digit run and its
+/// overall span end, both exclusive, relative to the same `bytes` slice
+/// [`find_number_end`] scanned. `int_end` marks the end of the digit run
+/// that follows an optional leading `-` (i.e. where a leading-zero strip
+/// would need to stop); `end` marks the end of the whole token, including
+/// any fraction/exponent. `int_end..end`, if non-empty, is always exactly
+/// the token's fraction-plus-exponent suffix, contiguous by construction
+/// since the scan that produces both is strictly sequential.
+#[derive(Debug, PartialEq, Eq)]
+struct NumberTokenEnd {
+    int_end: usize,
+    end: usize,
+}
+
+/// Find a lenient, JSON-*ish* number token's boundaries, starting at
+/// `pos`, which must point at `-` or an ASCII digit. Unlike
 /// [`crate::json::validate::is_valid_number`] (a strict RFC 8259
 /// whole-slice checker, not a token-boundary finder, and not reusable here
 /// for that reason), this tolerates a leading zero in the integer part
@@ -1551,6 +1565,21 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// `-` with no digit following it at all (`-`, `[-,1]`, `{"a":-}`) --
 /// not a number token in the first place.
 ///
+/// Also deliberately **not** [`succinctly::json::light::number_literal_end`]
+/// (#1154 review) despite that function already living in this same file's
+/// import list two functions above, for a `find_json_values` caller with
+/// a similar-sounding job: its own doc comment explicitly scopes it to
+/// *top-level* document splitting and warns against reuse elsewhere, and
+/// its grammar genuinely diverges from what this repair pass needs --
+/// it rejects a dangling exponent marker outright (`"5e"` -> `None`,
+/// whereas real jq's own parser, and this function, consume it leniently
+/// and let the later `serde_json` re-validation reject the whole string
+/// instead), and it accepts a leading-dot fraction with zero integer
+/// digits (`".5"`/`"-.5"`) that this function's caller has no leading-zero
+/// stripping to do for in the first place (a bare `-.5` isn't reachable
+/// here: `normalize_leading_zero_numbers` only calls this when `b == '-'`
+/// or `b` is itself a digit, never `.`).
+///
 /// Mirrors [`find_string_end`]/[`find_matching_close`]'s "find the end of
 /// this token" shape (#1154) rather than interleaving grammar-walking
 /// with a transformation, the way an earlier version of
@@ -1558,7 +1587,19 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// let a real bug (fabricating a bare `-` into `-0`, turning genuinely
 /// invalid input into something that would silently validate) hide until
 /// review caught it before #1152 merged.
-fn find_number_end(bytes: &[u8], pos: usize) -> Option<usize> {
+///
+/// Returns [`NumberTokenEnd`] rather than just the overall end (#1154
+/// review) so the caller's own leading-zero strip doesn't need a second,
+/// independent scan to re-derive `int_end` -- an earlier version of this
+/// function discarded that boundary internally, forcing
+/// `normalize_leading_zero_numbers` to re-walk the same digit run with its
+/// own `take_while(is_ascii_digit)`, provably redundant work and, worse, a
+/// second definition of "where the integer part ends" that could silently
+/// drift from this one if either were ever edited without the other (a
+/// future digit-separator or different-digit-set change to just this
+/// function's loop, for instance, wouldn't be caught by any test that
+/// only exercises this function in isolation).
+fn find_number_end(bytes: &[u8], pos: usize) -> Option<NumberTokenEnd> {
     let mut i = pos;
     if bytes[i] == b'-' {
         i += 1;
@@ -1570,6 +1611,7 @@ fn find_number_end(bytes: &[u8], pos: usize) -> Option<usize> {
     if i == int_start {
         return None;
     }
+    let int_end = i;
     if i < bytes.len() && bytes[i] == b'.' {
         i += 1;
         while i < bytes.len() && bytes[i].is_ascii_digit() {
@@ -1585,7 +1627,7 @@ fn find_number_end(bytes: &[u8], pos: usize) -> Option<usize> {
             i += 1;
         }
     }
-    Some(i)
+    Some(NumberTokenEnd { int_end, end: i })
 }
 
 /// Strip a leading zero from every JSON number token in `s` (`007` ->
@@ -1620,7 +1662,7 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
         }
         if b == b'-' || b.is_ascii_digit() {
             let start = i;
-            let Some(end) = find_number_end(bytes, start) else {
+            let Some(NumberTokenEnd { int_end, end }) = find_number_end(bytes, start) else {
                 // Bare `-`, not a number token -- see `find_number_end`'s
                 // own doc comment for why this must stay untouched rather
                 // than fabricating a digit.
@@ -1628,12 +1670,13 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
                 i += 1;
                 continue;
             };
+            // `int_start` is one byte past `start` for a signed token,
+            // `start` itself otherwise -- not re-derived from `int_end`
+            // via a second scan (#1154 review): `find_number_end` already
+            // computed and returned `int_end` directly, so this is the
+            // only "where does the integer part start/end" logic in the
+            // whole function.
             let int_start = if b == b'-' { start + 1 } else { start };
-            let int_end = int_start
-                + bytes[int_start..end]
-                    .iter()
-                    .take_while(|c| c.is_ascii_digit())
-                    .count();
             let stripped = s[int_start..int_end].trim_start_matches('0');
             out.extend_from_slice(&bytes[start..int_start]);
             out.extend_from_slice(if stripped.is_empty() {
@@ -2707,32 +2750,41 @@ mod tests {
     /// finder, independent of the CLI-level `--argjson` tests (which
     /// already cover `normalize_leading_zero_numbers`'s end-to-end
     /// behavior via subprocess spawns invisible to `cargo llvm-cov`).
+    /// Checks both `int_end` and `end` (#1154 review) -- `int_end` is
+    /// what the caller actually needs to strip a leading zero without a
+    /// second scan, so a regression there wouldn't be caught by only
+    /// checking the overall token length.
     #[test]
     fn test_find_number_end_1154() {
-        // Plain and negative integers.
-        assert_eq!(find_number_end(b"42", 0), Some(2));
-        assert_eq!(find_number_end(b"-42", 0), Some(3));
+        fn ends(bytes: &[u8], pos: usize) -> Option<(usize, usize)> {
+            find_number_end(bytes, pos).map(|e| (e.int_end, e.end))
+        }
+
+        // Plain and negative integers: int_end == end, no frac/exp.
+        assert_eq!(ends(b"42", 0), Some((2, 2)));
+        assert_eq!(ends(b"-42", 0), Some((3, 3)));
         // Leading zeros tolerated (that's the whole point of this scan).
-        assert_eq!(find_number_end(b"007", 0), Some(3));
-        // Fraction and exponent, each optionally signed.
-        assert_eq!(find_number_end(b"1.5", 0), Some(3));
-        assert_eq!(find_number_end(b"1e10", 0), Some(4));
-        assert_eq!(find_number_end(b"1E+10", 0), Some(5));
-        assert_eq!(find_number_end(b"1.5e-10", 0), Some(7));
+        assert_eq!(ends(b"007", 0), Some((3, 3)));
+        // Fraction and exponent, each optionally signed: int_end stops at
+        // the integer digit run, end includes the rest.
+        assert_eq!(ends(b"1.5", 0), Some((1, 3)));
+        assert_eq!(ends(b"1e10", 0), Some((1, 4)));
+        assert_eq!(ends(b"1E+10", 0), Some((1, 5)));
+        assert_eq!(ends(b"1.5e-10", 0), Some((1, 7)));
         // A dangling '.' or 'e' with no digits after it still consumes
         // the marker itself, matching the lenient original behavior --
         // the retried `serde_json` validation rejects the result either
         // way, so this scan doesn't need to.
-        assert_eq!(find_number_end(b"5.", 0), Some(2));
-        assert_eq!(find_number_end(b"5e", 0), Some(2));
+        assert_eq!(ends(b"5.", 0), Some((1, 2)));
+        assert_eq!(ends(b"5e", 0), Some((1, 2)));
         // Stops at the token's own end, not the end of a larger buffer.
-        assert_eq!(find_number_end(b"42,43", 0), Some(2));
+        assert_eq!(ends(b"42,43", 0), Some((2, 2)));
         // A bare '-' with nothing (or nothing digit-shaped) after it is
         // not a number token at all.
-        assert_eq!(find_number_end(b"-", 0), None);
-        assert_eq!(find_number_end(b"-,", 0), None);
-        // Starting position other than 0.
-        assert_eq!(find_number_end(b"[1,007]", 3), Some(6));
+        assert_eq!(ends(b"-", 0), None);
+        assert_eq!(ends(b"-,", 0), None);
+        // Starting position other than 0, with a multi-digit int_end.
+        assert_eq!(ends(b"[1,007]", 3), Some((6, 6)));
     }
 
     #[test]

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1541,6 +1541,53 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
     }
 }
 
+/// Find the end (exclusive) of a lenient, JSON-*ish* number token starting
+/// at `pos`, which must point at `-` or an ASCII digit. Unlike
+/// [`crate::json::validate::is_valid_number`] (a strict RFC 8259
+/// whole-slice checker, not a token-boundary finder, and not reusable here
+/// for that reason), this tolerates a leading zero in the integer part
+/// (`007`) the way real jq's own number parser does (#1094) -- the whole
+/// point of the caller this exists for. Returns `None` only for a bare
+/// `-` with no digit following it at all (`-`, `[-,1]`, `{"a":-}`) --
+/// not a number token in the first place.
+///
+/// Mirrors [`find_string_end`]/[`find_matching_close`]'s "find the end of
+/// this token" shape (#1154) rather than interleaving grammar-walking
+/// with a transformation, the way an earlier version of
+/// [`normalize_leading_zero_numbers`] did -- that shape is exactly what
+/// let a real bug (fabricating a bare `-` into `-0`, turning genuinely
+/// invalid input into something that would silently validate) hide until
+/// review caught it before #1152 merged.
+fn find_number_end(bytes: &[u8], pos: usize) -> Option<usize> {
+    let mut i = pos;
+    if bytes[i] == b'-' {
+        i += 1;
+    }
+    let int_start = i;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == int_start {
+        return None;
+    }
+    if i < bytes.len() && bytes[i] == b'.' {
+        i += 1;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+    }
+    if i < bytes.len() && (bytes[i] == b'e' || bytes[i] == b'E') {
+        i += 1;
+        if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+            i += 1;
+        }
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+    }
+    Some(i)
+}
+
 /// Strip a leading zero from every JSON number token in `s` (`007` ->
 /// `7`, `-00` -> `-0`, `007.5` -> `7.5`), leaving string contents/keys and
 /// all other structure untouched. Real jq's own number parser tolerates a
@@ -1548,83 +1595,58 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// divergence before re-validating with `serde_json` (#1094) -- the
 /// trailing-garbage/number-range checks that validation exists for still
 /// apply to the normalized text exactly as before.
+///
+/// Delegates string-skipping to [`find_string_end`] and number-token
+/// boundaries to [`find_number_end`] (#1154) rather than hand-rolling
+/// both scans again -- see the latter's own doc comment for why this
+/// matters beyond tidiness.
 fn normalize_leading_zero_numbers(s: &str) -> String {
     let bytes = s.as_bytes();
     let mut out: Vec<u8> = Vec::with_capacity(s.len());
     let mut i = 0;
-    let mut in_string = false;
     while i < bytes.len() {
         let b = bytes[i];
-        if in_string {
-            out.push(b);
-            if b == b'\\' && i + 1 < bytes.len() {
-                out.push(bytes[i + 1]);
-                i += 2;
-                continue;
-            }
-            if b == b'"' {
-                in_string = false;
-            }
-            i += 1;
-            continue;
-        }
         if b == b'"' {
-            in_string = true;
-            out.push(b);
-            i += 1;
+            // `s` has already failed `validate_and_materialize_json`'s
+            // stricter check by the time this repair function runs (see
+            // `parse_json_value`), so an unterminated string here is a
+            // real, reachable case, not just hypothetical -- copy to
+            // end-of-input verbatim rather than panicking; the retried
+            // validation below will reject the result either way.
+            let end = find_string_end(bytes, i).unwrap_or(bytes.len());
+            out.extend_from_slice(&bytes[i..end]);
+            i = end;
             continue;
         }
         if b == b'-' || b.is_ascii_digit() {
             let start = i;
-            if b == b'-' {
-                i += 1;
-            }
-            let int_start = i;
-            while i < bytes.len() && bytes[i].is_ascii_digit() {
-                i += 1;
-            }
-            if int_start == i {
-                // A bare `-` with no digit following it at all (`-`,
-                // `[-,1]`, `{"a":-}`) isn't a number token in the first
-                // place -- only reachable when `b == '-'`, since a digit
-                // `b` always advances the scan above by at least one.
-                // Leaving it untouched (not fabricating a `0` digit) is
-                // required, not just tidier: filling one in turns a
-                // genuinely malformed token into a syntactically valid
-                // one (`-0`), which would make the retried `serde_json`
-                // validation below wrongly pass and this genuinely
-                // invalid input silently reach `json_bytes_to_owned_value`
-                // as `null` instead of erroring (found by review before
-                // merge).
+            let Some(end) = find_number_end(bytes, start) else {
+                // Bare `-`, not a number token -- see `find_number_end`'s
+                // own doc comment for why this must stay untouched rather
+                // than fabricating a digit.
                 out.push(b'-');
+                i += 1;
                 continue;
-            }
-            let stripped = s[int_start..i].trim_start_matches('0');
+            };
+            let int_start = if b == b'-' { start + 1 } else { start };
+            let int_end = int_start
+                + bytes[int_start..end]
+                    .iter()
+                    .take_while(|c| c.is_ascii_digit())
+                    .count();
+            let stripped = s[int_start..int_end].trim_start_matches('0');
             out.extend_from_slice(&bytes[start..int_start]);
             out.extend_from_slice(if stripped.is_empty() {
                 b"0"
             } else {
                 stripped.as_bytes()
             });
-            if i < bytes.len() && bytes[i] == b'.' {
-                let frac_start = i;
-                i += 1;
-                while i < bytes.len() && bytes[i].is_ascii_digit() {
-                    i += 1;
-                }
-                out.extend_from_slice(&bytes[frac_start..i]);
-            }
-            if i < bytes.len() && (bytes[i] == b'e' || bytes[i] == b'E') {
-                let exp_start = i;
-                i += 1;
-                if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
-                    i += 1;
-                }
-                while i < bytes.len() && bytes[i].is_ascii_digit() {
-                    i += 1;
-                }
-                out.extend_from_slice(&bytes[exp_start..i]);
-            }
+            // Fraction and exponent, if any, are contiguous from
+            // `int_end` to `end` by construction of `find_number_end` --
+            // copied verbatim in one slice, unlike the two separate
+            // frac/exp copies an earlier version of this function did.
+            out.extend_from_slice(&bytes[int_end..end]);
+            i = end;
             continue;
         }
         // Every byte reaching here is copied verbatim, one at a time,
@@ -2680,6 +2702,65 @@ fn format_json(value: &OwnedValue, config: &OutputConfig) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1154: direct unit coverage for the extracted token-boundary
+    /// finder, independent of the CLI-level `--argjson` tests (which
+    /// already cover `normalize_leading_zero_numbers`'s end-to-end
+    /// behavior via subprocess spawns invisible to `cargo llvm-cov`).
+    #[test]
+    fn test_find_number_end_1154() {
+        // Plain and negative integers.
+        assert_eq!(find_number_end(b"42", 0), Some(2));
+        assert_eq!(find_number_end(b"-42", 0), Some(3));
+        // Leading zeros tolerated (that's the whole point of this scan).
+        assert_eq!(find_number_end(b"007", 0), Some(3));
+        // Fraction and exponent, each optionally signed.
+        assert_eq!(find_number_end(b"1.5", 0), Some(3));
+        assert_eq!(find_number_end(b"1e10", 0), Some(4));
+        assert_eq!(find_number_end(b"1E+10", 0), Some(5));
+        assert_eq!(find_number_end(b"1.5e-10", 0), Some(7));
+        // A dangling '.' or 'e' with no digits after it still consumes
+        // the marker itself, matching the lenient original behavior --
+        // the retried `serde_json` validation rejects the result either
+        // way, so this scan doesn't need to.
+        assert_eq!(find_number_end(b"5.", 0), Some(2));
+        assert_eq!(find_number_end(b"5e", 0), Some(2));
+        // Stops at the token's own end, not the end of a larger buffer.
+        assert_eq!(find_number_end(b"42,43", 0), Some(2));
+        // A bare '-' with nothing (or nothing digit-shaped) after it is
+        // not a number token at all.
+        assert_eq!(find_number_end(b"-", 0), None);
+        assert_eq!(find_number_end(b"-,", 0), None);
+        // Starting position other than 0.
+        assert_eq!(find_number_end(b"[1,007]", 3), Some(6));
+    }
+
+    #[test]
+    fn test_normalize_leading_zero_numbers_1154() {
+        assert_eq!(normalize_leading_zero_numbers("007"), "7");
+        assert_eq!(normalize_leading_zero_numbers("-00"), "-0");
+        assert_eq!(normalize_leading_zero_numbers("007.5"), "7.5");
+        assert_eq!(normalize_leading_zero_numbers("007e10"), "7e10");
+        assert_eq!(normalize_leading_zero_numbers("-007.5e-10"), "-7.5e-10");
+        // String contents and object keys are never touched, even when
+        // they look like a leading-zero number themselves.
+        assert_eq!(
+            normalize_leading_zero_numbers(r#"{"007":"007"}"#),
+            r#"{"007":"007"}"#
+        );
+        // An escaped quote inside a string doesn't end the string early.
+        assert_eq!(
+            normalize_leading_zero_numbers(r#"["a\"b",007]"#),
+            r#"["a\"b",7]"#
+        );
+        // A bare '-' is left untouched, not fabricated into "-0" (#1094
+        // review finding, the bug this whole delegation exists to avoid
+        // reintroducing).
+        assert_eq!(normalize_leading_zero_numbers("-"), "-");
+        assert_eq!(normalize_leading_zero_numbers("[-,1]"), "[-,1]");
+        // A normal, already-valid number is unaffected.
+        assert_eq!(normalize_leading_zero_numbers("42"), "42");
+    }
 
     #[test]
     fn test_jq_compat_formatter_format_raw_number() {


### PR DESCRIPTION
## Summary

`normalize_leading_zero_numbers` (`--argjson` leading-zero repair, #1094) hand-rolled its own string-escape state machine and JSON number grammar walk, interleaved with the leading-zero-stripping transform itself — exactly the pattern the issue's own text points at as having let a real bug slip through review before #1152 merged (a bare `-` briefly got fabricated into `-0`, per this repo's own #106 "duplicated predicates diverge silently" lesson).

## Design

- Extracts `find_number_end`, mirroring `find_string_end`/`find_matching_close`'s existing "find this token's boundary" shape in the same file, so the number-token scan is its own small, independently testable function rather than interleaved with the transform.
- Reuses the existing `find_string_end` for string-skipping instead of a second, separately hand-rolled escape scanner — this eliminates the `in_string` state variable from the outer loop entirely.
- `is_valid_number` (`src/json/validate.rs`), the issue's other cited duplicate, turned out **not** directly reusable here on inspection: it's a whole-slice validator ("is all of this one number"), not a token-boundary finder. `find_number_end` fills that gap as its own definition.

I also found the issue's own citation of a `find_number_end` at a specific line number was stale (no such function existed in the current code) — the codebase had moved on since the issue was filed. The core duplication concern (string-scanning) was still real and current, confirmed by reading the live code before implementing.

## Code review

Review (10 parallel finder agents, several with differential fuzzing — one ran 2M+ random cases against the pre-refactor implementation with zero mismatches) found and fixed one real issue, independently converged on by 4+ separate passes: `find_number_end` computed its integer-digit-run boundary internally but discarded it, forcing the caller to redundantly re-derive the same boundary via a second scan — two separate definitions of "where the integer part ends" that happened to agree only by construction, with no test able to catch them drifting apart. Fixed by returning a small `NumberTokenEnd { int_end, end }` struct instead of a bare `usize`, computed once.

Also added a doc-comment note explaining why this file's already-imported `json::light::number_literal_end` isn't reused here (differential fuzzing confirmed its grammar genuinely diverges — it rejects a dangling exponent marker like `"5e"` outright, while this repair pass needs to tolerate it leniently, matching real jq).

Filed **#1218** (separate, broader, not attempted here): the crate now has four independent hand-rolled "find a JSON number token's boundaries" implementations across three files with different, cross-undocumented strictness grammars — worth a real design pass to consolidate, out of scope for this narrow, single-file dedup fix.

## Verification

Verified byte-identical output for the transform itself (not just CLI-observable behavior) by hand-tracing several cases before relying on the existing test suite; independently re-confirmed via reviewers' differential fuzzing.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features` (no_std)
- [x] Local patch coverage: 100% (71/71 new lines)
- [x] All 13 pre-existing `--argjson`/#1094 CLI tests pass **unchanged** — confirms behavior preservation, not just "still compiles"
- [x] New direct unit tests for `find_number_end`/`normalize_leading_zero_numbers` (the CLI tests spawn a subprocess invisible to `cargo llvm-cov`)

Fixes #1154