### PR TITLE
fix(jq): thread resolve_seq's fan-out escape through remaining dynamic stages

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14285,12 +14285,11 @@ fn resolve_static_tail<'a, S: EvalSemantics>(
 /// whatever branches were already extended, paired with that failure —
 /// `resolve_seq`'s own `Err`-side "keep what already resolved" contract.
 ///
-/// Shared by `resolve_seq`'s success path (every fan-out element resolved
-/// without escaping) and its escape path (#977: an earlier fan-out element
-/// itself escaped with a partial prefix) so the two can't independently
-/// drift on how a static tail gets applied — before this fix, the escape
-/// path skipped tail application entirely, silently dropping a literal
-/// `.foo`/`[N]`/`[N:M]` suffix from the partial output already produced.
+/// `resolve_seq` calls this exactly once, after its fan-out loop finishes —
+/// whether every element resolved cleanly or some element escaped along the
+/// way (#977, #1013). Funneling both outcomes through one call site is what
+/// keeps a purely-static tail (a literal `.foo`/`[N]`/`[N:M]`) from silently
+/// getting dropped off a partial, escaped prefix.
 fn apply_static_tail<'a, S: EvalSemantics>(
     branches: Vec<PathBranch<'a>>,
     tail: &[Expr],
@@ -14375,16 +14374,32 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // those through element N+1, ...) rather than threading each branch
     // depth-first through the *entire* remaining pipe the way jq's own
     // generator composition does — so for a pipe with more than one dynamic
-    // element, a failure partway through preserves everything already
-    // completed in the *current* stage (this element, for the branches
-    // already processed) but not a later stage's contribution from an
-    // earlier-stage branch that had not yet reached it. That is a known
-    // simplification, not a byte-for-byte reproduction of jq's stream order;
-    // the single-dynamic-element case (the overwhelmingly common one, and
-    // the one every #530 sibling repro exercises) is exact.
+    // element, an escape partway through a stage still drops every
+    // not-yet-reached sibling branch *at that same stage* (branches from an
+    // earlier stage's own fan-out that hadn't reached this stage yet). That
+    // is a known simplification, not a byte-for-byte reproduction of jq's
+    // stream order; the single-dynamic-element case (the overwhelmingly
+    // common one, and the one every #530 sibling repro exercises) is exact.
+    // What *does* survive an escape (#1013): the escaping branch's own
+    // partial output (everything it produced before hitting its escape) is
+    // still threaded through every remaining dynamic stage and the tail,
+    // exactly like a branch that never escaped at all — see below.
     let tail = &flat[last_dynamic + 1..];
     let mut branches: Vec<PathBranch<'a>> = vec![(Vec::new(), Cow::Borrowed(value))];
-    for (i, element) in flat[..=last_dynamic].iter().enumerate() {
+    // Set the first time any stage's branch escapes, and overwritten by any
+    // later stage's own escape (#1013) — mirroring the pre-existing "a later
+    // step's own failure outranks an earlier deferred one" rule this
+    // function already applies between the fan-out loop and
+    // `apply_static_tail` below (also used by `resolve_slice_expr`'s
+    // `target_escape`). This matches jq's real generator order: jq threads
+    // an already-yielded value all the way through the rest of the pipe
+    // (potentially hitting a *later* escape) before it ever backtracks to
+    // try a fan-out's next alternative, so a downstream escape is the one
+    // jq actually raises, not an earlier one it never got back to. Verified
+    // live against jq 1.7.1: `path(.a[(0,error("t1"))] | .c[(0,error("t2"))]
+    // | .foo)` on `{"a":[{"c":[{"foo":1}]}]}` raises `t2`, not `t1`.
+    let mut deferred_escape: Option<EvalEscape> = None;
+    for element in &flat[..=last_dynamic] {
         let mut next = Vec::new();
         // Consumes `branches` (not `&branches`) so each `current` arrives by
         // value: only then can `resolve_against_cow` recover the branch's
@@ -14405,41 +14420,28 @@ fn resolve_seq<'a, S: EvalSemantics>(
                         path.extend(components);
                         next.push((path, resulting));
                     }
-                    // #977: apply the static tail to whatever branches
-                    // survived up to this escape, instead of dropping it —
-                    // mirroring the success path below via the shared
-                    // `apply_static_tail` helper. If tail application
-                    // itself also fails, that later failure takes priority
-                    // over the earlier deferred `e` (propagated via `?`);
-                    // otherwise the tail's fully-extended result carries
-                    // `e` forward via `path_result`, the same pairing
-                    // `resolve_slice_expr`'s `target_escape` already uses.
-                    //
-                    // Only when `i == last_dynamic`: `tail` is everything
-                    // *after* the pipe's last dynamic element, so an escape
-                    // at an *earlier* dynamic element (i < last_dynamic)
-                    // still has one or more further dynamic stages
-                    // (`flat[i+1..=last_dynamic]`) that haven't run yet —
-                    // splicing `tail` directly onto this stage's branches
-                    // would skip those entirely and fabricate a wrong
-                    // path/value (found in code review, confirmed live
-                    // against jq: `path(.a[(0,error("t"))] | .c[(0,1)] |
-                    // .foo)` produced a bogus `["a",0,"foo"]` instead of
-                    // the pre-existing, already-documented "known
-                    // simplification" truncation this preserves for that
-                    // shape instead).
-                    if i == last_dynamic {
-                        let tailed = apply_static_tail::<S>(next, tail, trackable)?;
-                        return path_result(tailed, Some(e));
-                    }
-                    return Err((next, e));
+                    // Keep whatever this branch produced before its escape,
+                    // record the escape, and stop attempting any
+                    // not-yet-reached sibling at this stage (the "known
+                    // simplification" above) — but do *not* return early:
+                    // `next` still feeds the remaining dynamic stages
+                    // (#1013) exactly like a branch that never escaped,
+                    // since e.g. `.a[(0,error("t"))]`'s successful `0`
+                    // alternative still has to run through everything after
+                    // it (`.c[(0,1)] | .foo`) before jq would ever raise
+                    // `t`.
+                    deferred_escape = Some(e);
+                    break;
                 }
             }
         }
         branches = next;
     }
 
-    apply_static_tail::<S>(branches, tail, trackable)
+    match apply_static_tail::<S>(branches, tail, trackable) {
+        Ok(tailed) => path_result(tailed, deferred_escape),
+        Err(tail_err) => Err(tail_err),
+    }
 }
 
 /// Rewrite every computed key in a path expression into the static component it

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8851,45 +8851,90 @@ fn test_resolve_seq_static_tail_failure_outranks_earlier_fanout_escape_977() -> 
     Ok(())
 }
 
-/// #977 (found in code review of the fix itself): when a pipe has 2+
-/// dynamic (fan-out) elements and an *earlier* one escapes — not the last,
-/// i.e. `flat`'s dynamic element at some index `i < last_dynamic` — the
-/// static tail lives *after* `last_dynamic`, not after `i`. Applying it
-/// directly to `i`'s partial branches (as an early version of this fix
-/// did) skips every dynamic stage between `i` and `last_dynamic` entirely
-/// and fabricates a wrong path/value instead of the pre-existing,
-/// already-documented "known simplification" truncation `resolve_seq`'s
-/// own top comment describes for this exact shape. Verified against jq
-/// 1.7.1: `.c[(0,1)]` (the second dynamic element) must still run before
-/// `.foo` (the tail) is ever applied — the correct output threads through
-/// it (`["a",0,"c",0,"foo"]`/`["a",0,"c",1,"foo"]`); this pins the
-/// truncated-but-honest fallback succinctly's own architecture produces
-/// instead (a pre-existing, accepted limitation for multi-dynamic-element
-/// pipes, not what this test asserts jq itself does).
+/// #1013 (split from #977's own review): when a pipe has 2+ dynamic
+/// (fan-out) elements and an *earlier* one escapes — not the last, i.e.
+/// `flat`'s dynamic element at some index `i < last_dynamic` — the
+/// escaping branch's own partial output (the successful alternative(s) it
+/// produced before its escape) still has to thread through every remaining
+/// dynamic stage (`flat[i+1..=last_dynamic]`) and the static tail after
+/// `last_dynamic`, exactly like a branch that never escaped. Before #1013,
+/// `resolve_seq` returned that partial prefix immediately instead —
+/// pre-#977's silent-tail-drop shape, just for this narrower,
+/// 2+-dynamic-element pipe shape. Verified against jq 1.7.1: `.c[(0,1)]`
+/// (the second dynamic element) and `.foo` (the tail) both still have to
+/// run for `.a[0]`, the successful alternative, before jq ever raises `t`.
 #[test]
-fn test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977() -> Result<()> {
+fn test_resolve_seq_earlier_fanout_escape_threads_through_later_dynamic_stage_1013() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
         &["-c", r#"path(.a[(0,error("t"))] | .c[(0,1)] | .foo)"#],
         Some(r#"{"a":[{"c":[{"foo":1},{"foo":2}]}]}"#),
     )?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    // Must not fabricate `["a",0,"foo"]` by skipping `.c[(0,1)]` — the
-    // pre-existing "known simplification" truncates to the partial prefix
-    // through the escaping element instead.
-    assert_eq!(stdout, "[\"a\",0]\n");
+    assert_eq!(
+        stdout,
+        "[\"a\",0,\"c\",0,\"foo\"]\n[\"a\",0,\"c\",1,\"foo\"]\n"
+    );
     assert!(stderr.contains('t'), "stderr: {stderr:?}");
 
-    // A second shape, where the skipped-over tail would otherwise silently
-    // resolve against unrelated data and mask the original escape (found
-    // in review): confirms the original deferred "t" still surfaces,
-    // rather than a bogus type error from misapplying `.d` to `.a[0]`.
+    // A second shape, with a dynamic (not literal) second stage (`.k[.c]`)
+    // and a static tail (`.d`) after it.
     let (stdout, stderr, code) = run_jq_full(
         &["-c", r#"path(.a[(0,error("t"))] | .k[.c] | .d)"#],
         Some(r#"{"a":[{"c":"k","k":{"d":99}}]}"#),
     )?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "[\"a\",0]\n");
+    assert_eq!(stdout, "[\"a\",0,\"k\",\"k\",\"d\"]\n");
     assert!(stderr.contains('t'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1013: the fix generalizes past exactly 2 dynamic elements — a 3-dynamic
+/// pipe with the escape in the *middle* (`.b[(0,error("t"))]`, neither
+/// first nor last) still has to thread its `0` alternative through the
+/// remaining dynamic stage (`.c[(0,1)]`) and the tail (`.foo`). Verified
+/// against jq 1.7.1.
+#[test]
+fn test_resolve_seq_earlier_fanout_escape_threads_through_middle_of_three_dynamic_stages_1013(
+) -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path(.a[0] | .b[(0,error("t"))] | .c[(0,1)] | .foo)"#,
+        ],
+        Some(r#"{"a":[{"b":[{"c":[{"foo":1},{"foo":2}]}]}]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[\"a\",0,\"b\",0,\"c\",0,\"foo\"]\n[\"a\",0,\"b\",0,\"c\",1,\"foo\"]\n"
+    );
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1013: when *two* dynamic stages each escape (not just one), the later
+/// stage's escape outranks the earlier deferred one — the same "later
+/// step's own failure outranks an earlier deferred one" rule
+/// `test_resolve_seq_static_tail_failure_outranks_earlier_fanout_escape_977`
+/// already pins between a fan-out escape and a tail failure, extended here
+/// across two fan-out stages. This matches jq's real generator order: jq
+/// fully threads `.a[0]` through everything downstream — including
+/// `.c[...]`'s own escape — before it would ever backtrack to try
+/// `.a[...]`'s second alternative (`error("t1")`), so `t2` is the error jq
+/// actually raises, not `t1`. Verified against jq 1.7.1.
+#[test]
+fn test_resolve_seq_later_fanout_escape_outranks_earlier_one_1013() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path(.a[(0,error("t1"))] | .c[(0,error("t2"))] | .foo)"#,
+        ],
+        Some(r#"{"a":[{"c":[{"foo":1}]}]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\",0,\"c\",0,\"foo\"]\n");
+    assert!(stderr.contains("t2"), "stderr: {stderr:?}");
+    assert!(!stderr.contains("t1"), "stderr: {stderr:?}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Closes #1013.

`path()` on a pipe with 2+ dynamic (fan-out) elements, where an *earlier*
dynamic element escapes rather than the pipe's *last* one, used to fall back
to returning the partial prefix as-is — dropping every remaining dynamic
stage and the static tail after it. This is the same silent-truncation shape
#977 fixed, just for a narrower pipe shape #977's own fix deliberately
didn't cover (its regression test pinned the truncation as the accepted
behavior for this shape).

`resolve_seq`'s fan-out loop now keeps threading the escaping branch's own
partial output through the remaining dynamic stages and the tail, deferring
the escape until the very end instead of returning immediately. A later
stage's own escape supersedes an earlier deferred one — the same
"later step's own failure outranks an earlier deferred one" rule this
function already applied between the fan-out loop and its tail application,
now extended across stages. This matches real jq's DFS generator order: jq
fully threads an already-yielded value through everything downstream
(potentially hitting a later escape) before it ever backtracks to try a
fan-out's next alternative.

All new/updated expected outputs were verified live against the pinned jq
1.7.1 oracle, including a two-escaping-stage case confirming the later
error (`t2`) is reported, not the earlier one (`t1`) jq never backtracks to.

## Test plan

- [x] Updated `test_resolve_seq_earlier_fanout_escape_does_not_skip_later_dynamic_stage_977`
  (renamed to `..._threads_through_later_dynamic_stage_1013`) — its two cases now
  assert the fully-threaded output instead of the old truncation.
- [x] Added `test_resolve_seq_earlier_fanout_escape_threads_through_middle_of_three_dynamic_stages_1013`
  — confirms the fix generalizes past exactly 2 dynamic elements.
- [x] Added `test_resolve_seq_later_fanout_escape_outranks_earlier_one_1013`
  — locks in the "later escape wins" priority across two escaping stages.
- [x] `cargo test` (full suite: 892+ integration tests, golden/consistency
  suites, doc-tests) — all green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the
  SIMD-specific feature-set invocation — both clean.