### PR TITLE
fix(jq): resolve earlier fan-out escape through remaining dynamic stages

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14311,7 +14311,37 @@ fn resolve_seq<'a, S: EvalSemantics>(
                         let tailed = apply_static_tail::<S>(next, tail, trackable)?;
                         return path_result(tailed, Some(e));
                     }
-                    return Err((next, e));
+                    // #1013: when an earlier dynamic element escapes (i < last_dynamic),
+                    // continue the fan-out loop to process remaining dynamic elements against
+                    // the partial branches that succeeded, but preserve the error to return at the end.
+                    // Store the error and continue processing.
+                    let deferred_error = Some(e);
+                    // Continue processing remaining stages with the partial results
+                    for remaining_element in flat[i+1..=last_dynamic].iter() {
+                        let mut next_next = Vec::new();
+                        for (prefix, current) in next {
+                            match resolve_against_cow::<S>(remaining_element, current, trackable) {
+                                Ok(resolved) => {
+                                    for (components, resulting) in resolved {
+                                        let mut path = prefix.clone();
+                                        path.extend(components);
+                                        next_next.push((path, resulting));
+                                    }
+                                }
+                                Err((partial, _)) => {
+                                    // Ignore further errors - we already have our deferred_error
+                                    for (components, resulting) in partial {
+                                        let mut path = prefix.clone();
+                                        path.extend(components);
+                                        next_next.push((path, resulting));
+                                    }
+                                }
+                            }
+                        }
+                        next = next_next;
+                    }
+                    let tailed = apply_static_tail::<S>(next, tail, trackable)?;
+                    return path_result(tailed, deferred_error);
                 }
             }
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14317,7 +14317,7 @@ fn resolve_seq<'a, S: EvalSemantics>(
                     // Store the error and continue processing.
                     let deferred_error = Some(e);
                     // Continue processing remaining stages with the partial results
-                    for remaining_element in flat[i+1..=last_dynamic].iter() {
+                    for remaining_element in &flat[i + 1..=last_dynamic] {
                         let mut next_next = Vec::new();
                         for (prefix, current) in next {
                             match resolve_against_cow::<S>(remaining_element, current, trackable) {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8778,11 +8778,10 @@ fn test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977(
         &["-c", r#"path(.a[(0,error("t"))] | .c[(0,1)] | .foo)"#],
         Some(r#"{"a":[{"c":[{"foo":1},{"foo":2}]}]}"#),
     )?;
+    // #1013 fixed: now processes remaining dynamic elements instead of truncating
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    // Must not fabricate `["a",0,"foo"]` by skipping `.c[(0,1)]` — the
-    // pre-existing "known simplification" truncates to the partial prefix
-    // through the escaping element instead.
-    assert_eq!(stdout, "[\"a\",0]\n");
+    // Now produces full paths through all remaining stages, not just truncated prefix
+    assert_eq!(stdout, "[\"a\",0,\"c\",0,\"foo\"]\n[\"a\",0,\"c\",1,\"foo\"]\n");
     assert!(stderr.contains('t'), "stderr: {stderr:?}");
 
     // A second shape, where the skipped-over tail would otherwise silently
@@ -8794,7 +8793,8 @@ fn test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977(
         Some(r#"{"a":[{"c":"k","k":{"d":99}}]}"#),
     )?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "[\"a\",0]\n");
+    // Now processes through .k[.c] instead of truncating
+    assert_eq!(stdout, "[\"a\",0,\"k\",\"k\",\"d\"]\n");
     assert!(stderr.contains('t'), "stderr: {stderr:?}");
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8781,7 +8781,10 @@ fn test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977(
     // #1013 fixed: now processes remaining dynamic elements instead of truncating
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     // Now produces full paths through all remaining stages, not just truncated prefix
-    assert_eq!(stdout, "[\"a\",0,\"c\",0,\"foo\"]\n[\"a\",0,\"c\",1,\"foo\"]\n");
+    assert_eq!(
+        stdout,
+        "[\"a\",0,\"c\",0,\"foo\"]\n[\"a\",0,\"c\",1,\"foo\"]\n"
+    );
     assert!(stderr.contains('t'), "stderr: {stderr:?}");
 
     // A second shape, where the skipped-over tail would otherwise silently


### PR DESCRIPTION
## Summary

When an earlier dynamic element escapes in a pipe expression with 2+ dynamic elements (e.g., `path(.a[(0,error("t"))] | .c[(0,1)] | .foo)`), the current behavior truncates output to the partial prefix through the escaping element, skipping remaining dynamic stages and the static tail.

Real jq continues processing the remaining dynamic elements (`flat[i+1..=last_dynamic]`) against the partial branches that succeeded from the escape, then applies the static tail, producing full paths while still reporting the original error.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Verified output matches real jq for the repro case
- [x] Updated test `test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977` to expect new correct behavior
- [x] All 663 jq CLI tests pass

Fixes #1013