### PR TITLE
fix(jq): yq del() through a chained slice with more path (#1219)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10770,7 +10770,11 @@ pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
 /// parent key, not the slice's own contents) needs the parent *container*
 /// in hand, which `through_slice` never has (it only ever sees the sliced
 /// value itself).
-fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Option<Expr> {
+fn yq_del_scalar_slice_parent_path(
+    path_expr: &Expr,
+    root: &OwnedValue,
+    empty_prefix_is_identity: bool,
+) -> Option<Expr> {
     // `unwrap_path_component`, not a direct match or the narrower
     // `unwrap_paren`: a parenthesized chained target (`del((.a[0:1]))`)
     // must apply the same parent-key-delete rule as its bare form
@@ -10789,11 +10793,37 @@ fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Optio
     let Expr::Pipe(exprs) = unwrap_path_component(path_expr).0 else {
         return None;
     };
-    let (last, _) = unwrap_path_component(exprs.last()?);
-    if !matches!(last, Expr::Slice { .. }) {
+    // #1219: real yq's rule strips a *maximal trailing run* of consecutive
+    // slices, not just one -- `del(.a[1:3][0:2])` drops `.a` entirely, same
+    // target as the single-slice `del(.a[0:2])`, live-verified against yq
+    // v4.53.3 (a chained slice-then-slice run of any length collapses to
+    // the same "drop what's before the run" target; a run of 3 behaves
+    // identically to a run of 2). `cut` is the index where that run begins.
+    let mut cut = exprs.len();
+    while cut > 0 && matches!(unwrap_path_component(&exprs[cut - 1]).0, Expr::Slice { .. }) {
+        cut -= 1;
+    }
+    if cut == exprs.len() {
+        // Last component isn't a slice at all -- this rule never applies,
+        // regardless of what's earlier in the path. `builtin_del`'s own
+        // `yq_del_chained_slice_is_noop` decides what happens instead
+        // (#1219: a slice anywhere in the path with something other than
+        // more trailing slices after it makes the whole `del()` a no-op).
         return None;
     }
-    let prefix = &exprs[..exprs.len() - 1];
+    let prefix = &exprs[..cut];
+    if prefix.is_empty() && !empty_prefix_is_identity {
+        // A bare trailing slice-run with *nothing* before it at all
+        // (`del(.[1:3][0:1])` on the root value itself, no leading
+        // `Field`/`Index`) live-verifies as a no-op, not "delete the root" --
+        // unlike the `Expr::Iterate` per-element case below, there is no
+        // parent key here to drop in the first place. Callers that walk a
+        // whole resolved path (not a per-element `rest` after `.[]`) pass
+        // `false` here so this returns `None` and lets
+        // `yq_del_chained_slice_is_noop` recognize the no-op instead of this
+        // function wrongly answering `Some(Expr::Identity)`.
+        return None;
+    }
     // Existence only, not type — #1162 confirmed live that real yq's rule
     // applies uniformly to every target type once the target actually
     // exists; `navigate_read_only` returning `None` (missing field/index)
@@ -10801,30 +10831,77 @@ fn yq_del_scalar_slice_parent_path(path_expr: &Expr, root: &OwnedValue) -> Optio
     // absent-path handling instead.
     navigate_read_only(root, prefix)?;
     Some(match prefix.len() {
-        // Unreachable from `builtin_del`'s own top-level call site:
-        // `resolve_dynamic_indexes`'s own `assemble()` never wraps a single
-        // resolved component in `Expr::Pipe` (a length-1 component list
-        // returns that component directly, `strip_resolved_optional` only
-        // strips wrappers *within* an existing `Pipe`, never collapses
-        // one), so `exprs.len() >= 2` always holds there and `prefix.len()`
-        // can never be `0` for that caller.
-        //
-        // *Is* reached from `delete_at_path`'s `Expr::Iterate` arm (#1182),
+        // Reached only when `empty_prefix_is_identity` is `true` --
+        // `delete_at_path`'s `Expr::Iterate` arm (#1182, generalized by
+        // #1219 to a whole trailing slice-run rather than just one slice),
         // which always wraps its `rest` in `Expr::Pipe` regardless of
         // length -- a bare `.[]` directly followed by the trailing slice
-        // (`del(.a[][0:1])`, no `Field`/`Index` between) resolves `prefix`
-        // to the empty slice, so `target` (from `navigate_read_only` with
-        // zero steps) is the element itself. `Expr::Identity` signals that
-        // case back to the caller: there is no parent *key* to drop here,
-        // the element itself is the thing to remove from its container --
-        // that caller special-cases this return value rather than
-        // recursing `delete_at_path` on it (which would just null the
-        // element in place via its own `Expr::Identity` arm, not remove
-        // it).
+        // run (`del(.a[][0:1])`, `del(.a[][1:3][0:1])`, no `Field`/`Index`
+        // between), resolves `prefix` to the empty slice, so `target` (from
+        // `navigate_read_only` with zero steps) is the element itself.
+        // `Expr::Identity` signals that case back to the caller: there is
+        // no parent *key* to drop here, the element itself is the thing to
+        // remove from its container -- that caller special-cases this
+        // return value rather than recursing `delete_at_path` on it (which
+        // would just null the element in place via its own `Expr::Identity`
+        // arm, not remove it).
         0 => Expr::Identity,
         1 => prefix[0].clone(),
         _ => Expr::Pipe(prefix.to_vec()),
     })
+}
+
+/// Whether a *resolved* `del()` path (already unwrapped to its `Pipe`
+/// component list, or a bare single component) contains a chained
+/// [`Expr::Slice`] that real yq's del() renders inert -- the *other* half of
+/// #1219, alongside [`yq_del_scalar_slice_parent_path`]'s trailing-run
+/// parent-key-drop rule above. Purely syntactic (no `root`/navigation
+/// needed): live-verified against yq v4.53.3 across every combination of
+/// leading `Field`/`Index`, trailing-run length, and what (if anything)
+/// follows the run, the whole call no-ops whenever:
+///
+/// - the path's *last* component isn't a slice at all (`del(.a[1:3][0])`,
+///   `del(.a[1:3][0].x)`, `del(.a[1:3][])`, `del(.a[1:3][0:2][0])` -- a
+///   trailing slice-run followed by anything non-slice makes the entire
+///   `del()` inert, not just that one step); or
+/// - the path *does* end in a slice-run, but what's left before that run
+///   either is empty (`del(.[1:3][0:1])`, a bare chained-slice-run with no
+///   leading `Field`/`Index` to drop) or itself contains another slice
+///   (`del(.a[0:2][1][3:5])`: the run is just the trailing `[3:5]`, but the
+///   residual prefix `.a[0:2][1]` still has a slice in it) -- in both cases
+///   `yq_del_scalar_slice_parent_path` already declines (returns `None`) for
+///   exactly this reason, so this function mirrors its own trailing-run
+///   walk rather than re-deriving a different one.
+///
+/// Not applicable to `delete_at_path`'s `Expr::Iterate` arm's per-element
+/// `rest`: an empty residual prefix there legitimately means "drop this
+/// element" (`Expr::Identity`, live-verified to hold for a trailing-run of
+/// any length, not just one slice), the opposite of this function's
+/// top-level "nothing to drop" reading of the same shape -- see
+/// `empty_prefix_is_identity`'s doc comment on the sibling function.
+fn yq_del_chained_slice_is_noop(path_expr: &Expr) -> bool {
+    let (unwrapped, _) = unwrap_path_component(path_expr);
+    let owned;
+    let exprs: &[Expr] = match unwrapped {
+        Expr::Pipe(list) => list,
+        other => {
+            owned = [other.clone()];
+            &owned
+        }
+    };
+    let is_slice = |e: &Expr| matches!(unwrap_path_component(e).0, Expr::Slice { .. });
+    if !exprs.iter().any(is_slice) {
+        return false;
+    }
+    let mut cut = exprs.len();
+    while cut > 0 && is_slice(&exprs[cut - 1]) {
+        cut -= 1;
+    }
+    if cut == exprs.len() {
+        return true;
+    }
+    let head = &exprs[..cut];
+    head.is_empty() || head.iter().any(is_slice)
 }
 
 /// Read-only navigation for [`yq_del_scalar_slice_parent_path`]'s prefix
@@ -20485,7 +20562,7 @@ fn rewrite_yq_del_comma_branches(expr: &Expr, root: &OwnedValue) -> Option<Expr>
                     if let Some(nested) = rewrite_yq_del_comma_branches(branch, root) {
                         nested
                     } else if !needs_path_prepass(branch) {
-                        yq_del_scalar_slice_parent_path(branch, root)
+                        yq_del_scalar_slice_parent_path(branch, root, false)
                             .unwrap_or_else(|| branch.clone())
                     } else {
                         branch.clone()
@@ -20594,14 +20671,30 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     if paths.len() <= 1 {
         let mut result = result;
         for path in &paths {
-            // yq's chained-scalar-slice del() rule (#1116) — a *different*
-            // rule from #1101's no-op above: rewrite the path to delete the
-            // parent key outright, rather than walking the original path
-            // at all, when it applies. See
-            // `yq_del_scalar_slice_parent_path`'s doc comment.
+            // yq's chained-scalar-slice del() rule (#1116, generalized by
+            // #1219 to a whole trailing slice-run) — a *different* rule from
+            // #1101's no-op above: rewrite the path to delete the parent key
+            // outright, rather than walking the original path at all, when
+            // it applies. See `yq_del_scalar_slice_parent_path`'s doc
+            // comment. `false`: this walks the whole resolved path, not a
+            // per-element `rest` after `.[]`, so an empty residual prefix
+            // must defer to the no-op check below rather than deleting the
+            // root outright.
             let rewritten = (S::TAG == EvalTag::Yq)
-                .then(|| yq_del_scalar_slice_parent_path(path, &result))
+                .then(|| yq_del_scalar_slice_parent_path(path, &result, false))
                 .flatten();
+            // #1219: a chained slice with more path after it that *isn't*
+            // itself another trailing slice (`.a[1:3][0]`, `.a[1:3][0].x`,
+            // `.a[1:3][]`) real-yq no-ops entirely, live-verified — it does
+            // *not* fall through to walking the slice and then the rest of
+            // the path, which is what `delete_at_path`'s own per-step walk
+            // would otherwise do here and get wrong. Checked only once the
+            // parent-key-drop rewrite above has declined, same ordering as
+            // that rule: a chained slice-run always has one of these two
+            // outcomes, never a normal walk.
+            if rewritten.is_none() && S::TAG == EvalTag::Yq && yq_del_chained_slice_is_noop(path) {
+                continue;
+            }
             let path = rewritten.as_ref().unwrap_or(path);
             if let Err(e) = delete_at_path(&mut result, path, false, S::TAG == EvalTag::Yq) {
                 return if optional {
@@ -20628,11 +20721,23 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // machinery this fix doesn't otherwise need to touch, so the rewrite
     // happens once, per path, before either ever sees it, rather than
     // teaching them the rule directly.
+    //
+    // #1219's *other* half (a chained slice-run followed by something that
+    // isn't itself a slice no-ops the whole `del()` call) is deliberately
+    // **not** applied here: unlike the single-path branch above, a no-op
+    // here can't just skip the loop iteration — it would need to drop this
+    // one sibling's steps from `flattened` while still deleting the others,
+    // and real yq's own answer for a multi-path `del()` mixing this shape
+    // with a sibling is untested territory, same class of gap #1223 already
+    // scoped out of `rewrite_yq_del_comma_branches` above. Left as a
+    // pre-existing gap for this branch specifically; tracked as a follow-up
+    // rather than guessed at here.
     let rewritten: Vec<Expr> = paths
         .iter()
         .map(|path| {
             if S::TAG == EvalTag::Yq {
-                yq_del_scalar_slice_parent_path(path, &result).unwrap_or_else(|| path.clone())
+                yq_del_scalar_slice_parent_path(path, &result, false)
+                    .unwrap_or_else(|| path.clone())
             } else {
                 path.clone()
             }
@@ -20832,8 +20937,9 @@ fn delete_at_path(
                     Expr::Iterate => match root {
                         OwnedValue::Array(arr) => {
                             // #1182: yq's chained-scalar-slice del() rule
-                            // (#1116) can't be applied upfront for this
-                            // shape -- the caller's own rewrite
+                            // (#1116, generalized by #1219 to a whole
+                            // trailing slice-run) can't be applied upfront
+                            // for this shape -- the caller's own rewrite
                             // (`yq_del_scalar_slice_parent_path`) only
                             // runs once, before this walk even starts,
                             // and its `navigate_read_only` prefix-peek
@@ -20849,23 +20955,39 @@ fn delete_at_path(
                             //
                             // `Some(Expr::Identity)` is a distinct signal
                             // from any other rewrite: it means the *element
-                            // itself* is the scalar the trailing slice would
-                            // have targeted (`.[]` directly followed by the
-                            // slice, no `Field`/`Index` between). There is
-                            // no parent key to drop one level down from an
-                            // `&mut` reference into this array slot --
+                            // itself* is the scalar the trailing slice-run
+                            // would have targeted (`.[]` directly followed
+                            // by the run, no `Field`/`Index` between --
+                            // `true` for `empty_prefix_is_identity`, unlike
+                            // the top-level callers). There is no parent key
+                            // to drop one level down from an `&mut`
+                            // reference into this array slot --
                             // `delete_at_path`'s own `Expr::Identity` arm
                             // would just null the element in place, not
                             // remove it, so this element's index is queued
                             // for removal from `arr` itself after the loop
                             // instead of being recursed into.
+                            //
+                            // #1219: when the rewrite declines *and* `rest`
+                            // is a chained slice-run followed by something
+                            // that isn't itself another trailing slice
+                            // (`.a[][1:3][0]`), real yq no-ops that element
+                            // outright rather than walking `rest` against
+                            // it, live-verified -- the element is left
+                            // completely untouched (neither removed nor
+                            // recursed into).
                             let mut remove_indices = Vec::new();
                             for (i, elem) in arr.iter_mut().enumerate() {
                                 let rewritten = yq_mode
-                                    .then(|| yq_del_scalar_slice_parent_path(&rest, elem))
+                                    .then(|| yq_del_scalar_slice_parent_path(&rest, elem, true))
                                     .flatten();
                                 if matches!(rewritten, Some(Expr::Identity)) {
                                     remove_indices.push(i);
+                                } else if rewritten.is_none()
+                                    && yq_mode
+                                    && yq_del_chained_slice_is_noop(&rest)
+                                {
+                                    // Leave this element untouched.
                                 } else {
                                     delete_at_path(
                                         elem,
@@ -20881,15 +21003,21 @@ fn delete_at_path(
                             Ok(())
                         }
                         OwnedValue::Object(map) => {
-                            // Same per-element rewrite and elem-is-target
-                            // removal as the array arm above.
+                            // Same per-element rewrite, elem-is-target
+                            // removal, and #1219 no-op as the array arm
+                            // above.
                             let mut remove_keys = Vec::new();
                             for (key, value) in map.iter_mut() {
                                 let rewritten = yq_mode
-                                    .then(|| yq_del_scalar_slice_parent_path(&rest, value))
+                                    .then(|| yq_del_scalar_slice_parent_path(&rest, value, true))
                                     .flatten();
                                 if matches!(rewritten, Some(Expr::Identity)) {
                                     remove_keys.push(key.clone());
+                                } else if rewritten.is_none()
+                                    && yq_mode
+                                    && yq_del_chained_slice_is_noop(&rest)
+                                {
+                                    // Leave this entry untouched.
                                 } else {
                                     delete_at_path(
                                         value,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41676,21 +41676,29 @@ mod tests {
         // `through_slice` deliberately forces `terminal_write: true` for a
         // string target, keeping the OLD, unconditional "Cannot update
         // string slices" refusal there byte-for-byte unchanged -- NOT the
-        // new jq-mode fix above. This case is the same real-yq-diverges
-        // gap #1219 already tracks for a container target
-        // (`del(.a[1:3][0])` on an array): real yq silently no-ops it
-        // (confirmed live, `del(.a[0:1].b)` on `a: hello` leaves `a:
-        // hello` untouched), which is #1219's own scope to fix, not this
-        // issue's. Pinning the *unchanged* wrong message here so a future
-        // edit doesn't silently swap it for a different-but-still-wrong
-        // one and make this string case look fixed relative to #1219's
-        // still-open array/object case.
+        // new jq-mode fix above. At the time #1321 landed, this was the
+        // same real-yq-diverges gap #1219 tracked for a container target
+        // (`del(.a[1:3][0])` on an array), left open as "#1219's own scope
+        // to fix, not this issue's."
+        //
+        // #1219 has since landed and closes this string case too, as a
+        // side effect rather than a deliberate target: `yq_del_slice_
+        // outcome` classifies a chained-slice-then-non-slice path as
+        // `Noop` from its *shape* alone, before `builtin_del` ever calls
+        // `delete_at_path` -- so `through_slice`'s `terminal_write` forcing
+        // above is never reached for this query at all, regardless of
+        // `.a`'s type. The whole `del()` call now correctly no-ops,
+        // matching real yq exactly (confirmed live, `del(.a[0:1].b)` on
+        // `a: hello` leaves `a: hello` untouched) -- this test's own
+        // *previous* expectation (the old, unconditional "Cannot update
+        // string slices" error) is what's now stale, not this update.
         yq_query!(br#"{"a":"hello"}"#, r"del(.a[0:1].b)",
-            QueryResult::Error(e) => {
-                assert_eq!(e.message, "Cannot update string slices");
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":"hello"}"#);
             }
         );
-        // jq mode is unaffected by this yq-only gating.
+        // jq mode is unaffected by #1219's yq-only gating -- still the
+        // ordinary per-step error #1312/#1321 already established above.
         query!(br#"{"a":"hello"}"#, r"del(.a[0:1].b)",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, r#"Cannot index string with string "b""#);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10770,141 +10770,151 @@ pub(crate) fn is_yq_scalar_slice_assign_path(path_expr: &Expr) -> bool {
 /// parent key, not the slice's own contents) needs the parent *container*
 /// in hand, which `through_slice` never has (it only ever sees the sliced
 /// value itself).
-fn yq_del_scalar_slice_parent_path(
+enum YqDelSliceOutcome {
+    /// Delete this rewritten path instead of the original one (drops the
+    /// parent key/element the trailing slice-run sits inside).
+    /// `Expr::Identity` is a distinct signal within this variant: there is
+    /// no parent *key* to drop, the target reached by navigating the
+    /// residual prefix *is itself* the thing to remove from its container
+    /// -- only produced when the caller passed `empty_prefix_is_identity:
+    /// true` (the `Expr::Iterate` per-element case below).
+    DropParent(Expr),
+    /// The whole `del()` call (or, for a multi-path caller, this one
+    /// sibling path) does nothing.
+    Noop,
+    /// This rule doesn't apply at all -- walk `path_expr` normally.
+    NotApplicable,
+}
+
+/// Classifies a resolved `del()` path against real yq's chained-slice rules
+/// (#1116, #1162, #1182, generalized by #1219 to a *maximal trailing run* of
+/// slices and to paths with more than one flat step buried inside nested
+/// `Pipe`/`Paren`/`Optional` wrappers). Live-verified against yq v4.53.3
+/// across every combination of leading `Field`/`Index`, trailing-run
+/// length, and what (if anything) follows the run:
+///
+/// - the path's *last* component isn't a slice at all (`del(.a[1:3][0])`,
+///   `del(.a[1:3][0].x)`, `del(.a[1:3][])`, `del(.a[1:3][0:2][0])` -- a
+///   trailing slice-run followed by anything non-slice makes the entire
+///   `del()` inert, not just that one step): [`YqDelSliceOutcome::Noop`].
+/// - the path ends in a slice-run of *any* length ≥ 2 (`del(.a[1:3][0:2])`,
+///   `del(.a[1:3][0:2][0:1])`) and the residual prefix before that run is
+///   itself slice-free and non-empty: [`YqDelSliceOutcome::DropParent`],
+///   same target a single trailing slice already resolves to (#1162) --
+///   whatever the residual prefix navigates to (a `navigate_read_only`
+///   *existence* check only, not a type check, per #1162) is what gets
+///   dropped.
+/// - the residual prefix before the trailing run is empty (no leading
+///   `Field`/`Index` at all, e.g. `del(.[1:3][0:1])` on the root value
+///   itself) or itself contains another slice elsewhere
+///   (`del(.a[0:2][1][3:5])`: the run is just the trailing `[3:5]`, but the
+///   residual prefix `.a[0:2][1]` still has a slice in it):
+///   [`YqDelSliceOutcome::Noop`] -- *unless* `empty_prefix_is_identity` is
+///   `true` and the prefix is empty, the one case where an empty residual
+///   prefix means "drop this element" instead (see the parameter's own doc
+///   below).
+/// - the residual prefix is syntactically clean but doesn't actually exist
+///   in `root` (a missing field/out-of-range index):
+///   [`YqDelSliceOutcome::NotApplicable`], deferring to `delete_at_path`'s
+///   own already-correct del()-through-absent handling rather than
+///   duplicating it here.
+/// - no `Expr::Slice` anywhere in the path at all:
+///   [`YqDelSliceOutcome::NotApplicable`] (an ordinary path, not this
+///   rule's concern).
+///
+/// `path_expr` is flattened via [`flatten_delete_path`] rather than a
+/// single-level `Expr::Pipe` match -- #1219's original fix only unwrapped
+/// `Optional`/`Paren` around the *whole* path and matched one flat
+/// `Expr::Pipe` level, missing a slice hidden inside a *nested* `Pipe`
+/// (`del((.a[0:1])[0:2])`, or even parens-free `del(.a | .[0:1][0:2])`,
+/// since `Expr::pipe` doesn't flatten nested pipes when combining stages
+/// during parsing) -- both live-verified to silently fall through to the
+/// old buggy per-step walk instead of this rule. `flatten_delete_path` is
+/// the same recursive flattener `delete_expr_paths_at`'s sibling-grouping
+/// machinery already relies on to see through exactly this nesting, so
+/// reusing it here closes the gap instead of re-deriving a second,
+/// shallower flattening pass.
+///
+/// `empty_prefix_is_identity: true` is for `delete_at_path`'s
+/// `Expr::Iterate` arm's per-element `rest`: there, an empty residual
+/// prefix legitimately means "drop this element" (live-verified to hold
+/// for a trailing-run of any length, not just one slice), the opposite of
+/// the top-level "nothing to drop, no-op instead" reading every other
+/// caller needs for the same shape (a bare chained-slice-run directly on
+/// the root value, with no leading `Field`/`Index`).
+fn yq_del_slice_outcome(
     path_expr: &Expr,
     root: &OwnedValue,
     empty_prefix_is_identity: bool,
-) -> Option<Expr> {
-    // `unwrap_path_component`, not a direct match or the narrower
-    // `unwrap_paren`: a parenthesized chained target (`del((.a[0:1]))`)
-    // must apply the same parent-key-delete rule as its bare form
-    // (`del(.a[0:1])`) -- previously this shape-check required
-    // `path_expr` to literally be `Expr::Pipe`, so wrapping it in `()`
-    // silently opted out of the rule and fell through to
-    // `delete_at_path`'s own per-step walk, which errors trying to slice
-    // a scalar directly (#1153). `unwrap_path_component` (already used a
-    // few lines down for `exprs.last()`, and by `navigate_read_only`
-    // below) peels both `Expr::Paren` *and* `Expr::Optional` in either
-    // order, unlike `unwrap_paren` alone -- needed so `?` applied
-    // *outside* the closing paren (`del((.a[0:1])?)`) doesn't also opt
-    // out of the rule the way a bare `unwrap_paren` would have left it
-    // (caught by review before merge: that narrower version silently
-    // no-op'd instead of deleting the parent key, for that one shape).
-    let Expr::Pipe(exprs) = unwrap_path_component(path_expr).0 else {
-        return None;
-    };
+) -> YqDelSliceOutcome {
+    let mut steps = Vec::new();
+    flatten_delete_path(path_expr, false, &mut steps);
+    if !steps
+        .iter()
+        .any(|s| matches!(s.component, Expr::Slice { .. }))
+    {
+        return YqDelSliceOutcome::NotApplicable;
+    }
     // #1219: real yq's rule strips a *maximal trailing run* of consecutive
     // slices, not just one -- `del(.a[1:3][0:2])` drops `.a` entirely, same
     // target as the single-slice `del(.a[0:2])`, live-verified against yq
     // v4.53.3 (a chained slice-then-slice run of any length collapses to
     // the same "drop what's before the run" target; a run of 3 behaves
     // identically to a run of 2). `cut` is the index where that run begins.
-    let mut cut = exprs.len();
-    while cut > 0 && matches!(unwrap_path_component(&exprs[cut - 1]).0, Expr::Slice { .. }) {
+    let mut cut = steps.len();
+    while cut > 0 && matches!(steps[cut - 1].component, Expr::Slice { .. }) {
         cut -= 1;
     }
-    if cut == exprs.len() {
-        // Last component isn't a slice at all -- this rule never applies,
-        // regardless of what's earlier in the path. `builtin_del`'s own
-        // `yq_del_chained_slice_is_noop` decides what happens instead
-        // (#1219: a slice anywhere in the path with something other than
-        // more trailing slices after it makes the whole `del()` a no-op).
-        return None;
+    if cut == steps.len() {
+        // Last component isn't a slice at all -- the whole call/path
+        // no-ops, regardless of what's earlier in the path.
+        return YqDelSliceOutcome::Noop;
     }
-    let prefix = &exprs[..cut];
-    if prefix.is_empty() && !empty_prefix_is_identity {
+    let prefix = &steps[..cut];
+    if prefix
+        .iter()
+        .any(|s| matches!(s.component, Expr::Slice { .. }))
+    {
+        // An interior slice separated from the trailing run by something
+        // else (`del(.a[0:2][1][3:5])`) still no-ops the whole call, even
+        // though the path's last component is itself a slice.
+        return YqDelSliceOutcome::Noop;
+    }
+    if prefix.is_empty() {
         // A bare trailing slice-run with *nothing* before it at all
         // (`del(.[1:3][0:1])` on the root value itself, no leading
-        // `Field`/`Index`) live-verifies as a no-op, not "delete the root" --
-        // unlike the `Expr::Iterate` per-element case below, there is no
-        // parent key here to drop in the first place. Callers that walk a
-        // whole resolved path (not a per-element `rest` after `.[]`) pass
-        // `false` here so this returns `None` and lets
-        // `yq_del_chained_slice_is_noop` recognize the no-op instead of this
-        // function wrongly answering `Some(Expr::Identity)`.
-        return None;
+        // `Field`/`Index`) live-verifies as a no-op, not "delete the root"
+        // -- unlike the `Expr::Iterate` per-element case, there is no
+        // parent key here to drop in the first place.
+        return if empty_prefix_is_identity {
+            YqDelSliceOutcome::DropParent(Expr::Identity)
+        } else {
+            YqDelSliceOutcome::Noop
+        };
     }
     // Existence only, not type — #1162 confirmed live that real yq's rule
     // applies uniformly to every target type once the target actually
     // exists; `navigate_read_only` returning `None` (missing field/index)
     // is the only remaining reason to defer to `delete_at_path`'s own
     // absent-path handling instead.
-    navigate_read_only(root, prefix)?;
-    Some(match prefix.len() {
-        // Reached only when `empty_prefix_is_identity` is `true` --
-        // `delete_at_path`'s `Expr::Iterate` arm (#1182, generalized by
-        // #1219 to a whole trailing slice-run rather than just one slice),
-        // which always wraps its `rest` in `Expr::Pipe` regardless of
-        // length -- a bare `.[]` directly followed by the trailing slice
-        // run (`del(.a[][0:1])`, `del(.a[][1:3][0:1])`, no `Field`/`Index`
-        // between), resolves `prefix` to the empty slice, so `target` (from
-        // `navigate_read_only` with zero steps) is the element itself.
-        // `Expr::Identity` signals that case back to the caller: there is
-        // no parent *key* to drop here, the element itself is the thing to
-        // remove from its container -- that caller special-cases this
-        // return value rather than recursing `delete_at_path` on it (which
-        // would just null the element in place via its own `Expr::Identity`
-        // arm, not remove it).
-        0 => Expr::Identity,
-        1 => prefix[0].clone(),
-        _ => Expr::Pipe(prefix.to_vec()),
+    let prefix_components: Vec<Expr> = prefix.iter().map(|s| s.component.clone()).collect();
+    if navigate_read_only(root, &prefix_components).is_none() {
+        return YqDelSliceOutcome::NotApplicable;
+    }
+    let wrap = |s: &DeleteStep| {
+        if s.optional {
+            Expr::Optional(Box::new(s.component.clone()))
+        } else {
+            s.component.clone()
+        }
+    };
+    YqDelSliceOutcome::DropParent(match prefix {
+        [one] => wrap(one),
+        many => Expr::Pipe(many.iter().map(wrap).collect()),
     })
 }
 
-/// Whether a *resolved* `del()` path (already unwrapped to its `Pipe`
-/// component list, or a bare single component) contains a chained
-/// [`Expr::Slice`] that real yq's del() renders inert -- the *other* half of
-/// #1219, alongside [`yq_del_scalar_slice_parent_path`]'s trailing-run
-/// parent-key-drop rule above. Purely syntactic (no `root`/navigation
-/// needed): live-verified against yq v4.53.3 across every combination of
-/// leading `Field`/`Index`, trailing-run length, and what (if anything)
-/// follows the run, the whole call no-ops whenever:
-///
-/// - the path's *last* component isn't a slice at all (`del(.a[1:3][0])`,
-///   `del(.a[1:3][0].x)`, `del(.a[1:3][])`, `del(.a[1:3][0:2][0])` -- a
-///   trailing slice-run followed by anything non-slice makes the entire
-///   `del()` inert, not just that one step); or
-/// - the path *does* end in a slice-run, but what's left before that run
-///   either is empty (`del(.[1:3][0:1])`, a bare chained-slice-run with no
-///   leading `Field`/`Index` to drop) or itself contains another slice
-///   (`del(.a[0:2][1][3:5])`: the run is just the trailing `[3:5]`, but the
-///   residual prefix `.a[0:2][1]` still has a slice in it) -- in both cases
-///   `yq_del_scalar_slice_parent_path` already declines (returns `None`) for
-///   exactly this reason, so this function mirrors its own trailing-run
-///   walk rather than re-deriving a different one.
-///
-/// Not applicable to `delete_at_path`'s `Expr::Iterate` arm's per-element
-/// `rest`: an empty residual prefix there legitimately means "drop this
-/// element" (`Expr::Identity`, live-verified to hold for a trailing-run of
-/// any length, not just one slice), the opposite of this function's
-/// top-level "nothing to drop" reading of the same shape -- see
-/// `empty_prefix_is_identity`'s doc comment on the sibling function.
-fn yq_del_chained_slice_is_noop(path_expr: &Expr) -> bool {
-    let (unwrapped, _) = unwrap_path_component(path_expr);
-    let owned;
-    let exprs: &[Expr] = match unwrapped {
-        Expr::Pipe(list) => list,
-        other => {
-            owned = [other.clone()];
-            &owned
-        }
-    };
-    let is_slice = |e: &Expr| matches!(unwrap_path_component(e).0, Expr::Slice { .. });
-    if !exprs.iter().any(is_slice) {
-        return false;
-    }
-    let mut cut = exprs.len();
-    while cut > 0 && is_slice(&exprs[cut - 1]) {
-        cut -= 1;
-    }
-    if cut == exprs.len() {
-        return true;
-    }
-    let head = &exprs[..cut];
-    head.is_empty() || head.iter().any(is_slice)
-}
-
-/// Read-only navigation for [`yq_del_scalar_slice_parent_path`]'s prefix
+/// Read-only navigation for [`yq_del_slice_outcome`]'s prefix
 /// peek. Unlike `get_path_mut`, never autovivifies (a peek must not create
 /// structure the delete itself would otherwise leave untouched) and simply
 /// returns `None` for anything it can't resolve — a missing field, an
@@ -20525,7 +20535,7 @@ fn delete_expr_iterate_paths(
 }
 
 /// Recursively rewrite every already-static branch of `expr` with
-/// [`yq_del_scalar_slice_parent_path`]'s chained-slice-parent-key rule
+/// [`yq_del_slice_outcome`]'s chained-slice-parent-key rule
 /// (#1223), unwrapping and rewrapping any `Expr::Paren`/`Expr::Optional`
 /// around a `Comma` (or a nested `Comma` branch, however wrapped) so the
 /// rewrite reaches every syntactic route to the same comma-grouped shape --
@@ -20562,8 +20572,12 @@ fn rewrite_yq_del_comma_branches(expr: &Expr, root: &OwnedValue) -> Option<Expr>
                     if let Some(nested) = rewrite_yq_del_comma_branches(branch, root) {
                         nested
                     } else if !needs_path_prepass(branch) {
-                        yq_del_scalar_slice_parent_path(branch, root, false)
-                            .unwrap_or_else(|| branch.clone())
+                        match yq_del_slice_outcome(branch, root, false) {
+                            YqDelSliceOutcome::DropParent(rewritten) => rewritten,
+                            YqDelSliceOutcome::Noop | YqDelSliceOutcome::NotApplicable => {
+                                branch.clone()
+                            }
+                        }
                     } else {
                         branch.clone()
                     }
@@ -20600,7 +20614,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `resolve_dynamic_indexes`'s own generic navigation raises a hard type
     // error on a comma branch shaped like `.a[0:1]` when `.a` is an
     // `Object` -- *before* `builtin_del` ever gets a resolved `paths` vector
-    // to apply the `yq_del_scalar_slice_parent_path` rewrite below (that
+    // to apply the `yq_del_slice_outcome` rewrite below (that
     // rewrite runs on the navigation's *output*, too late to prevent the
     // navigation's own crash). `rewrite_yq_del_comma_branches` applies the
     // same rewrite to every already-static branch up front, so `.a[0:1]`
@@ -20637,7 +20651,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // yq's bare-root slice `del()` no-op (#1101's scalar case; #1162 widened
     // this to every target type, matching real yq's bare-root behavior
     // being type-uniform the same way the *chained* case is — see
-    // `yq_del_scalar_slice_parent_path`'s doc comment) — the `paths.len()
+    // `yq_del_slice_outcome`'s doc comment) — the `paths.len()
     // <= 1` branch below already checks this per path, but
     // `delete_expr_paths_at` (the `paths.len() > 1` branch after it) is a
     // completely separate sibling-grouping walker that has no equivalent
@@ -20674,29 +20688,31 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // yq's chained-scalar-slice del() rule (#1116, generalized by
             // #1219 to a whole trailing slice-run) — a *different* rule from
             // #1101's no-op above: rewrite the path to delete the parent key
-            // outright, rather than walking the original path at all, when
-            // it applies. See `yq_del_scalar_slice_parent_path`'s doc
-            // comment. `false`: this walks the whole resolved path, not a
-            // per-element `rest` after `.[]`, so an empty residual prefix
-            // must defer to the no-op check below rather than deleting the
-            // root outright.
-            let rewritten = (S::TAG == EvalTag::Yq)
-                .then(|| yq_del_scalar_slice_parent_path(path, &result, false))
-                .flatten();
-            // #1219: a chained slice with more path after it that *isn't*
-            // itself another trailing slice (`.a[1:3][0]`, `.a[1:3][0].x`,
-            // `.a[1:3][]`) real-yq no-ops entirely, live-verified — it does
-            // *not* fall through to walking the slice and then the rest of
-            // the path, which is what `delete_at_path`'s own per-step walk
-            // would otherwise do here and get wrong. Checked only once the
-            // parent-key-drop rewrite above has declined, same ordering as
-            // that rule: a chained slice-run always has one of these two
-            // outcomes, never a normal walk.
-            if rewritten.is_none() && S::TAG == EvalTag::Yq && yq_del_chained_slice_is_noop(path) {
-                continue;
-            }
-            let path = rewritten.as_ref().unwrap_or(path);
-            if let Err(e) = delete_at_path(&mut result, path, false, S::TAG == EvalTag::Yq) {
+            // outright (or no-op the whole call) rather than walking the
+            // original path at all, when it applies. See
+            // `yq_del_slice_outcome`'s doc comment. `false`: this walks the
+            // whole resolved path, not a per-element `rest` after `.[]`, so
+            // an empty residual prefix means "no-op," not "delete the root."
+            let outcome = if S::TAG == EvalTag::Yq {
+                yq_del_slice_outcome(path, &result, false)
+            } else {
+                YqDelSliceOutcome::NotApplicable
+            };
+            let effective_path: &Expr = match &outcome {
+                YqDelSliceOutcome::DropParent(rewritten) => rewritten,
+                // #1219: a chained slice with more path after it that
+                // *isn't* itself another trailing slice (`.a[1:3][0]`,
+                // `.a[1:3][0].x`, `.a[1:3][]`) real-yq no-ops entirely,
+                // live-verified — it does *not* fall through to walking the
+                // slice and then the rest of the path, which is what
+                // `delete_at_path`'s own per-step walk would otherwise do
+                // here and get wrong.
+                YqDelSliceOutcome::Noop => continue,
+                YqDelSliceOutcome::NotApplicable => path,
+            };
+            if let Err(e) =
+                delete_at_path(&mut result, effective_path, false, S::TAG == EvalTag::Yq)
+            {
                 return if optional {
                     QueryResult::None
                 } else {
@@ -20723,23 +20739,26 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // teaching them the rule directly.
     //
     // #1219's *other* half (a chained slice-run followed by something that
-    // isn't itself a slice no-ops the whole `del()` call) is deliberately
-    // **not** applied here: unlike the single-path branch above, a no-op
-    // here can't just skip the loop iteration — it would need to drop this
-    // one sibling's steps from `flattened` while still deleting the others,
-    // and real yq's own answer for a multi-path `del()` mixing this shape
-    // with a sibling is untested territory, same class of gap #1223 already
-    // scoped out of `rewrite_yq_del_comma_branches` above. Left as a
-    // pre-existing gap for this branch specifically; tracked as a follow-up
-    // rather than guessed at here.
+    // isn't itself a slice no-ops the whole `del()` call) applies per
+    // sibling here too — live-verified `del(.a[1:3][0], .c)` on
+    // `{"a":[1,2,3,4],"c":9}` leaves `.a` completely untouched while still
+    // deleting `.c`, the same independent-per-path treatment #1162's rule
+    // already gets one line up. `filter_map` drops a no-op sibling's steps
+    // from `rewritten` entirely rather than passing its original,
+    // unrewritten path through — `delete_expr_paths_at` already treats an
+    // empty path list as a no-op (its own `paths.is_empty()` guard), so
+    // this composes cleanly even when every sibling turns out to be a
+    // no-op.
     let rewritten: Vec<Expr> = paths
         .iter()
-        .map(|path| {
-            if S::TAG == EvalTag::Yq {
-                yq_del_scalar_slice_parent_path(path, &result, false)
-                    .unwrap_or_else(|| path.clone())
-            } else {
-                path.clone()
+        .filter_map(|path| {
+            if S::TAG != EvalTag::Yq {
+                return Some(path.clone());
+            }
+            match yq_del_slice_outcome(path, &result, false) {
+                YqDelSliceOutcome::DropParent(rewritten) => Some(rewritten),
+                YqDelSliceOutcome::Noop => None,
+                YqDelSliceOutcome::NotApplicable => Some(path.clone()),
             }
         })
         .collect();
@@ -20768,7 +20787,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// bools over a full generic, since this is the only thing here that needs
 /// mode-awareness at all). Consulted only by the `Expr::Iterate` arm below,
 /// to apply yq's chained-scalar-slice parent-key-delete rule
-/// (`yq_del_scalar_slice_parent_path`) *per element* when a `.[]` precedes
+/// (`yq_del_slice_outcome`) *per element* when a `.[]` precedes
 /// the trailing slice (`del(.a[].b[0:1])`) -- the top-level caller's own
 /// upfront rewrite (see this function's caller) can't handle that shape at
 /// all, since `navigate_read_only` has no way to peek through an
@@ -20939,62 +20958,57 @@ fn delete_at_path(
                             // #1182: yq's chained-scalar-slice del() rule
                             // (#1116, generalized by #1219 to a whole
                             // trailing slice-run) can't be applied upfront
-                            // for this shape -- the caller's own rewrite
-                            // (`yq_del_scalar_slice_parent_path`) only
-                            // runs once, before this walk even starts,
-                            // and its `navigate_read_only` prefix-peek
-                            // has no way to look *through* an
+                            // for this shape -- the caller's own
+                            // classification (see the mode-guard comment
+                            // above) only runs once, before this walk even
+                            // starts, and its `navigate_read_only`
+                            // prefix-peek has no way to look *through* an
                             // as-yet-unresolved `.[]` to find each
                             // element's own scalar target. So the rule is
-                            // attempted again here, once per element,
-                            // against `rest` (the path remaining after
-                            // this `.[]`) -- `None` (rule doesn't apply
-                            // to this element, or not yq mode at all)
-                            // just walks `rest` unchanged, exactly as
-                            // before this fix.
+                            // re-classified here, once per element, against
+                            // `rest` (the path remaining after this `.[]`).
                             //
-                            // `Some(Expr::Identity)` is a distinct signal
-                            // from any other rewrite: it means the *element
-                            // itself* is the scalar the trailing slice-run
-                            // would have targeted (`.[]` directly followed
-                            // by the run, no `Field`/`Index` between --
-                            // `true` for `empty_prefix_is_identity`, unlike
-                            // the top-level callers). There is no parent key
-                            // to drop one level down from an `&mut`
-                            // reference into this array slot --
-                            // `delete_at_path`'s own `Expr::Identity` arm
+                            // `DropParent(Expr::Identity)` is a distinct
+                            // signal from any other rewrite: it means the
+                            // *element itself* is the scalar the trailing
+                            // slice-run would have targeted (`.[]` directly
+                            // followed by the run, no `Field`/`Index`
+                            // between -- `true` for `empty_prefix_is_
+                            // identity`, unlike the top-level callers).
+                            // There is no parent key to drop one level down
+                            // from an `&mut` reference into this array slot
+                            // -- `delete_at_path`'s own `Expr::Identity` arm
                             // would just null the element in place, not
                             // remove it, so this element's index is queued
                             // for removal from `arr` itself after the loop
                             // instead of being recursed into.
                             //
-                            // #1219: when the rewrite declines *and* `rest`
-                            // is a chained slice-run followed by something
-                            // that isn't itself another trailing slice
-                            // (`.a[][1:3][0]`), real yq no-ops that element
-                            // outright rather than walking `rest` against
-                            // it, live-verified -- the element is left
-                            // completely untouched (neither removed nor
-                            // recursed into).
+                            // #1219: `Noop` (`rest` is a chained slice-run
+                            // followed by something that isn't itself
+                            // another trailing slice, e.g. `.a[][1:3][0]`)
+                            // leaves this element completely untouched
+                            // (neither removed nor recursed into),
+                            // live-verified.
                             let mut remove_indices = Vec::new();
                             for (i, elem) in arr.iter_mut().enumerate() {
-                                let rewritten = yq_mode
-                                    .then(|| yq_del_scalar_slice_parent_path(&rest, elem, true))
-                                    .flatten();
-                                if matches!(rewritten, Some(Expr::Identity)) {
-                                    remove_indices.push(i);
-                                } else if rewritten.is_none()
-                                    && yq_mode
-                                    && yq_del_chained_slice_is_noop(&rest)
-                                {
-                                    // Leave this element untouched.
+                                let outcome = if yq_mode {
+                                    yq_del_slice_outcome(&rest, elem, true)
                                 } else {
-                                    delete_at_path(
-                                        elem,
-                                        rewritten.as_ref().unwrap_or(&rest),
-                                        optional,
-                                        yq_mode,
-                                    )?;
+                                    YqDelSliceOutcome::NotApplicable
+                                };
+                                match outcome {
+                                    YqDelSliceOutcome::DropParent(Expr::Identity) => {
+                                        remove_indices.push(i);
+                                    }
+                                    YqDelSliceOutcome::DropParent(ref target) => {
+                                        delete_at_path(elem, target, optional, yq_mode)?;
+                                    }
+                                    YqDelSliceOutcome::Noop => {
+                                        // Leave this element untouched.
+                                    }
+                                    YqDelSliceOutcome::NotApplicable => {
+                                        delete_at_path(elem, &rest, optional, yq_mode)?;
+                                    }
                                 }
                             }
                             for i in remove_indices.into_iter().rev() {
@@ -21003,28 +21017,29 @@ fn delete_at_path(
                             Ok(())
                         }
                         OwnedValue::Object(map) => {
-                            // Same per-element rewrite, elem-is-target
-                            // removal, and #1219 no-op as the array arm
-                            // above.
+                            // Same per-element re-classification, elem-is-
+                            // target removal, and #1219 no-op as the array
+                            // arm above.
                             let mut remove_keys = Vec::new();
                             for (key, value) in map.iter_mut() {
-                                let rewritten = yq_mode
-                                    .then(|| yq_del_scalar_slice_parent_path(&rest, value, true))
-                                    .flatten();
-                                if matches!(rewritten, Some(Expr::Identity)) {
-                                    remove_keys.push(key.clone());
-                                } else if rewritten.is_none()
-                                    && yq_mode
-                                    && yq_del_chained_slice_is_noop(&rest)
-                                {
-                                    // Leave this entry untouched.
+                                let outcome = if yq_mode {
+                                    yq_del_slice_outcome(&rest, value, true)
                                 } else {
-                                    delete_at_path(
-                                        value,
-                                        rewritten.as_ref().unwrap_or(&rest),
-                                        optional,
-                                        yq_mode,
-                                    )?;
+                                    YqDelSliceOutcome::NotApplicable
+                                };
+                                match outcome {
+                                    YqDelSliceOutcome::DropParent(Expr::Identity) => {
+                                        remove_keys.push(key.clone());
+                                    }
+                                    YqDelSliceOutcome::DropParent(ref target) => {
+                                        delete_at_path(value, target, optional, yq_mode)?;
+                                    }
+                                    YqDelSliceOutcome::Noop => {
+                                        // Leave this entry untouched.
+                                    }
+                                    YqDelSliceOutcome::NotApplicable => {
+                                        delete_at_path(value, &rest, optional, yq_mode)?;
+                                    }
                                 }
                             }
                             for key in remove_keys {
@@ -21063,35 +21078,51 @@ fn delete_at_path(
                     // yq rules (#1116/#1162, now type-uniform) are handled
                     // by del()'s own separate mechanisms, not
                     // `through_slice`'s built-in no-op (see
-                    // `yq_del_scalar_slice_parent_path` for the case this
+                    // `yq_del_slice_outcome` for the case this
                     // covers -- the slice is the *last* path component).
                     // This arm only fires when there's more path *after*
                     // the slice (`.[1:3][0]`), which isn't that shape — in
                     // jq mode it correctly descends into the sliced
-                    // sub-range and deletes within it. In yq mode this is a
-                    // known divergence, tracked as #1219: real yq no-ops
-                    // the whole thing instead (live-verified,
-                    // `del(.a[1:3][0])` on `a: [1,2,3,4]` leaves `.a`
-                    // untouched, for both a container and a scalar target
-                    // reached through the slice) — broader than #1162's own
-                    // scope (slice as the path's *last* component), needing
-                    // its own investigation before it's fixed.
+                    // sub-range and deletes within it, matching real jq
+                    // (which has no chained-slice-parent-drop rule at all).
+                    //
+                    // In yq mode, #1219 makes this arm provably unreachable
+                    // for the common case: every entry point that can
+                    // construct a `rest`/`path` ending in "a slice with more
+                    // path after it" -- `builtin_del`'s single-path and
+                    // multi-path/comma branches, `rewrite_yq_del_comma_
+                    // branches`, and this very `Expr::Iterate` arm's own
+                    // per-element re-classification above -- calls
+                    // `yq_del_slice_outcome` first and either rewrites to a
+                    // slice-free target or no-ops before ever reaching here.
+                    // Confirmed empirically (not just by this reasoning): a
+                    // temporary probe on this exact arm, gated on `yq_mode`,
+                    // never fired across the full test suite or any of the
+                    // nested-`Pipe`/`Paren` shapes #1219 fixed. Kept as a
+                    // real match arm (not a `debug_assert!(!yq_mode)`)
+                    // because jq mode still legitimately reaches it, and
+                    // because a *computed* key resolving to a slice-headed
+                    // shape `yq_del_slice_outcome` doesn't yet cover would
+                    // fail closed here (a normal walk) rather than
+                    // panicking -- which is exactly why `terminal_write:
+                    // yq_mode` below still matters for that residual case.
                     //
                     // `terminal_write: yq_mode` (#1321 code review): a
-                    // string target here is the *same* #1219 divergence,
-                    // just for a scalar rather than a container -- yq
-                    // silently no-ops it (confirmed live, `del(.a[0:1].b)`
-                    // on `a: hello` leaves `a: hello` untouched), which
-                    // this PR doesn't attempt to fix. Forcing
-                    // `terminal_write: true` in yq mode keeps
-                    // `through_slice`'s String arm on its old, unconditional
-                    // refusal there -- the exact same wrong-but-unchanged
-                    // "Cannot update string slices" message yq mode already
-                    // raised before this PR -- instead of trading it for a
-                    // *different* wrong message ("Cannot index string with
-                    // string \"b\"") that would make this string case look
-                    // fixed relative to #1219's own array/object case when
-                    // it isn't. jq mode is unaffected either way.
+                    // string target reached through this still-possible
+                    // fallback path is the *same* #1219 divergence, just for
+                    // a scalar rather than a container -- yq silently
+                    // no-ops it (confirmed live, `del(.a[0:1].b)` on
+                    // `a: hello` leaves `a: hello` untouched), which this PR
+                    // doesn't attempt to fix. Forcing `terminal_write: true`
+                    // in yq mode keeps `through_slice`'s String arm on its
+                    // old, unconditional refusal there -- the exact same
+                    // wrong-but-unchanged "Cannot update string slices"
+                    // message yq mode already raised before this PR --
+                    // instead of trading it for a *different* wrong message
+                    // ("Cannot index string with string \"b\"") that would
+                    // make this string case look fixed relative to #1219's
+                    // own array/object case when it isn't. jq mode is
+                    // unaffected either way.
                     Expr::Slice { start, end } => through_slice(
                         root,
                         *start,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20568,18 +20568,34 @@ fn rewrite_yq_del_comma_branches(expr: &Expr, root: &OwnedValue) -> Option<Expr>
         Expr::Comma(branches) => {
             let new_branches: Vec<Expr> = branches
                 .iter()
-                .map(|branch| {
+                .filter_map(|branch| {
                     if let Some(nested) = rewrite_yq_del_comma_branches(branch, root) {
-                        nested
+                        Some(nested)
                     } else if !needs_path_prepass(branch) {
                         match yq_del_slice_outcome(branch, root, false) {
-                            YqDelSliceOutcome::DropParent(rewritten) => rewritten,
-                            YqDelSliceOutcome::Noop | YqDelSliceOutcome::NotApplicable => {
-                                branch.clone()
-                            }
+                            YqDelSliceOutcome::DropParent(rewritten) => Some(rewritten),
+                            // A `Noop`-classified branch is inert *regardless*
+                            // of what `root` actually contains: every `Noop`
+                            // return in `yq_del_slice_outcome` happens before
+                            // its own `navigate_read_only` call, so the
+                            // classification is pure syntax, decidable without
+                            // ever touching the document. Drop it from the
+                            // comma group entirely here, rather than leaving
+                            // its raw, still-slice-bearing branch in place --
+                            // `resolve_dynamic_indexes`'s navigation has no
+                            // `?`-style tolerance for a type mismatch (`.a[1:3]`
+                            // against an `Object` `.a` hard-errors there), so a
+                            // Noop branch combined with an incompatible sibling
+                            // type used to crash the whole `del()` call instead
+                            // of correctly leaving just this branch untouched
+                            // (`del(.a[1:3][0], .c)` on `{"a":{"x":1},"c":9}` —
+                            // live-verified against yq v4.53.3: `.a` stays put,
+                            // only `.c` is deleted).
+                            YqDelSliceOutcome::Noop => None,
+                            YqDelSliceOutcome::NotApplicable => Some(branch.clone()),
                         }
                     } else {
-                        branch.clone()
+                        Some(branch.clone())
                     }
                 })
                 .collect();

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12883,7 +12883,7 @@ fn test_jq_chained_scalar_slice_assign_and_del_still_error_1116() -> Result<()> 
 /// #1153's `delete_at_path` `Expr::Paren` arm is general (not gated by
 /// `EvalSemantics`), so a plain parenthesized delete target now works in
 /// jq mode too, matching real jq (`del((.a))` succeeds there). But the
-/// *other* half of #1153 -- `yq_del_scalar_slice_parent_path`'s
+/// *other* half of #1153 -- `yq_del_slice_outcome`'s
 /// `unwrap_paren` fix -- is itself gated to yq mode by its caller
 /// (`S::TAG == EvalTag::Yq`), so a parenthesized chained scalar-slice
 /// target must still error in jq mode exactly like its unparenthesized

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15515,28 +15515,210 @@ fn test_1220_delpaths_jq_mode_unaffected() -> Result<()> {
     Ok(())
 }
 
-/// #1219 characterization: a chained slice with more path *after* it
-/// (`.[1:3][0]`) is a structurally different shape than #1162 covers —
-/// `yq_del_scalar_slice_parent_path` only rewrites when the slice is the
-/// path's *last* component, so this never reaches that rewrite at all, and
-/// falls through to `delete_at_path`'s ordinary `Expr::Slice` walker arm
-/// instead. Real yq no-ops the whole thing here (verified live); succinctly
-/// still descends into the sliced sub-range and deletes within it. Confirmed
-/// unaffected by #1162's diff either way (identical on `main` before this
-/// fix). If this is ever fixed (tracked as #1219), update this expectation.
+/// #1219: a chained slice with more path *after* it (`.a[1:3][0]`) is a
+/// structurally different shape than #1162 covers — `yq_del_scalar_slice_
+/// parent_path` only rewrote when the slice was the path's *last*
+/// component, so this fell through to `delete_at_path`'s ordinary
+/// `Expr::Slice` walker arm and wrongly descended into the sliced
+/// sub-range, deleting an unrelated element. Real yq no-ops the whole
+/// `del()` call here — live-verified against yq v4.53.3, not assumed.
+/// `.a[1:3][0]`: slice then `Index` — one of several trailing-tail shapes
+/// (`Index`/`Field`/`Iterate`/a different `Index`) that all no-op
+/// identically, see the sibling tests below.
 #[test]
-fn test_1219_chained_slice_with_trailing_path_characterize_preexisting_bug() -> Result<()> {
+fn test_1219_chained_slice_then_index_is_noop() -> Result<()> {
     let (out, code) = run_yq_stdin(
         "del(.a[1:3][0])",
         r#"{"a":[1,2,3,4]}"#,
         &["-o=json", "-I=0"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(
-        out.trim(),
-        r#"{"a":[1,3,4]}"#,
-        "if this now matches real yq's no-op ({{\"a\":[1,2,3,4]}}), update this test and close #1219"
-    );
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4]}"#);
+    Ok(())
+}
+
+/// #1219: same no-op rule, but the tail after the chained slice is a
+/// `Field`, not an `Index` — confirms the rule doesn't depend on the
+/// specific step type following the slice, only on it not being another
+/// slice.
+#[test]
+fn test_1219_chained_slice_then_field_is_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3][0].x)",
+        r#"{"a":[1,2,3,4]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4]}"#);
+    Ok(())
+}
+
+/// #1219: chained slice then `.[]` (`Expr::Iterate`) also no-ops the whole
+/// call, same as the `Index`/`Field` tails above.
+#[test]
+fn test_1219_chained_slice_then_iterate_is_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[1:3][])", r#"{"a":[1,2,3,4]}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4]}"#);
+    Ok(())
+}
+
+/// #1219: a chained slice immediately followed by *another* slice is the
+/// exception to the no-op rule above — real yq drops the parent key
+/// entirely instead, the same target #1162 already computes for a single
+/// trailing slice (`del(.a[0:2])` also gives `{"b":6}` on this input) —
+/// live-verified that a run of exactly two trailing slices collapses to
+/// the same "drop what's before the run" target, regardless of either
+/// slice's own bounds.
+#[test]
+fn test_1219_chained_slice_then_slice_drops_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3][0:1])",
+        r#"{"a":[1,2,3,4],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// #1219: three consecutive trailing slices behave identically to two —
+/// the "drop the parent key" rule fires for a trailing run of *any* length
+/// ≥ 2, not just exactly two — live-verified.
+#[test]
+fn test_1219_triple_chained_slice_drops_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3][0:2][0:1])",
+        r#"{"a":[1,2,3,4,5,6],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// #1219: a *third* trailing component after a two-slice run flips the
+/// result back to a no-op — the "drop parent" rule only fires when the
+/// slice-run is the path's true tail, not merely "contains two adjacent
+/// slices somewhere." This is what falsifies the simpler "any adjacent
+/// slice pair drops the parent" hypothesis and pins the real rule to a
+/// maximal *trailing* run specifically — live-verified.
+#[test]
+fn test_1219_chained_slice_slice_then_index_is_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3][0:2][0])",
+        r#"{"a":[1,2,3,4],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4],"b":6}"#);
+    Ok(())
+}
+
+/// #1219: an `Index` prefix before the chained slice run drops the
+/// *indexed element* wholesale, not just the parent field — the same
+/// target `Expr::Index`-prefixed chains already resolved to before this
+/// fix (an `Index`, unlike a bare `Field`-only prefix, is itself
+/// unaffected by #1219; this pins that a *run* of trailing slices behaves
+/// the same as a single one for this prefix shape too).
+#[test]
+fn test_1219_index_prefix_chained_slice_run_drops_element() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0][1:3][0:1])",
+        r#"{"a":[[10,20,30,40,50],[1,2,3,4,5,6]],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[[1,2,3,4,5,6]],"b":6}"#);
+    Ok(())
+}
+
+/// #1219: a slice that is *not* part of the trailing run (an interior
+/// slice, with a non-slice step between it and the trailing slice) still
+/// no-ops the whole call, even though the path's *last* component is
+/// itself a slice — `yq_del_scalar_slice_parent_path`'s residual prefix
+/// (`.a[0:2][1]`) still contains a slice, so the rewrite correctly
+/// declines and `yq_del_chained_slice_is_noop` catches it instead.
+/// Live-verified this is a no-op, not a partial delete or a parent-key
+/// drop.
+#[test]
+fn test_1219_interior_slice_before_trailing_slice_is_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:2][1][3:5])",
+        r#"{"a":[[10,20,30],[1,2,3,4,5,6]],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[[10,20,30],[1,2,3,4,5,6]],"b":6}"#);
+    Ok(())
+}
+
+/// #1219: a bare chained slice-run with *no* leading `Field`/`Index` at
+/// all (`del(.[1:3][0:1])` on the root value itself) is a no-op, not
+/// "delete the root" — unlike #1101's already-established single-slice
+/// bare-root no-op, this shape (`Pipe` of two-or-more slices) wasn't
+/// covered by `is_yq_scalar_slice_assign_path`'s single-`Expr::Slice`
+/// check, so it fell through to `yq_del_scalar_slice_parent_path`'s
+/// generalized trailing-run stripping — which must decline (empty prefix,
+/// `empty_prefix_is_identity: false` at this top-level call site) rather
+/// than answering `Expr::Identity`, or this would wrongly null/replace the
+/// root. Live-verified against yq v4.53.3.
+#[test]
+fn test_1219_bare_root_chained_slice_run_is_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[1:3][0:1])", "[1,2,3,4]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2,3,4]");
+    Ok(())
+}
+
+/// #1219: the `Expr::Iterate` per-element path (`.a[][1:3][0:1]`) hits the
+/// *opposite* empty-prefix reading from the bare-root case above — here an
+/// empty residual prefix legitimately means "drop this element entirely"
+/// (`empty_prefix_is_identity: true`), the same #1182 rule already applies
+/// for a single trailing slice, now confirmed to generalize to a run of
+/// two. Live-verified both elements are removed, matching the identical
+/// single-slice control case.
+#[test]
+fn test_1219_iterate_chained_slice_run_drops_each_element() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[][1:3][0:1])",
+        r#"{"a":[[1,2,3,4],[10,20,30,40]],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[],"b":6}"#);
+    Ok(())
+}
+
+/// #1219: the `Expr::Iterate` per-element path also picks up the plain
+/// no-op half of the rule — `.a[][1:3][0]` (slice then `Index`, no
+/// trailing slice) leaves every element completely untouched, matching
+/// the top-level no-op tests above but exercised through the separate
+/// per-element walker in `delete_at_path`'s own `Expr::Iterate` arm.
+#[test]
+fn test_1219_iterate_chained_slice_then_index_is_noop_per_element() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[][1:3][0])",
+        r#"{"a":[[1,2,3,4],[10,20,30,40]],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[[1,2,3,4],[10,20,30,40]],"b":6}"#);
+    Ok(())
+}
+
+/// #1219 jq-mode control: jq has no #1116/#1162/#1219 "chained slice"
+/// rule at all — `del(.a[1:3][0])` is an ordinary path delete there,
+/// removing the element at the sliced sub-range's index 0
+/// (`[2,3][0]` == `2`), confirmed against real jq 1.7.1. This pins that
+/// #1219's fix is entirely yq-mode-gated and doesn't touch jq's own
+/// `delete_at_path` walk.
+#[test]
+fn test_1219_jq_mode_unaffected() -> Result<()> {
+    let (out, _stderr, code) =
+        run_jq_stdin_with_stderr("del(.a[1:3][0])", r#"{"a":[1,2,3,4]}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,3,4]}"#);
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16134,6 +16134,46 @@ fn test_1223_bare_slice_sibling_object_target_no_longer_crashes_but_still_diverg
     Ok(())
 }
 
+/// #1219 follow-up (found by `/code-review`'s third pass): the same
+/// bare-slice-sibling gap above, but with a trailing slice-*run*
+/// (`.a[0:2][0:1]`, #1219's own generalization) instead of a single
+/// trailing slice. On `main` (pre-#1219), this exact input hard-errored
+/// (`Cannot index object with object`) the same way the single-slice case
+/// used to; post-#1219 it no longer crashes, but -- like the single-slice
+/// case above -- still diverges from real yq for this specific ordering
+/// (real yq leaves the whole document unchanged here; the reversed
+/// ordering, `del(.[2:3], .a[0:2][0:1])`, happens to match real yq
+/// exactly, live-verified). Same "no coherent rule, order-sensitive"
+/// territory as the test above, extended to the run-generalized shape --
+/// not a new gap, just this one now reachable for a run as well as a
+/// single slice. If this is ever reconciled, update this expectation.
+#[test]
+fn test_1219_bare_slice_sibling_trailing_run_no_longer_crashes_but_still_diverges() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:2][0:1], .[2:3])",
+        r#"{"a":[1,2,3,4,5,6],"b":6,"c":9}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(
+        out.trim(),
+        r#"{"b":6,"c":9}"#,
+        "real yq gives {{\"a\":[1,2,3,4,5,6],\"b\":6,\"c\":9}} (fully unchanged) for this ordering"
+    );
+
+    // The reversed ordering, unlike the one above, happens to match real
+    // yq exactly (same coincidental-agreement pattern the #1223 test above
+    // documents for the single-slice shape).
+    let (out_reversed, code_reversed) = run_yq_stdin(
+        "del(.[2:3], .a[0:2][0:1])",
+        r#"{"a":[1,2,3,4,5,6],"b":6,"c":9}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code_reversed, 0, "out: {out_reversed:?}");
+    assert_eq!(out_reversed.trim(), r#"{"b":6,"c":9}"#);
+    Ok(())
+}
+
 /// #1223 follow-up (found by `/code-review`, filed separately): a comma
 /// branch reaching its trailing slice through an `Expr::Iterate` prefix
 /// (`.arr[][0:1]`) still crashes, because `navigate_read_only` (the prefix

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15819,6 +15819,26 @@ fn test_1219_computed_key_all_noop_siblings() -> Result<()> {
     Ok(())
 }
 
+/// #1219: a computed-key multi-path `del()` where *every* resolved sibling
+/// is `DropParent`-classified (a bare trailing slice on each) -- the
+/// mirror image of the all-`Noop` case above. Unlike a syntactic comma
+/// (whose `DropParent` branches are already rewritten pre-navigation by
+/// `rewrite_yq_del_comma_branches`), a computed-key fan-out reaches
+/// `builtin_del`'s own `paths.len() > 1` `filter_map` still carrying the
+/// raw slice, so this is the only route that exercises that filter_map's
+/// own `DropParent(rewritten) => Some(rewritten)` arm directly.
+#[test]
+fn test_1219_computed_key_all_drop_parent_siblings() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        r#"del(.[("a","z")][0:1])"#,
+        r#"{"a":[1,2,3,4],"z":[5,6,7,8]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r"{}");
+    Ok(())
+}
+
 /// #1219: a `DropParent`-classified chained slice whose *residual prefix*
 /// contains a multi-step `Expr::Optional` group (`.a?.b?[0:2]`) reconstructs
 /// correctly via `yq_del_slice_outcome`'s `wrap` closure -- each prefix

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15800,6 +15800,57 @@ fn test_1219_comma_grouped_all_noop_siblings_object_targets() -> Result<()> {
     Ok(())
 }
 
+/// #1219: the same all-siblings-`Noop` collapse as above, but reached
+/// through a *computed* key (`.[("a","z")]`) fanning out to two resolved
+/// paths in `builtin_del`'s `paths.len() > 1` branch, rather than a
+/// syntactic top-level `Comma` reaching `rewrite_yq_del_comma_branches`.
+/// These are two structurally distinct code paths that happen to share
+/// the same "every sibling filters out to empty" edge case -- flagged by
+/// review as untested since only the syntactic-comma variant had a pin.
+#[test]
+fn test_1219_computed_key_all_noop_siblings() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        r#"del(.[("a","z")][1:3][0])"#,
+        r#"{"a":[10,20,30,40],"z":[1,2,3,4]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[10,20,30,40],"z":[1,2,3,4]}"#);
+    Ok(())
+}
+
+/// #1219: a `DropParent`-classified chained slice whose *residual prefix*
+/// contains a multi-step `Expr::Optional` group (`.a?.b?[0:2]`) reconstructs
+/// correctly via `yq_del_slice_outcome`'s `wrap` closure -- each prefix
+/// step's own `optional` flag (from `flatten_delete_path`) is independently
+/// re-wrapped, reproducing the same swallow-on-mismatch behavior a single
+/// `Optional` around the whole group would give (an established precedent,
+/// see `splice_optional_group`, #1294). A mid-prefix type mismatch (`.a` is
+/// a scalar, not an object) is swallowed by `?` and the whole call no-ops;
+/// live-verified against yq v4.53.3.
+#[test]
+fn test_1219_optional_wrapped_multistep_prefix_swallows_mismatch() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a?.b?[0:2])", r#"{"a":5}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+    Ok(())
+}
+
+/// #1219: the same `Optional`-wrapped-prefix shape when it *does* resolve
+/// cleanly -- drops `.a.b` entirely, the ordinary drop-parent rule, `?`
+/// never needing to swallow anything here.
+#[test]
+fn test_1219_optional_wrapped_multistep_prefix_drops_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a?.b?[0:2])",
+        r#"{"a":{"b":[10,20,30,40]}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":{}}"#);
+    Ok(())
+}
+
 /// #1219: a chained slice hidden inside a parenthesized sub-path, combined
 /// with more path *outside* the parens (`(.a[0:1])[0:2]`), must get the
 /// same drop-parent-key treatment as the unparenthesized `del(.a[0:2])`.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15094,7 +15094,7 @@ fn test_1153_parenthesized_del_target_works() -> Result<()> {
     Ok(())
 }
 
-/// Gap 2: `yq_del_scalar_slice_parent_path`'s own shape check required
+/// Gap 2: `yq_del_slice_outcome`'s own shape check required
 /// `path_expr` to literally be `Expr::Pipe`, so wrapping a chained
 /// scalar-slice target in `()` opted out of #1116's parent-key-delete rule
 /// entirely and fell through to `delete_at_path`'s per-step walk, which
@@ -15636,11 +15636,10 @@ fn test_1219_index_prefix_chained_slice_run_drops_element() -> Result<()> {
 /// #1219: a slice that is *not* part of the trailing run (an interior
 /// slice, with a non-slice step between it and the trailing slice) still
 /// no-ops the whole call, even though the path's *last* component is
-/// itself a slice — `yq_del_scalar_slice_parent_path`'s residual prefix
-/// (`.a[0:2][1]`) still contains a slice, so the rewrite correctly
-/// declines and `yq_del_chained_slice_is_noop` catches it instead.
-/// Live-verified this is a no-op, not a partial delete or a parent-key
-/// drop.
+/// itself a slice — `yq_del_slice_outcome`'s residual prefix
+/// (`.a[0:2][1]`) still contains a slice, so it returns `Noop` rather than
+/// `DropParent`. Live-verified this is a no-op, not a partial delete or a
+/// parent-key drop.
 #[test]
 fn test_1219_interior_slice_before_trailing_slice_is_noop() -> Result<()> {
     let (out, code) = run_yq_stdin(
@@ -15658,11 +15657,11 @@ fn test_1219_interior_slice_before_trailing_slice_is_noop() -> Result<()> {
 /// "delete the root" — unlike #1101's already-established single-slice
 /// bare-root no-op, this shape (`Pipe` of two-or-more slices) wasn't
 /// covered by `is_yq_scalar_slice_assign_path`'s single-`Expr::Slice`
-/// check, so it fell through to `yq_del_scalar_slice_parent_path`'s
-/// generalized trailing-run stripping — which must decline (empty prefix,
+/// check, so it falls to `yq_del_slice_outcome`'s generalized
+/// trailing-run stripping — which must answer `Noop` (empty prefix,
 /// `empty_prefix_is_identity: false` at this top-level call site) rather
-/// than answering `Expr::Identity`, or this would wrongly null/replace the
-/// root. Live-verified against yq v4.53.3.
+/// than `DropParent(Expr::Identity)`, or this would wrongly null/replace
+/// the root. Live-verified against yq v4.53.3.
 #[test]
 fn test_1219_bare_root_chained_slice_run_is_noop() -> Result<()> {
     let (out, code) = run_yq_stdin("del(.[1:3][0:1])", "[1,2,3,4]", &["-o=json", "-I=0"])?;
@@ -15739,6 +15738,65 @@ fn test_1219_comma_grouped_noop_sibling_leaves_other_siblings_untouched() -> Res
     )?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), r#"{"a":[1,2,3,4]}"#);
+    Ok(())
+}
+
+/// #1219: the same comma-grouped no-op rule, but with `.a` an `Object`
+/// rather than an `Array` — this used to crash instead of no-op'ing.
+/// `rewrite_yq_del_comma_branches` (the pre-navigation crash-avoidance pass
+/// #1223 introduced) only rewrote a `DropParent`-classified branch away
+/// from its raw slice before `resolve_dynamic_indexes` navigated it; a
+/// `Noop`-classified branch was left completely unrewritten, so
+/// `resolve_dynamic_indexes` still tried to navigate `.a[1:3]` against the
+/// `Object` `.a` and hard-errored ("Cannot index object with object")
+/// instead of leaving `.a` untouched and deleting only `.c`. Every `Noop`
+/// classification is decided purely from the path's own shape (never
+/// touches the document), so it's always safe to drop a `Noop` branch from
+/// the comma group before navigation ever sees it — fixed by doing exactly
+/// that. Live-verified against yq v4.53.3.
+#[test]
+fn test_1219_comma_grouped_noop_sibling_object_target_no_longer_crashes() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3][0], .c)",
+        r#"{"a":{"x":1,"y":2},"c":9}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":{"x":1,"y":2}}"#);
+    Ok(())
+}
+
+/// #1219: the same `Object`-target no-op-sibling fix, reached through a
+/// *nested* comma group (`del((.a[1:3][0], .z), .c)`) — confirms
+/// `rewrite_yq_del_comma_branches`'s recursive branch-dropping applies at
+/// every nesting depth, not just the top level.
+#[test]
+fn test_1219_comma_grouped_noop_sibling_object_target_nested_comma() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del((.a[1:3][0], .z), .c)",
+        r#"{"a":{"x":1,"y":2},"z":3,"c":9}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":{"x":1,"y":2}}"#);
+    Ok(())
+}
+
+/// #1219: every comma sibling classifying as `Noop` (all `Object`-typed
+/// targets, all no-op-shaped) collapses `rewrite_yq_del_comma_branches`'s
+/// output to an empty `Expr::Comma`, which `resolve_dynamic_indexes`
+/// resolves to zero paths — `builtin_del`'s `paths.len() <= 1` branch then
+/// correctly treats that as a full no-op (its `for path in &paths` loop
+/// simply never executes), not a crash or an empty-`Comma` panic.
+#[test]
+fn test_1219_comma_grouped_all_noop_siblings_object_targets() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3][0], .b[1:3][0])",
+        r#"{"a":{"x":1},"b":{"y":2}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":{"x":1},"b":{"y":2}}"#);
     Ok(())
 }
 
@@ -15859,12 +15917,12 @@ fn test_1219_interior_slice_separated_by_iterate_is_noop() -> Result<()> {
 /// chained-slice target was an `Object`, instead of applying #1162's own
 /// parent-key-drop rule (which the *single-path* form of this exact query
 /// already got correctly — see `test_1162_chained_object_slice_del_removes_
-/// parent_key`). Root cause was upstream of `yq_del_scalar_slice_parent_path`,
+/// parent_key`). Root cause was upstream of `yq_del_slice_outcome`,
 /// in `resolve_dynamic_indexes`'s generic multi-path navigation for a
 /// top-level `Comma`: it navigated `.a[0:1]` against the real document
 /// before `builtin_del` ever got a resolved `paths` vector to apply its own
 /// rewrite to, and `Object` has no slice-navigation arm. Fixed by rewriting
-/// every already-static `Comma` branch with `yq_del_scalar_slice_parent_path`
+/// every already-static `Comma` branch with `yq_del_slice_outcome`
 /// *before* handing the path to `resolve_dynamic_indexes`, so navigation
 /// only ever sees `.a` (the rewritten form), never the crashing `.a[0:1]`.
 #[test]
@@ -15990,31 +16048,37 @@ fn test_1223_multi_path_del_object_target_jq_mode_unaffected() -> Result<()> {
 
 /// #1223 follow-up (found by `/code-review`, filed separately): a comma
 /// branch that is itself a bare root slice (`.[2:3]`, not chained under a
-/// `Field`/`Index`) still reaches `resolve_dynamic_indexes`'s crashing
-/// navigation, because `yq_del_scalar_slice_parent_path` only rewrites a
-/// *chained* slice (`unwrap_path_component`'s result must be `Expr::Pipe`)
-/// -- a bare `Expr::Slice` isn't one, so it's correctly left unrewritten by
-/// `rewrite_yq_del_comma_branches`, same as it always was. Distinct from,
-/// and deliberately not chased by, this PR's own fix: real yq's actual
-/// answer for this exact combination is the *unchanged* document (verified
-/// live against yq v4.53.3), not the composition of the chained-slice's
-/// parent-key-drop with the bare-slice's own no-op rule -- squarely the
-/// same "no coherent rule to replicate" territory as the order-sensitivity
-/// gap below. If this is ever addressed, update this expectation.
+/// `Field`/`Index`) used to still reach `resolve_dynamic_indexes`'s
+/// crashing navigation, because `rewrite_yq_del_comma_branches` only
+/// rewrote a `DropParent`-classified branch away from its raw slice and
+/// left a `Noop`-classified one (which a bare root slice always is --
+/// empty residual prefix, `empty_prefix_is_identity: false`) completely
+/// unrewritten. #1219's own fix for the *sibling* crash (an `Object`
+/// target combined with a chained-slice-then-non-slice branch, see
+/// `test_1219_comma_grouped_noop_sibling_object_target_no_longer_crashes`)
+/// generalized to drop *every* `Noop`-classified branch from the comma
+/// group before navigation, which incidentally also fixes this crash --
+/// `Noop` classification never depends on `root`, so it's always safe to
+/// decide before navigation regardless of which specific shape produced
+/// it. The crash is gone, but the *result* still isn't what real yq gives:
+/// real yq leaves this whole combination completely unchanged (verified
+/// live against yq v4.53.3), while succinctly still applies the chained
+/// slice's own correct-in-isolation parent-key-drop rule to `.a` -- the
+/// same "no coherent rule to replicate" territory as the
+/// order-sensitivity gap below, now non-crashing but still a real
+/// divergence. If this is ever addressed, update this expectation.
 #[test]
-fn test_1223_bare_slice_sibling_object_target_characterize_preexisting_bug() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+fn test_1223_bare_slice_sibling_object_target_no_longer_crashes_but_still_diverges() -> Result<()> {
+    let (out, code) = run_yq_stdin(
         "del(.a[0:1], .[2:3])",
         r#"{"a":{"x":1,"y":2},"b":6,"c":9}"#,
-        &[],
+        &["-o=json", "-I=0"],
     )?;
-    assert_ne!(
-        code, 0,
-        "if this now succeeds, update this test (real yq leaves the document unchanged here)"
-    );
-    assert!(
-        stderr.contains("Cannot index object with object"),
-        "stderr: {stderr}"
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(
+        out.trim(),
+        r#"{"b":6,"c":9}"#,
+        "real yq gives {{\"a\":{{\"x\":1,\"y\":2}},\"b\":6,\"c\":9}} (fully unchanged) for this combination"
     );
     Ok(())
 }
@@ -16022,7 +16086,7 @@ fn test_1223_bare_slice_sibling_object_target_characterize_preexisting_bug() -> 
 /// #1223 follow-up (found by `/code-review`, filed separately): a comma
 /// branch reaching its trailing slice through an `Expr::Iterate` prefix
 /// (`.arr[][0:1]`) still crashes, because `navigate_read_only` (the prefix
-/// walker `yq_del_scalar_slice_parent_path` uses to confirm the prefix
+/// walker `yq_del_slice_outcome` uses to confirm the prefix
 /// actually exists) only understands `Field`/`Index` steps -- an
 /// `Iterate` step returns `None` immediately, so the rewrite silently
 /// declines and the branch reaches `resolve_dynamic_indexes` unrewritten.
@@ -16089,7 +16153,7 @@ fn test_1223_computed_key_with_trailing_slice_characterize_preexisting_bug() -> 
 /// separately-tracked gap rather than silently unasserted.
 ///
 /// #1219 changed *what* succinctly gets wrong here, as a side effect of
-/// wiring `yq_del_chained_slice_is_noop` into the multi-path branch (a bare
+/// wiring `yq_del_slice_outcome` into the multi-path branch (a bare
 /// `.[2:3]` sibling, with nothing else in its own path, is itself a no-op
 /// shape and now correctly drops out of the delete set on its own) —
 /// live-verified this happens to make the *second* ordering (`out_b`) match
@@ -16213,7 +16277,7 @@ fn test_1182_chained_scalar_slice_del_through_iterate_removes_parent_key_per_ele
 /// Two `.[]` steps before the trailing slice -- the per-element retry in
 /// `delete_at_path`'s `Expr::Iterate` arm fires independently at each
 /// nesting level (the first iterate's own `rest` still contains the second
-/// iterate, so `yq_del_scalar_slice_parent_path` correctly returns `None`
+/// iterate, so `yq_del_slice_outcome` correctly returns `NotApplicable`
 /// there and only fires once the walk reaches the second, innermost
 /// iterate). Live-verified against real yq.
 #[test]
@@ -16232,7 +16296,7 @@ fn test_1182_chained_scalar_slice_del_through_nested_iterate() -> Result<()> {
 }
 
 /// The per-element rewrite applies to an array-valued element exactly the
-/// same as a scalar one (#1162 widened `yq_del_scalar_slice_parent_path`
+/// same as a scalar one (#1162 widened `yq_del_slice_outcome`
 /// itself, so this per-element retry — reusing that same function — picks
 /// the widening up automatically with no `.[]`-specific change needed): a
 /// mixed array of array-valued and scalar-valued `.b` fields both lose the
@@ -16265,7 +16329,7 @@ fn test_1182_chained_scalar_slice_del_through_iterate_jq_mode_unaffected() -> Re
 
 /// `.[]` directly followed by the trailing slice, with no `Field`/`Index`
 /// between -- the element itself (not a field reached through it) is the
-/// scalar the rule applies to. `yq_del_scalar_slice_parent_path`'s
+/// scalar the rule applies to. `yq_del_slice_outcome`'s
 /// `prefix.len() == 0` case signals this back as `Expr::Identity`; the
 /// `Expr::Iterate` arm must special-case that as "remove this element from
 /// its container" rather than recursing `delete_at_path` on it (which would

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15722,6 +15722,139 @@ fn test_1219_jq_mode_unaffected() -> Result<()> {
     Ok(())
 }
 
+/// #1219: a chained-slice-then-non-slice sibling inside a comma-grouped
+/// `del()` gets the no-op rule too, not just a single-path `del()` — real
+/// yq leaves `.a` completely untouched while still deleting the unrelated
+/// `.c` sibling, live-verified. `builtin_del`'s multi-path branch
+/// (`paths.len() > 1`) used to apply only the "drop parent" half of
+/// #1219's rule per sibling, never the "no-op" half, so this exact shape
+/// still fell through to the old buggy in-range delete for `.a` even after
+/// the single-path case above was fixed.
+#[test]
+fn test_1219_comma_grouped_noop_sibling_leaves_other_siblings_untouched() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[1:3][0], .c)",
+        r#"{"a":[1,2,3,4],"c":9}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4]}"#);
+    Ok(())
+}
+
+/// #1219: a chained slice hidden inside a parenthesized sub-path, combined
+/// with more path *outside* the parens (`(.a[0:1])[0:2]`), must get the
+/// same drop-parent-key treatment as the unparenthesized `del(.a[0:2])`.
+/// The original #1219 fix only inspected one flat `Expr::Pipe` level after
+/// unwrapping `Optional`/`Paren` around the *whole* path, so a slice
+/// nested inside a `Paren`-wrapped sub-`Pipe` was invisible to it and fell
+/// through to the pre-#1219 buggy walk — `yq_del_slice_outcome` now uses
+/// `flatten_delete_path` (the same recursive flattener the comma-grouped
+/// multi-path walker already relies on) to see through this nesting.
+/// Live-verified against yq v4.53.3.
+#[test]
+fn test_1219_paren_wrapped_nested_slice_drops_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del((.a[0:1])[0:2])",
+        r#"{"a":[1,2,3,4],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// #1219: the same `Paren`-nesting gap, but for a shape that used to hard
+/// *error* instead of silently misbehaving — `(.a[0])[0:1]` is
+/// index-then-slice (the already-#1162-correct "drop this element" shape),
+/// but nested inside a `Paren` it used to reach `delete_at_path`'s ordinary
+/// walk with a raw `Expr::Paren` in an unexpected position and fail with
+/// "Cannot index number with object." Real yq succeeds silently, dropping
+/// the trailing `[0:1)` range from the sub-array at `.a[0]`.
+#[test]
+fn test_1219_paren_wrapped_index_then_slice_no_longer_errors() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del((.a[0])[0:1])",
+        r#"{"a":[1,2,3,4],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[2,3,4],"b":6}"#);
+    Ok(())
+}
+
+/// #1219: the identical nested-`Pipe` gap reachable with *no* parentheses
+/// at all — `.a | .[0:1][0]` parses to a genuinely nested `Expr::Pipe`
+/// (each pipe-stage with more than one postfix component becomes its own
+/// `Pipe`, and `Expr::pipe` doesn't flatten nested pipes when combining
+/// stages), so this was just as invisible to the original single-level
+/// check as the `Paren`-wrapped case above. Real yq no-ops here (slice
+/// then a non-slice tail, same rule as the unparenthesized
+/// `del(.a[0:1][0])`).
+#[test]
+fn test_1219_plain_pipe_nested_chained_slice_is_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a | .[0:1][0])",
+        r#"{"a":[1,2,3,4]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3,4]}"#);
+    Ok(())
+}
+
+/// #1219: the plain-pipe nesting gap combined with a trailing slice-*run*
+/// (rather than a single trailing slice) — drops the parent key, same
+/// target the unparenthesized `del(.a[0:1][0:2])` already resolves to.
+#[test]
+fn test_1219_plain_pipe_nested_chained_slice_run_drops_parent_key() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a | .[0:1][0:2])",
+        r#"{"a":[1,2,3,4],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// #1219: the plain-pipe nesting gap reached through `delete_at_path`'s own
+/// `Expr::Iterate` per-element re-classification, confirming the fix there
+/// also sees through a nested `Pipe` per element, not just at the
+/// top-level caller.
+#[test]
+fn test_1219_iterate_plain_pipe_nested_chained_slice_is_noop_per_element() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[] | .[0:1][0])",
+        r#"{"a":[[1,2,3,4],[10,20,30,40]],"b":6}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[[1,2,3,4],[10,20,30,40]],"b":6}"#);
+    Ok(())
+}
+
+/// #1219: an interior slice separated from the trailing slice-run by an
+/// `Expr::Iterate` (rather than by a `Field`/`Index`, already covered
+/// above) still no-ops the whole call — `yq_del_slice_outcome`'s "residual
+/// prefix contains another slice" check doesn't special-case an `Iterate`
+/// in that prefix, and real yq agrees: every element stays completely
+/// untouched. Live-verified.
+#[test]
+fn test_1219_interior_slice_separated_by_iterate_is_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:2][].b[0:1])",
+        r#"{"a":[{"b":[1,2,3,4]},{"b":[10,20,30,40]},{"b":[100,200]}]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        r#"{"a":[{"b":[1,2,3,4]},{"b":[10,20,30,40]},{"b":[100,200]}]}"#
+    );
+    Ok(())
+}
+
 /// #1223: a comma-grouped multi-path `del()` used to crash when a sibling's
 /// chained-slice target was an `Object`, instead of applying #1162's own
 /// parent-key-drop rule (which the *single-path* form of this exact query
@@ -15946,35 +16079,48 @@ fn test_1223_computed_key_with_trailing_slice_characterize_preexisting_bug() -> 
 
 /// #1223's own issue text names a second, unrelated finding: succinctly's
 /// multi-path `del()` combining a chained-slice branch with a bare-slice
-/// sibling is order-*insensitive* (both orderings agree, deleting both
+/// sibling was order-*insensitive* (both orderings agreed, deleting both
 /// index 0 and the `.[2:3]` range) — real yq is itself order-*sensitive*
 /// for this exact shape (confirmed live against yq v4.53.3: the two
 /// orderings give two different answers, neither of which is the
-/// composition of the two single-path results, and neither matches
-/// succinctly's own consistent-but-different answer). There is no coherent
-/// rule to replicate here (`delete_expr_paths_at`'s sibling-index-shifting
-/// logic, not #1223's own fix, drives this) — pinned as a known,
-/// separately-tracked gap rather than silently unasserted. If this is ever
-/// reconciled, update this test's expectations and the doc comment above.
+/// composition of the two single-path results). There is no coherent rule
+/// to replicate here (`delete_expr_paths_at`'s sibling-index-shifting
+/// logic, not #1223's/#1219's own fixes, drives this) — pinned as a known,
+/// separately-tracked gap rather than silently unasserted.
+///
+/// #1219 changed *what* succinctly gets wrong here, as a side effect of
+/// wiring `yq_del_chained_slice_is_noop` into the multi-path branch (a bare
+/// `.[2:3]` sibling, with nothing else in its own path, is itself a no-op
+/// shape and now correctly drops out of the delete set on its own) —
+/// live-verified this happens to make the *second* ordering (`out_b`) match
+/// real yq exactly now, while the first ordering (`out_a`) remains a
+/// mismatch, just a different one than before. Still no coherent single
+/// rule underlies real yq's own order-sensitivity, so this stays pinned as
+/// a known gap rather than chased further. If this is ever reconciled,
+/// update this test's expectations and the doc comment above.
 #[test]
 fn test_yq_mixed_bare_root_and_chained_slice_del_known_gap_1223() -> Result<()> {
     let input = r"[[1,2,3],[4,5,6],[7,8,9],[10,11,12]]";
-    let expected_succinctly = r"[[4,5,6],[10,11,12]]";
 
     let (out_a, code_a) = run_yq_stdin("del(.[0][0:1], .[2:3])", input, &["-o=json", "-I=0"])?;
     assert_eq!(code_a, 0, "out: {out_a:?}");
     assert_eq!(
         out_a.trim(),
-        expected_succinctly,
+        r"[[4,5,6],[7,8,9],[10,11,12]]",
         "real yq gives [[1,2,3],[4,5,6],[7,8,9],[10,11,12]] (unchanged) for this ordering"
     );
 
+    // This ordering now matches real yq exactly (#1219 side effect) — kept
+    // in this "known gap" test rather than promoted to its own passing
+    // test, since it's one half of an order-sensitive pair whose *other*
+    // half (`out_a` above) still diverges; splitting them would obscure
+    // that they're the same underlying gap.
     let (out_b, code_b) = run_yq_stdin("del(.[2:3], .[0][0:1])", input, &["-o=json", "-I=0"])?;
     assert_eq!(code_b, 0, "out: {out_b:?}");
     assert_eq!(
         out_b.trim(),
-        expected_succinctly,
-        "real yq gives [[4,5,6],[7,8,9],[10,11,12]] (only index 0 dropped) for this ordering"
+        r"[[4,5,6],[7,8,9],[10,11,12]]",
+        "real yq gives [[4,5,6],[7,8,9],[10,11,12]] (only index 0 dropped) for this ordering -- now matches"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

Fixes #1219. `yq_del_scalar_slice_parent_path` only rewrote a `del()` path
when a single trailing slice was the path's very last component (#1116,
#1162). A chained slice followed by more path (`.a[1:3][0]`) never matched
that check, so it fell through to `delete_at_path`'s ordinary `Expr::Slice`
walker and wrongly descended into the sliced sub-range, deleting the wrong
element — instead of matching real yq's actual behavior.

Live-verified against yq v4.53.3 across leading-prefix, trailing-run-length,
and tail-shape combinations, the real rule is:

- A trailing slice run followed by anything that isn't itself another slice
  (`Index`/`Field`/`Iterate`) no-ops the **whole** `del()` call.
- A maximal trailing run of **two or more** consecutive slices drops the
  parent key/element instead — the same target a single trailing slice
  already resolved to (#1162) — but only once the residual prefix before
  that run is itself slice-free. An interior slice elsewhere in the path
  still no-ops the call even when the path's last component is a slice.
- A bare chained-slice-run with no leading `Field`/`Index` (directly on the
  root value) is a no-op, not "delete the root" — distinct from the
  `Expr::Iterate` per-element case, where an empty residual prefix
  legitimately means "drop this element" (#1182, now generalized to a
  trailing run of any length, not just one slice).

## Revision history (this PR went through two rounds)

The first version of this fix (see earlier commit) covered the shapes
above but `/code-review`'s 9-angle fan-out found two real gaps:

1. **Multi-path/comma `del()` never got the no-op half of the rule.**
   `del(.a[1:3][0], .c)` applied the drop-parent rewrite per sibling but
   fell through to the old buggy walk for a no-op-shaped sibling instead of
   skipping it — live-verified real yq leaves `.a` fully untouched while
   still deleting `.c`.
2. **A slice hidden inside a nested `Pipe` was invisible to the classifier.**
   Both original functions only inspected one flat `Expr::Pipe` level, so
   `del((.a[0:1])[0:2])` (parens) and even parens-free `del(.a | .[0:1][0:2])`
   (an ordinary explicit pipe — `Expr::pipe` doesn't flatten nested pipes
   when combining parser stages) bypassed the rule entirely. One variant,
   `del((.a[0])[0:1])`, even hard-errored where real yq succeeds silently.

Both gaps traced back to the same root cause: the two classifier functions
each independently re-derived the same trailing-slice-run logic from a
shallow, single-level `Pipe` match. Fixed by replacing them with one
function, `yq_del_slice_outcome`, returning a `YqDelSliceOutcome` enum
(`DropParent`/`Noop`/`NotApplicable`) and built on `flatten_delete_path` —
the same recursive flattener `delete_expr_paths_at`'s sibling-grouping
machinery already relies on to see through exactly this kind of nesting.
This also removes the duplicated cut-loop the two old functions had, and
lets every call site pattern-match one clear result instead of chaining two
`Option`/`bool` calls with implicit "`None` means defer" ordering.

## Changes

- `yq_del_slice_outcome` (replacing `yq_del_scalar_slice_parent_path` +
  `yq_del_chained_slice_is_noop`): classifies a resolved `del()` path
  against every verified rule above in one pass, using `flatten_delete_path`
  to see through nested `Pipe`/`Paren`/`Optional` wrapping.
- Wired into the single-path walker, the multi-path/comma branch (now via
  `filter_map`, dropping a no-op sibling's steps from the delete set
  entirely — `delete_expr_paths_at` already treats an empty path list as a
  no-op, so this composes cleanly), `rewrite_yq_del_comma_branches`, and
  both `Expr::Iterate` per-element walkers (array and object).
- Removed the now-stale "known divergence, tracked as #1219" comment on
  `delete_at_path`'s `Expr::Slice{..}` mid-chain arm and replaced it with
  why the arm is now provably unreachable in yq mode — verified empirically
  via a temporary debug probe across the full test suite (and every shape
  this PR fixes) before removing it, not just by the reasoning.
- Updated the one pre-existing test whose pinned "known gap" values shifted
  as a side effect (`test_yq_mixed_bare_root_and_chained_slice_del_known_gap_1223`,
  a bare-slice + chained-slice comma pair, #1223's own documented
  order-sensitivity gap): one ordering now matches real yq exactly, the
  other is still a mismatch but a different one — both re-verified live and
  re-pinned rather than left silently stale.

## Test plan

- [x] 31 tests in `tests/yq_cli_tests.rs` covering every verified shape:
  chained-slice-then-Index/Field/Iterate (no-op), chained double/triple
  slice (drop parent key), an `Index`-prefixed chain (drop element), an
  interior slice breaking the trailing run (both `Index`- and
  `Iterate`-separated), a bare-root chain (no-op), the `Expr::Iterate`
  per-element equivalents, the comma-grouped no-op gap, the nested-`Pipe`/
  `Paren` gap (including the former hard-error case), and a jq-mode control
  (unaffected — jq has no such rule).
- [x] Full test suite passes (`cargo test --features cli,simd,regex,serde`,
  sequential, 2700+ tests) — re-verified after the revision and after
  rebasing onto latest `main`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean.
- [x] `cargo check --no-default-features` (no_std) still builds.
- [x] `cargo fmt -- --check` clean.
- [x] jq mode spot-checked unaffected against real jq 1.7.1.

## Round 3 (this /code-review pass)

Found one more real bug (independently confirmed by 3+ reviewers): `rewrite_yq_del_comma_branches`'s `Noop` case was left unrewritten, so a comma sibling classified `Noop` still reached `resolve_dynamic_indexes`'s crashing navigation when combined with a type-incompatible sibling (`del(.a[1:3][0], .c)` on an Object `.a` gave `Cannot index object with object` instead of leaving `.a` untouched). Every `Noop` verdict is decided purely from path shape (never touches the document), so it's always safe to drop a `Noop` branch from the comma group before navigation — switched `Comma`'s branch mapping from `map` to `filter_map` accordingly. This also incidentally fixed a related pre-existing #1223 gap (a bare root-slice comma sibling is always `Noop`-classified, so it stopped crashing too).

Remaining review output was test-coverage/doc-comment polish (addressed) and one already-accepted, order-sensitive "no coherent rule" divergence (real yq's own comma-sibling behavior is inconsistent across orderings for a bare-slice + chained-slice combination — pre-existing per #1223, now also reachable for #1219's trailing-run generalization; pinned as a known-gap test, not chased further, consistent with #1223's own established precedent).