### PR TITLE
fix(jq): give Expr::Array/Comma native cursor-native eval_single arms

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1045,6 +1045,55 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// Re-derives every `Float`'s spelling in `values` through
+/// [`eval_on_owned`]'s reindex bridge (`to_json_for_reindex`'s `S`-gated
+/// formatter, #953), without touching anything else in the input document.
+///
+/// `Expr::Array`/`Expr::Comma`'s own native `eval_single` arms (#1168) build
+/// `values` straight from `to_owned`/`to_owned_cursor`, which have no notion
+/// of "this bare `Float` came from a document-sourced literal that
+/// overflowed `i64`, keep its decimal point regardless of magnitude" — only
+/// `to_json_for_reindex`'s own `S`-gated fallback applies that rule (see its
+/// doc comment, `src/jq/value.rs`), and *only* because, before those two
+/// arms existed, `[...]`/`,` had no choice but to fall through to this same
+/// bridge for lack of a native cursor arm. Adding one without also keeping
+/// this fix regressed #953 (caught by its own regression test).
+///
+/// Round-tripping just `values` (not the whole input document, unlike the
+/// old wildcard fallback these two arms replace) keeps `Expr::Array`'s and
+/// `Expr::Comma`'s actual fix — duplicate mapping keys survive a builtin's
+/// own cursor-native conversion (`to_entries`, etc.) intact. Safe with
+/// respect to that fix: nothing in `values` still has a duplicate *mapping
+/// key* left to lose by round-tripping again — any genuine YAML duplicate
+/// was already collapsed the moment `to_owned`/`to_owned_cursor` first
+/// converted its mapping to an `IndexMap`-backed `Object`, before this ever
+/// runs; a builtin with its own dedup-preserving fix has already turned its
+/// duplicates into distinct array elements by this point instead, which
+/// round-trip through JSON text with no collision to lose.
+///
+/// A no-op in jq mode (`to_json_for_reindex`'s own `S`-gate already makes
+/// the round trip itself a no-op there — jq drops a computed float's
+/// literal formatting unconditionally) — skipped outright rather than paying
+/// for a round trip jq mode never needs. `Ok` carries the fixed-up values
+/// back for the caller to package (`Expr::Array` always wraps them in one
+/// `OwnedValue::Array`; `Expr::Comma` collapses via
+/// [`owned_vec_to_generic_result`]); `Err` carries an already-terminal
+/// `GenericResult` (an `Error`, in practice — see [`eval_on_owned`]'s own
+/// doc comment for why this is defense-in-depth rather than a reachable
+/// path for internally-constructed input) for the caller to return as-is.
+fn yq_float_fidelity_fixup<S: EvalSemantics, V: DocumentValue>(
+    values: Vec<OwnedValue>,
+) -> Result<Vec<OwnedValue>, GenericResult<V>> {
+    if S::TAG != EvalTag::Yq || values.is_empty() {
+        return Ok(values);
+    }
+    match eval_on_owned::<S, V>(&Expr::Identity, OwnedValue::Array(values), false) {
+        GenericResult::Owned(OwnedValue::Array(fixed)) => Ok(fixed),
+        GenericResult::Error(e) => Err(GenericResult::Error(e)),
+        other => Err(other),
+    }
+}
+
 /// Normalize a prefix and its terminator into a `GenericResult` (#400, #494).
 /// Mirrors [`super::eval::partial`] (the `QueryResult` equivalent) — an empty
 /// prefix collapses to the bare `Error`/`Break` variant.
@@ -1138,6 +1187,40 @@ fn push_generic_owned_values<V: DocumentValue>(
         }
     }
     None
+}
+
+/// [`push_generic_owned_values`]'s `Expr::Comma` sibling (#1168): identical
+/// except a direct cursor result (`OneCursor`/`ManyCursor`) is routed
+/// through [`yq_float_fidelity_fixup`] first. Scoped to exactly those two
+/// variants for the same reason as `Expr::Array`'s own arm in `eval_single`
+/// -- an already-constructed value reaching here (`Owned`/`ManyOwned`, e.g.
+/// a computed arithmetic result or a builtin's own object construction)
+/// can't be distinguished from a document-sourced one anymore, and forcing
+/// a decimal point onto it would introduce the same over-eager-forcing gap
+/// `test_yq_join_element_computed_float_known_gap_1124` (#1124/#1144)
+/// already documents as out of scope here.
+///
+/// Returns `Ok(Some(control))`/`Ok(None)` mirroring
+/// [`push_generic_owned_values`]'s `Option<Control>`, or `Err` with an
+/// already-terminal `GenericResult` if the fixup's own round trip failed
+/// (see [`yq_float_fidelity_fixup`]'s doc comment for why that's
+/// defense-in-depth rather than reachable in practice).
+fn push_generic_owned_values_yq_fixed<S: EvalSemantics, V: DocumentValue>(
+    result: GenericResult<V>,
+    out: &mut Vec<OwnedValue>,
+) -> Result<Option<Control>, GenericResult<V>> {
+    match result.materialize_lazy() {
+        GenericResult::OneCursor(c) => {
+            out.extend(yq_float_fidelity_fixup::<S, V>(vec![to_owned_cursor(&c)])?);
+            Ok(None)
+        }
+        GenericResult::ManyCursor(cs) => {
+            let values: Vec<OwnedValue> = cs.iter().map(to_owned_cursor).collect();
+            out.extend(yq_float_fidelity_fixup::<S, V>(values)?);
+            Ok(None)
+        }
+        other => Ok(push_generic_owned_values(other, out)),
+    }
 }
 
 /// Append one truthiness bit per output of a `GenericResult` stream to
@@ -2709,6 +2792,106 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             }
 
             finish_fork_generic(out, right_control, optional)
+        }
+
+        // Array construction: collect every output of the inner expression
+        // into one array. Handled natively (mirrors `eval::eval_array_construction`)
+        // so a builtin with its own cursor-native, duplicate-key-preserving fix
+        // (e.g. #443's `to_entries`) keeps that fix when wrapped in `[...]`,
+        // instead of losing it to the wildcard fallback's whole-document
+        // `to_owned()`, which collapses duplicate mapping keys before the
+        // wrapped expression ever runs (#1168).
+        Expr::Array(inner) => {
+            let items: Vec<OwnedValue> = match eval_single::<S, _>(inner, value, optional, cursor)
+                .materialize_lazy()
+            {
+                GenericResult::One(v) => vec![to_owned(&v)],
+                // Fixed up (#953/#1168, `yq_float_fidelity_fixup`'s own doc
+                // comment): a direct cursor result reflects the input
+                // document itself, which needs the same round-trip decimal-
+                // point forcing the old wildcard fallback applied to the
+                // *whole* document before this arm existed.
+                GenericResult::OneCursor(c) => {
+                    match yq_float_fidelity_fixup::<S, _>(vec![to_owned_cursor(&c)]) {
+                        Ok(fixed) => fixed,
+                        Err(result) => return result,
+                    }
+                }
+                GenericResult::Many(vs) => vs.iter().map(to_owned).collect(),
+                GenericResult::ManyCursor(cs) => {
+                    let values: Vec<OwnedValue> = cs.iter().map(to_owned_cursor).collect();
+                    match yq_float_fidelity_fixup::<S, _>(values) {
+                        Ok(fixed) => fixed,
+                        Err(result) => return result,
+                    }
+                }
+                GenericResult::None => Vec::new(),
+                // NOT fixed up, deliberately: an already-constructed value
+                // (a builtin's own object/array, a genuinely computed
+                // arithmetic result, ...) can't be distinguished here from a
+                // document-sourced one once it's inside this shape --
+                // running the same round trip on it would force a decimal
+                // point onto a *computed* float too, which this codebase
+                // already treats as a separate, out-of-scope gap rather
+                // than "fixed" (`test_yq_join_element_computed_float_known_gap_1124`,
+                // #1124/#1144). Scoping the fixup to `OneCursor`/`ManyCursor`
+                // above avoids introducing that same over-eager-decimal-
+                // forcing for a case (bare computed arithmetic wrapped in
+                // `[...]`) that doesn't have it today.
+                GenericResult::Owned(v) => vec![v],
+                GenericResult::ManyOwned(vs) => vs,
+                GenericResult::Error(e) => return GenericResult::Error(e),
+                GenericResult::Break(label) => return GenericResult::Break(label),
+                GenericResult::Halt(code) => return GenericResult::Halt(code),
+                // Array construction is atomic in jq (verified: `[1,error("x"),3]`
+                // produces no output at all, not a partial array) -- a `Partial`
+                // inner stream surfaces only its terminating control, discarding
+                // whatever prefix it already produced. Mirrors
+                // `eval::eval_array_construction`'s identical arm.
+                GenericResult::Partial(_, Control::Error(e)) => return GenericResult::Error(e),
+                GenericResult::Partial(_, Control::Break(label)) => {
+                    return GenericResult::Break(label)
+                }
+                GenericResult::Partial(_, Control::Halt(code)) => return GenericResult::Halt(code),
+                GenericResult::LazyKeys { .. }
+                | GenericResult::LazyIndexRange(_)
+                | GenericResult::LazySeq(_) => {
+                    unreachable!("materialize_lazy() already normalized every lazy variant")
+                }
+            };
+            GenericResult::Owned(OwnedValue::Array(items))
+        }
+
+        // Comma: evaluate each operand in source order against the ambient
+        // `optional` (mirrors `eval::eval_comma`, minus its borrowed/owned
+        // fast path -- `Expr::Compare` above already establishes the
+        // "collect into an owned Vec" shape for a multi-operand native arm
+        // in this file). A sibling's own `Error`/`Break`/`Halt`/`Partial`
+        // always propagates as a `Partial` carrying whatever prefix already
+        // ran (#400) -- unlike `Expr::Array` above, comma is not atomic, and
+        // unlike `Expr::Compare`'s `finish_fork_generic` calls, this never
+        // consults `optional` itself: an ambient `?` catches the aggregate
+        // result exactly once at `Expr::Optional`'s own arm, same as
+        // `eval::eval_comma` defers to `eval::eval_try`. Handled natively so
+        // a cursor-native builtin's fix doesn't lose it to the wildcard
+        // fallback just for being joined with `,` either (#1168).
+        //
+        // Each sibling's own `push_generic_owned_values_yq_fixed` call fixes
+        // up only a direct cursor result (`OneCursor`/`ManyCursor`), same
+        // scoping and reasoning as `Expr::Array`'s own arm above -- an
+        // already-constructed value (an already-computed arithmetic result,
+        // a builtin's own object construction) is passed through untouched.
+        Expr::Comma(exprs) => {
+            let mut out: Vec<OwnedValue> = Vec::new();
+            for expr in exprs {
+                let result = eval_single::<S, _>(expr, value.clone(), optional, cursor);
+                match push_generic_owned_values_yq_fixed::<S, _>(result, &mut out) {
+                    Ok(Some(control)) => return partial_generic(out, control),
+                    Ok(None) => {}
+                    Err(result) => return result,
+                }
+            }
+            owned_vec_to_generic_result(out)
         }
 
         // Fall back to the full evaluator for complex expressions
@@ -5653,6 +5836,82 @@ mod tests {
             owned,
             OwnedValue::Array(vec![expected_entry(1), expected_entry(2)])
         );
+    }
+
+    /// #1168: `Expr::Array` had no native `eval_single` arm, so wrapping a
+    /// cursor-native, duplicate-key-preserving builtin (`to_entries`, #443
+    /// above) in `[...]` fell to the wildcard fallback, which materializes
+    /// the *whole document* into an `OwnedValue` first -- silently
+    /// re-collapsing the very duplicates `to_entries` had just preserved.
+    /// In-process (not just the CLI test in `tests/yq_cli_tests.rs`) for the
+    /// same coverage-attribution reason as [`test_yaml_shuffle_resolves_explicit_tag_903`].
+    #[test]
+    fn test_yaml_generic_array_wrapped_to_entries_preserves_duplicate_keys_1168() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: 1\na: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let cursor = index.root(yaml);
+
+        let mapping_cursor = cursor
+            .first_child()
+            .expect("YAML document should have content");
+        let value = mapping_cursor.value();
+
+        let result = eval(
+            &Expr::Array(Box::new(Expr::Builtin(Builtin::ToEntries))),
+            value,
+        );
+        let owned = result.into_owned().unwrap();
+
+        let expected_entry = |v: i64| {
+            let mut entry = IndexMap::new();
+            entry.insert("key".to_string(), OwnedValue::String("a".to_string()));
+            entry.insert("value".to_string(), OwnedValue::Int(v));
+            OwnedValue::Object(entry)
+        };
+        assert_eq!(
+            owned,
+            OwnedValue::Array(vec![OwnedValue::Array(vec![
+                expected_entry(1),
+                expected_entry(2)
+            ])])
+        );
+    }
+
+    /// #1168, comma sibling of the `Array` case above: `Expr::Comma` had no
+    /// native arm either, so `to_entries, to_entries` hit the same
+    /// whole-document-materializing fallback for both operands.
+    #[test]
+    fn test_yaml_generic_comma_wrapped_to_entries_preserves_duplicate_keys_1168() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: 1\na: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let cursor = index.root(yaml);
+
+        let mapping_cursor = cursor
+            .first_child()
+            .expect("YAML document should have content");
+        let value = mapping_cursor.value();
+
+        let result = eval(
+            &Expr::Comma(vec![
+                Expr::Builtin(Builtin::ToEntries),
+                Expr::Builtin(Builtin::ToEntries),
+            ]),
+            value,
+        );
+        let owned = result.collect_owned();
+
+        let expected_entry = |v: i64| {
+            let mut entry = IndexMap::new();
+            entry.insert("key".to_string(), OwnedValue::String("a".to_string()));
+            entry.insert("value".to_string(), OwnedValue::Int(v));
+            OwnedValue::Object(entry)
+        };
+        let expected_array = OwnedValue::Array(vec![expected_entry(1), expected_entry(2)]);
+        assert_eq!(owned, vec![expected_array.clone(), expected_array]);
     }
 
     /// #1170: unlike YAML's genuine duplicates (above), a duplicate JSON

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -33,7 +33,7 @@ use super::eval::{
 };
 use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
-use super::value::OwnedValue;
+use super::value::{NumberRepr, OwnedValue};
 use crate::json::JsonIndex;
 
 /// Recursion-depth ceiling for [`to_owned`]/[`to_owned_cursor`]/
@@ -1050,14 +1050,37 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
 /// formatter, #953), without touching anything else in the input document.
 ///
 /// `Expr::Array`/`Expr::Comma`'s own native `eval_single` arms (#1168) build
-/// `values` straight from `to_owned`/`to_owned_cursor`, which have no notion
-/// of "this bare `Float` came from a document-sourced literal that
-/// overflowed `i64`, keep its decimal point regardless of magnitude" — only
-/// `to_json_for_reindex`'s own `S`-gated fallback applies that rule (see its
-/// doc comment, `src/jq/value.rs`), and *only* because, before those two
-/// arms existed, `[...]`/`,` had no choice but to fall through to this same
-/// bridge for lack of a native cursor arm. Adding one without also keeping
-/// this fix regressed #953 (caught by its own regression test).
+/// `values` straight from `to_owned`/`to_owned_cursor` -- or, for a builtin
+/// with its own native construction (`to_entries`, ...), from whatever *that*
+/// builtin's arm produced, which uses the identical `to_owned`/`to_owned_cursor`
+/// conversion internally. Neither has any notion of "this bare `Float` came
+/// from a document-sourced literal that overflowed `i64`, keep its decimal
+/// point regardless of magnitude" -- only `to_json_for_reindex`'s own
+/// `S`-gated fallback applies that rule (see its doc comment,
+/// `src/jq/value.rs`), and *only* because, before `Expr::Array`/`Expr::Comma`
+/// had native arms, `[...]`/`,` had no choice but to fall through to this
+/// same bridge for lack of one. Adding native arms without also keeping this
+/// fix regressed #953 for a direct cursor result (`[.a]`, caught by its own
+/// regression test) *and*, less obviously, for a value one layer removed
+/// through a builtin's own construction (`[to_entries]` on an overflow
+/// field, caught in code review -- `Builtin::ToEntries` also reads the field
+/// via `to_owned_cursor`, just wrapped in an entry object before `Expr::Array`
+/// ever sees it, so scoping the fixup to only direct `GenericResult::
+/// OneCursor`/`ManyCursor` results missed this case entirely).
+///
+/// This is why the fixup applies unconditionally to the *whole* constructed
+/// result rather than trying to track, per value, whether it's document-
+/// sourced or genuinely computed (e.g. `1e10 * 2`) -- that distinction isn't
+/// recoverable from a `GenericResult` variant once a value has passed through
+/// even one further construction step (`to_entries`'s object wrapping looks
+/// identical, from here, to freshly computed arithmetic). The trade-off this
+/// accepts, matching an already-documented precedent
+/// (`test_yq_array_wrapped_computed_float_keeps_scientific_notation_known_gap_1168`,
+/// same shape as #1124/#1144's `join` gap): a genuinely computed float
+/// wrapped directly in `[...]`/`,` (`[1e10 * 2]`) also gets its decimal point
+/// forced, when real yq would keep scientific notation there. Getting both
+/// right needs provenance tagged at `OwnedValue::Float`'s own construction
+/// site, not reconstructed after the fact here -- out of scope for this fix.
 ///
 /// Round-tripping just `values` (not the whole input document, unlike the
 /// old wildcard fallback these two arms replace) keeps `Expr::Array`'s and
@@ -1073,24 +1096,47 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
 ///
 /// A no-op in jq mode (`to_json_for_reindex`'s own `S`-gate already makes
 /// the round trip itself a no-op there — jq drops a computed float's
-/// literal formatting unconditionally) — skipped outright rather than paying
-/// for a round trip jq mode never needs. `Ok` carries the fixed-up values
-/// back for the caller to package (`Expr::Array` always wraps them in one
-/// `OwnedValue::Array`; `Expr::Comma` collapses via
-/// [`owned_vec_to_generic_result`]); `Err` carries an already-terminal
-/// `GenericResult` (an `Error`, in practice — see [`eval_on_owned`]'s own
-/// doc comment for why this is defense-in-depth rather than a reachable
-/// path for internally-constructed input) for the caller to return as-is.
+/// literal formatting unconditionally), and a no-op whenever `values` has no
+/// `Float`/`NumberLiteral(Float, _)` anywhere in its tree (`contains_float`)
+/// — skipped outright rather than paying for a round trip that has nothing
+/// to fix, which is the common case (`[.a, .b, .c]` over strings/objects/
+/// plain ints). `Ok` carries the fixed-up values back for the caller to
+/// package (`Expr::Array` always wraps them in one `OwnedValue::Array`;
+/// `Expr::Comma` collapses via [`owned_vec_to_generic_result`]); `Err`
+/// carries an already-terminal `GenericResult` (an `Error`, in practice —
+/// see [`eval_on_owned`]'s own doc comment for why this is defense-in-depth
+/// rather than a reachable path for internally-constructed input) for the
+/// caller to return as-is.
 fn yq_float_fidelity_fixup<S: EvalSemantics, V: DocumentValue>(
     values: Vec<OwnedValue>,
 ) -> Result<Vec<OwnedValue>, GenericResult<V>> {
-    if S::TAG != EvalTag::Yq || values.is_empty() {
+    if S::TAG != EvalTag::Yq || values.is_empty() || !values.iter().any(contains_float) {
         return Ok(values);
     }
     match eval_on_owned::<S, V>(&Expr::Identity, OwnedValue::Array(values), false) {
         GenericResult::Owned(OwnedValue::Array(fixed)) => Ok(fixed),
         GenericResult::Error(e) => Err(GenericResult::Error(e)),
         other => Err(other),
+    }
+}
+
+/// Whether `value`'s tree contains a `Float`/`NumberLiteral(Float, _)`
+/// anywhere -- the only shapes [`yq_float_fidelity_fixup`]'s round trip can
+/// possibly change (see `to_json_for_reindex`'s own `S`-gated fallback,
+/// which is scoped identically). A cheap pre-check so a document with no
+/// float anywhere in the wrapped result skips the round trip entirely,
+/// rather than paying for one that has nothing to do.
+fn contains_float(value: &OwnedValue) -> bool {
+    match value {
+        OwnedValue::Float(_) => true,
+        OwnedValue::NumberLiteral(NumberRepr::Float(_), _) => true,
+        OwnedValue::Array(items) => items.iter().any(contains_float),
+        OwnedValue::Object(fields) => fields.values().any(contains_float),
+        OwnedValue::Null
+        | OwnedValue::Bool(_)
+        | OwnedValue::Int(_)
+        | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
+        | OwnedValue::String(_) => false,
     }
 }
 
@@ -1187,40 +1233,6 @@ fn push_generic_owned_values<V: DocumentValue>(
         }
     }
     None
-}
-
-/// [`push_generic_owned_values`]'s `Expr::Comma` sibling (#1168): identical
-/// except a direct cursor result (`OneCursor`/`ManyCursor`) is routed
-/// through [`yq_float_fidelity_fixup`] first. Scoped to exactly those two
-/// variants for the same reason as `Expr::Array`'s own arm in `eval_single`
-/// -- an already-constructed value reaching here (`Owned`/`ManyOwned`, e.g.
-/// a computed arithmetic result or a builtin's own object construction)
-/// can't be distinguished from a document-sourced one anymore, and forcing
-/// a decimal point onto it would introduce the same over-eager-forcing gap
-/// `test_yq_join_element_computed_float_known_gap_1124` (#1124/#1144)
-/// already documents as out of scope here.
-///
-/// Returns `Ok(Some(control))`/`Ok(None)` mirroring
-/// [`push_generic_owned_values`]'s `Option<Control>`, or `Err` with an
-/// already-terminal `GenericResult` if the fixup's own round trip failed
-/// (see [`yq_float_fidelity_fixup`]'s doc comment for why that's
-/// defense-in-depth rather than reachable in practice).
-fn push_generic_owned_values_yq_fixed<S: EvalSemantics, V: DocumentValue>(
-    result: GenericResult<V>,
-    out: &mut Vec<OwnedValue>,
-) -> Result<Option<Control>, GenericResult<V>> {
-    match result.materialize_lazy() {
-        GenericResult::OneCursor(c) => {
-            out.extend(yq_float_fidelity_fixup::<S, V>(vec![to_owned_cursor(&c)])?);
-            Ok(None)
-        }
-        GenericResult::ManyCursor(cs) => {
-            let values: Vec<OwnedValue> = cs.iter().map(to_owned_cursor).collect();
-            out.extend(yq_float_fidelity_fixup::<S, V>(values)?);
-            Ok(None)
-        }
-        other => Ok(push_generic_owned_values(other, out)),
-    }
 }
 
 /// Append one truthiness bit per output of a `GenericResult` stream to
@@ -2806,73 +2818,57 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 .materialize_lazy()
             {
                 GenericResult::One(v) => vec![to_owned(&v)],
-                // Fixed up (#953/#1168, `yq_float_fidelity_fixup`'s own doc
-                // comment): a direct cursor result reflects the input
-                // document itself, which needs the same round-trip decimal-
-                // point forcing the old wildcard fallback applied to the
-                // *whole* document before this arm existed.
-                GenericResult::OneCursor(c) => {
-                    match yq_float_fidelity_fixup::<S, _>(vec![to_owned_cursor(&c)]) {
-                        Ok(fixed) => fixed,
-                        Err(result) => return result,
-                    }
-                }
+                GenericResult::OneCursor(c) => vec![to_owned_cursor(&c)],
                 GenericResult::Many(vs) => vs.iter().map(to_owned).collect(),
-                GenericResult::ManyCursor(cs) => {
-                    let values: Vec<OwnedValue> = cs.iter().map(to_owned_cursor).collect();
-                    match yq_float_fidelity_fixup::<S, _>(values) {
-                        Ok(fixed) => fixed,
-                        Err(result) => return result,
-                    }
-                }
+                GenericResult::ManyCursor(cs) => cs.iter().map(to_owned_cursor).collect(),
                 GenericResult::None => Vec::new(),
-                // NOT fixed up, deliberately: an already-constructed value
-                // (a builtin's own object/array, a genuinely computed
-                // arithmetic result, ...) can't be distinguished here from a
-                // document-sourced one once it's inside this shape --
-                // running the same round trip on it would force a decimal
-                // point onto a *computed* float too, which this codebase
-                // already treats as a separate, out-of-scope gap rather
-                // than "fixed" (`test_yq_join_element_computed_float_known_gap_1124`,
-                // #1124/#1144). Scoping the fixup to `OneCursor`/`ManyCursor`
-                // above avoids introducing that same over-eager-decimal-
-                // forcing for a case (bare computed arithmetic wrapped in
-                // `[...]`) that doesn't have it today.
                 GenericResult::Owned(v) => vec![v],
                 GenericResult::ManyOwned(vs) => vs,
-                GenericResult::Error(e) => return GenericResult::Error(e),
-                // `Break`/`Partial`-`Break` (bare and below): kept for
-                // exhaustiveness over `GenericResult`, mirroring
-                // `eval::eval_array_construction`'s own arms, but not
-                // reachable via any query this CLI can currently parse --
-                // `break $out` needs an enclosing `label $out`, and
-                // `Expr::Label` has no native `eval_single` arm of its own
-                // (see #1168's scope-widening comment), so any query where a
-                // `break` could reach *past* this arm's own boundary
-                // necessarily puts `Label` above `Array` in the tree, which
-                // routes the *whole* expression through the wildcard
-                // fallback below before this arm ever runs. Same
+                // `Break`/`Partial`-`Break` (below): kept for exhaustiveness
+                // over `GenericResult`, mirroring `eval::eval_array_construction`'s
+                // own arms, but not reachable via any query this CLI can
+                // currently parse -- `break $out` needs an enclosing
+                // `label $out`, and `Expr::Label` has no native `eval_single`
+                // arm of its own (see #1168's scope-widening comment), so any
+                // query where a `break` could reach *past* this arm's own
+                // boundary necessarily puts `Label` above `Array` in the
+                // tree, which routes the *whole* expression through the
+                // wildcard fallback below before this arm ever runs. Same
                 // "unreachable but exhaustive" shape #1064 documents
                 // elsewhere in this codebase.
-                GenericResult::Break(label) => return GenericResult::Break(label),
-                GenericResult::Halt(code) => return GenericResult::Halt(code),
-                // Array construction is atomic in jq (verified: `[1,error("x"),3]`
-                // produces no output at all, not a partial array) -- a `Partial`
-                // inner stream surfaces only its terminating control, discarding
-                // whatever prefix it already produced. Mirrors
-                // `eval::eval_array_construction`'s identical arm.
-                GenericResult::Partial(_, Control::Error(e)) => return GenericResult::Error(e),
-                GenericResult::Partial(_, Control::Break(label)) => {
+                //
+                // Array construction is atomic in jq (verified:
+                // `[1,error("x"),3]` produces no output at all, not a
+                // partial array) -- a bare `Error`/`Break`/`Halt` and its
+                // `Partial` sibling return the identical result (the
+                // `Partial` prefix is unconditionally discarded), so they
+                // merge via or-patterns. Mirrors `eval::eval_array_construction`'s
+                // identical arms.
+                GenericResult::Error(e) | GenericResult::Partial(_, Control::Error(e)) => {
+                    return GenericResult::Error(e)
+                }
+                GenericResult::Break(label) | GenericResult::Partial(_, Control::Break(label)) => {
                     return GenericResult::Break(label)
                 }
-                GenericResult::Partial(_, Control::Halt(code)) => return GenericResult::Halt(code),
+                GenericResult::Halt(code) | GenericResult::Partial(_, Control::Halt(code)) => {
+                    return GenericResult::Halt(code)
+                }
                 GenericResult::LazyKeys { .. }
                 | GenericResult::LazyIndexRange(_)
                 | GenericResult::LazySeq(_) => {
                     unreachable!("materialize_lazy() already normalized every lazy variant")
                 }
             };
-            GenericResult::Owned(OwnedValue::Array(items))
+            // Fixed up as one whole unit, not per-source (#953/#1168, see
+            // `yq_float_fidelity_fixup`'s own doc comment for why -- in
+            // short, a builtin's own construction around a document value
+            // (`to_entries`, ...) is indistinguishable here from a genuinely
+            // computed one, so the fixup can't be scoped any narrower than
+            // this without missing that case).
+            match yq_float_fidelity_fixup::<S, _>(items) {
+                Ok(fixed) => GenericResult::Owned(OwnedValue::Array(fixed)),
+                Err(result) => result,
+            }
         }
 
         // Comma: evaluate each operand in source order against the ambient
@@ -2889,22 +2885,25 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // a cursor-native builtin's fix doesn't lose it to the wildcard
         // fallback just for being joined with `,` either (#1168).
         //
-        // Each sibling's own `push_generic_owned_values_yq_fixed` call fixes
-        // up only a direct cursor result (`OneCursor`/`ManyCursor`), same
-        // scoping and reasoning as `Expr::Array`'s own arm above -- an
-        // already-constructed value (an already-computed arithmetic result,
-        // a builtin's own object construction) is passed through untouched.
+        // `yq_float_fidelity_fixup` runs once over the whole collected `out`
+        // after the loop, not per-sibling -- same reasoning as `Expr::Array`
+        // above, and cheaper (one round trip for `.a, .b, .c` instead of up
+        // to three).
         Expr::Comma(exprs) => {
             let mut out: Vec<OwnedValue> = Vec::new();
             for expr in exprs {
                 let result = eval_single::<S, _>(expr, value.clone(), optional, cursor);
-                match push_generic_owned_values_yq_fixed::<S, _>(result, &mut out) {
-                    Ok(Some(control)) => return partial_generic(out, control),
-                    Ok(None) => {}
-                    Err(result) => return result,
+                if let Some(control) = push_generic_owned_values(result, &mut out) {
+                    return match yq_float_fidelity_fixup::<S, _>(out) {
+                        Ok(fixed) => partial_generic(fixed, control),
+                        Err(result) => result,
+                    };
                 }
             }
-            owned_vec_to_generic_result(out)
+            match yq_float_fidelity_fixup::<S, _>(out) {
+                Ok(fixed) => owned_vec_to_generic_result(fixed),
+                Err(result) => result,
+            }
         }
 
         // Fall back to the full evaluator for complex expressions

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2841,6 +2841,19 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Owned(v) => vec![v],
                 GenericResult::ManyOwned(vs) => vs,
                 GenericResult::Error(e) => return GenericResult::Error(e),
+                // `Break`/`Partial`-`Break` (bare and below): kept for
+                // exhaustiveness over `GenericResult`, mirroring
+                // `eval::eval_array_construction`'s own arms, but not
+                // reachable via any query this CLI can currently parse --
+                // `break $out` needs an enclosing `label $out`, and
+                // `Expr::Label` has no native `eval_single` arm of its own
+                // (see #1168's scope-widening comment), so any query where a
+                // `break` could reach *past* this arm's own boundary
+                // necessarily puts `Label` above `Array` in the tree, which
+                // routes the *whole* expression through the wildcard
+                // fallback below before this arm ever runs. Same
+                // "unreachable but exhaustive" shape #1064 documents
+                // elsewhere in this codebase.
                 GenericResult::Break(label) => return GenericResult::Break(label),
                 GenericResult::Halt(code) => return GenericResult::Halt(code),
                 // Array construction is atomic in jq (verified: `[1,error("x"),3]`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13141,21 +13141,79 @@ fn test_yq_array_wrapped_overflow_int_keeps_decimal_point_953() -> Result<()> {
     Ok(())
 }
 
-/// #1168 review: fixing #953's regression above (`Expr::Array`'s new native
-/// arm bypasses the old wildcard fallback's own `to_json_for_reindex`
-/// round-trip, which is where #953's decimal-point forcing actually lives)
-/// must not force it onto a *genuinely computed* float too -- only a direct
-/// cursor result (a value read from the input document, e.g. `.a` above)
-/// gets `yq_float_fidelity_fixup`'s round-trip; an arithmetic result never
-/// touches the input document at all, and must keep real yq's ordinary
-/// scientific-notation threshold instead (matching `1e20*1 | tostring`, and
-/// the same distinction `test_yq_join_element_computed_float_known_gap_1124`
-/// already documents for `join`).
+/// #1168 review round: `[to_entries]`/`to_entries, to_entries` regressed
+/// #953 the same way `[.a]` above does, but less obviously -- `to_entries`
+/// (`Builtin::ToEntries`) reads the overflow field via `to_owned_cursor`
+/// exactly like `.a` does, just wrapped in its own `{key, value}` object
+/// construction before `Expr::Array`/`Expr::Comma` ever sees the result,
+/// so it reaches them as `GenericResult::Owned`, not `OneCursor`. An
+/// earlier version of `yq_float_fidelity_fixup` scoped itself to only
+/// `OneCursor`/`ManyCursor` on the theory that `Owned` always means
+/// "already computed" -- wrong, and this test pins the case that proved it
+/// (found live against a rebuilt pre-#1168 baseline during code review).
 #[test]
-fn test_yq_array_wrapped_computed_float_keeps_scientific_notation_1168() -> Result<()> {
+fn test_yq_array_comma_wrapped_to_entries_overflow_int_keeps_decimal_point_1168() -> Result<()> {
+    let yaml = "a: 99999999999999999999\n";
+    let extra_args = ["-o", "json", "-I0"];
+
+    let (array_output, code) = run_yq_stdin("[to_entries]", yaml, &extra_args)?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        array_output.trim_end(),
+        r#"[[{"key":"a","value":100000000000000000000.0}]]"#
+    );
+
+    let (comma_output, code) = run_yq_stdin("to_entries, to_entries", yaml, &extra_args)?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        comma_output.trim_end(),
+        "[{\"key\":\"a\",\"value\":100000000000000000000.0}]\n[{\"key\":\"a\",\"value\":100000000000000000000.0}]"
+    );
+    Ok(())
+}
+
+/// #1168 review round: `Expr::Comma`'s fixup used to round-trip once per
+/// cursor-backed sibling instead of once for the whole comma expression --
+/// this doesn't assert on the round-trip count directly (no test hook for
+/// that), but pins the observable correctness the batched version must
+/// still deliver: every sibling's own overflow field independently forced
+/// to a decimal spelling, plain values untouched.
+#[test]
+fn test_yq_comma_multiple_overflow_fields_all_fixed_1168() -> Result<()> {
+    let yaml = "a: 99999999999999999999\nb: 1\nc: 88888888888888888888\n";
+    let (stdout, code) = run_yq_stdin(".a, .b, .c", yaml, &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout,
+        "100000000000000000000.0\n1\n88888888888888890000.0\n"
+    );
+    Ok(())
+}
+
+/// #1168 review round: `yq_float_fidelity_fixup` first tried scoping itself
+/// to only a direct cursor result (`OneCursor`/`ManyCursor`), leaving an
+/// already-constructed value (`Owned`/`ManyOwned`) untouched on the theory
+/// that it can't be a document literal. That theory was wrong -- code review
+/// found `Builtin::ToEntries` (and any other builtin with its own native
+/// construction around a document value) *also* reaches `Expr::Array` as
+/// `Owned`, so the narrower scoping silently regressed #953 for exactly
+/// that shape (`[to_entries]` on an overflow field, see
+/// `test_yq_array_wrapped_to_entries_overflow_int_keeps_decimal_point_1168`
+/// below) while it was trying to avoid over-forcing a genuinely computed
+/// float like this one. Since a `GenericResult` variant can't distinguish
+/// "builtin construction around a document value" from "genuinely computed"
+/// once a value has passed through even one further construction step, the
+/// fixup now applies uniformly to the whole constructed result -- accepting
+/// this known, pre-existing-class gap (same shape as #1124/#1144's `join`
+/// gap) as the trade-off: a bare computed float wrapped directly in
+/// `[...]`/`,` also gets its decimal point forced, when real yq would keep
+/// scientific notation. Pinned here so a future attempt to "fix" this case
+/// re-checks it doesn't reintroduce the `to_entries` regression instead.
+#[test]
+fn test_yq_array_wrapped_computed_float_forces_decimal_known_gap_1168() -> Result<()> {
     let (stdout, code) = run_yq_stdin("[1e20 * 1]", "null\n", &["-o", "json", "-I0"])?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "[1e+20]");
+    assert_eq!(stdout.trim_end(), "[100000000000000000000.0]");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -992,26 +992,20 @@ fn test_yq_array_comma_wrapped_iterate_many_cursor_1168() -> Result<()> {
     Ok(())
 }
 
-/// #1168 coverage: `Expr::Array`'s atomicity arms (`Break`/`Halt`, and their
-/// `Partial` siblings once something already output before the break/halt
-/// fired) -- mirrors `eval::eval_array_construction`'s identical control-flow
+/// #1168 coverage: `Expr::Array`'s `Halt`/`Partial`-`Halt` atomicity arms --
+/// mirrors `eval::eval_array_construction`'s identical control-flow
 /// handling, which this native arm replaces the wildcard-fallback route to.
-#[test]
-fn test_yq_array_wrapped_break_produces_no_output_1168() -> Result<()> {
-    let (stdout, code) = run_yq_stdin("label $out | [break $out]", "null\n", &["-o=json"])?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout, "");
-    Ok(())
-}
-
-#[test]
-fn test_yq_array_wrapped_partial_break_discards_prefix_1168() -> Result<()> {
-    let (stdout, code) = run_yq_stdin("label $out | [(1, break $out)]", "null\n", &["-o=json"])?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout, "");
-    Ok(())
-}
-
+/// No `Break` sibling test: unlike `halt`, `break $out` needs an enclosing
+/// `label $out` to even parse, and `Expr::Label` itself has no native
+/// `eval_single` arm (see the scope-widening comment on #1168 itself) -- any
+/// query shaped so a `break` could reach *past* this arm's own boundary
+/// necessarily puts `Label` above `Array` in the tree, which routes the
+/// *whole* expression through the wildcard fallback before this arm ever
+/// runs. Its `Break`/`Partial`-`Break` arms are kept for exhaustiveness over
+/// the shared `GenericResult` enum (mirroring `eval::eval_array_construction`'s
+/// own arms), not because a reachable CLI query hits them today -- same
+/// "unreachable but exhaustive" shape #1064 documents elsewhere in this
+/// codebase; see `eval_generic.rs`'s own comment on those two arms.
 #[test]
 fn test_yq_array_wrapped_halt_exits_with_no_output_1168() -> Result<()> {
     let (stdout, code) = run_yq_stdin("[halt]", "null\n", &["-o=json"])?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -973,6 +973,61 @@ fn test_json_duplicate_key_array_comma_wrapped_to_entries_still_dedupes_1168() -
     Ok(())
 }
 
+/// #1168 coverage: `yq_float_fidelity_fixup`'s `ManyCursor` call sites
+/// (`Expr::Array`'s own arm, and `push_generic_owned_values_yq_fixed`'s
+/// `Expr::Comma` sibling) are only reached when the wrapped expression's
+/// *own* result is multi-valued and still cursor-backed -- `.[]`'s own
+/// native `Expr::Iterate` arm is exactly that shape, unlike the single-
+/// cursor `.a` case `test_yq_array_wrapped_overflow_int_keeps_decimal_point_953`
+/// already covers.
+#[test]
+fn test_yq_array_comma_wrapped_iterate_many_cursor_1168() -> Result<()> {
+    let (array_output, code) = run_yq_stdin("[.[]]", "[1, 2, 3]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(array_output.trim(), "[1,2,3]");
+
+    let (comma_output, code) = run_yq_stdin(".[], .[]", "[1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(comma_output.trim(), "1\n2\n1\n2");
+    Ok(())
+}
+
+/// #1168 coverage: `Expr::Array`'s atomicity arms (`Break`/`Halt`, and their
+/// `Partial` siblings once something already output before the break/halt
+/// fired) -- mirrors `eval::eval_array_construction`'s identical control-flow
+/// handling, which this native arm replaces the wildcard-fallback route to.
+#[test]
+fn test_yq_array_wrapped_break_produces_no_output_1168() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("label $out | [break $out]", "null\n", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+#[test]
+fn test_yq_array_wrapped_partial_break_discards_prefix_1168() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("label $out | [(1, break $out)]", "null\n", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+#[test]
+fn test_yq_array_wrapped_halt_exits_with_no_output_1168() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("[halt]", "null\n", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+#[test]
+fn test_yq_array_wrapped_partial_halt_discards_prefix_1168() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("[(1, halt)]", "null\n", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
 /// #1170: unlike YAML's genuine duplicates (preserved unmerged above, per
 /// #443), a duplicate key on `--input-format json` input must collapse to
 /// one entry -- keeping the first occurrence's position but the last

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -913,6 +913,66 @@ fn test_duplicate_mapping_key_to_entries_json_compact() -> Result<()> {
     Ok(())
 }
 
+/// #1168: `to_entries` has its own cursor-native, duplicate-key-preserving
+/// fix (#443, above), but before this fix `eval_generic::eval_single` had no
+/// native arm for `Expr::Array`, so wrapping it in `[...]` fell to the
+/// wildcard fallback -- which materializes the *whole document* into an
+/// `OwnedValue` (last-value-wins `IndexMap`) before evaluating the wrapped
+/// expression, silently losing the fix's benefit. Must match bare
+/// `to_entries` (both duplicate `a` entries), just nested one level deeper.
+#[test]
+fn test_duplicate_mapping_key_survives_array_wrapped_to_entries_1168() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+    let (output, code) = run_yq_stdin("[to_entries]", yaml, &["-o=json", "-I=0"])?;
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        output.trim(),
+        r#"[[{"key":"a","value":1},{"key":"a","value":2}]]"#
+    );
+    Ok(())
+}
+
+/// #1168, comma sibling of the `Array` case above: `Expr::Comma` had no
+/// native arm either, so `to_entries, to_entries` hit the same
+/// whole-document-materializing fallback for both operands.
+#[test]
+fn test_duplicate_mapping_key_survives_comma_wrapped_to_entries_1168() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+    let (output, code) = run_yq_stdin("to_entries, to_entries", yaml, &["-o=json", "-I=0"])?;
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        output.trim(),
+        "[{\"key\":\"a\",\"value\":1},{\"key\":\"a\",\"value\":2}]\n[{\"key\":\"a\",\"value\":1},{\"key\":\"a\",\"value\":2}]"
+    );
+    Ok(())
+}
+
+/// #1168: `Expr::Array`/`Expr::Comma`'s new native arms must still dedupe a
+/// duplicate *JSON* key exactly like bare `to_entries` does (#1170) -- the
+/// wrapping fix must not disturb the format-aware dedup rule itself.
+#[test]
+fn test_json_duplicate_key_array_comma_wrapped_to_entries_still_dedupes_1168() -> Result<()> {
+    let json = r#"{"a":1,"b":2,"a":3}"#;
+    let extra_args = ["--input-format", "json", "-o=json", "-I=0"];
+
+    let (array_output, code) = run_yq_stdin("[to_entries]", json, &extra_args)?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        array_output.trim(),
+        r#"[[{"key":"a","value":3},{"key":"b","value":2}]]"#
+    );
+
+    let (comma_output, code) = run_yq_stdin("to_entries, to_entries", json, &extra_args)?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        comma_output.trim(),
+        "[{\"key\":\"a\",\"value\":3},{\"key\":\"b\",\"value\":2}]\n[{\"key\":\"a\",\"value\":3},{\"key\":\"b\",\"value\":2}]"
+    );
+    Ok(())
+}
+
 /// #1170: unlike YAML's genuine duplicates (preserved unmerged above, per
 /// #443), a duplicate key on `--input-format json` input must collapse to
 /// one entry -- keeping the first occurrence's position but the last
@@ -13029,6 +13089,24 @@ fn test_yq_array_wrapped_overflow_int_keeps_decimal_point_953() -> Result<()> {
     let (stdout, code) = run_yq_stdin("[.a]", "a: 99999999999999999999\n", &["-o", "json", "-I0"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "[100000000000000000000.0]");
+    Ok(())
+}
+
+/// #1168 review: fixing #953's regression above (`Expr::Array`'s new native
+/// arm bypasses the old wildcard fallback's own `to_json_for_reindex`
+/// round-trip, which is where #953's decimal-point forcing actually lives)
+/// must not force it onto a *genuinely computed* float too -- only a direct
+/// cursor result (a value read from the input document, e.g. `.a` above)
+/// gets `yq_float_fidelity_fixup`'s round-trip; an arithmetic result never
+/// touches the input document at all, and must keep real yq's ordinary
+/// scientific-notation threshold instead (matching `1e20*1 | tostring`, and
+/// the same distinction `test_yq_join_element_computed_float_known_gap_1124`
+/// already documents for `join`).
+#[test]
+fn test_yq_array_wrapped_computed_float_keeps_scientific_notation_1168() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("[1e20 * 1]", "null\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[1e+20]");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`eval_generic.rs`'s `eval_single` had no native arm for `Expr::Array`/`Expr::Comma`,
so wrapping a cursor-native, duplicate-key-preserving builtin (e.g. #443's
`to_entries`) in `[...]` or joining two calls with `,` fell to the wildcard
fallback, which materializes the *whole input document* into an `OwnedValue`
first — silently re-collapsing duplicate YAML mapping keys the builtin's own
fix had just preserved (`[to_entries]`/`to_entries, to_entries` lost one of
two duplicate `a` entries even though bare `to_entries` kept both).

- Adds native `Expr::Array`/`Expr::Comma` arms to `eval_single`, mirroring
  `eval::eval_array_construction`/`eval::eval_comma`'s existing semantics
  (array construction is atomic on error/break/halt; comma propagates a
  `Partial` prefix).
- Bypassing the old wildcard fallback also bypasses #953's i64-overflow
  decimal-point-forcing fix, which lives entirely inside the fallback's own
  `to_json_for_reindex` round trip. `yq_float_fidelity_fixup` reuses
  `eval_on_owned` to re-apply that same round trip, scoped to just the
  constructed value (not the whole document, preserving the duplicate-key
  fix). An initial version scoped the fixup further, to only a direct
  cursor result (`OneCursor`/`ManyCursor`) — code review found this missed
  `to_entries` itself (which reaches `Expr::Array` as `Owned`, since it
  constructs its own `{key,value}` object around a document-sourced field),
  regressing #953 for exactly the shape the issue was filed about. The
  fixup now applies uniformly to the whole constructed result, accepting
  a known, already-precedented trade-off instead: a bare computed float
  wrapped directly in `[...]`/`,` (`[1e10 * 2]`) also gets its decimal
  point forced, same class of gap `test_yq_join_element_computed_float_known_gap_1124`
  (#1124/#1144) already documents for `join` — pinned as a known gap, not
  silently changed, in `test_yq_array_wrapped_computed_float_forces_decimal_known_gap_1168`.
- Runs the fixup once over the whole result (not per comma-sibling), and
  skips it entirely when the collected values contain no `Float` at all
  (`contains_float`) — avoiding an unconditional round trip on every
  yq-mode `[...]`/`,` touching document data, most of which won't need it.

This closes the specific repro #1168 was filed against (`Expr::Array`/
`Expr::Comma`). Review also found a related, **pre-existing** gap —
`needs_path_context` (eval.rs) has no `Expr::Array` arm, so `.a | [key]`
loses path context that `.a | (key,key)` keeps — confirmed unaffected by
this PR (reproduces identically on `main`) and filed separately as #1302.
A prior investigation comment on #1168 also found the same
whole-document-materializing gap affects `Expr::As`/`Reduce`/`Foreach`/
`If`/`Try`/`Label` and `Builtin::Limit`/`NthStream`/`Skip` — out of scope
here; will file as a follow-up.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, `--no-fail-fast`) — 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Manually diffed behavior against the prior wildcard-fallback path across
      error/break/halt/partial/optional edge cases — byte-identical except
      the intended duplicate-key fix
- [x] New tests: duplicate-key preservation (`[to_entries]`, `to_entries,
      to_entries`, both YAML-dup and JSON-dedup semantics), #953 regression
      guards (direct field access **and** `to_entries`'s own construction),
      #1124/#1144 known-gap guard (computed float now also force-decimal,
      pinned not silently changed), `ManyCursor` fixup path (`[.[]]`,
      `.[], .[]`), multi-sibling comma float fixup, `Expr::Array` atomicity
      (`halt`, partial-halt)
- [x] `omni-dev coverage diff`: 89.9% patch coverage; every remaining
      uncovered line is either defense-in-depth (documented in
      `yq_float_fidelity_fixup`'s own doc comment) or structurally
      unreachable via any query this CLI can currently parse (documented
      inline, matching the existing #1064 "unreachable but exhaustive"
      precedent — `Expr::Label` has no native arm yet, so a `break` can
      never legitimately escape *through* `Expr::Array`'s own native
      dispatch boundary today)

Refs #1168