### PR TITLE
docs(docs): record #1301's cost-attribution technique as A/B rule 8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -618,6 +618,7 @@ For detailed documentation on optimization techniques used in this project, see 
 - **A benchmark cannot measure a shape it does not generate** — "all neutral" is not evidence. Add the generator pattern first.
 - **A share of runtime is not a comparison.** Name a baseline commit that predates the change being judged — not a sibling from the same series (#1514: "cut the probe from 10.4% to 3.9%" shipped inside a 2-3x regression).
 - **Measure a precheck where the guarded code is already fastest.** It is charged to every input including the ones it cannot help, so the workload with least work to save is where its cost shows (#1514: the same detector read +14% on record-shaped input and +141% on one wide object).
+- **Attribute the cost before you A/B it.** A perf issue's named culprit is a hypothesis — #1213 and #1301 both named the wrong one. When the issue blames quantity A and you suspect B, build inputs holding A *provably constant* while varying B; if the time moves, A is not the term. #1301 blamed the resolved-path count, so holding it at 80,000 while widening the fan-out from 2 to 512 branches settled it in one table (890ms → 95ms). Unlike a profile, which only samples the window it runs in, that table has no escape hatch — and fitting its model predicts the post-fix floor before you change a line.
 
 **Recent YAML optimizations:**
 - ✅ P2.5 (Cached Type Checking): 1-17% improvement depending on nesting depth

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -954,6 +954,45 @@ rule and never pinned codegen-units — see #1587 for the re-check. It does not,
 `scripts/perf-guard.py`'s CI gate in question: that gate reads cachegrind `Ir`, which stayed
 flat in the same investigation — only `I1mr`, which perf-guard doesn't gate on, moved.
 
+### 10. Attribute the cost before you A/B it — hold one suspect quantity fixed
+
+Rules 1-9 assume you already know what to change. When a performance *issue* names a suspected
+cause, that is a hypothesis, not a diagnosis — and implementing its suggested fix before testing
+it can mean a large, unnecessary change that does not even address the real term. #1213 and #1301
+were both filed with a specific named culprit; both named the wrong one.
+
+When the issue blames quantity A and you suspect quantity B, construct inputs that **hold A
+provably constant while varying B**. If the time moves, A is not the term.
+
+#1301 reported `del(.items[(0,1)].foo[])` as O(n^2) and attributed it to the path resolver
+emitting `k*n` resolved paths instead of `k`. Holding total elements at 80,000 while widening the
+computed key from `k = 2` branches to `k = 512` keeps the resolver emitting exactly 80,000 paths
+in every row, while the sibling count within one container falls from 40,000 to 156:
+
+| k   | siblings per container | time  | model `82.5ms + 2.52e-7*(n^2/k)` |
+|-----|------------------------|-------|----------------------------------|
+| 2   | 40,000                 | 890ms | 890                              |
+| 8   | 10,000                 | 289ms | 284                              |
+| 32  | 2,500                  | 133ms | 133                              |
+| 128 | 625                    |  93ms |  92                              |
+| 512 | 156                    |  95ms |  85                              |
+
+A one-parameter model fit every row within ~3%, which located the term (`k*m^2`, the square of the
+per-container sibling count) and pointed at the four linear scans responsible. The resolver was
+never involved.
+
+Two things this buys that a profile does not:
+
+- **It cannot be argued with.** `sample`/`perf` only observe the window they run in, so "you
+  attached too late, the resolver had already finished" is a live objection to a profile. A table
+  where the blamed quantity is constant by construction has no such escape hatch.
+- **It gives you the shape of the term, and therefore a prediction.** Fitting `a + b*(n^2/k)`
+  yielded a floor of ~90ms at 80,000 elements *before any code changed*. The fix landed at 88ms.
+  A pre-registered target is much stronger evidence than a number admired afterwards.
+
+Report the fitted model alongside the measurements in the commit message and PR, not just in your
+own head — "the model fits all seven widths within 3%" is what makes a diagnosis reviewable.
+
 ### Building both halves on a remote box
 
 A source-only tarball plus a reverse patch of the commit under test is enough, with no pushing:


### PR DESCRIPTION
Refs #1301.

## Why

Rules 1-7 of the A/B method all assume you already know what to change. Nothing
in the guide covers the step before that: deciding *which cost you are actually
looking at*.

Two issues have now been filed with a specific suspected culprit named in the
body, and both named the wrong one:

- **#1213** blamed `--seq`'s per-record `serde_json::Value` allocation; the real
  bug was `line_at` rescanning the input from byte 0 per call.
- **#1301** blamed `resolve_dynamic_indexes` emitting `k*n` resolved paths where
  `path()` gets `k`, and scoped the fix as resolving four divergence families —
  a substantial rework of the path resolver. The real term was four linear
  scans in `del`'s sibling grouping, ~20 lines away from each other and nowhere
  near the resolver.

In both cases, implementing the issue's suggested fix as written would have been
a large change that did not address the cost.

## What

A new §8, **"Attribute the cost before you A/B it — hold one suspect quantity
fixed"**, plus a matching bullet in `CLAUDE.md`'s Benchmarking Discipline list.

The technique: when the issue blames quantity A and you suspect B, construct
inputs that hold A *provably constant* while varying B. On #1301, holding the
resolved-path count at 80,000 while widening the computed key from `k = 2`
branches to `k = 512` keeps the resolver emitting exactly 80,000 paths in every
row, while the per-container sibling count falls from 40,000 to 156 — and `del`
goes from 890ms to 95ms, which no per-path cost can produce.

The section also records the two things this buys over a profile, since a
profile is the more obvious tool and was not sufficient here:

- **It cannot be argued with.** `sample`/`perf` observe only the window they run
  in, so "you attached too late, the resolver had already finished" is a live
  objection. A table where the blamed quantity is constant by construction has
  no such escape hatch.
- **It gives the shape of the term, and therefore a prediction.** Fitting
  `a + b*(n²/k)` yielded a floor of ~90ms at 80,000 elements before any code
  changed; the fix landed at 88ms. A pre-registered target is stronger evidence
  than a number admired afterwards.

## Note on placement

Appended as §8 rather than inserted after §3, where it fits logically, because
`docs/plan/cspoppy.md:254` links the numbered anchor
`#5-measure-both-architectures--the-effect-size-differs-not-just-the-noise`.
Renumbering would break that link. The section opens by saying it precedes rules
1-7, so the ordering reads correctly despite the number.

Docs only — no code, no tests, no benchmarks touched.
