### PR TITLE
fix(ci, test): add yq commit scope, extend scope drift guard for wildcard filenames

### DIFF
--- a/.omni-dev/scopes.yaml
+++ b/.omni-dev/scopes.yaml
@@ -19,6 +19,10 @@ scopes:
     description: "jq query language parser and evaluator"
     examples: ["jq: add array slicing", "jq: fix negative index"]
     file_patterns: ["src/jq/**"]
+  - name: "yq"
+    description: "yq CLI mode: YAML-flavoured query semantics and yq-oracle compatibility"
+    examples: ["yq: emit an explicit !!float tag on nested computed floats", "yq: match real yq's bare sub() replace-all"]
+    file_patterns: ["src/bin/succinctly/yq_*.rs", "tests/yq_*.rs", "tests/data/yq-golden/**", "benches/yq_*.rs", "docs/benchmarks/yq.md", "docs/reference/yq-language.md"]
   - name: "dsv"
     description: "DSV/CSV semi-indexing and parsing"
     examples: ["dsv: add BMI2 quote indexing", "dsv: fix delimiter escaping"]

--- a/tests/scopes_yaml_tests.rs
+++ b/tests/scopes_yaml_tests.rs
@@ -120,7 +120,32 @@ fn pattern_matches_something(root: &Path, pattern: &str) -> bool {
     if !pattern.contains('/') && pattern.contains('*') {
         return matches_bare_wildcard(root, pattern);
     }
+    if let Some((dir, filename_glob)) = pattern.rsplit_once('/') {
+        if filename_glob.contains('*') {
+            return matches_wildcard_in_dir(root, dir, filename_glob);
+        }
+    }
     root.join(pattern).exists()
+}
+
+/// Resolves a `dir/prefix*suffix`-shaped pattern (a single `*` inside the
+/// final path segment, e.g. `"src/bin/succinctly/yq_*.rs"`) against real
+/// files directly inside `dir`.
+fn matches_wildcard_in_dir(root: &Path, dir: &str, filename_glob: &str) -> bool {
+    let Some((prefix, suffix)) = filename_glob.split_once('*') else {
+        return false;
+    };
+    let Ok(entries) = fs::read_dir(root.join(dir)) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|e| {
+        e.path().is_file() && {
+            let name = e.file_name().to_string_lossy().into_owned();
+            name.len() >= prefix.len() + suffix.len()
+                && name.starts_with(prefix)
+                && name.ends_with(suffix)
+        }
+    })
 }
 
 /// Resolves a `/**`-stripped prefix like `src/*/simd` against real
@@ -430,6 +455,27 @@ fn pattern_matches_something_stats_the_concrete_prefix() {
     assert!(pattern_matches_something(root, "src/*/simd/**"));
     assert!(pattern_matches_something(root, "*.md"));
     assert!(!pattern_matches_something(root, "*.rs"));
+}
+
+#[test]
+fn pattern_matches_something_supports_wildcard_filename_in_a_real_dir() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src/bin/succinctly")).unwrap();
+    fs::write(root.join("src/bin/succinctly/yq_runner.rs"), "").unwrap();
+
+    assert!(pattern_matches_something(
+        root,
+        "src/bin/succinctly/yq_*.rs"
+    ));
+    assert!(!pattern_matches_something(
+        root,
+        "src/bin/succinctly/xq_*.rs"
+    ));
+    assert!(!pattern_matches_something(
+        root,
+        "src/bin/nonexistent/yq_*.rs"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a dedicated `yq` scope to `.omni-dev/scopes.yaml`, pointing at yq's own runner, CLI tests, golden fixtures, benchmarks, and docs — closes #1363.
- Extend `tests/scopes_yaml_tests.rs`'s hand-rolled pattern matcher to resolve a `dir/prefix*suffix` glob (e.g. `src/bin/succinctly/yq_*.rs`) against a real directory's contents, since the new scope's file_patterns use that shape and the existing matcher would have silently treated them as literal, always-missing paths.

## Test plan
- [x] `cargo test --test scopes_yaml_tests` — all 11 tests pass, including a new case covering the wildcard-filename matcher
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `omni-dev git commit message lint --verbose HEAD~1..HEAD` — 0 errors, 0 warnings
- [x] Manually confirmed the exact commit message the issue cites as failing (`fix(yq): scope the tag-forced float respelling to the reindex bridge`) now lints clean via `omni-dev git commit message lint --stdin`