### PR TITLE
fix(jq): defer overflow-literal mantissa truncation until notation is known

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -841,6 +841,14 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // a redundant check here.
     if new_exp < digit_count {
         let full_mantissa_str = full_mantissa_if_capped(s, exp_pos, &mantissa_str, digit_count);
+        // Provably always `Some` here (not just usually): `full_mantissa_str`
+        // is uncapped whenever `full_mantissa_if_capped` had to re-derive at
+        // all, so its own digit count equals `digit_count` exactly, and
+        // `format_positive_shifted_plain`'s `split_pos > digits.len()` guard
+        // reduces to the `new_exp < digit_count` this branch already
+        // checked. Kept as `if let` rather than `.expect(..)` so a future
+        // change to either function's contract fails safe (falls to
+        // scientific) instead of panicking.
         if let Some(plain) =
             format_positive_shifted_plain(sign, &full_mantissa_str, new_exp, digit_count)
         {

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -359,7 +359,7 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // unlike `format_near_zero_literal` (#1273), this path can't actually
     // observe a saturated exponent in practice.
     let Ok((mantissa_str, shifted_exp, digit_count, _exp_saturated)) =
-        normalize_extreme_literal_mantissa(s, exp_pos)
+        normalize_extreme_literal_mantissa(s, exp_pos, Some(MAX_RENDERED_MANTISSA_DIGITS))
     else {
         unreachable!("nonzero value implies normalize_extreme_literal_mantissa succeeds")
     };
@@ -554,6 +554,40 @@ fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
     mantissa.split_once('.').unwrap_or((mantissa, ""))
 }
 
+/// `dump_truncated`'s whole design keeps preview cost independent of the
+/// value's own size (see its doc comment) - a document-controlled mantissa
+/// of unbounded length must not turn into unbounded work in
+/// [`normalize_extreme_literal_mantissa`] when a caller doesn't need every
+/// given digit rendered anyway (scientific notation only ever shows a
+/// bounded prefix). Bounding the *copy* is enough: `shift` only ever needs
+/// `int_part.len()` (an O(1) property read once leading zeros are trimmed),
+/// so truncating what gets copied into `rest` doesn't touch the exponent
+/// math's correctness, only how many digits past the first one actually get
+/// rendered.
+///
+/// Real jq preserves a literal's full given precision unconditionally --
+/// oracle-verified exact round-trips up to exactly this many significant
+/// digits (#1253; raised from an earlier `32`, which was chosen for the
+/// overflow/near-zero paths specifically, then silently inherited by every
+/// other caller once #1206 routed the ordinary scientific-notation case
+/// through this same function). This *is* still a cap, not a proven
+/// ceiling: a literal with more true significant digits than this still
+/// renders truncated rather than erroring when a caller opts into it (`Some`
+/// below) -- code review on #1253 confirmed the truncation is silent, not
+/// that raising the number removes it. Set to what this session actually
+/// verified against pinned jq 1.7.1, not a round number chosen past it, so
+/// the constant and the oracle claim it rests on can't drift apart again the
+/// way `32` (tuned for a different use case entirely) drifted from the
+/// fidelity the ordinary case actually needs.
+///
+/// A caller whose own notation choice needs every given digit regardless of
+/// this cap -- [`format_overflow_literal_mantissa`]'s plain-notation retry,
+/// #1274 -- passes `None` to [`normalize_extreme_literal_mantissa`] instead
+/// of this constant, since plain notation's whole point is rendering every
+/// given digit; there is no bounded prefix to fall back on the way
+/// scientific notation has.
+const MAX_RENDERED_MANTISSA_DIGITS: usize = 100_000;
+
 /// Shift a literal's own mantissa digits (the text before `exp_pos`, i.e.
 /// before `e`/`E`) into jq's one-digit-before-the-point normalized form,
 /// and fold that shift into the literal's own written exponent -- returns
@@ -589,39 +623,18 @@ fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
 /// pre-checked separately by each caller, so "is this mantissa all-zero"
 /// has exactly one implementation instead of two that must be kept in sync
 /// by convention (#106).
+///
+/// `mantissa_digit_cap` bounds how many digits of `rest` actually get
+/// copied into the returned `mantissa_str` -- see
+/// [`MAX_RENDERED_MANTISSA_DIGITS`] for why a cap exists at all and when a
+/// caller passes `None` instead. It never affects `new_exp`/`digit_count`,
+/// both derived from `shift`/`int_part.len()`/`frac_part.len()` directly,
+/// not from what got copied.
 fn normalize_extreme_literal_mantissa(
     s: &str,
     exp_pos: usize,
+    mantissa_digit_cap: Option<usize>,
 ) -> Result<(String, i128, i128, bool), i128> {
-    // `dump_truncated`'s whole design keeps preview cost independent of the
-    // value's own size (see its doc comment) - a document-controlled
-    // mantissa of unbounded length must not turn into unbounded work here.
-    // Bounding the *copy* is enough: `shift` below only ever needs
-    // `int_part.len()` (an O(1) property read once leading zeros are
-    // trimmed -- the `trim_start_matches('0')` just below is itself an O(k)
-    // scan over any leading-zero run, #1180), so truncating what gets
-    // copied into `rest` doesn't touch the exponent math's correctness,
-    // only how many digits past the first one actually get rendered. The
-    // trim doesn't change the function's overall cost class either way:
-    // `format_number_jq_compat`'s own `s.parse::<f64>()` ahead of this call
-    // already scans every byte of `s` once.
-    //
-    // Real jq preserves a literal's full given precision unconditionally --
-    // oracle-verified exact round-trips up to exactly this many significant
-    // digits (#1253; raised from an earlier `32`, which was chosen for the
-    // overflow/near-zero paths specifically, then silently inherited by
-    // every other caller once #1206 routed the ordinary scientific-notation
-    // case through this same function). This *is* still a cap, not a proven
-    // ceiling: a literal with more true significant digits than this still
-    // renders truncated rather than erroring, exactly as it did at the old
-    // `32` -- code review on #1253 confirmed the truncation is silent, not
-    // that raising the number removes it. Set to what this session actually
-    // verified against pinned jq 1.7.1, not a round number chosen past it,
-    // so the constant and the oracle claim it rests on can't drift apart
-    // again the way `32` (tuned for a different use case entirely) drifted
-    // from the fidelity the ordinary case actually needs.
-    const MAX_RENDERED_MANTISSA_DIGITS: usize = 100_000;
-
     let (int_part, frac_part) = split_mantissa(s, exp_pos);
 
     // Insignificant leading zeros (`007`) don't change which digit is the
@@ -651,26 +664,28 @@ fn normalize_extreme_literal_mantissa(
         };
         let after = &frac_part[k + 1..];
         let digit_count = (after.len() + 1) as i128;
-        (
-            -(k as i128 + 1),
-            &frac_part[k..=k],
-            after[..after.len().min(MAX_RENDERED_MANTISSA_DIGITS)].to_string(),
-            digit_count,
-        )
+        let rest = match mantissa_digit_cap {
+            Some(cap) => after[..after.len().min(cap)].to_string(),
+            None => after.to_string(),
+        };
+        (-(k as i128 + 1), &frac_part[k..=k], rest, digit_count)
     } else {
         // Mantissa >= 1: shift left past every extra significant
         // integer-part digit. `int_part[1..]` is a slice (no copy); only
-        // what actually gets concatenated into `rest` is capped.
+        // what actually gets concatenated into `rest` is capped (when
+        // `mantissa_digit_cap` is `Some` at all).
         let after_leading = &int_part[1..];
         let digit_count = (int_part.len() + frac_part.len()) as i128;
-        let rest = if after_leading.len() >= MAX_RENDERED_MANTISSA_DIGITS {
-            after_leading[..MAX_RENDERED_MANTISSA_DIGITS].to_string()
-        } else {
-            let budget = MAX_RENDERED_MANTISSA_DIGITS - after_leading.len();
-            format!(
-                "{after_leading}{}",
-                &frac_part[..frac_part.len().min(budget)]
-            )
+        let rest = match mantissa_digit_cap {
+            Some(cap) if after_leading.len() >= cap => after_leading[..cap].to_string(),
+            Some(cap) => {
+                let budget = cap - after_leading.len();
+                format!(
+                    "{after_leading}{}",
+                    &frac_part[..frac_part.len().min(budget)]
+                )
+            }
+            None => format!("{after_leading}{frac_part}"),
         };
         (
             int_part.len() as i128 - 1,
@@ -734,7 +749,7 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // unlike `format_near_zero_literal` (#1273), there is no case here
     // where the distinction changes what gets rendered.
     let Ok((mantissa_str, new_exp, digit_count, _exp_saturated)) =
-        normalize_extreme_literal_mantissa(s, exp_pos)
+        normalize_extreme_literal_mantissa(s, exp_pos, Some(MAX_RENDERED_MANTISSA_DIGITS))
     else {
         unreachable!("overflow implies a nonzero mantissa")
     };
@@ -764,6 +779,40 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // violation of that invariant, not a redundant check here.
     if let Some(plain) = format_positive_shifted_plain(sign, &mantissa_str, new_exp, digit_count) {
         return plain;
+    }
+
+    // #1274: `format_positive_shifted_plain` above declined for one of two
+    // reasons -- genuinely not enough given digits to stay plain (`new_exp
+    // >= digit_count`), or because `mantissa_str` was truncated by the
+    // `Some(MAX_RENDERED_MANTISSA_DIGITS)` cap just above, short of the
+    // digit `new_exp` needs to place the decimal point at, even though
+    // `new_exp < digit_count` says there *were* enough true digits. Retry
+    // with the cap lifted only in that second case: a literal with more
+    // than `MAX_RENDERED_MANTISSA_DIGITS + 1` significant digits still
+    // deserves the plain rendering real jq gives it (oracle-verified past
+    // 500,000 digits, no ceiling found), regardless of how many of those
+    // digits the display-cost cap above would normally elide for a
+    // scientific-notation rendering. Provably succeeds once retried:
+    // with `mantissa_digit_cap: None`, the returned mantissa's own digit
+    // count is exactly `digit_count` by construction (nothing was
+    // discarded), so `format_positive_shifted_plain`'s `split_pos >
+    // digits.len()` guard can no longer fire when `new_exp < digit_count`
+    // already held. Paying for a second `normalize_extreme_literal_mantissa`
+    // pass here, rather than always computing the uncapped mantissa up
+    // front, keeps the common (non-astronomically-long-literal) case at its
+    // original cost -- this combination (`f64` overflow *and* a
+    // >100,000-significant-digit literal) is essentially unreachable
+    // outside synthetic/adversarial input.
+    if new_exp < digit_count {
+        let Ok((full_mantissa_str, _, _, _)) = normalize_extreme_literal_mantissa(s, exp_pos, None)
+        else {
+            unreachable!("overflow implies a nonzero mantissa")
+        };
+        if let Some(plain) =
+            format_positive_shifted_plain(sign, &full_mantissa_str, new_exp, digit_count)
+        {
+            return plain;
+        }
     }
 
     assemble_scientific(sign, &mantissa_str, new_exp)
@@ -822,7 +871,7 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
 /// (`-0e5` -> `-0E+5`, `-0e0` -> `-0`, `-0.0e-1` -> `-0.00`).
 fn format_near_zero_literal(s: &str, exp_pos: usize, negative: bool) -> String {
     let sign = if negative { "-" } else { "" };
-    match normalize_extreme_literal_mantissa(s, exp_pos) {
+    match normalize_extreme_literal_mantissa(s, exp_pos, Some(MAX_RENDERED_MANTISSA_DIGITS)) {
         // #1273: this is the one caller with no ceiling of its own (see the
         // doc comment above), so it's the one place a saturated exponent
         // must not reach `assemble_scientific` -- that would display
@@ -933,26 +982,24 @@ fn join_sign_digits_with_optional_point(sign: &str, before: &str, after: &str) -
 /// to place the decimal point at. Unreachable from
 /// `format_number_jq_compat`'s own call site (a `shifted_exp` reaching this
 /// function only from there is bounded by a finite `f64`'s representable
-/// magnitude, ~308, far below the render cap) -- but *is* live-reachable
-/// from `format_overflow_literal_mantissa`'s call site, whose `shifted_exp`
-/// has no comparable bound (only the unrelated `1_000_000_000` exponent
-/// ceiling). A literal with more than `MAX_RENDERED_MANTISSA_DIGITS + 1`
-/// significant digits *and* an `f64`-overflowing value (e.g.
-/// `"9".repeat(100_002) + "e0"`) hits exactly this: real jq stays plain at
-/// that scale (oracle-verified past 500,000 digits, no ceiling found), but
-/// this function's own decision already used the *true* `digit_count` to
-/// commit to "should be plain," then discovers mid-render that the
-/// (already-truncated) `mantissa_str` doesn't have enough surviving digits
-/// to actually place the decimal point -- so it falls to scientific
-/// notation instead, itself also mantissa-truncated by the same cap. This
-/// is an accepted, documented divergence from real jq at that scale (#1274
-/// code review), the same class of trade-off `MAX_RENDERED_MANTISSA_DIGITS`
-/// already makes elsewhere in this module -- fixing it exactly would need
-/// `normalize_extreme_literal_mantissa` to defer its own truncation
-/// decision until the caller's notation choice is known (currently the
-/// reverse order), which is a larger restructuring than this fallback
-/// alone; not attempted here given how rare the trigger combination is
-/// (`f64` overflow *and* a >100,000-significant-digit literal).
+/// magnitude, ~308, far below the render cap). It *was* live-reachable from
+/// `format_overflow_literal_mantissa`'s call site (#1274), whose
+/// `shifted_exp` has no comparable bound (only the unrelated
+/// `1_000_000_000` exponent ceiling) -- a literal with more than
+/// `MAX_RENDERED_MANTISSA_DIGITS + 1` significant digits *and* an
+/// `f64`-overflowing value (e.g. `"9".repeat(100_002) + "e0"`) used to hit
+/// exactly this: real jq stays plain at that scale (oracle-verified past
+/// 500,000 digits, no ceiling found), but this function's own decision
+/// already used the *true* `digit_count` to commit to "should be plain,"
+/// then discovered mid-render that the (already-truncated) `mantissa_str`
+/// didn't have enough surviving digits to actually place the decimal
+/// point. `format_overflow_literal_mantissa` now retries with the cap
+/// lifted (`mantissa_digit_cap: None`) whenever `new_exp < digit_count`
+/// held but this function still returned `None`, so this guard is no
+/// longer reachable from that call site in practice -- kept as a defensive
+/// invariant check (a future caller that reintroduces a capped mantissa
+/// alongside a true `digit_count` would silently mis-render without it)
+/// rather than removed.
 ///
 /// `mantissa_str` is `"d"` or `"d.ddd"` (one leading digit,
 /// `normalize_extreme_literal_mantissa`'s normalized form) -- concatenating
@@ -3623,47 +3670,48 @@ mod tests {
         );
     }
 
-    /// #1274 characterization test (not a regression test -- this pins
-    /// known, accepted-divergent-from-jq behavior, not desired behavior;
-    /// see the testing skill's characterization-test convention). Before
-    /// this PR the mechanism was undocumented and the doc comment claiming
-    /// it "provably unreachable" was simply wrong; after this PR the
-    /// behavior itself is unchanged, only correctly documented and pinned.
-    /// If a future fix defers `normalize_extreme_literal_mantissa`'s
-    /// truncation until the caller's notation choice is known (the
-    /// restructuring `format_positive_shifted_plain`'s own doc comment
-    /// describes as the real fix), update or delete this test rather than
-    /// treating a failure here as a regression.
+    /// #1274 fix: `format_overflow_literal_mantissa` used to flip a literal
+    /// with more than `MAX_RENDERED_MANTISSA_DIGITS + 1` significant digits
+    /// from plain to (truncated) scientific notation even when the
+    /// literal's own given digits were enough to cover the shift and stay
+    /// plain -- `format_positive_shifted_plain`'s decision used the true
+    /// `digit_count`, but `mantissa_str` had already been truncated to
+    /// `MAX_RENDERED_MANTISSA_DIGITS` before that decision could see it.
+    /// Fixed by retrying with the digit cap lifted
+    /// (`normalize_extreme_literal_mantissa`'s `mantissa_digit_cap: None`)
+    /// whenever the true digit count says plain notation should have
+    /// worked. Real jq stays plain at this scale unconditionally
+    /// (oracle-verified past 500,000 digits, no ceiling found).
     ///
-    /// `format_positive_shifted_plain`'s truncation-vs-decision mismatch is
-    /// live-reachable only via the overflow path
-    /// (`format_overflow_literal_mantissa`) since the ordinary path's own
-    /// `shifted_exp` can never exceed `MAX_RENDERED_MANTISSA_DIGITS`
-    /// (bounded by `f64`'s own finite range). One digit past
-    /// `MAX_RENDERED_MANTISSA_DIGITS` given digits (exactly filling the
-    /// render cap, no truncation yet): still plain, matching real jq
-    /// (oracle-verified past 500,000 digits). Two digits past it (one digit
-    /// truncated away): falls to scientific instead -- see
-    /// `format_positive_shifted_plain`'s own doc comment for why. Pins the
-    /// exact, intentional boundary so a future change to the render cap or
-    /// the truncation/decision ordering can't silently move it without a
-    /// test noticing.
+    /// This test used to pin the pre-fix divergence at exactly this
+    /// boundary (`git log` has the characterization-test version); it now
+    /// pins the fix instead: both sides of the old boundary, plus a scale
+    /// well past it, stay plain and match real jq exactly.
     #[test]
-    fn test_format_number_jq_compat_overflow_plain_scientific_flip_boundary_characterize_preexisting_bug_1274(
-    ) {
+    fn test_format_number_jq_compat_overflow_plain_stays_plain_past_the_render_cap_1274() {
         let at_cap = "9".repeat(100_001); // MAX_RENDERED_MANTISSA_DIGITS + 1 given digits
         assert_eq!(
             format_number_jq_compat(format!("{at_cap}e0").as_bytes()),
             at_cap,
-            "at MAX_RENDERED_MANTISSA_DIGITS + 1 given digits: still plain, matching real jq"
+            "at MAX_RENDERED_MANTISSA_DIGITS + 1 given digits: stays plain"
         );
+
         let past_cap = "9".repeat(100_002); // MAX_RENDERED_MANTISSA_DIGITS + 2 given digits
         assert_eq!(
             format_number_jq_compat(format!("{past_cap}e0").as_bytes()),
-            format!("9.{}E+100001", "9".repeat(100_000)),
-            "at MAX_RENDERED_MANTISSA_DIGITS + 2 given digits: falls to \
-             (also-truncated) scientific, diverging from real jq's own \
-             plain output at this scale"
+            past_cap,
+            "at MAX_RENDERED_MANTISSA_DIGITS + 2 given digits: previously \
+             flipped to truncated scientific -- now stays plain, matching \
+             real jq"
+        );
+
+        // Well past the old cap (2x), to prove this is genuinely unbounded
+        // now, not just a boundary shifted by one -- oracle-verified
+        // against real jq up to 500,000 digits, no ceiling found.
+        let well_past_cap = "3".repeat(200_000);
+        assert_eq!(
+            format_number_jq_compat(format!("{well_past_cap}e0").as_bytes()),
+            well_past_cap
         );
     }
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -396,13 +396,17 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // 150,050 given digits. Reusing the capped `mantissa_str` from above
     // for a plain render this large would silently drop trailing digits
     // (see `format_positive_shifted_plain`'s doc comment on why that
-    // failure mode doesn't even return `None`) -- so, same as
-    // `format_overflow_literal_mantissa` (#1274), re-derive uncapped only
-    // once eligibility is confirmed cap-independently.
-    if shifted_exp > 0 && shifted_exp < digit_count {
-        let full_mantissa_str = full_mantissa_if_capped(s, exp_pos, &mantissa_str, digit_count);
+    // failure mode doesn't even return `None`) -- `try_positive_shifted_plain`
+    // (shared with `format_overflow_literal_mantissa`, #1274) re-derives
+    // uncapped only once eligibility is confirmed cap-independently. The
+    // `shifted_exp > 0` guard stays here rather than folding into the
+    // shared helper: unlike the overflow call site, this one can also see
+    // small/negative shifted exponents (already routed to
+    // `format_shifted_mantissa` above), so it's the one caller that
+    // actually needs it.
+    if shifted_exp > 0 {
         if let Some(plain) =
-            format_positive_shifted_plain(sign, &full_mantissa_str, shifted_exp, digit_count)
+            try_positive_shifted_plain(sign, s, exp_pos, shifted_exp, digit_count, &mantissa_str)
         {
             return plain;
         }
@@ -581,10 +585,14 @@ fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
 /// [`normalize_extreme_literal_mantissa`] when a caller doesn't need every
 /// given digit rendered anyway (scientific notation only ever shows a
 /// bounded prefix). Bounding the *copy* is enough: `shift` only ever needs
-/// `int_part.len()` (an O(1) property read once leading zeros are trimmed),
-/// so truncating what gets copied into `rest` doesn't touch the exponent
-/// math's correctness, only how many digits past the first one actually get
-/// rendered.
+/// `int_part.len()` (an O(1) property read once leading zeros are trimmed
+/// -- the `trim_start_matches('0')` itself is an O(k) scan over any
+/// leading-zero run, #1180), so truncating what gets copied into `rest`
+/// doesn't touch the exponent math's correctness, only how many digits past
+/// the first one actually get rendered. The trim doesn't change the
+/// function's overall cost class either way: `format_number_jq_compat`'s
+/// own `s.parse::<f64>()` ahead of every call into this function already
+/// scans every byte of `s` once.
 ///
 /// Real jq preserves a literal's full given precision unconditionally --
 /// oracle-verified exact round-trips up to exactly this many significant
@@ -602,11 +610,19 @@ fn split_mantissa(s: &str, exp_pos: usize) -> (&str, &str) {
 /// fidelity the ordinary case actually needs.
 ///
 /// A caller whose own notation choice needs every given digit regardless of
-/// this cap -- [`format_overflow_literal_mantissa`]'s plain-notation retry,
-/// #1274 -- passes `None` to [`normalize_extreme_literal_mantissa`] instead
-/// of this constant, since plain notation's whole point is rendering every
-/// given digit; there is no bounded prefix to fall back on the way
-/// scientific notation has.
+/// this cap -- [`try_positive_shifted_plain`]'s and
+/// [`format_shifted_mantissa`]'s callers, #1274 -- passes `None` to
+/// [`normalize_extreme_literal_mantissa`] instead of this constant, since
+/// plain notation's whole point is rendering every given digit; there is no
+/// bounded prefix to fall back on the way scientific notation has. This
+/// deliberately reintroduces document-length-proportional cost for that
+/// specific case (a many-hundred-thousand-digit literal that turns out to
+/// be plain-eligible pays for rendering every one of those digits) rather
+/// than adding a second, independent cap -- because real jq itself has no
+/// such cap either (oracle-verified past 500,000 digits, no ceiling found),
+/// matching it exactly means matching its cost profile too, and the input
+/// already had to contain that many bytes to trigger it in the first place
+/// (linear cost in the attacker's own paid-for input, not an amplification).
 const MAX_RENDERED_MANTISSA_DIGITS: usize = 100_000;
 
 /// Shift a literal's own mantissa digits (the text before `exp_pos`, i.e.
@@ -746,9 +762,17 @@ fn normalize_extreme_literal_mantissa(
 
 /// Re-derive `mantissa_str` without [`normalize_extreme_literal_mantissa`]'s
 /// `MAX_RENDERED_MANTISSA_DIGITS` cap, but only when the cap could actually
-/// have truncated something (`digit_count` past it) -- when it's within the
-/// cap, `mantissa_str` already holds every given digit, so this avoids a
-/// wasted second pass over `s` in the overwhelmingly common case.
+/// have truncated something -- when it's within the cap, `mantissa_str`
+/// already holds every given digit, so this avoids a wasted second pass
+/// over `s` in the overwhelmingly common case. Truncation of `rest` only
+/// starts at `digit_count == cap + 2` (both branches of
+/// `normalize_extreme_literal_mantissa` copy up to `cap` digits *after* the
+/// mandatory leading one, so `digit_count == cap + 1` -- one leading digit
+/// plus exactly `cap` more -- is already complete); the `+ 1` below matches
+/// that exactly rather than the more conservative `digit_count > cap`,
+/// which would trigger one boundary value early on an already-untruncated
+/// mantissa (#1274 review, confirmed live: both give identical output at
+/// that boundary, but only this bound avoids the redundant re-derivation).
 ///
 /// Every caller that must echo every given digit verbatim --
 /// [`format_shifted_mantissa`]'s unconditional decimal window,
@@ -765,7 +789,7 @@ fn full_mantissa_if_capped<'a>(
     mantissa_str: &'a str,
     digit_count: i128,
 ) -> Cow<'a, str> {
-    if digit_count > MAX_RENDERED_MANTISSA_DIGITS as i128 {
+    if digit_count > MAX_RENDERED_MANTISSA_DIGITS as i128 + 1 {
         let Ok((full, _, _, _)) = normalize_extreme_literal_mantissa(s, exp_pos, None) else {
             unreachable!("digit_count > 0 implies a nonzero mantissa was already found")
         };
@@ -824,36 +848,25 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // 400 significant digits were given (`shifted_exp` 399 `<` `digit_count`
     // 400) -- oracle-verified, code review on #1253.
     //
-    // #1274: decide eligibility first (cap-independent, since
-    // `new_exp`/`digit_count` never depend on `mantissa_digit_cap`), and
-    // only then fetch an uncapped mantissa via `full_mantissa_if_capped` --
-    // rather than just trying `mantissa_str` (capped, from above) and
+    // #1274: `try_positive_shifted_plain` (shared with
+    // `format_number_jq_compat`) decides eligibility first (cap-independent,
+    // since `new_exp`/`digit_count` never depend on `mantissa_digit_cap`),
+    // and only then fetches an uncapped mantissa via `full_mantissa_if_capped`
+    // -- rather than just trying `mantissa_str` (capped, from above) and
     // falling back to `None` -- since a capped mantissa can silently
     // *succeed* in `format_positive_shifted_plain` too when the split point
     // falls within the capped prefix, not just fail outright (see that
-    // function's own doc comment, and `full_mantissa_if_capped`'s). No
-    // `new_exp > 0` guard needed before calling it (unlike
-    // `format_number_jq_compat`'s own call site, which also sees
+    // function's own doc comment). No `new_exp > 0` guard needed here
+    // (unlike `format_number_jq_compat`'s own call site, which also sees
     // small/negative shifted exponents): overflow requires `|value| >
     // f64::MAX` (~1.8e308), so `new_exp` is always well past `300` by the
-    // time this function is ever reached -- its own `debug_assert!` on a
-    // positive shift is what would catch a violation of that invariant, not
-    // a redundant check here.
-    if new_exp < digit_count {
-        let full_mantissa_str = full_mantissa_if_capped(s, exp_pos, &mantissa_str, digit_count);
-        // Provably always `Some` here (not just usually): `full_mantissa_str`
-        // is uncapped whenever `full_mantissa_if_capped` had to re-derive at
-        // all, so its own digit count equals `digit_count` exactly, and
-        // `format_positive_shifted_plain`'s `split_pos > digits.len()` guard
-        // reduces to the `new_exp < digit_count` this branch already
-        // checked. Kept as `if let` rather than `.expect(..)` so a future
-        // change to either function's contract fails safe (falls to
-        // scientific) instead of panicking.
-        if let Some(plain) =
-            format_positive_shifted_plain(sign, &full_mantissa_str, new_exp, digit_count)
-        {
-            return plain;
-        }
+    // time this function is ever reached -- `format_positive_shifted_plain`'s
+    // own `debug_assert!` on a positive shift is what would catch a
+    // violation of that invariant, not a redundant check here.
+    if let Some(plain) =
+        try_positive_shifted_plain(sign, s, exp_pos, new_exp, digit_count, &mantissa_str)
+    {
+        return plain;
     }
 
     assemble_scientific(sign, &mantissa_str, new_exp)
@@ -910,6 +923,17 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
 /// caller's `value.is_sign_negative()`) still needs applying in every arm --
 /// real jq keeps the sign throughout, since `log10(0)` is undefined
 /// (`-0e5` -> `-0E+5`, `-0e0` -> `-0`, `-0.0e-1` -> `-0.00`).
+///
+/// **#1274 review note:** every arm below feeds its mantissa to
+/// `assemble_scientific`/`assemble_scientific_from_raw_exponent`, both
+/// bounded-prefix consumers that are safe with a `Some(MAX_RENDERED_MANTISSA_DIGITS)`-capped
+/// `mantissa_str` -- this function is safe *because* it has no plain-decimal
+/// branch, not because anything here enforces that. If a future change ever
+/// adds one (mirroring `format_shifted_mantissa`'s `-6..=-1` window or
+/// `format_positive_shifted_plain`'s), it must fetch an uncapped mantissa
+/// via `full_mantissa_if_capped` first, the same as every other caller that
+/// needs to echo every given digit -- reusing `mantissa_str` directly would
+/// reintroduce exactly the silent-truncation bug this issue fixed.
 fn format_near_zero_literal(s: &str, exp_pos: usize, negative: bool) -> String {
     let sign = if negative { "-" } else { "" };
     match normalize_extreme_literal_mantissa(s, exp_pos, Some(MAX_RENDERED_MANTISSA_DIGITS)) {
@@ -1066,6 +1090,46 @@ fn format_positive_shifted_plain(
     }
     let (before, after) = digits.split_at(split_pos);
     Some(join_sign_digits_with_optional_point(sign, before, after))
+}
+
+/// Attempt [`format_positive_shifted_plain`], fetching an uncapped mantissa
+/// via [`full_mantissa_if_capped`] only once eligibility (`shifted_exp <
+/// digit_count`) is confirmed -- the shared "gate on cap-independent
+/// eligibility, fetch, render" sequence both [`format_number_jq_compat`]
+/// and [`format_overflow_literal_mantissa`] need. `mantissa_str` is the
+/// caller's own (possibly `MAX_RENDERED_MANTISSA_DIGITS`-capped) mantissa;
+/// it's used as-is only to decide there's nothing to fetch (`full_mantissa_if_capped`'s
+/// own within-cap fast path), never passed uncapped-required call sites
+/// directly.
+///
+/// #1274 review: this exact sequence, plus ~15 lines of near-duplicate
+/// prose explaining why the gate-then-fetch ordering matters, was
+/// duplicated between the two call sites before this helper existed --
+/// shared here so a future fix to this pattern lands in one place instead
+/// of two.
+///
+/// `format_positive_shifted_plain` is provably always `Some` once reached
+/// here (not just usually): `full_mantissa_str` is uncapped whenever
+/// `full_mantissa_if_capped` had to re-derive at all, so its own digit
+/// count equals `digit_count` exactly, and `format_positive_shifted_plain`'s
+/// `split_pos > digits.len()` guard reduces to the `shifted_exp <
+/// digit_count` this function already checked above. Still returns
+/// `Option<String>` rather than unwrapping internally, so a future change
+/// to either function's contract fails safe (caller falls back to
+/// scientific notation) instead of panicking.
+fn try_positive_shifted_plain(
+    sign: &str,
+    s: &str,
+    exp_pos: usize,
+    shifted_exp: i128,
+    digit_count: i128,
+    mantissa_str: &str,
+) -> Option<String> {
+    if shifted_exp >= digit_count {
+        return None;
+    }
+    let full_mantissa_str = full_mantissa_if_capped(s, exp_pos, mantissa_str, digit_count);
+    format_positive_shifted_plain(sign, &full_mantissa_str, shifted_exp, digit_count)
 }
 
 /// An owned JSON value.

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -365,7 +365,14 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     };
     let sign = if value.is_sign_negative() { "-" } else { "" };
     if shifted_exp == 0 || (-6..=-1).contains(&shifted_exp) {
-        return format_shifted_mantissa(sign, &mantissa_str, shifted_exp);
+        // #1274: this window is *unconditionally* a decimal render --
+        // `format_shifted_mantissa` never falls back to scientific notation
+        // within it -- so it always needs every given digit, not just the
+        // capped `mantissa_str` from above (see `full_mantissa_if_capped`'s
+        // doc comment for why trying the capped one is unsafe, not just
+        // wasteful).
+        let full_mantissa_str = full_mantissa_if_capped(s, exp_pos, &mantissa_str, digit_count);
+        return format_shifted_mantissa(sign, &full_mantissa_str, shifted_exp);
     }
 
     // #1244: a *positive* shifted exponent doesn't follow a comparably
@@ -379,9 +386,23 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     // one short -- goes scientific `9.9999999999999E+14`). `shifted_exp <
     // digit_count` is exactly that condition (oracle-verified against jq
     // 1.7.1 across a broad randomized/boundary sweep, both signs).
-    if shifted_exp > 0 {
+    //
+    // #1274: `digit_count` -- not `shifted_exp` -- is what can exceed
+    // `MAX_RENDERED_MANTISSA_DIGITS` here, and it can do so even for a
+    // small, ordinary shift: a modest-magnitude literal with an enormous
+    // fractional part (`"1".repeat(50) + "." + "9".repeat(150_000) + "e0"`,
+    // parses to a perfectly ordinary finite `f64` around `1e49`, well under
+    // any overflow concern) still gives real jq's own display the full
+    // 150,050 given digits. Reusing the capped `mantissa_str` from above
+    // for a plain render this large would silently drop trailing digits
+    // (see `format_positive_shifted_plain`'s doc comment on why that
+    // failure mode doesn't even return `None`) -- so, same as
+    // `format_overflow_literal_mantissa` (#1274), re-derive uncapped only
+    // once eligibility is confirmed cap-independently.
+    if shifted_exp > 0 && shifted_exp < digit_count {
+        let full_mantissa_str = full_mantissa_if_capped(s, exp_pos, &mantissa_str, digit_count);
         if let Some(plain) =
-            format_positive_shifted_plain(sign, &mantissa_str, shifted_exp, digit_count)
+            format_positive_shifted_plain(sign, &full_mantissa_str, shifted_exp, digit_count)
         {
             return plain;
         }
@@ -723,6 +744,37 @@ fn normalize_extreme_literal_mantissa(
     Ok((mantissa_str, new_exp, digit_count, exp_saturated))
 }
 
+/// Re-derive `mantissa_str` without [`normalize_extreme_literal_mantissa`]'s
+/// `MAX_RENDERED_MANTISSA_DIGITS` cap, but only when the cap could actually
+/// have truncated something (`digit_count` past it) -- when it's within the
+/// cap, `mantissa_str` already holds every given digit, so this avoids a
+/// wasted second pass over `s` in the overwhelmingly common case.
+///
+/// Every caller that must echo every given digit verbatim --
+/// [`format_shifted_mantissa`]'s unconditional decimal window,
+/// [`format_positive_shifted_plain`]'s plain branch -- shares this rather
+/// than each repeating the "is this actually capped" gate and the
+/// `unreachable!()` (#1274: a caller that skipped the gate and always tried
+/// the capped mantissa first could still get a *wrong* answer, not just an
+/// `Option::None` -- see `format_positive_shifted_plain`'s own doc comment
+/// -- so this helper exists specifically so no call site can shortcut past
+/// it that way again).
+fn full_mantissa_if_capped<'a>(
+    s: &str,
+    exp_pos: usize,
+    mantissa_str: &'a str,
+    digit_count: i128,
+) -> Cow<'a, str> {
+    if digit_count > MAX_RENDERED_MANTISSA_DIGITS as i128 {
+        let Ok((full, _, _, _)) = normalize_extreme_literal_mantissa(s, exp_pos, None) else {
+            unreachable!("digit_count > 0 implies a nonzero mantissa was already found")
+        };
+        Cow::Owned(full)
+    } else {
+        Cow::Borrowed(mantissa_str)
+    }
+}
+
 /// Renormalize an overflowed literal's own mantissa digits into jq's
 /// one-digit-before-the-point scientific form -- see
 /// [`normalize_extreme_literal_mantissa`] for the shared shift math. `s` is
@@ -770,44 +822,25 @@ fn format_overflow_literal_mantissa(s: &str, exp_pos: usize, negative: bool) -> 
     // (400 nines vastly exceeds `f64::MAX`), yet real jq still renders it
     // as a plain 400-digit integer, not scientific notation, because all
     // 400 significant digits were given (`shifted_exp` 399 `<` `digit_count`
-    // 400) -- oracle-verified, code review on #1253. No `new_exp > 0` guard
-    // needed here (unlike `format_number_jq_compat`'s own call site, which
-    // also sees small/negative shifted exponents): overflow requires
-    // `|value| > f64::MAX` (~1.8e308), so `new_exp` is always well past
-    // `300` by the time this function is ever reached -- `format_positive_shifted_plain`'s
-    // own `debug_assert!` on a positive shift is what would catch a
-    // violation of that invariant, not a redundant check here.
-    if let Some(plain) = format_positive_shifted_plain(sign, &mantissa_str, new_exp, digit_count) {
-        return plain;
-    }
-
-    // #1274: `format_positive_shifted_plain` above declined for one of two
-    // reasons -- genuinely not enough given digits to stay plain (`new_exp
-    // >= digit_count`), or because `mantissa_str` was truncated by the
-    // `Some(MAX_RENDERED_MANTISSA_DIGITS)` cap just above, short of the
-    // digit `new_exp` needs to place the decimal point at, even though
-    // `new_exp < digit_count` says there *were* enough true digits. Retry
-    // with the cap lifted only in that second case: a literal with more
-    // than `MAX_RENDERED_MANTISSA_DIGITS + 1` significant digits still
-    // deserves the plain rendering real jq gives it (oracle-verified past
-    // 500,000 digits, no ceiling found), regardless of how many of those
-    // digits the display-cost cap above would normally elide for a
-    // scientific-notation rendering. Provably succeeds once retried:
-    // with `mantissa_digit_cap: None`, the returned mantissa's own digit
-    // count is exactly `digit_count` by construction (nothing was
-    // discarded), so `format_positive_shifted_plain`'s `split_pos >
-    // digits.len()` guard can no longer fire when `new_exp < digit_count`
-    // already held. Paying for a second `normalize_extreme_literal_mantissa`
-    // pass here, rather than always computing the uncapped mantissa up
-    // front, keeps the common (non-astronomically-long-literal) case at its
-    // original cost -- this combination (`f64` overflow *and* a
-    // >100,000-significant-digit literal) is essentially unreachable
-    // outside synthetic/adversarial input.
+    // 400) -- oracle-verified, code review on #1253.
+    //
+    // #1274: decide eligibility first (cap-independent, since
+    // `new_exp`/`digit_count` never depend on `mantissa_digit_cap`), and
+    // only then fetch an uncapped mantissa via `full_mantissa_if_capped` --
+    // rather than just trying `mantissa_str` (capped, from above) and
+    // falling back to `None` -- since a capped mantissa can silently
+    // *succeed* in `format_positive_shifted_plain` too when the split point
+    // falls within the capped prefix, not just fail outright (see that
+    // function's own doc comment, and `full_mantissa_if_capped`'s). No
+    // `new_exp > 0` guard needed before calling it (unlike
+    // `format_number_jq_compat`'s own call site, which also sees
+    // small/negative shifted exponents): overflow requires `|value| >
+    // f64::MAX` (~1.8e308), so `new_exp` is always well past `300` by the
+    // time this function is ever reached -- its own `debug_assert!` on a
+    // positive shift is what would catch a violation of that invariant, not
+    // a redundant check here.
     if new_exp < digit_count {
-        let Ok((full_mantissa_str, _, _, _)) = normalize_extreme_literal_mantissa(s, exp_pos, None)
-        else {
-            unreachable!("overflow implies a nonzero mantissa")
-        };
+        let full_mantissa_str = full_mantissa_if_capped(s, exp_pos, &mantissa_str, digit_count);
         if let Some(plain) =
             format_positive_shifted_plain(sign, &full_mantissa_str, new_exp, digit_count)
         {
@@ -975,31 +1008,27 @@ fn join_sign_digits_with_optional_point(sign: &str, before: &str, after: &str) -
 /// `None` when that condition doesn't hold (caller falls back to
 /// scientific notation).
 ///
-/// The `split_pos > digits.len()` check below is a second, independent
-/// guard against `mantissa_str` having been truncated by
-/// `normalize_extreme_literal_mantissa`'s own render cap
-/// (`MAX_RENDERED_MANTISSA_DIGITS`) short of the digit `shifted_exp` needs
-/// to place the decimal point at. Unreachable from
-/// `format_number_jq_compat`'s own call site (a `shifted_exp` reaching this
-/// function only from there is bounded by a finite `f64`'s representable
-/// magnitude, ~308, far below the render cap). It *was* live-reachable from
-/// `format_overflow_literal_mantissa`'s call site (#1274), whose
-/// `shifted_exp` has no comparable bound (only the unrelated
-/// `1_000_000_000` exponent ceiling) -- a literal with more than
-/// `MAX_RENDERED_MANTISSA_DIGITS + 1` significant digits *and* an
-/// `f64`-overflowing value (e.g. `"9".repeat(100_002) + "e0"`) used to hit
-/// exactly this: real jq stays plain at that scale (oracle-verified past
-/// 500,000 digits, no ceiling found), but this function's own decision
-/// already used the *true* `digit_count` to commit to "should be plain,"
-/// then discovered mid-render that the (already-truncated) `mantissa_str`
-/// didn't have enough surviving digits to actually place the decimal
-/// point. `format_overflow_literal_mantissa` now retries with the cap
-/// lifted (`mantissa_digit_cap: None`) whenever `new_exp < digit_count`
-/// held but this function still returned `None`, so this guard is no
-/// longer reachable from that call site in practice -- kept as a defensive
-/// invariant check (a future caller that reintroduces a capped mantissa
-/// alongside a true `digit_count` would silently mis-render without it)
-/// rather than removed.
+/// **Caller contract (#1274):** `mantissa_str`'s own digit count must equal
+/// `digit_count` exactly -- i.e. never a `normalize_extreme_literal_mantissa`
+/// mantissa truncated by `MAX_RENDERED_MANTISSA_DIGITS` (`Some(..)`), only
+/// an uncapped one (`None`). This function cannot detect a violation from
+/// its own inputs alone: the `split_pos > digits.len()` check below only
+/// catches a truncated mantissa when the decimal point's position
+/// (`shifted_exp + 1`) falls *past* the truncated prefix -- but when it
+/// falls *within* the truncated prefix, the check passes and this function
+/// returns `Some` anyway, silently missing whatever trailing digits the cap
+/// elided rather than erroring or falling back. `format_overflow_literal_mantissa`
+/// (#1274) learned this the hard way: an earlier version of that caller
+/// tried the capped mantissa first and only retried uncapped when this
+/// function returned `None`, which fixed the "wrongly flips to truncated
+/// scientific" symptom the issue reported but missed this quieter sibling
+/// -- a "successful" plain render silently short digits whenever the split
+/// point happened to land inside the capped prefix (e.g. `shifted_exp`
+/// small relative to a `>100,000`-digit `digit_count`). The caller now
+/// decides plain-vs-scientific eligibility itself, before ever building a
+/// mantissa, and only calls this function with an uncapped one when
+/// eligible -- this function's own guards remain as defense in depth, not
+/// the primary correctness mechanism.
 ///
 /// `mantissa_str` is `"d"` or `"d.ddd"` (one leading digit,
 /// `normalize_extreme_literal_mantissa`'s normalized form) -- concatenating
@@ -3677,11 +3706,11 @@ mod tests {
     /// plain -- `format_positive_shifted_plain`'s decision used the true
     /// `digit_count`, but `mantissa_str` had already been truncated to
     /// `MAX_RENDERED_MANTISSA_DIGITS` before that decision could see it.
-    /// Fixed by retrying with the digit cap lifted
-    /// (`normalize_extreme_literal_mantissa`'s `mantissa_digit_cap: None`)
-    /// whenever the true digit count says plain notation should have
-    /// worked. Real jq stays plain at this scale unconditionally
-    /// (oracle-verified past 500,000 digits, no ceiling found).
+    /// Fixed by deciding eligibility on the cap-independent `new_exp`/
+    /// `digit_count` first and only then fetching an uncapped mantissa
+    /// (`full_mantissa_if_capped`) when eligible. Real jq stays plain at
+    /// this scale unconditionally (oracle-verified past 500,000 digits, no
+    /// ceiling found).
     ///
     /// This test used to pin the pre-fix divergence at exactly this
     /// boundary (`git log` has the characterization-test version); it now
@@ -3712,6 +3741,69 @@ mod tests {
         assert_eq!(
             format_number_jq_compat(format!("{well_past_cap}e0").as_bytes()),
             well_past_cap
+        );
+    }
+
+    /// #1274 review: the magnitude-`< 1` branch of
+    /// `normalize_extreme_literal_mantissa` (a leading-zero-fraction
+    /// mantissa, e.g. `0.999...e400`) has its own independent digit-cap
+    /// truncation site (`after[..after.len().min(cap)]`), reached via the
+    /// same `format_overflow_literal_mantissa` plain-eligibility path as
+    /// the magnitude-`>= 1` case `test_format_number_jq_compat_overflow_plain_stays_plain_past_the_render_cap_1274`
+    /// above already covers -- but a *different* code path inside
+    /// `normalize_extreme_literal_mantissa` (the `int_part.is_empty()` arm,
+    /// not the `else` arm), so it needed its own coverage: a full round-trip
+    /// test on only the `else` arm doesn't exercise this one at all.
+    #[test]
+    fn test_format_number_jq_compat_overflow_plain_stays_plain_past_the_render_cap_fraction_branch_1274(
+    ) {
+        // `0.` + 100,002 nines + `e400`: mantissa shift is `-1` (leading
+        // nonzero fractional digit at position 0), so `new_exp = 400 - 1 =
+        // 399`, still `< digit_count` (100,002) -- plain-eligible. Unlike
+        // the magnitude->=1 sibling test above, `new_exp` doesn't land on
+        // `digit_count - 1` here, so the correct output isn't a bare
+        // integer -- it's the decimal point inserted 400 digits in
+        // (oracle-verified against real jq 1.7.1).
+        let digits = "9".repeat(100_002); // MAX_RENDERED_MANTISSA_DIGITS + 2 given digits
+        let expected = format!("{}.{}", "9".repeat(400), "9".repeat(99_602));
+        assert_eq!(
+            format_number_jq_compat(format!("0.{digits}e400").as_bytes()),
+            expected,
+            "magnitude < 1, past the render cap: stays plain, matching real jq"
+        );
+    }
+
+    /// #1274 review: `digit_count` -- not `shifted_exp` -- is what actually
+    /// needs to exceed `MAX_RENDERED_MANTISSA_DIGITS` to trigger this bug
+    /// class, so it's reachable even through `format_number_jq_compat`'s
+    /// *ordinary* (non-overflow) path, for a perfectly ordinary-magnitude
+    /// value with an enormous fractional part -- previously undetected
+    /// because every other test in this area happened to pair a huge digit
+    /// count with a huge shift (the overflow path's own territory). Also
+    /// covers `format_shifted_mantissa`'s `shifted_exp == 0` window
+    /// directly (`shift = 0` here, both cases), which -- unlike
+    /// `format_positive_shifted_plain` -- has no scientific fallback to
+    /// silently mask a truncated mantissa behind at all: it must always
+    /// render every given digit.
+    #[test]
+    fn test_format_number_jq_compat_ordinary_path_plain_stays_plain_past_the_render_cap_1274() {
+        let frac = "9".repeat(150_000);
+        // shift = 0 (single leading digit `7`): exercises
+        // `format_shifted_mantissa`'s `shifted_exp == 0` arm directly.
+        assert_eq!(
+            format_number_jq_compat(format!("7.{frac}e0").as_bytes()),
+            format!("7.{frac}"),
+            "ordinary (non-overflow) path, shifted_exp == 0, digit_count past the cap"
+        );
+
+        // A modest positive shift, still nowhere near overflowing `f64`,
+        // routes through `format_positive_shifted_plain` instead --
+        // exercising this bug class's other branch on the ordinary path.
+        let int_part = "1".repeat(50);
+        assert_eq!(
+            format_number_jq_compat(format!("{int_part}.{frac}e0").as_bytes()),
+            format!("{int_part}.{frac}"),
+            "ordinary (non-overflow) path, positive shifted_exp, digit_count past the cap"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #1274: `succinctly jq` wrongly flipped a literal with more than `MAX_RENDERED_MANTISSA_DIGITS + 1` (100,001+) significant digits from plain to (truncated) scientific notation whenever the literal's own given digits were enough to cover the shift and stay plain. Real jq stays plain unconditionally at this scale (oracle-verified past 500,000 digits, no ceiling found).

```bash
$ python3 -c "print('9'*100002 + 'e0')" | jq -c .
999...9   # plain, all 100,002 nines

$ python3 -c "print('9'*100002 + 'e0')" | succinctly jq -c .   # before this PR
9.999...9E+100001   # wrongly flipped to truncated scientific
```

## Root cause

`normalize_extreme_literal_mantissa` truncates its returned mantissa text to `MAX_RENDERED_MANTISSA_DIGITS` before its caller ever gets to decide plain-vs-scientific notation. `format_positive_shifted_plain`'s own decision uses the *true* `digit_count` (never truncated), so it correctly commits to "should be plain" -- but then discovers mid-render that the already-truncated mantissa doesn't have enough surviving digits to actually place the decimal point, and falls back to (also-truncated) scientific notation instead.

**A more severe sibling bug surfaced during my own review of this fix**: a capped mantissa doesn't always *fail* in that situation -- when the decimal-point split falls *within* the truncated prefix rather than past it, `format_positive_shifted_plain` returns `Some(...)` anyway, silently rendering a plain result that's missing whatever trailing digits the cap elided. This is reachable via three call sites, not just the overflow path the issue originally reported: `format_overflow_literal_mantissa` (the issue's own repro), `format_number_jq_compat`'s ordinary (non-overflow) path (an everyday-magnitude value with an enormous fractional part), and `format_shifted_mantissa`'s unconditional `shifted_exp == 0`/`-6..=-1` decimal window (which never even considers a scientific fallback, so nothing there was checking digit count at all before this fix).

## Fix

Added an explicit `mantissa_digit_cap: Option<usize>` parameter to `normalize_extreme_literal_mantissa` (`None` = uncapped). A new shared helper, `full_mantissa_if_capped`, decides plain-vs-scientific eligibility from the cap-independent `digit_count` *before* materializing any mantissa text, and only re-derives an uncapped mantissa when the cap could actually have truncated something -- keeping the common case (well under 100,000 given digits) at its original cost. All three call sites that must render every given digit verbatim now go through this helper.

## Verification

- Oracle-probed real jq 1.7.1 extensively: the issue's own repro, a magnitude-`<1` sibling case, the ordinary-path case, a 200,000-digit and 500,000-digit scale check, plus a ~130-case combinatorial sweep and a 60-case randomized differential fuzz across digit-count/shift/sign combinations -- confirmed zero new mismatches against the fixed binary, and confirmed (by diffing against unmodified `main`) that the handful of remaining divergences are an unrelated, already-documented, pre-existing scientific-notation precision cap (`MAX_RENDERED_MANTISSA_DIGITS`'s own doc comment already frames this as an accepted trade-off, out of #1274's scope).
- New tests: the fixed boundary at both the old cap (`test_format_number_jq_compat_overflow_plain_stays_plain_past_the_render_cap_1274`), the magnitude-`<1` branch, and the ordinary (non-overflow) path's two sub-cases.
- All existing regression tests (`#1244`, `#1253`, leading-zero/near-zero/overflow boundary tests) still pass unchanged.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` -- all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo check --no-default-features` (no_std) -- compiles (pre-existing unrelated dead-code warnings only)
- [x] `omni-dev coverage diff` -- 96.61% patch coverage (both remaining lines are provably-unreachable defensive branches, documented inline)
- [x] Oracle differential sweep (combinatorial + randomized) against real jq 1.7.1