### PR TITLE
fix(jq): remove del()'s discarded terminal-optional merge, verify the rest

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20901,20 +20901,31 @@ enum ArrayStep {
 ///
 /// `paths` here always traces back to [`resolve_dynamic_indexes`]'s own
 /// output, which strips every `Expr::Optional` wrapper via
-/// `strip_resolved_optional` before returning (#1331's own investigation
-/// confirmed this holds for every comma-grouped shape that can reach
-/// `delete_expr_paths_at`/this function at all, live-tested across field,
-/// index, and iterate steps -- including a mixed comma with one computed
-/// and one already-static branch, where `resolve_dynamic_indexes` still
-/// strips the static branch before this function ever sees it). So
-/// `optional` below is always `false` in practice; kept as a live value
-/// (not deleted) rather than hardcoded, with a `debug_assert` verifying the
-/// invariant rather than silently trusting it -- #1331 found that a
-/// sibling claim ("this can never be true") was wrong for a *different*
-/// consumer of the same `DeleteStep.optional` field
-/// ([`yq_del_slice_outcome`]'s own `wrap` closure, reachable via
-/// `del(.a?[1:3])`-shaped input), so this function's own narrower version
-/// of the claim is verified here rather than assumed to generalize.
+/// `strip_resolved_optional` before returning -- so `optional` below is
+/// always `false` in practice; kept as a live value (not deleted) rather
+/// than hardcoded, with a `debug_assert` verifying the invariant rather
+/// than silently trusting it (#1331 found that an identically-worded
+/// claim was wrong for a *different* consumer of the same
+/// `DeleteStep.optional` field -- [`yq_del_slice_outcome`]'s own `wrap`
+/// closure, reachable via `del(.a?[1:3])`-shaped input -- so each site's
+/// own version of the claim needs its own verification, not assumed to
+/// generalize).
+///
+/// This function itself may be entirely unreachable from `del()`'s own
+/// comma-grouped route: extensive live probing (#1331's second review
+/// round, three independent passes) found `resolve_node`'s own handling
+/// of `Expr::Iterate` eagerly expands a bare `.[]`/`.[]?` into concrete
+/// per-element `Field`/`Index` components *before* `flatten_delete_path`
+/// ever runs, for every shape tried -- meaning a literal `DeleteStep`
+/// carrying `Expr::Iterate` may never actually get constructed via
+/// `builtin_del`'s `paths.len() > 1` branch (the only external entry to
+/// `delete_expr_paths_at`) at all. Left as-is rather than removed:
+/// proving a function is *never* reachable, as opposed to not reachable
+/// via every input tried so far, needs more exhaustive verification than
+/// #1331's own scope covers -- filed as #1382 rather than assumed here.
+/// If genuinely dead, the `debug_assert` below (and the two `optional`-
+/// gated match arms further down, pre-dating this issue) are dead along
+/// with it, harmlessly.
 fn delete_expr_iterate_paths(
     value: OwnedValue,
     paths: &[&[DeleteStep]],

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20741,7 +20741,25 @@ fn delete_expr_array_paths(
     // element, and the linear `find`/scan these two used to do never matched,
     // so every sibling walked the whole growing list. 99.9% of a 200,000-element
     // run's samples sat in those two loops.
-    let mut terminal: IndexMap<ArrayStep, bool> = IndexMap::new();
+    //
+    // `IndexSet<ArrayStep>`, not `IndexMap<ArrayStep, bool>`: an earlier form
+    // (both here and in the pre-#1301 `Vec` version) also merged each step's
+    // `optional` flag (`*entry.or_insert(false) |= path[start].optional`) to
+    // cover every occurrence rather than just whichever sibling was inserted
+    // first. That merged bool had no reader -- the one consumer below
+    // (building `owned_keys` for `delete_keys`) already discarded it. Dropped,
+    // not because the flag can never be `true` here (#1331's investigation
+    // found the broader claim that it can't doesn't generalize past this
+    // specific dead-write site -- see `delete_expr_iterate_paths`'s own doc
+    // comment for the narrower, verified version of that claim), but because
+    // deleting a *terminal* index/slice always goes through `delete_keys`,
+    // which already silently skips a step naming nothing to delete
+    // (#415/#477) -- `optional` never had anything left to gate once it
+    // reached this merge, whether or not it was ever `true`. Order-
+    // independence for `del(.[(0,5)], .[5]?)` (either argument order) still
+    // holds: `IndexSet::insert` already dedupes a repeated `step` regardless
+    // of which occurrence's own `?` set the (now-untracked) flag.
+    let mut terminal: IndexSet<ArrayStep> = IndexSet::new();
     let mut groups: IndexMap<ArrayStep, Vec<&[DeleteStep]>> = IndexMap::new();
     for path in paths {
         let step = match &path[start].component {
@@ -20750,12 +20768,7 @@ fn delete_expr_array_paths(
             _ => unreachable!("delete_expr_paths_at only dispatches Index/Slice paths here"),
         };
         if path.len() == start + 1 {
-            // One occurrence of `step` marking it optional is enough to cover
-            // every other occurrence — merge rather than keep only whichever
-            // one was inserted first, which used to make the outcome depend on
-            // argument order (`del(.[(0,5)], .[5]?)` errored or not
-            // depending on which side `.[5]?` was written on).
-            *terminal.entry(step).or_insert(false) |= path[start].optional;
+            terminal.insert(step);
             continue;
         }
         groups.entry(step).or_default().push(*path);
@@ -20779,11 +20792,18 @@ fn delete_expr_array_paths(
         // any comma-grouped `del()` path reaches `flatten_delete_path`, so
         // no `DeleteStep` here can ever carry `optional == true`. Fourth
         // occurrence of this repo's "optional never forced true in nested
-        // calls" bug family (#928, #1003, #1034) -- a sibling instance in
-        // `delete_expr_iterate_paths` below, and the general fix (a
-        // `debug_assert` at `DeleteStep`'s own construction site instead
-        // of a fifth discovery), are tracked separately, out of scope
-        // here.
+        // calls" bug family (#928, #1003, #1034), and a sibling instance
+        // fixed the same way in `delete_expr_iterate_paths` below -- but
+        // #1331's investigation found the *general* form of this claim
+        // (a single `debug_assert` at `DeleteStep`'s own construction
+        // site in `flatten_delete_path`, covering every caller at once)
+        // does not hold: `DeleteStep.optional` genuinely is `true` in
+        // live-reachable input for `yq_del_slice_outcome`'s own internal
+        // use (`del(.a?[1:3])`, confirmed live), a different consumer of
+        // the same field that isn't reached through this comma-grouped
+        // machinery at all. Each site's own version of "is this ever
+        // true here" needs verifying on its own terms, not assumed to
+        // generalize from this one.
         //
         // *Which* sentence comes from `paths[0]` specifically, because jq
         // walks the paths in source order and dies on the first: the
@@ -20848,7 +20868,7 @@ fn delete_expr_array_paths(
     if !terminal.is_empty() {
         let owned_keys: Vec<OwnedValue> = terminal
             .iter()
-            .map(|(step, _)| match step {
+            .map(|step| match step {
                 ArrayStep::Index(idx) => OwnedValue::Int(*idx),
                 ArrayStep::Slice(s, e) => slice::literal_component(*s, *e),
             })
@@ -20881,12 +20901,35 @@ enum ArrayStep {
 /// is nothing to group. Either every path ends here, clearing the whole
 /// container, or every path continues, and each element/value recurses with
 /// the same sibling list.
+///
+/// `paths` here always traces back to [`resolve_dynamic_indexes`]'s own
+/// output, which strips every `Expr::Optional` wrapper via
+/// `strip_resolved_optional` before returning (#1331's own investigation
+/// confirmed this holds for every comma-grouped shape that can reach
+/// `delete_expr_paths_at`/this function at all, live-tested across field,
+/// index, and iterate steps -- including a mixed comma with one computed
+/// and one already-static branch, where `resolve_dynamic_indexes` still
+/// strips the static branch before this function ever sees it). So
+/// `optional` below is always `false` in practice; kept as a live value
+/// (not deleted) rather than hardcoded, with a `debug_assert` verifying the
+/// invariant rather than silently trusting it -- #1331 found that a
+/// sibling claim ("this can never be true") was wrong for a *different*
+/// consumer of the same `DeleteStep.optional` field
+/// ([`yq_del_slice_outcome`]'s own `wrap` closure, reachable via
+/// `del(.a?[1:3])`-shaped input), so this function's own narrower version
+/// of the claim is verified here rather than assumed to generalize.
 fn delete_expr_iterate_paths(
     value: OwnedValue,
     paths: &[&[DeleteStep]],
     start: usize,
 ) -> Result<OwnedValue, EvalError> {
     let optional = paths[0][start].optional;
+    debug_assert!(
+        !optional,
+        "delete_expr_iterate_paths: DeleteStep.optional should always be false here -- \
+         resolve_dynamic_indexes strips Expr::Optional before any comma-grouped del() path \
+         reaches this function (#1331)"
+    );
     if paths[0].len() == start + 1 {
         return match value {
             OwnedValue::Array(mut arr) => {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20784,27 +20784,24 @@ fn delete_expr_array_paths(
     if !matches!(value, OwnedValue::Array(_)) {
         // A non-array container fails every path here identically, so a
         // single non-optional path among the siblings has to raise even
-        // when others are optional -- this used to be gated behind
-        // `paths.iter().all(|p| p[start].optional)`, unconditionally
-        // errors now instead, because that gate was dead (#1322):
+        // when others are optional -- unconditional since #1322 found the
+        // old `paths.iter().all(|p| p[start].optional)` gate dead:
         // `resolve_dynamic_indexes`'s `assemble` strips every
-        // `Expr::Optional` wrapper via `strip_resolved_optional` before
-        // any comma-grouped `del()` path reaches `flatten_delete_path`, so
-        // no `DeleteStep` here can ever carry `optional == true`. Fourth
-        // occurrence of this repo's "optional never forced true in nested
-        // calls" bug family (#928, #1003, #1034), and a sibling instance
-        // fixed the same way in `delete_expr_iterate_paths` below -- but
-        // #1331's investigation found the *general* form of this claim
-        // (a single `debug_assert` at `DeleteStep`'s own construction
-        // site in `flatten_delete_path`, covering every caller at once)
-        // does not hold: `DeleteStep.optional` genuinely is `true` in
-        // live-reachable input for `yq_del_slice_outcome`'s own internal
-        // use (`del(.a?[1:3])`, confirmed live), a different consumer of
-        // the same field that isn't reached through this comma-grouped
-        // machinery at all. Each site's own version of "is this ever
-        // true here" needs verifying on its own terms, not assumed to
-        // generalize from this one.
-        //
+        // `Expr::Optional` before any comma-grouped `del()` path reaches
+        // `flatten_delete_path`, so no `DeleteStep` here can carry
+        // `optional == true`. Verified (not just asserted in a comment,
+        // #1331): see `delete_expr_iterate_paths`'s matching
+        // `debug_assert` below for the full rationale, including the one
+        // confirmed exception (`yq_del_slice_outcome`'s own `wrap`
+        // closure, a different, non-comma-grouped consumer of the same
+        // field) that this crate's usual "optional never forced true"
+        // pattern (#928/#1003/#1034) doesn't cover here.
+        debug_assert!(
+            !paths.iter().any(|p| p[start].optional),
+            "delete_expr_array_paths: no DeleteStep here should ever carry optional == true -- \
+             resolve_dynamic_indexes strips Expr::Optional before any comma-grouped del() path \
+             reaches this function (#1331)"
+        );
         // *Which* sentence comes from `paths[0]` specifically, because jq
         // walks the paths in source order and dies on the first: the
         // `Slice { .. } => "object"`/catch-all `"number"` arms below are

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15678,15 +15678,18 @@ fn test_1331_comma_computed_key_and_static_optional_sibling_dedup() -> Result<()
     Ok(())
 }
 
-/// #1331: the other two tests above reach `delete_expr_array_paths`
-/// (Index/Slice siblings), not `delete_expr_iterate_paths` -- neither
-/// exercises the debug_assert added to that function specifically. Two
-/// top-level comma branches each ending in a `?`-marked bare iterate
-/// forces the multi-path walker's `Iterate` dispatch, verifying the
-/// invariant holds (this test would panic in a debug build if it didn't)
-/// as well as the ordinary "each array gets cleared" behavior.
+/// #1331: two top-level comma branches each ending in a `?`-marked bare
+/// iterate. This was originally meant to exercise `delete_expr_iterate_paths`'s
+/// own `debug_assert`, but a live debug probe (#1331's second review
+/// round) found it doesn't: `resolve_node` eagerly expands `.a[]`/`.b[]?`
+/// into concrete per-element `Index` components before `flatten_delete_path`
+/// ever runs, so this actually reaches `delete_expr_array_paths` (already
+/// covered above) -- see `delete_expr_iterate_paths`'s own doc comment and
+/// #1382 for whether that function is reachable via `del()` at all. Kept
+/// as a plain correctness regression test for this realistic input shape,
+/// not as coverage for that specific debug_assert.
 #[test]
-fn test_1331_comma_optional_iterate_siblings_reach_iterate_dispatch() -> Result<()> {
+fn test_1331_comma_optional_iterate_siblings_clear_both_arrays() -> Result<()> {
     let (out, code) = run_yq_stdin(
         "del(.a[]?, .b[]?)",
         "a: [1,2]\nb: [3,4,5]\n",

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15678,6 +15678,25 @@ fn test_1331_comma_computed_key_and_static_optional_sibling_dedup() -> Result<()
     Ok(())
 }
 
+/// #1331: the other two tests above reach `delete_expr_array_paths`
+/// (Index/Slice siblings), not `delete_expr_iterate_paths` -- neither
+/// exercises the debug_assert added to that function specifically. Two
+/// top-level comma branches each ending in a `?`-marked bare iterate
+/// forces the multi-path walker's `Iterate` dispatch, verifying the
+/// invariant holds (this test would panic in a debug build if it didn't)
+/// as well as the ordinary "each array gets cleared" behavior.
+#[test]
+fn test_1331_comma_optional_iterate_siblings_reach_iterate_dispatch() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[]?, .b[]?)",
+        "a: [1,2]\nb: [3,4,5]\n",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[],"b":[]}"#);
+    Ok(())
+}
+
 /// del()'s parent-key rule applies to an array target too (#1162 widened it
 /// from #1116's original scalar-only scope) — real yq drops the whole `a`
 /// key, not a partial 2-element range, whatever bounds are given (verified

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15643,6 +15643,41 @@ fn test_1116_chained_scalar_slice_del_with_optional() -> Result<()> {
     Ok(())
 }
 
+/// #1331: unlike the `?`-on-the-slice case above, `.a?[0:1]` puts the `?`
+/// on the *field* preceding the chained slice -- the shape that actually
+/// makes `yq_del_slice_outcome`'s own `DeleteStep.optional` (and its
+/// `wrap` closure) live-true, per #1331's own investigation. `.a` exists
+/// here, so the rewrite still drops it outright either way; this pins the
+/// same observable outcome as the unmarked form, guarding against a
+/// regression in `wrap`'s Optional-preserving rewrite (`Expr::Optional`
+/// wrapped back around the dropped parent key) changing this.
+#[test]
+fn test_1331_field_level_optional_before_chained_slice_del() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a?[0:1])", r#"{"a":5,"b":6}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":6}"#);
+    Ok(())
+}
+
+/// #1331: a comma of a computed-key branch (needing real path resolution)
+/// alongside an already-static branch carrying its own `?` -- the same
+/// shape `del(.[(0,5)], .[5]?)` that originally motivated merging each
+/// sibling's `optional` flag into `delete_expr_paths_at`'s `terminal`
+/// list (a merge #1331 found had no reader and removed). Both branches
+/// name index 5; deleting it twice (once via the generator, once via the
+/// redundant `?`-marked static index) must not error either way.
+#[test]
+fn test_1331_comma_computed_key_and_static_optional_sibling_dedup() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.[(0,5)], .[5]?)",
+        "[0,1,2,3,4,5]",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2,3,4]");
+    Ok(())
+}
+
 /// del()'s parent-key rule applies to an array target too (#1162 widened it
 /// from #1116's original scalar-only scope) — real yq drops the whole `a`
 /// key, not a partial 2-element range, whatever bounds are given (verified


### PR DESCRIPTION
## Summary

#1331 claimed `DeleteStep.optional` is "dead end-to-end" (never constructed as `true` in any way that reaches a live consumer) and suggested a `debug_assert!(!optional)` at its own construction site in `flatten_delete_path` as "the real fix."

Live verification (see below) found this premise is **partially wrong** — implementing the suggested fix as literally described would have introduced a live, reachable panic in debug builds.

## What's actually true (verified live)

- **`delete_expr_paths_at`'s own comma-grouped consumers** (`delete_expr_iterate_paths`, and the `terminal` vector's merge logic) genuinely never see `optional == true` — confirmed via extensive live probing (couldn't construct a counter-example across field/index/slice/iterate shapes, including mixed commas with one computed-key branch and one static branch). `resolve_dynamic_indexes`'s `assemble()` does strip `Expr::Optional` before any path reaches this specific machinery. This part of #1331's premise holds.
- **A *different* consumer does not have this guarantee**: `yq_del_slice_outcome`'s own `wrap` closure (reached via `rewrite_yq_del_comma_branches`'s pre-rewrite pass, and `builtin_del`'s own per-path calls) genuinely receives `DeleteStep.optional == true` on ordinary, live-reachable input — confirmed via `del(.a?[1:3])` (optional on the field, not the slice) and `del(.[(0,5)], .[5]?)` (a mixed comma). A `debug_assert!(!optional)` at `flatten_delete_path`'s own construction site — the general fix #1331 suggested — would have panicked on exactly this input in any debug build, including this crate's own `cargo test`.
- That said, `wrap`'s optional-preserving rewrite (re-wrapping the dropped parent key in `Expr::Optional`) turned out to be **observably inert everywhere I could test**: `yq_del_slice_outcome` already gates entry to `wrap` on `navigate_read_only` confirming the whole prefix exists, so by the time `wrap` runs, deleting that prefix can never error regardless of whether it's wrapped in `Optional` or not. I didn't find a way to make this matter, but I also didn't find a way to *prove* it can't — so I left `wrap`'s own logic untouched rather than risk removing something I can't fully rule out being load-bearing.

## What changed

- Simplified `delete_expr_paths_at`'s `terminal: Vec<(ArrayStep, bool)>` to `Vec<ArrayStep>` — the merged `optional` bool (`entry.1 |= path[start].optional`) was computed but its only consumer already discarded it via `.map(|(step, _)| ...)`. This part of #1331's finding #2 was correct and is a safe, zero-behavior-change cleanup.
- Added a `debug_assert!` in `delete_expr_iterate_paths` itself — correctly scoped to *that function's own* verified invariant, not the general `DeleteStep` type. Replaced the stale comment (in both this function and the neighboring `delete_expr_paths_at` non-array-container branch) that had generalized the claim beyond what's actually true.
- Did **not** add anything at `flatten_delete_path`'s construction site, and did **not** remove `DeleteStep.optional`/its plumbing — both would be wrong given the live counter-example above.

## Verification

- Two new CLI tests: `del(.a?[1:3])`-shaped input (field-level optional before a chained slice — the shape that's actually live-true) and the `del(.[(0,5)], .[5]?)` mixed-comma dedup shape from #1331's own example.
- Full local suite (build, full test suite — debug mode, so the new `debug_assert!` gets exercised — both CI clippy legs, `cargo doc --no-deps --all-features` under `-D warnings`, `no_std` check, `cargo fmt --check`) all green.
- Patch coverage: no new uncovered lines.

Refs #1331