### PR TITLE
fix(jq): make integer modulo by zero error in yq mode

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -893,6 +893,15 @@ impl EvalError {
         )
     }
 
+    /// `cannot modulo by 0` — real yq's own wording for an integer modulo
+    /// by zero (#1231), confirmed live against yq v4.53.3. Unlike jq's
+    /// [`Self::divisor_is_zero`], this is a fixed sentence with no embedded
+    /// operand values, and applies only to the integer case: a
+    /// float-involving modulo by zero returns NaN in yq, not an error.
+    pub fn yq_modulo_by_zero() -> Self {
+        Self::new("cannot modulo by 0")
+    }
+
     /// `<a> and <b> cannot have their containment checked`.
     pub fn containment_check(left: &OwnedValue, right: &OwnedValue) -> Self {
         Self::pair(left, right, "cannot have their containment checked")

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2518,11 +2518,21 @@ fn arith_mod<S: EvalSemantics>(
     match (left.number_repr(), right.number_repr()) {
         (Some(NumberRepr::Int(a)), Some(NumberRepr::Int(b))) => {
             if b == 0 {
-                if S::DIV_BY_ZERO_IS_INFINITY {
-                    // yq behavior: return NaN (will be serialized as null)
-                    Ok(OwnedValue::Float(f64::NAN))
+                // Integer modulo by zero errors in both jq and yq --
+                // unlike division, yq's Infinity-on-zero-divisor rule
+                // (`DIV_BY_ZERO_IS_INFINITY`) does not extend to this
+                // case (#1231, confirmed live against yq v4.53.3: `5 %
+                // 0` errors "cannot modulo by 0", where `5 / 0` succeeds
+                // as `+Inf`). Only a *float*-involving modulo by zero
+                // returns NaN in yq (`mod_floats` below, gated by
+                // `MOD_TRUNCATES_FLOATS`) -- so this arm is unconditional
+                // on `S::DIV_BY_ZERO_IS_INFINITY`, unlike every other
+                // zero-divisor check in this file. yq's own wording is a
+                // fixed, terser sentence with no embedded operand values,
+                // unlike jq's `divisor_is_zero`.
+                if S::TAG == EvalTag::Yq {
+                    Err(EvalError::yq_modulo_by_zero())
                 } else {
-                    // jq behavior: error
                     Err(EvalError::divisor_is_zero(&left, &right, BinOp::Modulo))
                 }
             } else {
@@ -27948,6 +27958,45 @@ mod tests {
         // jq: infinite saturates to i64::MAX, so infinite % 3 == 1
         query!(b"null", "infinite % 3",
             QueryResult::Owned(OwnedValue::Int(1)) => {}
+        );
+    }
+
+    #[test]
+    fn test_yq_modulo_by_zero_errors_but_division_does_not_1231() {
+        // #1231: real yq's DIV_BY_ZERO_IS_INFINITY rule (5 / 0 -> +Inf)
+        // does not extend to an *integer* modulo -- 5 % 0 errors there,
+        // unlike jq's own `divisor_is_zero` wording, yq's own message has
+        // no embedded operand values. Confirmed live against yq v4.53.3.
+        yq_query!(b"null", "5 % 0",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "cannot modulo by 0");
+            }
+        );
+        // Division by zero is unaffected -- still succeeds as Infinity.
+        yq_query!(b"null", "5 / 0",
+            QueryResult::Owned(OwnedValue::Float(f)) if f.is_infinite() && f > 0.0 => {}
+        );
+        // A *float*-involving modulo by zero is also unaffected -- yq
+        // performs real float modulo and returns NaN, not an error, for
+        // any of the three float/int-zero combinations.
+        yq_query!(b"null", "5.5 % 0",
+            QueryResult::Owned(OwnedValue::Float(f)) if f.is_nan() => {}
+        );
+        yq_query!(b"null", "5 % 0.0",
+            QueryResult::Owned(OwnedValue::Float(f)) if f.is_nan() => {}
+        );
+        yq_query!(b"null", "5.5 % 0.0",
+            QueryResult::Owned(OwnedValue::Float(f)) if f.is_nan() => {}
+        );
+        // jq mode is unaffected either way -- both already errored, and
+        // still do, with jq's own wording.
+        query!(b"null", "5 % 0",
+            QueryResult::Error(e) => {
+                assert_eq!(
+                    e.message,
+                    "number (5) and number (0) cannot be divided (remainder) because the divisor is zero"
+                );
+            }
         );
     }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14938,25 +14938,43 @@ fn test_1198_mixed_int_float_subtraction_unaffected() -> Result<()> {
 // apply unchanged. See tests/jq_cli_tests.rs's own `_1199` tests for the
 // full jq-mode coverage of every operator, including `divisor_is_zero`.
 //
-// succinctly's own yq mode never reaches `divisor_is_zero` for `/`/`%` at
-// all (`YqSemantics::DIV_BY_ZERO_IS_INFINITY = true` routes both to a
-// success value -- `1e10 / 0` and `1e10 % 0` both exit 0 against this
-// binary), so there is no yq-mode `divisor_is_zero` case to test here.
-// This is *not* the same as saying real yq itself succeeds on these --
-// checked directly against the oracle and it doesn't: `10 % 0` errors
-// there too ("cannot modulo by 0", tracked separately as #1231, since
-// `DIV_BY_ZERO_IS_INFINITY` conflates div and mod where real yq treats
-// them differently), and `10 / 0` also errors there, but for an unrelated
-// reason -- real yq's JSON output layer refuses to serialize the
-// resulting `+Inf` at all ("json: unsupported value: +Inf"), a pre-
-// existing output-formatting gap, not an arithmetic-evaluation one, and
-// out of scope for both #1199 and #1231.
+// succinctly's own yq mode never reaches `divisor_is_zero` for `/` (still
+// routes to a success value -- `YqSemantics::DIV_BY_ZERO_IS_INFINITY =
+// true`, `1e10 / 0` exits 0 against this binary), so there is no yq-mode
+// `divisor_is_zero` case to test for division. `%` is different: #1231
+// found real yq treats div and mod differently at zero (`10 % 0` errors
+// there, `10 / 0` succeeds as `+Inf`) where `DIV_BY_ZERO_IS_INFINITY`
+// conflated the two -- fixed by #1231, which routes an integer
+// modulo-by-zero to `EvalError::yq_modulo_by_zero()` ("cannot modulo by
+// 0") unconditionally, matching the oracle; see
+// `test_yq_modulo_by_zero_errors_but_division_does_not_1231` in
+// `src/jq/eval.rs` for that coverage. `10 / 0` still errors against the
+// real oracle too, but for an unrelated reason -- real yq's JSON output
+// layer refuses to serialize the resulting `+Inf` at all ("json:
+// unsupported value: +Inf"), a pre-existing output-formatting gap, not an
+// arithmetic-evaluation one, and out of scope for both #1199 and #1231.
 
 #[test]
 fn test_1199_binary_op_error_preserves_number_literal_spelling_yq_mode() -> Result<()> {
     let (_out, err, code) = run_yq_stdin_with_stderr("1e10 * {}", "null", &["-o=json"])?;
     assert_eq!(code, 1, "{err}");
     assert!(err.contains("number (1E+10)"), "{err}");
+    Ok(())
+}
+
+#[test]
+fn test_1231_yq_integer_modulo_by_zero_errors_but_division_does_not() -> Result<()> {
+    let (_out, err, code) = run_yq_stdin_with_stderr("10 % 0", "null", &["-o=json"])?;
+    assert_eq!(code, 1, "{err}");
+    assert!(err.contains("cannot modulo by 0"), "{err}");
+
+    // Division by zero is unaffected -- still succeeds (as Infinity, which
+    // `-o=json` serializes as `null`, JSON having no numeric representation
+    // for it -- a pre-existing, unrelated serialization choice, not part of
+    // #1231's own scope).
+    let (out, code) = run_yq_stdin("10 / 0", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`5 % 0` silently returned `null` (a serialized NaN) in yq mode instead of erroring.

```
$ echo null | yq '5 % 0'
Error: cannot modulo by 0
$ echo null | succinctly yq '5 % 0'   # before
null
```

Real yq's Infinity-on-zero-divisor rule for division doesn't extend to an integer modulo — confirmed live against yq v4.53.3: `5 / 0` succeeds as `+Inf`, but `5 % 0` errors.

## Root cause

`arith_mod`'s `Int`-`Int` arm deferred to `DIV_BY_ZERO_IS_INFINITY`, the same `EvalSemantics` flag `arith_div` uses to decide whether a zero divisor succeeds (yq) or errors (jq). That's correct for division, but wrong for this one case: real yq's own modulo-by-zero behavior doesn't follow the same rule its division does.

A *float*-involving modulo by zero was already correct — `mod_floats` (gated by the separate `MOD_TRUNCATES_FLOATS` flag) already returns NaN for `5.5 % 0`, `5 % 0.0`, and `5.5 % 0.0` in yq mode, matching real yq exactly. Only the pure-integer case needed a fix.

## Fix

No new `EvalSemantics` flag needed — jq and yq behave *identically* for integer modulo by zero (both error), just with different wording. The `Int`-`Int` arm is now unconditional on `DIV_BY_ZERO_IS_INFINITY`; it branches only on `S::TAG` to pick which message to raise: jq's existing `divisor_is_zero` (unchanged), or a new `yq_modulo_by_zero()` constructor producing yq's own terser, operand-value-free wording (`"cannot modulo by 0"`).

## Verification

- [x] `5 % 0` in yq mode now byte-matches real yq's exact message (`"cannot modulo by 0"`)
- [x] Division by zero unaffected — still succeeds as `+Inf` in yq mode
- [x] All three float-involving modulo-by-zero combinations (`5.5 % 0`, `5 % 0.0`, `5.5 % 0.0`) unaffected — still correctly return NaN
- [x] jq mode unaffected — `5 % 0` still errors with jq's own existing wording, byte-identical to real jq
- [x] No existing yq-golden fixture covers this case (checked) — no drift risk
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `omni-dev coverage diff` — 100% patch coverage (21/21 new lines)

Fixes #1231