### PR TITLE
fix(jq): route array-literal construction through path context

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -505,6 +505,15 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         Expr::Paren(inner) => needs_path_context(inner),
         Expr::Optional(inner) => needs_path_context(inner),
         Expr::Comma(exprs) => exprs.iter().any(needs_path_context),
+        // `[key]`/`[parent]`/`[file_index]` (#1302): an array literal is
+        // still just "collect this inner expression's outputs", the same
+        // reasoning as `Comma` above -- whatever the wrapped expression
+        // needs, the `[...]` wrapper needs too. `Expr::Object` isn't
+        // included here yet: it has the identical gap (`{"x": key}` also
+        // stubs to `null`, confirmed live), but its multi-entry/generator-key
+        // shape needs more design work than a single recursive call, so it's
+        // tracked separately rather than folded into this fix.
+        Expr::Array(inner) => needs_path_context(inner),
         Expr::IndexExpr { target, key } => needs_path_context(target) || needs_path_context(key),
         Expr::SliceExpr { target, start, end } => {
             needs_path_context(target)
@@ -18342,6 +18351,60 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // (#791).
                 Err(EvalEscape::Error(_)) if optional => QueryResult::None,
                 Err(escape) => escape.into(),
+            }
+        }
+        // `[key]`/`[parent]`/`[file_index]` (#1302): the generic
+        // `Expr::Array` arm below builds the array via `eval_owned_expr_opt`
+        // -- the plain, context-less evaluator -- so a `key`/`parent`/
+        // `file_index` nested inside the literal would still stub to
+        // `null`/`0` even once `needs_path_context` correctly routes the
+        // enclosing pipe here. Route the array's *own* inner expression
+        // through this same path-context evaluator instead, collecting its
+        // outputs the same way `eval_array_construction` collects the plain
+        // evaluator's outputs elsewhere, then continue exactly as the
+        // generic arm below does (reset path/root for `rest`).
+        Expr::Array(inner) if needs_path_context(inner) => {
+            let inner_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(inner),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let items: Vec<OwnedValue> = match inner_result {
+                QueryResult::Owned(v) => vec![v],
+                QueryResult::ManyOwned(vs) => vs,
+                QueryResult::None => vec![],
+                QueryResult::Error(e) => return QueryResult::Error(e),
+                QueryResult::Break(label) => return QueryResult::Break(label),
+                QueryResult::Halt(code) => return QueryResult::Halt(code),
+                // Array construction is atomic (`eval_array_construction`'s
+                // identical reasoning): a control signal after some output
+                // still abandons the whole array rather than keeping a
+                // partial one.
+                QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
+                QueryResult::Partial(_, Control::Break(label)) => return QueryResult::Break(label),
+                QueryResult::Partial(_, Control::Halt(code)) => return QueryResult::Halt(code),
+                QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                    unreachable!(
+                        "eval_pipe_with_path_context_internal only ever produces \
+                         Owned/ManyOwned/None/Error/Break/Partial"
+                    )
+                }
+            };
+            let result = OwnedValue::Array(items);
+            if rest.is_empty() {
+                QueryResult::Owned(result)
+            } else {
+                eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &result,
+                    &result,
+                    file_origin,
+                    &[],
+                    optional,
+                )
             }
         }
         Expr::Object(_) | Expr::Array(_) | Expr::Literal(_) => {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11012,9 +11012,10 @@ pub fn eval_lenient<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `eval_pipe_with_path_context_internal` can reach it: plain
 /// `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`,
 /// `if`/`then`/`else`, `try`/`catch`, comma, and `label` (the same
-/// capability level `key`/`document_index` already have; array/object
-/// literals and user-defined functions remain out of scope, matching those
-/// builtins' own existing limits).
+/// capability level `key`/`document_index` already have; an array literal
+/// gained this capability too, #1302 -- object literals, string
+/// interpolation, and user-defined functions remain out of scope, matching
+/// those builtins' own existing limits).
 ///
 /// Routes through the ordinary evaluator, untouched, whenever `expr`
 /// doesn't reference `file_index`/`key`/`parent`/`path` anywhere
@@ -18363,6 +18364,28 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // outputs the same way `eval_array_construction` collects the plain
         // evaluator's outputs elsewhere, then continue exactly as the
         // generic arm below does (reset path/root for `rest`).
+        //
+        // The inner evaluation is deliberately run with `optional` forced
+        // to `false`, not the ambient value this arm itself received (code
+        // review, #1302): `Expr::Optional`'s own dispatch a few arms above
+        // just broadcasts `optional=true` into whatever it wraps, with no
+        // catch of its own -- unlike the plain evaluator's `Expr::Optional`
+        // arm, which delegates to `eval_try` (evaluate, then explicitly
+        // convert an escaping `Error`/`Partial(_, Error)` to `None` at the
+        // top). Passing the ambient value straight through here let a
+        // genuine error deep inside the array (e.g. `error(...)`) get
+        // self-swallowed by its own leaf-level `if optional` check before
+        // ever reaching this match, corrupting `[key, error("boom")]?`
+        // into a partial array (`["a"]`) instead of catching the whole
+        // construction atomically the way real jq's `[1, error("x")]?`
+        // does. Forcing `false` here lets a genuine error surface as a
+        // real `Error`/`Partial(_, Error)`, which this arm then catches
+        // itself using *its own* `optional` -- the same
+        // evaluate-then-catch shape as `eval_try`, and the same catch
+        // condition the sibling `Object`/`Array`/`Literal` arm below
+        // already applies (`Err(EvalEscape::Error(_)) if optional`). Only
+        // `Error` is caught, not `Break`/`Halt` -- `?` never catches those
+        // (matches the sibling arm and `eval_try` above).
         Expr::Array(inner) if needs_path_context(inner) => {
             let inner_result = eval_pipe_with_path_context_internal::<W, S>(
                 core::slice::from_ref(inner),
@@ -18370,12 +18393,15 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 root,
                 file_origin,
                 current_path,
-                optional,
+                false,
             );
             let items: Vec<OwnedValue> = match inner_result {
                 QueryResult::Owned(v) => vec![v],
                 QueryResult::ManyOwned(vs) => vs,
                 QueryResult::None => vec![],
+                QueryResult::Error(_) | QueryResult::Partial(_, Control::Error(_)) if optional => {
+                    return QueryResult::None;
+                }
                 QueryResult::Error(e) => return QueryResult::Error(e),
                 QueryResult::Break(label) => return QueryResult::Break(label),
                 QueryResult::Halt(code) => return QueryResult::Halt(code),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5130,6 +5130,58 @@ fn test_array_wrapped_path_context_builtin_control_flow_1302() -> Result<()> {
     Ok(())
 }
 
+/// Code review on #1302's own PR (#1333): the new array arm originally
+/// passed the ambient `optional` straight into evaluating the array's
+/// inner expression, letting a leaf error deep inside self-swallow via its
+/// own local `if optional` check before ever reaching the array's own
+/// atomicity match -- corrupting `[key, error("boom")]?` into a partial
+/// array (`["a"]`) instead of the whole construction being caught, unlike
+/// real jq's structurally identical `[1, error("x")]?` (empty output).
+/// Verified live against real jq for the baseline comparison.
+#[test]
+fn test_array_wrapped_path_context_builtin_optional_is_atomic_1302() -> Result<()> {
+    // A comma branch that succeeds (`key`) before a later branch errors:
+    // `?` must discard the whole array, not just the erroring branch.
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | [key, error(\"boom\")]?"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // Same shape via a genuine type error instead of an explicit `error()`.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [key, 1 + \"x\"]?"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // An error as the array's *only* content: must produce no output at
+    // all, not a spurious `[]` (which would conflate a caught error with
+    // #1280's genuine-zero-output-generator case).
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [(key | error(\"boom\"))]?"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // Without `?`, the same query still hard-errors -- the fix must not
+    // accidentally make every error inside such an array silently vanish.
+    let (_stdout, stderr, code) =
+        run_jq_full(&["-c", ".a | [key, error(\"boom\")]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // A genuinely nested `?` *inside* the array (not on the array itself)
+    // must still work on its own terms, independent of the array's own
+    // (here absent) `?`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [key, (error(\"boom\"))?]"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a"]"#);
+
+    Ok(())
+}
+
 /// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
 /// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
 /// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5008,6 +5008,128 @@ fn test_path_context_fanout_preserves_output_before_break_or_error_715() -> Resu
     Ok(())
 }
 
+/// `needs_path_context` had no `Expr::Array` arm (#1302), so `[key]` --
+/// semantically equivalent to `(key,key)`'s single-branch case, just
+/// array-wrapped instead of comma-joined -- silently lost path context and
+/// stubbed to `null`, even though `needs_path_context` already recursed
+/// into the structurally-identical `Comma` wrapper. Fixing just the
+/// recursion wasn't enough on its own: `eval_pipe_with_path_context_internal`'s
+/// array-construction arm built the array via the plain, context-less
+/// evaluator, so `key`/`parent`/`file_index` nested inside `[...]` needed a
+/// second, dedicated fix to route through the path-context evaluator during
+/// construction itself. Verified live against real yq v4.53.3 for `[key]`
+/// and `[parent]` (`key`/`parent` have no real-jq equivalent -- succinctly
+/// extensions -- so jq mode here pins internal consistency, not an oracle).
+#[test]
+fn test_array_wrapped_path_context_builtins_1302() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [key]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a"]"#);
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [parent]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"[{"a":1}]"#);
+
+    // Multiple path-context builtins in the same array literal, plus a
+    // plain value alongside them -- all outputs collected into one array,
+    // matching `[...]`'s ordinary multi-output-collection semantics.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [key, key, parent]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a","a",{"a":1}]"#);
+
+    // Nested inside a longer pipe: `rest` after the array must still see
+    // the newly constructed array as its fresh root (path reset), matching
+    // the plain `Expr::Array`/`Expr::Object`/`Expr::Literal` arm's own
+    // "reset path and root to the new value" behavior.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [key] | .[0]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""a""#);
+
+    // A plain array (no path-context builtin inside) takes the original,
+    // unmodified code path and must be entirely unaffected.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [1,2,3]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[1,2,3]");
+
+    Ok(())
+}
+
+/// Exercises the non-`Owned`/`ManyOwned` arms of #1302's new inner-result
+/// match (`None`/`Error`/`Break`/`Halt`/`Partial`) -- array construction is
+/// atomic, so each of these must abandon the whole array rather than
+/// producing a partial one, mirroring `eval_array_construction`'s identical
+/// reasoning for the plain (non-path-context) case.
+#[test]
+fn test_array_wrapped_path_context_builtin_control_flow_1302() -> Result<()> {
+    // Zero output from the inner expression (`select` with a false
+    // condition on `key`) -> an empty array, not an error.
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | [select(key == \"z\")]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[]");
+
+    // An error from the inner expression, as the pipe's very first output
+    // (no successful output preceding it), aborts the whole array
+    // construction as a bare error.
+    let (_stdout, stderr, code) =
+        run_jq_full(&["-c", ".a | [key | error(\"boom\")]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // Same, but with real output already produced by an earlier comma
+    // branch (`key` succeeds with "a" before `error` fires) -- exercises
+    // the `Partial(_, Control::Error(_))` arm rather than the bare one
+    // above. Still discards the whole array, matching jq's atomic array
+    // construction.
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | [key, error(\"boom\")]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout, "");
+
+    // A bare `break` out of the inner expression (pipe form, no prior
+    // output) aborts the whole array construction and unwinds past it to
+    // the enclosing label -- the comma's second branch ("reached") must
+    // never run.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | ((.a | [key | break $out]), \"reached\")",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "",
+        "break must discard the whole array, not emit it"
+    );
+
+    // Same, but as a comma branch with real output already produced first
+    // (`key` succeeds with "a" before `break` fires) -- exercises the
+    // `Partial(_, Control::Break(_))` arm rather than the bare one above.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | ((.a | [key, break $out]), \"reached\")"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // `halt_error(n)` from the inner expression, as the pipe's very first
+    // output (no successful output preceding it), propagates its own exit
+    // code as a bare halt.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [key | halt_error(9)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 9);
+    assert_eq!(stdout, "");
+
+    // Same, but with real output already produced by an earlier comma
+    // branch -- exercises the `Partial(_, Control::Halt(_))` arm rather
+    // than the bare one above.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [key, halt_error(9)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 9);
+    assert_eq!(stdout, "");
+
+    Ok(())
+}
+
 /// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
 /// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
 /// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that


### PR DESCRIPTION
## Summary

`needs_path_context` (`src/jq/eval.rs`) decides whether a pipe stage needs the full path-tracking evaluator rather than the plain-value one. It recurses into `Expr::Comma` but had no arm for `Expr::Array`, falling to the `_ => false` catch-all — so `.a | [key]`, semantically equivalent to `.a | (key,key)` just array-wrapped, silently lost path context and reported `null` instead of resolving `key`.

## Root cause

Two-part gap:
1. `needs_path_context` had no `Expr::Array` arm, so a pipe containing `[key]`/`[parent]`/`[file_index]` was routed to the plain evaluator instead of the path-context one.
2. Adding that arm alone isn't sufficient: `eval_pipe_with_path_context_internal`'s existing array-construction arm (shared with `Object`/`Literal`) builds the array via `eval_owned_expr_opt` — the plain, context-less evaluator — regardless of whether the routing decision said the pipe needs path context. `Builtin::Key`'s own plain-evaluator fallback always returns `Null` ("Key requires path context which is handled in eval_pipe_with_context ... return null"), so the array construction itself needed a second fix.

## Fix

- Added `Expr::Array(inner) => needs_path_context(inner)` to `needs_path_context`, mirroring the existing `Comma` arm.
- Split `Expr::Array` out of the shared `Expr::Object(_) | Expr::Array(_) | Expr::Literal(_)` arm in `eval_pipe_with_path_context_internal`: a new `Expr::Array(inner) if needs_path_context(inner)` arm evaluates `inner` through the same path-context evaluator (`eval_pipe_with_path_context_internal` recursively) and collects every output into the array — mirroring how `eval_array_construction` collects the plain evaluator's outputs for the ordinary case. The ordinary (non-path-context) array case, and `Object`/`Literal`, stay on the original unmodified code path.

## Verification

- Confirmed live against real yq v4.53.3 for `[key]` and `[parent]` (`key`/`parent`/`file_index` have no real-jq equivalent — succinctly extensions — so jq-mode testing here pins internal consistency, not an oracle).
- New tests: `test_array_wrapped_path_context_builtins_1302` (basic cases, multiple builtins in one array, `rest`-after-array path reset, plain-array non-regression) and `test_array_wrapped_path_context_builtin_control_flow_1302` (exercises every non-`Owned`/`ManyOwned` branch of the new match: zero-output, bare and `Partial`-wrapped error/break/halt — array construction is atomic, so each must abandon the whole array).
- Regression-checked against existing `_554_`/`_715_`/`_1280_` path-context and array-construction tests (42 tests, all pass).
- Full `cargo test --features cli,simd,regex,serde` clean (0 failed).
- Both required clippy invocations clean; `cargo fmt --check` clean.
- Patch coverage 96.67% (29/30 new lines); the one uncovered line is a documented-unreachable `unreachable!()` arm matching an existing sibling arm's identical, already-accepted invariant a few hundred lines above.

`Expr::Object` has the identical gap (`{"x": key}` also stubs to `null`, confirmed live) but needs its own design pass over multi-entry/generator-key semantics rather than a one-line mirror of this fix — filed as #1332.

Fixes #1302