### PR TITLE
fix(jq): to_entries collapses duplicate JSON keys, matching jq

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -6,6 +6,8 @@
 
 #[cfg(not(test))]
 use alloc::{borrow::Cow, string::String, vec::Vec};
+
+use indexmap::IndexMap;
 #[cfg(test)]
 use std::borrow::Cow;
 
@@ -400,6 +402,50 @@ pub trait DocumentFields: Sized + Clone {
 
     /// Check if there are no fields.
     fn is_empty(&self) -> bool;
+
+    /// Whether a repeated key collapses to one field (`true`) or every
+    /// occurrence is kept, distinct (`false`).
+    ///
+    /// Must agree with [`find`](Self::find)/[`find_cursor`](Self::find_cursor)'s
+    /// own per-format contract: JSON dedupes (`true`), YAML doesn't
+    /// (`false`) -- duplicate mapping keys are semantically distinct there.
+    /// Backs [`effective_fields`](Self::effective_fields) (#1170).
+    fn keys_dedup(&self) -> bool;
+
+    /// Walk every field, applying this format's own duplicate-key rule (see
+    /// [`keys_dedup`](Self::keys_dedup)): a deduping format collapses a
+    /// repeated key to its first position but *last*-seen value (#1170,
+    /// matching real jq's own `.foo`/`to_entries` behavior on duplicate
+    /// JSON keys); a non-deduping format keeps every occurrence, in
+    /// document order.
+    ///
+    /// The default implementation is the shared, format-agnostic algorithm;
+    /// individual formats only need to answer `keys_dedup`, not reimplement
+    /// the walk.
+    fn effective_fields(&self) -> Vec<DocumentField<Self::Value, Self::Cursor>> {
+        let mut fields = self.clone();
+        if !self.keys_dedup() {
+            let mut out = Vec::new();
+            while let Some((field, rest)) = fields.uncons() {
+                out.push(field);
+                fields = rest;
+            }
+            return out;
+        }
+        // `IndexMap::insert` on an existing key retains its original
+        // position but replaces the stored value -- exactly "first
+        // position, last value", so a plain walk-and-insert already
+        // implements the whole rule.
+        let mut by_key: IndexMap<String, DocumentField<Self::Value, Self::Cursor>> =
+            IndexMap::new();
+        while let Some((field, rest)) = fields.uncons() {
+            if let Some(key) = field.key_str() {
+                by_key.insert(key.into_owned(), field);
+            }
+            fields = rest;
+        }
+        by_key.into_values().collect()
+    }
 
     /// Count the number of fields.
     fn len(&self) -> usize {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3696,7 +3696,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // entry before this builtin ever runs (#443). Building one entry
         // object per field directly off the field cursor -- like `Keys`/
         // `Iterate` above -- means no user key is ever put into a shared
-        // map, so duplicates can't collapse.
+        // map, so YAML duplicates can't collapse. `effective_fields` (#1170)
+        // applies each format's own duplicate-key rule during this same
+        // direct walk: YAML keeps every occurrence (`#443`'s point, above);
+        // JSON collapses a repeated key to its first position but
+        // last-seen value, matching real jq (`{"a":1,"a":2}|to_entries` is
+        // one entry, value `2`) -- previously this arm showed JSON's raw,
+        // undeduplicated token occurrences instead.
         Builtin::ToEntries => {
             if let Some(elements) = value.as_array() {
                 let entries: Vec<OwnedValue> = elements
@@ -3712,17 +3718,17 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     .collect();
                 GenericResult::Owned(OwnedValue::Array(entries))
             } else if let Some(fields) = value.as_object() {
-                let mut entries: Vec<OwnedValue> = Vec::new();
-                let mut f = fields;
-                while let Some((field, rest)) = f.uncons() {
-                    if let Some(key) = field.key_str() {
+                let entries: Vec<OwnedValue> = fields
+                    .effective_fields()
+                    .into_iter()
+                    .filter_map(|field| {
+                        let key = field.key_str()?;
                         let mut entry = IndexMap::new();
                         entry.insert("key".to_string(), OwnedValue::String(key.into_owned()));
                         entry.insert("value".to_string(), to_owned_cursor(&field.value_cursor));
-                        entries.push(OwnedValue::Object(entry));
-                    }
-                    f = rest;
-                }
+                        Some(OwnedValue::Object(entry))
+                    })
+                    .collect();
                 GenericResult::Owned(OwnedValue::Array(entries))
             } else {
                 // No `optional`-guarded arm here: `Builtin::ToEntries` isn't
@@ -5647,6 +5653,30 @@ mod tests {
             owned,
             OwnedValue::Array(vec![expected_entry(1), expected_entry(2)])
         );
+    }
+
+    /// #1170: unlike YAML's genuine duplicates (above), a duplicate JSON
+    /// key must collapse to one entry -- keeping the *first* occurrence's
+    /// position but the *last* occurrence's value, matching real jq
+    /// (`{"a":1,"b":2,"a":3}|to_entries` is `[{"key":"a","value":3},
+    /// {"key":"b","value":2}]`, oracle-verified against jq 1.7.1).
+    #[test]
+    fn test_json_generic_to_entries_deduplicates_repeated_key_1170() {
+        let json: &[u8] = br#"{"a":1,"b":2,"a":3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(&Expr::Builtin(Builtin::ToEntries), value);
+        let owned = result.into_owned().unwrap();
+
+        let entry = |k: &str, v: i64| {
+            let mut entry = IndexMap::new();
+            entry.insert("key".to_string(), OwnedValue::String(k.to_string()));
+            entry.insert("value".to_string(), OwnedValue::Int(v));
+            OwnedValue::Object(entry)
+        };
+        assert_eq!(owned, OwnedValue::Array(vec![entry("a", 3), entry("b", 2)]));
     }
 
     #[test]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1895,6 +1895,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
     fn is_empty(&self) -> bool {
         JsonFields::is_empty(self)
     }
+
+    fn keys_dedup(&self) -> bool {
+        true
+    }
 }
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for JsonElements<'a, W> {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6165,6 +6165,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for YamlFields<'a, W> {
     fn is_empty(&self) -> bool {
         YamlFields::is_empty(self)
     }
+
+    fn keys_dedup(&self) -> bool {
+        false
+    }
 }
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for YamlElements<'a, W> {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12423,3 +12423,34 @@ fn test_jq_parenthesized_del_target_works_but_chained_slice_still_errors_1153() 
     assert_eq!(code, 5);
     Ok(())
 }
+
+/// #1170: `to_entries` on a JSON object with a repeated key must collapse
+/// it to one entry -- keeping the first occurrence's position but the
+/// last occurrence's value -- matching real jq (oracle-verified against
+/// jq 1.7.1: `{"a":1,"b":2,"a":3}|to_entries` is
+/// `[{"key":"a","value":3},{"key":"b","value":2}]`), not the raw,
+/// undeduplicated per-token walk this crate previously used (which showed
+/// three entries, one per JSON token occurrence).
+#[test]
+fn test_jq_to_entries_deduplicates_repeated_json_key_1170() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "to_entries"], Some(r#"{"a":1,"b":2,"a":3}"#))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(
+        out.trim(),
+        r#"[{"key":"a","value":3},{"key":"b","value":2}]"#
+    );
+    Ok(())
+}
+
+/// #1170 regression guard: a plain object with no repeated keys is
+/// unaffected by the dedup logic.
+#[test]
+fn test_jq_to_entries_no_duplicate_keys_unaffected_1170() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "to_entries"], Some(r#"{"x":1,"y":2}"#))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(
+        out.trim(),
+        r#"[{"key":"x","value":1},{"key":"y","value":2}]"#
+    );
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -913,6 +913,29 @@ fn test_duplicate_mapping_key_to_entries_json_compact() -> Result<()> {
     Ok(())
 }
 
+/// #1170: unlike YAML's genuine duplicates (preserved unmerged above, per
+/// #443), a duplicate key on `--input-format json` input must collapse to
+/// one entry -- keeping the first occurrence's position but the last
+/// occurrence's value, matching real jq's own `to_entries` behavior on
+/// duplicate JSON keys (the two formats have opposite correct behavior
+/// here, and `to_entries`'s cursor-native walk is shared between them).
+#[test]
+fn test_duplicate_json_key_to_entries_deduplicates_1170() -> Result<()> {
+    let json = r#"{"a":1,"b":2,"a":3}"#;
+    let (output, code) = run_yq_stdin(
+        "to_entries",
+        json,
+        &["--input-format", "json", "-o=json", "-I=0"],
+    )?;
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        output.trim(),
+        r#"[{"key":"a","value":3},{"key":"b","value":2}]"#
+    );
+    Ok(())
+}
+
 /// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion
 /// (`yaml_to_owned_value`) #442 didn't touch, so it kept collapsing
 /// duplicate keys within each slurped element even after plain `yq '.'`


### PR DESCRIPTION
## Summary

`Builtin::ToEntries`'s cursor-native arm (`src/jq/eval_generic.rs`, added by #443 to preserve YAML's genuine duplicate mapping keys) walked an object's fields via raw `uncons()` unconditionally — correct for YAML, but wrong for JSON, where a duplicate key should collapse to its last value, reported once at its first position (RFC 8259 convention, matching real jq).

Repro (oracle-verified against jq 1.7.1):

```
$ echo '{"a":1,"b":2,"a":3}' | jq -c 'to_entries'
[{"key":"a","value":3},{"key":"b","value":2}]
$ echo '{"a":1,"b":2,"a":3}' | succinctly jq -c 'to_entries'   # before this fix
[{"key":"a","value":1},{"key":"b","value":2},{"key":"a","value":3}]
```

## Fix

Adds a new `DocumentFields::effective_fields()` default method (`src/jq/document.rs`) backed by a required `keys_dedup()` flag each format answers (`JsonFields`: `true`, `YamlFields`: `false`) — a single shared walk-and-insert algorithm handles both formats, reusing `IndexMap::insert`'s own "first position, last value" semantics for the JSON case (confirmed via `indexmap`'s own doc comment: an existing key retains its position, the value is updated). `ToEntries`'s object arm now walks `effective_fields()` instead of raw `uncons()`. No change to the array arm, or to YAML's own behavior (still verified unmerged — #443's existing test and a live check both pass).

## Scope

Deliberately limited to this issue's own literal repro (bare `to_entries` on JSON). **Not** bundling #868/#1169's `[to_entries]`/`paths` array-wrapping case — that's a separate, broader gap (`Expr::Array`/`Comma` have no cursor-native handling at all, #1168's own territory) where PR #1169 was already closed unmerged after bundling widened its scope past a clean review.

## A related, separate bug found (not fixed here)

While investigating, confirmed live that `JsonFields::find`/`find_cursor` (`src/json/light.rs`) return the **first** match on a duplicate JSON key instead of the last, so plain field access also diverges from jq:

```
$ echo '{"a":1,"b":2,"a":3}' | jq -c '.a'
3
$ echo '{"a":1,"b":2,"a":3}' | succinctly jq -c '.a'   # unaffected by this PR
1
```

This is a different function than the one this PR touches (`find`/`find_cursor` vs. the `ToEntries`-only `effective_fields()` walk) and a different code path entirely — filing as its own follow-up issue rather than expanding this PR's scope, consistent with the "one issue, one PR" principle this session has been following.

## Testing

- New library-level test: `test_json_generic_to_entries_deduplicates_repeated_key_1170` (`eval_generic.rs`), mirroring the existing YAML duplicate-key test's own style.
- New CLI-level tests (this file previously had **zero** `to_entries` tests): `test_jq_to_entries_deduplicates_repeated_json_key_1170`, `test_jq_to_entries_no_duplicate_keys_unaffected_1170` (`tests/jq_cli_tests.rs`), `test_duplicate_json_key_to_entries_deduplicates_1170` (`tests/yq_cli_tests.rs`, via `--input-format json`).
- Full local verification: `cargo fmt --check`, both required clippy invocations, `cargo check --no-default-features` (no_std), and the full `cargo test --features cli,simd,regex,serde --no-fail-fast` suite (54 test binaries, 0 failures).

Fixes #1170