### PR TITLE
fix(jq): preserve leading-zero number spelling through exponent/trailing zeros

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -854,6 +854,32 @@ impl OwnedValue {
                 return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
             }
         }
+        // Real jq's own number reader also tolerates a redundant leading
+        // zero in the integer part -- but unlike the leading-dot case
+        // above (which *adds* a digit and keeps everything else from the
+        // original text), real jq's own display *drops* the redundant
+        // zero itself while preserving everything else about the
+        // spelling (`007` -> `7`, `007e5` -> `7E+5` [reformatted like any
+        // exponent literal], `007.500` -> `7.500` [trailing zeros kept]).
+        // So the literal materialized here is the *stripped* text, not
+        // the original `bytes` -- confirmed live against jq 1.7.1 (an
+        // earlier draft of this fix materialized the original,
+        // leading-zero-intact text instead, which is wrong: caught by
+        // review before merge). The *only* reason this needs handling
+        // here at all: the CLI's own `--argjson`-style "normalize, retry"
+        // fix (#1094, `normalize_leading_zero_numbers` in
+        // `src/bin/succinctly/jq_runner.rs`) doesn't reach here -- it's a
+        // CLI-arg-only helper, not wired into this shared conversion, so
+        // the plain document-input path (and `--argjson` too, since it
+        // also ends up here) still fell all the way through to the lossy
+        // `parse_i64_or_f64` below, losing the leading zero *and* any
+        // exponent notation *and* any trailing zeros in one go (#1149).
+        if let Some(stripped) = crate::json::validate::strip_redundant_leading_zeros(bytes) {
+            if crate::json::validate::is_valid_number(&stripped) {
+                return core::str::from_utf8(&stripped)
+                    .map_or(Self::Null, Self::from_number_literal);
+            }
+        }
         let Ok(s) = core::str::from_utf8(bytes) else {
             return Self::Null;
         };

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -225,11 +225,16 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
         // Plain integer - canonicalize away an insignificant leading
         // zero/`+` (#1224, mirroring #1180's identical fix for the
         // exponent-notation mantissa path -- `split_mantissa`/
-        // `normalize_extreme_literal_mantissa` below). `is_valid_number`-
-        // gated callers never reach this function with such a spelling in
-        // the first place (strict RFC 8259 has no leading zero or `+`);
-        // this only matters for a caller that constructs a `NumberLiteral`
-        // directly, bypassing that gate.
+        // `normalize_extreme_literal_mantissa` below). Originally
+        // reachable only via a directly-constructed `NumberLiteral`
+        // bypassing `is_valid_number`'s gate (#1224's own note) -- #1149's
+        // leading-zero materialization fix (`from_number_bytes`,
+        // `DocumentValue::number_literal`) now makes this a real,
+        // exercised path too: both store the *original* un-stripped bytes
+        // as the literal spelling (matching the leading-dot case just
+        // below) and rely entirely on this canonicalization to fix
+        // display, rather than each independently stripping the zero
+        // themselves.
         return strip_insignificant_leading_zero_and_plus(s);
     }
 
@@ -241,12 +246,9 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
         // leading-dot spelling even under plain identity -- confirmed
         // live: `.500 | .` -> `0.500` (#1171) -- for free: an *absent*
         // integer part strips to the same canonical `0` a `007`-style one
-        // does. `is_valid_number`-gated callers never reach this function
-        // with a leading-dot `s` in the first place (strict RFC 8259 has
-        // no such spelling); this only fires for `s` sourced from a
-        // `NumberLiteral` this crate's own document-input scanners now
-        // recognize as jq-lenient (see `number_literal_end`,
-        // `src/json/light.rs`).
+        // does. Also now the real display fix for #1149's leading-zero
+        // leniency (`007.500` -> `7.500`), for the same reason as the
+        // plain-integer branch above.
         return strip_insignificant_leading_zero_and_plus(s);
     }
 
@@ -855,19 +857,28 @@ impl OwnedValue {
             }
         }
         // Real jq's own number reader also tolerates a redundant leading
-        // zero in the integer part -- but unlike the leading-dot case
-        // above (which *adds* a digit and keeps everything else from the
-        // original text), real jq's own display *drops* the redundant
-        // zero itself while preserving everything else about the
-        // spelling (`007` -> `7`, `007e5` -> `7E+5` [reformatted like any
-        // exponent literal], `007.500` -> `7.500` [trailing zeros kept]).
-        // So the literal materialized here is the *stripped* text, not
-        // the original `bytes` -- confirmed live against jq 1.7.1 (an
-        // earlier draft of this fix materialized the original,
-        // leading-zero-intact text instead, which is wrong: caught by
-        // review before merge). The *only* reason this needs handling
-        // here at all: the CLI's own `--argjson`-style "normalize, retry"
-        // fix (#1094, `normalize_leading_zero_numbers` in
+        // zero in the integer part (`007` -> `7`, `007e5` -> `7E+5`,
+        // `007.500` -> `7.500`, trailing zeros and exponent notation
+        // otherwise kept) -- confirmed live against jq 1.7.1. As with the
+        // leading-dot case just above, materialize the *original* `bytes`
+        // as the literal spelling, not a stripped copy: dropping the
+        // redundant zero is purely a display-time concern
+        // (`format_number_jq_compat` strips it in its plain-integer and
+        // plain-decimal-without-exponent branches, the only branches that
+        // echo `NumberLiteral` text verbatim -- every exponent-bearing
+        // branch already reformats from the *parsed* value/exponent
+        // digits, leading zeros and all, so it needs no separate
+        // handling), not something the stored spelling itself needs to
+        // already reflect. `bytes` was already gated by
+        // `strip_redundant_leading_zeros` + `is_valid_number` below, so no
+        // separate reparse of the original text is needed here (an
+        // earlier draft of this fix stored the *stripped* text directly
+        // here instead, duplicating the display-time fix at both
+        // materializer call sites; review found it simpler to store the
+        // original everywhere, matching the leading-dot case, and fix
+        // display once). The *only* reason this needs handling here at
+        // all: the CLI's own `--argjson`-style "normalize, retry" fix
+        // (#1094, `normalize_leading_zero_numbers` in
         // `src/bin/succinctly/jq_runner.rs`) doesn't reach here -- it's a
         // CLI-arg-only helper, not wired into this shared conversion, so
         // the plain document-input path (and `--argjson` too, since it
@@ -876,8 +887,7 @@ impl OwnedValue {
         // exponent notation *and* any trailing zeros in one go (#1149).
         if let Some(stripped) = crate::json::validate::strip_redundant_leading_zeros(bytes) {
             if crate::json::validate::is_valid_number(&stripped) {
-                return core::str::from_utf8(&stripped)
-                    .map_or(Self::Null, Self::from_number_literal);
+                return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
             }
         }
         let Ok(s) = core::str::from_utf8(bytes) else {

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1773,15 +1773,32 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
         match self {
             StandardJson::Number(n) => {
                 let bytes = n.raw_bytes();
-                if !crate::json::validate::is_valid_number(bytes) {
-                    // The semi-index scanner accepts number *spans* more
-                    // leniently than RFC 8259 (e.g. `007`, `1.2.3` — see
-                    // #966): echoing such text verbatim would produce
-                    // invalid JSON output. Fall through to `as_i64`/`as_f64`
-                    // (still lenient, but numerically sound) or `Null`.
-                    return None;
+                if crate::json::validate::is_valid_number(bytes) {
+                    return core::str::from_utf8(bytes).ok().map(Cow::Borrowed);
                 }
-                core::str::from_utf8(bytes).ok().map(Cow::Borrowed)
+                // Real jq's own number reader tolerates a redundant
+                // leading zero that strict RFC 8259 doesn't (`007e5` ->
+                // `7E+5`, `007.500` -> `7.500`) -- #1149, same fix as
+                // `OwnedValue::from_number_bytes`'s own leading-zero
+                // handling (shared via `strip_redundant_leading_zeros`,
+                // since this trait impl has no access to that jq-layer
+                // type). Reached by `--argjson`/`--slurpfile`/`--seq`
+                // and this crate's own `.json`-file input paths, which
+                // materialize through this generic `DocumentValue`
+                // trait rather than `from_number_bytes` directly.
+                if let Some(stripped) = crate::json::validate::strip_redundant_leading_zeros(bytes)
+                {
+                    if crate::json::validate::is_valid_number(&stripped) {
+                        return String::from_utf8(stripped).ok().map(Cow::Owned);
+                    }
+                }
+                // The semi-index scanner accepts number *spans* more
+                // leniently than RFC 8259 beyond just a leading zero
+                // (e.g. `1.2.3` — see #966): echoing such text verbatim
+                // would produce invalid JSON output. Fall through to
+                // `as_i64`/`as_f64` (still lenient, but numerically
+                // sound) or `Null`.
+                None
             }
             _ => None,
         }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1777,19 +1777,37 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
                     return core::str::from_utf8(bytes).ok().map(Cow::Borrowed);
                 }
                 // Real jq's own number reader tolerates a redundant
-                // leading zero that strict RFC 8259 doesn't (`007e5` ->
-                // `7E+5`, `007.500` -> `7.500`) -- #1149, same fix as
-                // `OwnedValue::from_number_bytes`'s own leading-zero
-                // handling (shared via `strip_redundant_leading_zeros`,
-                // since this trait impl has no access to that jq-layer
-                // type). Reached by `--argjson`/`--slurpfile`/`--seq`
-                // and this crate's own `.json`-file input paths, which
-                // materialize through this generic `DocumentValue`
-                // trait rather than `from_number_bytes` directly.
+                // leading zero that strict RFC 8259 doesn't (`007` ->
+                // `7`, `007e5` -> `7E+5`, `007.500` -> `7.500`) -- #1149,
+                // same leniency as `OwnedValue::from_number_bytes`'s own
+                // leading-zero handling (shared gate via
+                // `strip_redundant_leading_zeros`, since this trait impl
+                // has no access to that jq-layer type). Reached by
+                // `--argjson`/`--jsonargs` (`parse_json_value`'s own
+                // normalize-and-retry validation lets a leading-zero
+                // literal survive to materialize here) and this crate's
+                // own `.json`-file input path, which both materialize
+                // through this generic `DocumentValue` trait rather than
+                // `from_number_bytes` directly. `--slurpfile`/`--seq`
+                // don't reach this arm at all -- both validate via a
+                // stricter path with no leading-zero retry
+                // (`parse_json_stream`'s `serde_json::Deserializer`,
+                // `parse_json_seq`'s `validate_and_materialize_json`), so
+                // a leading-zero literal there still errors/is dropped
+                // before ever reaching `number_literal()` (confirmed
+                // live; pre-existing, out-of-scope gap, unchanged by this
+                // fix). Returns the *original*
+                // `bytes` here, not the stripped copy the gate check
+                // builds -- dropping the redundant zero is purely a
+                // display-time concern (`format_number_jq_compat`), not
+                // something the stored spelling itself needs to already
+                // reflect (matches `from_number_bytes`'s own leading-dot
+                // and leading-zero handling, both of which store the
+                // original text for the same reason).
                 if let Some(stripped) = crate::json::validate::strip_redundant_leading_zeros(bytes)
                 {
                     if crate::json::validate::is_valid_number(&stripped) {
-                        return String::from_utf8(stripped).ok().map(Cow::Owned);
+                        return core::str::from_utf8(bytes).ok().map(Cow::Borrowed);
                     }
                 }
                 // The semi-index scanner accepts number *spans* more

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -26,6 +26,8 @@
 
 #[cfg(not(test))]
 use alloc::string::String;
+#[cfg(not(test))]
+use alloc::vec::Vec;
 
 use core::fmt;
 
@@ -807,6 +809,51 @@ pub fn is_valid_number(bytes: &[u8]) -> bool {
         }
     }
     i == bytes.len()
+}
+
+/// Strip a redundant leading zero (`007` -> `7`, `-007` -> `-7`) from a
+/// single, already-isolated number token's integer part.
+///
+/// Real jq's own number reader tolerates a leading zero that strict
+/// RFC 8259 doesn't; this is the shared building block two independent
+/// "recover a lenient-but-invalid number's own literal spelling"
+/// call sites use (`OwnedValue::from_number_bytes` in `src/jq/value.rs`,
+/// and [`crate::json::light`]'s `DocumentValue::number_literal`
+/// implementation, #1149) -- strip the redundant zero(s), re-check
+/// [`is_valid_number`] on the result, and materialize *that* stripped
+/// text as the literal spelling if it passes (real jq's own display
+/// drops the redundant zero but otherwise preserves the spelling
+/// unchanged, e.g. `007e5` -> `7E+5`, `007.500` -> `7.500`).
+///
+/// Returns `None` when there's nothing to strip -- either the integer
+/// part doesn't start with a redundant `0` at all (an ordinary number,
+/// the overwhelmingly common case, kept allocation-free), or it's a bare
+/// `0`/`0.x`-style integer part RFC 8259 already accepts unchanged. An
+/// all-zero run (`00`, `-000`) strips down to a single `0`, not empty.
+///
+/// Deliberately scoped to one token, unlike
+/// `normalize_leading_zero_numbers` (`src/bin/succinctly/jq_runner.rs`,
+/// #1094) which scans a whole raw JSON *string* while tracking
+/// string-literal context to find every number token inside it -- both
+/// of this function's callers already receive one isolated span, so
+/// neither needs that machinery.
+#[must_use]
+pub fn strip_redundant_leading_zeros(bytes: &[u8]) -> Option<Vec<u8>> {
+    let (sign, rest) = match bytes.first() {
+        Some(b'-') => (&bytes[..1], &bytes[1..]),
+        _ => (&bytes[..0], bytes),
+    };
+    if rest.first() != Some(&b'0') || !rest.get(1).is_some_and(u8::is_ascii_digit) {
+        return None;
+    }
+    let mut i = 0;
+    while rest.get(i) == Some(&b'0') && rest.get(i + 1).is_some_and(u8::is_ascii_digit) {
+        i += 1;
+    }
+    let mut stripped = Vec::with_capacity(bytes.len() - i);
+    stripped.extend_from_slice(sign);
+    stripped.extend_from_slice(&rest[i..]);
+    Some(stripped)
 }
 
 #[cfg(test)]

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -1722,4 +1722,64 @@ mod tests {
             ValidationErrorKind::UnexpectedCharacter { .. }
         ));
     }
+
+    // ========================================================================
+    // strip_redundant_leading_zeros tests (#1149)
+    // ========================================================================
+
+    #[test]
+    fn test_strip_redundant_leading_zeros_basic() {
+        assert_eq!(strip_redundant_leading_zeros(b"007"), Some(b"7".to_vec()));
+        assert_eq!(strip_redundant_leading_zeros(b"-007"), Some(b"-7".to_vec()));
+        assert_eq!(
+            strip_redundant_leading_zeros(b"007e5"),
+            Some(b"7e5".to_vec())
+        );
+        assert_eq!(
+            strip_redundant_leading_zeros(b"007.500"),
+            Some(b"7.500".to_vec())
+        );
+    }
+
+    #[test]
+    fn test_strip_redundant_leading_zeros_all_zero_run_collapses_to_one_zero() {
+        // An all-zero digit run strips down to a single `0`, not empty.
+        assert_eq!(strip_redundant_leading_zeros(b"00"), Some(b"0".to_vec()));
+        assert_eq!(strip_redundant_leading_zeros(b"000"), Some(b"0".to_vec()));
+        assert_eq!(strip_redundant_leading_zeros(b"-000"), Some(b"-0".to_vec()));
+    }
+
+    #[test]
+    fn test_strip_redundant_leading_zeros_nothing_to_strip_returns_none() {
+        // Bare `0`/`0.x` is already RFC-8259-valid; no allocation, no strip.
+        assert_eq!(strip_redundant_leading_zeros(b"0"), None);
+        assert_eq!(strip_redundant_leading_zeros(b"-0"), None);
+        assert_eq!(strip_redundant_leading_zeros(b"0.5"), None);
+        // Ordinary numbers with no leading zero at all.
+        assert_eq!(strip_redundant_leading_zeros(b"42"), None);
+        assert_eq!(strip_redundant_leading_zeros(b"-42"), None);
+        assert_eq!(strip_redundant_leading_zeros(b"7e5"), None);
+    }
+
+    #[test]
+    fn test_strip_redundant_leading_zeros_non_number_input_returns_none() {
+        // No leading digit at all -- not this function's job to validate,
+        // just to decline stripping when there's nothing zero-prefixed.
+        assert_eq!(strip_redundant_leading_zeros(b""), None);
+        assert_eq!(strip_redundant_leading_zeros(b"-"), None);
+        assert_eq!(strip_redundant_leading_zeros(b"abc"), None);
+        assert_eq!(strip_redundant_leading_zeros(b".5"), None);
+    }
+
+    #[test]
+    fn test_strip_redundant_leading_zeros_result_may_still_be_invalid() {
+        // The stripped result can itself be invalid -- this function only
+        // strips, it doesn't validate; callers re-check `is_valid_number`
+        // on the result before trusting it (#966's `1.2.3`-style leniency).
+        assert_eq!(
+            strip_redundant_leading_zeros(b"007.5.3"),
+            Some(b"7.5.3".to_vec())
+        );
+        assert!(!is_valid_number(b"7.5.3"));
+    }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -604,20 +604,19 @@ fn test_argjson_tolerates_leading_zero_number_1094() -> Result<()> {
 }
 
 /// A leading-zero number combined with a *trailing* zero (`007.500`) is
-/// accepted (not rejected outright, this issue's own scope), but loses the
-/// trailing zero's spelling (`7.5`, not real jq's `7.500`) -- a pre-existing
-/// gap in this crate's own `NumberLiteral`-preservation fast path for any
-/// leading-zero literal, reproducing identically via plain document input
-/// (`echo '007.500' | succinctly jq '.'`), unrelated to `--argjson` and out
-/// of this fix's scope. Tracked as #1149 (filed for the sibling
-/// scientific-notation case; same root cause, broader than its title
-/// suggests). This test pins current, non-regressed behavior, not the
-/// (still wrong) spelling.
+/// accepted (not rejected outright, this issue's own scope) and, since
+/// #1149, also keeps the trailing zero's spelling (`7.500`, matching real
+/// jq) rather than losing it (`7.5`) the way this crate's own
+/// `NumberLiteral`-preservation fast path used to for any leading-zero
+/// literal -- same fix (`OwnedValue::from_number_bytes` /
+/// `DocumentValue::number_literal`) as the sibling scientific-notation
+/// case below, since it's one root cause, broader than #1149's own title
+/// suggested.
 #[test]
-fn test_argjson_leading_zero_accepted_but_trailing_zero_spelling_lost_1094() -> Result<()> {
+fn test_argjson_leading_zero_accepted_and_trailing_zero_spelling_preserved_1149() -> Result<()> {
     let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007.500", "$n"], None)?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "7.5");
+    assert_eq!(stdout.trim_end(), "7.500");
     Ok(())
 }
 
@@ -827,14 +826,14 @@ fn test_argjson_escaped_string_alongside_leading_zero_1094() -> Result<()> {
 
 /// A leading-zero number combined with scientific notation is accepted
 /// (not rejected outright), exercising `normalize_leading_zero_numbers`'s
-/// exponent-handling branch -- exact spelling is a separate, pre-existing
-/// gap (#1149), so this only pins acceptance and the correct numeric
-/// value, not the display spelling.
+/// exponent-handling branch, and -- since #1149 -- keeps its scientific
+/// notation on display (`7E+5`, matching real jq) instead of being
+/// expanded to a plain decimal (`700000`).
 #[test]
-fn test_argjson_leading_zero_with_exponent_accepted_1094() -> Result<()> {
+fn test_argjson_leading_zero_with_exponent_spelling_preserved_1149() -> Result<()> {
     let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007e5", "$n"], None)?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "700000");
+    assert_eq!(stdout.trim_end(), "7E+5");
     Ok(())
 }
 
@@ -842,10 +841,65 @@ fn test_argjson_leading_zero_with_exponent_accepted_1094() -> Result<()> {
 /// exercises `normalize_leading_zero_numbers`'s explicit-exponent-sign
 /// branch specifically.
 #[test]
-fn test_argjson_leading_zero_with_signed_exponent_accepted_1094() -> Result<()> {
+fn test_argjson_leading_zero_with_signed_exponent_spelling_preserved_1149() -> Result<()> {
     let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007e+5", "$n"], None)?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "700000");
+    assert_eq!(stdout.trim_end(), "7E+5");
+    Ok(())
+}
+
+// --- #1149: the same leading-zero spelling loss, via the crate's primary
+// document-input path (not just --argjson) -- the issue's own repro shape.
+
+/// A leading-zero number combined with scientific notation, via plain
+/// document input, keeps its scientific notation on display (matching
+/// real jq: `007e5 | .` -> `7E+5`) instead of being expanded to a plain
+/// decimal.
+#[test]
+fn test_document_input_leading_zero_exponent_spelling_preserved_1149() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "."], Some("007e5"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "7E+5");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "."], Some("-007e5"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "-7E+5");
+    Ok(())
+}
+
+/// A leading-zero number combined with a trailing zero, via plain
+/// document input, keeps the trailing zero's spelling (matching real jq:
+/// `007.500 | .` -> `7.500`) instead of collapsing it to `7.5`.
+#[test]
+fn test_document_input_leading_zero_trailing_zero_spelling_preserved_1149() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "."], Some("007.500"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "7.500");
+    Ok(())
+}
+
+/// An all-zero leading-zero run (`00`) and a plain leading-zero integer
+/// (`007`) still strip down to their correct, minimal spelling -- not
+/// regressed by the new exponent/trailing-zero handling above.
+#[test]
+fn test_document_input_leading_zero_plain_and_all_zero_unaffected_1149() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "."], Some("007"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "7");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "."], Some("00"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "0");
+    Ok(())
+}
+
+/// A leading-zero number nested inside a container, via plain document
+/// input, gets the same spelling fix as a bare top-level scalar.
+#[test]
+fn test_document_input_nested_leading_zero_exponent_spelling_preserved_1149() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "."], Some(r#"{"a":007e5,"b":007.500}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), r#"{"a":7E+5,"b":7.500}"#);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Real jq's own number reader tolerates a redundant leading zero (`007` -> `7`)
that strict RFC 8259 rejects — #1094 already handled recovering the *value*
for this case, but not the full *spelling*: `007e5` printed as `700000`
instead of jq's own `7E+5`, and `007.500` lost its trailing zeros, printing
`7.5` instead of `7.500`.

```
$ echo '007e5' | succinctly jq -c .
700000        # before
7E+5          # after (matches jq 1.7.1)

$ succinctly jq -n --argjson n '007.500' '$n'
7.5           # before
7.500         # after (matches jq 1.7.1)
```

## Root cause

Two independent materializers convert raw JSON bytes to `OwnedValue` in this
crate: `OwnedValue::from_number_bytes` (`src/jq/value.rs`, the primary
document-input path) and `DocumentValue::number_literal`
(`src/json/light.rs`, used by `--argjson`/`--slurpfile`/`--seq` and this
crate's own `.json`-file input). Both independently gate on strict
`is_valid_number` with no leading-zero fallback, so both needed the same
fix. The shared strip-and-retry helper (`strip_redundant_leading_zeros`) now
lives in `src/json/validate.rs`, since `json` can't depend on `jq` but both
call sites need it.

Unlike the leading-dot case (#1171), which *adds* a `0` prefix and keeps the
rest of the original text, the leading-zero case *strips* the redundant
zero(s) from the materialized text while keeping everything else (exponent
notation, trailing zeros) unchanged — confirmed live against jq 1.7.1.

## Scope notes

`--slurpfile` (strict `serde_json::Deserializer`, no normalize-retry step)
and yq's own `.json` input path (a separate `serde_json_to_owned`
implementation in `yq_runner.rs`) have pre-existing, out-of-scope gaps on
this same input shape — confirmed unchanged by this fix, not regressions.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Patch coverage 97.5% (39/40 new lines); the one flagged line is a closing `}` brace after an early `return` — a known llvm-cov line-attribution artifact, not a real gap (confirmed by isolated coverage run: the return statement itself is hit)

Fixes #1149