### PR TITLE
fix(jq): .foo on a duplicate JSON key resolves to the last value

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -395,9 +395,14 @@ pub trait DocumentFields: Sized + Clone {
     /// Find a field by name and return a cursor to its value.
     ///
     /// Must agree with [`find`](Self::find) on which field wins when a name
-    /// is repeated (YAML keeps the last duplicate key; JSON keeps the
-    /// first), so callers can switch between the two without a behavior
-    /// change — see the per-format `find`/`find_cursor` implementations.
+    /// is repeated -- both formats keep the *last* duplicate key here
+    /// (YAML: #174; JSON: #1251, matching real jq/RFC 8259), so callers can
+    /// switch between the two without a behavior change. This is the
+    /// opposite of YAML's own genuine-duplicates *preservation* elsewhere
+    /// (`to_entries`'s cursor-native walk, #443) -- `find`/`find_cursor`
+    /// answer "what does this key resolve to", `to_entries` answers "what
+    /// are all the entries", and only YAML keeps every entry distinct for
+    /// the latter question.
     fn find_cursor(&self, name: &str) -> Option<Self::Cursor>;
 
     /// Check if there are no fields.

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1010,35 +1010,42 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
 
     /// Find a field by name.
     ///
-    /// Returns the value of the first field with the given name,
-    /// or `None` if not found.
+    /// A duplicate JSON key collapses to its *last* occurrence, matching
+    /// real jq / RFC 8259 convention (see issue #1251) -- the same rule
+    /// `YamlFields::find` already applies for YAML's own last-duplicate-
+    /// key-wins semantics (#174), just the opposite of YAML's genuine-
+    /// duplicates preservation elsewhere (`to_entries`, #443).
     pub fn find(&self, name: &str) -> Option<StandardJson<'a, W>> {
         let mut fields = *self;
+        let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
             if let StandardJson::String(key) = field.key() {
                 if key.as_str().ok()? == name {
-                    return Some(field.value());
+                    result = Some(field.value());
                 }
             }
             fields = rest;
         }
-        None
+        result
     }
 
     /// Find a field by name and return a cursor to its value.
     ///
-    /// Same first-match semantics as [`find`](Self::find).
+    /// Same last-duplicate-key-wins semantics as [`find`](Self::find) — kept
+    /// as a separate loop rather than reusing `find` so the returned cursor
+    /// (needed for `line`/`column`) doesn't require re-navigating.
     pub fn find_cursor(&self, name: &str) -> Option<JsonCursor<'a, W>> {
         let mut fields = *self;
+        let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
             if let StandardJson::String(key) = field.key() {
                 if key.as_str().ok()? == name {
-                    return Some(field.value_cursor());
+                    result = Some(field.value_cursor());
                 }
             }
             fields = rest;
         }
-        None
+        result
     }
 }
 
@@ -2605,6 +2612,32 @@ mod tests {
 
                 // Non-existent field
                 assert!(fields.find("missing").is_none());
+            }
+            _ => panic!("expected object"),
+        }
+    }
+
+    /// #1251: a duplicate JSON key must resolve to its *last* value,
+    /// matching real jq / RFC 8259 -- this used to return the first,
+    /// diverging from `.a` field access in real jq (`{"a":1,"a":3}|.a`
+    /// is `3`, not `1`).
+    #[test]
+    fn test_object_find_field_duplicate_key_last_wins_1251() {
+        let json = br#"{"a": 1, "b": 2, "a": 3}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+
+        match root.value() {
+            StandardJson::Object(fields) => {
+                match fields.find("a") {
+                    Some(StandardJson::Number(n)) => assert_eq!(n.as_i64().unwrap(), 3),
+                    other => panic!("expected number 3, got {other:?}"),
+                }
+                let value_cursor = fields.find_cursor("a").expect("should find a cursor");
+                match value_cursor.value() {
+                    StandardJson::Number(n) => assert_eq!(n.as_i64().unwrap(), 3),
+                    other => panic!("expected number 3, got {other:?}"),
+                }
             }
             _ => panic!("expected object"),
         }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12486,3 +12486,15 @@ fn test_jq_to_entries_no_duplicate_keys_unaffected_1170() -> Result<()> {
     );
     Ok(())
 }
+
+/// #1251: `.foo` field access on a duplicate JSON key must resolve to the
+/// *last* value, matching real jq / RFC 8259 convention -- this used to
+/// return the first (oracle-verified against jq 1.7.1:
+/// `{"a":1,"b":2,"a":3}|.a` is `3`).
+#[test]
+fn test_jq_field_access_duplicate_key_last_wins_1251() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", ".a"], Some(r#"{"a":1,"b":2,"a":3}"#))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "3");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -936,6 +936,21 @@ fn test_duplicate_json_key_to_entries_deduplicates_1170() -> Result<()> {
     Ok(())
 }
 
+/// #1251: `.a` field access on `--input-format json` input with a
+/// duplicate key must resolve to the *last* value, matching real jq /
+/// RFC 8259 convention -- the JSON-side sibling of #174's YAML fix, and
+/// the opposite of YAML's own genuine-duplicates preservation for
+/// `to_entries` (#443, above).
+#[test]
+fn test_duplicate_json_key_field_access_last_wins_1251() -> Result<()> {
+    let json = r#"{"a":1,"b":2,"a":3}"#;
+    let (output, code) = run_yq_stdin(".a", json, &["--input-format", "json"])?;
+
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "3");
+    Ok(())
+}
+
 /// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion
 /// (`yaml_to_owned_value`) #442 didn't touch, so it kept collapsing
 /// duplicate keys within each slurped element even after plain `yq '.'`


### PR DESCRIPTION
## Summary

`JsonFields::find`/`find_cursor` returned early on the first key match, so field access on a duplicate JSON key resolved to the *first* value instead of jq's own last-value-wins behavior.

Repro (oracle-verified against jq 1.7.1):

```
$ echo '{"a":1,"b":2,"a":3}' | jq -c '.a'
3
$ echo '{"a":1,"b":2,"a":3}' | succinctly jq -c '.a'   # before this fix
1
```

## Fix

`YamlFields::find`/`find_cursor` already loop through every field and keep the last match (fixed for YAML by #174) — this mirrors that exact shape for JSON's own sibling functions in `src/json/light.rs`.

Not the same bug or code path as #1170's `to_entries` fix: that one is a full-object walk answering "what are all the entries" (where YAML correctly keeps every duplicate distinct, #443); `find`/`find_cursor` answer "what does this key resolve to" for both formats, and both now agree on last-wins there. Also corrected `DocumentFields::find_cursor`'s own stale doc comment (`src/jq/document.rs`), which still described JSON as first-wins.

## Testing

- `test_object_find_field_duplicate_key_last_wins_1251` (`src/json/light.rs`) — library-level, both `find` and `find_cursor`.
- `test_jq_field_access_duplicate_key_last_wins_1251` (`tests/jq_cli_tests.rs`).
- `test_duplicate_json_key_field_access_last_wins_1251` (`tests/yq_cli_tests.rs`, via `--input-format json`).
- Confirmed live that YAML's own duplicate-key `find` behavior (#174) and `to_entries`'s duplicate-preservation (#443) are both unaffected.
- Full local verification: `cargo fmt --check`, both required clippy invocations, `cargo check --no-default-features` (no_std), and the full `cargo test --features cli,simd,regex,serde --no-fail-fast` suite (54 test binaries, 0 failures).

Fixes #1251