### PR TITLE
fix(cli): emit an explicit !!float tag on a nested computed whole float

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -176,6 +176,13 @@ impl OutputConfig {
 /// number 5, matching real `yq` (#224). Every recursive call passes a
 /// cursor too (`field.value_cursor()`, `YamlElements::uncons_cursor`), so a
 /// tag on a nested element is never lost.
+///
+/// Materializes through `to_owned_value_for_json_bridge`, not the plain
+/// `to_owned_value`: everything this function builds is headed for
+/// [`evaluate_input`]'s `to_json_for_reindex::<JqSemantics>` round trip,
+/// the one bridge that would otherwise flatten a tag-forced `!!float 2`
+/// to an `Int` (#1176). That variant's doc comment explains why no other
+/// `ResolvedScalar -> OwnedValue` caller wants the same treatment.
 fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<OwnedValue> {
     match cursor.value() {
         YamlValue::String(s) => {
@@ -185,7 +192,7 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
 
             if let Some(explicit) = cursor.explicit_tag() {
                 if let Some(resolved) = resolve_tagged(&str_value, explicit) {
-                    return Ok(resolved.to_owned_value(str_value));
+                    return Ok(resolved.to_owned_value_for_json_bridge(str_value));
                 }
             }
 
@@ -196,7 +203,7 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
             }
 
             // Resolve plain scalars per the YAML 1.2 core schema
-            Ok(resolve_plain(&str_value).to_owned_value(str_value))
+            Ok(resolve_plain(&str_value).to_owned_value_for_json_bridge(str_value))
         }
         YamlValue::Mapping(fields) => {
             let mut map = IndexMap::new();

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -22,15 +22,15 @@ use succinctly::jq::{
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
-    format_float_yq_yaml, resolve_plain, resolve_tagged, stream_yaml_sequence, YamlCursor,
-    YamlIndex, YamlValue,
+    format_float_yq_yaml, format_float_yq_yaml_nested, resolve_plain, resolve_tagged,
+    stream_yaml_sequence, YamlCursor, YamlIndex, YamlValue,
 };
 
 use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
 use crate::front_matter;
 use crate::output::{
-    self, exit_codes, format_float_yq, ColorScheme, ControlEscape, DiagStyle, ErrorSink,
-    FloatStyle, InputLocation, JsonFormatOpts,
+    self, exit_codes, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation,
+    JsonFormatOpts,
 };
 
 /// yq's diagnostics carry no `(at <file>:<line>)` marker, so the yq paths have
@@ -1618,19 +1618,14 @@ fn emit_yaml_value_at_depth(
             nonfinite_display_string::<YqSemantics>(*f).to_string()
         }
         // Real yq drops a computed whole float's decimal point (`2`, not
-        // `2.0`) only at document-root scalar position -- issue #949.
-        // Anywhere nested (an object field, an array element, an `-i`
-        // in-place edit) it instead emits an explicit `!!float` tag to
-        // keep the value's type unambiguous on reparse (`a: !!float 2`);
-        // succinctly has no tag-emission mechanism to match that, so
-        // falling back to `format_float_yq`'s decimal-preserving spelling
-        // here is the safer of the two available choices -- it's not
-        // byte-identical to real yq, but unlike the bare, untagged `2`
-        // this fix originally used at every depth, it doesn't silently
-        // change the value's inferred type from float to int on
-        // reparse/round-trip through `-i`.
+        // `2.0`) only at document-root scalar position, where it suppresses
+        // every tag (issue #949; `echo '!!str 5' | yq '.'` prints a bare
+        // `5` too). Anywhere nested -- an object field, an array element,
+        // an `-i` in-place edit -- it keeps the same shortest spelling but
+        // precedes it with an explicit `!!float` tag whenever that spelling
+        // would read back as an int (`a: !!float 2`, issue #1090).
         OwnedValue::Float(f) if depth == 0 => format_float_yq_yaml(*f),
-        OwnedValue::Float(f) => format_float_yq(*f),
+        OwnedValue::Float(f) => format_float_yq_yaml_nested(*f),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             nonfinite_display_string::<YqSemantics>(*f).to_string()
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6949,8 +6949,16 @@ pub(super) fn tonumber_from_str(s: &str) -> Result<OwnedValue, EvalError> {
     // `NumberLiteral`'s text is re-read as JSON by the reindex bridge --
     // the same constraint `preservable_float_literal_text` documents on the
     // YAML side.)
+    //
+    // The digit check is load-bearing, not defensive: `is_valid_number`
+    // accepts a leading `-` of its own, so a doubled sign (`+-1`) would
+    // otherwise strip to a perfectly valid `-1` and silently succeed where
+    // both oracles error out (jq 1.7.1: "Invalid numeric literal"; yq
+    // 4.53.3: "cannot convert node value [+-1] ... to number").
     if let Some(unsigned) = trimmed.strip_prefix('+') {
-        if crate::json::validate::is_valid_number(unsigned.as_bytes()) {
+        if unsigned.starts_with(|c: char| c.is_ascii_digit())
+            && crate::json::validate::is_valid_number(unsigned.as_bytes())
+        {
             return Ok(OwnedValue::from_number_literal(unsigned));
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6905,11 +6905,62 @@ fn builtin_tonumber<W: Clone + AsRef<[u64]>>(
 pub(super) fn tonumber_from_str(s: &str) -> Result<OwnedValue, EvalError> {
     // jq's JSON parser skips surrounding whitespace, so `" 1 "` is 1.
     let trimmed = s.trim();
+    // Materialize a JSON-shaped number as a `NumberLiteral` so it keeps its
+    // *source spelling*, rather than collapsing it through a bare
+    // `parse::<i64>()`/`parse::<f64>()` pair. Both oracles preserve the
+    // spelling and both modes were wrong without this -- real jq 1.7.1
+    // renders `"2.50" | tonumber` as `2.50` and `"1e3"` as `1E+3`, real yq
+    // echoes `2.50` and `1e3` verbatim, while a bare `Float` collapsed all
+    // four to `2.5`/`1000`.
+    //
+    // It also keeps yq's `!!float` tagging correct without any notion of
+    // value provenance (#1090). Real yq tags a nested float exactly when the
+    // text it is about to print would read back as an int, so `tonumber`'s
+    // result is untagged (its spelling survives) while `(. | tonumber) + 0`
+    // is tagged (arithmetic replaced the spelling). `into_plain_number`,
+    // which every arithmetic op already calls, *is* that boundary --
+    // preserving the literal here is what puts the value on the correct side
+    // of it. Constructing a bare `Float` instead made `.b = (.a | tonumber)`
+    // on `a: "2.0"` print `!!float 2`, the regression that closed PR #1179.
+    //
+    // Gate on strict RFC 8259 number syntax, and *not* on
+    // `OwnedValue::from_number_bytes`: that decoder also recognizes this
+    // crate's internal overflow sentinels (`9e999e999` -> NaN, `8e999e999`
+    // -> Infinity), which are reachable here as ordinary user text. Real jq
+    // rejects all three outright ("Invalid numeric literal", confirmed live
+    // against 1.7.1), so routing user input through the bridge decoder would
+    // turn a documented error into a silent NaN.
+    //
+    // The bare `parse::<i64>`/`parse::<f64>` fallback below still handles
+    // every spelling JSON refuses but the oracles accept -- `007`, `+2.0`,
+    // `.5`, and the `inf`/`NaN` words -- unchanged, and keeps those on the
+    // plain `Int`/`Float` path where they belong (a
+    // `NumberLiteral(Float(inf), "inf")` would make `format_number_jq_compat`
+    // emit a bare `inf`, which is not a number in either output language).
+    if crate::json::validate::is_valid_number(trimmed.as_bytes()) {
+        return Ok(OwnedValue::from_number_literal(trimmed));
+    }
+    // A leading `+` is the one spelling both oracles accept that JSON does
+    // not, and that still has an exact JSON-safe equivalent: drop the sign
+    // and preserve the rest. Real jq renders `"+2.0" | tonumber` as `2.0`,
+    // which only a preserved literal can produce -- the `parse::<f64>`
+    // fallback below would yield a bare `Float` and print `2`. (yq echoes
+    // `+2.0` verbatim; that spelling cannot be stored, since a
+    // `NumberLiteral`'s text is re-read as JSON by the reindex bridge --
+    // the same constraint `preservable_float_literal_text` documents on the
+    // YAML side.)
+    if let Some(unsigned) = trimmed.strip_prefix('+') {
+        if crate::json::validate::is_valid_number(unsigned.as_bytes()) {
+            return Ok(OwnedValue::from_number_literal(unsigned));
+        }
+    }
     if let Ok(i) = trimmed.parse::<i64>() {
-        Ok(OwnedValue::Int(i))
-    } else if let Ok(f) = trimmed.parse::<f64>() {
-        Ok(OwnedValue::Float(f))
-    } else if parse_complete_json(trimmed).is_ok() {
+        return Ok(OwnedValue::Int(i));
+    }
+    if let Ok(f) = trimmed.parse::<f64>() {
+        return Ok(OwnedValue::Float(f));
+    }
+    if parse_complete_json(trimmed).is_ok() {
         Err(EvalError::cannot_parse_as_number(&OwnedValue::String(
             s.to_string(),
         )))
@@ -32954,17 +33005,39 @@ mod tests {
         );
     }
 
+    /// `tonumber` keeps the string's own spelling as a `NumberLiteral`
+    /// rather than collapsing it to a bare `Int`/`Float` (#1090): both
+    /// oracles preserve it (`"2.50" | tonumber` is `2.50` in jq 1.7.1 and
+    /// yq 4.53.3 alike), and in yq mode it is also what keeps the value on
+    /// the untagged side of `into_plain_number`'s arithmetic boundary, so a
+    /// converted float does not pick up a spurious `!!float` tag.
     #[test]
     fn test_builtin_tonumber() {
         query!(br#""42""#, "tonumber",
-            QueryResult::Owned(OwnedValue::Int(n)) => {
+            QueryResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Int(n), literal)) => {
                 assert_eq!(n, 42);
+                assert_eq!(&*literal, "42");
             }
         );
 
         query!(br#""2.75""#, "tonumber",
-            QueryResult::Owned(OwnedValue::Float(f)) => {
+            QueryResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Float(f), literal)) => {
                 assert!((f - 2.75).abs() < 0.001);
+                assert_eq!(&*literal, "2.75");
+            }
+        );
+
+        // A spelling JSON accepts is echoed verbatim, not renormalized.
+        query!(br#""2.50""#, "tonumber",
+            QueryResult::Owned(OwnedValue::NumberLiteral(_, literal)) => {
+                assert_eq!(&*literal, "2.50");
+            }
+        );
+
+        // A spelling JSON rejects still falls back to a plain number.
+        query!(br#""007""#, "tonumber",
+            QueryResult::Owned(v) => {
+                assert_eq!(v, OwnedValue::Int(7));
             }
         );
 

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -29,7 +29,7 @@ use super::value::{
     assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text,
     jq_bare_float_display, NumberRepr, OwnedValue,
 };
-use crate::yaml::{format_float_with_fraction, format_float_yq, format_float_yq_yaml};
+use crate::yaml::{format_float_with_fraction, format_float_yq_yaml, format_float_yq_yaml_nested};
 
 /// A value that can be streamed directly to output without intermediate allocation.
 ///
@@ -623,28 +623,22 @@ fn stream_owned_value_yaml_at_depth<W: core::fmt::Write>(
             out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
         // Mirrors `emit_yaml_value_at_depth`'s identical depth split
-        // (yq_runner.rs, issue #949): real yq drops a computed whole
-        // float's decimal point only at document-root scalar position,
-        // and tags it (`!!float`) everywhere else to keep its type
-        // unambiguous on reparse -- a mechanism succinctly has no way to
-        // emit, so `format_float_yq`'s decimal-preserving fallback is the
-        // safer of the two available choices below root (also matching
-        // `emit_yaml_value_at_depth`'s nested-position fallback exactly,
-        // including its scientific-notation threshold for an
-        // extreme-magnitude nested value -- `format_float_with_fraction`
-        // alone has no such threshold and would diverge from the DOM path
-        // on that case). `can_use_m2_streaming` (yq_runner.rs) has no
-        // arithmetic arm, so this function is likely unreachable with a
-        // genuinely *computed* bare `Float` through any current CLI path
-        // -- kept in sync with the DOM path anyway for
-        // `StreamableValue::stream_yaml`'s other, non-CLI callers and to
-        // avoid a silent behavioral split if a future M2-eligible
-        // construct ever does carry one through (#1064 documents this
-        // same "unreachable but exhaustive" shape elsewhere in this
-        // codebase). An untouched literal keeps its own `.0` via the
-        // `NumberLiteral` arm below, unaffected by this.
+        // (yq_runner.rs, issues #949 and #1090): real yq drops a computed
+        // whole float's decimal point only at document-root scalar
+        // position, where it suppresses every tag; nested it keeps that
+        // same shortest spelling but precedes it with an explicit
+        // `!!float` tag whenever the spelling would read back as an int.
+        // `can_use_m2_streaming` (yq_runner.rs) has no arithmetic arm, so
+        // this function is likely unreachable with a genuinely *computed*
+        // bare `Float` through any current CLI path -- kept in sync with
+        // the DOM path anyway for `StreamableValue::stream_yaml`'s other,
+        // non-CLI callers and to avoid a silent behavioral split if a
+        // future M2-eligible construct ever does carry one through (#1064
+        // documents this same "unreachable but exhaustive" shape
+        // elsewhere in this codebase). An untouched literal keeps its own
+        // `.0` via the `NumberLiteral` arm below, unaffected by this.
         OwnedValue::Float(f) if depth == 0 => out.write_str(&format_float_yq_yaml(*f)),
-        OwnedValue::Float(f) => out.write_str(&format_float_yq(*f)),
+        OwnedValue::Float(f) => out.write_str(&format_float_yq_yaml_nested(*f)),
         OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f.is_nan() || f.is_infinite() => {
             out.write_str(super::nonfinite_display_string::<super::YqSemantics>(*f))
         }
@@ -1131,11 +1125,10 @@ mod tests {
     /// required to agree, matching real yq. An untouched literal still keeps
     /// its own `.0` via the sibling `NumberLiteral` variant, unaffected by
     /// this. A *nested* computed float (inside the array case below) keeps
-    /// its decimal point instead — real yq disambiguates a nested computed
-    /// float with an explicit `!!float` tag, which this codebase has no way
-    /// to emit, so falling back to the point-preserving spelling avoids
-    /// silently losing the value's float-ness on reparse (see
-    /// `format_float_yq_yaml`'s own doc comment for the full reasoning).
+    /// the same shortest spelling but gains an explicit `!!float` tag when
+    /// that spelling would read back as an int — real yq's own nested
+    /// disambiguation, added in #1090 (see `format_float_yq_yaml_nested`'s
+    /// doc comment for the full reasoning).
     #[test]
     fn test_stream_yaml_computed_whole_float_drops_decimal_point_949() {
         let mut buf = String::new();
@@ -1150,13 +1143,14 @@ mod tests {
             .unwrap();
         assert_eq!(buf, "-0");
 
-        // Nested (depth > 0): keeps the decimal point, unlike the root case
-        // above.
+        // Nested (depth > 0): same shortest spelling as the root case above,
+        // but tagged when it would otherwise read back as an int. `2.5`
+        // needs no tag — its own `.` is already unambiguous.
         buf.clear();
         OwnedValue::Array(vec![OwnedValue::Float(1.0), OwnedValue::Float(2.5)])
             .stream_yaml(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
-        assert_eq!(buf, "[1.0, 2.5]");
+        assert_eq!(buf, "[!!float 1, 2.5]");
 
         // Scientific-notation threshold agrees with the DOM path's
         // `format_float_yq_yaml` (and `format_float_yq`'s own JSON

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3373,6 +3373,41 @@ pub fn format_float_yq_yaml(f: f64) -> String {
     format_float_yq_with(f, |f| f.to_string())
 }
 
+/// [`format_float_yq_yaml`] for a computed float at any **nested**
+/// (non-document-root) YAML position, prefixed with an explicit `!!float `
+/// tag whenever the bare spelling would read back as an int.
+///
+/// Real yq's rule here is a pure function of the node's *text*, not of how
+/// the value was produced: it emits the tag exactly when re-resolving the
+/// spelling it is about to print would not yield `!!float`. Oracle-verified
+/// against yq v4.53.3 over a 41-value sweep -- `1`, `0`, `-1`, `1000`,
+/// `100000` are tagged; `2.5`, `0.5`, `1e+06`, `1e-05`, `1e+10`, `1e+300`
+/// are not, their own `.`/`e` already being unambiguous. Placement is
+/// style-insensitive: block mapping, flow mapping (`{a: !!float 2}`) and
+/// block sequence (`- !!float 2`) all take the same unconditional prefix.
+///
+/// That text-only rule is why no value-provenance tracking is needed to
+/// match yq here, despite the shape of the problem suggesting otherwise:
+/// `OwnedValue`'s existing `Float`-versus-`NumberLiteral` split already
+/// draws the same line, since `into_plain_number` drops a `NumberLiteral`'s
+/// spelling on exactly the arithmetic that makes yq start tagging.
+///
+/// Document-root scalars are excluded because real yq suppresses *every*
+/// tag there, not just this one (`echo '!!str 5' | yq '.'` prints a bare
+/// `5`) -- callers keep making that root-vs-nested choice themselves via
+/// [`format_float_yq_yaml`], exactly as before (#949).
+///
+/// `f` must be finite, like [`format_float_yq_yaml`].
+#[must_use]
+pub fn format_float_yq_yaml_nested(f: f64) -> String {
+    let spelling = format_float_yq_yaml(f);
+    if super::scalar::needs_explicit_float_tag(&spelling) {
+        format!("!!float {spelling}")
+    } else {
+        spelling
+    }
+}
+
 /// Shared magnitude-threshold logic behind [`format_float_yq`] and
 /// [`format_float_yq_yaml`]: scientific notation (`e+NN`/`e-NN`) once the
 /// value's decimal exponent is `>= 6` or `<= -5`, otherwise
@@ -12558,5 +12593,69 @@ mod tests {
         assert_eq!(format_float_yq_yaml(-1_500_000.0), "-1.5e+06");
         assert_eq!(format_float_yq_yaml(1e100), "1e+100");
         assert_eq!(format_float_yq_yaml(1e-100), "1e-100");
+    }
+
+    /// [`format_float_yq_yaml_nested`]'s tag rule (#1090), pinned against
+    /// real yq v4.53.3. Each expectation below was read off the oracle with
+    /// `printf 'a: 1.0\n' | yq '.a = (.a * X)'`, which puts the computed
+    /// float at a nested (object-field) position.
+    ///
+    /// The rule is a pure function of the emitted *text*: tag exactly when
+    /// re-resolving that text would not yield `!!float`. Nothing here
+    /// depends on how the value was produced, which is why matching yq
+    /// needs no value-provenance tracking.
+    #[test]
+    fn test_format_float_yq_yaml_nested_1090() {
+        // Integer-shaped spellings would reparse as `!!int` -- tagged.
+        assert_eq!(format_float_yq_yaml_nested(1.0), "!!float 1");
+        assert_eq!(format_float_yq_yaml_nested(2.0), "!!float 2");
+        assert_eq!(format_float_yq_yaml_nested(0.0), "!!float 0");
+        assert_eq!(format_float_yq_yaml_nested(-1.0), "!!float -1");
+        assert_eq!(format_float_yq_yaml_nested(1000.0), "!!float 1000");
+        assert_eq!(format_float_yq_yaml_nested(100_000.0), "!!float 100000");
+
+        // A `.` or an exponent marker is already unambiguous -- untagged.
+        assert_eq!(format_float_yq_yaml_nested(2.5), "2.5");
+        assert_eq!(format_float_yq_yaml_nested(0.5), "0.5");
+        assert_eq!(format_float_yq_yaml_nested(0.00015), "0.00015");
+        assert_eq!(format_float_yq_yaml_nested(1_500_000.0), "1.5e+06");
+        assert_eq!(format_float_yq_yaml_nested(0.000015), "1.5e-05");
+        assert_eq!(format_float_yq_yaml_nested(1e10), "1e+10");
+        assert_eq!(format_float_yq_yaml_nested(1e100), "1e+100");
+        assert_eq!(format_float_yq_yaml_nested(1e-100), "1e-100");
+
+        // The one accepted divergence from the oracle: real yq leaves a
+        // computed negative zero bare (`-0`), because go-yaml resolves `-0`
+        // as `!!float`. `resolve_plain` calls it `!!int`, so tagging is what
+        // keeps *this* crate's emitter and reader in agreement -- the
+        // type-safe side of the disagreement. Fixing `resolve_plain`'s `-0`
+        // classification would make this byte-identical to yq with no change
+        // to `format_float_yq_yaml_nested` itself.
+        assert_eq!(format_float_yq_yaml_nested(-0.0), "!!float -0");
+    }
+
+    /// Whatever `format_float_yq_yaml_nested` emits must read back at the
+    /// same type -- the round-trip invariant the tag exists to protect, and
+    /// the reason the predicate is defined in terms of `resolve_plain`
+    /// rather than an independent scan for `.`/`e`.
+    #[test]
+    fn test_nested_float_spelling_round_trips_as_float_1090() {
+        for f in [
+            1.0, 2.0, 0.0, -0.0, -1.0, 1000.0, 100_000.0, 2.5, 0.5, 1e10, 1e-5, 1e100, -1e100,
+        ] {
+            let emitted = format_float_yq_yaml_nested(f);
+            let scalar = emitted.strip_prefix("!!float ").map_or_else(
+                || super::super::scalar::resolve_plain(&emitted),
+                |text| {
+                    super::super::scalar::resolve_tagged(text, "!!float")
+                        .expect("!!float is a core-schema tag")
+                },
+            );
+            assert!(
+                matches!(scalar, super::super::scalar::ResolvedScalar::Float(_)),
+                "{f} emitted as {emitted:?}, which reads back as {:?}",
+                scalar.tag()
+            );
+        }
     }
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3354,18 +3354,14 @@ pub fn format_float_yq(f: f64) -> String {
 /// prints `2` on YAML output but `2.0` on JSON output (compact and pretty
 /// always agree with each other, just not with YAML) -- confirmed against
 /// real yq v4.53.3 (issue #949). Nested (any object field, array element,
-/// or `-i` in-place edit), real yq instead emits an explicit `!!float`
-/// tag to keep the value's type unambiguous on reparse (`a: !!float 2`);
-/// succinctly's YAML emitters have no tag-emission mechanism to match
-/// that, so a nested position falls back to [`format_float_yq`]'s
-/// decimal-preserving spelling instead of calling this function --
-/// imperfect versus the oracle, but it doesn't silently change the
-/// value's inferred type from float to int on round trip the way this
-/// function's bare, untagged spelling would. Callers are responsible for
-/// making that root-vs-nested choice themselves (see the `depth`-gated
-/// call sites in `src/bin/succinctly/yq_runner.rs` and
-/// `src/jq/stream.rs`); this function always drops the point
-/// unconditionally.
+/// or `-i` in-place edit), real yq keeps this same shortest spelling but
+/// precedes it with an explicit `!!float` tag whenever the spelling would
+/// read back as an int (`a: !!float 2`) -- see
+/// [`format_float_yq_yaml_nested`], which wraps this function to do
+/// exactly that (#1090). This function itself always drops the point and
+/// never emits a tag, so it is the *root-position* formatter; callers own
+/// the root-vs-nested choice (see the `depth`-gated call sites in
+/// `src/bin/succinctly/yq_runner.rs` and `src/jq/stream.rs`).
 ///
 /// `f` must be finite, like [`format_float_yq`].
 #[must_use]

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -275,12 +275,12 @@ pub(crate) enum QuotedSpanEnd {
 pub use error::YamlError;
 pub use index::YamlIndex;
 pub use light::{
-    format_float_with_fraction, format_float_yq, format_float_yq_yaml, stream_yaml_sequence,
-    ChompingIndicator, YamlCursor, YamlElements, YamlField, YamlFields, YamlNumber, YamlString,
-    YamlValue,
+    format_float_with_fraction, format_float_yq, format_float_yq_yaml, format_float_yq_yaml_nested,
+    stream_yaml_sequence, ChompingIndicator, YamlCursor, YamlElements, YamlField, YamlFields,
+    YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
-pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};
+pub use scalar::{needs_explicit_float_tag, resolve_plain, resolve_tagged, ResolvedScalar};
 
 #[cfg(test)]
 mod tests {

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -280,7 +280,7 @@ pub use light::{
     YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
-pub use scalar::{needs_explicit_float_tag, resolve_plain, resolve_tagged, ResolvedScalar};
+pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};
 
 #[cfg(test)]
 mod tests {

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -106,8 +106,64 @@ impl ResolvedScalar {
     /// (`light.rs`'s `write_resolved_scalar_as_json`/
     /// `stream_resolved_scalar_as_json`) are a different output type and
     /// weren't folded in here — see the #907 follow-up issue.
+    ///
+    /// A tag-forced float (`!!float 2`) stays a bare
+    /// [`OwnedValue::Float`] here, keeping the value's *text* out of it.
+    /// Only the one caller whose round trip cannot carry float-ness any
+    /// other way needs the re-spelling — see
+    /// [`to_owned_value_for_json_bridge`](Self::to_owned_value_for_json_bridge),
+    /// and that function's doc comment for why giving it to every caller
+    /// is wrong.
     #[must_use]
     pub fn to_owned_value(self, text: Cow<'_, str>) -> OwnedValue {
+        self.to_owned_value_with_bridge_respelling(text, false)
+    }
+
+    /// [`to_owned_value`](Self::to_owned_value) for a value about to cross
+    /// `yq_runner.rs`'s `evaluate_input` reindex bridge, which re-spells a
+    /// tag-forced float so its type survives that round trip (#1176).
+    ///
+    /// A *finite* float whose text a plain reader would type as something
+    /// other than `!!float` — i.e. one that is only a float because an
+    /// explicit tag forced it (`!!float 2`, `!!float 0x2A`) — has nowhere
+    /// left to carry that float-ness: neither spelling gate in
+    /// [`to_owned_value`](Self::to_owned_value) accepts an integer-shaped
+    /// mantissa, so it arrives at that bridge as a bare
+    /// [`OwnedValue::Float`], serializes as `2`, and reparses as an `Int`.
+    /// Reproducible with no `-i` at all, via `--slurp '.[0]'` on
+    /// `a: !!float 2`. Re-spelling with a forced decimal point puts the
+    /// type back into the literal itself, where the round trip preserves
+    /// it.
+    ///
+    /// **Only that one caller.** `evaluate_input` is the sole bridge in
+    /// the codebase that hardcodes `to_json_for_reindex::<JqSemantics>`
+    /// (deliberately — `YqSemantics` there re-breaks #978's
+    /// JSON-sourced-`1e2`-renders-as-`100` rule), and jq's plain-`Float`
+    /// fallback is the one that drops the point. Every other bridge is
+    /// `S`-gated and already spells a bare `Float` with
+    /// `format_float_with_fraction` under `YqSemantics`, so a tag-forced
+    /// float survives those untouched. Handing the re-spelling to
+    /// `eval_generic`'s cursor materialization and to `load()` as well
+    /// costs real oracle fidelity: their values reach string-producing
+    /// builtins, where real yq prints the scalar's own text, so
+    /// `!!float 2 | tostring` would answer `2.0` against yq's `2` (and
+    /// likewise `@yaml`, `@props`) — pinned by
+    /// `test_explicit_float_tag_respelling_stays_out_of_string_builtins_1090`
+    /// in `tests/yq_cli_tests.rs`.
+    ///
+    /// `.inf`/`.nan` stay on the bare-`Float` path: they have no decimal
+    /// spelling, and `resolve_plain` already types them `!!float`, so they
+    /// never need this anyway.
+    #[must_use]
+    pub fn to_owned_value_for_json_bridge(self, text: Cow<'_, str>) -> OwnedValue {
+        self.to_owned_value_with_bridge_respelling(text, true)
+    }
+
+    fn to_owned_value_with_bridge_respelling(
+        self,
+        text: Cow<'_, str>,
+        respell_tag_forced_float: bool,
+    ) -> OwnedValue {
         match self {
             Self::Null => OwnedValue::Null,
             Self::Bool(b) => OwnedValue::Bool(b),
@@ -117,29 +173,14 @@ impl ResolvedScalar {
             }
             Self::Float(f) => match preservable_float_literal_text(&text) {
                 Some(normalized) => OwnedValue::from_number_literal(&normalized),
-                // A *finite* float whose text a plain reader would type as
-                // something other than `!!float` -- i.e. one that is only a
-                // float because an explicit tag forced it (`!!float 2`,
-                // `!!float 0x2A`) -- has nowhere left to carry that
-                // float-ness: neither spelling gate above accepts an
-                // integer-shaped mantissa, so it falls through to a bare
-                // `OwnedValue::Float`, and `to_json_for_reindex`'s jq-mode
-                // fallback then serializes that as `2`, which reparses as an
-                // `Int`. The value silently changes type on the DOM route
-                // taken by `-i` and `--slurp` (#1176) -- reproducible with
-                // no `-i` at all via `--slurp '.[0]'` on `a: !!float 2`.
-                //
-                // Re-spelling it with a forced decimal point puts the type
-                // back into the literal itself, where the round trip
-                // preserves it, without touching the reindex bridge's own
-                // semantics gate (flipping that to `YqSemantics` is the
-                // obvious alternative and it re-breaks #978's
-                // JSON-sourced-`1e2`-renders-as-`100` rule).
-                //
-                // `is_finite` keeps `.inf`/`.nan` on the bare-`Float` path:
-                // they have no decimal spelling, and `resolve_plain` already
-                // types them `!!float` so they never need this anyway.
-                None if f.is_finite() && needs_explicit_float_tag(&text) => {
+                // The tag-forced-float re-spelling (#1176) -- gated to
+                // `to_owned_value_for_json_bridge`'s single caller, whose
+                // doc comment carries the full reasoning and the cost of
+                // applying it any wider.
+                None if respell_tag_forced_float
+                    && f.is_finite()
+                    && needs_explicit_float_tag(&text) =>
+                {
                     OwnedValue::from_number_literal(&super::format_float_with_fraction(f))
                 }
                 None => OwnedValue::Float(f),
@@ -470,7 +511,7 @@ pub(super) fn preservable_float_literal_text(s: &str) -> Option<String> {
 /// `resolve_plain`'s `-0` classification later makes both callers
 /// oracle-exact with no change to either.
 #[must_use]
-pub fn needs_explicit_float_tag(text: &str) -> bool {
+pub(crate) fn needs_explicit_float_tag(text: &str) -> bool {
     !matches!(resolve_plain(text), ResolvedScalar::Float(_))
 }
 

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -117,6 +117,31 @@ impl ResolvedScalar {
             }
             Self::Float(f) => match preservable_float_literal_text(&text) {
                 Some(normalized) => OwnedValue::from_number_literal(&normalized),
+                // A *finite* float whose text a plain reader would type as
+                // something other than `!!float` -- i.e. one that is only a
+                // float because an explicit tag forced it (`!!float 2`,
+                // `!!float 0x2A`) -- has nowhere left to carry that
+                // float-ness: neither spelling gate above accepts an
+                // integer-shaped mantissa, so it falls through to a bare
+                // `OwnedValue::Float`, and `to_json_for_reindex`'s jq-mode
+                // fallback then serializes that as `2`, which reparses as an
+                // `Int`. The value silently changes type on the DOM route
+                // taken by `-i` and `--slurp` (#1176) -- reproducible with
+                // no `-i` at all via `--slurp '.[0]'` on `a: !!float 2`.
+                //
+                // Re-spelling it with a forced decimal point puts the type
+                // back into the literal itself, where the round trip
+                // preserves it, without touching the reindex bridge's own
+                // semantics gate (flipping that to `YqSemantics` is the
+                // obvious alternative and it re-breaks #978's
+                // JSON-sourced-`1e2`-renders-as-`100` rule).
+                //
+                // `is_finite` keeps `.inf`/`.nan` on the bare-`Float` path:
+                // they have no decimal spelling, and `resolve_plain` already
+                // types them `!!float` so they never need this anyway.
+                None if f.is_finite() && needs_explicit_float_tag(&text) => {
+                    OwnedValue::from_number_literal(&super::format_float_with_fraction(f))
+                }
                 None => OwnedValue::Float(f),
             },
             Self::Str => OwnedValue::String(text.into_owned()),
@@ -419,6 +444,34 @@ pub(super) fn preservable_float_literal_text(s: &str) -> Option<String> {
         .unwrap_or(mantissa);
     let normalized = format!("{mantissa}{exponent}");
     is_preservable_float_literal(&normalized).then_some(normalized)
+}
+
+/// Whether emitting `text` as a plain YAML scalar would lose its
+/// float-ness, so a `!!float` tag (or a float-shaped respelling) is needed
+/// to keep the value's type stable across a round trip.
+///
+/// Deliberately defined as "what [`resolve_plain`] — this crate's own
+/// reader — would say", rather than a hand-rolled scan for `.`/`e`. Two
+/// callers need the identical question answered and a second, independent
+/// spelling of YAML's float grammar would drift from the first (CLAUDE.md's
+/// #106 lesson: duplicated predicates diverge silently):
+/// - `format_float_yq_yaml_nested` (`light.rs`), deciding whether nested
+///   YAML output must precede a computed float with `!!float ` (#1090).
+/// - [`ResolvedScalar::to_owned_value`] below, deciding whether a
+///   tag-forced float needs a float-shaped literal to survive
+///   `to_json_for_reindex`'s JSON round trip (#1176).
+///
+/// Anchoring on `resolve_plain` also guarantees the emitter and the reader
+/// agree: whatever spelling this crate writes, this crate reads back at the
+/// same type. That costs one byte against real yq on exactly one value —
+/// yq resolves `-0` as `!!float` while `resolve_plain` calls it `!!int`, so
+/// a computed negative zero emits `!!float -0` here versus yq's bare `-0`.
+/// Tagging it is the type-safe side of that divergence, and fixing
+/// `resolve_plain`'s `-0` classification later makes both callers
+/// oracle-exact with no change to either.
+#[must_use]
+pub fn needs_explicit_float_tag(text: &str) -> bool {
+    !matches!(resolve_plain(text), ResolvedScalar::Float(_))
 }
 
 /// Force-resolves a scalar's value under an explicit YAML tag.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -14205,3 +14205,56 @@ fn test_1088_path_reports_float_index_as_written() {
         "{stderr}"
     );
 }
+
+/// #1090: `tonumber` preserves the string's own spelling instead of
+/// renormalizing it through `f64`. Every expectation below was read off
+/// real jq 1.7.1 -- succinctly previously collapsed `"2.50"` to `2.5` and
+/// `"1e3"` to `1000`.
+///
+/// This lives in the jq suite as well as the yq one because
+/// `tonumber_from_str` is shared by both evaluators, and the two apply
+/// *different* final formatters to the preserved literal: jq renormalizes
+/// through `format_number_jq_compat` (hence `1E+3`, not `1e3`), while yq
+/// echoes it verbatim. A change that satisfies only one oracle would look
+/// correct in half the test suite.
+#[test]
+fn test_tonumber_preserves_source_spelling_1090() {
+    for (input, expected) in [
+        (r#""2.0""#, "2.0\n"),
+        (r#""2.50""#, "2.50\n"),
+        (r#""1e3""#, "1E+3\n"),
+        (r#""1E5""#, "1E+5\n"),
+        (r#""2e0""#, "2\n"),
+        (r#""42""#, "42\n"),
+        // Spellings JSON rejects fall back to a plain number, matching jq.
+        (r#""007""#, "7\n"),
+        (r#"".5""#, "0.5\n"),
+        // A leading `+` has an exact JSON-safe equivalent, so the literal
+        // still survives -- a bare `Float` here would print `2`, not `2.0`.
+        (r#""+2.0""#, "2.0\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["tonumber"], Some(input))
+            .unwrap_or_else(|e| panic!("`{input} | tonumber` failed to run: {e}"));
+        assert_eq!(code, 0, "`{input}`\nstdout: {stdout}\nstderr: {stderr}");
+        assert_eq!(stdout, expected, "`{input}`\nstderr: {stderr}");
+    }
+}
+
+/// #1090 follow-on: preserving `tonumber`'s literal must not start
+/// accepting text real jq rejects. The internal overflow sentinels
+/// (`9e999e999` -> NaN, `8e999e999` -> Infinity) are ordinary user input
+/// here, and routing this builtin through `OwnedValue::from_number_bytes`
+/// -- which decodes them -- would silently turn jq's documented error into
+/// a NaN. Error wording confirmed against jq 1.7.1.
+#[test]
+fn test_tonumber_rejects_internal_overflow_sentinels_1090() {
+    for input in [r#""9e999e999""#, r#""8e999e999""#, r#""-8e999e999""#] {
+        let (stdout, stderr, code) = run_jq_full(&["tonumber"], Some(input))
+            .unwrap_or_else(|e| panic!("`{input} | tonumber` failed to run: {e}"));
+        assert_ne!(code, 0, "`{input}` should error\nstdout: {stdout}");
+        assert!(
+            stderr.contains("Invalid numeric literal"),
+            "`{input}`\nstderr: {stderr}"
+        );
+    }
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -14240,6 +14240,30 @@ fn test_tonumber_preserves_source_spelling_1090() {
     }
 }
 
+/// #1090 follow-on: the leading-`+` retry must not turn a *doubled* sign
+/// into an accepted number. `is_valid_number` accepts a leading `-` of its
+/// own, so stripping the `+` off `"+-1"` leaves a perfectly valid `-1` --
+/// which real jq 1.7.1 rejects outright, and which this crate rejected
+/// before the retry existed. Error wording confirmed against jq 1.7.1.
+#[test]
+fn test_tonumber_rejects_doubled_sign_1090() {
+    for input in [
+        r#""+-1""#,
+        r#""+-1.5""#,
+        r#""+-0""#,
+        r#""+-1e3""#,
+        r#""-+1""#,
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["tonumber"], Some(input))
+            .unwrap_or_else(|e| panic!("`{input} | tonumber` failed to run: {e}"));
+        assert_ne!(code, 0, "`{input}` should error\nstdout: {stdout}");
+        assert!(
+            stderr.contains("Invalid numeric literal"),
+            "`{input}`\nstderr: {stderr}"
+        );
+    }
+}
+
 /// #1090 follow-on: preserving `tonumber`'s literal must not start
 /// accepting text real jq rejects. The internal overflow sentinels
 /// (`9e999e999` -> NaN, `8e999e999` -> Infinity) are ordinary user input

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8311,17 +8311,13 @@ fn test_jq_mode_computed_float_formatting_unaffected_by_997() -> Result<()> {
 // computed whole float's decimal point regardless of compact/pretty --
 // `test_compact_and_pretty_agree_on_whole_floats` above), YAML output of
 // the *same* computed value drops it -- but **only at document-root
-// scalar position**. Real yq v4.53.3 disambiguates a nested computed
-// float with an explicit `!!float` tag instead (`a: !!float 2`);
-// succinctly has no tag-emission mechanism to match that, so a nested
-// computed float here keeps its pre-existing decimal-point-preserving
-// spelling (`a: 2.0`) rather than dropping the point *without* a tag,
-// which would silently reparse as an int and lose the value's type --
-// worse than the pre-#949 status quo, not just non-byte-identical to the
-// oracle. Each root-scalar expectation was measured directly against the
-// pinned `yq` v4.53.3 binary; the nested-position fallback is
-// succinctly's own choice among its two imperfect options, not itself an
-// oracle-matched spelling (see `test_computed_whole_float_nested_yaml_output_keeps_type_949`).
+// scalar position**, where real yq suppresses every tag. Nested, real yq
+// keeps that same shortest spelling and precedes it with an explicit
+// `!!float` tag (`a: !!float 2`); #1090 added the tag-emission path, so
+// the nested expectations below are now the oracle's own bytes rather
+// than #949's type-preserving-but-not-identical `a: 2.0` fallback. Every
+// expectation in this section was measured directly against the pinned
+// `yq` v4.53.3 binary.
 // =============================================================================
 
 #[test]
@@ -8566,6 +8562,32 @@ fn test_tonumber_preserves_source_spelling_1090() -> Result<()> {
         let (out, code) = run_yq_stdin(".a | tonumber", &input, &[])?;
         assert_eq!(code, 0, "for {text:?}");
         assert_eq!(out.trim(), want, "for {text:?}");
+    }
+    Ok(())
+}
+
+/// #1090 follow-on: #1176's tag-forced-float re-spelling is scoped to the
+/// one materialization that crosses `evaluate_input`'s reindex bridge, and
+/// must not reach the cursor materialization that string-producing
+/// builtins read.
+///
+/// Real yq prints the scalar's own text in all three of these, so an
+/// `!!float 2` node answers `2`, not `2.0`. Handing
+/// `to_owned_value_for_json_bridge`'s re-spelling to every
+/// `ResolvedScalar -> OwnedValue` caller (the shape this fix's first draft
+/// shipped) silently moved all three off the oracle -- including
+/// `tostring | length`, which went from `1` to `3`. Every expectation
+/// below read off real yq v4.53.3.
+#[test]
+fn test_explicit_float_tag_respelling_stays_out_of_string_builtins_1090() -> Result<()> {
+    for (filter, want) in [
+        (".a | tostring", "2"),
+        (".a | @yaml", "2"),
+        (".a | tostring | length", "1"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, "a: !!float 2\n", &[])?;
+        assert_eq!(code, 0, "for {filter:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
     }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8376,16 +8376,18 @@ fn test_literal_whole_float_unaffected_by_949_fix() -> Result<()> {
     Ok(())
 }
 
-/// The critical regression this fix's first draft shipped (caught by code
-/// review, not by real yq's own byte-for-byte spelling): applying the
-/// root-only decimal-point drop at *every* nesting depth turned a
-/// type-preserving-if-imperfect output (`a: 2.0`, reparses as `!!float`)
-/// into a type-losing one (`a: 2`, reparses as `!!int`) for the much more
-/// common real-world shape of incrementing a float field in place. Real
-/// yq itself never drops the point here -- it tags instead (`a: !!float
-/// 2`) -- so `a: 2.0` is the closer of succinctly's two available
-/// spellings; `a: 2` would be closer in byte count but wrong in type,
-/// which is the worse defect for a data-format round trip.
+/// A nested computed whole float must keep its float type on reparse.
+///
+/// #949's fix originally applied the root-only decimal-point drop at
+/// *every* nesting depth, turning a type-preserving output into a
+/// type-losing one (`a: 2`, reparses as `!!int`) for the common shape of
+/// incrementing a float field in place; it settled on `a: 2.0` as the
+/// type-safe spelling succinctly could actually emit. #1090 closes the
+/// remaining gap by emitting real yq's own spelling, `a: !!float 2`, which
+/// is byte-identical to the oracle *and* type-correct.
+///
+/// The `.a | tag` round-trip assertion below is the invariant that
+/// outlived both spellings and is the real point of this test.
 #[test]
 fn test_computed_whole_float_nested_yaml_output_keeps_type_949() -> Result<()> {
     for (filter, yaml) in [
@@ -8395,11 +8397,11 @@ fn test_computed_whole_float_nested_yaml_output_keeps_type_949() -> Result<()> {
     ] {
         let (out, code) = run_yq_stdin(filter, yaml, &[])?;
         assert_eq!(code, 0, "for {filter:?}");
-        assert_eq!(out.trim(), "a: 2.0", "for {filter:?}");
+        assert_eq!(out.trim(), "a: !!float 2", "for {filter:?}");
 
         // Round-trip: re-parsing the emitted YAML must still resolve to
         // `!!float`, not `!!int` -- the actual invariant this test
-        // protects, independent of the exact decimal spelling chosen.
+        // protects, independent of the exact spelling chosen.
         let (tag, tag_code) = run_yq_stdin(".a | tag", &out, &[])?;
         assert_eq!(tag_code, 0, "for {filter:?}");
         assert_eq!(tag.trim(), "!!float", "for {filter:?}");
@@ -8407,7 +8409,7 @@ fn test_computed_whole_float_nested_yaml_output_keeps_type_949() -> Result<()> {
 
     let (out, code) = run_yq_stdin("map(. + 1)", "- 1.0\n", &[])?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), "- 2.0");
+    assert_eq!(out.trim(), "- !!float 2");
 
     Ok(())
 }
@@ -8415,13 +8417,19 @@ fn test_computed_whole_float_nested_yaml_output_keeps_type_949() -> Result<()> {
 /// `-i`/`--inplace` must stay type-idempotent: repeatedly incrementing a
 /// float field must never degrade it to an int-looking value, which would
 /// silently change downstream `tag`/`type` results after just one edit.
+///
+/// This is the case that gates #1090 on #1176. Once the first edit writes
+/// `a: !!float 2`, the second has to *read* that explicit tag back through
+/// the DOM route -- which used to flatten it to `Int` at the JSON reindex
+/// bridge, producing `a: 3` and losing the type after exactly one edit.
+/// Both halves have to be in place for this loop to hold.
 #[test]
 fn test_computed_whole_float_inplace_stays_float_typed_949() -> Result<()> {
     let mut file = NamedTempFile::new()?;
     writeln!(file, "a: 1.0")?;
     let path = file.path().to_path_buf();
 
-    for want in ["a: 2.0", "a: 3.0"] {
+    for want in ["a: !!float 2", "a: !!float 3"] {
         let status = Command::new(env!("CARGO_BIN_EXE_succinctly"))
             .args(["yq", "-i", ".a += 1"])
             .arg(&path)
@@ -8429,6 +8437,159 @@ fn test_computed_whole_float_inplace_stays_float_typed_949() -> Result<()> {
         assert!(status.success());
         assert_eq!(std::fs::read_to_string(&path)?.trim(), want);
     }
+    Ok(())
+}
+
+/// #1090: real yq's `!!float` placement is style-insensitive -- a block
+/// mapping, a flow mapping and a block sequence all take the same
+/// unconditional prefix, and nesting depth past the first makes no
+/// difference. All four expectations read off yq v4.53.3.
+#[test]
+fn test_nested_float_tag_is_style_insensitive_1090() -> Result<()> {
+    for (filter, input, want) in [
+        (".a += 1", "a: 1.0\n", "a: !!float 2"),
+        (".a += 1", "{a: 1.0}\n", "{a: !!float 2}"),
+        (".[0] += 1", "[1.0]\n", "[!!float 2]"),
+        (".[0] += 1", "- 1.0\n", "- !!float 2"),
+        (
+            ".a.b.c += 1",
+            "a:\n  b:\n    c: 1.0\n",
+            "a:\n  b:\n    c: !!float 2",
+        ),
+    ] {
+        let (out, code) = run_yq_stdin(filter, input, &[])?;
+        assert_eq!(code, 0, "for {filter:?} on {input:?}");
+        assert_eq!(out.trim(), want, "for {filter:?} on {input:?}");
+    }
+    Ok(())
+}
+
+/// #1090: the tag depends only on whether the emitted spelling would read
+/// back as an int -- never on the value's magnitude, sign, or how it was
+/// computed. Every row verified against real yq v4.53.3 via
+/// `printf 'a: 1.0\n' | yq '.a = (.a * X)'`.
+#[test]
+fn test_nested_float_tag_only_when_spelling_is_ambiguous_1090() -> Result<()> {
+    for (multiplier, want) in [
+        // Integer-shaped => tagged.
+        ("1", "a: !!float 1"),
+        ("0", "a: !!float 0"),
+        ("-1", "a: !!float -1"),
+        ("1000", "a: !!float 1000"),
+        ("100000", "a: !!float 100000"),
+        // Already unambiguous => bare.
+        ("2.5", "a: 2.5"),
+        ("0.5", "a: 0.5"),
+        ("1000000", "a: 1e+06"),
+        ("0.00001", "a: 1e-05"),
+        ("10000000000", "a: 1e+10"),
+    ] {
+        let filter = format!(".a = (.a * {multiplier})");
+        let (out, code) = run_yq_stdin(&filter, "a: 1.0\n", &[])?;
+        assert_eq!(code, 0, "for {filter:?}");
+        assert_eq!(out.trim(), want, "for {filter:?}");
+    }
+    Ok(())
+}
+
+/// #1090 must not leak outside nested YAML output. Real yq suppresses
+/// *every* tag at document-root scalar position (`echo '!!str 5' | yq '.'`
+/// prints a bare `5`), and JSON has no tag syntax at all -- so both keep
+/// their pre-#1090 spellings, verified against yq v4.53.3.
+#[test]
+fn test_nested_float_tag_does_not_leak_to_root_or_json_1090() -> Result<()> {
+    // Root scalar: bare, untagged, decimal point dropped (#949).
+    let (out, code) = run_yq_stdin(". + 1", "1.0\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+
+    // JSON output keeps the decimal point and never gains a tag.
+    for extra_args in [&["-o=json", "-I=0"][..], &["-o=json"][..]] {
+        let (out, code) = run_yq_stdin(".a += 1", "a: 1.0\n", extra_args)?;
+        assert_eq!(code, 0, "for {extra_args:?}");
+        assert!(
+            out.contains("2.0") && !out.contains("!!float"),
+            "for {extra_args:?}: {out:?}"
+        );
+    }
+
+    // `@json` and `tostring` are string-producing and likewise untagged
+    // (both spellings read off real yq v4.53.3, which unwraps a root
+    // scalar by default).
+    let (out, code) = run_yq_stdin(".a += 1 | @json", "a: 1.0\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":2.0}"#);
+
+    let (out, code) = run_yq_stdin("(.a + 1) | tostring", "a: 1.0\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+
+    Ok(())
+}
+
+/// #1090: a converted float must *not* be tagged, because `tonumber`
+/// preserves the source spelling -- but the same value put through
+/// arithmetic must be, because arithmetic replaces that spelling.
+/// `into_plain_number` is the boundary, and this pins both sides of it.
+/// Both expectations verified against real yq v4.53.3.
+///
+/// This is the regression that closed PR #1179, which tagged every nested
+/// whole float regardless of spelling.
+#[test]
+fn test_tonumber_result_is_not_tagged_but_arithmetic_on_it_is_1090() -> Result<()> {
+    let (out, code) = run_yq_stdin(".b = (.a | tonumber)", "a: \"2.0\"\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "a: \"2.0\"\nb: 2.0");
+
+    let (out, code) = run_yq_stdin(".b = ((.a | tonumber) + 0)", "a: \"2.0\"\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "a: \"2.0\"\nb: !!float 2");
+
+    Ok(())
+}
+
+/// #1090: `tonumber` echoes the string's own spelling, matching real yq
+/// v4.53.3 -- it does not renormalize through `f64`. Before this, all four
+/// collapsed (`2.50` -> `2.5`, `1e3` -> `1000`).
+#[test]
+fn test_tonumber_preserves_source_spelling_1090() -> Result<()> {
+    for (text, want) in [
+        ("2.0", "2.0"),
+        ("2.50", "2.50"),
+        ("1.500", "1.500"),
+        ("1e3", "1e3"),
+        ("1E5", "1E5"),
+        ("2e0", "2e0"),
+        ("2", "2"),
+    ] {
+        let input = format!("a: \"{text}\"\n");
+        let (out, code) = run_yq_stdin(".a | tonumber", &input, &[])?;
+        assert_eq!(code, 0, "for {text:?}");
+        assert_eq!(out.trim(), want, "for {text:?}");
+    }
+    Ok(())
+}
+
+/// #1176: an explicit `!!float` tag on an int-shaped scalar must survive
+/// the DOM route's JSON reindex bridge. It used to reach the bridge as a
+/// bare `Float`, serialize as `2`, and reparse as an `Int` -- silently
+/// changing the value's type. Reproducible with no `-i` at all.
+///
+/// This gates #1090: once tag emission exists, succinctly's own output
+/// becomes an input of exactly this shape, so a second `-i` edit would
+/// otherwise lose the type (see
+/// `test_computed_whole_float_inplace_stays_float_typed_949`).
+#[test]
+fn test_explicit_float_tag_survives_reindex_bridge_1176() -> Result<()> {
+    // `--slurp` takes the same DOM route as `-i`, without a temp file.
+    let (out, code) = run_yq_stdin(".[0].a | tag", "a: !!float 2\n", &["--slurp"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "!!float");
+
+    let (out, code) = run_yq_stdin(".[0].a + 1 | tag", "a: !!float 2\n", &["--slurp"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "!!float");
+
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1090. Also materially fixes #1176.

## Summary

Real yq keeps a computed float's type unambiguous by tagging it at any nested position, dropping the decimal point only at document-root scalar position (where it suppresses *every* tag):

```
$ printf 'a: 1.0\n' | yq '.a += 1'     # real yq v4.53.3
a: !!float 2
$ printf 'a: 1.0\n' | succinctly yq '.a += 1'   # before
a: 2.0                                  # type-correct, not byte-identical
```

## The issue's own plan was wrong, and this supersedes it

#1090's 2026-08-20 comment concluded — from PR #1179's failure — that yq's rule depends on **how a value was produced** (arithmetic -> tagged, `tonumber` -> untagged), that `OwnedValue::Float` carries no such provenance, and that an **ADR-0018 + ~183-site `NumberSource`/`NumberOrigin` widening must land first**, blocking nine issues.

Widening the oracle probe set by one input collapsed that theory:

```
$ printf 'a: "2e0"\n' | yq '.b = (.a|tonumber)'
b: 2e0        # the EXACT source text, not 2.0
```

Also `"2.50"`->`2.50`, `"1.500"`->`1.500`, `"1e3"`->`1e3`, `"007"`->`007`. yq is not tracking provenance — it is **preserving the source spelling**, and `(.a|tonumber) + 0` *is* tagged because arithmetic replaces that spelling with Go's `%v` output.

**The real rule is a pure function of (node tag, node text): tag iff re-resolving the text about to be printed would not yield `!!float`.** Verified over a 41-value sweep — `1`, `0`, `-1`, `1000`, `100000` tagged; `-0`, `0.5`, `2.5`, `1e+06`, `1e-05`, `1e+10`, `1e+300` not. `1.0/0` -> `!!float +Inf`, tagged because `+Inf` resolves as `!!str`.

succinctly already had both halves of that rule: the `Float`-vs-`NumberLiteral(repr, text)` split, and `into_plain_number()` — which every arithmetic op already calls — dropping the spelling on exactly the operations that make yq start tagging. No new type, no wide refactor. `format_float_yq_yaml`'s spelling already equalled yq's on 26/26 swept values, so only the tag prefix is new.

Two further corrections posted on the issue: `-0` is not an exception (YAML resolves it as `!!float`), and the "619 `GenericResult::` sites" precedent the plan cites does not appear in ADR-0017 at all.

## Commits

1. **`fix(yaml): keep a tag-forced float's type across the JSON reindex bridge`** — the #1176 gate. Root-caused to the *bridge*, not the reader: `--slurp '.[0]'` on `a: !!float 2` gave `a: 2` with no `-i` involved. A scalar that is only a float because a tag forced it has an integer-shaped mantissa, so it falls through to a bare `Float`, which `to_json_for_reindex`'s jq-mode fallback serializes as `2` — reparsing as an `Int`. Fixed read-side by giving it a float-shaped literal. Deliberately **not** by flipping the bridge to `YqSemantics`, which re-breaks #978 (and would change JSON-sourced `1e20`/`1e100` output).

   Also adds `needs_explicit_float_tag`, defined as `!matches!(resolve_plain(text), Float(_))` — the reader's own answer, so emitter and reader cannot drift (CLAUDE.md's #106 lesson), and whatever this crate writes it reads back at the same type.

2. **`fix(jq): preserve tonumber's source spelling instead of collapsing it`** — required; without it this reproduces PR #1179's exact regression. Real jq 1.7.1 preserves the spelling too, so succinctly was wrong in **both** modes (`"2.50"`->`2.5`, `"1e3"`->`1000`). Gated on strict RFC 8259 syntax and explicitly *not* on `from_number_bytes`, which decodes the internal `9e999e999` NaN sentinel that jq rejects outright.

3. **`fix(yq): emit an explicit !!float tag on a nested computed whole float`** — the two YAML emitters. `-o json`, `@yaml`, `@props`, `tostring` and the reindex bridge are untouched; a tag is not valid in any of them.

## Verification

Oracle matrix against real yq v4.53.3 (script checked in under `.ai/scratch/`, gitignored): **44 ok, 2 diff**.

Both diffs are known and accepted:
- `-0.0` -> `!!float -0` vs yq's `-0`. The one value in the sweep where the reader-anchored predicate diverges; it is the type-safe side, since succinctly's own reader calls a bare `-0` an int. Filed as #1355 — fixing `resolve_plain` there makes this byte-identical **with no change to this PR's code**.
- `join` on an array-wrapped computed float. Pre-existing and already documented in-tree as `test_yq_array_wrapped_computed_float_keeps_scientific_notation_known_gap_1168`.

Every gate transcribed from `.github/workflows/ci.yml` and run sequentially: full suite plus the `simd`, `portable-popcount`, `simd,scalar-yaml` and `SUCCINCTLY_SIMD=sse2` legs, all three clippy invocations, `fmt`, `no_std`, rustdoc. All pass. Re-run in full after a concurrent process rebased this branch onto a main that had landed overlapping number-canonicalization work (#999); #978's behaviour confirmed intact (`{"a":1e2}` still renders `100`).

## Follow-ups filed

- #1355 — `resolve_plain` types `-0` as `!!int` where yq says `!!float`
- #1356 — `tonumber` drops non-JSON spellings (`+2.0`, `007`, `2.`, `.5`)

Provenance may still be genuinely required for #1144/#1168 — `yq_float_fidelity_fixup`'s own doc comment makes an independent argument that it cannot distinguish document-sourced from computed floats after the fact. That is untouched here; only #1090's provenance claim is retracted.