### PR TITLE
fix(jq): zero-mantissa literal picks notation on its shifted, not written, exponent

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -227,7 +227,7 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // stays necessary for a *nonzero* integer-valued literal like `-5e0`,
     // just no longer for `-0e0` specifically).
     if value == 0.0 {
-        return format_zero_value_literal(s, exp_pos, value.is_sign_negative());
+        return format_near_zero_literal(s, exp_pos, value.is_sign_negative());
     }
 
     // For e0 or e-0, jq eliminates the exponent
@@ -271,16 +271,17 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // smallest representable subnormal), making `abs_value / 0.0 = +inf`
     // and rendering the mantissa as the literal text `"inf"`, which isn't
     // valid JSON at all. Routing every subnormal through the same
-    // string-based path `format_zero_value_literal` uses for exact-zero
+    // string-based path `format_near_zero_literal` uses for exact-zero
     // underflow sidesteps both: that path derives the mantissa from `s`'s
     // own source digits, never from `f64` arithmetic that's already lost
     // precision by this magnitude. Always scientific here (the #1207
     // small-magnitude decimal window applies only to a *genuinely*
     // zero-mantissa literal, never to one merely underflowed to zero) --
     // a subnormal `value` can only come from a nonzero mantissa in the
-    // first place.
+    // first place, so `format_near_zero_literal` always takes its `Ok`
+    // arm for this caller.
     if !value.is_normal() {
-        return format_underflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
+        return format_near_zero_literal(s, exp_pos, value.is_sign_negative());
     }
 
     let abs_value = value.abs();
@@ -341,13 +342,10 @@ fn parse_literal_exponent(exp_text: &str) -> i64 {
 }
 
 /// Split a literal's mantissa text (`s[..exp_pos]`, sign stripped) into its
-/// integer and fractional parts -- shared by
-/// [`normalize_extreme_literal_mantissa`] and
-/// [`format_underflow_literal_mantissa`]'s own genuinely-all-zero-mantissa
-/// fallback (#1178), so "how do we split the mantissa out of `s`" has
-/// exactly one implementation instead of two hand-copied ones that must be
-/// kept in sync by convention (#106) -- the same duplicated-predicate shape
-/// this codebase has already been bitten by once.
+/// integer and fractional parts -- the sole implementation
+/// [`normalize_extreme_literal_mantissa`] builds on, so "how do we split the
+/// mantissa out of `s`" has exactly one implementation rather than one
+/// hand-copied at each of its own call sites (#106).
 fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
     let raw = &s[..exp_pos];
     // Strip either sign: `+` is as insignificant to the mantissa's own
@@ -361,24 +359,28 @@ fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
 /// Shift a literal's own mantissa digits (the text before `exp_pos`, i.e.
 /// before `e`/`E`) into jq's one-digit-before-the-point normalized form,
 /// and fold that shift into the literal's own written exponent -- returns
-/// `Some((mantissa_str, new_exp))`, or `None` if the mantissa is genuinely
-/// all-zero (`0.0e400`, `0.00e-400`), which has no magnitude to normalize
-/// against. Entirely via string manipulation on `s` rather than
-/// `log10`/`pow` on the parsed value, since the caller only reaches here
-/// when the parsed value has already lost the precision this exists to
-/// recover (`+/-infinity` on overflow, exactly `0.0` on underflow).
+/// `Ok((mantissa_str, new_exp))`, or `Err(frac_len)` if the mantissa is
+/// genuinely all-zero (`0.0e400`, `0.00e-400`), which has no magnitude to
+/// normalize against (`frac_len` is the fractional-digit count the `Err`
+/// caller needs for its own shift math, #1207 -- surfaced here rather than
+/// re-derived by every `Err` caller via a second `split_mantissa` call).
+/// Entirely via string manipulation on `s` rather than `log10`/`pow` on the
+/// parsed value, since the caller only reaches here when the parsed value
+/// has already lost the precision this exists to recover (`+/-infinity` on
+/// overflow, exactly `0.0` on underflow/genuine zero).
 ///
 /// Shared by [`format_overflow_literal_mantissa`] and
-/// [`format_underflow_literal_mantissa`] (#1099) -- the shift math is
-/// identical whether the literal's written exponent is enormous-positive
-/// (overflow) or enormous-negative (underflow); only what each caller does
-/// with `new_exp` afterward differs (overflow caps to infinity text past a
-/// ceiling; underflow has no such ceiling, oracle-verified on its own doc
-/// comment). The `None` case is centralized here rather than pre-checked
-/// separately by each caller, so "is this mantissa all-zero" has exactly
-/// one implementation instead of two that must be kept in sync by
-/// convention (#106).
-fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Option<(String, i64)> {
+/// [`format_near_zero_literal`] (#1099) -- the shift math is identical
+/// whether the literal's written exponent is enormous-positive (overflow)
+/// or enormous-negative (underflow/zero); only what each caller does with
+/// `new_exp` afterward differs (overflow caps to infinity text past a
+/// ceiling; the near-zero case has no such ceiling, and additionally uses
+/// `Err`'s `frac_len` for its own small-magnitude notation choice, #1207).
+/// The all-zero-mantissa detection is centralized here rather than
+/// pre-checked separately by each caller, so "is this mantissa all-zero"
+/// has exactly one implementation instead of two that must be kept in sync
+/// by convention (#106).
+fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String, i64), i64> {
     // `dump_truncated`'s whole design keeps preview cost independent of the
     // value's own size (see its doc comment) - a document-controlled
     // mantissa of unbounded length must not turn into unbounded work here
@@ -407,8 +409,16 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Option<(String
     let (shift, leading, rest): (i64, &str, String) = if int_part.is_empty() {
         // Shift right to the first nonzero fractional digit. Genuinely
         // all-zero mantissa (`0.0e400`/`0.0e-400`) has no nonzero digit to
-        // shift to -- `?` propagates that as `None`.
-        let k = frac_part.find(|c: char| c != '0')?;
+        // shift to -- return `Err(frac_len)` instead, `frac_part.len()` is
+        // exactly what the `Err` caller's own shift math needs (#1207).
+        let Some(k) = frac_part.find(|c: char| c != '0') else {
+            // `try_from`, not a bare `as` cast: `frac_part.len()` is
+            // document-controlled and unbounded, same as the exponent digit
+            // string `parse_literal_exponent` below saturates rather than
+            // wraps -- matching that same discipline here instead of
+            // silently flipping sign past `i64::MAX` bytes.
+            return Err(i64::try_from(frac_part.len()).unwrap_or(i64::MAX));
+        };
         let after = &frac_part[k + 1..];
         (
             -(k as i64 + 1),
@@ -440,7 +450,7 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Option<(String
     } else {
         format!("{leading}.{rest}")
     };
-    Some((mantissa_str, new_exp))
+    Ok((mantissa_str, new_exp))
 }
 
 /// Renormalize an overflowed literal's own mantissa digits into jq's
@@ -462,7 +472,7 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // A mantissa of exactly `0` times any exponent is still exactly `0.0`,
     // never `+/-infinity` -- callers only reach this function when `value`
     // has already overflowed, which guarantees a nonzero mantissa.
-    let Some((mantissa_str, new_exp)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
+    let Ok((mantissa_str, new_exp)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
         unreachable!("overflow implies a nonzero mantissa")
     };
 
@@ -477,81 +487,62 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     assemble_scientific(sign, &mantissa_str, new_exp)
 }
 
-/// Renormalize an underflowed-but-*nonzero*-mantissa literal's own mantissa
-/// digits into jq's one-digit-before-the-point scientific form (#1099) --
-/// see [`normalize_extreme_literal_mantissa`] for the shared shift math, and
-/// [`format_overflow_literal_mantissa`] for the symmetric overflow case.
-/// Callers only reach this for a *subnormal* `value` (`format_number_jq_compat`
-/// handles `value == 0.0` separately via [`format_zero_value_literal`]
-/// before this function is ever called), which can only come from a nonzero
-/// mantissa in the first place -- `normalize_extreme_literal_mantissa` is
-/// therefore guaranteed `Some` here.
-///
-/// Oracle-verified against real jq: `1e-400` -> `1E-400`, `12.34e-400` ->
-/// `1.234E-399`, `0.5e-400` -> `5E-401`, `100.5e-400` -> `1.005E-398`.
-/// Unlike overflow, underflow has no *deliberate* ceiling here --
-/// `1e-1000000000` (exponent magnitude *at* the overflow ceiling) still
-/// prints `1E-1000000000` unchanged, not a fallback to plain `0`. Real jq
-/// itself, however, breaks down for magnitudes beyond ~1,147,483,647
-/// (`i32::MAX - 1e9`; an apparent internal int32-overflow bug in its own
-/// decNumber), printing a fixed sentinel (`1e-1200000000` -> real jq's
-/// `0E-1147483646`) rather than continuing to preserve the mantissa. This
-/// function deliberately does **not** replicate that breakdown -- it keeps
-/// preserving the mantissa past jq's own failure point, on the basis that
-/// jq's behavior there is itself a bug, not a rule worth matching.
-fn format_underflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> String {
-    let sign = if negative { "-" } else { "" };
-    let Some((mantissa_str, new_exp)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
-        unreachable!("a subnormal value implies a nonzero mantissa")
-    };
-    assemble_scientific(sign, &mantissa_str, new_exp)
-}
-
-/// Format a literal whose *parsed value* is exactly `0.0` (`-0.0` included)
-/// -- the single call site in `format_number_jq_compat` reaches here before
-/// any of that function's other notation checks run, since #1207 found this
-/// case picks notation on a different axis than every other literal (see
-/// the call site's own comment).
+/// Format a literal whose parsed `f64` `value` has lost precision to (or
+/// started at) zero -- either genuinely equal to `0.0` (`-0.0` included), or
+/// nonzero but *subnormal* (#1099/#1177). `format_number_jq_compat` routes
+/// both callers here: `value == 0.0` before any of its other notation
+/// checks run (#1207 found this picks notation on a different axis than
+/// every other literal, see that call site's own comment), and
+/// `!value.is_normal()` afterward for the subnormal case (symmetric with
+/// [`format_overflow_literal_mantissa`] on the overflow side).
 ///
 /// [`normalize_extreme_literal_mantissa`] itself distinguishes the two ways
-/// a literal can parse to exactly `0.0`:
+/// a literal reaches this function:
 ///
-/// - A genuinely all-zero mantissa (`0.0e-400`, `None` here) has no nonzero
-///   digit to renormalize around at all -- real jq still shifts the printed
-///   exponent by the fractional-zero-digit count the same way it does for a
-///   nonzero mantissa (#1178: `0.000e-400` -> `0E-403`, not `0E-400`; a
-///   no-fraction spelling like `0e-400` has shift `0` and needs none). That
-///   *shifted* exponent, not the literal's raw written one, is what
-///   actually determines notation (#1207, oracle-verified for shifted
+/// - A genuinely all-zero mantissa (`0.0e-400`, `Err(frac_len)` here) has no
+///   nonzero digit to renormalize around at all -- real jq still shifts the
+///   printed exponent by the fractional-zero-digit count the same way it
+///   does for a nonzero mantissa (#1178: `0.000e-400` -> `0E-403`, not
+///   `0E-400`; a no-fraction spelling like `0e-400` has shift `0` and needs
+///   none). That *shifted* exponent, not the literal's raw written one, is
+///   what actually determines notation (#1207, oracle-verified for shifted
 ///   exponents `-8..=2`): `0` picks a bare integer (`0e1` shifts to `0`,
 ///   prints `0`); `-6..=-1` picks an expanded decimal with `-shifted` zeros
 ///   after the point (`0e-1` -> `0.0`, ..., `0e-6` -> `0.000000`); anything
 ///   else keeps the scientific form this function used unconditionally
-///   before #1207 (`0e-7` -> `0E-7`, `0e2` -> `0E+2`).
+///   before #1207 (`0e-7` -> `0E-7`, `0e2` -> `0E+2`). Only reachable from
+///   the `value == 0.0` caller -- a subnormal `value` can only come from a
+///   nonzero mantissa in the first place, so the `!value.is_normal()`
+///   caller always takes the `Ok` arm below instead.
 /// - A nonzero mantissa that simply underflowed `f64` during parsing
 ///   (`1e-400`, far below `f64::MIN_POSITIVE`) can't be told apart from the
 ///   above by the parsed value alone (#1099) -- but real jq's small-window
 ///   decimal/bare notation never applies to it regardless of its shifted
 ///   exponent's own magnitude (a mantissa with real precision to preserve
-///   always stays scientific); only `assemble_scientific` on the `Some`
-///   arm's own shift math is needed, unaffected by #1207.
+///   always stays scientific); only `assemble_scientific` on the `Ok` arm's
+///   own shift math is needed, unaffected by #1207. Oracle-verified against
+///   real jq: `1e-400` -> `1E-400`, `12.34e-400` -> `1.234E-399`, `0.5e-400`
+///   -> `5E-401`, `100.5e-400` -> `1.005E-398`. Unlike overflow, this side
+///   has no *deliberate* ceiling -- `1e-1000000000` (exponent magnitude *at*
+///   the overflow ceiling) still prints `1E-1000000000` unchanged, not a
+///   fallback to plain `0`. Real jq itself, however, breaks down for
+///   magnitudes beyond ~1,147,483,647 (`i32::MAX - 1e9`; an apparent
+///   internal int32-overflow bug in its own decNumber), printing a fixed
+///   sentinel (`1e-1200000000` -> real jq's `0E-1147483646`) rather than
+///   continuing to preserve the mantissa. This function deliberately does
+///   **not** replicate that breakdown -- it keeps preserving the mantissa
+///   past jq's own failure point, on the basis that jq's behavior there is
+///   itself a bug, not a rule worth matching.
 ///
 /// `value == 0.0` is true for `-0.0` too (IEEE 754), so `negative` (from the
 /// caller's `value.is_sign_negative()`) still needs applying in every arm --
 /// real jq keeps the sign throughout, since `log10(0)` is undefined
 /// (`-0e5` -> `-0E+5`, `-0e0` -> `-0`, `-0.0e-1` -> `-0.00`).
-fn format_zero_value_literal(s: &str, exp_pos: usize, negative: bool) -> String {
+fn format_near_zero_literal(s: &str, exp_pos: usize, negative: bool) -> String {
     let sign = if negative { "-" } else { "" };
     match normalize_extreme_literal_mantissa(s, exp_pos) {
-        Some((mantissa_str, new_exp)) => assemble_scientific(sign, &mantissa_str, new_exp),
-        None => {
-            let (_, frac_part) = split_mantissa(s, exp_pos);
-            // `try_from`, not a bare `as` cast: `frac_part.len()` is
-            // document-controlled and unbounded, same as the exponent digit
-            // string `parse_literal_exponent` already saturates rather than
-            // wraps a couple lines down -- matching that same discipline
-            // here instead of silently flipping sign past `i64::MAX` bytes.
-            let frac_len = i64::try_from(frac_part.len()).unwrap_or(i64::MAX);
+        Ok((mantissa_str, new_exp)) => assemble_scientific(sign, &mantissa_str, new_exp),
+        Err(frac_len) => {
             let shifted_exp = parse_literal_exponent(&s[exp_pos + 1..]).saturating_sub(frac_len);
             if shifted_exp == 0 {
                 format!("{sign}0")
@@ -2710,9 +2701,9 @@ mod tests {
     /// literal's raw written exponent the way `format_number_jq_compat`'s
     /// `exp == 0`/`(-5..0)` fast paths do for everything else -- before this
     /// fix, every zero-mantissa literal with a nonzero written exponent went
-    /// straight to `format_underflow_literal_mantissa`'s unconditional
-    /// scientific output, regardless of how small the resulting exponent
-    /// magnitude actually was. Oracle-verified against jq 1.7.1 for the
+    /// straight to `format_near_zero_literal`'s unconditional scientific
+    /// output, regardless of how small the resulting exponent magnitude
+    /// actually was. Oracle-verified against jq 1.7.1 for the
     /// full boundary, shifted exponents -8..=2 (`0e{shifted}` has no
     /// fraction digits, so its shift is 0 and its shifted exponent equals
     /// its written one).

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -2392,6 +2392,12 @@ mod tests {
         // e0 eliminates the exponent; when the result is a whole number it
         // takes the integer-formatting branch rather than float Display.
         assert_eq!(format_number_jq_compat(b"5e0"), "5");
+        // #1207 review: this branch's own `is_sign_negative()` arm is only
+        // reachable via a genuinely negative *nonzero* integer literal now
+        // that `value == 0.0` (including `-0.0`) is intercepted earlier by
+        // `format_near_zero_literal` -- no existing test exercised that arm
+        // through its real case rather than incidentally through `-0e0`.
+        assert_eq!(format_number_jq_compat(b"-5e0"), "-5");
     }
 
     /// #1008 code review: this was pinned to `"0"`, but real jq keeps the

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -212,14 +212,33 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
         return format_overflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
     }
 
+    // A zero-valued literal (`0.0e-400` or a genuinely-underflowed nonzero
+    // mantissa like `1e-400`) picks its notation on a *different* threshold
+    // than every other case below -- both `exp == 0` and the `-5..0` window
+    // just below use the literal's own *written* exponent, which #1207
+    // found is simply the wrong axis once a written exponent and a fraction
+    // are both present (`0.0e-400`'s written exponent is `-400`, but its
+    // *shifted* exponent -- what actually determines notation, matching
+    // #1178's own shift math -- is `-401`). Intercepting here, before either
+    // raw-exponent check, keeps this one shifted-exponent rule as the only
+    // path a zero-valued literal can take (`value == 0.0` is true for
+    // `-0.0` too, so this also subsumes the old `exp == 0` branch's
+    // negative-zero special case below -- that branch's own sign-handling
+    // stays necessary for a *nonzero* integer-valued literal like `-5e0`,
+    // just no longer for `-0e0` specifically).
+    if value == 0.0 {
+        return format_zero_value_literal(s, exp_pos, value.is_sign_negative());
+    }
+
     // For e0 or e-0, jq eliminates the exponent
     if exp == 0 {
         // Check if result is integer
         if value.fract() == 0.0 && value.abs() < 1e15 {
             // `value as i64` truncates -0.0's sign (`-0.0 as i64 == 0`),
-            // dropping it from the formatted text too -- `1e-0`/`-0e0`-style
-            // literals #1008 made newly reachable from YAML hit this.
-            // Real jq keeps the sign (`-0e0` -> `-0`).
+            // dropping it from the formatted text too -- but `value == 0.0`
+            // above already returned for that case, so this is reachable
+            // only via a *nonzero* negative integer-valued literal here
+            // (`-5e0` -> `-5`), where `value as i64` is exact regardless.
             return if value.is_sign_negative() {
                 format!("-{}", value.abs() as i64)
             } else {
@@ -241,32 +260,25 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // jq normalizes mantissa to have one digit before decimal point
     //
     // `!value.is_normal()` -- `value` is already known finite (the
-    // `!value.is_finite()` overflow check above returned first), so this
-    // is exactly "zero or subnormal," covering two distinct situations
-    // that both need the string-based path below instead of the
-    // `log10`/`pow` renormalization that follows it:
-    //
-    // - `value == 0.0`: true both for a genuinely-zero-mantissa literal
-    //   (`0e-400`) and for a *nonzero*-mantissa literal whose magnitude
-    //   simply underflowed `f64` during parsing (`1e-400`, far below
-    //   `f64::MIN_POSITIVE`) -- the two can't be told apart from `value`
-    //   alone (#1099). `format_underflow_literal_mantissa` (and the shared
-    //   `normalize_extreme_literal_mantissa` beneath it) tells them apart
-    //   from the literal's own source digits.
-    // - nonzero but *subnormal* (#1177): the `log10`/`pow` renormalization
-    //   below is already measurably imprecise across most of the subnormal
-    //   range (e.g. `1e-315` mis-renormalizes to a mantissa of
-    //   `10.000000148219696` instead of `1.0`, oracle-verified), and at
-    //   the extreme low end `libm::pow(10.0, log10(abs_value).floor())`
-    //   can itself underflow to exactly `0.0` (its own result is smaller
-    //   than the smallest representable subnormal), making
-    //   `abs_value / 0.0 = +inf` and rendering the mantissa as the literal
-    //   text `"inf"`, which isn't valid JSON at all.
-    //
-    // Routing every subnormal through the same string-based path as
-    // exact-zero underflow sidesteps both: that path derives the mantissa
-    // from `s`'s own source digits, never from `f64` arithmetic that's
-    // already lost precision by this magnitude.
+    // `!value.is_finite()` overflow check above returned first) and known
+    // nonzero (the `value == 0.0` check above returned first too), so this
+    // is exactly "nonzero but subnormal" (#1177): the `log10`/`pow`
+    // renormalization below is already measurably imprecise across most of
+    // the subnormal range (e.g. `1e-315` mis-renormalizes to a mantissa of
+    // `10.000000148219696` instead of `1.0`, oracle-verified), and at the
+    // extreme low end `libm::pow(10.0, log10(abs_value).floor())` can
+    // itself underflow to exactly `0.0` (its own result is smaller than the
+    // smallest representable subnormal), making `abs_value / 0.0 = +inf`
+    // and rendering the mantissa as the literal text `"inf"`, which isn't
+    // valid JSON at all. Routing every subnormal through the same
+    // string-based path `format_zero_value_literal` uses for exact-zero
+    // underflow sidesteps both: that path derives the mantissa from `s`'s
+    // own source digits, never from `f64` arithmetic that's already lost
+    // precision by this magnitude. Always scientific here (the #1207
+    // small-magnitude decimal window applies only to a *genuinely*
+    // zero-mantissa literal, never to one merely underflowed to zero) --
+    // a subnormal `value` can only come from a nonzero mantissa in the
+    // first place.
     if !value.is_normal() {
         return format_underflow_literal_mantissa(s, exp_pos, value.is_sign_negative());
     }
@@ -465,23 +477,15 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     assemble_scientific(sign, &mantissa_str, new_exp)
 }
 
-/// Renormalize an underflowed literal's own mantissa digits into jq's
-/// one-digit-before-the-point scientific form (#1099) -- see
-/// [`normalize_extreme_literal_mantissa`] for the shared shift math, and
+/// Renormalize an underflowed-but-*nonzero*-mantissa literal's own mantissa
+/// digits into jq's one-digit-before-the-point scientific form (#1099) --
+/// see [`normalize_extreme_literal_mantissa`] for the shared shift math, and
 /// [`format_overflow_literal_mantissa`] for the symmetric overflow case.
-///
-/// A literal whose magnitude underflows `f64` to exactly `0.0` (nonzero
-/// mantissa, deeply negative exponent) can't be told apart from a
-/// genuinely-zero-mantissa literal by looking at the parsed value alone --
-/// both are `0.0`. Unlike an earlier version of this function, the caller
-/// does *not* pre-check the mantissa's own source digits before calling
-/// this -- `normalize_extreme_literal_mantissa` (below) makes that
-/// determination itself and returns `None` for a genuinely all-zero
-/// mantissa, handled explicitly in the `match` below. The single call site
-/// in `format_number_jq_compat` reaches here for both `value == 0.0` (#1099)
-/// and nonzero-but-subnormal `value` (#1177) -- in the subnormal case the
-/// mantissa is always nonzero in practice (a subnormal `f64` can't come
-/// from an all-zero-mantissa literal), but nothing here depends on that.
+/// Callers only reach this for a *subnormal* `value` (`format_number_jq_compat`
+/// handles `value == 0.0` separately via [`format_zero_value_literal`]
+/// before this function is ever called), which can only come from a nonzero
+/// mantissa in the first place -- `normalize_extreme_literal_mantissa` is
+/// therefore guaranteed `Some` here.
 ///
 /// Oracle-verified against real jq: `1e-400` -> `1E-400`, `12.34e-400` ->
 /// `1.234E-399`, `0.5e-400` -> `5E-401`, `100.5e-400` -> `1.005E-398`.
@@ -497,27 +501,65 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
 /// jq's behavior there is itself a bug, not a rule worth matching.
 fn format_underflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> String {
     let sign = if negative { "-" } else { "" };
+    let Some((mantissa_str, new_exp)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
+        unreachable!("a subnormal value implies a nonzero mantissa")
+    };
+    assemble_scientific(sign, &mantissa_str, new_exp)
+}
+
+/// Format a literal whose *parsed value* is exactly `0.0` (`-0.0` included)
+/// -- the single call site in `format_number_jq_compat` reaches here before
+/// any of that function's other notation checks run, since #1207 found this
+/// case picks notation on a different axis than every other literal (see
+/// the call site's own comment).
+///
+/// [`normalize_extreme_literal_mantissa`] itself distinguishes the two ways
+/// a literal can parse to exactly `0.0`:
+///
+/// - A genuinely all-zero mantissa (`0.0e-400`, `None` here) has no nonzero
+///   digit to renormalize around at all -- real jq still shifts the printed
+///   exponent by the fractional-zero-digit count the same way it does for a
+///   nonzero mantissa (#1178: `0.000e-400` -> `0E-403`, not `0E-400`; a
+///   no-fraction spelling like `0e-400` has shift `0` and needs none). That
+///   *shifted* exponent, not the literal's raw written one, is what
+///   actually determines notation (#1207, oracle-verified for shifted
+///   exponents `-8..=2`): `0` picks a bare integer (`0e1` shifts to `0`,
+///   prints `0`); `-6..=-1` picks an expanded decimal with `-shifted` zeros
+///   after the point (`0e-1` -> `0.0`, ..., `0e-6` -> `0.000000`); anything
+///   else keeps the scientific form this function used unconditionally
+///   before #1207 (`0e-7` -> `0E-7`, `0e2` -> `0E+2`).
+/// - A nonzero mantissa that simply underflowed `f64` during parsing
+///   (`1e-400`, far below `f64::MIN_POSITIVE`) can't be told apart from the
+///   above by the parsed value alone (#1099) -- but real jq's small-window
+///   decimal/bare notation never applies to it regardless of its shifted
+///   exponent's own magnitude (a mantissa with real precision to preserve
+///   always stays scientific); only `assemble_scientific` on the `Some`
+///   arm's own shift math is needed, unaffected by #1207.
+///
+/// `value == 0.0` is true for `-0.0` too (IEEE 754), so `negative` (from the
+/// caller's `value.is_sign_negative()`) still needs applying in every arm --
+/// real jq keeps the sign throughout, since `log10(0)` is undefined
+/// (`-0e5` -> `-0E+5`, `-0e0` -> `-0`, `-0.0e-1` -> `-0.00`).
+fn format_zero_value_literal(s: &str, exp_pos: usize, negative: bool) -> String {
+    let sign = if negative { "-" } else { "" };
     match normalize_extreme_literal_mantissa(s, exp_pos) {
         Some((mantissa_str, new_exp)) => assemble_scientific(sign, &mantissa_str, new_exp),
-        // Genuinely all-zero mantissa (`0.0e-400`) -- no nonzero digit to
-        // shift *to*, but real jq still shifts the printed exponent by the
-        // fractional-zero-digit count, the same normalization it applies to
-        // a nonzero mantissa (#1178) -- `0.000e-400` -> `0E-403`, not
-        // `0E-400`. A no-fraction spelling (`0e-400`, empty `frac_part`) has
-        // shift `0` and was already correct. `value == 0.0` is true for
-        // `-0.0` too (IEEE 754), so the sign still needs preserving -- real
-        // jq keeps both the sign and this shifted exponent for a zero
-        // mantissa, since log10(0) is undefined (`-0e5` -> `-0E+5`).
         None => {
             let (_, frac_part) = split_mantissa(s, exp_pos);
             // `try_from`, not a bare `as` cast: `frac_part.len()` is
             // document-controlled and unbounded, same as the exponent digit
             // string `parse_literal_exponent` already saturates rather than
-            // wraps for a couple lines up -- matching that same discipline
+            // wraps a couple lines down -- matching that same discipline
             // here instead of silently flipping sign past `i64::MAX` bytes.
             let frac_len = i64::try_from(frac_part.len()).unwrap_or(i64::MAX);
             let shifted_exp = parse_literal_exponent(&s[exp_pos + 1..]).saturating_sub(frac_len);
-            assemble_scientific(sign, "0", shifted_exp)
+            if shifted_exp == 0 {
+                format!("{sign}0")
+            } else if (-6..0).contains(&shifted_exp) {
+                format!("{sign}0.{}", "0".repeat((-shifted_exp) as usize))
+            } else {
+                assemble_scientific(sign, "0", shifted_exp)
+            }
         }
     }
 }
@@ -2660,6 +2702,63 @@ mod tests {
         let mantissa = format!("{}9", "0".repeat(2_000_000));
         let literal = format!("{mantissa}e400");
         assert_eq!(format_number_jq_compat(literal.as_bytes()), "9E+400");
+    }
+
+    /// #1207: a genuinely-zero-mantissa literal (`value == 0.0`) picks
+    /// notation on its own *shifted* exponent (written exponent minus the
+    /// mantissa's fractional-zero-digit count, #1178's shift math), not the
+    /// literal's raw written exponent the way `format_number_jq_compat`'s
+    /// `exp == 0`/`(-5..0)` fast paths do for everything else -- before this
+    /// fix, every zero-mantissa literal with a nonzero written exponent went
+    /// straight to `format_underflow_literal_mantissa`'s unconditional
+    /// scientific output, regardless of how small the resulting exponent
+    /// magnitude actually was. Oracle-verified against jq 1.7.1 for the
+    /// full boundary, shifted exponents -8..=2 (`0e{shifted}` has no
+    /// fraction digits, so its shift is 0 and its shifted exponent equals
+    /// its written one).
+    #[test]
+    fn test_format_number_jq_compat_zero_mantissa_notation_threshold_1207() {
+        // Deep in scientific territory on the underflow side, and the one
+        // step just past the decimal window's own boundary.
+        assert_eq!(format_number_jq_compat(b"0e-8"), "0E-8");
+        assert_eq!(format_number_jq_compat(b"0e-7"), "0E-7");
+        // The decimal-expansion window: shifted exponent -6..=-1, i.e.
+        // 6 down to 1 zeros after the point.
+        assert_eq!(format_number_jq_compat(b"0e-6"), "0.000000");
+        assert_eq!(format_number_jq_compat(b"0e-5"), "0.00000");
+        assert_eq!(format_number_jq_compat(b"0e-4"), "0.0000");
+        assert_eq!(format_number_jq_compat(b"0e-3"), "0.000");
+        assert_eq!(format_number_jq_compat(b"0e-2"), "0.00");
+        assert_eq!(format_number_jq_compat(b"0e-1"), "0.0");
+        // Shifted exponent exactly 0: bare integer, no decimal point at all.
+        assert_eq!(format_number_jq_compat(b"0e0"), "0");
+        // Positive shifted exponent: scientific again.
+        assert_eq!(format_number_jq_compat(b"0e1"), "0E+1");
+        assert_eq!(format_number_jq_compat(b"0e2"), "0E+2");
+        // Sign is preserved through every branch (`-0.0` is `value == 0.0`
+        // too, and `log10(0)` is undefined so jq keeps the written sign
+        // rather than trying to derive one).
+        assert_eq!(format_number_jq_compat(b"-0e-8"), "-0E-8");
+        assert_eq!(format_number_jq_compat(b"-0e-1"), "-0.0");
+        assert_eq!(format_number_jq_compat(b"-0e0"), "-0");
+        assert_eq!(format_number_jq_compat(b"-0e1"), "-0E+1");
+        // A written fractional zero digit shifts the exponent exactly like
+        // #1178's already-scientific case does, so the same classification
+        // above is reachable via a *different* written exponent than the
+        // no-fraction cases -- e.g. `0.0e-5`'s shift is -6 (written -5,
+        // minus 1 fractional digit), landing in the same decimal window as
+        // `0e-6` above despite a different written exponent.
+        assert_eq!(format_number_jq_compat(b"0.0e-5"), "0.000000"); // shift -6
+        assert_eq!(format_number_jq_compat(b"0.0e0"), "0.0"); // shift -1
+        assert_eq!(format_number_jq_compat(b"0.0e1"), "0"); // shift 0
+        assert_eq!(format_number_jq_compat(b"0.00e-1"), "0.000"); // shift -3
+        assert_eq!(format_number_jq_compat(b"0.0000e-1"), "0.00000"); // shift -5
+                                                                      // A genuinely-underflowed *nonzero* mantissa (`value == 0.0` from
+                                                                      // parsing, but the literal's own digits are not all zero) never
+                                                                      // enters this small-window notation regardless of its own shifted
+                                                                      // exponent's magnitude -- unaffected by #1207, still always
+                                                                      // scientific, matching #1099/#1178's existing coverage.
+        assert_eq!(format_number_jq_compat(b"1e-400"), "1E-400");
     }
 
     /// `depth` levels of single-element array nesting: `[[[...[Null]...]]]`.


### PR DESCRIPTION
## Summary

`format_number_jq_compat`'s `exp == 0` and `(-5..0).contains(&exp)` fast paths decide decimal/bare/scientific notation from the literal's raw **written** exponent. That's correct for a nonzero mantissa in that range, but wrong for a genuinely-zero-mantissa literal, whose real notation threshold is its **shifted** exponent (written exponent minus the mantissa's own fractional-zero-digit count — the same shift math #1178 already applies once the scientific path is reached). Every zero-mantissa literal with a nonzero written exponent used to go straight to unconditional scientific notation, regardless of how small the resulting shifted exponent actually was.

```
$ echo '0.0e1'  | jq -c .   ->  0          (plain integer)
$ echo '0.0e-1' | jq -c .   ->  0.00       (expanded decimal)
$ echo '0.0e1'  | succinctly jq -c .  (before)  -> 0E+0   (wrong)
$ echo '0.0e-1' | succinctly jq -c .  (before)  -> 0E-2   (wrong)
```

## Fix

New `format_zero_value_literal` intercepts `value == 0.0` before either raw-exponent check runs. It reuses `normalize_extreme_literal_mantissa` to tell a genuinely-zero mantissa apart from a nonzero mantissa that merely underflowed to `0.0` during parsing (#1099's existing case — always scientific regardless of its own shifted exponent, unaffected by this fix):

- Genuinely-zero mantissa: dispatch on the shifted exponent — `0` → bare integer, `-6..=-1` → decimal expansion with the matching zero count, else → scientific (unchanged mechanism, just reached correctly now).
- Underflowed nonzero mantissa: unconditionally scientific, same as before.

`format_underflow_literal_mantissa`'s own `None` arm — now unreachable, since `value == 0.0` is intercepted earlier — simplifies to match `format_overflow_literal_mantissa`'s existing `unreachable!()` shape.

## Verification

Oracle-verified against pinned jq 1.7.1 across the full shifted-exponent boundary (`-8..=2`) and multiple mantissa spellings (with/without fraction digits, various fractional-zero-digit counts, both signs). All 36 combinations tested live match exactly; zero regressions on the pre-existing #1099/#1177/#1178/#1180 test suite.

**Out of scope, filed as #1226**: the same written-vs-shifted-exponent bug also misclassifies **nonzero** mantissas (`5e-6` → `5E-6` instead of `0.000005`; `123e-6`/`100e-7`/`999e-6` similarly wrong) — a distinct, broader defect discovered while characterizing this fix's boundary, left out of this PR's scope.

Fixes #1207.

## Test plan
- [x] `cargo test --lib jq::value` — new + existing tests pass
- [x] `cargo test --features cli,simd,regex,serde` (full suite incl. jq/yq golden conformance) — green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --no-default-features` (no_std) — builds
- [x] Local patch coverage: 97.3% (36/37; the one uncovered line is a provably-dead `unreachable!()`, same pattern as the sibling `format_overflow_literal_mantissa`)