### PR TITLE
fix(jq): accept a float repeat count in string multiplication

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2121,13 +2121,21 @@ fn arith_mul<S: EvalSemantics>(
                     Ok(OwnedValue::Float(a * b))
                 }
                 // String repetition: "ab" * 3 = "ababab". jq >= 1.7 yields ""
-                // for n == 0 and null only for n < 0 (jqlang/jq#1593). The
-                // repeat count must specifically be `Int`-repr -- a `Float`
-                // (or a `NumberLiteral` carrying a float repr) paired with
-                // a `String` falls through to the type-mismatch arm below,
-                // matching real jq (`"ab" * 2.5` errors there too).
-                (OwnedValue::String(s), _, _, Some(NumberRepr::Int(n)))
-                | (_, OwnedValue::String(s), Some(NumberRepr::Int(n)), _) => {
+                // for n == 0 and null only for n < 0 (jqlang/jq#1593). A
+                // `Float`-repr count (or a `NumberLiteral` carrying one)
+                // truncates toward zero first, matching real jq's own
+                // `intmax_t` cast (confirmed live: `2.5 * "ab"` -> `"abab"`,
+                // `2.9 * "ab"` -> `"abab"`, not rounded; `"ab" * 0.5` -> `""`,
+                // not an error) -- the same truncation `mod_floats` already
+                // performs for `%` (#1230).
+                (OwnedValue::String(s), _, _, Some(n_repr))
+                | (_, OwnedValue::String(s), Some(n_repr), _) => {
+                    let n = match n_repr {
+                        NumberRepr::Int(n) => n,
+                        // `as` truncates toward zero and saturates, matching
+                        // jq's intmax_t cast (mirrors `mod_floats` above).
+                        NumberRepr::Float(n) => n as i64,
+                    };
                     if n < 0 {
                         Ok(OwnedValue::Null)
                     } else {
@@ -26608,6 +26616,32 @@ mod tests {
         // matches real jq (#713).
         query!(br#"{"a": [1, 2], "b": [3, 4]}"#, ".a * .b",
             QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1230: a `Float`-repr repeat count truncates toward zero, matching
+    /// real jq's own `intmax_t` cast, instead of falling through to the
+    /// generic type-mismatch error.
+    #[test]
+    fn test_arithmetic_mul_string_repetition_float_count_1230() {
+        // Truncates down (not rounds), oracle-verified against jq 1.7.1
+        // (`2.5 * "ab"` -> `"abab"`, `2.9 * "ab"` -> `"abab"`).
+        query!(br#"{"s": "ab", "n": 2.5}"#, ".n * .s",
+            QueryResult::Owned(OwnedValue::String(s)) if s == "abab" => {}
+        );
+        query!(br#"{"s": "ab", "n": 2.9}"#, ".n * .s",
+            QueryResult::Owned(OwnedValue::String(s)) if s == "abab" => {}
+        );
+
+        // Truncates to 0 -> empty string, not an error (`"ab" * 0.5` -> `""`).
+        query!(br#"{"s": "ab", "n": 0.5}"#, ".s * .n",
+            QueryResult::Owned(OwnedValue::String(s)) if s.is_empty() => {}
+        );
+
+        // A negative float still yields null, same as a negative int
+        // (jqlang/jq#1593).
+        query!(br#"{"s": "ab", "n": -1.5}"#, ".s * .n",
+            QueryResult::Owned(OwnedValue::Null) => {}
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12355,30 +12355,52 @@ fn test_jq_binary_op_success_paths_unaffected_1199() -> Result<()> {
 }
 
 /// A `Float` (or a `NumberLiteral` carrying a float repr) paired with a
-/// `String` for `*` must return a clean type-mismatch error, not panic --
-/// regression guard for a bug an earlier draft of this fix introduced and
-/// code review caught before merge. `arith_mul`'s restructuring initially
-/// gated its numeric/string-repetition arm behind `is_number()` (true for
-/// `Float` too, not just `Int`), but the inner match's string-repetition
-/// pattern only ever handled `Int`, so a `Float`+`String` pair fell through
-/// every named arm into an `unreachable!()` that was, in fact, reachable --
-/// `"ab" * 2.5` crashed the process (exit 101) instead of erroring (exit
-/// 5). succinctly has never supported a float repeat count at all (a
-/// separate, pre-existing, narrower-than-real-jq gap tracked as #1230,
-/// unaffected by this fix either way) -- the requirement here is only that
-/// the unsupported shape errors cleanly, not that it succeeds.
+/// `String` for `*` must never panic -- regression guard for a bug an
+/// earlier draft of this fix introduced and code review caught before
+/// merge. `arith_mul`'s restructuring initially gated its numeric/
+/// string-repetition arm behind `is_number()` (true for `Float` too, not
+/// just `Int`), but the inner match's string-repetition pattern only ever
+/// handled `Int`, so a `Float`+`String` pair fell through every named arm
+/// into an `unreachable!()` that was, in fact, reachable -- `"ab" * 2.5`
+/// crashed the process (exit 101) instead of erroring (exit 5).
+///
+/// At the time this test was written, succinctly had no float-repeat-count
+/// support at all, so "doesn't panic" meant "errors cleanly" (exit 5,
+/// "cannot be multiplied"). #1230 added that support (truncating toward
+/// zero, matching real jq's own `intmax_t` cast), so a moderate float count
+/// now succeeds instead -- that success path is covered by
+/// `test_jq_string_repetition_accepts_float_count_1230` above. This test
+/// keeps only the still-relevant "doesn't panic" cases: `nan` and negative
+/// `infinite` repeat counts, both of which now succeed cleanly (Rust's `as
+/// i64` cast saturates `NaN` to `0` and `-inf` to `i64::MIN`, so neither
+/// reaches `String::repeat` with an unreasonable count -- `i64::MIN` is
+/// negative, so it takes the existing negative-count-returns-null branch
+/// instead).
+///
+/// Positive `infinite` (and a very large finite magnitude like `1e10`) are
+/// deliberately not covered here: truncating either yields a huge repeat
+/// count fed to `String::repeat`, an unbounded-allocation hang/OOM hazard,
+/// not a panic -- and that exact hazard already exists, unguarded, for a
+/// same-magnitude `Int` operand (`"ab" * 10000000000`) on `main` today, so
+/// it's a pre-existing characteristic of this arm rather than something
+/// #1230 introduced. Live-verified against real jq: `timeout 3 jq -cn
+/// '(infinite) * "ab"'` hangs (no output, no error) rather than rejecting
+/// the input, so there's no clean "must error" behavior to pin here either.
+///
+/// Note real jq's own `nan * "ab"` returns `null` (verified: jq-1.7.1),
+/// not `""` -- but that's `(int)NaN` C-cast undefined behavior (platform-
+/// dependent; jq has no explicit NaN check here), not a deliberate
+/// contract, so succinctly's well-defined saturating-cast result (`""`) is
+/// intentionally not matched to it.
 #[test]
 fn test_jq_string_times_float_errors_cleanly_not_panics_1199() -> Result<()> {
-    for expr in [
-        "2.5 * \"ab\"",
-        "\"ab\" * 2.5",
-        "1e10 * \"ab\"",
-        "\"ab\" * 1e10",
-    ] {
-        let (out, err, code) = run_jq_full(&["-cn", expr], None)?;
-        assert_eq!(code, 5, "expr {expr:?}: out={out:?} err={err:?}");
-        assert!(err.contains("cannot be multiplied"), "expr {expr:?}: {err}");
-    }
+    let (out, _, code) = run_jq_full(&["-cn", "(nan) * \"ab\""], None)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"\"");
+
+    let (out, _, code) = run_jq_full(&["-cn", "\"ab\" * (0 - infinite)"], None)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
     Ok(())
 }
 
@@ -12591,5 +12613,28 @@ fn test_jq_field_access_duplicate_key_last_wins_1251() -> Result<()> {
     let (out, _, code) = run_jq_full(&["-c", ".a"], Some(r#"{"a":1,"b":2,"a":3}"#))?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "3");
+    Ok(())
+}
+
+/// #1230: `"x" * n` accepts a float repeat count, truncating toward zero
+/// like real jq's own `intmax_t` cast, instead of erroring as a type
+/// mismatch.
+#[test]
+fn test_jq_string_repetition_accepts_float_count_1230() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-cn", "2.5 * \"ab\""], None)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"abab\"");
+
+    let (out, _, code) = run_jq_full(&["-cn", "2.9 * \"ab\""], None)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"abab\"");
+
+    let (out, _, code) = run_jq_full(&["-cn", "\"ab\" * 0.5"], None)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"\"");
+
+    let (out, _, code) = run_jq_full(&["-cn", "\"ab\" * (0.0 - 1.5)"], None)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
     Ok(())
 }


### PR DESCRIPTION
## Summary

- `arith_mul`'s string-repetition arm (`"ab" * n`) only ever matched a `NumberRepr::Int` count, so a `Float`-repr operand (e.g. `2.5 * "ab"`) fell through to the generic type-mismatch error instead of succeeding, unlike real jq.
- Real jq truncates a float repeat count toward zero (its `intmax_t` cast) before repeating — confirmed live: `2.5 * "ab"` -> `"abab"`, `2.9 * "ab"` -> `"abab"` (not rounded), `"ab" * 0.5` -> `""`, a negative float -> `null`.
- Widened the arm to accept either `NumberRepr` shape, truncating a `Float` via `as i64` (mirrors `mod_floats`' existing truncation for `%`, added under #1230's sibling fix).

## Note on the #1199 regression test

This fix changes the output of some inputs `test_jq_string_times_float_errors_cleanly_not_panics_1199` (added for #1199) had pinned as "must error cleanly" — that test's own doc comment already flagged this exact scenario, since #1199 was about preventing a *panic* for `Float`+`String`, at a time when succinctly had no float-repeat-count support at all (so "doesn't panic" meant "errors cleanly"). #1230 adds that support, so `2.5 * "ab"` and friends now correctly succeed instead.

I updated that test to keep only the still-relevant "doesn't panic" cases (`nan`, negative `infinite`) and dropped the moderate-float cases (now covered by the new `test_jq_string_repetition_accepts_float_count_1230`). I deliberately did **not** add coverage for a positive-infinity or very-large-magnitude (`1e10`-scale) repeat count: truncating either produces a huge count fed to `String::repeat`, an unbounded-allocation hang/OOM hazard rather than a panic — and that hazard already exists, unguarded, for a same-magnitude `Int` operand on `main` today, so it's a pre-existing characteristic of this arm, not something this PR introduces. Live-verified against real jq: `timeout 3 jq -cn '(infinite) * "ab"'` hangs with no output rather than rejecting the input, so there's no clean "must error" behavior to pin here either way.

Fixes #1230

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green (one unrelated `test_keys_lazy_length_output_683` failure on the first run was confirmed environmental — subprocess-spawn flakiness under concurrent system load — and passed clean on retry)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] New/updated behavior live-verified against real jq (jq-1.7.1)