### PR TITLE
fix(jq): correct format_positive_shifted_plain's stale unreachability claim

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -805,13 +805,31 @@ fn join_sign_digits_with_optional_point(sign: &str, before: &str, after: &str) -
 ///
 /// The `split_pos > digits.len()` check below is a second, independent
 /// guard against `mantissa_str` having been truncated by
-/// `normalize_extreme_literal_mantissa`'s own render cap short of the digit
-/// `shifted_exp` needs to place the decimal point at -- provably
-/// unreachable *today* (a `shifted_exp` this function ever sees is bounded
-/// by a finite `f64`'s own representable magnitude, ~308, far below the
-/// render cap), so no live literal takes this branch; it exists as a safety
-/// net against a future, much smaller render cap rather than a case this
-/// code currently handles (code review, #1253).
+/// `normalize_extreme_literal_mantissa`'s own render cap
+/// (`MAX_RENDERED_MANTISSA_DIGITS`) short of the digit `shifted_exp` needs
+/// to place the decimal point at. Unreachable from
+/// `format_number_jq_compat`'s own call site (a `shifted_exp` reaching this
+/// function only from there is bounded by a finite `f64`'s representable
+/// magnitude, ~308, far below the render cap) -- but *is* live-reachable
+/// from `format_overflow_literal_mantissa`'s call site, whose `shifted_exp`
+/// has no comparable bound (only the unrelated `1_000_000_000` exponent
+/// ceiling). A literal with more than `MAX_RENDERED_MANTISSA_DIGITS + 1`
+/// significant digits *and* an `f64`-overflowing value (e.g.
+/// `"9".repeat(100_002) + "e0"`) hits exactly this: real jq stays plain at
+/// that scale (oracle-verified past 500,000 digits, no ceiling found), but
+/// this function's own decision already used the *true* `digit_count` to
+/// commit to "should be plain," then discovers mid-render that the
+/// (already-truncated) `mantissa_str` doesn't have enough surviving digits
+/// to actually place the decimal point -- so it falls to scientific
+/// notation instead, itself also mantissa-truncated by the same cap. This
+/// is an accepted, documented divergence from real jq at that scale (#1274
+/// code review), the same class of trade-off `MAX_RENDERED_MANTISSA_DIGITS`
+/// already makes elsewhere in this module -- fixing it exactly would need
+/// `normalize_extreme_literal_mantissa` to defer its own truncation
+/// decision until the caller's notation choice is known (currently the
+/// reverse order), which is a larger restructuring than this fallback
+/// alone; not attempted here given how rare the trigger combination is
+/// (`f64` overflow *and* a >100,000-significant-digit literal).
 ///
 /// `mantissa_str` is `"d"` or `"d.ddd"` (one leading digit,
 /// `normalize_extreme_literal_mantissa`'s normalized form) -- concatenating
@@ -3387,6 +3405,50 @@ mod tests {
         assert_eq!(
             format_number_jq_compat(format!("{mantissa}e1").as_bytes()),
             format!("9.{}E+400", "9".repeat(399))
+        );
+    }
+
+    /// #1274 characterization test (not a regression test -- this pins
+    /// known, accepted-divergent-from-jq behavior, not desired behavior;
+    /// see the testing skill's characterization-test convention). Before
+    /// this PR the mechanism was undocumented and the doc comment claiming
+    /// it "provably unreachable" was simply wrong; after this PR the
+    /// behavior itself is unchanged, only correctly documented and pinned.
+    /// If a future fix defers `normalize_extreme_literal_mantissa`'s
+    /// truncation until the caller's notation choice is known (the
+    /// restructuring `format_positive_shifted_plain`'s own doc comment
+    /// describes as the real fix), update or delete this test rather than
+    /// treating a failure here as a regression.
+    ///
+    /// `format_positive_shifted_plain`'s truncation-vs-decision mismatch is
+    /// live-reachable only via the overflow path
+    /// (`format_overflow_literal_mantissa`) since the ordinary path's own
+    /// `shifted_exp` can never exceed `MAX_RENDERED_MANTISSA_DIGITS`
+    /// (bounded by `f64`'s own finite range). One digit past
+    /// `MAX_RENDERED_MANTISSA_DIGITS` given digits (exactly filling the
+    /// render cap, no truncation yet): still plain, matching real jq
+    /// (oracle-verified past 500,000 digits). Two digits past it (one digit
+    /// truncated away): falls to scientific instead -- see
+    /// `format_positive_shifted_plain`'s own doc comment for why. Pins the
+    /// exact, intentional boundary so a future change to the render cap or
+    /// the truncation/decision ordering can't silently move it without a
+    /// test noticing.
+    #[test]
+    fn test_format_number_jq_compat_overflow_plain_scientific_flip_boundary_characterize_preexisting_bug_1274(
+    ) {
+        let at_cap = "9".repeat(100_001); // MAX_RENDERED_MANTISSA_DIGITS + 1 given digits
+        assert_eq!(
+            format_number_jq_compat(format!("{at_cap}e0").as_bytes()),
+            at_cap,
+            "at MAX_RENDERED_MANTISSA_DIGITS + 1 given digits: still plain, matching real jq"
+        );
+        let past_cap = "9".repeat(100_002); // MAX_RENDERED_MANTISSA_DIGITS + 2 given digits
+        assert_eq!(
+            format_number_jq_compat(format!("{past_cap}e0").as_bytes()),
+            format!("9.{}E+100001", "9".repeat(100_000)),
+            "at MAX_RENDERED_MANTISSA_DIGITS + 2 given digits: falls to \
+             (also-truncated) scientific, diverging from real jq's own \
+             plain output at this scale"
         );
     }
 


### PR DESCRIPTION
## Summary

`format_positive_shifted_plain`'s own doc comment claimed its `split_pos > digits.len()` truncation guard was "provably unreachable" -- true for `format_number_jq_compat`'s own call site (`shifted_exp` bounded to ~308 by `f64`'s finite range), but false for the other caller, `format_overflow_literal_mantissa`, whose `shifted_exp` has no comparable bound. A literal past `MAX_RENDERED_MANTISSA_DIGITS + 1` significant digits combined with an `f64`-overflowing value hits it live:

```
$ python3 -c "print('9'*100002 + 'e0')" | succinctly jq -c .
9.999...9E+100001            # scientific, truncated

$ python3 -c "print('9'*100002 + 'e0')" | jq -c .
999...9                      # real jq: plain, exact (verified past 500,000 digits, no ceiling found)
```

## Scope decision -- this does NOT close issue #1274's own behavioral gap

A byte-exact fix would need `normalize_extreme_literal_mantissa` to defer its own mantissa-truncation decision until the caller's notation choice (plain vs. scientific) is known -- currently the reverse order, since the exponent isn't even parsed yet at the point the mantissa gets truncated. That's a larger restructuring than the trigger warrants: this needs an `f64`-overflowing value *and* a >100,000-significant-digit literal at once, a combination essentially only reachable via synthetic/adversarial input, not a realistic document.

This PR corrects the doc comment's factual claim ("provably unreachable" was simply wrong) and adds a characterization test pinning the *current* behavior as documented and accepted-for-now -- not a resolution of issue #1274's own reported symptom, which remains open. This PR body intentionally avoids GitHub's auto-close keyword syntax for that issue number, since GitHub's keyword parser doesn't understand negation and would close it on merge regardless of surrounding wording. See the follow-up comment on that issue for the actual remaining scope (the truncation-deferral restructuring) if anyone wants to pick it up.

## Verification

- Oracle-probed real jq (`jq 1.7.1`) at the exact boundary and well past it (up to 500,000 digits) to confirm it has no comparable ceiling before writing the doc comment's claim.
- Confirmed the current build's exact behavior at and past the boundary (100,001 digits stays plain; 100,002 flips).
- Added a characterization test (per this repo's testing-skill convention for pinning known-divergent-but-accepted behavior, not desired behavior) so a future change to the render cap or truncation ordering can't silently move the boundary without a test noticing.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, no-fail-fast) -- all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo check --no-default-features` (no_std) -- compiles (pre-existing unrelated dead-code warnings only)
- [x] New characterization test pinning the documented boundary

Related to issue number 1274 (intentionally left open, see above)