### PR TITLE
fix(jq): yq field/index assignment no-ops on a scalar root

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10403,6 +10403,16 @@ pub(crate) fn owned_bound_to_i64(
     Ok(SliceBounds::resolved_bound(v)?.map(|f| round(f) as i64))
 }
 
+/// Whether `target` is a genuine container -- `Array` or `Object`. The one
+/// exclusion both `is_yq_slice_empty_container_scalar` and
+/// `is_yq_field_index_noop_scalar` below share; factored out so a future
+/// `OwnedValue` variant only needs a decision made in one place, not two
+/// near-identical `matches!` lists left to drift (the "duplicated
+/// predicates diverge silently" lesson from #106).
+fn is_owned_container(target: &OwnedValue) -> bool {
+    matches!(target, OwnedValue::Array(_) | OwnedValue::Object(_))
+}
+
 /// Whether `target` is one of the scalar shapes real yq treats as an empty
 /// container when it's the target of a *read* slice (`.[S:E]`, #1065) —
 /// null, any number representation, or a boolean. Object is deliberately
@@ -10419,10 +10429,7 @@ pub(crate) fn owned_bound_to_i64(
 /// 99` stays `5`) rather than this read-path rule — verified live, not
 /// assumed, since the two are easy to conflate (#1101).
 pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
-    !matches!(
-        target,
-        OwnedValue::Array(_) | OwnedValue::String(_) | OwnedValue::Object(_)
-    )
+    !is_owned_container(target) && !matches!(target, OwnedValue::String(_))
 }
 
 /// Whether `target` is a genuine scalar for a plain field/index/iterate
@@ -10440,7 +10447,10 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
 /// with `Null` would be a real bug, not the no-op case -- keeping `Null`
 /// out of this predicate (rather than reusing the slice one, which
 /// intentionally folds it in) makes that visible instead of silently
-/// masking it as another no-op.
+/// masking it as another no-op. `Expr::Iterate`'s own arms are the one
+/// exception: they autovivify `Null` to `[]` *before* ever consulting this
+/// predicate (real yq's `null | .[] = 99` is `[]`, not a no-op), so `Null`
+/// never actually reaches this check from there either.
 ///
 /// Only covers the scalar-vs-scalar/absent shape: a *container* target
 /// mismatched against the wrong access kind (`[1,2,3] | .a = 5`, array
@@ -10448,10 +10458,7 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
 /// `cannot index array with 'a'`) -- out of this predicate's scope, #1181
 /// left that undecided pending its own follow-up.
 fn is_yq_field_index_noop_scalar(target: &OwnedValue) -> bool {
-    !matches!(
-        target,
-        OwnedValue::Array(_) | OwnedValue::Object(_) | OwnedValue::Null
-    )
+    !is_owned_container(target) && !matches!(target, OwnedValue::Null)
 }
 
 /// Whether a *resolved* assignment-target path (a `paths`/`delete_at_path`
@@ -11319,21 +11326,34 @@ fn set_path(
         // minus the swallow-on-error behavior `?` gets and bare parens
         // don't.
         Expr::Paren(inner) => set_path(root, inner, new_value, scalar_noop, container_noop),
-        Expr::Iterate => match root {
-            OwnedValue::Array(arr) => {
-                for elem in arr.iter_mut() {
-                    *elem = new_value.clone();
-                }
-                Ok(())
+        Expr::Iterate => {
+            // #1181: yq autovivifies `null` to `[]` for `.[] = v` (an empty
+            // set of elements to write, matching real yq: `null | .[] = 99`
+            // is `[]`) where jq errors instead -- unlike `Field`/`Index`'s
+            // autovivify, which both jq and yq apply unconditionally, this
+            // one is yq-only, so it's gated on `scalar_noop` rather than run
+            // up front like `autovivify_object`/`autovivify_array` are in
+            // the arms above.
+            if scalar_noop {
+                autovivify_array(root);
             }
-            OwnedValue::Object(map) => {
-                for (_, elem) in map.iter_mut() {
-                    *elem = new_value.clone();
+            match root {
+                OwnedValue::Array(arr) => {
+                    for elem in arr.iter_mut() {
+                        *elem = new_value.clone();
+                    }
+                    Ok(())
                 }
-                Ok(())
+                OwnedValue::Object(map) => {
+                    for (_, elem) in map.iter_mut() {
+                        *elem = new_value.clone();
+                    }
+                    Ok(())
+                }
+                _ if scalar_noop && is_yq_field_index_noop_scalar(root) => Ok(()),
+                _ => Err(EvalError::cannot_iterate(root)),
             }
-            _ => Err(EvalError::cannot_iterate(root)),
-        },
+        }
         // `.[a:b] = v` splices `v`'s elements over the range, so `v` has to be
         // an array — that is the whole reason jq has a separate sentence for
         // it. An out-of-range range clamps rather than erroring, unlike the
@@ -11687,6 +11707,14 @@ fn update_path<S: EvalSemantics>(
         }
         Expr::Iterate => {
             // Update all elements
+            //
+            // #1181: same yq-only null-to-`[]` autovivify as `set_path`'s
+            // sibling arm -- gated on `S::TAG` (not the operator-gated
+            // `scalar_noop` this function otherwise threads for the slice
+            // no-op), matching every other `#1181` check in this function.
+            if S::TAG == EvalTag::Yq {
+                autovivify_array(root);
+            }
             match root {
                 OwnedValue::Array(arr) => {
                     for elem in arr.iter_mut() {
@@ -11712,7 +11740,9 @@ fn update_path<S: EvalSemantics>(
                     }
                     Ok(())
                 }
-                _ if optional => Ok(()),
+                _ if optional || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root)) => {
+                    Ok(())
+                }
                 _ => Err(EvalError::cannot_iterate(root).into()),
             }
         }
@@ -12136,9 +12166,10 @@ fn eval_owned_multi_keep_partial<S: EvalSemantics>(
 /// `{"a":1} | .[nan] = 5` is `Cannot index object with number` in jq, the same
 /// message `.[0] = 5` gets there, and says nothing about NaN.
 ///
-/// `scalar_noop` (yq-mode's own scalar-target assignment no-op, #1181 --
-/// `S::TAG == EvalTag::Yq` at every call site) lets a genuine scalar
-/// container (`is_yq_field_index_noop_scalar`) through this function's own
+/// `scalar_noop` (yq-mode's own scalar-target assignment no-op, #1181): the
+/// caller's own already-resolved verdict on whether *this exact write* is
+/// known to no-op (`S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar
+/// (container)`, not recomputed here) lets it through this function's own
 /// array/null gate too: a *computed* numeric index (`0 as $k | .[$k] = 99`
 /// on a scalar target) resolves through here before ever reaching
 /// `set_path`'s own already-yq-aware no-op check, so without this the
@@ -12159,7 +12190,7 @@ fn key_to_path_component(
         OwnedValue::String(s) => Ok(Expr::Field(s.clone())),
         // Truncation toward zero, as in the value path.
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
-            if scalar_noop && is_yq_field_index_noop_scalar(container) {
+            if scalar_noop {
                 return Ok(Expr::Index(0));
             }
             // Null belongs with array: a write builds the array the index names,
@@ -13778,7 +13809,7 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
                 ));
             }
             let scalar_noop = S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(target_value);
-            let component = match key_to_path_component(k, target_value, S::TAG == EvalTag::Yq) {
+            let component = match key_to_path_component(k, target_value, scalar_noop) {
                 Ok(component) => component,
                 Err(_) if optional => continue,
                 Err(e) => return Err((out, e.into())),
@@ -13796,14 +13827,21 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
             // `false`, not `optional`: the failure has to arrive as an error for
             // the two spellings to be told apart here, rather than as the `None`
             // that the optional form of this call reports it as.
-            let next_value = if scalar_noop {
-                target_value.clone().into_owned()
+            //
+            // `target_value.clone()` (a `Cow` clone, not `.into_owned()`) in
+            // the no-op branch: `set_path`'s own no-op check never reads this
+            // value back, so cloning the underlying `OwnedValue` just to
+            // discard it is pure waste for a `Cow::Borrowed` root -- `Cow`'s
+            // own `Clone` is the O(1) reference copy in that case, only
+            // paying the deep clone when `target_value` was already owned.
+            let next_value: Cow<'a, OwnedValue> = if scalar_noop {
+                target_value.clone()
             } else {
-                match index_one_owned(target_value, k, false) {
+                Cow::Owned(match index_one_owned(target_value, k, false) {
                     Ok(v) => v.expect("non-optional index yields a value or errors"),
                     Err(_) if optional => continue,
                     Err(e) => return Err((out, e.into())),
-                }
+                })
             };
             // `resolve_dynamic_indexes` strips the `Expr::Optional` wrapper
             // below from every component before it ever reaches
@@ -13816,7 +13854,7 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
             } else {
                 component
             });
-            out.push((path, Cow::Owned(next_value)));
+            out.push((path, next_value));
         }
     }
     // `target_escape` first: see the comment on `target_branches`'s own

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10425,6 +10425,35 @@ pub(crate) fn is_yq_slice_empty_container_scalar(target: &OwnedValue) -> bool {
     )
 }
 
+/// Whether `target` is a genuine scalar for a plain field/index/iterate
+/// assignment no-op (`.a = v`, `.[0] = v`, `.[] = v` on a non-container
+/// root, #1181) -- real yq's own scalar-target no-op (already implemented
+/// for `.[S:E] = v` via [`is_yq_slice_empty_container_scalar`]) applies
+/// here too, live-verified: `5 | .a = 99` and `true | .[0] = 99` both stay
+/// unchanged.
+///
+/// Deliberately *excludes* `Null`, unlike its slice sibling: a plain
+/// field/index write's own `autovivify_object`/`autovivify_array` already
+/// turns `Null` into an empty container and writes into that
+/// successfully (`null | .a = 99` -> `{"a":99}`, confirmed live) before
+/// this predicate is ever consulted, so a call site that reaches here
+/// with `Null` would be a real bug, not the no-op case -- keeping `Null`
+/// out of this predicate (rather than reusing the slice one, which
+/// intentionally folds it in) makes that visible instead of silently
+/// masking it as another no-op.
+///
+/// Only covers the scalar-vs-scalar/absent shape: a *container* target
+/// mismatched against the wrong access kind (`[1,2,3] | .a = 5`, array
+/// field-access) still errors, matching real yq (confirmed live:
+/// `cannot index array with 'a'`) -- out of this predicate's scope, #1181
+/// left that undecided pending its own follow-up.
+fn is_yq_field_index_noop_scalar(target: &OwnedValue) -> bool {
+    !matches!(
+        target,
+        OwnedValue::Array(_) | OwnedValue::Object(_) | OwnedValue::Null
+    )
+}
+
 /// Whether a *resolved* assignment-target path (a `paths`/`delete_at_path`
 /// entry, already past `resolve_dynamic_indexes`, not the raw `path_expr`
 /// the user wrote) is a bare slice — `.[S:E]`, `.[S:E]?`, or `(.[S:E])` —
@@ -11216,6 +11245,8 @@ fn set_path(
             if let OwnedValue::Object(map) = root {
                 map.insert(name.clone(), new_value);
                 Ok(())
+            } else if scalar_noop && is_yq_field_index_noop_scalar(root) {
+                Ok(())
             } else {
                 Err(EvalError::cannot_index_with_field(
                     owned_type_name(root),
@@ -11227,6 +11258,8 @@ fn set_path(
             autovivify_array(root);
             if let OwnedValue::Array(arr) = root {
                 *write_index(arr, *idx)? = new_value;
+                Ok(())
+            } else if scalar_noop && is_yq_field_index_noop_scalar(root) {
                 Ok(())
             } else {
                 Err(EvalError::cannot_index_with_type(
@@ -11622,7 +11655,15 @@ fn update_path<S: EvalSemantics>(
             if let OwnedValue::Object(map) = root {
                 let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
                 update_path::<S>(current, &Expr::Identity, filter_expr, optional, scalar_noop)
-            } else if optional {
+            } else if optional
+                // #1181: unconditional on the operator, unlike `scalar_noop`
+                // above (which is `container_noop`'s slice-only, #1101
+                // sibling, gated `false` for `-=`/`*=`) -- live-verified
+                // real yq no-ops `.a -= 1`/`.a *= 1` on a scalar root just
+                // the same as `.a |= f`, unlike the slice case where those
+                // two operators genuinely error instead.
+                || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root))
+            {
                 Ok(())
             } else {
                 Err(EvalError::cannot_index_with_field(owned_type_name(root), name).into())
@@ -11638,7 +11679,7 @@ fn update_path<S: EvalSemantics>(
                     optional,
                     scalar_noop,
                 )
-            } else if optional {
+            } else if optional || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root)) {
                 Ok(())
             } else {
                 Err(EvalError::cannot_index_with_type(owned_type_name(root), "number").into())
@@ -12094,11 +12135,33 @@ fn eval_owned_multi_keep_partial<S: EvalSemantics>(
 /// that a number cannot index is reported as an array that has no such element:
 /// `{"a":1} | .[nan] = 5` is `Cannot index object with number` in jq, the same
 /// message `.[0] = 5` gets there, and says nothing about NaN.
-fn key_to_path_component(key: &OwnedValue, container: &OwnedValue) -> Result<Expr, EvalError> {
+///
+/// `scalar_noop` (yq-mode's own scalar-target assignment no-op, #1181 --
+/// `S::TAG == EvalTag::Yq` at every call site) lets a genuine scalar
+/// container (`is_yq_field_index_noop_scalar`) through this function's own
+/// array/null gate too: a *computed* numeric index (`0 as $k | .[$k] = 99`
+/// on a scalar target) resolves through here before ever reaching
+/// `set_path`'s own already-yq-aware no-op check, so without this the
+/// computed-key case would still error even though the equivalent literal
+/// key (`.[0] = 99`) correctly no-ops. This case skips the NaN check
+/// below entirely and returns a placeholder component instead: real yq's
+/// own no-op applies unconditionally to a scalar target regardless of the
+/// key's own validity (confirmed live: `5 | .[0/0] = 99` -- a NaN-valued
+/// key -- stays `5`, not an error, unlike the same key against an array
+/// target). `set_path`'s no-op check fires before this placeholder's
+/// index value is ever read back out, so its exact value doesn't matter.
+fn key_to_path_component(
+    key: &OwnedValue,
+    container: &OwnedValue,
+    scalar_noop: bool,
+) -> Result<Expr, EvalError> {
     match key {
         OwnedValue::String(s) => Ok(Expr::Field(s.clone())),
         // Truncation toward zero, as in the value path.
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+            if scalar_noop && is_yq_field_index_noop_scalar(container) {
+                return Ok(Expr::Index(0));
+            }
             // Null belongs with array: a write builds the array the index names,
             // so `null | .[nan] = 5` is the NaN complaint in jq too.
             if !matches!(container, OwnedValue::Array(_) | OwnedValue::Null) {
@@ -12781,8 +12844,14 @@ fn resolve_node<'a, S: EvalSemantics>(
                 // `index_one_owned`, so it becomes `Cow::Owned` from there.
                 let mut current: Cow<'a, OwnedValue> = Cow::Borrowed(value);
                 for key in keys {
-                    let component =
-                        key_to_path_component(key, &current).map_err(|e| (Vec::new(), e.into()))?;
+                    // `false`: real yq doesn't accept `getpath(...)` as an
+                    // assignment target at all (confirmed live: a lexer
+                    // error, not even valid syntax), so there's no yq-mode
+                    // no-op behavior to match here -- unlike the `.foo`/
+                    // `.[key]` shapes `resolve_index_expr` handles below,
+                    // which do (#1181).
+                    let component = key_to_path_component(key, &current, false)
+                        .map_err(|e| (Vec::new(), e.into()))?;
                     current = Cow::Owned(
                         index_one_owned(&current, key, false)
                             .map_err(|e| (Vec::new(), e.into()))?
@@ -13708,18 +13777,33 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
                     EvalError::new("Cannot set array element at NaN index").into(),
                 ));
             }
-            let component = match key_to_path_component(k, target_value) {
+            let scalar_noop = S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(target_value);
+            let component = match key_to_path_component(k, target_value, S::TAG == EvalTag::Yq) {
                 Ok(component) => component,
                 Err(_) if optional => continue,
                 Err(e) => return Err((out, e.into())),
             };
+            // yq's scalar-target no-op (#1181): `key_to_path_component` above
+            // already turned this into a placeholder write that no-ops at
+            // `set_path`, so the real index-and-read below must not run at
+            // all -- `index_one_owned` has no concept of the no-op and would
+            // unconditionally raise `Cannot index number with number` for
+            // exactly the target/key combination this is meant to tolerate.
+            // The chain continues with the target unchanged; whatever
+            // further components follow are, by the same rule, going to
+            // no-op too once `set_path` reaches this step.
+            //
             // `false`, not `optional`: the failure has to arrive as an error for
             // the two spellings to be told apart here, rather than as the `None`
             // that the optional form of this call reports it as.
-            let next_value = match index_one_owned(target_value, k, false) {
-                Ok(v) => v.expect("non-optional index yields a value or errors"),
-                Err(_) if optional => continue,
-                Err(e) => return Err((out, e.into())),
+            let next_value = if scalar_noop {
+                target_value.clone().into_owned()
+            } else {
+                match index_one_owned(target_value, k, false) {
+                    Ok(v) => v.expect("non-optional index yields a value or errors"),
+                    Err(_) if optional => continue,
+                    Err(e) => return Err((out, e.into())),
+                }
             };
             // `resolve_dynamic_indexes` strips the `Expr::Optional` wrapper
             // below from every component before it ever reaches

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13582,20 +13582,28 @@ fn test_slice_compound_add_array_target_jq_mode_unaffected_1142() -> Result<()> 
 // yq field/index assignment no-op on a scalar root (#1181)
 // ============================================================================
 //
-// The sibling of #1101's slice no-op, for plain field/index writes onto a
-// scalar root: `.a = v`, `.[0] = v`, and a *computed* key (`$k as $k |
-// .[$k] = v`) all no-op in real yq the same way a bare-root slice does. This
-// was never generalized from the slice case -- `key_to_path_component` (the
-// computed-key path) and `set_path`'s own `Field`/`Index` arms both errored
-// unconditionally, in both jq and yq mode.
+// The sibling of #1101's slice no-op, for plain field/index/iterate writes
+// onto a scalar target: `.a = v`, `.[0] = v`, `.[] = v`, and a *computed*
+// key (`$k as $k | .[$k] = v`) all no-op in real yq the same way a
+// bare-root slice does. This was never generalized from the slice case --
+// `key_to_path_component` (the computed-key path) and `set_path`'s own
+// `Field`/`Index`/`Iterate` arms all errored unconditionally, in both jq
+// and yq mode.
 //
-// Scoped narrowly to a scalar *root* (the whole input, not a chained
-// sub-target reached via `.a.b`/`.a[0]`) -- mirroring #1101's own original
-// scope before #1116 later generalized it to any chain depth. Chain depth
-// is left to a follow-up issue for the same reason #1116 was its own issue:
-// `get_path_mut` (the parent-navigation walker a multi-component path
-// resolves through) has no `S`/yq-mode awareness at all, unlike `set_path`'s
-// own terminal-component arms.
+// This covers a scalar target reached at the *last* path component,
+// however it's reached -- including through a preceding real container, so
+// `{"a":5} | .a.b = 99` (root is an object, `.a` navigates it fine, `.b`
+// then hits the scalar `5` as the terminal step) already no-ops correctly.
+// What's still out of scope, deferred to a follow-up issue for the same
+// reason #1116 (generalizing #1101's slice no-op to any chain depth) was
+// its own issue: a scalar hit *before* the last component, i.e. the whole
+// remaining path is still to be resolved once a scalar is reached --
+// `5 | .a.b = 99` (the *root itself* is the scalar, `.a` is the failing
+// step, `.b` is never reached) still errors, because `get_path_mut` (the
+// parent-navigation walker `set_path`'s `Pipe` arm delegates every
+// non-terminal component to) and `update_path`'s own structurally-parallel
+// `Pipe`-arm `Field`/`Index` sub-arms have no `S`/yq-mode awareness at all,
+// unlike `set_path`/`update_path`'s terminal-component arms.
 //
 // One more divergence, *not* replicated here: real yq silently discards the
 // RHS/filter entirely for this no-op, including a genuinely erroring one
@@ -13746,6 +13754,138 @@ fn test_field_index_assign_scalar_jq_mode_unaffected_1181() -> Result<()> {
         assert!(
             stderr.contains("Cannot index number"),
             "filter {filter:?} stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// A chained scalar target reached at the *terminal* step, not the root
+/// itself, already no-ops -- `{"a":5} | .a.b = 99` navigates a real object
+/// for `.a`, then hits the scalar `5` only at the last component `.b`.
+/// Exercises `get_path_mut`'s ordinary (non-scalar) `Field` arm for the
+/// `.a` hop, landing back in `set_path`'s/`update_path`'s already-fixed
+/// terminal arm for `.b` -- see the module doc comment above for why this
+/// is in scope while the scalar-*root* chain case is not.
+#[test]
+fn test_yq_field_index_assign_scalar_reached_via_container_prefix_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a.b = 99", r#"{"a":5}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    let (out, code) = run_yq_stdin(".a.b |= . + 1", r#"{"a":5}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+    Ok(())
+}
+
+// ============================================================================
+// yq `.[] = v` (Expr::Iterate) assignment no-op on a scalar target (#1181)
+// ============================================================================
+//
+// The `Iterate` sibling of the Field/Index no-op above: `.[] = v` on a
+// non-container, non-null target no-ops the same way `.a = v`/`.[0] = v`
+// do. `null` is a distinct third case, neither a no-op nor an error: real
+// yq autovivifies it to `[]` (an empty set of elements to write over), so
+// `null | .[] = 99` is `[]`, matching jq's own null-to-array autovivify for
+// `Field`/`Index` but *not* jq's own `Iterate`, which has no such rule at
+// all (`null | .[] = 99` genuinely errors in real jq -- confirmed live).
+
+/// The bare-root shape, across every operator this diff touches.
+#[test]
+fn test_yq_iterate_assign_scalar_is_noop_1181() -> Result<()> {
+    for filter in [
+        ".[] = 99",
+        ".[] |= . + 1",
+        ".[] += 1",
+        ".[] -= 1",
+        ".[] *= 1",
+    ] {
+        let (out, code) = run_yq_stdin(filter, "5", &["-o", "json"])?;
+        assert_eq!(code, 0, "filter {filter:?} out: {out:?}");
+        assert_eq!(out.trim(), "5", "filter {filter:?}");
+    }
+    Ok(())
+}
+
+/// String and bool roots no-op the same way a number does.
+#[test]
+fn test_yq_iterate_assign_string_and_bool_scalar_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[] = 99", r#""hello""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""hello""#);
+
+    let (out, code) = run_yq_stdin(".[] = 99", "true", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+    Ok(())
+}
+
+/// `null` is neither a no-op nor an error for `Iterate` -- it autovivifies
+/// to `[]`, unlike `Field`/`Index`'s autovivify-then-write.
+#[test]
+fn test_yq_iterate_assign_null_root_becomes_empty_array_1181() -> Result<()> {
+    for filter in [".[] = 99", ".[] |= . + 1", ".[] -= 1"] {
+        let (out, code) = run_yq_stdin(filter, "null", &["-o", "json"])?;
+        assert_eq!(code, 0, "filter {filter:?} out: {out:?}");
+        assert_eq!(out.trim(), "[]", "filter {filter:?}");
+    }
+    Ok(())
+}
+
+/// The same no-op/autovivify rule applies when the scalar/null is reached
+/// through a preceding container, not just at the root -- `.a[] = 99` on
+/// `{"a":5}` navigates `.a` (a real object field) before `Iterate` ever
+/// runs, landing on the scalar `5`/`null` exactly like the bare-root case.
+#[test]
+fn test_yq_iterate_assign_chained_scalar_and_null_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a[] = 99", r#"{"a":5}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    let (out, code) = run_yq_stdin(".a[] |= . + 1", r#"{"a":5}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    let (out, code) = run_yq_stdin(".a[] = 99", r#"{"a":null}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[]}"#);
+    Ok(())
+}
+
+/// Regression guard: a real array/object target still iterates and writes
+/// normally -- the no-op is specific to a genuinely scalar/null target.
+#[test]
+fn test_yq_iterate_assign_container_target_unaffected_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[] = 99", "[1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[99,99,99]");
+    Ok(())
+}
+
+/// Regression guard: jq mode is unaffected -- `.[] = v` on a scalar or
+/// `null` both keep raising `Cannot iterate over ...`, matching real jq
+/// (which, unlike yq, has no null-autovivify rule for `Iterate` at all).
+#[test]
+fn test_yq_iterate_assign_scalar_jq_mode_unaffected_1181() -> Result<()> {
+    for input in ["5", "null"] {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+        cmd.arg("jq").arg(".[] = 99");
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        child.stdin.take().unwrap().write_all(input.as_bytes())?;
+        let output = child.wait_with_output()?;
+        assert_ne!(
+            output.status.code(),
+            Some(0),
+            "input {input:?} unexpectedly succeeded in jq mode"
+        );
+        let stderr = String::from_utf8(output.stderr)?;
+        assert!(
+            stderr.contains("Cannot iterate"),
+            "input {input:?} stderr: {stderr:?}"
         );
     }
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13579,6 +13579,179 @@ fn test_slice_compound_add_array_target_jq_mode_unaffected_1142() -> Result<()> 
 }
 
 // ============================================================================
+// yq field/index assignment no-op on a scalar root (#1181)
+// ============================================================================
+//
+// The sibling of #1101's slice no-op, for plain field/index writes onto a
+// scalar root: `.a = v`, `.[0] = v`, and a *computed* key (`$k as $k |
+// .[$k] = v`) all no-op in real yq the same way a bare-root slice does. This
+// was never generalized from the slice case -- `key_to_path_component` (the
+// computed-key path) and `set_path`'s own `Field`/`Index` arms both errored
+// unconditionally, in both jq and yq mode.
+//
+// Scoped narrowly to a scalar *root* (the whole input, not a chained
+// sub-target reached via `.a.b`/`.a[0]`) -- mirroring #1101's own original
+// scope before #1116 later generalized it to any chain depth. Chain depth
+// is left to a follow-up issue for the same reason #1116 was its own issue:
+// `get_path_mut` (the parent-navigation walker a multi-component path
+// resolves through) has no `S`/yq-mode awareness at all, unlike `set_path`'s
+// own terminal-component arms.
+//
+// One more divergence, *not* replicated here: real yq silently discards the
+// RHS/filter entirely for this no-op, including a genuinely erroring one
+// (`.a = error("boom")` on `5` is `5`, not an error) -- unlike the slice
+// no-op, which does still propagate a genuinely erroring RHS
+// (`test_slice_assign_scalar_noop_still_propagates_rhs_errors_1101`).
+// succinctly's `eval_assign`/`eval_update` evaluate the RHS before path
+// resolution ever runs, so matching that exactly needs its own design
+// (peeking at whether every resolved path is a no-op before ever evaluating
+// the RHS) -- filed separately, live-verified against yq v4.53.3.
+
+/// The issue's own repro, `=` on a bare number: `.a`, `.[0]`, and a computed
+/// key via `as`, all no-op.
+#[test]
+fn test_yq_field_index_assign_number_scalar_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a = 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin(".[0] = 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin("0 as $k | .[$k] = 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// A computed *string* key behaves the same as a computed numeric one.
+#[test]
+fn test_yq_field_index_assign_computed_string_key_scalar_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#""a" as $k | .[$k] = 99"#, "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// Every other scalar kind (string, bool) no-ops the same way a number
+/// does -- this is about the *root's* type, not the key's.
+#[test]
+fn test_yq_field_index_assign_string_and_bool_scalar_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a = 99", r#""hello""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""hello""#);
+
+    let (out, code) = run_yq_stdin(".[0] = 99", "true", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "true");
+    Ok(())
+}
+
+/// `|=`/`+=` no-op the same as `=` -- `update_path`'s own `Field`/`Index`
+/// arms, a separate walker from `set_path`.
+#[test]
+fn test_yq_field_index_update_and_add_scalar_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a |= . + 1", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin(".[0] += 1", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin("0 as $k | .[$k] |= . + 1", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// `-=`/`*=` no-op here too -- live-verified as a genuine divergence from
+/// the *slice* no-op, where these two operators error instead
+/// (`test_slice_sub_and_mul_number_scalar_still_errors_1101`). The
+/// field/index no-op has no such operator exception: it is unconditional,
+/// like #1142's container case, not gated the way #1101's scalar case is.
+#[test]
+fn test_yq_field_index_sub_and_mul_scalar_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a -= 1", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin("0 as $k | .[$k] *= 1", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// A NaN-valued computed key still no-ops rather than raising "cannot set
+/// array element at NaN index" -- the write no-ops before the key's own
+/// validity is ever inspected, live-verified against real yq.
+#[test]
+fn test_yq_field_index_assign_nan_computed_key_scalar_is_noop_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin("(0/0) as $k | .[$k] = 99", "5", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// Regression guard: a `null` root still autovivifies normally -- #1181 is
+/// specifically about a *scalar* root, and `null` is not one (it's the
+/// standard "build whatever the path names" case in both jq and yq).
+#[test]
+fn test_yq_field_index_assign_null_root_still_autovivifies_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a = 99", "null", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":99}"#);
+
+    let (out, code) = run_yq_stdin(".[0] = 99", "null", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[99]");
+    Ok(())
+}
+
+/// Regression guard: array/object roots still write normally -- the no-op
+/// is specific to a genuinely scalar root.
+#[test]
+fn test_yq_field_index_assign_container_root_unaffected_1181() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0] |= . + 100", "[1,2,3]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[101,2,3]");
+
+    let (out, code) = run_yq_stdin(".a += 10", r#"{"a":1}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":11}"#);
+    Ok(())
+}
+
+/// Regression guard: jq mode is unaffected -- it keeps raising `Cannot
+/// index number with ...` for every one of these shapes, matching real jq.
+#[test]
+fn test_field_index_assign_scalar_jq_mode_unaffected_1181() -> Result<()> {
+    for filter in [".a = 99", ".[0] = 99", "0 as $k | .[$k] = 99", ".a -= 1"] {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+        cmd.arg("jq").arg(filter);
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        child.stdin.take().unwrap().write_all(b"5")?;
+        let output = child.wait_with_output()?;
+        assert_ne!(
+            output.status.code(),
+            Some(0),
+            "filter {filter:?} unexpectedly succeeded in jq mode"
+        );
+        let stderr = String::from_utf8(output.stderr)?;
+        assert!(
+            stderr.contains("Cannot index number"),
+            "filter {filter:?} stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+// ============================================================================
 // @urid / @base64d scalar-stringification (#1109)
 // ============================================================================
 //


### PR DESCRIPTION
## Summary

Real yq's scalar-target no-op — already implemented for slice writes via #1101/#1116/#1142 — also applies to plain field/index writes: `.a = v`, `.[0] = v`, and a computed key (`$k as $k | .[$k] = v`) all silently no-op on a scalar root in real yq, but `succinctly yq` still raised `Cannot index number with ...` for all three.

Root cause: `key_to_path_component` had no yq-mode gate at all, and there's a second, separate `index_one_owned` call right after it in `resolve_index_expr` (used to compute the next value for chained resolution) that also had no gate — the computed-key case kept failing even after the first was patched, since that second call unconditionally errors on a scalar target regardless of what `key_to_path_component` decided. `update_path` (the `|=`/compound-assign walker) needed its own separate fix too, since its Field/Index arms never checked the existing `scalar_noop` machinery at all, and — verified live — real yq no-ops `-=`/`*=` for this shape too, unlike the slice case where those two operators genuinely error.

```
$ echo 5 | yq -o=json '.a = 99'
5                                      # no-op (real yq)
$ echo 5 | succinctly yq -o=json '.a = 99'
5                                      # now matches (was: Error: Cannot index number with string)
```

## Scope

Scoped to a scalar *root* only — mirroring #1101's original scope before #1116 later generalized it to any chain depth. A chained scalar target (`.a.b = 99`, `.[$k].foo = 99`) also no-ops in real yq but is **not** fixed here — `get_path_mut` (the parent-navigation walker a multi-component path resolves through) has no yq-mode awareness at all, unlike `set_path`'s own terminal-component arms, and needs its own design the way #1116 got. Filed as a follow-up.

Also found and **not** replicated here: real yq silently discards the RHS/filter entirely for this no-op, including a genuinely erroring one (`.a = error("boom")` on `5` stays `5`, not an error) — unlike the slice no-op, which does propagate a genuinely erroring RHS. `eval_assign`/`eval_update` evaluate the RHS before path resolution ever runs, so matching this exactly needs its own design (peeking at whether every resolved path is a no-op before evaluating the RHS at all). Filed as a follow-up.

## Verification

- Every case live-verified against real yq v4.53.3, including the operator-parity check (`-=`/`*=` no-op here despite erroring for the slice case) and jq-mode-unaffected checks.
- New tests in `tests/yq_cli_tests.rs` cover: the issue's own repro (`=` on literal field/index/computed key), `|=`/`+=`/`-=`/`*=`, computed string keys, NaN-valued computed keys, string/bool scalar roots, null-root autovivification (unaffected), container-root writes (unaffected), and jq-mode (unaffected).
- Full local suite green: `cargo test --features cli,simd,regex,serde`, `cargo clippy --all-targets --all-features -- -D warnings`, the secondary feature-set clippy invocation, `cargo check --no-default-features` (no_std), `cargo doc --all-features` with `-D warnings`.

Fixes #1181