### PR TITLE
refactor(cli): consolidate #1163's validate-and-discard pattern in main.rs

### DIFF
--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1293,14 +1293,20 @@ fn main() -> Result<()> {
                     args.escape_density,
                 );
 
-                if args.verify {
-                    serde_json::from_str::<serde_json::Value>(&json)
+                let verified_parse = if args.verify {
+                    let parsed = validate_generated_json(&json, args.pretty)
                         .context("Generated invalid JSON")?;
                     eprintln!("✓ JSON validated successfully");
-                }
+                    parsed
+                } else {
+                    None
+                };
 
                 let output = if args.pretty {
-                    let value: serde_json::Value = serde_json::from_str(&json)?;
+                    let value = match verified_parse {
+                        Some(v) => v,
+                        None => serde_json::from_str(&json)?,
+                    };
                     serde_json::to_string_pretty(&value)?
                 } else {
                     json
@@ -1834,6 +1840,19 @@ const SUITE_SIZES: &[(&str, usize)] = &[
     ("1gb", 1024 * 1024 * 1024),
 ];
 
+/// Validates that self-generated `json` is well-formed, via `serde_json::Value` --
+/// shared by `json generate --verify` and `json generate-suite --verify`'s own
+/// generator-self-check (#1212, following #1163's identical consolidation for
+/// `jq_runner.rs`'s CLI-arg validation). Neither caller wants the parsed tree for its
+/// own sake (both are checking "did the generator itself produce valid JSON", not
+/// materializing a value) -- but `generate --verify --pretty` needs to immediately
+/// re-parse the same string to pretty-print it, so `keep_parsed` lets that one caller
+/// reuse this validation pass's own parse instead of paying for a second one.
+fn validate_generated_json(json: &str, keep_parsed: bool) -> Result<Option<serde_json::Value>> {
+    let value: serde_json::Value = serde_json::from_str(json)?;
+    Ok(keep_parsed.then_some(value))
+}
+
 fn generate_json_suite(args: GenerateSuite) -> Result<()> {
     let output_dir = &args.output_dir;
 
@@ -1881,7 +1900,7 @@ fn generate_json_suite(args: GenerateSuite) -> Result<()> {
             let json = generate_json(*size, *pattern, Some(seed), 5, 0.1);
 
             if args.verify {
-                serde_json::from_str::<serde_json::Value>(&json)
+                validate_generated_json(&json, false)
                     .with_context(|| format!("Generated invalid JSON for {}", path.display()))?;
             }
 

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -4,7 +4,7 @@
 //! Run with: cargo test --features cli --test cli_golden_tests
 
 use anyhow::Result;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
 /// Maximum retries for cargo run commands that fail with exit code 101.
@@ -345,5 +345,90 @@ fn test_json_generate_reproducible() -> Result<()> {
         "Different seed should produce different output"
     );
 
+    Ok(())
+}
+
+/// Runs the pre-built `succinctly` binary directly (unlike `run_cli` above, which
+/// spawns a second, uninstrumented binary via `cargo run` and so is invisible to
+/// `cargo llvm-cov`) -- needed for #1212's own coverage, since its
+/// `validate_generated_json` consolidation and both call sites are otherwise
+/// unexercised by any existing test in this file.
+fn run_cli_bin(args: &[&str]) -> Result<(String, String, i32)> {
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    Ok((stdout, stderr, exit_code))
+}
+
+/// #1212: `--verify` alone validates and discards the parsed tree (the
+/// `keep_parsed = false` path through `validate_generated_json`).
+#[test]
+fn test_json_generate_verify_only_1212() -> Result<()> {
+    let (stdout, stderr, code) = run_cli_bin(&["json", "generate", "1kb", "--verify"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stderr.contains("JSON validated successfully"), "{stderr}");
+    // No --pretty, no -o: output goes to stdout unmodified.
+    serde_json::from_str::<serde_json::Value>(stdout.trim())?;
+    Ok(())
+}
+
+/// #1212: `--pretty` alone (no `--verify`) takes the `None` arm of
+/// `validate_generated_json`'s reuse match -- its own independent parse, not the
+/// validation pass's (there is none).
+#[test]
+fn test_json_generate_pretty_only_1212() -> Result<()> {
+    let (stdout, stderr, code) = run_cli_bin(&["json", "generate", "1kb", "--pretty"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(!stderr.contains("validated"), "{stderr}");
+    assert!(
+        stdout.starts_with("{\n"),
+        "expected pretty-printed JSON, got: {stdout:?}"
+    );
+    serde_json::from_str::<serde_json::Value>(&stdout)?;
+    Ok(())
+}
+
+/// #1212: `--verify --pretty` together is the one combination that reuses
+/// `validate_generated_json`'s own parsed tree (`keep_parsed = true`, the `Some`
+/// arm) instead of parsing the generated JSON a second time.
+#[test]
+fn test_json_generate_verify_and_pretty_1212() -> Result<()> {
+    let (stdout, stderr, code) = run_cli_bin(&["json", "generate", "1kb", "--verify", "--pretty"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stderr.contains("JSON validated successfully"), "{stderr}");
+    assert!(
+        stdout.starts_with("{\n"),
+        "expected pretty-printed JSON, got: {stdout:?}"
+    );
+    serde_json::from_str::<serde_json::Value>(&stdout)?;
+    Ok(())
+}
+
+/// #1212: `generate-suite --verify`'s own, separately-worded call site
+/// (`validate_generated_json(&json, false)` with a per-file error context) --
+/// keeps everything within `--max-size` tiny so the suite finishes quickly.
+#[test]
+fn test_json_generate_suite_verify_1212() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (_, stderr, code) = run_cli_bin(&[
+        "json",
+        "generate-suite",
+        "--verify",
+        "--max-size",
+        "2kb",
+        "--output-dir",
+        dir.path().to_str().expect("tempdir path is valid UTF-8"),
+    ])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(
+        stderr.contains("All files validated successfully"),
+        "{stderr}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

`json generate --verify` and `json generate-suite --verify` both had their
own copy of the same "parse via `serde_json::Value` purely to check
validity, discard the tree" shape #1163 already consolidated for
`jq_runner.rs`'s CLI-arg validation. Consolidated into a shared
`validate_generated_json` helper.

`json generate --verify --pretty` also previously parsed the same
self-generated string **twice** — once to validate, once (unconditionally,
whenever `--pretty` was set) to build the pretty-printed output — whenever
both flags were combined. `validate_generated_json`'s `keep_parsed` flag
lets that one call site reuse the validation pass's own parse instead of
paying for a second one.

## Scope

No known bug — pure DRY/efficiency follow-up, matching #1163's own
severity/framing. Every other flag combination (`--verify` alone,
`--pretty` alone, neither, and `generate-suite`'s own per-file verify)
keeps its exact existing behavior and error-message wording unchanged.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Manual CLI verification across every flag combination (`--verify`, `--pretty`, `--verify --pretty`, neither, `generate-suite --verify`)
- [x] Added 4 new coverage-visible CLI tests (the existing `cli_golden_tests.rs` helper spawns a second binary via `cargo run`, invisible to `cargo llvm-cov`, so this refactor had zero patch coverage without them)
- [x] Patch coverage 100% (12/12 new lines)

Fixes #1212