### PR TITLE
fix(jq): reject all non-str/int delpaths path components in yq mode

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -518,20 +518,24 @@ impl EvalError {
         Self::new(format!("Path must be specified as array, not {type_name}"))
     }
 
-    /// `DELPATHS: expected either a !!str or !!int in the path, found !!map instead`.
+    /// `DELPATHS: expected either a !!str or !!int in the path, found <tag> instead`.
     ///
-    /// yq-mode-only (#1162): unlike real jq, which accepts a slice-descriptor
-    /// path component (`{"start":s,"end":e}`, `path(.[a:b])`'s own output
-    /// shape) at any position in a `delpaths()` path and splices through the
-    /// named sub-range, real yq rejects one outright — verified live against
-    /// yq v4.53.3 with this exact wording, at both a top-level and a nested
-    /// position. Real yq's `delpaths()` is actually stricter still (also
-    /// rejects a float/bool/array component with the same message, substituting
-    /// its own type's tag), but this constructor covers only the slice-
-    /// descriptor shape #1162 itself scoped — the broader rejection is
-    /// tracked separately as #1220.
-    pub fn delpaths_rejects_slice_descriptor() -> Self {
-        Self::new("DELPATHS: expected either a !!str or !!int in the path, found !!map instead")
+    /// yq-mode-only. Real yq's `delpaths()` accepts only `!!str`/`!!int`
+    /// path components — every other YAML type errors here, `tag` naming
+    /// whichever one was actually found. Originally #1162 (a slice-
+    /// descriptor path component, `{"start":s,"end":e}`, `path(.[a:b])`'s
+    /// own output shape — unlike real jq, which accepts one at any position
+    /// and splices through the named sub-range) scoped this to just
+    /// `!!map`; #1220 found the real rule is this much broader one —
+    /// `!!null`/`!!bool`/`!!float`/`!!seq` all hit the identical message,
+    /// substituting their own tag. Verified live against yq v4.53.3 for
+    /// every variant, at both a top-level and a nested position, including
+    /// that a plain `!!int` is accepted but a whole-number-valued `!!float`
+    /// (`1.0`) is not.
+    pub fn delpaths_rejects_type(tag: &str) -> Self {
+        Self::new(format!(
+            "DELPATHS: expected either a !!str or !!int in the path, found {tag} instead"
+        ))
     }
 
     /// `Cannot delete fields from <type>`.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23659,31 +23659,49 @@ fn builtin_delpaths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // (`1.0`) is rejected too -- real yq's check is on the YAML type, not
     // the numeric value, confirmed live. Folded into this same `retain`
     // pass rather than a separate loop before it: both checks need to
-    // visit every path's every component before any deletion runs. Gated
-    // on `keeps` (the same per-path NaN survival this `retain` already
-    // computes), not checked unconditionally, so a path that's *also*
-    // NaN-headed doesn't surface the type error for a path already headed
-    // for silent removal. `rejected_component_tag` keeps only the first
-    // offender found (path order, then component order within a path) --
-    // confirmed live that real yq reports whichever type-mismatched
-    // component it reaches first when several paths/components each
-    // qualify.
+    // visit every path's every component before any deletion runs.
+    //
+    // No exemption for a `path()`-sourced float index (#1220 issue thread):
+    // yq-mode `path()` is itself a succinctly extension with no upstream
+    // behavior (real yq has no `path`/`getpath`/`setpath` at all), so a
+    // float index it emits isn't oracle-constrained either way. This check
+    // stays strict rather than special-casing that producer, because its
+    // own job -- matching real yq's `delpaths()` -- is oracle-backed and
+    // takes priority; a `path()` round-trip through `delpaths()` was never
+    // a real-yq guarantee to preserve.
+    //
+    // Deliberately run *unconditionally*, not gated on `keeps` (the NaN
+    // survival this `retain` also computes): a NaN-headed path can still
+    // carry a genuinely bad-typed component alongside its NaN (e.g.
+    // `delpaths([[nan, true]])`), and that component must still be caught
+    // even though the NaN itself heads the path for silent removal. The
+    // `find` predicate below explicitly exempts a NaN `Float` from being
+    // *itself* reported as the offender -- `delpaths([[nan]])` alone still
+    // silently drops rather than erroring, preserving the NaN-drop behavior
+    // above unchanged. (Gating this on `keeps` would let a co-located
+    // non-NaN bad component through unnoticed whenever any NaN shared its
+    // path -- confirmed live before this exemption was added.)
+    // `rejected_component_tag` keeps only the first offender found (path
+    // order, then component order within a path) -- confirmed live that
+    // real yq reports whichever type-mismatched component it reaches first
+    // when several paths/components each qualify.
     let mut rejected_component_tag: Option<&'static str> = None;
     paths.retain(|path| match path {
         OwnedValue::Array(components) => {
             let keeps = !components
                 .iter()
                 .any(|key| matches!(key, OwnedValue::Float(f) if f.is_nan()));
-            if keeps && S::TAG == EvalTag::Yq && rejected_component_tag.is_none() {
+            if S::TAG == EvalTag::Yq && rejected_component_tag.is_none() {
                 rejected_component_tag = components
                     .iter()
                     .find(|component| {
-                        !matches!(
-                            component,
-                            OwnedValue::String(_)
-                                | OwnedValue::Int(_)
-                                | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
-                        )
+                        !matches!(component, OwnedValue::Float(f) if f.is_nan())
+                            && !matches!(
+                                component,
+                                OwnedValue::String(_)
+                                    | OwnedValue::Int(_)
+                                    | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
+                            )
                     })
                     .map(delpaths_component_type_tag);
             }
@@ -45864,5 +45882,34 @@ mod tests {
             result.is_err(),
             "collect_leaf_paths should panic at MAX_VALUE_TREE_DEPTH (Object arm)"
         );
+    }
+
+    /// #1220 code review: `delpaths_component_type_tag` (`OwnedValue` ->
+    /// tag) and `yaml_type_tag` (`StandardJson` -> tag, backs the `tag`
+    /// builtin and `join`'s yq-mode error) independently implement the same
+    /// seven-category YAML tag mapping ~1400 lines apart, with nothing
+    /// enforcing they agree -- the exact "duplicated predicates diverge
+    /// silently" shape this codebase's own optimization notes warn about
+    /// (issue #106). Pins them to the same answer for one representative
+    /// value per category so a future edit to either one's tag spelling
+    /// (or int/float boundary) that isn't mirrored in the other fails here
+    /// instead of silently producing inconsistent error wording between
+    /// `tag`/`join` and `delpaths`.
+    #[test]
+    fn test_1220_delpaths_and_tag_type_tags_agree() {
+        macro_rules! assert_tag_agrees {
+            ($json:expr, $owned:expr) => {{
+                let via_tag_builtin =
+                    yq_query!($json, "tag", QueryResult::Owned(OwnedValue::String(s)) => s);
+                assert_eq!(via_tag_builtin, delpaths_component_type_tag(&$owned));
+            }};
+        }
+        assert_tag_agrees!(b"null", OwnedValue::Null);
+        assert_tag_agrees!(b"true", OwnedValue::Bool(true));
+        assert_tag_agrees!(b"1", OwnedValue::Int(1));
+        assert_tag_agrees!(b"1.5", OwnedValue::Float(1.5));
+        assert_tag_agrees!(b"\"a\"", OwnedValue::String("a".to_string()));
+        assert_tag_agrees!(b"[1]", OwnedValue::Array(vec![OwnedValue::Int(1)]));
+        assert_tag_agrees!(b"{}", OwnedValue::Object(IndexMap::new()));
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23568,6 +23568,30 @@ fn builtin_isempty<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     QueryResult::Owned(OwnedValue::Bool(is_empty))
 }
 
+/// The YAML type tag (`!!str`, `!!int`, `!!float`, ...) `builtin_delpaths`'s
+/// own yq-mode type check reports for a rejected path component (#1220).
+/// Distinguishes `Int`/`Float` where `OwnedValue::type_name()` collapses
+/// both to `"number"` — real yq's own check cares about the difference (a
+/// plain `!!int` is accepted, a `!!float` never is, even a whole-number-
+/// valued one like `1.0` — confirmed live against yq v4.53.3).
+///
+/// The `!!int`/`!!str` arms are unreachable in practice: the sole call
+/// site below only invokes this on a component its own `find` already
+/// filtered to exclude `String`/`Int`/`NumberLiteral(Int)`. Both arms stay
+/// for match exhaustiveness (no catch-all) rather than being coverage-dead
+/// weight to chase.
+fn delpaths_component_type_tag(value: &OwnedValue) -> &'static str {
+    match value {
+        OwnedValue::Null => "!!null",
+        OwnedValue::Bool(_) => "!!bool",
+        OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _) => "!!int",
+        OwnedValue::Float(_) | OwnedValue::NumberLiteral(NumberRepr::Float(_), _) => "!!float",
+        OwnedValue::String(_) => "!!str",
+        OwnedValue::Array(_) => "!!seq",
+        OwnedValue::Object(_) => "!!map",
+    }
+}
+
 /// Builtin: delpaths(paths) - delete multiple paths
 fn builtin_delpaths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     paths_expr: &Expr,
@@ -23626,37 +23650,49 @@ fn builtin_delpaths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // jq cannot arbitrate either — 1.7.1 loops forever on `delpaths([[nan]])`
     // — so this is pinned by unit test rather than by a golden.
     //
-    // yq-mode-only (#1162): real yq's `delpaths()` also rejects a
-    // slice-descriptor path component (`{"start":s,"end":e}`, `path(.[a:b])`'s
-    // own output shape) outright, at any position, rather than splicing
-    // through the named sub-range the way `delete_paths_under`/`delete_keys`'s
-    // own `OwnedValue::Object(desc)` arms below do for jq mode. Folded into
-    // this same `retain` pass rather than a separate loop before it: both
-    // checks need to visit every path's every component before any deletion
-    // runs. Gated on `keeps` (the same per-path NaN survival this `retain`
-    // already computes), not checked unconditionally, so a path that's
-    // *also* NaN-headed doesn't surface the slice-descriptor error for a
-    // path already headed for silent removal — #1220 (not implemented here)
-    // covers matching real yq's own float/NaN rejection precisely; this
-    // fix only avoids the internally-inconsistent "a doomed path still
-    // aborts the whole call" shape.
-    let mut has_slice_descriptor = false;
+    // yq-mode-only (#1162, widened by #1220): real yq's `delpaths()` accepts
+    // only a `!!str`/`!!int` path component -- every other YAML type errors,
+    // including a slice-descriptor (`{"start":s,"end":e}`, `path(.[a:b])`'s
+    // own output shape, #1162's own narrower repro) that jq mode instead
+    // splices through via `delete_paths_under`/`delete_keys`'s own
+    // `OwnedValue::Object(desc)` arms below. A whole-number-valued float
+    // (`1.0`) is rejected too -- real yq's check is on the YAML type, not
+    // the numeric value, confirmed live. Folded into this same `retain`
+    // pass rather than a separate loop before it: both checks need to
+    // visit every path's every component before any deletion runs. Gated
+    // on `keeps` (the same per-path NaN survival this `retain` already
+    // computes), not checked unconditionally, so a path that's *also*
+    // NaN-headed doesn't surface the type error for a path already headed
+    // for silent removal. `rejected_component_tag` keeps only the first
+    // offender found (path order, then component order within a path) --
+    // confirmed live that real yq reports whichever type-mismatched
+    // component it reaches first when several paths/components each
+    // qualify.
+    let mut rejected_component_tag: Option<&'static str> = None;
     paths.retain(|path| match path {
         OwnedValue::Array(components) => {
             let keeps = !components
                 .iter()
                 .any(|key| matches!(key, OwnedValue::Float(f) if f.is_nan()));
-            has_slice_descriptor |= keeps
-                && S::TAG == EvalTag::Yq
-                && components
+            if keeps && S::TAG == EvalTag::Yq && rejected_component_tag.is_none() {
+                rejected_component_tag = components
                     .iter()
-                    .any(|component| matches!(component, OwnedValue::Object(_)));
+                    .find(|component| {
+                        !matches!(
+                            component,
+                            OwnedValue::String(_)
+                                | OwnedValue::Int(_)
+                                | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
+                        )
+                    })
+                    .map(delpaths_component_type_tag);
+            }
             keeps
         }
         _ => false,
     });
-    if has_slice_descriptor {
-        return QueryResult::Error(EvalError::delpaths_rejects_slice_descriptor());
+    if let Some(tag) = rejected_component_tag {
+        return QueryResult::Error(EvalError::delpaths_rejects_type(tag));
     }
 
     // jq sorts the whole path list in its total value order — arrays compare

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15463,6 +15463,39 @@ fn test_1220_delpaths_reports_first_offending_component() -> Result<()> {
     )?;
     assert_ne!(code, 0);
     assert!(stderr.contains("found !!bool instead"), "stderr: {stderr}");
+
+    // `compare_values` ranks Bool below Number, so `[[true],[1.5]]` above
+    // can't distinguish "first in argument order" from "first in
+    // compare_values sort order" -- both rules pick the bool. Swap the
+    // order so the two rules disagree: if sort order won, this would still
+    // report !!bool; real yq (and this check, which runs before any
+    // sorting) reports the argument-order-first component, !!float.
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr("delpaths([[1.5],[true]])", "[1,2,3]", &["-o=json"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("found !!float instead"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// #1220 code-review fix: a NaN component only suppresses the type check
+/// for *itself* (preserving the pre-existing "NaN path silently drops"
+/// behavior, unrelated to #1220's own scope), not for other, genuinely
+/// bad-typed components sharing the same path. Unreachable via real yq
+/// (its lexer rejects a bare `nan` token outright), so this pins
+/// succinctly's own internal consistency rather than an oracle behavior.
+#[test]
+fn test_1220_delpaths_nan_does_not_suppress_sibling_type_check() -> Result<()> {
+    // A NaN alongside a bad-typed sibling still reports the sibling.
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr("delpaths([[nan,true]])", "[1,2,3]", &["-o=json"])?;
+    assert_ne!(code, 0, "stderr: {stderr}");
+    assert!(stderr.contains("found !!bool instead"), "stderr: {stderr}");
+
+    // A NaN alone still silently drops rather than erroring (NaN itself is
+    // never reported as the offending type, matching pre-#1220 behavior).
+    let (out, code) = run_yq_stdin("delpaths([[nan]])", "[1,2,3]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1,2,3]");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15403,6 +15403,85 @@ fn test_1162_delpaths_slice_descriptor_jq_mode_unaffected() -> Result<()> {
     Ok(())
 }
 
+/// #1220: real yq's `delpaths()` rejects essentially any path component
+/// that isn't literally a `!!str` or `!!int` — not just the slice-
+/// descriptor (`!!map`) shape #1162 scoped. `!!bool`/`!!seq`/`!!float`/
+/// `!!null` all hit the identical message, substituting their own tag.
+/// Exact wording, and each type, verified live against yq v4.53.3.
+#[test]
+fn test_1220_delpaths_rejects_bool_seq_float_null_components() -> Result<()> {
+    for (filter, expected_tag) in [
+        ("delpaths([[true]])", "!!bool"),
+        ("delpaths([[[1,2]]])", "!!seq"),
+        ("delpaths([[1.5]])", "!!float"),
+        ("delpaths([[1.0]])", "!!float"), // whole-number float still rejected
+        ("delpaths([[null]])", "!!null"),
+    ] {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "[1,2,3]", &["-o=json"])?;
+        assert_ne!(code, 0, "filter: {filter}");
+        let expected = format!(
+            "DELPATHS: expected either a !!str or !!int in the path, found {expected_tag} instead"
+        );
+        assert!(
+            stderr.contains(&expected),
+            "filter: {filter}, stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// A plain `!!int` (including negative) and `!!str` are still accepted —
+/// #1220 only widens the *rejection*, not the acceptance rule #1162 already
+/// established.
+#[test]
+fn test_1220_delpaths_still_accepts_str_and_int() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        r#"delpaths([["a"],["b",-1]])"#,
+        r#"{"a":1,"b":[1,2,3]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    // "a" removed entirely; index -1 (last element) removed from "b".
+    assert_eq!(out.trim(), r#"{"b":[1,2]}"#);
+    Ok(())
+}
+
+/// When multiple paths/components each qualify, real yq reports whichever
+/// type-mismatched component it reaches first — path order, then component
+/// order within a path. Verified live both ways.
+#[test]
+fn test_1220_delpaths_reports_first_offending_component() -> Result<()> {
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr("delpaths([[true],[1.5]])", "[1,2,3]", &["-o=json"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("found !!bool instead"), "stderr: {stderr}");
+
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        r#"delpaths([["a",true,1.5]])"#,
+        r#"{"a":{"b":1}}"#,
+        &["-o=json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("found !!bool instead"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// `delpaths()`'s float/bool/array/null acceptance stays intact in jq
+/// mode — #1220's new rejection is yq-mode-only, same as #1162's.
+#[test]
+fn test_1220_delpaths_jq_mode_unaffected() -> Result<()> {
+    // jq mode's own error for a boolean path component is a different,
+    // pre-existing one -- not this yq-mode-only DELPATHS wording.
+    let (_out, stderr, code) =
+        run_jq_stdin_with_stderr("delpaths([[true]])", r#"{"a":1}"#, &["-c"])?;
+    assert_ne!(code, 0);
+    assert!(
+        !stderr.contains("DELPATHS: expected either a !!str or !!int"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 /// #1219 characterization: a chained slice with more path *after* it
 /// (`.[1:3][0]`) is a structurally different shape than #1162 covers —
 /// `yq_del_scalar_slice_parent_path` only rewrites when the slice is the
@@ -15424,31 +15503,6 @@ fn test_1219_chained_slice_with_trailing_path_characterize_preexisting_bug() -> 
         out.trim(),
         r#"{"a":[1,3,4]}"#,
         "if this now matches real yq's no-op ({{\"a\":[1,2,3,4]}}), update this test and close #1219"
-    );
-    Ok(())
-}
-
-/// #1220 characterization: real yq's `delpaths()` is stricter than the
-/// slice-descriptor-only rejection #1162 implements — it also rejects a
-/// float path component (`found !!float instead`, verified live), where
-/// jq's own model treats a float as a valid array index (truncated toward
-/// zero by `resolve_read_index`) and succinctly currently follows that
-/// jq-consistent behavior in yq mode too, silently succeeding instead of
-/// erroring. (A bool or array component, unlike a float, already errors in
-/// succinctly today too — just with jq's own wrong-key-type wording instead
-/// of real yq's `DELPATHS:` message — so the float case is the cleanest
-/// "silently accepted where real yq errors" example; #1220's own issue text
-/// covers the full scope.) Unaffected by #1162's diff (the new check only
-/// matches `OwnedValue::Object`). If this is ever widened (tracked as
-/// #1220), update this expectation.
-#[test]
-fn test_1220_delpaths_accepts_float_component_characterize_preexisting_bug() -> Result<()> {
-    let (out, code) = run_yq_stdin("delpaths([[1.0]])", "[1,2,3]", &["-o=json", "-I=0"])?;
-    assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(
-        out.trim(),
-        "[1,3]",
-        "if this now errors like real yq (found !!float instead), update this test and close #1220"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Real yq's `delpaths()` only accepts `!!str`/`!!int` components in a path array. Every other YAML type errors — `!!null`, `!!bool`, `!!float` (including whole-number-valued ones like `1.0`), and `!!seq` all raise `DELPATHS: expected either a !!str or !!int in the path, found <tag> instead`. Succinctly previously only rejected the `!!map` case (a slice-descriptor object, #1162's narrower scope) and silently accepted everything else, following jq's own more permissive model instead.

## Root cause

`builtin_delpaths`'s yq-mode type check (`src/jq/eval.rs`) only matched `OwnedValue::Object` (the slice-descriptor shape `path(.[a:b])` produces). A float, bool, null, or array path component fell through unchecked and was evaluated the same way jq mode evaluates it (a float truncated toward zero as an array index, etc.), rather than erroring the way real yq does.

## Fix

- Generalized `EvalError::delpaths_rejects_slice_descriptor()` into `EvalError::delpaths_rejects_type(tag: &str)`, parameterized by the YAML type tag of the actual offending component.
- Added `delpaths_component_type_tag()`, mapping an `OwnedValue` to its YAML type tag (`!!null`/`!!bool`/`!!int`/`!!float`/`!!str`/`!!seq`/`!!map`), distinguishing `Int`/`Float` where `OwnedValue::type_name()` collapses both to `"number"`.
- Rewrote the detection loop inside `builtin_delpaths` to scan every path's every component for the first one that isn't `String`/`Int`, reporting its type tag — matching real yq's first-offender-in-path/component-order precedence (confirmed live).
- The two arms of `delpaths_component_type_tag` for `!!int`/`!!str` are structurally unreachable from the function's sole call site (which already filters those types out before calling it) — kept only for match exhaustiveness, documented inline rather than chased for coverage.

## Verification

- Confirmed live against real yq v4.53.3 for every rejected type (`!!null`, `!!bool`, `!!float` including `1.0`, `!!seq`), the still-accepted `!!str`/`!!int` (including negative int), first-offender precedence across and within paths, and jq-mode non-regression.
- New tests: `test_1220_delpaths_rejects_bool_seq_float_null_components`, `test_1220_delpaths_still_accepts_str_and_int`, `test_1220_delpaths_reports_first_offending_component`, `test_1220_delpaths_jq_mode_unaffected`.
- Removed the obsolete `test_1220_delpaths_accepts_float_component_characterize_preexisting_bug`, which asserted the old buggy behavior this PR fixes.
- Full `cargo test --features cli,simd,regex,serde` clean (0 failed).
- Both required clippy invocations clean; `cargo fmt --check` clean.
- Patch coverage 91.3% (21/23 new lines); the 2 uncovered lines are the documented-unreachable match arms above.

Fixes #1220