### PR TITLE
perf(jq): make del() linear by hashing its sibling grouping, not scanning it

### DIFF
--- a/benches/jq_write_path_bench.rs
+++ b/benches/jq_write_path_bench.rs
@@ -83,6 +83,35 @@ fn computed_key_doc(n: usize) -> Vec<u8> {
     format!(r#"{{"items":[{one},{one}]}}"#).into_bytes()
 }
 
+/// [`computed_key_doc`]'s object-valued twin: `{"items": [{"foo": {"k0": 0,
+/// ...}}, {...}]}`. `del(.items[(0,1)].foo[])` over this routes the same
+/// per-element siblings into `delete_expr_object_paths`' grouping rather
+/// than `delete_expr_array_paths`', which is a separate copy of the same
+/// logic and was quadratic in the same way (#1301). `bench_del_object` does
+/// not cover it -- without a computed key, `del(.foo[])` takes
+/// `builtin_del`'s single-path route and never reaches the grouping at all.
+fn computed_key_object_doc(n: usize) -> Vec<u8> {
+    let one = object_doc(n);
+    let one = core::str::from_utf8(&one).unwrap();
+    format!(r#"{{"items":[{one},{one}]}}"#).into_bytes()
+}
+
+/// `{"foo": [{"a": 0, "b": 0, "c": 0}, ...]}` -- for the comma-through-iterate
+/// shape (`del(.foo[].a, .foo[].b)`), which needs no computed key at all to
+/// reach the multi-path delete walker: a top-level comma already routes there
+/// (#475), and the `[]` ahead of it still enumerates one sibling per element.
+fn comma_through_iterate_doc(n: usize) -> Vec<u8> {
+    let mut out = String::from(r#"{"foo":["#);
+    for i in 0..n {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(&format!(r#"{{"a":{i},"b":{i},"c":{i}}}"#));
+    }
+    out.push_str("]}");
+    out.into_bytes()
+}
+
 /// Evaluate `expr` against `json`, asserting it produced exactly one
 /// non-error output (every shape benchmarked here is a single-document
 /// write or a `[path(...)]`-collected array, never a fan-out), and return
@@ -306,30 +335,31 @@ fn bench_computed_key_with_trailing_iterate(c: &mut Criterion) {
     group.finish();
 }
 
-/// The `del` half of the shape above, which #888 did **not** make linear.
+/// The `del` half of the shape above, which #888 did **not** make linear and
+/// #1301 since has.
 ///
-/// #888's own table reported `del`/`=`/`|=` as flat on this shape, but it
-/// stopped at 16,000 elements. `=` and `|=` really are linear; `del` is not
-/// -- it only looks flat because its constant is small enough that the
-/// quadratic term does not dominate until roughly 50,000 elements. Measured
-/// on an Apple M-series, release, total elements = 2n:
+/// #888's own table reported `del`/`=`/`|=` as flat here, but it stopped at
+/// 16,000 elements; `del`'s quadratic term did not dominate until roughly
+/// 50,000. The cause was **not** the trailing-iterate deferral `path()` got
+/// -- widening the computed key from 2 branches to 512 while holding the
+/// resolved-path count at 80,000 took `del` from 890ms to 95ms, which a
+/// deferral-shaped cost cannot do -- but `delete_expr_array_paths`'
+/// own sibling grouping, which scanned an insertion-ordered `Vec` linearly
+/// per sibling. Interleaved A/B, Apple M-series, release, total elements = 2n:
 ///
-/// | 2n      | del    | path  |
-/// |---------|--------|-------|
-/// | 20,000  | 0.10s  | 0.03s |
-/// | 50,000  | 0.54s  | 0.07s |
-/// | 100,000 | 1.51s  | 0.10s |
-/// | 200,000 | 5.98s  | 0.20s |
+/// | 2n      | before  | after  | path  |
+/// |---------|---------|--------|-------|
+/// | 20,000  |  0.07s  | 0.02s  | 0.03s |
+/// | 100,000 |  1.34s  | 0.09s  | 0.10s |
+/// | 200,000 |  5.92s  | 0.20s  | 0.20s |
+/// | 400,000 | 22.03s  | 0.38s  | 0.72s |
 ///
-/// So the sizes here are deliberately capped well below the other groups'
-/// `SIZES`, small enough to finish in reasonable time under that *existing*
-/// bug rather than chosen for statistical smoothness -- the same convention
-/// `bench_computed_key_with_trailing_iterate` used before #888 landed.
-/// Raise them to `SIZES` once `del` is linear here too.
+/// So this shares the other groups' `SIZES` now, where it used to be capped
+/// at 1,000/5,000/10,000 to finish in reasonable time under the bug.
 fn bench_del_computed_key_with_trailing_iterate(c: &mut Criterion) {
     let mut group = c.benchmark_group("jq_write_path_del_computed_key_trailing_iterate");
     let expr = parse("del(.items[(0,1)].foo[])").expect("must parse");
-    for &n in &[1_000usize, 5_000, 10_000] {
+    for &n in SIZES {
         let json = computed_key_doc(n);
 
         // Guard the premise: both `.items` entries must come back emptied,
@@ -367,6 +397,93 @@ fn bench_del_computed_key_with_trailing_iterate(c: &mut Criterion) {
     group.finish();
 }
 
+/// [`bench_del_computed_key_with_trailing_iterate`]'s object-tail twin,
+/// covering `delete_expr_object_paths`' half of #1301's fix. Interleaved
+/// A/B, Apple M-series, release, total elements = 2n: 20,000 0.18s -> 0.03s;
+/// 80,000 2.02s -> 0.12s.
+fn bench_del_computed_key_with_trailing_iterate_object(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_del_computed_key_trailing_iterate_object");
+    let expr = parse("del(.items[(0,1)].foo[])").expect("must parse");
+    for &n in SIZES {
+        let json = computed_key_object_doc(n);
+
+        // Guard the premise, as the array twin does: both `.items` entries
+        // must come back with an emptied object, so a bug that turns this
+        // into a no-op fails here instead of reading as a speedup.
+        let OwnedValue::Object(doc) = eval_one(&expr, &json) else {
+            panic!("n={n}: query must produce an object");
+        };
+        let Some(OwnedValue::Array(items)) = doc.get("items") else {
+            panic!("n={n}: `.items` must survive as an array");
+        };
+        assert_eq!(items.len(), 2, "n={n}: both branches must survive");
+        for (i, item) in items.iter().enumerate() {
+            let OwnedValue::Object(item) = item else {
+                panic!("n={n}: `.items[{i}]` must stay an object");
+            };
+            let Some(OwnedValue::Object(entries)) = item.get("foo") else {
+                panic!("n={n}: `.items[{i}].foo` must stay an object");
+            };
+            assert!(
+                entries.is_empty(),
+                "n={n}: `.items[{i}].foo` must be emptied"
+            );
+        }
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements(2 * n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
+/// The shape that reaches #1301's grouping without any computed key.
+///
+/// `del(.foo[].a, .foo[].b)` is an ordinary two-path comma, but the multi-path
+/// walker it routes through saw one `Index(i)` sibling per element all the
+/// same, and `delete_expr_array_paths`' *group* loop -- a different loop from
+/// the terminal one the computed-key groups above exercise -- scanned them
+/// linearly. Interleaved A/B, Apple M-series, release: 10,000 0.09s -> 0.04s;
+/// 20,000 0.28s -> 0.09s; 40,000 0.96s -> 0.17s (before, x3.0 and x3.5 per
+/// doubling; after, x1.95 and x1.92).
+fn bench_del_comma_through_iterate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_del_comma_through_iterate");
+    let expr = parse("del(.foo[].a, .foo[].b)").expect("must parse");
+    for &n in SIZES {
+        let json = comma_through_iterate_doc(n);
+
+        // Guard the premise: every element must lose `a` and `b` and keep `c`.
+        let OwnedValue::Object(doc) = eval_one(&expr, &json) else {
+            panic!("n={n}: query must produce an object");
+        };
+        let Some(OwnedValue::Array(items)) = doc.get("foo") else {
+            panic!("n={n}: `.foo` must survive as an array");
+        };
+        assert_eq!(items.len(), n, "n={n}: no element may be removed");
+        for (i, item) in items.iter().enumerate() {
+            let OwnedValue::Object(entries) = item else {
+                panic!("n={n}: `.foo[{i}]` must stay an object");
+            };
+            assert_eq!(entries.len(), 1, "n={n}: `.foo[{i}]` must keep exactly `c`");
+        }
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_del_array,
@@ -376,5 +493,7 @@ criterion_group!(
     bench_path_trailing_iterate,
     bench_computed_key_with_trailing_iterate,
     bench_del_computed_key_with_trailing_iterate,
+    bench_del_computed_key_with_trailing_iterate_object,
+    bench_del_comma_through_iterate,
 );
 criterion_main!(benches);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19,7 +19,7 @@ use alloc::vec::Vec;
 #[cfg(test)]
 use std::borrow::Cow;
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 
 use super::slice::{self, SliceBounds};
 
@@ -15219,10 +15219,23 @@ fn resolve_seq<'a, S: EvalSemantics>(
 ///   the iterate is still a fan-out stage.
 ///
 /// So this is `false` for `=`/`|=`/`del()`, which keeps them byte-identical
-/// to before #888. They pay for it: `del` on the same shape is quadratic too
-/// — not visible in #888's own table, which stopped at 16,000 elements, but
-/// 24.8s at 400,000 on `main` — tracked separately, since fixing it needs
-/// the four items above resolved rather than bypassed.
+/// to before #888. What they pay for it is `k * n` resolved path expressions
+/// where `path()` gets `k` — linear in the element count, with a real
+/// constant (each path's components are deep-cloned again on the way to the
+/// walkers), but linear.
+///
+/// It is *not* what made `del` quadratic on this shape. #888's follow-up
+/// (#1301) recorded 24.8s at 400,000 here and attributed it to this gate;
+/// measuring it says otherwise. Holding the resolved-path count fixed at
+/// 80,000 while widening the computed key from 2 branches to 512 — so this
+/// function emits exactly as many paths every time — took `del` from 890ms
+/// to 95ms, and a profile put 99.9% of the samples in
+/// `delete_expr_array_paths`. The quadratic was that function's own sibling
+/// grouping, which scanned an insertion-ordered `Vec` linearly per sibling;
+/// it and its three siblings are `IndexMap`/`IndexSet` now, and `del` on the
+/// repro is 22.0s -> 0.38s at 400,000. The four items above remain the
+/// reason this flag is `false`; they are not a prerequisite for `del`'s
+/// scaling.
 fn resolve_dynamic_indexes<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
@@ -20476,30 +20489,27 @@ fn delete_expr_object_paths(
         delete_expr_paths_through_absent(paths, start + 1)?;
         return Ok(value);
     }
-    let mut terminal: Vec<&str> = Vec::new();
-    let mut groups: Vec<(&str, Vec<&[DeleteStep]>)> = Vec::new();
+    // Insertion-ordered *and* hashed (#1301). Both structures used to be a
+    // plain `Vec` scanned linearly for a match, which is O(siblings) per
+    // sibling — fine for the handful a hand-written comma produces, quadratic
+    // once a computed key ahead of a trailing iterate turns every element into
+    // its own sibling (`del(.items[(0,1)].foo[])` over an object-valued
+    // `.foo`). The insertion order is load-bearing, not incidental: the
+    // recursion below visits groups in source order, which is the order jq
+    // dies in, so `IndexMap`/`IndexSet` rather than a `BTreeMap` — they keep
+    // that order structurally instead of leaving it to a parallel side index.
+    let mut terminal: IndexSet<&str> = IndexSet::new();
+    let mut groups: IndexMap<&str, Vec<&[DeleteStep]>> = IndexMap::new();
     for path in paths {
         let Expr::Field(name) = &path[start].component else {
             unreachable!("delete_expr_paths_at only dispatches Field paths here")
         };
         let name = name.as_str();
         if path.len() == start + 1 {
-            if !terminal.contains(&name) {
-                terminal.push(name);
-            }
+            terminal.insert(name);
             continue;
         }
-        let mut appended = false;
-        for group in &mut groups {
-            if group.0 == name {
-                group.1.push(*path);
-                appended = true;
-                break;
-            }
-        }
-        if !appended {
-            groups.push((name, vec![*path]));
-        }
+        groups.entry(name).or_default().push(*path);
     }
 
     // Every path here is Field-kind, so `resolve_node` (invoked by
@@ -20557,8 +20567,15 @@ fn delete_expr_array_paths(
         delete_expr_paths_through_absent(paths, start + 1)?;
         return Ok(value);
     }
-    let mut terminal: Vec<(ArrayStep, bool)> = Vec::new();
-    let mut groups: Vec<(ArrayStep, Vec<&[DeleteStep]>)> = Vec::new();
+    // Insertion-ordered *and* hashed — see the matching comment in
+    // `delete_expr_object_paths` for why both properties are needed (#1301).
+    // This is the arm the issue's own repro lands on: `del(.items[(0,1)].foo[])`
+    // resolves the trailing `[]` into one distinct `Index(i)` sibling per
+    // element, and the linear `find`/scan these two used to do never matched,
+    // so every sibling walked the whole growing list. 99.9% of a 200,000-element
+    // run's samples sat in those two loops.
+    let mut terminal: IndexMap<ArrayStep, bool> = IndexMap::new();
+    let mut groups: IndexMap<ArrayStep, Vec<&[DeleteStep]>> = IndexMap::new();
     for path in paths {
         let step = match &path[start].component {
             Expr::Index(idx) | Expr::IndexNumber { idx, .. } => ArrayStep::Index(*idx),
@@ -20568,26 +20585,13 @@ fn delete_expr_array_paths(
         if path.len() == start + 1 {
             // One occurrence of `step` marking it optional is enough to cover
             // every other occurrence — merge rather than keep only whichever
-            // one was pushed first, which used to make the outcome depend on
+            // one was inserted first, which used to make the outcome depend on
             // argument order (`del(.[(0,5)], .[5]?)` errored or not
             // depending on which side `.[5]?` was written on).
-            match terminal.iter_mut().find(|(s, _)| *s == step) {
-                Some(entry) => entry.1 |= path[start].optional,
-                None => terminal.push((step, path[start].optional)),
-            }
+            *terminal.entry(step).or_insert(false) |= path[start].optional;
             continue;
         }
-        let mut appended = false;
-        for group in &mut groups {
-            if group.0 == step {
-                group.1.push(*path);
-                appended = true;
-                break;
-            }
-        }
-        if !appended {
-            groups.push((step, vec![*path]));
-        }
+        groups.entry(step).or_default().push(*path);
     }
 
     // Unlike the object case above, this is NOT dead code: `resolve_node`
@@ -20695,7 +20699,11 @@ fn delete_expr_array_paths(
 /// elements of the same array and have to reach [`delete_keys`] in one batch —
 /// see the comment there on why splitting them would compound overlapping
 /// ranges instead of unioning them.
-#[derive(Clone, Copy, PartialEq, Eq)]
+///
+/// `Hash` is for use as an [`IndexMap`] key in [`delete_expr_array_paths`]'s
+/// grouping (#1301) — a lookup accelerator only. It implies no meaningful
+/// ordering or identity beyond the `PartialEq` above.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 enum ArrayStep {
     Index(i64),
     Slice(Option<i64>, Option<i64>),

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -998,6 +998,104 @@ fn test_untracked_terminal_before_a_deferred_iterate_says_near_iterate_888() {
     );
 }
 
+/// #1301: `del`'s sibling grouping is hashed now, not linearly scanned, and
+/// nothing about *which* sibling is visited first may change.
+///
+/// `del(.items[(0,1)].foo[])` was quadratic because `delete_expr_array_paths`
+/// and `delete_expr_object_paths` each kept their terminal keys and their
+/// recursion groups in an insertion-ordered `Vec` and scanned it linearly for
+/// a match — one O(siblings) scan per sibling. A computed key ahead of a
+/// trailing iterate makes every element its own sibling, so that scan never
+/// matched and never stopped early: 22.0s at 400,000 elements. Both are
+/// `IndexMap`/`IndexSet` now.
+///
+/// Insertion order is the whole reason for `IndexMap` over a `BTreeMap` here:
+/// `del` recurses into groups in source order and dies on the first that
+/// fails, so a container keyed in *sort* order would silently rewrite which
+/// error jq reports. Every expectation below is captured from jq 1.7.1.
+#[test]
+fn test_del_sibling_grouping_preserves_source_order_1301() {
+    // Group order follows the source, not the key: `(1,0)` visits index 1
+    // first. Harmless when both succeed...
+    check(
+        r#"[{"x":1,"y":2},{"x":3,"y":4}]"#,
+        "del(.[(1,0)].x)",
+        Outcome::values(&[r#"[{"y":2},{"y":4}]"#]),
+    );
+    // ...and load-bearing when one does not: the string at index 1 is
+    // reached before the object at index 0, so *its* error is the one jq
+    // reports. Sorting the groups would report neither.
+    check(
+        r#"[{"x":1},"s"]"#,
+        "del(.[(1,0)].x)",
+        Outcome::error(r#"Cannot index string with string "x""#),
+    );
+    // Same for object field groups, whose keys are also out of sort order.
+    check(
+        r#"{"b":{"k":1},"a":{"k":2}}"#,
+        r#"del(.[("b","a")].k)"#,
+        Outcome::values(&[r#"{"b":{},"a":{}}"#]),
+    );
+    // Nested on both levels, so the outer and inner groupings each have to
+    // keep their own order.
+    check(
+        "[[1,2],[3,4],[5,6]]",
+        "del(.[(2,0)][(1,0)])",
+        Outcome::values(&["[[],[3,4],[]]"]),
+    );
+
+    // The terminal `optional` merge survives the move to `entry()`: one
+    // occurrence marking a step optional still covers the other, whichever
+    // side it is written on (the argument-order dependence #477 fixed).
+    check(
+        "[1,2,3]",
+        "del(.[(0,5)], .[5]?)",
+        Outcome::values(&["[2,3]"]),
+    );
+    check(
+        "[1,2,3]",
+        "del(.[5]?, .[(0,5)])",
+        Outcome::values(&["[2,3]"]),
+    );
+
+    // A repeated key still collapses to one deletion rather than deleting
+    // twice — the dedupe the linear scan used to provide.
+    check("[1,2,3,4]", "del(.[(0,0,1)])", Outcome::values(&["[3,4]"]));
+
+    // The two arms of the shape that was quadratic, at more than one
+    // distinct key per container so the grouping actually has work to do.
+    check(
+        r#"{"items":[{"foo":{"a":1,"b":2}},{"foo":{"b":3,"c":4}}]}"#,
+        "del(.items[(0,1)].foo[])",
+        Outcome::values(&[r#"{"items":[{"foo":{}},{"foo":{}}]}"#]),
+    );
+    // Non-terminal groups, which are a separate loop from the terminal keys
+    // above and were quadratic in the same way.
+    check(
+        r#"{"items":[{"foo":[{"x":1},{"x":2}]},{"foo":[{"x":3}]}]}"#,
+        "del(.items[(0,1)].foo[].x)",
+        Outcome::values(&[r#"{"items":[{"foo":[{},{}]},{"foo":[{}]}]}"#]),
+    );
+
+    // No computed key needed to reach the same loop: a plain top-level comma
+    // already routes through the multi-path walker (#475), and the iterate
+    // ahead of it still enumerates one sibling per element. This shape was
+    // quadratic too -- 0.96s at 40,000 elements, 0.17s after -- which is why
+    // `bench_del_comma_through_iterate` exists.
+    check(
+        r#"{"foo":[{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6}]}"#,
+        "del(.foo[].a, .foo[].b)",
+        Outcome::values(&[r#"{"foo":[{"c":3},{"c":6}]}"#]),
+    );
+    // Array elements rather than object fields, and named out of order, so
+    // the index grouping has to keep source order here too.
+    check(
+        r#"{"foo":[[1,2,3],[4,5,6]]}"#,
+        "del(.foo[][2], .foo[][0])",
+        Outcome::values(&[r#"{"foo":[[2],[5]]}"#]),
+    );
+}
+
 /// A computed key is checked against the container it will actually index, not
 /// against the value the chain started from.
 ///


### PR DESCRIPTION
Fixes #1301.

## The issue's diagnosis was wrong

#1301 attributed `del(.items[(0,1)].foo[])`'s O(n²) to `defer_trailing_iterate`
being `false` for the write-side callers, and scoped the fix as resolving the
four divergence families `test_trailing_iterate_deferral_is_read_only_888` pins
— "a real pass over `resolve_dynamic_indexes`/`resolve_seq`". Measuring first,
per CLAUDE.md's #1213 lesson, says otherwise.

**The decisive experiment.** Hold the resolved-path count fixed at 80,000 and
widen the computed key from `k = 2` branches to `k = 512`, so
`resolve_dynamic_indexes` emits exactly as many paths in every row while the
sibling count *within one parent container* falls from 40,000 to 156:

| k | m = n/k | measured | model `82.5ms + 2.52e-7·(n²/k)` |
|---|---------|----------|----------------------------------|
| 2 | 40,000 | 890ms | 890 |
| 4 | 20,000 | 498ms | 486 |
| 8 | 10,000 | 289ms | 284 |
| 16 | 5,000 | 183ms | 183 |
| 32 | 2,500 | 133ms | 133 |
| 128 | 625 | 93ms | 92 |
| 512 | 156 | 95ms | 85 |

A one-parameter model fits every row within ~3%. The cost is the square of the
per-container sibling count, not the path count — which a deferral-shaped cost
cannot produce. `sample` agrees: 3330 of 3334 samples on an n=200,000 run are
self time in `delete_expr_array_paths`; `resolve_dynamic_indexes` and
`resolve_seq` never appear.

## The actual bug

Four loops in `del`'s sibling grouping did an O(siblings) linear scan per
sibling. A trailing iterate makes every element its own sibling, so the scan
never matched and never stopped early: two in `delete_expr_array_paths`
(`terminal.iter_mut().find(...)`, the repro's hot loop, and the `groups` scan)
and two in `delete_expr_object_paths` (`terminal.contains(&name)` and its
`groups` scan).

The removal itself was already linear — `delete_keys` sorts+dedups into one
cursor-driven `retain`, and c2e331e72 fixed this same class of bug on its object
arm (4.4s → 0.05s). The quadratic was purely the bookkeeping in front of it.

All four become `IndexMap`/`IndexSet`. Insertion order is load-bearing rather
than incidental — `del` recurses into groups in source order and dies on the
first that fails, so a sort-ordered container would silently rewrite which error
jq reports — which is why these and not `BTreeMap`. `indexmap` was already a
dependency and already imported in this file.

## Measurements

Interleaved per `docs/guides/benchmarking.md#ab-benchmarking-method`, release,
total elements = 2n, on **both** pinned hosts. Output identity gated first in
each run; both boxes verified idle (load average 0.00-0.03 at start).

**ARM64 — Apple M4 Pro (johns-mac-mini)**

| 2n | before | after | speedup | after, growth/doubling |
|----|--------|-------|---------|------------------------|
| 20,000 | 0.07s | 0.02s | 3.8x | — |
| 80,000 | 0.92s | 0.07s | 13.6x | ~1.9x |
| 200,000 | 5.54s | 0.18s | 31.4x | ~1.9x |
| 400,000 | 22.01s | 0.38s | 58.5x | ~1.9x |

**x86_64 — AMD Ryzen 9 7950X (terminus)**

| 2n | before | after | speedup | after, growth/doubling |
|----|--------|-------|---------|------------------------|
| 20,000 | 0.08s | 0.04s | 2.3x | — |
| 80,000 | 0.91s | 0.14s | 6.3x | ~2.0x |
| 200,000 | 5.12s | 0.36s | 14.1x | ~2.0x |
| 400,000 | 19.73s | 0.72s | 27.4x | ~2.0x |

The exponent drops on both, not just a constant — the after column doubles per
doubling on each. The absolute speedup differs (58x vs 27x) only because the
7950X's post-fix constant is about 2x the M4 Pro's; the *scaling*, which is what
this fix is about, is identical. `del` at 400,000 is now faster than
both `|=` (0.57s) and post-#888 `path()` (0.72s).

Other shapes reaching the same loops, local:
- object-valued tail: 2.02s → 0.12s at 80,000
- non-terminal groups (`del(.items[(0,1)].foo[].x)`): 1.01s → 0.22s at 80,000

Shapes that never reach the grouping are neutral: `del(.foo[])` 0.99x,
`del(.foo[(0,1)])` 0.98x — the per-call map costs nothing measurable, so no
size threshold is needed.

## Wider than #1301 described

`del(.foo[].a, .foo[].b)` — an ordinary two-path comma with **no computed key
anywhere** — was quadratic too. A top-level comma already routes through the
multi-path walker (#475), and the `[]` ahead of it still enumerates one sibling
per element:

| n | before | after |
|---|--------|-------|
| 10,000 | 0.09s | 0.04s |
| 20,000 | 0.28s | 0.09s |
| 40,000 | 0.96s | 0.17s |

x3.0 / x3.5 per doubling before; x1.95 / x1.92 after.

## Correctness

Output is byte-identical to the pre-fix binary and to jq 1.7.1 across a 26-case
shape grid — array/object tail, terminal/non-terminal, `?`, negative indices,
slices, duplicate keys, dead ends, the #888 guard cases — in both `jq` and `yq`
modes, error text and exit codes included. The `yq` slice-`del` rewrites
(#1101/#1116/#1219/#1223) are checked separately against the pre-fix binary.

`test_del_sibling_grouping_preserves_source_order_1301` pins what the rewrite is
newly responsible for: group order following source rather than key order
(including the case where it decides *which* error jq reports), the terminal
`optional` merge surviving the move to `entry()` in both argument orders,
duplicate-key collapse, and both container arms of the formerly-quadratic shape.
Every expectation captured from jq 1.7.1 first.

## Benchmarks

`bench_del_computed_key_with_trailing_iterate` moves to the file's shared
`SIZES`, as #1301 asked. Two new groups:
`bench_del_computed_key_with_trailing_iterate_object` guards
`delete_expr_object_paths`' half, and `bench_del_comma_through_iterate` guards
the array `groups` loop via the no-computed-key shape above.

## Verification

Gates taken from `.github/workflows/ci.yml`, run serially, after rebase onto
`58e459f57`:

- `cargo test --verbose --no-fail-fast` — 4061 passed, 0 failed
- `cargo test --features cli --test yq_cli_tests --test yq_golden_tests …` (the CI list) — 1073 passed, 0 failed
- `cargo test --verbose --features simd --no-fail-fast` — 4060 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- `cargo fmt --all -- --check`, `cargo check --no-default-features` — clean
- `cargo bench --bench jq_write_path_bench -- --test` — every group's premise guard passes at the raised sizes

## Follow-up not taken

Extending `defer_trailing_iterate` to the write callers remains unimplemented
and still blocked by the four families. It would cut the resolved-path count
from `k*n` to `k` — a real allocation win at 400,000 elements — but it is not
needed for the scaling fix and is strictly *less* general: it would leave
`del(.[(0,1,2,…)])` with many literal keys quadratic, which this fix does not.
#701 is not subsumed either — its cost is O(d²) in path *depth*, in
`push_recursive_branches`/`resolve_recurse`, a different axis.

#1301's body and the `resolve_dynamic_indexes` doc comment are both corrected;
the original text of the two disproved sections is archived in a comment on the
issue.

