### PR TITLE
fix(jq): let a ? on a multi-component group reach = through more path

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11943,23 +11943,17 @@ struct SliceSplit {
 /// Each flattened element is matched via [`unwrap_path_component`] (not a
 /// bare `matches!`), so a `?`-marked slice — `.a[0:1]?[0] = 9`, or
 /// `(.a[0:1]?)[0] = 9` once `push_path_components` has flattened the
-/// enclosing parens away — is still found (#1303): `push_path_components`
-/// itself leaves `Expr::Optional` opaque (its other callers need that), so
-/// without this the wrapped `Slice` reaches this scan unrecognized.
+/// enclosing parens away — is still found (#1303).
 ///
-/// Still does *not* reach through a `Pipe`/`Paren` left nested *inside* an
-/// `Optional` wrapper — e.g. a `?` on a whole multi-component group ahead of
-/// a further step, `((.a[0:1])? | .[0]) = 9`. `unwrap_path_component`'s peel
-/// stops at that `Pipe`, which isn't itself a `Slice`, so the scan still
-/// misses it. Unlike the glued-postfix form (`(.a|.c)?[0] = 9`, confirmed a
-/// jq parse error), the `|`-separated spelling above genuinely parses in
-/// both real jq and here (`path((.a[0:1])? | .[0])` resolves fine) and does
-/// still reproduce the "invalid path component" fallback this whole function
-/// exists to close — found during this fix's own review, tracked separately
-/// rather than folded in here since closing it properly likely means
-/// reworking this function to unwrap one path element at a time (mirroring
-/// `update_path`'s already-correct `Expr::Pipe` arm) instead of a single
-/// flatten-then-scan pass, not another incremental patch to this one.
+/// Also reaches through a `Pipe`/`Paren` nested *inside* an `Optional`
+/// wrapper — e.g. a `?` on a whole multi-component group ahead of a further
+/// step, `((.a[0:1])? | .[0]) = 9` — since `push_path_components` (#1311)
+/// recursively flattens an `Expr::Optional`'s own contents and re-wraps each
+/// resulting component individually, rather than leaving the wrapper
+/// opaque. Unlike the glued-postfix form (`(.a|.c)?[0] = 9`, confirmed a jq
+/// parse error), the `|`-separated spelling above genuinely parses in both
+/// real jq and here (`path((.a[0:1])? | .[0])` resolves fine), and now
+/// resolves through `=` too, matching jq.
 fn split_at_slice(exprs: &[Expr]) -> Option<SliceSplit> {
     // Cheap common-case guard: the overwhelming majority of assignment
     // targets (`.a.b.c[2] = 9`) contain neither a slice nor a nested
@@ -14448,7 +14442,12 @@ fn type_filter_matches(builtin: &Builtin, value: &OwnedValue) -> bool {
 /// Reuses [`push_path_components`]'s own Identity/Pipe/Paren unwrapping
 /// rather than a bespoke `matches!` — `.[.k]` and `. | .[.k]` and `(.)[.k]`
 /// all name the same no-op target, and this is the one existing place in
-/// the file that already knows how to recognise that.
+/// the file that already knows how to recognise that. `push_path_components`
+/// also unwraps a bare `Optional(Identity)` (`.?`) to empty since #1311, but
+/// that shape can never actually reach `target` here: `parse_postfix` only
+/// lets `?` precede continued `[...]` when it's attached to a `Field`/prior
+/// bracket, never to a passthrough node, so `.?[0]`/`(.)?[0]` are parse
+/// errors in both real jq and here.
 fn is_passthrough_target(target: &Expr) -> bool {
     let mut components = Vec::new();
     push_path_components(&mut components, target);
@@ -14975,18 +14974,23 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // so an untracked `value` (#843) needs its own check here rather than
     // inheriting `resolve_leaf`'s: `push_path_components` above already
     // dropped every `Identity` from `flat` (see its doc comment), so an
-    // *empty* `flat` means the whole chain was a no-op (`.`, `. | .`, ...)
-    // — the ordinary `#530` "with result" case — while a *non-empty* one
-    // means `flat[0]` is the first real navigation attempted, using the
+    // *empty* `flat` means the whole chain was a no-op (`.`, `. | .`, `.?`,
+    // ...) — the ordinary `#530` "with result" case — while a *non-empty*
+    // one means `flat[0]` is the first real navigation attempted, using the
     // untracked root `value` itself (confirmed live: `path(try (.a,
     // error({a:{c:1}})) catch .a.b)` on the caught object reports "near
     // attempt to access element \"a\" of {\"a\":{\"c\":1}}", not `.b`'s
-    // resolved value — jq never even computes `.a`'s result). A `flat[0]`
-    // that isn't `Field`/`Index`/`Slice` (e.g. `Expr::Optional` from a
-    // mid-chain `.a?.b`) is rare enough, and already `#498`-adjacent
-    // territory, that this falls back to the "with result" wording rather
-    // than growing a bespoke message for it — still a hard error either
-    // way, never the silent wrong-success #843 is about.
+    // resolved value — jq never even computes `.a`'s result). Since #1311,
+    // `push_path_components` recurses into an `Expr::Optional`'s own
+    // contents (re-wrapping each resulting component individually) rather
+    // than leaving it opaque, so `.?` alone now correctly contributes zero
+    // components here too, same as `.`. A `flat[0]` that isn't a bare
+    // `Field`/`Index`/`Slice` (e.g. the `Optional`-wrapped one from a
+    // mid-chain `.a?.b`, or from a flattened group like `(.a[0:1])? | .b`)
+    // is rare enough, and already `#498`-adjacent territory, that this
+    // falls back to the "with result" wording rather than growing a
+    // bespoke message for it — still a hard error either way, never the
+    // silent wrong-success #843 is about.
     let Some(last_dynamic) = flat.iter().rposition(needs_fanout_pass) else {
         let end = resolve_static_tail::<S>(&flat, value, trackable)?;
         // `resolve_static_tail` above already raised for an untracked

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12511,6 +12511,21 @@ fn push_path_components(out: &mut Vec<Expr>, expr: &Expr) {
             }
         }
         Expr::Paren(inner) => push_path_components(out, inner),
+        // A `?` on a whole multi-component group ((.a[0:1])? | .[0]) needs
+        // each of the group's own components individually scoped with
+        // that `?` -- the same reasoning `splice_optional_group` already
+        // applies for `update_path`/`delete_at_path` (#1294) -- rather
+        // than being pushed as one opaque `Optional(Pipe(...))` element.
+        // Without this, neither `split_at_slice`'s slice scan (which
+        // unwraps `Optional`/`Paren` but not into a `Pipe` inside them)
+        // nor `get_path_mut`'s own per-step `Identity | Field | Index`
+        // match can see through it, and the whole thing falls to
+        // "invalid path component" (#1311).
+        Expr::Optional(inner) => {
+            let mut group = Vec::new();
+            push_path_components(&mut group, inner);
+            out.extend(group.into_iter().map(|e| Expr::Optional(Box::new(e))));
+        }
         other => out.push(other.clone()),
     }
 }
@@ -40832,6 +40847,37 @@ mod tests {
             // A genuinely non-sliceable target under this same nested shape
             // is a navigation failure too, and stays suppressed.
             (br#"{"a":true}"#, ".a[0:1]?[0] = 9", Ok(r#"{"a":true}"#)),
+        ]);
+    }
+
+    #[test]
+    fn test_assign_optional_group_with_more_path_1311() {
+        // #1311: `?` on a *whole multi-component group* ((.a[0:1])? | .[0]),
+        // not directly on the slice itself the way #1303's Gap 2 covered --
+        // `push_path_components` pushed the group as one opaque
+        // `Optional(Paren(Pipe(...)))` element, which neither
+        // `split_at_slice`'s slice scan nor `get_path_mut`'s own per-step
+        // match could see through. All confirmed against real jq 1.7.1.
+        assert_outcomes(&[
+            (
+                br#"{"a":[1,2,3]}"#,
+                "((.a[0:1])? | .[0]) = 9",
+                Ok(r#"{"a":[9,2,3]}"#),
+            ),
+            // A genuinely non-sliceable target under this same grouped
+            // shape is a navigation failure, and stays suppressed.
+            (
+                br#"{"a":true}"#,
+                "((.a[0:1])? | .[0]) = 9",
+                Ok(r#"{"a":true}"#),
+            ),
+            // Multiple components inside the group, each individually
+            // suppressible -- not just a bare slice.
+            (
+                br#"{"a":{"b":[1,2,3]}}"#,
+                "((.a.b[0:1])? | .[0]) = 9",
+                Ok(r#"{"a":{"b":[9,2,3]}}"#),
+            ),
         ]);
     }
 


### PR DESCRIPTION
## Summary

`((.a[0:1])? | .[0]) = 9` — a `?` on a whole parenthesized multi-component group, with more path after it — reported `invalid path component` for `=` where real jq performs the write. `|=`/`del()` already handled this exact shape correctly.

## Root cause

`push_path_components` (used by `set_path`'s `split_at_slice` pre-pass to flatten a chained path before scanning for a slice) had no arm for `Expr::Optional`. For `((.a[0:1])? | .[0])`, the flattening pass hit `Optional(Paren(Pipe([Field("a"), Slice{0,1}])))` as one element of the outer `Pipe` and pushed it verbatim (via the catch-all arm) as one opaque component, instead of seeing through it. Neither `split_at_slice`'s subsequent slice scan (which unwraps `Optional`/`Paren` but doesn't recurse into a `Pipe` found underneath) nor `get_path_mut`'s own per-step `Identity | Field | Index` match could then make sense of it, so the whole thing fell to the generic `invalid path component` catch-all.

`update_path` (`|=`) and `delete_at_path` (`del()`) don't share this gap: their own `Expr::Pipe(inner)` arms already call `splice_optional_group` (added by #1294) to splice a resolved `Optional(Pipe([…]))` component's own elements into the walk, each individually re-wrapped in `Optional` so the group's `?` scopes to each of its own components rather than leaking onto what comes after.

## Fix

Added an `Expr::Optional(inner)` arm to `push_path_components` mirroring `splice_optional_group`'s identical reasoning: recursively flatten `inner` into a temporary list (reusing the function's own existing `Pipe`/`Paren` flattening), then wrap each resulting component individually in `Expr::Optional` before appending to the output. This makes `((.a[0:1])? | .[0])` flatten to `[Optional(Field("a")), Optional(Slice{0,1}), Index(0)]` — `split_at_slice`'s scan now correctly finds the (still-optional) slice, and `get_path_mut`'s per-step navigation already understands a per-component `Optional` wrapper (confirmed by the pre-existing `.a?.b.c = 1` behavior).

## Verification

- Confirmed live against real jq 1.7.1 for the primary repro, the non-sliceable-target boundary case (should suppress via navigation failure, not a write-time refusal), and a multi-component variant with a field before the slice.
- New test: `test_assign_optional_group_with_more_path_1311` in `src/jq/eval.rs`'s own unit test module, matching #1303's established convention.
- Regression-checked against every other `push_path_components` caller (`split_at_slice`, `resolve_leaf`, `is_passthrough_target`, `resolve_seq`, `resolve_dynamic_indexes`) with live spot-checks of `path()`, `del()`, and a computed key through an optional group — all match real jq.
- Regression-checked against the #1287/#1292/#1294/#1303 test families (167 tests, all pass).
- Full `cargo test --features cli,simd,regex,serde` clean (0 failed).
- Both required clippy invocations clean; `cargo fmt --check` clean.
- Patch coverage 100% (27/27 new lines).

Fixes #1311