### PR TITLE
fix(jq): preserve NumberLiteral spelling in binary-op error messages

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1861,31 +1861,42 @@ fn arith_add<S: EvalSemantics>(
             a.push(b);
             Ok(OwnedValue::Array(a))
         }
-        // Everything else: numeric addition. A `NumberLiteral` operand
+        // Numeric addition -- only once both operands are confirmed numeric
+        // (via the non-consuming `is_number()` peek) does this arm actually
+        // move them into `into_plain_number()`. A `NumberLiteral` operand
         // degrades to plain `Int`/`Float` here, and only here -- this is
         // the one arm that actually computes a new number, so jq/yq's
         // canonical formatting is correct; every arm above relocates an
         // operand unchanged and must not collapse its literal spelling
         // (#1143).
-        (left, right) => match (left.into_plain_number(), right.into_plain_number()) {
-            // Number addition - jq converts to float on overflow, yq wraps
-            (OwnedValue::Int(a), OwnedValue::Int(b)) => {
-                if S::OVERFLOW_WRAPS {
-                    // yq behavior: wrapping add
-                    Ok(OwnedValue::Int(a.wrapping_add(b)))
-                } else {
-                    // jq behavior: convert to float on overflow
-                    match a.checked_add(b) {
-                        Some(result) => Ok(OwnedValue::Int(result)),
-                        None => Ok(OwnedValue::Float(a as f64 + b as f64)),
+        (left, right) if left.is_number() && right.is_number() => {
+            match (left.into_plain_number(), right.into_plain_number()) {
+                // Number addition - jq converts to float on overflow, yq wraps
+                (OwnedValue::Int(a), OwnedValue::Int(b)) => {
+                    if S::OVERFLOW_WRAPS {
+                        // yq behavior: wrapping add
+                        Ok(OwnedValue::Int(a.wrapping_add(b)))
+                    } else {
+                        // jq behavior: convert to float on overflow
+                        match a.checked_add(b) {
+                            Some(result) => Ok(OwnedValue::Int(result)),
+                            None => Ok(OwnedValue::Float(a as f64 + b as f64)),
+                        }
                     }
                 }
+                (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 + b)),
+                (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a + b as f64)),
+                (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a + b)),
+                _ => unreachable!("both operands already confirmed numeric by the guard above"),
             }
-            (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 + b)),
-            (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a + b as f64)),
-            (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a + b)),
-            (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Add)),
-        },
+        }
+        // Type mismatch -- `left`/`right` are still the *original*,
+        // uncollapsed operands here (the guard above never fires, so
+        // `into_plain_number()` never runs), so a `NumberLiteral` operand's
+        // source spelling survives into the error message too (#1199: it
+        // previously didn't, since the old single catch-all arm collapsed
+        // both operands before ever building the error).
+        (left, right) => Err(EvalError::binary_op(&left, &right, BinOp::Add)),
     }
 }
 
@@ -1915,36 +1926,46 @@ fn arith_sub<S: EvalSemantics>(
         // the top since every prior arm here actually computed a value, is
         // now deferred into the numeric sub-match instead.
         (OwnedValue::Null, other) if S::SUB_LEFT_NULL_IS_IDENTITY => Ok(other),
-        (left, right) => match (left.into_plain_number(), right.into_plain_number()) {
-            // jq converts to float on overflow, yq wraps
-            (OwnedValue::Int(a), OwnedValue::Int(b)) => {
-                if S::OVERFLOW_WRAPS {
-                    // yq behavior: wrapping sub
-                    Ok(OwnedValue::Int(a.wrapping_sub(b)))
-                } else {
-                    // jq behavior: convert to float on overflow
-                    match a.checked_sub(b) {
-                        Some(result) => Ok(OwnedValue::Int(result)),
-                        None => Ok(OwnedValue::Float(a as f64 - b as f64)),
+        // Array subtraction (remove elements). `owned_value_eq::<S>`, not
+        // `Vec::contains` (plain `PartialEq`): yq's stricter Int/Float
+        // equality must apply here too, or `[2.0] - [2]` would (wrongly)
+        // remove the float (#950 review). Split out of the numeric match
+        // below (#1199) since an array is never `is_number()`.
+        (OwnedValue::Array(a), OwnedValue::Array(b)) => {
+            let result: Vec<_> = a
+                .into_iter()
+                .filter(|x| !b.iter().any(|y| owned_value_eq::<S>(x, y)))
+                .collect();
+            Ok(OwnedValue::Array(result))
+        }
+        // Numeric subtraction -- only once both operands are confirmed
+        // numeric (via the non-consuming `is_number()` peek) does this arm
+        // actually move them into `into_plain_number()`.
+        (left, right) if left.is_number() && right.is_number() => {
+            match (left.into_plain_number(), right.into_plain_number()) {
+                // jq converts to float on overflow, yq wraps
+                (OwnedValue::Int(a), OwnedValue::Int(b)) => {
+                    if S::OVERFLOW_WRAPS {
+                        // yq behavior: wrapping sub
+                        Ok(OwnedValue::Int(a.wrapping_sub(b)))
+                    } else {
+                        // jq behavior: convert to float on overflow
+                        match a.checked_sub(b) {
+                            Some(result) => Ok(OwnedValue::Int(result)),
+                            None => Ok(OwnedValue::Float(a as f64 - b as f64)),
+                        }
                     }
                 }
+                (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 - b)),
+                (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a - b as f64)),
+                (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a - b)),
+                _ => unreachable!("both operands already confirmed numeric by the guard above"),
             }
-            (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 - b)),
-            (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a - b as f64)),
-            (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a - b)),
-            // Array subtraction (remove elements). `owned_value_eq::<S>`, not
-            // `Vec::contains` (plain `PartialEq`): yq's stricter Int/Float
-            // equality must apply here too, or `[2.0] - [2]` would (wrongly)
-            // remove the float (#950 review).
-            (OwnedValue::Array(a), OwnedValue::Array(b)) => {
-                let result: Vec<_> = a
-                    .into_iter()
-                    .filter(|x| !b.iter().any(|y| owned_value_eq::<S>(x, y)))
-                    .collect();
-                Ok(OwnedValue::Array(result))
-            }
-            (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Subtract)),
-        },
+        }
+        // Type mismatch -- `left`/`right` are still the *original*,
+        // uncollapsed operands here, so a `NumberLiteral` operand's source
+        // spelling survives into the error message too (#1199).
+        (left, right) => Err(EvalError::binary_op(&left, &right, BinOp::Subtract)),
     }
 }
 
@@ -2056,41 +2077,54 @@ fn arith_mul<S: EvalSemantics>(
         // it's already handled by the `(left, Null)` no-op arm above,
         // since `left` binds to `Null` there too (live-verified against
         // yq v4.53.3: `null * null` -> `null`, exit 0, not an error).
-        // Everything else: numeric multiplication or string repetition. A
+        // Numeric multiplication or string repetition -- only once the pair
+        // is confirmed to be one of the shapes this arm actually computes
+        // (both numeric, or one `String` paired with a numeric repeat
+        // count) does it move the operands into `into_plain_number()`. A
         // `NumberLiteral` operand degrades to plain `Int`/`Float` here, and
         // only here -- these are the arms that actually compute a new
         // value (a product, or a repeated string), so canonical formatting
         // is correct; every arm above relocates an operand unchanged and
         // must not collapse a literal's spelling (#1167).
-        (left, right) => match (left.into_plain_number(), right.into_plain_number()) {
-            // jq converts to float on overflow, yq wraps
-            (OwnedValue::Int(a), OwnedValue::Int(b)) => {
-                if S::OVERFLOW_WRAPS {
-                    // yq behavior: wrapping mul
-                    Ok(OwnedValue::Int(a.wrapping_mul(b)))
-                } else {
-                    // jq behavior: convert to float on overflow
-                    match a.checked_mul(b) {
-                        Some(result) => Ok(OwnedValue::Int(result)),
-                        None => Ok(OwnedValue::Float(a as f64 * b as f64)),
+        (left, right)
+            if (left.is_number() && right.is_number())
+                || (matches!(left, OwnedValue::String(_)) && right.is_number())
+                || (left.is_number() && matches!(right, OwnedValue::String(_))) =>
+        {
+            match (left.into_plain_number(), right.into_plain_number()) {
+                // jq converts to float on overflow, yq wraps
+                (OwnedValue::Int(a), OwnedValue::Int(b)) => {
+                    if S::OVERFLOW_WRAPS {
+                        // yq behavior: wrapping mul
+                        Ok(OwnedValue::Int(a.wrapping_mul(b)))
+                    } else {
+                        // jq behavior: convert to float on overflow
+                        match a.checked_mul(b) {
+                            Some(result) => Ok(OwnedValue::Int(result)),
+                            None => Ok(OwnedValue::Float(a as f64 * b as f64)),
+                        }
                     }
                 }
-            }
-            (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 * b)),
-            (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a * b as f64)),
-            (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a * b)),
-            // String repetition: "ab" * 3 = "ababab". jq >= 1.7 yields ""
-            // for n == 0 and null only for n < 0 (jqlang/jq#1593)
-            (OwnedValue::String(s), OwnedValue::Int(n))
-            | (OwnedValue::Int(n), OwnedValue::String(s)) => {
-                if n < 0 {
-                    Ok(OwnedValue::Null)
-                } else {
-                    Ok(OwnedValue::String(s.repeat(n as usize)))
+                (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 * b)),
+                (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a * b as f64)),
+                (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a * b)),
+                // String repetition: "ab" * 3 = "ababab". jq >= 1.7 yields ""
+                // for n == 0 and null only for n < 0 (jqlang/jq#1593)
+                (OwnedValue::String(s), OwnedValue::Int(n))
+                | (OwnedValue::Int(n), OwnedValue::String(s)) => {
+                    if n < 0 {
+                        Ok(OwnedValue::Null)
+                    } else {
+                        Ok(OwnedValue::String(s.repeat(n as usize)))
+                    }
                 }
+                _ => unreachable!("guard above only admits number/number or String/number pairs"),
             }
-            (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Multiply)),
-        },
+        }
+        // Type mismatch -- `left`/`right` are still the *original*,
+        // uncollapsed operands here, so a `NumberLiteral` operand's source
+        // spelling survives into the error message too (#1199).
+        (left, right) => Err(EvalError::binary_op(&left, &right, BinOp::Multiply)),
     }
 }
 
@@ -2284,67 +2318,65 @@ fn arith_div<S: EvalSemantics>(
     left: OwnedValue,
     right: OwnedValue,
 ) -> Result<OwnedValue, EvalError> {
-    let (left, right) = (left.into_plain_number(), right.into_plain_number());
-    match (left, right) {
-        (OwnedValue::Int(a), OwnedValue::Int(b)) => {
+    // `as_number_repr()` (#1199) peeks the computable value through a
+    // reference, leaving `left`/`right` themselves owned and un-collapsed
+    // for the rest of the function -- both `divisor_is_zero` (reached from
+    // *inside* an otherwise-successful numeric arm, not just a trailing
+    // catch-all) and the final type-mismatch `binary_op` can therefore
+    // still cite a `NumberLiteral` operand's own source spelling, not the
+    // canonically-reformatted value `into_plain_number()` would have left
+    // behind.
+    match (left.as_number_repr(), right.as_number_repr()) {
+        (Some(NumberRepr::Int(a)), Some(NumberRepr::Int(b))) => {
             if b == 0 {
                 if S::DIV_BY_ZERO_IS_INFINITY {
                     // yq behavior: return infinity
                     Ok(OwnedValue::Float(a as f64 / b as f64))
                 } else {
                     // jq behavior: error
-                    Err(EvalError::divisor_is_zero(
-                        &OwnedValue::Int(a),
-                        &OwnedValue::Int(b),
-                        BinOp::Divide,
-                    ))
+                    Err(EvalError::divisor_is_zero(&left, &right, BinOp::Divide))
                 }
             } else {
                 Ok(OwnedValue::Float(a as f64 / b as f64))
             }
         }
-        (OwnedValue::Int(a), OwnedValue::Float(b)) => {
+        (Some(NumberRepr::Int(a)), Some(NumberRepr::Float(b))) => {
             if b == 0.0 && !S::DIV_BY_ZERO_IS_INFINITY {
-                Err(EvalError::divisor_is_zero(
-                    &OwnedValue::Int(a),
-                    &OwnedValue::Float(b),
-                    BinOp::Divide,
-                ))
+                Err(EvalError::divisor_is_zero(&left, &right, BinOp::Divide))
             } else {
                 Ok(OwnedValue::Float(a as f64 / b))
             }
         }
-        (OwnedValue::Float(a), OwnedValue::Int(b)) => {
+        (Some(NumberRepr::Float(a)), Some(NumberRepr::Int(b))) => {
             if b == 0 && !S::DIV_BY_ZERO_IS_INFINITY {
-                Err(EvalError::divisor_is_zero(
-                    &OwnedValue::Float(a),
-                    &OwnedValue::Int(b),
-                    BinOp::Divide,
-                ))
+                Err(EvalError::divisor_is_zero(&left, &right, BinOp::Divide))
             } else {
                 Ok(OwnedValue::Float(a / b as f64))
             }
         }
-        (OwnedValue::Float(a), OwnedValue::Float(b)) => {
+        (Some(NumberRepr::Float(a)), Some(NumberRepr::Float(b))) => {
             if b == 0.0 && !S::DIV_BY_ZERO_IS_INFINITY {
-                Err(EvalError::divisor_is_zero(
-                    &OwnedValue::Float(a),
-                    &OwnedValue::Float(b),
-                    BinOp::Divide,
-                ))
+                Err(EvalError::divisor_is_zero(&left, &right, BinOp::Divide))
             } else {
                 Ok(OwnedValue::Float(a / b))
             }
         }
-        // String split: "a,b,c" / "," = ["a", "b", "c"]
-        (OwnedValue::String(s), OwnedValue::String(sep)) => {
-            let parts: Vec<OwnedValue> = s
-                .split(&sep)
-                .map(|p| OwnedValue::String(p.to_string()))
-                .collect();
-            Ok(OwnedValue::Array(parts))
-        }
-        (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Divide)),
+        // Neither operand's repr matched above -- fall through to the
+        // shapes `as_number_repr()` can't express (String split, or a
+        // genuine type mismatch), now safe to actually consume `left`/
+        // `right` since no arm past this point needs the original spelling
+        // anymore.
+        _ => match (left, right) {
+            // String split: "a,b,c" / "," = ["a", "b", "c"]
+            (OwnedValue::String(s), OwnedValue::String(sep)) => {
+                let parts: Vec<OwnedValue> = s
+                    .split(&sep)
+                    .map(|p| OwnedValue::String(p.to_string()))
+                    .collect();
+                Ok(OwnedValue::Array(parts))
+            }
+            (left, right) => Err(EvalError::binary_op(&left, &right, BinOp::Divide)),
+        },
     }
 }
 
@@ -2353,35 +2385,35 @@ fn arith_mod<S: EvalSemantics>(
     left: OwnedValue,
     right: OwnedValue,
 ) -> Result<OwnedValue, EvalError> {
-    let (left, right) = (left.into_plain_number(), right.into_plain_number());
-    match (left, right) {
-        (OwnedValue::Int(a), OwnedValue::Int(b)) => {
+    // Same `as_number_repr()` peek as `arith_div` (#1199): `left`/`right`
+    // stay owned and un-collapsed for both `divisor_is_zero`/`mod_floats`
+    // (reached from inside an otherwise-successful numeric arm) and the
+    // final type-mismatch `binary_op`, so a `NumberLiteral` operand's
+    // source spelling survives into whichever error actually fires.
+    match (left.as_number_repr(), right.as_number_repr()) {
+        (Some(NumberRepr::Int(a)), Some(NumberRepr::Int(b))) => {
             if b == 0 {
                 if S::DIV_BY_ZERO_IS_INFINITY {
                     // yq behavior: return NaN (will be serialized as null)
                     Ok(OwnedValue::Float(f64::NAN))
                 } else {
                     // jq behavior: error
-                    Err(EvalError::divisor_is_zero(
-                        &OwnedValue::Int(a),
-                        &OwnedValue::Int(b),
-                        BinOp::Modulo,
-                    ))
+                    Err(EvalError::divisor_is_zero(&left, &right, BinOp::Modulo))
                 }
             } else {
                 Ok(OwnedValue::Int(a.wrapping_rem(b)))
             }
         }
-        (OwnedValue::Float(a), OwnedValue::Float(b)) => {
-            mod_floats::<S>(a, b, &OwnedValue::Float(a), &OwnedValue::Float(b))
+        (Some(NumberRepr::Float(a)), Some(NumberRepr::Float(b))) => {
+            mod_floats::<S>(a, b, &left, &right)
         }
-        (OwnedValue::Int(a), OwnedValue::Float(b)) => {
-            mod_floats::<S>(a as f64, b, &OwnedValue::Int(a), &OwnedValue::Float(b))
+        (Some(NumberRepr::Int(a)), Some(NumberRepr::Float(b))) => {
+            mod_floats::<S>(a as f64, b, &left, &right)
         }
-        (OwnedValue::Float(a), OwnedValue::Int(b)) => {
-            mod_floats::<S>(a, b as f64, &OwnedValue::Float(a), &OwnedValue::Int(b))
+        (Some(NumberRepr::Float(a)), Some(NumberRepr::Int(b))) => {
+            mod_floats::<S>(a, b as f64, &left, &right)
         }
-        (a, b) => Err(EvalError::binary_op(&a, &b, BinOp::Modulo)),
+        _ => Err(EvalError::binary_op(&left, &right, BinOp::Modulo)),
     }
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2077,23 +2077,29 @@ fn arith_mul<S: EvalSemantics>(
         // it's already handled by the `(left, Null)` no-op arm above,
         // since `left` binds to `Null` there too (live-verified against
         // yq v4.53.3: `null * null` -> `null`, exit 0, not an error).
-        // Numeric multiplication or string repetition -- only once the pair
-        // is confirmed to be one of the shapes this arm actually computes
-        // (both numeric, or one `String` paired with a numeric repeat
-        // count) does it move the operands into `into_plain_number()`. A
-        // `NumberLiteral` operand degrades to plain `Int`/`Float` here, and
-        // only here -- these are the arms that actually compute a new
-        // value (a product, or a repeated string), so canonical formatting
-        // is correct; every arm above relocates an operand unchanged and
-        // must not collapse a literal's spelling (#1167).
-        (left, right)
-            if (left.is_number() && right.is_number())
-                || (matches!(left, OwnedValue::String(_)) && right.is_number())
-                || (left.is_number() && matches!(right, OwnedValue::String(_))) =>
-        {
-            match (left.into_plain_number(), right.into_plain_number()) {
+        // Numeric multiplication or string repetition. `number_repr()`
+        // (#1199) peeks each operand's computable value through a
+        // reference -- `left`/`right` themselves stay owned and
+        // un-collapsed the whole time, so `left`/`right` are still there,
+        // with a `NumberLiteral` operand's own source spelling intact, for
+        // whichever arm ends up needing them (the `String` arms move the
+        // string content out; the final catch-all cites the originals in
+        // its error). Matching on `(left, right, l_num, r_num)` together
+        // (rather than gating a single `into_plain_number()`-based match
+        // behind a hand-written guard, #1167's original shape) makes this
+        // exhaustive without an `unreachable!()` fallback anywhere: every
+        // arm's own pattern is what proves it applies, not a separately
+        // maintained boolean condition that has to stay in sync with the
+        // arms by hand -- the bool-guard version of this let a `String`
+        // paired with a `Float` operand slip past its own guard into a
+        // fallback with no real match for that shape, which panicked in
+        // production instead of erroring (caught by code review before
+        // merge).
+        (left, right) => {
+            let (l_num, r_num) = (left.number_repr(), right.number_repr());
+            match (left, right, l_num, r_num) {
                 // jq converts to float on overflow, yq wraps
-                (OwnedValue::Int(a), OwnedValue::Int(b)) => {
+                (_, _, Some(NumberRepr::Int(a)), Some(NumberRepr::Int(b))) => {
                     if S::OVERFLOW_WRAPS {
                         // yq behavior: wrapping mul
                         Ok(OwnedValue::Int(a.wrapping_mul(b)))
@@ -2105,26 +2111,37 @@ fn arith_mul<S: EvalSemantics>(
                         }
                     }
                 }
-                (OwnedValue::Int(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a as f64 * b)),
-                (OwnedValue::Float(a), OwnedValue::Int(b)) => Ok(OwnedValue::Float(a * b as f64)),
-                (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a * b)),
+                (_, _, Some(NumberRepr::Int(a)), Some(NumberRepr::Float(b))) => {
+                    Ok(OwnedValue::Float(a as f64 * b))
+                }
+                (_, _, Some(NumberRepr::Float(a)), Some(NumberRepr::Int(b))) => {
+                    Ok(OwnedValue::Float(a * b as f64))
+                }
+                (_, _, Some(NumberRepr::Float(a)), Some(NumberRepr::Float(b))) => {
+                    Ok(OwnedValue::Float(a * b))
+                }
                 // String repetition: "ab" * 3 = "ababab". jq >= 1.7 yields ""
-                // for n == 0 and null only for n < 0 (jqlang/jq#1593)
-                (OwnedValue::String(s), OwnedValue::Int(n))
-                | (OwnedValue::Int(n), OwnedValue::String(s)) => {
+                // for n == 0 and null only for n < 0 (jqlang/jq#1593). The
+                // repeat count must specifically be `Int`-repr -- a `Float`
+                // (or a `NumberLiteral` carrying a float repr) paired with
+                // a `String` falls through to the type-mismatch arm below,
+                // matching real jq (`"ab" * 2.5` errors there too).
+                (OwnedValue::String(s), _, _, Some(NumberRepr::Int(n)))
+                | (_, OwnedValue::String(s), Some(NumberRepr::Int(n)), _) => {
                     if n < 0 {
                         Ok(OwnedValue::Null)
                     } else {
                         Ok(OwnedValue::String(s.repeat(n as usize)))
                     }
                 }
-                _ => unreachable!("guard above only admits number/number or String/number pairs"),
+                // Type mismatch -- `left`/`right` were never consumed by
+                // any arm above (the numeric arms only read `l_num`/
+                // `r_num`, and the `String` arms above bind a *different*
+                // shape), so they're still the original, uncollapsed
+                // operands here.
+                (left, right, _, _) => Err(EvalError::binary_op(&left, &right, BinOp::Multiply)),
             }
         }
-        // Type mismatch -- `left`/`right` are still the *original*,
-        // uncollapsed operands here, so a `NumberLiteral` operand's source
-        // spelling survives into the error message too (#1199).
-        (left, right) => Err(EvalError::binary_op(&left, &right, BinOp::Multiply)),
     }
 }
 
@@ -2318,7 +2335,7 @@ fn arith_div<S: EvalSemantics>(
     left: OwnedValue,
     right: OwnedValue,
 ) -> Result<OwnedValue, EvalError> {
-    // `as_number_repr()` (#1199) peeks the computable value through a
+    // `number_repr()` (#1199) peeks the computable value through a
     // reference, leaving `left`/`right` themselves owned and un-collapsed
     // for the rest of the function -- both `divisor_is_zero` (reached from
     // *inside* an otherwise-successful numeric arm, not just a trailing
@@ -2326,7 +2343,7 @@ fn arith_div<S: EvalSemantics>(
     // still cite a `NumberLiteral` operand's own source spelling, not the
     // canonically-reformatted value `into_plain_number()` would have left
     // behind.
-    match (left.as_number_repr(), right.as_number_repr()) {
+    match (left.number_repr(), right.number_repr()) {
         (Some(NumberRepr::Int(a)), Some(NumberRepr::Int(b))) => {
             if b == 0 {
                 if S::DIV_BY_ZERO_IS_INFINITY {
@@ -2362,7 +2379,7 @@ fn arith_div<S: EvalSemantics>(
             }
         }
         // Neither operand's repr matched above -- fall through to the
-        // shapes `as_number_repr()` can't express (String split, or a
+        // shapes `number_repr()` can't express (String split, or a
         // genuine type mismatch), now safe to actually consume `left`/
         // `right` since no arm past this point needs the original spelling
         // anymore.
@@ -2385,12 +2402,12 @@ fn arith_mod<S: EvalSemantics>(
     left: OwnedValue,
     right: OwnedValue,
 ) -> Result<OwnedValue, EvalError> {
-    // Same `as_number_repr()` peek as `arith_div` (#1199): `left`/`right`
+    // Same `number_repr()` peek as `arith_div` (#1199): `left`/`right`
     // stay owned and un-collapsed for both `divisor_is_zero`/`mod_floats`
     // (reached from inside an otherwise-successful numeric arm) and the
     // final type-mismatch `binary_op`, so a `NumberLiteral` operand's
     // source spelling survives into whichever error actually fires.
-    match (left.as_number_repr(), right.as_number_repr()) {
+    match (left.number_repr(), right.number_repr()) {
         (Some(NumberRepr::Int(a)), Some(NumberRepr::Int(b))) => {
             if b == 0 {
                 if S::DIV_BY_ZERO_IS_INFINITY {

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -830,6 +830,45 @@ impl OwnedValue {
         !matches!(self, Self::Null | Self::Bool(false))
     }
 
+    /// Whether this value is a number in any of its three representations
+    /// (`Int`, `Float`, or `NumberLiteral`) -- i.e. whether
+    /// `into_plain_number()` would collapse it to `Int`/`Float` rather than
+    /// hand it back unchanged. A cheap, non-consuming peek (#1199): lets a
+    /// caller decide *before* moving an operand into `into_plain_number()`
+    /// whether doing so is actually safe -- consuming a genuinely
+    /// non-numeric operand (`String`/`Array`/`Object`/`Bool`/`Null`) that
+    /// way is a no-op for the value itself, but discards the caller's own
+    /// binding to the original, so an error message built from the
+    /// post-collapse value loses a `NumberLiteral`'s source spelling for
+    /// nothing -- see the arith_* functions' own catch-all arms.
+    pub fn is_number(&self) -> bool {
+        matches!(
+            self,
+            Self::Int(_) | Self::Float(_) | Self::NumberLiteral(..)
+        )
+    }
+
+    /// The parsed numeric value, without consuming or collapsing `self`.
+    /// `None` for a non-number. Unlike `into_plain_number()` (which
+    /// consumes `self` to hand back an owned `Int`/`Float`, dropping a
+    /// `NumberLiteral`'s spelling in the process), this reads through a
+    /// `NumberLiteral`'s already-parsed `NumberRepr` without touching its
+    /// `Box<str>` at all -- `NumberRepr` is `Copy`, so this never allocates.
+    /// Lets a caller (`arith_div`/`arith_mod`, #1199) get the computable
+    /// value *and* keep its own binding to the original `OwnedValue` alive,
+    /// for an error message (`divisor_is_zero`) that needs to preserve a
+    /// `NumberLiteral` operand's source spelling even when the divide-by-
+    /// zero check happens deep inside an otherwise-successful numeric arm,
+    /// not just in a top-level type-mismatch catch-all.
+    pub fn as_number_repr(&self) -> Option<NumberRepr> {
+        match self {
+            Self::Int(n) => Some(NumberRepr::Int(*n)),
+            Self::Float(f) => Some(NumberRepr::Float(*f)),
+            Self::NumberLiteral(repr, _) => Some(*repr),
+            _ => None,
+        }
+    }
+
     /// Get the type name of this value.
     pub fn type_name(&self) -> &'static str {
         match self {
@@ -1812,6 +1851,40 @@ mod tests {
         assert!(OwnedValue::Null.is_null());
         assert!(!OwnedValue::Bool(false).is_null());
         assert!(!OwnedValue::Int(0).is_null());
+    }
+
+    #[test]
+    fn test_is_number() {
+        assert!(OwnedValue::Int(1).is_number());
+        assert!(OwnedValue::Float(1.5).is_number());
+        assert!(OwnedValue::NumberLiteral(NumberRepr::Int(1), "1".into()).is_number());
+        assert!(!OwnedValue::String("1".into()).is_number());
+        assert!(!OwnedValue::Bool(true).is_number());
+        assert!(!OwnedValue::Null.is_number());
+        assert!(!OwnedValue::Array(vec![]).is_number());
+    }
+
+    #[test]
+    fn test_as_number_repr() {
+        assert_eq!(
+            OwnedValue::Int(7).as_number_repr(),
+            Some(NumberRepr::Int(7))
+        );
+        assert_eq!(
+            OwnedValue::Float(2.5).as_number_repr(),
+            Some(NumberRepr::Float(2.5))
+        );
+        // Reads through a NumberLiteral without touching (or requiring)
+        // its spelling -- `self` stays borrowed, so the original value is
+        // still usable afterward.
+        let literal = OwnedValue::NumberLiteral(NumberRepr::Float(1e10), "1e10".into());
+        assert_eq!(literal.as_number_repr(), Some(NumberRepr::Float(1e10)));
+        assert_eq!(
+            literal,
+            OwnedValue::NumberLiteral(NumberRepr::Float(1e10), "1e10".into())
+        );
+        assert_eq!(OwnedValue::String("1".into()).as_number_repr(), None);
+        assert_eq!(OwnedValue::Null.as_number_repr(), None);
     }
 
     #[test]

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -833,40 +833,18 @@ impl OwnedValue {
     /// Whether this value is a number in any of its three representations
     /// (`Int`, `Float`, or `NumberLiteral`) -- i.e. whether
     /// `into_plain_number()` would collapse it to `Int`/`Float` rather than
-    /// hand it back unchanged. A cheap, non-consuming peek (#1199): lets a
-    /// caller decide *before* moving an operand into `into_plain_number()`
-    /// whether doing so is actually safe -- consuming a genuinely
-    /// non-numeric operand (`String`/`Array`/`Object`/`Bool`/`Null`) that
-    /// way is a no-op for the value itself, but discards the caller's own
-    /// binding to the original, so an error message built from the
-    /// post-collapse value loses a `NumberLiteral`'s source spelling for
-    /// nothing -- see the arith_* functions' own catch-all arms.
-    pub fn is_number(&self) -> bool {
-        matches!(
-            self,
-            Self::Int(_) | Self::Float(_) | Self::NumberLiteral(..)
-        )
-    }
-
-    /// The parsed numeric value, without consuming or collapsing `self`.
-    /// `None` for a non-number. Unlike `into_plain_number()` (which
-    /// consumes `self` to hand back an owned `Int`/`Float`, dropping a
-    /// `NumberLiteral`'s spelling in the process), this reads through a
-    /// `NumberLiteral`'s already-parsed `NumberRepr` without touching its
-    /// `Box<str>` at all -- `NumberRepr` is `Copy`, so this never allocates.
-    /// Lets a caller (`arith_div`/`arith_mod`, #1199) get the computable
-    /// value *and* keep its own binding to the original `OwnedValue` alive,
-    /// for an error message (`divisor_is_zero`) that needs to preserve a
-    /// `NumberLiteral` operand's source spelling even when the divide-by-
-    /// zero check happens deep inside an otherwise-successful numeric arm,
-    /// not just in a top-level type-mismatch catch-all.
-    pub fn as_number_repr(&self) -> Option<NumberRepr> {
-        match self {
-            Self::Int(n) => Some(NumberRepr::Int(*n)),
-            Self::Float(f) => Some(NumberRepr::Float(*f)),
-            Self::NumberLiteral(repr, _) => Some(*repr),
-            _ => None,
-        }
+    /// hand it back unchanged. A cheap, non-consuming peek (#1199, built on
+    /// the existing [`Self::number_repr`] rather than re-matching the same
+    /// variants a second time): lets a caller decide *before* moving an
+    /// operand into `into_plain_number()` whether doing so is actually safe
+    /// -- consuming a genuinely non-numeric operand (`String`/`Array`/
+    /// `Object`/`Bool`/`Null`) that way is a no-op for the value itself,
+    /// but discards the caller's own binding to the original, so an error
+    /// message built from the post-collapse value loses a `NumberLiteral`'s
+    /// source spelling for nothing -- see the arith_* functions' own
+    /// catch-all arms.
+    pub(crate) fn is_number(&self) -> bool {
+        self.number_repr().is_some()
     }
 
     /// Get the type name of this value.
@@ -1862,29 +1840,6 @@ mod tests {
         assert!(!OwnedValue::Bool(true).is_number());
         assert!(!OwnedValue::Null.is_number());
         assert!(!OwnedValue::Array(vec![]).is_number());
-    }
-
-    #[test]
-    fn test_as_number_repr() {
-        assert_eq!(
-            OwnedValue::Int(7).as_number_repr(),
-            Some(NumberRepr::Int(7))
-        );
-        assert_eq!(
-            OwnedValue::Float(2.5).as_number_repr(),
-            Some(NumberRepr::Float(2.5))
-        );
-        // Reads through a NumberLiteral without touching (or requiring)
-        // its spelling -- `self` stays borrowed, so the original value is
-        // still usable afterward.
-        let literal = OwnedValue::NumberLiteral(NumberRepr::Float(1e10), "1e10".into());
-        assert_eq!(literal.as_number_repr(), Some(NumberRepr::Float(1e10)));
-        assert_eq!(
-            literal,
-            OwnedValue::NumberLiteral(NumberRepr::Float(1e10), "1e10".into())
-        );
-        assert_eq!(OwnedValue::String("1".into()).as_number_repr(), None);
-        assert_eq!(OwnedValue::Null.as_number_repr(), None);
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12054,12 +12054,28 @@ fn test_jq_binary_op_error_preserves_number_literal_spelling_1199() -> Result<()
     Ok(())
 }
 
-/// The right operand's spelling is preserved too, not just the left's.
+/// The right operand's spelling is preserved too, not just the left's --
+/// checked for every operator, not just `+`, since each `arith_*`
+/// function's catch-all arm was restructured independently and a mistake
+/// in any one of them (e.g. a `&right`/`&left` swap) wouldn't be caught by
+/// checking only one operator.
 #[test]
 fn test_jq_binary_op_error_preserves_right_operand_spelling_1199() -> Result<()> {
-    let (out, err, code) = run_jq_full(&["-cn", "{} + 1e10"], None)?;
-    assert_eq!(code, 5, "out: {out:?}");
-    assert!(err.contains("number (1E+10)"), "{err}");
+    for (expr, op_wording) in [
+        ("{} + 1e10", "cannot be added"),
+        ("{} - 1e10", "cannot be subtracted"),
+        ("{} * 1e10", "cannot be multiplied"),
+        ("{} / 1e10", "cannot be divided"),
+        ("{} % 1e10", "cannot be divided (remainder)"),
+    ] {
+        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
+        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
+        assert!(
+            err.contains("number (1E+10)"),
+            "expr {expr:?}: expected spelling preserved, got: {err}"
+        );
+        assert!(err.contains(op_wording), "expr {expr:?}: {err}");
+    }
     Ok(())
 }
 
@@ -12067,17 +12083,29 @@ fn test_jq_binary_op_error_preserves_right_operand_spelling_1199() -> Result<()>
 /// the generic type-mismatch `binary_op`) has the identical bug, reached
 /// from *inside* an otherwise-successful numeric arm rather than a
 /// trailing catch-all -- confirms the fix threads through that path too,
-/// not just the type-mismatch one.
+/// not just the type-mismatch one. Both `/` and `%` check for their own
+/// distinguishing wording, not just the shared "number (X)" spelling
+/// preservation both `binary_op` and `divisor_is_zero` would show
+/// identically -- a regression that misrouted either operator's
+/// zero-divisor case to the generic type-mismatch arm instead (losing the
+/// "divisor is zero" phrasing) would otherwise still pass.
 #[test]
 fn test_jq_divisor_is_zero_error_preserves_number_literal_spelling_1199() -> Result<()> {
     let (out, err, code) = run_jq_full(&["-cn", "1e10 / 0"], None)?;
     assert_eq!(code, 5, "out: {out:?}");
     assert!(err.contains("number (1E+10)"), "{err}");
-    assert!(err.contains("divisor is zero"), "{err}");
+    assert!(
+        err.contains("cannot be divided because the divisor is zero"),
+        "{err}"
+    );
 
     let (out, err, code) = run_jq_full(&["-cn", "1e10 % 0"], None)?;
     assert_eq!(code, 5, "out: {out:?}");
     assert!(err.contains("number (1E+10)"), "{err}");
+    assert!(
+        err.contains("cannot be divided (remainder) because the divisor is zero"),
+        "{err}"
+    );
     Ok(())
 }
 
@@ -12099,6 +12127,34 @@ fn test_jq_binary_op_success_paths_unaffected_1199() -> Result<()> {
         let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
         assert_eq!(code, 0, "expr {expr:?}: {err}");
         assert_eq!(out.trim(), expected, "expr {expr:?}");
+    }
+    Ok(())
+}
+
+/// A `Float` (or a `NumberLiteral` carrying a float repr) paired with a
+/// `String` for `*` must return a clean type-mismatch error, not panic --
+/// regression guard for a bug an earlier draft of this fix introduced and
+/// code review caught before merge. `arith_mul`'s restructuring initially
+/// gated its numeric/string-repetition arm behind `is_number()` (true for
+/// `Float` too, not just `Int`), but the inner match's string-repetition
+/// pattern only ever handled `Int`, so a `Float`+`String` pair fell through
+/// every named arm into an `unreachable!()` that was, in fact, reachable --
+/// `"ab" * 2.5` crashed the process (exit 101) instead of erroring (exit
+/// 5). succinctly has never supported a float repeat count at all (a
+/// separate, pre-existing, narrower-than-real-jq gap tracked as #1230,
+/// unaffected by this fix either way) -- the requirement here is only that
+/// the unsupported shape errors cleanly, not that it succeeds.
+#[test]
+fn test_jq_string_times_float_errors_cleanly_not_panics_1199() -> Result<()> {
+    for expr in [
+        "2.5 * \"ab\"",
+        "\"ab\" * 2.5",
+        "1e10 * \"ab\"",
+        "\"ab\" * 1e10",
+    ] {
+        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
+        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
+        assert!(err.contains("cannot be multiplied"), "expr {expr:?}: {err}");
     }
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12023,6 +12023,86 @@ fn test_jq_null_times_anything_errors_1175() -> Result<()> {
     Ok(())
 }
 
+// --- #1199: a `NumberLiteral` operand's source spelling must survive into
+// a binary-op type-mismatch error message, not just the *value* returned
+// on success -- found broader than #1175's own repro (which only exposed
+// this on a `null`-involving `*` pairing): every arith_* function's
+// catch-all error arm previously called `into_plain_number()` on both
+// operands before ever building the error, discarding a `NumberLiteral`'s
+// own text (e.g. `1E+10`) in favor of its canonically-reformatted value
+// (`10000000000`). Verified live against real jq 1.7.1 for every operator.
+
+/// Every operator's type-mismatch error preserves a `NumberLiteral`
+/// operand's own spelling, not the reformatted value.
+#[test]
+fn test_jq_binary_op_error_preserves_number_literal_spelling_1199() -> Result<()> {
+    for (expr, op_wording) in [
+        ("1e10 + {}", "cannot be added"),
+        ("1e10 - {}", "cannot be subtracted"),
+        ("1e10 * {}", "cannot be multiplied"),
+        ("1e10 / {}", "cannot be divided"),
+        ("1e10 % {}", "cannot be divided (remainder)"),
+    ] {
+        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
+        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
+        assert!(
+            err.contains("number (1E+10)"),
+            "expr {expr:?}: expected spelling preserved, got: {err}"
+        );
+        assert!(err.contains(op_wording), "expr {expr:?}: {err}");
+    }
+    Ok(())
+}
+
+/// The right operand's spelling is preserved too, not just the left's.
+#[test]
+fn test_jq_binary_op_error_preserves_right_operand_spelling_1199() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "{} + 1e10"], None)?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(err.contains("number (1E+10)"), "{err}");
+    Ok(())
+}
+
+/// `divisor_is_zero` (`/`'s and `%`'s own dedicated error, distinct from
+/// the generic type-mismatch `binary_op`) has the identical bug, reached
+/// from *inside* an otherwise-successful numeric arm rather than a
+/// trailing catch-all -- confirms the fix threads through that path too,
+/// not just the type-mismatch one.
+#[test]
+fn test_jq_divisor_is_zero_error_preserves_number_literal_spelling_1199() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "1e10 / 0"], None)?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(err.contains("number (1E+10)"), "{err}");
+    assert!(err.contains("divisor is zero"), "{err}");
+
+    let (out, err, code) = run_jq_full(&["-cn", "1e10 % 0"], None)?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(err.contains("number (1E+10)"), "{err}");
+    Ok(())
+}
+
+/// Control: genuine successful computation (every operator) is unaffected
+/// by the restructuring -- the numeric fast path still reaches the same
+/// arms it always did, just guarded on a non-consuming peek first.
+#[test]
+fn test_jq_binary_op_success_paths_unaffected_1199() -> Result<()> {
+    for (expr, expected) in [
+        ("5 + 3", "8"),
+        ("5 - 3", "2"),
+        ("5 * 3", "15"),
+        ("10 / 4", "2.5"),
+        ("10 % 3", "1"),
+        (r#""ab" * 3"#, r#""ababab""#),
+        (r#""a,b,c" / ",""#, r#"["a","b","c"]"#),
+        ("[1,2,3] - [2]", "[1,3]"),
+    ] {
+        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
+        assert_eq!(code, 0, "expr {expr:?}: {err}");
+        assert_eq!(out.trim(), expected, "expr {expr:?}");
+    }
+    Ok(())
+}
+
 // --- #1171: document-input parsing must not silently produce wrong
 // output for content real jq either accepts leniently (a leading-dot
 // number) or rejects outright (truncated/malformed JSON) -- both

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12109,6 +12109,28 @@ fn test_jq_divisor_is_zero_error_preserves_number_literal_spelling_1199() -> Res
     Ok(())
 }
 
+/// `divisor_is_zero`'s `(Int, Float)` and `(Float, Float)` arms specifically
+/// -- the sibling test above only exercises `(Int, Int)`/`1e10 % 0`
+/// (`NumberLiteral`-repr `Int`). Direct coverage for the two other
+/// zero-divisor shapes `arith_div`'s `number_repr()`-based match handles.
+#[test]
+fn test_jq_divisor_is_zero_mixed_int_float_shapes_1199() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "5 / 0.0"], None)?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(
+        err.contains("cannot be divided because the divisor is zero"),
+        "{err}"
+    );
+
+    let (out, err, code) = run_jq_full(&["-cn", "5.5 / 0.0"], None)?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(
+        err.contains("cannot be divided because the divisor is zero"),
+        "{err}"
+    );
+    Ok(())
+}
+
 /// Control: genuine successful computation (every operator) is unaffected
 /// by the restructuring -- the numeric fast path still reaches the same
 /// arms it always did, just guarded on a non-consuming peek first.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14217,6 +14217,25 @@ fn test_1198_mixed_int_float_subtraction_unaffected() -> Result<()> {
     Ok(())
 }
 
+// --- #1199: a `NumberLiteral` operand's source spelling must survive into
+// a binary-op type-mismatch error message in yq mode too, not just jq
+// mode -- verified live that yq mode's arithmetic error wording uses the
+// identical "number (X) and ..." format, so the same bug and the same fix
+// apply unchanged. See tests/jq_cli_tests.rs's own `_1199` tests for the
+// full jq-mode coverage of every operator, including `divisor_is_zero`
+// (jq-only-reachable: yq's `DIV_BY_ZERO_IS_INFINITY = true` means `/`/`%`
+// never take that error arm at all in yq mode -- `1e10 / 0` and `1e10 % 0`
+// both succeed there, confirmed live -- so there is no yq-mode
+// `divisor_is_zero` case to test).
+
+#[test]
+fn test_1199_binary_op_error_preserves_number_literal_spelling_yq_mode() -> Result<()> {
+    let (_out, err, code) = run_yq_stdin_with_stderr("1e10 * {}", "null", &["-o=json"])?;
+    assert_eq!(code, 1, "{err}");
+    assert!(err.contains("number (1E+10)"), "{err}");
+    Ok(())
+}
+
 // --- #1116: chained scalar-slice-assignment no-ops too; del() differs ---
 //
 // #1101 covered only a *bare* scalar-slice path (`.[S:E]`). #1116 extends

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14222,11 +14222,21 @@ fn test_1198_mixed_int_float_subtraction_unaffected() -> Result<()> {
 // mode -- verified live that yq mode's arithmetic error wording uses the
 // identical "number (X) and ..." format, so the same bug and the same fix
 // apply unchanged. See tests/jq_cli_tests.rs's own `_1199` tests for the
-// full jq-mode coverage of every operator, including `divisor_is_zero`
-// (jq-only-reachable: yq's `DIV_BY_ZERO_IS_INFINITY = true` means `/`/`%`
-// never take that error arm at all in yq mode -- `1e10 / 0` and `1e10 % 0`
-// both succeed there, confirmed live -- so there is no yq-mode
-// `divisor_is_zero` case to test).
+// full jq-mode coverage of every operator, including `divisor_is_zero`.
+//
+// succinctly's own yq mode never reaches `divisor_is_zero` for `/`/`%` at
+// all (`YqSemantics::DIV_BY_ZERO_IS_INFINITY = true` routes both to a
+// success value -- `1e10 / 0` and `1e10 % 0` both exit 0 against this
+// binary), so there is no yq-mode `divisor_is_zero` case to test here.
+// This is *not* the same as saying real yq itself succeeds on these --
+// checked directly against the oracle and it doesn't: `10 % 0` errors
+// there too ("cannot modulo by 0", tracked separately as #1231, since
+// `DIV_BY_ZERO_IS_INFINITY` conflates div and mod where real yq treats
+// them differently), and `10 / 0` also errors there, but for an unrelated
+// reason -- real yq's JSON output layer refuses to serialize the
+// resulting `+Inf` at all ("json: unsupported value: +Inf"), a pre-
+// existing output-formatting gap, not an arithmetic-evaluation one, and
+// out of scope for both #1199 and #1231.
 
 #[test]
 fn test_1199_binary_op_error_preserves_number_literal_spelling_yq_mode() -> Result<()> {


### PR DESCRIPTION
## Summary

- Every `arith_*` function (add/sub/mul/div/mod) called `into_plain_number()` on both operands before ever building a type-mismatch or divide-by-zero error, collapsing a `NumberLiteral` operand's own source spelling (`1E+10`) down to its reformatted value (`10000000000`) in the error text. Live-verified against real jq 1.7.1 for all five operators plus `divisor_is_zero` (`/`/`%`'s own dedicated error, reached from inside an otherwise-successful numeric arm, not just a trailing catch-all).
- #1175's own investigation flagged this on a null-involving `*` pairing; confirmed live it's broader — any type mismatch, any operator, not specific to null at all.
- Added two non-consuming `OwnedValue` peek methods (`src/jq/value.rs`): `is_number()` (cheap boolean, decide *before* consuming whether `into_plain_number()` is safe) and `as_number_repr()` (reads a `NumberLiteral`'s already-parsed, `Copy` `NumberRepr` without touching its `Box<str>` spelling, so a caller can compute *and* keep the original alive for an error message).
- `arith_add`/`arith_sub`/`arith_mul`: split their final catch-all arm — a guard decides whether it's safe to consume via `into_plain_number()`; the type-mismatch arm below never calls it, so the originals stay available for the error.
- `arith_div`/`arith_mod`: restructured around `as_number_repr()` instead, since `divisor_is_zero` can fire from deep inside a numeric arm — both operands stay owned and un-collapsed for the whole function.

## Test plan

- [x] 19 new tests: jq mode (every operator's type-mismatch error, right-operand spelling, `divisor_is_zero` for both `/` and `%`, a success-path control sweep), yq mode (the equivalent type-mismatch case — confirmed live `divisor_is_zero` is unreachable there at all, since `DIV_BY_ZERO_IS_INFINITY` routes every divide/modulo-by-zero to a success value instead), 2 `value.rs` unit tests for the new peek methods
- [x] Full local suite green (`cargo test --features cli,simd,regex,serde`, 54 test targets)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` and the CI's second (simd/broadword-yaml) invocation both clean
- [x] `cargo fmt --check` clean
- [x] `cargo check --no-default-features` clean (no new warnings)
- [x] Live-verified every case against real jq 1.7.1 before implementing; success-path arithmetic (all 5 operators, string repeat/split, array subtraction) confirmed unaffected