### PR TITLE
feat(jq): implement input/inputs/input_line_number builtins

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -673,14 +673,26 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // (#723) -- a conservative text-level check on the raw source rather than
     // an AST walk: every real use of any of the three necessarily contains
     // "input" as a contiguous substring (jq identifiers can't be split
-    // across an escape/continuation), so this never under-detects. A false
-    // positive (`.input` field access, an `"input"` string literal, a
-    // comment) only costs a missed fast-path optimization below, never a
-    // wrong result -- the opposite of an AST walk that missed a `Builtin`
-    // variant deep in some argument position, which would silently produce
-    // wrong output instead. Doesn't see inside an imported/included module's
-    // own definitions (`-L`) -- out of scope for this pass, filed as a
-    // follow-up.
+    // across an escape/continuation) *within this same source string*, so a
+    // direct top-level use is never under-detected. A false positive (`.input`
+    // field access, an `"input"` string literal, a comment) only costs a
+    // missed fast-path optimization below, never a wrong result.
+    //
+    // Known real gap, NOT just a theoretical one (code review, #723): this
+    // check runs on `filter_str` alone, before `module_loader.process_program`
+    // (below) inlines any `-L`/`import`/`include`-loaded module body. A call
+    // to `input`/`inputs`/`input_line_number` that only exists inside an
+    // imported module's own function -- never spelled out in `filter_str`
+    // itself -- is invisible here, so the filter wrongly takes the
+    // fast/lazy path and those builtins run against an unseeded queue,
+    // producing a *wrong result* (confirmed live: every document reports
+    // spurious exhaustion instead of only the true last one). Filed as
+    // follow-up issue #1309 rather than fixed here -- fixing it correctly
+    // means walking the expanded, post-module `expr` a few lines below
+    // instead of scanning source text, which needs the same exhaustive,
+    // no-wildcard `Expr`/`Builtin` match this file's own `contains_split_doc`
+    // (`yq_runner.rs`) already establishes as the safe pattern for this kind
+    // of check -- real work, not a one-line fix.
     let uses_input_builtins = filter_str.contains("input");
 
     // Parse the filter as a full program (with module directives)
@@ -949,12 +961,32 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
             // `-n`, `force_read_under_null_input` (passed above) made it
             // read the real documents instead of faking `[null]`, precisely
             // so they're available here.
-            let queue: Vec<(OwnedValue, u32)> = inputs
-                .iter()
-                .enumerate()
-                .map(|(idx, v)| (v.clone(), locations.get(idx).line.unwrap_or(0) as u32))
-                .collect();
-            jq::seed_remaining_inputs(queue);
+            //
+            // `!force_read_under_null_input` (TTY-safety suppressed the real
+            // read) is the one case where `inputs` isn't real data -- it's
+            // `get_inputs`'s own `[null]` placeholder for plain `-n`
+            // (review catch: seeding straight from `inputs` unconditionally
+            // fed that placeholder into the queue as if it were a genuine
+            // document, so `input` silently returned `null` instead of
+            // reporting exhausted). Seed nothing in that case instead --
+            // `input`/`inputs` then correctly see an empty queue, matching
+            // this function's own stated safety goal.
+            if args.null_input && !force_read_under_null_input {
+                jq::seed_remaining_inputs(Vec::new());
+            } else {
+                // Moves rather than clones: `inputs` isn't read again on
+                // this branch (the null-input arm below uses `OwnedValue::
+                // Null` directly; the non-null arm pops from the queue this
+                // seeds, not from `inputs`) -- review catch: an earlier
+                // version cloned every document here for no reason, doubling
+                // peak memory for the whole input set.
+                let queue: Vec<(OwnedValue, u32)> = inputs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, v)| (v, locations.get(idx).line.unwrap_or(0) as u32))
+                    .collect();
+                jq::seed_remaining_inputs(queue);
+            }
 
             if args.null_input {
                 // `.` is null exactly once, matching `-n`'s own existing

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -669,6 +669,20 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // Get the filter expression
     let filter_str = get_filter(&args)?;
 
+    // Whether the filter could reference `input`/`inputs`/`input_line_number`
+    // (#723) -- a conservative text-level check on the raw source rather than
+    // an AST walk: every real use of any of the three necessarily contains
+    // "input" as a contiguous substring (jq identifiers can't be split
+    // across an escape/continuation), so this never under-detects. A false
+    // positive (`.input` field access, an `"input"` string literal, a
+    // comment) only costs a missed fast-path optimization below, never a
+    // wrong result -- the opposite of an AST walk that missed a `Builtin`
+    // variant deep in some argument position, which would silently produce
+    // wrong output instead. Doesn't see inside an imported/included module's
+    // own definitions (`-L`) -- out of scope for this pass, filed as a
+    // follow-up.
+    let uses_input_builtins = filter_str.contains("input");
+
     // Parse the filter as a full program (with module directives)
     let program = jq::parse_program(&filter_str).map_err(|e| {
         eprintln!("jq: compile error: {e}");
@@ -716,7 +730,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // This uses the DSV cursor to iterate rows and writes JSON arrays directly to output.
     // Memory usage: file bytes + DSV index (~3-4% overhead) + small output buffer.
     if let Some(delimiter) = args.input_dsv {
-        if !args.slurp && !args.null_input {
+        if !args.slurp && !args.null_input && !uses_input_builtins {
             // Streaming mode: process each row independently
             let files = get_input_files(&args);
             let raw_inputs: Vec<Vec<u8>> = if files.is_empty() {
@@ -802,6 +816,9 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // It's available when:
     // - Not using features that require serde_json parsing (slurp, raw_input, seq input, dsv)
     // - Not using output transformations that need full access to values (sort_keys, color, ascii)
+    // - Not using input/inputs/input_line_number (#723): those need the
+    //   "original" path's own already-materialized Vec<OwnedValue> to share
+    //   with the shared input queue below; the lazy path never builds one.
     // Both jq_compat (reformatting numbers) and preserve mode (keeping original formatting)
     // use the lazy path for correctness.
     let can_use_lazy_path = !args.slurp
@@ -810,7 +827,8 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
         && !args.seq // seq input mode parses differently
         && !output_config.sort_keys
         && !output_config.color_output
-        && !output_config.ascii_output; // ASCII output requires escaping
+        && !output_config.ascii_output // ASCII output requires escaping
+        && !uses_input_builtins;
 
     if can_use_lazy_path && !args.null_input {
         // Lazy path: read files as raw bytes and process directly
@@ -895,24 +913,108 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
         }
     } else {
         // Original path: parse through serde_json (loses number formatting)
-        let (inputs, locations) = match get_inputs(&args) {
+        //
+        // `force_read_under_null_input` narrows `uses_input_builtins` by one
+        // safety check: never force a real read under `-n` when stdin is an
+        // interactive terminal with no files given. `uses_input_builtins` is
+        // a conservative text-level heuristic (see its own doc comment) that
+        // can false-positive on a filter that merely *contains* the
+        // substring "input" (a `.input` field, an `"input"` string literal)
+        // without actually calling the builtin -- harmless everywhere else
+        // (just a missed fast-path optimization), except specifically here:
+        // forcing a read under `-n` on a false positive, with no piped input
+        // and no files, would otherwise hang waiting on a TTY that was never
+        // going to send anything. Narrowing it this way means a false
+        // positive just makes `input`/`inputs` report exhausted immediately
+        // (the queue never gets seeded) instead of hanging -- never a wrong
+        // *answer*, only conceivably a real `input`/`inputs` call losing its
+        // data if someone runs `-n 'inputs'` at a bare interactive prompt
+        // with data they intend to type in live rather than pipe/redirect --
+        // an already-unusual way to invoke `-n` in the first place.
+        let force_read_under_null_input = should_force_read_under_null_input(
+            uses_input_builtins,
+            args.null_input,
+            get_input_files(&args).is_empty(),
+            std::io::stdin().is_terminal(),
+        );
+        let (inputs, locations) = match get_inputs(&args, force_read_under_null_input) {
             Ok(Ok(inputs)) => inputs,
             Ok(Err(e)) => return Err(e),
             Err(exit_code) => return Ok(exit_code), // Validation error
         };
 
-        for (idx, input) in inputs.iter().enumerate() {
-            let at = locations.get(idx);
-            let results = evaluate_input(input, &expr, &context, &at, &mut sink)?;
+        if uses_input_builtins {
+            // Seed `input`/`inputs`/`input_line_number`'s shared queue
+            // (#723) with every document `get_inputs` just read -- under
+            // `-n`, `force_read_under_null_input` (passed above) made it
+            // read the real documents instead of faking `[null]`, precisely
+            // so they're available here.
+            let queue: Vec<(OwnedValue, u32)> = inputs
+                .iter()
+                .enumerate()
+                .map(|(idx, v)| (v.clone(), locations.get(idx).line.unwrap_or(0) as u32))
+                .collect();
+            jq::seed_remaining_inputs(queue);
 
-            for result in results {
-                had_output = true;
-                last_output = Some(result.clone());
-                write_output(&mut out, &result, &output_config)?;
+            if args.null_input {
+                // `.` is null exactly once, matching `-n`'s own existing
+                // contract -- `input`/`inputs` inside the filter draw from
+                // the queue just seeded above, not from this invocation.
+                let results = evaluate_input(
+                    &OwnedValue::Null,
+                    &expr,
+                    &context,
+                    &InputLocation::unknown(),
+                    &mut sink,
+                )?;
+                for result in results {
+                    had_output = true;
+                    last_output = Some(result.clone());
+                    write_output(&mut out, &result, &output_config)?;
+                }
+                if let Some(code) = sink.halted() {
+                    out.flush()?;
+                    return Ok(code);
+                }
+            } else {
+                // The outer loop and `input`/`inputs` draw from the exact
+                // same queue (#723): a document a filter's own `input` call
+                // consumes mid-evaluation is never also re-processed here as
+                // a fresh top-level invocation, and vice versa -- one shared
+                // cursor, not two kept in sync by hand. Loses the per-value
+                // filename `locations.get(idx)` would have carried (the
+                // queue only tracks line numbers, matching real jq's own
+                // `input_line_number`); accepted for this pass since
+                // `input`/`inputs` combined with multiple named input files
+                // is a narrow case, not the common single-stream one.
+                while let Some((input, line)) = jq::pop_remaining_input() {
+                    let at = InputLocation::at(None, line as usize);
+                    let results = evaluate_input(&input, &expr, &context, &at, &mut sink)?;
+                    for result in results {
+                        had_output = true;
+                        last_output = Some(result.clone());
+                        write_output(&mut out, &result, &output_config)?;
+                    }
+                    if let Some(code) = sink.halted() {
+                        out.flush()?;
+                        return Ok(code);
+                    }
+                }
             }
-            if let Some(code) = sink.halted() {
-                out.flush()?;
-                return Ok(code);
+        } else {
+            for (idx, input) in inputs.iter().enumerate() {
+                let at = locations.get(idx);
+                let results = evaluate_input(input, &expr, &context, &at, &mut sink)?;
+
+                for result in results {
+                    had_output = true;
+                    last_output = Some(result.clone());
+                    write_output(&mut out, &result, &output_config)?;
+                }
+                if let Some(code) = sink.halted() {
+                    out.flush()?;
+                    return Ok(code);
+                }
             }
         }
     }
@@ -1054,13 +1156,47 @@ fn get_input_files(args: &JqCommand) -> Vec<std::path::PathBuf> {
     files
 }
 
+/// Whether to force a real read under `-n` for `input`/`inputs`/
+/// `input_line_number` (#723), given `uses_input_builtins`' own text-level
+/// heuristic (see its doc comment at the call site for why it can
+/// false-positive). Narrowed by one safety check, pulled out as a pure
+/// function so it's unit-testable without a real terminal: never force the
+/// read when `-n` is set, no files were given, and stdin is an interactive
+/// terminal -- a false positive there would otherwise hang waiting on a TTY
+/// that was never going to send anything, instead of just costing a missed
+/// fast-path optimization the way every other false positive does.
+///
+/// Four bools, each independently meaningful and named at every call site
+/// (no adjacent pair is ever confusable) -- a two-variant-enum refactor
+/// would add ceremony without adding clarity for this single-call-site,
+/// private helper.
+#[allow(clippy::fn_params_excessive_bools)]
+fn should_force_read_under_null_input(
+    uses_input_builtins: bool,
+    null_input: bool,
+    no_files_given: bool,
+    stdin_is_terminal: bool,
+) -> bool {
+    uses_input_builtins && !(null_input && no_files_given && stdin_is_terminal)
+}
+
 /// Get input values based on arguments.
 /// Returns Err(i32) for validation failures (exit code), Ok(Err) for other errors.
 fn get_inputs(
     args: &JqCommand,
+    force_read_under_null_input: bool,
 ) -> std::result::Result<Result<(Vec<OwnedValue>, InputLocations)>, i32> {
-    // Null input mode: use null as the single input
-    if args.null_input {
+    // Null input mode: use null as the single input -- unless the filter
+    // itself uses `input`/`inputs`/`input_line_number` (#723), in which case
+    // the caller passes `force_read_under_null_input: true` to fall through
+    // to the real read below instead: `-n` makes the top-level `.` null, but
+    // `input`/`inputs` must still see the real stdin/files (`jq -n 'reduce
+    // inputs as $x (0;.+$x)'` is jq's own idiomatic streaming-aggregation
+    // pattern, oracle-confirmed). The caller is responsible for still
+    // presenting `.` as `null` to the filter itself in that case -- this
+    // function only controls what gets *read*, not what the top-level
+    // invocation's input value is.
+    if args.null_input && !force_read_under_null_input {
         // jq prints `(at <unknown>)` under -n: there is no input to point at.
         return Ok(Ok((vec![OwnedValue::Null], InputLocations::unknown())));
     }
@@ -2932,6 +3068,41 @@ fn format_json(value: &OwnedValue, config: &OutputConfig) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #723: direct unit coverage for the TTY-safety narrowing, independent
+    /// of a real terminal (which `cargo test` never has one of anyway).
+    /// Only the exact combination -- `-n`, no files, an interactive stdin --
+    /// should suppress the forced real read; every other combination (any
+    /// one of the three false) must force it whenever `uses_input_builtins`
+    /// says the filter might need it.
+    #[test]
+    fn test_should_force_read_under_null_input_723() {
+        // Never forces anything when the filter doesn't reference these
+        // builtins at all, regardless of the other three inputs.
+        assert!(!should_force_read_under_null_input(false, true, true, true));
+        assert!(!should_force_read_under_null_input(
+            false, false, false, false
+        ));
+
+        // Not under -n at all: always forces (there's no hang risk --
+        // non-null-input mode already reads stdin/files unconditionally).
+        assert!(should_force_read_under_null_input(true, false, true, true));
+        assert!(should_force_read_under_null_input(
+            true, false, false, false
+        ));
+
+        // Under -n with files given: forces (files can't block like a bare
+        // TTY read can).
+        assert!(should_force_read_under_null_input(true, true, false, true));
+
+        // Under -n with no files but stdin isn't a terminal (piped/redirected):
+        // forces -- this is the canonical `jq -n 'reduce inputs as $x (...)'`
+        // streaming-aggregation case.
+        assert!(should_force_read_under_null_input(true, true, true, false));
+
+        // The one suppressed combination: -n, no files, interactive stdin.
+        assert!(!should_force_read_under_null_input(true, true, true, true));
+    }
 
     /// #1154: direct unit coverage for the extracted token-boundary
     /// finder, independent of the CLI-level `--argjson` tests (which

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3352,6 +3352,9 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
         // Phase 12: Additional builtins
         Builtin::Now => builtin_now::<W>(),
+        Builtin::Input => builtin_input::<W>(),
+        Builtin::Inputs => builtin_inputs::<W>(),
+        Builtin::InputLineNumber => builtin_input_line_number::<W>(),
         Builtin::Abs => builtin_fabs::<W>(value, optional), // abs is an alias for fabs
         Builtin::Builtins => builtin_builtins::<W>(),
         Builtin::Normals => builtin_normals::<W>(value),
@@ -15654,6 +15657,9 @@ fn substitute_var_in_builtin(
         Builtin::Del(e) => Builtin::Del(Box::new(substitute_var(e, var_name, replacement))),
         // Phase 12 builtins (no args to substitute)
         Builtin::Now => Builtin::Now,
+        Builtin::Input => Builtin::Input,
+        Builtin::Inputs => Builtin::Inputs,
+        Builtin::InputLineNumber => Builtin::InputLineNumber,
         Builtin::Abs => Builtin::Abs,
         Builtin::Builtins => Builtin::Builtins,
         Builtin::Normals => Builtin::Normals,
@@ -20602,6 +20608,154 @@ fn builtin_now<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
     {
         // no_std environment - return 0.0 as a fallback
         QueryResult::Owned(OwnedValue::Float(0.0))
+    }
+}
+
+/// Backing store for `input`/`inputs`/`input_line_number` (#723): a
+/// per-thread queue of not-yet-consumed input documents, seeded by the CLI
+/// driver (`jq_runner.rs`) before it starts evaluating any filter, and drained
+/// from here rather than threaded through `eval`/`eval_generic::eval`'s own
+/// signatures -- the same "reach outside the pure per-document evaluation
+/// model via ambient state" shape `builtin_now`/`builtin_env` already use for
+/// the OS clock/environment, chosen over a new parameter because the CLI's
+/// per-document loop itself needs to share this exact queue (see
+/// `pop_remaining_input`'s own doc comment) to keep a filter's own `input`
+/// calls and the loop's "next top-level document" in sync without a second,
+/// separately-maintained cursor.
+///
+/// `#[cfg(feature = "std")]` only: `thread_local!` needs `std`, and there is
+/// no meaningful "remaining input stream" concept in a `no_std` embedding
+/// with no CLI driver to seed it anyway.
+#[cfg(feature = "std")]
+mod remaining_inputs {
+    use super::OwnedValue;
+    use std::cell::{Cell, RefCell};
+    use std::collections::VecDeque;
+
+    thread_local! {
+        static QUEUE: RefCell<VecDeque<(OwnedValue, u32)>> = const { RefCell::new(VecDeque::new()) };
+        // jq reports the *last successfully read* document's line, not the
+        // next one still queued -- starts at 0 (matching real jq's own
+        // `input_line_number` before anything has been read yet).
+        static LAST_LINE: Cell<u32> = const { Cell::new(0) };
+    }
+
+    /// Replaces the queue's contents wholesale. Called once by the CLI driver
+    /// before evaluating any filter against any document -- never mid-run,
+    /// so this doesn't need to merge with whatever a prior call left behind.
+    pub fn seed(documents: Vec<(OwnedValue, u32)>) {
+        QUEUE.with(|q| *q.borrow_mut() = documents.into());
+        LAST_LINE.with(|l| l.set(0));
+    }
+
+    /// Pops the next queued document, recording its line for
+    /// `input_line_number`. Shared by `builtin_input`/`builtin_inputs` *and*
+    /// the CLI driver's own per-document loop (for a document the filter
+    /// itself never explicitly reads via `input`) -- one shared queue, not
+    /// two cursors kept in sync by hand.
+    pub fn pop() -> Option<(OwnedValue, u32)> {
+        let popped = QUEUE.with(|q| q.borrow_mut().pop_front());
+        if let Some((_, line)) = &popped {
+            LAST_LINE.with(|l| l.set(*line));
+        }
+        popped
+    }
+
+    /// Drains every remaining document at once, for `inputs`'s eager
+    /// generator collection (matching `range`'s own eager-with-a-cap
+    /// convention elsewhere in this file -- this codebase has no lazy
+    /// generator machinery at the `Builtin` dispatch level, so `inputs`
+    /// doesn't invent one; `first(inputs)`/`limit(1; inputs)` draining more
+    /// than needed is the same accepted trade-off `range`'s own callers
+    /// already have).
+    pub fn drain_all() -> Vec<(OwnedValue, u32)> {
+        let all: alloc::vec::Vec<_> = QUEUE.with(|q| q.borrow_mut().drain(..).collect());
+        if let Some((_, line)) = all.last() {
+            LAST_LINE.with(|l| l.set(*line));
+        }
+        all
+    }
+
+    pub fn last_line() -> u32 {
+        LAST_LINE.with(Cell::get)
+    }
+}
+
+/// Seeds the `input`/`inputs`/`input_line_number` queue (#723).
+///
+/// The CLI driver's own entry point into [`remaining_inputs`], called once
+/// before evaluating any filter. A no-op under `no_std` (nothing to seed
+/// there).
+#[cfg(feature = "std")]
+pub fn seed_remaining_inputs(documents: Vec<(OwnedValue, u32)>) {
+    remaining_inputs::seed(documents);
+}
+
+/// Pops the next queued input document (#723).
+///
+/// Exposed so the CLI driver's own per-document loop can share the exact
+/// same queue `input`/`inputs` draw from (see [`remaining_inputs::pop`]'s
+/// doc comment for why this must be one shared queue, not two cursors). A
+/// no-op under `no_std`.
+#[cfg(feature = "std")]
+pub fn pop_remaining_input() -> Option<(OwnedValue, u32)> {
+    remaining_inputs::pop()
+}
+
+/// Builtin: input - read and return the next input document (#723), erroring
+/// with real jq's own exact text (`break`, confirmed live against jq 1.7.1 --
+/// not a more descriptive message) once the input stream is exhausted. A
+/// normal, `?`/`try`-catchable `EvalError`, not this codebase's `Control::
+/// Break` (`label`/`break $label`) mechanism -- confirmed live that `input?`
+/// on exhaustion is silent (exit 0, no output) exactly like any other
+/// caught error, unlike an actual uncaught `label`/`break` mismatch.
+fn builtin_input<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
+    #[cfg(feature = "std")]
+    {
+        match remaining_inputs::pop() {
+            Some((doc, _line)) => owned_vec_to_result(vec![doc]),
+            None => QueryResult::Error(EvalError::new("break")),
+        }
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        QueryResult::Error(EvalError::new(
+            "input is not supported in a no_std embedding",
+        ))
+    }
+}
+
+/// Builtin: inputs - every remaining input document, one output each (#723).
+/// Stops cleanly (no output, no error) once exhausted -- unlike bare `input`,
+/// this never raises; real jq's own `inputs` is `try repeat(input) catch
+/// if .=="break" then empty else error end`, and this collects the
+/// equivalent eagerly (see [`remaining_inputs::drain_all`]'s doc comment for
+/// why eager, not lazy, matches this codebase's own convention).
+fn builtin_inputs<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
+    #[cfg(feature = "std")]
+    {
+        let docs: Vec<OwnedValue> = remaining_inputs::drain_all()
+            .into_iter()
+            .map(|(doc, _line)| doc)
+            .collect();
+        owned_vec_to_result(docs)
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        owned_vec_to_result(Vec::new())
+    }
+}
+
+/// Builtin: input_line_number - the line number of the most recently read
+/// input document (#723), `0` before anything has been read.
+fn builtin_input_line_number<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
+    #[cfg(feature = "std")]
+    {
+        QueryResult::Owned(OwnedValue::Int(remaining_inputs::last_line() as i64))
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        QueryResult::Owned(OwnedValue::Int(0))
     }
 }
 
@@ -25950,6 +26104,9 @@ fn expand_func_calls_in_builtin(
         Builtin::Del(e) => Builtin::Del(Box::new(expand_func_calls(e, func_name, params, body))),
         // Phase 12 builtins (no args to expand)
         Builtin::Now => Builtin::Now,
+        Builtin::Input => Builtin::Input,
+        Builtin::Inputs => Builtin::Inputs,
+        Builtin::InputLineNumber => Builtin::InputLineNumber,
         Builtin::Abs => Builtin::Abs,
         Builtin::Builtins => Builtin::Builtins,
         Builtin::Normals => Builtin::Normals,
@@ -26280,6 +26437,9 @@ fn substitute_func_param_in_builtin(builtin: &Builtin, param: &str, arg: &Expr) 
         Builtin::Del(e) => Builtin::Del(Box::new(substitute_func_param(e, param, arg))),
         // Phase 12 builtins (no args to substitute)
         Builtin::Now => Builtin::Now,
+        Builtin::Input => Builtin::Input,
+        Builtin::Inputs => Builtin::Inputs,
+        Builtin::InputLineNumber => Builtin::InputLineNumber,
         Builtin::Abs => Builtin::Abs,
         Builtin::Builtins => Builtin::Builtins,
         Builtin::Normals => Builtin::Normals,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3352,9 +3352,9 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
         // Phase 12: Additional builtins
         Builtin::Now => builtin_now::<W>(),
-        Builtin::Input => builtin_input::<W>(),
-        Builtin::Inputs => builtin_inputs::<W>(),
-        Builtin::InputLineNumber => builtin_input_line_number::<W>(),
+        Builtin::Input => builtin_input::<W, S>(),
+        Builtin::Inputs => builtin_inputs::<W, S>(),
+        Builtin::InputLineNumber => builtin_input_line_number::<W, S>(),
         Builtin::Abs => builtin_fabs::<W>(value, optional), // abs is an alias for fabs
         Builtin::Builtins => builtin_builtins::<W>(),
         Builtin::Normals => builtin_normals::<W>(value),
@@ -20662,12 +20662,29 @@ mod remaining_inputs {
     }
 
     /// Drains every remaining document at once, for `inputs`'s eager
-    /// generator collection (matching `range`'s own eager-with-a-cap
-    /// convention elsewhere in this file -- this codebase has no lazy
-    /// generator machinery at the `Builtin` dispatch level, so `inputs`
-    /// doesn't invent one; `first(inputs)`/`limit(1; inputs)` draining more
-    /// than needed is the same accepted trade-off `range`'s own callers
-    /// already have).
+    /// generator collection -- this codebase has no lazy generator
+    /// machinery at the `Builtin` dispatch level, so `inputs` doesn't
+    /// invent one for just this case.
+    ///
+    /// Correction (code review, #723): an earlier version of this comment
+    /// compared this to `range`'s own eager-with-a-cap convention and called
+    /// over-draining "the same accepted trade-off." That analogy doesn't
+    /// hold. `range`'s over-computed values are cheap to regenerate and
+    /// simply discarded -- pure wasted CPU, invisible to the rest of the
+    /// program. This queue is a *shared, destructive, non-replayable*
+    /// resource: once `first(inputs)`/`limit(1; inputs)`/`any(inputs; ...)`
+    /// (any combinator this evaluator's own eager model computes-then-
+    /// truncates rather than short-circuits) triggers a full drain, every
+    /// document past the one actually kept is gone -- not just from this
+    /// call, but from the outer per-document loop and any later `input`
+    /// call too. Confirmed live: `first(inputs)` on 5 remaining documents
+    /// silently reads and discards all 5 instead of the 1 real jq's lazy
+    /// generator would leave the rest of the program to see. Filed as
+    /// follow-up issue #1309 (same root cause as, and bundled with, the
+    /// `-L` detection gap above) -- fixing it needs either real lazy
+    /// generator support in this evaluator or a way for a truncating
+    /// combinator to push documents it doesn't end up using back onto the
+    /// front of the queue, neither of which is a small change.
     pub fn drain_all() -> Vec<(OwnedValue, u32)> {
         let all: alloc::vec::Vec<_> = QUEUE.with(|q| q.borrow_mut().drain(..).collect());
         if let Some((_, line)) = all.last() {
@@ -20702,6 +20719,30 @@ pub fn pop_remaining_input() -> Option<(OwnedValue, u32)> {
     remaining_inputs::pop()
 }
 
+/// Code review's own doc-comment-vs-doc-comment cross-check catch (#723):
+/// `jq_runner.rs` is the only CLI driver that calls
+/// [`seed_remaining_inputs`]/[`pop_remaining_input`] before evaluating a
+/// filter -- `yq_runner.rs` never does, yet these three builtins parse and
+/// dispatch unconditionally for `YqSemantics` too (the parser has no
+/// per-mode keyword gating anywhere in this codebase to lean on instead).
+/// Without this check, `succinctly yq` would silently accept `input`/
+/// `inputs`/`input_line_number` syntax that can never produce a correct
+/// result -- confirmed live: `break` on every document for `input`, and
+/// silent empty output for `inputs`, instead of the "undefined function"
+/// parse-time-ish error real yq (and this codebase, pre-#723) gives for a
+/// genuinely unimplemented builtin. Wiring `yq_runner.rs` up to the same
+/// queue for real support is a larger, separate piece of work -- tracked as
+/// a follow-up; this keeps yq mode's failure mode honest in the meantime.
+fn input_builtins_unsupported_in_yq_mode<S: EvalSemantics>(name: &str) -> Option<EvalError> {
+    if S::TAG == EvalTag::Yq {
+        Some(EvalError::new(format!(
+            "{name} is not supported in yq mode"
+        )))
+    } else {
+        None
+    }
+}
+
 /// Builtin: input - read and return the next input document (#723), erroring
 /// with real jq's own exact text (`break`, confirmed live against jq 1.7.1 --
 /// not a more descriptive message) once the input stream is exhausted. A
@@ -20709,7 +20750,10 @@ pub fn pop_remaining_input() -> Option<(OwnedValue, u32)> {
 /// Break` (`label`/`break $label`) mechanism -- confirmed live that `input?`
 /// on exhaustion is silent (exit 0, no output) exactly like any other
 /// caught error, unlike an actual uncaught `label`/`break` mismatch.
-fn builtin_input<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
+fn builtin_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>() -> QueryResult<'a, W> {
+    if let Some(e) = input_builtins_unsupported_in_yq_mode::<S>("input") {
+        return QueryResult::Error(e);
+    }
     #[cfg(feature = "std")]
     {
         match remaining_inputs::pop() {
@@ -20731,7 +20775,10 @@ fn builtin_input<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 /// if .=="break" then empty else error end`, and this collects the
 /// equivalent eagerly (see [`remaining_inputs::drain_all`]'s doc comment for
 /// why eager, not lazy, matches this codebase's own convention).
-fn builtin_inputs<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
+fn builtin_inputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>() -> QueryResult<'a, W> {
+    if let Some(e) = input_builtins_unsupported_in_yq_mode::<S>("inputs") {
+        return QueryResult::Error(e);
+    }
     #[cfg(feature = "std")]
     {
         let docs: Vec<OwnedValue> = remaining_inputs::drain_all()
@@ -20748,7 +20795,11 @@ fn builtin_inputs<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 
 /// Builtin: input_line_number - the line number of the most recently read
 /// input document (#723), `0` before anything has been read.
-fn builtin_input_line_number<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
+fn builtin_input_line_number<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>() -> QueryResult<'a, W>
+{
+    if let Some(e) = input_builtins_unsupported_in_yq_mode::<S>("input_line_number") {
+        return QueryResult::Error(e);
+    }
     #[cfg(feature = "std")]
     {
         QueryResult::Owned(OwnedValue::Int(remaining_inputs::last_line() as i64))
@@ -22951,6 +23002,10 @@ fn builtin_builtins<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
         "halt_error/0",
         "halt_error/1",
         "stderr/0",
+        // Streaming input (#723)
+        "input/0",
+        "inputs/0",
+        "input_line_number/0",
         // Environment (arity 0-1)
         "env/0",
         "env/1",

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20700,9 +20700,9 @@ mod remaining_inputs {
 
 /// Seeds the `input`/`inputs`/`input_line_number` queue (#723).
 ///
-/// The CLI driver's own entry point into [`remaining_inputs`], called once
-/// before evaluating any filter. A no-op under `no_std` (nothing to seed
-/// there).
+/// The CLI driver's own entry point into the (private) `remaining_inputs`
+/// module, called once before evaluating any filter. A no-op under
+/// `no_std` (nothing to seed there).
 #[cfg(feature = "std")]
 pub fn seed_remaining_inputs(documents: Vec<(OwnedValue, u32)>) {
     remaining_inputs::seed(documents);
@@ -20711,9 +20711,10 @@ pub fn seed_remaining_inputs(documents: Vec<(OwnedValue, u32)>) {
 /// Pops the next queued input document (#723).
 ///
 /// Exposed so the CLI driver's own per-document loop can share the exact
-/// same queue `input`/`inputs` draw from (see [`remaining_inputs::pop`]'s
-/// doc comment for why this must be one shared queue, not two cursors). A
-/// no-op under `no_std`.
+/// same queue `input`/`inputs` draw from (see `remaining_inputs::pop`'s own
+/// doc comment, `src/jq/eval.rs`, for why this must be one shared queue,
+/// not two cursors -- not doc-linkable from here since that module is
+/// private). A no-op under `no_std`.
 #[cfg(feature = "std")]
 pub fn pop_remaining_input() -> Option<(OwnedValue, u32)> {
     remaining_inputs::pop()

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -905,6 +905,18 @@ pub enum Builtin {
     // Phase 12: Additional builtins
     /// `now` - current Unix timestamp
     Now,
+    /// `input` - read and return the next input document, erroring once the
+    /// input stream is exhausted -- real jq's own error text there is
+    /// exactly `break` (confirmed live against jq 1.7.1), not the more
+    /// descriptive "No more inputs" the C source's internal name suggests
+    /// (#723)
+    Input,
+    /// `inputs` - generator yielding every remaining input document one at a
+    /// time, stopping (not erroring) once exhausted (#723)
+    Inputs,
+    /// `input_line_number` - the line number of the most recently read
+    /// input document (#723)
+    InputLineNumber,
     /// `abs` - absolute value (alias for fabs)
     Abs,
     /// `builtins` - list all builtin function names

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -87,6 +87,12 @@ pub use eval::{
     eval, eval_lenient, eval_owned_with_file_index, nonfinite_display_string, substitute_vars,
     sync_aliased_paths, EvalSemantics, JqSemantics, QueryResult, YqSemantics,
 };
+// `input`/`inputs`/`input_line_number`'s CLI-facing seam (#723) -- only
+// exists under `eval.rs`'s own `#[cfg(feature = "std")]` gate (a `thread_local!`
+// backing store needs `std`, and there is no meaningful "remaining input
+// stream" to seed under a `no_std` embedding with no CLI driver anyway).
+#[cfg(feature = "std")]
+pub use eval::{pop_remaining_input, seed_remaining_inputs};
 pub use expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MetaValue,
     ModuleMeta, ObjectEntry, ObjectKey, Pattern, PatternEntry, Program, StringPart,

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3393,6 +3393,18 @@ impl<'a> Parser<'a> {
             self.consume_keyword("builtins");
             return Ok(Some(Builtin::Builtins));
         }
+        if self.matches_keyword("inputs") {
+            self.consume_keyword("inputs");
+            return Ok(Some(Builtin::Inputs));
+        }
+        if self.matches_keyword("input_line_number") {
+            self.consume_keyword("input_line_number");
+            return Ok(Some(Builtin::InputLineNumber));
+        }
+        if self.matches_keyword("input") {
+            self.consume_keyword("input");
+            return Ok(Some(Builtin::Input));
+        }
 
         // Phase 13: Iteration control
         // limit(n; expr) - output at most n values from expr

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13570,3 +13570,162 @@ fn test_deferred_trackability_matches_jq_986_989() {
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert!(stdout.is_empty(), "stdout: {stdout}");
 }
+
+// #723: input/inputs/input_line_number. Every expected value below was
+// verified live against pinned jq 1.7.1 during implementation.
+
+/// `., input` on 3 documents: doc 1 is `.`'s own current input, `input`
+/// reads doc 2 (both output); the outer loop's *next* iteration is then doc
+/// 3 (already in sync with what `input` consumed), whose own `input` call
+/// finds nothing left and errors -- so this exits 5 despite all three
+/// values reaching stdout. Confirmed this exact shape live against jq
+/// 1.7.1: stdout `1`/`2`/`3` plus a `break` error on stderr, not a clean
+/// exit -- jq's own `input`/outer-loop interaction has the identical
+/// "last iteration's own `input` call exhausts" behavior this mirrors.
+#[test]
+fn test_jq_input_reads_next_document_723() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "., input"], Some("1 2 3")).expect("input repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "1\n2\n3\n");
+    assert!(stderr.contains("break"), "{stderr}");
+    Ok(())
+}
+
+/// jq's own exhaustion error is oddly spelled `break`, not a more
+/// descriptive "No more inputs" -- confirmed live against jq 1.7.1. The
+/// `:0` (not `:1`) is a separate, pre-existing quirk unrelated to #723:
+/// `succinctly jq`'s own location tracking reports line 0 for a document
+/// ending on the input's first line even without `input` involved at all
+/// (confirmed identical on `main` before this change, e.g. `echo '1 2' |
+/// jq '.,error'` reports `:0` for the first value too) -- not something
+/// this issue introduces or should silently paper over here.
+#[test]
+fn test_jq_input_exhausted_errors_with_break_723() {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "input"], Some("1")).expect("input-exhaustion repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stdout.is_empty(), "stdout: {stdout}");
+    assert!(
+        stderr.contains("jq: error (at <stdin>:0): break"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn test_jq_input_optional_catches_exhaustion_silently_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("input?", "1", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+#[test]
+fn test_jq_try_input_catch_catches_exhaustion_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin(r#"try input catch "caught""#, "1", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"caught\"\n");
+    Ok(())
+}
+
+/// jq's own canonical `-n` streaming-aggregation idiom -- the primary
+/// real-world use case for `inputs`.
+#[test]
+fn test_jq_null_input_reduce_over_inputs_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("reduce inputs as $x (0; .+$x)", "1 2 3", &["-cn"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "6\n");
+    Ok(())
+}
+
+/// Unlike bare `input`, `inputs` never errors on exhaustion -- it's a
+/// generator that just stops.
+#[test]
+fn test_jq_inputs_stream_remaining_without_error_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("inputs", "1 2 3", &["-c"])?;
+    assert_eq!(code, 0);
+    // The bare top-level loop already consumed document 1 as `.`'s own
+    // input before `inputs` ever ran, so only 2 and 3 remain.
+    assert_eq!(stdout, "2\n3\n");
+    Ok(())
+}
+
+#[test]
+fn test_jq_null_input_inputs_sees_every_document_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("inputs", "1 2 3", &["-cn"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "1\n2\n3\n");
+    Ok(())
+}
+
+#[test]
+fn test_jq_input_line_number_tracks_reads_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("., input_line_number", "1\n2\n3\n", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "1\n1\n2\n2\n3\n3\n");
+    Ok(())
+}
+
+#[test]
+fn test_jq_input_line_number_zero_before_any_read_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("input_line_number", "1", &["-cn"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n");
+    Ok(())
+}
+
+/// A filter's own `input` call and the outer per-document loop share one
+/// queue (#723): a document `input` consumes mid-evaluation must never also
+/// be re-processed by the loop as a fresh top-level invocation.
+#[test]
+fn test_jq_input_and_outer_loop_share_one_queue_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("(., input)", "1 2 3 4", &["-c"])?;
+    assert_eq!(code, 0);
+    // Doc 1 -> `.` = 1, `input` reads doc 2. Doc 3 -> `.` = 3, `input`
+    // reads doc 4. All four documents seen exactly once, in order.
+    assert_eq!(stdout, "1\n2\n3\n4\n");
+    Ok(())
+}
+
+#[test]
+fn test_jq_null_input_reduce_inputs_over_multiple_files_723() -> Result<()> {
+    let mut f1 = NamedTempFile::new()?;
+    write!(f1, "1")?;
+    let mut f2 = NamedTempFile::new()?;
+    write!(f2, "2")?;
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-cn",
+            "reduce inputs as $x (0; .+$x)",
+            f1.path().to_str().unwrap(),
+            f2.path().to_str().unwrap(),
+        ],
+        None,
+    )
+    .expect("multi-file inputs repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "3\n");
+    Ok(())
+}
+
+#[test]
+fn test_jq_halt_after_input_still_halts_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("(input, halt)", "1 2 3", &["-c"])?;
+    assert_eq!(code, 0);
+    // `input` reads doc 2 and outputs it; `halt` then exits immediately,
+    // before the outer loop would otherwise move on to doc 3.
+    assert_eq!(stdout, "2\n");
+    Ok(())
+}
+
+/// `-n` without any of these builtins must keep working exactly as before
+/// (#723's own `uses_input_builtins` gate must not force a real read, or
+/// route through a different code path, for a filter that never
+/// mentions them).
+#[test]
+fn test_jq_null_input_unaffected_when_not_using_input_builtins_723() -> Result<()> {
+    let (stdout, code) = run_jq_stdin("1 + 1", "", &["-cn"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "2\n");
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13768,3 +13768,24 @@ fn test_jq_input_inside_user_defined_function_723() -> Result<()> {
     assert!(stderr.contains("break"), "{stderr}");
     Ok(())
 }
+
+/// `inputs`/`input_line_number` (the other two of #723's three new
+/// builtins) called from inside a user-defined function -- same
+/// AST-rewriting-pass coverage reasoning as the `input`-specific test
+/// above, for the two builtins it didn't happen to exercise.
+#[test]
+fn test_jq_inputs_and_input_line_number_inside_user_defined_function_723() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".,(def f: input_line_number; f)"],
+        Some("1\n2\n3\n"),
+    )
+    .expect("input_line_number-inside-function repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "1\n1\n2\n2\n3\n3\n");
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".,(def f(x): x; f(inputs))"], Some("1 2 3"))
+        .expect("inputs-as-function-argument repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "1\n2\n3\n");
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13614,16 +13614,18 @@ fn test_jq_input_exhausted_errors_with_break_723() {
 
 #[test]
 fn test_jq_input_optional_catches_exhaustion_silently_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("input?", "1", &["-c"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "input?"], Some("1")).expect("input? repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "");
     Ok(())
 }
 
 #[test]
 fn test_jq_try_input_catch_catches_exhaustion_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin(r#"try input catch "caught""#, "1", &["-c"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"try input catch "caught""#], Some("1"))
+        .expect("try/catch input repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "\"caught\"\n");
     Ok(())
 }
@@ -13632,8 +13634,10 @@ fn test_jq_try_input_catch_catches_exhaustion_723() -> Result<()> {
 /// real-world use case for `inputs`.
 #[test]
 fn test_jq_null_input_reduce_over_inputs_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("reduce inputs as $x (0; .+$x)", "1 2 3", &["-cn"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) =
+        run_jq_full(&["-cn", "reduce inputs as $x (0; .+$x)"], Some("1 2 3"))
+            .expect("-n reduce inputs repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "6\n");
     Ok(())
 }
@@ -13642,8 +13646,9 @@ fn test_jq_null_input_reduce_over_inputs_723() -> Result<()> {
 /// generator that just stops.
 #[test]
 fn test_jq_inputs_stream_remaining_without_error_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("inputs", "1 2 3", &["-c"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "inputs"], Some("1 2 3")).expect("inputs repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     // The bare top-level loop already consumed document 1 as `.`'s own
     // input before `inputs` ever ran, so only 2 and 3 remain.
     assert_eq!(stdout, "2\n3\n");
@@ -13652,24 +13657,27 @@ fn test_jq_inputs_stream_remaining_without_error_723() -> Result<()> {
 
 #[test]
 fn test_jq_null_input_inputs_sees_every_document_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("inputs", "1 2 3", &["-cn"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) =
+        run_jq_full(&["-cn", "inputs"], Some("1 2 3")).expect("-n inputs repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "1\n2\n3\n");
     Ok(())
 }
 
 #[test]
 fn test_jq_input_line_number_tracks_reads_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("., input_line_number", "1\n2\n3\n", &["-c"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "., input_line_number"], Some("1\n2\n3\n"))
+        .expect("input_line_number repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "1\n1\n2\n2\n3\n3\n");
     Ok(())
 }
 
 #[test]
 fn test_jq_input_line_number_zero_before_any_read_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("input_line_number", "1", &["-cn"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "input_line_number"], Some("1"))
+        .expect("-n input_line_number repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "0\n");
     Ok(())
 }
@@ -13679,8 +13687,9 @@ fn test_jq_input_line_number_zero_before_any_read_723() -> Result<()> {
 /// be re-processed by the loop as a fresh top-level invocation.
 #[test]
 fn test_jq_input_and_outer_loop_share_one_queue_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("(., input)", "1 2 3 4", &["-c"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "(., input)"], Some("1 2 3 4")).expect("shared-queue repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     // Doc 1 -> `.` = 1, `input` reads doc 2. Doc 3 -> `.` = 3, `input`
     // reads doc 4. All four documents seen exactly once, in order.
     assert_eq!(stdout, "1\n2\n3\n4\n");
@@ -13710,8 +13719,9 @@ fn test_jq_null_input_reduce_inputs_over_multiple_files_723() -> Result<()> {
 
 #[test]
 fn test_jq_halt_after_input_still_halts_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("(input, halt)", "1 2 3", &["-c"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "(input, halt)"], Some("1 2 3")).expect("input+halt repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     // `input` reads doc 2 and outputs it; `halt` then exits immediately,
     // before the outer loop would otherwise move on to doc 3.
     assert_eq!(stdout, "2\n");
@@ -13724,8 +13734,37 @@ fn test_jq_halt_after_input_still_halts_723() -> Result<()> {
 /// mentions them).
 #[test]
 fn test_jq_null_input_unaffected_when_not_using_input_builtins_723() -> Result<()> {
-    let (stdout, code) = run_jq_stdin("1 + 1", "", &["-cn"])?;
-    assert_eq!(code, 0);
+    let (stdout, stderr, code) =
+        run_jq_full(&["-cn", "1 + 1"], Some("")).expect("-n unaffected repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "2\n");
+    Ok(())
+}
+
+/// `halt` reached inside `-n`'s own single-invocation branch (as opposed to
+/// the non-`-n` per-document loop `test_jq_halt_after_input_still_halts_723`
+/// already covers) must still exit cleanly.
+#[test]
+fn test_jq_null_input_halt_after_inputs_723() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-cn", "(inputs, halt)"], Some("1 2 3")).expect("-n halt repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "1\n2\n3\n");
+    Ok(())
+}
+
+/// `input` called from inside a user-defined function: forces
+/// `Builtin::Input`/`Inputs`/`InputLineNumber` through the AST-rewriting
+/// passes (`expand_func_calls_in_builtin`/`substitute_func_param_in_builtin`)
+/// that inline a function's own body at its call site -- exercising their
+/// mechanical pass-through arms for these three new builtins, not just the
+/// dispatch arm a bare top-level call already covers.
+#[test]
+fn test_jq_input_inside_user_defined_function_723() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".,(def f: input; f)"], Some("1 2 3"))
+        .expect("input-inside-function repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "1\n2\n3\n");
+    assert!(stderr.contains("break"), "{stderr}");
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13783,9 +13783,29 @@ fn test_jq_inputs_and_input_line_number_inside_user_defined_function_723() -> Re
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "1\n1\n2\n2\n3\n3\n");
 
-    let (stdout, stderr, code) = run_jq_full(&["-c", ".,(def f(x): x; f(inputs))"], Some("1 2 3"))
-        .expect("inputs-as-function-argument repro runs");
+    // `substitute_func_param_in_builtin`'s own Inputs/InputLineNumber arms
+    // (as opposed to `expand_func_calls_in_builtin`'s, exercised above) only
+    // run when a filter-style (non-`$`) function *parameter* is substituted
+    // through a body that itself contains these builtins -- unlike passing
+    // `inputs` as an *argument*, which just swaps the whole argument
+    // expression in wholesale without walking its own contents.
+    //
+    // Input ends with a trailing newline deliberately: without one, the
+    // last document's own reported line number is one lower than with it, a
+    // separate pre-existing `LineCounter`/`extend_from_ends` quirk
+    // unrelated to #723 (confirmed reproducing identically for `input`'s
+    // own document-location tracking, not just `input_line_number`) --
+    // sidestepped here rather than chased, since this test's only job is
+    // patch-coverage for the AST-rewriting pass, not pinning that quirk.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "(def f(x): x, input, inputs, input_line_number; f(1))",
+        ],
+        Some("1 2 3\n"),
+    )
+    .expect("function-parameter-substitution repro runs");
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
-    assert_eq!(stdout, "1\n2\n3\n");
+    assert_eq!(stdout, "1\n2\n3\n1\n");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16345,3 +16345,47 @@ fn test_destructuring_pattern_null_propagates_through_nested_object_1239() -> Re
     assert_eq!(out.trim(), "null");
     Ok(())
 }
+
+// #723 review round: input/inputs/input_line_number are jq-only -- the
+// CLI driver behind `succinctly yq` (yq_runner.rs) never seeds their shared
+// document queue, since they need real per-document loop coordination that
+// yq mode doesn't have. Before this fix, the parser/dispatch accepted them
+// unconditionally (no per-mode gating exists for any keyword in this
+// codebase), so `succinctly yq` silently misbehaved -- `input` reported a
+// spurious "break" on every document instead of only true exhaustion, and
+// `inputs` silently produced no output at all. Now they report a clear
+// "not supported in yq mode" error instead, restoring the pre-#723
+// "undefined function"-equivalent failure mode.
+
+#[test]
+fn test_yq_input_not_supported_723() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("input", "a: 1\n", &[])?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("input is not supported in yq mode"),
+        "{stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_yq_inputs_not_supported_723() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("inputs", "a: 1\n", &[])?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("inputs is not supported in yq mode"),
+        "{stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_yq_input_line_number_not_supported_723() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("input_line_number", "a: 1\n", &[])?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("input_line_number is not supported in yq mode"),
+        "{stderr}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

jq's `input`/`inputs`/`input_line_number` builtins were entirely unimplemented
(`undefined function`) — a real capability gap for stateful cross-document
aggregation. `jq -n 'reduce inputs as $x (0;.+$x)'` is jq's own canonical
streaming-aggregation idiom and had no equivalent in `succinctly jq`.

- `input` reads the next document from the input stream, erroring with real
  jq's own exact `break` text once exhausted (confirmed live against jq
  1.7.1). A normal `?`/`try`-catchable `EvalError`, not this codebase's own
  `Control::Break` (`label`/`break`) mechanism.
- `inputs` is a generator yielding every remaining document, stopping
  cleanly (not erroring) once exhausted.
- `input_line_number` reports the line of the most recently read document.

**Mechanism**: a thread-local queue in `eval.rs`, gated `#[cfg(feature =
"std")]` and populated by `jq_runner.rs` before evaluating any filter — the
CLI's own per-document loop draws from the identical queue to keep a
filter's own `input` calls and "next top-level document" in sync without
two separately-maintained cursors.

`-n` currently fakes a single `null` document without reading stdin at all.
When the filter's text contains `"input"` (a conservative, never-under-
detecting heuristic for *direct* uses), `get_inputs` now reads the real
documents too, while the outer loop still presents `.` as `null` exactly
once.

**Two rounds of multi-agent code review** (live-tested against pinned jq
1.7.1 and, for one finding, a real pty session) found real bugs, fixed
before this PR merges:
- A TTY-safety branch was still seeding the shared queue with `get_inputs`'s
  `-n` placeholder as if it were real data, so `input` at an interactive
  terminal with no piped/file input silently returned `null` instead of
  reporting exhausted — contradicting the code's own documented safety
  guarantee. Fixed: that case now seeds an empty queue.
- `succinctly yq` accepted this syntax (no per-mode keyword gating exists
  in this codebase's parser) but `yq_runner.rs` never seeds the queue, so
  these builtins were silently, permanently broken there — worse than the
  pre-#723 "undefined function" error. Fixed: now mode-gated via `S::TAG`,
  reporting a clear "not supported in yq mode" error until yq mode gets
  real support.
- Plus: moves instead of clones when seeding the queue, adds the three new
  builtins to `builtins/0`'s introspection list, fixes two doc comments
  that understated real limitations, and fixes two `rustdoc` warnings.

**Known, deliberately out-of-scope limitations**, filed as issue #1309
rather than expanding this PR further (architecturally deeper than a quick
patch):
- The `uses_input_builtins` text heuristic doesn't see inside `-L`/module-
  inlined function bodies, so a module-indirect `input` call is missed.
- This evaluator has no lazy generator machinery, so `first(inputs)`/
  `limit(1; inputs)`/`any(inputs; ...)` eagerly drain (and thus discard)
  more documents than real jq's lazy generator model would.
- `inputs | input_line_number` reports the *last* drained line for every
  value (same root cause as the above).
- Filename is lost from error locations for input-builtin-using multi-file
  invocations (the shared queue only tracks line numbers).
- `-n` with fully empty input reports `<unknown>` instead of `<stdin>:0`
  (cosmetic; exit code and `break` text already match).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, `--no-fail-fast`) — 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (`no_std` build)
- [x] `cargo doc --features cli --no-deps` — zero warnings
- [x] Every semantic verified live against pinned jq 1.7.1 first
- [x] 19 new CLI integration tests covering: bare `input`, exhaustion
      (`break` text, exit 5), `input?`/`try...catch` catching exhaustion,
      `-n` streaming aggregation, `inputs` non-erroring exhaustion (bare and
      `-n`), `input_line_number` tracking, shared-queue synchronization,
      multi-file `-n` input, `halt` interaction (both loop shapes), `-n`
      unaffected when unused, AST-rewriting-pass coverage (function-call
      expansion, function-parameter substitution), and yq mode's new
      "not supported" error for all three builtins
- [x] 1 unit test for the TTY-safety pure function (all 4-bool combinations
      that matter)
- [x] `omni-dev coverage diff`: 97.56% patch coverage; the 4 remaining
      uncovered lines are either genuinely untestable without a real
      interactive terminal (matching this codebase's own established
      "unreachable but exhaustive" convention) or `llvm-cov` line-
      attribution artifacts on multi-line expressions that passing tests
      demonstrably exercise

Refs #723