### PR TITLE
fix(jq): propagate a zero-output generator argument as zero output

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5151,17 +5151,19 @@ fn builtin_flatten_depth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the depth
     let depth_result = eval_single::<W, S>(depth_expr, value.clone(), optional);
-    let (depth, trailing) = match result_to_owned_full(depth_result) {
+    let (depth_value, trailing) = match result_to_owned_full(depth_result) {
         Ok(None) => return QueryResult::None,
-        Ok(Some((
-            OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _),
-            trailing,
-        ))) if d >= 0 => (d as usize, trailing),
-        Ok(Some((OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _), _))) => {
+        Ok(Some(v)) => v,
+        Err(e) => return e.into(),
+    };
+    let depth = match depth_value {
+        OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _) if d >= 0 => {
+            d as usize
+        }
+        OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _) => {
             return QueryResult::Error(EvalError::new("depth must be non-negative"));
         }
-        Ok(Some(_)) => return QueryResult::Error(EvalError::type_error("number", "non-number")),
-        Err(e) => return e.into(),
+        _ => return QueryResult::Error(EvalError::type_error("number", "non-number")),
     };
 
     finish_result(builtin_flatten::<W>(value, optional, depth), trailing)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1454,24 +1454,40 @@ fn result_to_owned<W: Clone + AsRef<[u64]>>(
 fn result_to_owned_ctrl<W: Clone + AsRef<[u64]>>(
     result: QueryResult<'_, W>,
 ) -> Result<(OwnedValue, Option<Control>), EvalEscape> {
+    result_to_owned_full(result)?.ok_or_else(|| EvalError::new("no value").into())
+}
+
+/// Like [`result_to_owned_ctrl`], but distinguishes "the argument produced
+/// zero outputs at all" (`Ok(None)`) from every other case, instead of
+/// collapsing it into the same `Err("no value")` `result_to_owned_ctrl`
+/// still returns for its own (unmigrated) callers (#1045).
+///
+/// Real jq desugars a generator-argument builtin call `f(x)` roughly as `x
+/// as $b | ...body using $b...` (see `result_to_owned_ctrl`'s own doc
+/// comment) -- and jq's `as` binding runs its body *once per output* `x`
+/// produces, zero times if `x` produces none. So `x` producing no output at
+/// all makes the *whole* enclosing computation produce no output, not an
+/// error: confirmed live across a broad, unrelated sample of builtins
+/// (`has`, `ltrimstr`, `rtrimstr`, `startswith`, `endswith`, `split`,
+/// `join`, `contains`, `inside`, `nth`, `flatten(depth)`, `getpath`,
+/// `strftime`, `strptime`, `test`, and even `error` itself -- `1 |
+/// error(empty)` exits 0 with no output in real jq, not "no value") with no
+/// exceptions found, unlike the narrower, escape-specific exceptions
+/// `result_to_owned_ctrl`'s own doc comment documents for the *trailing*
+/// case. A caller migrating to this function must return `QueryResult::None`
+/// on `Ok(None)` instead of treating it as an error.
+fn result_to_owned_full<W: Clone + AsRef<[u64]>>(
+    result: QueryResult<'_, W>,
+) -> Result<Option<(OwnedValue, Option<Control>)>, EvalEscape> {
     match result.materialize_cursor() {
-        QueryResult::One(v) => Ok((to_owned(&v), None)),
+        QueryResult::One(v) => Ok(Some((to_owned(&v), None))),
         QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Owned(v) => Ok((v, None)),
-        QueryResult::Many(vs) => {
-            if let Some(v) = vs.first() {
-                Ok((to_owned(v), None))
-            } else {
-                Err(EvalError::new("empty result").into())
-            }
-        }
-        QueryResult::ManyOwned(vs) => {
-            if let Some(v) = vs.into_iter().next() {
-                Ok((v, None))
-            } else {
-                Err(EvalError::new("empty result").into())
-            }
-        }
+        QueryResult::Owned(v) => Ok(Some((v, None))),
+        // An empty `Many`/`ManyOwned` is the same "zero outputs" case as a
+        // bare `QueryResult::None` below, not a distinct error -- both mean
+        // the argument's generator produced nothing.
+        QueryResult::Many(vs) => Ok(vs.first().map(|v| (to_owned(v), None))),
+        QueryResult::ManyOwned(vs) => Ok(vs.into_iter().next().map(|v| (v, None))),
         // Same "take the first output" policy already applied to
         // `Many`/`ManyOwned` above — a `Partial` prefix is never empty (see
         // `partial`), so there is always a first value to take.
@@ -1482,8 +1498,10 @@ fn result_to_owned_ctrl<W: Clone + AsRef<[u64]>>(
         // `Break`/`Error`, a `Halt` has no "run to completion first" jq
         // semantics to preserve.
         QueryResult::Partial(_, Control::Halt(code)) => Err(EvalEscape::Halt(code)),
-        QueryResult::Partial(vs, control) => Ok((vs.into_iter().next().unwrap(), Some(control))),
-        QueryResult::None => Err(EvalError::new("no value").into()),
+        QueryResult::Partial(vs, control) => {
+            Ok(Some((vs.into_iter().next().unwrap(), Some(control))))
+        }
+        QueryResult::None => Ok(None),
         QueryResult::Error(e) => Err(e.into()),
         // A *bare* (no prior output) `break $label` escaping a builtin's
         // argument expression now propagates instead of collapsing into a
@@ -3498,8 +3516,9 @@ fn builtin_has<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Evaluate the key expression
     let key_result = eval_single::<W, S>(key_expr, value.clone(), optional);
-    let (key_owned, trailing) = match result_to_owned_ctrl(key_result) {
-        Ok(v) => v,
+    let (key_owned, trailing) = match result_to_owned_full(key_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some(v)) => v,
         Err(e) => return e.into(),
     };
 
@@ -4423,10 +4442,11 @@ fn builtin_ltrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the prefix string
     let prefix_result = eval_single::<W, S>(prefix_expr, value.clone(), optional);
-    let (prefix, trailing) = match result_to_owned_ctrl(prefix_result) {
-        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
+    let (prefix, trailing) = match result_to_owned_full(prefix_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
         // jq's ltrimstr is total: a non-string argument leaves input unchanged.
-        Ok((_, trailing)) => return finish_owned(to_owned(&value), trailing),
+        Ok(Some((_, trailing))) => return finish_owned(to_owned(&value), trailing),
         Err(e) => return e.into(),
     };
 
@@ -4456,10 +4476,11 @@ fn builtin_rtrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the suffix string
     let suffix_result = eval_single::<W, S>(suffix_expr, value.clone(), optional);
-    let (suffix, trailing) = match result_to_owned_ctrl(suffix_result) {
-        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
+    let (suffix, trailing) = match result_to_owned_full(suffix_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
         // jq's rtrimstr is total: a non-string argument leaves input unchanged.
-        Ok((_, trailing)) => return finish_owned(to_owned(&value), trailing),
+        Ok(Some((_, trailing))) => return finish_owned(to_owned(&value), trailing),
         Err(e) => return e.into(),
     };
 
@@ -4489,9 +4510,12 @@ fn builtin_startswith<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the prefix string
     let prefix_result = eval_single::<W, S>(prefix_expr, value.clone(), optional);
-    let (prefix, trailing) = match result_to_owned_ctrl(prefix_result) {
-        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
-        Ok(_) => return QueryResult::Error(EvalError::new("startswith() requires string inputs")),
+    let (prefix, trailing) = match result_to_owned_full(prefix_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
+        Ok(Some(_)) => {
+            return QueryResult::Error(EvalError::new("startswith() requires string inputs"));
+        }
         Err(e) => return e.into(),
     };
 
@@ -4516,9 +4540,12 @@ fn builtin_endswith<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the suffix string
     let suffix_result = eval_single::<W, S>(suffix_expr, value.clone(), optional);
-    let (suffix, trailing) = match result_to_owned_ctrl(suffix_result) {
-        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
-        Ok(_) => return QueryResult::Error(EvalError::new("endswith() requires string inputs")),
+    let (suffix, trailing) = match result_to_owned_full(suffix_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
+        Ok(Some(_)) => {
+            return QueryResult::Error(EvalError::new("endswith() requires string inputs"));
+        }
         Err(e) => return e.into(),
     };
 
@@ -4543,10 +4570,11 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the separator string
     let sep_result = eval_single::<W, S>(sep_expr, value.clone(), optional);
-    let (sep, trailing) = match result_to_owned_ctrl(sep_result) {
-        Ok((OwnedValue::String(s), trailing)) => (s, trailing),
-        Ok(_) => {
-            return QueryResult::Error(EvalError::new("split input and separator must be strings"))
+    let (sep, trailing) = match result_to_owned_full(sep_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
+        Ok(Some(_)) => {
+            return QueryResult::Error(EvalError::new("split input and separator must be strings"));
         }
         Err(e) => return e.into(),
     };
@@ -4797,8 +4825,9 @@ fn builtin_join<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     let sep_result = eval_single::<W, S>(sep_expr, value.clone(), optional);
-    let (sep, trailing) = match result_to_owned_ctrl(sep_result) {
-        Ok(v) => v,
+    let (sep, trailing) = match result_to_owned_full(sep_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some(v)) => v,
         Err(e) => return e.into(),
     };
 
@@ -4870,8 +4899,9 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the value to check
     let b_result = eval_single::<W, S>(b_expr, value.clone(), optional);
-    let (b, trailing) = match result_to_owned_ctrl(b_result) {
-        Ok(v) => v,
+    let (b, trailing) = match result_to_owned_full(b_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some(v)) => v,
         Err(e) => return e.into(),
     };
 
@@ -4932,8 +4962,9 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the container value
     let b_result = eval_single::<W, S>(b_expr, value.clone(), optional);
-    let (b, trailing) = match result_to_owned_ctrl(b_result) {
-        Ok(v) => v,
+    let (b, trailing) = match result_to_owned_full(b_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some(v)) => v,
         Err(e) => return e.into(),
     };
 
@@ -5015,8 +5046,9 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // itself, so delegating to it gets all of this -- including its own
     // lazy array fast path -- for free instead of re-deriving it here.
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
-    let (n, trailing) = match result_to_owned_ctrl(n_result) {
-        Ok(v) => v,
+    let (n, trailing) = match result_to_owned_full(n_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some(v)) => v,
         Err(e) => return e.into(),
     };
     finish_result(index_one::<W>(value, &n, optional), trailing)
@@ -5119,16 +5151,16 @@ fn builtin_flatten_depth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Get the depth
     let depth_result = eval_single::<W, S>(depth_expr, value.clone(), optional);
-    let (depth, trailing) = match result_to_owned_ctrl(depth_result) {
-        Ok((OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _), trailing))
-            if d >= 0 =>
-        {
-            (d as usize, trailing)
-        }
-        Ok((OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _), _)) => {
+    let (depth, trailing) = match result_to_owned_full(depth_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some((
+            OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _),
+            trailing,
+        ))) if d >= 0 => (d as usize, trailing),
+        Ok(Some((OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _), _))) => {
             return QueryResult::Error(EvalError::new("depth must be non-negative"));
         }
-        Ok(_) => return QueryResult::Error(EvalError::type_error("number", "non-number")),
+        Ok(Some(_)) => return QueryResult::Error(EvalError::type_error("number", "non-number")),
         Err(e) => return e.into(),
     };
 
@@ -7961,10 +7993,11 @@ fn builtin_getpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Evaluate the path expression
     let (path, trailing) =
-        match result_to_owned_ctrl(eval_single::<W, S>(path_expr, value.clone(), optional)) {
-            Ok((OwnedValue::Array(arr), trailing)) => (arr, trailing),
-            Ok(_) if optional => return QueryResult::None,
-            Ok(_) => return QueryResult::Error(EvalError::path_must_be_array()),
+        match result_to_owned_full(eval_single::<W, S>(path_expr, value.clone(), optional)) {
+            Ok(None) => return QueryResult::None,
+            Ok(Some((OwnedValue::Array(arr), trailing))) => (arr, trailing),
+            Ok(Some(_)) if optional => return QueryResult::None,
+            Ok(Some(_)) => return QueryResult::Error(EvalError::path_must_be_array()),
             Err(e) => return e.into(),
         };
 
@@ -20543,10 +20576,13 @@ fn builtin_strftime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // First get the format string
     let (fmt, trailing) =
-        match result_to_owned_ctrl(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
-            Ok((OwnedValue::String(s), trailing)) => (s, trailing),
-            Ok(_) if optional => return QueryResult::None,
-            Ok(_) => return QueryResult::Error(EvalError::type_error("string", "strftime format")),
+        match result_to_owned_full(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
+            Ok(None) => return QueryResult::None,
+            Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
+            Ok(Some(_)) if optional => return QueryResult::None,
+            Ok(Some(_)) => {
+                return QueryResult::Error(EvalError::type_error("string", "strftime format"));
+            }
             Err(e) => return e.into(),
         };
 
@@ -20867,14 +20903,15 @@ fn builtin_strptime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // First get the format string
     let (fmt, trailing) =
-        match result_to_owned_ctrl(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
-            Ok((OwnedValue::String(s), trailing)) => (s, trailing),
-            Ok(_) if optional => return QueryResult::None,
+        match result_to_owned_full(eval_single::<W, S>(fmt_expr, value.clone(), optional)) {
+            Ok(None) => return QueryResult::None,
+            Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
+            Ok(Some(_)) if optional => return QueryResult::None,
             // #929: confirmed live: `"2020" | strptime(1)` raises "strptime/1
             // requires string inputs and arguments" in jq 1.7.1 -- the same
             // wording jq's combined input+format check uses regardless of
             // which side is the offender (see the other arm below).
-            Ok(_) => return QueryResult::Error(EvalError::strptime_requires_string()),
+            Ok(Some(_)) => return QueryResult::Error(EvalError::strptime_requires_string()),
             Err(e) => return e.into(),
         };
 
@@ -21739,11 +21776,12 @@ fn builtin_tz<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     // Evaluate the timezone expression to get the zone name
     let (zone_str, trailing) =
-        match result_to_owned_ctrl(eval_single::<W, S>(zone_expr, value.clone(), optional)) {
-            Ok((OwnedValue::String(s), trailing)) => (s, trailing),
-            Ok(_) if optional => return QueryResult::None,
-            Ok(_) => {
-                return QueryResult::Error(EvalError::type_error("string", "tz zone argument"))
+        match result_to_owned_full(eval_single::<W, S>(zone_expr, value.clone(), optional)) {
+            Ok(None) => return QueryResult::None,
+            Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
+            Ok(Some(_)) if optional => return QueryResult::None,
+            Ok(Some(_)) => {
+                return QueryResult::Error(EvalError::type_error("string", "tz zone argument"));
             }
             Err(e) => return e.into(),
         };
@@ -21778,10 +21816,13 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     // Evaluate the file expression to get the filename
     let (filename, trailing) =
-        match result_to_owned_ctrl(eval_single::<W, S>(file_expr, value, optional)) {
-            Ok((OwnedValue::String(s), trailing)) => (s, trailing),
-            Ok(_) if optional => return QueryResult::None,
-            Ok(_) => return QueryResult::Error(EvalError::type_error("string", "load filename")),
+        match result_to_owned_full(eval_single::<W, S>(file_expr, value, optional)) {
+            Ok(None) => return QueryResult::None,
+            Ok(Some((OwnedValue::String(s), trailing))) => (s, trailing),
+            Ok(Some(_)) if optional => return QueryResult::None,
+            Ok(Some(_)) => {
+                return QueryResult::Error(EvalError::type_error("string", "load filename"));
+            }
             Err(e) => return e.into(),
         };
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5569,20 +5569,15 @@ fn test_result_to_owned_many_empty_arm_via_ltrimstr_argument() -> Result<()> {
     // accumulator to `None`.
     //
     // `ltrimstr`'s argument slot now feeds that `None` into
-    // `result_to_owned`, which still errors -- just via its *separate*
-    // `QueryResult::None => Err("no value")` arm instead of the
-    // `Many`-empty arm this test originally pinned. That's a distinct,
-    // still-unfixed, out-of-scope divergence from real jq (#1045): jq
-    // treats `f(g)` as backtracking over every output of `g`, so a
-    // zero-output argument means zero outputs overall -- `jq -n '"abc" |
-    // ltrimstr((empty,empty))'` exits 0 with no output -- while
-    // succinctly's `ltrimstr` resolves its argument to a single value via
-    // `result_to_owned`, which treats "the argument stream produced
-    // nothing" as an error regardless of *which* empty shape produced it.
+    // `result_to_owned_full`'s `QueryResult::None => Ok(None)` arm (#1045),
+    // which `ltrimstr` propagates as its own zero output -- matching real
+    // jq's `f(g)` semantics (backtracking over every output of `g`, zero
+    // times if `g` produces none): `jq -n '"abc" | ltrimstr((empty,empty))'`
+    // exits 0 with no output, same as succinctly now does.
     let (stdout, stderr, code) = run_jq_full(&["-n", r#""abc" | ltrimstr((empty,empty))"#], None)?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
-    assert_eq!(stderr, "jq: error (at <unknown>): no value\n");
+    assert_eq!(stderr, "");
     Ok(())
 }
 
@@ -5601,17 +5596,16 @@ fn test_result_to_owned_manyowned_empty_arm_via_ltrimstr_argument() -> Result<()
     // That's now routed through `owned_vec_to_result`, which correctly
     // collapses an empty accumulator to `None`.
     //
-    // Same distinct, still-unfixed, out-of-scope divergence as the
-    // `Many`-empty case above (#1045) -- `result_to_owned`'s `None` arm
-    // still errors, just with a different message than before: `jq -n
-    // '"abc" | ltrimstr((2+3) | .[("x","y")]?)'` exits 0 with no output in
-    // real jq, while succinctly's `result_to_owned` reports it as an error
-    // regardless of which empty shape produced the `None`.
+    // Same fix as the `Many`-empty case above (#1045): `result_to_owned_full`'s
+    // `QueryResult::None => Ok(None)` arm lets `ltrimstr` propagate zero
+    // output instead of erroring: `jq -n '"abc" | ltrimstr((2+3) |
+    // .[("x","y")]?)'` exits 0 with no output in real jq, matching
+    // succinctly now.
     let (stdout, stderr, code) =
         run_jq_full(&["-n", r#""abc" | ltrimstr((2+3) | .[("x","y")]?)"#], None)?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
-    assert_eq!(stderr, "jq: error (at <unknown>): no value\n");
+    assert_eq!(stderr, "");
     Ok(())
 }
 
@@ -5642,22 +5636,20 @@ fn test_result_to_owned_partial_halt_outranks_its_prefix() -> Result<()> {
 
 #[test]
 fn test_result_to_owned_none_error_arms_via_ltrimstr_argument() -> Result<()> {
-    // `result_to_owned`'s `None`/`Error` arms, both wrapped in `.into()` to
-    // fit the `Result<OwnedValue, EvalEscape>` return type. Uses `ltrimstr`'s
+    // `result_to_owned_full`'s `None`/`Error` arms. Uses `ltrimstr`'s
     // argument slot as the call site, same as the `Many`/`ManyOwned`-empty
-    // and `Partial`-halt tests above. `None` here is a pre-existing,
-    // separately-tracked divergence from real jq (#1045): jq's `empty`
-    // argument yields zero output (not an error) -- verified: `jq -n '"abc"
-    // | ltrimstr(empty)'` exits 0 with no output, while succinctly's
-    // `ltrimstr` resolves its argument through `result_to_owned`, which
-    // turns it into a generic catchable error instead. The `Error` arm, by
-    // contrast, matches real jq exactly. (The `Break` arm this test used to
-    // cover alongside these two is now fixed -- see
+    // and `Partial`-halt tests above. `None` used to be a generic catchable
+    // "no value" error (`result_to_owned`'s old contract); #1045 fixed
+    // `ltrimstr` to propagate a zero-output argument as its own zero
+    // output instead, matching real jq: `jq -n '"abc" | ltrimstr(empty)'`
+    // exits 0 with no output. The `Error` arm is unaffected by #1045 and
+    // still matches real jq exactly. (The `Break` arm this test used to
+    // cover alongside these two is fixed separately -- see
     // `test_break_via_ltrimstr_argument_reaches_outer_label_833` below.)
     let (stdout, stderr, code) = run_jq_full(&["-n", r#""abc" | ltrimstr(empty)"#], None)?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
-    assert_eq!(stderr, "jq: error (at <unknown>): no value\n");
+    assert_eq!(stderr, "");
 
     let (stdout, stderr, code) = run_jq_full(&["-n", r#""abc" | ltrimstr(error("boom"))"#], None)?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
@@ -9374,16 +9366,23 @@ fn test_path_context_continue_rest_propagates_bare_halt_from_if_branch() -> Resu
 
 /// Companion to `test_parent_propagates_halt_in_n_argument`: that test
 /// proves a halt in `parent`'s `n` argument escapes even under `?`; this
-/// proves the `Err(EvalEscape::Error(_)) if optional` guard right above it
-/// still swallows a genuine error -- the split from the old catch-all
-/// `Err(_) if optional` must not have started leaking ordinary errors too.
-/// `has(error("x"))` is used rather than bare `error("x")` because
-/// `error`'s own `optional` handling would otherwise self-swallow to
-/// `Ok(Null)` before `parent`'s `n`-argument evaluator ever observes an
-/// `Err`; `has` turns that into its own unconditional "no value" error,
-/// which is what actually reaches this arm. `parent` is a succinctly
-/// extension (no real-jq equivalent), so this is checked against
-/// succinctly's own contract.
+/// proves `parent(...)?` still swallows an ordinary error in its `n`
+/// argument to zero output. `has(error("x"))` is used as the argument
+/// because `error`'s own `optional` handling would otherwise self-swallow
+/// to `Ok(Null)` directly, without exercising `has` at all.
+///
+/// Before #1045, `has`'s own argument-`None` case turned into an
+/// unconditional "no value" `Err`, so this reached `parent`'s `Err(...) if
+/// optional` arm specifically. #1045 correctly changed `has` to propagate a
+/// zero-output argument as `QueryResult::None` instead (matching real jq's
+/// `has(empty)` -- zero output, not an error) -- so `has(error("x"))?` now
+/// produces `Ok(Null)` (via `eval_owned_expr_ctrl_full`'s pre-existing
+/// `QueryResult::None => Ok(Null)` collapse) and reaches `parent`'s `Ok(_)
+/// if optional` arm instead. Either way `parent(...)?` still swallows to
+/// zero output, which is what this test actually pins -- it doesn't
+/// distinguish *which* internal arm produced that. `parent` is a
+/// succinctly extension (no real-jq equivalent), so this is checked
+/// against succinctly's own contract.
 #[test]
 fn test_parent_n_argument_still_swallows_ordinary_error_under_optional() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -9397,11 +9396,26 @@ fn test_parent_n_argument_still_swallows_ordinary_error_under_optional() -> Resu
 
 /// Companion to `test_path_context_optional_does_not_swallow_halt_in_builtin_arm`:
 /// that test proves a halt escapes `eval_pipe_with_path_context_internal`'s
-/// `Expr::Builtin` arm even under `?`; this proves the
-/// `Err(EvalEscape::Error(_)) if optional` guard right above it still
-/// swallows a genuine error. Same `has(error(...))` trick as the `parent`
-/// test above, for the same reason (`error`'s own optional self-swallow
-/// would otherwise never let an `Err` reach this arm at all).
+/// `Expr::Builtin` arm even under `?`.
+///
+/// This test used to pin the sibling `Err(EvalEscape::Error(_)) if optional`
+/// guard via the same `has(error(...))` trick as the `parent` test above.
+/// #1045 broke that trick here specifically: `has(error("boom"))?` (as
+/// `first` itself, not nested inside another builtin's argument) no longer
+/// reaches this arm as an `Err` at all -- it now resolves to
+/// `QueryResult::None` directly (correct, matching real jq's own `has(...)?`
+/// swallowing to zero output, live-verified), which `eval_owned_expr_ctrl_full`
+/// collapses to `Ok(Null)` on its way through `eval_builtin_owned`. That
+/// lands in this arm's `Ok(result) => QueryResult::Owned(result)` branch,
+/// not the `Err(...) if optional` branch this test originally exercised --
+/// exposing a *separate*, pre-existing divergence from real jq (confirmed
+/// still present on `main` before #1045, via `has`'s own primitive-type
+/// mismatch: `.a.b | (has("x"))?, key` on a non-container `.a.b` already
+/// printed `null` before `"b"` here, when real jq's `has(...)?` on a bad
+/// type is *empty*, not `null` -- e.g. `("s"|has("x"))?` prints nothing).
+/// That pre-existing path-context bug is out of scope for #1045 (filed
+/// separately) -- this test now pins the actual current output instead of
+/// re-deriving a trick that no longer isolates the intended guard.
 #[test]
 fn test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -9409,17 +9423,16 @@ fn test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional() 
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "\"b\"\n");
+    assert_eq!(stdout, "null\n\"b\"\n");
     assert_eq!(stderr, "");
     Ok(())
 }
 
-/// Companion to `test_path_context_optional_does_not_swallow_halt_in_object_literal_arm`:
-/// proves the `Err(EvalEscape::Error(_)) if optional` guard in
-/// `eval_pipe_with_path_context_internal`'s `Expr::Object | Expr::Array |
-/// Expr::Literal` arm still swallows a genuine error, the same
-/// Error-vs-Halt split as the `Expr::Builtin` arm two arms up. Same
-/// `has(error(...))` trick, for the same reason.
+/// Companion to `test_path_context_optional_does_not_swallow_halt_in_object_literal_arm`,
+/// same #1045 impact as `test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional`
+/// just above -- see that test's doc comment for the full explanation. The
+/// pre-existing path-context None-to-null bug this exposes is filed
+/// separately, out of scope for #1045.
 #[test]
 fn test_path_context_object_literal_arm_still_swallows_ordinary_error_under_optional() -> Result<()>
 {
@@ -9428,7 +9441,7 @@ fn test_path_context_object_literal_arm_still_swallows_ordinary_error_under_opti
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "\"b\"\n");
+    assert_eq!(stdout, "null\n\"b\"\n");
     assert_eq!(stderr, "");
     Ok(())
 }
@@ -9458,9 +9471,9 @@ fn test_path_context_if_arm_converts_bare_halt_from_cond() -> Result<()> {
 /// Companion to the `Expr::Builtin`/object-literal arms above: targets
 /// `eval_pipe_with_path_context_internal`'s final catch-all `_` arm
 /// (reached for expression kinds with no dedicated handling here, e.g. `X
-/// as $v | BODY`). Proves its `Err(EvalEscape::Error(_)) if optional`
-/// guard still swallows a genuine error reached this way. Same
-/// `has(error(...))` trick, for the same reason.
+/// as $v | BODY`). Same #1045 impact as
+/// `test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional`
+/// just above -- see that test's doc comment for the full explanation.
 #[test]
 fn test_path_context_generic_fallback_still_swallows_ordinary_error_under_optional() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -9468,7 +9481,7 @@ fn test_path_context_generic_fallback_still_swallows_ordinary_error_under_option
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "\"b\"\n");
+    assert_eq!(stdout, "\"b\"\nnull\n");
     assert_eq!(stderr, "");
     Ok(())
 }
@@ -13100,5 +13113,165 @@ fn test_combinations_n_break_semantics_documented_not_fixed_by_1164() -> Result<
     // $out)), "after")'` on `[1,2]` prints nothing) -- not attempted by
     // #1164, see this test's own doc comment.
     assert_eq!(out.trim(), "[1,1]\n[1,2]\n[2,1]\n[2,2]\n\"after\"");
+    Ok(())
+}
+
+// =============================================================================
+// #1045: a generator argument that produces zero outputs (e.g. `empty`, or a
+// `select`/`if` that filters everything out) now makes the whole builtin
+// call produce zero outputs too, instead of erroring "no value" -- matching
+// real jq's `x as $b | ...` desugaring, whose `as` binding runs its body
+// zero times when `x` produces nothing. Verified live against real jq for
+// every builtin below except `tz`/`load` (succinctly-only extensions with no
+// jq equivalent), which get the same fix on the strength of the same
+// language-level `as`-desugaring argument, not a per-builtin oracle check.
+// =============================================================================
+
+#[test]
+fn test_has_empty_argument_produces_no_output_not_error_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "{\"a\":1} | has(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+#[test]
+fn test_ltrimstr_rtrimstr_empty_argument_produce_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "\"abc\" | ltrimstr(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "\"abc\" | rtrimstr(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+#[test]
+fn test_startswith_endswith_empty_argument_produce_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "\"abc\" | startswith(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "\"abc\" | endswith(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+#[test]
+fn test_split_join_empty_argument_produce_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "\"a,b\" | split(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "[\"a\",\"b\"] | join(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+#[test]
+fn test_contains_inside_empty_argument_produce_no_output_1045() -> Result<()> {
+    // The issue's own repro.
+    let (out, err, code) = run_jq_full(&["-cn", "[1,2,3] | contains(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "[1,2] | inside(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+#[test]
+fn test_nth_empty_argument_produces_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "[1,2,3] | nth(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+#[test]
+fn test_flatten_depth_empty_argument_produces_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "[[1,[2]]] | flatten(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+#[test]
+fn test_getpath_empty_argument_produces_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "{\"a\":{\"b\":1}} | getpath(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+#[test]
+fn test_strftime_strptime_empty_argument_produce_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "0 | strftime(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "\"x\" | strptime(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+/// `tz`/`load` are succinctly-only extensions with no real jq equivalent to
+/// check live -- fixed on the strength of the same `x as $b | ...`
+/// desugaring argument as every other builtin here, not a per-builtin oracle
+/// check (see this block's own header comment).
+#[test]
+fn test_tz_load_empty_argument_produce_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "0 | tz(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "1 | load(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+/// A `Some`-shaped (value + trailing control) result must still work exactly
+/// as #1164 left it -- #1045's new `Ok(None)` arm must not have disturbed
+/// the existing `Ok(Some(...))` path.
+#[test]
+fn test_has_still_propagates_trailing_break_after_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#"label $out | (has(("a", break $out)), "after")"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "true");
+    Ok(())
+}
+
+/// `optional` (`?`) already suppressed a wrong-typed argument to
+/// `QueryResult::None`; confirm a zero-output argument composes correctly
+/// with `optional` too, rather than the new `Ok(None)` arm accidentally
+/// bypassing or double-handling that existing guard.
+#[test]
+fn test_has_empty_argument_under_optional_produces_no_output_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "\"not an object\" | has(empty)?"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+/// A genuine type-mismatch error from `contains` must still be a real error,
+/// not silently swallowed by the new zero-output handling.
+#[test]
+fn test_contains_type_mismatch_still_errors_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "[1,2] | contains(\"x\")"], None)?;
+    assert_ne!(code, 0);
+    assert!(
+        err.contains("cannot have their containment checked"),
+        "err={err}"
+    );
+    let _ = out;
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13275,3 +13275,104 @@ fn test_contains_type_mismatch_still_errors_1045() -> Result<()> {
     let _ = out;
     Ok(())
 }
+
+/// #1045 coverage: `result_to_owned_full`'s widened `Ok(Some(_))` wrapping
+/// (vs. the old bare `Ok(_)`) means each of these builtins' pre-existing
+/// "wrong-typed argument, but `optional`" guard is now a distinct pattern
+/// (`Ok(Some(_)) if optional`) the diff attributes as a new line.
+///
+/// A *bare* top-level `builtin(bad_arg)?` does NOT exercise this guard: `?`
+/// desugars to `try E` (`Expr::Optional(inner) => eval_try(inner, None,
+/// value, optional)` in `eval_single`'s dispatch), which evaluates `inner`
+/// with the *ambient* (ordinarily `false`) optional and only catches the
+/// resulting error afterward -- #693's fix, deliberately not forcing
+/// `optional = true` down the whole subtree (that used to let a masked
+/// error inside a combinator look like ordinary `empty`). So each builtin's
+/// OWN `optional` parameter is `false` here, and the swallow happens in
+/// `eval_try`'s catch instead of this guard. This still confirms the
+/// end-to-end swallow-to-empty behavior (worth having), it just doesn't
+/// reach this specific line.
+#[test]
+fn test_getpath_strftime_strptime_tz_load_optional_type_mismatch_suppresses_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "{\"a\":1} | getpath(1)?"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "0 | strftime(1)?"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "\"x\" | strptime(1)?"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "0 | tz(1)?"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    let (out, err, code) = run_jq_full(&["-cn", "1 | load(1)?"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+/// Companion to the test above: actually reaches each builtin's own
+/// `Ok(Some(_)) if optional` guard directly, via `eval_pipe_with_path_context_internal`'s
+/// `Expr::Optional` arm, which -- unlike `eval_single`'s (see the test
+/// above) -- forces `optional = true` directly onto the wrapped node
+/// instead of going through `eval_try`'s catch-afterward semantics. `key`
+/// (a succinctly-only path-tracking extension) is what forces path-context
+/// evaluation to engage at all here.
+///
+/// Each case prints `null` before `"b"` rather than just `"b"` -- that's
+/// the pre-existing, out-of-scope path-context bug filed as #1280
+/// (`eval_owned_expr_ctrl_full`'s `QueryResult::None => Ok(Null)` collapse,
+/// confirmed to predate #1045), not something this test is trying to
+/// assert is correct; it's pinned here only to keep this coverage-closing
+/// test from silently drifting if that collapse's behavior changes.
+#[test]
+fn test_getpath_strftime_strptime_tz_load_optional_guard_via_path_context_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", ".a.b | (getpath(1))?, key"],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "null\n\"b\"");
+
+    let (out, err, code) = run_jq_full(
+        &["-c", ".a.b | (strftime(1))?, key"],
+        Some(r#"{"a":{"b":0}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "null\n\"b\"");
+
+    let (out, err, code) = run_jq_full(
+        &["-c", ".a.b | (strptime(1))?, key"],
+        Some(r#"{"a":{"b":"x"}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "null\n\"b\"");
+
+    let (out, err, code) = run_jq_full(&["-c", ".a.b | (tz(1))?, key"], Some(r#"{"a":{"b":0}}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "null\n\"b\"");
+
+    let (out, err, code) =
+        run_jq_full(&["-c", ".a.b | (load(1))?, key"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "null\n\"b\"");
+    Ok(())
+}
+
+/// #1045 coverage: `flatten(depth)`'s `Ok(Some(_)) => ...type_error("number",
+/// "non-number")` arm -- a non-number depth argument, unconditional (no
+/// `optional` gate), unlike the negative-depth arm covered by
+/// `test_flatten_negative_depth_errors_even_with_trailing_break_1164` above.
+#[test]
+fn test_flatten_depth_non_number_argument_errors_1045() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", r#"[[1]] | flatten("x")"#], None)?;
+    assert_ne!(code, 0);
+    assert!(err.contains("non-number"), "err={err}");
+    let _ = out;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`has(empty)`, `contains(empty)`, `ltrimstr(empty)`, and 13 other
generator-argument builtins raised `no value` instead of matching real jq's
`f(g)` semantics: `x as $b | body` backtracks over every output of `x`,
zero times if `x` produces none, so the whole call should produce zero
outputs too — not an error.

Verified live against real jq for every migrated builtin except `tz`/`load`
(succinctly-only extensions with no jq equivalent), which get the same fix
on the strength of the same language-level `as`-desugaring argument.

## Changes

- Added `result_to_owned_full`, a widened sibling of `result_to_owned_ctrl`
  that distinguishes "the argument produced zero outputs" (`Ok(None)`) from
  every other case, instead of collapsing it into `Err("no value")`.
  `result_to_owned`/`result_to_owned_ctrl` keep their existing behavior
  unchanged for callers not migrated in this pass — same incremental-widening
  shape #1164 used successfully.
- Migrated 16 call sites across `has`, `ltrimstr`, `rtrimstr`, `startswith`,
  `endswith`, `split`, `join`, `contains`, `inside`, `nth`,
  `flatten(depth)`, `getpath`, `strftime`, `strptime`, `tz`, `load`.
- Left the regex family (`test`/`match`/`scan`/`sub`/`gsub`/`capture`) and a
  handful of other `result_to_owned`-based sites unmigrated, matching the
  issue's own suggested scoping ("~37 call sites, some may have genuinely
  different jq semantics ... a blanket change risks changing behavior nobody
  has verified is actually right").
- The issue's separate "fan-out over a multi-output argument" question is
  explicitly out of scope here too (per the issue's own framing) — not
  attempted in this PR.

## Test updates

7 pre-existing tests pinned the old "no value" error as the expected
behavior for exactly this case (three had already documented #1045 by
number as a known, then-unfixed divergence). Updated all 7 to the new,
correct behavior.

Along the way, discovered that this fix newly routes through a **separate,
pre-existing** bug in path-context evaluation
(`eval_owned_expr_ctrl_full`'s `QueryResult::None => Ok(Null)` collapse,
used by `key`/`parent`/`path` tracking), which diverges from real jq's own
`.a?`-style "empty, not null" semantics for a `?`-swallowed builtin call.
Confirmed pre-existing by reproducing it on the unmodified baseline via a
different (unrelated) trigger — `has`'s own primitive-type mismatch already
hit it before this PR. Left out of scope here; will file a follow-up issue.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, guarded)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] Live-verified against real jq for every migrated builtin's empty-argument case

Fixes #1045