### PR TITLE
docs(json): cross-reference the crate's 4 independent number scanners

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1642,6 +1642,15 @@ struct NumberTokenEnd {
 /// here: `normalize_leading_zero_numbers` only calls this when `b == '-'`
 /// or `b` is itself a digit, never `.`).
 ///
+/// This is the fourth of (at least) four independent number-token
+/// scanners in the crate, none delegating to any other (#1218) -- besides
+/// `number_literal_end` above, see `succinctly::json::light`'s private
+/// `nested_number_span` (greedy, backs `StandardJson`'s nested-value
+/// materialization) and `succinctly::json::simple_light`'s private
+/// `find_number_end` (also greedy, backs the separate `SimpleJsonIndex`).
+/// See #1218 for the full survey and why a blanket consolidation needs
+/// its own design pass.
+///
 /// Mirrors [`find_string_end`]/[`find_matching_close`]'s "find the end of
 /// this token" shape (#1154) rather than interleaving grammar-walking
 /// with a transformation, the way an earlier version of
@@ -2952,7 +2961,10 @@ mod tests {
         // A dangling '.' or 'e' with no digits after it still consumes
         // the marker itself, matching the lenient original behavior --
         // the retried `serde_json` validation rejects the result either
-        // way, so this scan doesn't need to.
+        // way, so this scan doesn't need to. This is the concrete example
+        // #1218 uses to illustrate the crate's 4-way number-scanner
+        // divergence -- `succinctly::json::light::number_literal_end`
+        // deliberately rejects the same `5e`/`1E` shape outright instead.
         assert_eq!(ends(b"5.", 0), Some((1, 2)));
         assert_eq!(ends(b"5e", 0), Some((1, 2)));
         // Stops at the token's own end, not the end of a larger buffer.

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1472,6 +1472,18 @@ fn parse_hex4(hex: &[u8]) -> Result<u16, JsonError> {
 /// materializing the wrong, fabricated value `1.2` instead of `null`
 /// (caught by review of #1171 before merge, 4 `#966` regression tests
 /// failed).
+///
+/// One of (at least) four independent "find a JSON-ish number token's
+/// boundaries" functions in the crate, each with a genuinely different
+/// strictness grammar for its own caller (#1218) -- besides
+/// `nested_number_span` above, see
+/// [`crate::json::simple_light`]'s private `find_number_end` (backs the
+/// separate `SimpleJsonIndex`, fully greedy) and
+/// `src/bin/succinctly/jq_runner.rs`'s private `find_number_end` (a
+/// `--argjson` leading-zero repair pass, lenient on a dangling exponent
+/// marker unlike this function). None delegate to any other; see #1218
+/// for the full survey and why a blanket consolidation needs its own
+/// design pass.
 pub fn number_literal_end(text: &[u8], start: usize) -> Option<usize> {
     let mut i = start;
     if i < text.len() && text[i] == b'-' {
@@ -1537,6 +1549,12 @@ pub fn number_literal_end(text: &[u8], start: usize) -> Option<usize> {
 /// round-trip correctly: their whole span must survive intact for
 /// `is_nan_sentinel`/`is_infinity_sentinel`'s exact-text comparison to
 /// recognize them.
+///
+/// See [`number_literal_end`]'s own doc comment for the full four-way
+/// survey of this crate's independent number-token scanners (#1218) --
+/// this one's greedy character class (`[0-9.eE+-]`, no grammar
+/// validation) is closest in spirit to `simple_light`'s own scanner, but
+/// they still don't share an implementation.
 fn nested_number_span(text: &[u8], start: usize) -> usize {
     let mut i = start;
     if i < text.len() && text[i] == b'-' {
@@ -3598,5 +3616,29 @@ mod tests {
         let range = root.text_range().unwrap();
         assert_eq!(range, (0, 9));
         assert_eq!(&json[range.0..range.1], b"[1, 2, 3]");
+    }
+
+    /// Pins `number_literal_end`'s deliberate rejection of a dangling
+    /// exponent marker (#1218's documented example of the crate's 4-way
+    /// number-scanner divergence) -- a future edit that accidentally makes
+    /// this function lenient here, matching `nested_number_span`'s own
+    /// permissive contract, would defeat the whole reason it's the
+    /// stricter of the two (see the type's own doc comment).
+    #[test]
+    fn test_number_literal_end_rejects_dangling_exponent_marker_1218() {
+        assert_eq!(number_literal_end(b"5e", 0), None);
+        assert_eq!(number_literal_end(b"1E", 0), None);
+        // A well-formed exponent still parses, so this isn't blanket
+        // exponent-hostility.
+        assert_eq!(number_literal_end(b"5e1", 0), Some(3));
+    }
+
+    /// Companion to the test above: `nested_number_span` -- unlike
+    /// `number_literal_end` -- absorbs the same dangling exponent marker
+    /// into one span rather than rejecting it, by design (#966, #1218).
+    #[test]
+    fn test_nested_number_span_absorbs_dangling_exponent_marker_1218() {
+        assert_eq!(nested_number_span(b"5e", 0), 2);
+        assert_eq!(nested_number_span(b"1E", 0), 2);
     }
 }

--- a/src/json/simple_light.rs
+++ b/src/json/simple_light.rs
@@ -367,7 +367,35 @@ fn find_string_end(json: &[u8], start: usize) -> usize {
     json.len()
 }
 
-// Find the end of a number (position of first non-number char)
+/// Find the end of a number-*shaped* span starting at `start` in `json` --
+/// this module's own copy of the "scan a JSON-ish number token" job, one
+/// of (at least) four independent implementations in the crate with
+/// genuinely different strictness grammars (#1218); none delegate to any
+/// other, each backing a different, already-load-bearing contract:
+///
+/// - [`crate::json::light::number_literal_end`] -- strict, `Option`-returning,
+///   used only for top-level document splitting (a malformed number there
+///   must error).
+/// - [`crate::json::light`]'s private `nested_number_span` -- greedy but still
+///   character-class-limited to `[0-9.eE+-]`, backing `StandardJson`'s
+///   nested-value materialization (a malformed nested number degrades to
+///   `null` downstream instead of erroring the whole document).
+/// - `src/bin/succinctly/jq_runner.rs`'s private `find_number_end` --
+///   structured optional frac/exp, but lenient on a dangling exponent
+///   marker, purpose-built for `--argjson`'s leading-zero repair.
+///
+/// This one is the *most* permissive of the four: same greedy character
+/// class as `nested_number_span` (any `[0-9.eE+-]` byte, no grammar
+/// validation at all -- a malformed shape like `1.2.3` or a dangling `5e`
+/// still consumes as one span), backing the separate, simpler
+/// `SimpleJsonIndex`'s own value-length detection, which has no downstream
+/// re-validation step of its own to catch a malformed span the way
+/// `StandardJson`'s number materialization does. Deliberately *not* shared
+/// with any of the above: each function's grammar is tuned to its own
+/// caller's error-handling contract, and collapsing them without an
+/// audited leniency-level parameter risks silently changing which
+/// malformed inputs each caller accepts (see #1218 for the full survey and
+/// why a blanket consolidation needs its own design pass).
 fn find_number_end(json: &[u8], start: usize) -> usize {
     let mut i = start;
     while i < json.len() {
@@ -703,5 +731,17 @@ mod tests {
         assert_eq!(index.find_close(json, 2), Some(6));
         // Innermost [ at 3 closes at 5
         assert_eq!(index.find_close(json, 3), Some(5));
+    }
+
+    /// Pins this module's `find_number_end`'s own contract on the
+    /// dangling-exponent-marker example #1218 uses to illustrate the
+    /// crate's 4-way number-scanner divergence: fully greedy, absorbing
+    /// `5e`/`1E` into one span with no grammar validation at all, unlike
+    /// `json::light::number_literal_end`'s deliberate rejection of the
+    /// same shape.
+    #[test]
+    fn test_find_number_end_absorbs_dangling_exponent_marker_1218() {
+        assert_eq!(find_number_end(b"5e", 0), 2);
+        assert_eq!(find_number_end(b"1E", 0), 2);
     }
 }


### PR DESCRIPTION
## Summary

#1218 found the crate has (at least) four independent "find a JSON-ish number
token's boundaries" implementations, each with a genuinely different
strictness grammar, none cross-referenced against each other — so a reader
investigating one has no way to know the others exist, and a future
correctness fix applied to only one won't propagate.

Scoped to the issue's own "at minimum" suggestion: cross-reference the doc
comments, don't attempt the full "consolidate onto one parameterized
scanner" direction (which the issue itself says needs its own design pass).

## Changes

- `src/json/light.rs`'s `number_literal_end` and `nested_number_span` already
  referenced each other (from #966/#1171); now also mention
  `simple_light::find_number_end` and `jq_runner::find_number_end`.
- `src/bin/succinctly/jq_runner.rs`'s `find_number_end` already referenced
  `number_literal_end` (from #1154); now also mentions `nested_number_span`
  and `simple_light::find_number_end`.
- `src/json/simple_light.rs`'s `find_number_end` had **no** cross-reference
  to any of the other three (just a one-line `// Find the end of a number`
  comment) — given a full doc comment explaining its own greedy, no-validation
  grammar and referencing all three siblings.
- Added a direct unit test to each of the two scanners that lacked one
  (`number_literal_end`/`nested_number_span` in `light.rs`,
  `find_number_end` in `simple_light.rs`) pinning the concrete divergence
  #1218 uses as its example: a dangling exponent marker (`"5e"`/`"1E"`).
  `jq_runner`'s `find_number_end` already had this case covered by an
  existing test — added a comment there cross-referencing the other three
  instead of a duplicate test.

No behavior change — docs and tests only.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, guarded)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features cli` (no broken intra-doc links)

Fixes #1218