### PR TITLE
fix(jq): flatten a parenthesized multi-component parent in get_path_mut

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39973,6 +39973,78 @@ mod tests {
     }
 
     #[test]
+    fn test_get_path_mut_flattens_a_nested_pipe_path_component() {
+        // #1287's fix, exercised directly (bypassing the parser, like the
+        // autovivify test above): a resolved `path_parts` slot can itself
+        // be a `Pipe` -- from a parenthesized multi-component sub-path
+        // reaching `resolve_dynamic_indexes`'s no-computed-key fast path
+        // verbatim, or from `resolve_node`'s `?` arm handing back
+        // `Optional(Pipe([...]))`. `get_path_mut` has to recurse into it
+        // rather than fall to the "invalid path component" catch-all. The
+        // last two cases here (a `?` swallowing the nested walk's error,
+        // one wrapping the whole slot and one sitting mid-chain inside it)
+        // have no standalone query-syntax repro today -- `(.a.b)?[0]` does
+        // not parse, since postfix `?` cannot be followed by `[...]` -- so
+        // they are only reachable by constructing the `Expr` directly.
+
+        // The nested pipe resolves fine: `Ok(Some(_))`.
+        let mut root = OwnedValue::Object(IndexMap::from([(
+            "a".to_string(),
+            OwnedValue::Object(IndexMap::from([("b".to_string(), OwnedValue::Int(1))])),
+        )]));
+        let slot = get_path_mut(
+            &mut root,
+            &[Expr::Pipe(vec![
+                Expr::Field("a".to_string()),
+                Expr::Field("b".to_string()),
+            ])],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(*slot, OwnedValue::Int(1));
+
+        // The nested pipe fails, and nothing marks it optional: the error
+        // propagates.
+        let mut root = OwnedValue::Object(IndexMap::from([("a".to_string(), OwnedValue::Int(5))]));
+        let err = get_path_mut(
+            &mut root,
+            &[Expr::Pipe(vec![
+                Expr::Field("a".to_string()),
+                Expr::Field("b".to_string()),
+            ])],
+        )
+        .unwrap_err();
+        assert_eq!(err.message, "Cannot index number with string \"b\"");
+
+        // A `?` wrapping the *whole* nested-pipe slot swallows that same
+        // error.
+        let mut root = OwnedValue::Object(IndexMap::from([("a".to_string(), OwnedValue::Int(5))]));
+        let slot = get_path_mut(
+            &mut root,
+            &[Expr::Optional(Box::new(Expr::Pipe(vec![
+                Expr::Field("a".to_string()),
+                Expr::Field("b".to_string()),
+            ])))],
+        )
+        .unwrap();
+        assert!(slot.is_none());
+
+        // A `?` *inside* the nested pipe (mid-chain, not wrapping the whole
+        // slot) makes the recursive call itself return `Ok(None)`, which
+        // propagates the same way.
+        let mut root = OwnedValue::Object(IndexMap::from([("a".to_string(), OwnedValue::Int(5))]));
+        let slot = get_path_mut(
+            &mut root,
+            &[Expr::Pipe(vec![
+                Expr::Field("a".to_string()),
+                Expr::Optional(Box::new(Expr::Field("b".to_string()))),
+            ])],
+        )
+        .unwrap();
+        assert!(slot.is_none());
+    }
+
+    #[test]
     fn test_assign_computed_index_on_parenthesized_multi_component_target_reports_type_mismatch() {
         // #1287: `get_path_mut` (only `=`'s own walker -- `path()`/`del()`/
         // `|=` already resolved this shape correctly) fell to its generic

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11796,6 +11796,23 @@ fn get_path_mut<'a>(
                     ));
                 }
             }
+            // A parenthesized multi-component sub-path (`(.a|.c)[0] = 9`) or
+            // `resolve_node`'s `?` arm (which emits `Optional(Pipe([...]))`
+            // when a branch resolves to more than one component) can hand
+            // back a single path slot that is itself a `Pipe` — recurse into
+            // it rather than falling to the catch-all below. Mirrors
+            // `update_path`'s matching `Expr::Pipe` splice arm, which
+            // already had to solve the same problem (#1287): without this,
+            // `(.a|.c)[0] = 9` on `{"a":{"c":1}}` reported the generic
+            // "invalid path component" here instead of jq's own "Cannot
+            // index number with number", even though `path()`/`del()`/`|=`
+            // already resolved the identical shape correctly.
+            Expr::Pipe(inner) => match get_path_mut(current, inner) {
+                Ok(Some(next)) => next,
+                Ok(None) => return Ok(None),
+                Err(_) if optional => return Ok(None),
+                Err(e) => return Err(e),
+            },
             Expr::IndexExpr { .. } => {
                 return Err(EvalError::new(
                     "internal error: unresolved computed index in path component",
@@ -39952,6 +39969,33 @@ mod tests {
                 "a".to_string(),
                 OwnedValue::Object(IndexMap::from([("b".to_string(), OwnedValue::Null)])),
             )]))
+        );
+    }
+
+    #[test]
+    fn test_assign_computed_index_on_parenthesized_multi_component_target_reports_type_mismatch() {
+        // #1287: `get_path_mut` (only `=`'s own walker -- `path()`/`del()`/
+        // `|=` already resolved this shape correctly) fell to its generic
+        // "invalid path component" catch-all whenever a parenthesized
+        // multi-component sub-path preceded the final index/key/slice --
+        // `(.a|.c)` never flattens into two matched `Field` arms here, it
+        // arrives as one opaque `Expr::Pipe` slot. Confirmed against real jq
+        // 1.7.1: all three report jq's own `Cannot index number with
+        // <type>`, not a generic parse-shaped complaint.
+        query!(br#"{"a":{"c":1}}"#, r"((.a|.c)[0]) = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with number");
+            }
+        );
+        query!(br#"{"a":{"c":1}}"#, r#"((.a|.c)["c"]) = 9"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with string \"c\"");
+            }
+        );
+        query!(br#"{"a":{"c":1}}"#, r"((.a|.c)[0:1]) = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with object");
+            }
         );
     }
 


### PR DESCRIPTION
## Summary

`(.a|.c)[0] = 9` (or any assignment whose lvalue is `(PATH)[K]` where `PATH` has more than one static component) reported a generic `invalid path component` instead of jq's own `Cannot index <type> with <type>`.

```
$ echo '{"a":{"c":1}}' | succinctly jq -c '((.a|.c)[0]) = 9'
jq: error (at <stdin>:1): invalid path component        # before
jq: error (at <stdin>:1): Cannot index number with number   # after, matches jq 1.7.1
```

## Root cause

The issue that filed this (#1287) guessed the fallback was in `key_to_path_component`. It wasn't — `key_to_path_component` already calls `EvalError::cannot_index` correctly. Tracing the actual repro found a different function: `get_path_mut`, the walker `set_path` (i.e. `=`) uses to reach a path's parent. Its per-part loop only strips `Optional`/`Paren` wrappers (`unwrap_path_component`), so when a parenthesized multi-component sub-path like `(.a|.c)` lands in `parent_path` as a single slot, it arrives as one opaque `Expr::Pipe`, which the loop doesn't understand and falls to the catch-all `"invalid path component"`.

`path()`, `del()`, and `|=` all resolve the identical shape correctly today — `update_path` (`|=`'s walker) already has an `Expr::Pipe(inner)` splice arm for exactly this reason (added for a related case, `resolve_node`'s `?` arm emitting `Optional(Pipe([...]))`). `get_path_mut` — used only by `set_path`/`=` — was missing the analogous arm.

## Fix

Added an `Expr::Pipe(inner)` arm to `get_path_mut` that recurses into the nested pipe against the current position, mirroring `update_path`'s existing splice arm. `Ok(None)`/`Err` from the recursive call are threaded through the same `optional`-swallowing logic every other arm in the function already uses.

## Verification

- [x] All three of the issue's own repros (`[0]`, `["c"]`, `[0:1]`) now byte-match pinned jq 1.7.1, confirmed live
- [x] Regression-checked adjacent shapes that already worked (`.a.c[0]`, `.a[0]`, dynamic-key `[$x]`, `path()`, `del()`, `|=`) — all unchanged
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (2657 lib tests + all integration suites)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `omni-dev coverage diff` — 100% patch coverage (58/58 new lines), including two branches (`?` swallowing the nested walk's error) that have no standalone query-syntax repro today (`(.a.b)?[0]` doesn't parse — postfix `?` can't be followed by `[`), covered via direct-function construction instead

Fixes #1287