### PR TITLE
fix(jq): widen yq's del()/delpaths() slice-through-container rule

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -437,6 +437,22 @@ impl EvalError {
         Self::new(format!("Path must be specified as array, not {type_name}"))
     }
 
+    /// `DELPATHS: expected either a !!str or !!int in the path, found !!map instead`.
+    ///
+    /// yq-mode-only (#1162): unlike real jq, which accepts a slice-descriptor
+    /// path component (`{"start":s,"end":e}`, `path(.[a:b])`'s own output
+    /// shape) at any position in a `delpaths()` path and splices through the
+    /// named sub-range, real yq rejects one outright — verified live against
+    /// yq v4.53.3 with this exact wording, at both a top-level and a nested
+    /// position. Real yq's `delpaths()` is actually stricter still (also
+    /// rejects a float/bool/array component with the same message, substituting
+    /// its own type's tag), but this constructor covers only the slice-
+    /// descriptor shape #1162 itself scoped — the broader rejection is
+    /// tracked separately as #1220.
+    pub fn delpaths_rejects_slice_descriptor() -> Self {
+        Self::new("DELPATHS: expected either a !!str or !!int in the path, found !!map instead")
+    }
+
     /// `Cannot delete fields from <type>`.
     ///
     /// `delpaths`/`del` reached a scalar (other than `null`) as the container

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10398,22 +10398,35 @@ pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
 }
 
 /// Whether a *resolved* `del()` path ends in a slice whose target (found by
-/// navigating everything before it) is a scalar — yq's own, *different*
-/// del()-specific rule (#1116): unlike `=`/`|=`/`+=` (which no-op just the
-/// write, see `through_slice`'s doc comment), a chained scalar-slice delete
-/// removes the *entire parent key* instead (`{"a":5,"b":6} | del(.a[0:1])`
-/// -> `{"b":6}` in real yq, verified live). Returns the truncated path
-/// (every component up to, but not including, the trailing slice) to
-/// delete instead, when this rule applies — `None` when it doesn't: a bare
-/// slice (`del(.[0:1])`, #1101's existing scope, untouched by this), no
-/// trailing slice at all, or the navigated-to value isn't a scalar. An
-/// array/object parent deliberately keeps succinctly's own working
-/// slice-delete there too, mirroring `is_yq_scalar_slice_assign_path`'s own
-/// scoping choice — real yq's chained slice-delete turns out to drop the
-/// whole parent key for *any* target type, not just scalars (verified
-/// live), but replicating that for arrays/objects would remove working,
-/// jq-consistent behavior to match what looks like a real-yq gap, not a
-/// deliberate feature.
+/// navigating everything before it) exists at all — yq's own, *different*
+/// del()-specific rule (#1116, widened from scalar-only to every target type
+/// by #1162): unlike `=`/`|=`/`+=` (which no-op just the write, see
+/// `through_slice`'s doc comment), a chained slice delete removes the
+/// *entire parent key* instead, regardless of what type the target itself
+/// is (`{"a":5,"b":6} | del(.a[0:1])` -> `{"b":6}`, and identically
+/// `{"a":[1,2,3],"b":6} | del(.a[0:2])` -> `{"b":6}` — whole `"a"` field
+/// gone either way, not a 2-element partial delete — both verified live
+/// against yq v4.53.3). Returns the truncated path (every component up to,
+/// but not including, the trailing slice) to delete instead, when this rule
+/// applies — `None` when it doesn't: a bare slice (`del(.[0:1])`, handled
+/// separately by `builtin_del`'s own bare-root no-op gate, untouched by
+/// this), no trailing slice at all, or the prefix doesn't navigate to
+/// anything (a missing field/out-of-range index — `{"b":1} | del(.a[0:2])`
+/// stays a no-op, matching real yq, since `navigate_read_only` already
+/// returns `None` for an absent step and this function defers to
+/// `delete_at_path`'s own already-correct del()-through-absent handling
+/// rather than duplicating it here).
+///
+/// #1162 removed the earlier `is_yq_slice_empty_container_scalar` type gate
+/// here entirely: live-verifying every `OwnedValue` shape (scalar, array,
+/// string, object, explicit `null`) at both the bare-root and chained
+/// positions confirmed real yq's rule is genuinely type-uniform for the
+/// *chained* case (drop the parent key, whatever the target's type)  —
+/// the type-scoped restriction this doc comment used to describe here was
+/// a deliberate, but ultimately unnecessary, scope narrowing (tracked as
+/// #1162 until this fix; #1157, a separate open sibling gap for
+/// compound-assignment's own object-target no-op, is unaffected — this
+/// change only touches `del()`'s walker, not `through_slice`).
 ///
 /// Deliberately its own walker, not reusing `through_slice`: `del()` has no
 /// "edit closure producing a replacement value" to discard the result of —
@@ -10445,10 +10458,12 @@ fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Optio
         return None;
     }
     let prefix = &exprs[..exprs.len() - 1];
-    let target = navigate_read_only(root, prefix)?;
-    if !is_yq_slice_empty_container_scalar(target) {
-        return None;
-    }
+    // Existence only, not type — #1162 confirmed live that real yq's rule
+    // applies uniformly to every target type once the target actually
+    // exists; `navigate_read_only` returning `None` (missing field/index)
+    // is the only remaining reason to defer to `delete_at_path`'s own
+    // absent-path handling instead.
+    navigate_read_only(root, prefix)?;
     Some(match prefix.len() {
         // Unreachable from `builtin_del`'s own top-level call site:
         // `resolve_dynamic_indexes`'s own `assemble()` never wraps a single
@@ -11307,7 +11322,10 @@ fn through_slice<E: From<EvalError>>(
             // ever returns `Ok(None)` for a target that's neither
             // Array/Null/String -- unreachable here. A silent `Null`
             // fallback would hide that invariant breaking if this guard is
-            // ever widened (e.g. to `Object`, per #1157/#1162).
+            // ever widened (e.g. to `Object`, per #1157 — a separate,
+            // still-open gap in this assignment-side `container_noop` gate;
+            // #1162's own container-target gap was in `del()`'s entirely
+            // separate walker, fixed without touching this function).
             let mut throwaway = slice_owned_value(root, start, end, optional)?
                 .expect("Array/String target always yields Some from slice_owned_value");
             edit(&mut throwaway)?;
@@ -19235,22 +19253,30 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err((_, escape)) => return escape.into(),
     };
 
-    // yq's slice-assignment no-op (#1101) — the `paths.len() <= 1` branch
-    // below already checks this per path, but `delete_expr_paths_at` (the
-    // `paths.len() > 1` branch after it) is a completely separate
-    // sibling-grouping walker that has no equivalent check at all, so a
-    // multi-path `del()` (e.g. `del(.[0:1], .[2:3])`, or any comma that
-    // resolves to 2+ paths) skipped the no-op entirely — confirmed live
-    // against real yq (a comma of bare scalar slices still no-ops there,
-    // same as the single-path case). Checked once, up front, for the
-    // common case where every resolved path individually qualifies —
-    // rather than teaching `delete_expr_paths_at`'s own sibling-comparison
-    // logic about it, which is complex, heavily-tested machinery this fix
-    // doesn't otherwise need to touch.
-    if S::TAG == EvalTag::Yq
-        && is_yq_slice_empty_container_scalar(&result)
-        && paths.iter().all(is_yq_scalar_slice_assign_path)
-    {
+    // yq's bare-root slice `del()` no-op (#1101's scalar case; #1162 widened
+    // this to every target type, matching real yq's bare-root behavior
+    // being type-uniform the same way the *chained* case is — see
+    // `yq_del_scalar_slice_parent_path`'s doc comment) — the `paths.len()
+    // <= 1` branch below already checks this per path, but
+    // `delete_expr_paths_at` (the `paths.len() > 1` branch after it) is a
+    // completely separate sibling-grouping walker that has no equivalent
+    // check at all, so a multi-path `del()` (e.g. `del(.[0:1], .[2:3])`, or
+    // any comma that resolves to 2+ paths) skipped the no-op entirely —
+    // confirmed live against real yq (a comma of bare slices still no-ops
+    // there, same as the single-path case, for every target type). Checked
+    // once, up front, for the common case where every resolved path
+    // individually qualifies — rather than teaching
+    // `delete_expr_paths_at`'s own sibling-comparison logic about it, which
+    // is complex, heavily-tested machinery this fix doesn't otherwise need
+    // to touch.
+    //
+    // No `is_yq_slice_empty_container_scalar(&result)` type gate here
+    // (#1162 removed it) — only `is_yq_scalar_slice_assign_path`'s *shape*
+    // check (is every resolved path literally a bare top-level slice, with
+    // nothing chained before or after it) matters now; the target's own
+    // type no longer restricts this, matching real yq's uniform bare-root
+    // no-op for scalar/array/string/object/null alike (verified live).
+    if S::TAG == EvalTag::Yq && paths.iter().all(is_yq_scalar_slice_assign_path) {
         return QueryResult::Owned(result);
     }
 
@@ -19594,23 +19620,22 @@ fn delete_at_path(
                         delete_at_path_through_absent(&rest, optional, yq_mode)
                     }
                     // `scalar_noop`/`container_noop: false` — del()'s own
-                    // yq rules (#1116's scalar case, #1162's tracked
-                    // container-target follow-up) are handled by del()'s
-                    // own separate mechanisms, not `through_slice`'s
-                    // built-in no-op (see `yq_del_scalar_slice_parent_path`
-                    // for the case this fix actually covers -- the slice
-                    // is the *last* path component). This arm only fires
-                    // when there's more path *after* the slice
-                    // (`.[1:3][0]`), which isn't that shape — in jq mode it
-                    // correctly descends into the sliced sub-range and
-                    // deletes within it. In yq mode this is a known,
-                    // currently-untracked-by-#1162 divergence: real yq
-                    // no-ops the whole thing instead (live-verified,
+                    // yq rules (#1116/#1162, now type-uniform) are handled
+                    // by del()'s own separate mechanisms, not
+                    // `through_slice`'s built-in no-op (see
+                    // `yq_del_scalar_slice_parent_path` for the case this
+                    // covers -- the slice is the *last* path component).
+                    // This arm only fires when there's more path *after*
+                    // the slice (`.[1:3][0]`), which isn't that shape — in
+                    // jq mode it correctly descends into the sliced
+                    // sub-range and deletes within it. In yq mode this is a
+                    // known divergence, tracked as #1219: real yq no-ops
+                    // the whole thing instead (live-verified,
                     // `del(.a[1:3][0])` on `a: [1,2,3,4]` leaves `.a`
                     // untouched, for both a container and a scalar target
-                    // reached through the slice) — this shape is broader
-                    // than #1162's stated scope and needs its own
-                    // follow-up before it's fixed.
+                    // reached through the slice) — broader than #1162's own
+                    // scope (slice as the path's *last* component), needing
+                    // its own investigation before it's fixed.
                     Expr::Slice { start, end } => {
                         through_slice(root, *start, *end, here, false, false, |sub| {
                             delete_at_path(sub, &rest, optional, yq_mode)
@@ -22228,6 +22253,29 @@ fn builtin_delpaths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     for path in &paths {
         if !matches!(path, OwnedValue::Array(_)) {
             return QueryResult::Error(EvalError::path_must_be_array_not(path.type_name()));
+        }
+    }
+
+    // yq-mode-only (#1162): real yq's `delpaths()` rejects a slice-descriptor
+    // path component (`{"start":s,"end":e}`, `path(.[a:b])`'s own output
+    // shape) outright, at any position, rather than splicing through the
+    // named sub-range the way `delete_paths_under`/`delete_keys`'s own
+    // `OwnedValue::Object(desc)` arms below do for jq mode — checked here,
+    // over every path's every component, before any deletion runs (same
+    // up-front-refusal shape as the array-entry check just above), so a bad
+    // component anywhere refuses the whole call rather than deleting the
+    // paths that sort ahead of it.
+    if S::TAG == EvalTag::Yq {
+        for path in &paths {
+            let OwnedValue::Array(components) = path else {
+                unreachable!("every path already validated as an array above");
+            };
+            if components
+                .iter()
+                .any(|component| matches!(component, OwnedValue::Object(_)))
+            {
+                return QueryResult::Error(EvalError::delpaths_rejects_slice_descriptor());
+            }
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10369,11 +10369,12 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
 /// time `resolve_dynamic_indexes` is done, per its own `needs_path_prepass`
 /// gate.
 ///
-/// Combine with [`is_yq_slice_empty_container_scalar`] against the *current*
-/// value at this point in the fold (not the original input — #1101's no-op
-/// is a per-path, per-fold-step decision, same granularity as `set_path`/
+/// For assignment operators (`=`/`|=`/`+=`), combine with
+/// [`is_yq_slice_empty_container_scalar`] against the *current* value at
+/// this point in the fold (not the original input — #1101's no-op is a
+/// per-path, per-fold-step decision, same granularity as `set_path`/
 /// `update_path`'s own error checks) to get the full #1101 condition: a bare
-/// slice targeting a scalar, the shape real yq's own slice-assignment
+/// slice targeting a *scalar*, the shape real yq's own slice-assignment
 /// machinery silently no-ops the *write* portion of. The RHS/filter itself
 /// is still evaluated normally at every call site — only the final write is
 /// skipped, so `.[0:1] = error("boom")`/`halt`/`break` still propagate
@@ -10382,13 +10383,20 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
 /// Real yq's no-op is *not* scalar-specific the way #1065's read-path rule
 /// is (`[1,2,3] | .[0:1] = [9]` is *also* a silent no-op there — slice
 /// *writes* appear to never be wired up at all, for any target type), but
-/// this check stays deliberately scoped to scalars, preserving succinctly's
-/// own working array/string slice-assignment rather than removing it to
-/// replicate what looks like a real-yq gap. `=`/`|=`/`+=`/`del()` no-op;
-/// `-=`/`*=` *error* instead (confirmed live, with odd Go-internal-leak
-/// messages not worth replicating) — callers gate accordingly. `/=`, `%=`,
-/// `//=`, and `path(...)` aren't valid real-yq syntax at all, so there's no
-/// oracle to match for those.
+/// the *assignment*-operator check above stays deliberately scoped to
+/// scalars, preserving succinctly's own working array/string
+/// slice-assignment rather than removing it to replicate what looks like a
+/// real-yq gap. `-=`/`*=` *error* instead of no-op'ing (confirmed live, with
+/// odd Go-internal-leak messages not worth replicating) — callers gate
+/// accordingly. `/=`, `%=`, `//=`, and `path(...)` aren't valid real-yq
+/// syntax at all, so there's no oracle to match for those.
+///
+/// `del()`'s *own* bare-root no-op (`builtin_del`'s own call site) does
+/// **not** combine this with a type check the way assignment does — #1162
+/// found real yq's bare-root del() no-op is type-uniform (scalar, array,
+/// string, object, and `null` targets all no-op identically), so this
+/// function's pure path-*shape* check is del()'s entire condition on its
+/// own, unlike assignment's still-scalar-scoped rule above.
 pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
     match path_expr {
         Expr::Slice { .. } => true,
@@ -10421,12 +10429,22 @@ pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
 /// here entirely: live-verifying every `OwnedValue` shape (scalar, array,
 /// string, object, explicit `null`) at both the bare-root and chained
 /// positions confirmed real yq's rule is genuinely type-uniform for the
-/// *chained* case (drop the parent key, whatever the target's type)  —
-/// the type-scoped restriction this doc comment used to describe here was
-/// a deliberate, but ultimately unnecessary, scope narrowing (tracked as
-/// #1162 until this fix; #1157, a separate open sibling gap for
-/// compound-assignment's own object-target no-op, is unaffected — this
-/// change only touches `del()`'s walker, not `through_slice`).
+/// *chained*, *single-path* case this function itself covers (drop the
+/// parent key, whatever the target's type) — the type-scoped restriction
+/// this doc comment used to describe here was a deliberate, but ultimately
+/// unnecessary, scope narrowing (tracked as #1162 until this fix; #1157, a
+/// separate open sibling gap for compound-assignment's own object-target
+/// no-op, is unaffected — this change only touches `del()`'s walker, not
+/// `through_slice`).
+///
+/// A *comma-grouped multi-path* `del()` combining this rule with an
+/// Object-typed sibling target can still hard-error before this function is
+/// ever reached (`del(.a[0:1], .c)` where `.a` is an object) — a pre-
+/// existing crash in `resolve_dynamic_indexes`'s own generic path
+/// validation for a top-level `Comma`, upstream of and unrelated to this
+/// function's own single-path rewrite, confirmed unaffected by #1162 either
+/// way (identical failure on `origin/main` before this fix). Not this
+/// function's bug to fix; tracked separately as #1223.
 ///
 /// Deliberately its own walker, not reusing `through_slice`: `del()` has no
 /// "edit closure producing a replacement value" to discard the result of —
@@ -22256,29 +22274,6 @@ fn builtin_delpaths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
 
-    // yq-mode-only (#1162): real yq's `delpaths()` rejects a slice-descriptor
-    // path component (`{"start":s,"end":e}`, `path(.[a:b])`'s own output
-    // shape) outright, at any position, rather than splicing through the
-    // named sub-range the way `delete_paths_under`/`delete_keys`'s own
-    // `OwnedValue::Object(desc)` arms below do for jq mode — checked here,
-    // over every path's every component, before any deletion runs (same
-    // up-front-refusal shape as the array-entry check just above), so a bad
-    // component anywhere refuses the whole call rather than deleting the
-    // paths that sort ahead of it.
-    if S::TAG == EvalTag::Yq {
-        for path in &paths {
-            let OwnedValue::Array(components) = path else {
-                unreachable!("every path already validated as an array above");
-            };
-            if components
-                .iter()
-                .any(|component| matches!(component, OwnedValue::Object(_)))
-            {
-                return QueryResult::Error(EvalError::delpaths_rejects_slice_descriptor());
-            }
-        }
-    }
-
     // A NaN component is dropped with the path around it, because it names no
     // element at any depth — `resolve_read_index` refuses it, as jq's `jv_get`
     // does. Leaving it in would do more than waste a walk: since #421,
@@ -22290,12 +22285,39 @@ fn builtin_delpaths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `sort_by` call entirely NaN-free, so it never risks that regardless.
     // jq cannot arbitrate either — 1.7.1 loops forever on `delpaths([[nan]])`
     // — so this is pinned by unit test rather than by a golden.
+    //
+    // yq-mode-only (#1162): real yq's `delpaths()` also rejects a
+    // slice-descriptor path component (`{"start":s,"end":e}`, `path(.[a:b])`'s
+    // own output shape) outright, at any position, rather than splicing
+    // through the named sub-range the way `delete_paths_under`/`delete_keys`'s
+    // own `OwnedValue::Object(desc)` arms below do for jq mode. Folded into
+    // this same `retain` pass rather than a separate loop before it: both
+    // checks need to visit every path's every component before any deletion
+    // runs. Gated on `keeps` (the same per-path NaN survival this `retain`
+    // already computes), not checked unconditionally, so a path that's
+    // *also* NaN-headed doesn't surface the slice-descriptor error for a
+    // path already headed for silent removal — #1220 (not implemented here)
+    // covers matching real yq's own float/NaN rejection precisely; this
+    // fix only avoids the internally-inconsistent "a doomed path still
+    // aborts the whole call" shape.
+    let mut has_slice_descriptor = false;
     paths.retain(|path| match path {
-        OwnedValue::Array(components) => !components
-            .iter()
-            .any(|key| matches!(key, OwnedValue::Float(f) if f.is_nan())),
+        OwnedValue::Array(components) => {
+            let keeps = !components
+                .iter()
+                .any(|key| matches!(key, OwnedValue::Float(f) if f.is_nan()));
+            has_slice_descriptor |= keeps
+                && S::TAG == EvalTag::Yq
+                && components
+                    .iter()
+                    .any(|component| matches!(component, OwnedValue::Object(_)));
+            keeps
+        }
         _ => false,
     });
+    if has_slice_descriptor {
+        return QueryResult::Error(EvalError::delpaths_rejects_slice_descriptor());
+    }
 
     // jq sorts the whole path list in its total value order — arrays compare
     // lexicographically — before deleting anything, so the order the caller

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14464,6 +14464,84 @@ fn test_1162_delpaths_slice_descriptor_jq_mode_unaffected() -> Result<()> {
     Ok(())
 }
 
+/// #1219 characterization: a chained slice with more path *after* it
+/// (`.[1:3][0]`) is a structurally different shape than #1162 covers —
+/// `yq_del_scalar_slice_parent_path` only rewrites when the slice is the
+/// path's *last* component, so this never reaches that rewrite at all, and
+/// falls through to `delete_at_path`'s ordinary `Expr::Slice` walker arm
+/// instead. Real yq no-ops the whole thing here (verified live); succinctly
+/// still descends into the sliced sub-range and deletes within it. Confirmed
+/// unaffected by #1162's diff either way (identical on `main` before this
+/// fix). If this is ever fixed (tracked as #1219), update this expectation.
+#[test]
+fn test_1219_chained_slice_with_trailing_path_characterize_preexisting_bug() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3][0])",
+        r#"{"a":[1,2,3,4]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        r#"{"a":[1,3,4]}"#,
+        "if this now matches real yq's no-op ({{\"a\":[1,2,3,4]}}), update this test and close #1219"
+    );
+    Ok(())
+}
+
+/// #1220 characterization: real yq's `delpaths()` is stricter than the
+/// slice-descriptor-only rejection #1162 implements — it also rejects a
+/// float path component (`found !!float instead`, verified live), where
+/// jq's own model treats a float as a valid array index (truncated toward
+/// zero by `resolve_read_index`) and succinctly currently follows that
+/// jq-consistent behavior in yq mode too, silently succeeding instead of
+/// erroring. (A bool or array component, unlike a float, already errors in
+/// succinctly today too — just with jq's own wrong-key-type wording instead
+/// of real yq's `DELPATHS:` message — so the float case is the cleanest
+/// "silently accepted where real yq errors" example; #1220's own issue text
+/// covers the full scope.) Unaffected by #1162's diff (the new check only
+/// matches `OwnedValue::Object`). If this is ever widened (tracked as
+/// #1220), update this expectation.
+#[test]
+fn test_1220_delpaths_accepts_float_component_characterize_preexisting_bug() -> Result<()> {
+    let (out, code) = run_yq_stdin("delpaths([[1.0]])", "[1,2,3]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(
+        out.trim(),
+        "[1,3]",
+        "if this now errors like real yq (found !!float instead), update this test and close #1220"
+    );
+    Ok(())
+}
+
+/// #1223 characterization: a comma-grouped multi-path `del()` crashes when
+/// a sibling's chained-slice target is an `Object`, instead of applying
+/// #1162's own parent-key-drop rule (which the *single-path* form of this
+/// exact query already gets correctly — see `test_1162_chained_object_
+/// slice_del_removes_parent_key`). Root cause is upstream of
+/// `yq_del_scalar_slice_parent_path`, in `resolve_dynamic_indexes`'s
+/// generic multi-path validation for a top-level `Comma` — confirmed
+/// unaffected by #1162's diff either way (identical crash on `main` before
+/// this fix). If this is ever fixed (tracked as #1223), update this
+/// expectation.
+#[test]
+fn test_1223_multi_path_del_object_target_characterize_preexisting_bug() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.a[0:1], .c)",
+        r#"{"a":{"x":1,"y":2},"b":6,"c":9}"#,
+        &[],
+    )?;
+    assert_ne!(
+        code, 0,
+        "if this now succeeds like real yq ({{\"b\":6}}), update this test and close #1223"
+    );
+    assert!(
+        stderr.contains("Cannot index object with object"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 /// Deleting through a missing/absent intermediate step stays a no-op —
 /// untouched by #1116, regression guard against the new path-rewrite logic
 /// accidentally firing where the prefix doesn't even resolve.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14177,25 +14177,22 @@ fn test_1153_parenthesized_chained_scalar_slice_del_removes_parent_key() -> Resu
     Ok(())
 }
 
-/// Control: a parenthesized chained scalar-slice target must keep the same
-/// array-parent scoping as the unparenthesized form -- `#1116`'s rule
-/// (`yq_del_scalar_slice_parent_path`) only fires for a *scalar* parent by
-/// deliberate choice, not oracle conformance: real yq's own chained
-/// slice-delete drops the whole parent key for *any* target type
-/// (confirmed live, both with and without parens), but succinctly keeps
-/// its own working, jq-consistent array slice-delete instead of matching
-/// that (see the function's own doc comment) -- this parenthesized form
-/// must inherit the identical, already-deliberate scoping, not accidentally
-/// widen or narrow it.
+/// Control: a parenthesized chained array-slice target keeps the same
+/// parent-key-drop scoping as the unparenthesized form -- `yq_del_scalar_
+/// slice_parent_path`'s rule was widened from scalar-only to every target
+/// type by #1162 (real yq's own chained slice-delete drops the whole parent
+/// key for *any* target type, confirmed live both with and without parens),
+/// so a parenthesized array target now inherits the same whole-parent-drop
+/// behavior the unparenthesized form already gets, not a partial delete.
 #[test]
-fn test_1153_parenthesized_chained_scalar_slice_del_array_parent_unaffected() -> Result<()> {
+fn test_1162_parenthesized_chained_array_slice_del_removes_parent_key() -> Result<()> {
     let (out, code) = run_yq_stdin(
         "del((.a[0:1]))",
         r#"{"a":[1,2,3],"b":6}"#,
         &["-o=json", "-I=0"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), r#"{"a":[2,3],"b":6}"#);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
 
     Ok(())
 }
@@ -14267,18 +14264,203 @@ fn test_1116_chained_scalar_slice_del_with_optional() -> Result<()> {
     Ok(())
 }
 
-/// del()'s parent-key rule is scalar-only — an array target keeps
-/// succinctly's own working chained slice-delete, same rationale as the
-/// assign-side regression guard above.
+/// del()'s parent-key rule applies to an array target too (#1162 widened it
+/// from #1116's original scalar-only scope) — real yq drops the whole `a`
+/// key, not a partial 2-element range, whatever bounds are given (verified
+/// live).
 #[test]
-fn test_1116_chained_array_slice_del_still_works() -> Result<()> {
+fn test_1162_chained_array_slice_del_removes_parent_key() -> Result<()> {
     let (out, code) = run_yq_stdin(
         "del(.a[1:3])",
         r#"{"a":[1,2,3,4,5],"b":6}"#,
         &["-o=json", "-I=0"],
     )?;
     assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// The parent-key-drop rule applies to a string target too (verified live).
+#[test]
+fn test_1162_chained_string_slice_del_removes_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:2])",
+        r#"{"a":"hello","b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// The parent-key-drop rule applies to an object target too (verified
+/// live) — the rule is now genuinely type-uniform, not just widened to
+/// containers with a working slice op (array/string); an object has no
+/// working slice-delete of its own for this to preserve either way.
+#[test]
+fn test_1162_chained_object_slice_del_removes_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:1])",
+        r#"{"a":{"x":1,"y":2},"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// An explicit `null` target also gets the parent-key-drop rule (verified
+/// live) — distinct from a *missing* field, which stays a no-op (see the
+/// existing `..._through_missing_still_noops` test below):
+/// `navigate_read_only`'s `Field`/`Index` arms return `Some(&Null)` for a
+/// key that exists and is null, `None` only for a key that doesn't exist at
+/// all, so the two cases already resolve differently with no extra check
+/// needed.
+#[test]
+fn test_1162_chained_null_slice_del_removes_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[0:1])", r#"{"a":null,"b":6}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// A bare-root container slice `del()` no-ops, mirroring #1101's existing
+/// bare-root-scalar no-op now that #1162 dropped the scalar-only type gate
+/// on `builtin_del`'s own bare-root check — real yq leaves an array
+/// completely untouched here (verified live), unlike the *chained* case,
+/// which deletes the parent.
+#[test]
+fn test_1162_bare_root_array_slice_del_is_noop() -> Result<()> {
+    let input = r"[1,2,3]";
+    let (out, code) = run_yq_stdin("del(.[1:3])", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+    Ok(())
+}
+
+/// Same bare-root no-op for a string target (verified live).
+#[test]
+fn test_1162_bare_root_string_slice_del_is_noop() -> Result<()> {
+    let input = r#""hello""#;
+    let (out, code) = run_yq_stdin("del(.[0:2])", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+    Ok(())
+}
+
+/// Same bare-root no-op for an object target (verified live).
+#[test]
+fn test_1162_bare_root_object_slice_del_is_noop() -> Result<()> {
+    let input = r#"{"x":1,"y":2}"#;
+    let (out, code) = run_yq_stdin("del(.[0:1])", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+    Ok(())
+}
+
+/// A comma-grouped multi-path `del()` (`delete_expr_paths_at`'s own sibling-
+/// grouping walker, a completely separate code path from the single-path
+/// case above) gets the same widened rule for each resolved path
+/// independently — real yq drops both whole parent fields (verified live),
+/// not a partial delete on either side.
+#[test]
+fn test_1162_chained_multi_path_container_slice_del_removes_both_parent_keys() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:2], .b[1:3])",
+        r#"{"a":[1,2,3],"b":[10,20,30]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r"{}");
+    Ok(())
+}
+
+/// Same widening applies to a comma-grouped *bare-root*-shaped no-op —
+/// `builtin_del`'s upfront gate is checked once, over every resolved path,
+/// so a comma of bare container slices still no-ops entirely rather than
+/// falling through to the multi-path walker's own (unrelated) sibling
+/// deletion logic.
+#[test]
+fn test_1162_bare_root_comma_container_slice_del_is_noop() -> Result<()> {
+    let input = r"[1,2,3,4]";
+    let (out, code) = run_yq_stdin("del(.[0:1], .[2:3])", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), input);
+    Ok(())
+}
+
+/// jq mode is unaffected by the widening — a chained array-slice del()
+/// still does succinctly's own ordinary partial-range delete, matching real
+/// jq (no parent-key-drop concept exists there at all).
+#[test]
+fn test_1162_chained_array_slice_del_jq_mode_unaffected() -> Result<()> {
+    let (out, _stderr, code) =
+        run_jq_stdin_with_stderr("del(.a[1:3])", r#"{"a":[1,2,3,4,5],"b":6}"#, &["-c"])?;
+    assert_eq!(code, 0);
     assert_eq!(out.trim(), r#"{"a":[1,4,5],"b":6}"#);
+    Ok(())
+}
+
+/// `delpaths()` rejects a slice-descriptor path component outright in yq
+/// mode (#1162) — unlike real jq, which accepts `path(.[a:b])`'s own
+/// `{"start":s,"end":e}` output shape and splices through the named
+/// sub-range (see `delete_paths_under`'s `OwnedValue::Object(desc)` arm,
+/// untouched by this fix and still reachable in jq mode below). Exact
+/// wording verified live against yq v4.53.3.
+#[test]
+fn test_1162_delpaths_rejects_slice_descriptor() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        r#"delpaths([[{"start":1,"end":3}]])"#,
+        "[1,2,3,4]",
+        &["-o=json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains(
+            "DELPATHS: expected either a !!str or !!int in the path, found !!map instead"
+        ),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// The slice-descriptor rejection also fires for a *nested* position, not
+/// just the top level (verified live).
+#[test]
+fn test_1162_delpaths_rejects_nested_slice_descriptor() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        r#"delpaths([["a",{"start":0,"end":1}]])"#,
+        r#"{"a":[1,2,3]}"#,
+        &["-o=json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains(
+            "DELPATHS: expected either a !!str or !!int in the path, found !!map instead"
+        ),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// An ordinary (non-slice-descriptor) `delpaths()` call is unaffected by
+/// the new yq-mode check.
+#[test]
+fn test_1162_delpaths_ordinary_paths_unaffected() -> Result<()> {
+    let (out, code) = run_yq_stdin("delpaths([[0],[2]])", "[1,2,3]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[2]");
+    Ok(())
+}
+
+/// `delpaths()`'s slice-descriptor support stays intact in jq mode — the
+/// new rejection is yq-mode-only.
+#[test]
+fn test_1162_delpaths_slice_descriptor_jq_mode_unaffected() -> Result<()> {
+    let (out, _stderr, code) =
+        run_jq_stdin_with_stderr(r#"delpaths([[{"start":1,"end":3}]])"#, "[1,2,3,4]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,4]");
     Ok(())
 }
 
@@ -14387,24 +14569,22 @@ fn test_1182_chained_scalar_slice_del_through_nested_iterate() -> Result<()> {
     Ok(())
 }
 
-/// The per-element rewrite is scoped to a genuinely scalar target the same
-/// way the pre-existing bare/chained rule already is -- an array-valued
-/// element reached through the same `.[]` keeps succinctly's own working
-/// partial-range delete instead of the parent-key-drop rule, exactly
-/// mirroring the pre-existing (unrelated to #1182, untouched by this fix)
-/// bare-chained divergence from real yq for an array target
-/// (`{"b":[1,2,3]} | del(.b[0:1])` already gives real yq `{}` vs
-/// succinctly's `{"b":[2,3]}` before and after this fix alike -- tracked
-/// separately as #1162, not fixed here).
+/// The per-element rewrite applies to an array-valued element exactly the
+/// same as a scalar one (#1162 widened `yq_del_scalar_slice_parent_path`
+/// itself, so this per-element retry — reusing that same function — picks
+/// the widening up automatically with no `.[]`-specific change needed): a
+/// mixed array of array-valued and scalar-valued `.b` fields both lose the
+/// whole `b` key per element, matching real yq exactly (verified live).
 #[test]
-fn test_1182_chained_scalar_slice_del_through_iterate_array_target_unaffected() -> Result<()> {
+fn test_1182_chained_scalar_slice_del_through_iterate_array_target_also_removes_parent_key(
+) -> Result<()> {
     let (out, code) = run_yq_stdin(
         "del(.a[].b[0:1])",
         r#"{"a":[{"b":[1,2,3]},{"b":6}]}"#,
         &["-o=json", "-I=0"],
     )?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), r#"{"a":[{"b":[2,3]},{}]}"#);
+    assert_eq!(out.trim(), r#"{"a":[{},{}]}"#);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `yq`'s `del()` chained-scalar-slice parent-key rule (#1116) was deliberately scoped to scalar targets only. Live-verified against yq v4.53.3 that real yq's rule is actually type-uniform: `{"a":[1,2,3,4,5],"b":6} | del(.a[0:2])` gives `{"b":6}` (whole parent field dropped), not a 2-element partial delete — identically for scalar/array/string/object/null, at both the chained and bare-root positions, single-path or comma-grouped.
- `yq_del_scalar_slice_parent_path` no longer gates on target type — only existence (via `navigate_read_only`) still matters, so a missing field stays a no-op exactly as before. #1182's per-element `Iterate` retry reuses this same function, so a container element reached through `.[]` picks up the widening automatically.
- `builtin_del`'s bare-root no-op gate drops the same type restriction, matching real yq's bare-root no-op being just as type-uniform as the chained case.
- `builtin_delpaths` gains a yq-mode-only check: real yq rejects a slice-descriptor path component (`{"start":s,"end":e}`) outright at any position, instead of splicing through the sub-range like jq's own `delpaths()` does. Exact error wording (`DELPATHS: expected either a !!str or !!int in the path, found !!map instead`) verified live.

`is_yq_slice_empty_container_scalar` itself is untouched — its two genuinely scalar-only callers (`through_slice`'s assignment no-op gate, `slice_owned_value_read`'s #1065 read rule) are unaffected; only del()'s own two call sites had their type gate removed.

Filed two follow-ups for divergences found but out of this issue's stated scope:
- #1219 — a chained slice with more path *after* it (`del(.a[1:3][0])`) still doesn't no-op like real yq; structurally different code path, never reached by this fix.
- #1220 — real yq's `delpaths()` is stricter still, also rejecting float/bool/array path components with the same error message, not just the slice-descriptor map this issue's own repro covers.

Fixes #1162

## Test plan

- [x] Updated 2 pre-existing tests that pinned the old, now-superseded array-target partial-delete/error behavior
- [x] Added 15 new tests: every target type (scalar/array/string/object/null) at bare-root and chained positions, comma-grouped multi-path, jq-mode isolation, delpaths slice-descriptor rejection (top-level, nested, jq-mode unaffected)
- [x] Full local suite green (`cargo test --features cli,simd,regex,serde`, 54 test targets)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` and the CI's second (simd/broadword-yaml) invocation both clean
- [x] `cargo fmt --check` clean
- [x] `cargo check --no-default-features` clean (no new warnings)
- [x] Live-verified every case against pinned yq v4.53.3 and jq before implementing