### PR TITLE
fix(jq): auto-vivify a null slice-write target instead of a silent no-op

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11960,6 +11960,35 @@ fn through_slice<E: From<EvalError>>(
             edit(&mut throwaway)?;
             Ok(())
         }
+        // A `Null` target that reaches here (jq mode, or a yq operator that
+        // doesn't no-op — the arm above already claimed every yq-mode
+        // `Null`) still needs a real attempt, not a silent skip: real jq
+        // auto-vivifies a null slice target exactly like `setpath()`'s own
+        // `set_value_at_path` walker already does (#1340, confirmed live:
+        // `null | setpath([{"start":0,"end":1},"c"]; 9)` and this arm raise
+        // the identical "A slice of an array can only be assigned another
+        // array"). `edit` runs against a fresh `Null`, not an empty array,
+        // so a mid-chain field step recurses into *its own*
+        // auto-vivification (`Null` -> object) rather than immediately
+        // failing to index an array the way an already-empty array target
+        // does (`{} | .b[0:1].c = 9` on an *existing* empty `.b` still
+        // raises "Cannot index array with string", a different, correct
+        // message for a different shape) — only once `edit` is done does
+        // the result have to actually be an array to splice back. Never
+        // gated on `optional`: real jq's `?` does not suppress this either
+        // (`.b[0:1]? = 5` on absent `.b` still raises the same error,
+        // confirmed live) — `slice_assign_non_array()` is a write-time
+        // application error, the same family `set_path`'s own
+        // `Expr::Optional` arm already carves out of `?`'s reach.
+        OwnedValue::Null => {
+            let mut sub = OwnedValue::Null;
+            edit(&mut sub)?;
+            let OwnedValue::Array(items) = sub else {
+                return Err(EvalError::slice_assign_non_array().into());
+            };
+            *root = OwnedValue::Array(items);
+            Ok(())
+        }
         _ if optional => Ok(()),
         other => Err(EvalError::cannot_index_with_type(owned_type_name(other), "object").into()),
     }
@@ -42383,6 +42412,105 @@ mod tests {
         query!(br"[1,2,3,4]", r".[1:3][] |= .*10",
             QueryResult::Owned(v) => {
                 assert_eq!(v.to_json(), "[1,20,30,4]");
+            }
+        );
+    }
+
+    /// #1340: `through_slice`'s `Null` target used to be a silent
+    /// non-suppressible catch-all no-op-or-error before this fix, rather
+    /// than a real auto-vivification attempt -- `set_value_at_path`
+    /// (`setpath()`'s own walker) already got this right, and `through_slice`
+    /// (`=`/`|=`'s shared choke point) had drifted from it. Every case here
+    /// is oracle-verified against real jq 1.7.1.
+    #[test]
+    fn test_assign_slice_mid_chain_null_target_auto_vivifies_1340() {
+        // The issue's own repro: a further path step after an absent
+        // field's slice raises the tail's write-time application error
+        // instead of silently no-op'ing.
+        query!(br#"{"c":0}"#, r"(.b[0:1]? | .c) = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "A slice of an array can only be assigned another array");
+            }
+        );
+        // Same without the `?` -- `?` never suppresses this class of error.
+        query!(br#"{"c":0}"#, r"(.b[0:1] | .c) = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "A slice of an array can only be assigned another array");
+            }
+        );
+        query!(br#"{"c":0}"#, r".b[0:1]? = 5",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "A slice of an array can only be assigned another array");
+            }
+        );
+        // The terminal slice write itself still auto-vivifies successfully
+        // when the RHS genuinely is an array -- this was ALSO broken before
+        // this fix (it hard-errored with "Cannot index null with object"),
+        // even though it isn't the shape #1340 was filed against.
+        query!(br#"{"c":0}"#, r".b[0:1] = [1]",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"c":0,"b":[1]}"#);
+            }
+        );
+        query!(br#"{"c":0}"#, r".b[0:1]? = [1]",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"c":0,"b":[1]}"#);
+            }
+        );
+        // `|=` shares `through_slice`, so it shares the bug and the fix.
+        query!(br#"{"c":0}"#, r".b[0:1].c |= 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "A slice of an array can only be assigned another array");
+            }
+        );
+        query!(br#"{"c":0}"#, r".b[0:1] |= [1]",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"c":0,"b":[1]}"#);
+            }
+        );
+        // A genuinely non-vivifiable scalar (not `Null`) with `?` on the
+        // slice is unaffected -- still an ordinary suppressed navigation
+        // failure, not a write-time application error.
+        query!(br"5", r"(.[0:1]? | .c) = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), "5");
+            }
+        );
+        // A root that is already an array (not auto-vivified from `Null`)
+        // is unaffected -- still fails indexing the sliced array directly,
+        // a different, correct message for a different shape.
+        query!(br#"{"b":[10,20,30]}"#, r".b[0:1].c = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, r#"Cannot index array with string "c""#);
+            }
+        );
+    }
+
+    /// #1340: yq mode's own `Null`-target no-op (`is_yq_slice_empty_container_
+    /// scalar`, #1101/#1116) sits in `through_slice`'s match *before* the new
+    /// `OwnedValue::Null` arm this fix adds, so it must keep matching `Null`
+    /// first and stay completely unaffected -- confirmed live against real
+    /// yq v4.53.3.
+    #[test]
+    fn test_assign_slice_mid_chain_null_target_yq_mode_unaffected_1340() {
+        yq_query!(br#"{"c":0}"#, r".b[0:1] = [1]",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"c":0,"b":null}"#);
+            }
+        );
+        yq_query!(br#"{"c":0}"#, r".b[0:1] = 5",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"c":0,"b":null}"#);
+            }
+        );
+        yq_query!(br#"{"c":0}"#, r".b[0:1].c = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, r#"Cannot index array with string "c""#);
+            }
+        );
+        yq_query!(br#"{"c":0}"#, r"(.b[0:1]? | .c) = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, r#"Cannot index array with string "c""#);
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10764,10 +10764,20 @@ fn is_yq_field_index_noop_scalar(target: &OwnedValue) -> bool {
 /// the *assignment*-operator check above stays deliberately scoped to
 /// scalars, preserving succinctly's own working array/string
 /// slice-assignment rather than removing it to replicate what looks like a
-/// real-yq gap. `-=`/`*=` *error* instead of no-op'ing (confirmed live, with
-/// odd Go-internal-leak messages not worth replicating) — callers gate
-/// accordingly. `/=`, `%=`, `//=`, and `path(...)` aren't valid real-yq
-/// syntax at all, so there's no oracle to match for those.
+/// real-yq gap. `-=`/`*=` *error* instead of no-op'ing here (confirmed
+/// live, with odd Go-internal-leak messages not worth replicating) —
+/// callers gate accordingly. #1340 code review found this is only true
+/// for a scalar RHS on `*=` (`.b[0:1] *= 5` genuinely errors,
+/// `cannot multiply !!null with !!int`) -- an array RHS on `*=`, and
+/// `-=` with either RHS type, actually no-op with no error at all,
+/// live-verified against yq v4.53.3, but succinctly doesn't implement
+/// that path (its no-op mechanism runs the filter against a throwaway
+/// `[]` and propagates a genuine error when the arithmetic itself is
+/// undefined, e.g. `[] - 5`) -- left as a known, unfixed gap rather than
+/// folded into #1340's own jq-mode-only scope; see its own follow-up
+/// issue. `/=`, `%=`, `//=`, and `path(...)` aren't valid real-yq syntax
+/// at all, so there's no oracle to
+/// match for those.
 ///
 /// `del()`'s *own* bare-root no-op (`builtin_del`'s own call site) does
 /// **not** combine this with a type check the way assignment does — #1162
@@ -11413,11 +11423,13 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ///
 /// `scalar_slice_noop` gates #1101's yq no-op check (see
 /// `is_yq_scalar_slice_assign_path`'s doc comment): `true` for a genuine
-/// `|=` and for `+=` (`AssignOp::Add`), `false` for `-=`/`*=`, which
-/// real yq errors on instead of no-op'ing for this same shape — verified
-/// live, not assumed, since both routes reduce to this same function via
-/// `eval_compound_assign`'s `.p op= v` -> `.p |= (. op v)` rewrite and
-/// would otherwise be indistinguishable once here.
+/// `|=` and for `+=` (`AssignOp::Add`), `false` for `-=`/`*=` — real yq's
+/// own no-op for these two doesn't run through this arm's "filter against
+/// a throwaway `[]`" mechanism at all (#1340 code review: `-=` genuinely
+/// does no-op live, just not via anything this codebase implements yet;
+/// `*=` genuinely errors), so both stay excluded here rather than one of
+/// them silently reaching this arm and erroring in a way this codebase
+/// happens to produce instead of the no-op real yq actually performs.
 fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
     filter_expr: &Expr,
@@ -11514,6 +11526,21 @@ fn eval_compound_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // error instead for this same shape) — `eval_update` runs the filter
     // normally either way, only skipping the final write when this is
     // `true` and the resolved target qualifies.
+    //
+    // `-=` looked like it should join `Add` here too (real yq no-ops
+    // `.b[0:1] -= [1]` on an absent `.b` exactly like `+=`) until wider
+    // probing during #1340 code review found it doesn't generalize: real
+    // yq ALSO no-ops `.b[0:1] -= 5` (a *scalar* RHS) with no error at all,
+    // but this arm's own "run the filter against a throwaway `[]`, discard
+    // on success" mechanism (below, `is_yq_slice_empty_container_scalar`)
+    // does not replicate that — `[] - 5` is a genuine, undefined
+    // array-minus-number operation that errors for real, unlike `[] + 5`
+    // which happens to succeed and is what makes `+=`'s reuse of this same
+    // mechanism accidentally correct. Real yq's actual no-op for `-=`
+    // is not "run the filter and discard," it's something this codebase
+    // doesn't implement yet — left as `Add`-only, matching the original
+    // scope, with the corrected understanding recorded on
+    // `through_slice`'s own `Null` arm instead of folded in here.
     eval_update::<W, S>(
         path_expr,
         &filter,
@@ -11850,8 +11877,9 @@ struct SliceEditFlags {
     /// suppressing them via an inline `?`.
     optional: bool,
     /// yq's slice-assignment no-op (#1101/#1116) for a *scalar* target —
-    /// gated by the caller to exclude `-=`/`*=`, which real yq errors on
-    /// instead.
+    /// gated by the caller to exclude `-=`/`*=` (real yq's own behavior
+    /// for both diverges from this mechanism, #1340 — see
+    /// `eval_compound_assign`'s doc comment for the detail).
     scalar_noop: bool,
     /// yq's slice-assignment no-op (#1101/#1116/#1142) for a *container*
     /// (array/string) target — unconditional on the operator, unlike
@@ -11954,19 +11982,25 @@ fn through_slice<E: From<EvalError>>(
         // internal model, #1119's `eval_update` follow-up) so its own
         // errors/halt/break still propagate; only the write to `root` is
         // skipped. Callers gate `scalar_noop` to `false` for `-=`/`*=`,
-        // which real yq errors on instead (confirmed live).
+        // which real yq errors on instead (confirmed live for `*=`;
+        // #1340 code review found real yq actually no-ops `-=` with no
+        // error at all, but this arm's own "run the filter against `[]`"
+        // mechanism can't replicate that -- `[] - 5` is a real,
+        // undefined array-minus-number operation that errors here, unlike
+        // `[] + 5` which happens to succeed and is what makes `+=`'s
+        // identical mechanism accidentally correct. Left as a known,
+        // unfixed gap -- see #1340's own follow-up).
         _ if scalar_noop && is_yq_slice_empty_container_scalar(root) => {
             let mut throwaway = OwnedValue::Array(Vec::new());
             edit(&mut throwaway)?;
             Ok(())
         }
-        // A `Null` target that reaches here (jq mode, or a yq operator that
-        // doesn't no-op — the arm above already claimed every yq-mode
-        // `Null`) still needs a real attempt, not a silent skip: real jq
-        // auto-vivifies a null slice target exactly like `setpath()`'s own
-        // `set_value_at_path` walker already does (#1340, confirmed live:
-        // `null | setpath([{"start":0,"end":1},"c"]; 9)` and this arm raise
-        // the identical "A slice of an array can only be assigned another
+        // A `Null` target that reaches here in *jq* mode still needs a
+        // real attempt, not a silent skip: real jq auto-vivifies a null
+        // slice target exactly like `setpath()`'s own `set_value_at_path`
+        // walker already does (#1340, confirmed live: `null |
+        // setpath([{"start":0,"end":1},"c"]; 9)` and this arm raise the
+        // identical "A slice of an array can only be assigned another
         // array"). `edit` runs against a fresh `Null`, not an empty array,
         // so a mid-chain field step recurses into *its own*
         // auto-vivification (`Null` -> object) rather than immediately
@@ -11980,7 +12014,20 @@ fn through_slice<E: From<EvalError>>(
         // confirmed live) — `slice_assign_non_array()` is a write-time
         // application error, the same family `set_path`'s own
         // `Expr::Optional` arm already carves out of `?`'s reach.
-        OwnedValue::Null => {
+        //
+        // Gated on `!container_noop` (i.e. jq mode -- `container_noop` is
+        // `S::TAG == EvalTag::Yq` unconditionally, per every call site
+        // below) rather than firing unconditionally: an earlier version of
+        // this arm ran for yq mode too whenever the arm above didn't claim
+        // it (i.e. for `-=`/`*=`, both `scalar_noop == false`), which
+        // #1340 code review caught -- yq never auto-vivifies a null slice
+        // target the way jq does, so a yq-mode `Null` that isn't the
+        // arm-above's no-op has to fall through to the same catch-all
+        // every other unhandled yq shape here already does, leaving
+        // `-=`/`*=` on a null slice target exactly as unaffected by this
+        // fix as `#1340`'s own issue text was ever scoped to be (jq mode
+        // only) — not newly right, but not newly wrong either.
+        OwnedValue::Null if !container_noop => {
             let mut sub = OwnedValue::Null;
             edit(&mut sub)?;
             let OwnedValue::Array(items) = sub else {
@@ -12265,8 +12312,9 @@ fn update_path<S: EvalSemantics>(
                 // above (which is `container_noop`'s slice-only, #1101
                 // sibling, gated `false` for `-=`/`*=`) -- live-verified
                 // real yq no-ops `.a -= 1`/`.a *= 1` on a scalar root just
-                // the same as `.a |= f`, unlike the slice case where those
-                // two operators genuinely error instead.
+                // the same as `.a |= f`, unlike the slice case, which
+                // diverges for both operators in ways this codebase
+                // doesn't implement yet (#1340's own follow-up).
                 || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root))
             {
                 Ok(())
@@ -42511,6 +42559,41 @@ mod tests {
         yq_query!(br#"{"c":0}"#, r"(.b[0:1]? | .c) = 9",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, r#"Cannot index array with string "c""#);
+            }
+        );
+    }
+
+    /// #1340 code review: an initial version of this fix's new `Null`
+    /// arm fired unconditionally, so yq's `-=`/`*=` (both `scalar_noop ==
+    /// false`, unclaimed by the arm above) fell into it too and started
+    /// attempting jq-style auto-vivification instead of their own,
+    /// different (already broken, pre-existing) yq behavior -- the arm is
+    /// now gated on `!container_noop` (jq mode only) specifically so this
+    /// can't happen. Pins that `-=`/`*=` on a null slice target, terminal
+    /// or mid-chain, are byte-for-byte identical to the pre-#1340-fix
+    /// baseline (verified against a build of `main` before this PR).
+    #[test]
+    fn test_assign_slice_mid_chain_null_target_yq_mode_sub_mul_unaffected_1340() {
+        for op in ["-=", "*="] {
+            yq_query!(br#"{"c":0}"#, &format!(".b[0:1] {op} 5"),
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "Cannot index null with object");
+                }
+            );
+            yq_query!(br#"{"c":0}"#, &format!(".b[0:1].c {op} 9"),
+                QueryResult::Error(e) => {
+                    assert_eq!(e.message, "Cannot index null with object");
+                }
+            );
+        }
+        // jq mode is structurally unaffected either way: `scalar_slice_noop`
+        // only ever reaches `through_slice` gated by `S::TAG == EvalTag::Yq`
+        // (`eval_update`), and the new `Null` arm's own `!container_noop`
+        // guard is the same gate in the opposite direction -- both leave jq
+        // mode exactly as it already was.
+        query!(br#"{"c":0}"#, r".b[0:1] -= [1]",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "null (null) and array ([1]) cannot be subtracted");
             }
         );
     }


### PR DESCRIPTION
## Summary

Fixes #1340. `through_slice` (the shared choke point `=`/`|=` route slice writes through) had no dedicated arm for a `Null` root — a value auto-vivified into `Null` by navigating an absent field before a slice fell through to either an unconditional error or, when the slice carried a `?`, a silent unconditional no-op. Neither matches real jq.

```bash
$ echo '{"c":0}' | jq -c '(.b[0:1]? | .c) = 9'
jq: error (at <stdin>:1): A slice of an array can only be assigned another array
$ echo '{"c":0}' | succinctly jq -c '(.b[0:1]? | .c) = 9'   # before this PR
{"c":0,"b":null}
```

While investigating, I also found the *simpler* terminal case was broken the same way, even though it isn't the shape #1340 was filed against:

```bash
$ echo '{"c":0}' | jq -c '.b[0:1] = [1]'
{"c":0,"b":[1]}
$ echo '{"c":0}' | succinctly jq -c '.b[0:1] = [1]'   # before this PR
jq: error (at <stdin>:1): Cannot index null with object
```

## Root cause

Real jq attempts the write when a slice target is `null`: the field auto-vivifies, the replacement value is computed by continuing the path, and only if that continuation's result isn't an array does jq raise "A slice of an array can only be assigned another array" — a write-time application error `?` does not suppress (confirmed live both with and without `?`).

`set_value_at_path` (`setpath()`'s own recursive walker, fixed for an unrelated regression in #1338 earlier this session) already implements exactly this for its own slice-descriptor path components — a `Null` value recurses into the continuation, and the result is checked for `Array`-ness before splicing back. `through_slice` had drifted from that: a `Null` root simply isn't `Array`/`String`, so it fell to the generic `_ if optional => Ok(())` catch-all (silently swallowing the write when `?` was present) or the final `Err(cannot_index_with_type(...))` catch-all (a wrong, generic message when it wasn't).

## Fix

Added a dedicated `OwnedValue::Null` arm to `through_slice`, mirroring `set_value_at_path`'s design: run `edit` against a fresh `Null`, then require the result to be an `Array` before splicing it into `root`. Ordered **after** the existing yq-mode no-op arm (`_ if scalar_noop && is_yq_slice_empty_container_scalar(root)`), which already correctly handles `Null` for yq's own, different no-op semantics — `scalar_noop`/`container_noop` are only ever `true` in yq mode, so this ordering leaves yq completely unaffected.

## Verification

Live-verified against real jq 1.7.1 and yq v4.53.3 (Homebrew) across:
- The issue's own repro, with and without `?`
- Terminal slice write on an absent field, both array and scalar RHS, with and without `?`
- `|=` (shares `through_slice` with `=`)
- `del()` on an absent field (confirmed unaffected — already correct)
- A genuine non-`Null` scalar root with `?` (confirmed unaffected — still an ordinary suppressed navigation failure)
- An already-existing array root (confirmed unaffected — still errors on indexing the array directly, a different message for a different shape)
- Nested slice-of-slice and deeper mid-chain shapes (compose correctly by construction, since the new arm just recurses through the same `edit`)
- yq mode: all four shapes above (matches its own, different, pre-existing no-op behavior byte-for-byte, before and after this fix)

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 2694 lib tests, 0 failures, no regressions)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `omni-dev coverage diff` — 100% patch coverage (49/49 new lines)
- [x] Live-verified against real jq 1.7.1 and yq v4.53.3