### PR TITLE
fix(yaml): bound alias-chain depth to stop stack-overflow DoS

### DIFF
--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -199,6 +199,33 @@ Neither costs this page's conformance numbers anything: no case in the corpus co
 alias to an out-of-scope anchor, so the loader-alone reject figure, the accepted-but-invalid
 document count, and the `lax:anchors` row are unmoved by #372.
 
+### A third, differently-timed check: excessively long alias chains
+
+Unlike the cyclic and unknown-anchor cases above, an alias chain that is merely very long —
+`a0: &a0 v`, `a1: &a1 *a0`, `a2: &a2 *a1`, ... — is not rejected at `YamlIndex::build`
+time; the index builds successfully regardless of chain length. [#153](https://github.com/rust-works/succinctly/issues/153)'s
+cycle check only rejects a chain that revisits its own anchor, and a long non-cyclic chain
+never does. Before [#1193](https://github.com/rust-works/succinctly/issues/1193), *walking*
+such a chain (via `type`, `tostring`, `-o json` output, arithmetic, or any other query that
+resolves the aliased value) drove real, uncatchable stack overflow through several
+independent self-recursive code paths in `src/yaml/light.rs`, `src/bin/succinctly/yq_runner.rs`,
+and `src/jq/eval.rs` — the same underlying failure mode #153 fixed for cycles specifically,
+recurring for long-but-acyclic chains that #153's own check does not cover.
+
+The fix is a runtime ceiling, not a build-time rejection: `MAX_ALIAS_CHAIN_DEPTH` (65,536
+hops, `src/yaml/light.rs`) bounds every alias-resolving accessor to a clean `panic!` past
+that depth, rather than allowing the resolution loop to run unbounded. Because the fix
+converts what used to be self-recursion into an explicit iterative loop, the ceiling exists
+only to cap adversarial CPU time, not stack depth — the loop itself costs O(1) stack
+regardless of chain length. A chain within the limit resolves normally; one beyond it
+panics with a `nesting depth exceeds limit` message (a clean Rust panic, not a stack
+overflow) rather than crashing the process the way #1193's own repro did:
+
+```
+$ succinctly yq -o json '.' 70000-hop-chain.yaml
+thread 'main' panicked at ...: nesting depth exceeds limit of 65536
+```
+
 ### The other ways `YamlIndex::build` fails
 
 Structure aside, `build` still refuses input it has no reading for at all. None of these is

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -233,12 +233,14 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
             Ok(OwnedValue::Array(arr))
         }
         YamlValue::Alias { target, .. } => {
-            // Resolve alias by following the target cursor
-            if let Some(target_cursor) = target {
-                yaml_to_owned_value(target_cursor)
-            } else {
-                // Unresolved alias - treat as null
-                Ok(OwnedValue::Null)
+            // Resolve the *entire* alias chain first (#1193), not just this
+            // one hop: the resolved cursor's own `.value()` is guaranteed
+            // non-`Alias`, so this recursive call terminates in exactly one
+            // more step regardless of chain length.
+            match target.and_then(|t| t.resolve_alias_target_cursor()) {
+                Some(resolved) => yaml_to_owned_value(resolved),
+                // Unresolved (dangling) target - treat as null
+                None => Ok(OwnedValue::Null),
             }
         }
         YamlValue::Error(msg) => Err(anyhow::anyhow!("YAML error: {msg}")),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23468,11 +23468,14 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
             OwnedValue::Object(map)
         }
         YamlValue::Alias { target, .. } => {
-            // Resolve alias by following the target cursor
-            if let Some(target_cursor) = target {
-                yaml_value_to_owned(target_cursor)
-            } else {
-                OwnedValue::Null
+            // Resolve the *entire* alias chain first (#1193), not just this
+            // one hop: the resolved cursor's own `.value()` is guaranteed
+            // non-`Alias`, so this recursive call terminates in exactly one
+            // more step regardless of chain length.
+            match target.and_then(|t| t.resolve_alias_target_cursor()) {
+                Some(resolved) => yaml_value_to_owned(resolved),
+                // Unresolved (dangling) target - treat as null
+                None => OwnedValue::Null,
             }
         }
         YamlValue::Error(_) => OwnedValue::Null,

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -105,8 +105,9 @@ pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
     assert_value_tree_depth, format_number_jq_compat, NumberRepr, OwnedValue, MAX_VALUE_TREE_DEPTH,
 };
-// `pub(crate)`, not `pub`: only `yaml::light`'s `resolve_alias_chain` (#1191
-// code review) needs this from outside `jq::value` -- re-exporting it as a
-// real public API item would put a crate-internal depth-guard helper on
-// docs.rs with no external caller to justify the exposure.
+// `pub(crate)`, not `pub`: only `yaml::light`'s alias-chain resolvers (#1191
+// code review, #1193/PR #1314) need this from outside `jq::value` --
+// re-exporting it as a real public API item would put a crate-internal
+// depth-guard helper on docs.rs with no external caller to justify the
+// exposure.
 pub(crate) use value::assert_depth;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5817,21 +5817,28 @@ use crate::jq::document::{
 /// On `main` prior to this constant, `as_str()`'s `Alias` arm checked only a
 /// single hop (`if let YamlValue::String(s) = t.value() {...} else { None }`)
 /// -- correctness-buggy (a 2+-hop alias-to-string silently returned `None`)
-/// but not itself a stack-overflow risk, since it never recursed. Every
-/// *other* typed accessor on [`YamlValue`] -- `as_bool`, `as_i64`, `as_f64`,
-/// `number_literal`, `as_object`, `as_array`, `type_name`, `is_null` --
-/// already resolves an alias chain via genuine self-recursion
+/// but not itself a stack-overflow risk, since it never recursed (#1191).
+/// Every *other* typed accessor on [`YamlValue`] -- `as_bool`, `as_i64`,
+/// `as_f64`, `number_literal`, `as_object`, `as_array`, `type_name`,
+/// `is_null` -- resolved an alias chain via genuine self-recursion
 /// (`target.and_then(|t| t.value().<accessor>())`, re-entering itself once
-/// per hop) and so already carries a real, uncatchable stack-overflow DoS
+/// per hop) and so already carried a real, uncatchable stack-overflow DoS
 /// on a syntactically valid, non-cyclic chain of tens of thousands of
 /// anchored aliases -- separate from #153's build-time acyclicity check,
 /// which only rejects a chain that revisits its own anchor, not one that is
-/// merely very long. #1193 tracks fixing those 8; out of scope here. This
-/// PR's own first attempt at fixing `as_str()`'s correctness bug copied
-/// that same self-recursive shape, which introduced the identical
-/// stack-overflow regression into `as_str()` too before review caught it --
-/// `resolve_alias_chain`'s iterative loop is the fix for that regression,
-/// not for anything that was ever live on `main`.
+/// merely very long. #1193/PR #1314 fixes all 8 of those, routing each
+/// through this same `resolve_alias_chain`, alongside the YAML->JSON
+/// streaming writers (`stream_json_value`/`write_json_to`), `tag()`, and
+/// the CLI/evaluator's `yaml_to_owned_value`/`yaml_value_to_owned` -- five
+/// more independently-self-recursive sites #1191's own review didn't
+/// cover, each needing the resolved *cursor* rather than just the value
+/// (see `YamlCursor::resolve_alias_target_cursor`, this method's
+/// cursor-returning sibling). #1191's own first attempt at fixing
+/// `as_str()`'s correctness bug copied that same self-recursive shape,
+/// which introduced the identical stack-overflow regression into
+/// `as_str()` too before review caught it -- `resolve_alias_chain`'s
+/// iterative loop is the fix for that regression, not for anything that
+/// was ever live on `main` before #1191.
 ///
 /// Unlike this crate's other `MAX_*` depth ceilings
 /// ([`eval_generic::MAX_NESTING_DEPTH`](crate::jq::eval_generic::MAX_NESTING_DEPTH),
@@ -6060,11 +6067,18 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
                 }
             }
             YamlValue::Alias { target, .. } => {
-                // An alias is null exactly when its target is. The `None` arm is
-                // unreachable for an index from `YamlIndex::build`, which since
-                // #372 refuses an alias it cannot resolve; it is kept, rather
-                // than unwrapped, so a hand-built index cannot panic here.
-                target.map_or(true, |t| t.value().is_null())
+                // Resolve the *entire* alias chain first via the target
+                // cursor's own `resolve_alias_chain` (#1193/PR #1314; see
+                // `MAX_ALIAS_CHAIN_DEPTH`'s doc comment, and `as_str`'s own
+                // `Alias` arm above, fixed the same way for #1191), not a
+                // single-hop `t.value()` match. The `None` arm is
+                // unreachable for an index from `YamlIndex::build`, which
+                // since #372 refuses an alias it cannot resolve; it is
+                // kept, rather than unwrapped, so a hand-built index
+                // cannot panic here.
+                target.map_or(true, |t| {
+                    t.resolve_alias_chain().map_or(true, |v| v.is_null())
+                })
             }
             _ => false,
         }
@@ -6082,7 +6096,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
                     _ => None,
                 }
             }
-            YamlValue::Alias { target, .. } => target.and_then(|t| t.value().as_bool()),
+            // See `is_null`'s `Alias` arm above (#1193/PR #1314).
+            YamlValue::Alias { target, .. } => {
+                target.and_then(|t| t.resolve_alias_chain()?.as_bool())
+            }
             _ => None,
         }
     }
@@ -6096,7 +6113,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
                     _ => None,
                 }
             }
-            YamlValue::Alias { target, .. } => target.and_then(|t| t.value().as_i64()),
+            // See `is_null`'s `Alias` arm above (#1193/PR #1314).
+            YamlValue::Alias { target, .. } => {
+                target.and_then(|t| t.resolve_alias_chain()?.as_i64())
+            }
             _ => None,
         }
     }
@@ -6112,7 +6132,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
                     _ => None,
                 }
             }
-            YamlValue::Alias { target, .. } => target.and_then(|t| t.value().as_f64()),
+            // See `is_null`'s `Alias` arm above (#1193/PR #1314).
+            YamlValue::Alias { target, .. } => {
+                target.and_then(|t| t.resolve_alias_chain()?.as_f64())
+            }
             _ => None,
         }
     }
@@ -6161,11 +6184,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
                     _ => None,
                 }
             }
-            // `t.value()` is a temporary, so (as `as_str`'s alias arm above
-            // also has to) any borrowed `Cow` it hands back must be owned
-            // before the closure returns.
+            // See `as_str`'s `Alias` arm below (#1191/#1193, PR #1314): the
+            // resolved value is a temporary, so any borrowed `Cow` it hands
+            // back must be owned before the closure returns.
             YamlValue::Alias { target, .. } => target.and_then(|t| {
-                t.value()
+                t.resolve_alias_chain()?
                     .number_literal()
                     .map(|cow| Cow::Owned(cow.into_owned()))
             }),
@@ -6205,7 +6228,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     fn as_object(&self) -> Option<Self::Fields> {
         match self {
             YamlValue::Mapping(fields) => Some(fields.clone()),
-            YamlValue::Alias { target, .. } => target.and_then(|t| t.value().as_object()),
+            // See `as_str`'s `Alias` arm above (#1191/#1193, PR #1314).
+            YamlValue::Alias { target, .. } => {
+                target.and_then(|t| t.resolve_alias_chain()?.as_object())
+            }
             _ => None,
         }
     }
@@ -6213,7 +6239,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     fn as_array(&self) -> Option<Self::Elements> {
         match self {
             YamlValue::Sequence(elements) => Some(*elements),
-            YamlValue::Alias { target, .. } => target.and_then(|t| t.value().as_array()),
+            // See `as_str`'s `Alias` arm above (#1191/#1193, PR #1314).
+            YamlValue::Alias { target, .. } => {
+                target.and_then(|t| t.resolve_alias_chain()?.as_array())
+            }
             _ => None,
         }
     }
@@ -6232,7 +6261,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
             }
             YamlValue::Mapping(_) => "object",
             YamlValue::Sequence(_) => "array",
-            YamlValue::Alias { target, .. } => target.map_or("null", |t| t.value().type_name()),
+            // See `as_str`'s `Alias` arm above (#1191/#1193, PR #1314).
+            YamlValue::Alias { target, .. } => target.map_or("null", |t| {
+                t.resolve_alias_chain().map_or("null", |v| v.type_name())
+            }),
             YamlValue::Error(_) => "error",
         }
     }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -7335,6 +7335,43 @@ mod tests {
         let _ = z.as_str();
     }
 
+    /// #1193/PR #1314 code review: `YamlCursor::tag`'s own `Alias` arm had
+    /// the identical self-recursive shape as the typed accessors above
+    /// (`t.tag()`, re-entering itself once per hop) -- found live via a
+    /// direct call to this method (not reachable through the yq CLI's own
+    /// `tag` builtin, which operates on an already-materialized value, not
+    /// a cursor -- see `resolve_alias_target_cursor`'s doc comment for the
+    /// other methods in the same boat). Confirms the fix resolves a
+    /// 50,000-hop chain without panicking or overflowing the stack.
+    #[test]
+    fn test_tag_resolves_deep_alias_chain_without_stack_overflow_1193() {
+        let yaml = build_alias_chain_yaml(50_000);
+        let index = YamlIndex::build(yaml.as_bytes()).unwrap();
+        let root = index.root(yaml.as_bytes());
+        let YamlValue::Mapping(fields) = first_doc(root) else {
+            panic!("expected root document to be a mapping");
+        };
+        let z_cursor = fields.find_cursor("z").expect("z field must exist");
+        assert_eq!(z_cursor.tag(), "!!str");
+    }
+
+    /// #1193/PR #1314 code review: the success-path test above never
+    /// exercises `MAX_ALIAS_CHAIN_DEPTH`'s own boundary for `tag()` -- see
+    /// `test_as_str_panics_past_max_alias_chain_depth_1191`'s matching
+    /// rationale and its `+ 2` note, which applies identically here.
+    #[test]
+    #[should_panic(expected = "nesting depth exceeds limit")]
+    fn test_tag_panics_past_max_alias_chain_depth_1193() {
+        let yaml = build_alias_chain_yaml(MAX_ALIAS_CHAIN_DEPTH + 2);
+        let index = YamlIndex::build(yaml.as_bytes()).unwrap();
+        let root = index.root(yaml.as_bytes());
+        let YamlValue::Mapping(fields) = first_doc(root) else {
+            panic!("expected root document to be a mapping");
+        };
+        let z_cursor = fields.find_cursor("z").expect("z field must exist");
+        let _ = z_cursor.tag();
+    }
+
     #[test]
     fn test_simple_mapping_navigation() {
         let yaml = b"name: Alice";

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -452,16 +452,31 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// rather than just the resolved value. `self` need not itself be an
     /// alias -- returns `self` unchanged (zero hops) if it isn't.
     ///
-    /// Kept as its own loop rather than
-    /// `self.resolve_alias_chain().map(|_| some_cursor)`: there is no
-    /// cursor to hand back from that method's own result (its loop
-    /// deliberately discards `current` once it has `current`'s `.value()`
-    /// -- see its own doc comment's efficiency finding, #1191 code
-    /// review), so reusing it here would mean re-deriving the target
-    /// cursor by some other means anyway. A `pub`, not `pub(crate)`,
-    /// visibility (unlike its sibling): `yaml_to_owned_value`
-    /// (`src/bin/succinctly/yq_runner.rs`) is a separate binary crate and
-    /// needs to call this directly.
+    /// Deliberately its own loop, not composed with `resolve_alias_chain`
+    /// in *either* direction, both for the same reason (avoiding a
+    /// redundant `.value()` call -- `#1191`'s own review already
+    /// established this cost is real and unconditional, not just on long
+    /// chains): `resolve_alias_chain` couldn't hand back a cursor even if
+    /// asked (its loop discards `current` once it has computed
+    /// `current.value()`, by design), and this method can't be *defined*
+    /// via `resolve_alias_chain().map(|_| cursor)` either, for the same
+    /// reason in reverse -- there is no cursor left to map from by the
+    /// time that method returns.
+    ///
+    /// This method's own 5 call sites still pay a version of that same
+    /// cost: each calls `resolved.<method>(...)`, and every one of those
+    /// methods opens with its own `match self.value() {...}` -- so
+    /// `.value()` on the terminal cursor is computed once by this loop's
+    /// exit check (and discarded) and once more by the method the caller
+    /// invokes. Unlike `resolve_alias_chain`'s callers, there is no way to
+    /// avoid this without threading an already-computed `YamlValue`
+    /// through 5 otherwise-cursor-only method signatures -- accepted as a
+    /// real but small (non-chain-scaling) cost, not benchmarked separately
+    /// from the fix as a whole.
+    ///
+    /// A `pub`, not `pub(crate)`, visibility (unlike its sibling):
+    /// `yaml_to_owned_value` (`src/bin/succinctly/yq_runner.rs`) is a
+    /// separate binary crate and needs to call this directly.
     ///
     /// Returns `None` only for a dangling (unresolvable) target. Panics
     /// past `MAX_ALIAS_CHAIN_DEPTH` (both private, not linkable from this
@@ -469,7 +484,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// via the shared `assert_depth` -- the loop itself costs O(1) stack
     /// regardless of chain length, so this bound exists purely to cap the
     /// CPU time one call can be forced to spend on a pathologically long,
-    /// adversarially crafted chain.
+    /// adversarially crafted chain. `#[track_caller]`, matching
+    /// `resolve_alias_chain`'s own convention (and this crate's general
+    /// one, #1020 code review) so a panic through any of this method's 5
+    /// call sites is attributable rather than collapsing to this shared
+    /// loop's own line.
+    #[track_caller]
     pub fn resolve_alias_target_cursor(&self) -> Option<Self> {
         let mut current = *self;
         let mut depth = 0usize;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -442,6 +442,45 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         }
     }
 
+    /// Follows a chain of `Alias` nodes to the *cursor* of its final
+    /// non-alias target, iteratively rather than recursively (#1193, PR
+    /// #1314) -- the cursor-returning sibling of `resolve_alias_chain`
+    /// above (a private method, not linkable from this public one), for
+    /// callers that need to re-invoke a cursor method on the
+    /// resolved target (`stream_json_value`, `write_json_to`, `tag`, and
+    /// the CLI/evaluator's `yaml_to_owned_value`/`yaml_value_to_owned`)
+    /// rather than just the resolved value. `self` need not itself be an
+    /// alias -- returns `self` unchanged (zero hops) if it isn't.
+    ///
+    /// Kept as its own loop rather than
+    /// `self.resolve_alias_chain().map(|_| some_cursor)`: there is no
+    /// cursor to hand back from that method's own result (its loop
+    /// deliberately discards `current` once it has `current`'s `.value()`
+    /// -- see its own doc comment's efficiency finding, #1191 code
+    /// review), so reusing it here would mean re-deriving the target
+    /// cursor by some other means anyway. A `pub`, not `pub(crate)`,
+    /// visibility (unlike its sibling): `yaml_to_owned_value`
+    /// (`src/bin/succinctly/yq_runner.rs`) is a separate binary crate and
+    /// needs to call this directly.
+    ///
+    /// Returns `None` only for a dangling (unresolvable) target. Panics
+    /// past `MAX_ALIAS_CHAIN_DEPTH` (both private, not linkable from this
+    /// public method), mirroring every other depth ceiling in this crate
+    /// via the shared `assert_depth` -- the loop itself costs O(1) stack
+    /// regardless of chain length, so this bound exists purely to cap the
+    /// CPU time one call can be forced to spend on a pathologically long,
+    /// adversarially crafted chain.
+    pub fn resolve_alias_target_cursor(&self) -> Option<Self> {
+        let mut current = *self;
+        let mut depth = 0usize;
+        while let YamlValue::Alias { target, .. } = current.value() {
+            assert_depth(depth, MAX_ALIAS_CHAIN_DEPTH);
+            depth += 1;
+            current = target?;
+        }
+        Some(current)
+    }
+
     /// Skip past a leading `&anchor` and/or `!tag` (either order, each at
     /// most once) and any following whitespace.
     ///
@@ -2074,16 +2113,19 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 out.write_char(']')
             }
             YamlValue::Alias { target, .. } => {
-                if let Some(target_cursor) = target {
-                    target_cursor.stream_json_value(
+                // Resolve the *entire* chain first (#1193), not just this
+                // one hop: the resolved cursor's own `.value()` is
+                // guaranteed non-`Alias`, so this recursive call terminates
+                // in exactly one more step regardless of chain length.
+                match target.and_then(|t| t.resolve_alias_target_cursor()) {
+                    Some(resolved) => resolved.stream_json_value(
                         out,
                         current_indent,
                         indent_spaces,
                         unit,
                         sort_keys,
-                    )
-                } else {
-                    out.write_str("null")
+                    ),
+                    None => out.write_str("null"),
                 }
             }
             YamlValue::Error(_) => out.write_str("null"),
@@ -2192,10 +2234,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 output.push(']');
             }
             YamlValue::Alias { target, .. } => {
-                if let Some(target_cursor) = target {
-                    target_cursor.write_json_to(output);
-                } else {
-                    output.push_str("null");
+                // See `stream_json_value`'s matching `Alias` arm (#1193):
+                // resolve the whole chain first so this call terminates in
+                // exactly one more step regardless of chain length.
+                match target.and_then(|t| t.resolve_alias_target_cursor()) {
+                    Some(resolved) => resolved.write_json_to(output),
+                    None => output.push_str("null"),
                 }
             }
             YamlValue::Error(_) => output.push_str("null"),
@@ -2579,11 +2623,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             YamlValue::Mapping(_) => "!!map",
             YamlValue::Sequence(_) => "!!seq",
             YamlValue::Alias { target, .. } => {
-                // Return tag of target
-                if let Some(t) = target {
-                    t.tag()
-                } else {
-                    "!!null"
+                // Return the tag of the fully-resolved target (#1193): see
+                // `stream_json_value`'s matching `Alias` arm.
+                match target.and_then(|t| t.resolve_alias_target_cursor()) {
+                    Some(resolved) => resolved.tag(),
+                    None => "!!null",
                 }
             }
             YamlValue::Error(_) => "!!null",

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4841,6 +4841,84 @@ fn test_yaml_direct_self_alias_cycle() -> Result<()> {
 }
 
 // =============================================================================
+// Deep (non-cyclic) alias-chain recursion guard (#1193) -- a syntactically
+// valid chain of anchored aliases, each referencing the previous, that never
+// revisits its own anchor (so #153's cycle check above doesn't reject it),
+// used to drive real, uncatchable stack overflow through
+// `YamlValue::Alias`'s recursive scalar accessors.
+// =============================================================================
+
+/// Builds `k0: &a0 <leaf>`, `k1: &a1 *a0`, ..., `z: *a{depth - 1}` -- a
+/// chain of `depth` anchored aliases, each hopping to the previous, with a
+/// top-level `z` referencing the tail.
+fn deep_alias_chain(depth: usize, leaf: &str) -> String {
+    let mut doc = String::new();
+    for i in 0..depth {
+        if i == 0 {
+            doc.push_str(&format!("k{i}: &a{i} {leaf}\n"));
+        } else {
+            doc.push_str(&format!("k{i}: &a{i} *a{}\n", i - 1));
+        }
+    }
+    doc.push_str(&format!("z: *a{}\n", depth - 1));
+    doc
+}
+
+#[test]
+fn test_yaml_deep_alias_chain_does_not_stack_overflow_1193() -> Result<()> {
+    // 50,000 hops crashed with SIGABRT (exit 134, "stack overflow, aborting")
+    // before the fix; the issue's own measurement found 20,000 hops still
+    // safe under the old recursive accessors. `[.z]` array-wraps the tail so
+    // the query is forced through `to_owned_at_depth`'s typed accessors
+    // (`as_bool`/`as_i64`/.../`type_name`) rather than the identity-output
+    // streaming path, which resolves aliases differently (and is untouched
+    // by this fix). An integer leaf exercises `as_i64`, confirming the fix
+    // doesn't just avoid the crash but resolves the full chain correctly.
+    let input = deep_alias_chain(50_000, "42");
+    let (stdout, stderr, exit_code) =
+        run_yq_stdin_with_stderr("[.z]", &input, &["-o", "json", "--indent", "0"])?;
+    assert_eq!(exit_code, 0, "expected a clean exit, stderr: {stderr}");
+    assert_eq!(stdout.trim(), "[42]");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_moderate_alias_chain_resolves_through_every_hop_1193() -> Result<()> {
+    // A chain well short of any depth guard, confirming the iterative
+    // `resolve_alias_chain` walk is correct at ordinary depths, not just
+    // crash-safe at extreme ones. `as_bool` is one of the accessors that
+    // used to recurse via `target.and_then(|t| t.value().as_bool())`.
+    let input = deep_alias_chain(25, "true");
+    let (stdout, exit_code) = run_yq_stdin("[.z, (.z and true)]", &input, &["-o", "json"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(stdout.trim(), "[\n  true,\n  true\n]");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_alias_chain_past_depth_cap_panics_cleanly_not_via_stack_overflow_1193() -> Result<()> {
+    // Past `MAX_ALIAS_CHAIN_DEPTH` (65,536), `resolve_alias_chain` panics
+    // (via `assert_depth`, mirroring this crate's other `MAX_*` depth
+    // ceilings) rather than looping forever. A `Result::unwrap`-style Rust
+    // panic unwinds cleanly to exit 101 with a message -- a world apart from
+    // the uncatchable exit-134 SIGABRT this issue reports, even though
+    // neither is catchable by a jq `try`/`catch` inside the query itself.
+    let input = deep_alias_chain(70_000, "42");
+    let (stdout, stderr, exit_code) =
+        run_yq_stdin_with_stderr("[.z]", &input, &["-o", "json", "--indent", "0"])?;
+    assert_eq!(
+        exit_code, 101,
+        "expected a clean panic exit, stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("nesting depth exceeds limit"),
+        "stderr should name the depth guard: {stderr}"
+    );
+    Ok(())
+}
+
+// =============================================================================
 // Compatibility tests - Block scalar edge cases
 // =============================================================================
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4918,6 +4918,44 @@ fn test_yaml_alias_chain_past_depth_cap_panics_cleanly_not_via_stack_overflow_11
     Ok(())
 }
 
+#[test]
+fn test_yaml_deep_alias_chain_json_stream_output_does_not_stack_overflow_1193() -> Result<()> {
+    // `[.z]` (used by the tests above) forces materialization through
+    // `to_owned_at_depth`'s typed accessors. Bare `.z` with `-o json`
+    // instead forces `YamlCursor::stream_json_value`/`write_json_to` -- a
+    // completely separate alias-following code path with its own
+    // independent self-recursion, found live during this PR's own review:
+    // `succinctly yq -o json '.'` (this repo's own CLAUDE.md-documented
+    // standard invocation) SIGABRTed on a long chain even after the
+    // typed-accessor fix above, since neither `stream_json_value` nor
+    // `write_json_to` called into `resolve_alias_chain` at all yet.
+    let input = deep_alias_chain(50_000, "42");
+    let (stdout, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".z", &input, &["-o", "json", "--indent", "0"])?;
+    assert_eq!(exit_code, 0, "expected a clean exit, stderr: {stderr}");
+    assert_eq!(stdout.trim(), "42");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_alias_chain_through_owned_evaluator_bridge_does_not_stack_overflow_1193() -> Result<()>
+{
+    // Arithmetic (`+`) isn't cursor-native in the lazy evaluator, so it
+    // bridges to the full/owned evaluator, which materializes the input
+    // document via `yaml_value_to_owned` (src/jq/eval.rs) -- a third
+    // independent alias-following recursion found live during this PR's
+    // own review, distinct from both the typed accessors and the JSON
+    // streaming writer above. Kept small (500 hops, not 50,000): this
+    // whole-document conversion path has a separate, pre-existing O(n^2)
+    // total-work cost for a document shaped like this one (#1317) that
+    // isn't this test's concern -- only crash-safety and correctness are.
+    let input = deep_alias_chain(500, "42");
+    let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".z + 1", &input, &[])?;
+    assert_eq!(exit_code, 0, "expected a clean exit, stderr: {stderr}");
+    assert_eq!(stdout.trim(), "43");
+    Ok(())
+}
+
 // =============================================================================
 // Compatibility tests - Block scalar edge cases
 // =============================================================================


### PR DESCRIPTION
## Summary

- `YamlValue::Alias`'s typed accessors (`as_bool`/`as_i64`/`as_f64`/`number_literal`/`as_object`/`as_array`/`type_name`/`is_null`) each resolved one alias hop via `target.and_then(|t| t.value().<same accessor>())`, re-entering themselves once per hop. A syntactically valid, **non-cyclic** chain of tens of thousands of anchored aliases drove real, uncatchable stack overflow (`SIGABRT`, exit 134) through that self-recursion — confirmed live, matching the issue's own repro.
- This is distinct from #153's existing build-time cycle check, which only rejects a chain that revisits its own anchor, not one that is merely very long.
- Fix: replace the self-recursion with an explicit iterative walk (`YamlValue::resolve_alias_chain`), which costs O(1) stack regardless of chain length, plus a `MAX_ALIAS_CHAIN_DEPTH` (65,536) ceiling — via the crate's existing shared `assert_depth` helper, mirroring `MAX_NESTING_DEPTH`/`MAX_VALUE_TREE_DEPTH` — to bound the worst-case CPU time one accessor call can be forced to spend on a pathologically long adversarial chain. Past the cap it panics cleanly (exit 101 with a message), not via stack corruption.

## Verification

- Confirmed the crash reproduces on `main` today (`[.z]` over a 50,000-hop chain → exit 134, `thread 'main' has overflowed its stack`).
- Confirmed it no longer crashes on this branch (same query → exit 0, correct value for an int/bool-terminated chain).
- Confirmed `as_i64`/`as_bool` correctly resolve the *full* chain (not just avoid crashing) at both moderate (25-hop) and extreme (50,000-hop) depths.
- Confirmed the depth cap itself fires cleanly (exit 101, not a crash) past 65,536 hops.
- Full existing test suite green (`cargo test --features cli,simd,regex,serde`, 0 failures), both CI `clippy` legs clean, `cargo fmt --check` clean, `cargo check --no-default-features` (no_std) clean.

## Scope notes (deliberately not fixed here — filed as follow-ups)

- `as_str`/`key_string` were **not** touched — they were already non-recursive (bounded to a single alias hop), so not a DoS vector, but they also don't correctly resolve a chain more than 1 hop deep (a separate, pre-existing correctness gap, confirmed present on `main` today too).
- Identity/streaming output (`succinctly yq '.z'` with no wrapping) shows the alias's *literal source text* (`*a0`) rather than resolving it at all for a multi-hop chain — a different, pre-existing code path (the M2/P9 direct-streaming writer), also confirmed present on `main` today, unrelated to the accessors this PR fixes.
- Full-document materialization (`.`, or any query that forces the full/owned evaluator) on a document shaped like "every field's own alias chain is one hop longer than the previous field's" costs O(n²) — confirmed via direct A/B timing to be **identical** between `main` and this branch (same total work, this PR only removes the *stack growth*, not the *time complexity*). A genuinely compact adversarial document could still exploit this for CPU-time (not crash) DoS; that needs alias-target memoization, a deeper architectural change out of scope here.

I'll file GitHub issues for the three items above right after this PR.

Fixes #1193