### PR TITLE
fix(jq): scope update_path/delete_at_path's ?-guarded pipe splice to itself

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12077,10 +12077,38 @@ fn update_path<S: EvalSemantics>(
                     // when a branch resolved to more than one component, so
                     // unwrapping can expose a nested pipe. Splice it in rather
                     // than recursing on it alone, which would strand `rest`.
+                    //
+                    // Wrap the group's own components in `Optional` when
+                    // `here` is set, rather than threading `here` through as
+                    // this call's blanket `optional` -- that kept suppressing
+                    // whatever follows the group too, past its own scope
+                    // (#1294): `(.a|.c)? | .y` must suppress a failure in
+                    // `.a`/`.c` (the `try (.a|.c)` the `?` desugars to) but
+                    // not `.y` failing afterward, outside that scope. Each
+                    // spliced-in component now self-reports its own
+                    // optionality via the wrapper, which `unwrap_path_component`
+                    // already peels at every step -- `rest` (`exprs[1..]`),
+                    // left unwrapped, keeps whatever optionality it already
+                    // had on its own once `optional` (not `here`) is passed
+                    // as this call's baseline again.
                     Expr::Pipe(inner) => {
-                        let mut spliced = inner.clone();
+                        let mut spliced: Vec<Expr> = if here {
+                            inner
+                                .iter()
+                                .cloned()
+                                .map(|e| Expr::Optional(Box::new(e)))
+                                .collect()
+                        } else {
+                            inner.clone()
+                        };
                         spliced.extend_from_slice(&exprs[1..]);
-                        update_path::<S>(root, &Expr::Pipe(spliced), filter_expr, here, scalar_noop)
+                        update_path::<S>(
+                            root,
+                            &Expr::Pipe(spliced),
+                            filter_expr,
+                            optional,
+                            scalar_noop,
+                        )
                     }
                     // The chain continues *inside* the slice, so the update
                     // runs against the sub-array and is spliced back:
@@ -20516,10 +20544,25 @@ fn delete_at_path(
                     },
                     // A nested pipe from `Optional(Pipe([…]))` — splice, do
                     // not recurse on it alone, or `rest` is stranded.
+                    //
+                    // Same per-slot scoping as `update_path`'s matching arm
+                    // (#1294): wrap the group's own components in `Optional`
+                    // when `here` is set, instead of threading `here` through
+                    // as this call's blanket `optional` — that let a `?` on
+                    // the group (`del((.a|.c)? | .y)`) keep suppressing `.y`
+                    // failing afterward too, outside the group's own scope.
                     Expr::Pipe(inner) => {
-                        let mut spliced = inner.clone();
+                        let mut spliced: Vec<Expr> = if here {
+                            inner
+                                .iter()
+                                .cloned()
+                                .map(|e| Expr::Optional(Box::new(e)))
+                                .collect()
+                        } else {
+                            inner.clone()
+                        };
                         spliced.extend_from_slice(&exprs[1..]);
-                        delete_at_path(root, &Expr::Pipe(spliced), here, yq_mode)
+                        delete_at_path(root, &Expr::Pipe(spliced), optional, yq_mode)
                     }
                     // The chain continues *inside* the slice, so the delete
                     // happens in the sub-array and the remainder is spliced
@@ -39707,6 +39750,39 @@ mod tests {
                 Err(r#"Cannot index number with string "y""#),
             ),
         ]);
+    }
+
+    #[test]
+    fn test_update_and_del_optional_group_scopes_suppression_to_the_group_only_1294() {
+        // #1294: `update_path`'s (`|=`) and `delete_at_path`'s (`del()`)
+        // sibling `Expr::Pipe(inner)` splice arms threaded `here` (which
+        // folds in the group's own `?`) as the blanket `optional` for the
+        // *entire* spliced continuation, over-suppressing whatever follows
+        // the group too -- the same bug #1287's review round found and
+        // fixed for `=`'s `get_path_mut`, independently present here. All
+        // confirmed against real jq 1.7.1.
+        query!(br#"{"a":{"c":5}}"#, "((.a|.c)? | .y) |= 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with string \"y\"");
+            }
+        );
+        query!(br#"{"a":{"c":5}}"#, "del((.a|.c)? | .y)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with string \"y\"");
+            }
+        );
+        // Boundary: the group's own failure is still correctly suppressed
+        // -- only what comes *after* it must stop being covered.
+        query!(br#"{"a":"notobj"}"#, "((.a|.c)? | .y) |= 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":"notobj"}"#);
+            }
+        );
+        query!(br#"{"a":"notobj"}"#, "del((.a|.c)? | .y)",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":"notobj"}"#);
+            }
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39783,6 +39783,21 @@ mod tests {
                 assert_eq!(v.to_json(), r#"{"a":"notobj"}"#);
             }
         );
+        // The splice arm's non-optional path (no `?` anywhere, `here` is
+        // `false`): `(.a|.c)[0]` reaches `update_path`/`delete_at_path`'s
+        // `Expr::Pipe` arm the same un-flattened way `set_path` used to
+        // before #1287, and was already handled correctly pre-#1294 -- this
+        // pins that pre-existing behavior rather than a new fix.
+        query!(br#"{"a":{"c":1}}"#, "(.a|.c)[0] |= 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with number");
+            }
+        );
+        query!(br#"{"a":{"c":1}}"#, "del((.a|.c)[0])",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with number");
+            }
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11610,6 +11610,37 @@ fn unwrap_path_component(expr: &Expr) -> (&Expr, bool) {
     }
 }
 
+/// Splice a nested `Pipe`'s components in front of whatever follows it in
+/// the enclosing path, scoping any `?` on the group to just the group's own
+/// components rather than letting it leak onto what comes after.
+///
+/// Shared by `update_path`'s and `delete_at_path`'s matching `Expr::Pipe(inner)`
+/// arms (#1294) — both are recursive-descent walkers that splice a resolved
+/// `Optional(Pipe([…]))` component and continue with one recursive call over
+/// the combined list, so the same fix applies identically to each: when
+/// `here` (the group's own `?`, folded with whatever optionality was already
+/// ambient before it) is set, wrap each of `inner`'s own components in
+/// `Expr::Optional` — [`unwrap_path_component`] already peels this at every
+/// step — instead of threading `here` as the recursive call's blanket
+/// `optional` parameter, which previously kept suppressing `rest` too, past
+/// the group's own scope (`(.a|.c)? | .y` must suppress a failure in
+/// `.a`/`.c`, not `.y` failing afterward). The caller passes the *original*
+/// `optional` — not `here` — as that call's baseline, so `rest` keeps
+/// whatever optionality it already had on its own.
+fn splice_optional_group(inner: &[Expr], rest: &[Expr], here: bool) -> Vec<Expr> {
+    let mut spliced: Vec<Expr> = if here {
+        inner
+            .iter()
+            .cloned()
+            .map(|e| Expr::Optional(Box::new(e)))
+            .collect()
+    } else {
+        inner.to_vec()
+    };
+    spliced.extend_from_slice(rest);
+    spliced
+}
+
 /// Run `edit` over the sub-array a slice names, splicing the answer back over
 /// the original range.
 ///
@@ -12077,31 +12108,10 @@ fn update_path<S: EvalSemantics>(
                     // when a branch resolved to more than one component, so
                     // unwrapping can expose a nested pipe. Splice it in rather
                     // than recursing on it alone, which would strand `rest`.
-                    //
-                    // Wrap the group's own components in `Optional` when
-                    // `here` is set, rather than threading `here` through as
-                    // this call's blanket `optional` -- that kept suppressing
-                    // whatever follows the group too, past its own scope
-                    // (#1294): `(.a|.c)? | .y` must suppress a failure in
-                    // `.a`/`.c` (the `try (.a|.c)` the `?` desugars to) but
-                    // not `.y` failing afterward, outside that scope. Each
-                    // spliced-in component now self-reports its own
-                    // optionality via the wrapper, which `unwrap_path_component`
-                    // already peels at every step -- `rest` (`exprs[1..]`),
-                    // left unwrapped, keeps whatever optionality it already
-                    // had on its own once `optional` (not `here`) is passed
-                    // as this call's baseline again.
+                    // See `splice_optional_group`'s doc comment for why this
+                    // passes `optional`, not `here`, as the baseline (#1294).
                     Expr::Pipe(inner) => {
-                        let mut spliced: Vec<Expr> = if here {
-                            inner
-                                .iter()
-                                .cloned()
-                                .map(|e| Expr::Optional(Box::new(e)))
-                                .collect()
-                        } else {
-                            inner.clone()
-                        };
-                        spliced.extend_from_slice(&exprs[1..]);
+                        let spliced = splice_optional_group(inner, &exprs[1..], here);
                         update_path::<S>(
                             root,
                             &Expr::Pipe(spliced),
@@ -20543,25 +20553,11 @@ fn delete_at_path(
                         _ => Err(EvalError::cannot_iterate(root)),
                     },
                     // A nested pipe from `Optional(Pipe([…]))` — splice, do
-                    // not recurse on it alone, or `rest` is stranded.
-                    //
-                    // Same per-slot scoping as `update_path`'s matching arm
-                    // (#1294): wrap the group's own components in `Optional`
-                    // when `here` is set, instead of threading `here` through
-                    // as this call's blanket `optional` — that let a `?` on
-                    // the group (`del((.a|.c)? | .y)`) keep suppressing `.y`
-                    // failing afterward too, outside the group's own scope.
+                    // not recurse on it alone, or `rest` is stranded. See
+                    // `splice_optional_group`'s doc comment for why this
+                    // passes `optional`, not `here`, as the baseline (#1294).
                     Expr::Pipe(inner) => {
-                        let mut spliced: Vec<Expr> = if here {
-                            inner
-                                .iter()
-                                .cloned()
-                                .map(|e| Expr::Optional(Box::new(e)))
-                                .collect()
-                        } else {
-                            inner.clone()
-                        };
-                        spliced.extend_from_slice(&exprs[1..]);
+                        let spliced = splice_optional_group(inner, &exprs[1..], here);
                         delete_at_path(root, &Expr::Pipe(spliced), optional, yq_mode)
                     }
                     // The chain continues *inside* the slice, so the delete
@@ -39796,6 +39792,26 @@ mod tests {
         query!(br#"{"a":{"c":1}}"#, "del((.a|.c)[0])",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "Cannot index number with number");
+            }
+        );
+        // yq mode shares this exact arm (`S`-generic, no `S::TAG` branch in
+        // it) -- confirmed with a live yq v4.53.3 comparison. A *scalar*
+        // intermediate (`.c: 5`, mirroring the jq cases above) would not
+        // actually exercise the fix here: `is_yq_field_index_noop_scalar`
+        // makes `|=`'s own `Field`/`Index` arms no-op unconditionally on a
+        // scalar target, before this arm's `?`-scoping ever matters, and
+        // would pass identically whether this fix existed or not. An array
+        // intermediate keeps the failure genuine (`Cannot index array with
+        // string "y"`, matching real yq's own container-vs-container
+        // mismatch, which is not covered by the scalar no-op).
+        yq_query!(br#"{"a":{"c":[1,2,3]}}"#, "((.a|.c)? | .y) |= 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index array with string \"y\"");
+            }
+        );
+        yq_query!(br#"{"a":"notobj"}"#, "((.a|.c)? | .y) |= 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":"notobj"}"#);
             }
         );
     }


### PR DESCRIPTION
## Summary

`((.a|.c)? | .y) |= 9` and `del((.a|.c)? | .y)` silently no-op'd instead of raising when `.a|.c` succeeds and `.y` fails afterward.

```
$ echo '{"a":{"c":5}}' | jq -c '((.a|.c)? | .y) |= 9'
jq: error (at <stdin>:1): Cannot index number with string "y"
$ echo '{"a":{"c":5}}' | succinctly jq -c '((.a|.c)? | .y) |= 9'   # before
{"a":{"c":5}}
```

The group's own `?` correctly suppresses a failure *inside* `try (.a|.c)`, but real jq does not extend that protection past the closing paren — `.y` is a separate pipe stage outside the group's scope.

Found during review of #1290/#1299 — filed as #1294, independently duplicated by my own #1293 around the same time (closed in #1294's favor as the more precisely-scoped filing).

## Root cause

`update_path`'s and `delete_at_path`'s `Expr::Pipe(inner)` splice arms both thread `here` (which folds in the group's own `?`) as the blanket `optional` parameter for the *entire* spliced continuation — `inner`'s own components **plus** whatever follows the group (`exprs[1..]`). Since both functions carry `optional` forward unchanged through every subsequent recursive step, that inherited `true` from the group's `?` keeps suppressing `.y` too.

Independently present in both functions — the exact bug class #1287's review round found and fixed for `=` (`get_path_mut`), just never ported to these two siblings. `get_path_mut`'s own fix used a per-slot tracking array (loop-based, so a parallel `Vec<bool>` was natural); these two are pure recursive-descent, so the equivalent needed a different shape.

## Fix

Wrap the group's own components in `Expr::Optional` when `here` is set — `unwrap_path_component` already peels this at every step, so each spliced-in component now self-reports its own optionality instead of relying on a blanket flag. Pass the *original* `optional` (not `here`) as the spliced call's baseline, so anything after the group keeps whatever optionality it already had on its own, unaffected by the group's `?`.

## Verification

- [x] Both confirmed repros (`|=`, `del()`) now byte-match pinned jq 1.7.1
- [x] Boundary preserved: the group's own failure (first or second component) is still correctly suppressed — only what comes *after* it stops being covered
- [x] Non-optional splice case (`(.a|.c)[0] |= 9`, `del((.a|.c)[0])` — no `?` anywhere) unaffected, confirmed still correct
- [x] yq mode sanity-checked live (shared code path, `S::TAG`-agnostic)
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `omni-dev coverage diff` — 100% patch coverage (49/49 new lines)

Fixes #1294