### PR TITLE
fix(jq): flatten a nested Pipe before split_at_slice scans for a slice

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11472,7 +11472,7 @@ fn set_path(
             if exprs.len() == 1 {
                 set_path(root, &exprs[0], new_value, scalar_noop, container_noop)
             } else if let Some(split) = split_at_slice(exprs) {
-                match get_path_mut(root, split.before)? {
+                match get_path_mut(root, &split.before)? {
                     None => Ok(()),
                     Some(parent) => through_slice(
                         parent,
@@ -11698,9 +11698,9 @@ fn through_slice<E: From<EvalError>>(
 }
 
 /// Where a chained path crosses a slice, as [`split_at_slice`] found it.
-struct SliceSplit<'a> {
+struct SliceSplit {
     /// The components to navigate before reaching the slice.
-    before: &'a [Expr],
+    before: Vec<Expr>,
     start: Option<i64>,
     end: Option<i64>,
     /// Everything left to apply *inside* the slice, as one expression.
@@ -11712,22 +11712,37 @@ struct SliceSplit<'a> {
 /// A slice names a *range*, not a slot, so `get_path_mut` cannot navigate
 /// through one — `.a[1:2][0] = 9` would fail on the middle component — and the
 /// walker has to hand off to [`through_slice`] there instead.
-fn split_at_slice(exprs: &[Expr]) -> Option<SliceSplit<'_>> {
-    let at = exprs.iter().position(|e| matches!(e, Expr::Slice { .. }))?;
-    let Expr::Slice { start, end } = &exprs[at] else {
-        unreachable!("position matched a Slice")
+///
+/// Flattens via [`push_path_components`] before scanning, so a slice nested
+/// inside a parenthesized sub-path that is itself only one of several
+/// top-level components — `(.a[0:1])[0] = 9`, where `(.a[0:1])` arrives as a
+/// single `Expr::Pipe([Field("a"), Slice{..}])` slot — is still found (#1292).
+/// A single-element Pipe never reaches here: `set_path`'s own `Paren`/`Pipe`
+/// arms already unwrap that case before calling this function, so the slice
+/// would already be at the top level of a *fresh* call. This function only
+/// has to handle a compound sub-path sitting *alongside* other components.
+fn split_at_slice(exprs: &[Expr]) -> Option<SliceSplit> {
+    let mut flat = Vec::with_capacity(exprs.len());
+    for e in exprs {
+        push_path_components(&mut flat, e);
+    }
+    let at = flat.iter().position(|e| matches!(e, Expr::Slice { .. }))?;
+    let (start, end) = match &flat[at] {
+        Expr::Slice { start, end } => (*start, *end),
+        _ => unreachable!("position matched a Slice"),
     };
-    let rest = &exprs[at + 1..];
+    let rest = flat.split_off(at + 1);
+    flat.truncate(at);
     Some(SliceSplit {
-        before: &exprs[..at],
-        start: *start,
-        end: *end,
+        before: flat,
+        start,
+        end,
         // An empty tail means the slice itself is the target, which `Identity`
         // against the extracted sub-array says exactly.
         tail: if rest.is_empty() {
             Expr::Identity
         } else {
-            Expr::Pipe(rest.to_vec())
+            Expr::Pipe(rest)
         },
     })
 }
@@ -39539,6 +39554,36 @@ mod tests {
                 br#"{"a":{"c":5}}"#,
                 "((.a|.c)? | .y) = 9",
                 Err(r#"Cannot index number with string "y""#),
+            ),
+        ]);
+    }
+
+    #[test]
+    fn test_assign_slice_nested_in_a_parenthesized_non_terminal_component_1292() {
+        // #1292: `split_at_slice` only scanned the *top-level* `exprs` list
+        // `set_path`'s `Expr::Pipe` arm was called with -- a slice nested
+        // inside a parenthesized sub-path that is itself only one of
+        // several top-level components (`(.a[0:1])[0] = 9`, where
+        // `(.a[0:1])` arrives as a single `Expr::Pipe([Field("a"),
+        // Slice{..}])` slot) was invisible to that scan, so the slice never
+        // reached `through_slice` and the write fell to the generic
+        // "invalid path component" catch-all instead. `|=`/`del()` already
+        // handled this shape correctly, isolating the gap to `=`. All
+        // confirmed against real jq 1.7.1.
+        assert_outcomes(&[
+            (
+                br#"{"a":[1,2,3]}"#,
+                "(.a[0:1])[0] = 9",
+                Ok(r#"{"a":[9,2,3]}"#),
+            ),
+            // A plain top-level slice (no nesting) is unaffected.
+            (br#"{"a":[1,2,3]}"#, ".a[0:1] = [9]", Ok(r#"{"a":[9,2,3]}"#)),
+            // Nesting depth beyond one level of parens still flattens
+            // correctly.
+            (
+                br#"{"a":{"b":[1,2,3]}}"#,
+                "(((.a.b)[0:1]))[0] = 9",
+                Ok(r#"{"a":{"b":[9,2,3]}}"#),
             ),
         ]);
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11721,7 +11721,29 @@ struct SliceSplit {
 /// arms already unwrap that case before calling this function, so the slice
 /// would already be at the top level of a *fresh* call. This function only
 /// has to handle a compound sub-path sitting *alongside* other components.
+///
+/// Does **not** see through `Expr::Optional` — `push_path_components` leaves
+/// it opaque (its other callers need that), so `.a[0:1]?[0] = 9` still misses
+/// its slice here. Pre-existing, unrelated to #1292's own repro shape (which
+/// has no `?` anywhere): confirmed identical, unaffected behavior before and
+/// after this function's flattening was added.
 fn split_at_slice(exprs: &[Expr]) -> Option<SliceSplit> {
+    // Cheap common-case guard: the overwhelming majority of assignment
+    // targets (`.a.b.c[2] = 9`) contain neither a slice nor a nested
+    // `Pipe`/`Paren` component that could hide one, so skip the
+    // allocate-and-clone flatten below entirely when nothing here could
+    // possibly need it. Exactly equivalent to running the flatten and
+    // finding nothing: `push_path_components` only ever transforms a
+    // `Pipe`/`Paren` element, so a top-level element that is none of
+    // `Slice`/`Pipe`/`Paren` reaches the flattened list completely
+    // unchanged, and a literal `Slice` already at the top level is caught
+    // directly either way.
+    if exprs
+        .iter()
+        .all(|e| !matches!(e, Expr::Slice { .. } | Expr::Pipe(_) | Expr::Paren(_)))
+    {
+        return None;
+    }
     let mut flat = Vec::with_capacity(exprs.len());
     for e in exprs {
         push_path_components(&mut flat, e);


### PR DESCRIPTION
## Summary

`(.a[0:1])[0] = 9` (a slice nested inside a parenthesized sub-path, itself only one of several top-level path components) reported a generic `invalid path component` instead of performing the write real jq gives.

```
$ echo '{"a":[1,2,3]}' | jq -c '(.a[0:1])[0] = 9'
{"a":[9,2,3]}
$ echo '{"a":[1,2,3]}' | succinctly jq -c '(.a[0:1])[0] = 9'   # before
jq: error (at <stdin>:1): invalid path component
```

Found during review of #1290 (fixes #1287, the adjacent `Field`/`Index`-only case) — filed as #1292, confirmed pre-existing on `main` before that PR and unaffected by it.

## Root cause

`set_path`'s `Expr::Pipe` arm calls `split_at_slice(exprs)` to find where a chained path crosses a slice — but that function only scanned the *top-level* `exprs` list. `(.a[0:1])` arrives as a single `Expr::Pipe([Field("a"), Slice{..}])` slot (the same `needs_path_prepass` fast-path shape #1287 fixed for `get_path_mut`'s own loop), so the slice hidden inside it was invisible to `split_at_slice`'s scan and the whole thing fell through to `get_path_mut`'s catch-all.

`|=` and `del()` already handle this exact shape correctly (confirmed live) — the gap was isolated to `=`/`set_path`.

## Fix

`split_at_slice` now flattens `exprs` via `push_path_components` (the same flattening helper already used elsewhere in this file, including by #1287's fix) before scanning for the slice position. `SliceSplit::before` changes from a borrowed `&'a [Expr]` to an owned `Vec<Expr>` since it's now built from a fresh flattened list rather than sliced directly out of the input.

## Scope note

The sibling `Iterate` case (`(.a[])[0] = 9`) is **not** fixed here — split out to #1298. It needs a structurally different fix: `get_path_mut`'s `Result<Option<&'a mut OwnedValue>, EvalError>` signature can only ever return one mutable slot, but `.[]` fans out over every element, so it can't be handled by the same mechanical flatten-then-scan technique this PR uses. Filing separately rather than blocking this fix on a bigger scoping question.

## Verification

- [x] The issue's own repro, plus a 3-level-deep-parens variant and a plain-unnested-slice regression check, all byte-match pinned jq 1.7.1
- [x] `yq` container-noop confirmed live against real yq v4.53.3 (writing through this shape silently no-ops, matching #1101/#1142's convention)
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `omni-dev coverage diff` — 97.06% patch coverage (33/34 new lines); the one uncovered line is an `unreachable!()` guard the preceding `position()` call already proves unreachable by construction (the original code had the identical pattern) — genuinely untestable, not a gap

Fixes #1292