### PR TITLE
fix(jq): stop Expr::Comma answering trackability a position too early (#986)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12574,15 +12574,24 @@ fn resolve_node<'a, S: EvalSemantics>(
         Expr::Comma(exprs) => {
             let mut out = Vec::new();
             for e in exprs {
-                // `reject_if_untracked` (#843): each sibling's own output is
-                // final the moment it's produced — jq streams it before ever
-                // touching the next one — so this is one of the two places
-                // in the whole resolver that has to apply that check itself
-                // rather than leaving it to a caller. See that function's
-                // doc comment for why.
-                match resolve_node::<S>(e, value, trackable)
-                    .and_then(|b| reject_if_untracked(b, trackable))
-                {
+                // No `reject_if_untracked` here (#986 Stage 2). It used to
+                // run per sibling, on the premise that a sibling's output is
+                // "final the moment it's produced". That premise is false
+                // whenever the `Comma` is a non-terminal element of a pipe:
+                // in `(.a, 1) | .c` there is very much something left to
+                // navigate into `1`, and checking here reported
+                // `path()`'s own "with result 1" instead of letting `.c`
+                // raise jq's "near attempt to access element \"c\" of 1".
+                //
+                // Each sibling already resolves independently, so its
+                // branches now simply carry their own `trackable` outward
+                // and whoever turns out to be terminal decides — the
+                // enclosing pipe's static tail, `resolve_catch`, or
+                // `resolve_dynamic_indexes`. Streaming order is unaffected:
+                // siblings are still appended to `out` in source order, and
+                // an untracked one still stops everything after it, just at
+                // the point that knows enough to say so.
+                match resolve_node::<S>(e, value, trackable) {
                     Ok(branches) => out.extend(branches),
                     Err((prefix, e)) => {
                         out.extend(prefix);
@@ -13298,17 +13307,19 @@ fn recurse_untracked_error<'a>(value: &OwnedValue) -> (Vec<PathBranch<'a>>, Eval
 /// `resolve_index_expr`/`resolve_slice_expr`'s own post-target check and
 /// `resolve_static_tail` already handle that) or whether they are the
 /// final answer (in which case *this* function is what has to catch it) —
-/// only their caller knows which. The two callers that call this are
-/// exactly the two places in the whole resolver where a value becomes
-/// final without anything else in the same expression left to navigate
-/// into it: each `Expr::Comma` sibling's own output (jq streams one
-/// sibling's result before ever touching the next — confirmed live,
-/// `path(try (.a, error({y:99})) catch (select(true), "z"))` raises on
-/// `select(true)`'s own branch and never reaches `"z"`) and
-/// `resolve_catch`'s own top-level result (the bare, non-`Comma` case,
-/// e.g. `catch select(true)` alone). Found in review: before this existed,
+/// only their caller knows which. `resolve_catch` is now the sole caller:
+/// a `catch` handler's result genuinely is final, because nothing in
+/// `Expr::Try`'s own shape can follow the handler within the same node.
+/// Found in review: before this existed,
 /// `try (.a, error({y:99})) catch select(true) = "X"` silently replaced
 /// the entire document with `"X"` instead of raising and writing nothing.
+///
+/// `Expr::Comma`'s arm used to call this too, per sibling. #986 Stage 2
+/// removed that: a `Comma` mid-pipe (`(.a, 1) | .c`) does have something
+/// left to navigate into, so the check was firing a position too early.
+/// Its siblings now carry their own `trackable` outward instead — see
+/// that arm's own comment, and
+/// `docs/plan/jq-path-trackability-deferral.md`.
 fn reject_if_untracked(branches: Vec<PathBranch<'_>>, trackable: bool) -> PathResolveResult<'_> {
     // Two ways to be untracked now (#986): the whole call was made against
     // an untracked value (`trackable == false`, #843's caught-payload case),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13484,3 +13484,89 @@ fn test_non_pipe_path_expressions_still_raise_986() -> Result<()> {
     }
     Ok(())
 }
+
+/// Pins the shapes #986/#989's deferred-trackability rework fixed, so a later
+/// change to `resolve_leaf`/`resolve_seq`/`Expr::Comma` cannot quietly undo
+/// them.
+///
+/// Companion to `test_non_pipe_path_expressions_still_raise_986`, which pins
+/// the shapes that had to *keep* working. This pins the ones that had to
+/// start. All expectations captured live from pinned jq 1.7.1.
+///
+/// The grouping matters: Stage 1 moved the trackability decision to the
+/// genuinely terminal position, which is what lets a non-path-shaped value
+/// reach `resolve_index_expr`'s pre-existing #843 checks and pick up jq's
+/// "near attempt to access element K of V" wording. Stage 2 then stopped
+/// `Expr::Comma` from answering the same question a position too early.
+#[test]
+fn test_deferred_trackability_matches_jq_986_989() {
+    // (query, expected stderr fragment) -- all exit 5, no stdout.
+    let raising = [
+        // Stage 1: the error names the *navigation* that failed, not the
+        // value that merely wasn't a path.
+        (
+            r"path(1|.foo)",
+            r#"near attempt to access element "foo" of 1"#,
+        ),
+        (
+            r#"(1 | .[("x","y")]) = 9"#,
+            r#"near attempt to access element "x" of 1"#,
+        ),
+        (
+            r#"(range(3) | .[("x","y")]) = 9"#,
+            r#"near attempt to access element "x" of 0"#,
+        ),
+        (
+            r#"(1 | .a)[("x","y")] = 9"#,
+            r#"near attempt to access element "a" of 1"#,
+        ),
+        (
+            r#"path((1|.)[("x","y")])"#,
+            r#"near attempt to access element "x" of 1"#,
+        ),
+        // A pipe's *last* output is the one named, not its first.
+        (r"path(1|2)", "Invalid path expression with result 2"),
+        // The downstream error is reported, not masked by #530's wording.
+        (r#"path(1|error("boom"))"#, "boom"),
+    ];
+    for (query, fragment) in raising {
+        let (stdout, stderr, code) = run_jq_full(&["-c", query], Some(r#"{"a":1,"foo":10}"#))
+            .unwrap_or_else(|e| panic!("`{query}` failed to run: {e}"));
+        assert_eq!(code, 5, "`{query}`\nstdout: {stdout}\nstderr: {stderr}");
+        assert!(
+            stderr.contains(fragment),
+            "`{query}` should mention `{fragment}`, got: {stderr}"
+        );
+    }
+
+    // Stage 2: a `Comma` mid-pipe is not the terminal position. The `.a`
+    // branch resolves and is emitted first; only then does `.c` raise
+    // against the literal `1` -- naming `.c`, not the literal.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r"path((.a, 1)|.c)"], Some(r#"{"a":{"c":1},"x":2}"#))
+            .expect("comma-mid-pipe repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "[\"a\",\"c\"]\n", "stderr: {stderr}");
+    assert!(
+        stderr.contains(r#"near attempt to access element "c" of 1"#),
+        "{stderr}"
+    );
+
+    // `halt_error` must still halt rather than being downgraded into a
+    // catchable "Invalid path expression" -- the one repro here that is a
+    // genuine correctness violation rather than a wording fix. Exit code is
+    // part of the contract.
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", r"path(1|halt_error(3))"], Some("{}")).expect("halt_error repro runs");
+    assert_eq!(code, 3, "halt_error must halt with its own code");
+    assert!(stdout.is_empty(), "stdout: {stdout}");
+
+    // `break` must still unwind to its label rather than raising.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r"label $out | path(1|break $out)"],
+        Some(r#"{"a":10}"#),
+    )
+    .expect("break repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stdout.is_empty(), "stdout: {stdout}");
+}


### PR DESCRIPTION
## Summary

Stage 2 of [`docs/plan/jq-path-trackability-deferral.md`](../blob/main/docs/plan/jq-path-trackability-deferral.md) — **completes #1283's cluster A**.

`Expr::Comma`'s arm called `reject_if_untracked` on each sibling as it resolved, on the premise — stated in that helper's own doc comment — that a sibling's output is *"final the moment it's produced"*. That premise is false whenever the `Comma` is a **non-terminal element of a pipe**: in `(.a, 1) | .c` there is very much something left to navigate into `1`, so the check fired one position too early.

```
$ echo '{"a":{"c":1},"x":2}' | jq -c 'path((.a, 1)|.c)'
["a","c"]
jq: error (at <stdin>:1): Invalid path expression near attempt to access element "c" of 1

# before: ["a","c"] then  Invalid path expression with result 1
# now:    identical to jq
```

Since each sibling already resolved independently, this is mostly a **deletion**. Their branches now carry their own `trackable` outward and whoever turns out to be terminal decides — the enclosing pipe's static tail, `resolve_catch`, or `resolve_dynamic_indexes`.

`reject_if_untracked` is left with one caller, `resolve_catch`, where "nothing follows" genuinely holds: no part of `Expr::Try`'s shape can come after the handler within the same node.

## Streaming order is unchanged

The removed check was protecting a real property — jq streams one sibling's result before touching the next, so `catch (select(true), "z")` raises on `select(true)`'s branch and never reaches `"z"`. Siblings still append to `out` in source order, and an untracked one still stops everything after it; it just happens at the point that knows enough to say so. That exact repro is re-verified against jq below.

## Also adds the regression tests the design asked for

`test_deferred_trackability_matches_jq_986_989` pins what **both** stages fixed. The design document asks for its confirmed-live repros to become permanent regression tests rather than ad hoc probes, and Stage 1's PR only updated an existing expectation. Companion to #1284's `test_non_pipe_path_expressions_still_raise_986`, which pins the shapes that had to *keep* working.

## Verification

- [x] **5221 tests pass, 0 fail**
- [x] **236-case oracle sweep** — adds 60 `Comma` shapes (`(.a, 1)`, `(1, .a)`, `(.a, .b, 1)`, `((.a, 1), .b)`, `(.a, 1, "s")` × terminal/`.c`/`.[0]`/`.["c"]`) crossed with `path()`/`del()`/`=`. **233 match**; the 3 that don't are #1287, pre-existing on `main` and untouched.
- [x] **#843 catch/`Comma` family** re-verified, including the exact `catch (select(true), "z")` streaming repro the removed check protected.
- [x] **Design Open Risk 2 checked directly**: 3+ siblings and a nested `Comma` (`((.a, 1), .b) | .c`) both match jq — the two cases the design flagged as unverified.
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo check --no-default-features` (no_std) all clean.

## Stage 3 looks unnecessary

The design deferred `resolve_recurse` + mixed-trackability `f` to Stage 3 *"only if Stage 1/2's own test sweep finds it's actually needed"*. It doesn't: `(1, .a) | recurse(.b)`, `(.a, 1) | recurse(.[]?)` and `(1, .a) | ..` all match jq, consistent with the recurse-family guard at `eval.rs` intercepting an untracked value before `resolve_recurse` runs. Suggest closing Stage 3 without implementation rather than filing it.

Refs #986, #989, #1282, #1283, #1284