### PR TITLE
fix(jq): route 2 of #1192's decode-failure sites through EvalError

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1991,13 +1991,33 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
     sink: &mut ErrorSink,
 ) -> Vec<JqValue<'a, W>> {
     match result {
-        GenericResult::One(v) => vec![standard_json_to_jq_value(v, &cursor)],
+        GenericResult::One(v) => match standard_json_to_jq_value(v, &cursor) {
+            Ok(jq_value) => vec![jq_value],
+            Err(e) => {
+                sink.report(DiagStyle::Jq, &e, at);
+                vec![]
+            }
+        },
         // OneCursor: directly use the cursor - most memory efficient for unchanged values
         GenericResult::OneCursor(c) => vec![JqValue::Cursor(c)],
-        GenericResult::Many(vs) => vs
-            .into_iter()
-            .map(|v| standard_json_to_jq_value(v, &cursor))
-            .collect(),
+        // Stops at the first element that fails to decode, keeping the
+        // already-converted prefix -- matching how an ordinary `error`/
+        // `break` mid-generator stops the rest of a stream elsewhere in this
+        // evaluator (#1164), not a "skip the bad one and keep going"
+        // semantic (no precedent for that at this granularity).
+        GenericResult::Many(vs) => {
+            let mut out = Vec::new();
+            for v in vs {
+                match standard_json_to_jq_value(v, &cursor) {
+                    Ok(jq_value) => out.push(jq_value),
+                    Err(e) => {
+                        sink.report(DiagStyle::Jq, &e, at);
+                        break;
+                    }
+                }
+            }
+            out
+        }
         // ManyCursor: same lazy-cursor efficiency as OneCursor, per element.
         GenericResult::ManyCursor(cs) => cs.into_iter().map(JqValue::Cursor).collect(),
         // Stays lazy all the way to output: a bare `keys_unsorted` never
@@ -2085,11 +2105,21 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
 /// **Phase 1 Lazy Optimization**: Arrays and objects store `JqValue::Cursor` for
 /// each child instead of recursively materializing. This defers allocation until
 /// the value is actually needed (e.g., for computation or output formatting).
+///
+/// Errors (#1192) rather than silently degrading when a top-level result
+/// string (or an immediate key of a top-level result object) passes
+/// structural validation but fails to *decode* -- this used to substitute an
+/// empty string for such a value, and an empty-string *key* (colliding
+/// multiple decode-failing keys together) for such a key, instead of
+/// surfacing a real error. Only the immediate level is checked here because
+/// array/object children stay lazy (`JqValue::Cursor`) rather than
+/// recursively converting -- a decode failure nested deeper is caught later,
+/// if and when that child cursor is itself materialized.
 fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
     value: StandardJson<'a, W>,
     _parent_cursor: &JsonCursor<'a, W>,
-) -> JqValue<'a, W> {
-    match value {
+) -> Result<JqValue<'a, W>, EvalError> {
+    Ok(match value {
         StandardJson::Null => JqValue::Null,
         StandardJson::Bool(b) => JqValue::Bool(b),
         StandardJson::Number(n) => {
@@ -2098,7 +2128,11 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
         }
         StandardJson::String(s) => {
             // Keep string lazy - use raw bytes reference instead of decoding
-            JqValue::String(s.as_str().map(|c| c.to_string()).unwrap_or_default())
+            JqValue::String(
+                s.as_str()
+                    .map_err(|e| EvalError::new(format!("{e}")))?
+                    .to_string(),
+            )
         }
         StandardJson::Array(elements) => {
             // LAZY: Store cursor references instead of materializing children
@@ -2107,20 +2141,25 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
         }
         StandardJson::Object(fields) => {
             // LAZY: Store cursor references instead of materializing values
-            let map: IndexMap<String, JqValue<'a, W>> = fields
-                .map(|f| {
-                    let key = match f.key() {
-                        StandardJson::String(s) => s.as_str().unwrap_or_default().to_string(),
-                        _ => String::new(),
-                    };
-                    // Use cursor for value instead of materializing
-                    (key, JqValue::Cursor(f.value_cursor()))
-                })
-                .collect();
+            let mut map: IndexMap<String, JqValue<'a, W>> = IndexMap::new();
+            for f in fields {
+                // A key that isn't `StandardJson::String` at all is a
+                // structurally malformed key, not a decode failure -- out of
+                // scope here (#1194's territory), same as before this fix.
+                let key = match f.key() {
+                    StandardJson::String(s) => match s.as_str() {
+                        Ok(cow) => cow.to_string(),
+                        Err(e) => return Err(EvalError::new(format!("{e} in object key"))),
+                    },
+                    _ => continue,
+                };
+                // Use cursor for value instead of materializing
+                map.insert(key, JqValue::Cursor(f.value_cursor()));
+            }
             JqValue::Object(map)
         }
         StandardJson::Error(_) => JqValue::Null,
-    }
+    })
 }
 
 /// Write a single output JqValue (preserves number formatting when possible).
@@ -2942,5 +2981,46 @@ mod tests {
         let stream = r#"{"a":1} {"b":2} {"c":3}"#;
         let values = parse_json_stream(stream).unwrap();
         assert_eq!(values.len(), 3);
+    }
+
+    /// #1192: `standard_json_to_jq_value` now surfaces a genuinely
+    /// undecodable top-level string as an `EvalError` instead of silently
+    /// substituting an empty string. Array/object children stay lazy
+    /// (`JqValue::Cursor`) here, so only a decode failure at the immediate
+    /// top level is caught by this function itself -- a nested one surfaces
+    /// later, if and when that child cursor is materialized.
+    ///
+    /// No CLI-level regression test accompanies this: this function
+    /// converts a query *result*, not the input document, and every
+    /// ordinary top-level jq/yq expression tried against a document
+    /// containing this malformed byte sequence resolves its result through
+    /// `to_owned`/`cursor_to_owned` (`eval_generic.rs`/`lazy.rs`, unaffected
+    /// by this fix) before ever reaching here -- see
+    /// `test_owned_from_standard_json_errors_on_string_decode_failure_1192`
+    /// in `eval_generic.rs` for the full account of what was tried.
+    #[test]
+    fn test_standard_json_to_jq_value_errors_on_string_decode_failure_1192() {
+        let json: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = standard_json_to_jq_value(value, &cursor).unwrap_err();
+        assert!(err.message.contains("invalid UTF-8"), "{err:?}");
+    }
+
+    /// #1192: an immediate object key that fails to decode now errors too,
+    /// instead of silently substituting an empty-string key -- which used
+    /// to collide multiple decode-failing keys together into one field.
+    #[test]
+    fn test_standard_json_to_jq_value_errors_on_object_key_decode_failure_1192() {
+        let json: &[u8] = b"{\"\xff\xfe\": 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = standard_json_to_jq_value(value, &cursor).unwrap_err();
+        assert!(
+            err.message.contains("invalid UTF-8") && err.message.contains("object key"),
+            "{err:?}"
+        );
     }
 }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3023,4 +3023,107 @@ mod tests {
             "{err:?}"
         );
     }
+
+    /// #1192: the `Ok` side of `standard_json_to_jq_value`'s string arm and
+    /// its object-key handling -- the decode-*failure* tests above only
+    /// exercise the `Err` side of each.
+    #[test]
+    fn test_standard_json_to_jq_value_succeeds_on_valid_input_1192() {
+        let json: &[u8] = b"\"hello\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let jq_value = standard_json_to_jq_value(value, &cursor).unwrap();
+        assert!(matches!(jq_value, JqValue::String(s) if s == "hello"));
+
+        let json: &[u8] = b"{\"a\": 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let jq_value = standard_json_to_jq_value(value, &cursor).unwrap();
+        let JqValue::Object(map) = jq_value else {
+            panic!("expected an object");
+        };
+        assert_eq!(map.keys().collect::<Vec<_>>(), vec!["a", "b"]);
+    }
+
+    /// #1192: a key that isn't `StandardJson::String` at all (structurally
+    /// malformed, not a decode failure) still silently drops the field --
+    /// unchanged from before this fix, and deliberately so (#1194's
+    /// territory). A bare numeric key with a valid sibling field reaches
+    /// the per-field drop (`{invalid}` alone does not -- see the matching
+    /// test in `eval_generic.rs` for why).
+    #[test]
+    fn test_standard_json_to_jq_value_drops_structurally_malformed_key_1194() {
+        let json: &[u8] = b"{123: 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let jq_value = standard_json_to_jq_value(value, &cursor).unwrap();
+        let JqValue::Object(map) = jq_value else {
+            panic!("expected an object");
+        };
+        assert_eq!(map.keys().collect::<Vec<_>>(), vec!["b"]);
+    }
+
+    /// #1192: `generic_result_to_jq_values`'s own `One`/`Many` arms --
+    /// direct construction, since no ordinary top-level jq/yq expression
+    /// found during this fix's development routes a *document-sourced*
+    /// decode failure through this wrapper (see the sibling note on
+    /// `standard_json_to_jq_value`'s doc comment).
+    #[test]
+    fn test_generic_result_to_jq_values_one_ok_and_err_1192() {
+        let json: &[u8] = b"\"hello\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let mut sink = ErrorSink::default();
+        let out = generic_result_to_jq_values(
+            GenericResult::One(value),
+            cursor,
+            &InputLocation::at(None, 1),
+            &mut sink,
+        );
+        assert_eq!(out.len(), 1);
+        assert!(!sink.hit());
+
+        let json: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let mut sink = ErrorSink::default();
+        let out = generic_result_to_jq_values(
+            GenericResult::One(value),
+            cursor,
+            &InputLocation::at(None, 1),
+            &mut sink,
+        );
+        assert!(out.is_empty());
+        assert!(sink.hit());
+    }
+
+    /// #1192: `generic_result_to_jq_values`'s `Many` arm stops at the first
+    /// decode failure, keeping the already-converted prefix and reporting
+    /// exactly once -- matching how an ordinary `error`/`break` mid-
+    /// generator stops the rest of a stream elsewhere in this evaluator
+    /// (#1164), not a "skip the bad one and keep going" semantic.
+    #[test]
+    fn test_generic_result_to_jq_values_many_stops_at_first_failure_1192() {
+        let json: &[u8] = b"[1, \"\xff\xfe\", 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let StandardJson::Array(elements) = cursor.value() else {
+            panic!("expected an array");
+        };
+        let vs: Vec<StandardJson<_>> = elements.collect();
+        let mut sink = ErrorSink::default();
+        let out = generic_result_to_jq_values(
+            GenericResult::Many(vs),
+            cursor,
+            &InputLocation::at(None, 1),
+            &mut sink,
+        );
+        assert!(matches!(out.as_slice(), [JqValue::RawNumber(_)]));
+        assert!(sink.hit());
+    }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -990,6 +990,20 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     // `Error` this bridge returns is caught, if at all, by the *caller's*
     // own `Expr::Optional`/`eval_try`-style boundary, not by wrapping it a
     // second time here.
+    // Every `Err(e)` arm below (#1192) is defense-in-depth rather than a
+    // reachable path: `cursor` is always rooted at `owned.to_json_for_reindex
+    // ::<S>()`, a fresh serialization of an already-decoded `OwnedValue`
+    // (a Rust `String`, which by construction can't hold invalid UTF-8, and
+    // whose escapes this crate's own serializer writes). `owned_from_
+    // standard_json` can only fail on genuinely malformed source bytes, which
+    // this function never sees -- confirmed empirically (~25 jq expressions
+    // over documents with real malformed UTF-8, none reached these `Err`
+    // arms) as well as structurally (same "can this document ever be
+    // malformed" argument `eval.rs`'s own textually-similar `to_owned`
+    // copy relies on to stay out of #1192's scope entirely). Kept as `Err`
+    // arms rather than `.unwrap()`/`.expect()` because the *type* (`Result`)
+    // is what lets a real failure, if this invariant is ever violated by a
+    // future change, surface as a normal `EvalError` instead of a panic.
     match full_eval::<Vec<u64>, S>(expr, cursor) {
         QueryResult::One(v) => match owned_from_standard_json(&v) {
             Ok(o) => GenericResult::Owned(o),
@@ -2719,6 +2733,16 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // *caller's* own `Expr::Optional`/`eval_try`-style boundary.
 
             // Evaluate using the full evaluator
+            //
+            // Every `Err(e)` arm below (#1192) is defense-in-depth, same as
+            // `eval_on_owned`'s matching comment: `cursor` is rooted at a
+            // fresh serialization (`to_json_for_reindex`) of `owned`, and
+            // `owned` itself already went through `to_owned_with_cursor`
+            // above -- any malformed string in the *original* document was
+            // already silently degraded there (that gap is #1192's
+            // remaining, out-of-scope half, tracked as #1247), not carried
+            // through as malformed bytes for `owned_from_standard_json` to
+            // ever encounter here.
             match full_eval::<Vec<u64>, S>(expr, cursor) {
                 QueryResult::One(v) => {
                     // Convert StandardJson back to OwnedValue
@@ -9424,6 +9448,136 @@ mod tests {
         assert!(
             err.message.contains("invalid UTF-8") && err.message.contains("object key"),
             "{err:?}"
+        );
+    }
+
+    /// #1192: a key that isn't `StandardJson::String` at all (structurally
+    /// malformed, not a decode failure) still silently drops the field --
+    /// unchanged from before this fix, and deliberately so (#1194's
+    /// territory). `{invalid}` (#1194's own repro) doesn't reach the
+    /// dropping arm this test targets: its lone malformed field never gets
+    /// paired into a `JsonField` at all (a *different* #1194 swallow point,
+    /// `JsonFields::uncons()`'s own collapse of "no sibling to pair as a
+    /// value" into "no more fields"), so `{123: 1, "b": 2}` is used instead
+    /// -- a bare numeric key with a valid sibling field, which does reach
+    /// the per-field drop this fix's object handling deliberately leaves
+    /// alone.
+    #[test]
+    fn test_owned_from_standard_json_drops_structurally_malformed_key_1194() {
+        let json: &[u8] = b"{123: 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let owned = owned_from_standard_json(&value).unwrap();
+        let OwnedValue::Object(map) = owned else {
+            panic!("expected an object");
+        };
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("b"), Some(&OwnedValue::from_number_literal("2")));
+    }
+
+    /// #1192: the `Ok` side of `eval_on_owned`'s `QueryResult::One` arm --
+    /// the decode-failure tests above only exercise its `Err` side.
+    /// `keys_unsorted | sort` isn't one of `LazyKeys`'s dedicated fast-path
+    /// arms (only `.[]`/computed-index/`first`/`last`/a leading `map` are),
+    /// so it materializes and routes through `eval_on_owned`'s "reindex
+    /// bridge" -- confirmed by direct instrumentation while developing this
+    /// test, not just inferred from the doc comments.
+    #[test]
+    fn test_eval_on_owned_one_ok_via_keys_sort_1192() {
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse("keys_unsorted | sort").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("b".to_string()),
+                OwnedValue::String("c".to_string()),
+            ])
+        );
+    }
+
+    /// #1192: the `Ok` (all-succeed) side of `eval_on_owned`'s `QueryResult::
+    /// Many` loop -- same reasoning as the `One` test above, but for a query
+    /// that produces multiple outputs through the same bridge.
+    #[test]
+    fn test_eval_on_owned_many_ok_via_keys_comma_index_1192() {
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse("keys_unsorted | (.[0], .[1])").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(
+            result.collect_owned(),
+            vec![
+                OwnedValue::String("b".to_string()),
+                OwnedValue::String("a".to_string()),
+            ]
+        );
+    }
+
+    /// #1192: the `Ok` side of `eval_single`'s *own* full-evaluator fallback
+    /// arm (a duplicate of `eval_on_owned`'s bridge, see the comment on that
+    /// arm) -- `reduce`'s own accumulator handling routes here directly,
+    /// without going through `eval_on_owned` at all (confirmed by direct
+    /// instrumentation), so it needs its own dedicated coverage.
+    #[test]
+    fn test_eval_single_fallback_one_ok_via_reduce_1192() {
+        let json = br"[1, 2, 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse("reduce .[] as $x (0; $x)").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(3));
+    }
+
+    /// #1192: the `Ok` (all-succeed) side of `eval_single`'s fallback
+    /// `QueryResult::Many` loop -- `foreach`'s per-step output list routes
+    /// here directly, same as the `reduce` case above.
+    #[test]
+    fn test_eval_single_fallback_many_ok_via_foreach_1192() {
+        let json = br"null";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse(r#"foreach range(3) as $i (""; . + "x"; .)"#).unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(
+            result.collect_owned(),
+            vec![
+                OwnedValue::String("x".to_string()),
+                OwnedValue::String("xx".to_string()),
+                OwnedValue::String("xxx".to_string()),
+            ]
+        );
+    }
+
+    /// #1192: the `Ok` side of `eval_on_owned`'s `QueryResult::OneCursor`
+    /// arm -- `keys_unsorted | .` re-evaluates the identity against the
+    /// freshly-reindexed materialized-keys JSON inside the bridge, which
+    /// `full_eval` resolves as a cursor rather than a decoded value
+    /// (confirmed by direct instrumentation while developing this test).
+    #[test]
+    fn test_eval_on_owned_onecursor_ok_via_keys_identity_1192() {
+        let json = br#"{"b": 1, "a": 2, "c": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse("keys_unsorted | .").unwrap();
+        let result = eval(&expr, value);
+        assert_eq!(
+            result.into_owned().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("b".to_string()),
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("c".to_string()),
+            ])
         );
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -842,54 +842,77 @@ fn into_lazy_items<V: DocumentValue>(
 /// above (#965) rather than merged into it: this one is used only by this
 /// module's own `eval_on_owned`/`eval_single` fallback arm on a value it
 /// constructs internally (e.g. a `reduce`/`foreach` accumulator), and its
-/// Number/String arms carry two real behavioral differences from `to_owned`
-/// that a naive merge would lose -- NaN/Infinity-sentinel decoding (its
-/// callers round-trip through `to_json_for_reindex`, which bakes those as a
-/// sentinel number literal `to_owned`'s plain `number_literal()`/`as_f64()`
-/// path doesn't decode) and a different malformed-UTF-8-string fallback
-/// (`OwnedValue::String("")` here vs. `OwnedValue::Null` there). Before this
-/// rename it also happened to share a name with an unrelated, now-deleted
-/// `yq_runner.rs` helper (#907) -- a real naming-confusion risk for anyone
-/// grepping the codebase, even though the two never collided at compile
-/// time (module-private on both sides).
+/// Number arm carries a real behavioral difference from `to_owned` that a
+/// naive merge would lose -- NaN/Infinity-sentinel decoding (its callers
+/// round-trip through `to_json_for_reindex`, which bakes those as a sentinel
+/// number literal `to_owned`'s plain `number_literal()`/`as_f64()` path
+/// doesn't decode). Before this rename it also happened to share a name with
+/// an unrelated, now-deleted `yq_runner.rs` helper (#907) -- a real
+/// naming-confusion risk for anyone grepping the codebase, even though the
+/// two never collided at compile time (module-private on both sides).
+///
+/// Errors (#1192) rather than silently degrading when a string scalar (or an
+/// object key) passes structural validation but fails to *decode* (invalid
+/// UTF-8, an invalid escape, an invalid `\u` codepoint) -- this used to
+/// return `OwnedValue::String("")` for such a value and silently drop the
+/// whole field for such a key. `to_owned`/`to_owned_cursor` (this file) and
+/// `cursor_to_owned` (`lazy.rs`) still have the older silent-degrade
+/// behavior for this same failure; making those three fallible too needs a
+/// much larger signature change (each is called from 100+ sites, many mid-
+/// evaluation, not just at an output boundary -- the same blast-radius
+/// tradeoff `MAX_NESTING_DEPTH`'s panic-not-`Result` design already made) --
+/// tracked separately, not attempted here.
 fn owned_from_standard_json<W: Clone + AsRef<[u64]>>(
     value: &crate::json::light::StandardJson<'_, W>,
-) -> OwnedValue {
+) -> Result<OwnedValue, EvalError> {
     owned_from_standard_json_at_depth(value, 0)
 }
 
 fn owned_from_standard_json_at_depth<W: Clone + AsRef<[u64]>>(
     value: &crate::json::light::StandardJson<'_, W>,
     depth: usize,
-) -> OwnedValue {
+) -> Result<OwnedValue, EvalError> {
     use crate::json::light::StandardJson;
     assert_nesting_depth(depth);
-    match value {
+    Ok(match value {
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(*b),
         StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
-        StandardJson::String(s) => {
-            OwnedValue::String(s.as_str().map(|c| c.to_string()).unwrap_or_default())
+        StandardJson::String(s) => OwnedValue::String(
+            s.as_str()
+                .map_err(|e| EvalError::new(format!("{e}")))?
+                .to_string(),
+        ),
+        StandardJson::Array(elements) => {
+            let mut items = Vec::new();
+            for e in *elements {
+                items.push(owned_from_standard_json_at_depth(&e, depth + 1)?);
+            }
+            OwnedValue::Array(items)
         }
-        StandardJson::Array(elements) => OwnedValue::Array(
-            (*elements)
-                .map(|e| owned_from_standard_json_at_depth(&e, depth + 1))
-                .collect(),
-        ),
-        StandardJson::Object(fields) => OwnedValue::Object(
-            (*fields)
-                .filter_map(|field| {
-                    let key = match field.key() {
-                        StandardJson::String(s) => s.as_str().ok()?.to_string(),
-                        _ => return None,
-                    };
-                    let value = owned_from_standard_json_at_depth(&field.value(), depth + 1);
-                    Some((key, value))
-                })
-                .collect(),
-        ),
+        StandardJson::Object(fields) => {
+            let mut map = IndexMap::new();
+            for field in *fields {
+                // A key that isn't `StandardJson::String` at all (e.g.
+                // `StandardJson::Error`, a *structurally* malformed key like
+                // a bare non-string token) silently drops the field, same as
+                // before this fix -- that's #1194's territory, not #1192's:
+                // this fix only covers a key that passed structural
+                // validation but failed to *decode*.
+                let key = match field.key() {
+                    StandardJson::String(s) => match s.as_str() {
+                        Ok(cow) => cow.to_string(),
+                        Err(e) => return Err(EvalError::new(format!("{e} in object key"))),
+                    },
+                    _ => continue,
+                };
+                let value = owned_from_standard_json_at_depth(&field.value(), depth + 1)?;
+                map.insert(key, value);
+            }
+            OwnedValue::Object(map)
+        }
         StandardJson::Error(_) => OwnedValue::Null,
-    }
+    })
 }
 
 /// Apply a format to an owned value and wrap it as a `GenericResult`.
@@ -968,10 +991,35 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     // own `Expr::Optional`/`eval_try`-style boundary, not by wrapping it a
     // second time here.
     match full_eval::<Vec<u64>, S>(expr, cursor) {
-        QueryResult::One(v) => GenericResult::Owned(owned_from_standard_json(&v)),
-        QueryResult::OneCursor(c) => GenericResult::Owned(owned_from_standard_json(&c.value())),
+        QueryResult::One(v) => match owned_from_standard_json(&v) {
+            Ok(o) => GenericResult::Owned(o),
+            Err(e) => GenericResult::Error(e),
+        },
+        QueryResult::OneCursor(c) => match owned_from_standard_json(&c.value()) {
+            Ok(o) => GenericResult::Owned(o),
+            Err(e) => GenericResult::Error(e),
+        },
+        // Stops at the first element that fails to decode, keeping the
+        // already-converted prefix (`partial_generic`) -- matching how an
+        // ordinary `error`/`break` mid-generator stops the rest of a stream
+        // elsewhere in this evaluator (#1164), not a "skip the bad one and
+        // keep going" semantic (no precedent for that at this granularity).
         QueryResult::Many(vs) => {
-            GenericResult::ManyOwned(vs.iter().map(owned_from_standard_json).collect())
+            let mut out = Vec::new();
+            let mut failure = None;
+            for v in &vs {
+                match owned_from_standard_json(v) {
+                    Ok(o) => out.push(o),
+                    Err(e) => {
+                        failure = Some(e);
+                        break;
+                    }
+                }
+            }
+            match failure {
+                Some(e) => partial_generic(out, Control::Error(e)),
+                None => GenericResult::ManyOwned(out),
+            }
         }
         QueryResult::None => GenericResult::None,
         QueryResult::Error(e) => GenericResult::Error(e),
@@ -2674,13 +2722,33 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             match full_eval::<Vec<u64>, S>(expr, cursor) {
                 QueryResult::One(v) => {
                     // Convert StandardJson back to OwnedValue
-                    GenericResult::Owned(owned_from_standard_json(&v))
+                    match owned_from_standard_json(&v) {
+                        Ok(o) => GenericResult::Owned(o),
+                        Err(e) => GenericResult::Error(e),
+                    }
                 }
-                QueryResult::OneCursor(c) => {
-                    GenericResult::Owned(owned_from_standard_json(&c.value()))
-                }
+                QueryResult::OneCursor(c) => match owned_from_standard_json(&c.value()) {
+                    Ok(o) => GenericResult::Owned(o),
+                    Err(e) => GenericResult::Error(e),
+                },
+                // See the matching arm in `eval_on_owned` above for why this
+                // stops at the first decode failure instead of skipping it.
                 QueryResult::Many(vs) => {
-                    GenericResult::ManyOwned(vs.iter().map(owned_from_standard_json).collect())
+                    let mut out = Vec::new();
+                    let mut failure = None;
+                    for v in &vs {
+                        match owned_from_standard_json(v) {
+                            Ok(o) => out.push(o),
+                            Err(e) => {
+                                failure = Some(e);
+                                break;
+                            }
+                        }
+                    }
+                    match failure {
+                        Some(e) => partial_generic(out, Control::Error(e)),
+                        None => GenericResult::ManyOwned(out),
+                    }
                 }
                 QueryResult::None => GenericResult::None,
                 QueryResult::Error(e) => GenericResult::Error(e),
@@ -9279,7 +9347,7 @@ mod tests {
         let json = linear_nest(255);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
-        let owned = owned_from_standard_json(&cursor.value());
+        let owned = owned_from_standard_json(&cursor.value()).unwrap();
         assert!(matches!(owned, OwnedValue::Object(_)));
 
         let json = linear_nest(256);
@@ -9292,6 +9360,70 @@ mod tests {
         assert!(
             result.is_err(),
             "owned_from_standard_json should panic at depth 256"
+        );
+    }
+
+    /// #1192: unlike `to_owned`/`to_owned_cursor` (this file, still silently
+    /// degrading to `OwnedValue::Null` -- see
+    /// `test_to_owned_degrades_to_null_on_string_decode_failure_1098` above)
+    /// and `cursor_to_owned` (`lazy.rs`, still degrading to an empty
+    /// string), `owned_from_standard_json` now surfaces a genuinely
+    /// undecodable string as an `EvalError` instead of silently
+    /// materializing `""`. A nested occurrence (inside an array) propagates
+    /// the same way, since the whole containing value can't be represented
+    /// once any of its scalars can't be.
+    ///
+    /// No CLI-level regression test accompanies this: extensive live probing
+    /// (~25 distinct jq expressions over a document containing exactly this
+    /// malformed byte sequence, covering navigation, construction,
+    /// `reduce`/`foreach`, assignment, and every builtin category this
+    /// crate implements) found no ordinary top-level jq syntax that reaches
+    /// `owned_from_standard_json` for a *document-sourced* value --
+    /// `eval_generic.rs`'s own native dispatch (which uses `to_owned`,
+    /// unaffected by this fix) already handles every case tried. This
+    /// function is reached only via the "reindex bridge" (`eval_on_owned`/
+    /// `eval_single`'s full-evaluator fallback) on a value *constructed*
+    /// mid-evaluation (e.g. a `reduce`/`foreach` accumulator) that itself
+    /// then needs an expression `eval_generic` can't handle natively --
+    /// unlike `to_owned`'s doc comment (#1098), which explicitly confirms
+    /// live-CLI reachability "through completely ordinary CLI usage (any
+    /// non-identity query over a document containing such a string)", this
+    /// function's own doc comment makes no such claim.
+    #[test]
+    fn test_owned_from_standard_json_errors_on_string_decode_failure_1192() {
+        let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = owned_from_standard_json(&value).unwrap_err();
+        assert!(err.message.contains("invalid UTF-8"), "{err:?}");
+
+        let json: &[u8] = b"[1, \"\xff\xfe\", 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = owned_from_standard_json(&value).unwrap_err();
+        assert!(err.message.contains("invalid UTF-8"), "{err:?}");
+    }
+
+    /// #1192: an object key that passes structural validation but fails to
+    /// *decode* now errors too, instead of silently dropping the whole
+    /// field (the pre-#1192 behavior, still true of `to_owned`/
+    /// `to_owned_cursor`/`cursor_to_owned` -- see the sibling test above). A
+    /// key that is *not* a string at all (structurally malformed, e.g. a
+    /// bare non-string token) is a separate, still-open gap (#1194) and is
+    /// deliberately left alone -- this fix only covers a string-shaped key
+    /// that failed to decode.
+    #[test]
+    fn test_owned_from_standard_json_errors_on_object_key_decode_failure_1192() {
+        let json: &[u8] = b"{\"\xff\xfe\": 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = owned_from_standard_json(&value).unwrap_err();
+        assert!(
+            err.message.contains("invalid UTF-8") && err.message.contains("object key"),
+            "{err:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

#1192 enumerates 4 call sites where a JSON/YAML string scalar (or object/mapping key) that passes structural validation but fails to *decode* (invalid UTF-8, an invalid escape, an invalid `\u` codepoint) silently degrades instead of surfacing a proper `EvalError`. This PR fixes 2 of the 4:

- `owned_from_standard_json_at_depth` (`src/jq/eval_generic.rs`) -- the "reindex bridge" full-evaluator fallback (`eval_on_owned` and its duplicate in `eval_single`'s fallback arm)
- `standard_json_to_jq_value` (`src/bin/succinctly/jq_runner.rs`) -- builds the top-level `JqValue` for CLI output

Both now return `Result<_, EvalError>` and route a decode failure through this crate's normal `ErrorSink` per-record reporting (a `Many`/multi-output result stops at the first failing element, keeping the already-converted prefix -- matching how an ordinary `error`/`break` mid-generator stops the rest of a stream elsewhere in this evaluator, #1164). Object/mapping key decode failures get the same treatment as values in both functions; a key that isn't string-shaped *at all* (a separate, still-open structural-malformation bug, #1194) is left untouched.

## This is not a full fix for #1192 -- please read before merging

#1192's own text states "a fix that only closes 2 of 4 is inconsistent and still leaves silent degradation reachable through the other two paths" -- and that's exactly the situation here. Extensive live probing (~25 distinct `jq` expressions over a document containing genuinely malformed UTF-8 -- navigation, construction, `reduce`/`foreach`, assignment, every builtin category the crate implements) found **no ordinary top-level CLI usage that reaches either of the 2 sites fixed here**. `eval_generic.rs`'s own native dispatch resolves virtually everything through `to_owned`/`cursor_to_owned` (the other 2 of #1192's 4 sites) instead, without ever falling back to the "reindex bridge". Those two remaining sites are the issue's actual live, CLI-reachable bug, confirmed independently by `to_owned_at_depth`'s own doc comment.

Their true scope also turned out to be much larger than #1192 estimated: **58+ call sites for `to_owned`/`to_owned_at_depth` within `eval_generic.rs` alone**, plus a comparably pervasive set of callers for `cursor_to_owned` via `JqValue::materialize()`/`into_owned()`. Both are currently infallible, called deep mid-evaluation, not just at output boundaries -- the same blast-radius shape the codebase already chose a `panic!()` over threading a `Result` for once before (`MAX_NESTING_DEPTH`, same functions). Fixing this properly needs a genuine architecture decision (thread `Result` through 58+ call sites, or move decode-validation upfront to a per-record boundary before evaluation starts), not a same-pattern continuation of this PR -- filed as #1247 with the full writeup, including #1191 as a YAML-side prerequisite.

Given #1192's own stated bar, this PR does **not** close #1192. Recommend closing #1192 in favor of #1247 (which now captures 100% of the real remaining risk) plus this merged partial fix -- see the comment left on #1192.

## Testing

Library-level unit tests only (no CLI-level test): the CLI-reachability probing above found no live path to either fixed function, so a CLI-level regression test would be testing an artifact, not real behavior. Both new tests are documented accordingly:

- `test_owned_from_standard_json_errors_on_string_decode_failure_1192` / `test_owned_from_standard_json_errors_on_object_key_decode_failure_1192` (`eval_generic.rs`)
- `test_standard_json_to_jq_value_errors_on_string_decode_failure_1192` / `test_standard_json_to_jq_value_errors_on_object_key_decode_failure_1192` (`jq_runner.rs`)

Full local verification: `cargo fmt --check`, both required clippy invocations, `cargo check --no-default-features` (no_std), and the full `cargo test --features cli,simd,regex,serde --no-fail-fast` suite (54 test binaries, 0 failures).