### PR TITLE
fix(yaml): recurse YamlValue::as_str() through a chained alias (#1191)

### DIFF
--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -103,5 +103,6 @@ pub use parser::{
 };
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
-    assert_value_tree_depth, format_number_jq_compat, NumberRepr, OwnedValue, MAX_VALUE_TREE_DEPTH,
+    assert_depth, assert_value_tree_depth, format_number_jq_compat, NumberRepr, OwnedValue,
+    MAX_VALUE_TREE_DEPTH,
 };

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -103,6 +103,10 @@ pub use parser::{
 };
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
-    assert_depth, assert_value_tree_depth, format_number_jq_compat, NumberRepr, OwnedValue,
-    MAX_VALUE_TREE_DEPTH,
+    assert_value_tree_depth, format_number_jq_compat, NumberRepr, OwnedValue, MAX_VALUE_TREE_DEPTH,
 };
+// `pub(crate)`, not `pub`: only `yaml::light`'s `resolve_alias_chain` (#1191
+// code review) needs this from outside `jq::value` -- re-exporting it as a
+// real public API item would put a crate-internal depth-guard helper on
+// docs.rs with no external caller to justify the exposure.
+pub(crate) use value::assert_depth;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -407,28 +407,39 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         }
     }
 
-    /// Follow a chain of `Alias` nodes to the cursor of its final non-alias
-    /// target, iteratively rather than recursively (#1191 code review, fixing
-    /// a real stack-overflow DoS in `as_str()`'s own alias resolution --
-    /// see `MAX_ALIAS_CHAIN_DEPTH`'s doc comment for the full rationale).
-    /// `self` need not itself be an alias -- returns `self` unchanged (zero
-    /// hops) if it isn't, so a call site can invoke this unconditionally on
-    /// a resolved `Alias` target rather than checking first.
+    /// Follows a chain of `Alias` nodes to its final non-alias *value*,
+    /// iteratively rather than recursively (#1191 code review, fixing a
+    /// real stack-overflow DoS in `as_str()`'s own alias resolution -- see
+    /// `MAX_ALIAS_CHAIN_DEPTH`'s doc comment for the full rationale). `self`
+    /// need not itself be an alias -- returns `self.value()` unchanged
+    /// (zero hops) if it isn't, so a call site can invoke this
+    /// unconditionally on a resolved `Alias` target rather than checking
+    /// first. Returns the resolved value directly rather than a cursor to
+    /// it, since every call site wants the value and the loop's own
+    /// exit check has already computed it once -- returning a cursor here
+    /// would make each call site recompute the same `.value()` a second
+    /// time (#1191 code review, efficiency finding: this is a real,
+    /// unconditional cost on every aliased call, not just long chains).
     ///
-    /// Returns `None` only for a dangling (unresolvable) target. `#[track_caller]`
-    /// so a panic past `MAX_ALIAS_CHAIN_DEPTH` reports the caller's own
-    /// location, matching this crate's convention for every other panicking
-    /// depth guard.
+    /// Returns `None` only for a dangling (unresolvable) target.
+    /// `#[track_caller]`, matching this crate's convention for every other
+    /// panicking depth guard -- though today's one call site is inside an
+    /// `Option::and_then` closure, which stops a `#[track_caller]` location
+    /// from propagating any further than that closure's own call to this
+    /// method, not out to whatever external code ultimately triggered it.
     #[track_caller]
-    pub(crate) fn resolve_alias_chain(&self) -> Option<Self> {
+    pub(crate) fn resolve_alias_chain(&self) -> Option<YamlValue<'a, W>> {
         let mut current = *self;
         let mut depth = 0usize;
-        while let YamlValue::Alias { target, .. } = current.value() {
+        loop {
+            let value = current.value();
+            let YamlValue::Alias { target, .. } = value else {
+                return Some(value);
+            };
             assert_depth(depth, MAX_ALIAS_CHAIN_DEPTH);
             depth += 1;
             current = target?;
         }
-        Some(current)
     }
 
     /// Skip past a leading `&anchor` and/or `!tag` (either order, each at
@@ -5772,15 +5783,24 @@ use crate::jq::document::{
 /// stated; other doc comments in this module point back here rather than
 /// repeating it.
 ///
-/// `as_str()`'s `Alias` arm used to resolve one hop via its own
-/// `target.and_then(|t| t.value().as_str())`, re-entering itself once per
-/// hop -- the same self-recursive shape every other typed accessor on
-/// [`YamlValue`] still independently has (#1193 tracks fixing those; out of
-/// scope here). A syntactically valid, non-cyclic chain of tens of
-/// thousands of anchored aliases drives real, uncatchable stack overflow
-/// through that kind of self-recursion; this is separate from #153's
-/// build-time acyclicity check, which only rejects a chain that revisits
-/// its own anchor, not one that is merely very long.
+/// On `main` prior to this constant, `as_str()`'s `Alias` arm checked only a
+/// single hop (`if let YamlValue::String(s) = t.value() {...} else { None }`)
+/// -- correctness-buggy (a 2+-hop alias-to-string silently returned `None`)
+/// but not itself a stack-overflow risk, since it never recursed. Every
+/// *other* typed accessor on [`YamlValue`] -- `as_bool`, `as_i64`, `as_f64`,
+/// `number_literal`, `as_object`, `as_array`, `type_name`, `is_null` --
+/// already resolves an alias chain via genuine self-recursion
+/// (`target.and_then(|t| t.value().<accessor>())`, re-entering itself once
+/// per hop) and so already carries a real, uncatchable stack-overflow DoS
+/// on a syntactically valid, non-cyclic chain of tens of thousands of
+/// anchored aliases -- separate from #153's build-time acyclicity check,
+/// which only rejects a chain that revisits its own anchor, not one that is
+/// merely very long. #1193 tracks fixing those 8; out of scope here. This
+/// PR's own first attempt at fixing `as_str()`'s correctness bug copied
+/// that same self-recursive shape, which introduced the identical
+/// stack-overflow regression into `as_str()` too before review caught it --
+/// `resolve_alias_chain`'s iterative loop is the fix for that regression,
+/// not for anything that was ever live on `main`.
 ///
 /// Unlike this crate's other `MAX_*` depth ceilings
 /// ([`eval_generic::MAX_NESTING_DEPTH`](crate::jq::eval_generic::MAX_NESTING_DEPTH),
@@ -6122,17 +6142,17 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
             YamlValue::String(s) => s.as_str().ok(),
             // Resolve the *entire* alias chain first via the target
             // cursor's own `resolve_alias_chain` (#1191 code review; see
-            // `MAX_ALIAS_CHAIN_DEPTH`'s doc comment for the full rationale
-            // and its explicit note that the other typed accessors --
-            // `type_name()`/`as_object()`/`as_array()`/`number_literal()` --
-            // still have the pre-existing bug this fixes only for
-            // `as_str()`), not a direct match against `YamlValue::String` on
-            // a single hop. The resolved value is a temporary, so any
-            // borrowed `Cow` it hands back must still be made owned before
-            // this arm returns.
+            // `MAX_ALIAS_CHAIN_DEPTH`'s doc comment for the full rationale,
+            // including which other typed accessors still have the
+            // pre-existing bug this fixes only for `as_str()`), not a
+            // direct match against `YamlValue::String` on a single hop.
+            // `resolve_alias_chain` already returns the resolved value
+            // (not a cursor needing a second `.value()` call) -- see its
+            // own doc comment. That value is still a temporary, so any
+            // borrowed `Cow` it hands back must be made owned before this
+            // arm returns.
             YamlValue::Alias { target, .. } => target.and_then(|t| {
                 t.resolve_alias_chain()?
-                    .value()
                     .as_str()
                     .map(|cow| Cow::Owned(cow.into_owned()))
             }),
@@ -7137,6 +7157,19 @@ mod tests {
         }
     }
 
+    /// Builds YAML defining a `depth`-hop alias chain terminating in the
+    /// string `"hello"`, with a `z` field aliasing the last link (#1191 code
+    /// review: shared by the two tests below instead of each duplicating
+    /// this construction).
+    fn build_alias_chain_yaml(depth: usize) -> String {
+        let mut yaml = String::from("a0: &a0 hello\n");
+        for i in 1..depth {
+            yaml.push_str(&format!("a{i}: &a{i} *a{}\n", i - 1));
+        }
+        yaml.push_str(&format!("z: *a{}\n", depth - 1));
+        yaml
+    }
+
     /// #1191 code review: `as_str()`'s `Alias` arm was first fixed by
     /// self-recursing (`t.value().as_str()`), matching every sibling typed
     /// accessor's own pre-existing shape -- but that shape has no depth
@@ -7153,13 +7186,7 @@ mod tests {
     fn test_as_str_resolves_deep_alias_chain_without_stack_overflow_1191() {
         use crate::jq::document::DocumentValue;
 
-        let mut yaml = String::from("a0: &a0 hello\n");
-        const DEPTH: usize = 50_000;
-        for i in 1..DEPTH {
-            yaml.push_str(&format!("a{i}: &a{i} *a{}\n", i - 1));
-        }
-        yaml.push_str(&format!("z: *a{}\n", DEPTH - 1));
-
+        let yaml = build_alias_chain_yaml(50_000);
         let index = YamlIndex::build(yaml.as_bytes()).unwrap();
         let root = index.root(yaml.as_bytes());
         let YamlValue::Mapping(fields) = first_doc(root) else {
@@ -7180,19 +7207,13 @@ mod tests {
     fn test_as_str_panics_past_max_alias_chain_depth_1191() {
         use crate::jq::document::DocumentValue;
 
-        let mut yaml = String::from("a0: &a0 hello\n");
         // `z`'s own hop is consumed by `as_str`'s outer match before
         // `resolve_alias_chain` ever runs, so the chain it walks (starting
-        // at `z`'s target) is one hop shorter than the full text below --
-        // `+ 2`, not `+ 1`, is what actually pushes that inner walk past
-        // `MAX_ALIAS_CHAIN_DEPTH` (confirmed empirically: `+ 1` still
-        // resolves successfully with room to spare).
-        let depth = MAX_ALIAS_CHAIN_DEPTH + 2;
-        for i in 1..depth {
-            yaml.push_str(&format!("a{i}: &a{i} *a{}\n", i - 1));
-        }
-        yaml.push_str(&format!("z: *a{}\n", depth - 1));
-
+        // at `z`'s target) is one hop shorter than `build_alias_chain_yaml`'s
+        // `depth` -- `+ 2`, not `+ 1`, is what actually pushes that inner
+        // walk past `MAX_ALIAS_CHAIN_DEPTH` (confirmed empirically: `+ 1`
+        // still resolves successfully with room to spare).
+        let yaml = build_alias_chain_yaml(MAX_ALIAS_CHAIN_DEPTH + 2);
         let index = YamlIndex::build(yaml.as_bytes()).unwrap();
         let root = index.root(yaml.as_bytes());
         let YamlValue::Mapping(fields) = first_doc(root) else {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6069,16 +6069,18 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     fn as_str(&self) -> Option<Cow<'_, str>> {
         match self {
             YamlValue::String(s) => s.as_str().ok(),
+            // Recurse via `t.value().as_str()`, not a direct match against
+            // `YamlValue::String` -- an alias pointing at another alias
+            // (`y: &b *a` chained through `z: *b`) previously stopped after
+            // one hop and returned `None` even though `type_name()`/
+            // `as_object()`/`as_array()`/`number_literal()` all correctly
+            // resolve the same chain by recursing the same way this arm now
+            // does (#1191). `t.value()` is a temporary, so (as
+            // `number_literal`'s identical alias arm above also needs) any
+            // borrowed `Cow` it hands back must be made owned before the
+            // closure returns.
             YamlValue::Alias { target, .. } => {
-                // For aliases, we need to return an owned string since the
-                // target value is created temporarily
-                target.and_then(|t| {
-                    if let YamlValue::String(s) = t.value() {
-                        s.as_str().ok().map(|cow| Cow::Owned(cow.into_owned()))
-                    } else {
-                        None
-                    }
-                })
+                target.and_then(|t| t.value().as_str().map(|cow| Cow::Owned(cow.into_owned())))
             }
             _ => None,
         }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -407,6 +407,39 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         }
     }
 
+    /// Follow a chain of `Alias` nodes to the cursor of its final non-alias
+    /// target, iteratively rather than recursively (#1191 code review).
+    /// `self` need not itself be an alias -- returns `self` unchanged (zero
+    /// hops) if it isn't, so a call site can invoke this unconditionally on
+    /// a resolved `Alias` target rather than checking first.
+    ///
+    /// `as_str()`'s `Alias` arm below used to resolve one alias hop via
+    /// `target.and_then(|t| t.value().as_str())`, re-entering itself once
+    /// per hop -- the same self-recursive shape every other typed accessor
+    /// on [`YamlValue`] independently has. A syntactically valid, non-cyclic
+    /// chain of tens of thousands of anchored aliases drives real,
+    /// uncatchable stack overflow through that self-recursion; this is
+    /// separate from #153's build-time acyclicity check, which only rejects
+    /// a chain that revisits its own anchor, not one that is merely very
+    /// long.
+    ///
+    /// Returns `None` only for a dangling (unresolvable) target. Panics past
+    /// `MAX_ALIAS_CHAIN_DEPTH`, mirroring every other depth ceiling in this
+    /// crate ([`assert_depth`]) -- the loop itself costs O(1) stack
+    /// regardless of chain length, so this bound exists purely to cap the
+    /// CPU time one call can be forced to spend on a pathologically long,
+    /// adversarially crafted chain.
+    pub fn resolve_alias_chain(&self) -> Option<Self> {
+        let mut current = *self;
+        let mut depth = 0usize;
+        while let YamlValue::Alias { target, .. } = current.value() {
+            assert_depth(depth, MAX_ALIAS_CHAIN_DEPTH);
+            depth += 1;
+            current = target?;
+        }
+        Some(current)
+    }
+
     /// Skip past a leading `&anchor` and/or `!tag` (either order, each at
     /// most once) and any following whitespace.
     ///
@@ -5738,9 +5771,23 @@ impl core::fmt::Display for YamlNumberError {
 // Document trait implementations
 // ============================================================================
 
+use crate::jq::assert_depth;
 use crate::jq::document::{
     DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
+
+/// Caps the number of alias hops [`YamlCursor::resolve_alias_chain`] will
+/// follow. Unlike this crate's other `MAX_*` depth ceilings
+/// ([`eval_generic::MAX_NESTING_DEPTH`](crate::jq::eval_generic::MAX_NESTING_DEPTH),
+/// [`value::MAX_VALUE_TREE_DEPTH`](crate::jq::MAX_VALUE_TREE_DEPTH)), this one
+/// isn't tuned against a measured stack-overflow boundary --
+/// `resolve_alias_chain` is an explicit loop, not recursion, so it costs
+/// O(1) stack regardless of chain length (#1191 code review). It exists
+/// only to bound the CPU time one accessor call can be forced to spend on a
+/// pathologically long, adversarially-crafted alias chain; picked
+/// generously (no legitimate document plausibly nears it) rather than
+/// against any specific measurement.
+pub(crate) const MAX_ALIAS_CHAIN_DEPTH: usize = 65_536;
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     type Value = YamlValue<'a, W>;
@@ -5916,6 +5963,33 @@ impl<'a, W: AsRef<[u64]>> YamlValue<'a, W> {
             _ => Cow::Borrowed(""),
         }
     }
+
+    /// Follow a chain of `Alias` values to its final non-alias target,
+    /// iteratively rather than recursively (#1191 code review).
+    ///
+    /// `as_str()` below used to resolve one alias hop via its own
+    /// `target.and_then(|t| t.value().as_str())`, re-entering itself once
+    /// per hop -- a syntactically valid, non-cyclic chain of tens of
+    /// thousands of anchored aliases drives real, uncatchable stack
+    /// overflow through that self-recursion. This is separate from #153's
+    /// build-time acyclicity check, which only rejects a chain that
+    /// revisits its own anchor, not one that is merely very long.
+    ///
+    /// A thin wrapper around [`YamlCursor::resolve_alias_chain`] -- the
+    /// actual iterative walk -- rather than a second, separately-maintained
+    /// copy of the same loop.
+    ///
+    /// Returns `None` for a dangling (unresolvable) target, matching this
+    /// call site's pre-existing handling of a `None` target -- only the
+    /// depth bound ([`MAX_ALIAS_CHAIN_DEPTH`]) panics, since that path is
+    /// adversarial-input-only, mirroring [`assert_depth`]'s own convention
+    /// for every other depth ceiling in this crate.
+    fn resolve_alias_chain(&self) -> Option<Self> {
+        let YamlValue::Alias { target, .. } = self else {
+            return None;
+        };
+        Some(target.as_ref()?.resolve_alias_chain()?.value())
+    }
 }
 
 // FORMER KNOWN LIMITATION (#224, fixed by #747): the typed getters below
@@ -6069,19 +6143,27 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     fn as_str(&self) -> Option<Cow<'_, str>> {
         match self {
             YamlValue::String(s) => s.as_str().ok(),
-            // Recurse via `t.value().as_str()`, not a direct match against
-            // `YamlValue::String` -- an alias pointing at another alias
-            // (`y: &b *a` chained through `z: *b`) previously stopped after
-            // one hop and returned `None` even though `type_name()`/
-            // `as_object()`/`as_array()`/`number_literal()` all correctly
-            // resolve the same chain by recursing the same way this arm now
-            // does (#1191). `t.value()` is a temporary, so (as
-            // `number_literal`'s identical alias arm above also needs) any
-            // borrowed `Cow` it hands back must be made owned before the
-            // closure returns.
-            YamlValue::Alias { target, .. } => {
-                target.and_then(|t| t.value().as_str().map(|cow| Cow::Owned(cow.into_owned())))
-            }
+            // Resolve the *entire* alias chain first via
+            // `resolve_alias_chain` (#1191 code review), not a direct match
+            // against `YamlValue::String` on a single hop -- an alias
+            // pointing at another alias (`y: &b *a` chained through
+            // `z: *b`) previously stopped after one hop and returned `None`
+            // even though `type_name()`/`as_object()`/`as_array()`/
+            // `number_literal()` all correctly resolve the same chain. A
+            // naive fix (self-recursing via `t.value().as_str()`, matching
+            // those siblings' own pre-existing shape) was tried first and
+            // caught by review: those siblings' self-recursion has no depth
+            // bound, and a syntactically valid, non-cyclic chain of tens of
+            // thousands of anchored aliases drives real, uncatchable stack
+            // overflow through it -- the same class of bug #1193 already
+            // tracks for those siblings, just reachable here too if this
+            // arm copied their shape verbatim. `resolve_alias_chain`'s
+            // iterative walk costs O(1) stack regardless of chain length.
+            // The resolved value is a temporary, so any borrowed `Cow` it
+            // hands back must still be made owned before this arm returns.
+            YamlValue::Alias { .. } => self
+                .resolve_alias_chain()
+                .and_then(|v| v.as_str().map(|cow| Cow::Owned(cow.into_owned()))),
             _ => None,
         }
     }
@@ -7081,6 +7163,38 @@ mod tests {
                 .expect("expected at least one document"),
             other => panic!("expected root to be document array (sequence), got {other:?}"),
         }
+    }
+
+    /// #1191 code review: `as_str()`'s `Alias` arm was first fixed by
+    /// self-recursing (`t.value().as_str()`), matching every sibling typed
+    /// accessor's own pre-existing shape -- but that shape has no depth
+    /// bound, and review found it drives a real, uncatchable stack overflow
+    /// on a long, non-cyclic alias chain (the same class of bug #1193
+    /// tracks for the other accessors). Confirms the actual fix
+    /// (`resolve_alias_chain`'s iterative walk) resolves a 50,000-hop
+    /// chain -- comfortably below `MAX_ALIAS_CHAIN_DEPTH` -- without
+    /// panicking or overflowing the stack, calling `DocumentValue::as_str()`
+    /// directly so this test can't be satisfied by some other, unrelated
+    /// code path (e.g. `type_name()`'s own still-unbounded recursion,
+    /// separately tracked by #1193) happening to also resolve correctly.
+    #[test]
+    fn test_as_str_resolves_deep_alias_chain_without_stack_overflow_1191() {
+        use crate::jq::document::DocumentValue;
+
+        let mut yaml = String::from("a0: &a0 hello\n");
+        const DEPTH: usize = 50_000;
+        for i in 1..DEPTH {
+            yaml.push_str(&format!("a{i}: &a{i} *a{}\n", i - 1));
+        }
+        yaml.push_str(&format!("z: *a{}\n", DEPTH - 1));
+
+        let index = YamlIndex::build(yaml.as_bytes()).unwrap();
+        let root = index.root(yaml.as_bytes());
+        let YamlValue::Mapping(fields) = first_doc(root) else {
+            panic!("expected root document to be a mapping");
+        };
+        let z = fields.find("z").expect("z field must exist");
+        assert_eq!(z.as_str().as_deref(), Some("hello"));
     }
 
     #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -408,28 +408,19 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     }
 
     /// Follow a chain of `Alias` nodes to the cursor of its final non-alias
-    /// target, iteratively rather than recursively (#1191 code review).
+    /// target, iteratively rather than recursively (#1191 code review, fixing
+    /// a real stack-overflow DoS in `as_str()`'s own alias resolution --
+    /// see `MAX_ALIAS_CHAIN_DEPTH`'s doc comment for the full rationale).
     /// `self` need not itself be an alias -- returns `self` unchanged (zero
     /// hops) if it isn't, so a call site can invoke this unconditionally on
     /// a resolved `Alias` target rather than checking first.
     ///
-    /// `as_str()`'s `Alias` arm below used to resolve one alias hop via
-    /// `target.and_then(|t| t.value().as_str())`, re-entering itself once
-    /// per hop -- the same self-recursive shape every other typed accessor
-    /// on [`YamlValue`] independently has. A syntactically valid, non-cyclic
-    /// chain of tens of thousands of anchored aliases drives real,
-    /// uncatchable stack overflow through that self-recursion; this is
-    /// separate from #153's build-time acyclicity check, which only rejects
-    /// a chain that revisits its own anchor, not one that is merely very
-    /// long.
-    ///
-    /// Returns `None` only for a dangling (unresolvable) target. Panics past
-    /// `MAX_ALIAS_CHAIN_DEPTH`, mirroring every other depth ceiling in this
-    /// crate ([`assert_depth`]) -- the loop itself costs O(1) stack
-    /// regardless of chain length, so this bound exists purely to cap the
-    /// CPU time one call can be forced to spend on a pathologically long,
-    /// adversarially crafted chain.
-    pub fn resolve_alias_chain(&self) -> Option<Self> {
+    /// Returns `None` only for a dangling (unresolvable) target. `#[track_caller]`
+    /// so a panic past `MAX_ALIAS_CHAIN_DEPTH` reports the caller's own
+    /// location, matching this crate's convention for every other panicking
+    /// depth guard.
+    #[track_caller]
+    pub(crate) fn resolve_alias_chain(&self) -> Option<Self> {
         let mut current = *self;
         let mut depth = 0usize;
         while let YamlValue::Alias { target, .. } = current.value() {
@@ -5776,18 +5767,31 @@ use crate::jq::document::{
     DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
 
-/// Caps the number of alias hops [`YamlCursor::resolve_alias_chain`] will
-/// follow. Unlike this crate's other `MAX_*` depth ceilings
+/// Caps the number of alias hops `YamlCursor::resolve_alias_chain` will
+/// follow (#1191 code review) -- the single place this rule's rationale is
+/// stated; other doc comments in this module point back here rather than
+/// repeating it.
+///
+/// `as_str()`'s `Alias` arm used to resolve one hop via its own
+/// `target.and_then(|t| t.value().as_str())`, re-entering itself once per
+/// hop -- the same self-recursive shape every other typed accessor on
+/// [`YamlValue`] still independently has (#1193 tracks fixing those; out of
+/// scope here). A syntactically valid, non-cyclic chain of tens of
+/// thousands of anchored aliases drives real, uncatchable stack overflow
+/// through that kind of self-recursion; this is separate from #153's
+/// build-time acyclicity check, which only rejects a chain that revisits
+/// its own anchor, not one that is merely very long.
+///
+/// Unlike this crate's other `MAX_*` depth ceilings
 /// ([`eval_generic::MAX_NESTING_DEPTH`](crate::jq::eval_generic::MAX_NESTING_DEPTH),
 /// [`value::MAX_VALUE_TREE_DEPTH`](crate::jq::MAX_VALUE_TREE_DEPTH)), this one
 /// isn't tuned against a measured stack-overflow boundary --
 /// `resolve_alias_chain` is an explicit loop, not recursion, so it costs
-/// O(1) stack regardless of chain length (#1191 code review). It exists
-/// only to bound the CPU time one accessor call can be forced to spend on a
-/// pathologically long, adversarially-crafted alias chain; picked
-/// generously (no legitimate document plausibly nears it) rather than
-/// against any specific measurement.
-pub(crate) const MAX_ALIAS_CHAIN_DEPTH: usize = 65_536;
+/// O(1) stack regardless of chain length. It exists only to bound the CPU
+/// time one call can be forced to spend on a pathologically long,
+/// adversarially-crafted chain; picked generously (no legitimate document
+/// plausibly nears it) rather than against any specific measurement.
+const MAX_ALIAS_CHAIN_DEPTH: usize = 65_536;
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     type Value = YamlValue<'a, W>;
@@ -5963,33 +5967,6 @@ impl<'a, W: AsRef<[u64]>> YamlValue<'a, W> {
             _ => Cow::Borrowed(""),
         }
     }
-
-    /// Follow a chain of `Alias` values to its final non-alias target,
-    /// iteratively rather than recursively (#1191 code review).
-    ///
-    /// `as_str()` below used to resolve one alias hop via its own
-    /// `target.and_then(|t| t.value().as_str())`, re-entering itself once
-    /// per hop -- a syntactically valid, non-cyclic chain of tens of
-    /// thousands of anchored aliases drives real, uncatchable stack
-    /// overflow through that self-recursion. This is separate from #153's
-    /// build-time acyclicity check, which only rejects a chain that
-    /// revisits its own anchor, not one that is merely very long.
-    ///
-    /// A thin wrapper around [`YamlCursor::resolve_alias_chain`] -- the
-    /// actual iterative walk -- rather than a second, separately-maintained
-    /// copy of the same loop.
-    ///
-    /// Returns `None` for a dangling (unresolvable) target, matching this
-    /// call site's pre-existing handling of a `None` target -- only the
-    /// depth bound ([`MAX_ALIAS_CHAIN_DEPTH`]) panics, since that path is
-    /// adversarial-input-only, mirroring [`assert_depth`]'s own convention
-    /// for every other depth ceiling in this crate.
-    fn resolve_alias_chain(&self) -> Option<Self> {
-        let YamlValue::Alias { target, .. } = self else {
-            return None;
-        };
-        Some(target.as_ref()?.resolve_alias_chain()?.value())
-    }
 }
 
 // FORMER KNOWN LIMITATION (#224, fixed by #747): the typed getters below
@@ -6143,27 +6120,22 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     fn as_str(&self) -> Option<Cow<'_, str>> {
         match self {
             YamlValue::String(s) => s.as_str().ok(),
-            // Resolve the *entire* alias chain first via
-            // `resolve_alias_chain` (#1191 code review), not a direct match
-            // against `YamlValue::String` on a single hop -- an alias
-            // pointing at another alias (`y: &b *a` chained through
-            // `z: *b`) previously stopped after one hop and returned `None`
-            // even though `type_name()`/`as_object()`/`as_array()`/
-            // `number_literal()` all correctly resolve the same chain. A
-            // naive fix (self-recursing via `t.value().as_str()`, matching
-            // those siblings' own pre-existing shape) was tried first and
-            // caught by review: those siblings' self-recursion has no depth
-            // bound, and a syntactically valid, non-cyclic chain of tens of
-            // thousands of anchored aliases drives real, uncatchable stack
-            // overflow through it -- the same class of bug #1193 already
-            // tracks for those siblings, just reachable here too if this
-            // arm copied their shape verbatim. `resolve_alias_chain`'s
-            // iterative walk costs O(1) stack regardless of chain length.
-            // The resolved value is a temporary, so any borrowed `Cow` it
-            // hands back must still be made owned before this arm returns.
-            YamlValue::Alias { .. } => self
-                .resolve_alias_chain()
-                .and_then(|v| v.as_str().map(|cow| Cow::Owned(cow.into_owned()))),
+            // Resolve the *entire* alias chain first via the target
+            // cursor's own `resolve_alias_chain` (#1191 code review; see
+            // `MAX_ALIAS_CHAIN_DEPTH`'s doc comment for the full rationale
+            // and its explicit note that the other typed accessors --
+            // `type_name()`/`as_object()`/`as_array()`/`number_literal()` --
+            // still have the pre-existing bug this fixes only for
+            // `as_str()`), not a direct match against `YamlValue::String` on
+            // a single hop. The resolved value is a temporary, so any
+            // borrowed `Cow` it hands back must still be made owned before
+            // this arm returns.
+            YamlValue::Alias { target, .. } => target.and_then(|t| {
+                t.resolve_alias_chain()?
+                    .value()
+                    .as_str()
+                    .map(|cow| Cow::Owned(cow.into_owned()))
+            }),
             _ => None,
         }
     }
@@ -7195,6 +7167,39 @@ mod tests {
         };
         let z = fields.find("z").expect("z field must exist");
         assert_eq!(z.as_str().as_deref(), Some("hello"));
+    }
+
+    /// #1191 code review: the success-path test above never exercises
+    /// `MAX_ALIAS_CHAIN_DEPTH`'s own boundary, so an off-by-one in
+    /// `resolve_alias_chain`'s loop (e.g. `<=` vs `<`, or a shifted
+    /// increment) would go uncaught. A chain one hop *past* the ceiling must
+    /// panic cleanly (a controlled `assert_depth` failure), not silently
+    /// succeed and not stack-overflow.
+    #[test]
+    #[should_panic(expected = "nesting depth exceeds limit")]
+    fn test_as_str_panics_past_max_alias_chain_depth_1191() {
+        use crate::jq::document::DocumentValue;
+
+        let mut yaml = String::from("a0: &a0 hello\n");
+        // `z`'s own hop is consumed by `as_str`'s outer match before
+        // `resolve_alias_chain` ever runs, so the chain it walks (starting
+        // at `z`'s target) is one hop shorter than the full text below --
+        // `+ 2`, not `+ 1`, is what actually pushes that inner walk past
+        // `MAX_ALIAS_CHAIN_DEPTH` (confirmed empirically: `+ 1` still
+        // resolves successfully with room to spare).
+        let depth = MAX_ALIAS_CHAIN_DEPTH + 2;
+        for i in 1..depth {
+            yaml.push_str(&format!("a{i}: &a{i} *a{}\n", i - 1));
+        }
+        yaml.push_str(&format!("z: *a{}\n", depth - 1));
+
+        let index = YamlIndex::build(yaml.as_bytes()).unwrap();
+        let root = index.root(yaml.as_bytes());
+        let YamlValue::Mapping(fields) = first_doc(root) else {
+            panic!("expected root document to be a mapping");
+        };
+        let z = fields.find("z").expect("z field must exist");
+        let _ = z.as_str();
     }
 
     #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2554,6 +2554,54 @@ fn test_yaml_anchor_alias_without_merge() -> Result<()> {
     Ok(())
 }
 
+/// #1191: `as_str()`'s `Alias` arm only unwrapped a single level of alias
+/// indirection, unlike its `type_name()`/`as_object()`/`as_array()`/
+/// `number_literal()` siblings, which all correctly recurse through a chain
+/// of any length. A string slice (`.[S:E]`) is one of the few call sites
+/// that goes through `as_str()` directly (`slice_one_generic`,
+/// `src/jq/eval_generic.rs`), so it's an observable way to exercise the bug:
+/// before this fix, `.z[0:2]` on a value reached through two alias hops
+/// silently gave `[]` (the "not a string, not an array either" empty-slice
+/// fallback) instead of slicing the resolved string, even though `.z | type`
+/// already correctly reported `"string"` for the exact same node -- the
+/// contradiction the issue itself calls out.
+#[test]
+fn test_yaml_chained_alias_as_str_slices_correctly_1191() -> Result<()> {
+    let input = "x: &a hello\ny: &b *a\nz: *b\n";
+    let (output, exit_code) = run_yq_stdin(".z[0:2]", input, &["-o=json"])?;
+    assert_eq!(exit_code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), r#""he""#);
+    Ok(())
+}
+
+/// #1191: a single-hop alias (the case that already worked) must keep
+/// working identically after generalizing the `Alias` arm to recurse.
+#[test]
+fn test_yaml_single_hop_alias_as_str_slices_correctly_1191() -> Result<()> {
+    let input = "x: &a hello\ny: *a\n";
+    let (output, exit_code) = run_yq_stdin(".y[0:2]", input, &["-o=json"])?;
+    assert_eq!(exit_code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), r#""he""#);
+    Ok(())
+}
+
+/// #1191: `type_name()` and `as_str()` must agree on a triply-chained alias
+/// -- the exact contradiction the issue reports (told it's a `"string"` by
+/// `type_name()`, but unable to read it as one via `as_str()`) must not
+/// reappear for a longer chain than the doubly-aliased case above.
+#[test]
+fn test_yaml_triple_hop_alias_as_str_slices_correctly_1191() -> Result<()> {
+    let input = "x: &a hello\ny: &b *a\nw: &c *b\nz: *c\n";
+    let (type_output, code) = run_yq_stdin(".z | type", input, &[])?;
+    assert_eq!(code, 0, "out: {type_output:?}");
+    assert_eq!(type_output.trim(), "string");
+
+    let (slice_output, code) = run_yq_stdin(".z[0:2]", input, &["-o=json"])?;
+    assert_eq!(code, 0, "out: {slice_output:?}");
+    assert_eq!(slice_output.trim(), r#""he""#);
+    Ok(())
+}
+
 // =============================================================================
 // Assignment through an anchor propagates to aliases (#711) - real yq treats
 // an anchor/alias pair as one shared node in the representation graph, so a


### PR DESCRIPTION
## Summary

Fixes #1191. `YamlValue::as_str()`'s `Alias` arm only unwrapped a single level of alias indirection — pattern-matching `t.value()` directly against `YamlValue::String` — unlike every sibling accessor on the same type (`type_name`, `as_bool`, `as_i64`, `as_f64`, `as_object`, `as_array`, `number_literal`), all of which recurse fully via `t.value().xxx()`. An alias pointing at another alias (`y: &b *a`, chained through `z: *b`) stopped after one hop.

## Repro

A string slice (`.[S:E]`) is one of the few call sites that reaches `as_str()` directly (`slice_one_generic` in `src/jq/eval_generic.rs`), making the bug directly observable:

```
$ printf 'x: &a hello\ny: &b *a\nz: *b\n' | succinctly yq -o=json '.z[0:2]'
[]                    # wrong: "not a string, not an array either" empty-slice fallback
$ printf 'x: &a hello\ny: &b *a\nz: *b\n' | succinctly yq '.z | type'
string                # already correct — the contradiction the issue describes
```

Debug-probed the `Alias` arm directly to confirm the fix genuinely changes this code path's behavior (pre-fix: `[]`, post-fix: `"he"`) rather than assuming from the diff alone.

## Note on oracle comparability

Real yq v4.53.3 can't parse an anchor placed directly on a bare alias node at all (`&b *a` is a hard parse error there — confirmed live), so this specific construction isn't oracle-comparable. The fix is grounded in internal consistency instead: `as_str()` must agree with `type_name()`'s own already-correct recursive resolution — the same criterion #868 already established for a case with no real-yq oracle to match.

## Changes

- `YamlValue::as_str()`'s `Alias` arm now recurses via `t.value().as_str()`, matching every sibling accessor's existing structure (including the identical "must own the `Cow` before the temporary `t.value()` drops" handling `number_literal`'s own alias arm already uses).

## Test plan

- [x] 3 new tests in `tests/yq_cli_tests.rs`: doubly-chained alias slices correctly, single-hop alias (control, must keep working), triple-chained alias with an explicit `type`/`as_str` agreement check.
- [x] Full test suite passes (`cargo test --features cli,simd,regex,serde`, sequential, 2700+ tests).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean.
- [x] `cargo check --no-default-features` (no_std) still builds.
- [x] `cargo fmt -- --check` clean.

## Round 2 (/code-review) — critical correction: stack-overflow DoS

Multiple independent review angles (one with a direct isolated before/after reproduction on a 50,000-hop chain) found the original fix traded one bug for a worse one: making `as_str()` self-recurse through the whole alias chain removed the old code's *accidental* single-hop termination without adding any depth bound — a syntactically valid, non-cyclic chain of tens of thousands of anchored aliases drives a real, uncatchable stack overflow (SIGABRT), reachable via ordinary CLI usage.

This is the exact vulnerability class an independent, unmerged branch (issue-1193-yaml-alias-recursion-dos, PR #1314) already found and fixed for 8 sibling accessors — that fix predates this PR's `as_str` change and doesn't cover it, so `as_str` would have become an uncovered 9th vulnerable site.

**Fixed**: ported the same `resolve_alias_chain` mechanism (iterative, not recursive; bounded by `MAX_ALIAS_CHAIN_DEPTH = 65_536`), scoped to just `as_str()`, using identical naming to #1314's own design so a future rebase against it resolves as a trivial conflict rather than a real reconciliation. Verified via an isolated unit test calling `as_str()` directly on a 50,000-hop chain — resolves correctly in ~0.2s, no crash.

Confirmed the CLI-level crashes reviewers also observed (`.z[0:2]`, `.z | type` still crashing at very large depths) are **not** from anything left unfixed here: `slice_one_generic` calls `as_array()`/`type_name()`/`is_null()` (all still unbounded on `main` today) before it ever reaches `as_str()` — those crashes come entirely from #1193's own separate, not-yet-merged scope.

## Round 3 (/code-review) — corrections to Round 2's own fix

A third review pass on Round 2's depth-bound correction found that correction had introduced its own new bugs, all now fixed:

- **Off-by-one between two identically-shaped methods**: `YamlValue::resolve_alias_chain` (a thin wrapper added in Round 2) pre-consumed one alias hop via its own initial match before ever calling into `YamlCursor::resolve_alias_chain`'s counted loop — so a chain of `MAX_ALIAS_CHAIN_DEPTH + 1` hops panicked through the cursor method directly but resolved successfully through the wrapper. Confirmed empirically by the reviewer.
- **Contract mismatch**: the cursor method returns `Some(self)` (zero hops) for a non-`Alias` input; the wrapper returned `None` for the same case.
- **Redundant `.value()` computation**: computed twice per resolved alias (once in the wrapper's own match, again inside the loop it delegates to).

**Fixed** by deleting the `YamlValue`-level wrapper entirely — `as_str()`'s `Alias` arm now binds `target` directly and calls `t.resolve_alias_chain()` (the cursor-level method) itself, the same way every other call site in this file already does. Narrowed `resolve_alias_chain`/`MAX_ALIAS_CHAIN_DEPTH`/`assert_depth`'s re-export to `pub(crate)` (from `pub`) since the only external caller was the now-deleted wrapper — this also resolves Round 2's rustdoc doc-link workaround more directly, since a crate-internal method is simply excluded from rustdoc's public-only build. Consolidated the depth-ceiling rationale into `MAX_ALIAS_CHAIN_DEPTH`'s own doc comment as the single source instead of repeating it at every call site.

Also added a companion test exercising the actual panic boundary (a chain one hop past `MAX_ALIAS_CHAIN_DEPTH` must panic cleanly through `as_str()`) — the existing 50,000-hop test only ever exercised the success path, comfortably under the ceiling, and so could not have caught any of the three bugs above.

**Scope note (unchanged from Round 2)**: this still fixes only `as_str()`'s own instance of the unbounded-alias-chain bug class. `.z[0:2]`/bare `.z` via the CLI still crash today on a long chain, since `slice_one_generic` calls `as_array()`/`type_name()`/`is_null()` — all still unbounded on `main` — before ever reaching `as_str()`. That remains #1193/PR #1314's separate, unmerged scope.

Filed #1347 as a follow-up: `YamlValue::key_string` has the identical single-hop-only alias bug (confirmed live: `a: &k hello`, `b: &kk *k`, `m: {*kk: 1}` → `.m | keys` gives `[""]` instead of `["hello"]`), a different accessor with its own call sites and its own infallibility contract to reconcile with the depth bound.

Re-ran the full local verification suite (build, full test suite, both clippy invocations, rustdoc, no_std check, fmt) after these corrections — all clean. Rebased cleanly onto latest `main` with no conflicts.

## Round 4 (/code-review) — cleanup: efficiency + documentation accuracy

A fourth review pass (multi-angle fan-out, this time correctly targeted at this PR after an earlier misfire reviewed the wrong PR by mistake) found no new correctness bugs, but surfaced several real lower-severity issues, all fixed:

- **Efficiency**: `resolve_alias_chain`'s loop computed `.value()` on the terminal cursor to test its own exit condition, then discarded it and returned the bare cursor — `as_str()`'s `Alias` arm then computed `.value()` again on the same cursor. This was a real, unconditional double computation of a non-trivial operation on *every* `as_str()` call through any alias, not just long chains. Fixed by changing `resolve_alias_chain`'s return type to the resolved value directly (`Option<YamlValue<'a, W>>` instead of `Option<Self>`), removing the redundant second call.
- **Doc-comment inaccuracy**: `MAX_ALIAS_CHAIN_DEPTH`'s doc comment described `main`'s pre-PR code as self-recursive; that description only ever matched this PR's own transient first-draft commit, not anything that shipped on `main`. Reworded to state plainly what was and wasn't true of `main`.
- **Doc-comment undercount**: two comments named only 4 of the 8 sibling accessors sharing the same unbounded-recursion bug (omitting `as_bool`/`as_i64`/`as_f64`/`is_null`). Corrected to list all 8.
- **STYLE_GUIDE.md STYLE-0006**: `resolve_alias_chain`'s doc comment opened in imperative mood; fixed to third-person singular, matching its neighbor.
- **`#[track_caller]` doc overclaim**: its only call site is inside an `Option::and_then` closure, which `#[track_caller]` can't see through — the doc comment overstated the practical benefit. Reworded to say so.
- **Test duplication**: extracted a shared `build_alias_chain_yaml(depth)` helper for the two new unit tests.

Also: cross-referenced against issue #1315 (a differently-framed, overlapping report of this same bug). Confirmed live that this fix resolves #1315's own 2-hop repro too. Closed a duplicate I'd filed for `key_string`'s identical bug (#1347) in favor of #1315, which already tracked it with a fuller writeup and suggested fix.

Re-ran the full local verification suite — all clean. No behavior change from Round 3; this round is purely efficiency + documentation accuracy.
