### PR TITLE
perf(jq): fix O(n^2) per-value line-number lookup in multi-value input

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -845,6 +845,10 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                     continue;
                 }
             };
+            // `values`' end offsets are non-decreasing (find_json_values is
+            // a single left-to-right scan), so one LineCounter shared across
+            // every value in this file keeps the whole loop O(n) (#1213).
+            let mut line_counter = LineCounter::new(raw);
             for (start, end) in values {
                 let json_bytes = &raw[start..end];
 
@@ -868,7 +872,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 let index = JsonIndex::build(json_bytes);
                 // jq names the line the input value ends on, counted in the
                 // whole file rather than in this value's slice.
-                let at = InputLocation::at(filename.as_deref(), line_at(raw, end));
+                let at = InputLocation::at(filename.as_deref(), line_counter.advance_to(end));
                 let results = evaluate_bytes_lazy(json_bytes, &expr, &index, &at, &mut sink);
 
                 // Consume results to free memory after each value is written
@@ -1262,10 +1266,16 @@ impl InputLocations {
     /// Falls back to the last content line for every value when the counts
     /// disagree — modes that skip unparsable records can produce fewer values
     /// than the scan found offsets, and a wrong line is worse than a vague one.
+    ///
+    /// `ends` is already non-decreasing (both of this crate's own callers --
+    /// `find_json_values`/`json_seq_ends` -- are single left-to-right scans),
+    /// so one shared `LineCounter` keeps this whole loop O(n) rather than the
+    /// O(n^2) a per-value `line_at` rescan from byte 0 produced (#1213).
     fn extend_from_ends(&mut self, src: usize, raw: &str, ends: &[usize], values: usize) {
         if ends.len() == values {
+            let mut line_counter = LineCounter::new(raw.as_bytes());
             for &end in ends {
-                self.push(src, line_at(raw.as_bytes(), end));
+                self.push(src, line_counter.advance_to(end));
             }
         } else {
             let line = content_lines(raw);
@@ -1321,6 +1331,55 @@ fn read_file_bytes(path: &Path) -> Result<Vec<u8>> {
     std::fs::read(path).with_context(|| format!("Failed to read file: {}", path.display()))
 }
 
+/// Incremental version of [`line_at`] for a caller visiting a monotonically
+/// increasing sequence of `end` offsets into the same `bytes` (#1213) --
+/// every per-value location in a multi-value document or `--seq`/`--slurp`
+/// stream, not just a single error report. `line_at` itself scans from byte
+/// 0 on every call; calling it once per value in an N-value input makes the
+/// whole loop O(N^2) (confirmed: 80k JSON-lines records took ~27s wall time
+/// against a real-jq baseline under half a second). This type instead scans
+/// each byte of `bytes` at most once across the whole sequence of calls, by
+/// remembering how far the previous call already counted.
+///
+/// `advance_to` must be called with non-decreasing `end` values -- the same
+/// order [`find_json_values`]/`json_seq_ends` already produce their offsets
+/// in, since both are themselves single left-to-right scans.
+struct LineCounter<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+    newlines_before_pos: usize,
+}
+
+impl<'a> LineCounter<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            pos: 0,
+            newlines_before_pos: 0,
+        }
+    }
+
+    /// Same result [`line_at`] would return for this `end`, given every
+    /// prior call passed a `end` no greater than this one.
+    fn advance_to(&mut self, end: usize) -> usize {
+        let end = end.min(self.bytes.len());
+        debug_assert!(
+            end >= self.pos,
+            "LineCounter::advance_to called with a smaller end than a previous call"
+        );
+        self.newlines_before_pos += self.bytes[self.pos..end]
+            .iter()
+            .filter(|&&b| b == b'\n')
+            .count();
+        self.pos = end;
+        let mut count = self.newlines_before_pos;
+        if self.bytes.get(end) == Some(&b'\n') {
+            count += 1;
+        }
+        count
+    }
+}
+
 /// jq's line number for the value whose exclusive end offset is `end` within
 /// `bytes`.
 ///
@@ -1330,8 +1389,11 @@ fn read_file_bytes(path: &Path) -> Result<Vec<u8>> {
 /// time the value's boundary is confirmed: every newline strictly before
 /// `end`, plus exactly one byte of trailing lookahead if it exists and is a
 /// newline. It is zero-based, not one-based — a value ending before any `\n`
-/// reports line 0. Only reached on the error path, so a plain scan is cheap
-/// enough.
+/// reports line 0. Only for a single, one-off lookup (a parse-error report,
+/// reached at most once per input) -- a caller visiting many `end` values
+/// for the same `bytes` in increasing order (one location per value in a
+/// multi-value document) must use [`LineCounter`] instead, or an O(n) scan
+/// per call becomes an O(n^2) loop (#1213).
 fn line_at(bytes: &[u8], end: usize) -> usize {
     let end = end.min(bytes.len());
     let mut count = bytes[..end].iter().filter(|&&b| b == b'\n').count();
@@ -2947,6 +3009,40 @@ mod tests {
         let bytes = b"1\n2\n";
         assert_eq!(line_at(bytes, 1), 1);
         assert_eq!(line_at(bytes, 3), 2);
+    }
+
+    /// #1213: `LineCounter::advance_to` must return exactly what `line_at`
+    /// would for the same offset, for every offset in a monotonic sequence
+    /// -- the whole point of introducing it is replacing a hot loop's
+    /// repeated `line_at` calls without changing what line number any value
+    /// gets reported at.
+    #[test]
+    fn test_line_counter_matches_line_at_for_monotonic_sequence_1213() {
+        let bytes = b"1\n2\n{\n\"a\":1\n}\n3";
+        let ends: Vec<usize> = find_json_values(bytes)
+            .unwrap()
+            .into_iter()
+            .map(|(_, end)| end)
+            .collect();
+
+        let mut counter = LineCounter::new(bytes);
+        for &end in &ends {
+            assert_eq!(counter.advance_to(end), line_at(bytes, end), "end={end}");
+        }
+    }
+
+    /// A value with no `\n` bytes between it and the previous one (adjacent
+    /// values with no separator between them, e.g. `12` split into `1` then
+    /// `2` isn't valid, but two values on the same line with only a space
+    /// between them is) still gets the correct, un-advanced line number --
+    /// `advance_to`'s internal scan window can be empty.
+    #[test]
+    fn test_line_counter_same_line_consecutive_values_1213() {
+        let bytes = b"1 2\n3";
+        let mut counter = LineCounter::new(bytes);
+        assert_eq!(counter.advance_to(1), 0); // "1" ends before any '\n'
+        assert_eq!(counter.advance_to(3), 1); // "2" ends right before the '\n'
+        assert_eq!(counter.advance_to(5), 1); // "3" ends at EOF, no lookahead
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3198,6 +3198,30 @@ fn test_seq_ignores_parse_errors() -> Result<()> {
     Ok(())
 }
 
+/// #1213: `--seq`'s error-location reporting stays correct once its
+/// per-value line lookup is incremental (`LineCounter`) instead of a
+/// from-scratch rescan per value -- the erroring record here is deep enough
+/// into the stream (record 50 of 100) that an off-by-one in the incremental
+/// bookkeeping would show up as a wrong line number, not just a wrong
+/// answer.
+#[test]
+fn test_seq_error_location_correct_with_many_preceding_records_1213() -> Result<()> {
+    let mut input = String::new();
+    for i in 0..100 {
+        input.push('\u{1e}');
+        input.push_str(&format!("{{\"n\":{i}}}\n"));
+    }
+    let (_, stderr, code) = run_jq_full(
+        &["--seq", r#"if .n==50 then error("boom") else . end"#],
+        Some(&input),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    // Record 50 (0-indexed) is the 51st RS-delimited record, ending on the
+    // 51st line of the input.
+    assert!(stderr.contains("(at <stdin>:51): boom"), "stderr: {stderr}");
+    Ok(())
+}
+
 #[test]
 fn test_seq_multiple_outputs() -> Result<()> {
     // Each output from iterator should get RS prefix


### PR DESCRIPTION
## Summary

Filed as #1213 to measure whether `--seq`'s per-record `serde_json::Value` validation tree matters at scale. It does — but not for the suspected reason. Investigating it found a much larger, previously-unknown bug: `line_at` (reports a value's `(at <file>:<line>)` location) rescans the whole input from byte 0 on **every call**, and both of its per-value callers invoke it once per value inside a loop:

- The primary multi-value JSON input path's own per-value loop (`run_jq`, reached by every ordinary `succinctly jq` invocation on a file with multiple top-level JSON values — this is the *default* codepath, not an edge case: `jq_compat` defaults on, so the "identity fast path" that would otherwise skip this is essentially never taken)
- `InputLocations::extend_from_ends`, used by `--seq` and plain `--slurp`/general multi-value input

For an N-value input, this makes location tracking O(N²), not the O(N) the surrounding per-value work already is.

## Measurement (synthetic multi-value inputs, default flags, no `--slurp`/`-c`-only tricks)

| Input | Records | Before | After | Speedup |
|---|---:|---:|---:|---:|
| Ordinary multi-value JSON | 80,000 | 25.98s | 0.04s | ~650x |
| `--seq` | 80,000 | 26.81s | 0.21s | ~130x |
| `--seq` | 500,000 | (would be ~1000s+, extrapolated) | 1.38s | — |

Confirmed O(n) scaling post-fix at 5k/20k/80k/500k for both paths.

## Fix

`LineCounter`: a small incremental scanner that remembers how far the previous call already counted. Both loops now share one instance across their whole input — safe because `find_json_values`/`json_seq_ends` (the only two producers of the `end` offsets these loops feed it) are themselves single left-to-right scans, so the offsets are always non-decreasing. Total scan work across the whole loop is now bounded by the input's own byte length, not by it squared.

`line_at` itself is untouched, still used for its two single-shot error-report call sites — its own doc comment always scoped it to "only reached on the error path, so a plain scan is cheap enough," which was true for those call sites but not for the two it got reused in without that assumption being re-checked.

Every existing line-number-reporting test passes unmodified, including the `#524` no-trailing-newline edge cases. Added a new test (`test_line_counter_matches_line_at_for_monotonic_sequence_1213`) that directly asserts `LineCounter::advance_to` returns exactly what `line_at` would for the same offset, across a representative sequence — the actual correctness guarantee this fix depends on.

## Follow-up filed: #1267

Once this was fixed, `--seq`'s *original* suspected cost (the validation-tree allocation #1213 itself asked about) became cleanly measurable on its own: 500k records now takes 1.38s against real jq's own 0.46s — confirming it's real and worth the crate's own zero-allocation RFC 8259 validator this issue suggested. Filed as #1267 rather than folded in here: swapping validators needs its own grammar-equivalence verification against `serde_json`'s acceptance behavior, a separate correctness question from the O(n²) bug this PR fixes.

Fixes #1213

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std; unaffected, changes are CLI-only)
- [x] Manually benchmarked (release build) at 5k/20k/80k/500k records, both the ordinary multi-value path and `--seq`, before and after — table above
- [x] All existing line-number-reporting CLI tests re-verified passing, including the `#524` edge cases