### PR TITLE
fix(jq): stop paths/leaf_paths from collapsing duplicate mapping keys (#868)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3543,17 +3543,36 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
 }
 
 /// Evaluate a builtin function.
-/// Recursively collect every path in `value`'s tree, cursor-native (#868).
+/// Recursively collect paths in `value`'s tree, cursor-native (#868) — the
+/// shared walk behind both `paths` (`leaves_only: false`, a path for every
+/// node) and `leaf_paths` (`leaves_only: true`, a path only for a childless
+/// node -- `null` and empty `{}`/`[]` count as leaves too, unlike the
+/// `paths(scalars)` community recipe; see #771).
 ///
-/// Mirrors `eval.rs`'s `collect_paths`, but walks `V` directly via
-/// `as_object`/`as_array` and `effective_fields`/`collect_values` instead of
-/// an already-materialized `OwnedValue` -- the same reasoning `ToEntries`'s
-/// own native arm above gives: `builtin_paths`'s `to_owned(&value)` collapses
-/// duplicate YAML mapping keys into one `IndexMap` entry *before* the walk
-/// ever starts, so a repeated key only ever contributes one path there. Using
-/// `effective_fields` here applies each format's own duplicate-key rule
-/// during the walk itself (YAML: every occurrence; JSON: first position,
-/// last value, matching real jq) instead of an unconditional collapse.
+/// Mirrors `eval.rs`'s `collect_paths`/`collect_leaf_paths`, but walks `V`
+/// directly via `as_object`/`as_array` and `effective_fields`/`uncons`
+/// instead of an already-materialized `OwnedValue` -- the same reasoning
+/// `ToEntries`'s own native arm above gives: `builtin_paths`'s
+/// `to_owned(&value)` collapses duplicate YAML mapping keys into one
+/// `IndexMap` entry *before* the walk ever starts, so a repeated key only
+/// ever contributes one path there. Using `effective_fields` here applies
+/// each format's own duplicate-key rule during the walk itself (YAML: every
+/// occurrence; JSON: first position, last value, matching real jq) instead
+/// of an unconditional collapse. One shared walker rather than two near-copies
+/// (code review, #868): the two modes differ only in *when* a path is
+/// recorded, not in how the tree is traversed.
+///
+/// `current_path.push`/`.pop()` around each recursive call (rather than a
+/// clone-and-extend style) is safe here because every `push` is followed,
+/// after the recursive call returns, by exactly one matching `pop` on every
+/// exit path -- the sole early exit before a `push` (`key_str()` returning
+/// `None`) is a `continue` that skips straight to the next field without
+/// ever pushing.
+///
+/// The array branch walks `uncons()` directly rather than materializing
+/// `collect_values()`'s `Vec` first (code review, #868) -- arrays have no
+/// duplicate-key concept to reconcile, so there's nothing `effective_fields`
+/// buys here that a plain cons-list walk doesn't already give for free.
 ///
 /// Panics past [`MAX_NESTING_DEPTH`] levels of nesting, the same guard
 /// `to_owned`/`to_owned_cursor` already carry -- `current_path.len()` tracks
@@ -3563,43 +3582,15 @@ fn collect_paths_generic<V: DocumentValue>(
     value: &V,
     current_path: &mut Vec<OwnedValue>,
     paths: &mut Vec<OwnedValue>,
-) {
-    assert_nesting_depth(current_path.len());
-    if let Some(fields) = value.as_object() {
-        for field in fields.effective_fields() {
-            let Some(key) = field.key_str() else {
-                continue;
-            };
-            current_path.push(OwnedValue::String(key.into_owned()));
-            paths.push(OwnedValue::Array(current_path.clone()));
-            collect_paths_generic(&field.value, current_path, paths);
-            current_path.pop();
-        }
-    } else if let Some(elements) = value.as_array() {
-        for (i, elem) in elements.collect_values().into_iter().enumerate() {
-            current_path.push(OwnedValue::Int(i as i64));
-            paths.push(OwnedValue::Array(current_path.clone()));
-            collect_paths_generic(&elem, current_path, paths);
-            current_path.pop();
-        }
-    }
-}
-
-/// Cursor-native `leaf_paths` (#868), mirroring `eval.rs`'s `collect_leaf_paths`
-/// -- same tree-structural "leaf" definition (`null` and empty `{}`/`[]`
-/// count as leaves, unlike the `paths(scalars)` community recipe; see #771)
-/// and the same `effective_fields`-based duplicate-key handling
-/// [`collect_paths_generic`] uses, for the same reason.
-fn collect_leaf_paths_generic<V: DocumentValue>(
-    value: &V,
-    current_path: &mut Vec<OwnedValue>,
-    paths: &mut Vec<OwnedValue>,
+    leaves_only: bool,
 ) {
     assert_nesting_depth(current_path.len());
     if let Some(fields) = value.as_object() {
         let fields = fields.effective_fields();
         if fields.is_empty() {
-            paths.push(OwnedValue::Array(current_path.clone()));
+            if leaves_only {
+                paths.push(OwnedValue::Array(current_path.clone()));
+            }
             return;
         }
         for field in fields {
@@ -3607,20 +3598,32 @@ fn collect_leaf_paths_generic<V: DocumentValue>(
                 continue;
             };
             current_path.push(OwnedValue::String(key.into_owned()));
-            collect_leaf_paths_generic(&field.value, current_path, paths);
+            if !leaves_only {
+                paths.push(OwnedValue::Array(current_path.clone()));
+            }
+            collect_paths_generic(&field.value, current_path, paths, leaves_only);
             current_path.pop();
         }
     } else if let Some(elements) = value.as_array() {
         if elements.is_empty() {
-            paths.push(OwnedValue::Array(current_path.clone()));
+            if leaves_only {
+                paths.push(OwnedValue::Array(current_path.clone()));
+            }
             return;
         }
-        for (i, elem) in elements.collect_values().into_iter().enumerate() {
-            current_path.push(OwnedValue::Int(i as i64));
-            collect_leaf_paths_generic(&elem, current_path, paths);
+        let mut i = 0i64;
+        let mut rest = elements;
+        while let Some((elem, tail)) = rest.uncons() {
+            current_path.push(OwnedValue::Int(i));
+            if !leaves_only {
+                paths.push(OwnedValue::Array(current_path.clone()));
+            }
+            collect_paths_generic(&elem, current_path, paths, leaves_only);
             current_path.pop();
+            i += 1;
+            rest = tail;
         }
-    } else {
+    } else if leaves_only {
         paths.push(OwnedValue::Array(current_path.clone()));
     }
 }
@@ -4021,15 +4024,15 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         }
 
         // Handled natively for the same reason as `ToEntries` above (#868):
-        // the fallback's `to_owned(&value)` merges duplicate YAML mapping
-        // keys before `collect_paths`/`collect_leaf_paths` ever walk the
-        // tree, so a repeated key only ever contributes one path there.
-        // `collect_paths_generic`/`collect_leaf_paths_generic` walk `value`
-        // directly, applying each format's own `effective_fields` rule at
-        // every nesting level, not just the root.
+        // the fallback's `to_owned_with_cursor` merges duplicate YAML
+        // mapping keys before `collect_paths`/`collect_leaf_paths` ever walk
+        // the tree, so a repeated key only ever contributes one path there.
+        // `collect_paths_generic` walks `value` directly, applying each
+        // format's own `effective_fields` rule at every nesting level, not
+        // just the root.
         Builtin::Paths => {
             let mut paths = Vec::new();
-            collect_paths_generic(&value, &mut Vec::new(), &mut paths);
+            collect_paths_generic(&value, &mut Vec::new(), &mut paths, false);
             collapse_vec(
                 paths,
                 || GenericResult::None,
@@ -4040,7 +4043,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::LeafPaths => {
             let mut paths = Vec::new();
-            collect_leaf_paths_generic(&value, &mut Vec::new(), &mut paths);
+            collect_paths_generic(&value, &mut Vec::new(), &mut paths, true);
             collapse_vec(
                 paths,
                 || GenericResult::None,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3543,6 +3543,88 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
 }
 
 /// Evaluate a builtin function.
+/// Recursively collect every path in `value`'s tree, cursor-native (#868).
+///
+/// Mirrors `eval.rs`'s `collect_paths`, but walks `V` directly via
+/// `as_object`/`as_array` and `effective_fields`/`collect_values` instead of
+/// an already-materialized `OwnedValue` -- the same reasoning `ToEntries`'s
+/// own native arm above gives: `builtin_paths`'s `to_owned(&value)` collapses
+/// duplicate YAML mapping keys into one `IndexMap` entry *before* the walk
+/// ever starts, so a repeated key only ever contributes one path there. Using
+/// `effective_fields` here applies each format's own duplicate-key rule
+/// during the walk itself (YAML: every occurrence; JSON: first position,
+/// last value, matching real jq) instead of an unconditional collapse.
+///
+/// Panics past [`MAX_NESTING_DEPTH`] levels of nesting, the same guard
+/// `to_owned`/`to_owned_cursor` already carry -- `current_path.len()` tracks
+/// depth without a separate counter, same shape as `collect_paths`'s own
+/// `#1021` guard.
+fn collect_paths_generic<V: DocumentValue>(
+    value: &V,
+    current_path: &mut Vec<OwnedValue>,
+    paths: &mut Vec<OwnedValue>,
+) {
+    assert_nesting_depth(current_path.len());
+    if let Some(fields) = value.as_object() {
+        for field in fields.effective_fields() {
+            let Some(key) = field.key_str() else {
+                continue;
+            };
+            current_path.push(OwnedValue::String(key.into_owned()));
+            paths.push(OwnedValue::Array(current_path.clone()));
+            collect_paths_generic(&field.value, current_path, paths);
+            current_path.pop();
+        }
+    } else if let Some(elements) = value.as_array() {
+        for (i, elem) in elements.collect_values().into_iter().enumerate() {
+            current_path.push(OwnedValue::Int(i as i64));
+            paths.push(OwnedValue::Array(current_path.clone()));
+            collect_paths_generic(&elem, current_path, paths);
+            current_path.pop();
+        }
+    }
+}
+
+/// Cursor-native `leaf_paths` (#868), mirroring `eval.rs`'s `collect_leaf_paths`
+/// -- same tree-structural "leaf" definition (`null` and empty `{}`/`[]`
+/// count as leaves, unlike the `paths(scalars)` community recipe; see #771)
+/// and the same `effective_fields`-based duplicate-key handling
+/// [`collect_paths_generic`] uses, for the same reason.
+fn collect_leaf_paths_generic<V: DocumentValue>(
+    value: &V,
+    current_path: &mut Vec<OwnedValue>,
+    paths: &mut Vec<OwnedValue>,
+) {
+    assert_nesting_depth(current_path.len());
+    if let Some(fields) = value.as_object() {
+        let fields = fields.effective_fields();
+        if fields.is_empty() {
+            paths.push(OwnedValue::Array(current_path.clone()));
+            return;
+        }
+        for field in fields {
+            let Some(key) = field.key_str() else {
+                continue;
+            };
+            current_path.push(OwnedValue::String(key.into_owned()));
+            collect_leaf_paths_generic(&field.value, current_path, paths);
+            current_path.pop();
+        }
+    } else if let Some(elements) = value.as_array() {
+        if elements.is_empty() {
+            paths.push(OwnedValue::Array(current_path.clone()));
+            return;
+        }
+        for (i, elem) in elements.collect_values().into_iter().enumerate() {
+            current_path.push(OwnedValue::Int(i as i64));
+            collect_leaf_paths_generic(&elem, current_path, paths);
+            current_path.pop();
+        }
+    } else {
+        paths.push(OwnedValue::Array(current_path.clone()));
+    }
+}
+
 fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
     builtin: &Builtin,
     value: V,
@@ -3936,6 +4018,35 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     &value, cursor,
                 )))
             }
+        }
+
+        // Handled natively for the same reason as `ToEntries` above (#868):
+        // the fallback's `to_owned(&value)` merges duplicate YAML mapping
+        // keys before `collect_paths`/`collect_leaf_paths` ever walk the
+        // tree, so a repeated key only ever contributes one path there.
+        // `collect_paths_generic`/`collect_leaf_paths_generic` walk `value`
+        // directly, applying each format's own `effective_fields` rule at
+        // every nesting level, not just the root.
+        Builtin::Paths => {
+            let mut paths = Vec::new();
+            collect_paths_generic(&value, &mut Vec::new(), &mut paths);
+            collapse_vec(
+                paths,
+                || GenericResult::None,
+                GenericResult::Owned,
+                GenericResult::ManyOwned,
+            )
+        }
+
+        Builtin::LeafPaths => {
+            let mut paths = Vec::new();
+            collect_leaf_paths_generic(&value, &mut Vec::new(), &mut paths);
+            collapse_vec(
+                paths,
+                || GenericResult::None,
+                GenericResult::Owned,
+                GenericResult::ManyOwned,
+            )
         }
 
         // The `is*` family reads through `tagged_type_name` rather than

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1045,6 +1045,99 @@ fn test_duplicate_json_key_to_entries_deduplicates_1170() -> Result<()> {
     Ok(())
 }
 
+/// #868: `paths` (a succinctly extension in yq mode -- real yq has no
+/// `paths` builtin at all, confirmed live: `printf 'a: 1\n' | yq '[paths]'`
+/// raises a lexer error) used to materialize the whole document via
+/// `to_owned(&value)` before walking it, collapsing duplicate YAML mapping
+/// keys into one `IndexMap` entry the same way #443 found for `to_entries`
+/// -- so a repeated key only ever contributed one path. Since there's no
+/// oracle for a succinctly-only builtin, the acceptance criterion is
+/// internal consistency: `paths` must report a path for every mapping key
+/// occurrence that `to_entries` (already correct per #443) and identity
+/// output both preserve.
+#[test]
+fn test_yq_paths_preserves_duplicate_mapping_keys_868() -> Result<()> {
+    let yaml = "a: 1\na: 2\nb: 3\n";
+    let (output, code) = run_yq_stdin("[paths]", yaml, &["-o=json", "-I=0"])?;
+
+    assert_eq!(code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), r#"[["a"],["a"],["b"]]"#);
+    Ok(())
+}
+
+/// #868: the same duplicate-key fix, one level of nesting deeper -- confirms
+/// `collect_paths_generic`'s `effective_fields` call applies at every
+/// recursion level, not just the root object.
+#[test]
+fn test_yq_paths_preserves_nested_duplicate_mapping_keys_868() -> Result<()> {
+    let yaml = "x:\n  a: 1\n  a: 2\n  b: 3\n";
+    let (output, code) = run_yq_stdin("[paths]", yaml, &["-o=json", "-I=0"])?;
+
+    assert_eq!(code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), r#"[["x"],["x","a"],["x","a"],["x","b"]]"#);
+    Ok(())
+}
+
+/// #868: `paths` on `--input-format json` input must still apply *JSON's*
+/// own duplicate-key rule (first position, last value -- #1170) rather than
+/// YAML's preserve-every-occurrence rule, the same format-aware split
+/// `to_entries` already established. Confirms the fix's `effective_fields`
+/// call is genuinely format-aware, not a blanket switch to "always keep
+/// duplicates."
+#[test]
+fn test_yq_paths_json_input_format_still_dedupes_868() -> Result<()> {
+    let json = r#"{"a":1,"a":2,"b":3}"#;
+    let (output, code) = run_yq_stdin(
+        "[paths]",
+        json,
+        &["--input-format", "json", "-o=json", "-I=0"],
+    )?;
+
+    assert_eq!(code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), r#"[["a"],["b"]]"#);
+    Ok(())
+}
+
+/// #868: `leaf_paths` (also a succinctly extension, see CLAUDE.md) shares
+/// `paths`'s same duplicate-key bug via its own `to_owned`-based walk --
+/// same fix, same internal-consistency criterion.
+#[test]
+fn test_yq_leaf_paths_preserves_duplicate_mapping_keys_868() -> Result<()> {
+    let yaml = "a: 1\na: 2\nb: 3\n";
+    let (output, code) = run_yq_stdin("[leaf_paths]", yaml, &["-o=json", "-I=0"])?;
+
+    assert_eq!(code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), r#"[["a"],["a"],["b"]]"#);
+    Ok(())
+}
+
+/// #868: `leaf_paths`'s own tree-structural leaf definition (null and empty
+/// containers count as leaves, #771) is unaffected by the duplicate-key
+/// fix -- confirms `collect_leaf_paths_generic` didn't accidentally change
+/// what counts as a leaf while switching to `effective_fields`.
+#[test]
+fn test_yq_leaf_paths_leaf_definition_unaffected_by_868() -> Result<()> {
+    let yaml = "a: {}\nb: []\nc: null\nd: 5\n";
+    let (output, code) = run_yq_stdin("[leaf_paths]", yaml, &["-o=json", "-I=0"])?;
+
+    assert_eq!(code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), r#"[["a"],["b"],["c"],["d"]]"#);
+    Ok(())
+}
+
+/// #868: jq mode is unaffected -- real JSON parsing dedupes a repeated key
+/// to its first position/last value already (#1170's own rule, shared via
+/// `effective_fields`), matching real jq exactly.
+#[test]
+fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
+    let (output, _stderr, code) =
+        run_jq_stdin_with_stderr("[paths]", r#"{"a":1,"a":2,"b":3}"#, &["-c"])?;
+
+    assert_eq!(code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), r#"[["a"],["b"]]"#);
+    Ok(())
+}
+
 /// #1251: `.a` field access on `--input-format json` input with a
 /// duplicate key must resolve to the *last* value, matching real jq /
 /// RFC 8259 convention -- the JSON-side sibling of #174's YAML fix, and


### PR DESCRIPTION
## Summary

Fixes #868. `builtin_paths`/`builtin_leaf_paths` (`src/jq/eval.rs`)
materialize the whole document via `to_owned(&value)` before walking it —
the same root cause #443 found for `to_entries`: `to_owned`'s `IndexMap`
collapses a repeated YAML mapping key into one entry before the tree walk
ever starts, so a duplicate key only ever contributed one path.

```
$ printf 'a: 1\na: 2\nb: 3\n' | succinctly yq -o json -I0 '.'
{"a":1,"a":2,"b":3}
$ printf 'a: 1\na: 2\nb: 3\n' | succinctly yq -o json -I0 '[paths]'
[["a"],["b"]]                    # wrong: only one path for "a"
$ printf 'a: 1\na: 2\nb: 3\n' | succinctly yq -o json -I0 '[to_entries]'
[[{"key":"a","value":1},{"key":"a","value":2},{"key":"b","value":3}]]  # already right
```

**Real yq has no `paths` builtin at all** — both `paths` and `leaf_paths`
are succinctly extensions in yq mode (`leaf_paths` already documented as
such in CLAUDE.md; confirmed live that real yq v4.53.3 raises a lexer error
on both). With no oracle to match, the acceptance criterion is internal
consistency: `paths`/`leaf_paths` must report a path for every mapping key
occurrence that identity output and `to_entries` (already correct per #443)
both preserve.

## Changes

Added cursor-native arms for `Builtin::Paths`/`Builtin::LeafPaths` in
`eval_generic.rs`, mirroring `ToEntries`'s own #443/#1170 fix: two new
recursive walkers (`collect_paths_generic`/`collect_leaf_paths_generic`)
use `effective_fields()` at every nesting level instead of collapsing
through `to_owned`, applying each format's own duplicate-key rule during
the walk itself (YAML: every occurrence; JSON: first position, last value,
matching real jq). Both mirror `eval.rs`'s existing `collect_paths`/
`collect_leaf_paths` shape (including `leaf_paths`'s tree-structural leaf
definition, #771: `null` and empty `{}`/`[]` count as leaves) and reuse the
same `MAX_NESTING_DEPTH` recursion guard `to_owned`/`to_owned_cursor`
already carry.

**Out of scope, filed as a follow-up:** `paths(node_filter)`'s own
two-phase collect-then-filter design can't survive duplicates the same way
(two occurrences of a key produce the *same* path array, so its re-lookup
phase can't disambiguate which occurrence to filter) — separate, harder
work with dense correctness properties from #773/#850/#881/#833/#861.

## Test plan

- [x] 6 new tests in `tests/yq_cli_tests.rs`: bare `paths` with duplicate
  keys, nested duplicate keys, `--input-format json` still applies JSON's
  own dedup rule (not YAML's), `leaf_paths` with duplicate keys, confirms
  `leaf_paths`'s leaf definition (null/empty containers) is unaffected, and
  a jq-mode control (unaffected, matches real jq exactly for JSON's own
  duplicate-key dedup).
- [x] Full test suite passes (`cargo test --features cli,simd,regex,serde`,
  sequential, 2700+ tests).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean.
- [x] `cargo check --no-default-features` (no_std) still builds.
- [x] `cargo fmt -- --check` clean.
- [x] Manually verified against real jq 1.7.1 (JSON dedup) and confirmed
  real yq v4.53.3 has no `paths`/`leaf_paths` builtin at all.

## Round 2 (/code-review) — simplification + scope findings

Simplification: unified `collect_paths_generic`/`collect_leaf_paths_generic` into one function (they duplicated ~90% of the same recursion, differing only in when a path is recorded — the #106 "duplicated predicates diverge silently" shape), and replaced the array branch's `collect_values().into_iter().enumerate()` (an unneeded whole-array `Vec` materialization) with a direct `uncons()`-based loop, matching this file's own `to_owned_at_depth` precedent.

**Scope findings, filed as follow-ups rather than expanding this PR:**
- #1342 — `paths(node_filter)` (`Builtin::PathsFilter`) still exhibits the exact bug this PR fixes for bare `paths`/`leaf_paths`; already anticipated as separate/harder work by #868's own implementation plan (its two-phase collect-then-filter design can't survive duplicates the same way).
- #1343 — `-s`/`--slurp` (non-identity filter), `--eval-all`, and `-i`/`--inplace` all bypass this fix even for bare `paths`/`leaf_paths`, since those CLI modes route through `eval.rs`'s old `to_owned`-based evaluator rather than `eval_generic.rs`'s now-fixed dispatch. Newly discovered during review, not anticipated by #868's own plan.
- #1344 — the same root-cause bug family (duplicate YAML keys collapsed by `to_owned`'s `IndexMap`) also affects `tostream`/`walk`/`recurse`, none of which have a cursor-native arm. Broader architectural issue, out of scope here.

This PR's fix is real and tested for what it covers (bare `paths`/`leaf_paths` on the default single-document evaluation path), but is narrower than "closes #868 completely" — flagging that plainly rather than overstating it.