### PR TITLE
fix(yq): preserve &anchor/*alias syntax through the DOM write path (#763)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,12 @@ yq. A node's mark rides `NodeMeta` in the `CommentTree` side-tree alongside its 
 and style; `enforce_anchor_soundness` (`yq_runner.rs`) then drops any `*name` the
 document cannot resolve.
 
+Two routes carry no `CommentTree` at all and so preserve nothing — not anchors, not
+comments, not style. Both predate #763 and neither is specific to anchors: a filter
+yielding *multiple* results (anything with a comma) loses its cursor to
+`GenericResult::Many` before `evaluate_yaml_cursor` can capture one, and `--inplace`
+never builds a tree in the first place (#1349).
+
 **succinctly never emits YAML it cannot read back — real yq does.** A `*name` is written
 only when a matching `&name` exists, is emitted *earlier*, and holds an *equal* value.
 Real yq fails all three in ordinary use (both verified against v4.53.3):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,33 @@ printf 'a:\n  x: 1\nb:\n  x: 2\n  y: 3\n' | succinctly yq '.a *=n .b'  # a: {x: 
 
 Real yq's bare, 2-arg `sub(re; s)` replaces *every* match, not just the first — jq's `sub` = first match only, `gsub` = all matches; yq's bare `sub` behaves like jq's `gsub` unconditionally (`"aaa" | sub("a";"X")` => `"XXX"` in yq, `"Xaa"` in jq, confirmed against yq v4.53.3). `gsub` itself, and the 3-arg `sub(re;s;flags)` form, are unaffected by this and keep matching jq's model — the 3-arg form's real-yq semantics don't fit any hypothesis tried so far (#1122).
 
+### Anchor/alias preservation and its soundness rule (yq mode only)
+
+YAML-target output re-emits `&anchor`/`*alias` on both the cursor-streaming path and the
+DOM path taken by a write (`=`, `|=`, `+=`, `del()`) or a DOM-forcing flag (`-P`,
+`--arg`) — ADR-0017's mechanism 2, #763. `-o=json` still expands aliases, matching real
+yq. A node's mark rides `NodeMeta` in the `CommentTree` side-tree alongside its comment
+and style; `enforce_anchor_soundness` (`yq_runner.rs`) then drops any `*name` the
+document cannot resolve.
+
+**succinctly never emits YAML it cannot read back — real yq does.** A `*name` is written
+only when a matching `&name` exists, is emitted *earlier*, and holds an *equal* value.
+Real yq fails all three in ordinary use (both verified against v4.53.3):
+
+```bash
+printf 'a: &x 1\nb: *x\n' | yq 'del(.a)'          # b: *x   <- no &x anywhere; yq then
+                                                  #            rejects its own output with
+                                                  #            "unknown anchor 'x' referenced"
+printf 'a: &x 1\nb: *x\n' | succinctly yq 'del(.a)'   # b: 1
+```
+
+`--sort-keys` diverges the same way when sorting would move an alias above its
+declaration. The equal-value rule also contains a real gap rather than papering over it:
+succinctly's alias sync is one-directional (anchor → aliases), so a write *through* an
+alias (`.b.p = 9`) updates only `.b`, where yq mutates the shared node. Emitting `b: *x`
+there would silently discard the write, so the mark is dropped and the computed value
+printed instead. True alias node identity remains unimplemented.
+
 ### jq Position-Based Navigation (succinctly extension)
 
 Succinctly extends jq with position-based navigation builtins that allow jumping directly to a node at a specific byte offset or line/column position. This is unique to succinctly and not available in standard jq or yq.

--- a/docs/adrs/adr-0017.md
+++ b/docs/adrs/adr-0017.md
@@ -130,6 +130,47 @@ node as that one" (anchors). `OwnedValue` already clones every alias target
 independently with no shared identity, so this needs the alias-group machinery, not an
 extension of the metadata tree.
 
+### Amendment (#763, implemented): mechanism 2's *data* rides the side-tree after all
+
+Mechanism 2 shipped with one deliberate departure from the paragraph above. The claim
+that a shape-parallel side-tree cannot serve anchors conflates two questions that turned
+out to be separable:
+
+- **What to emit** is per-node — "write `&x` here", "write `*x` there" — structurally
+  identical to a comment or a style, and it is the only thing the writer consults. Each
+  node therefore carries an `Option<AnchorMark>` (`Declares(name)` / `Aliases(name)`) in
+  its `NodeMeta`, alongside `comment` and `style`.
+- **Whether a mark is still valid** *is* the cross-tree identity question this ADR
+  correctly identified, and it stayed separate logic: `enforce_anchor_soundness` in
+  `yq_runner.rs`, a pre-emit pass over the whole reconciled document.
+
+Carrying the data in the existing tree reuses threading that was already built and
+tested — capture, reconciliation, emission, `--inplace`, `--split-exp` — instead of
+duplicating all of it for a second parallel structure. It also gave the remaining slot
+this side-channel still owes, the explicit source tag the DOM path drops (#1132/#747), a
+home without a further pass over every construction site: grouping the loose
+`(comment, style)` tuple fields into `NodeMeta` is the one refactor, not the first of
+three.
+
+Two further findings from implementing it, both worth recording because they contradict
+what this ADR assumed:
+
+- **`resolve_dynamic_indexes` was not used**, and mechanism 1 had already declined it
+  for the same reasons: it is private to `eval.rs`, generic over `EvalSemantics`, and
+  returns `Vec<Expr>` where the alias machinery speaks `Vec<OwnedValue>` paths.
+  `reconcile_presentation`'s lockstep pristine-vs-result walk carries the anchor mark
+  under the rule it already applied to comments and style ("same kind ⇒ keep"), with no
+  new traversal and no per-expression-shape logic.
+- **Matching real `yq` exactly is not achievable here, and should not be the goal.**
+  `yq` emits YAML it cannot itself re-read in at least three ordinary cases —
+  `del(.a)` on `a: &x 1\nb: *x` prints `b: *x` with no anchor left anywhere, and
+  `sort_keys` will happily move a `*x` above its `&x`. succinctly instead enforces a
+  soundness rule (a `*name` is emitted only when a matching `&name` exists, is emitted
+  earlier, and holds an equal value) and diverges in those cases. That rule also
+  contains the gap in succinctly's alias *value* model: a write *through* an alias
+  (`.b.p = 9`) updates only that position, so the values disagree, the mark is dropped,
+  and the computed value is printed — rather than `*x` silently discarding the write.
+
 ## Consequences
 
 **Positive:**
@@ -152,13 +193,17 @@ extension of the metadata tree.
 - Two related mechanisms (side-tree for style/comments, alias-group extension for
   anchors) rather than one, because they solve structurally different problems
   (per-node data vs. cross-tree identity). Implementers need to keep that boundary
-  clear rather than trying to unify them.
+  clear rather than trying to unify them. *(Refined by the #763 amendment above: the
+  boundary is real but falls between mechanism 2's **data** and its **validation**, not
+  around the mechanism as a whole — the data shares the side-tree, the validation
+  doesn't.)*
 - The object/array-construction native arm and the path-mutation touched-path
   invalidation are both real, if scoped, changes to `eval_generic.rs`'s dispatch and the
   `eval_generic.rs`/`yq_runner.rs` boundary — not a one-file patch like #707 was.
-- Does not address `OwnedValue::Object`'s duplicate-key collapse (#796) or the
-  cursor-less `to_owned`'s tag blindness (#747); both remain open, separately-scoped
-  bugs after this decision lands.
+- Does not address `OwnedValue::Object`'s duplicate-key collapse (#796 — since closed
+  by PR #817) or the cursor-less `to_owned`'s tag blindness (#747); the latter remains
+  an open, separately-scoped bug after this decision lands, and #763's `NodeMeta` now
+  gives it a slot to land in.
 - Real `yq`'s own comment/style preservation under structural edits (`del`+reconstruct,
   `map`) has known rough edges upstream; per #752's own suggested fix shape, each
   concrete query shape this mechanism claims to fix should be verified against the

--- a/docs/adrs/adr-0017.md
+++ b/docs/adrs/adr-0017.md
@@ -145,12 +145,17 @@ out to be separable:
   `yq_runner.rs`, a pre-emit pass over the whole reconciled document.
 
 Carrying the data in the existing tree reuses threading that was already built and
-tested — capture, reconciliation, emission, `--inplace`, `--split-exp` — instead of
-duplicating all of it for a second parallel structure. It also gave the remaining slot
-this side-channel still owes, the explicit source tag the DOM path drops (#1132/#747), a
-home without a further pass over every construction site: grouping the loose
-`(comment, style)` tuple fields into `NodeMeta` is the one refactor, not the first of
-three.
+tested — capture, reconciliation, emission, `--split-exp` — instead of duplicating all of
+it for a second parallel structure. It also gave the remaining slot this side-channel
+still owes, the explicit source tag the DOM path drops (#1132/#747), a home without a
+further pass over every construction site: grouping the loose `(comment, style)` tuple
+fields into `NodeMeta` is the one refactor, not the first of three.
+
+The one output route that inherits *nothing* from this is `--inplace`, which never builds
+a `CommentTree` at all — it evaluates through `evaluate_input` with
+`CommentTree::empty()`, so it drops comments, style and anchors alike, and skips #711's
+alias value sync too. That is #1349: a gap in that route's own wiring, not something the
+side-tree choice can reach.
 
 Two further findings from implementing it, both worth recording because they contradict
 what this ADR assumed:

--- a/docs/plan/yq.md
+++ b/docs/plan/yq.md
@@ -139,6 +139,17 @@ succinctly yq '.spec.containers[]' deployment.yaml service.yaml
 - [ ] `--explode-anchors` flag
 - [ ] Merge keys (`<<: *alias`)
 
+**Anchor/alias round-tripping (#763)**: YAML-target output re-emits
+`&anchor`/`*alias` on both the M2 cursor-streaming path and the DOM path a
+write (`=`, `|=`, `del()`) or a DOM-forcing flag (`-P`, `--arg`) takes —
+see [ADR-0017](../adrs/adr-0017.md)'s mechanism 2 and its #763 amendment.
+`-o=json` still expands aliases, matching real yq. Two deliberate
+divergences, both cases where real yq emits YAML it cannot itself re-read:
+deleting an anchor's own key materializes its aliases rather than leaving
+them dangling, and `--sort-keys` drops a mark it would reorder above its
+declaration. Not yet covered: true alias *node identity* (a write through
+an alias updates only that position, where yq mutates the shared node).
+
 **Partial** (#710): trailing same-line comments (`a: 1 # comment`) are
 captured and preserved through output, always-on (no `--preserve-comments`
 flag needed or planned) — but only on paths that keep a live YAML cursor
@@ -686,7 +697,8 @@ EXAMPLES:
 - [x] All jq operators work on YAML input
 - [x] Multi-document YAML supported
 - [x] YAML output format supported
-- [x] Anchors/aliases handled correctly
+- [x] Anchors/aliases handled correctly (values #711, syntax #763; alias
+      node *identity* is still a known gap — see Phase 3 above)
 - [x] Performance within 2x of Mike Farah's yq (actually **2-8x faster**)
 
 ---
@@ -711,6 +723,10 @@ This plan depends on the YAML parser implementation phases defined in [parsing/y
 
 2. **Anchor expansion default**: Expand aliases automatically or preserve structure?
    - *Decision*: Expand automatically (matches user expectations from jq) ✅ Implemented
+   - *Superseded (#712, #763)*: real yq preserves the structure, so YAML-target
+     output does too — on the streaming path (#712) and, since #763, on the DOM
+     path as well. Expansion survives only where the target format has no alias
+     syntax to preserve (`-o=json`).
 
 3. **Comment handling**: How to expose comments in queries?
    - *Decision*: Deferred - implement on user demand

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -14,7 +14,7 @@ use succinctly::jq::document::{
 };
 use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
-    to_owned_with_comments, CommentTree, GenericResult,
+    to_owned_with_comments, AnchorMark, CommentTree, GenericResult, NodeMeta,
 };
 use succinctly::jq::{
     self, assert_value_tree_depth, nonfinite_display_string, sync_aliased_paths, Builtin,
@@ -554,6 +554,7 @@ fn evaluate_yaml_direct_filtered(
     sink: &mut ErrorSink,
     need_comments: bool,
     strip_style: bool,
+    sort_keys: bool,
 ) -> Result<(Vec<Vec<ResultWithComments>>, usize)> {
     let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
     let root = index.root(bytes);
@@ -571,8 +572,14 @@ fn evaluate_yaml_direct_filtered(
                 };
 
                 if should_eval {
-                    let results =
-                        evaluate_yaml_cursor(cursor, expr, sink, need_comments, strip_style)?;
+                    let results = evaluate_yaml_cursor(
+                        cursor,
+                        expr,
+                        sink,
+                        need_comments,
+                        strip_style,
+                        sort_keys,
+                    )?;
                     // Only include documents that have results (select may filter them out)
                     if !results.is_empty() {
                         doc_results.push(results);
@@ -609,6 +616,7 @@ fn evaluate_yaml_direct_filtered(
                         sink,
                         need_comments,
                         strip_style,
+                        sort_keys,
                     )?;
                     Ok((vec![results], 1))
                 } else {
@@ -937,8 +945,7 @@ fn reconcile_presentation_at_depth(
     assert_value_tree_depth(depth);
     match (pristine_value, result_value) {
         (OwnedValue::Object(p_fields), OwnedValue::Object(r_fields)) => {
-            let own_comment = pristine_tree.own().map(str::to_string);
-            let own_style = pristine_tree.style();
+            let own_meta = pristine_tree.meta().clone();
             let mut fields = IndexMap::new();
             let mut key_comments = IndexMap::new();
             for (k, r_v) in r_fields {
@@ -961,18 +968,17 @@ fn reconcile_presentation_at_depth(
                 // (`emit_yaml_value`'s block-mapping arm) renders only the
                 // key and comment, silently dropping the write's value
                 // entirely (found in review).
-                if let CommentTree::Object(_, _, _, pristine_key_comments) = pristine_tree {
+                if let CommentTree::Object(_, _, pristine_key_comments) = pristine_tree {
                     if let Some((kc, _)) = pristine_key_comments.get(k) {
                         let value_absent = matches!(r_v, OwnedValue::Null);
                         key_comments.insert(k.clone(), (kc.clone(), value_absent));
                     }
                 }
             }
-            CommentTree::Object(own_comment, own_style, fields, key_comments)
+            CommentTree::Object(own_meta, fields, key_comments)
         }
         (OwnedValue::Array(p_items), OwnedValue::Array(r_items)) => {
-            let own_comment = pristine_tree.own().map(str::to_string);
-            let own_style = pristine_tree.style();
+            let own_meta = pristine_tree.meta().clone();
             let items = r_items
                 .iter()
                 .enumerate()
@@ -986,18 +992,20 @@ fn reconcile_presentation_at_depth(
                     None => CommentTree::empty(),
                 })
                 .collect();
-            CommentTree::Array(own_comment, own_style, items)
+            CommentTree::Array(own_meta, items)
         }
         // A kind change (container <-> scalar, or Object <-> Array) is a
         // fresh node with no presentation memory of its own.
         (OwnedValue::Object(_) | OwnedValue::Array(_), _)
         | (_, OwnedValue::Object(_) | OwnedValue::Array(_)) => CommentTree::empty(),
         // Both scalars, any variant/value: same node, only its value
-        // changed - its own comment and style survive.
-        _ => CommentTree::Leaf(
-            pristine_tree.own().map(str::to_string),
-            pristine_tree.style(),
-        ),
+        // changed - its own comment, style and anchor mark survive. Real
+        // `yq` keeps `&x` across `.a = 99` for the same reason it keeps the
+        // comment: the write overwrites the node's value, not its identity
+        // (#763). Whether a surviving `*x` mark is still *emittable* is a
+        // separate question, settled afterwards by
+        // [`enforce_anchor_soundness`] once the whole result is known.
+        _ => CommentTree::Leaf(pristine_tree.meta().clone()),
     }
 }
 
@@ -1103,6 +1111,164 @@ fn write_split_result(
         .with_context(|| format!("failed to write --split-exp output file: {filename}"))
 }
 
+/// One step of a path into a paired `OwnedValue`/[`CommentTree`] tree, used
+/// by [`enforce_anchor_soundness`] to revisit a node it decided to strip.
+enum TreeStep {
+    Key(String),
+    Index(usize),
+}
+
+/// Drop every `*alias` mark this document cannot actually resolve, so the
+/// YAML written out always re-reads as the same values succinctly would
+/// have printed without any anchor syntax at all (#763).
+///
+/// A mark survives only when all three hold, checked in the emitter's own
+/// traversal order:
+///
+/// 1. some node declares that anchor name in the output;
+/// 2. it is emitted **before** this one — a `*x` above its `&x` is a
+///    forward reference, which YAML forbids;
+/// 3. the value there equals the value here — otherwise writing `*x` would
+///    silently replace this node's real value with the anchor's.
+///
+/// This is deliberately a *divergence* from real `yq`, which fails all
+/// three in practice: `yq 'del(.a)'` on `a: &x 1\nb: *x` prints `b: *x`
+/// with no anchor left anywhere, and `yq` then rejects its own output with
+/// `unknown anchor 'x' referenced` (verified against the pinned binary).
+/// Rule 3 is also what keeps the gap in succinctly's own alias *value*
+/// model safe rather than wrong: a write *through* an alias (`.b.p = 9`)
+/// updates only `.b`, where real `yq` mutates the shared node, so the two
+/// sides no longer agree and the mark is dropped — printing `b: {p: 9}`
+/// (the value succinctly computed) instead of `b: *x` (which would discard
+/// the write entirely).
+///
+/// Anchor *declarations* are never dropped: an unreferenced `&x` is valid
+/// YAML and real `yq` keeps it (`yq 'del(.b)'` still prints `a: &x 1`).
+fn enforce_anchor_soundness(value: &OwnedValue, comments: &mut CommentTree, sort_keys: bool) {
+    let mut declared: IndexMap<&str, &OwnedValue> = IndexMap::new();
+    let mut unresolvable: Vec<Vec<TreeStep>> = Vec::new();
+    let mut path = Vec::new();
+    scan_anchor_soundness(
+        value,
+        comments,
+        sort_keys,
+        &mut declared,
+        &mut unresolvable,
+        &mut path,
+        0,
+    );
+    for steps in &unresolvable {
+        if let Some(node) = comment_tree_at_path_mut(comments, steps) {
+            node.meta_mut().anchor = None;
+        }
+    }
+}
+
+/// Pre-order half of [`enforce_anchor_soundness`]: record each declaration
+/// as it is reached and flag every alias that fails the three rules.
+///
+/// Reads the tree immutably so the surviving declarations can borrow
+/// straight out of `value` rather than cloning whole anchored subtrees; the
+/// flagged paths are applied in a second pass. Panics past
+/// `MAX_VALUE_TREE_DEPTH`, like every other walker over this pair.
+fn scan_anchor_soundness<'a>(
+    value: &'a OwnedValue,
+    comments: &'a CommentTree,
+    sort_keys: bool,
+    declared: &mut IndexMap<&'a str, &'a OwnedValue>,
+    unresolvable: &mut Vec<Vec<TreeStep>>,
+    path: &mut Vec<TreeStep>,
+    depth: usize,
+) {
+    assert_value_tree_depth(depth);
+    match comments.anchor_mark() {
+        // A repeated name shadows the earlier one for every *later* alias,
+        // matching YAML's own "most recent preceding anchor wins".
+        Some(AnchorMark::Declares(name)) => {
+            declared.insert(name.as_str(), value);
+        }
+        Some(AnchorMark::Aliases(name)) => {
+            if declared.get(name.as_str()).map(|d| *d == value) != Some(true) {
+                unresolvable.push(clone_steps(path));
+            }
+        }
+        None => {}
+    }
+    match value {
+        OwnedValue::Object(fields) => {
+            // Mirror the block-mapping arm's own ordering, so "emitted
+            // before" here means the same thing it will at write time. The
+            // flow arm doesn't sort, but a flow container's keys can only
+            // have come from source order, where a declaration always
+            // precedes its aliases (a forward reference is rejected at
+            // index build) — so walking sorted there can only drop a mark
+            // that would have been fine, never keep one that wouldn't.
+            let mut keys: Vec<&String> = fields.keys().collect();
+            if sort_keys {
+                keys.sort();
+            }
+            for k in keys {
+                let Some(v) = fields.get(k) else { continue };
+                path.push(TreeStep::Key(k.clone()));
+                scan_anchor_soundness(
+                    v,
+                    comments.field(k),
+                    sort_keys,
+                    declared,
+                    unresolvable,
+                    path,
+                    depth + 1,
+                );
+                path.pop();
+            }
+        }
+        OwnedValue::Array(items) => {
+            for (i, v) in items.iter().enumerate() {
+                path.push(TreeStep::Index(i));
+                scan_anchor_soundness(
+                    v,
+                    comments.at_index(i),
+                    sort_keys,
+                    declared,
+                    unresolvable,
+                    path,
+                    depth + 1,
+                );
+                path.pop();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn clone_steps(path: &[TreeStep]) -> Vec<TreeStep> {
+    path.iter()
+        .map(|s| match s {
+            TreeStep::Key(k) => TreeStep::Key(k.clone()),
+            TreeStep::Index(i) => TreeStep::Index(*i),
+        })
+        .collect()
+}
+
+/// Mutable counterpart of [`CommentTree::field`]/[`CommentTree::at_index`],
+/// following a whole path. `None` if any step is missing — which cannot
+/// happen for a path [`scan_anchor_soundness`] just walked, but the
+/// accessors have no infallible form.
+fn comment_tree_at_path_mut<'t>(
+    tree: &'t mut CommentTree,
+    steps: &[TreeStep],
+) -> Option<&'t mut CommentTree> {
+    let mut node = tree;
+    for step in steps {
+        node = match (node, step) {
+            (CommentTree::Object(_, fields, _), TreeStep::Key(k)) => fields.get_mut(k)?,
+            (CommentTree::Array(_, items), TreeStep::Index(i)) => items.get_mut(*i)?,
+            _ => return None,
+        };
+    }
+    Some(node)
+}
+
 /// Evaluate a jq expression directly on a YAML cursor.
 ///
 /// This uses the generic evaluator to preserve position metadata (line/column).
@@ -1121,6 +1287,7 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     sink: &mut ErrorSink,
     need_comments: bool,
     strip_style: bool,
+    sort_keys: bool,
 ) -> Result<Vec<ResultWithComments>> {
     // Snapshot alias-sync context from the pristine document *before*
     // evaluation, only when it could possibly matter (#711): an
@@ -1285,19 +1452,34 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // needs its own always-on, top-level-only pass, independent of
     // `need_comments`/`is_alias_sensitive_assign` — real `yq` does this
     // unconditionally, not just for shape-preserving writes.
+    //
+    // The same is true of a bare scalar's own `&anchor` (#763): real `yq`
+    // prints `1`, not `&x 1`, for `.a` on `a: &x 1` — already pinned by
+    // `test_yaml_bare_scalar_anchor_dropped_on_query_result_712`. An
+    // *alias* mark is the exception and survives: `yq '.b'` on `b: *x`
+    // prints `*x` (verified against the pinned binary), because there the
+    // alias *is* the whole result rather than decoration on it.
     if let Ok(docs) = &mut docs {
         for (value, comments) in docs.iter_mut() {
             if !matches!(value, OwnedValue::Object(_) | OwnedValue::Array(_)) {
-                *comments = CommentTree::Leaf(comments.own().map(str::to_string), "");
+                let alias_mark = comments
+                    .alias_name()
+                    .map(|name| AnchorMark::Aliases(name.to_string()));
+                *comments = CommentTree::Leaf(NodeMeta {
+                    comment: comments.own().map(str::to_string),
+                    style: "",
+                    anchor: alias_mark,
+                });
             }
         }
     }
 
     // `-P`/`--pretty-print` (#705) forces block/plain style regardless of
     // source — a real style-clearing step, not just "there's no style data
-    // to clear" like before #739's style tracking existed. Comments stay
-    // (`-P` only ever claimed to affect style), so this only touches the
-    // style slot of every node, not the tree shape.
+    // to clear" like before #739's style tracking existed. Comments and
+    // anchor marks stay (`-P` only ever claimed to affect style, and real
+    // `yq -P '.'` does keep `&x`/`*x`), so this only touches the style slot
+    // of every node, not the tree shape.
     if strip_style {
         if let Ok(docs) = &mut docs {
             for (_value, comments) in docs.iter_mut() {
@@ -1306,12 +1488,28 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         }
     }
 
+    // Last, once every other pass has settled the values and the marks:
+    // strip any `*alias` this document can no longer resolve (#763). Must
+    // run after `sync_aliased_paths` above, whose whole job is making an
+    // alias's value agree with its anchor's again — running before it would
+    // see stale values and drop marks that are about to become valid.
+    if let Ok(docs) = &mut docs {
+        for (value, comments) in docs.iter_mut() {
+            enforce_anchor_soundness(value, comments, sort_keys);
+        }
+    }
+
     docs
 }
 
 /// Recursively clear every node's style (issue #705's `-P` gate) while
-/// keeping its comments and tree shape untouched — see the `strip_style`
-/// call in [`evaluate_yaml_cursor`].
+/// keeping its comments, anchor marks and tree shape untouched — see the
+/// `strip_style` call in [`evaluate_yaml_cursor`].
+///
+/// Anchors deliberately survive `-P`: real `yq -P '.'` on
+/// `a: &x 1\nb: *x\n` still prints `a: &x 1\nb: *x` (verified against the
+/// pinned binary). `-P` is documented as `... style = ""`, and anchor/alias
+/// syntax is identity, not style (#763).
 fn strip_presentation_style(tree: &CommentTree) -> CommentTree {
     strip_presentation_style_at_depth(tree, 0)
 }
@@ -1324,19 +1522,21 @@ fn strip_presentation_style(tree: &CommentTree) -> CommentTree {
 /// currently-live independent crash path.
 fn strip_presentation_style_at_depth(tree: &CommentTree, depth: usize) -> CommentTree {
     assert_value_tree_depth(depth);
+    let meta = NodeMeta {
+        style: "",
+        ..tree.meta().clone()
+    };
     match tree {
-        CommentTree::Leaf(c, _) => CommentTree::Leaf(c.clone(), ""),
-        CommentTree::Array(c, _, items) => CommentTree::Array(
-            c.clone(),
-            "",
+        CommentTree::Leaf(_) => CommentTree::Leaf(meta),
+        CommentTree::Array(_, items) => CommentTree::Array(
+            meta,
             items
                 .iter()
                 .map(|v| strip_presentation_style_at_depth(v, depth + 1))
                 .collect(),
         ),
-        CommentTree::Object(c, _, fields, key_comments) => CommentTree::Object(
-            c.clone(),
-            "",
+        CommentTree::Object(_, fields, key_comments) => CommentTree::Object(
+            meta,
             fields
                 .iter()
                 .map(|(k, v)| (k.clone(), strip_presentation_style_at_depth(v, depth + 1)))
@@ -1432,10 +1632,31 @@ fn output_value<W: Write>(
         // `--raw-input`, `--split-exp`, ... Redundant with (but harmless
         // alongside) `evaluate_yaml_cursor`'s equivalent root-scalar pass
         // for the cursor-based DOM path specifically.
-        let body = if let OwnedValue::String(s) = value {
+        // An aliased root renders as `*name` whatever its resolved value is
+        // — checked before the raw-string shortcut below, which would
+        // otherwise print an aliased string's *target text* instead (#763).
+        let body = if let Some(name) = comments.alias_name() {
+            format!("*{name}")
+        } else if let OwnedValue::String(s) = value {
             s.clone()
         } else {
-            emit_yaml_value(value, comments, config, "", false)
+            // A root anchor is written only for a container, matching
+            // `YamlCursor::write_leading_anchor` in `light.rs` — real yq
+            // drops a bare scalar root's own `&x` (pinned by
+            // `test_yaml_bare_scalar_anchor_dropped_on_query_result_712`),
+            // and `evaluate_yaml_cursor`'s root-scalar pass has already
+            // cleared the mark for that case anyway.
+            let rendered = emit_yaml_value(value, comments, config, "", false);
+            match comments.declared_anchor() {
+                Some(anchor) if matches!(value, OwnedValue::Array(_) | OwnedValue::Object(_)) => {
+                    if is_flow_safe(value, comments) {
+                        format!("&{anchor} {rendered}")
+                    } else {
+                        format!("&{anchor}\n{rendered}")
+                    }
+                }
+                _ => rendered,
+            }
         };
         // Every non-root node's own trailing comment is appended by its
         // *parent* during `emit_yaml_value`'s recursion (see its Array/Object
@@ -1541,6 +1762,34 @@ fn is_flow_safe(value: &OwnedValue, comments: &CommentTree) -> bool {
     }
 }
 
+/// Whether this node's content is deferred to its own indented block below
+/// the `key:`/`-` that introduces it, rather than sharing that line.
+///
+/// The single definition of a test the block-mapping and block-sequence arms
+/// of [`emit_yaml_value_at_depth`] each used to spell inline — extracted
+/// because #763 adds a third reason to stay on one line: an aliased node
+/// renders as `*name`, so it is inline no matter how large the anchored
+/// value it points at happens to be. Getting that wrong renders `b: *x` as
+/// a block mapping with `*x` dangling above it.
+fn defers_to_own_block(value: &OwnedValue, comments: &CommentTree) -> bool {
+    comments.alias_name().is_none()
+        && !is_flow_safe(value, comments)
+        && (matches!(value, OwnedValue::Object(o) if !o.is_empty())
+            || matches!(value, OwnedValue::Array(a) if !a.is_empty()))
+}
+
+/// This node's `&name` anchor declaration as ` &name` (leading space), or
+/// `""` if it declares none (#763).
+///
+/// The leading space is part of the returned string because every call site
+/// appends it directly after a `:` or `-`, exactly as `write_deferred_value`
+/// in `light.rs` does for the streaming writer.
+fn anchor_decl_prefix(comments: &CommentTree) -> String {
+    comments
+        .declared_anchor()
+        .map_or_else(String::new, |name| format!(" &{name}"))
+}
+
 /// Format a node's own trailing comment (issue #710) as `" # text"`, or
 /// `""` if it has none — the single point of change for the separator
 /// convention shared by every `emit_yaml_value` call site that appends one
@@ -1610,6 +1859,20 @@ fn emit_yaml_value_at_depth(
     depth: usize,
 ) -> String {
     assert_value_tree_depth(depth);
+    // An alias renders as `*name` and never writes the value it resolves
+    // to — the DOM twin of `stream_yaml_value`'s own `YamlValue::Alias`
+    // arm in `light.rs` (#763). This has to come before the value dispatch
+    // below, not inside it: `to_owned` already cloned the *target's* value
+    // into this position, so by here an alias is indistinguishable from a
+    // plain copy by shape alone. Emitted structurally rather than as a
+    // string, since `yaml_quote_string` quotes anything starting with `*`.
+    //
+    // `enforce_anchor_soundness` has already cleared any mark that could
+    // not be resolved from this document, so reaching here guarantees a
+    // matching `&name` is emitted earlier in the output.
+    if let Some(name) = comments.alias_name() {
+        return format!("*{name}");
+    }
     match value {
         OwnedValue::Null => "null".to_string(),
         OwnedValue::Bool(b) => b.to_string(),
@@ -1652,14 +1915,22 @@ fn emit_yaml_value_at_depth(
                     .iter()
                     .enumerate()
                     .map(|(i, v)| {
-                        emit_yaml_value_at_depth(
+                        let elem_comments = comments.at_index(i);
+                        let item = emit_yaml_value_at_depth(
                             v,
-                            comments.at_index(i),
+                            elem_comments,
                             config,
                             indent,
                             true,
                             depth + 1,
-                        )
+                        );
+                        // `[&x 1, *x]` — a flow item's own anchor sits
+                        // immediately before it (#763), the DOM twin of
+                        // `write_yaml_child_inline` in `light.rs`.
+                        match elem_comments.declared_anchor() {
+                            Some(anchor) => format!("&{anchor} {item}"),
+                            None => item,
+                        }
                     })
                     .collect();
                 format!("[{}]", items.join(", "))
@@ -1670,11 +1941,28 @@ fn emit_yaml_value_at_depth(
                     .enumerate()
                     .map(|(i, v)| {
                         let elem_comments = comments.at_index(i);
-                        let elem_is_flow = is_flow_safe(v, elem_comments);
-                        if !elem_is_flow
-                            && (matches!(v, OwnedValue::Object(o) if !o.is_empty())
-                                || matches!(v, OwnedValue::Array(a) if !a.is_empty()))
-                        {
+                        if defers_to_own_block(v, elem_comments) {
+                            // An anchor written on the item's own line
+                            // (`- &x\n  ...`) takes the slot the compact
+                            // form would use, so the value stays deferred
+                            // to its own full-indent line — mirroring
+                            // `stream_yaml_value`'s sequence arm in
+                            // `light.rs`, which real yq is pinned against
+                            // (#763).
+                            if let Some(anchor) = elem_comments.declared_anchor() {
+                                let val_indent = format!("{indent}{}", config.indent_str);
+                                let val = emit_yaml_value_at_depth(
+                                    v,
+                                    elem_comments,
+                                    config,
+                                    &val_indent,
+                                    false,
+                                    depth + 1,
+                                );
+                                let val =
+                                    append_own_comment_line(val, elem_comments.own(), &val_indent);
+                                return format!("{indent}- &{anchor}\n{val}");
+                            }
                             // A non-empty mapping/sequence element renders
                             // in real yq's "compact" form: `- ` shares its
                             // line with the value's own first field/
@@ -1728,7 +2016,8 @@ fn emit_yaml_value_at_depth(
                                 depth + 1,
                             );
                             let comment_suffix = trailing_comment_suffix(elem_comments);
-                            format!("{indent}- {item}{comment_suffix}")
+                            let anchor = anchor_decl_prefix(elem_comments);
+                            format!("{indent}-{anchor} {item}{comment_suffix}")
                         }
                     })
                     .collect();
@@ -1744,15 +2033,18 @@ fn emit_yaml_value_at_depth(
                     .iter()
                     .map(|(k, v)| {
                         let key = yaml_quote_key(k);
+                        let field_comments = comments.field(k);
                         let val = emit_yaml_value_at_depth(
                             v,
-                            comments.field(k),
+                            field_comments,
                             config,
                             indent,
                             true,
                             depth + 1,
                         );
-                        format!("{key}: {val}")
+                        // `{x: &y 1, z: *y}` (#763).
+                        let anchor = anchor_decl_prefix(field_comments);
+                        format!("{key}:{anchor} {val}")
                     })
                     .collect();
                 format!("{{{}}}", entries.join(", "))
@@ -1773,14 +2065,12 @@ fn emit_yaml_value_at_depth(
                         let field_comments = comments.field(k);
                         let comment_suffix = trailing_comment_suffix(field_comments);
                         let val_indent = format!("{indent}{}", config.indent_str);
+                        let anchor = anchor_decl_prefix(field_comments);
                         // Check if value needs to be on next line - a
                         // flow-styled container stays on the key's own line
-                        // instead, the same as a scalar (#739).
-                        let field_is_flow = is_flow_safe(v, field_comments);
-                        if !field_is_flow
-                            && (matches!(v, OwnedValue::Object(m) if !m.is_empty())
-                                || matches!(v, OwnedValue::Array(a) if !a.is_empty()))
-                        {
+                        // instead, the same as a scalar (#739), and so does
+                        // an alias, however large its target (#763).
+                        if defers_to_own_block(v, field_comments) {
                             // A comment trailing the key's own line, when the
                             // value is deferred to the next line, belongs to
                             // the key, not the value (#765).
@@ -1802,12 +2092,20 @@ fn emit_yaml_value_at_depth(
                             );
                             let val =
                                 append_own_comment_line(val, field_comments.own(), &val_indent);
-                            format!("{indent}{key}:{key_comment_suffix}\n{val}")
+                            // `&x` goes before the key's own comment, not
+                            // after it: a `#` runs to end of line, so the
+                            // reverse order would bury the anchor inside the
+                            // comment text (#763).
+                            format!("{indent}{key}:{anchor}{key_comment_suffix}\n{val}")
                         } else if let Some(kc) = comments.key_comment_if_value_absent(k) {
                             // The deferred value materialized as nothing at
                             // all - the key's own comment stands alone with
-                            // no value token, matching real yq (#765).
-                            format!("{indent}{key}: {kc}")
+                            // no value token, matching real yq (#765). An
+                            // anchor on that absent value still writes
+                            // (`? k # c\n: &anc` -> `k: &anc # c`), the DOM
+                            // twin of `write_deferred_value`'s own rule
+                            // (#1077/#1113).
+                            format!("{indent}{key}:{anchor} {kc}")
                         } else {
                             let val = emit_yaml_value_at_depth(
                                 v,
@@ -1832,7 +2130,7 @@ fn emit_yaml_value_at_depth(
                             } else {
                                 comment_suffix
                             };
-                            format!("{indent}{key}: {val}{comment_suffix}")
+                            format!("{indent}{key}:{anchor} {val}{comment_suffix}")
                         }
                     })
                     .collect();
@@ -3281,6 +3579,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             &mut sink,
                             need_comments,
                             args.pretty_print,
+                            output_config.sort_keys,
                         )?;
                         global_doc_index += num_docs;
                         for results in doc_results {
@@ -3859,6 +4158,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         &mut sink,
                         need_comments,
                         args.pretty_print,
+                        output_config.sort_keys,
                     )?;
                     global_doc_index += num_docs;
                     all_results.push(doc_results);
@@ -4151,14 +4451,15 @@ mod tests {
         let mut obj_comments = IndexMap::new();
         obj_comments.insert(
             "k".to_string(),
-            CommentTree::Leaf(Some("# k trailing".to_string()), ""),
+            CommentTree::Leaf(NodeMeta::from_comment_and_style(
+                Some("# k trailing".to_string()),
+                "",
+            )),
         );
         let comments = CommentTree::Array(
-            None,
-            "",
+            NodeMeta::empty(),
             vec![CommentTree::Object(
-                Some("# obj trailing".to_string()),
-                "",
+                NodeMeta::from_comment_and_style(Some("# obj trailing".to_string()), ""),
                 obj_comments,
                 IndexMap::new(),
             )],
@@ -4367,6 +4668,7 @@ mod tests {
             None,
             &mut ErrorSink::default(),
             true,
+            false,
             false,
         )
         .unwrap();
@@ -4741,7 +5043,7 @@ mod tests {
     fn linear_comment_tree_nest(depth: usize) -> CommentTree {
         let mut t = CommentTree::empty();
         for _ in 0..depth {
-            t = CommentTree::Array(None, "", vec![t]);
+            t = CommentTree::Array(NodeMeta::empty(), vec![t]);
         }
         t
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1187,11 +1187,16 @@ fn scan_anchor_soundness<'a>(
         Some(AnchorMark::Declares(name)) => {
             declared.insert(name.as_str(), value);
         }
-        Some(AnchorMark::Aliases(name)) => {
-            if declared.get(name.as_str()).map(|d| *d == value) != Some(true) {
-                unresolvable.push(clone_steps(path));
-            }
+        // No such declaration yet (missing entirely, or emitted later than
+        // this alias), or one whose value has since diverged from this one.
+        // Spelled as a negated `matches!` rather than clippy's suggested
+        // `is_none_or`, which is stable only since 1.82 and this crate's
+        // MSRV is 1.73.
+        Some(AnchorMark::Aliases(name)) if !matches!(declared.get(name.as_str()), Some(d) if *d == value) =>
+        {
+            unresolvable.push(clone_steps(path));
         }
+        Some(AnchorMark::Aliases(_)) => {}
         None => {}
     }
     match value {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1458,23 +1458,19 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // `need_comments`/`is_alias_sensitive_assign` — real `yq` does this
     // unconditionally, not just for shape-preserving writes.
     //
-    // The same is true of a bare scalar's own `&anchor` (#763): real `yq`
+    // A bare scalar's own `&anchor` goes the same way (#763): real `yq`
     // prints `1`, not `&x 1`, for `.a` on `a: &x 1` — already pinned by
-    // `test_yaml_bare_scalar_anchor_dropped_on_query_result_712`. An
-    // *alias* mark is the exception and survives: `yq '.b'` on `b: *x`
-    // prints `*x` (verified against the pinned binary), because there the
-    // alias *is* the whole result rather than decoration on it.
+    // `test_yaml_bare_scalar_anchor_dropped_on_query_result_712`. Clearing
+    // the whole `NodeMeta` here covers an alias mark too, which
+    // `enforce_anchor_soundness` below would drop regardless (see
+    // `output_value`'s own note on why a root `*name` is never emittable).
     if let Ok(docs) = &mut docs {
         for (value, comments) in docs.iter_mut() {
             if !matches!(value, OwnedValue::Object(_) | OwnedValue::Array(_)) {
-                let alias_mark = comments
-                    .alias_name()
-                    .map(|name| AnchorMark::Aliases(name.to_string()));
-                *comments = CommentTree::Leaf(NodeMeta {
-                    comment: comments.own().map(str::to_string),
-                    style: "",
-                    anchor: alias_mark,
-                });
+                *comments = CommentTree::Leaf(NodeMeta::from_comment_and_style(
+                    comments.own().map(str::to_string),
+                    "",
+                ));
             }
         }
     }
@@ -1637,12 +1633,19 @@ fn output_value<W: Write>(
         // `--raw-input`, `--split-exp`, ... Redundant with (but harmless
         // alongside) `evaluate_yaml_cursor`'s equivalent root-scalar pass
         // for the cursor-based DOM path specifically.
-        // An aliased root renders as `*name` whatever its resolved value is
-        // — checked before the raw-string shortcut below, which would
-        // otherwise print an aliased string's *target text* instead (#763).
-        let body = if let Some(name) = comments.alias_name() {
-            format!("*{name}")
-        } else if let OwnedValue::String(s) = value {
+        // No root case for an *alias* mark here, deliberately: a root
+        // `*name` can never survive `enforce_anchor_soundness`, because its
+        // `&name` would have to sit inside the alias's own subtree, and a
+        // cyclic anchor is rejected outright at index build
+        // (`YamlError::AliasCycle`). So the mark is always cleared before
+        // this point, and a branch for it would be dead code (#763).
+        //
+        // That does mean `succinctly yq '.b'` on `b: *x` prints `*x` (the
+        // streaming path) while `-P '.b'` prints the resolved value. Real
+        // yq prints `*x` for both — and cannot read either back
+        // (`unknown anchor 'x' referenced`). Making the streaming path
+        // agree with this one is issue #1350.
+        let body = if let OwnedValue::String(s) = value {
             s.clone()
         } else {
             // A root anchor is written only for a container, matching

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1113,8 +1113,16 @@ fn write_split_result(
 
 /// One step of a path into a paired `OwnedValue`/[`CommentTree`] tree, used
 /// by [`enforce_anchor_soundness`] to revisit a node it decided to strip.
-enum TreeStep {
-    Key(String),
+///
+/// Borrows its key straight out of the `OwnedValue` being scanned rather
+/// than owning it: the scan pushes a step for every object field it walks,
+/// so an owned `String` here would be one allocation per field on every DOM
+/// emit. The borrow is sound because the value tree and the `CommentTree`
+/// the second pass mutates are two distinct objects (see
+/// [`enforce_anchor_soundness`]'s two parameters).
+#[derive(Clone, Copy)]
+enum TreeStep<'a> {
+    Key(&'a str),
     Index(usize),
 }
 
@@ -1145,18 +1153,25 @@ enum TreeStep {
 /// Anchor *declarations* are never dropped: an unreferenced `&x` is valid
 /// YAML and real `yq` keeps it (`yq 'del(.b)'` still prints `a: &x 1`).
 fn enforce_anchor_soundness(value: &OwnedValue, comments: &mut CommentTree, sort_keys: bool) {
-    let mut declared: IndexMap<&str, &OwnedValue> = IndexMap::new();
-    let mut unresolvable: Vec<Vec<TreeStep>> = Vec::new();
-    let mut path = Vec::new();
-    scan_anchor_soundness(
-        value,
-        comments,
-        sort_keys,
-        &mut declared,
-        &mut unresolvable,
-        &mut path,
-        0,
-    );
+    // Scoped so the scan's immutable borrow of `*comments` (and the anchor
+    // names `declared` keys on, which live in it) has certainly ended
+    // before the second pass takes a mutable one. The flagged paths borrow
+    // only from `value`, which the second pass never touches.
+    let unresolvable: Vec<Vec<TreeStep<'_>>> = {
+        let mut declared: IndexMap<&str, &OwnedValue> = IndexMap::new();
+        let mut unresolvable = Vec::new();
+        let mut path = Vec::new();
+        scan_anchor_soundness(
+            value,
+            comments,
+            sort_keys,
+            &mut declared,
+            &mut unresolvable,
+            &mut path,
+            0,
+        );
+        unresolvable
+    };
     for steps in &unresolvable {
         if let Some(node) = comment_tree_at_path_mut(comments, steps) {
             node.meta_mut().anchor = None;
@@ -1171,13 +1186,13 @@ fn enforce_anchor_soundness(value: &OwnedValue, comments: &mut CommentTree, sort
 /// straight out of `value` rather than cloning whole anchored subtrees; the
 /// flagged paths are applied in a second pass. Panics past
 /// `MAX_VALUE_TREE_DEPTH`, like every other walker over this pair.
-fn scan_anchor_soundness<'a>(
-    value: &'a OwnedValue,
-    comments: &'a CommentTree,
+fn scan_anchor_soundness<'v, 'c>(
+    value: &'v OwnedValue,
+    comments: &'c CommentTree,
     sort_keys: bool,
-    declared: &mut IndexMap<&'a str, &'a OwnedValue>,
-    unresolvable: &mut Vec<Vec<TreeStep>>,
-    path: &mut Vec<TreeStep>,
+    declared: &mut IndexMap<&'c str, &'v OwnedValue>,
+    unresolvable: &mut Vec<Vec<TreeStep<'v>>>,
+    path: &mut Vec<TreeStep<'v>>,
     depth: usize,
 ) {
     assert_value_tree_depth(depth);
@@ -1194,7 +1209,7 @@ fn scan_anchor_soundness<'a>(
         // MSRV is 1.73.
         Some(AnchorMark::Aliases(name)) if !matches!(declared.get(name.as_str()), Some(d) if *d == value) =>
         {
-            unresolvable.push(clone_steps(path));
+            unresolvable.push(path.clone());
         }
         Some(AnchorMark::Aliases(_)) => {}
         None => {}
@@ -1214,7 +1229,7 @@ fn scan_anchor_soundness<'a>(
             }
             for k in keys {
                 let Some(v) = fields.get(k) else { continue };
-                path.push(TreeStep::Key(k.clone()));
+                path.push(TreeStep::Key(k.as_str()));
                 scan_anchor_soundness(
                     v,
                     comments.field(k),
@@ -1246,27 +1261,18 @@ fn scan_anchor_soundness<'a>(
     }
 }
 
-fn clone_steps(path: &[TreeStep]) -> Vec<TreeStep> {
-    path.iter()
-        .map(|s| match s {
-            TreeStep::Key(k) => TreeStep::Key(k.clone()),
-            TreeStep::Index(i) => TreeStep::Index(*i),
-        })
-        .collect()
-}
-
 /// Mutable counterpart of [`CommentTree::field`]/[`CommentTree::at_index`],
 /// following a whole path. `None` if any step is missing — which cannot
 /// happen for a path [`scan_anchor_soundness`] just walked, but the
 /// accessors have no infallible form.
 fn comment_tree_at_path_mut<'t>(
     tree: &'t mut CommentTree,
-    steps: &[TreeStep],
+    steps: &[TreeStep<'_>],
 ) -> Option<&'t mut CommentTree> {
     let mut node = tree;
     for step in steps {
         node = match (node, step) {
-            (CommentTree::Object(_, fields, _), TreeStep::Key(k)) => fields.get_mut(k)?,
+            (CommentTree::Object(_, fields, _), TreeStep::Key(k)) => fields.get_mut(*k)?,
             (CommentTree::Array(_, items), TreeStep::Index(i)) => items.get_mut(*i)?,
             _ => return None,
         };
@@ -1299,13 +1305,13 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // assignment-family expression against a document that actually has
     // aliases. Everything else (JSON, plain reads, alias-free YAML) pays
     // nothing beyond this one bool check.
-    let alias_sync_ctx =
-        (is_alias_sensitive_assign(expr) && cursor.index().has_aliases()).then(|| {
-            (
-                generic_to_owned(&cursor.value()),
-                collect_alias_groups(cursor),
-            )
-        });
+    let has_aliases = cursor.index().has_aliases();
+    let alias_sync_ctx = (is_alias_sensitive_assign(expr) && has_aliases).then(|| {
+        (
+            generic_to_owned(&cursor.value()),
+            collect_alias_groups(cursor),
+        )
+    });
 
     // Snapshot the pristine presentation tree *before* evaluation too
     // (#739, ADR-0017): same shape-preserving-write gate as `alias_sync_ctx`
@@ -1494,9 +1500,18 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // run after `sync_aliased_paths` above, whose whole job is making an
     // alias's value agree with its anchor's again — running before it would
     // see stale values and drop marks that are about to become valid.
-    if let Ok(docs) = &mut docs {
-        for (value, comments) in docs.iter_mut() {
-            enforce_anchor_soundness(value, comments, sort_keys);
+    //
+    // `has_aliases` gates it the way it gates `alias_sync_ctx` above, and
+    // for a stronger reason than "probably nothing to do": this pass only
+    // ever clears `Aliases` marks and never touches a `Declares` one, so a
+    // document with no `*name` anywhere has nothing it *could* change. The
+    // walk is not free — it visits every node of the reconciled tree — and
+    // an alias-free document is the overwhelmingly common case.
+    if has_aliases {
+        if let Ok(docs) = &mut docs {
+            for (value, comments) in docs.iter_mut() {
+                enforce_anchor_soundness(value, comments, sort_keys);
+            }
         }
     }
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -113,6 +113,19 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         None
     }
 
+    /// Get the name of the anchor this node is an *alias* to, if it is one
+    /// (`*name` yields `Some("name")`, without the `*`).
+    ///
+    /// The dual of [`anchor`](Self::anchor): a node is at most one of the
+    /// two, and both return `None` for formats without an alias concept
+    /// (JSON). Only YAML cursors override this. Needed by the write path
+    /// (issue #763) — unlike the value accessors, which resolve *through*
+    /// an alias to its target, re-emitting `*name` requires knowing the
+    /// node is an alias before that resolution happens.
+    fn alias(&self) -> Option<&str> {
+        None
+    }
+
     /// Get the explicit YAML tag at this node, if any (e.g. `"!!str"`).
     ///
     /// Returns `None` when the node has no explicit tag, and for formats

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -269,8 +269,9 @@ fn tagged_type_name<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> &
 /// Which YAML anchor/alias syntax a node carried in the source document
 /// (issue #763, ADR-0017's mechanism 2).
 ///
-/// A node is at most one of the two: [`YamlCursor::anchor`] returns `None`
-/// for an alias node, and an alias node cannot itself declare an anchor.
+/// A node is at most one of the two: [`DocumentCursor::anchor`] returns
+/// `None` for an alias node, and an alias node cannot itself declare an
+/// anchor.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AnchorMark {
     /// `&name` — this node declares an anchor. The name is stored without
@@ -304,8 +305,8 @@ pub struct NodeMeta {
 }
 
 impl NodeMeta {
-    /// Metadata-free: no comment, no style, no anchor. `const` so
-    /// [`EMPTY_COMMENT_TREE`] can be a genuine `static`.
+    /// Metadata-free: no comment, no style, no anchor. `const` so the
+    /// module's empty-tree `static` can be built from it.
     pub const fn empty() -> Self {
         Self {
             comment: None,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -266,12 +266,82 @@ fn tagged_type_name<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> &
         .map_or_else(|| value.type_name(), crate::yaml::ResolvedScalar::type_name)
 }
 
+/// Which YAML anchor/alias syntax a node carried in the source document
+/// (issue #763, ADR-0017's mechanism 2).
+///
+/// A node is at most one of the two: [`YamlCursor::anchor`] returns `None`
+/// for an alias node, and an alias node cannot itself declare an anchor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnchorMark {
+    /// `&name` — this node declares an anchor. The name is stored without
+    /// the leading `&`.
+    Declares(String),
+    /// `*name` — this node is an alias referring to anchor `name`, stored
+    /// without the leading `*`. A node marked this way renders as `*name`
+    /// and its own value is not written at all.
+    Aliases(String),
+}
+
+/// Per-node presentation metadata: everything about *how* a node was
+/// written that its `OwnedValue` doesn't record.
+///
+/// Grouped into a struct rather than kept as loose tuple fields on
+/// [`CommentTree`] so the remaining slot this side-channel still owes —
+/// the explicit source tag the DOM path drops (#1132/#747) — can be added
+/// without a third pass over every construction site.
+#[derive(Debug, Clone, Default)]
+pub struct NodeMeta {
+    /// This node's trailing same-line comment, `#` and all (issue #710),
+    /// or `None` if it has none.
+    pub comment: Option<String>,
+    /// This node's YAML style (issue #739): `""` for block/plain, or
+    /// `"flow"`/`"double"`/`"single"`/`"literal"`/`"folded"` per
+    /// [`DocumentCursor::style`].
+    pub style: &'static str,
+    /// This node's `&anchor`/`*alias` syntax (issue #763), or `None` if it
+    /// carried neither.
+    pub anchor: Option<AnchorMark>,
+}
+
+impl NodeMeta {
+    /// Metadata-free: no comment, no style, no anchor. `const` so
+    /// [`EMPTY_COMMENT_TREE`] can be a genuine `static`.
+    pub const fn empty() -> Self {
+        Self {
+            comment: None,
+            style: "",
+            anchor: None,
+        }
+    }
+
+    /// The comment/style pair read straight off a live cursor, with no
+    /// anchor mark — the shape every caller predating #763 built.
+    pub fn from_comment_and_style(comment: Option<String>, style: &'static str) -> Self {
+        Self {
+            comment,
+            style,
+            anchor: None,
+        }
+    }
+}
+
 /// A shape-parallel tree of per-node presentation metadata.
 ///
-/// Trailing same-line comments (issue #710) and YAML style (issue #739;
+/// Trailing same-line comments (issue #710), YAML style (issue #739;
 /// `""` for block/plain, `"flow"`/`"double"`/`"single"`/`"literal"`/
-/// `"folded"` per [`DocumentCursor::style`]) — built alongside an
-/// `OwnedValue` by [`to_owned_with_comments`].
+/// `"folded"` per [`DocumentCursor::style`]), and `&anchor`/`*alias`
+/// syntax (issue #763) — built alongside an `OwnedValue` by
+/// [`to_owned_with_comments`], one [`NodeMeta`] per node.
+///
+/// ADR-0017 originally specified that anchor/alias identity must *not*
+/// ride this tree, on the grounds that a shape-parallel side-tree "has no
+/// notion of cross-tree identity". That holds for deciding whether a mark
+/// is still *valid* after a write — which is why that stays separate logic
+/// in `yq_runner.rs` — but not for *emitting* one: what the writer needs is
+/// purely per-node ("write `&x` here", "write `*x` there"), the same shape
+/// as comments and style. Carrying it here reuses the threading this tree
+/// already has through capture, reconciliation, emission, `--inplace` and
+/// `--split-exp`; see that ADR's amendment for the full argument.
 ///
 /// `OwnedValue` itself carries no metadata — extending its enum would ripple
 /// through every match site in both the JSON and YAML evaluators for a
@@ -296,50 +366,86 @@ fn tagged_type_name<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> &
 /// keeps metadata for every node whose value the write didn't touch.
 #[derive(Debug, Clone)]
 pub enum CommentTree {
-    /// A scalar (or any node with no comment-bearing children): this node's
-    /// own trailing comment, if any, and its style.
-    Leaf(Option<String>, &'static str),
-    /// An array: this node's own trailing comment (e.g. `a: [1,2] # c`,
-    /// which trails the whole array, not an element) and style, plus one
-    /// subtree per element in order.
-    Array(Option<String>, &'static str, Vec<Self>),
-    /// An object: this node's own trailing comment and style, one subtree
-    /// per field (keyed the same as the parallel `OwnedValue::Object`),
-    /// plus one key-scoped comment per field for a comment trailing the
-    /// *key's* own line when its value is deferred to a following line
-    /// (issue #765, e.g. `a: # comment\n  b: 1`) - distinct from the
-    /// field's value subtree's own comment, which `.a | line_comment` etc.
-    /// read instead. The `bool` alongside each comment is whether the
-    /// deferred value materialized as nothing at all (a sibling key
-    /// follows, or EOF) - see [`Self::key_comment_if_value_absent`].
+    /// A scalar (or any node with no comment-bearing children).
+    Leaf(NodeMeta),
+    /// An array: this node's own metadata (e.g. the comment in
+    /// `a: [1,2] # c`, which trails the whole array, not an element) plus
+    /// one subtree per element in order.
+    Array(NodeMeta, Vec<Self>),
+    /// An object: this node's own metadata, one subtree per field (keyed
+    /// the same as the parallel `OwnedValue::Object`), plus one key-scoped
+    /// comment per field for a comment trailing the *key's* own line when
+    /// its value is deferred to a following line (issue #765, e.g.
+    /// `a: # comment\n  b: 1`) - distinct from the field's value subtree's
+    /// own comment, which `.a | line_comment` etc. read instead. The `bool`
+    /// alongside each comment is whether the deferred value materialized as
+    /// nothing at all (a sibling key follows, or EOF) - see
+    /// [`Self::key_comment_if_value_absent`].
     Object(
-        Option<String>,
-        &'static str,
+        NodeMeta,
         IndexMap<String, Self>,
         IndexMap<String, (String, bool)>,
     ),
 }
 
 impl CommentTree {
-    /// The empty tree: no comment or style at this node, and (for
-    /// containers) no children — used where a caller has no cursor at all
-    /// (metadata-less by construction, e.g. a computed value).
+    /// The empty tree: no metadata at this node, and (for containers) no
+    /// children — used where a caller has no cursor at all (metadata-less
+    /// by construction, e.g. a computed value).
     pub const fn empty() -> Self {
-        Self::Leaf(None, "")
+        Self::Leaf(NodeMeta::empty())
+    }
+
+    /// This node's own presentation metadata.
+    pub fn meta(&self) -> &NodeMeta {
+        match self {
+            Self::Leaf(m) | Self::Array(m, _) | Self::Object(m, _, _) => m,
+        }
+    }
+
+    /// This node's own presentation metadata, mutably — used by the
+    /// post-evaluation passes in `yq_runner.rs` that clear one slot
+    /// (`-P`'s style strip, #763's soundness gate) without rebuilding the
+    /// surrounding tree.
+    pub fn meta_mut(&mut self) -> &mut NodeMeta {
+        match self {
+            Self::Leaf(m) | Self::Array(m, _) | Self::Object(m, _, _) => m,
+        }
     }
 
     /// This node's own trailing comment, if any.
     pub fn own(&self) -> Option<&str> {
-        match self {
-            Self::Leaf(c, _) | Self::Array(c, _, _) | Self::Object(c, _, _, _) => c.as_deref(),
-        }
+        self.meta().comment.as_deref()
     }
 
     /// This node's own YAML style (`""`, `"flow"`, `"double"`, `"single"`,
     /// `"literal"`, or `"folded"` — see [`DocumentCursor::style`]).
     pub fn style(&self) -> &'static str {
-        match self {
-            Self::Leaf(_, s) | Self::Array(_, s, _) | Self::Object(_, s, _, _) => s,
+        self.meta().style
+    }
+
+    /// This node's own `&anchor`/`*alias` mark, if it carried one (#763).
+    pub fn anchor_mark(&self) -> Option<&AnchorMark> {
+        self.meta().anchor.as_ref()
+    }
+
+    /// The anchor name this node is an alias *reference* to (`*name`), or
+    /// `None` if it declares an anchor or carries no mark at all. The
+    /// writer treats such a node as rendering to `*name` instead of its
+    /// own value, so this is the check that must come before any
+    /// value-shape dispatch.
+    pub fn alias_name(&self) -> Option<&str> {
+        match self.meta().anchor.as_ref() {
+            Some(AnchorMark::Aliases(name)) => Some(name),
+            _ => None,
+        }
+    }
+
+    /// The anchor name this node *declares* (`&name`), or `None`.
+    pub fn declared_anchor(&self) -> Option<&str> {
+        match self.meta().anchor.as_ref() {
+            Some(AnchorMark::Declares(name)) => Some(name),
+            _ => None,
         }
     }
 
@@ -347,7 +453,7 @@ impl CommentTree {
     /// `Array` or the index is out of range.
     pub fn at_index(&self, i: usize) -> &Self {
         match self {
-            Self::Array(_, _, items) => items.get(i).unwrap_or(&EMPTY_COMMENT_TREE),
+            Self::Array(_, items) => items.get(i).unwrap_or(&EMPTY_COMMENT_TREE),
             _ => &EMPTY_COMMENT_TREE,
         }
     }
@@ -356,7 +462,7 @@ impl CommentTree {
     /// `Object` or has no such key.
     pub fn field(&self, key: &str) -> &Self {
         match self {
-            Self::Object(_, _, fields, _) => fields.get(key).unwrap_or(&EMPTY_COMMENT_TREE),
+            Self::Object(_, fields, _) => fields.get(key).unwrap_or(&EMPTY_COMMENT_TREE),
             _ => &EMPTY_COMMENT_TREE,
         }
     }
@@ -368,7 +474,7 @@ impl CommentTree {
     /// trailing comment (issue #710).
     pub fn key_comment(&self, key: &str) -> Option<&str> {
         match self {
-            Self::Object(_, _, _, key_comments) => key_comments.get(key).map(|(c, _)| c.as_str()),
+            Self::Object(_, _, key_comments) => key_comments.get(key).map(|(c, _)| c.as_str()),
             _ => None,
         }
     }
@@ -385,7 +491,7 @@ impl CommentTree {
     /// the key, a different, unhandled case).
     pub fn key_comment_if_value_absent(&self, key: &str) -> Option<&str> {
         match self {
-            Self::Object(_, _, _, key_comments) => key_comments
+            Self::Object(_, _, key_comments) => key_comments
                 .get(key)
                 .filter(|(_, absent)| *absent)
                 .map(|(c, _)| c.as_str()),
@@ -398,7 +504,7 @@ impl CommentTree {
 /// can't be borrowed as `'static` from inside a generic method call
 /// argument like `Option::unwrap_or`) — used by [`CommentTree::at_index`]/
 /// [`CommentTree::field`] wherever there's no comment data to return.
-static EMPTY_COMMENT_TREE: CommentTree = CommentTree::Leaf(None, "");
+static EMPTY_COMMENT_TREE: CommentTree = CommentTree::Leaf(NodeMeta::empty());
 
 /// Convert a `DocumentValue` to an `OwnedValue` alongside a parallel [`CommentTree`].
 ///
@@ -423,6 +529,22 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
     // getter: the write path re-emits this verbatim after one space.
     let own_comment = cursor.and_then(DocumentCursor::line_comment_raw);
     let own_style = cursor.map_or("", DocumentCursor::style);
+    // `&anchor`/`*alias` (#763). Checked alias-first: `anchor()` already
+    // returns `None` on an alias node, so the order can't actually
+    // mis-classify, but it states the precedence the writer relies on --
+    // an aliased node renders as `*name` and never writes its own value.
+    let own_anchor = cursor.and_then(|c| {
+        DocumentCursor::alias(c)
+            .map(|name| AnchorMark::Aliases(name.to_string()))
+            .or_else(|| {
+                DocumentCursor::anchor(c).map(|name| AnchorMark::Declares(name.to_string()))
+            })
+    });
+    let own_meta = NodeMeta {
+        comment: own_comment,
+        style: own_style,
+        anchor: own_anchor,
+    };
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut comment_map = IndexMap::new();
@@ -460,7 +582,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         }
         (
             OwnedValue::Object(map),
-            CommentTree::Object(own_comment, own_style, comment_map, key_comment_map),
+            CommentTree::Object(own_meta, comment_map, key_comment_map),
         )
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -478,13 +600,10 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         }
         (
             OwnedValue::Array(items),
-            CommentTree::Array(own_comment, own_style, comment_items),
+            CommentTree::Array(own_meta, comment_items),
         )
     } else {
-        (
-            to_owned_at_depth(value, depth),
-            CommentTree::Leaf(own_comment, own_style),
-        )
+        (to_owned_at_depth(value, depth), CommentTree::Leaf(own_meta))
     }
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -341,8 +341,14 @@ impl NodeMeta {
 /// in `yq_runner.rs` — but not for *emitting* one: what the writer needs is
 /// purely per-node ("write `&x` here", "write `*x` there"), the same shape
 /// as comments and style. Carrying it here reuses the threading this tree
-/// already has through capture, reconciliation, emission, `--inplace` and
-/// `--split-exp`; see that ADR's amendment for the full argument.
+/// already has through capture, reconciliation, emission and `--split-exp`;
+/// see that ADR's amendment for the full argument.
+///
+/// Deliberately *not* `--inplace`, which never builds one of these at all:
+/// it evaluates through `evaluate_input` with [`CommentTree::empty`], so it
+/// drops comments, style and anchors alike (and skips #711's alias value
+/// sync). That is issue #1349, a gap in that route's own wiring rather than
+/// anything this tree can reach.
 ///
 /// `OwnedValue` itself carries no metadata — extending its enum would ripple
 /// through every match site in both the JSON and YAML evaluators for a

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5867,6 +5867,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn alias(&self) -> Option<&str> {
+        YamlCursor::alias(self)
+    }
+
+    #[inline]
     fn explicit_tag(&self) -> Option<&str> {
         YamlCursor::explicit_tag(self)
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -17643,3 +17643,66 @@ fn test_yaml_json_output_still_resolves_aliases_763() -> Result<()> {
     assert_eq!(output.trim(), r#"{"a":99,"b":99}"#);
     Ok(())
 }
+
+#[test]
+fn test_yaml_root_container_anchor_survives_the_dom_path_763() -> Result<()> {
+    // A navigated result whose own node is anchored keeps `&x`, but only
+    // because it's a container -- `write_leading_anchor`'s rule in
+    // `light.rs`, mirrored here. `-P` is what forces this through the DOM
+    // emitter rather than the streaming one.
+    let input = "a: &x\n  p: 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a", input, &["-P"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "&x\np: 1\n");
+
+    // Flow style takes the same branch with a space instead of a newline;
+    // `-P` flattens the flow to block, so read it through the streaming
+    // path to see the space form.
+    let (output, exit_code) = run_yq_stdin(".a", "a: &x {p: 1}\nb: *x\n", &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "&x {p: 1}\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_bare_scalar_alias_result_is_materialized_on_the_dom_path_763() -> Result<()> {
+    // DELIBERATE DIVERGENCE, and the reason `output_value` has no root
+    // alias branch. Real yq prints `*x` for `.b` on `b: *x` -- an alias
+    // with no anchor anywhere, which it then cannot read back
+    // (`unknown anchor 'x' referenced`). A root `*name` can never satisfy
+    // the soundness gate, since its `&name` would have to be inside its own
+    // subtree and a cyclic anchor is rejected at index build. succinctly's
+    // streaming path still prints `*x` here; making the two agree is #1350.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".b", input, &["-P"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_flow_sequence_item_anchor_survives_a_write_763() -> Result<()> {
+    // The flow *array* arm, distinct from the flow mapping arm above: the
+    // anchor sits immediately before the item, with no `key:` to hang off.
+    let input = "l: [&x 1, *x]\n";
+    let (output, exit_code) = run_yq_stdin(".c = 1", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "l: [&x 1, *x]\nc: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_nested_alias_mark_is_dropped_at_its_own_path_763() -> Result<()> {
+    // Exercises the soundness gate's path bookkeeping: the mark it clears
+    // is two levels down, so it has to walk back to that exact node rather
+    // than the root. Object and array steps both, since they take separate
+    // branches.
+    let (output, exit_code) = run_yq_stdin(".o.b.p = 9", "o:\n  a: &x {p: 1}\n  b: *x\n", &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "o:\n  a: &x {p: 1}\n  b:\n    p: 9\n");
+
+    let (output, exit_code) = run_yq_stdin(".l[1].p = 9", "l:\n  - &x {p: 1}\n  - *x\n", &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "l:\n  - &x {p: 1}\n  - p: 9\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -17368,3 +17368,278 @@ fn test_yq_input_line_number_not_supported_723() -> Result<()> {
     );
     Ok(())
 }
+
+// =============================================================================
+// Issue #763 - `&anchor`/`*alias` syntax must survive the DOM write path, not
+// just the M2 cursor-streaming identity path. ADR-0017's mechanism 2.
+//
+// Every expected string below is pinned against mikefarah/yq v4.53.3, run
+// directly against that binary rather than copied from the issue text (whose
+// reconciliation rules were explicitly labelled hypotheses). The two
+// deliberate divergences are called out individually and say what real yq
+// prints instead, and why succinctly doesn't.
+//
+// Distinct from the #711 family above, which asserts on values via `-o=json`
+// because the syntax didn't round-trip when it was written. Those tests stay
+// as they are; these are their YAML-syntax counterparts.
+// =============================================================================
+
+#[test]
+fn test_yaml_assign_to_anchor_keeps_anchor_and_alias_763() -> Result<()> {
+    // The issue's own repro. The write replaces the anchored node's value,
+    // not its identity, so `&x` stays and `b` stays an alias to it.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 99\nb: *x\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_to_alias_detaches_it_but_keeps_anchor_763() -> Result<()> {
+    // Writing straight to the alias gives that position its own value, so it
+    // is no longer the same node; `&x` survives even though nothing refers
+    // to it any more (an unreferenced anchor is valid YAML, and yq keeps it).
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".b = 7", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: 7\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_unrelated_key_leaves_anchors_alone_763() -> Result<()> {
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = 3", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: *x\nc: 3\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_compound_and_update_assign_keep_anchor_763() -> Result<()> {
+    // `+=` and `|=` reach the same write path as `=` and must not differ.
+    let input = "a: &x 1\nb: *x\n";
+    for filter in [".a += 1", ".a |= . + 1"] {
+        let (output, exit_code) = run_yq_stdin(filter, input, &[])?;
+        assert_eq!(exit_code, 0, "filter: {filter}");
+        assert_eq!(output, "a: &x 2\nb: *x\n", "filter: {filter}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_yaml_computed_key_assign_to_alias_detaches_it_763() -> Result<()> {
+    // `.["b"] = 5` resolves to the same path as `.b = 5` and must agree
+    // with it -- a computed key takes a different route to the write.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(r#".["b"] = 5"#, input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: 5\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_del_alias_keeps_unreferenced_anchor_763() -> Result<()> {
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin("del(.b)", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_del_anchor_materializes_the_alias_763() -> Result<()> {
+    // DELIBERATE DIVERGENCE. Real yq prints `b: *x\n` here -- an alias with
+    // no anchor left anywhere in the document, which yq itself then refuses
+    // to read back (`unknown anchor 'x' referenced`, verified against the
+    // pinned binary). `enforce_anchor_soundness` drops a mark it cannot
+    // resolve, so succinctly writes the value instead and its own output
+    // always re-parses.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin("del(.a)", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "b: 1\n");
+
+    // The point of the divergence: feed it straight back in.
+    let (round_tripped, exit_code) = run_yq_stdin(".", &output, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(round_tripped, "b: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_write_inside_anchored_container_keeps_anchor_763() -> Result<()> {
+    // The anchored node is a container and the write lands inside it;
+    // `#711`'s value sync keeps `b` in step, so the alias is still emittable.
+    let input = "a: &x {p: 1}\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a.p = 9", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x {p: 9}\nb: *x\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_write_through_alias_drops_the_mark_rather_than_the_write_763() -> Result<()> {
+    // DELIBERATE DIVERGENCE. Real yq models an alias as a shared node, so
+    // `.b.p = 9` mutates the anchor's own value and prints
+    // `a: &x {p: 9}\nb: *x\n`. succinctly's alias sync is one-directional
+    // (anchor -> aliases), so `.a` still holds `{p: 1}` here. Emitting
+    // `b: *x` on top of that would silently throw the write away and print
+    // `p: 1` back; the soundness gate sees the two values disagree and drops
+    // the mark instead, so the computed value survives. Tracked separately
+    // as the alias-identity follow-up.
+    let input = "a: &x {p: 1}\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".b.p = 9", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x {p: 1}\nb:\n  p: 9\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_deferred_container_anchor_survives_a_write_763() -> Result<()> {
+    // `&x` sits on the key's own line, before the newline that starts the
+    // container -- the DOM twin of `stream_yaml_value`'s mapping-field arm.
+    let input = "a: &x\n  p: 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = 1", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x\n  p: 1\nb: *x\nc: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_sequence_item_anchor_survives_a_write_763() -> Result<()> {
+    let input = "l:\n  - &x 1\n  - *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = 1", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "l:\n  - &x 1\n  - *x\nc: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_deferred_sequence_item_anchor_survives_a_write_763() -> Result<()> {
+    // An anchor on the item's own line takes the slot the compact `- ` form
+    // would use, so the value stays deferred to its own full-indent line.
+    let input = "l:\n  - &x\n    p: 1\n  - *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = 1", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "l:\n  - &x\n    p: 1\n  - *x\nc: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_flow_style_anchor_alias_survives_a_write_763() -> Result<()> {
+    let input = "a: {x: &y 1, z: *y}\n";
+    let (output, exit_code) = run_yq_stdin(".c = 1", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: {x: &y 1, z: *y}\nc: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_anchors_survive_pretty_print_763() -> Result<()> {
+    // `-P` forces the DOM path for every query shape. It is documented as
+    // `... style = ""`, and anchor/alias syntax is identity, not style --
+    // real yq -P keeps both.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-P"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: *x\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_anchors_survive_arg_forced_dom_1133() -> Result<()> {
+    // #1133: a named variable forces the DOM path even for plain `.`.
+    let input = "k: &anc v\nb: *anc\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["--arg", "x", "y"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "k: &anc v\nb: *anc\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_arg_forced_dom_no_longer_nulls_an_absent_anchor_1133() -> Result<()> {
+    // #1133's third repro, the one that lost data rather than syntax: the
+    // anchored value is absent, so the alias resolved to nothing and `b`
+    // printed as `null`. `b` now renders as `*anc` and never consults the
+    // value at all.
+    let input = "? k # key comment\n: &anc\nb: *anc\n";
+    let expected = "k: &anc # key comment\nb: *anc\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["--arg", "x", "y"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, expected);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_select_true_keeps_anchors_786() -> Result<()> {
+    // #786's repro. Already correct before #763 (`select` is in
+    // `can_use_m2_streaming`'s allow-list, so this streams), pinned here so
+    // a future change to that allow-list has to route it through the DOM
+    // path's anchor support rather than silently regressing.
+    let input = "a: &anc\n  b: 1\nc: *anc\n";
+    let (output, exit_code) = run_yq_stdin("select(true)", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &anc\n  b: 1\nc: *anc\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_dom_output_matches_streaming_output_over_an_anchor_corpus_763() -> Result<()> {
+    // The strongest gate #1133 asks for: forcing the DOM path must not
+    // change a single byte of an identity query's output. `--arg` and `-P`
+    // are the two flags that force it while leaving the result a live
+    // cursor, so all three spellings have to agree.
+    let input = concat!(
+        "a: &x 1\n",
+        "b: *x\n",
+        "c: &y {p: 1, q: *x}\n",
+        "d: *y\n",
+        "l:\n",
+        "  - &z 1\n",
+        "  - *z\n",
+        "e: &w\n",
+        "  m: 1\n",
+        "f: *w\n",
+    );
+    let (streamed, exit_code) = run_yq_stdin(".", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(streamed, input, "identity must round-trip verbatim");
+
+    let (with_arg, exit_code) = run_yq_stdin(".", input, &["--arg", "x", "y"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(with_arg, streamed, "--arg must not change a byte");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_sort_keys_drops_an_alias_it_would_reorder_above_its_anchor_763() -> Result<()> {
+    // DELIBERATE DIVERGENCE, and the reason the soundness gate walks in the
+    // emitter's own order. Sorting moves `a: *x` above `z: &x 1`; real yq
+    // emits exactly that (verified via `sort_keys(.)`, whose output it then
+    // cannot read back). Dropping the mark keeps the document loadable.
+    let input = "z: &x 1\na: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = 1", input, &["--sort-keys"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: 1\nc: 1\nz: &x 1\n");
+
+    let (round_tripped, exit_code) = run_yq_stdin(".", &output, &[])?;
+    assert_eq!(
+        exit_code, 0,
+        "succinctly must be able to re-read its own output"
+    );
+    assert_eq!(round_tripped, output);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_json_output_still_resolves_aliases_763() -> Result<()> {
+    // JSON has no alias syntax, so `-o=json` must keep expanding them --
+    // matching real yq, and unchanged by any of the above.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 99", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":99,"b":99}"#);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -17655,12 +17655,17 @@ fn test_yaml_root_container_anchor_survives_the_dom_path_763() -> Result<()> {
     assert_eq!(exit_code, 0);
     assert_eq!(output, "&x\np: 1\n");
 
-    // Flow style takes the same branch with a space instead of a newline;
-    // `-P` flattens the flow to block, so read it through the streaming
-    // path to see the space form.
-    let (output, exit_code) = run_yq_stdin(".a", "a: &x {p: 1}\nb: *x\n", &[])?;
-    assert_eq!(exit_code, 0);
-    assert_eq!(output, "&x {p: 1}\n");
+    // Flow style takes the same branch with a space instead of a newline.
+    // `--arg`, not `-P`, is what forces the DOM path here: `-P` would
+    // flatten the flow to block and never reach the space form.
+    for (input, expected) in [
+        ("a: &x {p: 1}\nb: *x\n", "&x {p: 1}\n"),
+        ("a: &x [1, 2]\nb: *x\n", "&x [1, 2]\n"),
+    ] {
+        let (output, exit_code) = run_yq_stdin(".a", input, &["--arg", "z", "y"])?;
+        assert_eq!(exit_code, 0, "input: {input}");
+        assert_eq!(output, expected, "input: {input}");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Closes #763. Implements ADR-0017's **mechanism 2**, and fixes #1133 as a second acceptance surface.

## The bug

`succinctly yq` only re-emitted anchor/alias syntax on the M2 cursor-streaming path. Any query that left it — an assignment, `del()`, `-P`, `--arg` — flattened every anchor/alias pair into duplicated values:

```console
$ printf 'a: &x 1\nb: *x\n' | succinctly yq '.a = 99'
a: 99
b: 99                       # real yq: a: &x 99 / b: *x
```

#711 already fixed the *value* half (aliases stay in sync after a write); this is the syntax half.

## The oracle matrix came first, and moved the design

Every rule was probed against pinned yq v4.53.3 before any code. **Two of the four reconciliation rules #763's own plan comment proposed turned out to be wrong**, and the probes also turned up something the plan didn't anticipate: real yq emits YAML it *cannot itself read back* in at least three ordinary cases.

```console
$ printf 'a: &x 1\nb: *x\n' | yq 'del(.a)'
b: *x                                          # ...no &x anywhere
$ printf 'a: &x 1\nb: *x\n' | yq 'del(.a)' | yq '.'
Error: bad file '-': yaml: line 1, column 5: unknown anchor 'x' referenced
```

So byte-for-byte parity is not the right target. succinctly enforces a **soundness rule** instead — a `*name` is written only when a matching `&name` exists, is emitted *earlier*, and holds an *equal* value — and diverges in exactly those cases. 17 of the 18 matrix rows are now byte-identical to yq; the 18th is that divergence.

## How it works

**Per-node marks ride the presentation side-tree.** `CommentTree`'s loose `(comment, style)` tuple fields become one `NodeMeta`, which gains an `Option<AnchorMark>` (`Declares(name)` / `Aliases(name)`).

ADR-0017 said anchors must *not* ride this tree, because a shape-parallel side-tree "has no notion of cross-tree identity". That holds for deciding whether a mark is still **valid** — which stayed separate logic — but not for **emitting** one, which is per-node, exactly like a comment or a style. Carrying the data here reuses threading that was already built and tested (capture → reconcile → emit → `--split-exp`) instead of duplicating all of it, and gives the tag slot the DOM path still drops (#1132/#747) a home without a further pass over every construction site. The ADR is amended in this PR to record the change and the reasoning.

*(An earlier revision of this description, of the ADR amendment, and of `CommentTree`'s own doc comment all listed `--inplace` in that chain. It does not belong there: `--inplace` builds no `CommentTree` at all, which is exactly what #1349 below is about. All three copies are corrected on the branch.)*

**Two capture routes, both already threaded:**

- *cursor alive* (`-P`, `--arg`): `to_owned_with_comments_at_depth` was holding the right cursor and reading only `line_comment_raw()`/`style()`. It now reads the anchor too, via a new `DocumentCursor::alias()` mirroring the existing `anchor()`. No reconciliation — nothing was written.
- *cursor lost* (writes): `reconcile_presentation` carries the mark under the rule it already applied to comments and style ("same kind ⇒ keep"), matching real yq keeping `&x` across `.a = 99`. **`resolve_dynamic_indexes` went unused**, for the same reasons mechanism 1 had already declined it: private to `eval.rs`, generic over `EvalSemantics`, and speaking `Vec<Expr>` where the alias machinery speaks `Vec<OwnedValue>`.

**Emission** mirrors the five placements `light.rs`'s streaming writer already has rather than reinventing them. An aliased node short-circuits to `*name` before the value dispatch (by then `to_owned` has cloned the target's value in, so shape alone cannot tell them apart) and is written structurally, since `yaml_quote_string` quotes anything starting with `*`. `defers_to_own_block` replaces the block-vs-inline test both container arms spelled inline, so an alias stays on one line however large its target.

**`enforce_anchor_soundness`** then drops any mark the document cannot resolve. Besides the yq bugs above, this contains a real gap in succinctly's alias *value* model rather than papering over it: a write *through* an alias (`.b.p = 9`) updates only that position, so the values disagree, the mark is dropped, and the computed value is printed — instead of `b: *x` silently discarding the write.

## What this fixes

| | before | after |
|---|---|---|
| `.a = 99`, `+=`, `\|=`, `.["b"] = 5`, `del()` | flattened | matches yq |
| write inside an anchored container | flattened | matches yq |
| `-P '.'` | flattened | matches yq |
| `--arg x y '.'` (#1133) | flattened | matches yq |
| #1133's `? k # c\n: &anc\nb: *anc` | **`b: null`** (data loss) | matches yq |
| `-o=json` | resolves aliases | unchanged, matches yq |

#786's repro already passed before this PR (`select` is in `can_use_m2_streaming`'s allow-list, so it streams); it is pinned by a test here so a future change to that allow-list has to route it through the DOM path rather than regress silently. **#786 can be closed.**

## Tests

20 tests in `tests/yq_cli_tests.rs`, every expected string run against the pinned oracle rather than copied from the issue. Covers all three write shapes, both `del()` directions, all four new anchor placements, both DOM-forcing flags, and #1133's repros. Two gates beyond the matrix:

- **equivalence** (#1133's own suggestion): `yq '.' --arg x y` byte-identical to `yq '.'` over an anchor corpus.
- **round-trip**: each divergent case's output fed straight back in.

The three deliberate divergences each say what real yq prints instead and why succinctly doesn't. The existing #711 family asserts values via `-o=json` and is untouched.

## Verification

Run at the worktree, gate list derived from `ci.yml`:

- full suite **5362 passed / 0 failed**; `simd,scalar-yaml` leg **4004 / 0**
- all three `clippy` invocations, `cargo fmt --check`, `cargo check --no-default-features`, `cargo doc`
- `./scripts/sync-yq-golden.sh --check` — 74 goldens up to date

M2 streaming is untouched: `NodeMeta` only grows a structure that path never builds.

## Follow-ups filed while probing

- **#1349** — `--inplace` + a write drops comments, style and anchors, **and skips #711's alias sync** (`-i '.a = 99'` leaves `b` stale where the same query on stdout doesn't). A routing bug affecting mechanism 1 identically; highest-value of these.
- **#1350** — streaming `--sort-keys` can still emit an alias above its anchor; the DOM path no longer can, so the two paths now disagree.
- **#1351** — aliases are copies, not shared nodes (`.b.p = 9`, `.c = .b`) — mechanism 2's remaining half.
- **#1352** — an anchor on a mapping *key* (`&k key: 1`) is dropped even on identity.
- **#1353** — a redefined anchor name loses the earlier `&x` (`bp_to_anchor` keeps only the last position).

---

## Two findings from the coverage pass

**A root alias mark can never be emitted, so that branch was dead.** `output_value` originally had a root case for `*name`; `enforce_anchor_soundness` always clears it first, because the matching `&name` would have to sit inside the alias's own subtree and a cyclic anchor is rejected outright at index build (`YamlError::AliasCycle`). Removed, with the reasoning recorded where the branch was.

The visible consequence, stated plainly: `succinctly yq '.b'` on `b: *x` prints `*x` (streaming) while `-P '.b'` prints the resolved value. Real yq prints `*x` for both and can read back neither (`unknown anchor 'x' referenced`, verified). A test pins the DOM half; reconciling the streaming path with the soundness rule is #1350.

**Patch coverage: 98.39%** (245/249). The four remaining lines are three llvm-cov region artifacts on multi-line call arguments plus `comment_tree_at_path_mut`'s `_ => return None`, unreachable by construction — every path it walks was just produced by `scan_anchor_soundness` over the same tree.

Rebased onto `a4f44cbb8` (10 commits, including #1191/#1193's alias work in `light.rs`); the only conflict was an import list. Matrix, full suite and all gates re-run after the rebase.

