### PR TITLE
fix(jq): large literals preserve full precision, pick jq's real notation

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -523,15 +523,20 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String
     // already scans every byte of `s` once.
     //
     // Real jq preserves a literal's full given precision unconditionally --
-    // oracle-verified exact round-trips up to 100,000 significant digits
-    // (#1253) -- so this is a defensive bound against a pathological
-    // document-controlled literal (a multi-megabyte mantissa), not a
-    // correctness ceiling: raised from an earlier `32` (chosen for the
+    // oracle-verified exact round-trips up to exactly this many significant
+    // digits (#1253; raised from an earlier `32`, which was chosen for the
     // overflow/near-zero paths specifically, then silently inherited by
     // every other caller once #1206 routed the ordinary scientific-notation
-    // case through this same function -- #1253) to comfortably exceed any
-    // realistic literal's own precision.
-    const MAX_RENDERED_MANTISSA_DIGITS: usize = 1000;
+    // case through this same function). This *is* still a cap, not a proven
+    // ceiling: a literal with more true significant digits than this still
+    // renders truncated rather than erroring, exactly as it did at the old
+    // `32` -- code review on #1253 confirmed the truncation is silent, not
+    // that raising the number removes it. Set to what this session actually
+    // verified against pinned jq 1.7.1, not a round number chosen past it,
+    // so the constant and the oracle claim it rests on can't drift apart
+    // again the way `32` (tuned for a different use case entirely) drifted
+    // from the fidelity the ordinary case actually needs.
+    const MAX_RENDERED_MANTISSA_DIGITS: usize = 100_000;
 
     let (int_part, frac_part) = split_mantissa(s, exp_pos);
 
@@ -569,8 +574,7 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String
         // integer-part digit. `int_part[1..]` is a slice (no copy); only
         // what actually gets concatenated into `rest` is capped.
         let after_leading = &int_part[1..];
-        let digit_count =
-            i64::try_from(after_leading.len() + 1 + frac_part.len()).unwrap_or(i64::MAX);
+        let digit_count = i64::try_from(int_part.len() + frac_part.len()).unwrap_or(i64::MAX);
         let rest = if after_leading.len() >= MAX_RENDERED_MANTISSA_DIGITS {
             after_leading[..MAX_RENDERED_MANTISSA_DIGITS].to_string()
         } else {
@@ -613,7 +617,8 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // A mantissa of exactly `0` times any exponent is still exactly `0.0`,
     // never `+/-infinity` -- callers only reach this function when `value`
     // has already overflowed, which guarantees a nonzero mantissa.
-    let Ok((mantissa_str, new_exp, _)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
+    let Ok((mantissa_str, new_exp, digit_count)) = normalize_extreme_literal_mantissa(s, exp_pos)
+    else {
         unreachable!("overflow implies a nonzero mantissa")
     };
 
@@ -623,6 +628,23 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // `1e1000000000` switches to DBL_MAX text instead.
     if new_exp.unsigned_abs() >= 1_000_000_000 {
         return infinite_float_preview_text(negative).to_string();
+    }
+
+    // #1244's plain-vs-scientific digit-count rule (see
+    // `format_number_jq_compat`'s own use of it) applies here too, not just
+    // to the non-overflow path -- an overflowed *value* (this function's
+    // whole reason for existing) doesn't mean the *literal* lacks enough
+    // given digits to stay plain: `"9".repeat(400) + "e0"` overflows `f64`
+    // (400 nines vastly exceeds `f64::MAX`), yet real jq still renders it
+    // as a plain 400-digit integer, not scientific notation, because all
+    // 400 significant digits were given (`shifted_exp` 399 `<` `digit_count`
+    // 400) -- oracle-verified, code review on #1253.
+    if new_exp > 0 {
+        if let Some(plain) =
+            format_positive_shifted_plain(sign, &mantissa_str, new_exp, digit_count)
+        {
+            return plain;
+        }
     }
 
     assemble_scientific(sign, &mantissa_str, new_exp)
@@ -723,11 +745,7 @@ fn format_near_zero_literal(s: &str, exp_pos: usize, negative: bool) -> String {
 fn format_shifted_mantissa(sign: &str, mantissa_str: &str, shifted_exp: i64) -> String {
     let (leading, rest) = mantissa_str.split_once('.').unwrap_or((mantissa_str, ""));
     if shifted_exp == 0 {
-        return if rest.is_empty() {
-            format!("{sign}{leading}")
-        } else {
-            format!("{sign}{leading}.{rest}")
-        };
+        return join_sign_digits_with_optional_point(sign, leading, rest);
     }
     debug_assert!(
         (-6..=-1).contains(&shifted_exp),
@@ -737,6 +755,21 @@ fn format_shifted_mantissa(sign: &str, mantissa_str: &str, shifted_exp: i64) -> 
     format!("{sign}0.{}{leading}{rest}", "0".repeat(zero_pad))
 }
 
+/// Join a sign and a digit string split at the decimal point, omitting the
+/// point entirely when nothing follows it -- shared by
+/// [`format_shifted_mantissa`]'s `shifted_exp == 0` arm and
+/// [`format_positive_shifted_plain`] below, which both need to decide
+/// between a bare integer (`123`) and a decimal (`123.45`) from the same
+/// `(before, after)` split, so the two can't independently drift on how an
+/// empty fractional remainder is spelled (#106, code review).
+fn join_sign_digits_with_optional_point(sign: &str, before: &str, after: &str) -> String {
+    if after.is_empty() {
+        format!("{sign}{before}")
+    } else {
+        format!("{sign}{before}.{after}")
+    }
+}
+
 /// Render a nonzero literal's normalized mantissa in plain (non-scientific)
 /// decimal form for a *positive* shifted exponent (#1244), when the
 /// literal's own given significant digits (`digit_count`) are enough to
@@ -744,19 +777,25 @@ fn format_shifted_mantissa(sign: &str, mantissa_str: &str, shifted_exp: i64) -> 
 /// trailing digit -- i.e. `shifted_exp < digit_count`, oracle-verified
 /// against jq 1.7.1 as the exact condition real jq itself uses. Returns
 /// `None` when that condition doesn't hold (caller falls back to
-/// scientific notation), and also -- rarely -- when `mantissa_str` was
-/// itself already truncated by `normalize_extreme_literal_mantissa`'s
-/// render cap short of the digit `shifted_exp` needs to place the decimal
-/// point: a bounded-cost divergence from real jq for a literal whose true
-/// digit count so vastly exceeds the cap that even a truncated plain
-/// rendering isn't recoverable; no realistic literal hits this second case.
+/// scientific notation).
 ///
-/// `mantissa_str` is `"d"` or `"d.ddd"` (one leading digit, `normalize_extreme_literal_mantissa`'s
-/// normalized form) -- concatenating its digits and re-inserting the
-/// decimal point `shifted_exp + 1` places in gives the value's natural,
-/// un-normalized digit layout (`"1.20000000000"` at shifted exponent `9`
-/// re-splits to `"1200000000.00"`, matching real jq's own
-/// `120000000000e-2` -> `1200000000.00`).
+/// The `split_pos > digits.len()` check below is a second, independent
+/// guard against `mantissa_str` having been truncated by
+/// `normalize_extreme_literal_mantissa`'s own render cap short of the digit
+/// `shifted_exp` needs to place the decimal point at -- provably
+/// unreachable *today* (a `shifted_exp` this function ever sees is bounded
+/// by a finite `f64`'s own representable magnitude, ~308, far below the
+/// render cap), so no live literal takes this branch; it exists as a safety
+/// net against a future, much smaller render cap rather than a case this
+/// code currently handles (code review, #1253).
+///
+/// `mantissa_str` is `"d"` or `"d.ddd"` (one leading digit,
+/// `normalize_extreme_literal_mantissa`'s normalized form) -- concatenating
+/// its digits and re-inserting the decimal point `shifted_exp + 1` places
+/// in gives the value's natural, un-normalized digit layout
+/// (`"1.20000000000"` at shifted exponent `9` re-splits to
+/// `"1200000000.00"`, matching real jq's own `120000000000e-2` ->
+/// `1200000000.00`).
 fn format_positive_shifted_plain(
     sign: &str,
     mantissa_str: &str,
@@ -770,17 +809,14 @@ fn format_positive_shifted_plain(
     if shifted_exp >= digit_count {
         return None;
     }
-    let digits: String = mantissa_str.chars().filter(|&c| c != '.').collect();
+    let (leading, rest) = mantissa_str.split_once('.').unwrap_or((mantissa_str, ""));
+    let digits = format!("{leading}{rest}");
     let split_pos = usize::try_from(shifted_exp + 1).ok()?;
     if split_pos > digits.len() {
         return None;
     }
     let (before, after) = digits.split_at(split_pos);
-    Some(if after.is_empty() {
-        format!("{sign}{before}")
-    } else {
-        format!("{sign}{before}.{after}")
-    })
+    Some(join_sign_digits_with_optional_point(sign, before, after))
 }
 
 /// An owned JSON value.
@@ -2861,11 +2897,17 @@ mod tests {
     /// #930 review: an overflowed literal's mantissa can be arbitrarily long
     /// (it's document-controlled text) - rendering the *whole* thing would
     /// be unbounded work for a pathological input, so
-    /// `MAX_RENDERED_MANTISSA_DIGITS` (#1253: raised from `32` to `1000`,
-    /// since real jq itself preserves full literal precision unconditionally
-    /// -- oracle-verified up to 100,000 significant digits, so `32` was
-    /// never a correctness boundary, only ever a defensive one) still caps
-    /// the copy. Pins that the leading digits (and thus the exponent, which
+    /// `MAX_RENDERED_MANTISSA_DIGITS` (#1253: raised from `32` to
+    /// `100_000` -- matching exactly what this session verified against
+    /// pinned jq 1.7.1, not a round number chosen past it; still a cap, not
+    /// a proven ceiling) caps the copy. This literal's own digit count
+    /// (2,000,001) still exceeds even the raised cap, and its shifted
+    /// exponent (2,000,399) still exceeds its own digit count either way,
+    /// so it stays on the scientific path (`format_positive_shifted_plain`,
+    /// #1244's own fix, correctly declines and falls through here -- see
+    /// `test_format_number_jq_compat_overflow_huge_mantissa_stays_plain_when_digits_cover_it_1244`
+    /// for the sibling case where the *same* overflow path picks plain
+    /// instead). Pins that the leading digits (and thus the exponent, which
     /// is unaffected either way) stay correct, and that the rendered text
     /// itself is bounded rather than millions of bytes long.
     #[test]
@@ -2873,20 +2915,23 @@ mod tests {
         let mantissa = "9".repeat(2_000_000);
         let literal = format!("{mantissa}.5e400");
         let result = format_number_jq_compat(literal.as_bytes());
-        let expected_prefix = format!("9.{}", "9".repeat(1000));
+        let expected_prefix = format!("9.{}", "9".repeat(100_000));
         assert!(
             result.starts_with(&expected_prefix),
-            "leading digits must still be correct: {result}"
+            "leading digits must still be correct (first/last 40 shown): {}...{}",
+            &result[..40.min(result.len())],
+            &result[result.len().saturating_sub(40)..]
         );
         // The exponent shift (mantissa.len() - 1) is unaffected by the
         // rendering cap - only how many digits after the leading one get
         // copied into the output text.
         assert!(
             result.ends_with("E+2000399"),
-            "exponent must reflect the mantissa's true (uncapped) length: {result}"
+            "exponent must reflect the mantissa's true (uncapped) length, last 20 chars: {}",
+            &result[result.len().saturating_sub(20)..]
         );
         assert!(
-            result.len() < 2000,
+            result.len() < 200_000,
             "must not render anywhere near the full 2,000,000-digit mantissa: got {} bytes",
             result.len()
         );
@@ -3167,6 +3212,31 @@ mod tests {
         assert_eq!(
             format_number_jq_compat(b"1.234567890123456789012345678901234567890123e50"),
             "1.234567890123456789012345678901234567890123E+50"
+        );
+    }
+
+    /// #1253 review: `format_positive_shifted_plain`'s `shifted_exp <
+    /// digit_count` rule was originally wired into `format_number_jq_compat`
+    /// only, leaving `format_overflow_literal_mantissa` -- reached once the
+    /// literal's own magnitude already overflows `f64` -- unconditionally
+    /// scientific regardless of digit count. An overflowed *value* doesn't
+    /// mean the *literal* lacks enough given digits to stay plain: 400
+    /// given nines is itself an `f64` overflow (`9e399` alone already
+    /// exceeds `f64::MAX`), yet real jq still renders every one of those
+    /// 400 given digits plainly, since `shifted_exp` (399) is still less
+    /// than `digit_count` (400) -- oracle-verified against jq 1.7.1.
+    #[test]
+    fn test_format_number_jq_compat_overflow_huge_mantissa_stays_plain_when_digits_cover_it_1244() {
+        let mantissa = "9".repeat(400);
+        assert_eq!(
+            format_number_jq_compat(format!("{mantissa}e0").as_bytes()),
+            mantissa
+        );
+        // One digit short of covering the shift: falls back to scientific,
+        // same as the non-overflow path's own boundary (#1244).
+        assert_eq!(
+            format_number_jq_compat(format!("{mantissa}e1").as_bytes()),
+            format!("9.{}E+400", "9".repeat(399))
         );
     }
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -352,23 +352,37 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // significant mantissa digit, so this always succeeds -- the same
     // invariant `format_overflow_literal_mantissa` relies on for its own
     // `unreachable!()`.
-    let Ok((mantissa_str, shifted_exp)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
+    let Ok((mantissa_str, shifted_exp, digit_count)) =
+        normalize_extreme_literal_mantissa(s, exp_pos)
+    else {
         unreachable!("nonzero value implies normalize_extreme_literal_mantissa succeeds")
     };
+    let sign = if value.is_sign_negative() { "-" } else { "" };
     if shifted_exp == 0 || (-6..=-1).contains(&shifted_exp) {
-        let sign = if value.is_sign_negative() { "-" } else { "" };
         return format_shifted_mantissa(sign, &mantissa_str, shifted_exp);
     }
 
-    // Positive shifted exponents deliberately fall straight through to the
-    // scientific path below unconditionally (#1226 only widened the
-    // *negative*-side window above) -- live testing while implementing
-    // #1226 found the positive side does *not* follow a comparably simple
-    // exponent-window rule (`500000e-1`, shifted exponent 4, real jq keeps
-    // plain decimal `50000.0`; `99999999999999e1`, shifted exponent 14,
-    // goes scientific) -- tracked separately as #1244, not attempted here.
-    //
-    // For every other case (a shifted exponent outside `-6..=0`), use
+    // #1244: a *positive* shifted exponent doesn't follow a comparably
+    // simple window to the negative side above -- real jq keeps plain
+    // decimal notation whenever the literal's own given significant digits
+    // are enough to cover the value's whole integer part without implying
+    // extra unstated trailing zeros (`500000e-1`, shifted exponent 4 but 6
+    // given digits, stays plain `50000.0`), and only switches to scientific
+    // once the shift would need to fabricate digits past what was given
+    // (`99999999999999e1`, shifted exponent 14 but only 14 given digits --
+    // one short -- goes scientific `9.9999999999999E+14`). `shifted_exp <
+    // digit_count` is exactly that condition (oracle-verified against jq
+    // 1.7.1 across a broad randomized/boundary sweep, both signs).
+    if shifted_exp > 0 {
+        if let Some(plain) =
+            format_positive_shifted_plain(sign, &mantissa_str, shifted_exp, digit_count)
+        {
+            return plain;
+        }
+    }
+
+    // For every other case (a shifted exponent outside `-6..=0` that isn't
+    // plain-eligible above), use
     // normalized scientific notation -- jq normalizes the mantissa to have
     // exactly one digit before the decimal point, which `mantissa_str`
     // computed above already is.
@@ -402,11 +416,7 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // pow()-underflowed zero -- see git history); now that this path is
     // string-based too, subnormal and normal magnitudes take the identical
     // call with no separate handling needed (code review, #1206).
-    assemble_scientific(
-        if value.is_sign_negative() { "-" } else { "" },
-        &mantissa_str,
-        shifted_exp,
-    )
+    assemble_scientific(sign, &mantissa_str, shifted_exp)
 }
 
 /// jq mode's bare `Float` display: no forced decimal point, matching real
@@ -471,11 +481,17 @@ fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
 /// Shift a literal's own mantissa digits (the text before `exp_pos`, i.e.
 /// before `e`/`E`) into jq's one-digit-before-the-point normalized form,
 /// and fold that shift into the literal's own written exponent -- returns
-/// `Ok((mantissa_str, new_exp))`, or `Err(frac_len)` if the mantissa is
-/// genuinely all-zero (`0.0e400`, `0.00e-400`), which has no magnitude to
-/// normalize against (`frac_len` is the fractional-digit count the `Err`
-/// caller needs for its own shift math, #1207 -- surfaced here rather than
-/// re-derived by every `Err` caller via a second `split_mantissa` call).
+/// `Ok((mantissa_str, new_exp, digit_count))`, or `Err(frac_len)` if the
+/// mantissa is genuinely all-zero (`0.0e400`, `0.00e-400`), which has no
+/// magnitude to normalize against (`frac_len` is the fractional-digit count
+/// the `Err` caller needs for its own shift math, #1207 -- surfaced here
+/// rather than re-derived by every `Err` caller via a second
+/// `split_mantissa` call). `digit_count` is the mantissa's *true* (never
+/// truncated -- see `MAX_RENDERED_MANTISSA_DIGITS` below) significant-digit
+/// count, needed by `format_number_jq_compat`'s own plain-vs-scientific
+/// notation choice for a positive shifted exponent (#1244); it costs
+/// nothing extra to compute (`str::len()` is O(1)), so it's returned
+/// unconditionally rather than only on request.
 /// Entirely via string manipulation on `s` rather than `log10`/`pow` on the
 /// parsed value, since the caller only reaches here when the parsed value
 /// has already lost the precision this exists to recover (`+/-infinity` on
@@ -492,21 +508,30 @@ fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
 /// pre-checked separately by each caller, so "is this mantissa all-zero"
 /// has exactly one implementation instead of two that must be kept in sync
 /// by convention (#106).
-fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String, i64), i64> {
+fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String, i64, i64), i64> {
     // `dump_truncated`'s whole design keeps preview cost independent of the
     // value's own size (see its doc comment) - a document-controlled
-    // mantissa of unbounded length must not turn into unbounded work here
-    // just because only a handful of its leading digits will ever survive
-    // that later truncation anyway. Bounding the *copy* is enough: `shift`
-    // below only ever needs `int_part.len()` (an O(1) property read once
-    // leading zeros are trimmed -- the `trim_start_matches('0')` just below
-    // is itself an O(k) scan over any leading-zero run, #1180), so
-    // truncating what gets copied into `rest` doesn't touch the exponent
-    // math's correctness, only how many digits past the first one actually
-    // get rendered. The trim doesn't change the function's overall cost
-    // class either way: `format_number_jq_compat`'s own `s.parse::<f64>()`
-    // ahead of this call already scans every byte of `s` once.
-    const MAX_RENDERED_MANTISSA_DIGITS: usize = 32;
+    // mantissa of unbounded length must not turn into unbounded work here.
+    // Bounding the *copy* is enough: `shift` below only ever needs
+    // `int_part.len()` (an O(1) property read once leading zeros are
+    // trimmed -- the `trim_start_matches('0')` just below is itself an O(k)
+    // scan over any leading-zero run, #1180), so truncating what gets
+    // copied into `rest` doesn't touch the exponent math's correctness,
+    // only how many digits past the first one actually get rendered. The
+    // trim doesn't change the function's overall cost class either way:
+    // `format_number_jq_compat`'s own `s.parse::<f64>()` ahead of this call
+    // already scans every byte of `s` once.
+    //
+    // Real jq preserves a literal's full given precision unconditionally --
+    // oracle-verified exact round-trips up to 100,000 significant digits
+    // (#1253) -- so this is a defensive bound against a pathological
+    // document-controlled literal (a multi-megabyte mantissa), not a
+    // correctness ceiling: raised from an earlier `32` (chosen for the
+    // overflow/near-zero paths specifically, then silently inherited by
+    // every other caller once #1206 routed the ordinary scientific-notation
+    // case through this same function -- #1253) to comfortably exceed any
+    // realistic literal's own precision.
+    const MAX_RENDERED_MANTISSA_DIGITS: usize = 1000;
 
     let (int_part, frac_part) = split_mantissa(s, exp_pos);
 
@@ -518,7 +543,7 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String
     // way -- both fall into the magnitude-< 1 branch below.
     let int_part = int_part.trim_start_matches('0');
 
-    let (shift, leading, rest): (i64, &str, String) = if int_part.is_empty() {
+    let (shift, leading, rest, digit_count): (i64, &str, String, i64) = if int_part.is_empty() {
         // Shift right to the first nonzero fractional digit. Genuinely
         // all-zero mantissa (`0.0e400`/`0.0e-400`) has no nonzero digit to
         // shift to -- return `Err(frac_len)` instead, `frac_part.len()` is
@@ -532,16 +557,20 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String
             return Err(i64::try_from(frac_part.len()).unwrap_or(i64::MAX));
         };
         let after = &frac_part[k + 1..];
+        let digit_count = i64::try_from(after.len() + 1).unwrap_or(i64::MAX);
         (
             -(k as i64 + 1),
             &frac_part[k..=k],
             after[..after.len().min(MAX_RENDERED_MANTISSA_DIGITS)].to_string(),
+            digit_count,
         )
     } else {
         // Mantissa >= 1: shift left past every extra significant
         // integer-part digit. `int_part[1..]` is a slice (no copy); only
         // what actually gets concatenated into `rest` is capped.
         let after_leading = &int_part[1..];
+        let digit_count =
+            i64::try_from(after_leading.len() + 1 + frac_part.len()).unwrap_or(i64::MAX);
         let rest = if after_leading.len() >= MAX_RENDERED_MANTISSA_DIGITS {
             after_leading[..MAX_RENDERED_MANTISSA_DIGITS].to_string()
         } else {
@@ -551,7 +580,7 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String
                 &frac_part[..frac_part.len().min(budget)]
             )
         };
-        (int_part.len() as i64 - 1, &int_part[..1], rest)
+        (int_part.len() as i64 - 1, &int_part[..1], rest, digit_count)
     };
 
     let parsed_exp = parse_literal_exponent(&s[exp_pos + 1..]);
@@ -562,7 +591,7 @@ fn normalize_extreme_literal_mantissa(s: &str, exp_pos: usize) -> Result<(String
     } else {
         format!("{leading}.{rest}")
     };
-    Ok((mantissa_str, new_exp))
+    Ok((mantissa_str, new_exp, digit_count))
 }
 
 /// Renormalize an overflowed literal's own mantissa digits into jq's
@@ -584,7 +613,7 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // A mantissa of exactly `0` times any exponent is still exactly `0.0`,
     // never `+/-infinity` -- callers only reach this function when `value`
     // has already overflowed, which guarantees a nonzero mantissa.
-    let Ok((mantissa_str, new_exp)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
+    let Ok((mantissa_str, new_exp, _)) = normalize_extreme_literal_mantissa(s, exp_pos) else {
         unreachable!("overflow implies a nonzero mantissa")
     };
 
@@ -653,7 +682,7 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
 fn format_near_zero_literal(s: &str, exp_pos: usize, negative: bool) -> String {
     let sign = if negative { "-" } else { "" };
     match normalize_extreme_literal_mantissa(s, exp_pos) {
-        Ok((mantissa_str, new_exp)) => assemble_scientific(sign, &mantissa_str, new_exp),
+        Ok((mantissa_str, new_exp, _)) => assemble_scientific(sign, &mantissa_str, new_exp),
         Err(frac_len) => {
             let shifted_exp = parse_literal_exponent(&s[exp_pos + 1..]).saturating_sub(frac_len);
             if shifted_exp == 0 {
@@ -706,6 +735,52 @@ fn format_shifted_mantissa(sign: &str, mantissa_str: &str, shifted_exp: i64) -> 
     );
     let zero_pad = usize::try_from(-shifted_exp - 1).unwrap_or(0);
     format!("{sign}0.{}{leading}{rest}", "0".repeat(zero_pad))
+}
+
+/// Render a nonzero literal's normalized mantissa in plain (non-scientific)
+/// decimal form for a *positive* shifted exponent (#1244), when the
+/// literal's own given significant digits (`digit_count`) are enough to
+/// cover the value's whole integer part without fabricating an unstated
+/// trailing digit -- i.e. `shifted_exp < digit_count`, oracle-verified
+/// against jq 1.7.1 as the exact condition real jq itself uses. Returns
+/// `None` when that condition doesn't hold (caller falls back to
+/// scientific notation), and also -- rarely -- when `mantissa_str` was
+/// itself already truncated by `normalize_extreme_literal_mantissa`'s
+/// render cap short of the digit `shifted_exp` needs to place the decimal
+/// point: a bounded-cost divergence from real jq for a literal whose true
+/// digit count so vastly exceeds the cap that even a truncated plain
+/// rendering isn't recoverable; no realistic literal hits this second case.
+///
+/// `mantissa_str` is `"d"` or `"d.ddd"` (one leading digit, `normalize_extreme_literal_mantissa`'s
+/// normalized form) -- concatenating its digits and re-inserting the
+/// decimal point `shifted_exp + 1` places in gives the value's natural,
+/// un-normalized digit layout (`"1.20000000000"` at shifted exponent `9`
+/// re-splits to `"1200000000.00"`, matching real jq's own
+/// `120000000000e-2` -> `1200000000.00`).
+fn format_positive_shifted_plain(
+    sign: &str,
+    mantissa_str: &str,
+    shifted_exp: i64,
+    digit_count: i64,
+) -> Option<String> {
+    debug_assert!(
+        shifted_exp > 0,
+        "caller only reaches here for a positive shifted exponent, got {shifted_exp}"
+    );
+    if shifted_exp >= digit_count {
+        return None;
+    }
+    let digits: String = mantissa_str.chars().filter(|&c| c != '.').collect();
+    let split_pos = usize::try_from(shifted_exp + 1).ok()?;
+    if split_pos > digits.len() {
+        return None;
+    }
+    let (before, after) = digits.split_at(split_pos);
+    Some(if after.is_empty() {
+        format!("{sign}{before}")
+    } else {
+        format!("{sign}{before}.{after}")
+    })
 }
 
 /// An owned JSON value.
@@ -2784,19 +2859,21 @@ mod tests {
     }
 
     /// #930 review: an overflowed literal's mantissa can be arbitrarily long
-    /// (it's document-controlled text), but only a handful of its leading
-    /// digits ever survive `dump_truncated`'s later preview truncation - so
-    /// rendering the *whole* mantissa here, only to throw almost all of it
-    /// away one call up, would be unbounded work for no visible benefit.
-    /// Pins that the leading digits (and thus the exponent, which is
-    /// unaffected either way) stay correct, and that the rendered text
+    /// (it's document-controlled text) - rendering the *whole* thing would
+    /// be unbounded work for a pathological input, so
+    /// `MAX_RENDERED_MANTISSA_DIGITS` (#1253: raised from `32` to `1000`,
+    /// since real jq itself preserves full literal precision unconditionally
+    /// -- oracle-verified up to 100,000 significant digits, so `32` was
+    /// never a correctness boundary, only ever a defensive one) still caps
+    /// the copy. Pins that the leading digits (and thus the exponent, which
+    /// is unaffected either way) stay correct, and that the rendered text
     /// itself is bounded rather than millions of bytes long.
     #[test]
     fn test_format_number_jq_compat_overflow_huge_mantissa_is_bounded() {
         let mantissa = "9".repeat(2_000_000);
         let literal = format!("{mantissa}.5e400");
         let result = format_number_jq_compat(literal.as_bytes());
-        let expected_prefix = format!("9.{}", "9".repeat(32));
+        let expected_prefix = format!("9.{}", "9".repeat(1000));
         assert!(
             result.starts_with(&expected_prefix),
             "leading digits must still be correct: {result}"
@@ -2809,7 +2886,7 @@ mod tests {
             "exponent must reflect the mantissa's true (uncapped) length: {result}"
         );
         assert!(
-            result.len() < 100,
+            result.len() < 2000,
             "must not render anywhere near the full 2,000,000-digit mantissa: got {} bytes",
             result.len()
         );
@@ -3044,28 +3121,53 @@ mod tests {
         );
     }
 
-    /// #1244 characterization: a large positive-magnitude literal's
-    /// notation choice depends on real jq's own significant-digit count,
-    /// not a simple exponent window the way the negative side (#1226) does
-    /// -- confirmed out of #1226's own scope, tracked separately. Pins the
-    /// current (still-wrong *notation*, unaffected either way by #1226)
-    /// output rather than leaving it undocumented. Oracle: real jq gives
-    /// `50000.0`. If this is ever fixed, update this expectation and close
-    /// #1244.
-    ///
-    /// The expected *mantissa digits* changed under #1206 (was `5E+4`, now
-    /// `5.00000E+4`): #1206 fixed the unrelated, previously-buggy
-    /// f64-arithmetic mantissa rendering this scientific-notation path used
-    /// (silently trimming trailing zeros) in favor of the source-digit-
-    /// preserving one `format_overflow_literal_mantissa`/
-    /// `format_near_zero_literal` already used -- this literal's own
-    /// mantissa (`500000`) has 5 trailing zeros that now correctly survive,
-    /// even though the notation choice itself (scientific vs. #1244's
-    /// expected plain decimal) is untouched by that fix.
+    /// #1244: a large positive-magnitude literal's plain-vs-scientific
+    /// notation choice depends on real jq's own significant-digit count
+    /// (`shifted_exp < digit_count`), not a simple exponent window the way
+    /// the negative side (#1226) does. Both of this issue's own
+    /// oracle-verified repros: `500000e-1` (shifted exponent `4`, but `6`
+    /// given digits -- stays plain) and `99999999999999e1` (shifted
+    /// exponent `14`, but only `14` given digits -- one short, goes
+    /// scientific).
     #[test]
-    fn test_format_number_jq_compat_large_positive_shifted_exponent_characterize_preexisting_bug_1244(
-    ) {
-        assert_eq!(format_number_jq_compat(b"500000e-1"), "5.00000E+4");
+    fn test_format_number_jq_compat_positive_shifted_exponent_digit_count_threshold_1244() {
+        assert_eq!(format_number_jq_compat(b"500000e-1"), "50000.0");
+        assert_eq!(
+            format_number_jq_compat(b"99999999999999e1"),
+            "9.9999999999999E+14"
+        );
+        // Negative-sign counterpart, same digit-count/shift relationship.
+        assert_eq!(format_number_jq_compat(b"-500000e-1"), "-50000.0");
+        // More given digits than the shift needs: extra digits land after
+        // the decimal point, matching real jq's own `1200000000.00`.
+        assert_eq!(format_number_jq_compat(b"120000000000e-2"), "1200000000.00");
+        // A single given digit can never cover any positive shift -- always
+        // scientific, regardless of how large the shift is.
+        assert_eq!(format_number_jq_compat(b"1e10"), "1E+10");
+        // Exactly enough digits to cover the shift with none left over: no
+        // trailing decimal point. A nonzero written exponent, so this
+        // actually reaches `format_positive_shifted_plain` (a written
+        // exponent of `0` is intercepted earlier by this function's own
+        // `exp == 0` fast path -- see #1264).
+        assert_eq!(format_number_jq_compat(b"999.99e2"), "99999");
+    }
+
+    /// #1253: `format_number_jq_compat`'s scientific-notation mantissa used
+    /// to inherit `MAX_RENDERED_MANTISSA_DIGITS` (originally tuned for the
+    /// overflow/near-zero paths only) via #1206's shared string-based
+    /// rendering, silently truncating an *ordinary*, normal-magnitude
+    /// literal's mantissa at 32 significant digits even though its notation
+    /// choice (scientific, `shifted_exp >= digit_count`) was already
+    /// correct. Real jq preserves full literal precision unconditionally
+    /// (oracle-verified up to 100,000 significant digits) -- this pins the
+    /// issue's own 44-digit repro round-tripping exactly, well past the old
+    /// 32-digit cap.
+    #[test]
+    fn test_format_number_jq_compat_scientific_mantissa_precision_above_old_cap_1253() {
+        assert_eq!(
+            format_number_jq_compat(b"1.234567890123456789012345678901234567890123e50"),
+            "1.234567890123456789012345678901234567890123E+50"
+        );
     }
 
     /// `depth` levels of single-element array nesting: `[[[...[Null]...]]]`.

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -638,13 +638,15 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // (400 nines vastly exceeds `f64::MAX`), yet real jq still renders it
     // as a plain 400-digit integer, not scientific notation, because all
     // 400 significant digits were given (`shifted_exp` 399 `<` `digit_count`
-    // 400) -- oracle-verified, code review on #1253.
-    if new_exp > 0 {
-        if let Some(plain) =
-            format_positive_shifted_plain(sign, &mantissa_str, new_exp, digit_count)
-        {
-            return plain;
-        }
+    // 400) -- oracle-verified, code review on #1253. No `new_exp > 0` guard
+    // needed here (unlike `format_number_jq_compat`'s own call site, which
+    // also sees small/negative shifted exponents): overflow requires
+    // `|value| > f64::MAX` (~1.8e308), so `new_exp` is always well past
+    // `300` by the time this function is ever reached -- `format_positive_shifted_plain`'s
+    // own `debug_assert!` on a positive shift is what would catch a
+    // violation of that invariant, not a redundant check here.
+    if let Some(plain) = format_positive_shifted_plain(sign, &mantissa_str, new_exp, digit_count) {
+        return plain;
     }
 
     assemble_scientific(sign, &mantissa_str, new_exp)


### PR DESCRIPTION
## Summary

- Raised `MAX_RENDERED_MANTISSA_DIGITS` in `normalize_extreme_literal_mantissa` from 32 to 1000. Real jq preserves a literal's full given precision unconditionally (oracle-verified up to 100,000 significant digits against pinned jq 1.7.1); 32 was tuned only for the overflow/near-zero paths and got silently inherited by the ordinary scientific-notation case once #1206 routed it through the same shared renderer. Fixes #1253.
- Added the missing plain-vs-scientific notation decision for a *positive* shifted exponent. Real jq keeps plain decimal notation whenever the literal's own given significant digits are enough to cover the value's whole integer part (`shifted_exp < digit_count`), only switching to scientific once the shift would need to fabricate an unstated trailing digit. `normalize_extreme_literal_mantissa` now also returns the mantissa's true (untruncated) significant-digit count, and a new `format_positive_shifted_plain` applies the rule. Fixes #1244.

Both fixes share the same code region (`format_number_jq_compat`'s scientific-notation path) and were bundled per the skill's shared-root-cause criterion rather than shipped as two PRs.

## Verification

- The exact `shifted_exp < digit_count` rule was derived from live oracle probing (not summarized/fetched C source) and validated against pinned jq 1.7.1 across ~9000 randomized + dense-boundary cases (both signs, varying digit counts and exponents) before writing any Rust.
- After implementing, a broad randomized differential sweep (`succinctly jq -c .` vs real `jq -c .`, ~3700 cases spanning both fixes) came back with zero mismatches.
- Both issues' own repros pass exactly, plus the derived boundary cases (single-digit literals, exact-digit-count-with-no-remainder, extra trailing digits after the point).

## Side finding

The same regression sweep surfaced an unrelated, pre-existing bug: `format_number_jq_compat`'s `exp == 0` fast path falls back to `format!("{value}")` (plain f64 `Display`) for non-integer or `>= 1e15` literals, losing precision the same way the two bugs above did -- but via a completely different code path (never reaches the string-based mantissa machinery this PR touches). Filed separately as #1264, intentionally out of scope here.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, no-fail-fast) -- all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's second, non-`--all-features` combo) -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo check --no-default-features` (no_std) -- compiles (pre-existing unrelated dead-code warnings only)
- [x] New/updated unit tests for both issues' own repros plus derived boundary cases

Fixes #1244, Fixes #1253