### PR TITLE
fix(jq): thread resolve_seq's early fan-out escape through later stages

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14249,20 +14249,25 @@ fn resolve_seq<'a, S: EvalSemantics>(
         return Ok(vec![(flat, Cow::Owned(end))]);
     };
 
-    // Fan out one pipe element at a time. Note this rebuilds `branches` stage
-    // by stage (every currently-active branch through element N, then all of
+    // Fan out one pipe element at a time. This rebuilds `branches` stage by
+    // stage (every currently-active branch through element N, then all of
     // those through element N+1, ...) rather than threading each branch
     // depth-first through the *entire* remaining pipe the way jq's own
-    // generator composition does — so for a pipe with more than one dynamic
-    // element, a failure partway through preserves everything already
-    // completed in the *current* stage (this element, for the branches
-    // already processed) but not a later stage's contribution from an
-    // earlier-stage branch that had not yet reached it. That is a known
-    // simplification, not a byte-for-byte reproduction of jq's stream order;
-    // the single-dynamic-element case (the overwhelmingly common one, and
-    // the one every #530 sibling repro exercises) is exact.
+    // generator composition does. When an element escapes partway through a
+    // stage (#1013), the branches that stage already produced — every branch
+    // completed before the escaping one, plus the escaping branch's own
+    // partial prefix — still thread through the remaining dynamic elements
+    // and the tail below, with the escape carried in `deferred`. The
+    // escaping stage's not-yet-processed branches are dropped (the `break`
+    // in the escape arm): jq's depth-first generators die at the first
+    // error, so those branches never reach a later stage there either. A
+    // later element's escape overwrites `deferred` — depth-first, a
+    // surviving branch hits that escape before the pipe ever revisits the
+    // earlier element's generator. Only stream order can still differ from
+    // jq's for multi-escape interleavings, not which paths are emitted.
     let tail = &flat[last_dynamic + 1..];
     let mut branches: Vec<PathBranch<'a>> = vec![(Vec::new(), Cow::Borrowed(value))];
+    let mut deferred: Option<EvalEscape> = None;
     for (i, element) in flat[..=last_dynamic].iter().enumerate() {
         let mut next = Vec::new();
         // Consumes `branches` (not `&branches`) so each `current` arrives by
@@ -14284,41 +14289,50 @@ fn resolve_seq<'a, S: EvalSemantics>(
                         path.extend(components);
                         next.push((path, resulting));
                     }
-                    // #977: apply the static tail to whatever branches
-                    // survived up to this escape, instead of dropping it —
-                    // mirroring the success path below via the shared
-                    // `apply_static_tail` helper. If tail application
+                    // #977: when the *last* dynamic element escapes, apply
+                    // the static tail to whatever branches survived up to
+                    // this escape, instead of dropping it — via the shared
+                    // `apply_static_tail` helper the success path below
+                    // uses, so the two can't drift. If tail application
                     // itself also fails, that later failure takes priority
-                    // over the earlier deferred `e` (propagated via `?`);
-                    // otherwise the tail's fully-extended result carries
-                    // `e` forward via `path_result`, the same pairing
-                    // `resolve_slice_expr`'s `target_escape` already uses.
-                    //
-                    // Only when `i == last_dynamic`: `tail` is everything
-                    // *after* the pipe's last dynamic element, so an escape
-                    // at an *earlier* dynamic element (i < last_dynamic)
-                    // still has one or more further dynamic stages
-                    // (`flat[i+1..=last_dynamic]`) that haven't run yet —
-                    // splicing `tail` directly onto this stage's branches
-                    // would skip those entirely and fabricate a wrong
-                    // path/value (found in code review, confirmed live
-                    // against jq: `path(.a[(0,error("t"))] | .c[(0,1)] |
-                    // .foo)` produced a bogus `["a",0,"foo"]` instead of
-                    // the pre-existing, already-documented "known
-                    // simplification" truncation this preserves for that
-                    // shape instead).
+                    // over `e` (propagated via `?`); otherwise the tail's
+                    // fully-extended result carries `e` forward via
+                    // `path_result`, the same pairing `resolve_slice_expr`'s
+                    // `target_escape` already uses. Only at
+                    // `i == last_dynamic`: `tail` is everything *after* the
+                    // pipe's last dynamic element, so applying it at an
+                    // earlier escape would skip the dynamic stages
+                    // `flat[i+1..=last_dynamic]` entirely and fabricate a
+                    // wrong path/value (an early #977 review draft did
+                    // exactly that, confirmed live against jq).
                     if i == last_dynamic {
                         let tailed = apply_static_tail::<S>(next, tail, trackable)?;
                         return path_result(tailed, Some(e));
                     }
-                    return Err((next, e));
+                    // #1013: an earlier dynamic element's escape defers `e`
+                    // and stops only *this* stage. The branches already
+                    // produced above — including the escaping branch's own
+                    // partial prefix — keep threading through the remaining
+                    // dynamic elements and the tail below, matching what
+                    // jq's depth-first generators emit before the error
+                    // fires. The `break` also drops this stage's
+                    // not-yet-processed branches, which jq never reaches
+                    // either; a later stage's own escape overwrites
+                    // `deferred`, the one depth-first evaluation would
+                    // surface first.
+                    deferred = Some(e);
+                    break;
                 }
             }
         }
         branches = next;
     }
 
-    apply_static_tail::<S>(branches, tail, trackable)
+    // A deferred escape (#1013) surfaces only after the tail has extended
+    // every surviving branch; a tail-application failure propagated by `?`
+    // outranks it, the same later-failure-wins rule as the escape arm above.
+    let tailed = apply_static_tail::<S>(branches, tail, trackable)?;
+    path_result(tailed, deferred)
 }
 
 /// Rewrite every computed key in a path expression into the static component it

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8757,21 +8757,23 @@ fn test_resolve_seq_static_tail_failure_outranks_earlier_fanout_escape_977() -> 
     Ok(())
 }
 
-/// #977 (found in code review of the fix itself): when a pipe has 2+
-/// dynamic (fan-out) elements and an *earlier* one escapes — not the last,
-/// i.e. `flat`'s dynamic element at some index `i < last_dynamic` — the
-/// static tail lives *after* `last_dynamic`, not after `i`. Applying it
-/// directly to `i`'s partial branches (as an early version of this fix
-/// did) skips every dynamic stage between `i` and `last_dynamic` entirely
-/// and fabricates a wrong path/value instead of the pre-existing,
-/// already-documented "known simplification" truncation `resolve_seq`'s
-/// own top comment describes for this exact shape. Verified against jq
-/// 1.7.1: `.c[(0,1)]` (the second dynamic element) must still run before
-/// `.foo` (the tail) is ever applied — the correct output threads through
-/// it (`["a",0,"c",0,"foo"]`/`["a",0,"c",1,"foo"]`); this pins the
-/// truncated-but-honest fallback succinctly's own architecture produces
-/// instead (a pre-existing, accepted limitation for multi-dynamic-element
-/// pipes, not what this test asserts jq itself does).
+/// #977 (found in code review of the fix itself) → threading completed by
+/// #1013: when a pipe has 2+ dynamic (fan-out) elements and an *earlier*
+/// one escapes — not the last, i.e. `flat`'s dynamic element at some index
+/// `i < last_dynamic` — the static tail lives *after* `last_dynamic`, not
+/// after `i`. An early #977 review draft applied the tail directly to
+/// `i`'s partial branches, skipping every dynamic stage between `i` and
+/// `last_dynamic` entirely and fabricating a wrong path/value
+/// (`["a",0,"foo"]`); that was rejected in review, and merged #977
+/// returned the truncated partial prefix (`["a",0]`) as a documented,
+/// accepted limitation instead. #1013 lifted it: the escape is deferred
+/// and the surviving branches thread through the remaining dynamic stages
+/// and the tail. Verified against jq 1.7.1 for both shapes: `.c[(0,1)]`
+/// (the second dynamic element) runs before `.foo` (the tail) is applied,
+/// and the second shape's `.k[.c]` resolves `.c` = "k" against `.a[0]`,
+/// then indexes `.k`'s value by "k" (null) so `.d` threads on — the
+/// original deferred "t" still surfaces in both, never a bogus type error
+/// from misapplying the tail to `.a[0]`.
 #[test]
 fn test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -8779,23 +8781,93 @@ fn test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977(
         Some(r#"{"a":[{"c":[{"foo":1},{"foo":2}]}]}"#),
     )?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    // Must not fabricate `["a",0,"foo"]` by skipping `.c[(0,1)]` — the
-    // pre-existing "known simplification" truncates to the partial prefix
-    // through the escaping element instead.
-    assert_eq!(stdout, "[\"a\",0]\n");
+    // Must not fabricate `["a",0,"foo"]` by skipping `.c[(0,1)]`, nor
+    // truncate to the old `["a",0]` fallback: the surviving branch threads
+    // the second dynamic element and the `.foo` tail before "t" surfaces.
+    assert_eq!(stdout, "[\"a\",0,\"c\",0,\"foo\"]\n[\"a\",0,\"c\",1,\"foo\"]\n");
     assert!(stderr.contains('t'), "stderr: {stderr:?}");
 
-    // A second shape, where the skipped-over tail would otherwise silently
+    // A second shape, where a skipped-over tail would otherwise silently
     // resolve against unrelated data and mask the original escape (found
-    // in review): confirms the original deferred "t" still surfaces,
-    // rather than a bogus type error from misapplying `.d` to `.a[0]`.
+    // in review).
     let (stdout, stderr, code) = run_jq_full(
         &["-c", r#"path(.a[(0,error("t"))] | .k[.c] | .d)"#],
         Some(r#"{"a":[{"c":"k","k":{"d":99}}]}"#),
     )?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "[\"a\",0]\n");
+    assert_eq!(stdout, "[\"a\",0,\"k\",\"k\",\"d\"]\n");
     assert!(stderr.contains('t'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1013: `resolve_seq`'s fan-out loop used to truncate at the first
+/// escaping dynamic element — for a pipe with 2+ dynamic elements, an
+/// earlier element's escape returned its partial prefix (`["a",0]`)
+/// without running the remaining dynamic stages or the static tail, where
+/// jq 1.7.1's depth-first generators thread every branch produced before
+/// the error fires all the way through. The fix defers the escape and
+/// keeps threading the surviving branches stage by stage. All four shapes
+/// verified against jq 1.7.1; the last two are the two bugs the #1258
+/// review found in the first fix attempt's copied-inner-loop approach.
+#[test]
+fn test_resolve_seq_threads_remaining_dynamic_stages_after_earlier_escape_1013() -> Result<()> {
+    // Three dynamic stages, escape in the first: the surviving ["a",0]
+    // branch threads both later dynamic stages and the `.d` tail before
+    // the deferred "t" surfaces.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.a[(0,error("t"))] | .b[(0,1)] | .c[(0,1)] | .d)"#],
+        Some(r#"{"a":[{"b":[{"c":[{"d":1},{"d":2}]},{"c":[{"d":3},{"d":4}]}]}]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[\"a\",0,\"b\",0,\"c\",0,\"d\"]\n[\"a\",0,\"b\",0,\"c\",1,\"d\"]\n[\"a\",0,\"b\",1,\"c\",0,\"d\"]\n[\"a\",0,\"b\",1,\"c\",1,\"d\"]\n"
+    );
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    // Escape in a *middle* dynamic stage: `.b[(0,error("t"))]`'s surviving
+    // ["a",0,"b",0] branch still threads `.c[(0,1)]` and `.d`, while the
+    // stage's unprocessed sibling branch (["a",1]) is dropped — jq's
+    // depth-first generators die at the error before ever reaching it, so
+    // nothing under ["a",1] may appear.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.a[(0,1)] | .b[(0,error("t"))] | .c[(0,1)] | .d)"#],
+        Some(r#"{"a":[{"b":[{"c":[{"d":1},{"d":2}]}]},{"b":[{"c":[{"d":3},{"d":4}]}]}]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\",0,\"b\",0,\"c\",0,\"d\"]\n[\"a\",0,\"b\",0,\"c\",1,\"d\"]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    // A later stage's escape overwrites the deferred earlier one (verified
+    // against jq 1.7.1 in the #1258 review): depth-first, the surviving
+    // ["a",0] branch hits `.b[(0,error("late"))]`'s error before the pipe
+    // ever revisits `.a`'s generator to raise "early", so "late" is the
+    // error that surfaces — and the ["a",1] sibling is again dropped
+    // rather than threaded.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.a[(0,1,error("early"))] | .b[(0,error("late"))])"#],
+        Some(r#"{"a":[{"b":[10]},{"b":[20]}]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\",0,\"b\",0]\n");
+    assert!(stderr.contains("late"), "stderr: {stderr:?}");
+    assert!(!stderr.contains("early"), "stderr: {stderr:?}");
+
+    // The escaping stage's unprocessed siblings must not fabricate paths
+    // (verified against jq 1.7.1 in the #1258 review): `.a`'s generator
+    // yields 0 and 1 before "t", but the first branch's `.b[.c]` fails
+    // indexing an array with "bad", which overwrites the deferred "t" and
+    // leaves no surviving branch — jq emits no paths at all.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.a[(0,1,error("t"))] | .b[.c])"#],
+        Some(r#"{"a":[{"b":[10,20],"c":"bad"},{"b":[10,20],"c":1}]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Cannot index array with string \"bad\""),
+        "stderr: {stderr:?}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

For a `path()` pipe with 2+ dynamic (fan-out) elements where an **earlier** one escapes, `resolve_seq` truncated its output to the partial prefix — the shape #977 deliberately left as a documented limitation (#1013).

```console
$ echo '{"a":[{"c":[{"foo":1},{"foo":2}]}]}' | jq -c 'path(.a[(0,error("t"))] | .c[(0,1)] | .foo)'
jq: error (at <stdin>:1): t
["a",0,"c",0,"foo"]
["a",0,"c",1,"foo"]        # jq 1.7.1 threads the surviving branch fully
```

This implements the design prescribed in the #1258 review: the escape is **deferred** and the surviving branches (everything the escaping stage completed, plus its own partial prefix) keep threading through the remaining dynamic elements and the static tail:

- `deferred: Option<EvalEscape>` added to the fan-out loop; the `i < last_dynamic` arm sets it and `break`s only the current stage's branch loop instead of returning a truncated `Err`.
- The `break` drops the escaping stage's not-yet-processed siblings — jq's depth-first generators die at the first error and never reach them either (avoids #1258's fabricated-paths bug).
- A later element's escape **overwrites** the deferred one, matching depth-first evaluation order (avoids #1258's wrong-error-identity bug).
- The #977 `i == last_dynamic` arm is untouched; final fall-through is `path_result(apply_static_tail(...)?, deferred)` (a tail failure still outranks the deferred escape).

## Verification

All six pinned transcripts verified against jq 1.7.1 (exit code 5 in every case):

| shape | stdout | stderr |
|---|---|---|
| `path(.a[(0,error("t"))] \| .c[(0,1)] \| .foo)` | both full paths | `t` |
| `path(.a[(0,error("t"))] \| .k[.c] \| .d)` | `["a",0,"k","k","d"]` | `t` |
| 3 dynamic stages, escape in first | 4 full paths | `t` |
| escape in middle stage | 2 paths, `["a",1]` siblings dropped | `t` |
| `path(.a[(0,1,error("early"))] \| .b[(0,error("late"))])` | `["a",0,"b",0]` | `late`, not `early` |
| `path(.a[(0,1,error("t"))] \| .b[.c])` | *(empty)* | `Cannot index array with string "bad"` |

- `cargo test --features cli --test jq_cli_tests`: 664/664
- full workspace (`cli,simd,regex,serde`): green; `jq_golden_tests`: no drift
- `cargo clippy --all-targets --all-features -- -D warnings`: clean

## Tests

- `test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977` flipped from the pinned truncation to jq's real threaded output.
- New `test_resolve_seq_threads_remaining_dynamic_stages_after_earlier_escape_1013` covers the four additional shapes above (last two are the #1258-review bug repros).

Closes #1013
Supersedes #1258 (its copied-inner-loop approach fabricated paths from dropped siblings and surfaced the wrong deferred error; that branch can be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)