### PR TITLE
perf(jq): --seq validates without allocating a discarded parse tree

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1872,10 +1872,38 @@ fn parse_json_stream_strict(s: &str) -> Result<Vec<OwnedValue>> {
 ///
 /// Preserves number-literal source fidelity the same way `parse_json_value`
 /// does for `--argjson` (#1058, extended here to `--seq`, #1093): each
-/// segment is already isolated by the RS split, so
-/// `validate_and_materialize_json` can validate and materialize the same
-/// segment text directly -- no boundary-tracking needed, unlike
-/// `parse_json_stream` above.
+/// segment is already isolated by the RS split, so a validate-then-
+/// materialize step can validate and materialize the same segment text
+/// directly -- no boundary-tracking needed, unlike `parse_json_stream`
+/// above.
+///
+/// Validates via the crate's own zero-allocation RFC 8259 grammar
+/// validator (`json::validate::validate`, already used by `--validate`/
+/// `json validate`) rather than `validate_and_materialize_json`'s
+/// `serde_json::Value`-tree-based check (#1267) -- `--seq` is a streaming,
+/// record-oriented format, so a discarded parse tree's allocation cost is
+/// paid once per record rather than a bounded number of times per run the
+/// way `--argjson`/`--jsonargs` pay it. Measured (500k-record stream,
+/// interleaved A/B, 5 reps -- real jq's own baseline is ~0.47s either way):
+/// a real but modest ~10-20% improvement (median ~1.30s -> ~1.15s), not the
+/// dramatic win a first, non-interleaved measurement suggested (1.38s ->
+/// 1.56s, i.e. apparently *worse* -- sequential-halves noise, the exact
+/// trap this repo's own benchmarking guide warns about). The remaining gap
+/// to real jq is dominated by something else entirely, out of this issue's
+/// own scope.
+///
+/// This also fixes a real, jq-observable divergence, not just a speed one:
+/// `json::validate::validate` is a pure grammar check with no `f64`-range
+/// rejection, unlike `serde_json::Value` -- so a magnitude-overflowing
+/// literal (`1e400`) that used to silently drop as an "unparseable" record
+/// now materializes correctly (`1E+400`, matching real jq's own primary-
+/// document-input behavior, live-verified) instead. `validate_json_str`
+/// (used by `--argjson` and this function's own leading-zero retry below)
+/// keeps its `serde_json::Value`-based magnitude rejection unchanged --
+/// this fix is scoped to `parse_json_seq`'s own hot path only; see #1267's
+/// own text for why extending it to the shared `--argjson` helper too
+/// isn't attempted here (that path's error-message text is user-visible
+/// and untouched by this issue).
 ///
 /// Also retries a failed segment with its leading zeros stripped before
 /// giving up on it, mirroring `parse_json_value`'s own `--argjson` retry
@@ -1896,8 +1924,8 @@ fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
         }
 
         // Try to parse as JSON, silently ignore failures
-        if let Ok(v) = validate_and_materialize_json(segment) {
-            values.push(v);
+        if validate::validate(segment.as_bytes()).is_ok() {
+            values.push(crate::output::json_bytes_to_owned_value(segment.as_bytes()));
         } else {
             let normalized = normalize_leading_zero_numbers(segment);
             if normalized != segment && validate_json_str(&normalized).is_ok() {
@@ -3179,6 +3207,19 @@ mod tests {
         let values = parse_json_seq("\x1E{invalid\n\x1E5\n");
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].to_json(), "5");
+    }
+
+    /// #1267: the crate's own zero-allocation grammar validator has no
+    /// `f64`-range rejection, unlike `serde_json::Value` -- so swapping to
+    /// it for `--seq`'s per-record validation also fixed a real divergence
+    /// from real jq, not just a speed one. `1e400` no longer silently
+    /// drops as "unparseable"; it materializes with the same spelling
+    /// primary document input already produces for it.
+    #[test]
+    fn test_parse_json_seq_accepts_magnitude_overflowing_number_1267() {
+        let values = parse_json_seq("\x1E1e400\n");
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].to_json(), "1E+400");
     }
 
     /// #1192: `standard_json_to_jq_value` now surfaces a genuinely

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1118,6 +1118,36 @@ fn test_seq_tolerates_leading_zero_number_1243() -> Result<()> {
     Ok(())
 }
 
+/// #1267: swapping `--seq`'s per-record validation to the crate's own
+/// zero-allocation grammar validator (performance-motivated) also fixed a
+/// real correctness divergence discovered while verifying the swap's
+/// grammar equivalence against `serde_json`: a magnitude-overflowing float
+/// literal (`1e400`) real jq itself accepts on ordinary document input
+/// (`1E+400`, live-verified) used to silently drop as an "unparseable"
+/// record here instead, because the old `serde_json::Value`-based
+/// validator rejects anything that doesn't fit in a finite `f64`. The new
+/// validator is a pure grammar check with no such range rejection, so this
+/// now materializes correctly, matching real jq.
+#[test]
+fn test_seq_accepts_magnitude_overflowing_number_1267() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["--seq", "-c", "."], Some("\x1e1e400\n"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "\x1e1E+400");
+    Ok(())
+}
+
+/// Control: a genuinely malformed record is still silently dropped after
+/// the validator swap -- the new validator isn't accidentally more lenient
+/// on syntax, only on numeric magnitude.
+#[test]
+fn test_seq_still_drops_genuinely_malformed_record_1267() -> Result<()> {
+    let (stdout, _, code) =
+        run_jq_full(&["--seq", "-c", "."], Some("\x1enot valid json\n\x1e5\n"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "\x1e5");
+    Ok(())
+}
+
 /// A hyphen-prefixed `--slurpfile`/`--rawfile` FILE value must reach this
 /// crate's own file-open logic, not get rejected by clap as an unknown
 /// flag first (#1150, same `allow_hyphen_values` fix as `--arg`/


### PR DESCRIPTION
## Summary

`parse_json_seq` (`--seq`, RFC 7464) validated every RS-delimited record by parsing it into a full `serde_json::Value` tree purely to check validity, then discarded that tree and separately materialized the real `OwnedValue`. `--seq` is a streaming, record-oriented format by design, so this cost is paid once per record in a potentially large stream, not a bounded number of times per run the way `--argjson`/`--jsonargs` pay it.

Swapped to the crate's own zero-allocation RFC 8259 grammar validator (`json::validate::validate`, already used by `--validate`/`json validate`). Scoped narrowly to `parse_json_seq`'s own hot path — the shared `validate_json_str`/`validate_and_materialize_json` helper `--argjson` also uses is untouched, since that path's error-message text is user-visible and out of this issue's own scope.

## Correctness verification before trusting the swap

Before treating this as a drop-in replacement, ran a differential check (~30 cases) comparing `serde_json`'s acceptance against the new validator's: duplicate keys, `NaN`/`Infinity`, trailing commas, single-quoted keys, leading-dot numbers, unpaired surrogates, raw control chars, trailing garbage, leading zeros, `i64`/`u64` boundary numbers — all agree.

Found **one** real divergence: the new validator is a pure grammar check with no `f64`-magnitude-overflow rejection, unlike `serde_json::Value`. Live-verified this is actually a **correctness improvement** to adopt, not a regression to guard against — real jq accepts a magnitude-overflowing literal like `1e400` on ordinary document input (`1E+400`), which `--seq` used to silently drop as "unparseable" under the old validator's stricter rejection. Now materializes correctly, matching real jq.

(Also found, while stress-testing an even more extreme case: an astronomically large negative exponent overflows an `i64` and produces a nonsense result — but this reproduces via ordinary document input too, unrelated to `--seq`/this PR. Filed separately as #1270.)

## Performance

Measured (500k-record stream, **interleaved A/B**, 5 reps — real jq's own baseline is ~0.47s either way): a real but modest **~10-20% improvement** (median ~1.30s → ~1.15s). Worth flagging honestly: a first, *non-interleaved* measurement suggested this made things *worse* (1.38s → 1.56s) — exactly the sequential-halves noise trap this repo's own benchmarking guide warns against. The remaining gap to real jq is dominated by something else entirely, out of this issue's own scope.

Fixes #1267

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std; unaffected, changes are CLI-only)
- [x] Differential grammar-equivalence check against `serde_json` (~30 cases)
- [x] Interleaved A/B benchmark, 5 reps, against the pre-change binary
- [x] Live-verified the magnitude-overflow fix against real jq