### PR TITLE
fix(yaml): accept a tab before a trailing flow-collection comment

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3955,13 +3955,38 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Only called for `[`/`{` — a block scalar (`|`/`>`) has no equivalent
     /// same-line trailing-content shape to reject, since its own terminator
     /// is a dedent, not a delimiter byte a stray token could follow.
-    fn reject_trailing_flow_content(&self, permit_colon_terminator: bool) -> Result<(), YamlError> {
+    ///
+    /// Consumes the inline whitespace it validates (advancing `self.pos` to
+    /// the comment/break/EOI it finds) rather than only checking it (#1186):
+    /// this function previously left `self.pos` sitting on the flow
+    /// collection's own closing delimiter even after confirming a run of
+    /// inline whitespace (space *or* tab) followed. A tab specifically was
+    /// then left unconsumed for the caller's line-oriented loop
+    /// (`skip_newlines`, which only recognizes a leading *space* as
+    /// "possibly a blank/comment line", not a tab) to re-enter
+    /// `parse_document_line` mid-line, where `count_indent` -- which
+    /// assumes it's only ever called at a genuine line start -- misread the
+    /// tab as indentation. Consuming it here instead means the caller's
+    /// `self.pos` already sits at the line break (or EOI) by the time
+    /// control returns, so that mid-line reentry never happens. The `:`
+    /// terminator arm deliberately does *not* advance `self.pos` -- #902's
+    /// own compact-mapping-key parsing still needs to see the `:` itself.
+    fn reject_trailing_flow_content(
+        &mut self,
+        permit_colon_terminator: bool,
+    ) -> Result<(), YamlError> {
         let mut i = self.pos;
         while i < self.input.len() {
             match self.input[i] {
-                b'#' => return Ok(()),
+                b'#' => {
+                    self.pos = i;
+                    return Ok(());
+                }
                 b if Self::is_inline_whitespace(b) => i += 1,
-                b if Self::is_break(b) => return Ok(()),
+                b if Self::is_break(b) => {
+                    self.pos = i;
+                    return Ok(());
+                }
                 b':' if permit_colon_terminator
                     && Self::is_ws_break_or_eoi(self.input.get(i + 1).copied()) =>
                 {
@@ -3971,6 +3996,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             }
         }
         if i >= self.input.len() {
+            self.pos = i;
             return Ok(());
         }
         Err(YamlError::UnexpectedCharacter {
@@ -5770,6 +5796,36 @@ mod tests {
         let yaml = b"name:\n\tvalue";
         let result = build_semi_index(yaml);
         assert!(matches!(result, Err(YamlError::TabIndentation { .. })));
+    }
+
+    /// #1186: unlike the genuine-indentation tab above, a tab that sits
+    /// between a flow collection's closing delimiter and a trailing
+    /// comment on the *same* line must not be misread as indentation on a
+    /// (nonexistent) next line.
+    #[test]
+    fn test_tab_before_trailing_comment_after_flow_collection_accepted_1186() {
+        let yaml = b"a: [1, 2]\t# trailing comment\n";
+        let result = build_semi_index(yaml);
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    /// #1186 regression guard: a naive fix (widening the general
+    /// blank/comment-line skip loop, `skip_newlines`, to treat a leading
+    /// tab like a space unconditionally) broke this unrelated, official
+    /// YAML Test Suite case (`Y79Y/000`, "Tabs in various contexts") --
+    /// a block scalar's own content line containing *only* a tab must
+    /// still be rejected, since a tab is never valid indentation there
+    /// either. The real fix is scoped to `reject_trailing_flow_content`
+    /// alone (only reachable after a flow collection's own closing
+    /// delimiter), which never touches block-scalar content at all.
+    #[test]
+    fn test_tab_only_block_scalar_content_line_still_rejected_1186() {
+        let yaml = b"foo: |\n\t\nbar: 1\n";
+        let result = build_semi_index(yaml);
+        assert!(
+            matches!(result, Err(YamlError::TabIndentation { .. })),
+            "{result:?}"
+        );
     }
 
     /// #173: a tab following the leading spaces was treated as start-of-content, so

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6612,6 +6612,51 @@ fn test_trailing_content_after_flow_collection_errors_878() -> Result<()> {
     Ok(())
 }
 
+/// #1186: a *tab* before a trailing comment after a flow collection's
+/// closing delimiter must be accepted exactly like the space case above,
+/// not misread as leading indentation on a re-entered "next line" that's
+/// actually still the same line. `reject_trailing_flow_content` (#878,
+/// above) already *validated* a tab as ordinary inline whitespace here, but
+/// left `self.pos` sitting on it instead of consuming it -- the line-
+/// oriented loop that runs next only recognizes a leading *space* as
+/// "possibly a blank/comment line", not a tab, so it left the tab
+/// unconsumed and re-entered `parse_document_line` mid-line, where
+/// `count_indent` (which assumes it's only ever called at a genuine line
+/// start) misclassified it, erroring "tab character used for indentation".
+#[test]
+fn test_tab_before_trailing_comment_after_flow_collection_accepted_1186() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".a",
+        "a: [1, 2]\t# trailing comment\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2]");
+
+    // Flow mapping variant of the same shape.
+    let (out, code) = run_yq_stdin(
+        ".a",
+        "a: {b: 1}\t# trailing comment\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":1}"#);
+
+    // A tab followed by real content (not just a comment) must still error,
+    // same as the space case in #878 above -- the fix only widens what
+    // counts as "just trailing whitespace/comment", not what counts as
+    // trailing garbage.
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr(".", "a: [1, 2]\tb: 3\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("after a flow collection's closing delimiter"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_flow_collection_as_implicit_mapping_key_still_permitted_878() -> Result<()> {
     // #878's validation must not reject a flow collection followed by `:` -


### PR DESCRIPTION
## Summary

A tab between a flow collection's closing delimiter and a trailing comment on the same line incorrectly raised "tab character used for indentation", even though `reject_trailing_flow_content` (#878) already validated a tab as ordinary inline whitespace in this position.

Repro (verified against pinned yq v4.53.3):

```
$ printf 'a: [1, 2]\t# trailing comment\n' | succinctly yq -o json '.a'
Error: YAML parse error: tab character used for indentation at line 1 (offset 10)
$ printf 'a: [1, 2]\t# trailing comment\n' | yq -o json '.a'
[1,2]
```

## Root cause

`reject_trailing_flow_content` validated the tab as fine but never *consumed* it — it left `self.pos` sitting exactly on the tab. The caller's line-oriented `skip_newlines` loop only recognizes a leading **space** (not a tab) as "possibly a blank/comment line", so the tab was left unconsumed and the parser re-entered `parse_document_line` mid-line, where `count_indent` — which assumes it's only ever called at a genuine line start — misread the tab as indentation.

## Fix, and a near-miss worth flagging

`reject_trailing_flow_content` now consumes the whitespace it validates (advancing `self.pos` to the comment/break/EOI it finds), so the caller never re-enters mid-line for this shape. Deliberately scoped to just this one function — only reachable after a flow collection's own closing delimiter — rather than widening `skip_newlines` itself.

**An earlier attempt did widen `skip_newlines`** (treating a leading tab like a space unconditionally, matching `is_inline_whitespace`). It fixed this repro but broke the official [YAML Test Suite](https://github.com/yaml/yaml-test-suite)'s `Y79Y/000` case ("Tabs in various contexts"): a block scalar's own content line containing *only* a tab must still be rejected as invalid indentation, and `skip_newlines` is the shared blank/comment-line skip used everywhere, not just after a flow collection. Caught by `cargo test`'s `yaml_test_suite_conformance` check before this ever reached CI. Pinned both the fix and that near-miss as regression tests, per this repo's own "duplicated predicates diverge silently" and "narrow test matrix hides wrong algorithm" lessons — reverted the broad version and scoped the real fix down before committing.

The `:` terminator arm (#902's own compact-mapping-key handling) is deliberately left unchanged — it still doesn't advance `self.pos`, since that logic needs to see the `:` itself.

## Testing

- `test_tab_before_trailing_comment_after_flow_collection_accepted_1186` (`src/yaml/parser.rs` and `tests/yq_cli_tests.rs`, library- and CLI-level) — the fix itself, plus a flow-mapping variant and a "tab followed by real content still errors" case in the CLI test.
- `test_tab_only_block_scalar_content_line_still_rejected_1186` (`src/yaml/parser.rs`) — regression guard pinning the near-miss described above.
- Full local verification: `cargo fmt --check`, both required clippy invocations, `cargo check --no-default-features` (no_std), and the full `cargo test --features cli,simd,regex,serde --no-fail-fast` suite (54 test binaries, 0 failures, including `yaml_test_suite_conformance`).

Fixes #1186