### PR TITLE
fix(yaml): preserve JSON-unsafe-but-YAML-legal float spellings' decimal point

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -25,8 +25,8 @@ use std::string::ToString;
 use super::index::YamlIndex;
 use super::line_break::{is_line_break, line_break_len, line_break_len_before};
 use super::scalar::{
-    could_be_null_or_bool, is_preservable_float_literal, resolve_plain, resolve_tagged,
-    ResolvedScalar,
+    could_be_null_or_bool, is_preservable_float_literal, preservable_float_literal_text,
+    resolve_plain, resolve_tagged, ResolvedScalar,
 };
 use super::{starts_inline_seq_entry, starts_seq_entry};
 use crate::util::simd::escape::find_json_escape;
@@ -3444,20 +3444,25 @@ fn write_resolved_scalar_as_json(
         ResolvedScalar::Bool(false) => output.push_str("false"),
         ResolvedScalar::Int(n) => write_i64(output, n),
         // See `stream_resolved_scalar_as_json`'s matching arm for why this
-        // echoes `str_val` rather than always reconstructing from `f` (#993).
-        // No separate `is_finite()` check needed here: `resolve_plain`/
+        // echoes `str_val` (or a normalized, JSON-safe variant of it,
+        // #954) rather than always reconstructing from `f` (#993). No
+        // separate `is_finite()` check needed here: `resolve_plain`/
         // `resolve_tagged` (this function's only callers) never produce a
-        // non-finite `ResolvedScalar::Float` in the first place -- `parse_float`
-        // rejects an overflowing/underflowing literal to `Str` before this
-        // arm is ever reached. `is_preservable_float_literal`'s own digit
-        // cap does NOT bound magnitude (#1008): a 4-digit `1e400` sails
-        // through it trivially, so it must not be relied on for finiteness.
+        // non-finite `ResolvedScalar::Float` in the first place --
+        // `parse_float` rejects an overflowing/underflowing literal to
+        // `Str` before this arm is ever reached. `is_preservable_float_literal`'s
+        // own digit cap does NOT bound magnitude (#1008): a 4-digit
+        // `1e400` sails through it trivially, so it must not be relied on
+        // for finiteness.
         ResolvedScalar::Float(_) if is_preservable_float_literal(str_val) => {
             output.push_str(str_val);
         }
-        ResolvedScalar::Float(f) if f.is_finite() => write_f64(output, f),
-        // JSON cannot represent the `.inf`/`.nan` family.
-        ResolvedScalar::Float(_) => output.push_str("null"),
+        ResolvedScalar::Float(f) => match preservable_float_literal_text(str_val) {
+            Some(normalized) => output.push_str(&normalized),
+            None if f.is_finite() => write_f64(output, f),
+            // JSON cannot represent the `.inf`/`.nan` family.
+            None => output.push_str("null"),
+        },
         ResolvedScalar::Str => write_json_string(output, str_val),
     }
 }
@@ -3921,24 +3926,28 @@ fn stream_resolved_scalar_as_json<Out: core::fmt::Write>(
         ResolvedScalar::Bool(true) => out.write_str("true"),
         ResolvedScalar::Bool(false) => out.write_str("false"),
         ResolvedScalar::Int(n) => write!(out, "{n}"),
-        // Echo the source text when it's already safe, valid JSON number
-        // syntax (`number_literal()` below uses the same predicate for the
-        // DOM path) -- this is what keeps a trailing zero (`1.50`) intact;
-        // `format_float_with_fraction` only reconstructs the value's
-        // shortest round-trip spelling, which silently drops it (#993). No
-        // separate `is_finite()` check needed here: `resolved` is only ever
-        // constructed by `resolve_plain`/`resolve_tagged`, which never
-        // produce a non-finite `Float` -- `parse_float` rejects an
+        // Echo the source text (or a normalized, JSON-safe variant of it,
+        // #954) when it's already safe to preserve (`number_literal()`
+        // below uses the same predicate for the DOM path) -- this is what
+        // keeps a trailing zero (`1.50`) intact; `format_float_with_fraction`
+        // only reconstructs the value's shortest round-trip spelling,
+        // which silently drops it (#993). No separate `is_finite()` check
+        // needed here: `resolved` is only ever constructed by
+        // `resolve_plain`/`resolve_tagged`, which never produce a
+        // non-finite `Float` -- `parse_float` rejects an
         // overflowing/underflowing literal to `Str` upstream, before this
         // arm is reached. `is_preservable_float_literal`'s digit cap does
         // NOT bound magnitude (#1008): a 4-digit `1e400` sails through it
-        // trivially, so it must not be relied on for finiteness.
-        // Not `write!(out, "{f}")` either way: that drops the `.0` from a
+        // trivially, so it must not be relied on for finiteness. Not
+        // `write!(out, "{f}")` either way: that drops the `.0` from a
         // whole float.
         ResolvedScalar::Float(_) if is_preservable_float_literal(str_val) => out.write_str(str_val),
-        ResolvedScalar::Float(f) if f.is_finite() => out.write_str(&format_float_with_fraction(f)),
-        // JSON cannot represent the `.inf`/`.nan` family.
-        ResolvedScalar::Float(_) => out.write_str("null"),
+        ResolvedScalar::Float(f) => match preservable_float_literal_text(str_val) {
+            Some(normalized) => out.write_str(&normalized),
+            None if f.is_finite() => out.write_str(&format_float_with_fraction(f)),
+            // JSON cannot represent the `.inf`/`.nan` family.
+            None => out.write_str("null"),
+        },
         ResolvedScalar::Str => stream_json_string(out, str_val),
     }
 }
@@ -6038,6 +6047,9 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
                 match resolve_plain(&str_val) {
                     ResolvedScalar::Float(_) if is_preservable_float_literal(&str_val) => {
                         Some(str_val)
+                    }
+                    ResolvedScalar::Float(_) => {
+                        preservable_float_literal_text(&str_val).map(Cow::Owned)
                     }
                     _ => None,
                 }

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -31,7 +31,7 @@
 //! ```
 
 #[cfg(not(test))]
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, format, string::String, string::ToString};
 #[cfg(test)]
 use std::borrow::Cow;
 
@@ -115,7 +115,10 @@ impl ResolvedScalar {
             Self::Float(_) if is_preservable_float_literal(&text) => {
                 OwnedValue::from_number_literal(&text)
             }
-            Self::Float(f) => OwnedValue::Float(f),
+            Self::Float(f) => match preservable_float_literal_text(&text) {
+                Some(normalized) => OwnedValue::from_number_literal(&normalized),
+                None => OwnedValue::Float(f),
+            },
             Self::Str => OwnedValue::String(text.into_owned()),
         }
     }
@@ -250,16 +253,18 @@ fn parse_float(s: &str) -> ResolvedScalar {
 /// value... emitters must use the carried value, never echo the source
 /// text" (see the type's doc comment) precisely because YAML's core-schema
 /// number grammar is looser than JSON's: a leading-dot float (`.5`), a
-/// leading `+` (`+.5`), or a leading zero followed by more digits (`007.5`)
-/// all resolve here but are not valid JSON number text, and hex/octal ints
-/// (`0x2A`) obviously aren't either. A caller that ignores that warning and
-/// hands such text to something expecting JSON syntax — as
-/// `OwnedValue::NumberLiteral`'s downstream reindexing bridge does — gets a
-/// value silently misclassified as a parse error instead of a number
-/// (confirmed via the `tag` builtin, which maps that error node to
-/// `!!null` for a scalar that plainly has a `!!float` tag) rather than
-/// erroring loudly. This predicate is how [`super::light`]'s
-/// `number_literal()` override decides which literals are safe to echo.
+/// leading `+` (`+.5`), a leading zero followed by more digits (`007.5`),
+/// or a bare trailing dot (`1.`) all resolve here but are not valid JSON
+/// number text, and hex/octal ints (`0x2A`) obviously aren't either. A
+/// caller that ignores that warning and hands such text to something
+/// expecting JSON syntax — as `OwnedValue::NumberLiteral`'s downstream
+/// reindexing bridge does — gets a value silently misclassified as a parse
+/// error instead of a number (confirmed via the `tag` builtin, which maps
+/// that error node to `!!null` for a scalar that plainly has a `!!float`
+/// tag) rather than erroring loudly. This predicate is how
+/// [`super::light`]'s `number_literal()` override decides which literals
+/// are safe to echo *verbatim*; [`preservable_float_literal_text`] widens
+/// beyond it by normalizing first, for text this rejects outright.
 ///
 /// This grammar is the same one `crate::json::validate::is_valid_number`
 /// implements (extracted from this exact function, #957/#966) — delegate
@@ -317,11 +322,10 @@ const MAX_PRESERVABLE_FLOAT_DIGITS: usize = 17;
 /// literals byte-for-byte regardless of magnitude — confirmed empirically
 /// against the pinned oracle (`1e100` stays `1e100`, `1E5` stays `1E5`).
 ///
-/// Deliberately conservative: legal YAML core-schema spellings that don't
-/// meet this bar (`+2.0`, a trailing-dot `1.`) fall through to the
-/// pre-existing `as_f64` path unchanged rather than being force-fit here,
-/// leaving the #918 symptom open for that narrower spelling class — see
-/// the issue tracker for the follow-up.
+/// A YAML-legal-but-JSON-unsafe spelling (`+2.0`, `1.`, `007e2`) still
+/// fails this directly, even after #954 -- see
+/// [`preservable_float_literal_text`], which normalizes to an equivalent
+/// JSON-safe spelling before falling back to this same check.
 #[must_use]
 pub(super) fn is_preservable_float_literal(s: &str) -> bool {
     let mantissa = match s.find(['e', 'E']) {
@@ -331,6 +335,67 @@ pub(super) fn is_preservable_float_literal(s: &str) -> bool {
     (s.contains('.') || s.contains(['e', 'E']))
         && mantissa.bytes().filter(u8::is_ascii_digit).count() <= MAX_PRESERVABLE_FLOAT_DIGITS
         && is_json_number_syntax(s)
+}
+
+/// A normalized, JSON-safe equivalent spelling for `s`, for a `Float`
+/// scalar whose text is YAML-legal but rejected outright by
+/// [`is_preservable_float_literal`] (#954, the residual scope #918
+/// deliberately left open) -- a companion fallback to that predicate, not
+/// a replacement for it: callers check `is_preservable_float_literal(s)`
+/// first and only reach for this on that check's `false` (this function
+/// itself returns `None`, not `Some(s)`, when `s` was already
+/// preservable, so it can't be mistaken for the primary check). Handles a
+/// leading `+` stripped (`+1.0` -> `1.0`), a trailing bare `.` completed
+/// with a `0` (`1.` -> `1.0`), and/or a redundant leading zero stripped
+/// (`007e2` -> `7e2`, reusing
+/// [`crate::json::validate::strip_redundant_leading_zeros`], #1149's own
+/// JSON-side helper for the identical problem).
+///
+/// Normalizing (rather than preserving verbatim, the way
+/// `is_preservable_float_literal` does) is required, not a style choice:
+/// `OwnedValue::NumberLiteral`'s downstream JSON-reindexing bridge parses
+/// its stored text as if it *were* JSON, so a genuinely non-JSON-safe
+/// spelling passed through unchanged corrupts that round trip. This was
+/// caught live during this fix's own development (code review self-check):
+/// an earlier draft widened `is_preservable_float_literal` itself to
+/// accept anything this crate's own lenient semi-index scanner
+/// (`number_literal_end`) could find the boundaries of, on the theory that
+/// scanner-safety implied output-safety -- it doesn't. The scanner finding
+/// a clean span only means it won't mis-parse *already-embedded* text; it
+/// says nothing about whether that same text is valid to *emit* as new
+/// JSON output. That draft made `-o json` on `a: 1.`/`a: 007e2` literally
+/// emit `1.`/`007e2` as JSON number text -- invalid per RFC 8259 (confirmed
+/// via a real JSON parser rejecting it) -- for the same query shapes that
+/// happened to route through this text before any other validation caught
+/// it. Every consumer needs the stored spelling to be actual valid JSON,
+/// which normalizing up front guarantees uniformly.
+///
+/// This is a real, permanent divergence from real yq's own verbatim-echo
+/// `tostring`/`join`/`-o yaml` output for these spellings (`+1.0`, `1.`,
+/// `007e2` all echo completely unchanged in real yq, oracle-confirmed) --
+/// accepted, not fixed by this function, matching #954's own root-cause
+/// framing (real yq's Go-based number model has no equivalent internal
+/// JSON-reindexing constraint forcing it to normalize).
+///
+/// `None` when nothing here helps (not `.`-or-exponent-shaped at all, the
+/// digit cap is exceeded, or the normalized text is still invalid, e.g.
+/// `+1.2.3`) -- callers fall back to their own pre-existing bare-`Float`
+/// handling unchanged.
+#[must_use]
+pub(super) fn preservable_float_literal_text(s: &str) -> Option<String> {
+    if is_preservable_float_literal(s) {
+        return None;
+    }
+    let stripped_plus = s.strip_prefix('+').unwrap_or(s);
+    let with_trailing_zero = match stripped_plus.strip_suffix('.') {
+        Some(_) => format!("{stripped_plus}0"),
+        None => stripped_plus.to_string(),
+    };
+    let normalized =
+        crate::json::validate::strip_redundant_leading_zeros(with_trailing_zero.as_bytes())
+            .and_then(|stripped| String::from_utf8(stripped).ok())
+            .unwrap_or(with_trailing_zero);
+    is_preservable_float_literal(&normalized).then_some(normalized)
 }
 
 /// Force-resolves a scalar's value under an explicit YAML tag.
@@ -746,5 +811,88 @@ mod tests {
         assert!(!is_preservable_float_literal(&format!(
             "{mantissa_over_cap}e1"
         )));
+    }
+
+    // ========================================================================
+    // preservable_float_literal_text tests (#954)
+    // ========================================================================
+
+    #[test]
+    fn preservable_float_literal_text_returns_none_when_already_preservable() {
+        // Callers check `is_preservable_float_literal` first; this function
+        // is only the fallback, so it must not also claim the already-ok case.
+        for s in ["2.0", "-2.0", "1e100", "0.5"] {
+            assert_eq!(preservable_float_literal_text(s), None, "input: {s:?}");
+        }
+    }
+
+    #[test]
+    fn preservable_float_literal_text_strips_leading_plus() {
+        assert_eq!(
+            preservable_float_literal_text("+1.0"),
+            Some("1.0".to_string())
+        );
+        assert_eq!(
+            preservable_float_literal_text("+2.5e10"),
+            Some("2.5e10".to_string())
+        );
+    }
+
+    #[test]
+    fn preservable_float_literal_text_completes_a_bare_trailing_dot() {
+        assert_eq!(
+            preservable_float_literal_text("1."),
+            Some("1.0".to_string())
+        );
+        assert_eq!(
+            preservable_float_literal_text("-1."),
+            Some("-1.0".to_string())
+        );
+    }
+
+    #[test]
+    fn preservable_float_literal_text_strips_redundant_leading_zero() {
+        assert_eq!(
+            preservable_float_literal_text("007e2"),
+            Some("7e2".to_string())
+        );
+        assert_eq!(
+            preservable_float_literal_text("-007e2"),
+            Some("-7e2".to_string())
+        );
+        assert_eq!(
+            preservable_float_literal_text("007.500"),
+            Some("7.500".to_string())
+        );
+    }
+
+    #[test]
+    fn preservable_float_literal_text_composes_multiple_transforms() {
+        // Leading `+` AND a redundant leading zero, in one literal.
+        assert_eq!(
+            preservable_float_literal_text("+007e2"),
+            Some("7e2".to_string())
+        );
+        // Leading `+` AND a bare trailing dot.
+        assert_eq!(
+            preservable_float_literal_text("+1."),
+            Some("1.0".to_string())
+        );
+    }
+
+    #[test]
+    fn preservable_float_literal_text_none_when_normalized_form_still_invalid() {
+        // `+1.2.3` normalizes (strip `+`) to `1.2.3`, which is still not a
+        // single valid number -- #966's own multi-dot precedent, not
+        // something this function should paper over.
+        assert_eq!(preservable_float_literal_text("+1.2.3"), None);
+        // No dot or exponent at all after stripping -- not float-shaped.
+        assert_eq!(preservable_float_literal_text("+5"), None);
+    }
+
+    #[test]
+    fn preservable_float_literal_text_respects_the_digit_cap() {
+        let over_cap = "+1.".to_string() + &"1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS);
+        assert_eq!(preservable_float_literal_text(&over_cap), None);
     }
 }

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -381,20 +381,43 @@ pub(super) fn is_preservable_float_literal(s: &str) -> bool {
 /// digit cap is exceeded, or the normalized text is still invalid, e.g.
 /// `+1.2.3`) -- callers fall back to their own pre-existing bare-`Float`
 /// handling unchanged.
+///
+/// Splits on the exponent marker first, mirroring
+/// [`is_preservable_float_literal`]'s own mantissa/exponent split just
+/// above, so the trailing-dot completion applies to the *mantissa*, not
+/// the whole string -- an earlier draft completed a trailing `.` only at
+/// the very end of `s`, missing a bare dot immediately before an exponent
+/// (`1.e5`; code review caught this live, since it silently reproduced
+/// #954's own self-inconsistency symptom for that one shape: falling
+/// through to the bare-`Float` path left `tostring`/`join` disagreeing
+/// with each other again, exactly what this function exists to prevent).
+///
+/// A mantissa whose own digit count is right at
+/// [`MAX_PRESERVABLE_FLOAT_DIGITS`] can still lose preservation here if it
+/// also needs the trailing-dot completion (the appended `0` pushes it one
+/// digit over) -- accepted as a narrow, safe edge case: the digit cap's
+/// own re-check after normalizing means this never emits a wrong value,
+/// only occasionally declines to preserve an already-rare spelling
+/// (17-significant-digit mantissa *and* a bare trailing dot), falling
+/// back to the always-value-correct bare-`Float` reconstruction instead.
 #[must_use]
 pub(super) fn preservable_float_literal_text(s: &str) -> Option<String> {
     if is_preservable_float_literal(s) {
         return None;
     }
     let stripped_plus = s.strip_prefix('+').unwrap_or(s);
-    let with_trailing_zero = match stripped_plus.strip_suffix('.') {
-        Some(_) => format!("{stripped_plus}0"),
-        None => stripped_plus.to_string(),
+    let (mantissa, exponent) = match stripped_plus.find(['e', 'E']) {
+        Some(exp_pos) => stripped_plus.split_at(exp_pos),
+        None => (stripped_plus, ""),
     };
-    let normalized =
-        crate::json::validate::strip_redundant_leading_zeros(with_trailing_zero.as_bytes())
-            .and_then(|stripped| String::from_utf8(stripped).ok())
-            .unwrap_or(with_trailing_zero);
+    let mantissa = match mantissa.strip_suffix('.') {
+        Some(_) => format!("{mantissa}0"),
+        None => mantissa.to_string(),
+    };
+    let mantissa = crate::json::validate::strip_redundant_leading_zeros(mantissa.as_bytes())
+        .and_then(|stripped| String::from_utf8(stripped).ok())
+        .unwrap_or(mantissa);
+    let normalized = format!("{mantissa}{exponent}");
     is_preservable_float_literal(&normalized).then_some(normalized)
 }
 
@@ -880,6 +903,31 @@ mod tests {
         );
     }
 
+    /// Code review: a naive whole-string trailing-dot check (`s.strip_suffix('.')`)
+    /// misses a bare dot immediately before an exponent marker, since the
+    /// exponent digits are the actual string suffix, not the dot. Confirms
+    /// the mantissa/exponent split fixes this for every combination of
+    /// leading `+` and redundant leading zero too.
+    #[test]
+    fn preservable_float_literal_text_completes_a_trailing_dot_before_an_exponent() {
+        assert_eq!(
+            preservable_float_literal_text("1.e5"),
+            Some("1.0e5".to_string())
+        );
+        assert_eq!(
+            preservable_float_literal_text("+1.e5"),
+            Some("1.0e5".to_string())
+        );
+        assert_eq!(
+            preservable_float_literal_text("007.e2"),
+            Some("7.0e2".to_string())
+        );
+        assert_eq!(
+            preservable_float_literal_text("-1.e5"),
+            Some("-1.0e5".to_string())
+        );
+    }
+
     #[test]
     fn preservable_float_literal_text_none_when_normalized_form_still_invalid() {
         // `+1.2.3` normalizes (strip `+`) to `1.2.3`, which is still not a
@@ -894,5 +942,29 @@ mod tests {
     fn preservable_float_literal_text_respects_the_digit_cap() {
         let over_cap = "+1.".to_string() + &"1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS);
         assert_eq!(preservable_float_literal_text(&over_cap), None);
+    }
+
+    /// Code review: a mantissa with exactly [`MAX_PRESERVABLE_FLOAT_DIGITS`]
+    /// digits *and* a bare trailing dot (so its digit count is under the
+    /// cap *before* normalization) still gets rejected, because completing
+    /// the dot appends a `0` that pushes the count one over. Documented as
+    /// an accepted, narrow edge case in this function's own doc comment --
+    /// this test exists to pin the *safety* property (falls back to the
+    /// value-correct bare-`Float` path, never a wrong number or invalid
+    /// JSON), not to claim the spelling gets preserved.
+    #[test]
+    fn preservable_float_literal_text_digit_cap_boundary_with_trailing_dot_is_a_safe_miss() {
+        let digits_at_cap = "1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS);
+        // One digit short of the cap plus the completed dot's `0` lands
+        // exactly at the cap -- still preserved.
+        let one_under = "1".repeat(MAX_PRESERVABLE_FLOAT_DIGITS - 1) + ".";
+        assert_eq!(
+            preservable_float_literal_text(&one_under),
+            Some(one_under.clone() + "0")
+        );
+        // At the cap already, so completing the dot pushes one over --
+        // declines to preserve, rather than silently exceeding the cap.
+        let at_cap = digits_at_cap.clone() + ".";
+        assert_eq!(preservable_float_literal_text(&at_cap), None);
     }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12092,6 +12092,14 @@ fn test_yaml_legal_json_unsafe_float_spellings_normalize_954() -> Result<()> {
         ("a: 007e2\n", "7e2"),
         ("a: -1.\n", "-1.0"),
         ("a: -007e2\n", "-7e2"),
+        // Passes via the pre-existing bare-`f64` fallback, not this fix's
+        // new normalization: `preservable_float_literal_text` doesn't
+        // widen a bare leading dot (`.5`, no digit before the point) at
+        // all, only a leading `+`/trailing `.`/redundant leading zero --
+        // but `0.5_f64.to_string()` already includes the leading zero
+        // naturally, so there's no #954-style symptom here to begin with.
+        // Kept in this sweep as a non-regression check, not new-path coverage
+        // (code review flagged the distinction).
         ("a: +.5\n", "0.5"),
     ] {
         let (out, code) = run_yq_stdin(".a", yaml, &["-o=json", "-I=0"])?;
@@ -12141,6 +12149,13 @@ fn test_yaml_legal_json_unsafe_float_self_consistent_across_consumers_954() -> R
         ("a: +1.0\n", "1.0"),
         ("a: 1.\n", "1.0"),
         ("a: 007e2\n", "7e2"),
+        // A bare trailing dot immediately before an exponent marker --
+        // code review found the first draft's whole-string
+        // `strip_suffix('.')` missed this shape entirely (the exponent
+        // digits are the string's actual suffix, not the dot), silently
+        // reproducing this test's exact symptom for just this one spelling.
+        ("a: 1.e5\n", "1.0e5"),
+        ("a: 007.e2\n", "7.0e2"),
     ] {
         let (out, code) = run_yq_stdin(".a | tostring", yaml, &["-r"])?;
         assert_eq!(code, 0, "for {yaml:?}");
@@ -12161,6 +12176,11 @@ fn test_yaml_legal_json_unsafe_float_self_consistent_across_consumers_954() -> R
 /// failure mode #918 originally fixed for a leading dot.
 #[test]
 fn test_tag_yq_normalized_float_spellings_stay_float_954() -> Result<()> {
+    // `+.5` isn't actually widened by `preservable_float_literal_text` (a
+    // bare leading dot is out of this fix's scope, see the sibling test
+    // above) -- kept here as a non-regression check on a value `tag`
+    // never needed a reindex-bridge round trip for in the first place
+    // (falls to a bare `Float`, which serializes trivially to JSON).
     for yaml in ["+1.0", "1.", "007e2", "+.5"] {
         let (out, code) = run_yq_stdin("tag", yaml, &[])?;
         assert_eq!(code, 0, "for {yaml:?}");

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12073,6 +12073,103 @@ fn test_tag_yq_leading_dot_float_is_not_confused_for_null_918() -> Result<()> {
 }
 
 // =============================================================================
+// #918's residual scope: YAML-legal-but-JSON-unsafe float spellings — #954
+// =============================================================================
+
+/// The issue's own repro shapes: a leading `+`, a bare trailing `.`, and a
+/// redundant leading zero all normalize to a valid JSON number instead of
+/// losing their decimal point entirely (the pre-#954 symptom, `[2]` instead
+/// of `[2.0]`). Both the M2 streaming path (`.a`) and the DOM/array path
+/// (`[.a]`) are exercised, matching #918/#993's own dual coverage of these
+/// two independent materialization routes. Pinned against the pinned yq
+/// oracle v4.53.3 for the *value* (yq itself echoes the spelling verbatim
+/// instead of normalizing -- see the divergence test below).
+#[test]
+fn test_yaml_legal_json_unsafe_float_spellings_normalize_954() -> Result<()> {
+    for (yaml, want) in [
+        ("a: +2.0\n", "2.0"),
+        ("a: 1.\n", "1.0"),
+        ("a: 007e2\n", "7e2"),
+        ("a: -1.\n", "-1.0"),
+        ("a: -007e2\n", "-7e2"),
+        ("a: +.5\n", "0.5"),
+    ] {
+        let (out, code) = run_yq_stdin(".a", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(out.trim(), want, "M2 streaming path, for {yaml:?}");
+
+        let (out, code) = run_yq_stdin("[.a]", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(out.trim(), format!("[{want}]"), "DOM path, for {yaml:?}");
+    }
+    Ok(())
+}
+
+/// Every `-o json` output produced above must actually BE valid JSON, not
+/// merely byte-equal to an expected string -- this is the specific defect a
+/// draft of this fix introduced and code review self-check caught: widening
+/// literal preservation via this crate's own lenient semi-index scanner
+/// (safe for *finding* a span, not for *emitting* one) made `-o json` on
+/// `a: 1.`/`a: 007e2` literally emit the invalid JSON number text `1.`/
+/// `007e2`. Parses each output through `serde_json` to catch any repeat of
+/// that class of regression directly, independent of the exact expected text.
+#[test]
+fn test_yaml_legal_json_unsafe_float_spellings_produce_valid_json_954() -> Result<()> {
+    for yaml in ["a: +2.0\n", "a: 1.\n", "a: 007e2\n", "a: -1.\n"] {
+        let (out, code) = run_yq_stdin(".", yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        serde_json::from_str::<serde_json::Value>(out.trim())
+            .unwrap_or_else(|e| panic!("invalid JSON for {yaml:?}: {out:?}: {e}"));
+    }
+    Ok(())
+}
+
+/// Before #954, a `+`-prefixed float that failed literal preservation
+/// degraded to a bare `Float` with no source text -- and #1124 had, by that
+/// point, already split `tostring`/`join`'s float-formatting rule from the
+/// structural-output one, so the two disagreed *with each other* on the
+/// same bare value (`tostring` gave `"1"`, `join` gave `"1.0"`) even though
+/// neither matched real yq's own `+1.0`. #954's fix (materializing a
+/// preserved -- if normalized -- `NumberLiteral` instead of a bare `Float`)
+/// makes every consumer read the same stored text, so they can no longer
+/// diverge from each other, even though they still don't match real yq's
+/// own `+`-preserving spelling (a real, documented, permanent divergence --
+/// see `preservable_float_literal_text`'s own doc comment for why).
+#[test]
+fn test_yaml_legal_json_unsafe_float_self_consistent_across_consumers_954() -> Result<()> {
+    for (yaml, want) in [
+        ("a: +1.0\n", "1.0"),
+        ("a: 1.\n", "1.0"),
+        ("a: 007e2\n", "7e2"),
+    ] {
+        let (out, code) = run_yq_stdin(".a | tostring", yaml, &["-r"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(out.trim(), want, "tostring, for {yaml:?}");
+
+        let (out, code) = run_yq_stdin("[.a] | join(\",\")", yaml, &["-r"])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(out.trim(), want, "join, for {yaml:?}");
+    }
+    Ok(())
+}
+
+/// The `tag` builtin's own JSON-reindex-bridge round trip (see
+/// `test_tag_yq_leading_dot_float_is_not_confused_for_null_918` above) must
+/// keep working once these wider spellings can reach `NumberLiteral` too --
+/// a genuinely non-JSON-safe stored literal would silently misclassify as a
+/// parse error and report `!!null` instead of `!!float` here, the same
+/// failure mode #918 originally fixed for a leading dot.
+#[test]
+fn test_tag_yq_normalized_float_spellings_stay_float_954() -> Result<()> {
+    for yaml in ["+1.0", "1.", "007e2", "+.5"] {
+        let (out, code) = run_yq_stdin("tag", yaml, &[])?;
+        assert_eq!(code, 0, "for {yaml:?}");
+        assert_eq!(out.trim(), "!!float", "for {yaml:?}");
+    }
+    Ok(())
+}
+
+// =============================================================================
 // M2 JSON-output float literal fidelity — #993
 // =============================================================================
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12169,6 +12169,22 @@ fn test_tag_yq_normalized_float_spellings_stay_float_954() -> Result<()> {
     Ok(())
 }
 
+/// `--slurp`/`--eval-all`/`load()` all materialize a plain scalar through
+/// `ResolvedScalar::to_owned_value` (`resolve_plain(&str_value).
+/// to_owned_value(str_value)`, `eval.rs`/`yq_runner.rs`) rather than through
+/// `DocumentValue::number_literal()` or the streaming JSON writers the other
+/// #954 tests above exercise -- a fourth, independent call site gating on
+/// `is_preservable_float_literal` (see #907's own doc comment on the
+/// sibling `2.0` test just above this one). Confirms this normalization
+/// fix reaches that path too, not just the other three.
+#[test]
+fn test_slurp_normalizes_json_unsafe_float_spelling_954() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "+1.0", &["--slurp", "-o", "json", "-I", "0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1.0]");
+    Ok(())
+}
+
 // =============================================================================
 // M2 JSON-output float literal fidelity — #993
 // =============================================================================


### PR DESCRIPTION
## Summary

#918 fixed the "integer-valued float scalar loses its decimal point" bug
by preserving a scalar's literal source text as a `NumberLiteral`, but
only when that text is also valid JSON number syntax. A leading `+`
(`+2.0`), a bare trailing dot (`1.`), and a redundant leading zero
(`007e2`) are all YAML 1.2 core-schema-legal float spellings that aren't
valid JSON syntax, so `is_preservable_float_literal` declined them and
they fell through to a bare `Float`, losing the decimal point exactly
as #918 originally described — #918's own residual scope, tracked as
this issue.

```
$ printf 'a: +2.0\n' | succinctly yq '[.a]' -o json -I0
[2]           # before
[2.0]         # after (matches real yq)

$ printf 'a: +1.0\n' | succinctly yq -r '.a | tostring'
1             # before
1.0           # after (real yq: +1.0 -- see "Scope" below)
```

## Root cause and fix

Four independent call sites gate on `is_preservable_float_literal` to
decide whether to echo a `Float` scalar's source text verbatim:
`ResolvedScalar::to_owned_value`, `write_resolved_scalar_as_json`,
`stream_resolved_scalar_as_json`, and `DocumentValue::number_literal`.
All four now fall back to a new `preservable_float_literal_text`, which
normalizes the text to an equivalent JSON-safe spelling (strip a leading
`+`, complete a bare trailing `.` with a `0`, strip a redundant leading
zero via #1149's own `strip_redundant_leading_zeros`) before treating it
as preservable.

Normalizing — rather than preserving verbatim — is required, not a style
choice: `OwnedValue::NumberLiteral`'s downstream JSON-reindexing bridge
parses its stored text as if it *were* JSON, so genuinely non-JSON-safe
text passed through unchanged corrupts that round trip (confirmed via
the `tag` builtin misclassifying it as `!!null`).

An earlier draft of this fix widened `is_preservable_float_literal`
itself to accept anything this crate's own lenient semi-index scanner
could find the boundaries of, on the theory that scanner-safety implied
output-safety. It doesn't — the scanner finding a clean span only means
it won't mis-parse *already-embedded* text, not that the same text is
valid to *emit* as new JSON output. That draft made `-o json` on
`a: 1.`/`a: 007e2` literally emit invalid JSON number text (`{"a":1.}`).
Caught and fixed before merge; documented in
`preservable_float_literal_text`'s own doc comment as a pitfall to not
repeat.

## Scope

This is a real, permanent divergence from real yq's own verbatim-echo
`tostring`/`join`/`-o yaml` output for these spellings (`+1.0`/`1.`/
`007e2` all echo completely unchanged in real yq) — accepted per this
issue's own root-cause framing, since real yq's Go-based number model
has no equivalent internal JSON-reindexing constraint forcing it to
normalize.

The `!!float 5`-style int-widened case the issue also mentioned (no
literal float-shaped text to preserve at all, since `resolve_tagged`
widens the int under the tag) was verified already correct on main and
needed no fix here.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Every `-o json` output verified to actually parse as valid JSON (`serde_json::from_str`), not just byte-equal to an expected string — the specific class of regression this fix's own earlier draft introduced
- [x] `tostring`/`join`/`tag`/`--slurp` self-consistency verified across all 4 materialization call sites
- [x] Patch coverage 100% (73/73 new lines)

Fixes #954