### PR TITLE
fix(jq): stop collapsing a legitimately-empty path-context result to null

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16262,11 +16262,15 @@ fn eval_owned_expr_full<S: EvalSemantics>(
 /// Evaluate an expression with an OwnedValue as input, keeping a genuinely
 /// empty result -- a `?`-swallowed type mismatch, or a builtin's own
 /// zero-output result -- distinguishable from a real `null` value (#1280),
-/// via [`eval_owned_expr_full`]. Used by
-/// [`eval_pipe_with_path_context_internal`]'s `Builtin`/`Object`/`Array`/
-/// `Literal`/generic-fallback arms, so a comma/pipe branch that legitimately
-/// produces nothing (`(has("x"))?` on the wrong type, matching real jq's own
-/// `.a?` semantics) contributes zero outputs rather than a spurious `null`.
+/// via [`eval_owned_expr_full`]. Used by [`eval_pipe_with_path_context_internal`]'s
+/// `Builtin`/`Object`/`Array`/`Literal`/generic-fallback arms and `ParentN`'s
+/// own `n` argument, so a comma/pipe branch that legitimately produces
+/// nothing (`(has("x"))?` on the wrong type, matching real jq's own `.a?`
+/// semantics) contributes zero outputs rather than a spurious `null`.
+///
+/// Like `eval_owned_expr_ctrl`, this also drops a `QueryResult::Partial`'s
+/// own trailing `Control` (via the `_trailing` below) -- a still-open gap
+/// shared by both, not unique to `eval_owned_expr_ctrl`.
 fn eval_owned_expr_opt<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
@@ -16279,8 +16283,7 @@ fn eval_owned_expr_opt<S: EvalSemantics>(
             // A *bare* break (no prior output from the argument) propagates
             // instead of being collapsed into a synthetic "not in label"
             // error (#833) -- see `result_to_owned`'s identical fix for the
-            // full rationale, including why the `Partial` case in
-            // `eval_owned_expr_ctrl` is a separate, still-open gap.
+            // full rationale.
             Control::Break(label) => EvalEscape::Break(label),
             Control::Halt(code) => EvalEscape::Halt(code),
         })
@@ -18299,9 +18302,11 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 optional,
             )
         }
-        Expr::Builtin(builtin) => {
-            // Handle other builtins that don't need special path handling
-            match eval_builtin_owned::<S>(builtin, value, optional) {
+        Expr::Builtin(_) => {
+            // Handle other builtins that don't need special path handling.
+            // `first` already *is* this `Expr::Builtin`, so evaluate it
+            // directly rather than reconstructing an equivalent one.
+            match eval_owned_expr_opt::<S>(first, value, optional) {
                 // #1280: a builtin that legitimately produced nothing (a
                 // `?`-swallowed type mismatch, or its own zero-output
                 // result) contributes zero outputs to this comma/pipe
@@ -18642,21 +18647,6 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             }
         }
     }
-}
-
-/// Helper to evaluate a builtin with an OwnedValue. `Option`-returning
-/// (#1280), not `eval_owned_expr`'s always-one-value contract: a builtin
-/// that legitimately produces nothing under `?` (e.g. `(has("x"))?` on the
-/// wrong type) must stay distinguishable from one that produces `null`,
-/// since this function's only caller is a path-context arm that needs to
-/// treat the two differently.
-fn eval_builtin_owned<S: EvalSemantics>(
-    builtin: &Builtin,
-    value: &OwnedValue,
-    optional: bool,
-) -> Result<Option<OwnedValue>, EvalEscape> {
-    // For most builtins, we can just delegate to eval_owned_expr_opt
-    eval_owned_expr_opt::<S>(&Expr::Builtin(builtin.clone()), value, optional)
 }
 
 /// Builtin: path(expr) - return the path to values selected by expr

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -45163,6 +45163,45 @@ mod tests {
         }
     }
 
+    /// #1280: `eval_owned_expr_full` is a near-verbatim copy of
+    /// `eval_owned_expr_ctrl_full`'s own slow-path match, so patch coverage
+    /// treats every arm as new -- three of its success arms
+    /// (`One`/`Many(len==1)`/`ManyOwned(len==1)`) aren't reached by any of
+    /// this PR's other tests (all of which hit `Owned` or the fixed `None`
+    /// case). Covered directly here, one expression per arm, found by
+    /// probing which shapes `eval_single`'s own materialization produces
+    /// for each: `if`'s branches route through a borrowed single cursor
+    /// value (`One`); a single-key object's `.[]` keeps its one borrowed
+    /// result in the `Many` collection rather than collapsing it (`Many`,
+    /// len 1); slicing then iterating a constructed array produces one
+    /// already-owned value still inside the `ManyOwned` collection
+    /// (`ManyOwned`, len 1).
+    #[test]
+    fn eval_owned_expr_full_one_and_len1_many_shapes_1280() {
+        let input = OwnedValue::Object(IndexMap::from([("a".to_string(), OwnedValue::Int(1))]));
+
+        // QueryResult::One
+        let expr = parse("if true then .a else . end").unwrap();
+        match eval_owned_expr_full::<JqSemantics>(&expr, &input, false) {
+            Ok(Some((v, None))) => assert_eq!(v.to_json(), "1"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // QueryResult::Many, len() == 1
+        let expr = parse(".[]").unwrap();
+        match eval_owned_expr_full::<JqSemantics>(&expr, &input, false) {
+            Ok(Some((v, None))) => assert_eq!(v.to_json(), "1"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // QueryResult::ManyOwned, len() == 1
+        let expr = parse("[1,2,3] | .[0:1][]").unwrap();
+        match eval_owned_expr_full::<JqSemantics>(&expr, &input, false) {
+            Ok(Some((v, None))) => assert_eq!(v.to_json(), "1"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
     /// #1164: `result_to_owned_ctrl` (backs 16 of this fix's builtins) is
     /// exercised by every CLI-level `..._1164` test above only via shapes
     /// that land in its `Owned`/`One`/`Partial` arms -- a builtin argument

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16163,15 +16163,36 @@ fn eval_owned_expr_ctrl<S: EvalSemantics>(
 /// live-verified jq semantics this preserves for a caller that can re-wrap
 /// its own successful final result via [`partial`]/[`finish_owned`]/
 /// [`finish_result`] when this is `Some`.
+///
+/// A thin wrapper over [`eval_owned_expr_full`]: this function's own
+/// contract is "callers need exactly one owned value", so a genuinely empty
+/// result collapses to `Null` here -- callers that instead need to tell
+/// "produced nothing" apart from "produced `null`" (#1280) use
+/// [`eval_owned_expr_full`] directly.
 fn eval_owned_expr_ctrl_full<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
     optional: bool,
 ) -> Result<(OwnedValue, Option<Control>), Control> {
+    eval_owned_expr_full::<S>(expr, input, optional)
+        .map(|opt| opt.unwrap_or((OwnedValue::Null, None)))
+}
+
+/// Like [`eval_owned_expr_ctrl_full`], but keeps a genuinely empty result --
+/// a `?`-swallowed type mismatch in [`eval_owned_fast_path`], or the slow
+/// path's own `QueryResult::None` -- distinguishable from a real `null`
+/// value instead of collapsing the two (#1280). Real jq's own path-position
+/// semantics treat a swallowed/absent result as *no output*, not `null`
+/// (`jq -cn '1 | .a?'` produces nothing at all); [`eval_owned_expr_ctrl_full`]
+/// cannot express that in its own contract ("exactly one value"), so this is
+/// the function any new caller needing the distinction should reach for.
+fn eval_owned_expr_full<S: EvalSemantics>(
+    expr: &Expr,
+    input: &OwnedValue,
+    optional: bool,
+) -> Result<Option<(OwnedValue, Option<Control>)>, Control> {
     if let Some(result) = eval_owned_fast_path::<S>(expr, input, optional) {
-        return result
-            .map(|v| (v.unwrap_or(OwnedValue::Null), None))
-            .map_err(Control::Error);
+        return result.map(|v| v.map(|v| (v, None))).map_err(Control::Error);
     }
 
     // Create a synthetic JSON from the owned value
@@ -16190,24 +16211,29 @@ fn eval_owned_expr_ctrl_full<S: EvalSemantics>(
     let cursor = index.root(json_bytes);
 
     match eval_single::<Vec<u64>, S>(expr, cursor.value(), optional).materialize_cursor() {
-        QueryResult::One(v) => Ok((to_owned(&v), None)),
+        QueryResult::One(v) => Ok(Some((to_owned(&v), None))),
         QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Owned(v) => Ok((v, None)),
+        QueryResult::Owned(v) => Ok(Some((v, None))),
         QueryResult::Many(vs) => {
             if vs.len() == 1 {
-                Ok((to_owned(&vs[0]), None))
+                Ok(Some((to_owned(&vs[0]), None)))
             } else {
-                Ok((OwnedValue::Array(vs.iter().map(to_owned).collect()), None))
+                Ok(Some((
+                    OwnedValue::Array(vs.iter().map(to_owned).collect()),
+                    None,
+                )))
             }
         }
         QueryResult::ManyOwned(vs) => {
             if vs.len() == 1 {
-                Ok((vs.into_iter().next().unwrap(), None))
+                Ok(Some((vs.into_iter().next().unwrap(), None)))
             } else {
-                Ok((OwnedValue::Array(vs), None))
+                Ok(Some((OwnedValue::Array(vs), None)))
             }
         }
-        QueryResult::None => Ok((OwnedValue::Null, None)),
+        // The one behavior change from `eval_owned_expr_ctrl_full`'s own
+        // slow path (#1280): `None`, not `Ok(Some((Null, None)))`.
+        QueryResult::None => Ok(None),
         QueryResult::Error(e) => Err(Control::Error(e)),
         QueryResult::Break(label) => Err(Control::Break(label)),
         QueryResult::Halt(code) => Err(Control::Halt(code)),
@@ -16225,9 +16251,9 @@ fn eval_owned_expr_ctrl_full<S: EvalSemantics>(
         // above) is expected to apply it to its own final result.
         QueryResult::Partial(vs, control) => {
             if vs.len() == 1 {
-                Ok((vs.into_iter().next().unwrap(), Some(control)))
+                Ok(Some((vs.into_iter().next().unwrap(), Some(control))))
             } else {
-                Ok((OwnedValue::Array(vs), Some(control)))
+                Ok(Some((OwnedValue::Array(vs), Some(control))))
             }
         }
     }
@@ -16256,6 +16282,30 @@ fn eval_owned_expr<S: EvalSemantics>(
         // keeps its own `EvalEscape` variant, so `try`/`catch` never sees it.
         Control::Halt(code) => EvalEscape::Halt(code),
     })
+}
+
+/// Like [`eval_owned_expr`], but keeps a genuinely empty result -- a
+/// `?`-swallowed type mismatch, or a builtin's own zero-output result --
+/// distinguishable from a real `null` value (#1280), via
+/// [`eval_owned_expr_full`]. `eval_owned_expr` itself cannot express this:
+/// its `Result<OwnedValue, EvalEscape>` contract always carries exactly one
+/// value on the `Ok` side. Used by
+/// [`eval_pipe_with_path_context_internal`]'s `Builtin`/`Object`/`Array`/
+/// `Literal`/generic-fallback arms, so a comma/pipe branch that legitimately
+/// produces nothing (`(has("x"))?` on the wrong type, matching real jq's own
+/// `.a?` semantics) contributes zero outputs rather than a spurious `null`.
+fn eval_owned_expr_opt<S: EvalSemantics>(
+    expr: &Expr,
+    input: &OwnedValue,
+    optional: bool,
+) -> Result<Option<OwnedValue>, EvalEscape> {
+    eval_owned_expr_full::<S>(expr, input, optional)
+        .map(|opt| opt.map(|(v, _trailing)| v))
+        .map_err(|control| match control {
+            Control::Error(e) => e.into(),
+            Control::Break(label) => EvalEscape::Break(label),
+            Control::Halt(code) => EvalEscape::Halt(code),
+        })
 }
 
 /// Evaluate an expression with an OwnedValue as input, preserving the full
@@ -18264,7 +18314,13 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         Expr::Builtin(builtin) => {
             // Handle other builtins that don't need special path handling
             match eval_builtin_owned::<S>(builtin, value, optional) {
-                Ok(result) => {
+                // #1280: a builtin that legitimately produced nothing (a
+                // `?`-swallowed type mismatch, or its own zero-output
+                // result) contributes zero outputs to this comma/pipe
+                // branch, matching real jq's own `.a?`-style empty-not-null
+                // path semantics -- not `QueryResult::Owned(Null)`.
+                Ok(None) => QueryResult::None,
+                Ok(Some(result)) => {
                     if rest.is_empty() {
                         QueryResult::Owned(result)
                     } else {
@@ -18287,8 +18343,14 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         Expr::Object(_) | Expr::Array(_) | Expr::Literal(_) => {
             // Value-constructing expressions reset the path context
             // because we're now at the "root" of a newly constructed value
-            match eval_owned_expr::<S>(first, value, optional) {
-                Ok(result) => {
+            match eval_owned_expr_opt::<S>(first, value, optional) {
+                // #1280: a zero-output generator inside the construction
+                // (`{(empty): 1}`, `[empty]` behaves differently -- this is
+                // specifically the object-key-generator case) means the
+                // whole construction contributes zero outputs, matching real
+                // jq -- not a spurious `null`.
+                Ok(None) => QueryResult::None,
+                Ok(Some(result)) => {
                     if rest.is_empty() {
                         QueryResult::Owned(result)
                     } else {
@@ -18566,8 +18628,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         _ => {
             // For other expressions, evaluate normally and continue
             // Note: This loses path context for complex expressions
-            match eval_owned_expr::<S>(first, value, optional) {
-                Ok(result) => {
+            match eval_owned_expr_opt::<S>(first, value, optional) {
+                // #1280: a legitimately-empty result (a `?`-swallowed type
+                // mismatch reached through this generic fallback) is zero
+                // outputs, matching real jq -- not a spurious `null`.
+                Ok(None) => QueryResult::None,
+                Ok(Some(result)) => {
                     if rest.is_empty() {
                         QueryResult::Owned(result)
                     } else {
@@ -18590,14 +18656,19 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     }
 }
 
-/// Helper to evaluate a builtin with an OwnedValue
+/// Helper to evaluate a builtin with an OwnedValue. `Option`-returning
+/// (#1280), not [`eval_owned_expr`]'s always-one-value contract: a builtin
+/// that legitimately produces nothing under `?` (e.g. `(has("x"))?` on the
+/// wrong type) must stay distinguishable from one that produces `null`,
+/// since this function's only caller is a path-context arm that needs to
+/// treat the two differently.
 fn eval_builtin_owned<S: EvalSemantics>(
     builtin: &Builtin,
     value: &OwnedValue,
     optional: bool,
-) -> Result<OwnedValue, EvalEscape> {
-    // For most builtins, we can just delegate to eval_owned_expr
-    eval_owned_expr::<S>(&Expr::Builtin(builtin.clone()), value, optional)
+) -> Result<Option<OwnedValue>, EvalEscape> {
+    // For most builtins, we can just delegate to eval_owned_expr_opt
+    eval_owned_expr_opt::<S>(&Expr::Builtin(builtin.clone()), value, optional)
 }
 
 /// Builtin: path(expr) - return the path to values selected by expr

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8881,7 +8881,7 @@ fn stitch_split(input: &str, matches: &[regex::Captures]) -> Vec<String> {
 /// than attempted here.
 ///
 /// What this function does instead is deliberately *not* the natural
-/// consequence of routing through [`eval_owned_expr`] (array-collapsing a
+/// consequence of routing through `eval_owned_expr` (array-collapsing a
 /// multi-output filter, which — unlike here, where the immediate caller can
 /// only accept a `String` — would turn this into a hard type-mismatch error,
 /// a regression from the pre-#826 code's behavior on this same input): it
@@ -12336,7 +12336,7 @@ fn push_path_components(out: &mut Vec<Expr>, expr: &Expr) {
 /// Evaluate an expression against an owned value, preserving the whole output
 /// stream.
 ///
-/// [`eval_owned_expr`] cannot be used for keys: it collapses a multi-output
+/// `eval_owned_expr` cannot be used for keys: it collapses a multi-output
 /// result into a single `OwnedValue::Array`, which would turn `.[("a","b")]`
 /// into one array-valued key. `QueryResult::collect_owned` is likewise unsafe
 /// on its own because it silently maps `Error`/`Break` — including a
@@ -16053,7 +16053,7 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Fast path for the handful of expr shapes that dominate the cost of
-/// [`eval_owned_expr`]/[`eval_owned_input`]: bare `.`, `.foo`, `.[n]`. These
+/// `eval_owned_expr`/[`eval_owned_input`]: bare `.`, `.foo`, `.[n]`. These
 /// never fan out and never touch anything but `input`'s own top-level shape,
 /// so they can be answered directly against the `OwnedValue` tree — no
 /// `to_json_for_reindex` + `JsonIndex::build` round trip needed. `None`
@@ -16134,7 +16134,7 @@ fn eval_owned_fast_path<S: EvalSemantics>(
     }
 }
 
-/// Same evaluator as [`eval_owned_expr`], but keeps a `break` distinguishable
+/// Same evaluator as `eval_owned_expr`, but keeps a `break` distinguishable
 /// from a real error via [`Control`] instead of collapsing it into a
 /// synthetic "break $label not in label" [`EvalError`] — needed by any
 /// caller that must let a `break $label` inside its operand reach its
@@ -16259,37 +16259,10 @@ fn eval_owned_expr_full<S: EvalSemantics>(
     }
 }
 
-/// Evaluate an expression with an OwnedValue as input.
-fn eval_owned_expr<S: EvalSemantics>(
-    expr: &Expr,
-    input: &OwnedValue,
-    optional: bool,
-) -> Result<OwnedValue, EvalEscape> {
-    eval_owned_expr_ctrl::<S>(expr, input, optional).map_err(|control| match control {
-        Control::Error(e) => e.into(),
-        // A *bare* break (no prior output from the argument) now propagates
-        // instead of being collapsed into a synthetic "not in label" error
-        // (#833) -- see `result_to_owned`'s identical fix just above for
-        // the full rationale, including why the `Partial` case in
-        // `eval_owned_expr_ctrl` above is a separate, still-open gap; every
-        // caller here forwards the `EvalEscape` verbatim except
-        // `builtin_envvar`, which has its own dedicated arm mirroring the
-        // `Halt` one below.
-        Control::Break(label) => EvalEscape::Break(label),
-        // A halt reached here (e.g. inside `reduce`/`foreach`'s INIT/UPDATE
-        // via a caller that uses `eval_owned_expr` rather than
-        // `eval_owned_expr_ctrl`, which carries `Control` through losslessly)
-        // keeps its own `EvalEscape` variant, so `try`/`catch` never sees it.
-        Control::Halt(code) => EvalEscape::Halt(code),
-    })
-}
-
-/// Like [`eval_owned_expr`], but keeps a genuinely empty result -- a
-/// `?`-swallowed type mismatch, or a builtin's own zero-output result --
-/// distinguishable from a real `null` value (#1280), via
-/// [`eval_owned_expr_full`]. `eval_owned_expr` itself cannot express this:
-/// its `Result<OwnedValue, EvalEscape>` contract always carries exactly one
-/// value on the `Ok` side. Used by
+/// Evaluate an expression with an OwnedValue as input, keeping a genuinely
+/// empty result -- a `?`-swallowed type mismatch, or a builtin's own
+/// zero-output result -- distinguishable from a real `null` value (#1280),
+/// via [`eval_owned_expr_full`]. Used by
 /// [`eval_pipe_with_path_context_internal`]'s `Builtin`/`Object`/`Array`/
 /// `Literal`/generic-fallback arms, so a comma/pipe branch that legitimately
 /// produces nothing (`(has("x"))?` on the wrong type, matching real jq's own
@@ -16303,6 +16276,11 @@ fn eval_owned_expr_opt<S: EvalSemantics>(
         .map(|opt| opt.map(|(v, _trailing)| v))
         .map_err(|control| match control {
             Control::Error(e) => e.into(),
+            // A *bare* break (no prior output from the argument) propagates
+            // instead of being collapsed into a synthetic "not in label"
+            // error (#833) -- see `result_to_owned`'s identical fix for the
+            // full rationale, including why the `Partial` case in
+            // `eval_owned_expr_ctrl` is a separate, still-open gap.
             Control::Break(label) => EvalEscape::Break(label),
             Control::Halt(code) => EvalEscape::Halt(code),
         })
@@ -16311,7 +16289,7 @@ fn eval_owned_expr_opt<S: EvalSemantics>(
 /// Evaluate an expression with an OwnedValue as input, preserving the full
 /// output stream.
 ///
-/// [`eval_owned_expr`] collapses a multi-output result into a single array,
+/// `eval_owned_expr` collapses a multi-output result into a single array,
 /// which is what `reduce`/`foreach` want but wrong for a filter that is allowed
 /// to fan out: `try error("x") catch (., .)` must emit two values, not one
 /// two-element array. This variant keeps `Many`/`ManyOwned` intact.
@@ -17845,14 +17823,24 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
 
     // Handle ParentN - return the nth parent value
     if let Expr::Builtin(Builtin::ParentN(n_expr)) = first {
-        // Evaluate n
-        let n = match eval_owned_expr::<S>(n_expr, value, optional) {
-            Ok(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _)) => i as usize,
-            Ok(OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _)) => {
+        // Evaluate n. `eval_owned_expr_opt`, not `eval_owned_expr` (#1280
+        // review): `n_expr` producing zero outputs (e.g. `parent(empty)`)
+        // must contribute zero outputs itself, not fall through to the
+        // type-error arm below via a fabricated `Null` -- the exact
+        // collapse this PR's own three sibling arms fix, live-verified to
+        // have still been reachable here (`.a.b | parent(empty), key`
+        // errored `expected number, got other` instead of printing just
+        // `key`'s own value).
+        let n = match eval_owned_expr_opt::<S>(n_expr, value, optional) {
+            Ok(None) => return QueryResult::None,
+            Ok(Some(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _))) => {
+                i as usize
+            }
+            Ok(Some(OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _))) => {
                 f as usize
             }
-            Ok(_) if optional => return QueryResult::None,
-            Ok(_) => return QueryResult::Error(EvalError::type_error("number", "other")),
+            Ok(Some(_)) if optional => return QueryResult::None,
+            Ok(Some(_)) => return QueryResult::Error(EvalError::type_error("number", "other")),
             // `?` swallows only a genuine error; a halt always escapes
             // (#791).
             Err(EvalEscape::Error(_)) if optional => return QueryResult::None,
@@ -18657,7 +18645,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
 }
 
 /// Helper to evaluate a builtin with an OwnedValue. `Option`-returning
-/// (#1280), not [`eval_owned_expr`]'s always-one-value contract: a builtin
+/// (#1280), not `eval_owned_expr`'s always-one-value contract: a builtin
 /// that legitimately produces nothing under `?` (e.g. `(has("x"))?` on the
 /// wrong type) must stay distinguishable from one that produces `null`,
 /// since this function's only caller is a path-context arm that needs to

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13458,6 +13458,27 @@ fn test_path_context_generic_fallback_empty_source_swallows_to_empty_1280() -> R
     Ok(())
 }
 
+/// #1280's `ParentN` arm: a `parent(...)` call whose `n` argument produces
+/// zero outputs (`parent(empty)`) must contribute zero outputs itself, not
+/// fall through to the "expected number" type-error arm via a fabricated
+/// `Null`. This is the fourth call site the same review round found still
+/// routed through the old `eval_owned_expr` after the other three (Builtin,
+/// Object/Array/Literal, generic-fallback, covered above) were fixed --
+/// before the fix, `parent(empty), key` errored `expected number, got
+/// other` instead of printing just `key`'s own value. `parent` is a
+/// succinctly extension (no real-jq equivalent), so this is checked against
+/// succinctly's own contract, like the sibling test above it.
+#[test]
+fn test_path_context_parent_n_argument_empty_swallows_to_empty_1280() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", ".a.b | parent(empty), key"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "\"b\"");
+    Ok(())
+}
+
 /// #1045 coverage: `flatten(depth)`'s `Ok(Some(_)) => ...type_error("number",
 /// "non-number")` arm -- a non-number depth argument, unconditional (no
 /// `optional` gate), unlike the negative-depth arm covered by

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13479,6 +13479,46 @@ fn test_path_context_parent_n_argument_empty_swallows_to_empty_1280() -> Result<
     Ok(())
 }
 
+/// `ParentN`'s float-`n` arm (`f as usize`), reached only when the `n`
+/// argument evaluates to a float rather than an int -- unchanged logic from
+/// before this PR, just newly wrapped in `Ok(Some(_))`; otherwise dead for
+/// coverage purposes since #1280 rewrote every arm's own pattern.
+#[test]
+fn test_path_context_parent_n_argument_float_1280() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", ".a.b.c | parent(1.0), key"],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "{\"c\":1}\n\"c\"\n");
+    Ok(())
+}
+
+/// `ParentN`'s `Ok(Some(_)) if optional` arm: a non-number `n` argument
+/// under `?` swallows to zero output, same as any other type mismatch.
+#[test]
+fn test_path_context_parent_n_argument_wrong_type_optional_1280() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#".a.b | (parent("x"))?, key"#],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "\"b\"");
+    Ok(())
+}
+
+/// `ParentN`'s `Ok(Some(_))` unconditional arm: a non-number `n` argument
+/// without `?` is a hard type error, matching every other numeric-argument
+/// builtin's own unconditional type-check.
+#[test]
+fn test_path_context_parent_n_argument_wrong_type_errors_1280() -> Result<()> {
+    let (_out, err, code) =
+        run_jq_full(&["-c", r#".a.b | parent("x")"#], Some(r#"{"a":{"b":1}}"#))?;
+    assert_ne!(code, 0);
+    assert!(err.contains("expected number"), "err={err}");
+    Ok(())
+}
+
 /// #1045 coverage: `flatten(depth)`'s `Ok(Some(_)) => ...type_error("number",
 /// "non-number")` arm -- a non-number depth argument, unconditional (no
 /// `optional` gate), unlike the negative-depth arm covered by

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9449,18 +9449,11 @@ fn test_parent_n_argument_still_swallows_ordinary_error_under_optional() -> Resu
 /// `first` itself, not nested inside another builtin's argument) no longer
 /// reaches this arm as an `Err` at all -- it now resolves to
 /// `QueryResult::None` directly (correct, matching real jq's own `has(...)?`
-/// swallowing to zero output, live-verified), which `eval_owned_expr_ctrl_full`
-/// collapses to `Ok(Null)` on its way through `eval_builtin_owned`. That
-/// lands in this arm's `Ok(result) => QueryResult::Owned(result)` branch,
-/// not the `Err(...) if optional` branch this test originally exercised --
-/// exposing a *separate*, pre-existing divergence from real jq (confirmed
-/// still present on `main` before #1045, via `has`'s own primitive-type
-/// mismatch: `.a.b | (has("x"))?, key` on a non-container `.a.b` already
-/// printed `null` before `"b"` here, when real jq's `has(...)?` on a bad
-/// type is *empty*, not `null` -- e.g. `("s"|has("x"))?` prints nothing).
-/// That pre-existing path-context bug is out of scope for #1045 (filed
-/// separately) -- this test now pins the actual current output instead of
-/// re-deriving a trick that no longer isolates the intended guard.
+/// swallowing to zero output, live-verified). #1280 fixed the arm's own
+/// `Ok`-side handling to preserve that `None` as zero output instead of
+/// collapsing it to `Ok(Null)` via `eval_builtin_owned` -- this test now
+/// pins the corrected output (matching real jq's own `has(...)?` empty-not-
+/// null contract) instead of the characterized bug it originally caught.
 #[test]
 fn test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -9468,16 +9461,15 @@ fn test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional() 
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "null\n\"b\"\n");
+    assert_eq!(stdout, "\"b\"\n");
     assert_eq!(stderr, "");
     Ok(())
 }
 
 /// Companion to `test_path_context_optional_does_not_swallow_halt_in_object_literal_arm`,
-/// same #1045 impact as `test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional`
-/// just above -- see that test's doc comment for the full explanation. The
-/// pre-existing path-context None-to-null bug this exposes is filed
-/// separately, out of scope for #1045.
+/// same #1045/#1280 history as
+/// `test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional`
+/// just above -- see that test's doc comment for the full explanation.
 #[test]
 fn test_path_context_object_literal_arm_still_swallows_ordinary_error_under_optional() -> Result<()>
 {
@@ -9486,7 +9478,7 @@ fn test_path_context_object_literal_arm_still_swallows_ordinary_error_under_opti
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "null\n\"b\"\n");
+    assert_eq!(stdout, "\"b\"\n");
     assert_eq!(stderr, "");
     Ok(())
 }
@@ -9516,7 +9508,7 @@ fn test_path_context_if_arm_converts_bare_halt_from_cond() -> Result<()> {
 /// Companion to the `Expr::Builtin`/object-literal arms above: targets
 /// `eval_pipe_with_path_context_internal`'s final catch-all `_` arm
 /// (reached for expression kinds with no dedicated handling here, e.g. `X
-/// as $v | BODY`). Same #1045 impact as
+/// as $v | BODY`). Same #1045/#1280 history as
 /// `test_path_context_builtin_arm_still_swallows_ordinary_error_under_optional`
 /// just above -- see that test's doc comment for the full explanation.
 #[test]
@@ -9526,7 +9518,7 @@ fn test_path_context_generic_fallback_still_swallows_ordinary_error_under_option
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "\"b\"\nnull\n");
+    assert_eq!(stdout, "\"b\"\n");
     assert_eq!(stderr, "");
     Ok(())
 }
@@ -13369,12 +13361,10 @@ fn test_getpath_strftime_strptime_tz_load_optional_type_mismatch_suppresses_1045
 /// (a succinctly-only path-tracking extension) is what forces path-context
 /// evaluation to engage at all here.
 ///
-/// Each case prints `null` before `"b"` rather than just `"b"` -- that's
-/// the pre-existing, out-of-scope path-context bug filed as #1280
-/// (`eval_owned_expr_ctrl_full`'s `QueryResult::None => Ok(Null)` collapse,
-/// confirmed to predate #1045), not something this test is trying to
-/// assert is correct; it's pinned here only to keep this coverage-closing
-/// test from silently drifting if that collapse's behavior changes.
+/// Each case used to print `null` before `"b"` rather than just `"b"` --
+/// `eval_owned_expr_ctrl_full`'s `QueryResult::None => Ok(Null)` collapse
+/// (confirmed to predate #1045), fixed by #1280. Now pins the correct
+/// empty-not-null output.
 #[test]
 fn test_getpath_strftime_strptime_tz_load_optional_guard_via_path_context_1045() -> Result<()> {
     let (out, err, code) = run_jq_full(
@@ -13382,30 +13372,89 @@ fn test_getpath_strftime_strptime_tz_load_optional_guard_via_path_context_1045()
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out.trim(), "null\n\"b\"");
+    assert_eq!(out.trim(), "\"b\"");
 
     let (out, err, code) = run_jq_full(
         &["-c", ".a.b | (strftime(1))?, key"],
         Some(r#"{"a":{"b":0}}"#),
     )?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out.trim(), "null\n\"b\"");
+    assert_eq!(out.trim(), "\"b\"");
 
     let (out, err, code) = run_jq_full(
         &["-c", ".a.b | (strptime(1))?, key"],
         Some(r#"{"a":{"b":"x"}}"#),
     )?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out.trim(), "null\n\"b\"");
+    assert_eq!(out.trim(), "\"b\"");
 
     let (out, err, code) = run_jq_full(&["-c", ".a.b | (tz(1))?, key"], Some(r#"{"a":{"b":0}}"#))?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out.trim(), "null\n\"b\"");
+    assert_eq!(out.trim(), "\"b\"");
 
     let (out, err, code) =
         run_jq_full(&["-c", ".a.b | (load(1))?, key"], Some(r#"{"a":{"b":1}}"#))?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out.trim(), "null\n\"b\"");
+    assert_eq!(out.trim(), "\"b\"");
+    Ok(())
+}
+
+/// #1280's own issue repro: `has(...)` on a non-object/array primitive under
+/// `?` (not an error -- `eval_owned_fast_path`'s type-mismatch branch), the
+/// simplest live-reachable trigger for `eval_owned_expr_ctrl_full`'s
+/// `QueryResult::None => Ok(Null)` collapse. `key` forces path-context mode.
+#[test]
+fn test_path_context_builtin_arm_type_mismatch_swallows_to_empty_1280() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#".a.b | (has("x"))?, key"#],
+        Some(r#"{"a":{"b":"str"}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "\"b\"");
+    Ok(())
+}
+
+/// A non-swallowed builtin result alongside `key` still shows its own real
+/// value (`false`, not empty) -- confirms #1280's fix only changed the
+/// `None`-collapse case, not the ordinary success path. Verified against
+/// real jq 1.7.1 (`"b"`, the succinctly-only `key` swapped for a literal, is
+/// unaffected by which builtin runs first).
+#[test]
+fn test_path_context_builtin_arm_non_swallowed_result_unaffected_1280() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#".a.b | has("x"), key"#],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "false\n\"b\"\n");
+    Ok(())
+}
+
+/// #1280's `Expr::Object`/`Array`/`Literal` arm: an object-construction key
+/// generator that produces zero outputs (`{(empty): 1}`) means the whole
+/// construction contributes zero outputs, matching real jq
+/// (`{(empty): 1}` -> no output at all) -- confirmed live to have printed a
+/// spurious `null` before this fix, via `eval_owned_expr::<S>(first, ...)`'s
+/// same collapse (a distinct call site from the builtin arm above, since
+/// `Expr::Object` never reaches `eval_owned_fast_path`).
+#[test]
+fn test_path_context_object_arm_empty_key_generator_swallows_to_empty_1280() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-c", ".a | {(empty):1}, key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "\"a\"");
+    Ok(())
+}
+
+/// #1280's generic-fallback `_` arm: `X as $v | BODY` where the source `X`
+/// produces zero outputs (`empty as $x | $x`) means the whole binding
+/// contributes zero outputs -- confirmed live to have printed a spurious
+/// `null` before this fix.
+#[test]
+fn test_path_context_generic_fallback_empty_source_swallows_to_empty_1280() -> Result<()> {
+    let (out, err, code) =
+        run_jq_full(&["-c", ".a | (empty as $x | $x), key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "\"a\"");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`eval_owned_expr_ctrl_full` (`src/jq/eval.rs`) collapsed any
`QueryResult::None` — a real, "produced zero output" result, e.g.
`has(...)?` on the wrong type — to `Ok(OwnedValue::Null)`. That function
backs `eval_pipe_with_path_context_internal`'s `Builtin`/`Object`/`Array`/
`Literal`/generic-fallback arms (the `key`/`parent`/`path`/`file_index`
tracking machinery), so a comma/pipe branch that should contribute zero
outputs instead surfaced a spurious `null`:

```console
$ echo '{"a":{"b":"str"}}' | succinctly jq -c '.a.b | (has("x"))?, key'
null
"b"
```

Real jq's own equivalent semantics for a `?`-swallowed expression that
produces no value is *empty output*, not `null` (e.g. `jq -cn '1 | .a?'`
prints nothing).

## Scoping — checked against #1277/#1279 first

The issue itself flagged this as needing a scoping pass before
implementation, given the tier review's warning to check blast radius
against #1277/#1279 rather than assume independence (the lesson from
#1194/#1247 sharing an unnoticed blocker). Findings:

- **#1279** ("generator-argument builtins don't fan out over a multi-output
  argument") is a different function family entirely
  (`result_to_owned*`/inside individual builtin bodies, not
  `eval_owned_expr_ctrl*`) — safely independent.
- **#1277 cluster 4** ("trailing-escape-dropping callers") touches the
  *exact same three arms* this PR does. Real overlap, but not a blocker:
  this PR adds `eval_owned_expr_full` (returns
  `Option<(OwnedValue, Option<Control>)>`) and deliberately routes the
  `Option<Control>` field through unconsumed for now (a comment marks where
  #1277 picks it up), so that fix becomes a small follow-up at these
  already-relocated call sites rather than needing its own call-site
  discovery.

## Fix

Added `eval_owned_expr_full` (mirrors `eval_owned_expr_ctrl_full` but
returns `Option<...>` so "produced nothing" stays distinguishable from "one
real value") and its `EvalEscape`-based sibling `eval_owned_expr_opt`.
`eval_owned_expr_ctrl_full` itself is now a thin wrapper over
`eval_owned_expr_full` — its own other callers (`eval_owned_expr_ctrl`,
`builtin_envvar`) are unaffected, since that function's contract genuinely
needs exactly one value.

Repointed the three path-context arms (`Builtin`, `Object`/`Array`/
`Literal`, generic fallback) at the new `Option`-aware functions, treating
`Ok(None)` as `QueryResult::None`. This also fixes a second instance of the
same bug, reachable with **no `?` at all**: an object-construction key
generator with zero outputs (`{(empty): 1}`) previously printed a spurious
`null` through this same collapse in the `Object` arm — confirmed live,
both before and after.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, `--no-fail-fast`) — all 53 test binaries green, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Updated 4 existing tests that had pinned this collapse as characterized-but-out-of-scope buggy behavior (their own doc comments already named #1280 as the fix)
- [x] Added 4 new CLI tests: the issue's own repro (Builtin arm), a non-swallowed-result sanity check, the Object-arm empty-key-generator case, and the generic-fallback-arm case — all confirmed against real jq 1.7.1
- [x] Added a direct unit test closing `eval_owned_expr_full`'s `One`/`Many(len==1)`/`ManyOwned(len==1)` coverage gap (arms unreached by the CLI tests above)
- [x] `omni-dev coverage diff` — 94.92% patch (56/59); the 3 remaining lines are the `panic!` arms inside that same new unit test's own assertions, only reachable if the test itself fails — genuinely untestable without deliberately breaking the code

Fixes #1280