### PR TITLE
fix(jq): @urid's malformed escape now hex-escapes a truncated multi-byte char

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -259,6 +259,87 @@ fn describe(value: &OwnedValue) -> String {
     format!("{} ({})", value.type_name(), dump_truncated(value))
 }
 
+/// Go-`%q`-style raw-byte quoting for [`EvalError::urid_invalid_escape`]
+/// (#1216) -- unlike [`dump_truncated`]/[`describe`] above, this quotes
+/// arbitrary bytes that may not even be valid UTF-8, so it can't reuse
+/// `Debug` on a `&str` directly the way those do.
+///
+/// Walks `raw` left to right: a maximal run of complete, valid UTF-8
+/// characters is quoted via Rust's own `Debug` escaping (stripping the
+/// `Debug`-added surrounding quotes, since the caller wraps the whole
+/// result once) -- already confirmed to match real yq's Go-style quoting
+/// for embedded `"`/`\`/control characters exactly. Any byte that isn't
+/// part of a complete valid character (a genuinely invalid byte, or a
+/// multi-byte sequence truncated by running out of input) renders as
+/// `\xHH`, one escape per raw byte -- matching real yq's own behavior for
+/// a `%`-escape this close to the end of the input to leave a multi-byte
+/// character split mid-sequence (verified live: a 3-byte character
+/// truncated to its first two bytes by `@urid`'s 2-trailing-byte error
+/// window renders as `\xe4\xb8`, not the whole character and not a lossy
+/// replacement).
+fn quote_bytes_go_style(raw: &[u8]) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    let mut i = 0;
+    while i < raw.len() {
+        match core::str::from_utf8(&raw[i..]) {
+            // The rest of `raw` is entirely valid UTF-8 -- quote it all at
+            // once and stop.
+            Ok(s) => {
+                push_debug_escaped(&mut out, s);
+                break;
+            }
+            Err(e) => {
+                let valid_len = e.valid_up_to();
+                if valid_len > 0 {
+                    // `valid_up_to()` always lands on a char boundary, so
+                    // this slice is guaranteed valid UTF-8.
+                    let s = core::str::from_utf8(&raw[i..i + valid_len])
+                        .expect("valid_up_to() guarantees this prefix is valid UTF-8");
+                    push_debug_escaped(&mut out, s);
+                    i += valid_len;
+                }
+                // `error_len()` is `Some(n)` for n genuinely invalid bytes
+                // at this position (escape exactly those and keep
+                // scanning), or `None` when the remaining bytes are a
+                // valid *prefix* of some multi-byte character that simply
+                // ran out of input -- the truncated-character case this
+                // function exists for -- in which case every remaining
+                // byte is escaped and there's nothing left to scan.
+                match e.error_len() {
+                    Some(n) => {
+                        for b in &raw[i..i + n] {
+                            out.push_str(&format!("\\x{b:02x}"));
+                        }
+                        i += n;
+                    }
+                    None => {
+                        for b in &raw[i..] {
+                            out.push_str(&format!("\\x{b:02x}"));
+                        }
+                        i = raw.len();
+                    }
+                }
+            }
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Append `s`'s `Debug`-escaped contents to `out`, without the surrounding
+/// quotes `Debug` adds (the caller supplies its own, once, around the
+/// whole message) -- shared by [`quote_bytes_go_style`]'s two call sites
+/// (the all-valid fast path and the valid-prefix-before-a-truncation
+/// case) so they can't independently drift on how the strip is done.
+fn push_debug_escaped(out: &mut String, s: &str) {
+    let debug = format!("{s:?}");
+    // `Debug` on `&str` always wraps in a literal, single-byte `"` at each
+    // end, so trimming exactly one byte off each side can't split a
+    // multi-byte escape sequence it emitted in between.
+    out.push_str(&debug[1..debug.len() - 1]);
+}
+
 /// The binary operators jq names in arithmetic error messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOp {
@@ -638,22 +719,25 @@ impl EvalError {
     /// yq mode (`format_urid`'s malformed-escape check has no `S::TAG`
     /// branch).
     ///
-    /// `escape` is `%` plus whatever 0, 1, or 2 bytes actually follow it
-    /// in the input (not validated -- confirmed live against yq v4.53.3
-    /// that both bytes are echoed verbatim even when only one, or
-    /// neither, is a valid hex digit, and that a literal `%` immediately
-    /// after the first one is included unchanged rather than treated as a
-    /// new escape's start: `"x%y%zz" | @urid` -> `invalid URL escape
-    /// "%y%"`, not `"%y"`). The `Debug`-quoted `{escape:?}` below matches
-    /// real yq's own Go-style escaping for embedded `"`/`\`/control
-    /// characters exactly (confirmed live: `%"y` -> `%\"y`, `%\y` ->
-    /// `%\\y`, a literal tab -> `%\ty`) -- but for a multi-byte UTF-8
-    /// character split by the raw 2-byte cutoff, the caller widens to the
-    /// whole character rather than corrupting it into U+FFFD, which is
-    /// *not* a byte-for-byte oracle match (real yq hex-escapes the raw,
-    /// truncated bytes instead, e.g. `\xe4\xb8`) -- filed as #1216.
-    pub fn urid_invalid_escape(escape: &str) -> Self {
-        Self::new(format!("invalid URL escape {escape:?}"))
+    /// `raw` is `%` plus whatever 0, 1, or 2 bytes actually follow it in
+    /// the input (not validated -- confirmed live against yq v4.53.3 that
+    /// both bytes are echoed verbatim even when only one, or neither, is
+    /// a valid hex digit, and that a literal `%` immediately after the
+    /// first one is included unchanged rather than treated as a new
+    /// escape's start: `"x%y%zz" | @urid` -> `invalid URL escape "%y%"`,
+    /// not `"%y"`). Takes raw bytes, not a `&str` (#1216): a `%` this
+    /// close to the end of the input can truncate a multi-byte UTF-8
+    /// character mid-sequence, which no `&str` can represent at all.
+    /// `quote_bytes_go_style` (this module's own private helper) handles
+    /// both a complete, valid character
+    /// (Rust's own `Debug` escaping, confirmed live to match real yq's
+    /// Go-style quoting for embedded `"`/`\`/control characters exactly:
+    /// `%"y` -> `%\"y`, `%\y` -> `%\\y`, a literal tab -> `%\ty`) and a
+    /// truncated one (raw `\xHH` per byte, matching real yq's own
+    /// Go-`%q`-style escaping there too -- previously a documented,
+    /// deliberate divergence, this is what #1216 closes).
+    pub fn urid_invalid_escape(raw: &[u8]) -> Self {
+        Self::new(format!("invalid URL escape {}", quote_bytes_go_style(raw)))
     }
 
     /// `Invalid path expression with result <value>` (#530).
@@ -1212,6 +1296,58 @@ mod tests {
         assert_eq!(
             err.payload(),
             OwnedValue::String("Cannot iterate over number (1)".to_string())
+        );
+    }
+
+    /// #1216: a truncated multi-byte character hex-escapes each raw byte,
+    /// matching real yq's own Go-`%q`-style escaping (live-verified,
+    /// tests/yq_cli_tests.rs's own `_1216`-suffixed CLI tests carry the
+    /// oracle comparison) -- this is the unit-level equivalent, pinning
+    /// `quote_bytes_go_style` directly rather than only through `@urid`.
+    #[test]
+    fn quote_bytes_go_style_hex_escapes_a_truncated_multibyte_character() {
+        // 中 = E4 B8 AD, truncated to its first two bytes.
+        assert_eq!(quote_bytes_go_style(b"%\xe4\xb8"), r#""%\xe4\xb8""#);
+        // 4-byte character (outside the BMP), truncated the same way.
+        assert_eq!(quote_bytes_go_style(b"%\xf0\x9f"), r#""%\xf0\x9f""#);
+    }
+
+    #[test]
+    fn quote_bytes_go_style_leaves_a_complete_character_unescaped() {
+        // é = C3 A9, not truncated at all.
+        assert_eq!(quote_bytes_go_style("%é".as_bytes()), "\"%é\"");
+    }
+
+    #[test]
+    fn quote_bytes_go_style_escapes_special_ascii_like_rust_debug() {
+        assert_eq!(quote_bytes_go_style(br#"%"y"#), r#""%\"y""#);
+        assert_eq!(quote_bytes_go_style(br"%\y"), r#""%\\y""#);
+        assert_eq!(quote_bytes_go_style(b"%\ty"), r#""%\ty""#);
+    }
+
+    #[test]
+    fn quote_bytes_go_style_handles_empty_and_ascii_only() {
+        assert_eq!(quote_bytes_go_style(b""), "\"\"");
+        assert_eq!(quote_bytes_go_style(b"%"), "\"%\"");
+        assert_eq!(quote_bytes_go_style(b"%y"), "\"%y\"");
+    }
+
+    /// A run of genuinely invalid bytes (not just an incomplete valid
+    /// prefix) also hex-escapes, one `\xHH` per byte -- `error_len()`'s
+    /// `Some(n)` branch, not just its `None` (ran-out-of-input) branch
+    /// `quote_bytes_go_style`'s other tests exercise.
+    #[test]
+    fn quote_bytes_go_style_escapes_genuinely_invalid_bytes() {
+        // 0xFF is never a valid UTF-8 lead byte at all.
+        assert_eq!(quote_bytes_go_style(b"%\xff"), r#""%\xff""#);
+        assert_eq!(quote_bytes_go_style(b"%\xff\xfe"), r#""%\xff\xfe""#);
+    }
+
+    #[test]
+    fn urid_invalid_escape_message_matches_1216_wording() {
+        assert_eq!(
+            EvalError::urid_invalid_escape(b"%\xe4\xb8").message,
+            r#"invalid URL escape "%\xe4\xb8""#
         );
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5995,26 +5995,14 @@ fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<S
             // Malformed escape (#1138): real yq errors rather than
             // silently passing the `%` through, quoting `%` plus
             // whatever 0, 1, or 2 bytes actually follow it (up to end of
-            // string). `i` is always a valid char boundary here -- `%` is
-            // ASCII (0x25), and no UTF-8 continuation byte can equal an
-            // ASCII value, so `bytes[i] == b'%'` being true is on its own
-            // sufficient proof `i` doesn't sit inside another character --
-            // so `s[i..]` is a valid `&str` to walk char-wise. Widening to
-            // the next full character (rather than a fixed 3-byte window)
-            // when the raw 2-byte cutoff would otherwise split one avoids
-            // corrupting it into a single lossy replacement character;
-            // see `EvalError::urid_invalid_escape`'s own doc comment for
-            // why this is a deliberate, documented divergence from real
-            // yq's raw-byte hex-escaping for that specific case (#1216).
-            let rest = &s[i..];
-            let mut escape_len = 0;
-            for ch in rest.chars() {
-                if escape_len >= 3 {
-                    break;
-                }
-                escape_len += ch.len_utf8();
-            }
-            return Err(EvalError::urid_invalid_escape(&rest[..escape_len]));
+            // string) -- a raw byte slice, not widened to the next full
+            // character (#1216): `EvalError::urid_invalid_escape` now
+            // takes `&[u8]` and hex-escapes any byte that's part of a
+            // truncated multi-byte character itself, matching real yq's
+            // own raw-byte quoting exactly instead of only approximating
+            // it.
+            let end = (i + 3).min(bytes.len());
+            return Err(EvalError::urid_invalid_escape(&bytes[i..end]));
         }
         // Not a percent sign at all, just copy the byte
         result.push(bytes[i]);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15650,19 +15650,22 @@ fn test_yq_urid_valid_escape_still_decodes_1138() -> Result<()> {
     Ok(())
 }
 
-/// #1138 review self-check: a malformed escape immediately followed by a
-/// multi-byte UTF-8 character (so the raw 2-byte error-message cutoff
-/// would otherwise land mid-character) must widen to include the whole
-/// character rather than corrupt it into a lossy replacement character --
-/// not a byte-for-byte match for real yq's own raw-byte hex-escaping in
-/// this specific case (`\xe4\xb8`), a documented, deliberate divergence
-/// (see `EvalError::urid_invalid_escape`'s doc comment and #1216).
+/// #1216: a malformed escape immediately followed by a multi-byte UTF-8
+/// character (so the raw 2-byte error-message cutoff lands mid-character)
+/// now byte-for-byte matches real yq's own raw-byte hex-escaping -- `%`
+/// plus the truncated character's first 2 raw bytes, each rendered as
+/// `\xHH`, not the whole character and not a lossy replacement. Verified
+/// live against yq v4.53.3: `%<3-byte char 中 = E4 B8 AD>` truncates to
+/// `%\xe4\xb8`; `%<4-byte char 😀 = F0 9F 98 80>` truncates to `%\xf0\x9f`.
+/// Superseded a prior version of this test that pinned succinctly's
+/// then-current (documented, deliberate) divergence -- widening to the
+/// whole character instead of hex-escaping the truncated raw bytes.
 #[test]
-fn test_yq_urid_malformed_escape_multibyte_boundary_1138() -> Result<()> {
+fn test_yq_urid_malformed_escape_multibyte_boundary_1216() -> Result<()> {
     let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", "\"%\u{4e2d}\"", &[])?;
     assert_ne!(code, 0, "stderr: {stderr:?}");
     assert!(
-        stderr.contains("invalid URL escape \"%\u{4e2d}\""),
+        stderr.contains(r#"invalid URL escape "%\xe4\xb8""#),
         "stderr: {stderr:?}"
     );
 
@@ -15670,7 +15673,75 @@ fn test_yq_urid_malformed_escape_multibyte_boundary_1138() -> Result<()> {
     let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", "\"%\u{1f600}\"", &[])?;
     assert_ne!(code, 0, "stderr: {stderr:?}");
     assert!(
-        stderr.contains("invalid URL escape \"%\u{1f600}\""),
+        stderr.contains(r#"invalid URL escape "%\xf0\x9f""#),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1216: complementary shapes not covered by the multi-byte-boundary
+/// test above -- a fully valid multi-byte character with no truncation at
+/// all (the raw 2-byte window comfortably contains the whole 2-byte
+/// character, so it renders as itself, not hex-escaped), and embedded
+/// `"`/`\`/tab characters, which must still match real yq's own Go-style
+/// `Debug`-equivalent escaping exactly (unaffected by #1216's raw-byte
+/// change, since these are all complete, valid characters). Verified live
+/// against yq v4.53.3.
+#[test]
+fn test_yq_urid_malformed_escape_valid_and_special_chars_1216() -> Result<()> {
+    // A complete 2-byte character (é), not truncated at all.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", "\"%\u{e9}\"", &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid URL escape \"%\u{e9}\""),
+        "stderr: {stderr:?}"
+    );
+
+    // Embedded double quote.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", r#""%\"y""#, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"invalid URL escape "%\"y""#),
+        "stderr: {stderr:?}"
+    );
+
+    // Embedded backslash.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", r#""%\\y""#, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"invalid URL escape "%\\y""#),
+        "stderr: {stderr:?}"
+    );
+
+    // Embedded literal tab.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", "\"%\ty\"", &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"invalid URL escape "%\ty""#),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1216: `%` at the very end of the input (0 trailing bytes at all) and
+/// only 1 trailing byte still work correctly -- both shapes reach the
+/// all-valid-UTF-8 fast path in `quote_bytes_go_style` (there's nothing
+/// incomplete to hex-escape when there's nothing there, or only one plain
+/// ASCII byte), unaffected by the raw-byte-escaping change. Verified live
+/// against yq v4.53.3.
+#[test]
+fn test_yq_urid_malformed_escape_short_trailing_1216() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", r#""abc%""#, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"invalid URL escape "%""#),
+        "stderr: {stderr:?}"
+    );
+
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("@urid", r#""abc%y""#, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"invalid URL escape "%y""#),
         "stderr: {stderr:?}"
     );
     Ok(())


### PR DESCRIPTION
## Summary

- `#1138`'s own fix widened `@urid`'s malformed-escape error text's raw 2-byte cutoff to the next full character when it would otherwise split a multi-byte UTF-8 sequence mid-character — safe (no data loss, no U+FFFD corruption) but not byte-for-byte matching real yq (Go, raw byte sequences), which hex-escapes the truncated bytes instead (`\xe4\xb8`). Documented as a deliberate divergence at the time, filed as `#1216` to close.
- `EvalError::urid_invalid_escape` now takes `&[u8]` instead of `&str`, and a new `quote_bytes_go_style` helper walks the raw bytes: a complete, valid UTF-8 run is quoted via Rust's own `Debug` escaping (already confirmed to match real yq's Go-style quoting for embedded `"`/`\`/control characters), and any byte that's part of a genuinely invalid/incomplete sequence hex-escapes as `\xHH`. `format_urid`'s malformed-escape branch now passes the raw, un-widened `%` + up to 2 trailing bytes straight through instead of widening to a full character.
- Live-verified against yq v4.53.3 across every shape: the original 3-byte and a 4-byte (outside-BMP) truncated character, a complete 2-byte character with no truncation, embedded `"`/`\`/tab, malformed hex on plain ASCII, `%` with 0/1 trailing bytes, and a genuinely invalid (not just incomplete) byte run.

Fixes #1216

Found and did **not** fix, as out of scope: a `%` immediately followed by a single dangling, non-continuable UTF-8 byte at the very end of the *document* itself (not just the error-message window) is rejected by real yq's own YAML parser before `@urid` ever runs ("invalid trailing UTF-8 octet"), but succinctly's parser accepts the same malformed document and silently produces `null` — a pre-existing, unrelated divergence in document-level UTF-8 validation strictness, not in `@urid`'s own error formatting. Will file as its own follow-up.

## Test plan

- [x] Updated the 1 pre-existing test that pinned the old widened-to-whole-char behavior (its own doc comment already named #1216 as the fix that would supersede it)
- [x] 3 new CLI-level tests covering every shape live-verified above
- [x] 6 new unit-level tests for `quote_bytes_go_style` directly, including a genuinely-invalid (not just incomplete) byte run
- [x] Full local suite green (`cargo test --features cli,simd,regex,serde`, 54 test targets)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` and the CI's second (simd/broadword-yaml) invocation both clean
- [x] `cargo fmt --check` clean
- [x] `cargo check --no-default-features` clean (no new warnings — confirms the new code is `alloc`-only)