### PR TITLE
fix(jq): check del()'s string-slice refusal before its optional catch-all

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20432,8 +20432,15 @@ fn delete_at_path(
             }
             // `null` has no elements to drop, so jq leaves it alone.
             OwnedValue::Null => Ok(()),
-            _ if optional => Ok(()),
+            // Checked *before* the `optional` catch-all below, mirroring
+            // `through_slice`'s own ordering (#1312): a string slice target
+            // is a write-time application refusal jq's inline `?` does not
+            // suppress, not a navigation failure -- `del(.[0:1]?)` on a
+            // string still raises "Cannot delete fields from string" in
+            // real jq, confirmed live. The old order let `optional` shadow
+            // this arm entirely whenever a `?` was present.
             OwnedValue::String(_) => Err(EvalError::cannot_delete_fields_from("string")),
+            _ if optional => Ok(()),
             other => Err(EvalError::cannot_index_with_type(
                 owned_type_name(other),
                 "object",
@@ -40963,6 +40970,47 @@ mod tests {
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "Cannot index number with number");
             }
+        );
+    }
+
+    #[test]
+    fn test_del_slice_on_string_target_ignores_optional_1312() {
+        // #1312: `delete_at_path`'s standalone (terminal) `Expr::Slice` arm
+        // checked its `_ if optional => Ok(())` catch-all *before* the
+        // `OwnedValue::String(_)` arm, so a `?`-marked slice targeting a
+        // string was shadowed into a silent no-op instead of raising. Real
+        // jq's inline `?` only suppresses a failure to *reach* a target, not
+        // a write-time application refusal like this one -- the same
+        // distinction #1303 fixed for `=`'s equivalent gap. A genuinely
+        // non-sliceable target (a `?`-marked slice on a boolean) is a
+        // navigation failure and stays correctly suppressed either way. All
+        // confirmed against real jq 1.7.1.
+        query!(br#""hello""#, r"del(.[0:1]?)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot delete fields from string");
+            }
+        );
+        query!(br#"{"a":"hello"}"#, r"del(.a[0:1]?)",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot delete fields from string");
+            }
+        );
+        // Unaffected: no `?` at all still errors the same way.
+        query!(br#""hello""#, r"del(.[0:1])",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot delete fields from string");
+            }
+        );
+        // Unaffected: an array slice target still deletes normally.
+        query!(br"[1,2,3]", r"del(.[0:1]?)",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), "[2,3]");
+            }
+        );
+        // Unaffected: a genuinely non-sliceable target under `?` stays
+        // suppressed -- this is a navigation failure, not a write-time one.
+        query!(br"true", r"del(.[0:1]?)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
         );
     }
 


### PR DESCRIPTION
## Summary

`del(.[0:1]?)` on a string silently no-op'd instead of raising.

```
$ echo '"hello"' | jq 'del(.[0:1]?)'
jq: error (at <stdin>:1): Cannot delete fields from string
$ echo '"hello"' | succinctly jq 'del(.[0:1]?)'   # before
"hello"
```

Found during review of #1310 (fixes #1303, `=`'s equivalent gap) — filed as #1312.

## Root cause

`delete_at_path`'s standalone (terminal, non-mid-chain) `Expr::Slice` arm ordered its match:

```rust
Expr::Slice { start, end } => match root {
    OwnedValue::Array(arr) => { ... }
    OwnedValue::Null => Ok(()),
    _ if optional => Ok(()),                                          // <- checked first
    OwnedValue::String(_) => Err(cannot_delete_fields_from("string")),  // <- shadowed
    other => Err(cannot_index_with_type(...)),
},
```

Whenever `optional` was `true` (a `?` on the slice), the catch-all fired before the `String` arm ever got a chance — the write-time application refusal never ran. `through_slice` (used by `set_path`/`update_path`, and by `del()`'s own *mid-chain* `Pipe` arm when more path follows the slice) already orders these correctly: type-specific arms before the generic `_ if optional` catch-all. This standalone arm was the one place that didn't match that ordering.

Real jq's inline `?` only suppresses a failure to *reach* a target while collecting a path — not a mismatch in what's being deleted once one is found. This is the same distinction #1303 fixed for `=`'s equivalent gap (`is_write_time_application_error`).

## Fix

Reordered the match arms: `OwnedValue::String(_) => Err(...)` now comes before `_ if optional => Ok(())`, mirroring `through_slice`'s ordering. A genuinely non-sliceable target (e.g. a `?`-marked slice on a boolean) is unaffected — that's still a navigation failure, correctly suppressed either way.

## Verification

- [x] Both repros (bare and nested) byte-match pinned jq 1.7.1
- [x] Regression-checked: no-`?` case, array-slice-target case, and non-sliceable-target-under-`?` case all unaffected
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `omni-dev coverage diff` — 100% patch coverage (17/17 new lines)

## Note

While testing this, found a separate, unrelated, pre-existing divergence (reproduces identically with or without `?`, on both `main` before this PR and this branch): `del(.a[0:1]?.b)` on a string gives `Cannot update string slices` where real jq gives `Cannot index string with string "b"` (a mid-chain slice-then-field shape). Will file as its own follow-up rather than expand this PR's scope.

Fixes #1312