### PR TITLE
fix(jq): 17 builtins now propagate an argument's trailing escape

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1269,16 +1269,18 @@ fn finish_owned<'a, W>(value: OwnedValue, trailing: Option<Control>) -> QueryRes
 /// unchanged, preserving any zero-copy/cursor fast path it took; `Some`
 /// only forces materializing it, to splice the trailing control on.
 ///
-/// If `result` itself escapes (its own `Error`/`Break`/`Halt`, not the
-/// argument's), that escape wins outright and `trailing` is discarded --
+/// If `result` itself escapes (its own `Error`/`Break`/`Halt`/`Partial`, not
+/// the argument's), that escape wins outright and `trailing` is discarded --
 /// same "the computation that actually ran and escaped supersedes an
 /// earlier, never-revisited argument escape" rule `result_to_owned_ctrl`'s
 /// own doc comment describes and `has()`/`contains()`'s error paths above
-/// already follow. `result` becoming its own `Partial` here is not
-/// currently reachable by any caller of this function (each delegates to a
-/// function with no generator-argument evaluation of its own), so that
-/// combination -- two independent trailing escapes -- is left for whichever
-/// caller first needs it to actually decide, rather than guessed at here.
+/// already follow. No current caller can make `result` its own `Partial`
+/// (each delegates to a function with no generator-argument evaluation of
+/// its own) -- but unlike the true structural impossibility right above
+/// (`OneCursor`, ruled out by `materialize_cursor`'s own contract), this is
+/// just "not exercised by today's callers," not "cannot happen," so it gets
+/// the same defensible fallback as the plain `Error`/`Break`/`Halt` case
+/// instead of an assertion a future caller could legitimately trip.
 fn finish_result<W: Clone + AsRef<[u64]>>(
     result: QueryResult<'_, W>,
     trailing: Option<Control>,
@@ -1300,16 +1302,10 @@ fn finish_result<W: Clone + AsRef<[u64]>>(
             Control::Break(label) => QueryResult::Break(label),
             Control::Halt(code) => QueryResult::Halt(code),
         },
-        already_escaped
-        @ (QueryResult::Error(_) | QueryResult::Break(_) | QueryResult::Halt(_)) => already_escaped,
-        QueryResult::Partial(vs, inner_control) => {
-            debug_assert!(
-                false,
-                "finish_result: delegated computation itself produced a Partial -- \
-                 no current caller can reach this; needs its own semantics decision (#1164)"
-            );
-            partial(vs, inner_control)
-        }
+        already_escaped @ (QueryResult::Error(_)
+        | QueryResult::Break(_)
+        | QueryResult::Halt(_)
+        | QueryResult::Partial(..)) => already_escaped,
     }
 }
 
@@ -43844,6 +43840,184 @@ mod tests {
                 assert_eq!(vs.len(), 1);
                 assert!(matches!(vs[0], OwnedValue::String(_)), "vs[0]={:?}", vs[0]);
             }
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1164: `builtin_envvar`'s trailing-control fix must apply equally to
+    /// the "variable not set, `?` suppresses the miss" branch, not just the
+    /// "found" branch verified above -- `finish_result`'s own
+    /// `QueryResult::None` handling is what makes this shape work: no
+    /// output from the lookup itself, so the trailing control alone
+    /// determines the result. (A non-optional miss returns `Owned(Null)`
+    /// instead -- an unrelated, pre-existing choice this fix doesn't touch
+    /// -- covered directly for `finish_result` itself in the `None` test
+    /// above rather than needing its own env-lookup-shaped test here.)
+    #[cfg(feature = "std")]
+    #[test]
+    fn builtin_envvar_propagates_trailing_break_when_variable_not_set_optional_1164() {
+        let var = parse(r#"("SUCCINCTLY_TEST_VAR_1164_DOES_NOT_EXIST", break $out)"#).unwrap();
+        match builtin_envvar::<Vec<u64>, JqSemantics>(&var, StandardJson::Null, true) {
+            QueryResult::Break(label) => assert_eq!(label, "out"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1164 coverage: a non-optional lookup of an unset variable takes the
+    /// `Owned(Null)` arm (pre-existing, unrelated choice this fix doesn't
+    /// touch -- see the `optional` sibling test above for the `None` arm),
+    /// combined with a trailing break to confirm `finish_owned`/
+    /// `finish_result`'s ordinary success-wrap path still applies to it.
+    #[cfg(feature = "std")]
+    #[test]
+    fn builtin_envvar_not_set_non_optional_returns_null_with_trailing_break_1164() {
+        let var = parse(r#"("SUCCINCTLY_TEST_VAR_1164_DOES_NOT_EXIST", break $out)"#).unwrap();
+        match builtin_envvar::<Vec<u64>, JqSemantics>(&var, StandardJson::Null, false) {
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(label, "out");
+                assert_eq!(vs, vec![OwnedValue::Null]);
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1164 coverage: a non-string variable-name expression is a type
+    /// error, independent of any trailing control -- the generic fallback
+    /// arm every other envvar test above happens to skip past via a string
+    /// or `Halt`/`Break` match first.
+    #[cfg(feature = "std")]
+    #[test]
+    fn builtin_envvar_non_string_name_errors_1164() {
+        let var = parse("5").unwrap();
+        match builtin_envvar::<Vec<u64>, JqSemantics>(&var, StandardJson::Null, false) {
+            QueryResult::Error(e) => assert!(e.message.contains("must be a string"), "{e:?}"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1164: `finish_result` is a small shared helper (backs `nth`,
+    /// `flatten(depth)`, `has`, `load`, `env.VAR`), general enough to accept
+    /// every `QueryResult` shape a delegated computation could produce --
+    /// but only `Owned`/`One` are reachable through those five callers
+    /// today. Exercised directly here for the remaining shapes, so the
+    /// helper's own correctness doesn't depend on some future caller being
+    /// the first to notice a bug in an untested branch.
+    #[test]
+    fn finish_result_many_and_many_owned_splice_trailing_control_1164() {
+        let many: QueryResult<'_, Vec<u64>> =
+            QueryResult::Many(vec![StandardJson::Bool(true), StandardJson::Bool(false)]);
+        match finish_result(many, Some(Control::Break("out".to_string()))) {
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(label, "out");
+                assert_eq!(vs, vec![OwnedValue::Bool(true), OwnedValue::Bool(false)]);
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        let many_owned: QueryResult<'_, Vec<u64>> =
+            QueryResult::ManyOwned(vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+        match finish_result(many_owned, Some(Control::Break("out".to_string()))) {
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(label, "out");
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finish_result_none_collapses_to_each_bare_control_variant_1164() {
+        let none_result = || QueryResult::<'_, Vec<u64>>::None;
+
+        match finish_result(none_result(), Some(Control::Error(EvalError::new("boom")))) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boom"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+        match finish_result(none_result(), Some(Control::Break("out".to_string()))) {
+            QueryResult::Break(label) => assert_eq!(label, "out"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+        match finish_result(none_result(), Some(Control::Halt(3))) {
+            QueryResult::Halt(3) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// The delegated computation's own escape wins outright over an
+    /// argument's earlier trailing control, even when that computation's
+    /// own escape is itself a `Partial` (has its own prior output) -- same
+    /// "already escaped, argument's control is moot" rule as the plain
+    /// `Error`/`Break`/`Halt` case, extended to this shape too (#1164).
+    #[test]
+    fn finish_result_delegated_partial_wins_over_argument_trailing_control_1164() {
+        let delegated: QueryResult<'_, Vec<u64>> = QueryResult::Partial(
+            vec![OwnedValue::Int(1)],
+            Control::Error(EvalError::new("x")),
+        );
+        match finish_result(delegated, Some(Control::Break("out".to_string()))) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert_eq!(e.message, "x");
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1164: `eval_owned_expr_ctrl_full` (backs `builtin_envvar`'s fix
+    /// above) is exercised there only via a shape that lands in its
+    /// `Partial`, single-value arm. Its sibling arms -- an argument
+    /// generator with 2+ *borrowed* outputs and no escape at all (`Many`),
+    /// the owned equivalent (`ManyOwned`), and a `Partial` with 2+ prior
+    /// values -- are covered directly here instead of hunting for CLI
+    /// syntax that happens to produce each borrowed/owned distinction.
+    #[test]
+    fn eval_owned_expr_ctrl_full_many_shapes_and_multi_value_partial_1164() {
+        // Many (borrowed, 2+ outputs, no escape): `eval_owned_expr_ctrl_full`
+        // reindexes `input` into its own internal JsonIndex/cursor before
+        // evaluating, so a comma of two field accesses against an object
+        // input reaches `eval_single`'s `Many` arm (borrowed cursor values),
+        // not already-owned ones.
+        let expr = parse(".a, .b").unwrap();
+        match eval_owned_expr_ctrl_full::<JqSemantics>(
+            &expr,
+            &OwnedValue::Object(IndexMap::from([
+                ("a".to_string(), OwnedValue::Int(1)),
+                ("b".to_string(), OwnedValue::Int(2)),
+            ])),
+            false,
+        ) {
+            Ok((OwnedValue::Array(vs), None)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // Multi-value Partial (2+ values, then a break): the `else` branch
+        // of the `vs.len() == 1` check inside the `Partial` arm.
+        let expr = parse("(1, 2, break $out)").unwrap();
+        match eval_owned_expr_ctrl_full::<JqSemantics>(&expr, &OwnedValue::Null, false) {
+            Ok((OwnedValue::Array(vs), Some(Control::Break(label)))) => {
+                assert_eq!(label, "out");
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1164: `result_to_owned_ctrl` (backs 16 of this fix's builtins) is
+    /// exercised by every CLI-level `..._1164` test above only via shapes
+    /// that land in its `Owned`/`One`/`Partial` arms -- a builtin argument
+    /// with 2+ *borrowed* outputs and no escape (`Many`) never happened to
+    /// come up. Covered directly here instead.
+    #[test]
+    fn result_to_owned_ctrl_many_arm_takes_first_borrowed_value_1164() {
+        let json: &[u8] = br#"{"a":"x","b":"y"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse(".a, .b").unwrap();
+        let result = eval_single::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false);
+        match result_to_owned_ctrl(result) {
+            Ok((OwnedValue::String(s), None)) => assert_eq!(s, "x"),
             other => panic!("unexpected result: {other:?}"),
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1246,6 +1246,73 @@ fn borrowed_vec_to_result<W>(vs: Vec<StandardJson<'_, W>>) -> QueryResult<'_, W>
     )
 }
 
+/// Finish a builtin whose own computation succeeded with `value`, given the
+/// optional trailing [`Control`] [`result_to_owned_ctrl`] returned alongside
+/// the argument value that computation used (#1164). `None` is the ordinary
+/// case (`QueryResult::Owned(value)`); `Some(control)` means the argument
+/// generator produced that value and *then* broke/errored, which real jq
+/// still lets this builtin finish and use before unwinding -- see
+/// `result_to_owned_ctrl`'s own doc comment for the live-verified semantics
+/// this preserves.
+fn finish_owned<'a, W>(value: OwnedValue, trailing: Option<Control>) -> QueryResult<'a, W> {
+    match trailing {
+        None => QueryResult::Owned(value),
+        Some(control) => partial(vec![value], control),
+    }
+}
+
+/// Like [`finish_owned`], but for a builtin that delegates its own
+/// post-argument computation to another function returning a full
+/// `QueryResult<'a, W>` directly (e.g. `nth(n)` delegating to `index_one`,
+/// `flatten(depth)` delegating to `builtin_flatten`) instead of a single
+/// already-`OwnedValue` (#1164). `None` passes `result` through completely
+/// unchanged, preserving any zero-copy/cursor fast path it took; `Some`
+/// only forces materializing it, to splice the trailing control on.
+///
+/// If `result` itself escapes (its own `Error`/`Break`/`Halt`, not the
+/// argument's), that escape wins outright and `trailing` is discarded --
+/// same "the computation that actually ran and escaped supersedes an
+/// earlier, never-revisited argument escape" rule `result_to_owned_ctrl`'s
+/// own doc comment describes and `has()`/`contains()`'s error paths above
+/// already follow. `result` becoming its own `Partial` here is not
+/// currently reachable by any caller of this function (each delegates to a
+/// function with no generator-argument evaluation of its own), so that
+/// combination -- two independent trailing escapes -- is left for whichever
+/// caller first needs it to actually decide, rather than guessed at here.
+fn finish_result<W: Clone + AsRef<[u64]>>(
+    result: QueryResult<'_, W>,
+    trailing: Option<Control>,
+) -> QueryResult<'_, W> {
+    let Some(control) = trailing else {
+        return result;
+    };
+    match result.materialize_cursor() {
+        QueryResult::One(v) => partial(vec![to_owned(&v)], control),
+        QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
+        QueryResult::Owned(v) => partial(vec![v], control),
+        QueryResult::Many(vs) => partial(vs.iter().map(to_owned).collect(), control),
+        QueryResult::ManyOwned(vs) => partial(vs, control),
+        // No output from `result` itself (e.g. an `optional` filter matched
+        // nothing) -- nothing to splice the trailing control onto but the
+        // control itself, same as an empty `partial()` prefix.
+        QueryResult::None => match control {
+            Control::Error(e) => QueryResult::Error(e),
+            Control::Break(label) => QueryResult::Break(label),
+            Control::Halt(code) => QueryResult::Halt(code),
+        },
+        already_escaped
+        @ (QueryResult::Error(_) | QueryResult::Break(_) | QueryResult::Halt(_)) => already_escaped,
+        QueryResult::Partial(vs, inner_control) => {
+            debug_assert!(
+                false,
+                "finish_result: delegated computation itself produced a Partial -- \
+                 no current caller can reach this; needs its own semantics decision (#1164)"
+            );
+            partial(vs, inner_control)
+        }
+    }
+}
+
 /// Normalize a prefix and its terminator into a `QueryResult` (#400, #494).
 ///
 /// An empty prefix collapses to the bare `Error`/`Break`/`Halt` variant, so
@@ -1360,47 +1427,66 @@ fn prepend<W: Clone + AsRef<[u64]>>(
 }
 
 /// Convert a QueryResult to an OwnedValue for use in computations.
+///
+/// Drops a `Partial`'s trailing `Break`/`Error` (see [`result_to_owned_ctrl`]
+/// for why, and for the variant that exposes it) -- callers that can re-wrap
+/// their own final result via [`partial`] when that trailing control exists
+/// should use `result_to_owned_ctrl` instead (#1164).
 fn result_to_owned<W: Clone + AsRef<[u64]>>(
     result: QueryResult<'_, W>,
 ) -> Result<OwnedValue, EvalEscape> {
+    result_to_owned_ctrl(result).map(|(v, _trailing)| v)
+}
+
+/// Like [`result_to_owned`], but also returns whether the result carried a
+/// trailing [`Control`] after its first value -- a `Partial`'s own
+/// `control`, which `result_to_owned` silently drops (#1164).
+///
+/// Real jq's own generator-argument semantics (`f(x)` desugars roughly to
+/// `x as $b | ...body using $b...`) use the *first* output of `x` to run
+/// the caller's own computation to completion -- including surfacing that
+/// computation's own, unrelated error if it has one (confirmed live:
+/// `has(("a", break $out))` on a non-iterable input reports `has`'s own
+/// "cannot check ... key" error, the trailing `break` is never even
+/// observed) -- and only *after* a successful computation does the escape
+/// from `x`'s second (never fully consumed) output actually fire. So a
+/// caller using this function should wrap its own **successful** final
+/// result via `partial(vec![result], trailing)` when `trailing` is
+/// `Some`, and leave any of its own error paths alone (#833's `ltrimstr(("a",
+/// break $out))` repro: `ltrimstr` computes and returns `"bcabc"`, *then*
+/// unwinds to `$out` -- `"after"` never prints).
+fn result_to_owned_ctrl<W: Clone + AsRef<[u64]>>(
+    result: QueryResult<'_, W>,
+) -> Result<(OwnedValue, Option<Control>), EvalEscape> {
     match result.materialize_cursor() {
-        QueryResult::One(v) => Ok(to_owned(&v)),
+        QueryResult::One(v) => Ok((to_owned(&v), None)),
         QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Owned(v) => Ok(v),
+        QueryResult::Owned(v) => Ok((v, None)),
         QueryResult::Many(vs) => {
             if let Some(v) = vs.first() {
-                Ok(to_owned(v))
+                Ok((to_owned(v), None))
             } else {
                 Err(EvalError::new("empty result").into())
             }
         }
         QueryResult::ManyOwned(vs) => {
             if let Some(v) = vs.into_iter().next() {
-                Ok(v)
+                Ok((v, None))
             } else {
                 Err(EvalError::new("empty result").into())
             }
         }
-        // Same "take the first output, ignore the rest" policy already
-        // applied to `Many`/`ManyOwned` above — a `Partial` prefix is never
-        // empty (see `partial`), so there is always a first value to take.
+        // Same "take the first output" policy already applied to
+        // `Many`/`ManyOwned` above — a `Partial` prefix is never empty (see
+        // `partial`), so there is always a first value to take.
         //
         // A `Partial`'s trailing `Halt` still wins over the prefix, though:
         // an argument stream that produced values and *then* halted must
-        // halt, not quietly compute with the first value (#791).
+        // halt, not quietly compute with the first value (#791) -- unlike
+        // `Break`/`Error`, a `Halt` has no "run to completion first" jq
+        // semantics to preserve.
         QueryResult::Partial(_, Control::Halt(code)) => Err(EvalEscape::Halt(code)),
-        // A trailing `Break`/`Error` here is a separate, harder gap #833
-        // does NOT fix: real jq would still abort after this point (e.g.
-        // `ltrimstr(("a", break $out))` prints one result then unwinds to
-        // `$out`, never running whatever follows), but this function's
-        // whole contract is collapsing a generator argument to one scalar
-        // `Result` -- it cannot represent "here is a value, AND ALSO an
-        // escape for afterward" the way `QueryResult::Partial` itself can.
-        // Fixing this properly means making every caller `Partial`-aware
-        // (so it can emit its own transformed value *and* propagate the
-        // trailing escape), not something `result_to_owned` can do alone;
-        // tracked as #1164 rather than folded into this fix.
-        QueryResult::Partial(vs, _control) => Ok(vs.into_iter().next().unwrap()),
+        QueryResult::Partial(vs, control) => Ok((vs.into_iter().next().unwrap(), Some(control))),
         QueryResult::None => Err(EvalError::new("no value").into()),
         QueryResult::Error(e) => Err(e.into()),
         // A *bare* (no prior output) `break $label` escaping a builtin's
@@ -3416,12 +3502,12 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Evaluate the key expression
     let key_result = eval_single::<W, S>(key_expr, value.clone(), optional);
-    let key_owned = match result_to_owned(key_result) {
+    let (key_owned, trailing) = match result_to_owned_ctrl(key_result) {
         Ok(v) => v,
         Err(e) => return e.into(),
     };
 
-    match (&value, &key_owned) {
+    let result = match (&value, &key_owned) {
         // jq: null | has("key") => false
         (StandardJson::Null, _) => QueryResult::Owned(OwnedValue::Bool(false)),
         // Object has string key
@@ -3490,7 +3576,8 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             type_name(&value),
             key_owned.type_name(),
         )),
-    }
+    };
+    finish_result(result, trailing)
 }
 
 /// Builtin: in(xs)
@@ -4340,29 +4427,29 @@ fn builtin_ltrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the prefix string
     let prefix_result = eval_single::<W, S>(prefix_expr, value.clone(), optional);
-    let prefix = match result_to_owned(prefix_result) {
-        Ok(OwnedValue::String(s)) => s,
+    let (prefix, trailing) = match result_to_owned_ctrl(prefix_result) {
+        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
         // jq's ltrimstr is total: a non-string argument leaves input unchanged.
-        Ok(_) => return QueryResult::Owned(to_owned(&value)),
+        Ok((_, trailing)) => return finish_owned(to_owned(&value), trailing),
         Err(e) => return e.into(),
     };
 
-    match &value {
+    let result = match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
-                let result = if cow.starts_with(&prefix) {
-                    cow[prefix.len()..].to_string()
+                if cow.starts_with(&prefix) {
+                    OwnedValue::String(cow[prefix.len()..].to_string())
                 } else {
-                    cow.into_owned()
-                };
-                QueryResult::Owned(OwnedValue::String(result))
+                    OwnedValue::String(cow.into_owned())
+                }
             } else {
-                QueryResult::Owned(OwnedValue::String(String::new()))
+                OwnedValue::String(String::new())
             }
         }
         // jq's ltrimstr is total: a non-string input passes through unchanged.
-        _ => QueryResult::Owned(to_owned(&value)),
-    }
+        _ => to_owned(&value),
+    };
+    finish_owned(result, trailing)
 }
 
 /// Builtin: rtrimstr(s) - remove suffix s
@@ -4373,29 +4460,29 @@ fn builtin_rtrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the suffix string
     let suffix_result = eval_single::<W, S>(suffix_expr, value.clone(), optional);
-    let suffix = match result_to_owned(suffix_result) {
-        Ok(OwnedValue::String(s)) => s,
+    let (suffix, trailing) = match result_to_owned_ctrl(suffix_result) {
+        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
         // jq's rtrimstr is total: a non-string argument leaves input unchanged.
-        Ok(_) => return QueryResult::Owned(to_owned(&value)),
+        Ok((_, trailing)) => return finish_owned(to_owned(&value), trailing),
         Err(e) => return e.into(),
     };
 
-    match &value {
+    let result = match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
-                let result = if cow.ends_with(&suffix) {
-                    cow[..cow.len() - suffix.len()].to_string()
+                if cow.ends_with(&suffix) {
+                    OwnedValue::String(cow[..cow.len() - suffix.len()].to_string())
                 } else {
-                    cow.into_owned()
-                };
-                QueryResult::Owned(OwnedValue::String(result))
+                    OwnedValue::String(cow.into_owned())
+                }
             } else {
-                QueryResult::Owned(OwnedValue::String(String::new()))
+                OwnedValue::String(String::new())
             }
         }
         // jq's rtrimstr is total: a non-string input passes through unchanged.
-        _ => QueryResult::Owned(to_owned(&value)),
-    }
+        _ => to_owned(&value),
+    };
+    finish_owned(result, trailing)
 }
 
 /// Builtin: startswith(s) - check if string starts with s
@@ -4406,8 +4493,8 @@ fn builtin_startswith<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the prefix string
     let prefix_result = eval_single::<W, S>(prefix_expr, value.clone(), optional);
-    let prefix = match result_to_owned(prefix_result) {
-        Ok(OwnedValue::String(s)) => s,
+    let (prefix, trailing) = match result_to_owned_ctrl(prefix_result) {
+        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
         Ok(_) => return QueryResult::Error(EvalError::new("startswith() requires string inputs")),
         Err(e) => return e.into(),
     };
@@ -4415,9 +4502,9 @@ fn builtin_startswith<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
-                QueryResult::Owned(OwnedValue::Bool(cow.starts_with(&prefix)))
+                finish_owned(OwnedValue::Bool(cow.starts_with(&prefix)), trailing)
             } else {
-                QueryResult::Owned(OwnedValue::Bool(false))
+                finish_owned(OwnedValue::Bool(false), trailing)
             }
         }
         _ if optional => QueryResult::None,
@@ -4433,8 +4520,8 @@ fn builtin_endswith<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the suffix string
     let suffix_result = eval_single::<W, S>(suffix_expr, value.clone(), optional);
-    let suffix = match result_to_owned(suffix_result) {
-        Ok(OwnedValue::String(s)) => s,
+    let (suffix, trailing) = match result_to_owned_ctrl(suffix_result) {
+        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
         Ok(_) => return QueryResult::Error(EvalError::new("endswith() requires string inputs")),
         Err(e) => return e.into(),
     };
@@ -4442,9 +4529,9 @@ fn builtin_endswith<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     match &value {
         StandardJson::String(s) => {
             if let Ok(cow) = s.as_str() {
-                QueryResult::Owned(OwnedValue::Bool(cow.ends_with(&suffix)))
+                finish_owned(OwnedValue::Bool(cow.ends_with(&suffix)), trailing)
             } else {
-                QueryResult::Owned(OwnedValue::Bool(false))
+                finish_owned(OwnedValue::Bool(false), trailing)
             }
         }
         _ if optional => QueryResult::None,
@@ -4460,8 +4547,8 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the separator string
     let sep_result = eval_single::<W, S>(sep_expr, value.clone(), optional);
-    let sep = match result_to_owned(sep_result) {
-        Ok(OwnedValue::String(s)) => s,
+    let (sep, trailing) = match result_to_owned_ctrl(sep_result) {
+        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
         Ok(_) => {
             return QueryResult::Error(EvalError::new("split input and separator must be strings"))
         }
@@ -4482,9 +4569,9 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         .map(|p| OwnedValue::String(p.to_string()))
                         .collect()
                 };
-                QueryResult::Owned(OwnedValue::Array(parts))
+                finish_owned(OwnedValue::Array(parts), trailing)
             } else {
-                QueryResult::Owned(OwnedValue::Array(vec![]))
+                finish_owned(OwnedValue::Array(vec![]), trailing)
             }
         }
         _ if optional => QueryResult::None,
@@ -4714,7 +4801,7 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     let sep_result = eval_single::<W, S>(sep_expr, value.clone(), optional);
-    let sep = match result_to_owned(sep_result) {
+    let (sep, trailing) = match result_to_owned_ctrl(sep_result) {
         Ok(v) => v,
         Err(e) => return e.into(),
     };
@@ -4742,7 +4829,7 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         _ => yq_join_element_part(to_owned_key_shape(&e)),
                     })
                     .collect();
-                QueryResult::Owned(OwnedValue::String(parts.join(&sep_str)))
+                finish_owned(OwnedValue::String(parts.join(&sep_str)), trailing)
             }
             other => QueryResult::Error(EvalError::new(format!(
                 "cannot join with {}, can only join arrays of scalars",
@@ -4774,7 +4861,7 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     match result {
-        Ok(acc) => QueryResult::Owned(acc.unwrap_or(OwnedValue::String(String::new()))),
+        Ok(acc) => finish_owned(acc.unwrap_or(OwnedValue::String(String::new())), trailing),
         Err(e) => QueryResult::Error(e),
     }
 }
@@ -4787,7 +4874,7 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the value to check
     let b_result = eval_single::<W, S>(b_expr, value.clone(), optional);
-    let b = match result_to_owned(b_result) {
+    let (b, trailing) = match result_to_owned_ctrl(b_result) {
         Ok(v) => v,
         Err(e) => return e.into(),
     };
@@ -4799,7 +4886,7 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
         return QueryResult::Error(EvalError::containment_check(&input, &b));
     }
-    QueryResult::Owned(OwnedValue::Bool(owned_contains::<S>(&input, &b)))
+    finish_owned(OwnedValue::Bool(owned_contains::<S>(&input, &b)), trailing)
 }
 
 /// Check if `a` contains `b` (recursive containment check)
@@ -4849,7 +4936,7 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the container value
     let b_result = eval_single::<W, S>(b_expr, value.clone(), optional);
-    let b = match result_to_owned(b_result) {
+    let (b, trailing) = match result_to_owned_ctrl(b_result) {
         Ok(v) => v,
         Err(e) => return e.into(),
     };
@@ -4862,7 +4949,7 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
         return QueryResult::Error(EvalError::containment_check(&b, &input));
     }
-    QueryResult::Owned(OwnedValue::Bool(owned_contains::<S>(&b, &input)))
+    finish_owned(OwnedValue::Bool(owned_contains::<S>(&b, &input)), trailing)
 }
 
 // =============================================================================
@@ -4932,11 +5019,11 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // itself, so delegating to it gets all of this -- including its own
     // lazy array fast path -- for free instead of re-deriving it here.
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
-    let n = match result_to_owned(n_result) {
+    let (n, trailing) = match result_to_owned_ctrl(n_result) {
         Ok(v) => v,
         Err(e) => return e.into(),
     };
-    index_one::<W>(value, &n, optional)
+    finish_result(index_one::<W>(value, &n, optional), trailing)
 }
 
 /// Builtin: reverse - reverse array
@@ -5036,18 +5123,20 @@ fn builtin_flatten_depth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the depth
     let depth_result = eval_single::<W, S>(depth_expr, value.clone(), optional);
-    let depth = match result_to_owned(depth_result) {
-        Ok(OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _)) if d >= 0 => {
-            d as usize
+    let (depth, trailing) = match result_to_owned_ctrl(depth_result) {
+        Ok((OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _), trailing))
+            if d >= 0 =>
+        {
+            (d as usize, trailing)
         }
-        Ok(OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)) => {
+        Ok((OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _), _)) => {
             return QueryResult::Error(EvalError::new("depth must be non-negative"));
         }
         Ok(_) => return QueryResult::Error(EvalError::type_error("number", "non-number")),
         Err(e) => return e.into(),
     };
 
-    builtin_flatten::<W>(value, optional, depth)
+    finish_result(builtin_flatten::<W>(value, optional, depth), trailing)
 }
 
 /// Builtin: group_by(f) - group by key function
@@ -7875,12 +7964,13 @@ fn builtin_getpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     // Evaluate the path expression
-    let path = match result_to_owned(eval_single::<W, S>(path_expr, value.clone(), optional)) {
-        Ok(OwnedValue::Array(arr)) => arr,
-        Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::path_must_be_array()),
-        Err(e) => return e.into(),
-    };
+    let (path, trailing) =
+        match result_to_owned_ctrl(eval_single::<W, S>(path_expr, value.clone(), optional)) {
+            Ok((OwnedValue::Array(arr), trailing)) => (arr, trailing),
+            Ok(_) if optional => return QueryResult::None,
+            Ok(_) => return QueryResult::Error(EvalError::path_must_be_array()),
+            Err(e) => return e.into(),
+        };
 
     let mut current = to_owned(&value);
 
@@ -7888,7 +7978,7 @@ fn builtin_getpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         match (&current, &segment) {
             // jq: null | getpath(["a"]) => null
             (OwnedValue::Null, _) => {
-                return QueryResult::Owned(OwnedValue::Null);
+                return finish_owned(OwnedValue::Null, trailing);
             }
             (OwnedValue::Object(obj), OwnedValue::String(key)) => {
                 current = obj.get(key).cloned().unwrap_or(OwnedValue::Null);
@@ -7927,7 +8017,7 @@ fn builtin_getpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
 
-    QueryResult::Owned(current)
+    finish_owned(current, trailing)
 }
 
 // =============================================================================
@@ -15451,9 +15541,24 @@ fn eval_owned_expr_ctrl<S: EvalSemantics>(
     input: &OwnedValue,
     optional: bool,
 ) -> Result<OwnedValue, Control> {
+    eval_owned_expr_ctrl_full::<S>(expr, input, optional).map(|(v, _trailing)| v)
+}
+
+/// Like [`eval_owned_expr_ctrl`], but also returns whether the result
+/// carried a trailing [`Control`] after its first/only value -- a
+/// `QueryResult::Partial`'s own control, which the plain version silently
+/// drops (#1164). See [`result_to_owned_ctrl`]'s doc comment for the
+/// live-verified jq semantics this preserves for a caller that can re-wrap
+/// its own successful final result via [`partial`]/[`finish_owned`]/
+/// [`finish_result`] when this is `Some`.
+fn eval_owned_expr_ctrl_full<S: EvalSemantics>(
+    expr: &Expr,
+    input: &OwnedValue,
+    optional: bool,
+) -> Result<(OwnedValue, Option<Control>), Control> {
     if let Some(result) = eval_owned_fast_path::<S>(expr, input, optional) {
         return result
-            .map(|v| v.unwrap_or(OwnedValue::Null))
+            .map(|v| (v.unwrap_or(OwnedValue::Null), None))
             .map_err(Control::Error);
     }
 
@@ -15473,24 +15578,24 @@ fn eval_owned_expr_ctrl<S: EvalSemantics>(
     let cursor = index.root(json_bytes);
 
     match eval_single::<Vec<u64>, S>(expr, cursor.value(), optional).materialize_cursor() {
-        QueryResult::One(v) => Ok(to_owned(&v)),
+        QueryResult::One(v) => Ok((to_owned(&v), None)),
         QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Owned(v) => Ok(v),
+        QueryResult::Owned(v) => Ok((v, None)),
         QueryResult::Many(vs) => {
             if vs.len() == 1 {
-                Ok(to_owned(&vs[0]))
+                Ok((to_owned(&vs[0]), None))
             } else {
-                Ok(OwnedValue::Array(vs.iter().map(to_owned).collect()))
+                Ok((OwnedValue::Array(vs.iter().map(to_owned).collect()), None))
             }
         }
         QueryResult::ManyOwned(vs) => {
             if vs.len() == 1 {
-                Ok(vs.into_iter().next().unwrap())
+                Ok((vs.into_iter().next().unwrap(), None))
             } else {
-                Ok(OwnedValue::Array(vs))
+                Ok((OwnedValue::Array(vs), None))
             }
         }
-        QueryResult::None => Ok(OwnedValue::Null),
+        QueryResult::None => Ok((OwnedValue::Null, None)),
         QueryResult::Error(e) => Err(Control::Error(e)),
         QueryResult::Break(label) => Err(Control::Break(label)),
         QueryResult::Halt(code) => Err(Control::Halt(code)),
@@ -15502,17 +15607,15 @@ fn eval_owned_expr_ctrl<S: EvalSemantics>(
         // discarded (#791).
         QueryResult::Partial(_, Control::Halt(code)) => Err(Control::Halt(code)),
         // Same collapse-to-single-or-array policy as `Many`/`ManyOwned`
-        // above; the trailing `Error`/`Break` is dropped, consistent with how
-        // this function already doesn't fork over a multi-output update (a
-        // separate, pre-existing limitation, not #400/#494's concern) -- and,
-        // as of #833, still not this function's concern either: see
-        // `result_to_owned`'s identical arm for why a trailing escape after
-        // already-produced output needs its own, separate fix.
-        QueryResult::Partial(vs, _control) => {
+        // above; the trailing `Error`/`Break` is now exposed via the second
+        // tuple element instead of silently dropped (#1164) -- a caller
+        // using this function (rather than the plain `eval_owned_expr_ctrl`
+        // above) is expected to apply it to its own final result.
+        QueryResult::Partial(vs, control) => {
             if vs.len() == 1 {
-                Ok(vs.into_iter().next().unwrap())
+                Ok((vs.into_iter().next().unwrap(), Some(control)))
             } else {
-                Ok(OwnedValue::Array(vs))
+                Ok((OwnedValue::Array(vs), Some(control)))
             }
         }
     }
@@ -20443,12 +20546,13 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     // First get the format string
-    let fmt = match result_to_owned(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "strftime format")),
-        Err(e) => return e.into(),
-    };
+    let (fmt, trailing) =
+        match result_to_owned_ctrl(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
+            Ok((OwnedValue::String(s), trailing)) => (s, trailing),
+            Ok(_) if optional => return QueryResult::None,
+            Ok(_) => return QueryResult::Error(EvalError::type_error("string", "strftime format")),
+            Err(e) => return e.into(),
+        };
 
     // Value should be a broken-down time array, or a raw Unix timestamp
     // number (auto-converted the same way `gmtime` converts one).
@@ -20549,7 +20653,7 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(_) if optional => return QueryResult::None,
         Err(e) => return QueryResult::Error(e),
     };
-    QueryResult::Owned(OwnedValue::String(result))
+    finish_owned(OwnedValue::String(result), trailing)
 }
 
 /// Format a time according to strftime format specifiers
@@ -20766,16 +20870,17 @@ fn builtin_strptime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     // First get the format string
-    let fmt = match result_to_owned(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
-        // #929: confirmed live: `"2020" | strptime(1)` raises "strptime/1
-        // requires string inputs and arguments" in jq 1.7.1 -- the same
-        // wording jq's combined input+format check uses regardless of
-        // which side is the offender (see the other arm below).
-        Ok(_) => return QueryResult::Error(EvalError::strptime_requires_string()),
-        Err(e) => return e.into(),
-    };
+    let (fmt, trailing) =
+        match result_to_owned_ctrl(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
+            Ok((OwnedValue::String(s), trailing)) => (s, trailing),
+            Ok(_) if optional => return QueryResult::None,
+            // #929: confirmed live: `"2020" | strptime(1)` raises "strptime/1
+            // requires string inputs and arguments" in jq 1.7.1 -- the same
+            // wording jq's combined input+format check uses regardless of
+            // which side is the offender (see the other arm below).
+            Ok(_) => return QueryResult::Error(EvalError::strptime_requires_string()),
+            Err(e) => return e.into(),
+        };
 
     // Value should be a string
     let input = match &value {
@@ -20802,7 +20907,7 @@ fn builtin_strptime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 OwnedValue::Int(t.weekday),
                 OwnedValue::Int(t.yearday),
             ];
-            QueryResult::Owned(OwnedValue::Array(result))
+            finish_owned(OwnedValue::Array(result), trailing)
         }
         Err(_) if optional => QueryResult::None,
         Err(_) => QueryResult::Error(EvalError::strptime_no_match(&input, &fmt)),
@@ -21637,12 +21742,15 @@ fn builtin_tz<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     // Evaluate the timezone expression to get the zone name
-    let zone_str = match result_to_owned(eval_single::<W, S>(zone_expr, value.clone(), optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "tz zone argument")),
-        Err(e) => return e.into(),
-    };
+    let (zone_str, trailing) =
+        match result_to_owned_ctrl(eval_single::<W, S>(zone_expr, value.clone(), optional)) {
+            Ok((OwnedValue::String(s), trailing)) => (s, trailing),
+            Ok(_) if optional => return QueryResult::None,
+            Ok(_) => {
+                return QueryResult::Error(EvalError::type_error("string", "tz zone argument"))
+            }
+            Err(e) => return e.into(),
+        };
 
     // Get the timezone offset
     let offset = match get_timezone_offset(&zone_str, timestamp) {
@@ -21657,7 +21765,7 @@ fn builtin_tz<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Ok(s) => s,
             Err(r) => return r,
         };
-    QueryResult::Owned(OwnedValue::String(result))
+    finish_owned(OwnedValue::String(result), trailing)
 }
 
 // Phase 22: File operations (yq)
@@ -21673,12 +21781,13 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     use std::path::Path;
 
     // Evaluate the file expression to get the filename
-    let filename = match result_to_owned(eval_single::<W, S>(file_expr, value, optional)) {
-        Ok(OwnedValue::String(s)) => s,
-        Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("string", "load filename")),
-        Err(e) => return e.into(),
-    };
+    let (filename, trailing) =
+        match result_to_owned_ctrl(eval_single::<W, S>(file_expr, value, optional)) {
+            Ok((OwnedValue::String(s), trailing)) => (s, trailing),
+            Ok(_) if optional => return QueryResult::None,
+            Ok(_) => return QueryResult::Error(EvalError::type_error("string", "load filename")),
+            Err(e) => return e.into(),
+        };
 
     // Read the file contents
     let file_bytes = match std::fs::read(&filename) {
@@ -21701,7 +21810,7 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         .and_then(|e| e.to_str())
         .is_some_and(|ext| ext.eq_ignore_ascii_case("json"));
 
-    if is_json {
+    let result = if is_json {
         // Parse as JSON
         let index = crate::json::JsonIndex::build(&file_bytes);
         let cursor = index.root(&file_bytes);
@@ -21737,7 +21846,8 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 "load: failed to parse YAML file '{filename}': {e}"
             ))),
         }
-    }
+    };
+    finish_result(result, trailing)
 }
 
 /// Convert a YAML value to OwnedValue (helper for `load`).
@@ -23360,9 +23470,9 @@ fn builtin_envvar<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Evaluate the expression to get the variable name
     let owned_value = to_owned(&value);
-    let var_result = eval_owned_expr::<S>(var, &owned_value, optional);
-    let var_name = match var_result {
-        Ok(OwnedValue::String(s)) => s,
+    let var_result = eval_owned_expr_ctrl_full::<S>(var, &owned_value, optional);
+    let (var_name, trailing) = match var_result {
+        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
         // Checked ahead of the generic fallback below (which would
         // otherwise flatten either into a misleading "must be a string"
         // message and, when `optional`, silently swallow it): a halt must
@@ -23372,16 +23482,21 @@ fn builtin_envvar<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // (matching this file's own precedent, e.g. `QueryResult::is_error`
         // and `builtin_isvalid`'s `Halt`/`Break` arms) rather than two,
         // since both escapes get identical treatment here.
-        Err(escape @ (EvalEscape::Halt(_) | EvalEscape::Break(_))) => return escape.into(),
+        Err(control @ (Control::Halt(_) | Control::Break(_))) => {
+            return partial(Vec::new(), control)
+        }
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::new("env variable name must be a string")),
     };
 
-    match std::env::var(&var_name) {
-        Ok(val) => QueryResult::Owned(OwnedValue::String(val)),
-        Err(_) if optional => QueryResult::None,
-        Err(_) => QueryResult::Owned(OwnedValue::Null),
-    }
+    finish_result(
+        match std::env::var(&var_name) {
+            Ok(val) => QueryResult::Owned(OwnedValue::String(val)),
+            Err(_) if optional => QueryResult::None,
+            Err(_) => QueryResult::Owned(OwnedValue::Null),
+        },
+        trailing,
+    )
 }
 
 #[cfg(not(feature = "std"))]
@@ -43703,6 +43818,32 @@ mod tests {
         // downgraded to `None` the way an ordinary type error would be.
         match builtin_envvar::<Vec<u64>, JqSemantics>(&var, StandardJson::Null, true) {
             QueryResult::Break(label) => assert_eq!(label, "out"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1164: a variable-name generator that produces a name and *then*
+    /// breaks -- e.g. `("PATH", break $out)` -- must still look that name
+    /// up and use it (matching every other #1164 fix's "compute
+    /// successfully with the first value, then propagate the escape"
+    /// semantics, live-verified against real jq for the CLI-reachable
+    /// builtins) rather than silently dropping the trailing `Break` the
+    /// way `builtin_envvar` did before this fix. No CLI-level equivalent
+    /// exists (`Builtin::EnvVar` has no parser construction site, per the
+    /// tests above), so this is exercised directly like they are.
+    /// `PATH` is used only because it is virtually guaranteed to be set in
+    /// any process running this test suite -- its actual value is
+    /// irrelevant, only that a real lookup happened before the escape did.
+    #[cfg(feature = "std")]
+    #[test]
+    fn builtin_envvar_propagates_trailing_break_after_successful_lookup_1164() {
+        let var = parse(r#"("PATH", break $out)"#).unwrap();
+        match builtin_envvar::<Vec<u64>, JqSemantics>(&var, StandardJson::Null, false) {
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(label, "out");
+                assert_eq!(vs.len(), 1);
+                assert!(matches!(vs[0], OwnedValue::String(_)), "vs[0]={:?}", vs[0]);
+            }
             other => panic!("unexpected result: {other:?}"),
         }
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12780,3 +12780,285 @@ fn test_destructuring_pattern_null_propagates_through_nested_array_1239() -> Res
     assert_eq!(out.trim(), "null");
     Ok(())
 }
+
+// =============================================================================
+// #1164: a builtin argument generator that produces a value and *then*
+// breaks/errors no longer silently continues past that escape once the
+// builtin has finished using the value -- `result_to_owned`/
+// `eval_owned_expr_ctrl`'s own `Partial` arm used to drop the trailing
+// control entirely. All cases below live-verified against real jq (or, for
+// `tz` -- a succinctly-only extension with no jq equivalent -- checked for
+// internal consistency against the same builtin without the trailing
+// escape).
+//
+// The pattern throughout: `label $out | (builtin((v, break $out)), "after")`
+// -- real jq computes the builtin's result using `v`, produces it, and only
+// then unwinds to `$out`, so `"after"` never prints. Before this fix,
+// succinctly silently dropped the escape and printed both the builtin's
+// result *and* `"after"`.
+// =============================================================================
+
+#[test]
+fn test_ltrimstr_uses_first_arg_value_then_propagates_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (ltrimstr(("a", break $out)), "after")"#,
+        ],
+        Some(r#""abcabc""#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#""bcabc""#);
+    Ok(())
+}
+
+#[test]
+fn test_rtrimstr_uses_first_arg_value_then_propagates_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (rtrimstr(("c", break $out)), "after")"#,
+        ],
+        Some(r#""abcabc""#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#""abcab""#);
+    Ok(())
+}
+
+#[test]
+fn test_startswith_endswith_split_propagate_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (startswith(("a", break $out)), "after")"#,
+        ],
+        Some(r#""abcabc""#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (endswith(("c", break $out)), "after")"#,
+        ],
+        Some(r#""abcabc""#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, err, code) = run_jq_full(
+        &["-c", r#"label $out | (split((",", break $out)), "after")"#],
+        Some(r#""abcabc""#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#"["abcabc"]"#);
+    Ok(())
+}
+
+#[test]
+fn test_join_uses_first_separator_value_then_propagates_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#"label $out | (join((",", break $out)), "after")"#],
+        Some(r#"["a","b"]"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#""a,b""#);
+    Ok(())
+}
+
+#[test]
+fn test_contains_inside_propagate_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (contains(("a", break $out)), "after")"#,
+        ],
+        Some(r#""abc""#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (inside(("abc", break $out)), "after")"#,
+        ],
+        Some(r#""a""#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "true");
+    Ok(())
+}
+
+/// The issue's own repro for the deeper (not just bare-Break) case: real
+/// jq's own downstream error still wins over a trailing break the argument
+/// generator's second output would have raised -- `has`'s own type-mismatch
+/// error fires first, since the break's own generator output is never
+/// reached (control test, unaffected by this fix but confirming the "own
+/// error wins" rule this fix relies on).
+#[test]
+fn test_has_propagates_trailing_break_after_success_but_not_after_own_error_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#"label $out | (has(("a", break $out)), "after")"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "true");
+
+    let (_out, err, code) = run_jq_full(
+        &["-c", r#"label $out | (has(("a", break $out)), "after")"#],
+        Some("5"),
+    )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("Cannot check"), "err={err}");
+    Ok(())
+}
+
+#[test]
+fn test_nth_uses_first_arg_value_then_propagates_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#"label $out | (nth((1, break $out)), "after")"#],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "2");
+    Ok(())
+}
+
+#[test]
+fn test_flatten_depth_uses_first_arg_value_then_propagates_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#"label $out | (flatten((1, break $out)), "after")"#],
+        Some("[[1,[2]]]"),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "[1,[2]]");
+    Ok(())
+}
+
+#[test]
+fn test_getpath_uses_first_arg_value_then_propagates_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (getpath((["a"], break $out)), "after")"#,
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "1");
+    Ok(())
+}
+
+#[test]
+fn test_strftime_strptime_propagate_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (gmtime | strftime(("%Y", break $out)), "after")"#,
+        ],
+        Some("0"),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#""1970""#);
+
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (strptime(("%Y-%m-%d", break $out)), "after")"#,
+        ],
+        Some(r#""2020-01-01""#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "[2020,0,1,0,0,0,3,0]");
+    Ok(())
+}
+
+/// `tz` is a succinctly-only extension (no real jq equivalent to verify
+/// against) -- checked instead for internal consistency: the same query
+/// without the trailing break prints `"after"` normally, confirming the
+/// break (not some unrelated bug) is what suppresses it below.
+#[test]
+fn test_tz_uses_first_arg_value_then_propagates_trailing_break_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", r#"label $out | (0 | tz("UTC")), "after""#], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "\"1970-01-01T00:00:00Z\"\n\"after\"");
+
+    let (out, err, code) = run_jq_full(
+        &[
+            "-cn",
+            r#"label $out | (0 | tz(("UTC", break $out))), "after""#,
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "\"1970-01-01T00:00:00Z\"");
+    Ok(())
+}
+
+#[test]
+fn test_load_uses_first_arg_value_then_propagates_trailing_break_1164() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    writeln!(file, r#"{{"x":1}}"#)?;
+    let path = file.path().to_str().unwrap();
+
+    let query = format!(r#"label $out | (load(("{path}", break $out))), "after""#);
+    let (out, err, code) = run_jq_full(&["-cn", &query], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#"{"x":1}"#);
+    Ok(())
+}
+
+// `builtin_envvar`'s own fix (below) has no CLI-level test: `Builtin::EnvVar`
+// has no parser construction site anywhere in this codebase (confirmed by
+// that function's own pre-existing Halt/Break regression tests in
+// src/jq/eval.rs) -- `env.VAR`/`$ENV.VAR`/`$ENV["VAR"]` all resolve through
+// ordinary field/index access on a materialized object instead, never
+// through this function. Its #1164 fix is covered by a direct unit test in
+// src/jq/eval.rs instead, mirroring those same pre-existing tests' own
+// "exercise it directly, since the CLI can't reach it" convention.
+
+/// Control: `error(msg)`'s own "success" path already collapses into
+/// producing an error, matching what the trailing break would have done
+/// anyway -- deliberately left unfixed by #1164 (verified live: real jq's
+/// `try error(("a", break $out)) catch (.)` still prints `"after"` too, the
+/// break is never re-observed once the error is caught, so there is no
+/// separate escape to propagate here). Confirms this fix didn't
+/// accidentally change `error`'s own behavior.
+#[test]
+fn test_error_message_arg_break_semantics_unaffected_by_1164() -> Result<()> {
+    let (_out, err, code) =
+        run_jq_full(&["-cn", r#"label $out | error(("a", break $out))"#], None)?;
+    assert_ne!(code, 0);
+    assert!(err.contains('a'), "err={err}");
+    Ok(())
+}
+
+/// Control: `combinations(n)` uses `n` inside a nested `range(n)`
+/// generator (not as a simple scalar), so real jq's own escape semantics
+/// there are different from every other case above -- a trailing break in
+/// `n`'s own generator aborts the whole array-construction context real
+/// jq's `def combinations(n): ...` body uses internally, producing *no*
+/// output at all, not "the first n's worth of combinations, then stop".
+/// Deliberately left unfixed by #1164; this pins the current (pre-existing,
+/// still-divergent-from-jq) behavior so a future attempt doesn't assume
+/// the same simple wrap other builtins got would be correct here too.
+#[test]
+fn test_combinations_n_break_semantics_documented_not_fixed_by_1164() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#"label $out | (combinations((2, break $out)), "after")"#,
+        ],
+        Some("[1,2]"),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    // Pre-existing divergence from real jq (which produces no output at all
+    // here, verified live: `jq -c 'label $out | (combinations((2, break
+    // $out)), "after")'` on `[1,2]` prints nothing) -- not attempted by
+    // #1164, see this test's own doc comment.
+    assert_eq!(out.trim(), "[1,1]\n[1,2]\n[2,1]\n[2,2]\n\"after\"");
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13036,6 +13036,46 @@ fn test_error_message_arg_break_semantics_unaffected_by_1164() -> Result<()> {
     Ok(())
 }
 
+/// #1164 coverage: the `optional` (`?`) arm of a wrong-typed argument is a
+/// separate branch from the non-optional error arm every other test above
+/// already exercises -- `?` suppresses the type mismatch to no output
+/// (`QueryResult::None`) for each of these builtins' argument-evaluation
+/// gate, independent of whether the trailing-control fix applies at all.
+#[test]
+fn test_argument_type_mismatch_optional_arms_produce_no_output_1164() -> Result<()> {
+    for (expr, input) in [
+        ("getpath(\"notarray\")?", r#"{"a":1}"#),
+        ("gmtime | strftime(5)?", "0"),
+        ("strptime(5)?", r#""x""#),
+        ("tz(5)?", "0"),
+    ] {
+        let (out, err, code) = run_jq_full(&["-c", expr], Some(input))?;
+        assert_eq!(code, 0, "expr={expr}: err={err}");
+        assert_eq!(out, "", "expr={expr}: out={out:?}");
+    }
+
+    let (out, err, code) = run_jq_full(&["-cn", "load(5)?"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+/// #1164 coverage: a negative `flatten` depth still errors even when the
+/// argument generator that produced it also has a trailing break -- the
+/// error arm wins outright (own-error-supersedes-argument's-escape, same
+/// rule as `has`'s control test above), independent of the guard on the
+/// success arm every other `flatten` test above already exercises.
+#[test]
+fn test_flatten_negative_depth_errors_even_with_trailing_break_1164() -> Result<()> {
+    let (_out, err, code) = run_jq_full(
+        &["-c", r"label $out | flatten((-1, break $out))"],
+        Some("[[1]]"),
+    )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("non-negative"), "err={err}");
+    Ok(())
+}
+
 /// Control: `combinations(n)` uses `n` inside a nested `range(n)`
 /// generator (not as a simple scalar), so real jq's own escape semantics
 /// there are different from every other case above -- a trailing break in


### PR DESCRIPTION
## Summary

`result_to_owned`'s `Partial(vs, _control)` arm silently dropped the trailing control after taking a generator argument's first value — e.g. `ltrimstr(("a", break $out))` computed and used `"a"` correctly but then kept running instead of unwinding to `$out`, unlike real jq (which uses the first value, produces its result, and only *then* unwinds — live-verified: real jq prints `"bcabc"` then jumps past `"after"` entirely). `eval_owned_expr_ctrl` had the identical bug in its own `Partial` arm.

This issue was originally filed as Tier 2/3 ("likely needs a precursor spike classifying which of `result_to_owned`'s ~37 callers can tolerate becoming `Partial`-aware"). Did that classification (via an Explore agent, then verified each finding by hand against real jq) and implemented the clean subset it turned up.

## Fix

Added `result_to_owned_ctrl`/`eval_owned_expr_ctrl_full` — widened siblings of the existing functions that also expose the trailing `Control` instead of dropping it — alongside two small reusable finishers (`finish_owned`, `finish_result`) that wrap a builtin's own successful final result via `partial()` when a trailing control exists. The plain `result_to_owned`/`eval_owned_expr_ctrl` now just delegate and discard the second tuple element, so every **untouched** call site keeps today's behavior with zero risk.

Applied to 16 `result_to_owned` sites and 1 `eval_owned_expr_ctrl` site, whose own builtin computation is a single, simple use of the argument's value with no other generator involved: `ltrimstr`, `rtrimstr`, `startswith`, `endswith`, `split`, `join`, `contains`, `inside`, `has`, `nth`, `flatten(depth)`, `getpath`, `strftime`, `strptime`, `tz`, `load`, and `env.VAR` (`builtin_envvar` — confirmed via its own pre-existing tests to be unreachable from any CLI query at all, but fixed and unit-tested anyway, matching that function's own established "exercise it directly" precedent for the same reason). Every fix live-verified against real jq for the CLI-reachable builtins (`tz` has no jq equivalent; checked for internal self-consistency instead).

## Two investigated, deliberately-left-alone cases

- **`error()`/`halt_error()`**: their own "success" path already collapses into an escape, so the trailing control from their own argument is moot. Live-verified: real jq's `error(("a", break $out))` still just raises `"a"`, and once caught via `try`/`catch` the break is never re-observed — confirmed this isn't a narrower "will fix later" case, the current unfixed code is already correct.
- **`combinations(n)`**: uses `n` inside a nested `range(n)` generator rather than as a simple scalar, so a trailing escape in `n`'s own generator aborts the whole array-construction context real jq's `def combinations(n): ...` body uses internally, producing **no output at all** — not "the first n's worth, then stop" the way the simple `finish_owned`/`finish_result` wrap would have produced. Pinned as a known, still-open divergence via a dedicated regression test rather than silently left unverified.

## Remaining scope (not this PR)

~24 of the issue's own estimated ~37 sites need real, separate design work:
- `indices`/`index`/`rindex` have several scattered internal return points that would need restructuring to wrap safely.
- The regex pattern+flags family and `eval_sub_replacement`'s own per-match loop each have a **second, independent escape source** (the flags argument, or the replacement expression) whose interaction with this fix isn't verified.
- `eval_limit`/`eval_nth_expr`/`resolve_limit` already have bespoke `Partial`-reconciliation logic of their own to merge into.
- `eval_builtin_owned` is embedded inside the much larger `eval_pipe_with_path_context_internal`, which has its own existing `partial()`-based machinery three other call sites in that same function would need updating alongside it.

Left for a future, separately-scoped pass — will note this on the issue if there's appetite for a follow-up.

Fixes #1164

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] Every fixed builtin live-verified against real jq (14 new CLI tests + 1 new direct unit test for the CLI-unreachable `env.VAR` case)
- [x] Both deliberately-unfixed cases (`error`, `combinations(n)`) covered by regression tests documenting *why*, not just left silently unverified