### PR TITLE
fix(jq): let null absorb further access inside a destructuring pattern

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24311,6 +24311,15 @@ fn extract_pattern_bindings(
     match pattern {
         Pattern::Var(name) => Ok(vec![(name.clone(), value.clone())]),
         Pattern::Object(entries) => {
+            // Real jq lets `null` absorb any further field access the same
+            // way plain `.foo` on `null` does (`null | .foo` is `null`) --
+            // every variable this pattern (and anything nested inside it)
+            // would bind resolves to `null` instead of hard-erroring (#1239).
+            if matches!(value, OwnedValue::Null) {
+                let mut names = Vec::new();
+                collect_pattern_var_names(pattern, &mut names);
+                return Ok(names.into_iter().map(|n| (n, OwnedValue::Null)).collect());
+            }
             let mut bindings = Vec::new();
             for entry in entries {
                 // jq destructures by indexing once per key, so a non-object
@@ -24332,6 +24341,13 @@ fn extract_pattern_bindings(
             Ok(bindings)
         }
         Pattern::Array(patterns) => {
+            // Same `null`-absorbs-further-access tolerance as the Object arm
+            // above, for array-shaped destructuring (#1239).
+            if matches!(value, OwnedValue::Null) {
+                let mut names = Vec::new();
+                collect_pattern_var_names(pattern, &mut names);
+                return Ok(names.into_iter().map(|n| (n, OwnedValue::Null)).collect());
+            }
             let mut bindings = Vec::new();
             for (i, pat) in patterns.iter().enumerate() {
                 // As above: one index per element position, so the error is
@@ -34551,6 +34567,44 @@ mod tests {
             QueryResult::Owned(OwnedValue::Array(vs)) => {
                 assert_eq!(vs, vec![OwnedValue::Int(5), OwnedValue::Int(5)]);
             }
+        );
+    }
+
+    #[test]
+    fn test_destructuring_object_pattern_null_propagates_through_nested_object_1239() {
+        // `.x` is absent (-> null); real jq lets that null absorb the
+        // nested `{y: $y}` destructuring instead of erroring (#1239).
+        query!(br#"{"a":1}"#, r". as {x: {y: $y}} | $y",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+    }
+
+    #[test]
+    fn test_destructuring_object_pattern_null_propagates_through_nested_array_1239() {
+        query!(br#"{"a":1}"#, r". as {x: [$y]} | $y",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+    }
+
+    #[test]
+    fn test_destructuring_object_pattern_null_binds_every_nested_var_1239() {
+        // A multi-level, multi-var nested pattern under an absent field --
+        // every variable it would have bound resolves to null, not just the
+        // first one reached.
+        query!(br#"{"a":1}"#, r". as {x: {y: $y, z: [$p, $q]}} | [$y, $p, $q]",
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs, vec![OwnedValue::Null, OwnedValue::Null, OwnedValue::Null]);
+            }
+        );
+    }
+
+    #[test]
+    fn test_destructuring_object_pattern_non_null_non_object_still_errors_1239() {
+        // Control: null-tolerance doesn't widen into general leniency -- a
+        // genuinely wrong-typed value (not null, not an object) still hard-
+        // errors, same as before this fix.
+        query!(br#"{"x":"notobj"}"#, r". as {x: {y: $y}} | $y",
+            QueryResult::Error(_) => {}
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12659,3 +12659,22 @@ fn test_as_pattern_deep_nesting_exits_cleanly_not_stack_overflow_1240() -> Resul
     assert!(err.contains("depth limit"), "err={err}");
     Ok(())
 }
+
+/// A destructuring pattern nested under an absent/null field resolves every
+/// bound variable to `null`, matching real jq, instead of hard-erroring --
+/// regression test for #1239. Mirrors the issue's own live repro exactly.
+#[test]
+fn test_destructuring_pattern_null_propagates_through_nested_object_1239() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-c", ". as {x: {y: $y}} | $y"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}
+
+#[test]
+fn test_destructuring_pattern_null_propagates_through_nested_array_1239() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-c", ". as {x: [$y]} | $y"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16149,3 +16149,14 @@ fn test_jq_urid_malformed_escape_errors_1138() -> Result<()> {
     );
     Ok(())
 }
+
+/// #1239: destructuring under yq shares `extract_pattern_bindings` with jq
+/// mode, so the same null-propagation fix applies here too -- a nested
+/// pattern under an absent field resolves to `null` instead of erroring.
+#[test]
+fn test_destructuring_pattern_null_propagates_through_nested_object_1239() -> Result<()> {
+    let (out, code) = run_yq_stdin(". as {x: {y: $y}} | $y", "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `extract_pattern_bindings`'s `Object`/`Array` arms (`src/jq/eval.rs`) treated any non-container value as a hard type mismatch — including `Null`. Every other indexing path in this codebase already lets `null` absorb further field/index access the same way `null | .foo` does (plain field access, assignment autovivification #486, `del()` #476) — this one path never got the same treatment.
- A destructuring pattern nested under a field that's absent (defaults to `null`) or explicitly `null` hard-errored instead of resolving every variable it would have bound to `null`, matching real jq.

```
$ echo '{"a":1}' | jq -c '. as {x: {y: $y}} | $y'
null
$ echo '{"a":1}' | succinctly jq -c '. as {x: {y: $y}} | $y'
jq: error (at <stdin>:1): Cannot index null with string "y"
```
(same divergence for array-shaped nesting, `. as {x: [$y]} | $y`)

## Fix

Added a `null` check to both the `Object` and `Array` arms: when the value being destructured is `null`, walk the pattern with `collect_pattern_var_names` (already used elsewhere in this file) and bind every name it finds to `null`, instead of trying to index into a container that isn't there. A genuinely wrong-typed value (not `null`, not a container) still hard-errors exactly as before — this doesn't widen into general leniency.

Verified live against jq 1.7.1 for both repro shapes, and confirmed the fix applies uniformly in yq mode too, since destructuring shares this exact function across both parsers.

Fixes #1239

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] Live-verified against real jq 1.7.1 (both repro cases) and against the yq CLI