### PR TITLE
fix(jq): make path() linear for a computed key ahead of a trailing iterate

### DIFF
--- a/benches/jq_write_path_bench.rs
+++ b/benches/jq_write_path_bench.rs
@@ -264,16 +264,21 @@ fn bench_path_trailing_iterate(c: &mut Criterion) {
 fn bench_computed_key_with_trailing_iterate(c: &mut Criterion) {
     let mut group = c.benchmark_group("jq_write_path_computed_key_trailing_iterate");
     let expr = parse("[path(.items[(0,1)].foo[])]").expect("must parse");
-    // Much smaller sizes than the other groups: this shape is NOT the
-    // trailing-bare-iterate case #682 already fixed -- a computed key
-    // (`(0,1)`) ahead of the trailing `.foo[]` still routes through the
-    // multi-branch resolver's O(n^2) path (confirmed while writing this
-    // benchmark: doubling `n` roughly quadruples wall time, e.g. 2000 ->
-    // 4000 elements total went 0.27s -> 1.08s; filed as #888). The sizes
-    // here are deliberately small enough to finish in reasonable time
-    // under that *existing* bug, not chosen for statistical smoothness --
-    // once #888 lands, raise them to match the other groups.
-    for &n in &[200usize, 1_000, 2_000] {
+    // This shape is NOT the trailing-bare-iterate case #682 already fixed --
+    // a computed key (`(0,1)`) ahead of the trailing `.foo[]` used to route
+    // through the multi-branch resolver's O(n^2) path (doubling `n` roughly
+    // quadrupled wall time, e.g. 2000 -> 4000 elements total went 0.27s ->
+    // 1.08s; filed as #888, fixed by stripping a bare trailing iterate out
+    // of `resolve_dynamic_indexes`'s fan-out before it reaches
+    // `resolve_seq`, and re-attaching it as a single literal component per
+    // branch afterward). Same `SIZES` as the other groups now that this is
+    // linear.
+    //
+    // `path()` only. The same deferral is unsound for `del`/`=`/`|=` (see
+    // `resolve_dynamic_indexes`'s doc comment), so the `del` group below
+    // still carries the quadratic -- which is why it needs its own capped
+    // sizes rather than sharing these.
+    for &n in SIZES {
         let json = computed_key_doc(n);
 
         // Guard the premise: `(0,1)` fans out over both `.items` entries,
@@ -301,6 +306,67 @@ fn bench_computed_key_with_trailing_iterate(c: &mut Criterion) {
     group.finish();
 }
 
+/// The `del` half of the shape above, which #888 did **not** make linear.
+///
+/// #888's own table reported `del`/`=`/`|=` as flat on this shape, but it
+/// stopped at 16,000 elements. `=` and `|=` really are linear; `del` is not
+/// -- it only looks flat because its constant is small enough that the
+/// quadratic term does not dominate until roughly 50,000 elements. Measured
+/// on an Apple M-series, release, total elements = 2n:
+///
+/// | 2n      | del    | path  |
+/// |---------|--------|-------|
+/// | 20,000  | 0.10s  | 0.03s |
+/// | 50,000  | 0.54s  | 0.07s |
+/// | 100,000 | 1.51s  | 0.10s |
+/// | 200,000 | 5.98s  | 0.20s |
+///
+/// So the sizes here are deliberately capped well below the other groups'
+/// `SIZES`, small enough to finish in reasonable time under that *existing*
+/// bug rather than chosen for statistical smoothness -- the same convention
+/// `bench_computed_key_with_trailing_iterate` used before #888 landed.
+/// Raise them to `SIZES` once `del` is linear here too.
+fn bench_del_computed_key_with_trailing_iterate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_del_computed_key_trailing_iterate");
+    let expr = parse("del(.items[(0,1)].foo[])").expect("must parse");
+    for &n in &[1_000usize, 5_000, 10_000] {
+        let json = computed_key_doc(n);
+
+        // Guard the premise: both `.items` entries must come back emptied,
+        // so a future bug that turns this into a partial or no-op write
+        // fails here instead of reading as a speedup.
+        let OwnedValue::Object(doc) = eval_one(&expr, &json) else {
+            panic!("n={n}: query must produce an object");
+        };
+        let Some(OwnedValue::Array(items)) = doc.get("items") else {
+            panic!("n={n}: `.items` must survive as an array");
+        };
+        assert_eq!(items.len(), 2, "n={n}: both branches must survive");
+        for (i, item) in items.iter().enumerate() {
+            let OwnedValue::Object(item) = item else {
+                panic!("n={n}: `.items[{i}]` must stay an object");
+            };
+            assert_eq!(
+                item.get("foo"),
+                Some(&OwnedValue::Array(Vec::new())),
+                "n={n}: `.items[{i}].foo` must be emptied"
+            );
+        }
+
+        let index = JsonIndex::build(&json);
+        // Both n-element `.foo` arrays are touched, matching
+        // `bench_computed_key_with_trailing_iterate`'s own accounting.
+        group.throughput(Throughput::Elements(2 * n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_del_array,
@@ -309,5 +375,6 @@ criterion_group!(
     bench_update_array,
     bench_path_trailing_iterate,
     bench_computed_key_with_trailing_iterate,
+    bench_del_computed_key_with_trailing_iterate,
 );
 criterion_main!(benches);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11151,7 +11151,7 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `builtin_del` (#537) already separates `del(...)?` from a `?` written
     // inside the path.
     let mut pristine = to_owned(&input);
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine) {
+    let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
         Ok(paths) => paths,
         // `?` swallows only a genuine error; a halt always escapes, so
         // `(.[(halt_error(3))] = 1)?` still halts instead of becoming
@@ -11266,7 +11266,7 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // an outer `(.[-5] |= 9)?` needs exactly that swallowed. `update_path` is
     // always entered with `false` below; any `?` it still sees came from an
     // `Expr::Optional` node inside `path_expr` itself.
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result) {
+    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
         Ok(paths) => paths,
         // `?` swallows only a genuine error; a halt always escapes — see the
         // matching comment in `eval_assign` (#791).
@@ -14755,9 +14755,45 @@ fn resolve_seq<'a, S: EvalSemantics>(
 /// sibling fix); the write-side callers (`=`, `|=`, `del()`) discard it and
 /// treat this exactly like a plain failure, matching jq's atomic write
 /// semantics.
+///
+/// `defer_trailing_iterate` asks for #888's optimization: leave a bare
+/// trailing iterate as one literal `Expr::Iterate` component per branch
+/// instead of enumerating it here (see the comment at the strip loop below
+/// for the O(n^2) it avoids). Only `builtin_path` may ask, and the reason is
+/// the same asymmetry the paragraph above describes. Deferring moves the
+/// iterate's *expansion* from resolve time — against `input`, which is the
+/// pristine document, one branch at a time in source order — to whenever the
+/// consumer walks the result. `path()` can absorb that: it only reads, and
+/// `builtin_path`'s own `walk_error.or(resolve_error)` restores jq's "a
+/// later step's failure outranks an earlier deferred one" ordering. The
+/// write-side callers cannot, on four counts measured against jq 1.7.1:
+///
+/// - `get_path_mut`/`update_path` reject two adjacent `Iterate` components
+///   as an invalid path component, so `(.[("a","b")][][]) = 9` — which jq
+///   applies happily — would stop working entirely.
+/// - The spliced-back components never pass through `assemble()`'s
+///   `strip_resolved_optional`, so a deferred `.foo[]?` would carry its `?`
+///   into `set_path`, which then suppresses a *write*-time failure jq raises
+///   — and auto-vivifies on the way there, so `.[("b","nope")][]? = 1`
+///   invents a `"nope": null` key jq never creates.
+/// - Each branch would expand against the document as it stands *after* the
+///   earlier branches' writes, not against `input`; jq computes the whole
+///   path set first and applies it after (#498's clobber case).
+/// - `reject_untracked_at_terminal` below answers trackability for every
+///   branch before any branch's iterability is tested, inverting the two
+///   against `resolve_seq`'s per-branch interleaving: `del((.a, 1) | .[])`
+///   on `{"a":7}` reports jq's "Cannot iterate over number (7)" only while
+///   the iterate is still a fan-out stage.
+///
+/// So this is `false` for `=`/`|=`/`del()`, which keeps them byte-identical
+/// to before #888. They pay for it: `del` on the same shape is quadratic too
+/// — not visible in #888's own table, which stopped at 16,000 elements, but
+/// 24.8s at 400,000 on `main` — tracked separately, since fixing it needs
+/// the four items above resolved rather than bypassed.
 fn resolve_dynamic_indexes<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
+    defer_trailing_iterate: bool,
 ) -> Result<Vec<Expr>, (Vec<Expr>, EvalEscape)> {
     if !needs_path_prepass(expr) {
         return Ok(vec![expr.clone()]);
@@ -14802,20 +14838,61 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     /// `IndexExpr`/`SliceExpr` target, where its own tail is empty but the
     /// enclosing key still has to be navigated.
     ///
+    /// `near_iterate` picks the wording: `true` when a trailing bare iterate
+    /// was stripped off `branches`' own path expression and will be spliced
+    /// back on below (#888) — these branches are exactly the ones that would
+    /// otherwise have reached `resolve_node`'s own `Expr::Iterate` arm, whose
+    /// `if !trackable` guard raises `invalid_path_expression_near_iterate`,
+    /// not the generic message this function raises for every other shape.
+    /// Without it `path(1 | .[])` would report "Invalid path expression with
+    /// result 1" where jq says "near attempt to iterate through 1".
+    ///
     /// Branches already produced ahead of the offending one are kept and
     /// returned as the `Err` prefix, matching jq's never-un-emit streaming.
     fn reject_untracked_at_terminal(
         branches: Vec<PathBranch<'_>>,
+        near_iterate: bool,
     ) -> Result<Vec<PathBranch<'_>>, (Vec<PathBranch<'_>>, EvalEscape)> {
         let mut kept = Vec::with_capacity(branches.len());
         for branch in branches {
             if !branch.trackable {
-                let error = EvalError::invalid_path_expression(&branch.value).into();
+                let error = if near_iterate {
+                    EvalError::invalid_path_expression_near_iterate(&branch.value).into()
+                } else {
+                    EvalError::invalid_path_expression(&branch.value).into()
+                };
                 return Err((kept, error));
             }
             kept.push(branch);
         }
         Ok(kept)
+    }
+
+    /// Is this a bare trailing iterate — `Expr::Iterate` or
+    /// `Expr::Optional(Iterate)` (`.foo[]?`) — the shape `resolve_seq`'s
+    /// fan-out loop would otherwise fully enumerate one static `Index`
+    /// component at a time (#888, see below)?
+    fn is_bare_iterate(expr: &Expr) -> bool {
+        match expr {
+            Expr::Iterate => true,
+            Expr::Optional(inner) => matches!(inner.as_ref(), Expr::Iterate),
+            _ => false,
+        }
+    }
+
+    /// Splice a stripped trailing-iterate run back onto an already-assembled
+    /// static path expression. Only ever called with a non-empty `trailing`.
+    fn append_trailing(expr: Expr, trailing: &[Expr]) -> Expr {
+        let mut components = match expr {
+            Expr::Pipe(exprs) => exprs,
+            Expr::Identity => Vec::new(),
+            other => vec![other],
+        };
+        components.extend(trailing.iter().cloned());
+        match components.len() {
+            1 => components.into_iter().next().expect("len checked"),
+            _ => Expr::Pipe(components),
+        }
     }
 
     // The document `path()`/`=`/`|=`/`del()` were actually called on is
@@ -14825,9 +14902,61 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     // is about the *input*; individual branches can still come back
     // untracked from `resolve_leaf`'s deferred catch-all (#986), which is
     // what `reject_untracked_at_terminal` above answers for.
-    match resolve_node::<S>(expr, input, true).and_then(reject_untracked_at_terminal) {
-        Ok(branches) => Ok(assemble(branches)),
-        Err((prefix, e)) => Err((assemble(prefix), e)),
+
+    // #888: a bare trailing iterate never needs its per-element *value* here
+    // — this function is always the terminal entry point (see
+    // `reject_untracked_at_terminal`'s own doc comment above), so nothing
+    // downstream of it ever consults one. Left inside `resolve_seq`'s
+    // fan-out loop, it gets fully enumerated into one static `Index(i)`
+    // branch per array element, turning a computed key ahead of it into
+    // O(element count) resolved expressions instead of one per *branch* —
+    // and `builtin_path` walks every one of those independently from the
+    // document root, re-cloning the same subtree each time, for O(n^2)
+    // overall. Stripping it here and re-attaching it as one literal
+    // component per (already-necessary) branch keeps the computed-key
+    // resolution itself unchanged and lets the iterate fan out exactly once
+    // per branch, natively, in `walk_path`'s own `Expr::Iterate` arm.
+    //
+    // `path()` only — `defer_trailing_iterate` is `false` for the write-side
+    // callers, whose walkers cannot take a deferred iterate; see this
+    // function's doc comment for the four ways that goes wrong.
+    let mut flat = Vec::new();
+    push_path_components(&mut flat, expr);
+    let mut trailing = Vec::new();
+    if defer_trailing_iterate {
+        while let Some(true) = flat.last().map(is_bare_iterate) {
+            trailing.push(flat.pop().expect("checked Some above"));
+        }
+    }
+
+    if trailing.is_empty() {
+        return match resolve_node::<S>(expr, input, true)
+            .and_then(|branches| reject_untracked_at_terminal(branches, false))
+        {
+            Ok(branches) => Ok(assemble(branches)),
+            Err((prefix, e)) => Err((assemble(prefix), e)),
+        };
+    }
+    trailing.reverse();
+
+    let reduced_expr = match flat.len() {
+        1 => flat.into_iter().next().expect("len checked"),
+        _ => Expr::Pipe(flat),
+    };
+    match resolve_node::<S>(&reduced_expr, input, true)
+        .and_then(|branches| reject_untracked_at_terminal(branches, true))
+    {
+        Ok(branches) => Ok(assemble(branches)
+            .into_iter()
+            .map(|e| append_trailing(e, &trailing))
+            .collect()),
+        Err((prefix, e)) => Err((
+            assemble(prefix)
+                .into_iter()
+                .map(|e| append_trailing(e, &trailing))
+                .collect(),
+            e,
+        )),
     }
 }
 
@@ -18378,7 +18507,7 @@ fn builtin_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // a later one errors (confirmed live) — so that prefix is walked below
     // exactly like a successful resolution, and only the *error* is deferred
     // to the end.
-    let (exprs, resolve_error) = match resolve_dynamic_indexes::<S>(expr, &owned) {
+    let (exprs, resolve_error) = match resolve_dynamic_indexes::<S>(expr, &owned, true) {
         Ok(exprs) => (exprs, None),
         Err((exprs, e)) => (exprs, Some(e)),
     };
@@ -19997,7 +20126,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // Computed keys resolve against the original document; each becomes one
     // fully static path expression (Field/Index/Iterate components — see
     // `resolve_dynamic_indexes`).
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result) {
+    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
         Ok(paths) => paths,
         // `?` swallows only a genuine error; a halt always escapes — see the
         // matching comment in `eval_assign` (#791).

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -774,6 +774,230 @@ fn test_components_after_the_last_computed_key_may_fan_out() {
     );
 }
 
+/// #888: a genuinely multi-branch computed key (not just the single-valued
+/// `.[.k]` above) ahead of a trailing bare iterate — `path()` alone was
+/// O(n^2) here (`resolve_dynamic_indexes` let `resolve_seq`'s fan-out loop
+/// fully enumerate the trailing `[]` into one static `Index(i)` component
+/// per array element, so a computed key with `k` branches ahead of an
+/// `n`-element array produced `k*n` resolved paths instead of `k`, and
+/// `builtin_path` re-walked every one of them from the document root);
+/// `del`/`=`/`|=` were already linear on the identical shape. See
+/// `benches/jq_write_path_bench.rs`'s `bench_computed_key_with_trailing_iterate`
+/// for the scaling regression test.
+#[test]
+fn test_computed_key_ahead_of_trailing_iterate_888() {
+    let doc = r#"{"items":[{"foo":[1,2]},{"foo":[3,4]}]}"#;
+    check(
+        doc,
+        "[path(.items[(0,1)].foo[])]",
+        Outcome::values(&[
+            r#"[["items",0,"foo",0],["items",0,"foo",1],["items",1,"foo",0],["items",1,"foo",1]]"#,
+        ]),
+    );
+    check(
+        doc,
+        "del(.items[(0,1)].foo[])",
+        Outcome::values(&[r#"{"items":[{"foo":[]},{"foo":[]}]}"#]),
+    );
+    check(
+        doc,
+        "(.items[(0,1)].foo[]) |= .+1",
+        Outcome::values(&[r#"{"items":[{"foo":[2,3]},{"foo":[4,5]}]}"#]),
+    );
+    check(
+        doc,
+        "(.items[(0,1)].foo[]) = 9",
+        Outcome::values(&[r#"{"items":[{"foo":[9,9]},{"foo":[9,9]}]}"#]),
+    );
+
+    // `?` on the trailing iterate still suppresses a non-container error one
+    // branch at a time — the other branch's elements still come through.
+    let mixed = r#"{"items":[{"foo":[1,2]},{"foo":5}]}"#;
+    check(
+        mixed,
+        "[path(.items[(0,1)].foo[]?)]",
+        Outcome::values(&[r#"[["items",0,"foo",0],["items",0,"foo",1]]"#]),
+    );
+    // Without `?`, a non-container branch still raises "Cannot iterate
+    // over" — wrapped in `[...]` so a partial prefix from the other branch
+    // can't turn this into a `Values` outcome instead of a clean `Error`.
+    check(
+        mixed,
+        "[path(.items[(0,1)].foo[])]",
+        Outcome::error("Cannot iterate over number (5)"),
+    );
+    check(
+        r#"{"items":[{"foo":1},{"foo":2}]}"#,
+        "path(.items[(0,1)].foo[])",
+        Outcome::error("Cannot iterate over number (1)"),
+    );
+
+    // A non-trailing iterate is untouched by the #888 fix — it still fans
+    // out through the ordinary multi-branch resolver, not this shortcut.
+    check(
+        r#"{"a":[{"b":{"x":1,"y":2}},{"b":{"x":3,"y":4}}]}"#,
+        r#"[path(.a[].b[("x","y")])]"#,
+        Outcome::values(&[r#"[["a",0,"b","x"],["a",1,"b","x"],["a",0,"b","y"],["a",1,"b","y"]]"#]),
+    );
+    check(
+        r#"{"a":[{"b":[{"c":1},{"c":2}]},{"b":[{"c":3},{"c":4}]}]}"#,
+        "[path(.a[(0,1)].b[].c)]",
+        Outcome::values(&[
+            r#"[["a",0,"b",0,"c"],["a",0,"b",1,"c"],["a",1,"b",0,"c"],["a",1,"b",1,"c"]]"#,
+        ]),
+    );
+
+    // A stacked trailing iterate (`.foo[][]`) strips more than one element —
+    // covers the strip loop running more than once, not a realistic query.
+    check(
+        r#"{"items":[{"foo":[[1,2],[3,4]]},{"foo":[[5,6]]}]}"#,
+        "[path(.items[(0,1)].foo[][])]",
+        Outcome::values(&[concat!(
+            r#"[["items",0,"foo",0,0],["items",0,"foo",0,1],"#,
+            r#"["items",0,"foo",1,0],["items",0,"foo",1,1],"#,
+            r#"["items",1,"foo",0,0],["items",1,"foo",0,1]]"#
+        )]),
+    );
+}
+
+/// #888: everything the trailing-iterate deferral must *not* change, pinned
+/// on `=`/`|=`/`del()` — the three callers that pass
+/// `defer_trailing_iterate: false` precisely because each case below breaks
+/// when they don't.
+///
+/// A first cut of #888 deferred for all four callers. The whole suite stayed
+/// green and every check on the PR passed; a 1,680-case differential sweep
+/// against jq 1.7.1 found 186 divergences. These are the smallest
+/// representative of each family, all captured from jq 1.7.1.
+#[test]
+fn test_trailing_iterate_deferral_is_read_only_888() {
+    // A stacked `[][]` is a working write in jq, not just a `path()` shape.
+    // Deferred, the walkers see two adjacent `Iterate` components and reject
+    // the whole path as an invalid path component.
+    check(
+        r#"{"a":{"x":[1]},"b":{"y":[2]}}"#,
+        r#".[("a","b")][][] = 9"#,
+        Outcome::values(&[r#"{"a":{"x":[9]},"b":{"y":[9]}}"#]),
+    );
+    check(
+        r#"{"a":{"x":[1]},"b":{"y":[2]}}"#,
+        r#".[("a","b")][][] |= 9"#,
+        Outcome::values(&[r#"{"a":{"x":[9]},"b":{"y":[9]}}"#]),
+    );
+    check(
+        r#"{"a":[[1,2]],"b":[[3]]}"#,
+        r#"del(.[("a","b")][][])"#,
+        Outcome::values(&[r#"{"a":[[]],"b":[[]]}"#]),
+    );
+
+    // `?` finishes during path *production*. A deferred `[]?` carries its
+    // marker into `set_path`, which auto-vivifies every component on the way
+    // to discovering there is nothing to iterate — inventing keys and array
+    // slots jq never creates, and suppressing the write-time failure jq
+    // raises.
+    check(
+        r#"{"a":7,"b":[1,2]}"#,
+        r#".[("b","nope")][]? = 1"#,
+        Outcome::values(&[r#"{"a":7,"b":[1,1]}"#]),
+    );
+    check(
+        r#"{"a":7,"b":[1,2]}"#,
+        r#".[("b","nope")][]? |= .+1"#,
+        Outcome::values(&[r#"{"a":7,"b":[2,3]}"#]),
+    );
+    // No branch resolves at all: the document comes back untouched, not with
+    // two fabricated null keys.
+    check(
+        r#"{"a":7,"b":[1,2]}"#,
+        r#".[("nope","nope2")][]? = 1"#,
+        Outcome::values(&[r#"{"a":7,"b":[1,2]}"#]),
+    );
+    // Same for an out-of-range numeric branch — jq does not pad the array.
+    check(
+        r#"{"a":7,"b":[1,2]}"#,
+        ".b[(0,5)][]? = 1",
+        Outcome::values(&[r#"{"a":7,"b":[1,2]}"#]),
+    );
+
+    // jq computes the whole path set against the pristine document, then
+    // applies it. Here the first branch's write turns `.x.y` into a number,
+    // and jq still applies the second branch's already-resolved path to it
+    // and fails. Deferred, the second branch re-expands `[]` against the
+    // *mutated* document instead — where `?` prunes it and the write
+    // silently succeeds (#498's clobber case).
+    check(
+        r#"{"x":{"y":[1,2]},"z":5}"#,
+        "(.x,.x.y)[]? = 9",
+        Outcome::error("Cannot index number with number"),
+    );
+    check(
+        r#"{"x":{"y":[1,2]},"z":5}"#,
+        "(.x,.x.y)[] = 9",
+        Outcome::error("Cannot index number with number"),
+    );
+
+    // Trackability and iterability are interleaved per branch by
+    // `resolve_seq`'s fan-out loop, so the *first* branch decides. Deferred,
+    // every branch's trackability is answered before any branch's
+    // iterability, and the later branch wins instead.
+    check(
+        r#"{"a":7}"#,
+        "del((.a,1)|.[])",
+        Outcome::error("Cannot iterate over number (7)"),
+    );
+    check(
+        r#"{"a":7}"#,
+        r#"del((.a,error("boom"))|.[])"#,
+        Outcome::error("Cannot iterate over number (7)"),
+    );
+    // Reverse the order and the untracked branch really is first, so its own
+    // wording is the right answer — this is the control for the case above,
+    // not a repeat of it.
+    check(
+        r#"{"a":7}"#,
+        "del((1,.a)|.[])",
+        Outcome::error("Invalid path expression near attempt to iterate through 1"),
+    );
+
+    // A static tail after the fan-out is still applied before the iterate.
+    check(
+        r#"{"a":null,"b":[1]}"#,
+        r#".[("a","b")].k[] = 9"#,
+        Outcome::error("Cannot iterate over null (null)"),
+    );
+}
+
+/// #888: `reject_untracked_at_terminal`'s `near_iterate` wording, which only
+/// the deferring caller (`path()`) can reach.
+///
+/// Once the trailing iterate is stripped, the branch never reaches
+/// `resolve_node`'s `Expr::Iterate` arm, so its `if !trackable` guard cannot
+/// raise — the terminal check has to spell the same sentence itself. Forcing
+/// that argument to `false` leaves the whole suite green apart from one
+/// incidental destructuring test, so this case exists to say what the
+/// argument is actually for.
+#[test]
+fn test_untracked_terminal_before_a_deferred_iterate_says_near_iterate_888() {
+    check(
+        "{}",
+        "path(1|.[])",
+        Outcome::error("Invalid path expression near attempt to iterate through 1"),
+    );
+    check(
+        "{}",
+        "[path((1,2)|.[])]",
+        Outcome::error("Invalid path expression near attempt to iterate through 1"),
+    );
+    // `del()` reaches the same sentence by the other road — it does not
+    // defer, so `resolve_node`'s own `Expr::Iterate` arm raises it. Pinned
+    // together so the two roads cannot drift apart.
+    check(
+        "{}",
+        "del(1|.[])",
+        Outcome::error("Invalid path expression near attempt to iterate through 1"),
+    );
+}
+
 /// A computed key is checked against the container it will actually index, not
 /// against the value the chain started from.
 ///


### PR DESCRIPTION
Fixes #888.

## What

`path(.items[(0,1)].foo[])` — a computed key ahead of a trailing bare iterate — was O(n²). `resolve_dynamic_indexes` let `resolve_seq`'s fan-out loop fully enumerate the trailing `[]` into one static `Index(i)` component per array element, so a computed key with `k` branches ahead of an `n`-element array produced `k*n` resolved path expressions instead of `k`; `builtin_path` then re-walked every one of them from the document root, re-cloning the same subtree each time.

The fix strips a bare trailing `Iterate`/`Optional(Iterate)` run off the flattened path before resolving it, resolves the (already-cheap) remaining prefix through the unmodified `resolve_node`/`resolve_seq`, then splices the iterate back on as one literal component per branch so it fans out natively, once, in `walk_path`.

## Scope: `path()` only

The deferral is gated behind `defer_trailing_iterate`, passed `true` only by `builtin_path`. A first cut applied it to all four callers; a 1,680-case differential sweep against jq 1.7.1 (7 documents × 7 fan-out keys × 6 tails × 5 operations) found **186 divergences**, every one of them on `=`, `|=` or `del()`:

| # | family | example | jq 1.7.1 & `main` | deferred everywhere |
|---|--------|---------|-------------------|---------------------|
| 108 | adjacent `Iterate` components rejected by `get_path_mut`/`update_path` | `.[("a","b")][][] = 9` | `{"a":{"x":[9]},"b":{"y":[9]}}` | `invalid path component` |
| 21 | static tail applied after the iterate | `.[("a","b")].k[] = 9` on `{"a":null,"b":[1]}` | `Cannot iterate over null (null)` | `Cannot index array with string "k"` |
| ~40 | `?` reaches write time, auto-vivifying en route | `.[("b","nope")][]? = 1` | `{"a":7,"b":[1,1]}` | `{…,"nope":null}` |
| — | branch expands against the *mutated* document | `((.x,.x.y)[]?) = 9` | `Cannot index number with number` | silently returns `{"x":{"y":9},"z":5}` |
| — | trackability answered before iterability | `del((.a,1)\|.[])` on `{"a":7}` | `Cannot iterate over number (7)` | `…near attempt to iterate through 1` |

`path()` absorbs all five — it only reads, and `builtin_path`'s own `walk_error.or(resolve_error)` restores jq's "a later step's failure outranks an earlier deferred one" ordering. The write-side callers cannot, so they keep `main`'s behaviour byte for byte. Each family is pinned in `test_trailing_iterate_deferral_is_read_only_888`.

## Measurements

Apple M-series, release, interleaved per `docs/guides/benchmarking.md`. Total elements across both branches.

| total elements | `main` | this branch |
|----------------|--------|-------------|
| 4,000  | 0.55–0.58s | 0.00s |
| 8,000  | 2.25–2.26s | 0.01s |
| 16,000 | 9.16–12.44s | 0.02s |
| 200,000 | — | 0.24s |
| 400,000 | — | 0.48s |
| 800,000 | — | 0.93s |

The growth exponent drops, not just a constant factor. Output is byte-identical to `main` and to jq 1.7.1 at every size checked, and the 1,680-case sweep now diverges from neither.

## Follow-up: #1301

Re-measuring turned up something #888's own scope-correction table could not see, because it stopped at 16,000 elements: **`del` is quadratic on this shape too**, just with a small enough constant that it does not dominate until roughly 50,000 elements — 26.4s at 400,000. `=` and `|=` really are linear. The gate leaves that in place, since fixing it needs the five families above resolved rather than bypassed; filed as #1301. `bench_del_computed_key_with_trailing_iterate` now measures it, with sizes capped below the other groups' until it lands.

## History

This landed as two commits during review — the original fix, then the gate — and is squashed to one before merge on purpose: the queue merges by rebase, so the ungated commit would otherwise become a real, bisectable commit on `main` in which `.[("a","b")][][] = 9` errors out, `.[("b","nope")][]? = 1` invents a key, and `((.x,.x.y)[]?) = 9` silently returns a wrong document. The review comment below keeps the full record of what the first cut did and how it was found.

## Verification

- `cargo test --features cli,simd,regex,serde --workspace --no-fail-fast` — 5231 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI feature set — clean
- `cargo fmt --check`, `cargo check --no-default-features` — clean
- 1,680-case differential sweep vs jq 1.7.1 and `main` — 0 divergences

All re-run after this branch was rebased onto `f116c288e`, whose two new commits also touch `src/jq/eval.rs` in this area.
