### PR TITLE
fix(jq): cap expression nesting depth, no more stack overflow

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -122,11 +122,46 @@ fn push_bracket(chain: &mut Vec<Expr>, bracket: Bracket) {
     }
 }
 
+/// Maximum nesting depth for a single query expression's AST. Every nesting
+/// construct — parenthesized subexpressions, unary minus, bracket/index
+/// contents, keyword-form bodies (`if`/`reduce`/`foreach`/...) — re-enters
+/// the parser's expression recursion through [`Parser::parse_primary`], which
+/// counts this depth. Exceeding it returns a clean [`ParseError`] instead of
+/// recursing further: deeply nested filter text (`-----...-5`, `((((...))))`)
+/// is reachable from a query alone, with no input document involved, so an
+/// unguarded recursive-descent parse is a process-abort hazard fully within a
+/// client's control (#1156). Binary operators, pipes, and commas parse
+/// iteratively (accumulating into a `Vec`), so only genuine nesting consumes
+/// depth — a long `a | b | c | ...` chain or `1 + 2 + 3 + ...` stays at
+/// constant depth.
+///
+/// 64, measured: the parser's unguarded crash boundary on the tightest
+/// environment this crate documents (debug build, default 2MiB test-thread
+/// stack — same discipline as [`MAX_VALUE_TREE_DEPTH`]'s own rationale in
+/// `value.rs`) is ~88-96 nesting levels for the heaviest per-level shapes
+/// (array construction ~88-96, parenthesized subexpressions ~96-104, each
+/// level costing ~13-15 recursive-descent frames through the precedence
+/// ladder). 64 keeps ≥1.35x margin under the tightest boundary, mirroring
+/// the 384-vs-580 and 256-vs-200 ratios the existing depth limits use.
+/// Real jq tolerates ~5000 levels (its bison parser is table-driven with a
+/// heap-grown stack, not recursive descent), so queries nested 65..5000 deep
+/// now error cleanly here where jq would still run — a documented trade-off;
+/// real-world queries essentially never exceed ~30 levels.
+///
+/// This bounds the *parser's* recursion on query text; the evaluator walking
+/// a parser-produced `Expr` is transitively bounded too, since it cannot see
+/// a deeper tree than the parser built. `Expr`s reconstructed from input
+/// documents (`owned_to_expr`, see #945) are a separate construction path
+/// this limit does not cover.
+const MAX_EXPR_DEPTH: usize = 64;
+
 /// Parser state.
 struct Parser<'a> {
     input: &'a str,
     pos: usize,
     mode: ParserMode,
+    /// Current expression-nesting depth; see [`MAX_EXPR_DEPTH`].
+    expr_depth: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -136,6 +171,7 @@ impl<'a> Parser<'a> {
             input,
             pos: 0,
             mode: ParserMode::Jq,
+            expr_depth: 0,
         }
     }
 
@@ -144,6 +180,7 @@ impl<'a> Parser<'a> {
             input,
             pos: 0,
             mode,
+            expr_depth: 0,
         }
     }
 
@@ -970,16 +1007,32 @@ impl<'a> Parser<'a> {
     /// so by the time control reaches here any such `?` is already gone;
     /// this only wraps a `?` still left over the whole term.
     fn parse_primary(&mut self) -> Result<Expr, ParseError> {
-        let expr = self.parse_primary_inner()?;
-        self.skip_ws();
-        if self.peek() == Some('?') {
-            self.next();
-            Ok(Expr::Optional(Box::new(expr)))
+        self.expr_depth += 1;
+        let result = if self.expr_depth > MAX_EXPR_DEPTH {
+            Err(ParseError::new(
+                format!("expression nesting exceeds depth limit of {MAX_EXPR_DEPTH}"),
+                self.pos,
+            ))
         } else {
-            Ok(expr)
-        }
+            let expr = self.parse_primary_inner()?;
+            self.skip_ws();
+            if self.peek() == Some('?') {
+                self.next();
+                Ok(Expr::Optional(Box::new(expr)))
+            } else {
+                Ok(expr)
+            }
+        };
+        self.expr_depth -= 1;
+        result
     }
 
+    /// The real `parse_primary` body, entered only through the depth-checked
+    /// wrapper above. Every recursive descent into a subexpression — the
+    /// paren arm's `parse_expr`, unary minus's operand, bracket contents,
+    /// keyword-form bodies — comes back through `self.parse_primary()`, not
+    /// this function, so the depth counter sees every nesting level
+    /// (#1156; same shape as the pattern guard in #1240).
     fn parse_primary_inner(&mut self) -> Result<Expr, ParseError> {
         self.skip_ws();
 
@@ -6280,5 +6333,51 @@ mod tests {
         // Exercises the optional +/- sign branch in exponent parsing.
         assert!(parse("1e+5").is_ok());
         assert!(parse("1e-5").is_ok());
+    }
+
+    /// A query expression nested past `MAX_EXPR_DEPTH` returns a clean
+    /// `ParseError` instead of overflowing the stack -- regression test for
+    /// #1156 (`-----...-5`, `((((...5...))))` reachable from query text
+    /// alone, no input document needed; pre-fix boundary was ~596 unary
+    /// levels in a debug build, crashing with SIGABRT).
+    #[test]
+    fn test_expr_depth_limit_returns_parse_error_not_overflow_1156() {
+        let n = MAX_EXPR_DEPTH + 10;
+        let unary = format!("{}5", "-".repeat(n));
+        let err = parse(&unary).expect_err("over-depth unary chain must be a clean parse error");
+        assert!(
+            err.message.contains("depth limit"),
+            "unexpected error: {}",
+            err.message
+        );
+
+        let parens = format!("{}5{}", "(".repeat(n), ")".repeat(n));
+        let err = parse(&parens).expect_err("over-depth paren nesting must be a clean parse error");
+        assert!(
+            err.message.contains("depth limit"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    /// At-limit nesting still parses -- the guard must reject only genuinely
+    /// over-deep queries, not ones sitting exactly at the boundary (#1156).
+    /// Each `(` costs one depth unit, so `MAX_EXPR_DEPTH - 1` parens put the
+    /// innermost literal at exactly `MAX_EXPR_DEPTH`; a `-` chain folds its
+    /// innermost `-5` into one negative literal, so a full
+    /// `MAX_EXPR_DEPTH`-long chain is also at-limit. Both must parse on the
+    /// 2MiB default test-thread stack, the environment the limit itself was
+    /// measured against.
+    #[test]
+    fn test_expr_at_depth_limit_still_parses_1156() {
+        let parens = format!(
+            "{}5{}",
+            "(".repeat(MAX_EXPR_DEPTH - 1),
+            ")".repeat(MAX_EXPR_DEPTH - 1)
+        );
+        parse(&parens).expect("at-limit paren nesting must still parse");
+
+        let unary = format!("{}5", "-".repeat(MAX_EXPR_DEPTH));
+        parse(&unary).expect("at-limit unary chain must still parse");
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12638,3 +12638,36 @@ fn test_jq_string_repetition_accepts_float_count_1230() -> Result<()> {
     assert_eq!(out.trim(), "null");
     Ok(())
 }
+
+/// #1156: a deeply nested single-expression query (repeated unary minus,
+/// nested parens) must produce a clean compile error with the parser's
+/// depth-limit message -- not a stack-overflow abort (SIGABRT / exit 134),
+/// which was the pre-fix behavior at ~600 levels in a debug build.
+#[test]
+fn test_deeply_nested_expr_clean_error_not_stack_overflow_1156() -> Result<()> {
+    // Nested parens can go in as a direct filter argument.
+    let deep_parens = format!("{}5{}", "(".repeat(600), ")".repeat(600));
+    let (stdout, stderr, code) = run_jq_full(&["-c", &deep_parens], Some("null"))?;
+    assert_eq!(stdout, "", "no output expected: {stdout:?}");
+    assert!(
+        stderr.contains("depth limit"),
+        "expected depth-limit error, stderr: {stderr:?}"
+    );
+    assert_eq!(code, 1, "clean compile-error exit, not an abort (134)");
+
+    // A leading `-` would be eaten as a CLI flag, so the unary chain goes
+    // through a filter file.
+    let mut filter_file = NamedTempFile::new()?;
+    write!(filter_file, "{}5", "-".repeat(600))?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-f", filter_file.path().to_str().unwrap()],
+        Some("null"),
+    )?;
+    assert_eq!(stdout, "", "no output expected: {stdout:?}");
+    assert!(
+        stderr.contains("depth limit"),
+        "expected depth-limit error, stderr: {stderr:?}"
+    );
+    assert_eq!(code, 1, "clean compile-error exit, not an abort (134)");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`parse_primary` now counts recursion depth and returns a clean `ParseError` past `MAX_EXPR_DEPTH` (64) instead of recursing until the stack overflows. Every nesting construct re-enters expression parsing through `parse_primary` (parens, unary minus, bracket contents, keyword-form bodies), while pipes/commas/binary operators parse iteratively — so the counter sees genuine nesting only, and a long flat chain (`a | b | c | ...`) stays at constant depth.

**The limit is measured, not guessed.** On the tightest documented environment (debug build, default 2MiB test-thread stack — the same discipline as `MAX_VALUE_TREE_DEPTH`'s own rationale in `value.rs`), the unguarded parser crashes at **~88-96 levels** for the heaviest per-level shapes (array construction ~88-96, parens ~96-104; ~13-15 recursive-descent frames per level through the precedence ladder). 64 keeps ≥1.35x margin, mirroring the 384-vs-580 and 256-vs-200 ratios of the existing depth limits.

**Documented divergence:** real jq tolerates ~5000 levels (its bison parser is table-driven with a heap-grown stack; it errors `memory exhausted` around 10000). Queries nested 65..5000 deep now error cleanly here where jq would still run — necessitated by recursive descent vs. bison; real-world queries essentially never exceed ~30 levels.

The evaluator is transitively bounded (it cannot see a deeper query-text AST than the parser built). `Expr`s reconstructed from input documents (`owned_to_expr`, #945) are a separate construction path this limit does not cover.

### Before / after (issue repro: 600 nested unary minus, debug build)

```
$ echo null | succinctly jq -f <(python3 -c "print('-'*600 + '5')")
before: thread 'main' has overflowed its stack / fatal runtime error: stack overflow, aborting (SIGABRT, exit 134)
after:  jq: compile error: parse error at position 256: expression nesting exceeds depth limit of 64 (exit 1)
```

Same for 600 nested parens and 600 nested array constructions. At-limit shapes (63 parens / 64 unary / 255→63 arrays) still parse and evaluate correctly, including on the 2MiB test-thread stack the limit was measured against.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (2626 lib + 664 CLI + all integration tests, including the pinned depth-300 `jq_recurse_depth_tests` capability tests, which route deep *documents* through a path this query-text limit does not touch)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Oracle diff: realistic nested queries (`if`/`try`/`reduce`/nested literals) byte-identical to pinned jq 1.7.1, including error messages
- [x] New unit tests: over-limit unary/paren chains produce clean parse errors; at-limit chains still parse (run on the 2MiB test-thread stack)
- [x] New CLI test: 600-deep queries exit 1 with the depth-limit message, not SIGABRT/134
- [ ] `cargo llvm-cov` — not installed in this environment; the only new branches (depth-exceeded `Err` arm, wrapper path) are exercised by the new unit + CLI tests, and CI's coverage leg will verify

Fixes #1156